### PR TITLE
extraction: make name generation gensym independent

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -1653,12 +1653,16 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           in
           let lbs = extract_lb_sig g (is_rec, lbs) in
 
-          let env_body, lbs = List.fold_right (fun lb (env, lbs) ->
+          (* env_burn only matters for non-recursive lets and simply burns
+           * the let bound variable in its own definition to generate
+           * code that is more understandable. *)
+          let env_body, lbs, env_burn = List.fold_right (fun lb (env, lbs, env_burn) ->
               let (lbname, _, (t, (_, polytype)), add_unit, _) = lb in
               let env, nm, _ = UEnv.extend_lb env lbname t polytype add_unit in
-              env, (nm,lb)::lbs) lbs (g, []) in
+              let env_burn = UEnv.burn_name env_burn nm in
+              env, (nm,lb)::lbs, env_burn) lbs (g, [], g) in
 
-          let env_def = if is_rec then env_body else g in
+          let env_def = if is_rec then env_body else env_burn in
 
           let lbs = lbs |> List.map (check_lb env_def)  in
 

--- a/src/extraction/FStar.Extraction.ML.UEnv.fs
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fs
@@ -338,7 +338,7 @@ let rename_conventional (s:string) (is_local_type_variable:bool) : string =
 let root_name_of_bv (x:bv): mlident =
   if BU.starts_with (string_of_id x.ppname) Ident.reserved_prefix
   || is_null_bv x
-  then (string_of_id x.ppname) ^ "_" ^ (string_of_int x.index)
+  then Ident.reserved_prefix
   else string_of_id x.ppname
 
 (** Given a candidate root_name, generate an ML identifier

--- a/src/extraction/FStar.Extraction.ML.UEnv.fs
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fs
@@ -443,6 +443,9 @@ let extend_bv (g:uenv) (x:bv) (t_x:mltyscheme) (add_unit:bool)
     let tcenv = TypeChecker.Env.push_binders g.env_tcenv (binders_of_list [x]) in
     {g with env_bindings=gamma; env_mlident_map = mlident_map; env_tcenv=tcenv}, mlident, exp_binding
 
+let burn_name (g:uenv) (i:mlident) : uenv =
+  { g with env_mlident_map = BU.psmap_add g.env_mlident_map i "" }
+
 (** Generating a fresh local term variable *)
 let new_mlident (g:uenv)
   : uenv * mlident

--- a/src/extraction/FStar.Extraction.ML.UEnv.fsi
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fsi
@@ -119,6 +119,17 @@ val extend_bv:
     mk_unit: bool ->
     uenv * mlident * exp_binding
 
+(** Make sure a given ML name is not used in an environment. The
+scope of the environment is not changed at all. This can be used to
+generate less confusing names, for instance, in `let x = E in F`, we can
+burn `x` in `E` to avoid generating code like `let x = let x = 1 in x in
+x`, which does not have any shadowing, but is hard to read. Of course,
+`x` is burnt in `F` since it is in-scope there. *)
+val burn_name:
+    uenv ->
+    mlident ->
+    uenv
+
 (** Extend with an top-level term identifier, maybe thunked *)
 val extend_fv: 
     uenv ->

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -72,16 +72,13 @@ type tc_result_t =
   | Invalid of Prims.string 
   | Valid of Prims.string 
 let (uu___is_Unknown : tc_result_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unknown -> true | uu____241 -> false
+  fun projectee -> match projectee with | Unknown -> true | uu___ -> false
 let (uu___is_Invalid : tc_result_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Invalid _0 -> true | uu____248 -> false
+  fun projectee -> match projectee with | Invalid _0 -> true | uu___ -> false
 let (__proj__Invalid__item___0 : tc_result_t -> Prims.string) =
   fun projectee -> match projectee with | Invalid _0 -> _0
 let (uu___is_Valid : tc_result_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Valid _0 -> true | uu____261 -> false
+  fun projectee -> match projectee with | Valid _0 -> true | uu___ -> false
 let (__proj__Valid__item___0 : tc_result_t -> Prims.string) =
   fun projectee -> match projectee with | Valid _0 -> _0
 type cache_t =
@@ -98,122 +95,119 @@ let (hash_dependences :
   fun deps ->
     fun fn ->
       let fn1 =
-        let uu____309 = FStar_Options.find_file fn in
-        match uu____309 with
-        | FStar_Pervasives_Native.Some fn1 -> fn1
-        | uu____313 -> fn in
+        let uu___ = FStar_Options.find_file fn in
+        match uu___ with
+        | FStar_Pervasives_Native.Some fn2 -> fn2
+        | uu___1 -> fn in
       let module_name = FStar_Parser_Dep.lowercase_module_name fn1 in
       let source_hash = FStar_Util.digest_of_file fn1 in
       let has_interface =
-        let uu____319 = FStar_Parser_Dep.interface_of deps module_name in
-        FStar_Option.isSome uu____319 in
+        let uu___ = FStar_Parser_Dep.interface_of deps module_name in
+        FStar_Option.isSome uu___ in
       let interface_checked_file_name =
-        let uu____325 =
-          (FStar_Parser_Dep.is_implementation fn1) && has_interface in
-        if uu____325
+        let uu___ = (FStar_Parser_Dep.is_implementation fn1) && has_interface in
+        if uu___
         then
-          let uu____328 =
-            let uu____329 =
-              let uu____330 =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_All.pipe_right module_name
                   (FStar_Parser_Dep.interface_of deps) in
-              FStar_All.pipe_right uu____330 FStar_Util.must in
-            FStar_All.pipe_right uu____329 FStar_Parser_Dep.cache_file_name in
-          FStar_All.pipe_right uu____328
-            (fun uu____339 -> FStar_Pervasives_Native.Some uu____339)
+              FStar_All.pipe_right uu___3 FStar_Util.must in
+            FStar_All.pipe_right uu___2 FStar_Parser_Dep.cache_file_name in
+          FStar_All.pipe_right uu___1
+            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
         else FStar_Pervasives_Native.None in
       let binary_deps =
-        let uu____344 = FStar_Parser_Dep.deps_of deps fn1 in
-        FStar_All.pipe_right uu____344
+        let uu___ = FStar_Parser_Dep.deps_of deps fn1 in
+        FStar_All.pipe_right uu___
           (FStar_List.filter
              (fun fn2 ->
-                let uu____354 =
+                let uu___1 =
                   (FStar_Parser_Dep.is_interface fn2) &&
-                    (let uu____356 =
-                       FStar_Parser_Dep.lowercase_module_name fn2 in
-                     uu____356 = module_name) in
-                Prims.op_Negation uu____354)) in
+                    (let uu___2 = FStar_Parser_Dep.lowercase_module_name fn2 in
+                     uu___2 = module_name) in
+                Prims.op_Negation uu___1)) in
       let binary_deps1 =
         FStar_List.sortWith
           (fun fn11 ->
              fun fn2 ->
-               let uu____366 = FStar_Parser_Dep.lowercase_module_name fn11 in
-               let uu____367 = FStar_Parser_Dep.lowercase_module_name fn2 in
-               FStar_String.compare uu____366 uu____367) binary_deps in
+               let uu___ = FStar_Parser_Dep.lowercase_module_name fn11 in
+               let uu___1 = FStar_Parser_Dep.lowercase_module_name fn2 in
+               FStar_String.compare uu___ uu___1) binary_deps in
       let maybe_add_iface_hash out =
         match interface_checked_file_name with
         | FStar_Pervasives_Native.None ->
             FStar_Util.Inr (("source", source_hash) :: out)
         | FStar_Pervasives_Native.Some iface ->
-            let uu____417 = FStar_Util.smap_try_find mcache iface in
-            (match uu____417 with
+            let uu___ = FStar_Util.smap_try_find mcache iface in
+            (match uu___ with
              | FStar_Pervasives_Native.None ->
                  let msg =
                    FStar_Util.format1
                      "hash_dependences::the interface checked file %s does not exist\n"
                      iface in
-                 ((let uu____432 =
+                 ((let uu___2 =
                      FStar_Options.debug_at_level_no_module
                        (FStar_Options.Other "CheckedFiles") in
-                   if uu____432 then FStar_Util.print1 "%s\n" msg else ());
+                   if uu___2 then FStar_Util.print1 "%s\n" msg else ());
                   FStar_Util.Inl msg)
-             | FStar_Pervasives_Native.Some (Invalid msg, uu____441) ->
+             | FStar_Pervasives_Native.Some (Invalid msg, uu___1) ->
                  FStar_Util.Inl msg
-             | FStar_Pervasives_Native.Some (Valid h, uu____457) ->
+             | FStar_Pervasives_Native.Some (Valid h, uu___1) ->
                  FStar_Util.Inr (("source", source_hash) :: ("interface", h)
                    :: out)
-             | FStar_Pervasives_Native.Some (Unknown, uu____480) ->
-                 let uu____489 =
+             | FStar_Pervasives_Native.Some (Unknown, uu___1) ->
+                 let uu___2 =
                    FStar_Util.format1
                      "Impossible: unknown entry in the mcache for interface %s\n"
                      iface in
-                 failwith uu____489) in
-      let rec hash_deps out uu___0_528 =
-        match uu___0_528 with
+                 failwith uu___2) in
+      let rec hash_deps out uu___ =
+        match uu___ with
         | [] -> maybe_add_iface_hash out
         | fn2::deps1 ->
             let cache_fn = FStar_Parser_Dep.cache_file_name fn2 in
             let digest =
-              let uu____557 = FStar_Util.smap_try_find mcache cache_fn in
-              match uu____557 with
+              let uu___1 = FStar_Util.smap_try_find mcache cache_fn in
+              match uu___1 with
               | FStar_Pervasives_Native.None ->
                   let msg =
                     FStar_Util.format2
                       "For dependency %s, cache file %s is not loaded" fn2
                       cache_fn in
-                  ((let uu____566 =
+                  ((let uu___3 =
                       FStar_Options.debug_at_level_no_module
                         (FStar_Options.Other "CheckedFiles") in
-                    if uu____566 then FStar_Util.print1 "%s\n" msg else ());
+                    if uu___3 then FStar_Util.print1 "%s\n" msg else ());
                    FStar_Util.Inl msg)
-              | FStar_Pervasives_Native.Some (Invalid msg, uu____569) ->
+              | FStar_Pervasives_Native.Some (Invalid msg, uu___2) ->
                   FStar_Util.Inl msg
-              | FStar_Pervasives_Native.Some (Valid dig, uu____579) ->
+              | FStar_Pervasives_Native.Some (Valid dig, uu___2) ->
                   FStar_Util.Inr dig
-              | FStar_Pervasives_Native.Some (Unknown, uu____588) ->
-                  let uu____597 =
+              | FStar_Pervasives_Native.Some (Unknown, uu___2) ->
+                  let uu___3 =
                     FStar_Util.format2
                       "Impossible: unknown entry in the cache for dependence %s of module %s"
                       fn2 module_name in
-                  failwith uu____597 in
+                  failwith uu___3 in
             (match digest with
              | FStar_Util.Inl msg -> FStar_Util.Inl msg
              | FStar_Util.Inr dig ->
-                 let uu____620 =
-                   let uu____627 =
-                     let uu____632 =
-                       FStar_Parser_Dep.lowercase_module_name fn2 in
-                     (uu____632, dig) in
-                   uu____627 :: out in
-                 hash_deps uu____620 deps1) in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Parser_Dep.lowercase_module_name fn2 in
+                     (uu___3, dig) in
+                   uu___2 :: out in
+                 hash_deps uu___1 deps1) in
       hash_deps [] binary_deps1
 let (load_checked_file : Prims.string -> Prims.string -> cache_t) =
   fun fn ->
     fun checked_fn ->
       let elt =
         FStar_All.pipe_right checked_fn (FStar_Util.smap_try_find mcache) in
-      let uu____656 = FStar_All.pipe_right elt FStar_Util.is_some in
-      if uu____656
+      let uu___ = FStar_All.pipe_right elt FStar_Util.is_some in
+      if uu___
       then FStar_All.pipe_right elt FStar_Util.must
       else
         (let add_and_return elt1 =
@@ -241,10 +235,10 @@ let (load_checked_file : Prims.string -> Prims.string -> cache_t) =
                   (let current_digest = FStar_Util.digest_of_file fn in
                    if x.digest <> current_digest
                    then
-                     ((let uu____692 =
+                     ((let uu___5 =
                          FStar_Options.debug_at_level_no_module
                            (FStar_Options.Other "CheckedFiles") in
-                       if uu____692
+                       if uu___5
                        then
                          FStar_Util.print4
                            "Checked file %s is stale since incorrect digest of %s, expected: %s, found: %s\n"
@@ -269,115 +263,112 @@ let (load_checked_file_with_tc_result :
         let load_tc_result fn1 =
           let entry = FStar_Util.load_2values_from_file checked_fn in
           match entry with
-          | FStar_Pervasives_Native.Some (uu____770, s2) ->
+          | FStar_Pervasives_Native.Some (uu___, s2) ->
               ((s2.deps_dig), (s2.tc_res))
-          | uu____782 ->
+          | uu___ ->
               failwith
                 "Impossible! if first phase of loading was unknown, it should have succeeded" in
         let elt = load_checked_file fn checked_fn in
         match elt with
-        | (Invalid msg, uu____805) -> FStar_Util.Inl msg
-        | (Valid uu____814, uu____815) ->
-            let uu____824 =
-              let uu____825 = FStar_All.pipe_right checked_fn load_tc_result in
-              FStar_All.pipe_right uu____825 FStar_Pervasives_Native.snd in
-            FStar_All.pipe_right uu____824
-              (fun uu____866 -> FStar_Util.Inr uu____866)
+        | (Invalid msg, uu___) -> FStar_Util.Inl msg
+        | (Valid uu___, uu___1) ->
+            let uu___2 =
+              let uu___3 = FStar_All.pipe_right checked_fn load_tc_result in
+              FStar_All.pipe_right uu___3 FStar_Pervasives_Native.snd in
+            FStar_All.pipe_right uu___2 (fun uu___3 -> FStar_Util.Inr uu___3)
         | (Unknown, parsing_data) ->
-            let uu____876 = hash_dependences deps fn in
-            (match uu____876 with
+            let uu___ = hash_dependences deps fn in
+            (match uu___ with
              | FStar_Util.Inl msg ->
                  let elt1 = ((Invalid msg), parsing_data) in
                  (FStar_Util.smap_add mcache checked_fn elt1;
                   FStar_Util.Inl msg)
              | FStar_Util.Inr deps_dig' ->
-                 let uu____925 =
-                   FStar_All.pipe_right checked_fn load_tc_result in
-                 (match uu____925 with
+                 let uu___1 = FStar_All.pipe_right checked_fn load_tc_result in
+                 (match uu___1 with
                   | (deps_dig, tc_result1) ->
                       if deps_dig = deps_dig'
                       then
                         let elt1 =
-                          let uu____983 =
-                            let uu____984 =
-                              FStar_Util.digest_of_file checked_fn in
-                            Valid uu____984 in
-                          (uu____983, parsing_data) in
+                          let uu___2 =
+                            let uu___3 = FStar_Util.digest_of_file checked_fn in
+                            Valid uu___3 in
+                          (uu___2, parsing_data) in
                         (FStar_Util.smap_add mcache checked_fn elt1;
-                         (let validate_iface_cache uu____995 =
+                         (let validate_iface_cache uu___3 =
                             let iface =
-                              let uu____999 =
+                              let uu___4 =
                                 FStar_All.pipe_right fn
                                   FStar_Parser_Dep.lowercase_module_name in
-                              FStar_All.pipe_right uu____999
+                              FStar_All.pipe_right uu___4
                                 (FStar_Parser_Dep.interface_of deps) in
                             match iface with
                             | FStar_Pervasives_Native.None -> ()
                             | FStar_Pervasives_Native.Some iface1 ->
                                 (try
-                                   (fun uu___166_1008 ->
+                                   (fun uu___4 ->
                                       match () with
                                       | () ->
                                           let iface_checked_fn =
                                             FStar_All.pipe_right iface1
                                               FStar_Parser_Dep.cache_file_name in
-                                          let uu____1010 =
+                                          let uu___5 =
                                             FStar_Util.smap_try_find mcache
                                               iface_checked_fn in
-                                          (match uu____1010 with
+                                          (match uu___5 with
                                            | FStar_Pervasives_Native.Some
                                                (Unknown, parsing_data1) ->
-                                               let uu____1022 =
-                                                 let uu____1023 =
-                                                   let uu____1024 =
+                                               let uu___6 =
+                                                 let uu___7 =
+                                                   let uu___8 =
                                                      FStar_Util.digest_of_file
                                                        iface_checked_fn in
-                                                   Valid uu____1024 in
-                                                 (uu____1023, parsing_data1) in
+                                                   Valid uu___8 in
+                                                 (uu___7, parsing_data1) in
                                                FStar_Util.smap_add mcache
-                                                 iface_checked_fn uu____1022
-                                           | uu____1029 -> ())) ()
-                                 with | uu___165_1033 -> ()) in
+                                                 iface_checked_fn uu___6
+                                           | uu___6 -> ())) ()
+                                 with | uu___4 -> ()) in
                           validate_iface_cache (); FStar_Util.Inr tc_result1))
                       else
-                        ((let uu____1037 =
+                        ((let uu___4 =
                             FStar_Options.debug_at_level_no_module
                               (FStar_Options.Other "CheckedFiles") in
-                          if uu____1037
+                          if uu___4
                           then
-                            ((let uu____1039 =
+                            ((let uu___6 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length deps_dig') in
-                              let uu____1044 =
+                              let uu___7 =
                                 FStar_Parser_Dep.print_digest deps_dig' in
-                              let uu____1045 =
+                              let uu___8 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length deps_dig) in
-                              let uu____1050 =
+                              let uu___9 =
                                 FStar_Parser_Dep.print_digest deps_dig in
                               FStar_Util.print4
                                 "Expected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
-                                uu____1039 uu____1044 uu____1045 uu____1050);
+                                uu___6 uu___7 uu___8 uu___9);
                              if
                                (FStar_List.length deps_dig) =
                                  (FStar_List.length deps_dig')
                              then
                                FStar_List.iter2
-                                 (fun uu____1075 ->
-                                    fun uu____1076 ->
-                                      match (uu____1075, uu____1076) with
+                                 (fun uu___6 ->
+                                    fun uu___7 ->
+                                      match (uu___6, uu___7) with
                                       | ((x, y), (x', y')) ->
                                           if (x <> x') || (y <> y')
                                           then
-                                            let uu____1105 =
+                                            let uu___8 =
                                               FStar_Parser_Dep.print_digest
                                                 [(x, y)] in
-                                            let uu____1114 =
+                                            let uu___9 =
                                               FStar_Parser_Dep.print_digest
                                                 [(x', y')] in
                                             FStar_Util.print2
                                               "Differ at: Expected %s\n Got %s\n"
-                                              uu____1105 uu____1114
+                                              uu___8 uu___9
                                           else ()) deps_dig deps_dig'
                              else ())
                           else ());
@@ -395,22 +386,20 @@ let (load_parsing_data_from_cache :
   fun file_name ->
     let cache_file =
       try
-        (fun uu___195_1155 ->
+        (fun uu___ ->
            match () with
            | () ->
-               let uu____1158 = FStar_Parser_Dep.cache_file_name file_name in
-               FStar_All.pipe_right uu____1158
-                 (fun uu____1161 -> FStar_Pervasives_Native.Some uu____1161))
-          ()
-      with | uu___194_1163 -> FStar_Pervasives_Native.None in
+               let uu___1 = FStar_Parser_Dep.cache_file_name file_name in
+               FStar_All.pipe_right uu___1
+                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)) ()
+      with | uu___ -> FStar_Pervasives_Native.None in
     match cache_file with
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
     | FStar_Pervasives_Native.Some cache_file1 ->
-        let uu____1169 = load_checked_file file_name cache_file1 in
-        (match uu____1169 with
-         | (uu____1172, FStar_Util.Inl msg) -> FStar_Pervasives_Native.None
-         | (uu____1178, FStar_Util.Inr data) ->
-             FStar_Pervasives_Native.Some data)
+        let uu___ = load_checked_file file_name cache_file1 in
+        (match uu___ with
+         | (uu___1, FStar_Util.Inl msg) -> FStar_Pervasives_Native.None
+         | (uu___1, FStar_Util.Inr data) -> FStar_Pervasives_Native.Some data)
 let (load_module_from_cache :
   FStar_Extraction_ML_UEnv.uenv ->
     Prims.string -> tc_result FStar_Pervasives_Native.option)
@@ -418,7 +407,7 @@ let (load_module_from_cache :
   let already_failed = FStar_Util.mk_ref false in
   fun env ->
     fun fn ->
-      let load_it fn1 uu____1211 =
+      let load_it fn1 uu___ =
         let cache_file = FStar_Parser_Dep.cache_file_name fn1 in
         let fail msg cache_file1 =
           let suppress_warning =
@@ -427,33 +416,31 @@ let (load_module_from_cache :
           if Prims.op_Negation suppress_warning
           then
             (FStar_ST.op_Colon_Equals already_failed true;
-             (let uu____1238 =
-                let uu____1239 =
-                  FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
-                let uu____1240 =
-                  FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
-                FStar_Range.mk_range fn1 uu____1239 uu____1240 in
-              let uu____1241 =
-                let uu____1246 =
+             (let uu___2 =
+                let uu___3 = FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
+                let uu___4 = FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
+                FStar_Range.mk_range fn1 uu___3 uu___4 in
+              let uu___3 =
+                let uu___4 =
                   FStar_Util.format3
                     "Unable to load %s since %s; will recheck %s (suppressing this warning for further modules)"
                     cache_file1 msg fn1 in
-                (FStar_Errors.Warning_CachedFile, uu____1246) in
-              FStar_Errors.log_issue uu____1238 uu____1241))
+                (FStar_Errors.Warning_CachedFile, uu___4) in
+              FStar_Errors.log_issue uu___2 uu___3))
           else () in
-        let uu____1248 =
-          let uu____1253 =
-            let uu____1254 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-            FStar_TypeChecker_Env.dep_graph uu____1254 in
-          load_checked_file_with_tc_result uu____1253 fn1 cache_file in
-        match uu____1248 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+            FStar_TypeChecker_Env.dep_graph uu___3 in
+          load_checked_file_with_tc_result uu___2 fn1 cache_file in
+        match uu___1 with
         | FStar_Util.Inl msg ->
             (fail msg cache_file; FStar_Pervasives_Native.None)
         | FStar_Util.Inr tc_result1 ->
-            ((let uu____1261 =
+            ((let uu___3 =
                 FStar_Options.debug_at_level_no_module
                   (FStar_Options.Other "CheckedFiles") in
-              if uu____1261
+              if uu___3
               then
                 FStar_Util.print1
                   "Successfully loaded module from checked file %s\n"
@@ -464,21 +451,21 @@ let (load_module_from_cache :
         FStar_Profiling.profile (load_it fn1) FStar_Pervasives_Native.None
           "FStar.CheckedFiles" in
       let i_fn_opt =
-        let uu____1276 =
-          let uu____1277 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-          FStar_TypeChecker_Env.dep_graph uu____1277 in
-        let uu____1278 = FStar_Parser_Dep.lowercase_module_name fn in
-        FStar_Parser_Dep.interface_of uu____1276 uu____1278 in
-      let uu____1279 =
+        let uu___ =
+          let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+          FStar_TypeChecker_Env.dep_graph uu___1 in
+        let uu___1 = FStar_Parser_Dep.lowercase_module_name fn in
+        FStar_Parser_Dep.interface_of uu___ uu___1 in
+      let uu___ =
         (FStar_Parser_Dep.is_implementation fn) &&
           (FStar_All.pipe_right i_fn_opt FStar_Util.is_some) in
-      if uu____1279
+      if uu___
       then
         let i_fn = FStar_All.pipe_right i_fn_opt FStar_Util.must in
         let i_tc = load_with_profiling i_fn in
         match i_tc with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some uu____1292 -> load_with_profiling fn
+        | FStar_Pervasives_Native.Some uu___1 -> load_with_profiling fn
       else load_with_profiling fn
 let (store_values_to_cache :
   Prims.string ->
@@ -495,49 +482,49 @@ let (store_module_to_cache :
     fun fn ->
       fun parsing_data ->
         fun tc_result1 ->
-          let uu____1329 =
+          let uu___ =
             (FStar_Options.cache_checked_modules ()) &&
-              (let uu____1331 = FStar_Options.cache_off () in
-               Prims.op_Negation uu____1331) in
-          if uu____1329
+              (let uu___1 = FStar_Options.cache_off () in
+               Prims.op_Negation uu___1) in
+          if uu___
           then
             let cache_file = FStar_Parser_Dep.cache_file_name fn in
             let digest =
-              let uu____1344 =
-                let uu____1345 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-                FStar_TypeChecker_Env.dep_graph uu____1345 in
-              hash_dependences uu____1344 fn in
+              let uu___1 =
+                let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+                FStar_TypeChecker_Env.dep_graph uu___2 in
+              hash_dependences uu___1 fn in
             match digest with
             | FStar_Util.Inr hashes ->
                 let tc_result2 =
-                  let uu___254_1360 = tc_result1 in
+                  let uu___1 = tc_result1 in
                   {
-                    checked_module = (uu___254_1360.checked_module);
-                    mii = (uu___254_1360.mii);
-                    smt_decls = (uu___254_1360.smt_decls);
+                    checked_module = (uu___1.checked_module);
+                    mii = (uu___1.mii);
+                    smt_decls = (uu___1.smt_decls);
                     tc_time = Prims.int_zero;
                     extraction_time = Prims.int_zero
                   } in
                 let stage1 =
-                  let uu____1362 = FStar_Util.digest_of_file fn in
+                  let uu___1 = FStar_Util.digest_of_file fn in
                   {
                     version = cache_version_number;
-                    digest = uu____1362;
+                    digest = uu___1;
                     parsing_data
                   } in
                 let stage2 = { deps_dig = hashes; tc_res = tc_result2 } in
                 store_values_to_cache cache_file stage1 stage2
             | FStar_Util.Inl msg ->
-                let uu____1371 =
-                  let uu____1372 =
+                let uu___1 =
+                  let uu___2 =
                     FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
-                  let uu____1373 =
+                  let uu___3 =
                     FStar_Range.mk_pos Prims.int_zero Prims.int_zero in
-                  FStar_Range.mk_range fn uu____1372 uu____1373 in
-                let uu____1374 =
-                  let uu____1379 =
+                  FStar_Range.mk_range fn uu___2 uu___3 in
+                let uu___2 =
+                  let uu___3 =
                     FStar_Util.format2 "%s was not written since %s"
                       cache_file msg in
-                  (FStar_Errors.Warning_FileNotWritten, uu____1379) in
-                FStar_Errors.log_issue uu____1371 uu____1374
+                  (FStar_Errors.Warning_FileNotWritten, uu___3) in
+                FStar_Errors.log_issue uu___1 uu___2
           else ()

--- a/src/ocaml-output/FStar_Common.ml
+++ b/src/ocaml-output/FStar_Common.ml
@@ -1,29 +1,29 @@
 open Prims
 let (has_cygpath : Prims.bool) =
   try
-    (fun uu___2_2 ->
+    (fun uu___ ->
        match () with
        | () ->
            let t_out =
              FStar_Util.run_process "has_cygpath" "which" ["cygpath"]
                FStar_Pervasives_Native.None in
            (FStar_Util.trim_string t_out) = "/usr/bin/cygpath") ()
-  with | uu___1_5 -> false
+  with | uu___ -> false
 let (try_convert_file_name_to_mixed : Prims.string -> Prims.string) =
   let cache = FStar_Util.smap_create (Prims.of_int (20)) in
   fun s ->
     if has_cygpath && (FStar_Util.starts_with s "/")
     then
-      let uu____14 = FStar_Util.smap_try_find cache s in
-      match uu____14 with
+      let uu___ = FStar_Util.smap_try_find cache s in
+      match uu___ with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None ->
           let label = "try_convert_file_name_to_mixed" in
           let out =
-            let uu____20 =
+            let uu___1 =
               FStar_Util.run_process label "cygpath" ["-m"; s]
                 FStar_Pervasives_Native.None in
-            FStar_All.pipe_right uu____20 FStar_Util.trim_string in
+            FStar_All.pipe_right uu___1 FStar_Util.trim_string in
           (FStar_Util.smap_add cache s out; out)
     else s
 let snapshot :
@@ -34,10 +34,10 @@ let snapshot :
     fun stackref ->
       fun arg ->
         FStar_Util.atomically
-          (fun uu____77 ->
+          (fun uu___ ->
              let len =
-               let uu____79 = FStar_ST.op_Bang stackref in
-               FStar_List.length uu____79 in
+               let uu___1 = FStar_ST.op_Bang stackref in
+               FStar_List.length uu___1 in
              let arg' = push arg in (len, arg'))
 let rollback :
   'a 'c .
@@ -54,19 +54,18 @@ let rollback :
           else
             if n = Prims.int_one
             then pop ()
-            else ((let uu____146 = pop () in ()); aux (n - Prims.int_one)) in
+            else ((let uu___3 = pop () in ()); aux (n - Prims.int_one)) in
         let curdepth =
-          let uu____148 = FStar_ST.op_Bang stackref in
-          FStar_List.length uu____148 in
+          let uu___ = FStar_ST.op_Bang stackref in FStar_List.length uu___ in
         let n =
           match depth with
           | FStar_Pervasives_Native.Some d -> curdepth - d
           | FStar_Pervasives_Native.None -> Prims.int_one in
-        FStar_Util.atomically (fun uu____164 -> aux n)
-let raise_failed_assertion : 'uuuuuu169 . Prims.string -> 'uuuuuu169 =
+        FStar_Util.atomically (fun uu___ -> aux n)
+let raise_failed_assertion : 'uuuuu . Prims.string -> 'uuuuu =
   fun msg ->
-    let uu____175 = FStar_Util.format1 "Assertion failed: %s" msg in
-    failwith uu____175
+    let uu___ = FStar_Util.format1 "Assertion failed: %s" msg in
+    failwith uu___
 let (runtime_assert : Prims.bool -> Prims.string -> unit) =
   fun b ->
     fun msg -> if Prims.op_Negation b then raise_failed_assertion msg else ()
@@ -74,12 +73,11 @@ let string_of_list :
   'a . ('a -> Prims.string) -> 'a Prims.list -> Prims.string =
   fun f ->
     fun l ->
-      let uu____213 =
-        let uu____214 =
-          let uu____215 = FStar_List.map f l in
-          FStar_String.concat ", " uu____215 in
-        Prims.op_Hat uu____214 "]" in
-      Prims.op_Hat "[" uu____213
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_List.map f l in FStar_String.concat ", " uu___2 in
+        Prims.op_Hat uu___1 "]" in
+      Prims.op_Hat "[" uu___
 let list_of_option : 'a . 'a FStar_Pervasives_Native.option -> 'a Prims.list
   =
   fun o ->
@@ -87,24 +85,24 @@ let list_of_option : 'a . 'a FStar_Pervasives_Native.option -> 'a Prims.list
     | FStar_Pervasives_Native.None -> []
     | FStar_Pervasives_Native.Some x -> [x]
 let string_of_option :
-  'uuuuuu243 .
-    ('uuuuuu243 -> Prims.string) ->
-      'uuuuuu243 FStar_Pervasives_Native.option -> Prims.string
+  'uuuuu .
+    ('uuuuu -> Prims.string) ->
+      'uuuuu FStar_Pervasives_Native.option -> Prims.string
   =
   fun f ->
-    fun uu___0_258 ->
-      match uu___0_258 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.None -> "None"
       | FStar_Pervasives_Native.Some x ->
-          let uu____264 = f x in Prims.op_Hat "Some " uu____264
+          let uu___1 = f x in Prims.op_Hat "Some " uu___1
 let tabulate : 'a . Prims.int -> (Prims.int -> 'a) -> 'a Prims.list =
   fun n ->
     fun f ->
       let rec aux i =
         if i < n
         then
-          let uu____299 = f i in
-          let uu____300 = aux (i + Prims.int_one) in uu____299 :: uu____300
+          let uu___ = f i in
+          let uu___1 = aux (i + Prims.int_one) in uu___ :: uu___1
         else [] in
       aux Prims.int_zero
 let rec max_prefix :
@@ -115,8 +113,8 @@ let rec max_prefix :
       match xs with
       | [] -> ([], [])
       | x::xs1 when f x ->
-          let uu____347 = max_prefix f xs1 in
-          (match uu____347 with | (l, r) -> ((x :: l), r))
+          let uu___ = max_prefix f xs1 in
+          (match uu___ with | (l, r) -> ((x :: l), r))
       | x::xs1 -> ([], (x :: xs1))
 let max_suffix :
   'a . ('a -> Prims.bool) -> 'a Prims.list -> ('a Prims.list * 'a Prims.list)
@@ -128,9 +126,9 @@ let max_suffix :
         | [] -> (acc, [])
         | x::xs2 when f x -> aux (x :: acc) xs2
         | x::xs2 -> (acc, (x :: xs2)) in
-      let uu____471 =
-        let uu____480 = FStar_All.pipe_right xs FStar_List.rev in
-        FStar_All.pipe_right uu____480 (aux []) in
-      FStar_All.pipe_right uu____471
-        (fun uu____516 ->
-           match uu____516 with | (xs1, ys) -> ((FStar_List.rev ys), xs1))
+      let uu___ =
+        let uu___1 = FStar_All.pipe_right xs FStar_List.rev in
+        FStar_All.pipe_right uu___1 (aux []) in
+      FStar_All.pipe_right uu___
+        (fun uu___1 ->
+           match uu___1 with | (xs1, ys) -> ((FStar_List.rev ys), xs1))

--- a/src/ocaml-output/FStar_Const.ml
+++ b/src/ocaml-output/FStar_Const.ml
@@ -3,22 +3,22 @@ type signedness =
   | Unsigned 
   | Signed [@@deriving yojson,show]
 let (uu___is_Unsigned : signedness -> Prims.bool) =
-  fun projectee -> match projectee with | Unsigned -> true | uu____5 -> false
+  fun projectee -> match projectee with | Unsigned -> true | uu___ -> false
 let (uu___is_Signed : signedness -> Prims.bool) =
-  fun projectee -> match projectee with | Signed -> true | uu____11 -> false
+  fun projectee -> match projectee with | Signed -> true | uu___ -> false
 type width =
   | Int8 
   | Int16 
   | Int32 
   | Int64 [@@deriving yojson,show]
 let (uu___is_Int8 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int8 -> true | uu____17 -> false
+  fun projectee -> match projectee with | Int8 -> true | uu___ -> false
 let (uu___is_Int16 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int16 -> true | uu____23 -> false
+  fun projectee -> match projectee with | Int16 -> true | uu___ -> false
 let (uu___is_Int32 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int32 -> true | uu____29 -> false
+  fun projectee -> match projectee with | Int32 -> true | uu___ -> false
 let (uu___is_Int64 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int64 -> true | uu____35 -> false
+  fun projectee -> match projectee with | Int64 -> true | uu___ -> false
 type sconst =
   | Const_effect 
   | Const_unit 
@@ -38,66 +38,65 @@ type sconst =
   | Const_reflect of FStar_Ident.lid [@@deriving yojson,show]
 let (uu___is_Const_effect : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_effect -> true | uu____106 -> false
+    match projectee with | Const_effect -> true | uu___ -> false
 let (uu___is_Const_unit : sconst -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Const_unit -> true | uu____112 -> false
+  fun projectee -> match projectee with | Const_unit -> true | uu___ -> false
 let (uu___is_Const_bool : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_bool _0 -> true | uu____119 -> false
+    match projectee with | Const_bool _0 -> true | uu___ -> false
 let (__proj__Const_bool__item___0 : sconst -> Prims.bool) =
   fun projectee -> match projectee with | Const_bool _0 -> _0
 let (uu___is_Const_int : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_int _0 -> true | uu____142 -> false
+    match projectee with | Const_int _0 -> true | uu___ -> false
 let (__proj__Const_int__item___0 :
   sconst ->
     (Prims.string * (signedness * width) FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | Const_int _0 -> _0
 let (uu___is_Const_char : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_char _0 -> true | uu____185 -> false
+    match projectee with | Const_char _0 -> true | uu___ -> false
 let (__proj__Const_char__item___0 : sconst -> FStar_BaseTypes.char) =
   fun projectee -> match projectee with | Const_char _0 -> _0
 let (uu___is_Const_float : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_float _0 -> true | uu____198 -> false
+    match projectee with | Const_float _0 -> true | uu___ -> false
 let (__proj__Const_float__item___0 : sconst -> FStar_BaseTypes.double) =
   fun projectee -> match projectee with | Const_float _0 -> _0
 let (uu___is_Const_real : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_real _0 -> true | uu____211 -> false
+    match projectee with | Const_real _0 -> true | uu___ -> false
 let (__proj__Const_real__item___0 : sconst -> Prims.string) =
   fun projectee -> match projectee with | Const_real _0 -> _0
 let (uu___is_Const_bytearray : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_bytearray _0 -> true | uu____230 -> false
+    match projectee with | Const_bytearray _0 -> true | uu___ -> false
 let (__proj__Const_bytearray__item___0 :
   sconst -> (FStar_BaseTypes.byte Prims.array * FStar_Range.range)) =
   fun projectee -> match projectee with | Const_bytearray _0 -> _0
 let (uu___is_Const_string : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_string _0 -> true | uu____265 -> false
+    match projectee with | Const_string _0 -> true | uu___ -> false
 let (__proj__Const_string__item___0 :
   sconst -> (Prims.string * FStar_Range.range)) =
   fun projectee -> match projectee with | Const_string _0 -> _0
 let (uu___is_Const_range_of : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_range_of -> true | uu____289 -> false
+    match projectee with | Const_range_of -> true | uu___ -> false
 let (uu___is_Const_set_range_of : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_set_range_of -> true | uu____295 -> false
+    match projectee with | Const_set_range_of -> true | uu___ -> false
 let (uu___is_Const_range : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_range _0 -> true | uu____302 -> false
+    match projectee with | Const_range _0 -> true | uu___ -> false
 let (__proj__Const_range__item___0 : sconst -> FStar_Range.range) =
   fun projectee -> match projectee with | Const_range _0 -> _0
 let (uu___is_Const_reify : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_reify -> true | uu____314 -> false
+    match projectee with | Const_reify -> true | uu___ -> false
 let (uu___is_Const_reflect : sconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | Const_reflect _0 -> true | uu____321 -> false
+    match projectee with | Const_reflect _0 -> true | uu___ -> false
 let (__proj__Const_reflect__item___0 : sconst -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Const_reflect _0 -> _0
 let (eq_const : sconst -> sconst -> Prims.bool) =
@@ -105,23 +104,21 @@ let (eq_const : sconst -> sconst -> Prims.bool) =
     fun c2 ->
       match (c1, c2) with
       | (Const_int (s1, o1), Const_int (s2, o2)) ->
-          (let uu____370 = FStar_Util.ensure_decimal s1 in
-           let uu____371 = FStar_Util.ensure_decimal s2 in
-           uu____370 = uu____371) && (o1 = o2)
-      | (Const_bytearray (a, uu____379), Const_bytearray (b, uu____381)) ->
-          a = b
-      | (Const_string (a, uu____393), Const_string (b, uu____395)) -> a = b
+          (let uu___ = FStar_Util.ensure_decimal s1 in
+           let uu___1 = FStar_Util.ensure_decimal s2 in uu___ = uu___1) &&
+            (o1 = o2)
+      | (Const_bytearray (a, uu___), Const_bytearray (b, uu___1)) -> a = b
+      | (Const_string (a, uu___), Const_string (b, uu___1)) -> a = b
       | (Const_reflect l1, Const_reflect l2) -> FStar_Ident.lid_equals l1 l2
-      | uu____398 -> c1 = c2
+      | uu___ -> c1 = c2
 let rec (pow2 : FStar_BigInt.bigint -> FStar_BigInt.bigint) =
   fun x ->
-    let uu____408 = FStar_BigInt.eq_big_int x FStar_BigInt.zero in
-    if uu____408
+    let uu___ = FStar_BigInt.eq_big_int x FStar_BigInt.zero in
+    if uu___
     then FStar_BigInt.one
     else
-      (let uu____410 =
-         let uu____411 = FStar_BigInt.pred_big_int x in pow2 uu____411 in
-       FStar_BigInt.mult_big_int FStar_BigInt.two uu____410)
+      (let uu___2 = let uu___3 = FStar_BigInt.pred_big_int x in pow2 uu___3 in
+       FStar_BigInt.mult_big_int FStar_BigInt.two uu___2)
 let (bounds :
   signedness -> width -> (FStar_BigInt.bigint * FStar_BigInt.bigint)) =
   fun signedness1 ->
@@ -132,28 +129,27 @@ let (bounds :
         | Int16 -> FStar_BigInt.big_int_of_string "16"
         | Int32 -> FStar_BigInt.big_int_of_string "32"
         | Int64 -> FStar_BigInt.big_int_of_string "64" in
-      let uu____427 =
+      let uu___ =
         match signedness1 with
         | Unsigned ->
-            let uu____436 =
-              let uu____437 = pow2 n in FStar_BigInt.pred_big_int uu____437 in
-            (FStar_BigInt.zero, uu____436)
+            let uu___1 =
+              let uu___2 = pow2 n in FStar_BigInt.pred_big_int uu___2 in
+            (FStar_BigInt.zero, uu___1)
         | Signed ->
             let upper =
-              let uu____439 = FStar_BigInt.pred_big_int n in pow2 uu____439 in
-            let uu____440 = FStar_BigInt.minus_big_int upper in
-            let uu____441 = FStar_BigInt.pred_big_int upper in
-            (uu____440, uu____441) in
-      match uu____427 with | (lower, upper) -> (lower, upper)
+              let uu___1 = FStar_BigInt.pred_big_int n in pow2 uu___1 in
+            let uu___1 = FStar_BigInt.minus_big_int upper in
+            let uu___2 = FStar_BigInt.pred_big_int upper in (uu___1, uu___2) in
+      match uu___ with | (lower, upper) -> (lower, upper)
 let (within_bounds : Prims.string -> signedness -> width -> Prims.bool) =
   fun repr ->
     fun signedness1 ->
       fun width1 ->
-        let uu____463 = bounds signedness1 width1 in
-        match uu____463 with
+        let uu___ = bounds signedness1 width1 in
+        match uu___ with
         | (lower, upper) ->
             let value =
-              let uu____471 = FStar_Util.ensure_decimal repr in
-              FStar_BigInt.big_int_of_string uu____471 in
+              let uu___1 = FStar_Util.ensure_decimal repr in
+              FStar_BigInt.big_int_of_string uu___1 in
             (FStar_BigInt.le_big_int lower value) &&
               (FStar_BigInt.le_big_int value upper)

--- a/src/ocaml-output/FStar_Dependencies.ml
+++ b/src/ocaml-output/FStar_Dependencies.ml
@@ -7,9 +7,8 @@ let (find_deps_if_needed :
   =
   fun files ->
     fun get_parsing_data_from_cache ->
-      let uu____29 =
-        FStar_Parser_Dep.collect files get_parsing_data_from_cache in
-      match uu____29 with
+      let uu___ = FStar_Parser_Dep.collect files get_parsing_data_from_cache in
+      match uu___ with
       | (all_files, deps) ->
           (match all_files with
            | [] ->
@@ -17,4 +16,4 @@ let (find_deps_if_needed :
                   (FStar_Errors.Error_DependencyAnalysisFailed,
                     "Dependency analysis failed; reverting to using only the files provided\n");
                 (files, deps))
-           | uu____57 -> ((FStar_List.rev all_files), deps))
+           | uu___1 -> ((FStar_List.rev all_files), deps))

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -3,12 +3,12 @@ exception Invalid_warn_error_setting of Prims.string
 let (uu___is_Invalid_warn_error_setting : Prims.exn -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | Invalid_warn_error_setting uu____21 -> true
-    | uu____22 -> false
+    | Invalid_warn_error_setting uu___ -> true
+    | uu___ -> false
 let (__proj__Invalid_warn_error_setting__item__uu___ :
   Prims.exn -> Prims.string) =
   fun projectee ->
-    match projectee with | Invalid_warn_error_setting uu____28 -> uu____28
+    match projectee with | Invalid_warn_error_setting uu___ -> uu___
 type error_flag =
   | CFatal 
   | CAlwaysError 
@@ -16,17 +16,16 @@ type error_flag =
   | CWarning 
   | CSilent 
 let (uu___is_CFatal : error_flag -> Prims.bool) =
-  fun projectee -> match projectee with | CFatal -> true | uu____34 -> false
+  fun projectee -> match projectee with | CFatal -> true | uu___ -> false
 let (uu___is_CAlwaysError : error_flag -> Prims.bool) =
   fun projectee ->
-    match projectee with | CAlwaysError -> true | uu____40 -> false
+    match projectee with | CAlwaysError -> true | uu___ -> false
 let (uu___is_CError : error_flag -> Prims.bool) =
-  fun projectee -> match projectee with | CError -> true | uu____46 -> false
+  fun projectee -> match projectee with | CError -> true | uu___ -> false
 let (uu___is_CWarning : error_flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CWarning -> true | uu____52 -> false
+  fun projectee -> match projectee with | CWarning -> true | uu___ -> false
 let (uu___is_CSilent : error_flag -> Prims.bool) =
-  fun projectee -> match projectee with | CSilent -> true | uu____58 -> false
+  fun projectee -> match projectee with | CSilent -> true | uu___ -> false
 type raw_error =
   | Error_DependencyAnalysisFailed 
   | Error_IDETooManyPops 
@@ -370,1626 +369,1469 @@ let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_DependencyAnalysisFailed -> true
-    | uu____64 -> false
+    | uu___ -> false
 let (uu___is_Error_IDETooManyPops : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_IDETooManyPops -> true | uu____70 -> false
+    match projectee with | Error_IDETooManyPops -> true | uu___ -> false
 let (uu___is_Error_IDEUnrecognized : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_IDEUnrecognized -> true | uu____76 -> false
+    match projectee with | Error_IDEUnrecognized -> true | uu___ -> false
 let (uu___is_Error_InductiveTypeNotSatisfyPositivityCondition :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_InductiveTypeNotSatisfyPositivityCondition -> true
-    | uu____82 -> false
+    | uu___ -> false
 let (uu___is_Error_InvalidUniverseVar : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_InvalidUniverseVar -> true
-    | uu____88 -> false
+    match projectee with | Error_InvalidUniverseVar -> true | uu___ -> false
 let (uu___is_Error_MissingFileName : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_MissingFileName -> true | uu____94 -> false
+    match projectee with | Error_MissingFileName -> true | uu___ -> false
 let (uu___is_Error_ModuleFileNameMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_ModuleFileNameMismatch -> true
-    | uu____100 -> false
+    | uu___ -> false
 let (uu___is_Error_OpPlusInUniverse : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_OpPlusInUniverse -> true
-    | uu____106 -> false
+    match projectee with | Error_OpPlusInUniverse -> true | uu___ -> false
 let (uu___is_Error_OutOfRange : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_OutOfRange -> true | uu____112 -> false
+    match projectee with | Error_OutOfRange -> true | uu___ -> false
 let (uu___is_Error_ProofObligationFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_ProofObligationFailed -> true
-    | uu____118 -> false
+    | uu___ -> false
 let (uu___is_Error_TooManyFiles : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_TooManyFiles -> true | uu____124 -> false
+    match projectee with | Error_TooManyFiles -> true | uu___ -> false
 let (uu___is_Error_TypeCheckerFailToProve : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_TypeCheckerFailToProve -> true
-    | uu____130 -> false
+    | uu___ -> false
 let (uu___is_Error_TypeError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_TypeError -> true | uu____136 -> false
+    match projectee with | Error_TypeError -> true | uu___ -> false
 let (uu___is_Error_UncontrainedUnificationVar : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_UncontrainedUnificationVar -> true
-    | uu____142 -> false
+    | uu___ -> false
 let (uu___is_Error_UnexpectedGTotComputation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_UnexpectedGTotComputation -> true
-    | uu____148 -> false
+    | uu___ -> false
 let (uu___is_Error_UnexpectedInstance : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_UnexpectedInstance -> true
-    | uu____154 -> false
+    match projectee with | Error_UnexpectedInstance -> true | uu___ -> false
 let (uu___is_Error_UnknownFatal_AssertionFailure : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_UnknownFatal_AssertionFailure -> true
-    | uu____160 -> false
+    | uu___ -> false
 let (uu___is_Error_Z3InvocationError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_Z3InvocationError -> true
-    | uu____166 -> false
+    match projectee with | Error_Z3InvocationError -> true | uu___ -> false
 let (uu___is_Error_IDEAssertionFailure : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_IDEAssertionFailure -> true
-    | uu____172 -> false
+    match projectee with | Error_IDEAssertionFailure -> true | uu___ -> false
 let (uu___is_Error_Z3SolverError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_Z3SolverError -> true | uu____178 -> false
+    match projectee with | Error_Z3SolverError -> true | uu___ -> false
 let (uu___is_Fatal_AbstractTypeDeclarationInInterface :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_AbstractTypeDeclarationInInterface -> true
-    | uu____184 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ActionMustHaveFunctionType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ActionMustHaveFunctionType -> true
-    | uu____190 -> false
+    | uu___ -> false
 let (uu___is_Fatal_AlreadyDefinedTopLevelDeclaration :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_AlreadyDefinedTopLevelDeclaration -> true
-    | uu____196 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ArgumentLengthMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ArgumentLengthMismatch -> true
-    | uu____202 -> false
+    | uu___ -> false
 let (uu___is_Fatal_AssertionFailure : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_AssertionFailure -> true
-    | uu____208 -> false
+    match projectee with | Fatal_AssertionFailure -> true | uu___ -> false
 let (uu___is_Fatal_AssignToImmutableValues : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_AssignToImmutableValues -> true
-    | uu____214 -> false
+    | uu___ -> false
 let (uu___is_Fatal_AssumeValInInterface : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_AssumeValInInterface -> true
-    | uu____220 -> false
+    | uu___ -> false
 let (uu___is_Fatal_BadlyInstantiatedSynthByTactic : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_BadlyInstantiatedSynthByTactic -> true
-    | uu____226 -> false
+    | uu___ -> false
 let (uu___is_Fatal_BadSignatureShape : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_BadSignatureShape -> true
-    | uu____232 -> false
+    match projectee with | Fatal_BadSignatureShape -> true | uu___ -> false
 let (uu___is_Fatal_BinderAndArgsLengthMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_BinderAndArgsLengthMismatch -> true
-    | uu____238 -> false
+    | uu___ -> false
 let (uu___is_Fatal_BothValAndLetInInterface : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_BothValAndLetInInterface -> true
-    | uu____244 -> false
+    | uu___ -> false
 let (uu___is_Fatal_CardinalityConstraintViolated : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_CardinalityConstraintViolated -> true
-    | uu____250 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ComputationNotTotal : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_ComputationNotTotal -> true
-    | uu____256 -> false
+    match projectee with | Fatal_ComputationNotTotal -> true | uu___ -> false
 let (uu___is_Fatal_ComputationTypeNotAllowed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ComputationTypeNotAllowed -> true
-    | uu____262 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ComputedTypeNotMatchAnnotation : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_ComputedTypeNotMatchAnnotation -> true
-    | uu____268 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ConstructorArgLengthMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ConstructorArgLengthMismatch -> true
-    | uu____274 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ConstructorFailedCheck : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ConstructorFailedCheck -> true
-    | uu____280 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ConstructorNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_ConstructorNotFound -> true
-    | uu____286 -> false
+    match projectee with | Fatal_ConstructorNotFound -> true | uu___ -> false
 let (uu___is_Fatal_ConstsructorBuildWrongType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ConstsructorBuildWrongType -> true
-    | uu____292 -> false
+    | uu___ -> false
 let (uu___is_Fatal_CycleInRecTypeAbbreviation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_CycleInRecTypeAbbreviation -> true
-    | uu____298 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DataContructorNotFound : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DataContructorNotFound -> true
-    | uu____304 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DefaultQualifierNotAllowedOnEffects :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DefaultQualifierNotAllowedOnEffects -> true
-    | uu____310 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DefinitionNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_DefinitionNotFound -> true
-    | uu____316 -> false
+    match projectee with | Fatal_DefinitionNotFound -> true | uu___ -> false
 let (uu___is_Fatal_DisjuctivePatternVarsMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DisjuctivePatternVarsMismatch -> true
-    | uu____322 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DivergentComputationCannotBeIncludedInTotal :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DivergentComputationCannotBeIncludedInTotal -> true
-    | uu____328 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DuplicateInImplementation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DuplicateInImplementation -> true
-    | uu____334 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DuplicateModuleOrInterface : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DuplicateModuleOrInterface -> true
-    | uu____340 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DuplicateTopLevelNames : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DuplicateTopLevelNames -> true
-    | uu____346 -> false
+    | uu___ -> false
 let (uu___is_Fatal_DuplicateTypeAnnotationAndValDecl :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_DuplicateTypeAnnotationAndValDecl -> true
-    | uu____352 -> false
+    | uu___ -> false
 let (uu___is_Fatal_EffectCannotBeReified : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_EffectCannotBeReified -> true
-    | uu____358 -> false
+    | uu___ -> false
 let (uu___is_Fatal_EffectConstructorNotFullyApplied :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_EffectConstructorNotFullyApplied -> true
-    | uu____364 -> false
+    | uu___ -> false
 let (uu___is_Fatal_EffectfulAndPureComputationMismatch :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_EffectfulAndPureComputationMismatch -> true
-    | uu____370 -> false
+    | uu___ -> false
 let (uu___is_Fatal_EffectNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_EffectNotFound -> true | uu____376 -> false
+    match projectee with | Fatal_EffectNotFound -> true | uu___ -> false
 let (uu___is_Fatal_EffectsCannotBeComposed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_EffectsCannotBeComposed -> true
-    | uu____382 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ErrorInSolveDeferredConstraints : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_ErrorInSolveDeferredConstraints -> true
-    | uu____388 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ErrorsReported : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ErrorsReported -> true | uu____394 -> false
+    match projectee with | Fatal_ErrorsReported -> true | uu___ -> false
 let (uu___is_Fatal_EscapedBoundVar : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_EscapedBoundVar -> true | uu____400 -> false
+    match projectee with | Fatal_EscapedBoundVar -> true | uu___ -> false
 let (uu___is_Fatal_ExpectedArrowAnnotatedType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectedArrowAnnotatedType -> true
-    | uu____406 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExpectedGhostExpression : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectedGhostExpression -> true
-    | uu____412 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExpectedPureExpression : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectedPureExpression -> true
-    | uu____418 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExpectNormalizedEffect : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectNormalizedEffect -> true
-    | uu____424 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExpectTermGotFunction : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectTermGotFunction -> true
-    | uu____430 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExpectTrivialPreCondition : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExpectTrivialPreCondition -> true
-    | uu____436 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FailToCompileNativeTactic : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_FailToCompileNativeTactic -> true
-    | uu____442 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FailToExtractNativeTactic : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_FailToExtractNativeTactic -> true
-    | uu____448 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FailToProcessPragma : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_FailToProcessPragma -> true
-    | uu____454 -> false
+    match projectee with | Fatal_FailToProcessPragma -> true | uu___ -> false
 let (uu___is_Fatal_FailToResolveImplicitArgument : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_FailToResolveImplicitArgument -> true
-    | uu____460 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FailToSolveUniverseInEquality : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_FailToSolveUniverseInEquality -> true
-    | uu____466 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FieldsNotBelongToSameRecordType : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_FieldsNotBelongToSameRecordType -> true
-    | uu____472 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ForbiddenReferenceToCurrentModule :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ForbiddenReferenceToCurrentModule -> true
-    | uu____478 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FreeVariables : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_FreeVariables -> true | uu____484 -> false
+    match projectee with | Fatal_FreeVariables -> true | uu___ -> false
 let (uu___is_Fatal_FunctionTypeExpected : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_FunctionTypeExpected -> true
-    | uu____490 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IdentifierNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_IdentifierNotFound -> true
-    | uu____496 -> false
+    match projectee with | Fatal_IdentifierNotFound -> true | uu___ -> false
 let (uu___is_Fatal_IllAppliedConstant : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_IllAppliedConstant -> true
-    | uu____502 -> false
+    match projectee with | Fatal_IllAppliedConstant -> true | uu___ -> false
 let (uu___is_Fatal_IllegalCharInByteArray : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IllegalCharInByteArray -> true
-    | uu____508 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IllegalCharInOperatorName : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IllegalCharInOperatorName -> true
-    | uu____514 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IllTyped : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_IllTyped -> true | uu____520 -> false
+    match projectee with | Fatal_IllTyped -> true | uu___ -> false
 let (uu___is_Fatal_ImpossibleAbbrevLidBundle : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleAbbrevLidBundle -> true
-    | uu____526 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossibleAbbrevRenameBundle : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleAbbrevRenameBundle -> true
-    | uu____532 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossibleInductiveWithAbbrev : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleInductiveWithAbbrev -> true
-    | uu____538 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossiblePrePostAbs : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossiblePrePostAbs -> true
-    | uu____544 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossiblePrePostArrow : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossiblePrePostArrow -> true
-    | uu____550 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossibleToGenerateDMEffect : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleToGenerateDMEffect -> true
-    | uu____556 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossibleTypeAbbrevBundle : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleTypeAbbrevBundle -> true
-    | uu____562 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ImpossibleTypeAbbrevSigeltBundle :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ImpossibleTypeAbbrevSigeltBundle -> true
-    | uu____568 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IncludeModuleNotPrepared : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IncludeModuleNotPrepared -> true
-    | uu____574 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IncoherentInlineUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IncoherentInlineUniverse -> true
-    | uu____580 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IncompatibleKinds : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_IncompatibleKinds -> true
-    | uu____586 -> false
+    match projectee with | Fatal_IncompatibleKinds -> true | uu___ -> false
 let (uu___is_Fatal_IncompatibleNumberOfTypes : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IncompatibleNumberOfTypes -> true
-    | uu____592 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IncompatibleSetOfUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IncompatibleSetOfUniverse -> true
-    | uu____598 -> false
+    | uu___ -> false
 let (uu___is_Fatal_IncompatibleUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_IncompatibleUniverse -> true
-    | uu____604 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InconsistentImplicitArgumentAnnotation :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InconsistentImplicitArgumentAnnotation -> true
-    | uu____610 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InconsistentImplicitQualifier : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InconsistentImplicitQualifier -> true
-    | uu____616 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InconsistentQualifierAnnotation : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_InconsistentQualifierAnnotation -> true
-    | uu____622 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InferredTypeCauseVarEscape : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InferredTypeCauseVarEscape -> true
-    | uu____628 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InlineRenamedAsUnfold : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InlineRenamedAsUnfold -> true
-    | uu____634 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InsufficientPatternArguments : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InsufficientPatternArguments -> true
-    | uu____640 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InterfaceAlreadyProcessed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InterfaceAlreadyProcessed -> true
-    | uu____646 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InterfaceNotImplementedByModule : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_InterfaceNotImplementedByModule -> true
-    | uu____652 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InterfaceWithTypeImplementation : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_InterfaceWithTypeImplementation -> true
-    | uu____658 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidFloatingPointNumber : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidFloatingPointNumber -> true
-    | uu____664 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidFSDocKeyword : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_InvalidFSDocKeyword -> true
-    | uu____670 -> false
+    match projectee with | Fatal_InvalidFSDocKeyword -> true | uu___ -> false
 let (uu___is_Fatal_InvalidIdentifier : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_InvalidIdentifier -> true
-    | uu____676 -> false
+    match projectee with | Fatal_InvalidIdentifier -> true | uu___ -> false
 let (uu___is_Fatal_InvalidLemmaArgument : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidLemmaArgument -> true
-    | uu____682 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidNumericLiteral : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidNumericLiteral -> true
-    | uu____688 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidRedefinitionOfLexT : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidRedefinitionOfLexT -> true
-    | uu____694 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidUnicodeInStringLiteral : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidUnicodeInStringLiteral -> true
-    | uu____700 -> false
+    | uu___ -> false
 let (uu___is_Fatal_InvalidUTF8Encoding : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_InvalidUTF8Encoding -> true
-    | uu____706 -> false
+    match projectee with | Fatal_InvalidUTF8Encoding -> true | uu___ -> false
 let (uu___is_Fatal_InvalidWarnErrorSetting : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_InvalidWarnErrorSetting -> true
-    | uu____712 -> false
+    | uu___ -> false
 let (uu___is_Fatal_LetBoundMonadicMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_LetBoundMonadicMismatch -> true
-    | uu____718 -> false
+    | uu___ -> false
 let (uu___is_Fatal_LetMutableForVariablesOnly : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_LetMutableForVariablesOnly -> true
-    | uu____724 -> false
+    | uu___ -> false
 let (uu___is_Fatal_LetOpenModuleOnly : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_LetOpenModuleOnly -> true
-    | uu____730 -> false
+    match projectee with | Fatal_LetOpenModuleOnly -> true | uu___ -> false
 let (uu___is_Fatal_LetRecArgumentMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_LetRecArgumentMismatch -> true
-    | uu____736 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MalformedActionDeclaration : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MalformedActionDeclaration -> true
-    | uu____742 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MismatchedPatternType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MismatchedPatternType -> true
-    | uu____748 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MismatchUniversePolymorphic : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MismatchUniversePolymorphic -> true
-    | uu____754 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingDataConstructor : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingDataConstructor -> true
-    | uu____760 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingExposeInterfacesOption : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingExposeInterfacesOption -> true
-    | uu____766 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingFieldInRecord : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingFieldInRecord -> true
-    | uu____772 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingImplementation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingImplementation -> true
-    | uu____778 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingImplicitArguments : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingImplicitArguments -> true
-    | uu____784 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MissingInterface : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_MissingInterface -> true
-    | uu____790 -> false
+    match projectee with | Fatal_MissingInterface -> true | uu___ -> false
 let (uu___is_Fatal_MissingNameInBinder : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_MissingNameInBinder -> true
-    | uu____796 -> false
+    match projectee with | Fatal_MissingNameInBinder -> true | uu___ -> false
 let (uu___is_Fatal_MissingPrimsModule : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_MissingPrimsModule -> true
-    | uu____802 -> false
+    match projectee with | Fatal_MissingPrimsModule -> true | uu___ -> false
 let (uu___is_Fatal_MissingQuantifierBinder : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MissingQuantifierBinder -> true
-    | uu____808 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ModuleExpected : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ModuleExpected -> true | uu____814 -> false
+    match projectee with | Fatal_ModuleExpected -> true | uu___ -> false
 let (uu___is_Fatal_ModuleFileNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_ModuleFileNotFound -> true
-    | uu____820 -> false
+    match projectee with | Fatal_ModuleFileNotFound -> true | uu___ -> false
 let (uu___is_Fatal_ModuleFirstStatement : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ModuleFirstStatement -> true
-    | uu____826 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ModuleNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ModuleNotFound -> true | uu____832 -> false
+    match projectee with | Fatal_ModuleNotFound -> true | uu___ -> false
 let (uu___is_Fatal_ModuleOrFileNotFound : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ModuleOrFileNotFound -> true
-    | uu____838 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MonadAlreadyDefined : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_MonadAlreadyDefined -> true
-    | uu____844 -> false
+    match projectee with | Fatal_MonadAlreadyDefined -> true | uu___ -> false
 let (uu___is_Fatal_MoreThanOneDeclaration : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_MoreThanOneDeclaration -> true
-    | uu____850 -> false
+    | uu___ -> false
 let (uu___is_Fatal_MultipleLetBinding : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_MultipleLetBinding -> true
-    | uu____856 -> false
+    match projectee with | Fatal_MultipleLetBinding -> true | uu___ -> false
 let (uu___is_Fatal_NameNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_NameNotFound -> true | uu____862 -> false
+    match projectee with | Fatal_NameNotFound -> true | uu___ -> false
 let (uu___is_Fatal_NameSpaceNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_NameSpaceNotFound -> true
-    | uu____868 -> false
+    match projectee with | Fatal_NameSpaceNotFound -> true | uu___ -> false
 let (uu___is_Fatal_NegativeUniverseConstFatal_NotSupported :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NegativeUniverseConstFatal_NotSupported -> true
-    | uu____874 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NoFileProvided : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_NoFileProvided -> true | uu____880 -> false
+    match projectee with | Fatal_NoFileProvided -> true | uu___ -> false
 let (uu___is_Fatal_NonInductiveInMutuallyDefinedType :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonInductiveInMutuallyDefinedType -> true
-    | uu____886 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonLinearPatternNotPermitted : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonLinearPatternNotPermitted -> true
-    | uu____892 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonLinearPatternVars : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonLinearPatternVars -> true
-    | uu____898 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonSingletonTopLevel : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonSingletonTopLevel -> true
-    | uu____904 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonSingletonTopLevelModule : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonSingletonTopLevelModule -> true
-    | uu____910 -> false
+    | uu___ -> false
 let (uu___is_Error_NonTopRecFunctionNotFullyEncoded :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_NonTopRecFunctionNotFullyEncoded -> true
-    | uu____916 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonTrivialPreConditionInPrims : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonTrivialPreConditionInPrims -> true
-    | uu____922 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NonVariableInductiveTypeParameter :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NonVariableInductiveTypeParameter -> true
-    | uu____928 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NotApplicationOrFv : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_NotApplicationOrFv -> true
-    | uu____934 -> false
+    match projectee with | Fatal_NotApplicationOrFv -> true | uu___ -> false
 let (uu___is_Fatal_NotEnoughArgsToEffect : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NotEnoughArgsToEffect -> true
-    | uu____940 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NotEnoughArgumentsForEffect : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NotEnoughArgumentsForEffect -> true
-    | uu____946 -> false
+    | uu___ -> false
 let (uu___is_Fatal_NotFunctionType : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_NotFunctionType -> true | uu____952 -> false
+    match projectee with | Fatal_NotFunctionType -> true | uu___ -> false
 let (uu___is_Fatal_NotSupported : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_NotSupported -> true | uu____958 -> false
+    match projectee with | Fatal_NotSupported -> true | uu___ -> false
 let (uu___is_Fatal_NotTopLevelModule : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_NotTopLevelModule -> true
-    | uu____964 -> false
+    match projectee with | Fatal_NotTopLevelModule -> true | uu___ -> false
 let (uu___is_Fatal_NotValidFStarFile : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_NotValidFStarFile -> true
-    | uu____970 -> false
+    match projectee with | Fatal_NotValidFStarFile -> true | uu___ -> false
 let (uu___is_Fatal_NotValidIncludeDirectory : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_NotValidIncludeDirectory -> true
-    | uu____976 -> false
+    | uu___ -> false
 let (uu___is_Fatal_OneModulePerFile : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_OneModulePerFile -> true
-    | uu____982 -> false
+    match projectee with | Fatal_OneModulePerFile -> true | uu___ -> false
 let (uu___is_Fatal_OpenGoalsInSynthesis : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_OpenGoalsInSynthesis -> true
-    | uu____988 -> false
+    | uu___ -> false
 let (uu___is_Fatal_OptionsNotCompatible : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_OptionsNotCompatible -> true
-    | uu____994 -> false
+    | uu___ -> false
 let (uu___is_Fatal_OutOfOrder : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_OutOfOrder -> true | uu____1000 -> false
+    match projectee with | Fatal_OutOfOrder -> true | uu___ -> false
 let (uu___is_Fatal_ParseErrors : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ParseErrors -> true | uu____1006 -> false
+    match projectee with | Fatal_ParseErrors -> true | uu___ -> false
 let (uu___is_Fatal_ParseItError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ParseItError -> true | uu____1012 -> false
+    match projectee with | Fatal_ParseItError -> true | uu___ -> false
 let (uu___is_Fatal_PolyTypeExpected : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_PolyTypeExpected -> true
-    | uu____1018 -> false
+    match projectee with | Fatal_PolyTypeExpected -> true | uu___ -> false
 let (uu___is_Fatal_PossibleInfiniteTyp : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_PossibleInfiniteTyp -> true
-    | uu____1024 -> false
+    match projectee with | Fatal_PossibleInfiniteTyp -> true | uu___ -> false
 let (uu___is_Fatal_PreModuleMismatch : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_PreModuleMismatch -> true
-    | uu____1030 -> false
+    match projectee with | Fatal_PreModuleMismatch -> true | uu___ -> false
 let (uu___is_Fatal_QulifierListNotPermitted : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_QulifierListNotPermitted -> true
-    | uu____1036 -> false
+    | uu___ -> false
 let (uu___is_Fatal_RecursiveFunctionLiteral : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_RecursiveFunctionLiteral -> true
-    | uu____1042 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ReflectOnlySupportedOnEffects : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ReflectOnlySupportedOnEffects -> true
-    | uu____1048 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ReservedPrefix : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_ReservedPrefix -> true | uu____1054 -> false
+    match projectee with | Fatal_ReservedPrefix -> true | uu___ -> false
 let (uu___is_Fatal_SMTOutputParseError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_SMTOutputParseError -> true
-    | uu____1060 -> false
+    match projectee with | Fatal_SMTOutputParseError -> true | uu___ -> false
 let (uu___is_Fatal_SMTSolverError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_SMTSolverError -> true | uu____1066 -> false
+    match projectee with | Fatal_SMTSolverError -> true | uu___ -> false
 let (uu___is_Fatal_SyntaxError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_SyntaxError -> true | uu____1072 -> false
+    match projectee with | Fatal_SyntaxError -> true | uu___ -> false
 let (uu___is_Fatal_SynthByTacticError : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_SynthByTacticError -> true
-    | uu____1078 -> false
+    match projectee with | Fatal_SynthByTacticError -> true | uu___ -> false
 let (uu___is_Fatal_TacticGotStuck : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_TacticGotStuck -> true | uu____1084 -> false
+    match projectee with | Fatal_TacticGotStuck -> true | uu___ -> false
 let (uu___is_Fatal_TcOneFragmentFailed : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_TcOneFragmentFailed -> true
-    | uu____1090 -> false
+    match projectee with | Fatal_TcOneFragmentFailed -> true | uu___ -> false
 let (uu___is_Fatal_TermOutsideOfDefLanguage : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_TermOutsideOfDefLanguage -> true
-    | uu____1096 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ToManyArgumentToFunction : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ToManyArgumentToFunction -> true
-    | uu____1102 -> false
+    | uu___ -> false
 let (uu___is_Fatal_TooManyOrTooFewFileMatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_TooManyOrTooFewFileMatch -> true
-    | uu____1108 -> false
+    | uu___ -> false
 let (uu___is_Fatal_TooManyPatternArguments : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_TooManyPatternArguments -> true
-    | uu____1114 -> false
+    | uu___ -> false
 let (uu___is_Fatal_TooManyUniverse : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_TooManyUniverse -> true
-    | uu____1120 -> false
+    match projectee with | Fatal_TooManyUniverse -> true | uu___ -> false
 let (uu___is_Fatal_TypeMismatch : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_TypeMismatch -> true | uu____1126 -> false
+    match projectee with | Fatal_TypeMismatch -> true | uu___ -> false
 let (uu___is_Fatal_TypeWithinPatternsAllowedOnVariablesOnly :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_TypeWithinPatternsAllowedOnVariablesOnly -> true
-    | uu____1132 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnableToReadFile : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnableToReadFile -> true
-    | uu____1138 -> false
+    match projectee with | Fatal_UnableToReadFile -> true | uu___ -> false
 let (uu___is_Fatal_UnepxectedOrUnboundOperator : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnepxectedOrUnboundOperator -> true
-    | uu____1144 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedBinder : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedBinder -> true
-    | uu____1150 -> false
+    match projectee with | Fatal_UnexpectedBinder -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedBindShape : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedBindShape -> true
-    | uu____1156 -> false
+    match projectee with | Fatal_UnexpectedBindShape -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedChar : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_UnexpectedChar -> true | uu____1162 -> false
+    match projectee with | Fatal_UnexpectedChar -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedComputationTypeForLetRec :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedComputationTypeForLetRec -> true
-    | uu____1168 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedConstructorType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedConstructorType -> true
-    | uu____1174 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedDataConstructor : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedDataConstructor -> true
-    | uu____1180 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedEffect : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedEffect -> true
-    | uu____1186 -> false
+    match projectee with | Fatal_UnexpectedEffect -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedEmptyRecord : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedEmptyRecord -> true
-    | uu____1192 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedExpressionType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedExpressionType -> true
-    | uu____1198 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedFunctionParameterType : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedFunctionParameterType -> true
-    | uu____1204 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedGeneralizedUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedGeneralizedUniverse -> true
-    | uu____1210 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedGTotForLetRec : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedGTotForLetRec -> true
-    | uu____1216 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedGuard : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedGuard -> true
-    | uu____1222 -> false
+    match projectee with | Fatal_UnexpectedGuard -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedIdentifier : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedIdentifier -> true
-    | uu____1228 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedImplicitArgument : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedImplicitArgument -> true
-    | uu____1234 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedImplictArgument : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedImplictArgument -> true
-    | uu____1240 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedInductivetype : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedInductivetype -> true
-    | uu____1246 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedLetBinding : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedLetBinding -> true
-    | uu____1252 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedModuleDeclaration : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedModuleDeclaration -> true
-    | uu____1258 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedNumberOfUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedNumberOfUniverse -> true
-    | uu____1264 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedNumericLiteral : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedNumericLiteral -> true
-    | uu____1270 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedOperatorSymbol : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedOperatorSymbol -> true
-    | uu____1276 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedPattern : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedPattern -> true
-    | uu____1282 -> false
+    match projectee with | Fatal_UnexpectedPattern -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedPosition : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedPosition -> true
-    | uu____1288 -> false
+    match projectee with | Fatal_UnexpectedPosition -> true | uu___ -> false
 let (uu___is_Fatal_UnExpectedPreCondition : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnExpectedPreCondition -> true
-    | uu____1294 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedReturnShape : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedReturnShape -> true
-    | uu____1300 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedSignatureForMonad : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedSignatureForMonad -> true
-    | uu____1306 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedTerm : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_UnexpectedTerm -> true | uu____1312 -> false
+    match projectee with | Fatal_UnexpectedTerm -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedTermInUniverse : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedTermInUniverse -> true
-    | uu____1318 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedTermType : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnexpectedTermType -> true
-    | uu____1324 -> false
+    match projectee with | Fatal_UnexpectedTermType -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedTermVQuote : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedTermVQuote -> true
-    | uu____1330 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedUniversePolymorphicReturn :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedUniversePolymorphicReturn -> true
-    | uu____1336 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnexpectedUniverseVariable : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedUniverseVariable -> true
-    | uu____1342 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnfoldableDeprecated : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnfoldableDeprecated -> true
-    | uu____1348 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnificationNotWellFormed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnificationNotWellFormed -> true
-    | uu____1354 -> false
+    | uu___ -> false
 let (uu___is_Fatal_Uninstantiated : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_Uninstantiated -> true | uu____1360 -> false
+    match projectee with | Fatal_Uninstantiated -> true | uu___ -> false
 let (uu___is_Error_UninstantiatedUnificationVarInTactic :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_UninstantiatedUnificationVarInTactic -> true
-    | uu____1366 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UninstantiatedVarInTactic : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UninstantiatedVarInTactic -> true
-    | uu____1372 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UniverseMightContainSumOfTwoUnivVars :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UniverseMightContainSumOfTwoUnivVars -> true
-    | uu____1378 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UniversePolymorphicInnerLetBound :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UniversePolymorphicInnerLetBound -> true
-    | uu____1384 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnknownAttribute : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnknownAttribute -> true
-    | uu____1390 -> false
+    match projectee with | Fatal_UnknownAttribute -> true | uu___ -> false
 let (uu___is_Fatal_UnknownToolForDep : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnknownToolForDep -> true
-    | uu____1396 -> false
+    match projectee with | Fatal_UnknownToolForDep -> true | uu___ -> false
 let (uu___is_Fatal_UnrecognizedExtension : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnrecognizedExtension -> true
-    | uu____1402 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnresolvedPatternVar : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnresolvedPatternVar -> true
-    | uu____1408 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnsupportedConstant : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UnsupportedConstant -> true
-    | uu____1414 -> false
+    match projectee with | Fatal_UnsupportedConstant -> true | uu___ -> false
 let (uu___is_Fatal_UnsupportedDisjuctivePatterns : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnsupportedDisjuctivePatterns -> true
-    | uu____1420 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UnsupportedQualifier : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnsupportedQualifier -> true
-    | uu____1426 -> false
+    | uu___ -> false
 let (uu___is_Fatal_UserTacticFailure : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_UserTacticFailure -> true
-    | uu____1432 -> false
+    match projectee with | Fatal_UserTacticFailure -> true | uu___ -> false
 let (uu___is_Fatal_ValueRestriction : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_ValueRestriction -> true
-    | uu____1438 -> false
+    match projectee with | Fatal_ValueRestriction -> true | uu___ -> false
 let (uu___is_Fatal_VariableNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_VariableNotFound -> true
-    | uu____1444 -> false
+    match projectee with | Fatal_VariableNotFound -> true | uu___ -> false
 let (uu___is_Fatal_WrongBodyTypeForReturnWP : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_WrongBodyTypeForReturnWP -> true
-    | uu____1450 -> false
+    | uu___ -> false
 let (uu___is_Fatal_WrongDataAppHeadFormat : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_WrongDataAppHeadFormat -> true
-    | uu____1456 -> false
+    | uu___ -> false
 let (uu___is_Fatal_WrongDefinitionOrder : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_WrongDefinitionOrder -> true
-    | uu____1462 -> false
+    | uu___ -> false
 let (uu___is_Fatal_WrongResultTypeAfterConstrutor : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Fatal_WrongResultTypeAfterConstrutor -> true
-    | uu____1468 -> false
+    | uu___ -> false
 let (uu___is_Fatal_WrongTerm : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_WrongTerm -> true | uu____1474 -> false
+    match projectee with | Fatal_WrongTerm -> true | uu___ -> false
 let (uu___is_Fatal_WhenClauseNotSupported : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_WhenClauseNotSupported -> true
-    | uu____1480 -> false
+    | uu___ -> false
 let (uu___is_Unused01 : raw_error -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unused01 -> true | uu____1486 -> false
+  fun projectee -> match projectee with | Unused01 -> true | uu___ -> false
 let (uu___is_Warning_AddImplicitAssumeNewQualifier : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Warning_AddImplicitAssumeNewQualifier -> true
-    | uu____1492 -> false
+    | uu___ -> false
 let (uu___is_Warning_AdmitWithoutDefinition : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_AdmitWithoutDefinition -> true
-    | uu____1498 -> false
+    | uu___ -> false
 let (uu___is_Warning_CachedFile : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_CachedFile -> true | uu____1504 -> false
+    match projectee with | Warning_CachedFile -> true | uu___ -> false
 let (uu___is_Warning_DefinitionNotTranslated : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_DefinitionNotTranslated -> true
-    | uu____1510 -> false
+    | uu___ -> false
 let (uu___is_Warning_DependencyFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_DependencyFound -> true
-    | uu____1516 -> false
+    match projectee with | Warning_DependencyFound -> true | uu___ -> false
 let (uu___is_Warning_DeprecatedEqualityOnBinder : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_DeprecatedEqualityOnBinder -> true
-    | uu____1522 -> false
+    | uu___ -> false
 let (uu___is_Warning_DeprecatedOpaqueQualifier : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_DeprecatedOpaqueQualifier -> true
-    | uu____1528 -> false
+    | uu___ -> false
 let (uu___is_Warning_DocOverwrite : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_DocOverwrite -> true | uu____1534 -> false
+    match projectee with | Warning_DocOverwrite -> true | uu___ -> false
 let (uu___is_Warning_FileNotWritten : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_FileNotWritten -> true
-    | uu____1540 -> false
+    match projectee with | Warning_FileNotWritten -> true | uu___ -> false
 let (uu___is_Warning_Filtered : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_Filtered -> true | uu____1546 -> false
+    match projectee with | Warning_Filtered -> true | uu___ -> false
 let (uu___is_Warning_FunctionLiteralPrecisionLoss : raw_error -> Prims.bool)
   =
   fun projectee ->
     match projectee with
     | Warning_FunctionLiteralPrecisionLoss -> true
-    | uu____1552 -> false
+    | uu___ -> false
 let (uu___is_Warning_FunctionNotExtacted : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_FunctionNotExtacted -> true
-    | uu____1558 -> false
+    | uu___ -> false
 let (uu___is_Warning_HintFailedToReplayProof : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_HintFailedToReplayProof -> true
-    | uu____1564 -> false
+    | uu___ -> false
 let (uu___is_Warning_HitReplayFailed : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_HitReplayFailed -> true
-    | uu____1570 -> false
+    match projectee with | Warning_HitReplayFailed -> true | uu___ -> false
 let (uu___is_Warning_IDEIgnoreCodeGen : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_IDEIgnoreCodeGen -> true
-    | uu____1576 -> false
+    match projectee with | Warning_IDEIgnoreCodeGen -> true | uu___ -> false
 let (uu___is_Warning_IllFormedGoal : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_IllFormedGoal -> true
-    | uu____1582 -> false
+    match projectee with | Warning_IllFormedGoal -> true | uu___ -> false
 let (uu___is_Warning_InaccessibleArgument : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_InaccessibleArgument -> true
-    | uu____1588 -> false
+    | uu___ -> false
 let (uu___is_Warning_IncoherentImplicitQualifier : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_IncoherentImplicitQualifier -> true
-    | uu____1594 -> false
+    | uu___ -> false
 let (uu___is_Warning_IrrelevantQualifierOnArgumentToReflect :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_IrrelevantQualifierOnArgumentToReflect -> true
-    | uu____1600 -> false
+    | uu___ -> false
 let (uu___is_Warning_IrrelevantQualifierOnArgumentToReify :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_IrrelevantQualifierOnArgumentToReify -> true
-    | uu____1606 -> false
+    | uu___ -> false
 let (uu___is_Warning_MalformedWarnErrorList : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_MalformedWarnErrorList -> true
-    | uu____1612 -> false
+    | uu___ -> false
 let (uu___is_Warning_MetaAlienNotATmUnknown : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_MetaAlienNotATmUnknown -> true
-    | uu____1618 -> false
+    | uu___ -> false
 let (uu___is_Warning_MultipleAscriptions : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_MultipleAscriptions -> true
-    | uu____1624 -> false
+    | uu___ -> false
 let (uu___is_Warning_NondependentUserDefinedDataType :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_NondependentUserDefinedDataType -> true
-    | uu____1630 -> false
+    | uu___ -> false
 let (uu___is_Warning_NonListLiteralSMTPattern : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_NonListLiteralSMTPattern -> true
-    | uu____1636 -> false
+    | uu___ -> false
 let (uu___is_Warning_NormalizationFailure : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_NormalizationFailure -> true
-    | uu____1642 -> false
+    | uu___ -> false
 let (uu___is_Warning_NotDependentArrow : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_NotDependentArrow -> true
-    | uu____1648 -> false
+    match projectee with | Warning_NotDependentArrow -> true | uu___ -> false
 let (uu___is_Warning_NotEmbedded : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_NotEmbedded -> true | uu____1654 -> false
+    match projectee with | Warning_NotEmbedded -> true | uu___ -> false
 let (uu___is_Warning_PatternMissingBoundVar : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_PatternMissingBoundVar -> true
-    | uu____1660 -> false
+    | uu___ -> false
 let (uu___is_Warning_RecursiveDependency : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_RecursiveDependency -> true
-    | uu____1666 -> false
+    | uu___ -> false
 let (uu___is_Warning_RedundantExplicitCurrying : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_RedundantExplicitCurrying -> true
-    | uu____1672 -> false
+    | uu___ -> false
 let (uu___is_Warning_SMTPatTDeprecated : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_SMTPatTDeprecated -> true
-    | uu____1678 -> false
+    match projectee with | Warning_SMTPatTDeprecated -> true | uu___ -> false
 let (uu___is_Warning_SMTPatternIllFormed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_SMTPatternIllFormed -> true
-    | uu____1684 -> false
+    | uu___ -> false
 let (uu___is_Warning_TopLevelEffect : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_TopLevelEffect -> true
-    | uu____1690 -> false
+    match projectee with | Warning_TopLevelEffect -> true | uu___ -> false
 let (uu___is_Warning_UnboundModuleReference : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UnboundModuleReference -> true
-    | uu____1696 -> false
+    | uu___ -> false
 let (uu___is_Warning_UnexpectedFile : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_UnexpectedFile -> true
-    | uu____1702 -> false
+    match projectee with | Warning_UnexpectedFile -> true | uu___ -> false
 let (uu___is_Warning_UnexpectedFsTypApp : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UnexpectedFsTypApp -> true
-    | uu____1708 -> false
+    | uu___ -> false
 let (uu___is_Warning_UnexpectedZ3Output : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UnexpectedZ3Output -> true
-    | uu____1714 -> false
+    | uu___ -> false
 let (uu___is_Warning_UnprotectedTerm : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_UnprotectedTerm -> true
-    | uu____1720 -> false
+    match projectee with | Warning_UnprotectedTerm -> true | uu___ -> false
 let (uu___is_Warning_UnrecognizedAttribute : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UnrecognizedAttribute -> true
-    | uu____1726 -> false
+    | uu___ -> false
 let (uu___is_Warning_UpperBoundCandidateAlreadyVisited :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UpperBoundCandidateAlreadyVisited -> true
-    | uu____1732 -> false
+    | uu___ -> false
 let (uu___is_Warning_UseDefaultEffect : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_UseDefaultEffect -> true
-    | uu____1738 -> false
+    match projectee with | Warning_UseDefaultEffect -> true | uu___ -> false
 let (uu___is_Warning_WrongErrorLocation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_WrongErrorLocation -> true
-    | uu____1744 -> false
+    | uu___ -> false
 let (uu___is_Warning_Z3InvocationWarning : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_Z3InvocationWarning -> true
-    | uu____1750 -> false
+    | uu___ -> false
 let (uu___is_Warning_PluginNotImplemented : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_PluginNotImplemented -> true
-    | uu____1756 -> false
+    | uu___ -> false
 let (uu___is_Warning_MissingInterfaceOrImplementation :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_MissingInterfaceOrImplementation -> true
-    | uu____1762 -> false
+    | uu___ -> false
 let (uu___is_Warning_ConstructorBuildsUnexpectedType :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_ConstructorBuildsUnexpectedType -> true
-    | uu____1768 -> false
+    | uu___ -> false
 let (uu___is_Warning_ModuleOrFileNotFoundWarning : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_ModuleOrFileNotFoundWarning -> true
-    | uu____1774 -> false
+    | uu___ -> false
 let (uu___is_Error_NoLetMutable : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_NoLetMutable -> true | uu____1780 -> false
+    match projectee with | Error_NoLetMutable -> true | uu___ -> false
 let (uu___is_Error_BadImplicit : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_BadImplicit -> true | uu____1786 -> false
+    match projectee with | Error_BadImplicit -> true | uu___ -> false
 let (uu___is_Warning_DeprecatedDefinition : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_DeprecatedDefinition -> true
-    | uu____1792 -> false
+    | uu___ -> false
 let (uu___is_Fatal_SMTEncodingArityMismatch : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_SMTEncodingArityMismatch -> true
-    | uu____1798 -> false
+    | uu___ -> false
 let (uu___is_Warning_Defensive : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_Defensive -> true | uu____1804 -> false
+    match projectee with | Warning_Defensive -> true | uu___ -> false
 let (uu___is_Warning_CantInspect : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_CantInspect -> true | uu____1810 -> false
+    match projectee with | Warning_CantInspect -> true | uu___ -> false
 let (uu___is_Warning_NilGivenExplicitArgs : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_NilGivenExplicitArgs -> true
-    | uu____1816 -> false
+    | uu___ -> false
 let (uu___is_Warning_ConsAppliedExplicitArgs : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_ConsAppliedExplicitArgs -> true
-    | uu____1822 -> false
+    | uu___ -> false
 let (uu___is_Warning_UnembedBinderKnot : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_UnembedBinderKnot -> true
-    | uu____1828 -> false
+    match projectee with | Warning_UnembedBinderKnot -> true | uu___ -> false
 let (uu___is_Fatal_TacticProofRelevantGoal : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_TacticProofRelevantGoal -> true
-    | uu____1834 -> false
+    | uu___ -> false
 let (uu___is_Warning_TacAdmit : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_TacAdmit -> true | uu____1840 -> false
+    match projectee with | Warning_TacAdmit -> true | uu___ -> false
 let (uu___is_Fatal_IncoherentPatterns : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_IncoherentPatterns -> true
-    | uu____1846 -> false
+    match projectee with | Fatal_IncoherentPatterns -> true | uu___ -> false
 let (uu___is_Error_NoSMTButNeeded : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_NoSMTButNeeded -> true | uu____1852 -> false
+    match projectee with | Error_NoSMTButNeeded -> true | uu___ -> false
 let (uu___is_Fatal_UnexpectedAntiquotation : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_UnexpectedAntiquotation -> true
-    | uu____1858 -> false
+    | uu___ -> false
 let (uu___is_Fatal_SplicedUndef : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_SplicedUndef -> true | uu____1864 -> false
+    match projectee with | Fatal_SplicedUndef -> true | uu___ -> false
 let (uu___is_Fatal_SpliceUnembedFail : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_SpliceUnembedFail -> true
-    | uu____1870 -> false
+    match projectee with | Fatal_SpliceUnembedFail -> true | uu___ -> false
 let (uu___is_Warning_ExtractionUnexpectedEffect : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_ExtractionUnexpectedEffect -> true
-    | uu____1876 -> false
+    | uu___ -> false
 let (uu___is_Error_DidNotFail : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_DidNotFail -> true | uu____1882 -> false
+    match projectee with | Error_DidNotFail -> true | uu___ -> false
 let (uu___is_Warning_UnappliedFail : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_UnappliedFail -> true
-    | uu____1888 -> false
+    match projectee with | Warning_UnappliedFail -> true | uu___ -> false
 let (uu___is_Warning_QuantifierWithoutPattern : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_QuantifierWithoutPattern -> true
-    | uu____1894 -> false
+    | uu___ -> false
 let (uu___is_Error_EmptyFailErrs : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_EmptyFailErrs -> true | uu____1900 -> false
+    match projectee with | Error_EmptyFailErrs -> true | uu___ -> false
 let (uu___is_Warning_logicqualifier : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_logicqualifier -> true
-    | uu____1906 -> false
+    match projectee with | Warning_logicqualifier -> true | uu___ -> false
 let (uu___is_Fatal_CyclicDependence : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_CyclicDependence -> true
-    | uu____1912 -> false
+    match projectee with | Fatal_CyclicDependence -> true | uu___ -> false
 let (uu___is_Error_InductiveAnnotNotAType : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_InductiveAnnotNotAType -> true
-    | uu____1918 -> false
+    | uu___ -> false
 let (uu___is_Fatal_FriendInterface : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_FriendInterface -> true
-    | uu____1924 -> false
+    match projectee with | Fatal_FriendInterface -> true | uu___ -> false
 let (uu___is_Error_CannotRedefineConst : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_CannotRedefineConst -> true
-    | uu____1930 -> false
+    match projectee with | Error_CannotRedefineConst -> true | uu___ -> false
 let (uu___is_Error_BadClassDecl : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_BadClassDecl -> true | uu____1936 -> false
+    match projectee with | Error_BadClassDecl -> true | uu___ -> false
 let (uu___is_Error_BadInductiveParam : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_BadInductiveParam -> true
-    | uu____1942 -> false
+    match projectee with | Error_BadInductiveParam -> true | uu___ -> false
 let (uu___is_Error_FieldShadow : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_FieldShadow -> true | uu____1948 -> false
+    match projectee with | Error_FieldShadow -> true | uu___ -> false
 let (uu___is_Error_UnexpectedDM4FType : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_UnexpectedDM4FType -> true
-    | uu____1954 -> false
+    match projectee with | Error_UnexpectedDM4FType -> true | uu___ -> false
 let (uu___is_Fatal_EffectAbbreviationResultTypeMismatch :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_EffectAbbreviationResultTypeMismatch -> true
-    | uu____1960 -> false
+    | uu___ -> false
 let (uu___is_Error_AlreadyCachedAssertionFailure : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Error_AlreadyCachedAssertionFailure -> true
-    | uu____1966 -> false
+    | uu___ -> false
 let (uu___is_Error_MustEraseMissing : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Error_MustEraseMissing -> true
-    | uu____1972 -> false
+    match projectee with | Error_MustEraseMissing -> true | uu___ -> false
 let (uu___is_Warning_EffectfulArgumentToErasedFunction :
   raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_EffectfulArgumentToErasedFunction -> true
-    | uu____1978 -> false
+    | uu___ -> false
 let (uu___is_Fatal_EmptySurfaceLet : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Fatal_EmptySurfaceLet -> true
-    | uu____1984 -> false
+    match projectee with | Fatal_EmptySurfaceLet -> true | uu___ -> false
 let (uu___is_Warning_UnexpectedCheckedFile : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_UnexpectedCheckedFile -> true
-    | uu____1990 -> false
+    | uu___ -> false
 let (uu___is_Fatal_ExtractionUnsupported : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_ExtractionUnsupported -> true
-    | uu____1996 -> false
+    | uu___ -> false
 let (uu___is_Warning_SMTErrorReason : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_SMTErrorReason -> true
-    | uu____2002 -> false
+    match projectee with | Warning_SMTErrorReason -> true | uu___ -> false
 let (uu___is_Warning_CoercionNotFound : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_CoercionNotFound -> true
-    | uu____2008 -> false
+    match projectee with | Warning_CoercionNotFound -> true | uu___ -> false
 let (uu___is_Error_QuakeFailed : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_QuakeFailed -> true | uu____2014 -> false
+    match projectee with | Error_QuakeFailed -> true | uu___ -> false
 let (uu___is_Error_IllSMTPat : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_IllSMTPat -> true | uu____2020 -> false
+    match projectee with | Error_IllSMTPat -> true | uu___ -> false
 let (uu___is_Error_IllScopedTerm : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_IllScopedTerm -> true | uu____2026 -> false
+    match projectee with | Error_IllScopedTerm -> true | uu___ -> false
 let (uu___is_Warning_UnusedLetRec : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_UnusedLetRec -> true | uu____2032 -> false
+    match projectee with | Warning_UnusedLetRec -> true | uu___ -> false
 let (uu___is_Fatal_Effects_Ordering_Coherence : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Fatal_Effects_Ordering_Coherence -> true
-    | uu____2038 -> false
+    | uu___ -> false
 let (uu___is_Warning_BleedingEdge_Feature : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_BleedingEdge_Feature -> true
-    | uu____2044 -> false
+    | uu___ -> false
 let (uu___is_Warning_IgnoredBinding : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_IgnoredBinding -> true
-    | uu____2050 -> false
+    match projectee with | Warning_IgnoredBinding -> true | uu___ -> false
 let (uu___is_Warning_CouldNotReadHints : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_CouldNotReadHints -> true
-    | uu____2056 -> false
+    match projectee with | Warning_CouldNotReadHints -> true | uu___ -> false
 let (uu___is_Fatal_BadUvar : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Fatal_BadUvar -> true | uu____2062 -> false
+    match projectee with | Fatal_BadUvar -> true | uu___ -> false
 let (uu___is_Warning_WarnOnUse : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning_WarnOnUse -> true | uu____2068 -> false
+    match projectee with | Warning_WarnOnUse -> true | uu___ -> false
 let (uu___is_Warning_DeprecatedAttributeSyntax : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Warning_DeprecatedAttributeSyntax -> true
-    | uu____2074 -> false
+    | uu___ -> false
 let (uu___is_Warning_DeprecatedGeneric : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Warning_DeprecatedGeneric -> true
-    | uu____2080 -> false
+    match projectee with | Warning_DeprecatedGeneric -> true | uu___ -> false
 let (uu___is_Error_BadSplice : raw_error -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error_BadSplice -> true | uu____2086 -> false
+    match projectee with | Error_BadSplice -> true | uu___ -> false
 type flag = error_flag
 type error_setting = (raw_error * error_flag * Prims.int)
 let (default_settings : error_setting Prims.list) =
@@ -2338,142 +2180,132 @@ let (default_settings : error_setting Prims.list) =
   (Warning_DeprecatedGeneric, CWarning, (Prims.of_int (337)));
   (Error_BadSplice, CError, (Prims.of_int (338)))]
 let lookup_error :
-  'uuuuuu2105 'uuuuuu2106 'uuuuuu2107 .
-    ('uuuuuu2105 * 'uuuuuu2106 * 'uuuuuu2107) Prims.list ->
-      'uuuuuu2105 -> ('uuuuuu2105 * 'uuuuuu2106 * 'uuuuuu2107)
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    ('uuuuu * 'uuuuu1 * 'uuuuu2) Prims.list ->
+      'uuuuu -> ('uuuuu * 'uuuuu1 * 'uuuuu2)
   =
   fun settings ->
     fun e ->
-      let uu____2140 =
+      let uu___ =
         FStar_Util.try_find
-          (fun uu____2159 ->
-             match uu____2159 with | (v, uu____2167, i) -> e = v) settings in
-      match uu____2140 with
+          (fun uu___1 -> match uu___1 with | (v, uu___2, i) -> e = v)
+          settings in
+      match uu___ with
       | FStar_Pervasives_Native.Some i -> i
       | FStar_Pervasives_Native.None ->
           failwith "Impossible: unrecognized error"
 let lookup_error_range :
-  'uuuuuu2208 'uuuuuu2209 .
-    ('uuuuuu2208 * 'uuuuuu2209 * Prims.int) Prims.list ->
-      (Prims.int * Prims.int) ->
-        ('uuuuuu2208 * 'uuuuuu2209 * Prims.int) Prims.list
+  'uuuuu 'uuuuu1 .
+    ('uuuuu * 'uuuuu1 * Prims.int) Prims.list ->
+      (Prims.int * Prims.int) -> ('uuuuu * 'uuuuu1 * Prims.int) Prims.list
   =
   fun settings ->
-    fun uu____2239 ->
-      match uu____2239 with
+    fun uu___ ->
+      match uu___ with
       | (l, h) ->
-          let uu____2254 =
+          let uu___1 =
             FStar_List.partition
-              (fun uu____2285 ->
-                 match uu____2285 with
-                 | (uu____2292, uu____2293, i) -> (l <= i) && (i <= h))
-              settings in
-          (match uu____2254 with | (matches, uu____2304) -> matches)
+              (fun uu___2 ->
+                 match uu___2 with
+                 | (uu___3, uu___4, i) -> (l <= i) && (i <= h)) settings in
+          (match uu___1 with | (matches, uu___2) -> matches)
 let error_number :
-  'uuuuuu2345 'uuuuuu2346 'uuuuuu2347 .
-    ('uuuuuu2345 * 'uuuuuu2346 * 'uuuuuu2347) -> 'uuuuuu2347
-  =
-  fun uu____2358 -> match uu____2358 with | (uu____2365, uu____2366, i) -> i
+  'uuuuu 'uuuuu1 'uuuuu2 . ('uuuuu * 'uuuuu1 * 'uuuuu2) -> 'uuuuu2 =
+  fun uu___ -> match uu___ with | (uu___1, uu___2, i) -> i
 let (warn_on_use_errno : Prims.int) =
-  let uu____2368 = lookup_error default_settings Warning_WarnOnUse in
-  error_number uu____2368
+  let uu___ = lookup_error default_settings Warning_WarnOnUse in
+  error_number uu___
 let (defensive_errno : Prims.int) =
-  let uu____2375 = lookup_error default_settings Warning_Defensive in
-  error_number uu____2375
+  let uu___ = lookup_error default_settings Warning_Defensive in
+  error_number uu___
 let (update_flags :
   (error_flag * Prims.string) Prims.list -> error_setting Prims.list) =
   fun l ->
     let set_one_flag i flag1 default_flag =
       match (flag1, default_flag) with
       | (CWarning, CAlwaysError) ->
-          let uu____2419 =
-            let uu____2420 =
-              let uu____2421 = FStar_Util.string_of_int i in
-              FStar_Util.format1 "cannot turn error %s into warning"
-                uu____2421 in
-            Invalid_warn_error_setting uu____2420 in
-          FStar_Exn.raise uu____2419
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Util.string_of_int i in
+              FStar_Util.format1 "cannot turn error %s into warning" uu___2 in
+            Invalid_warn_error_setting uu___1 in
+          FStar_Exn.raise uu___
       | (CError, CAlwaysError) ->
-          let uu____2422 =
-            let uu____2423 =
-              let uu____2424 = FStar_Util.string_of_int i in
-              FStar_Util.format1 "cannot turn error %s into warning"
-                uu____2424 in
-            Invalid_warn_error_setting uu____2423 in
-          FStar_Exn.raise uu____2422
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Util.string_of_int i in
+              FStar_Util.format1 "cannot turn error %s into warning" uu___2 in
+            Invalid_warn_error_setting uu___1 in
+          FStar_Exn.raise uu___
       | (CSilent, CAlwaysError) ->
-          let uu____2425 =
-            let uu____2426 =
-              let uu____2427 = FStar_Util.string_of_int i in
-              FStar_Util.format1 "cannot silence error %s" uu____2427 in
-            Invalid_warn_error_setting uu____2426 in
-          FStar_Exn.raise uu____2425
-      | (uu____2428, CFatal) ->
-          let uu____2429 =
-            let uu____2430 =
-              let uu____2431 = FStar_Util.string_of_int i in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Util.string_of_int i in
+              FStar_Util.format1 "cannot silence error %s" uu___2 in
+            Invalid_warn_error_setting uu___1 in
+          FStar_Exn.raise uu___
+      | (uu___, CFatal) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Util.string_of_int i in
               FStar_Util.format1
-                "cannot change the error level of fatal error %s" uu____2431 in
-            Invalid_warn_error_setting uu____2430 in
-          FStar_Exn.raise uu____2429
-      | uu____2432 -> flag1 in
-    let set_flag_for_range uu____2458 =
-      match uu____2458 with
+                "cannot change the error level of fatal error %s" uu___3 in
+            Invalid_warn_error_setting uu___2 in
+          FStar_Exn.raise uu___1
+      | uu___ -> flag1 in
+    let set_flag_for_range uu___ =
+      match uu___ with
       | (flag1, range) ->
           let errs = lookup_error_range default_settings range in
           FStar_List.map
-            (fun uu____2511 ->
-               match uu____2511 with
+            (fun uu___1 ->
+               match uu___1 with
                | (v, default_flag, i) ->
-                   let uu____2527 = set_one_flag i flag1 default_flag in
-                   (v, uu____2527, i)) errs in
-    let compute_range uu____2545 =
-      match uu____2545 with
+                   let uu___2 = set_one_flag i flag1 default_flag in
+                   (v, uu___2, i)) errs in
+    let compute_range uu___ =
+      match uu___ with
       | (flag1, s) ->
           let r = FStar_Util.split s ".." in
-          let uu____2563 =
+          let uu___1 =
             match r with
             | r1::r2::[] ->
-                let uu____2574 = FStar_Util.int_of_string r1 in
-                let uu____2575 = FStar_Util.int_of_string r2 in
-                (uu____2574, uu____2575)
-            | uu____2576 ->
-                let uu____2579 =
-                  let uu____2580 =
+                let uu___2 = FStar_Util.int_of_string r1 in
+                let uu___3 = FStar_Util.int_of_string r2 in (uu___2, uu___3)
+            | uu___2 ->
+                let uu___3 =
+                  let uu___4 =
                     FStar_Util.format1 "Malformed warn-error range %s" s in
-                  Invalid_warn_error_setting uu____2580 in
-                FStar_Exn.raise uu____2579 in
-          (match uu____2563 with | (l1, h) -> (flag1, (l1, h))) in
+                  Invalid_warn_error_setting uu___4 in
+                FStar_Exn.raise uu___3 in
+          (match uu___1 with | (l1, h) -> (flag1, (l1, h))) in
     let error_range_settings = FStar_List.map compute_range l in
-    let uu____2622 =
-      FStar_List.collect set_flag_for_range error_range_settings in
-    FStar_List.append uu____2622 default_settings
+    let uu___ = FStar_List.collect set_flag_for_range error_range_settings in
+    FStar_List.append uu___ default_settings
 type error = (raw_error * Prims.string * FStar_Range.range)
 exception Err of (raw_error * Prims.string) 
 let (uu___is_Err : Prims.exn -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Err uu____2670 -> true | uu____2675 -> false
+  fun projectee -> match projectee with | Err uu___ -> true | uu___ -> false
 let (__proj__Err__item__uu___ : Prims.exn -> (raw_error * Prims.string)) =
-  fun projectee -> match projectee with | Err uu____2689 -> uu____2689
+  fun projectee -> match projectee with | Err uu___ -> uu___
 exception Error of error 
 let (uu___is_Error : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Error uu____2703 -> true | uu____2704 -> false
+    match projectee with | Error uu___ -> true | uu___ -> false
 let (__proj__Error__item__uu___ : Prims.exn -> error) =
-  fun projectee -> match projectee with | Error uu____2710 -> uu____2710
+  fun projectee -> match projectee with | Error uu___ -> uu___
 exception Warning of error 
 let (uu___is_Warning : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Warning uu____2720 -> true | uu____2721 -> false
+    match projectee with | Warning uu___ -> true | uu___ -> false
 let (__proj__Warning__item__uu___ : Prims.exn -> error) =
-  fun projectee -> match projectee with | Warning uu____2727 -> uu____2727
+  fun projectee -> match projectee with | Warning uu___ -> uu___
 exception Stop 
 let (uu___is_Stop : Prims.exn -> Prims.bool) =
-  fun projectee -> match projectee with | Stop -> true | uu____2733 -> false
+  fun projectee -> match projectee with | Stop -> true | uu___ -> false
 exception Empty_frag 
 let (uu___is_Empty_frag : Prims.exn -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Empty_frag -> true | uu____2739 -> false
+  fun projectee -> match projectee with | Empty_frag -> true | uu___ -> false
 type issue_level =
   | ENotImplemented 
   | EInfo 
@@ -2481,15 +2313,13 @@ type issue_level =
   | EError 
 let (uu___is_ENotImplemented : issue_level -> Prims.bool) =
   fun projectee ->
-    match projectee with | ENotImplemented -> true | uu____2745 -> false
+    match projectee with | ENotImplemented -> true | uu___ -> false
 let (uu___is_EInfo : issue_level -> Prims.bool) =
-  fun projectee -> match projectee with | EInfo -> true | uu____2751 -> false
+  fun projectee -> match projectee with | EInfo -> true | uu___ -> false
 let (uu___is_EWarning : issue_level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EWarning -> true | uu____2757 -> false
+  fun projectee -> match projectee with | EWarning -> true | uu___ -> false
 let (uu___is_EError : issue_level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EError -> true | uu____2763 -> false
+  fun projectee -> match projectee with | EError -> true | uu___ -> false
 type issue =
   {
   issue_message: Prims.string ;
@@ -2553,48 +2383,46 @@ let (format_issue : issue -> Prims.string) =
       | EWarning -> "Warning"
       | EError -> "Error"
       | ENotImplemented -> "Feature not yet implemented: " in
-    let uu____3020 =
+    let uu___ =
       match issue1.issue_range with
       | FStar_Pervasives_Native.None -> ("", "")
       | FStar_Pervasives_Native.Some r when r = FStar_Range.dummyRange ->
-          let uu____3030 =
-            let uu____3031 =
-              let uu____3032 = FStar_Range.def_range r in
-              let uu____3033 = FStar_Range.def_range FStar_Range.dummyRange in
-              uu____3032 = uu____3033 in
-            if uu____3031
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Range.def_range r in
+              let uu___4 = FStar_Range.def_range FStar_Range.dummyRange in
+              uu___3 = uu___4 in
+            if uu___2
             then ""
             else
-              (let uu____3035 = FStar_Range.string_of_range r in
-               FStar_Util.format1 " (see also %s)" uu____3035) in
-          ("", uu____3030)
+              (let uu___4 = FStar_Range.string_of_range r in
+               FStar_Util.format1 " (see also %s)" uu___4) in
+          ("", uu___1)
       | FStar_Pervasives_Native.Some r ->
-          let uu____3037 =
-            let uu____3038 = FStar_Range.string_of_use_range r in
-            FStar_Util.format1 "%s: " uu____3038 in
-          let uu____3039 =
-            let uu____3040 =
-              (let uu____3045 = FStar_Range.use_range r in
-               let uu____3046 = FStar_Range.def_range r in
-               uu____3045 = uu____3046) ||
-                (let uu____3049 = FStar_Range.def_range r in
-                 let uu____3050 =
-                   FStar_Range.def_range FStar_Range.dummyRange in
-                 uu____3049 = uu____3050) in
-            if uu____3040
+          let uu___1 =
+            let uu___2 = FStar_Range.string_of_use_range r in
+            FStar_Util.format1 "%s: " uu___2 in
+          let uu___2 =
+            let uu___3 =
+              (let uu___4 = FStar_Range.use_range r in
+               let uu___5 = FStar_Range.def_range r in uu___4 = uu___5) ||
+                (let uu___4 = FStar_Range.def_range r in
+                 let uu___5 = FStar_Range.def_range FStar_Range.dummyRange in
+                 uu___4 = uu___5) in
+            if uu___3
             then ""
             else
-              (let uu____3052 = FStar_Range.string_of_range r in
-               FStar_Util.format1 " (see also %s)" uu____3052) in
-          (uu____3037, uu____3039) in
-    match uu____3020 with
+              (let uu___5 = FStar_Range.string_of_range r in
+               FStar_Util.format1 " (see also %s)" uu___5) in
+          (uu___1, uu___2) in
+    match uu___ with
     | (range_str, see_also_str) ->
         let issue_number =
           match issue1.issue_number with
           | FStar_Pervasives_Native.None -> ""
           | FStar_Pervasives_Native.Some n ->
-              let uu____3057 = FStar_Util.string_of_int n in
-              FStar_Util.format1 " %s" uu____3057 in
+              let uu___1 = FStar_Util.string_of_int n in
+              FStar_Util.format1 " %s" uu___1 in
         FStar_Util.format5 "%s(%s%s) %s%s\n" range_str level_header
           issue_number issue1.issue_message see_also_str
 let (print_issue : issue -> unit) =
@@ -2605,52 +2433,49 @@ let (print_issue : issue -> unit) =
       | EWarning -> FStar_Util.print_warning
       | EError -> FStar_Util.print_error
       | ENotImplemented -> FStar_Util.print_error in
-    let uu____3071 = format_issue issue1 in printer uu____3071
+    let uu___ = format_issue issue1 in printer uu___
 let (compare_issues : issue -> issue -> Prims.int) =
   fun i1 ->
     fun i2 ->
       match ((i1.issue_range), (i2.issue_range)) with
       | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) ->
           Prims.int_zero
-      | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some
-         uu____3090) -> ~- Prims.int_one
-      | (FStar_Pervasives_Native.Some uu____3095,
-         FStar_Pervasives_Native.None) -> Prims.int_one
+      | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some uu___) ->
+          ~- Prims.int_one
+      | (FStar_Pervasives_Native.Some uu___, FStar_Pervasives_Native.None) ->
+          Prims.int_one
       | (FStar_Pervasives_Native.Some r1, FStar_Pervasives_Native.Some r2) ->
           FStar_Range.compare_use_range r1 r2
 let (mk_default_handler : Prims.bool -> error_handler) =
   fun print ->
     let issues = FStar_Util.mk_ref [] in
     let add_one e =
-      (let uu____3125 =
+      (let uu___1 =
          (FStar_Options.defensive_abort ()) &&
            (e.issue_number = (FStar_Pervasives_Native.Some defensive_errno)) in
-       if uu____3125
-       then failwith "Aborting due to --defensive abort"
-       else ());
+       if uu___1 then failwith "Aborting due to --defensive abort" else ());
       (match e.issue_level with
        | EInfo -> print_issue e
-       | uu____3129 ->
-           let uu____3130 =
-             let uu____3133 = FStar_ST.op_Bang issues in e :: uu____3133 in
-           FStar_ST.op_Colon_Equals issues uu____3130) in
-    let count_errors uu____3161 =
-      let uu____3162 = FStar_ST.op_Bang issues in
+       | uu___1 ->
+           let uu___2 = let uu___3 = FStar_ST.op_Bang issues in e :: uu___3 in
+           FStar_ST.op_Colon_Equals issues uu___2) in
+    let count_errors uu___ =
+      let uu___1 = FStar_ST.op_Bang issues in
       FStar_List.fold_left
         (fun n ->
            fun i ->
              match i.issue_level with
              | EError -> n + Prims.int_one
-             | uu____3179 -> n) Prims.int_zero uu____3162 in
-    let report uu____3187 =
+             | uu___2 -> n) Prims.int_zero uu___1 in
+    let report uu___ =
       let unique_issues =
-        let uu____3191 = FStar_ST.op_Bang issues in
-        FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu____3191 in
+        let uu___1 = FStar_ST.op_Bang issues in
+        FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu___1 in
       let sorted_unique_issues =
         FStar_List.sortWith compare_issues unique_issues in
       if print then FStar_List.iter print_issue sorted_unique_issues else ();
       sorted_unique_issues in
-    let clear uu____3218 = FStar_ST.op_Colon_Equals issues [] in
+    let clear uu___ = FStar_ST.op_Colon_Equals issues [] in
     {
       eh_add_one = add_one;
       eh_count_errors = count_errors;
@@ -2676,46 +2501,44 @@ let (mk_issue :
             issue_number = n
           }
 let (get_err_count : unit -> Prims.int) =
-  fun uu____3263 ->
-    let uu____3264 = FStar_ST.op_Bang current_handler in
-    uu____3264.eh_count_errors ()
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang current_handler in
+    uu___1.eh_count_errors ()
 let (wrapped_eh_add_one : error_handler -> issue -> unit) =
   fun h ->
     fun issue1 ->
       h.eh_add_one issue1;
       if issue1.issue_level <> EInfo
       then
-        ((let uu____3283 =
-            let uu____3284 = FStar_ST.op_Bang FStar_Options.abort_counter in
-            uu____3284 - Prims.int_one in
-          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu____3283);
-         (let uu____3297 =
-            let uu____3298 = FStar_ST.op_Bang FStar_Options.abort_counter in
-            uu____3298 = Prims.int_zero in
-          if uu____3297 then failwith "Aborting due to --abort_on" else ()))
+        ((let uu___2 =
+            let uu___3 = FStar_ST.op_Bang FStar_Options.abort_counter in
+            uu___3 - Prims.int_one in
+          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu___2);
+         (let uu___2 =
+            let uu___3 = FStar_ST.op_Bang FStar_Options.abort_counter in
+            uu___3 = Prims.int_zero in
+          if uu___2 then failwith "Aborting due to --abort_on" else ()))
       else ()
 let (add_one : issue -> unit) =
   fun issue1 ->
     FStar_Util.atomically
-      (fun uu____3314 ->
-         let uu____3315 = FStar_ST.op_Bang current_handler in
-         wrapped_eh_add_one uu____3315 issue1)
+      (fun uu___ ->
+         let uu___1 = FStar_ST.op_Bang current_handler in
+         wrapped_eh_add_one uu___1 issue1)
 let (add_many : issue Prims.list -> unit) =
   fun issues ->
     FStar_Util.atomically
-      (fun uu____3333 ->
-         let uu____3334 =
-           let uu____3339 = FStar_ST.op_Bang current_handler in
-           wrapped_eh_add_one uu____3339 in
-         FStar_List.iter uu____3334 issues)
+      (fun uu___ ->
+         let uu___1 =
+           let uu___2 = FStar_ST.op_Bang current_handler in
+           wrapped_eh_add_one uu___2 in
+         FStar_List.iter uu___1 issues)
 let (report_all : unit -> issue Prims.list) =
-  fun uu____3352 ->
-    let uu____3353 = FStar_ST.op_Bang current_handler in
-    uu____3353.eh_report ()
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang current_handler in uu___1.eh_report ()
 let (clear : unit -> unit) =
-  fun uu____3364 ->
-    let uu____3365 = FStar_ST.op_Bang current_handler in
-    uu____3365.eh_clear ()
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang current_handler in uu___1.eh_clear ()
 let (set_handler : error_handler -> unit) =
   fun handler ->
     let issues = report_all () in
@@ -2755,28 +2578,27 @@ let (__proj__Mkerror_message_prefix__item__append_prefixs :
 let (message_prefix : error_message_prefix) =
   let pfxs = FStar_Util.mk_ref [] in
   let push_prefix s =
-    let uu____3553 =
-      let uu____3556 = FStar_ST.op_Bang pfxs in s :: uu____3556 in
-    FStar_ST.op_Colon_Equals pfxs uu____3553 in
+    let uu___ = let uu___1 = FStar_ST.op_Bang pfxs in s :: uu___1 in
+    FStar_ST.op_Colon_Equals pfxs uu___ in
   let pop_prefix s =
-    let uu____3585 = FStar_ST.op_Bang pfxs in
-    match uu____3585 with
+    let uu___ = FStar_ST.op_Bang pfxs in
+    match uu___ with
     | h::t -> (FStar_ST.op_Colon_Equals pfxs t; h)
-    | uu____3613 -> failwith "cannot pop error prefix..." in
-  let clear_prefixs uu____3621 = FStar_ST.op_Colon_Equals pfxs [] in
+    | uu___1 -> failwith "cannot pop error prefix..." in
+  let clear_prefixs uu___ = FStar_ST.op_Colon_Equals pfxs [] in
   let append_prefixs s =
-    let uu____3638 = FStar_ST.op_Bang pfxs in
+    let uu___ = FStar_ST.op_Bang pfxs in
     FStar_List.fold_left
       (fun s1 ->
          fun p ->
-           let uu____3656 = FStar_String.op_Hat ":\n\t" s1 in
-           FStar_String.op_Hat p uu____3656) s uu____3638 in
+           let uu___1 = FStar_String.op_Hat ":\n\t" s1 in
+           FStar_String.op_Hat p uu___1) s uu___ in
   { push_prefix; pop_prefix; clear_prefixs; append_prefixs }
 let (diag : FStar_Range.range -> Prims.string -> unit) =
   fun r ->
     fun msg ->
-      let uu____3667 = FStar_Options.debug_any () in
-      if uu____3667
+      let uu___ = FStar_Options.debug_any () in
+      if uu___
       then
         add_one
           (mk_issue EInfo (FStar_Pervasives_Native.Some r) msg
@@ -2786,25 +2608,25 @@ let (warn_unsafe_options :
   FStar_Range.range FStar_Pervasives_Native.option -> Prims.string -> unit) =
   fun rng_opt ->
     fun msg ->
-      let uu____3683 = FStar_Options.report_assumes () in
-      match uu____3683 with
+      let uu___ = FStar_Options.report_assumes () in
+      match uu___ with
       | FStar_Pervasives_Native.Some "warn" ->
-          let uu____3686 =
-            let uu____3687 =
+          let uu___1 =
+            let uu___2 =
               FStar_String.op_Hat
                 "Every use of this option triggers a warning: " msg in
-            mk_issue EWarning rng_opt uu____3687
+            mk_issue EWarning rng_opt uu___2
               (FStar_Pervasives_Native.Some warn_on_use_errno) in
-          add_one uu____3686
+          add_one uu___1
       | FStar_Pervasives_Native.Some "error" ->
-          let uu____3688 =
-            let uu____3689 =
+          let uu___1 =
+            let uu___2 =
               FStar_String.op_Hat
                 "Every use of this option triggers an error: " msg in
-            mk_issue EError rng_opt uu____3689
+            mk_issue EError rng_opt uu___2
               (FStar_Pervasives_Native.Some warn_on_use_errno) in
-          add_one uu____3688
-      | uu____3690 -> ()
+          add_one uu___1
+      | uu___1 -> ()
 let (set_option_warning_callback_range :
   FStar_Range.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
@@ -2815,16 +2637,16 @@ let (uu___222 :
   =
   let parser_callback = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let error_flags = FStar_Util.smap_create (Prims.of_int (10)) in
-  let set_error_flags uu____3757 =
+  let set_error_flags uu___ =
     let parse s =
-      let uu____3766 = FStar_ST.op_Bang parser_callback in
-      match uu____3766 with
+      let uu___1 = FStar_ST.op_Bang parser_callback in
+      match uu___1 with
       | FStar_Pervasives_Native.None ->
           failwith "Callback for parsing warn_error strings is not set"
       | FStar_Pervasives_Native.Some f -> f s in
     let we = FStar_Options.warn_error () in
     try
-      (fun uu___234_3818 ->
+      (fun uu___1 ->
          match () with
          | () ->
              let r = parse we in
@@ -2834,15 +2656,15 @@ let (uu___222 :
     with
     | Invalid_warn_error_setting msg ->
         (FStar_Util.smap_add error_flags we FStar_Pervasives_Native.None;
-         (let uu____3842 =
+         (let uu___3 =
             FStar_String.op_Hat "Invalid --warn_error setting: " msg in
-          FStar_Getopt.Error uu____3842)) in
-  let get_error_flags uu____3850 =
+          FStar_Getopt.Error uu___3)) in
+  let get_error_flags uu___ =
     let we = FStar_Options.warn_error () in
-    let uu____3852 = FStar_Util.smap_try_find error_flags we in
-    match uu____3852 with
+    let uu___1 = FStar_Util.smap_try_find error_flags we in
+    match uu___1 with
     | FStar_Pervasives_Native.Some (FStar_Pervasives_Native.Some w) -> w
-    | uu____3874 -> default_settings in
+    | uu___2 -> default_settings in
   let set_callbacks f =
     FStar_ST.op_Colon_Equals parser_callback (FStar_Pervasives_Native.Some f);
     FStar_Options.set_error_flags_callback set_error_flags;
@@ -2852,14 +2674,14 @@ let (uu___222 :
 let (set_parse_warn_error :
   (Prims.string -> error_setting Prims.list) -> unit) =
   match uu___222 with
-  | (set_parse_warn_error, error_flags) -> set_parse_warn_error
+  | (set_parse_warn_error1, error_flags) -> set_parse_warn_error1
 let (error_flags : unit -> error_setting Prims.list) =
-  match uu___222 with | (set_parse_warn_error1, error_flags) -> error_flags
+  match uu___222 with | (set_parse_warn_error1, error_flags1) -> error_flags1
 let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
   fun err ->
     let flags = error_flags () in
-    let uu____4034 = lookup_error flags err in
-    match uu____4034 with
+    let uu___ = lookup_error flags err in
+    match uu___ with
     | (v, level, i) ->
         let with_level level1 = (v, level1, i) in
         (match v with
@@ -2869,117 +2691,111 @@ let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
              -> with_level CAlwaysError
          | Warning_WarnOnUse ->
              let level' =
-               let uu____4069 = FStar_Options.report_assumes () in
-               match uu____4069 with
+               let uu___1 = FStar_Options.report_assumes () in
+               match uu___1 with
                | FStar_Pervasives_Native.None -> level
                | FStar_Pervasives_Native.Some "warn" ->
-                   (match level with
-                    | CSilent -> CWarning
-                    | uu____4072 -> level)
+                   (match level with | CSilent -> CWarning | uu___2 -> level)
                | FStar_Pervasives_Native.Some "error" ->
                    (match level with
                     | CWarning -> CError
                     | CSilent -> CError
-                    | uu____4073 -> level)
-               | FStar_Pervasives_Native.Some uu____4074 -> level in
+                    | uu___2 -> level)
+               | FStar_Pervasives_Native.Some uu___2 -> level in
              with_level level'
-         | uu____4075 -> with_level level)
+         | uu___1 -> with_level level)
 let (log_issue : FStar_Range.range -> (raw_error * Prims.string) -> unit) =
   fun r ->
-    fun uu____4089 ->
-      match uu____4089 with
+    fun uu___ ->
+      match uu___ with
       | (e, msg) ->
-          let uu____4096 = lookup e in
-          (match uu____4096 with
-           | (uu____4103, CAlwaysError, errno) ->
+          let uu___1 = lookup e in
+          (match uu___1 with
+           | (uu___2, CAlwaysError, errno) ->
                add_one
                  (mk_issue EError (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4105, CError, errno) ->
+           | (uu___2, CError, errno) ->
                add_one
                  (mk_issue EError (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4107, CWarning, errno) ->
+           | (uu___2, CWarning, errno) ->
                add_one
                  (mk_issue EWarning (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4109, CSilent, uu____4110) -> ()
-           | (uu____4111, CFatal, errno) ->
+           | (uu___2, CSilent, uu___3) -> ()
+           | (uu___2, CFatal, errno) ->
                let i =
                  mk_issue EError (FStar_Pervasives_Native.Some r) msg
                    (FStar_Pervasives_Native.Some errno) in
-               let uu____4114 = FStar_Options.ide () in
-               if uu____4114
+               let uu___3 = FStar_Options.ide () in
+               if uu___3
                then add_one i
                else
-                 (let uu____4116 =
-                    let uu____4117 = format_issue i in
+                 (let uu___5 =
+                    let uu___6 = format_issue i in
                     FStar_String.op_Hat
                       "don't use log_issue to report fatal error, should use raise_error: "
-                      uu____4117 in
-                  failwith uu____4116))
+                      uu___6 in
+                  failwith uu___5))
 let (add_errors :
   (raw_error * Prims.string * FStar_Range.range) Prims.list -> unit) =
   fun errs ->
     FStar_Util.atomically
-      (fun uu____4140 ->
+      (fun uu___ ->
          FStar_List.iter
-           (fun uu____4152 ->
-              match uu____4152 with
+           (fun uu___1 ->
+              match uu___1 with
               | (e, msg, r) ->
-                  let uu____4162 =
-                    let uu____4167 = message_prefix.append_prefixs msg in
-                    (e, uu____4167) in
-                  log_issue r uu____4162) errs)
+                  let uu___2 =
+                    let uu___3 = message_prefix.append_prefixs msg in
+                    (e, uu___3) in
+                  log_issue r uu___2) errs)
 let (issue_of_exn : Prims.exn -> issue FStar_Pervasives_Native.option) =
-  fun uu___0_4174 ->
-    match uu___0_4174 with
+  fun uu___ ->
+    match uu___ with
     | Error (e, msg, r) ->
-        let errno = let uu____4181 = lookup e in error_number uu____4181 in
-        let uu____4188 =
-          let uu____4189 = message_prefix.append_prefixs msg in
-          mk_issue EError (FStar_Pervasives_Native.Some r) uu____4189
+        let errno = let uu___1 = lookup e in error_number uu___1 in
+        let uu___1 =
+          let uu___2 = message_prefix.append_prefixs msg in
+          mk_issue EError (FStar_Pervasives_Native.Some r) uu___2
             (FStar_Pervasives_Native.Some errno) in
-        FStar_Pervasives_Native.Some uu____4188
+        FStar_Pervasives_Native.Some uu___1
     | Err (e, msg) ->
-        let errno = let uu____4193 = lookup e in error_number uu____4193 in
-        let uu____4200 =
-          let uu____4201 = message_prefix.append_prefixs msg in
-          mk_issue EError FStar_Pervasives_Native.None uu____4201
+        let errno = let uu___1 = lookup e in error_number uu___1 in
+        let uu___1 =
+          let uu___2 = message_prefix.append_prefixs msg in
+          mk_issue EError FStar_Pervasives_Native.None uu___2
             (FStar_Pervasives_Native.Some errno) in
-        FStar_Pervasives_Native.Some uu____4200
-    | uu____4202 -> FStar_Pervasives_Native.None
+        FStar_Pervasives_Native.Some uu___1
+    | uu___1 -> FStar_Pervasives_Native.None
 let (err_exn : Prims.exn -> unit) =
   fun exn ->
     if exn = Stop
     then ()
     else
-      (let uu____4209 = issue_of_exn exn in
-       match uu____4209 with
+      (let uu___1 = issue_of_exn exn in
+       match uu___1 with
        | FStar_Pervasives_Native.Some issue1 -> add_one issue1
        | FStar_Pervasives_Native.None -> FStar_Exn.raise exn)
 let (handleable : Prims.exn -> Prims.bool) =
-  fun uu___1_4217 ->
-    match uu___1_4217 with
-    | Error uu____4218 -> true
+  fun uu___ ->
+    match uu___ with
+    | Error uu___1 -> true
     | Stop -> true
-    | Err uu____4219 -> true
-    | uu____4224 -> false
+    | Err uu___1 -> true
+    | uu___1 -> false
 let (stop_if_err : unit -> unit) =
-  fun uu____4229 ->
-    let uu____4230 =
-      let uu____4231 = get_err_count () in uu____4231 > Prims.int_zero in
-    if uu____4230 then FStar_Exn.raise Stop else ()
+  fun uu___ ->
+    let uu___1 = let uu___2 = get_err_count () in uu___2 > Prims.int_zero in
+    if uu___1 then FStar_Exn.raise Stop else ()
 let raise_error :
-  'uuuuuu4239 .
-    (raw_error * Prims.string) -> FStar_Range.range -> 'uuuuuu4239
-  =
-  fun uu____4252 ->
+  'uuuuu . (raw_error * Prims.string) -> FStar_Range.range -> 'uuuuu =
+  fun uu___ ->
     fun r ->
-      match uu____4252 with | (e, msg) -> FStar_Exn.raise (Error (e, msg, r))
-let raise_err : 'uuuuuu4264 . (raw_error * Prims.string) -> 'uuuuuu4264 =
-  fun uu____4273 ->
-    match uu____4273 with | (e, msg) -> FStar_Exn.raise (Err (e, msg))
+      match uu___ with | (e, msg) -> FStar_Exn.raise (Error (e, msg, r))
+let raise_err : 'uuuuu . (raw_error * Prims.string) -> 'uuuuu =
+  fun uu___ -> match uu___ with | (e, msg) -> FStar_Exn.raise (Err (e, msg))
 let catch_errors :
   'a . (unit -> 'a) -> (issue Prims.list * 'a FStar_Pervasives_Native.option)
   =
@@ -2989,17 +2805,15 @@ let catch_errors :
     FStar_ST.op_Colon_Equals current_handler newh;
     (let r =
        try
-         (fun uu___355_4325 ->
+         (fun uu___1 ->
             match () with
-            | () -> let r = f () in FStar_Pervasives_Native.Some r) ()
-       with
-       | uu___354_4331 ->
-           (err_exn uu___354_4331; FStar_Pervasives_Native.None) in
+            | () -> let r1 = f () in FStar_Pervasives_Native.Some r1) ()
+       with | uu___1 -> (err_exn uu___1; FStar_Pervasives_Native.None) in
      let all_issues = newh.eh_report () in
      FStar_ST.op_Colon_Equals current_handler old;
-     (let uu____4345 =
+     (let uu___2 =
         FStar_List.partition (fun i -> i.issue_level = EError) all_issues in
-      match uu____4345 with
+      match uu___2 with
       | (errs, rest) -> (FStar_List.iter old.eh_add_one rest; (errs, r))))
 let (find_multiset_discrepancy :
   Prims.int Prims.list ->
@@ -3013,22 +2827,22 @@ let (find_multiset_discrepancy :
         match l with
         | [] -> []
         | hd::tl ->
-            let uu____4455 = collect tl in
-            (match uu____4455 with
+            let uu___ = collect tl in
+            (match uu___ with
              | [] -> [(hd, Prims.int_one)]
              | (h, n)::t ->
                  if h = hd
                  then (h, (n + Prims.int_one)) :: t
                  else (hd, Prims.int_one) :: (h, n) :: t) in
       let summ l = collect l in
-      let l11 = let uu____4535 = sort l1 in summ uu____4535 in
-      let l21 = let uu____4545 = sort l2 in summ uu____4545 in
+      let l11 = let uu___ = sort l1 in summ uu___ in
+      let l21 = let uu___ = sort l2 in summ uu___ in
       let rec aux l12 l22 =
         match (l12, l22) with
         | ([], []) -> FStar_Pervasives_Native.None
-        | ((e, n)::uu____4639, []) ->
+        | ((e, n)::uu___, []) ->
             FStar_Pervasives_Native.Some (e, n, Prims.int_zero)
-        | ([], (e, n)::uu____4674) ->
+        | ([], (e, n)::uu___) ->
             FStar_Pervasives_Native.Some (e, Prims.int_zero, n)
         | ((hd1, n1)::tl1, (hd2, n2)::tl2) ->
             if hd1 < hd2

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -142,8 +142,7 @@ and typ =
   | TTuple of typ Prims.list 
   | TConstBuf of typ 
 let (uu___is_DGlobal : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | DGlobal _0 -> true | uu____709 -> false
+  fun projectee -> match projectee with | DGlobal _0 -> true | uu___ -> false
 let (__proj__DGlobal__item___0 :
   decl ->
     (flag Prims.list * (Prims.string Prims.list * Prims.string) * Prims.int *
@@ -151,7 +150,7 @@ let (__proj__DGlobal__item___0 :
   = fun projectee -> match projectee with | DGlobal _0 -> _0
 let (uu___is_DFunction : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DFunction _0 -> true | uu____802 -> false
+    match projectee with | DFunction _0 -> true | uu___ -> false
 let (__proj__DFunction__item___0 :
   decl ->
     (cc FStar_Pervasives_Native.option * flag Prims.list * Prims.int * typ *
@@ -159,7 +158,7 @@ let (__proj__DFunction__item___0 :
   = fun projectee -> match projectee with | DFunction _0 -> _0
 let (uu___is_DTypeAlias : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DTypeAlias _0 -> true | uu____909 -> false
+    match projectee with | DTypeAlias _0 -> true | uu___ -> false
 let (__proj__DTypeAlias__item___0 :
   decl ->
     ((Prims.string Prims.list * Prims.string) * flag Prims.list * Prims.int *
@@ -167,7 +166,7 @@ let (__proj__DTypeAlias__item___0 :
   = fun projectee -> match projectee with | DTypeAlias _0 -> _0
 let (uu___is_DTypeFlat : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DTypeFlat _0 -> true | uu____996 -> false
+    match projectee with | DTypeFlat _0 -> true | uu___ -> false
 let (__proj__DTypeFlat__item___0 :
   decl ->
     ((Prims.string Prims.list * Prims.string) * flag Prims.list * Prims.int *
@@ -177,7 +176,7 @@ let (uu___is_DUnusedRetainedForBackwardsCompat : decl -> Prims.bool) =
   fun projectee ->
     match projectee with
     | DUnusedRetainedForBackwardsCompat _0 -> true
-    | uu____1105 -> false
+    | uu___ -> false
 let (__proj__DUnusedRetainedForBackwardsCompat__item___0 :
   decl ->
     (cc FStar_Pervasives_Native.option * flag Prims.list * (Prims.string
@@ -187,7 +186,7 @@ let (__proj__DUnusedRetainedForBackwardsCompat__item___0 :
     match projectee with | DUnusedRetainedForBackwardsCompat _0 -> _0
 let (uu___is_DTypeVariant : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DTypeVariant _0 -> true | uu____1204 -> false
+    match projectee with | DTypeVariant _0 -> true | uu___ -> false
 let (__proj__DTypeVariant__item___0 :
   decl ->
     ((Prims.string Prims.list * Prims.string) * flag Prims.list * Prims.int *
@@ -196,384 +195,336 @@ let (__proj__DTypeVariant__item___0 :
   = fun projectee -> match projectee with | DTypeVariant _0 -> _0
 let (uu___is_DTypeAbstractStruct : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | DTypeAbstractStruct _0 -> true
-    | uu____1319 -> false
+    match projectee with | DTypeAbstractStruct _0 -> true | uu___ -> false
 let (__proj__DTypeAbstractStruct__item___0 :
   decl -> (Prims.string Prims.list * Prims.string)) =
   fun projectee -> match projectee with | DTypeAbstractStruct _0 -> _0
 let (uu___is_DExternal : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DExternal _0 -> true | uu____1372 -> false
+    match projectee with | DExternal _0 -> true | uu___ -> false
 let (__proj__DExternal__item___0 :
   decl ->
     (cc FStar_Pervasives_Native.option * flag Prims.list * (Prims.string
       Prims.list * Prims.string) * typ * Prims.string Prims.list))
   = fun projectee -> match projectee with | DExternal _0 -> _0
 let (uu___is_StdCall : cc -> Prims.bool) =
-  fun projectee ->
-    match projectee with | StdCall -> true | uu____1450 -> false
+  fun projectee -> match projectee with | StdCall -> true | uu___ -> false
 let (uu___is_CDecl : cc -> Prims.bool) =
-  fun projectee -> match projectee with | CDecl -> true | uu____1456 -> false
+  fun projectee -> match projectee with | CDecl -> true | uu___ -> false
 let (uu___is_FastCall : cc -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FastCall -> true | uu____1462 -> false
+  fun projectee -> match projectee with | FastCall -> true | uu___ -> false
 let (uu___is_Private : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Private -> true | uu____1468 -> false
+  fun projectee -> match projectee with | Private -> true | uu___ -> false
 let (uu___is_WipeBody : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | WipeBody -> true | uu____1474 -> false
+  fun projectee -> match projectee with | WipeBody -> true | uu___ -> false
 let (uu___is_CInline : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CInline -> true | uu____1480 -> false
+  fun projectee -> match projectee with | CInline -> true | uu___ -> false
 let (uu___is_Substitute : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Substitute -> true | uu____1486 -> false
+  fun projectee -> match projectee with | Substitute -> true | uu___ -> false
 let (uu___is_GCType : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | GCType -> true | uu____1492 -> false
+  fun projectee -> match projectee with | GCType -> true | uu___ -> false
 let (uu___is_Comment : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Comment _0 -> true | uu____1499 -> false
+  fun projectee -> match projectee with | Comment _0 -> true | uu___ -> false
 let (__proj__Comment__item___0 : flag -> Prims.string) =
   fun projectee -> match projectee with | Comment _0 -> _0
 let (uu___is_MustDisappear : flag -> Prims.bool) =
   fun projectee ->
-    match projectee with | MustDisappear -> true | uu____1511 -> false
+    match projectee with | MustDisappear -> true | uu___ -> false
 let (uu___is_Const : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Const _0 -> true | uu____1518 -> false
+  fun projectee -> match projectee with | Const _0 -> true | uu___ -> false
 let (__proj__Const__item___0 : flag -> Prims.string) =
   fun projectee -> match projectee with | Const _0 -> _0
 let (uu___is_Prologue : flag -> Prims.bool) =
   fun projectee ->
-    match projectee with | Prologue _0 -> true | uu____1531 -> false
+    match projectee with | Prologue _0 -> true | uu___ -> false
 let (__proj__Prologue__item___0 : flag -> Prims.string) =
   fun projectee -> match projectee with | Prologue _0 -> _0
 let (uu___is_Epilogue : flag -> Prims.bool) =
   fun projectee ->
-    match projectee with | Epilogue _0 -> true | uu____1544 -> false
+    match projectee with | Epilogue _0 -> true | uu___ -> false
 let (__proj__Epilogue__item___0 : flag -> Prims.string) =
   fun projectee -> match projectee with | Epilogue _0 -> _0
 let (uu___is_Abstract : flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Abstract -> true | uu____1556 -> false
+  fun projectee -> match projectee with | Abstract -> true | uu___ -> false
 let (uu___is_IfDef : flag -> Prims.bool) =
-  fun projectee -> match projectee with | IfDef -> true | uu____1562 -> false
+  fun projectee -> match projectee with | IfDef -> true | uu___ -> false
 let (uu___is_Macro : flag -> Prims.bool) =
-  fun projectee -> match projectee with | Macro -> true | uu____1568 -> false
+  fun projectee -> match projectee with | Macro -> true | uu___ -> false
 let (uu___is_Deprecated : flag -> Prims.bool) =
   fun projectee ->
-    match projectee with | Deprecated _0 -> true | uu____1575 -> false
+    match projectee with | Deprecated _0 -> true | uu___ -> false
 let (__proj__Deprecated__item___0 : flag -> Prims.string) =
   fun projectee -> match projectee with | Deprecated _0 -> _0
 let (uu___is_Eternal : lifetime -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Eternal -> true | uu____1587 -> false
+  fun projectee -> match projectee with | Eternal -> true | uu___ -> false
 let (uu___is_Stack : lifetime -> Prims.bool) =
-  fun projectee -> match projectee with | Stack -> true | uu____1593 -> false
+  fun projectee -> match projectee with | Stack -> true | uu___ -> false
 let (uu___is_ManuallyManaged : lifetime -> Prims.bool) =
   fun projectee ->
-    match projectee with | ManuallyManaged -> true | uu____1599 -> false
+    match projectee with | ManuallyManaged -> true | uu___ -> false
 let (uu___is_EBound : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EBound _0 -> true | uu____1606 -> false
+  fun projectee -> match projectee with | EBound _0 -> true | uu___ -> false
 let (__proj__EBound__item___0 : expr -> Prims.int) =
   fun projectee -> match projectee with | EBound _0 -> _0
 let (uu___is_EQualified : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EQualified _0 -> true | uu____1625 -> false
+    match projectee with | EQualified _0 -> true | uu___ -> false
 let (__proj__EQualified__item___0 :
   expr -> (Prims.string Prims.list * Prims.string)) =
   fun projectee -> match projectee with | EQualified _0 -> _0
 let (uu___is_EConstant : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EConstant _0 -> true | uu____1660 -> false
+    match projectee with | EConstant _0 -> true | uu___ -> false
 let (__proj__EConstant__item___0 : expr -> (width * Prims.string)) =
   fun projectee -> match projectee with | EConstant _0 -> _0
 let (uu___is_EUnit : expr -> Prims.bool) =
-  fun projectee -> match projectee with | EUnit -> true | uu____1684 -> false
+  fun projectee -> match projectee with | EUnit -> true | uu___ -> false
 let (uu___is_EApp : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EApp _0 -> true | uu____1697 -> false
+  fun projectee -> match projectee with | EApp _0 -> true | uu___ -> false
 let (__proj__EApp__item___0 : expr -> (expr * expr Prims.list)) =
   fun projectee -> match projectee with | EApp _0 -> _0
 let (uu___is_ETypApp : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ETypApp _0 -> true | uu____1734 -> false
+  fun projectee -> match projectee with | ETypApp _0 -> true | uu___ -> false
 let (__proj__ETypApp__item___0 : expr -> (expr * typ Prims.list)) =
   fun projectee -> match projectee with | ETypApp _0 -> _0
 let (uu___is_ELet : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ELet _0 -> true | uu____1771 -> false
+  fun projectee -> match projectee with | ELet _0 -> true | uu___ -> false
 let (__proj__ELet__item___0 : expr -> (binder * expr * expr)) =
   fun projectee -> match projectee with | ELet _0 -> _0
 let (uu___is_EIfThenElse : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EIfThenElse _0 -> true | uu____1808 -> false
+    match projectee with | EIfThenElse _0 -> true | uu___ -> false
 let (__proj__EIfThenElse__item___0 : expr -> (expr * expr * expr)) =
   fun projectee -> match projectee with | EIfThenElse _0 -> _0
 let (uu___is_ESequence : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | ESequence _0 -> true | uu____1841 -> false
+    match projectee with | ESequence _0 -> true | uu___ -> false
 let (__proj__ESequence__item___0 : expr -> expr Prims.list) =
   fun projectee -> match projectee with | ESequence _0 -> _0
 let (uu___is_EAssign : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EAssign _0 -> true | uu____1864 -> false
+  fun projectee -> match projectee with | EAssign _0 -> true | uu___ -> false
 let (__proj__EAssign__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EAssign _0 -> _0
 let (uu___is_EBufCreate : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufCreate _0 -> true | uu____1895 -> false
+    match projectee with | EBufCreate _0 -> true | uu___ -> false
 let (__proj__EBufCreate__item___0 : expr -> (lifetime * expr * expr)) =
   fun projectee -> match projectee with | EBufCreate _0 -> _0
 let (uu___is_EBufRead : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufRead _0 -> true | uu____1930 -> false
+    match projectee with | EBufRead _0 -> true | uu___ -> false
 let (__proj__EBufRead__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EBufRead _0 -> _0
 let (uu___is_EBufWrite : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufWrite _0 -> true | uu____1961 -> false
+    match projectee with | EBufWrite _0 -> true | uu___ -> false
 let (__proj__EBufWrite__item___0 : expr -> (expr * expr * expr)) =
   fun projectee -> match projectee with | EBufWrite _0 -> _0
 let (uu___is_EBufSub : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EBufSub _0 -> true | uu____1996 -> false
+  fun projectee -> match projectee with | EBufSub _0 -> true | uu___ -> false
 let (__proj__EBufSub__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EBufSub _0 -> _0
 let (uu___is_EBufBlit : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufBlit _0 -> true | uu____2031 -> false
+    match projectee with | EBufBlit _0 -> true | uu___ -> false
 let (__proj__EBufBlit__item___0 : expr -> (expr * expr * expr * expr * expr))
   = fun projectee -> match projectee with | EBufBlit _0 -> _0
 let (uu___is_EMatch : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EMatch _0 -> true | uu____2084 -> false
+  fun projectee -> match projectee with | EMatch _0 -> true | uu___ -> false
 let (__proj__EMatch__item___0 : expr -> (expr * (pattern * expr) Prims.list))
   = fun projectee -> match projectee with | EMatch _0 -> _0
 let (uu___is_EOp : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EOp _0 -> true | uu____2131 -> false
+  fun projectee -> match projectee with | EOp _0 -> true | uu___ -> false
 let (__proj__EOp__item___0 : expr -> (op * width)) =
   fun projectee -> match projectee with | EOp _0 -> _0
 let (uu___is_ECast : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ECast _0 -> true | uu____2160 -> false
+  fun projectee -> match projectee with | ECast _0 -> true | uu___ -> false
 let (__proj__ECast__item___0 : expr -> (expr * typ)) =
   fun projectee -> match projectee with | ECast _0 -> _0
 let (uu___is_EPushFrame : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EPushFrame -> true | uu____2184 -> false
+  fun projectee -> match projectee with | EPushFrame -> true | uu___ -> false
 let (uu___is_EPopFrame : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EPopFrame -> true | uu____2190 -> false
+  fun projectee -> match projectee with | EPopFrame -> true | uu___ -> false
 let (uu___is_EBool : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EBool _0 -> true | uu____2197 -> false
+  fun projectee -> match projectee with | EBool _0 -> true | uu___ -> false
 let (__proj__EBool__item___0 : expr -> Prims.bool) =
   fun projectee -> match projectee with | EBool _0 -> _0
 let (uu___is_EAny : expr -> Prims.bool) =
-  fun projectee -> match projectee with | EAny -> true | uu____2209 -> false
+  fun projectee -> match projectee with | EAny -> true | uu___ -> false
 let (uu___is_EAbort : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EAbort -> true | uu____2215 -> false
+  fun projectee -> match projectee with | EAbort -> true | uu___ -> false
 let (uu___is_EReturn : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EReturn _0 -> true | uu____2222 -> false
+  fun projectee -> match projectee with | EReturn _0 -> true | uu___ -> false
 let (__proj__EReturn__item___0 : expr -> expr) =
   fun projectee -> match projectee with | EReturn _0 -> _0
 let (uu___is_EFlat : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EFlat _0 -> true | uu____2245 -> false
+  fun projectee -> match projectee with | EFlat _0 -> true | uu___ -> false
 let (__proj__EFlat__item___0 :
   expr -> (typ * (Prims.string * expr) Prims.list)) =
   fun projectee -> match projectee with | EFlat _0 -> _0
 let (uu___is_EField : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EField _0 -> true | uu____2294 -> false
+  fun projectee -> match projectee with | EField _0 -> true | uu___ -> false
 let (__proj__EField__item___0 : expr -> (typ * expr * Prims.string)) =
   fun projectee -> match projectee with | EField _0 -> _0
 let (uu___is_EWhile : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EWhile _0 -> true | uu____2329 -> false
+  fun projectee -> match projectee with | EWhile _0 -> true | uu___ -> false
 let (__proj__EWhile__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EWhile _0 -> _0
 let (uu___is_EBufCreateL : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufCreateL _0 -> true | uu____2360 -> false
+    match projectee with | EBufCreateL _0 -> true | uu___ -> false
 let (__proj__EBufCreateL__item___0 : expr -> (lifetime * expr Prims.list)) =
   fun projectee -> match projectee with | EBufCreateL _0 -> _0
 let (uu___is_ETuple : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ETuple _0 -> true | uu____2393 -> false
+  fun projectee -> match projectee with | ETuple _0 -> true | uu___ -> false
 let (__proj__ETuple__item___0 : expr -> expr Prims.list) =
   fun projectee -> match projectee with | ETuple _0 -> _0
 let (uu___is_ECons : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ECons _0 -> true | uu____2420 -> false
+  fun projectee -> match projectee with | ECons _0 -> true | uu___ -> false
 let (__proj__ECons__item___0 :
   expr -> (typ * Prims.string * expr Prims.list)) =
   fun projectee -> match projectee with | ECons _0 -> _0
 let (uu___is_EBufFill : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufFill _0 -> true | uu____2463 -> false
+    match projectee with | EBufFill _0 -> true | uu___ -> false
 let (__proj__EBufFill__item___0 : expr -> (expr * expr * expr)) =
   fun projectee -> match projectee with | EBufFill _0 -> _0
 let (uu___is_EString : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EString _0 -> true | uu____2494 -> false
+  fun projectee -> match projectee with | EString _0 -> true | uu___ -> false
 let (__proj__EString__item___0 : expr -> Prims.string) =
   fun projectee -> match projectee with | EString _0 -> _0
 let (uu___is_EFun : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EFun _0 -> true | uu____2515 -> false
+  fun projectee -> match projectee with | EFun _0 -> true | uu___ -> false
 let (__proj__EFun__item___0 : expr -> (binder Prims.list * expr * typ)) =
   fun projectee -> match projectee with | EFun _0 -> _0
 let (uu___is_EAbortS : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EAbortS _0 -> true | uu____2552 -> false
+  fun projectee -> match projectee with | EAbortS _0 -> true | uu___ -> false
 let (__proj__EAbortS__item___0 : expr -> Prims.string) =
   fun projectee -> match projectee with | EAbortS _0 -> _0
 let (uu___is_EBufFree : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufFree _0 -> true | uu____2565 -> false
+    match projectee with | EBufFree _0 -> true | uu___ -> false
 let (__proj__EBufFree__item___0 : expr -> expr) =
   fun projectee -> match projectee with | EBufFree _0 -> _0
 let (uu___is_EBufCreateNoInit : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EBufCreateNoInit _0 -> true | uu____2582 -> false
+    match projectee with | EBufCreateNoInit _0 -> true | uu___ -> false
 let (__proj__EBufCreateNoInit__item___0 : expr -> (lifetime * expr)) =
   fun projectee -> match projectee with | EBufCreateNoInit _0 -> _0
 let (uu___is_EAbortT : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EAbortT _0 -> true | uu____2611 -> false
+  fun projectee -> match projectee with | EAbortT _0 -> true | uu___ -> false
 let (__proj__EAbortT__item___0 : expr -> (Prims.string * typ)) =
   fun projectee -> match projectee with | EAbortT _0 -> _0
 let (uu___is_EComment : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with | EComment _0 -> true | uu____2642 -> false
+    match projectee with | EComment _0 -> true | uu___ -> false
 let (__proj__EComment__item___0 :
   expr -> (Prims.string * expr * Prims.string)) =
   fun projectee -> match projectee with | EComment _0 -> _0
 let (uu___is_EStandaloneComment : expr -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | EStandaloneComment _0 -> true
-    | uu____2673 -> false
+    match projectee with | EStandaloneComment _0 -> true | uu___ -> false
 let (__proj__EStandaloneComment__item___0 : expr -> Prims.string) =
   fun projectee -> match projectee with | EStandaloneComment _0 -> _0
 let (uu___is_Add : op -> Prims.bool) =
-  fun projectee -> match projectee with | Add -> true | uu____2685 -> false
+  fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_AddW : op -> Prims.bool) =
-  fun projectee -> match projectee with | AddW -> true | uu____2691 -> false
+  fun projectee -> match projectee with | AddW -> true | uu___ -> false
 let (uu___is_Sub : op -> Prims.bool) =
-  fun projectee -> match projectee with | Sub -> true | uu____2697 -> false
+  fun projectee -> match projectee with | Sub -> true | uu___ -> false
 let (uu___is_SubW : op -> Prims.bool) =
-  fun projectee -> match projectee with | SubW -> true | uu____2703 -> false
+  fun projectee -> match projectee with | SubW -> true | uu___ -> false
 let (uu___is_Div : op -> Prims.bool) =
-  fun projectee -> match projectee with | Div -> true | uu____2709 -> false
+  fun projectee -> match projectee with | Div -> true | uu___ -> false
 let (uu___is_DivW : op -> Prims.bool) =
-  fun projectee -> match projectee with | DivW -> true | uu____2715 -> false
+  fun projectee -> match projectee with | DivW -> true | uu___ -> false
 let (uu___is_Mult : op -> Prims.bool) =
-  fun projectee -> match projectee with | Mult -> true | uu____2721 -> false
+  fun projectee -> match projectee with | Mult -> true | uu___ -> false
 let (uu___is_MultW : op -> Prims.bool) =
-  fun projectee -> match projectee with | MultW -> true | uu____2727 -> false
+  fun projectee -> match projectee with | MultW -> true | uu___ -> false
 let (uu___is_Mod : op -> Prims.bool) =
-  fun projectee -> match projectee with | Mod -> true | uu____2733 -> false
+  fun projectee -> match projectee with | Mod -> true | uu___ -> false
 let (uu___is_BOr : op -> Prims.bool) =
-  fun projectee -> match projectee with | BOr -> true | uu____2739 -> false
+  fun projectee -> match projectee with | BOr -> true | uu___ -> false
 let (uu___is_BAnd : op -> Prims.bool) =
-  fun projectee -> match projectee with | BAnd -> true | uu____2745 -> false
+  fun projectee -> match projectee with | BAnd -> true | uu___ -> false
 let (uu___is_BXor : op -> Prims.bool) =
-  fun projectee -> match projectee with | BXor -> true | uu____2751 -> false
+  fun projectee -> match projectee with | BXor -> true | uu___ -> false
 let (uu___is_BShiftL : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BShiftL -> true | uu____2757 -> false
+  fun projectee -> match projectee with | BShiftL -> true | uu___ -> false
 let (uu___is_BShiftR : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BShiftR -> true | uu____2763 -> false
+  fun projectee -> match projectee with | BShiftR -> true | uu___ -> false
 let (uu___is_BNot : op -> Prims.bool) =
-  fun projectee -> match projectee with | BNot -> true | uu____2769 -> false
+  fun projectee -> match projectee with | BNot -> true | uu___ -> false
 let (uu___is_Eq : op -> Prims.bool) =
-  fun projectee -> match projectee with | Eq -> true | uu____2775 -> false
+  fun projectee -> match projectee with | Eq -> true | uu___ -> false
 let (uu___is_Neq : op -> Prims.bool) =
-  fun projectee -> match projectee with | Neq -> true | uu____2781 -> false
+  fun projectee -> match projectee with | Neq -> true | uu___ -> false
 let (uu___is_Lt : op -> Prims.bool) =
-  fun projectee -> match projectee with | Lt -> true | uu____2787 -> false
+  fun projectee -> match projectee with | Lt -> true | uu___ -> false
 let (uu___is_Lte : op -> Prims.bool) =
-  fun projectee -> match projectee with | Lte -> true | uu____2793 -> false
+  fun projectee -> match projectee with | Lte -> true | uu___ -> false
 let (uu___is_Gt : op -> Prims.bool) =
-  fun projectee -> match projectee with | Gt -> true | uu____2799 -> false
+  fun projectee -> match projectee with | Gt -> true | uu___ -> false
 let (uu___is_Gte : op -> Prims.bool) =
-  fun projectee -> match projectee with | Gte -> true | uu____2805 -> false
+  fun projectee -> match projectee with | Gte -> true | uu___ -> false
 let (uu___is_And : op -> Prims.bool) =
-  fun projectee -> match projectee with | And -> true | uu____2811 -> false
+  fun projectee -> match projectee with | And -> true | uu___ -> false
 let (uu___is_Or : op -> Prims.bool) =
-  fun projectee -> match projectee with | Or -> true | uu____2817 -> false
+  fun projectee -> match projectee with | Or -> true | uu___ -> false
 let (uu___is_Xor : op -> Prims.bool) =
-  fun projectee -> match projectee with | Xor -> true | uu____2823 -> false
+  fun projectee -> match projectee with | Xor -> true | uu___ -> false
 let (uu___is_Not : op -> Prims.bool) =
-  fun projectee -> match projectee with | Not -> true | uu____2829 -> false
+  fun projectee -> match projectee with | Not -> true | uu___ -> false
 let (uu___is_PUnit : pattern -> Prims.bool) =
-  fun projectee -> match projectee with | PUnit -> true | uu____2835 -> false
+  fun projectee -> match projectee with | PUnit -> true | uu___ -> false
 let (uu___is_PBool : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PBool _0 -> true | uu____2842 -> false
+  fun projectee -> match projectee with | PBool _0 -> true | uu___ -> false
 let (__proj__PBool__item___0 : pattern -> Prims.bool) =
   fun projectee -> match projectee with | PBool _0 -> _0
 let (uu___is_PVar : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PVar _0 -> true | uu____2855 -> false
+  fun projectee -> match projectee with | PVar _0 -> true | uu___ -> false
 let (__proj__PVar__item___0 : pattern -> binder) =
   fun projectee -> match projectee with | PVar _0 -> _0
 let (uu___is_PCons : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PCons _0 -> true | uu____2874 -> false
+  fun projectee -> match projectee with | PCons _0 -> true | uu___ -> false
 let (__proj__PCons__item___0 :
   pattern -> (Prims.string * pattern Prims.list)) =
   fun projectee -> match projectee with | PCons _0 -> _0
 let (uu___is_PTuple : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PTuple _0 -> true | uu____2907 -> false
+  fun projectee -> match projectee with | PTuple _0 -> true | uu___ -> false
 let (__proj__PTuple__item___0 : pattern -> pattern Prims.list) =
   fun projectee -> match projectee with | PTuple _0 -> _0
 let (uu___is_PRecord : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PRecord _0 -> true | uu____2932 -> false
+  fun projectee -> match projectee with | PRecord _0 -> true | uu___ -> false
 let (__proj__PRecord__item___0 :
   pattern -> (Prims.string * pattern) Prims.list) =
   fun projectee -> match projectee with | PRecord _0 -> _0
 let (uu___is_PConstant : pattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | PConstant _0 -> true | uu____2967 -> false
+    match projectee with | PConstant _0 -> true | uu___ -> false
 let (__proj__PConstant__item___0 : pattern -> (width * Prims.string)) =
   fun projectee -> match projectee with | PConstant _0 -> _0
 let (uu___is_UInt8 : width -> Prims.bool) =
-  fun projectee -> match projectee with | UInt8 -> true | uu____2991 -> false
+  fun projectee -> match projectee with | UInt8 -> true | uu___ -> false
 let (uu___is_UInt16 : width -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UInt16 -> true | uu____2997 -> false
+  fun projectee -> match projectee with | UInt16 -> true | uu___ -> false
 let (uu___is_UInt32 : width -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UInt32 -> true | uu____3003 -> false
+  fun projectee -> match projectee with | UInt32 -> true | uu___ -> false
 let (uu___is_UInt64 : width -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UInt64 -> true | uu____3009 -> false
+  fun projectee -> match projectee with | UInt64 -> true | uu___ -> false
 let (uu___is_Int8 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int8 -> true | uu____3015 -> false
+  fun projectee -> match projectee with | Int8 -> true | uu___ -> false
 let (uu___is_Int16 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int16 -> true | uu____3021 -> false
+  fun projectee -> match projectee with | Int16 -> true | uu___ -> false
 let (uu___is_Int32 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int32 -> true | uu____3027 -> false
+  fun projectee -> match projectee with | Int32 -> true | uu___ -> false
 let (uu___is_Int64 : width -> Prims.bool) =
-  fun projectee -> match projectee with | Int64 -> true | uu____3033 -> false
+  fun projectee -> match projectee with | Int64 -> true | uu___ -> false
 let (uu___is_Bool : width -> Prims.bool) =
-  fun projectee -> match projectee with | Bool -> true | uu____3039 -> false
+  fun projectee -> match projectee with | Bool -> true | uu___ -> false
 let (uu___is_CInt : width -> Prims.bool) =
-  fun projectee -> match projectee with | CInt -> true | uu____3045 -> false
+  fun projectee -> match projectee with | CInt -> true | uu___ -> false
 let (__proj__Mkbinder__item__name : binder -> Prims.string) =
   fun projectee -> match projectee with | { name; typ = typ1; mut;_} -> name
 let (__proj__Mkbinder__item__typ : binder -> typ) =
@@ -581,51 +532,45 @@ let (__proj__Mkbinder__item__typ : binder -> typ) =
 let (__proj__Mkbinder__item__mut : binder -> Prims.bool) =
   fun projectee -> match projectee with | { name; typ = typ1; mut;_} -> mut
 let (uu___is_TInt : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TInt _0 -> true | uu____3076 -> false
+  fun projectee -> match projectee with | TInt _0 -> true | uu___ -> false
 let (__proj__TInt__item___0 : typ -> width) =
   fun projectee -> match projectee with | TInt _0 -> _0
 let (uu___is_TBuf : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TBuf _0 -> true | uu____3089 -> false
+  fun projectee -> match projectee with | TBuf _0 -> true | uu___ -> false
 let (__proj__TBuf__item___0 : typ -> typ) =
   fun projectee -> match projectee with | TBuf _0 -> _0
 let (uu___is_TUnit : typ -> Prims.bool) =
-  fun projectee -> match projectee with | TUnit -> true | uu____3101 -> false
+  fun projectee -> match projectee with | TUnit -> true | uu___ -> false
 let (uu___is_TQualified : typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | TQualified _0 -> true | uu____3114 -> false
+    match projectee with | TQualified _0 -> true | uu___ -> false
 let (__proj__TQualified__item___0 :
   typ -> (Prims.string Prims.list * Prims.string)) =
   fun projectee -> match projectee with | TQualified _0 -> _0
 let (uu___is_TBool : typ -> Prims.bool) =
-  fun projectee -> match projectee with | TBool -> true | uu____3144 -> false
+  fun projectee -> match projectee with | TBool -> true | uu___ -> false
 let (uu___is_TAny : typ -> Prims.bool) =
-  fun projectee -> match projectee with | TAny -> true | uu____3150 -> false
+  fun projectee -> match projectee with | TAny -> true | uu___ -> false
 let (uu___is_TArrow : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TArrow _0 -> true | uu____3161 -> false
+  fun projectee -> match projectee with | TArrow _0 -> true | uu___ -> false
 let (__proj__TArrow__item___0 : typ -> (typ * typ)) =
   fun projectee -> match projectee with | TArrow _0 -> _0
 let (uu___is_TBound : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TBound _0 -> true | uu____3186 -> false
+  fun projectee -> match projectee with | TBound _0 -> true | uu___ -> false
 let (__proj__TBound__item___0 : typ -> Prims.int) =
   fun projectee -> match projectee with | TBound _0 -> _0
 let (uu___is_TApp : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TApp _0 -> true | uu____3211 -> false
+  fun projectee -> match projectee with | TApp _0 -> true | uu___ -> false
 let (__proj__TApp__item___0 :
   typ -> ((Prims.string Prims.list * Prims.string) * typ Prims.list)) =
   fun projectee -> match projectee with | TApp _0 -> _0
 let (uu___is_TTuple : typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TTuple _0 -> true | uu____3262 -> false
+  fun projectee -> match projectee with | TTuple _0 -> true | uu___ -> false
 let (__proj__TTuple__item___0 : typ -> typ Prims.list) =
   fun projectee -> match projectee with | TTuple _0 -> _0
 let (uu___is_TConstBuf : typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | TConstBuf _0 -> true | uu____3281 -> false
+    match projectee with | TConstBuf _0 -> true | uu___ -> false
 let (__proj__TConstBuf__item___0 : typ -> typ) =
   fun projectee -> match projectee with | TConstBuf _0 -> _0
 type program = decl Prims.list
@@ -643,24 +588,15 @@ type version = Prims.int
 let (current_version : version) = (Prims.of_int (28))
 type file = (Prims.string * program)
 type binary_format = (version * file Prims.list)
-let fst3 :
-  'uuuuuu3354 'uuuuuu3355 'uuuuuu3356 .
-    ('uuuuuu3354 * 'uuuuuu3355 * 'uuuuuu3356) -> 'uuuuuu3354
-  =
-  fun uu____3367 -> match uu____3367 with | (x, uu____3375, uu____3376) -> x
-let snd3 :
-  'uuuuuu3385 'uuuuuu3386 'uuuuuu3387 .
-    ('uuuuuu3385 * 'uuuuuu3386 * 'uuuuuu3387) -> 'uuuuuu3386
-  =
-  fun uu____3398 -> match uu____3398 with | (uu____3405, x, uu____3407) -> x
-let thd3 :
-  'uuuuuu3416 'uuuuuu3417 'uuuuuu3418 .
-    ('uuuuuu3416 * 'uuuuuu3417 * 'uuuuuu3418) -> 'uuuuuu3418
-  =
-  fun uu____3429 -> match uu____3429 with | (uu____3436, uu____3437, x) -> x
+let fst3 : 'uuuuu 'uuuuu1 'uuuuu2 . ('uuuuu * 'uuuuu1 * 'uuuuu2) -> 'uuuuu =
+  fun uu___ -> match uu___ with | (x, uu___1, uu___2) -> x
+let snd3 : 'uuuuu 'uuuuu1 'uuuuu2 . ('uuuuu * 'uuuuu1 * 'uuuuu2) -> 'uuuuu1 =
+  fun uu___ -> match uu___ with | (uu___1, x, uu___2) -> x
+let thd3 : 'uuuuu 'uuuuu1 'uuuuu2 . ('uuuuu * 'uuuuu1 * 'uuuuu2) -> 'uuuuu2 =
+  fun uu___ -> match uu___ with | (uu___1, uu___2, x) -> x
 let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
-  fun uu___0_3445 ->
-    match uu___0_3445 with
+  fun uu___ ->
+    match uu___ with
     | "UInt8" -> FStar_Pervasives_Native.Some UInt8
     | "UInt16" -> FStar_Pervasives_Native.Some UInt16
     | "UInt32" -> FStar_Pervasives_Native.Some UInt32
@@ -669,21 +605,21 @@ let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
     | "Int16" -> FStar_Pervasives_Native.Some Int16
     | "Int32" -> FStar_Pervasives_Native.Some Int32
     | "Int64" -> FStar_Pervasives_Native.Some Int64
-    | uu____3448 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let (mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option) =
-  fun uu___1_3455 ->
-    match uu___1_3455 with
+  fun uu___ ->
+    match uu___ with
     | "op_Negation" -> FStar_Pervasives_Native.Some Not
     | "op_AmpAmp" -> FStar_Pervasives_Native.Some And
     | "op_BarBar" -> FStar_Pervasives_Native.Some Or
     | "op_Equality" -> FStar_Pervasives_Native.Some Eq
     | "op_disEquality" -> FStar_Pervasives_Native.Some Neq
-    | uu____3458 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_bool_op : Prims.string -> Prims.bool) =
   fun op1 -> (mk_bool_op op1) <> FStar_Pervasives_Native.None
 let (mk_op : Prims.string -> op FStar_Pervasives_Native.option) =
-  fun uu___2_3472 ->
-    match uu___2_3472 with
+  fun uu___ ->
+    match uu___ with
     | "add" -> FStar_Pervasives_Native.Some Add
     | "op_Plus_Hat" -> FStar_Pervasives_Native.Some Add
     | "add_underspec" -> FStar_Pervasives_Native.Some Add
@@ -725,7 +661,7 @@ let (mk_op : Prims.string -> op FStar_Pervasives_Native.option) =
     | "lt" -> FStar_Pervasives_Native.Some Lt
     | "op_Less_Equals_Hat" -> FStar_Pervasives_Native.Some Lte
     | "lte" -> FStar_Pervasives_Native.Some Lte
-    | uu____3475 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_op : Prims.string -> Prims.bool) =
   fun op1 -> (mk_op op1) <> FStar_Pervasives_Native.None
 let (is_machine_int : Prims.string -> Prims.bool) =
@@ -753,27 +689,27 @@ let (empty : Prims.string Prims.list -> env) =
 let (extend : env -> Prims.string -> env) =
   fun env1 ->
     fun x ->
-      let uu___168_3595 = env1 in
+      let uu___ = env1 in
       {
         names = ({ pretty = x } :: (env1.names));
-        names_t = (uu___168_3595.names_t);
-        module_name = (uu___168_3595.module_name)
+        names_t = (uu___.names_t);
+        module_name = (uu___.module_name)
       }
 let (extend_t : env -> Prims.string -> env) =
   fun env1 ->
     fun x ->
-      let uu___172_3606 = env1 in
+      let uu___ = env1 in
       {
-        names = (uu___172_3606.names);
+        names = (uu___.names);
         names_t = (x :: (env1.names_t));
-        module_name = (uu___172_3606.module_name)
+        module_name = (uu___.module_name)
       }
 let (find_name : env -> Prims.string -> name) =
   fun env1 ->
     fun x ->
-      let uu____3617 =
+      let uu___ =
         FStar_List.tryFind (fun name1 -> name1.pretty = x) env1.names in
-      match uu____3617 with
+      match uu___ with
       | FStar_Pervasives_Native.Some name1 -> name1
       | FStar_Pervasives_Native.None ->
           failwith "internal error: name not found"
@@ -781,60 +717,60 @@ let (find : env -> Prims.string -> Prims.int) =
   fun env1 ->
     fun x ->
       try
-        (fun uu___183_3634 ->
+        (fun uu___ ->
            match () with
            | () ->
                FStar_List.index (fun name1 -> name1.pretty = x) env1.names)
           ()
       with
-      | uu___182_3639 ->
-          let uu____3640 =
+      | uu___ ->
+          let uu___1 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____3640
+          failwith uu___1
 let (find_t : env -> Prims.string -> Prims.int) =
   fun env1 ->
     fun x ->
       try
-        (fun uu___192_3652 ->
+        (fun uu___ ->
            match () with
            | () -> FStar_List.index (fun name1 -> name1 = x) env1.names_t) ()
       with
-      | uu___191_3657 ->
-          let uu____3658 =
+      | uu___ ->
+          let uu___1 =
             FStar_Util.format1 "Internal error: name not found %s\n" x in
-          failwith uu____3658
-let add_binders :
-  'uuuuuu3665 . env -> (Prims.string * 'uuuuuu3665) Prims.list -> env =
+          failwith uu___1
+let add_binders : 'uuuuu . env -> (Prims.string * 'uuuuu) Prims.list -> env =
   fun env1 ->
     fun binders ->
       FStar_List.fold_left
         (fun env2 ->
-           fun uu____3697 ->
-             match uu____3697 with | (name1, uu____3703) -> extend env2 name1)
-        env1 binders
+           fun uu___ ->
+             match uu___ with | (name1, uu___1) -> extend env2 name1) env1
+        binders
 let (list_elements :
   FStar_Extraction_ML_Syntax.mlexpr ->
     FStar_Extraction_ML_Syntax.mlexpr Prims.list)
   =
   fun e2 ->
-    let rec list_elements acc e21 =
+    let rec list_elements1 acc e21 =
       match e21.FStar_Extraction_ML_Syntax.expr with
       | FStar_Extraction_ML_Syntax.MLE_CTor
-          (("Prims"::[], "Cons"), hd::tl::[]) -> list_elements (hd :: acc) tl
+          (("Prims"::[], "Cons"), hd::tl::[]) ->
+          list_elements1 (hd :: acc) tl
       | FStar_Extraction_ML_Syntax.MLE_CTor (("Prims"::[], "Nil"), []) ->
           FStar_List.rev acc
-      | uu____3740 ->
+      | uu___ ->
           failwith "Argument of FStar.Buffer.createL is not a list literal!" in
-    list_elements [] e2
+    list_elements1 [] e2
 let rec (translate_module :
   (FStar_Extraction_ML_Syntax.mlpath * (FStar_Extraction_ML_Syntax.mlsig *
     FStar_Extraction_ML_Syntax.mlmodule) FStar_Pervasives_Native.option *
     FStar_Extraction_ML_Syntax.mllib) -> file)
   =
   fun m ->
-    let uu____3962 = m in
-    match uu____3962 with
-    | (module_name, modul, uu____3977) ->
+    let uu___ = m in
+    match uu___ with
+    | (module_name, modul, uu___1) ->
         let module_name1 =
           FStar_List.append (FStar_Pervasives_Native.fst module_name)
             [FStar_Pervasives_Native.snd module_name] in
@@ -842,15 +778,15 @@ let rec (translate_module :
           match modul with
           | FStar_Pervasives_Native.Some (_signature, decls) ->
               FStar_List.collect (translate_decl (empty module_name1)) decls
-          | uu____4004 ->
+          | uu___2 ->
               failwith "Unexpected standalone interface or nested modules" in
         ((FStar_String.concat "_" module_name1), program1)
 and (translate_flags :
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list) =
   fun flags ->
     FStar_List.choose
-      (fun uu___3_4015 ->
-         match uu___3_4015 with
+      (fun uu___ ->
+         match uu___ with
          | FStar_Extraction_ML_Syntax.Private ->
              FStar_Pervasives_Native.Some Private
          | FStar_Extraction_ML_Syntax.NoExtract ->
@@ -879,24 +815,24 @@ and (translate_flags :
              FStar_Pervasives_Native.Some Macro
          | FStar_Extraction_ML_Syntax.Deprecated s ->
              FStar_Pervasives_Native.Some (Deprecated s)
-         | uu____4023 -> FStar_Pervasives_Native.None) flags
+         | uu___1 -> FStar_Pervasives_Native.None) flags
 and (translate_cc :
   FStar_Extraction_ML_Syntax.meta Prims.list ->
     cc FStar_Pervasives_Native.option)
   =
   fun flags ->
-    let uu____4027 =
+    let uu___ =
       FStar_List.choose
-        (fun uu___4_4032 ->
-           match uu___4_4032 with
+        (fun uu___1 ->
+           match uu___1 with
            | FStar_Extraction_ML_Syntax.CCConv s ->
                FStar_Pervasives_Native.Some s
-           | uu____4036 -> FStar_Pervasives_Native.None) flags in
-    match uu____4027 with
+           | uu___2 -> FStar_Pervasives_Native.None) flags in
+    match uu___ with
     | "stdcall"::[] -> FStar_Pervasives_Native.Some StdCall
     | "fastcall"::[] -> FStar_Pervasives_Native.Some FastCall
     | "cdecl"::[] -> FStar_Pervasives_Native.Some CDecl
-    | uu____4039 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 and (translate_decl :
   env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list) =
   fun env1 ->
@@ -904,12 +840,12 @@ and (translate_decl :
       match d with
       | FStar_Extraction_ML_Syntax.MLM_Let (flavor, lbs) ->
           FStar_List.choose (translate_let env1 flavor) lbs
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu____4052 -> []
+      | FStar_Extraction_ML_Syntax.MLM_Loc uu___ -> []
       | FStar_Extraction_ML_Syntax.MLM_Ty tys ->
           FStar_List.choose (translate_type_decl env1) tys
-      | FStar_Extraction_ML_Syntax.MLM_Top uu____4054 ->
+      | FStar_Extraction_ML_Syntax.MLM_Top uu___ ->
           failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn (m, uu____4058) ->
+      | FStar_Extraction_ML_Syntax.MLM_Exn (m, uu___) ->
           (FStar_Util.print1_warning
              "Not extracting exception %s to KreMLin (exceptions unsupported)\n"
              m;
@@ -926,51 +862,51 @@ and (translate_let :
         | { FStar_Extraction_ML_Syntax.mllb_name = name1;
             FStar_Extraction_ML_Syntax.mllb_tysc =
               FStar_Pervasives_Native.Some (tvars, t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____4080;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
             FStar_Extraction_ML_Syntax.mllb_def = e;
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu____4083;_} when
+            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} when
             FStar_Util.for_some
-              (fun uu___5_4085 ->
-                 match uu___5_4085 with
+              (fun uu___2 ->
+                 match uu___2 with
                  | FStar_Extraction_ML_Syntax.Assumed -> true
-                 | uu____4086 -> false) meta
+                 | uu___3 -> false) meta
             ->
             let name2 = ((env1.module_name), name1) in
             let arg_names =
               match e.FStar_Extraction_ML_Syntax.expr with
-              | FStar_Extraction_ML_Syntax.MLE_Fun (args, uu____4102) ->
+              | FStar_Extraction_ML_Syntax.MLE_Fun (args, uu___2) ->
                   FStar_List.map FStar_Pervasives_Native.fst args
-              | uu____4119 -> [] in
+              | uu___2 -> [] in
             if (FStar_List.length tvars) = Prims.int_zero
             then
-              let uu____4122 =
-                let uu____4123 =
-                  let uu____4146 = translate_cc meta in
-                  let uu____4149 = translate_flags meta in
-                  let uu____4152 = translate_type env1 t0 in
-                  (uu____4146, uu____4149, name2, uu____4152, arg_names) in
-                DExternal uu____4123 in
-              FStar_Pervasives_Native.Some uu____4122
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = translate_cc meta in
+                  let uu___5 = translate_flags meta in
+                  let uu___6 = translate_type env1 t0 in
+                  (uu___4, uu___5, name2, uu___6, arg_names) in
+                DExternal uu___3 in
+              FStar_Pervasives_Native.Some uu___2
             else
-              ((let uu____4167 =
+              ((let uu___4 =
                   FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
                 FStar_Util.print1_warning
                   "Not extracting %s to KreMLin (polymorphic assumes are not supported)\n"
-                  uu____4167);
+                  uu___4);
                FStar_Pervasives_Native.None)
         | { FStar_Extraction_ML_Syntax.mllb_name = name1;
             FStar_Extraction_ML_Syntax.mllb_tysc =
               FStar_Pervasives_Native.Some (tvars, t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____4171;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
             FStar_Extraction_ML_Syntax.mllb_def =
               {
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Fun (args, body);
-                FStar_Extraction_ML_Syntax.mlty = uu____4174;
-                FStar_Extraction_ML_Syntax.loc = uu____4175;_};
+                FStar_Extraction_ML_Syntax.mlty = uu___1;
+                FStar_Extraction_ML_Syntax.loc = uu___2;_};
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu____4177;_} ->
+            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
             if FStar_List.mem FStar_Extraction_ML_Syntax.NoExtract meta
             then FStar_Pervasives_Native.None
             else
@@ -980,27 +916,27 @@ and (translate_let :
                  else env1 in
                let env3 =
                  FStar_List.fold_left
-                   (fun env3 -> fun name2 -> extend_t env3 name2) env2 tvars in
-               let rec find_return_type eff i uu___6_4221 =
-                 match uu___6_4221 with
-                 | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____4228, eff1, t)
-                     when i > Prims.int_zero ->
+                   (fun env4 -> fun name2 -> extend_t env4 name2) env2 tvars in
+               let rec find_return_type eff i uu___5 =
+                 match uu___5 with
+                 | FStar_Extraction_ML_Syntax.MLTY_Fun (uu___6, eff1, t) when
+                     i > Prims.int_zero ->
                      find_return_type eff1 (i - Prims.int_one) t
                  | t -> (i, eff, t) in
                let name2 = ((env3.module_name), name1) in
-               let uu____4241 =
+               let uu___5 =
                  find_return_type FStar_Extraction_ML_Syntax.E_PURE
                    (FStar_List.length args) t0 in
-               match uu____4241 with
+               match uu___5 with
                | (i, eff, t) ->
                    (if i > Prims.int_zero
                     then
                       (let msg =
                          "function type annotation has less arrows than the number of arguments; please mark the return type abbreviation as inline_for_extraction" in
-                       let uu____4259 =
+                       let uu___7 =
                          FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
                        FStar_Util.print2_warning
-                         "Not extracting %s to KreMLin (%s)\n" uu____4259 msg)
+                         "Not extracting %s to KreMLin (%s)\n" uu___7 msg)
                     else ();
                     (let t1 = translate_type env3 t in
                      let binders = translate_binders env3 args in
@@ -1008,15 +944,15 @@ and (translate_let :
                      let cc1 = translate_cc meta in
                      let meta1 =
                        match (eff, t1) with
-                       | (FStar_Extraction_ML_Syntax.E_GHOST, uu____4274) ->
-                           let uu____4275 = translate_flags meta in
-                           MustDisappear :: uu____4275
+                       | (FStar_Extraction_ML_Syntax.E_GHOST, uu___7) ->
+                           let uu___8 = translate_flags meta in MustDisappear
+                             :: uu___8
                        | (FStar_Extraction_ML_Syntax.E_PURE, TUnit) ->
-                           let uu____4278 = translate_flags meta in
-                           MustDisappear :: uu____4278
-                       | uu____4281 -> translate_flags meta in
+                           let uu___7 = translate_flags meta in MustDisappear
+                             :: uu___7
+                       | uu___7 -> translate_flags meta in
                      try
-                       (fun uu___366_4290 ->
+                       (fun uu___7 ->
                           match () with
                           | () ->
                               let body1 = translate_expr env4 body in
@@ -1027,18 +963,18 @@ and (translate_let :
                      with
                      | e ->
                          let msg = FStar_Util.print_exn e in
-                         ((let uu____4317 =
-                             let uu____4322 =
-                               let uu____4323 =
+                         ((let uu___9 =
+                             let uu___10 =
+                               let uu___11 =
                                  FStar_Extraction_ML_Syntax.string_of_mlpath
                                    name2 in
                                FStar_Util.format2
                                  "Error while extracting %s to KreMLin (%s)\n"
-                                 uu____4323 msg in
+                                 uu___11 msg in
                              (FStar_Errors.Warning_FunctionNotExtacted,
-                               uu____4322) in
+                               uu___10) in
                            FStar_Errors.log_issue FStar_Range.dummyRange
-                             uu____4317);
+                             uu___9);
                           (let msg1 =
                              Prims.op_Hat
                                "This function was not extracted:\n" msg in
@@ -1049,21 +985,21 @@ and (translate_let :
         | { FStar_Extraction_ML_Syntax.mllb_name = name1;
             FStar_Extraction_ML_Syntax.mllb_tysc =
               FStar_Pervasives_Native.Some (tvars, t);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____4340;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
             FStar_Extraction_ML_Syntax.mllb_def = expr1;
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu____4343;_} ->
+            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} ->
             if FStar_List.mem FStar_Extraction_ML_Syntax.NoExtract meta
             then FStar_Pervasives_Native.None
             else
               (let meta1 = translate_flags meta in
                let env2 =
                  FStar_List.fold_left
-                   (fun env2 -> fun name2 -> extend_t env2 name2) env1 tvars in
+                   (fun env3 -> fun name2 -> extend_t env3 name2) env1 tvars in
                let t1 = translate_type env2 t in
                let name2 = ((env2.module_name), name1) in
                try
-                 (fun uu___393_4369 ->
+                 (fun uu___3 ->
                     match () with
                     | () ->
                         let expr2 = translate_expr env2 expr1 in
@@ -1073,37 +1009,36 @@ and (translate_let :
                                expr2))) ()
                with
                | e ->
-                   ((let uu____4389 =
-                       let uu____4394 =
-                         let uu____4395 =
+                   ((let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
-                         let uu____4396 = FStar_Util.print_exn e in
+                         let uu___8 = FStar_Util.print_exn e in
                          FStar_Util.format2
-                           "Error extracting %s to KreMLin (%s)\n" uu____4395
-                           uu____4396 in
-                       (FStar_Errors.Warning_DefinitionNotTranslated,
-                         uu____4394) in
-                     FStar_Errors.log_issue FStar_Range.dummyRange uu____4389);
+                           "Error extracting %s to KreMLin (%s)\n" uu___7
+                           uu___8 in
+                       (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
+                     FStar_Errors.log_issue FStar_Range.dummyRange uu___5);
                     FStar_Pervasives_Native.Some
                       (DGlobal
                          (meta1, name2, (FStar_List.length tvars), t1, EAny))))
         | { FStar_Extraction_ML_Syntax.mllb_name = name1;
             FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____4407;
-            FStar_Extraction_ML_Syntax.mllb_def = uu____4408;
-            FStar_Extraction_ML_Syntax.mllb_meta = uu____4409;
-            FStar_Extraction_ML_Syntax.print_typ = uu____4410;_} ->
-            ((let uu____4414 =
-                let uu____4419 =
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
+            FStar_Extraction_ML_Syntax.mllb_def = uu___1;
+            FStar_Extraction_ML_Syntax.mllb_meta = uu___2;
+            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
+            ((let uu___5 =
+                let uu___6 =
                   FStar_Util.format1 "Not extracting %s to KreMLin\n" name1 in
-                (FStar_Errors.Warning_DefinitionNotTranslated, uu____4419) in
-              FStar_Errors.log_issue FStar_Range.dummyRange uu____4414);
+                (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
+              FStar_Errors.log_issue FStar_Range.dummyRange uu___5);
              (match ts with
               | FStar_Pervasives_Native.Some (idents, t) ->
-                  let uu____4423 =
+                  let uu___6 =
                     FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
                   FStar_Util.print2 "Type scheme is: forall %s. %s\n"
-                    (FStar_String.concat ", " idents) uu____4423
+                    (FStar_String.concat ", " idents) uu___6
               | FStar_Pervasives_Native.None -> ());
              FStar_Pervasives_Native.None)
 and (translate_type_decl :
@@ -1113,10 +1048,9 @@ and (translate_type_decl :
   =
   fun env1 ->
     fun ty ->
-      let uu____4430 = ty in
-      match uu____4430 with
-      | (uu____4433, uu____4434, uu____4435, uu____4436, flags, uu____4438)
-          ->
+      let uu___ = ty in
+      match uu___ with
+      | (uu___1, uu___2, uu___3, uu___4, flags, uu___5) ->
           if FStar_List.mem FStar_Extraction_ML_Syntax.NoExtract flags
           then FStar_Pervasives_Native.None
           else
@@ -1127,7 +1061,7 @@ and (translate_type_decl :
                  let name2 = ((env1.module_name), name1) in
                  let env2 =
                    FStar_List.fold_left
-                     (fun env2 -> fun name3 -> extend_t env2 name3) env1 args in
+                     (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
                  if
                    assumed &&
                      (FStar_List.mem FStar_Extraction_ML_Syntax.CAbstract
@@ -1144,74 +1078,70 @@ and (translate_type_decl :
                         name3;
                       FStar_Pervasives_Native.None)
                    else
-                     (let uu____4486 =
-                        let uu____4487 =
-                          let uu____4504 = translate_flags flags1 in
-                          let uu____4507 = translate_type env2 t in
-                          (name2, uu____4504, (FStar_List.length args),
-                            uu____4507) in
-                        DTypeAlias uu____4487 in
-                      FStar_Pervasives_Native.Some uu____4486)
-             | (uu____4516, name1, _mangled_name, args, flags1,
+                     (let uu___9 =
+                        let uu___10 =
+                          let uu___11 = translate_flags flags1 in
+                          let uu___12 = translate_type env2 t in
+                          (name2, uu___11, (FStar_List.length args), uu___12) in
+                        DTypeAlias uu___10 in
+                      FStar_Pervasives_Native.Some uu___9)
+             | (uu___7, name1, _mangled_name, args, flags1,
                 FStar_Pervasives_Native.Some
                 (FStar_Extraction_ML_Syntax.MLTD_Record fields)) ->
                  let name2 = ((env1.module_name), name1) in
                  let env2 =
                    FStar_List.fold_left
-                     (fun env2 -> fun name3 -> extend_t env2 name3) env1 args in
-                 let uu____4548 =
-                   let uu____4549 =
-                     let uu____4576 = translate_flags flags1 in
-                     let uu____4579 =
+                     (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
+                 let uu___8 =
+                   let uu___9 =
+                     let uu___10 = translate_flags flags1 in
+                     let uu___11 =
                        FStar_List.map
-                         (fun uu____4606 ->
-                            match uu____4606 with
+                         (fun uu___12 ->
+                            match uu___12 with
                             | (f, t) ->
-                                let uu____4621 =
-                                  let uu____4626 = translate_type env2 t in
-                                  (uu____4626, false) in
-                                (f, uu____4621)) fields in
-                     (name2, uu____4576, (FStar_List.length args),
-                       uu____4579) in
-                   DTypeFlat uu____4549 in
-                 FStar_Pervasives_Native.Some uu____4548
-             | (uu____4649, name1, _mangled_name, args, flags1,
+                                let uu___13 =
+                                  let uu___14 = translate_type env2 t in
+                                  (uu___14, false) in
+                                (f, uu___13)) fields in
+                     (name2, uu___10, (FStar_List.length args), uu___11) in
+                   DTypeFlat uu___9 in
+                 FStar_Pervasives_Native.Some uu___8
+             | (uu___7, name1, _mangled_name, args, flags1,
                 FStar_Pervasives_Native.Some
                 (FStar_Extraction_ML_Syntax.MLTD_DType branches1)) ->
                  let name2 = ((env1.module_name), name1) in
                  let flags2 = translate_flags flags1 in
                  let env2 = FStar_List.fold_left extend_t env1 args in
-                 let uu____4686 =
-                   let uu____4687 =
-                     let uu____4720 =
+                 let uu___8 =
+                   let uu___9 =
+                     let uu___10 =
                        FStar_List.map
-                         (fun uu____4765 ->
-                            match uu____4765 with
+                         (fun uu___11 ->
+                            match uu___11 with
                             | (cons, ts) ->
-                                let uu____4804 =
+                                let uu___12 =
                                   FStar_List.map
-                                    (fun uu____4831 ->
-                                       match uu____4831 with
+                                    (fun uu___13 ->
+                                       match uu___13 with
                                        | (name3, t) ->
-                                           let uu____4846 =
-                                             let uu____4851 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                translate_type env2 t in
-                                             (uu____4851, false) in
-                                           (name3, uu____4846)) ts in
-                                (cons, uu____4804)) branches1 in
-                     (name2, flags2, (FStar_List.length args), uu____4720) in
-                   DTypeVariant uu____4687 in
-                 FStar_Pervasives_Native.Some uu____4686
-             | (uu____4890, name1, _mangled_name, uu____4893, uu____4894,
-                uu____4895) ->
-                 ((let uu____4905 =
-                     let uu____4910 =
+                                             (uu___15, false) in
+                                           (name3, uu___14)) ts in
+                                (cons, uu___12)) branches1 in
+                     (name2, flags2, (FStar_List.length args), uu___10) in
+                   DTypeVariant uu___9 in
+                 FStar_Pervasives_Native.Some uu___8
+             | (uu___7, name1, _mangled_name, uu___8, uu___9, uu___10) ->
+                 ((let uu___12 =
+                     let uu___13 =
                        FStar_Util.format1
                          "Error extracting type definition %s to KreMLin\n"
                          name1 in
-                     (FStar_Errors.Warning_DefinitionNotTranslated,
-                       uu____4910) in
-                   FStar_Errors.log_issue FStar_Range.dummyRange uu____4905);
+                     (FStar_Errors.Warning_DefinitionNotTranslated, uu___13) in
+                   FStar_Errors.log_issue FStar_Range.dummyRange uu___12);
                   FStar_Pervasives_Native.None))
 and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
@@ -1220,173 +1150,162 @@ and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
       | FStar_Extraction_ML_Syntax.MLTY_Tuple [] -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Top -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Var name1 ->
-          let uu____4914 = find_t env1 name1 in TBound uu____4914
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu____4916, t2) ->
-          let uu____4918 =
-            let uu____4923 = translate_type env1 t1 in
-            let uu____4924 = translate_type env1 t2 in
-            (uu____4923, uu____4924) in
-          TArrow uu____4918
+          let uu___ = find_t env1 name1 in TBound uu___
+      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu___, t2) ->
+          let uu___1 =
+            let uu___2 = translate_type env1 t1 in
+            let uu___3 = translate_type env1 t2 in (uu___2, uu___3) in
+          TArrow uu___1
       | FStar_Extraction_ML_Syntax.MLTY_Erased -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named ([], p) when
-          let uu____4928 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4928 = "Prims.unit" -> TUnit
+          let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___ = "Prims.unit" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named ([], p) when
-          let uu____4932 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4932 = "Prims.bool" -> TBool
+          let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___ = "Prims.bool" -> TBool
       | FStar_Extraction_ML_Syntax.MLTY_Named ([], ("FStar"::m::[], "t"))
           when is_machine_int m ->
-          let uu____4938 = FStar_Util.must (mk_width m) in TInt uu____4938
+          let uu___ = FStar_Util.must (mk_width m) in TInt uu___
       | FStar_Extraction_ML_Syntax.MLTY_Named ([], ("FStar"::m::[], "t'"))
           when is_machine_int m ->
-          let uu____4944 = FStar_Util.must (mk_width m) in TInt uu____4944
+          let uu___ = FStar_Util.must (mk_width m) in TInt uu___
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[], p) when
-          let uu____4949 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____4949 = "FStar.Monotonic.HyperStack.mem" -> TUnit
-      | FStar_Extraction_ML_Syntax.MLTY_Named
-          (uu____4950::arg::uu____4952::[], p) when
-          (((let uu____4958 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____4958 = "FStar.Monotonic.HyperStack.s_mref") ||
-              (let uu____4960 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____4960 = "FStar.Monotonic.HyperHeap.mrref"))
+          let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___ = "FStar.Monotonic.HyperStack.mem" -> TUnit
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu___::arg::uu___1::[], p)
+          when
+          (((let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.Monotonic.HyperStack.s_mref") ||
+              (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___2 = "FStar.Monotonic.HyperHeap.mrref"))
              ||
-             (let uu____4962 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____4962 = "FStar.HyperStack.ST.m_rref"))
+             (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___2 = "FStar.HyperStack.ST.m_rref"))
             ||
-            (let uu____4964 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____4964 = "FStar.HyperStack.ST.s_mref")
-          -> let uu____4965 = translate_type env1 arg in TBuf uu____4965
-      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu____4967::[], p) when
-          ((((((((((let uu____4973 =
+            (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.HyperStack.ST.s_mref")
+          -> let uu___2 = translate_type env1 arg in TBuf uu___2
+      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu___::[], p) when
+          ((((((((((let uu___1 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                    uu____4973 = "FStar.Monotonic.HyperStack.mreference") ||
-                     (let uu____4975 =
+                    uu___1 = "FStar.Monotonic.HyperStack.mreference") ||
+                     (let uu___1 =
                         FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                      uu____4975 = "FStar.Monotonic.HyperStack.mstackref"))
+                      uu___1 = "FStar.Monotonic.HyperStack.mstackref"))
                     ||
-                    (let uu____4977 =
+                    (let uu___1 =
                        FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                     uu____4977 = "FStar.Monotonic.HyperStack.mref"))
+                     uu___1 = "FStar.Monotonic.HyperStack.mref"))
                    ||
-                   (let uu____4979 =
+                   (let uu___1 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                    uu____4979 = "FStar.Monotonic.HyperStack.mmmstackref"))
+                    uu___1 = "FStar.Monotonic.HyperStack.mmmstackref"))
                   ||
-                  (let uu____4981 =
-                     FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                   uu____4981 = "FStar.Monotonic.HyperStack.mmmref"))
+                  (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                   uu___1 = "FStar.Monotonic.HyperStack.mmmref"))
                  ||
-                 (let uu____4983 =
-                    FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                  uu____4983 = "FStar.Monotonic.Heap.mref"))
+                 (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                  uu___1 = "FStar.Monotonic.Heap.mref"))
                 ||
-                (let uu____4985 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu____4985 = "FStar.HyperStack.ST.mreference"))
+                (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                 uu___1 = "FStar.HyperStack.ST.mreference"))
                ||
-               (let uu____4987 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                uu____4987 = "FStar.HyperStack.ST.mstackref"))
+               (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                uu___1 = "FStar.HyperStack.ST.mstackref"))
               ||
-              (let uu____4989 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____4989 = "FStar.HyperStack.ST.mref"))
+              (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___1 = "FStar.HyperStack.ST.mref"))
              ||
-             (let uu____4991 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____4991 = "FStar.HyperStack.ST.mmmstackref"))
+             (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___1 = "FStar.HyperStack.ST.mmmstackref"))
             ||
-            (let uu____4993 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____4993 = "FStar.HyperStack.ST.mmmref")
-          -> let uu____4994 = translate_type env1 arg in TBuf uu____4994
-      | FStar_Extraction_ML_Syntax.MLTY_Named
-          (arg::uu____4996::uu____4997::[], p) when
-          let uu____5001 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5001 = "LowStar.Monotonic.Buffer.mbuffer" ->
-          let uu____5002 = translate_type env1 arg in TBuf uu____5002
+            (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___1 = "FStar.HyperStack.ST.mmmref")
+          -> let uu___1 = translate_type env1 arg in TBuf uu___1
+      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu___::uu___1::[], p)
+          when
+          let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___2 = "LowStar.Monotonic.Buffer.mbuffer" ->
+          let uu___2 = translate_type env1 arg in TBuf uu___2
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[], p) when
-          let uu____5007 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5007 = "LowStar.ConstBuffer.const_buffer" ->
-          let uu____5008 = translate_type env1 arg in TConstBuf uu____5008
+          let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___ = "LowStar.ConstBuffer.const_buffer" ->
+          let uu___ = translate_type env1 arg in TConstBuf uu___
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[], p) when
-          (((((((((((((let uu____5015 =
+          (((((((((((((let uu___ =
                          FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                       uu____5015 = "FStar.Buffer.buffer") ||
-                        (let uu____5017 =
+                       uu___ = "FStar.Buffer.buffer") ||
+                        (let uu___ =
                            FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                         uu____5017 = "LowStar.Buffer.buffer"))
+                         uu___ = "LowStar.Buffer.buffer"))
                        ||
-                       (let uu____5019 =
+                       (let uu___ =
                           FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                        uu____5019 = "LowStar.ImmutableBuffer.ibuffer"))
+                        uu___ = "LowStar.ImmutableBuffer.ibuffer"))
                       ||
-                      (let uu____5021 =
+                      (let uu___ =
                          FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                       uu____5021 = "LowStar.UninitializedBuffer.ubuffer"))
+                       uu___ = "LowStar.UninitializedBuffer.ubuffer"))
                      ||
-                     (let uu____5023 =
+                     (let uu___ =
                         FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                      uu____5023 = "FStar.HyperStack.reference"))
+                      uu___ = "FStar.HyperStack.reference"))
                     ||
-                    (let uu____5025 =
+                    (let uu___ =
                        FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                     uu____5025 = "FStar.HyperStack.stackref"))
+                     uu___ = "FStar.HyperStack.stackref"))
                    ||
-                   (let uu____5027 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                    uu____5027 = "FStar.HyperStack.ref"))
+                   (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                    uu___ = "FStar.HyperStack.ref"))
                   ||
-                  (let uu____5029 =
-                     FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                   uu____5029 = "FStar.HyperStack.mmstackref"))
+                  (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                   uu___ = "FStar.HyperStack.mmstackref"))
                  ||
-                 (let uu____5031 =
-                    FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                  uu____5031 = "FStar.HyperStack.mmref"))
+                 (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                  uu___ = "FStar.HyperStack.mmref"))
                 ||
-                (let uu____5033 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu____5033 = "FStar.HyperStack.ST.reference"))
+                (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                 uu___ = "FStar.HyperStack.ST.reference"))
                ||
-               (let uu____5035 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                uu____5035 = "FStar.HyperStack.ST.stackref"))
+               (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                uu___ = "FStar.HyperStack.ST.stackref"))
               ||
-              (let uu____5037 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5037 = "FStar.HyperStack.ST.ref"))
+              (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___ = "FStar.HyperStack.ST.ref"))
              ||
-             (let uu____5039 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5039 = "FStar.HyperStack.ST.mmstackref"))
+             (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___ = "FStar.HyperStack.ST.mmstackref"))
             ||
-            (let uu____5041 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5041 = "FStar.HyperStack.ST.mmref")
-          -> let uu____5042 = translate_type env1 arg in TBuf uu____5042
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____5043::arg::[], p) when
-          (let uu____5050 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5050 = "FStar.HyperStack.s_ref") ||
-            (let uu____5052 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5052 = "FStar.HyperStack.ST.s_ref")
-          -> let uu____5053 = translate_type env1 arg in TBuf uu____5053
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____5054::[], p) when
-          let uu____5058 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5058 = "FStar.Ghost.erased" -> TAny
+            (let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___ = "FStar.HyperStack.ST.mmref")
+          -> let uu___ = translate_type env1 arg in TBuf uu___
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu___::arg::[], p) when
+          (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___1 = "FStar.HyperStack.s_ref") ||
+            (let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___1 = "FStar.HyperStack.ST.s_ref")
+          -> let uu___1 = translate_type env1 arg in TBuf uu___1
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu___::[], p) when
+          let uu___1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___1 = "FStar.Ghost.erased" -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Named ([], (path, type_name)) ->
           TQualified (path, type_name)
       | FStar_Extraction_ML_Syntax.MLTY_Named (args, (ns, t1)) when
           ((ns = ["Prims"]) || (ns = ["FStar"; "Pervasives"; "Native"])) &&
             (FStar_Util.starts_with t1 "tuple")
           ->
-          let uu____5084 = FStar_List.map (translate_type env1) args in
-          TTuple uu____5084
+          let uu___ = FStar_List.map (translate_type env1) args in
+          TTuple uu___
       | FStar_Extraction_ML_Syntax.MLTY_Named (args, lid) ->
           if (FStar_List.length args) > Prims.int_zero
           then
-            let uu____5093 =
-              let uu____5106 = FStar_List.map (translate_type env1) args in
-              (lid, uu____5106) in
-            TApp uu____5093
+            let uu___ =
+              let uu___1 = FStar_List.map (translate_type env1) args in
+              (lid, uu___1) in
+            TApp uu___
           else TQualified lid
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____5121 = FStar_List.map (translate_type env1) ts in
-          TTuple uu____5121
+          let uu___ = FStar_List.map (translate_type env1) ts in TTuple uu___
 and (translate_binders :
   env ->
     (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty)
@@ -1398,11 +1317,11 @@ and (translate_binder :
       binder)
   =
   fun env1 ->
-    fun uu____5137 ->
-      match uu____5137 with
+    fun uu___ ->
+      match uu___ with
       | (name1, typ1) ->
-          let uu____5144 = translate_type env1 typ1 in
-          { name = name1; typ = uu____5144; mut = false }
+          let uu___1 = translate_type env1 typ1 in
+          { name = name1; typ = uu___1; mut = false }
 and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
   fun env1 ->
     fun e ->
@@ -1410,20 +1329,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
       | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
       | FStar_Extraction_ML_Syntax.MLE_Var name1 ->
-          let uu____5149 = find env1 name1 in EBound uu____5149
+          let uu___ = find env1 name1 in EBound uu___
       | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[], op1) when
           (is_machine_int m) && (is_op op1) ->
-          let uu____5154 =
-            let uu____5159 = FStar_Util.must (mk_op op1) in
-            let uu____5160 = FStar_Util.must (mk_width m) in
-            (uu____5159, uu____5160) in
-          EOp uu____5154
+          let uu___ =
+            let uu___1 = FStar_Util.must (mk_op op1) in
+            let uu___2 = FStar_Util.must (mk_width m) in (uu___1, uu___2) in
+          EOp uu___
       | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[], op1) when
           is_bool_op op1 ->
-          let uu____5164 =
-            let uu____5169 = FStar_Util.must (mk_bool_op op1) in
-            (uu____5169, Bool) in
-          EOp uu____5164
+          let uu___ =
+            let uu___1 = FStar_Util.must (mk_bool_op op1) in (uu___1, Bool) in
+          EOp uu___
       | FStar_Extraction_ML_Syntax.MLE_Name n -> EQualified n
       | FStar_Extraction_ML_Syntax.MLE_Let
           ((flavor,
@@ -1437,18 +1354,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
            continuation)
           ->
           let binder1 =
-            let uu____5188 = translate_type env1 typ1 in
-            { name = name1; typ = uu____5188; mut = false } in
+            let uu___ = translate_type env1 typ1 in
+            { name = name1; typ = uu___; mut = false } in
           let body1 = translate_expr env1 body in
           let env2 = extend env1 name1 in
           let continuation1 = translate_expr env2 continuation in
           ELet (binder1, body1, continuation1)
       | FStar_Extraction_ML_Syntax.MLE_Match (expr1, branches1) ->
-          let uu____5214 =
-            let uu____5225 = translate_expr env1 expr1 in
-            let uu____5226 = translate_branches env1 branches1 in
-            (uu____5225, uu____5226) in
-          EMatch uu____5214
+          let uu___ =
+            let uu___1 = translate_expr env1 expr1 in
+            let uu___2 = translate_branches env1 branches1 in
+            (uu___1, uu___2) in
+          EMatch uu___
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1456,20 +1373,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5240;
-                  FStar_Extraction_ML_Syntax.loc = uu____5241;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
                 t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu____5243;
-             FStar_Extraction_ML_Syntax.loc = uu____5244;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
            arg::[])
           when
-          let uu____5250 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5250 = "FStar.Dyn.undyn" ->
-          let uu____5251 =
-            let uu____5256 = translate_expr env1 arg in
-            let uu____5257 = translate_type env1 t in
-            (uu____5256, uu____5257) in
-          ECast uu____5251
+          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___4 = "FStar.Dyn.undyn" ->
+          let uu___4 =
+            let uu___5 = translate_expr env1 arg in
+            let uu___6 = translate_type env1 t in (uu___5, uu___6) in
+          ECast uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1477,15 +1393,15 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5259;
-                  FStar_Extraction_ML_Syntax.loc = uu____5260;_},
-                uu____5261);
-             FStar_Extraction_ML_Syntax.mlty = uu____5262;
-             FStar_Extraction_ML_Syntax.loc = uu____5263;_},
-           uu____5264)
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
+           uu___5)
           when
-          let uu____5273 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5273 = "Prims.admit" -> EAbort
+          let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___6 = "Prims.admit" -> EAbort
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1493,23 +1409,22 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5275;
-                  FStar_Extraction_ML_Syntax.loc = uu____5276;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
                 t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu____5278;
-             FStar_Extraction_ML_Syntax.loc = uu____5279;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
            {
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s);
-             FStar_Extraction_ML_Syntax.mlty = uu____5281;
-             FStar_Extraction_ML_Syntax.loc = uu____5282;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___4;
+             FStar_Extraction_ML_Syntax.loc = uu___5;_}::[])
           when
-          let uu____5287 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5287 = "LowStar.Failure.failwith" ->
-          let uu____5288 =
-            let uu____5293 = translate_type env1 t in (s, uu____5293) in
-          EAbortT uu____5288
+          let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___6 = "LowStar.Failure.failwith" ->
+          let uu___6 = let uu___7 = translate_type env1 t in (s, uu___7) in
+          EAbortT uu___6
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1517,29 +1432,29 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5295;
-                  FStar_Extraction_ML_Syntax.loc = uu____5296;_},
-                uu____5297);
-             FStar_Extraction_ML_Syntax.mlty = uu____5298;
-             FStar_Extraction_ML_Syntax.loc = uu____5299;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            arg::[])
           when
-          ((let uu____5309 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____5309 = "FStar.HyperStack.All.failwith") ||
-             (let uu____5311 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5311 = "FStar.Error.unexpected"))
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.HyperStack.All.failwith") ||
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "FStar.Error.unexpected"))
             ||
-            (let uu____5313 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5313 = "FStar.Error.unreachable")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.Error.unreachable")
           ->
           (match arg with
            | {
                FStar_Extraction_ML_Syntax.expr =
                  FStar_Extraction_ML_Syntax.MLE_Const
                  (FStar_Extraction_ML_Syntax.MLC_String msg);
-               FStar_Extraction_ML_Syntax.mlty = uu____5315;
-               FStar_Extraction_ML_Syntax.loc = uu____5316;_} -> EAbortS msg
-           | uu____5317 ->
+               FStar_Extraction_ML_Syntax.mlty = uu___5;
+               FStar_Extraction_ML_Syntax.loc = uu___6;_} -> EAbortS msg
+           | uu___5 ->
                let print_nm = (["FStar"; "HyperStack"; "IO"], "print_string") in
                let print =
                  FStar_Extraction_ML_Syntax.with_ty
@@ -1557,17 +1472,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5333;
-                  FStar_Extraction_ML_Syntax.loc = uu____5334;_},
-                uu____5335);
-             FStar_Extraction_ML_Syntax.mlty = uu____5336;
-             FStar_Extraction_ML_Syntax.loc = uu____5337;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::[])
           when
-          (let uu____5347 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5347 = "LowStar.ToFStarBuffer.new_to_old_st") ||
-            (let uu____5349 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5349 = "LowStar.ToFStarBuffer.old_to_new_st")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "LowStar.ToFStarBuffer.new_to_old_st") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ToFStarBuffer.old_to_new_st")
           -> translate_expr env1 e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1576,33 +1491,31 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5351;
-                  FStar_Extraction_ML_Syntax.loc = uu____5352;_},
-                uu____5353);
-             FStar_Extraction_ML_Syntax.mlty = uu____5354;
-             FStar_Extraction_ML_Syntax.loc = uu____5355;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          ((((let uu____5366 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5366 = "FStar.Buffer.index") ||
-               (let uu____5368 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                uu____5368 = "FStar.Buffer.op_Array_Access"))
+          ((((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "FStar.Buffer.index") ||
+               (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                uu___5 = "FStar.Buffer.op_Array_Access"))
               ||
-              (let uu____5370 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5370 = "LowStar.Monotonic.Buffer.index"))
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "LowStar.Monotonic.Buffer.index"))
              ||
-             (let uu____5372 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5372 = "LowStar.UninitializedBuffer.uindex"))
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.UninitializedBuffer.uindex"))
             ||
-            (let uu____5374 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5374 = "LowStar.ConstBuffer.index")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ConstBuffer.index")
           ->
-          let uu____5375 =
-            let uu____5380 = translate_expr env1 e1 in
-            let uu____5381 = translate_expr env1 e2 in
-            (uu____5380, uu____5381) in
-          EBufRead uu____5375
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufRead uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1610,19 +1523,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5383;
-                  FStar_Extraction_ML_Syntax.loc = uu____5384;_},
-                uu____5385);
-             FStar_Extraction_ML_Syntax.mlty = uu____5386;
-             FStar_Extraction_ML_Syntax.loc = uu____5387;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::[])
           when
-          let uu____5395 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5395 = "FStar.HyperStack.ST.op_Bang" ->
-          let uu____5396 =
-            let uu____5401 = translate_expr env1 e1 in
-            (uu____5401, (EConstant (UInt32, "0"))) in
-          EBufRead uu____5396
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.HyperStack.ST.op_Bang" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            (uu___6, (EConstant (UInt32, "0"))) in
+          EBufRead uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1630,26 +1543,25 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5403;
-                  FStar_Extraction_ML_Syntax.loc = uu____5404;_},
-                uu____5405);
-             FStar_Extraction_ML_Syntax.mlty = uu____5406;
-             FStar_Extraction_ML_Syntax.loc = uu____5407;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          ((let uu____5418 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____5418 = "FStar.Buffer.create") ||
-             (let uu____5420 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5420 = "LowStar.Monotonic.Buffer.malloca"))
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.Buffer.create") ||
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.malloca"))
             ||
-            (let uu____5422 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5422 = "LowStar.ImmutableBuffer.ialloca")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.ialloca")
           ->
-          let uu____5423 =
-            let uu____5430 = translate_expr env1 e1 in
-            let uu____5431 = translate_expr env1 e2 in
-            (Stack, uu____5430, uu____5431) in
-          EBufCreate uu____5423
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (Stack, uu___6, uu___7) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1657,18 +1569,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5433;
-                  FStar_Extraction_ML_Syntax.loc = uu____5434;_},
-                uu____5435);
-             FStar_Extraction_ML_Syntax.mlty = uu____5436;
-             FStar_Extraction_ML_Syntax.loc = uu____5437;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            elen::[])
           when
-          let uu____5445 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5445 = "LowStar.UninitializedBuffer.ualloca" ->
-          let uu____5446 =
-            let uu____5451 = translate_expr env1 elen in (Stack, uu____5451) in
-          EBufCreateNoInit uu____5446
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "LowStar.UninitializedBuffer.ualloca" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 elen in (Stack, uu___6) in
+          EBufCreateNoInit uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1676,19 +1588,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5453;
-                  FStar_Extraction_ML_Syntax.loc = uu____5454;_},
-                uu____5455);
-             FStar_Extraction_ML_Syntax.mlty = uu____5456;
-             FStar_Extraction_ML_Syntax.loc = uu____5457;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            init::[])
           when
-          let uu____5465 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5465 = "FStar.HyperStack.ST.salloc" ->
-          let uu____5466 =
-            let uu____5473 = translate_expr env1 init in
-            (Stack, uu____5473, (EConstant (UInt32, "1"))) in
-          EBufCreate uu____5466
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.HyperStack.ST.salloc" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 init in
+            (Stack, uu___6, (EConstant (UInt32, "1"))) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1696,27 +1608,27 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5475;
-                  FStar_Extraction_ML_Syntax.loc = uu____5476;_},
-                uu____5477);
-             FStar_Extraction_ML_Syntax.mlty = uu____5478;
-             FStar_Extraction_ML_Syntax.loc = uu____5479;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e2::[])
           when
-          ((let uu____5489 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____5489 = "FStar.Buffer.createL") ||
-             (let uu____5491 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5491 = "LowStar.Monotonic.Buffer.malloca_of_list"))
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.Buffer.createL") ||
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.malloca_of_list"))
             ||
-            (let uu____5493 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5493 = "LowStar.ImmutableBuffer.ialloca_of_list")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.ialloca_of_list")
           ->
-          let uu____5494 =
-            let uu____5501 =
-              let uu____5504 = list_elements e2 in
-              FStar_List.map (translate_expr env1) uu____5504 in
-            (Stack, uu____5501) in
-          EBufCreateL uu____5494
+          let uu___5 =
+            let uu___6 =
+              let uu___7 = list_elements e2 in
+              FStar_List.map (translate_expr env1) uu___7 in
+            (Stack, uu___6) in
+          EBufCreateL uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1724,24 +1636,24 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5510;
-                  FStar_Extraction_ML_Syntax.loc = uu____5511;_},
-                uu____5512);
-             FStar_Extraction_ML_Syntax.mlty = uu____5513;
-             FStar_Extraction_ML_Syntax.loc = uu____5514;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _erid::e2::[])
           when
-          (let uu____5525 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5525 = "LowStar.Monotonic.Buffer.mgcmalloc_of_list") ||
-            (let uu____5527 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5527 = "LowStar.ImmutableBuffer.igcmalloc_of_list")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "LowStar.Monotonic.Buffer.mgcmalloc_of_list") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.igcmalloc_of_list")
           ->
-          let uu____5528 =
-            let uu____5535 =
-              let uu____5538 = list_elements e2 in
-              FStar_List.map (translate_expr env1) uu____5538 in
-            (Eternal, uu____5535) in
-          EBufCreateL uu____5528
+          let uu___5 =
+            let uu___6 =
+              let uu___7 = list_elements e2 in
+              FStar_List.map (translate_expr env1) uu___7 in
+            (Eternal, uu___6) in
+          EBufCreateL uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1749,22 +1661,22 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5544;
-                  FStar_Extraction_ML_Syntax.loc = uu____5545;_},
-                uu____5546);
-             FStar_Extraction_ML_Syntax.mlty = uu____5547;
-             FStar_Extraction_ML_Syntax.loc = uu____5548;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _rid::init::[])
           when
-          (let uu____5559 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5559 = "FStar.HyperStack.ST.ralloc") ||
-            (let uu____5561 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5561 = "FStar.HyperStack.ST.ralloc_drgn")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "FStar.HyperStack.ST.ralloc") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.HyperStack.ST.ralloc_drgn")
           ->
-          let uu____5562 =
-            let uu____5569 = translate_expr env1 init in
-            (Eternal, uu____5569, (EConstant (UInt32, "1"))) in
-          EBufCreate uu____5562
+          let uu___5 =
+            let uu___6 = translate_expr env1 init in
+            (Eternal, uu___6, (EConstant (UInt32, "1"))) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1772,26 +1684,25 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5571;
-                  FStar_Extraction_ML_Syntax.loc = uu____5572;_},
-                uu____5573);
-             FStar_Extraction_ML_Syntax.mlty = uu____5574;
-             FStar_Extraction_ML_Syntax.loc = uu____5575;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _e0::e1::e2::[])
           when
-          ((let uu____5587 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____5587 = "FStar.Buffer.rcreate") ||
-             (let uu____5589 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5589 = "LowStar.Monotonic.Buffer.mgcmalloc"))
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.Buffer.rcreate") ||
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.mgcmalloc"))
             ||
-            (let uu____5591 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5591 = "LowStar.ImmutableBuffer.igcmalloc")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.igcmalloc")
           ->
-          let uu____5592 =
-            let uu____5599 = translate_expr env1 e1 in
-            let uu____5600 = translate_expr env1 e2 in
-            (Eternal, uu____5599, uu____5600) in
-          EBufCreate uu____5592
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (Eternal, uu___6, uu___7) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1799,31 +1710,29 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5602;
-                  FStar_Extraction_ML_Syntax.loc = uu____5603;_},
-                uu____5604);
-             FStar_Extraction_ML_Syntax.mlty = uu____5605;
-             FStar_Extraction_ML_Syntax.loc = uu____5606;_},
-           uu____5607)
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
+           uu___5)
           when
-          (((((let uu____5618 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5618 = "LowStar.Monotonic.Buffer.mgcmalloc_and_blit") ||
-                (let uu____5620 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu____5620 = "LowStar.Monotonic.Buffer.mmalloc_and_blit"))
+          (((((let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___6 = "LowStar.Monotonic.Buffer.mgcmalloc_and_blit") ||
+                (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                 uu___6 = "LowStar.Monotonic.Buffer.mmalloc_and_blit"))
                ||
-               (let uu____5622 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                uu____5622 = "LowStar.Monotonic.Buffer.malloca_and_blit"))
+               (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                uu___6 = "LowStar.Monotonic.Buffer.malloca_and_blit"))
               ||
-              (let uu____5624 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5624 = "LowStar.ImmutableBuffer.igcmalloc_and_blit"))
+              (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___6 = "LowStar.ImmutableBuffer.igcmalloc_and_blit"))
              ||
-             (let uu____5626 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5626 = "LowStar.ImmutableBuffer.imalloc_and_blit"))
+             (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___6 = "LowStar.ImmutableBuffer.imalloc_and_blit"))
             ||
-            (let uu____5628 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5628 = "LowStar.ImmutableBuffer.ialloca_and_blit")
+            (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___6 = "LowStar.ImmutableBuffer.ialloca_and_blit")
           ->
           EAbortS
             "alloc_and_blit family of functions are not yet supported downstream"
@@ -1834,19 +1743,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5630;
-                  FStar_Extraction_ML_Syntax.loc = uu____5631;_},
-                uu____5632);
-             FStar_Extraction_ML_Syntax.mlty = uu____5633;
-             FStar_Extraction_ML_Syntax.loc = uu____5634;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _erid::elen::[])
           when
-          let uu____5643 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5643 = "LowStar.UninitializedBuffer.ugcmalloc" ->
-          let uu____5644 =
-            let uu____5649 = translate_expr env1 elen in
-            (Eternal, uu____5649) in
-          EBufCreateNoInit uu____5644
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "LowStar.UninitializedBuffer.ugcmalloc" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 elen in (Eternal, uu___6) in
+          EBufCreateNoInit uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1854,22 +1762,22 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5651;
-                  FStar_Extraction_ML_Syntax.loc = uu____5652;_},
-                uu____5653);
-             FStar_Extraction_ML_Syntax.mlty = uu____5654;
-             FStar_Extraction_ML_Syntax.loc = uu____5655;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _rid::init::[])
           when
-          (let uu____5666 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5666 = "FStar.HyperStack.ST.ralloc_mm") ||
-            (let uu____5668 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5668 = "FStar.HyperStack.ST.ralloc_drgn_mm")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "FStar.HyperStack.ST.ralloc_mm") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.HyperStack.ST.ralloc_drgn_mm")
           ->
-          let uu____5669 =
-            let uu____5676 = translate_expr env1 init in
-            (ManuallyManaged, uu____5676, (EConstant (UInt32, "1"))) in
-          EBufCreate uu____5669
+          let uu___5 =
+            let uu___6 = translate_expr env1 init in
+            (ManuallyManaged, uu___6, (EConstant (UInt32, "1"))) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1877,29 +1785,29 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5678;
-                  FStar_Extraction_ML_Syntax.loc = uu____5679;_},
-                uu____5680);
-             FStar_Extraction_ML_Syntax.mlty = uu____5681;
-             FStar_Extraction_ML_Syntax.loc = uu____5682;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _e0::e1::e2::[])
           when
-          (((let uu____5694 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5694 = "FStar.Buffer.rcreate_mm") ||
-              (let uu____5696 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5696 = "LowStar.Monotonic.Buffer.mmalloc"))
+          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.Buffer.rcreate_mm") ||
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "LowStar.Monotonic.Buffer.mmalloc"))
              ||
-             (let uu____5698 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5698 = "LowStar.Monotonic.Buffer.mmalloc"))
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.mmalloc"))
             ||
-            (let uu____5700 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5700 = "LowStar.ImmutableBuffer.imalloc")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.imalloc")
           ->
-          let uu____5701 =
-            let uu____5708 = translate_expr env1 e1 in
-            let uu____5709 = translate_expr env1 e2 in
-            (ManuallyManaged, uu____5708, uu____5709) in
-          EBufCreate uu____5701
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in
+            (ManuallyManaged, uu___6, uu___7) in
+          EBufCreate uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1907,19 +1815,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5711;
-                  FStar_Extraction_ML_Syntax.loc = uu____5712;_},
-                uu____5713);
-             FStar_Extraction_ML_Syntax.mlty = uu____5714;
-             FStar_Extraction_ML_Syntax.loc = uu____5715;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _erid::elen::[])
           when
-          let uu____5724 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5724 = "LowStar.UninitializedBuffer.umalloc" ->
-          let uu____5725 =
-            let uu____5730 = translate_expr env1 elen in
-            (ManuallyManaged, uu____5730) in
-          EBufCreateNoInit uu____5725
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "LowStar.UninitializedBuffer.umalloc" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 elen in
+            (ManuallyManaged, uu___6) in
+          EBufCreateNoInit uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1927,16 +1835,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5732;
-                  FStar_Extraction_ML_Syntax.loc = uu____5733;_},
-                uu____5734);
-             FStar_Extraction_ML_Syntax.mlty = uu____5735;
-             FStar_Extraction_ML_Syntax.loc = uu____5736;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e2::[])
           when
-          let uu____5744 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5744 = "FStar.HyperStack.ST.rfree" ->
-          let uu____5745 = translate_expr env1 e2 in EBufFree uu____5745
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.HyperStack.ST.rfree" ->
+          let uu___5 = translate_expr env1 e2 in EBufFree uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1944,18 +1852,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5747;
-                  FStar_Extraction_ML_Syntax.loc = uu____5748;_},
-                uu____5749);
-             FStar_Extraction_ML_Syntax.mlty = uu____5750;
-             FStar_Extraction_ML_Syntax.loc = uu____5751;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e2::[])
           when
-          (let uu____5761 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5761 = "FStar.Buffer.rfree") ||
-            (let uu____5763 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5763 = "LowStar.Monotonic.Buffer.free")
-          -> let uu____5764 = translate_expr env1 e2 in EBufFree uu____5764
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "FStar.Buffer.rfree") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.Monotonic.Buffer.free")
+          -> let uu___5 = translate_expr env1 e2 in EBufFree uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1963,20 +1871,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5766;
-                  FStar_Extraction_ML_Syntax.loc = uu____5767;_},
-                uu____5768);
-             FStar_Extraction_ML_Syntax.mlty = uu____5769;
-             FStar_Extraction_ML_Syntax.loc = uu____5770;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::_e3::[])
           when
-          let uu____5780 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5780 = "FStar.Buffer.sub" ->
-          let uu____5781 =
-            let uu____5786 = translate_expr env1 e1 in
-            let uu____5787 = translate_expr env1 e2 in
-            (uu____5786, uu____5787) in
-          EBufSub uu____5781
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.Buffer.sub" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufSub uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1984,23 +1891,22 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5789;
-                  FStar_Extraction_ML_Syntax.loc = uu____5790;_},
-                uu____5791);
-             FStar_Extraction_ML_Syntax.mlty = uu____5792;
-             FStar_Extraction_ML_Syntax.loc = uu____5793;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::_e3::[])
           when
-          (let uu____5805 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____5805 = "LowStar.Monotonic.Buffer.msub") ||
-            (let uu____5807 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5807 = "LowStar.ConstBuffer.sub")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "LowStar.Monotonic.Buffer.msub") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ConstBuffer.sub")
           ->
-          let uu____5808 =
-            let uu____5813 = translate_expr env1 e1 in
-            let uu____5814 = translate_expr env1 e2 in
-            (uu____5813, uu____5814) in
-          EBufSub uu____5808
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufSub uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2008,15 +1914,15 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5816;
-                  FStar_Extraction_ML_Syntax.loc = uu____5817;_},
-                uu____5818);
-             FStar_Extraction_ML_Syntax.mlty = uu____5819;
-             FStar_Extraction_ML_Syntax.loc = uu____5820;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          let uu____5829 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5829 = "FStar.Buffer.join" -> translate_expr env1 e1
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.Buffer.join" -> translate_expr env1 e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2024,20 +1930,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5831;
-                  FStar_Extraction_ML_Syntax.loc = uu____5832;_},
-                uu____5833);
-             FStar_Extraction_ML_Syntax.mlty = uu____5834;
-             FStar_Extraction_ML_Syntax.loc = uu____5835;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          let uu____5844 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5844 = "FStar.Buffer.offset" ->
-          let uu____5845 =
-            let uu____5850 = translate_expr env1 e1 in
-            let uu____5851 = translate_expr env1 e2 in
-            (uu____5850, uu____5851) in
-          EBufSub uu____5845
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.Buffer.offset" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufSub uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2045,20 +1950,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5853;
-                  FStar_Extraction_ML_Syntax.loc = uu____5854;_},
-                uu____5855);
-             FStar_Extraction_ML_Syntax.mlty = uu____5856;
-             FStar_Extraction_ML_Syntax.loc = uu____5857;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          let uu____5866 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5866 = "LowStar.Monotonic.Buffer.moffset" ->
-          let uu____5867 =
-            let uu____5872 = translate_expr env1 e1 in
-            let uu____5873 = translate_expr env1 e2 in
-            (uu____5872, uu____5873) in
-          EBufSub uu____5867
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "LowStar.Monotonic.Buffer.moffset" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufSub uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2066,30 +1970,29 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5875;
-                  FStar_Extraction_ML_Syntax.loc = uu____5876;_},
-                uu____5877);
-             FStar_Extraction_ML_Syntax.mlty = uu____5878;
-             FStar_Extraction_ML_Syntax.loc = uu____5879;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::e3::[])
           when
-          (((let uu____5891 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5891 = "FStar.Buffer.upd") ||
-              (let uu____5893 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____5893 = "FStar.Buffer.op_Array_Assignment"))
+          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.Buffer.upd") ||
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "FStar.Buffer.op_Array_Assignment"))
              ||
-             (let uu____5895 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5895 = "LowStar.Monotonic.Buffer.upd'"))
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.upd'"))
             ||
-            (let uu____5897 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5897 = "LowStar.UninitializedBuffer.uupd")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.UninitializedBuffer.uupd")
           ->
-          let uu____5898 =
-            let uu____5905 = translate_expr env1 e1 in
-            let uu____5906 = translate_expr env1 e2 in
-            let uu____5907 = translate_expr env1 e3 in
-            (uu____5905, uu____5906, uu____5907) in
-          EBufWrite uu____5898
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in
+            let uu___8 = translate_expr env1 e3 in (uu___6, uu___7, uu___8) in
+          EBufWrite uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2097,40 +2000,40 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5909;
-                  FStar_Extraction_ML_Syntax.loc = uu____5910;_},
-                uu____5911);
-             FStar_Extraction_ML_Syntax.mlty = uu____5912;
-             FStar_Extraction_ML_Syntax.loc = uu____5913;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          let uu____5922 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5922 = "FStar.HyperStack.ST.op_Colon_Equals" ->
-          let uu____5923 =
-            let uu____5930 = translate_expr env1 e1 in
-            let uu____5931 = translate_expr env1 e2 in
-            (uu____5930, (EConstant (UInt32, "0")), uu____5931) in
-          EBufWrite uu____5923
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "FStar.HyperStack.ST.op_Colon_Equals" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in
+            (uu___6, (EConstant (UInt32, "0")), uu___7) in
+          EBufWrite uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____5933;
-             FStar_Extraction_ML_Syntax.loc = uu____5934;_},
-           uu____5935::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           uu___2::[])
           when
-          let uu____5938 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5938 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
+          let uu___3 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___3 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____5940;
-             FStar_Extraction_ML_Syntax.loc = uu____5941;_},
-           uu____5942::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           uu___2::[])
           when
-          let uu____5945 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____5945 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
+          let uu___3 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___3 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2138,29 +2041,29 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5947;
-                  FStar_Extraction_ML_Syntax.loc = uu____5948;_},
-                uu____5949);
-             FStar_Extraction_ML_Syntax.mlty = uu____5950;
-             FStar_Extraction_ML_Syntax.loc = uu____5951;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::e3::e4::e5::[])
           when
-          ((let uu____5965 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____5965 = "FStar.Buffer.blit") ||
-             (let uu____5967 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____5967 = "LowStar.Monotonic.Buffer.blit"))
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.Buffer.blit") ||
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.Monotonic.Buffer.blit"))
             ||
-            (let uu____5969 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____5969 = "LowStar.UninitializedBuffer.ublit")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.UninitializedBuffer.ublit")
           ->
-          let uu____5970 =
-            let uu____5981 = translate_expr env1 e1 in
-            let uu____5982 = translate_expr env1 e2 in
-            let uu____5983 = translate_expr env1 e3 in
-            let uu____5984 = translate_expr env1 e4 in
-            let uu____5985 = translate_expr env1 e5 in
-            (uu____5981, uu____5982, uu____5983, uu____5984, uu____5985) in
-          EBufBlit uu____5970
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in
+            let uu___8 = translate_expr env1 e3 in
+            let uu___9 = translate_expr env1 e4 in
+            let uu___10 = translate_expr env1 e5 in
+            (uu___6, uu___7, uu___8, uu___9, uu___10) in
+          EBufBlit uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2168,32 +2071,31 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5987;
-                  FStar_Extraction_ML_Syntax.loc = uu____5988;_},
-                uu____5989);
-             FStar_Extraction_ML_Syntax.mlty = uu____5990;
-             FStar_Extraction_ML_Syntax.loc = uu____5991;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::e3::[])
           when
           let s = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           (s = "FStar.Buffer.fill") || (s = "LowStar.Monotonic.Buffer.fill")
           ->
-          let uu____6002 =
-            let uu____6009 = translate_expr env1 e1 in
-            let uu____6010 = translate_expr env1 e2 in
-            let uu____6011 = translate_expr env1 e3 in
-            (uu____6009, uu____6010, uu____6011) in
-          EBufFill uu____6002
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in
+            let uu___8 = translate_expr env1 e3 in (uu___6, uu___7, uu___8) in
+          EBufFill uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____6013;
-             FStar_Extraction_ML_Syntax.loc = uu____6014;_},
-           uu____6015::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           uu___2::[])
           when
-          let uu____6018 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____6018 = "FStar.HyperStack.ST.get" -> EUnit
+          let uu___3 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___3 = "FStar.HyperStack.ST.get" -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2201,17 +2103,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6020;
-                  FStar_Extraction_ML_Syntax.loc = uu____6021;_},
-                uu____6022);
-             FStar_Extraction_ML_Syntax.mlty = uu____6023;
-             FStar_Extraction_ML_Syntax.loc = uu____6024;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _rid::[])
           when
-          (let uu____6034 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____6034 = "FStar.HyperStack.ST.free_drgn") ||
-            (let uu____6036 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____6036 = "FStar.HyperStack.ST.new_drgn")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "FStar.HyperStack.ST.free_drgn") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "FStar.HyperStack.ST.new_drgn")
           -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2220,23 +2122,23 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6038;
-                  FStar_Extraction_ML_Syntax.loc = uu____6039;_},
-                uu____6040);
-             FStar_Extraction_ML_Syntax.mlty = uu____6041;
-             FStar_Extraction_ML_Syntax.loc = uu____6042;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _ebuf::_eseq::[])
           when
-          (((let uu____6053 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____6053 = "LowStar.Monotonic.Buffer.witness_p") ||
-              (let uu____6055 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu____6055 = "LowStar.Monotonic.Buffer.recall_p"))
+          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.Monotonic.Buffer.witness_p") ||
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "LowStar.Monotonic.Buffer.recall_p"))
              ||
-             (let uu____6057 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____6057 = "LowStar.ImmutableBuffer.witness_contents"))
+             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "LowStar.ImmutableBuffer.witness_contents"))
             ||
-            (let uu____6059 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____6059 = "LowStar.ImmutableBuffer.recall_contents")
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ImmutableBuffer.recall_contents")
           -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2245,17 +2147,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6061;
-                  FStar_Extraction_ML_Syntax.loc = uu____6062;_},
-                uu____6063);
-             FStar_Extraction_ML_Syntax.mlty = uu____6064;
-             FStar_Extraction_ML_Syntax.loc = uu____6065;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::[])
           when
-          (let uu____6075 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu____6075 = "LowStar.ConstBuffer.of_buffer") ||
-            (let uu____6077 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____6077 = "LowStar.ConstBuffer.of_ibuffer")
+          (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+           uu___5 = "LowStar.ConstBuffer.of_buffer") ||
+            (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "LowStar.ConstBuffer.of_ibuffer")
           -> translate_expr env1 e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2264,21 +2166,21 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6079;
-                  FStar_Extraction_ML_Syntax.loc = uu____6080;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
                 t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu____6082;
-             FStar_Extraction_ML_Syntax.loc = uu____6083;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
            _eqal::e1::[])
           when
-          let uu____6090 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____6090 = "LowStar.ConstBuffer.of_qbuf" ->
-          let uu____6091 =
-            let uu____6096 = translate_expr env1 e1 in
-            let uu____6097 =
-              let uu____6098 = translate_type env1 t in TConstBuf uu____6098 in
-            (uu____6096, uu____6097) in
-          ECast uu____6091
+          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___4 = "LowStar.ConstBuffer.of_qbuf" ->
+          let uu___4 =
+            let uu___5 = translate_expr env1 e1 in
+            let uu___6 =
+              let uu___7 = translate_type env1 t in TConstBuf uu___7 in
+            (uu___5, uu___6) in
+          ECast uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2286,112 +2188,110 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6100;
-                  FStar_Extraction_ML_Syntax.loc = uu____6101;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
                 t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu____6103;
-             FStar_Extraction_ML_Syntax.loc = uu____6104;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
            e1::[])
           when
-          ((let uu____6112 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu____6112 = "LowStar.ConstBuffer.cast") ||
-             (let uu____6114 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu____6114 = "LowStar.ConstBuffer.to_buffer"))
+          ((let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___4 = "LowStar.ConstBuffer.cast") ||
+             (let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___4 = "LowStar.ConstBuffer.to_buffer"))
             ||
-            (let uu____6116 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu____6116 = "LowStar.ConstBuffer.to_ibuffer")
+            (let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___4 = "LowStar.ConstBuffer.to_ibuffer")
           ->
-          let uu____6117 =
-            let uu____6122 = translate_expr env1 e1 in
-            let uu____6123 =
-              let uu____6124 = translate_type env1 t in TBuf uu____6124 in
-            (uu____6122, uu____6123) in
-          ECast uu____6117
+          let uu___4 =
+            let uu___5 = translate_expr env1 e1 in
+            let uu___6 = let uu___7 = translate_type env1 t in TBuf uu___7 in
+            (uu___5, uu___6) in
+          ECast uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____6126;
-             FStar_Extraction_ML_Syntax.loc = uu____6127;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            e1::[])
           when
-          let uu____6131 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____6131 = "Obj.repr" ->
-          let uu____6132 =
-            let uu____6137 = translate_expr env1 e1 in (uu____6137, TAny) in
-          ECast uu____6132
+          let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___2 = "Obj.repr" ->
+          let uu___2 = let uu___3 = translate_expr env1 e1 in (uu___3, TAny) in
+          ECast uu___2
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[], op1);
-             FStar_Extraction_ML_Syntax.mlty = uu____6140;
-             FStar_Extraction_ML_Syntax.loc = uu____6141;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            args)
           when (is_machine_int m) && (is_op op1) ->
-          let uu____6149 = FStar_Util.must (mk_width m) in
-          let uu____6150 = FStar_Util.must (mk_op op1) in
-          mk_op_app env1 uu____6149 uu____6150 args
+          let uu___2 = FStar_Util.must (mk_width m) in
+          let uu___3 = FStar_Util.must (mk_op op1) in
+          mk_op_app env1 uu___2 uu___3 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[], op1);
-             FStar_Extraction_ML_Syntax.mlty = uu____6152;
-             FStar_Extraction_ML_Syntax.loc = uu____6153;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            args)
           when is_bool_op op1 ->
-          let uu____6161 = FStar_Util.must (mk_bool_op op1) in
-          mk_op_app env1 Bool uu____6161 args
+          let uu___2 = FStar_Util.must (mk_bool_op op1) in
+          mk_op_app env1 Bool uu___2 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[], "int_to_t");
-             FStar_Extraction_ML_Syntax.mlty = uu____6163;
-             FStar_Extraction_ML_Syntax.loc = uu____6164;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            {
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_Int
                (c, FStar_Pervasives_Native.None));
-             FStar_Extraction_ML_Syntax.mlty = uu____6166;
-             FStar_Extraction_ML_Syntax.loc = uu____6167;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           when is_machine_int m ->
-          let uu____6182 =
-            let uu____6187 = FStar_Util.must (mk_width m) in (uu____6187, c) in
-          EConstant uu____6182
+          let uu___4 =
+            let uu___5 = FStar_Util.must (mk_width m) in (uu___5, c) in
+          EConstant uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[], "uint_to_t");
-             FStar_Extraction_ML_Syntax.mlty = uu____6189;
-             FStar_Extraction_ML_Syntax.loc = uu____6190;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            {
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_Int
                (c, FStar_Pervasives_Native.None));
-             FStar_Extraction_ML_Syntax.mlty = uu____6192;
-             FStar_Extraction_ML_Syntax.loc = uu____6193;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           when is_machine_int m ->
-          let uu____6208 =
-            let uu____6213 = FStar_Util.must (mk_width m) in (uu____6213, c) in
-          EConstant uu____6208
+          let uu___4 =
+            let uu___5 = FStar_Util.must (mk_width m) in (uu___5, c) in
+          EConstant uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::[], "string_of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____6214;
-             FStar_Extraction_ML_Syntax.loc = uu____6215;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            { FStar_Extraction_ML_Syntax.expr = e1;
-             FStar_Extraction_ML_Syntax.mlty = uu____6217;
-             FStar_Extraction_ML_Syntax.loc = uu____6218;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____6224 ->
+           | uu___4 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2399,16 +2299,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::"Compat"::"String"::[], "of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____6225;
-             FStar_Extraction_ML_Syntax.loc = uu____6226;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            { FStar_Extraction_ML_Syntax.expr = e1;
-             FStar_Extraction_ML_Syntax.mlty = uu____6228;
-             FStar_Extraction_ML_Syntax.loc = uu____6229;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____6235 ->
+           | uu___4 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2416,16 +2316,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::"String"::[], "of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____6236;
-             FStar_Extraction_ML_Syntax.loc = uu____6237;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            { FStar_Extraction_ML_Syntax.expr = e1;
-             FStar_Extraction_ML_Syntax.mlty = uu____6239;
-             FStar_Extraction_ML_Syntax.loc = uu____6240;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____6246 ->
+           | uu___4 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2435,25 +2335,23 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____6248;
-                  FStar_Extraction_ML_Syntax.loc = uu____6249;_},
-                uu____6250);
-             FStar_Extraction_ML_Syntax.mlty = uu____6251;
-             FStar_Extraction_ML_Syntax.loc = uu____6252;_},
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            { FStar_Extraction_ML_Syntax.expr = ebefore;
-             FStar_Extraction_ML_Syntax.mlty = uu____6254;
-             FStar_Extraction_ML_Syntax.loc = uu____6255;_}::e1::{
-                                                                   FStar_Extraction_ML_Syntax.expr
-                                                                    = eafter;
-                                                                   FStar_Extraction_ML_Syntax.mlty
-                                                                    =
-                                                                    uu____6258;
-                                                                   FStar_Extraction_ML_Syntax.loc
-                                                                    =
-                                                                    uu____6259;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___5;
+             FStar_Extraction_ML_Syntax.loc = uu___6;_}::e1::{
+                                                               FStar_Extraction_ML_Syntax.expr
+                                                                 = eafter;
+                                                               FStar_Extraction_ML_Syntax.mlty
+                                                                 = uu___7;
+                                                               FStar_Extraction_ML_Syntax.loc
+                                                                 = uu___8;_}::[])
           when
-          let uu____6266 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____6266 = "LowStar.Comment.comment_gen" ->
+          let uu___9 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___9 = "LowStar.Comment.comment_gen" ->
           (match (ebefore, eafter) with
            | (FStar_Extraction_ML_Syntax.MLE_Const
               (FStar_Extraction_ML_Syntax.MLC_String sbefore),
@@ -2465,24 +2363,24 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                 if FStar_Util.contains safter "*/"
                 then failwith "After Comment contains end-of-comment marker"
                 else ();
-                (let uu____6273 =
-                   let uu____6280 = translate_expr env1 e1 in
-                   (sbefore, uu____6280, safter) in
-                 EComment uu____6273))
-           | uu____6281 ->
+                (let uu___11 =
+                   let uu___12 = translate_expr env1 e1 in
+                   (sbefore, uu___12, safter) in
+                 EComment uu___11))
+           | uu___9 ->
                failwith "Cannot extract comment applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____6287;
-             FStar_Extraction_ML_Syntax.loc = uu____6288;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            { FStar_Extraction_ML_Syntax.expr = e1;
-             FStar_Extraction_ML_Syntax.mlty = uu____6290;
-             FStar_Extraction_ML_Syntax.loc = uu____6291;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           when
-          let uu____6294 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu____6294 = "LowStar.Comment.comment" ->
+          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___4 = "LowStar.Comment.comment" ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) ->
@@ -2492,24 +2390,24 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                     "Standalone Comment contains end-of-comment marker"
                 else ();
                 EStandaloneComment s)
-           | uu____6298 ->
+           | uu___4 ->
                failwith "Cannot extract comment applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("LowStar"::"Literal"::[], "buffer_of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____6299;
-             FStar_Extraction_ML_Syntax.loc = uu____6300;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            { FStar_Extraction_ML_Syntax.expr = e1;
-             FStar_Extraction_ML_Syntax.mlty = uu____6302;
-             FStar_Extraction_ML_Syntax.loc = uu____6303;_}::[])
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) ->
                ECast ((EString s), (TBuf (TInt UInt8)))
-           | uu____6309 ->
+           | uu___4 ->
                failwith
                  "Cannot extract buffer_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2517,8 +2415,8 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::"Int"::"Cast"::[], c);
-             FStar_Extraction_ML_Syntax.mlty = uu____6311;
-             FStar_Extraction_ML_Syntax.loc = uu____6312;_},
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
            arg::[])
           ->
           let is_known_type =
@@ -2532,156 +2430,149 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
               || (FStar_Util.starts_with c "int64") in
           if (FStar_Util.ends_with c "uint64") && is_known_type
           then
-            let uu____6319 =
-              let uu____6324 = translate_expr env1 arg in
-              (uu____6324, (TInt UInt64)) in
-            ECast uu____6319
+            let uu___2 =
+              let uu___3 = translate_expr env1 arg in (uu___3, (TInt UInt64)) in
+            ECast uu___2
           else
             if (FStar_Util.ends_with c "uint32") && is_known_type
             then
-              (let uu____6326 =
-                 let uu____6331 = translate_expr env1 arg in
-                 (uu____6331, (TInt UInt32)) in
-               ECast uu____6326)
+              (let uu___3 =
+                 let uu___4 = translate_expr env1 arg in
+                 (uu___4, (TInt UInt32)) in
+               ECast uu___3)
             else
               if (FStar_Util.ends_with c "uint16") && is_known_type
               then
-                (let uu____6333 =
-                   let uu____6338 = translate_expr env1 arg in
-                   (uu____6338, (TInt UInt16)) in
-                 ECast uu____6333)
+                (let uu___4 =
+                   let uu___5 = translate_expr env1 arg in
+                   (uu___5, (TInt UInt16)) in
+                 ECast uu___4)
               else
                 if (FStar_Util.ends_with c "uint8") && is_known_type
                 then
-                  (let uu____6340 =
-                     let uu____6345 = translate_expr env1 arg in
-                     (uu____6345, (TInt UInt8)) in
-                   ECast uu____6340)
+                  (let uu___5 =
+                     let uu___6 = translate_expr env1 arg in
+                     (uu___6, (TInt UInt8)) in
+                   ECast uu___5)
                 else
                   if (FStar_Util.ends_with c "int64") && is_known_type
                   then
-                    (let uu____6347 =
-                       let uu____6352 = translate_expr env1 arg in
-                       (uu____6352, (TInt Int64)) in
-                     ECast uu____6347)
+                    (let uu___6 =
+                       let uu___7 = translate_expr env1 arg in
+                       (uu___7, (TInt Int64)) in
+                     ECast uu___6)
                   else
                     if (FStar_Util.ends_with c "int32") && is_known_type
                     then
-                      (let uu____6354 =
-                         let uu____6359 = translate_expr env1 arg in
-                         (uu____6359, (TInt Int32)) in
-                       ECast uu____6354)
+                      (let uu___7 =
+                         let uu___8 = translate_expr env1 arg in
+                         (uu___8, (TInt Int32)) in
+                       ECast uu___7)
                     else
                       if (FStar_Util.ends_with c "int16") && is_known_type
                       then
-                        (let uu____6361 =
-                           let uu____6366 = translate_expr env1 arg in
-                           (uu____6366, (TInt Int16)) in
-                         ECast uu____6361)
+                        (let uu___8 =
+                           let uu___9 = translate_expr env1 arg in
+                           (uu___9, (TInt Int16)) in
+                         ECast uu___8)
                       else
                         if (FStar_Util.ends_with c "int8") && is_known_type
                         then
-                          (let uu____6368 =
-                             let uu____6373 = translate_expr env1 arg in
-                             (uu____6373, (TInt Int8)) in
-                           ECast uu____6368)
+                          (let uu___9 =
+                             let uu___10 = translate_expr env1 arg in
+                             (uu___10, (TInt Int8)) in
+                           ECast uu___9)
                         else
-                          (let uu____6375 =
-                             let uu____6382 =
-                               let uu____6385 = translate_expr env1 arg in
-                               [uu____6385] in
+                          (let uu___10 =
+                             let uu___11 =
+                               let uu___12 = translate_expr env1 arg in
+                               [uu___12] in
                              ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____6382) in
-                           EApp uu____6375)
+                               uu___11) in
+                           EApp uu___10)
       | FStar_Extraction_ML_Syntax.MLE_App (head, args) ->
-          let uu____6396 =
-            let uu____6403 = translate_expr env1 head in
-            let uu____6404 = FStar_List.map (translate_expr env1) args in
-            (uu____6403, uu____6404) in
-          EApp uu____6396
+          let uu___ =
+            let uu___1 = translate_expr env1 head in
+            let uu___2 = FStar_List.map (translate_expr env1) args in
+            (uu___1, uu___2) in
+          EApp uu___
       | FStar_Extraction_ML_Syntax.MLE_TApp (head, ty_args) ->
-          let uu____6415 =
-            let uu____6422 = translate_expr env1 head in
-            let uu____6423 = FStar_List.map (translate_type env1) ty_args in
-            (uu____6422, uu____6423) in
-          ETypApp uu____6415
+          let uu___ =
+            let uu___1 = translate_expr env1 head in
+            let uu___2 = FStar_List.map (translate_type env1) ty_args in
+            (uu___1, uu___2) in
+          ETypApp uu___
       | FStar_Extraction_ML_Syntax.MLE_Coerce (e1, t_from, t_to) ->
-          let uu____6431 =
-            let uu____6436 = translate_expr env1 e1 in
-            let uu____6437 = translate_type env1 t_to in
-            (uu____6436, uu____6437) in
-          ECast uu____6431
-      | FStar_Extraction_ML_Syntax.MLE_Record (uu____6438, fields) ->
-          let uu____6456 =
-            let uu____6467 =
-              assert_lid env1 e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____6468 =
+          let uu___ =
+            let uu___1 = translate_expr env1 e1 in
+            let uu___2 = translate_type env1 t_to in (uu___1, uu___2) in
+          ECast uu___
+      | FStar_Extraction_ML_Syntax.MLE_Record (uu___, fields) ->
+          let uu___1 =
+            let uu___2 = assert_lid env1 e.FStar_Extraction_ML_Syntax.mlty in
+            let uu___3 =
               FStar_List.map
-                (fun uu____6487 ->
-                   match uu____6487 with
+                (fun uu___4 ->
+                   match uu___4 with
                    | (field, expr1) ->
-                       let uu____6498 = translate_expr env1 expr1 in
-                       (field, uu____6498)) fields in
-            (uu____6467, uu____6468) in
-          EFlat uu____6456
+                       let uu___5 = translate_expr env1 expr1 in
+                       (field, uu___5)) fields in
+            (uu___2, uu___3) in
+          EFlat uu___1
       | FStar_Extraction_ML_Syntax.MLE_Proj (e1, path) ->
-          let uu____6507 =
-            let uu____6514 =
-              assert_lid env1 e1.FStar_Extraction_ML_Syntax.mlty in
-            let uu____6515 = translate_expr env1 e1 in
-            (uu____6514, uu____6515, (FStar_Pervasives_Native.snd path)) in
-          EField uu____6507
-      | FStar_Extraction_ML_Syntax.MLE_Let uu____6518 ->
-          let uu____6529 =
-            let uu____6530 =
-              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") e in
+          let uu___ =
+            let uu___1 = assert_lid env1 e1.FStar_Extraction_ML_Syntax.mlty in
+            let uu___2 = translate_expr env1 e1 in
+            (uu___1, uu___2, (FStar_Pervasives_Native.snd path)) in
+          EField uu___
+      | FStar_Extraction_ML_Syntax.MLE_Let uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Extraction_ML_Code.string_of_mlexpr ([], "") e in
             FStar_Util.format1 "todo: translate_expr [MLE_Let] (expr is: %s)"
-              uu____6530 in
-          failwith uu____6529
-      | FStar_Extraction_ML_Syntax.MLE_App (head, uu____6534) ->
-          let uu____6539 =
-            let uu____6540 =
+              uu___2 in
+          failwith uu___1
+      | FStar_Extraction_ML_Syntax.MLE_App (head, uu___) ->
+          let uu___1 =
+            let uu___2 =
               FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head in
             FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____6540 in
-          failwith uu____6539
+              uu___2 in
+          failwith uu___1
       | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____6546 = FStar_List.map (translate_expr env1) seqs in
-          ESequence uu____6546
+          let uu___ = FStar_List.map (translate_expr env1) seqs in
+          ESequence uu___
       | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____6552 = FStar_List.map (translate_expr env1) es in
-          ETuple uu____6552
-      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____6555, cons), es) ->
-          let uu____6566 =
-            let uu____6575 =
-              assert_lid env1 e.FStar_Extraction_ML_Syntax.mlty in
-            let uu____6576 = FStar_List.map (translate_expr env1) es in
-            (uu____6575, cons, uu____6576) in
-          ECons uu____6566
+          let uu___ = FStar_List.map (translate_expr env1) es in ETuple uu___
+      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu___, cons), es) ->
+          let uu___1 =
+            let uu___2 = assert_lid env1 e.FStar_Extraction_ML_Syntax.mlty in
+            let uu___3 = FStar_List.map (translate_expr env1) es in
+            (uu___2, cons, uu___3) in
+          ECons uu___1
       | FStar_Extraction_ML_Syntax.MLE_Fun (args, body) ->
           let binders = translate_binders env1 args in
           let env2 = add_binders env1 args in
-          let uu____6599 =
-            let uu____6608 = translate_expr env2 body in
-            let uu____6609 =
+          let uu___ =
+            let uu___1 = translate_expr env2 body in
+            let uu___2 =
               translate_type env2 body.FStar_Extraction_ML_Syntax.mlty in
-            (binders, uu____6608, uu____6609) in
-          EFun uu____6599
+            (binders, uu___1, uu___2) in
+          EFun uu___
       | FStar_Extraction_ML_Syntax.MLE_If (e1, e2, e3) ->
-          let uu____6619 =
-            let uu____6626 = translate_expr env1 e1 in
-            let uu____6627 = translate_expr env1 e2 in
-            let uu____6628 =
+          let uu___ =
+            let uu___1 = translate_expr env1 e1 in
+            let uu___2 = translate_expr env1 e2 in
+            let uu___3 =
               match e3 with
               | FStar_Pervasives_Native.None -> EUnit
               | FStar_Pervasives_Native.Some e31 -> translate_expr env1 e31 in
-            (uu____6626, uu____6627, uu____6628) in
-          EIfThenElse uu____6619
-      | FStar_Extraction_ML_Syntax.MLE_Raise uu____6630 ->
+            (uu___1, uu___2, uu___3) in
+          EIfThenElse uu___
+      | FStar_Extraction_ML_Syntax.MLE_Raise uu___ ->
           failwith "todo: translate_expr [MLE_Raise]"
-      | FStar_Extraction_ML_Syntax.MLE_Try uu____6637 ->
+      | FStar_Extraction_ML_Syntax.MLE_Try uu___ ->
           failwith "todo: translate_expr [MLE_Try]"
-      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____6652 ->
+      | FStar_Extraction_ML_Syntax.MLE_Coerce uu___ ->
           failwith "todo: translate_expr [MLE_Coerce]"
 and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
@@ -2690,18 +2581,17 @@ and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
       | FStar_Extraction_ML_Syntax.MLTY_Named (ts, lid) ->
           if (FStar_List.length ts) > Prims.int_zero
           then
-            let uu____6667 =
-              let uu____6680 = FStar_List.map (translate_type env1) ts in
-              (lid, uu____6680) in
-            TApp uu____6667
+            let uu___ =
+              let uu___1 = FStar_List.map (translate_type env1) ts in
+              (lid, uu___1) in
+            TApp uu___
           else TQualified lid
-      | uu____6692 ->
-          let uu____6693 =
-            let uu____6694 =
-              FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
             FStar_Util.format1
-              "invalid argument: expected MLTY_Named, got %s" uu____6694 in
-          failwith uu____6693
+              "invalid argument: expected MLTY_Named, got %s" uu___2 in
+          failwith uu___1
 and (translate_branches :
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr
@@ -2717,23 +2607,22 @@ and (translate_branch :
       (pattern * expr))
   =
   fun env1 ->
-    fun uu____6722 ->
-      match uu____6722 with
+    fun uu___ ->
+      match uu___ with
       | (pat, guard, expr1) ->
           if guard = FStar_Pervasives_Native.None
           then
-            let uu____6748 = translate_pat env1 pat in
-            (match uu____6748 with
+            let uu___1 = translate_pat env1 pat in
+            (match uu___1 with
              | (env2, pat1) ->
-                 let uu____6759 = translate_expr env2 expr1 in
-                 (pat1, uu____6759))
+                 let uu___2 = translate_expr env2 expr1 in (pat1, uu___2))
           else failwith "todo: translate_branch"
 and (translate_width :
   (FStar_Const.signedness * FStar_Const.width) FStar_Pervasives_Native.option
     -> width)
   =
-  fun uu___7_6765 ->
-    match uu___7_6765 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> CInt
     | FStar_Pervasives_Native.Some (FStar_Const.Signed, FStar_Const.Int8) ->
         Int8
@@ -2762,57 +2651,56 @@ and (translate_pat :
           (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env1, (PBool b))
       | FStar_Extraction_ML_Syntax.MLP_Const
           (FStar_Extraction_ML_Syntax.MLC_Int (s, sw)) ->
-          let uu____6829 =
-            let uu____6830 =
-              let uu____6835 = translate_width sw in (uu____6835, s) in
-            PConstant uu____6830 in
-          (env1, uu____6829)
+          let uu___ =
+            let uu___1 = let uu___2 = translate_width sw in (uu___2, s) in
+            PConstant uu___1 in
+          (env1, uu___)
       | FStar_Extraction_ML_Syntax.MLP_Var name1 ->
           let env2 = extend env1 name1 in
           (env2, (PVar { name = name1; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild ->
           let env2 = extend env1 "_" in
           (env2, (PVar { name = "_"; typ = TAny; mut = false }))
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____6839, cons), ps) ->
-          let uu____6850 =
+      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu___, cons), ps) ->
+          let uu___1 =
             FStar_List.fold_left
-              (fun uu____6870 ->
+              (fun uu___2 ->
                  fun p1 ->
-                   match uu____6870 with
+                   match uu___2 with
                    | (env2, acc) ->
-                       let uu____6890 = translate_pat env2 p1 in
-                       (match uu____6890 with
-                        | (env3, p2) -> (env3, (p2 :: acc)))) (env1, []) ps in
-          (match uu____6850 with
+                       let uu___3 = translate_pat env2 p1 in
+                       (match uu___3 with | (env3, p2) -> (env3, (p2 :: acc))))
+              (env1, []) ps in
+          (match uu___1 with
            | (env2, ps1) -> (env2, (PCons (cons, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____6919, ps) ->
-          let uu____6937 =
+      | FStar_Extraction_ML_Syntax.MLP_Record (uu___, ps) ->
+          let uu___1 =
             FStar_List.fold_left
-              (fun uu____6971 ->
-                 fun uu____6972 ->
-                   match (uu____6971, uu____6972) with
+              (fun uu___2 ->
+                 fun uu___3 ->
+                   match (uu___2, uu___3) with
                    | ((env2, acc), (field, p1)) ->
-                       let uu____7041 = translate_pat env2 p1 in
-                       (match uu____7041 with
+                       let uu___4 = translate_pat env2 p1 in
+                       (match uu___4 with
                         | (env3, p2) -> (env3, ((field, p2) :: acc))))
               (env1, []) ps in
-          (match uu____6937 with
+          (match uu___1 with
            | (env2, ps1) -> (env2, (PRecord (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____7103 =
+          let uu___ =
             FStar_List.fold_left
-              (fun uu____7123 ->
+              (fun uu___1 ->
                  fun p1 ->
-                   match uu____7123 with
+                   match uu___1 with
                    | (env2, acc) ->
-                       let uu____7143 = translate_pat env2 p1 in
-                       (match uu____7143 with
-                        | (env3, p2) -> (env3, (p2 :: acc)))) (env1, []) ps in
-          (match uu____7103 with
+                       let uu___2 = translate_pat env2 p1 in
+                       (match uu___2 with | (env3, p2) -> (env3, (p2 :: acc))))
+              (env1, []) ps in
+          (match uu___ with
            | (env2, ps1) -> (env2, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____7170 ->
+      | FStar_Extraction_ML_Syntax.MLP_Const uu___ ->
           failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____7175 ->
+      | FStar_Extraction_ML_Syntax.MLP_Branch uu___ ->
           failwith "todo: translate_pat [MLP_Branch]"
 and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
   fun c ->
@@ -2820,18 +2708,18 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
     | FStar_Extraction_ML_Syntax.MLC_Unit -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_String s ->
-        ((let uu____7186 =
-            let uu____7187 = FStar_String.list_of_string s in
-            FStar_All.pipe_right uu____7187
+        ((let uu___1 =
+            let uu___2 = FStar_String.list_of_string s in
+            FStar_All.pipe_right uu___2
               (FStar_Util.for_some
                  (fun c1 -> c1 = (FStar_Char.char_of_int Prims.int_zero))) in
-          if uu____7186
+          if uu___1
           then
-            let uu____7194 =
+            let uu___2 =
               FStar_Util.format1
                 "Refusing to translate a string literal that contains a null character: %s"
                 s in
-            failwith uu____7194
+            failwith uu___2
           else ());
          EString s)
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
@@ -2841,12 +2729,12 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
         let char_of_int = EQualified (["FStar"; "Char"], "char_of_int") in
         EApp (char_of_int, [c2])
     | FStar_Extraction_ML_Syntax.MLC_Int
-        (s, FStar_Pervasives_Native.Some uu____7206) ->
+        (s, FStar_Pervasives_Native.Some uu___) ->
         failwith
           "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____7221 ->
+    | FStar_Extraction_ML_Syntax.MLC_Float uu___ ->
         failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____7222 ->
+    | FStar_Extraction_ML_Syntax.MLC_Bytes uu___ ->
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s, FStar_Pervasives_Native.None) ->
         EConstant (CInt, s)
@@ -2857,39 +2745,39 @@ and (mk_op_app :
     fun w ->
       fun op1 ->
         fun args ->
-          let uu____7242 =
-            let uu____7249 = FStar_List.map (translate_expr env1) args in
-            ((EOp (op1, w)), uu____7249) in
-          EApp uu____7242
+          let uu___ =
+            let uu___1 = FStar_List.map (translate_expr env1) args in
+            ((EOp (op1, w)), uu___1) in
+          EApp uu___
 let (translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list) =
-  fun uu____7260 ->
-    match uu____7260 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Extraction_ML_Syntax.MLLib modules ->
         FStar_List.filter_map
           (fun m ->
              let m_name =
-               let uu____7308 = m in
-               match uu____7308 with
-               | (path, uu____7322, uu____7323) ->
+               let uu___1 = m in
+               match uu___1 with
+               | (path, uu___2, uu___3) ->
                    FStar_Extraction_ML_Syntax.string_of_mlpath path in
              try
-               (fun uu___1671_7341 ->
+               (fun uu___1 ->
                   match () with
                   | () ->
-                      ((let uu____7345 =
-                          let uu____7346 = FStar_Options.silent () in
-                          Prims.op_Negation uu____7346 in
-                        if uu____7345
+                      ((let uu___3 =
+                          let uu___4 = FStar_Options.silent () in
+                          Prims.op_Negation uu___4 in
+                        if uu___3
                         then
                           FStar_Util.print1
                             "Attempting to translate module %s\n" m_name
                         else ());
-                       (let uu____7348 = translate_module m in
-                        FStar_Pervasives_Native.Some uu____7348))) ()
+                       (let uu___3 = translate_module m in
+                        FStar_Pervasives_Native.Some uu___3))) ()
              with
-             | uu___1670_7351 ->
-                 ((let uu____7355 = FStar_Util.print_exn uu___1670_7351 in
+             | uu___1 ->
+                 ((let uu___3 = FStar_Util.print_exn uu___1 in
                    FStar_Util.print2
                      "Unable to translate module: %s because:\n  %s\n" m_name
-                     uu____7355);
+                     uu___3);
                   FStar_Pervasives_Native.None)) modules

--- a/src/ocaml-output/FStar_Extraction_ML_Code.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Code.ml
@@ -6,27 +6,25 @@ type assoc =
   | Right 
   | NonAssoc 
 let (uu___is_ILeft : assoc -> Prims.bool) =
-  fun projectee -> match projectee with | ILeft -> true | uu____6 -> false
+  fun projectee -> match projectee with | ILeft -> true | uu___ -> false
 let (uu___is_IRight : assoc -> Prims.bool) =
-  fun projectee -> match projectee with | IRight -> true | uu____12 -> false
+  fun projectee -> match projectee with | IRight -> true | uu___ -> false
 let (uu___is_Left : assoc -> Prims.bool) =
-  fun projectee -> match projectee with | Left -> true | uu____18 -> false
+  fun projectee -> match projectee with | Left -> true | uu___ -> false
 let (uu___is_Right : assoc -> Prims.bool) =
-  fun projectee -> match projectee with | Right -> true | uu____24 -> false
+  fun projectee -> match projectee with | Right -> true | uu___ -> false
 let (uu___is_NonAssoc : assoc -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NonAssoc -> true | uu____30 -> false
+  fun projectee -> match projectee with | NonAssoc -> true | uu___ -> false
 type fixity =
   | Prefix 
   | Postfix 
   | Infix of assoc 
 let (uu___is_Prefix : fixity -> Prims.bool) =
-  fun projectee -> match projectee with | Prefix -> true | uu____41 -> false
+  fun projectee -> match projectee with | Prefix -> true | uu___ -> false
 let (uu___is_Postfix : fixity -> Prims.bool) =
-  fun projectee -> match projectee with | Postfix -> true | uu____47 -> false
+  fun projectee -> match projectee with | Postfix -> true | uu___ -> false
 let (uu___is_Infix : fixity -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Infix _0 -> true | uu____54 -> false
+  fun projectee -> match projectee with | Infix _0 -> true | uu___ -> false
 let (__proj__Infix__item___0 : fixity -> assoc) =
   fun projectee -> match projectee with | Infix _0 -> _0
 type opprec = (Prims.int * fixity)
@@ -74,34 +72,34 @@ let (empty : doc) = Doc ""
 let (hardline : doc) = Doc "\n"
 let (text : Prims.string -> doc) = fun s -> Doc s
 let (num : Prims.int -> doc) =
-  fun i -> let uu____171 = FStar_Util.string_of_int i in Doc uu____171
+  fun i -> let uu___ = FStar_Util.string_of_int i in Doc uu___
 let (break1 : doc) = text " "
 let (enclose : doc -> doc -> doc -> doc) =
-  fun uu____184 ->
-    fun uu____185 ->
-      fun uu____186 ->
-        match (uu____184, uu____185, uu____186) with
+  fun uu___ ->
+    fun uu___1 ->
+      fun uu___2 ->
+        match (uu___, uu___1, uu___2) with
         | (Doc l, Doc r, Doc x) -> Doc (Prims.op_Hat l (Prims.op_Hat x r))
 let (cbrackets : doc -> doc) =
-  fun uu____194 ->
-    match uu____194 with | Doc d -> enclose (text "{") (text "}") (Doc d)
+  fun uu___ ->
+    match uu___ with | Doc d -> enclose (text "{") (text "}") (Doc d)
 let (parens : doc -> doc) =
-  fun uu____200 ->
-    match uu____200 with | Doc d -> enclose (text "(") (text ")") (Doc d)
+  fun uu___ ->
+    match uu___ with | Doc d -> enclose (text "(") (text ")") (Doc d)
 let (cat : doc -> doc -> doc) =
-  fun uu____210 ->
-    fun uu____211 ->
-      match (uu____210, uu____211) with
+  fun uu___ ->
+    fun uu___1 ->
+      match (uu___, uu___1) with
       | (Doc d1, Doc d2) -> Doc (Prims.op_Hat d1 d2)
 let (reduce : doc Prims.list -> doc) =
   fun docs -> FStar_List.fold_left cat empty docs
 let (combine : doc -> doc Prims.list -> doc) =
-  fun uu____233 ->
+  fun uu___ ->
     fun docs ->
-      match uu____233 with
+      match uu___ with
       | Doc sep ->
-          let select uu____245 =
-            match uu____245 with
+          let select uu___1 =
+            match uu___1 with
             | Doc d ->
                 if d = ""
                 then FStar_Pervasives_Native.None
@@ -113,9 +111,9 @@ let (hbox : doc -> doc) = fun d -> d
 let rec in_ns : 'a . ('a Prims.list * 'a Prims.list) -> Prims.bool =
   fun x ->
     match x with
-    | ([], uu____295) -> true
+    | ([], uu___) -> true
     | (x1::t1, x2::t2) when x1 = x2 -> in_ns (t1, t2)
-    | (uu____318, uu____319) -> false
+    | (uu___, uu___1) -> false
 let (path_of_ns :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     Prims.string Prims.list -> Prims.string Prims.list)
@@ -134,18 +132,18 @@ let (path_of_ns :
                 let cg_len = FStar_List.length cg_path in
                 if (FStar_List.length cg_path) < ns_len
                 then
-                  let uu____377 = FStar_Util.first_N cg_len ns in
-                  match uu____377 with
+                  let uu___1 = FStar_Util.first_N cg_len ns in
+                  match uu___1 with
                   | (pfx, sfx) ->
                       (if pfx = cg_path
                        then
-                         let uu____406 =
-                           let uu____409 =
-                             let uu____412 =
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 =
                                FStar_Extraction_ML_Util.flatten_ns sfx in
-                             [uu____412] in
-                           FStar_List.append pfx uu____409 in
-                         FStar_Pervasives_Native.Some uu____406
+                             [uu___4] in
+                           FStar_List.append pfx uu___3 in
+                         FStar_Pervasives_Native.Some uu___2
                        else FStar_Pervasives_Native.None)
                 else FStar_Pervasives_Native.None) in
          match found with
@@ -157,26 +155,25 @@ let (mlpath_of_mlpath :
   =
   fun currentModule ->
     fun x ->
-      let uu____440 = FStar_Extraction_ML_Syntax.string_of_mlpath x in
-      match uu____440 with
+      let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath x in
+      match uu___ with
       | "Prims.Some" -> ([], "Some")
       | "Prims.None" -> ([], "None")
-      | uu____445 ->
-          let uu____446 = x in
-          (match uu____446 with
+      | uu___1 ->
+          let uu___2 = x in
+          (match uu___2 with
            | (ns, x1) ->
-               let uu____453 = path_of_ns currentModule ns in (uu____453, x1))
+               let uu___3 = path_of_ns currentModule ns in (uu___3, x1))
 let (ptsym_of_symbol :
   FStar_Extraction_ML_Syntax.mlsymbol -> FStar_Extraction_ML_Syntax.mlsymbol)
   =
   fun s ->
-    let uu____463 =
-      let uu____464 =
-        let uu____465 = FStar_String.get s Prims.int_zero in
-        FStar_Char.lowercase uu____465 in
-      let uu____466 = FStar_String.get s Prims.int_zero in
-      uu____464 <> uu____466 in
-    if uu____463 then Prims.op_Hat "l__" s else s
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_String.get s Prims.int_zero in
+        FStar_Char.lowercase uu___2 in
+      let uu___2 = FStar_String.get s Prims.int_zero in uu___1 <> uu___2 in
+    if uu___ then Prims.op_Hat "l__" s else s
 let (ptsym :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol)
@@ -186,31 +183,30 @@ let (ptsym :
       if FStar_List.isEmpty (FStar_Pervasives_Native.fst mlp)
       then ptsym_of_symbol (FStar_Pervasives_Native.snd mlp)
       else
-        (let uu____483 = mlpath_of_mlpath currentModule mlp in
-         match uu____483 with
+        (let uu___1 = mlpath_of_mlpath currentModule mlp in
+         match uu___1 with
          | (p, s) ->
-             let uu____490 =
-               let uu____493 =
-                 let uu____496 = ptsym_of_symbol s in [uu____496] in
-               FStar_List.append p uu____493 in
-             FStar_String.concat "." uu____490)
+             let uu___2 =
+               let uu___3 = let uu___4 = ptsym_of_symbol s in [uu___4] in
+               FStar_List.append p uu___3 in
+             FStar_String.concat "." uu___2)
 let (ptctor :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol)
   =
   fun currentModule ->
     fun mlp ->
-      let uu____507 = mlpath_of_mlpath currentModule mlp in
-      match uu____507 with
+      let uu___ = mlpath_of_mlpath currentModule mlp in
+      match uu___ with
       | (p, s) ->
           let s1 =
-            let uu____515 =
-              let uu____516 =
-                let uu____517 = FStar_String.get s Prims.int_zero in
-                FStar_Char.uppercase uu____517 in
-              let uu____518 = FStar_String.get s Prims.int_zero in
-              uu____516 <> uu____518 in
-            if uu____515 then Prims.op_Hat "U__" s else s in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_String.get s Prims.int_zero in
+                FStar_Char.uppercase uu___3 in
+              let uu___3 = FStar_String.get s Prims.int_zero in
+              uu___2 <> uu___3 in
+            if uu___1 then Prims.op_Hat "U__" s else s in
           FStar_String.concat "." (FStar_List.append p [s1])
 let (infix_prim_ops :
   (Prims.string * (Prims.int * fixity) * Prims.string) Prims.list) =
@@ -229,17 +225,16 @@ let (infix_prim_ops :
   ("op_GreaterThan", e_bin_prio_order, ">");
   ("op_Modulus", e_bin_prio_order, "mod")]
 let (prim_uni_ops : unit -> (Prims.string * Prims.string) Prims.list) =
-  fun uu____748 ->
+  fun uu___ ->
     let op_minus =
-      let uu____750 =
-        let uu____751 = FStar_Options.codegen () in
-        uu____751 = (FStar_Pervasives_Native.Some FStar_Options.FSharp) in
-      if uu____750 then "-" else "~-" in
+      let uu___1 =
+        let uu___2 = FStar_Options.codegen () in
+        uu___2 = (FStar_Pervasives_Native.Some FStar_Options.FSharp) in
+      if uu___1 then "-" else "~-" in
     [("op_Negation", "not");
     ("op_Minus", op_minus);
     ("op_Bang", "Support.ST.read")]
-let prim_types : 'uuuuuu775 . unit -> 'uuuuuu775 Prims.list =
-  fun uu____779 -> []
+let prim_types : 'uuuuu . unit -> 'uuuuu Prims.list = fun uu___ -> []
 let (prim_constructors : (Prims.string * Prims.string) Prims.list) =
   [("Some", "Some"); ("None", "None"); ("Nil", "[]"); ("Cons", "::")]
 let (is_prims_ns :
@@ -250,38 +245,33 @@ let (as_bin_op :
     (FStar_Extraction_ML_Syntax.mlsymbol * (Prims.int * fixity) *
       Prims.string) FStar_Pervasives_Native.option)
   =
-  fun uu____833 ->
-    match uu____833 with
+  fun uu___ ->
+    match uu___ with
     | (ns, x) ->
         if is_prims_ns ns
         then
           FStar_List.tryFind
-            (fun uu____878 ->
-               match uu____878 with | (y, uu____890, uu____891) -> x = y)
+            (fun uu___1 -> match uu___1 with | (y, uu___2, uu___3) -> x = y)
             infix_prim_ops
         else FStar_Pervasives_Native.None
 let (is_bin_op : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
-  fun p ->
-    let uu____916 = as_bin_op p in uu____916 <> FStar_Pervasives_Native.None
+  fun p -> let uu___ = as_bin_op p in uu___ <> FStar_Pervasives_Native.None
 let (as_uni_op :
   FStar_Extraction_ML_Syntax.mlpath ->
     (FStar_Extraction_ML_Syntax.mlsymbol * Prims.string)
       FStar_Pervasives_Native.option)
   =
-  fun uu____961 ->
-    match uu____961 with
+  fun uu___ ->
+    match uu___ with
     | (ns, x) ->
         if is_prims_ns ns
         then
-          let uu____980 = prim_uni_ops () in
+          let uu___1 = prim_uni_ops () in
           FStar_List.tryFind
-            (fun uu____994 -> match uu____994 with | (y, uu____1000) -> x = y)
-            uu____980
+            (fun uu___2 -> match uu___2 with | (y, uu___3) -> x = y) uu___1
         else FStar_Pervasives_Native.None
 let (is_uni_op : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
-  fun p ->
-    let uu____1011 = as_uni_op p in
-    uu____1011 <> FStar_Pervasives_Native.None
+  fun p -> let uu___ = as_uni_op p in uu___ <> FStar_Pervasives_Native.None
 let (is_standard_type : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
   fun p -> false
 let (as_standard_constructor :
@@ -289,34 +279,33 @@ let (as_standard_constructor :
     (FStar_Extraction_ML_Syntax.mlsymbol * Prims.string)
       FStar_Pervasives_Native.option)
   =
-  fun uu____1043 ->
-    match uu____1043 with
+  fun uu___ ->
+    match uu___ with
     | (ns, x) ->
         if is_prims_ns ns
         then
           FStar_List.tryFind
-            (fun uu____1069 ->
-               match uu____1069 with | (y, uu____1075) -> x = y)
+            (fun uu___1 -> match uu___1 with | (y, uu___2) -> x = y)
             prim_constructors
         else FStar_Pervasives_Native.None
 let (is_standard_constructor :
   FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
   fun p ->
-    let uu____1086 = as_standard_constructor p in
-    uu____1086 <> FStar_Pervasives_Native.None
+    let uu___ = as_standard_constructor p in
+    uu___ <> FStar_Pervasives_Native.None
 let (maybe_paren :
   ((Prims.int * fixity) * assoc) -> (Prims.int * fixity) -> doc -> doc) =
-  fun uu____1127 ->
+  fun uu___ ->
     fun inner ->
       fun doc1 ->
-        match uu____1127 with
+        match uu___ with
         | (outer, side) ->
             let noparens _inner _outer side1 =
-              let uu____1184 = _inner in
-              match uu____1184 with
+              let uu___1 = _inner in
+              match uu___1 with
               | (pi, fi) ->
-                  let uu____1191 = _outer in
-                  (match uu____1191 with
+                  let uu___2 = _outer in
+                  (match uu___2 with
                    | (po, fo) ->
                        (pi > po) ||
                          ((match (fi, side1) with
@@ -330,8 +319,8 @@ let (maybe_paren :
                                (pi = po) && (fo = (Infix Left))
                            | (Infix (Right), IRight) ->
                                (pi = po) && (fo = (Infix Right))
-                           | (uu____1198, NonAssoc) -> (pi = po) && (fi = fo)
-                           | (uu____1199, uu____1200) -> false))) in
+                           | (uu___3, NonAssoc) -> (pi = po) && (fi = fo)
+                           | (uu___3, uu___4) -> false))) in
             if noparens inner outer side then doc1 else parens doc1
 let (escape_byte_hex : FStar_BaseTypes.byte -> Prims.string) =
   fun x -> Prims.op_Hat "\\x" (FStar_Util.hex_string_of_byte x)
@@ -342,40 +331,40 @@ let (escape_or :
     FStar_BaseTypes.char -> Prims.string)
   =
   fun fallback ->
-    fun uu___0_1224 ->
-      if uu___0_1224 = 92
+    fun uu___ ->
+      if uu___ = 92
       then "\\\\"
       else
-        if uu___0_1224 = 32
+        if uu___ = 32
         then " "
         else
-          if uu___0_1224 = 8
+          if uu___ = 8
           then "\\b"
           else
-            if uu___0_1224 = 9
+            if uu___ = 9
             then "\\t"
             else
-              if uu___0_1224 = 13
+              if uu___ = 13
               then "\\r"
               else
-                if uu___0_1224 = 10
+                if uu___ = 10
                 then "\\n"
                 else
-                  if uu___0_1224 = 39
+                  if uu___ = 39
                   then "\\'"
                   else
-                    if uu___0_1224 = 34
+                    if uu___ = 34
                     then "\\\""
                     else
-                      if FStar_Util.is_letter_or_digit uu___0_1224
-                      then FStar_Util.string_of_char uu___0_1224
+                      if FStar_Util.is_letter_or_digit uu___
+                      then FStar_Util.string_of_char uu___
                       else
-                        if FStar_Util.is_punctuation uu___0_1224
-                        then FStar_Util.string_of_char uu___0_1224
+                        if FStar_Util.is_punctuation uu___
+                        then FStar_Util.string_of_char uu___
                         else
-                          if FStar_Util.is_symbol uu___0_1224
-                          then FStar_Util.string_of_char uu___0_1224
-                          else fallback uu___0_1224
+                          if FStar_Util.is_symbol uu___
+                          then FStar_Util.string_of_char uu___
+                          else fallback uu___
 let (string_of_mlconstant :
   FStar_Extraction_ML_Syntax.mlconstant -> Prims.string) =
   fun sctt ->
@@ -385,8 +374,8 @@ let (string_of_mlconstant :
     | FStar_Extraction_ML_Syntax.MLC_Bool (false) -> "false"
     | FStar_Extraction_ML_Syntax.MLC_Char c ->
         let nc = FStar_Char.int_of_char c in
-        let uu____1234 = FStar_Util.string_of_int nc in
-        Prims.op_Hat uu____1234
+        let uu___ = FStar_Util.string_of_int nc in
+        Prims.op_Hat uu___
           (if
              ((nc >= (Prims.of_int (32))) && (nc <= (Prims.of_int (127)))) &&
                (nc <> (Prims.of_int (34)))
@@ -403,27 +392,24 @@ let (string_of_mlconstant :
          (FStar_Const.Signed, FStar_Const.Int64))
         -> Prims.op_Hat s "L"
     | FStar_Extraction_ML_Syntax.MLC_Int
-        (s, FStar_Pervasives_Native.Some (uu____1259, FStar_Const.Int8)) -> s
+        (s, FStar_Pervasives_Native.Some (uu___, FStar_Const.Int8)) -> s
     | FStar_Extraction_ML_Syntax.MLC_Int
-        (s, FStar_Pervasives_Native.Some (uu____1271, FStar_Const.Int16)) ->
-        s
+        (s, FStar_Pervasives_Native.Some (uu___, FStar_Const.Int16)) -> s
     | FStar_Extraction_ML_Syntax.MLC_Int (s, FStar_Pervasives_Native.None) ->
         Prims.op_Hat "(Prims.parse_int \"" (Prims.op_Hat s "\")")
     | FStar_Extraction_ML_Syntax.MLC_Float d -> FStar_Util.string_of_float d
     | FStar_Extraction_ML_Syntax.MLC_Bytes bytes ->
-        let uu____1297 =
-          let uu____1298 =
-            FStar_Compiler_Bytes.f_encode escape_byte_hex bytes in
-          Prims.op_Hat uu____1298 "\"" in
-        Prims.op_Hat "\"" uu____1297
+        let uu___ =
+          let uu___1 = FStar_Compiler_Bytes.f_encode escape_byte_hex bytes in
+          Prims.op_Hat uu___1 "\"" in
+        Prims.op_Hat "\"" uu___
     | FStar_Extraction_ML_Syntax.MLC_String chars ->
-        let uu____1300 =
-          let uu____1301 =
+        let uu___ =
+          let uu___1 =
             FStar_String.collect (escape_or FStar_Util.string_of_char) chars in
-          Prims.op_Hat uu____1301 "\"" in
-        Prims.op_Hat "\"" uu____1300
-    | uu____1302 ->
-        failwith "TODO: extract integer constants properly into OCaml"
+          Prims.op_Hat uu___1 "\"" in
+        Prims.op_Hat "\"" uu___
+    | uu___ -> failwith "TODO: extract integer constants properly into OCaml"
 let rec (doc_of_mltype' :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     level -> FStar_Extraction_ML_Syntax.mlty -> doc)
@@ -443,9 +429,9 @@ let rec (doc_of_mltype' :
               FStar_List.map (doc_of_mltype currentModule (t_prio_tpl, Left))
                 tys in
             let doc2 =
-              let uu____1345 =
-                let uu____1346 = combine (text " * ") doc1 in hbox uu____1346 in
-              parens uu____1345 in
+              let uu___ =
+                let uu___1 = combine (text " * ") doc1 in hbox uu___1 in
+              parens uu___ in
             doc2
         | FStar_Extraction_ML_Syntax.MLTY_Named (args, name) ->
             let args1 =
@@ -453,27 +439,25 @@ let rec (doc_of_mltype' :
               | [] -> empty
               | arg::[] ->
                   doc_of_mltype currentModule (t_prio_name, Left) arg
-              | uu____1355 ->
-                  let args1 =
+              | uu___ ->
+                  let args2 =
                     FStar_List.map
                       (doc_of_mltype currentModule (min_op_prec, NonAssoc))
                       args in
-                  let uu____1361 =
-                    let uu____1362 = combine (text ", ") args1 in
-                    hbox uu____1362 in
-                  parens uu____1361 in
+                  let uu___1 =
+                    let uu___2 = combine (text ", ") args2 in hbox uu___2 in
+                  parens uu___1 in
             let name1 = ptsym currentModule name in
-            let uu____1364 = reduce1 [args1; text name1] in hbox uu____1364
-        | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu____1366, t2) ->
+            let uu___ = reduce1 [args1; text name1] in hbox uu___
+        | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, uu___, t2) ->
             let d1 = doc_of_mltype currentModule (t_prio_fun, Left) t1 in
             let d2 = doc_of_mltype currentModule (t_prio_fun, Right) t2 in
-            let uu____1370 =
-              let uu____1371 = reduce1 [d1; text " -> "; d2] in
-              hbox uu____1371 in
-            maybe_paren outer t_prio_fun uu____1370
+            let uu___1 =
+              let uu___2 = reduce1 [d1; text " -> "; d2] in hbox uu___2 in
+            maybe_paren outer t_prio_fun uu___1
         | FStar_Extraction_ML_Syntax.MLTY_Top ->
-            let uu____1372 = FStar_Extraction_ML_Util.codegen_fsharp () in
-            if uu____1372 then text "obj" else text "Obj.t"
+            let uu___ = FStar_Extraction_ML_Util.codegen_fsharp () in
+            if uu___ then text "obj" else text "Obj.t"
         | FStar_Extraction_ML_Syntax.MLTY_Erased -> text "unit"
 and (doc_of_mltype :
   FStar_Extraction_ML_Syntax.mlsymbol ->
@@ -482,8 +466,8 @@ and (doc_of_mltype :
   fun currentModule ->
     fun outer ->
       fun ty ->
-        let uu____1377 = FStar_Extraction_ML_Util.resugar_mlty ty in
-        doc_of_mltype' currentModule outer uu____1377
+        let uu___ = FStar_Extraction_ML_Util.resugar_mlty ty in
+        doc_of_mltype' currentModule outer uu___
 let rec (doc_of_expr :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     level -> FStar_Extraction_ML_Syntax.mlexpr -> doc)
@@ -494,62 +478,62 @@ let rec (doc_of_expr :
         match e.FStar_Extraction_ML_Syntax.expr with
         | FStar_Extraction_ML_Syntax.MLE_Coerce (e1, t, t') ->
             let doc1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-            let uu____1461 = FStar_Extraction_ML_Util.codegen_fsharp () in
-            if uu____1461
+            let uu___ = FStar_Extraction_ML_Util.codegen_fsharp () in
+            if uu___
             then
-              let uu____1462 = reduce [text "Prims.unsafe_coerce "; doc1] in
-              parens uu____1462
+              let uu___1 = reduce [text "Prims.unsafe_coerce "; doc1] in
+              parens uu___1
             else
-              (let uu____1464 = reduce [text "Obj.magic "; parens doc1] in
-               parens uu____1464)
+              (let uu___2 = reduce [text "Obj.magic "; parens doc1] in
+               parens uu___2)
         | FStar_Extraction_ML_Syntax.MLE_Seq es ->
             let docs =
               FStar_List.map
                 (doc_of_expr currentModule (min_op_prec, NonAssoc)) es in
             let docs1 =
               FStar_List.map (fun d -> reduce [d; text ";"; hardline]) docs in
-            let uu____1476 = reduce docs1 in parens uu____1476
+            let uu___ = reduce docs1 in parens uu___
         | FStar_Extraction_ML_Syntax.MLE_Const c ->
-            let uu____1478 = string_of_mlconstant c in text uu____1478
+            let uu___ = string_of_mlconstant c in text uu___
         | FStar_Extraction_ML_Syntax.MLE_Var x -> text x
         | FStar_Extraction_ML_Syntax.MLE_Name path ->
-            let uu____1481 = ptsym currentModule path in text uu____1481
+            let uu___ = ptsym currentModule path in text uu___
         | FStar_Extraction_ML_Syntax.MLE_Record (path, fields) ->
-            let for1 uu____1509 =
-              match uu____1509 with
+            let for1 uu___ =
+              match uu___ with
               | (name, e1) ->
                   let doc1 =
                     doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  let uu____1517 =
-                    let uu____1520 =
-                      let uu____1521 = ptsym currentModule (path, name) in
-                      text uu____1521 in
-                    [uu____1520; text "="; doc1] in
-                  reduce1 uu____1517 in
-            let uu____1524 =
-              let uu____1525 = FStar_List.map for1 fields in
-              combine (text "; ") uu____1525 in
-            cbrackets uu____1524
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = ptsym currentModule (path, name) in
+                      text uu___3 in
+                    [uu___2; text "="; doc1] in
+                  reduce1 uu___1 in
+            let uu___ =
+              let uu___1 = FStar_List.map for1 fields in
+              combine (text "; ") uu___1 in
+            cbrackets uu___
         | FStar_Extraction_ML_Syntax.MLE_CTor (ctor, []) ->
             let name =
-              let uu____1536 = is_standard_constructor ctor in
-              if uu____1536
+              let uu___ = is_standard_constructor ctor in
+              if uu___
               then
-                let uu____1537 =
-                  let uu____1542 = as_standard_constructor ctor in
-                  FStar_Option.get uu____1542 in
-                FStar_Pervasives_Native.snd uu____1537
+                let uu___1 =
+                  let uu___2 = as_standard_constructor ctor in
+                  FStar_Option.get uu___2 in
+                FStar_Pervasives_Native.snd uu___1
               else ptctor currentModule ctor in
             text name
         | FStar_Extraction_ML_Syntax.MLE_CTor (ctor, args) ->
             let name =
-              let uu____1561 = is_standard_constructor ctor in
-              if uu____1561
+              let uu___ = is_standard_constructor ctor in
+              if uu___
               then
-                let uu____1562 =
-                  let uu____1567 = as_standard_constructor ctor in
-                  FStar_Option.get uu____1567 in
-                FStar_Pervasives_Native.snd uu____1562
+                let uu___1 =
+                  let uu___2 = as_standard_constructor ctor in
+                  FStar_Option.get uu___2 in
+                FStar_Pervasives_Native.snd uu___1
               else ptctor currentModule ctor in
             let args1 =
               FStar_List.map
@@ -557,25 +541,24 @@ let rec (doc_of_expr :
             let doc1 =
               match (name, args1) with
               | ("::", x::xs::[]) -> reduce [parens x; text "::"; xs]
-              | (uu____1589, uu____1590) ->
-                  let uu____1595 =
-                    let uu____1598 =
-                      let uu____1601 =
-                        let uu____1602 = combine (text ", ") args1 in
-                        parens uu____1602 in
-                      [uu____1601] in
-                    (text name) :: uu____1598 in
-                  reduce1 uu____1595 in
+              | (uu___, uu___1) ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 = combine (text ", ") args1 in
+                        parens uu___5 in
+                      [uu___4] in
+                    (text name) :: uu___3 in
+                  reduce1 uu___2 in
             maybe_paren outer e_app_prio doc1
         | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
             let docs =
               FStar_List.map
                 (fun x ->
-                   let uu____1612 =
+                   let uu___ =
                      doc_of_expr currentModule (min_op_prec, NonAssoc) x in
-                   parens uu____1612) es in
-            let docs1 =
-              let uu____1614 = combine (text ", ") docs in parens uu____1614 in
+                   parens uu___) es in
+            let docs1 = let uu___ = combine (text ", ") docs in parens uu___ in
             docs1
         | FStar_Extraction_ML_Syntax.MLE_Let ((rec_, lets), body) ->
             let pre =
@@ -583,52 +566,46 @@ let rec (doc_of_expr :
                 e.FStar_Extraction_ML_Syntax.loc <>
                   FStar_Extraction_ML_Syntax.dummy_loc
               then
-                let uu____1629 =
-                  let uu____1632 =
-                    let uu____1635 =
-                      doc_of_loc e.FStar_Extraction_ML_Syntax.loc in
-                    [uu____1635] in
-                  hardline :: uu____1632 in
-                reduce uu____1629
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 = doc_of_loc e.FStar_Extraction_ML_Syntax.loc in
+                    [uu___2] in
+                  hardline :: uu___1 in
+                reduce uu___
               else empty in
             let doc1 = doc_of_lets currentModule (rec_, false, lets) in
             let body1 =
               doc_of_expr currentModule (min_op_prec, NonAssoc) body in
-            let uu____1641 =
-              let uu____1642 =
-                let uu____1645 =
-                  let uu____1648 =
-                    let uu____1651 = reduce1 [text "in"; body1] in
-                    [uu____1651] in
-                  doc1 :: uu____1648 in
-                pre :: uu____1645 in
-              combine hardline uu____1642 in
-            parens uu____1641
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = reduce1 [text "in"; body1] in [uu___4] in
+                  doc1 :: uu___3 in
+                pre :: uu___2 in
+              combine hardline uu___1 in
+            parens uu___
         | FStar_Extraction_ML_Syntax.MLE_App (e1, args) ->
             (match ((e1.FStar_Extraction_ML_Syntax.expr), args) with
              | (FStar_Extraction_ML_Syntax.MLE_Name p,
                 {
                   FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Fun
-                    (uu____1661::[], scrutinee);
-                  FStar_Extraction_ML_Syntax.mlty = uu____1663;
-                  FStar_Extraction_ML_Syntax.loc = uu____1664;_}::{
-                                                                    FStar_Extraction_ML_Syntax.expr
-                                                                    =
-                                                                    FStar_Extraction_ML_Syntax.MLE_Fun
-                                                                    ((arg,
-                                                                    uu____1666)::[],
-                                                                    possible_match);
-                                                                    FStar_Extraction_ML_Syntax.mlty
-                                                                    =
-                                                                    uu____1668;
-                                                                    FStar_Extraction_ML_Syntax.loc
-                                                                    =
-                                                                    uu____1669;_}::[])
+                    FStar_Extraction_ML_Syntax.MLE_Fun (uu___::[], scrutinee);
+                  FStar_Extraction_ML_Syntax.mlty = uu___1;
+                  FStar_Extraction_ML_Syntax.loc = uu___2;_}::{
+                                                                FStar_Extraction_ML_Syntax.expr
+                                                                  =
+                                                                  FStar_Extraction_ML_Syntax.MLE_Fun
+                                                                  ((arg,
+                                                                    uu___3)::[],
+                                                                   possible_match);
+                                                                FStar_Extraction_ML_Syntax.mlty
+                                                                  = uu___4;
+                                                                FStar_Extraction_ML_Syntax.loc
+                                                                  = uu___5;_}::[])
                  when
-                 let uu____1704 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu____1704 = "FStar.All.try_with" ->
+                 let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+                 uu___6 = "FStar.All.try_with" ->
                  let branches =
                    match possible_match with
                    | {
@@ -637,12 +614,12 @@ let rec (doc_of_expr :
                          ({
                             FStar_Extraction_ML_Syntax.expr =
                               FStar_Extraction_ML_Syntax.MLE_Var arg';
-                            FStar_Extraction_ML_Syntax.mlty = uu____1727;
-                            FStar_Extraction_ML_Syntax.loc = uu____1728;_},
-                          branches);
-                       FStar_Extraction_ML_Syntax.mlty = uu____1730;
-                       FStar_Extraction_ML_Syntax.loc = uu____1731;_} when
-                       arg = arg' -> branches
+                            FStar_Extraction_ML_Syntax.mlty = uu___6;
+                            FStar_Extraction_ML_Syntax.loc = uu___7;_},
+                          branches1);
+                       FStar_Extraction_ML_Syntax.mlty = uu___8;
+                       FStar_Extraction_ML_Syntax.loc = uu___9;_} when
+                       arg = arg' -> branches1
                    | e2 ->
                        [(FStar_Extraction_ML_Syntax.MLP_Wild,
                           FStar_Pervasives_Native.None, e2)] in
@@ -662,8 +639,8 @@ let rec (doc_of_expr :
                 ({
                    FStar_Extraction_ML_Syntax.expr =
                      FStar_Extraction_ML_Syntax.MLE_Name p;
-                   FStar_Extraction_ML_Syntax.mlty = uu____1787;
-                   FStar_Extraction_ML_Syntax.loc = uu____1788;_},
+                   FStar_Extraction_ML_Syntax.mlty = uu___;
+                   FStar_Extraction_ML_Syntax.loc = uu___1;_},
                  unitVal::[]),
                 e11::e2::[]) when
                  (is_bin_op p) &&
@@ -675,167 +652,161 @@ let rec (doc_of_expr :
                 ({
                    FStar_Extraction_ML_Syntax.expr =
                      FStar_Extraction_ML_Syntax.MLE_Name p;
-                   FStar_Extraction_ML_Syntax.mlty = uu____1801;
-                   FStar_Extraction_ML_Syntax.loc = uu____1802;_},
+                   FStar_Extraction_ML_Syntax.mlty = uu___;
+                   FStar_Extraction_ML_Syntax.loc = uu___1;_},
                  unitVal::[]),
                 e11::[]) when
                  (is_uni_op p) &&
                    (unitVal = FStar_Extraction_ML_Syntax.ml_unit)
                  -> doc_of_uniop currentModule p e11
-             | uu____1809 ->
+             | uu___ ->
                  let e2 = doc_of_expr currentModule (e_app_prio, ILeft) e1 in
                  let args1 =
                    FStar_List.map
                      (doc_of_expr currentModule (e_app_prio, IRight)) args in
-                 let uu____1820 = reduce1 (e2 :: args1) in parens uu____1820)
+                 let uu___1 = reduce1 (e2 :: args1) in parens uu___1)
         | FStar_Extraction_ML_Syntax.MLE_Proj (e1, f) ->
             let e2 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
             let doc1 =
-              let uu____1825 = FStar_Extraction_ML_Util.codegen_fsharp () in
-              if uu____1825
+              let uu___ = FStar_Extraction_ML_Util.codegen_fsharp () in
+              if uu___
               then
                 reduce [e2; text "."; text (FStar_Pervasives_Native.snd f)]
               else
-                (let uu____1829 =
-                   let uu____1832 =
-                     let uu____1835 =
-                       let uu____1838 =
-                         let uu____1839 = ptsym currentModule f in
-                         text uu____1839 in
-                       [uu____1838] in
-                     (text ".") :: uu____1835 in
-                   e2 :: uu____1832 in
-                 reduce uu____1829) in
+                (let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 = ptsym currentModule f in text uu___6 in
+                       [uu___5] in
+                     (text ".") :: uu___4 in
+                   e2 :: uu___3 in
+                 reduce uu___2) in
             doc1
         | FStar_Extraction_ML_Syntax.MLE_Fun (ids, body) ->
             let bvar_annot x xt =
-              let uu____1869 = FStar_Extraction_ML_Util.codegen_fsharp () in
-              if uu____1869
+              let uu___ = FStar_Extraction_ML_Util.codegen_fsharp () in
+              if uu___
               then
-                let uu____1870 =
-                  let uu____1873 =
-                    let uu____1876 =
-                      let uu____1879 =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
                         match xt with
                         | FStar_Pervasives_Native.Some xxt ->
-                            let uu____1881 =
-                              let uu____1884 =
-                                let uu____1887 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   doc_of_mltype currentModule outer xxt in
-                                [uu____1887] in
-                              (text " : ") :: uu____1884 in
-                            reduce1 uu____1881
-                        | uu____1888 -> text "" in
-                      [uu____1879; text ")"] in
-                    (text x) :: uu____1876 in
-                  (text "(") :: uu____1873 in
-                reduce1 uu____1870
+                                [uu___7] in
+                              (text " : ") :: uu___6 in
+                            reduce1 uu___5
+                        | uu___5 -> text "" in
+                      [uu___4; text ")"] in
+                    (text x) :: uu___3 in
+                  (text "(") :: uu___2 in
+                reduce1 uu___1
               else text x in
             let ids1 =
               FStar_List.map
-                (fun uu____1902 ->
-                   match uu____1902 with
+                (fun uu___ ->
+                   match uu___ with
                    | (x, xt) ->
                        bvar_annot x (FStar_Pervasives_Native.Some xt)) ids in
             let body1 =
               doc_of_expr currentModule (min_op_prec, NonAssoc) body in
             let doc1 =
-              let uu____1911 =
-                let uu____1914 =
-                  let uu____1917 = reduce1 ids1 in
-                  [uu____1917; text "->"; body1] in
-                (text "fun") :: uu____1914 in
-              reduce1 uu____1911 in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = reduce1 ids1 in [uu___2; text "->"; body1] in
+                (text "fun") :: uu___1 in
+              reduce1 uu___ in
             parens doc1
         | FStar_Extraction_ML_Syntax.MLE_If
             (cond, e1, FStar_Pervasives_Native.None) ->
             let cond1 =
               doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
             let doc1 =
-              let uu____1924 =
-                let uu____1927 =
+              let uu___ =
+                let uu___1 =
                   reduce1 [text "if"; cond1; text "then"; text "begin"] in
-                let uu____1928 =
-                  let uu____1931 =
+                let uu___2 =
+                  let uu___3 =
                     doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  [uu____1931; text "end"] in
-                uu____1927 :: uu____1928 in
-              combine hardline uu____1924 in
+                  [uu___3; text "end"] in
+                uu___1 :: uu___2 in
+              combine hardline uu___ in
             maybe_paren outer e_bin_prio_if doc1
         | FStar_Extraction_ML_Syntax.MLE_If
             (cond, e1, FStar_Pervasives_Native.Some e2) ->
             let cond1 =
               doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
             let doc1 =
-              let uu____1939 =
-                let uu____1942 =
+              let uu___ =
+                let uu___1 =
                   reduce1 [text "if"; cond1; text "then"; text "begin"] in
-                let uu____1943 =
-                  let uu____1946 =
+                let uu___2 =
+                  let uu___3 =
                     doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                  let uu____1947 =
-                    let uu____1950 =
+                  let uu___4 =
+                    let uu___5 =
                       reduce1 [text "end"; text "else"; text "begin"] in
-                    let uu____1951 =
-                      let uu____1954 =
+                    let uu___6 =
+                      let uu___7 =
                         doc_of_expr currentModule (min_op_prec, NonAssoc) e2 in
-                      [uu____1954; text "end"] in
-                    uu____1950 :: uu____1951 in
-                  uu____1946 :: uu____1947 in
-                uu____1942 :: uu____1943 in
-              combine hardline uu____1939 in
+                      [uu___7; text "end"] in
+                    uu___5 :: uu___6 in
+                  uu___3 :: uu___4 in
+                uu___1 :: uu___2 in
+              combine hardline uu___ in
             maybe_paren outer e_bin_prio_if doc1
         | FStar_Extraction_ML_Syntax.MLE_Match (cond, pats) ->
             let cond1 =
               doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
             let pats1 = FStar_List.map (doc_of_branch currentModule) pats in
             let doc1 =
-              let uu____1992 =
-                reduce1 [text "match"; parens cond1; text "with"] in
-              uu____1992 :: pats1 in
+              let uu___ = reduce1 [text "match"; parens cond1; text "with"] in
+              uu___ :: pats1 in
             let doc2 = combine hardline doc1 in parens doc2
         | FStar_Extraction_ML_Syntax.MLE_Raise (exn, []) ->
-            let uu____1997 =
-              let uu____2000 =
-                let uu____2003 =
-                  let uu____2004 = ptctor currentModule exn in
-                  text uu____2004 in
-                [uu____2003] in
-              (text "raise") :: uu____2000 in
-            reduce1 uu____1997
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = ptctor currentModule exn in text uu___3 in
+                [uu___2] in
+              (text "raise") :: uu___1 in
+            reduce1 uu___
         | FStar_Extraction_ML_Syntax.MLE_Raise (exn, args) ->
             let args1 =
               FStar_List.map
                 (doc_of_expr currentModule (min_op_prec, NonAssoc)) args in
-            let uu____2014 =
-              let uu____2017 =
-                let uu____2020 =
-                  let uu____2021 = ptctor currentModule exn in
-                  text uu____2021 in
-                let uu____2022 =
-                  let uu____2025 =
-                    let uu____2026 = combine (text ", ") args1 in
-                    parens uu____2026 in
-                  [uu____2025] in
-                uu____2020 :: uu____2022 in
-              (text "raise") :: uu____2017 in
-            reduce1 uu____2014
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = ptctor currentModule exn in text uu___3 in
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = combine (text ", ") args1 in parens uu___5 in
+                  [uu___4] in
+                uu___2 :: uu___3 in
+              (text "raise") :: uu___1 in
+            reduce1 uu___
         | FStar_Extraction_ML_Syntax.MLE_Try (e1, pats) ->
-            let uu____2049 =
-              let uu____2052 =
-                let uu____2055 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
                   doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
-                let uu____2056 =
-                  let uu____2059 =
-                    let uu____2062 =
-                      let uu____2063 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
                         FStar_List.map (doc_of_branch currentModule) pats in
-                      combine hardline uu____2063 in
-                    [uu____2062] in
-                  (text "with") :: uu____2059 in
-                uu____2055 :: uu____2056 in
-              (text "try") :: uu____2052 in
-            combine hardline uu____2049
+                      combine hardline uu___6 in
+                    [uu___5] in
+                  (text "with") :: uu___4 in
+                uu___2 :: uu___3 in
+              (text "try") :: uu___1 in
+            combine hardline uu___
         | FStar_Extraction_ML_Syntax.MLE_TApp (head, ty_args) ->
             doc_of_expr currentModule outer head
 and (doc_of_binop :
@@ -848,10 +819,9 @@ and (doc_of_binop :
     fun p ->
       fun e1 ->
         fun e2 ->
-          let uu____2084 =
-            let uu____2095 = as_bin_op p in FStar_Option.get uu____2095 in
-          match uu____2084 with
-          | (uu____2118, prio, txt) ->
+          let uu___ = let uu___1 = as_bin_op p in FStar_Option.get uu___1 in
+          match uu___ with
+          | (uu___1, prio, txt) ->
               let e11 = doc_of_expr currentModule (prio, Left) e1 in
               let e21 = doc_of_expr currentModule (prio, Right) e2 in
               let doc1 = reduce1 [e11; text txt; e21] in parens doc1
@@ -863,10 +833,9 @@ and (doc_of_uniop :
   fun currentModule ->
     fun p ->
       fun e1 ->
-        let uu____2135 =
-          let uu____2140 = as_uni_op p in FStar_Option.get uu____2140 in
-        match uu____2135 with
-        | (uu____2151, txt) ->
+        let uu___ = let uu___1 = as_uni_op p in FStar_Option.get uu___1 in
+        match uu___ with
+        | (uu___1, txt) ->
             let e11 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
             let doc1 = reduce1 [text txt; parens e11] in parens doc1
 and (doc_of_pattern :
@@ -878,88 +847,86 @@ and (doc_of_pattern :
       match pattern with
       | FStar_Extraction_ML_Syntax.MLP_Wild -> text "_"
       | FStar_Extraction_ML_Syntax.MLP_Const c ->
-          let uu____2158 = string_of_mlconstant c in text uu____2158
+          let uu___ = string_of_mlconstant c in text uu___
       | FStar_Extraction_ML_Syntax.MLP_Var x -> text x
       | FStar_Extraction_ML_Syntax.MLP_Record (path, fields) ->
-          let for1 uu____2187 =
-            match uu____2187 with
+          let for1 uu___ =
+            match uu___ with
             | (name, p) ->
-                let uu____2194 =
-                  let uu____2197 =
-                    let uu____2198 = ptsym currentModule (path, name) in
-                    text uu____2198 in
-                  let uu____2201 =
-                    let uu____2204 =
-                      let uu____2207 = doc_of_pattern currentModule p in
-                      [uu____2207] in
-                    (text "=") :: uu____2204 in
-                  uu____2197 :: uu____2201 in
-                reduce1 uu____2194 in
-          let uu____2208 =
-            let uu____2209 = FStar_List.map for1 fields in
-            combine (text "; ") uu____2209 in
-          cbrackets uu____2208
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = ptsym currentModule (path, name) in
+                    text uu___3 in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = doc_of_pattern currentModule p in [uu___5] in
+                    (text "=") :: uu___4 in
+                  uu___2 :: uu___3 in
+                reduce1 uu___1 in
+          let uu___ =
+            let uu___1 = FStar_List.map for1 fields in
+            combine (text "; ") uu___1 in
+          cbrackets uu___
       | FStar_Extraction_ML_Syntax.MLP_CTor (ctor, []) ->
           let name =
-            let uu____2220 = is_standard_constructor ctor in
-            if uu____2220
+            let uu___ = is_standard_constructor ctor in
+            if uu___
             then
-              let uu____2221 =
-                let uu____2226 = as_standard_constructor ctor in
-                FStar_Option.get uu____2226 in
-              FStar_Pervasives_Native.snd uu____2221
+              let uu___1 =
+                let uu___2 = as_standard_constructor ctor in
+                FStar_Option.get uu___2 in
+              FStar_Pervasives_Native.snd uu___1
             else ptctor currentModule ctor in
           text name
       | FStar_Extraction_ML_Syntax.MLP_CTor (ctor, pats) ->
           let name =
-            let uu____2245 = is_standard_constructor ctor in
-            if uu____2245
+            let uu___ = is_standard_constructor ctor in
+            if uu___
             then
-              let uu____2246 =
-                let uu____2251 = as_standard_constructor ctor in
-                FStar_Option.get uu____2251 in
-              FStar_Pervasives_Native.snd uu____2246
+              let uu___1 =
+                let uu___2 = as_standard_constructor ctor in
+                FStar_Option.get uu___2 in
+              FStar_Pervasives_Native.snd uu___1
             else ptctor currentModule ctor in
           let doc1 =
             match (name, pats) with
             | ("::", x::xs::[]) ->
-                let uu____2270 =
-                  let uu____2273 =
-                    let uu____2274 = doc_of_pattern currentModule x in
-                    parens uu____2274 in
-                  let uu____2275 =
-                    let uu____2278 =
-                      let uu____2281 = doc_of_pattern currentModule xs in
-                      [uu____2281] in
-                    (text "::") :: uu____2278 in
-                  uu____2273 :: uu____2275 in
-                reduce uu____2270
-            | (uu____2282, (FStar_Extraction_ML_Syntax.MLP_Tuple
-               uu____2283)::[]) ->
-                let uu____2288 =
-                  let uu____2291 =
-                    let uu____2294 =
-                      let uu____2295 = FStar_List.hd pats in
-                      doc_of_pattern currentModule uu____2295 in
-                    [uu____2294] in
-                  (text name) :: uu____2291 in
-                reduce1 uu____2288
-            | uu____2296 ->
-                let uu____2303 =
-                  let uu____2306 =
-                    let uu____2309 =
-                      let uu____2310 =
-                        let uu____2311 =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 = doc_of_pattern currentModule x in
+                    parens uu___2 in
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = doc_of_pattern currentModule xs in
+                      [uu___4] in
+                    (text "::") :: uu___3 in
+                  uu___1 :: uu___2 in
+                reduce uu___
+            | (uu___, (FStar_Extraction_ML_Syntax.MLP_Tuple uu___1)::[]) ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = FStar_List.hd pats in
+                      doc_of_pattern currentModule uu___5 in
+                    [uu___4] in
+                  (text name) :: uu___3 in
+                reduce1 uu___2
+            | uu___ ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_List.map (doc_of_pattern currentModule) pats in
-                        combine (text ", ") uu____2311 in
-                      parens uu____2310 in
-                    [uu____2309] in
-                  (text name) :: uu____2306 in
-                reduce1 uu____2303 in
+                        combine (text ", ") uu___5 in
+                      parens uu___4 in
+                    [uu___3] in
+                  (text name) :: uu___2 in
+                reduce1 uu___1 in
           maybe_paren (min_op_prec, NonAssoc) e_app_prio doc1
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
           let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
-          let uu____2324 = combine (text ", ") ps1 in parens uu____2324
+          let uu___ = combine (text ", ") ps1 in parens uu___
       | FStar_Extraction_ML_Syntax.MLP_Branch ps ->
           let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
           let ps2 = FStar_List.map parens ps1 in combine (text " | ") ps2
@@ -968,50 +935,49 @@ and (doc_of_branch :
     FStar_Extraction_ML_Syntax.mlbranch -> doc)
   =
   fun currentModule ->
-    fun uu____2335 ->
-      match uu____2335 with
+    fun uu___ ->
+      match uu___ with
       | (p, cond, e) ->
           let case =
             match cond with
             | FStar_Pervasives_Native.None ->
-                let uu____2344 =
-                  let uu____2347 =
-                    let uu____2350 = doc_of_pattern currentModule p in
-                    [uu____2350] in
-                  (text "|") :: uu____2347 in
-                reduce1 uu____2344
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = doc_of_pattern currentModule p in [uu___3] in
+                  (text "|") :: uu___2 in
+                reduce1 uu___1
             | FStar_Pervasives_Native.Some c ->
                 let c1 = doc_of_expr currentModule (min_op_prec, NonAssoc) c in
-                let uu____2353 =
-                  let uu____2356 =
-                    let uu____2359 = doc_of_pattern currentModule p in
-                    [uu____2359; text "when"; c1] in
-                  (text "|") :: uu____2356 in
-                reduce1 uu____2353 in
-          let uu____2360 =
-            let uu____2363 = reduce1 [case; text "->"; text "begin"] in
-            let uu____2364 =
-              let uu____2367 =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = doc_of_pattern currentModule p in
+                    [uu___3; text "when"; c1] in
+                  (text "|") :: uu___2 in
+                reduce1 uu___1 in
+          let uu___1 =
+            let uu___2 = reduce1 [case; text "->"; text "begin"] in
+            let uu___3 =
+              let uu___4 =
                 doc_of_expr currentModule (min_op_prec, NonAssoc) e in
-              [uu____2367; text "end"] in
-            uu____2363 :: uu____2364 in
-          combine hardline uu____2360
+              [uu___4; text "end"] in
+            uu___2 :: uu___3 in
+          combine hardline uu___1
 and (doc_of_lets :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     (FStar_Extraction_ML_Syntax.mlletflavor * Prims.bool *
       FStar_Extraction_ML_Syntax.mllb Prims.list) -> doc)
   =
   fun currentModule ->
-    fun uu____2369 ->
-      match uu____2369 with
+    fun uu___ ->
+      match uu___ with
       | (rec_, top_level, lets) ->
-          let for1 uu____2390 =
-            match uu____2390 with
+          let for1 uu___1 =
+            match uu___1 with
             | { FStar_Extraction_ML_Syntax.mllb_name = name;
                 FStar_Extraction_ML_Syntax.mllb_tysc = tys;
-                FStar_Extraction_ML_Syntax.mllb_add_unit = uu____2393;
+                FStar_Extraction_ML_Syntax.mllb_add_unit = uu___2;
                 FStar_Extraction_ML_Syntax.mllb_def = e;
-                FStar_Extraction_ML_Syntax.mllb_meta = uu____2395;
+                FStar_Extraction_ML_Syntax.mllb_meta = uu___3;
                 FStar_Extraction_ML_Syntax.print_typ = pt;_} ->
                 let e1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e in
                 let ids = [] in
@@ -1019,15 +985,15 @@ and (doc_of_lets :
                   if Prims.op_Negation pt
                   then text ""
                   else
-                    (let uu____2405 =
+                    (let uu___5 =
                        (FStar_Extraction_ML_Util.codegen_fsharp ()) &&
                          ((rec_ = FStar_Extraction_ML_Syntax.Rec) ||
                             top_level) in
-                     if uu____2405
+                     if uu___5
                      then
                        match tys with
                        | FStar_Pervasives_Native.Some
-                           (uu____2406::uu____2407, uu____2408) -> text ""
+                           (uu___6::uu___7, uu___8) -> text ""
                        | FStar_Pervasives_Native.None -> text ""
                        | FStar_Pervasives_Native.Some ([], ty) ->
                            let ty1 =
@@ -1049,7 +1015,7 @@ and (doc_of_lets :
                                 doc_of_mltype currentModule
                                   (min_op_prec, NonAssoc) ty in
                               let vars =
-                                let uu____2420 =
+                                let uu___7 =
                                   FStar_All.pipe_right vs
                                     (FStar_List.map
                                        (fun x ->
@@ -1057,15 +1023,15 @@ and (doc_of_lets :
                                             (min_op_prec, NonAssoc)
                                             (FStar_Extraction_ML_Syntax.MLTY_Var
                                                x))) in
-                                FStar_All.pipe_right uu____2420 reduce1 in
+                                FStar_All.pipe_right uu___7 reduce1 in
                               reduce1 [text ":"; vars; text "."; ty1])
                        else text "") in
-                let uu____2432 =
-                  let uu____2435 =
-                    let uu____2438 = reduce1 ids in
-                    [uu____2438; ty_annot; text "="; e1] in
-                  (text name) :: uu____2435 in
-                reduce1 uu____2432 in
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = reduce1 ids in
+                    [uu___6; ty_annot; text "="; e1] in
+                  (text name) :: uu___5 in
+                reduce1 uu___4 in
           let letdoc =
             if rec_ = FStar_Extraction_ML_Syntax.Rec
             then reduce1 [text "let"; text "rec"]
@@ -1080,33 +1046,32 @@ and (doc_of_lets :
                      doc1]) lets1 in
           combine hardline lets2
 and (doc_of_loc : FStar_Extraction_ML_Syntax.mlloc -> doc) =
-  fun uu____2452 ->
-    match uu____2452 with
+  fun uu___ ->
+    match uu___ with
     | (lineno, file) ->
-        let uu____2455 =
+        let uu___1 =
           ((FStar_Options.no_location_info ()) ||
              (FStar_Extraction_ML_Util.codegen_fsharp ()))
             || (file = "<dummy>") in
-        if uu____2455
+        if uu___1
         then empty
         else
           (let file1 = FStar_Util.basename file in
-           let uu____2458 =
-             let uu____2461 =
-               let uu____2464 = num lineno in
-               [uu____2464;
-               text (Prims.op_Hat "\"" (Prims.op_Hat file1 "\""))] in
-             (text "#") :: uu____2461 in
-           reduce1 uu____2458)
+           let uu___3 =
+             let uu___4 =
+               let uu___5 = num lineno in
+               [uu___5; text (Prims.op_Hat "\"" (Prims.op_Hat file1 "\""))] in
+             (text "#") :: uu___4 in
+           reduce1 uu___3)
 let (doc_of_mltydecl :
   FStar_Extraction_ML_Syntax.mlsymbol ->
     FStar_Extraction_ML_Syntax.mltydecl -> doc)
   =
   fun currentModule ->
     fun decls ->
-      let for1 uu____2498 =
-        match uu____2498 with
-        | (uu____2517, x, mangle_opt, tparams, uu____2521, body) ->
+      let for1 uu___ =
+        match uu___ with
+        | (uu___1, x, mangle_opt, tparams, uu___2, body) ->
             let x1 =
               match mangle_opt with
               | FStar_Pervasives_Native.None -> x
@@ -1115,37 +1080,36 @@ let (doc_of_mltydecl :
               match tparams with
               | [] -> empty
               | x2::[] -> text x2
-              | uu____2539 ->
+              | uu___3 ->
                   let doc1 = FStar_List.map (fun x2 -> text x2) tparams in
-                  let uu____2547 = combine (text ", ") doc1 in
-                  parens uu____2547 in
+                  let uu___4 = combine (text ", ") doc1 in parens uu___4 in
             let forbody body1 =
               match body1 with
               | FStar_Extraction_ML_Syntax.MLTD_Abbrev ty ->
                   doc_of_mltype currentModule (min_op_prec, NonAssoc) ty
               | FStar_Extraction_ML_Syntax.MLTD_Record fields ->
-                  let forfield uu____2571 =
-                    match uu____2571 with
+                  let forfield uu___3 =
+                    match uu___3 with
                     | (name, ty) ->
                         let name1 = text name in
                         let ty1 =
                           doc_of_mltype currentModule (min_op_prec, NonAssoc)
                             ty in
                         reduce1 [name1; text ":"; ty1] in
-                  let uu____2580 =
-                    let uu____2581 = FStar_List.map forfield fields in
-                    combine (text "; ") uu____2581 in
-                  cbrackets uu____2580
+                  let uu___3 =
+                    let uu___4 = FStar_List.map forfield fields in
+                    combine (text "; ") uu___4 in
+                  cbrackets uu___3
               | FStar_Extraction_ML_Syntax.MLTD_DType ctors ->
-                  let forctor uu____2616 =
-                    match uu____2616 with
+                  let forctor uu___3 =
+                    match uu___3 with
                     | (name, tys) ->
-                        let uu____2641 = FStar_List.split tys in
-                        (match uu____2641 with
+                        let uu___4 = FStar_List.split tys in
+                        (match uu___4 with
                          | (_names, tys1) ->
                              (match tys1 with
                               | [] -> text name
-                              | uu____2660 ->
+                              | uu___5 ->
                                   let tys2 =
                                     FStar_List.map
                                       (doc_of_mltype currentModule
@@ -1157,31 +1121,29 @@ let (doc_of_mltydecl :
                     FStar_List.map (fun d -> reduce1 [text "|"; d]) ctors1 in
                   combine hardline ctors2 in
             let doc1 =
-              let uu____2686 =
-                let uu____2689 =
-                  let uu____2692 =
-                    let uu____2693 = ptsym currentModule ([], x1) in
-                    text uu____2693 in
-                  [uu____2692] in
-                tparams1 :: uu____2689 in
-              reduce1 uu____2686 in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = ptsym currentModule ([], x1) in text uu___6 in
+                  [uu___5] in
+                tparams1 :: uu___4 in
+              reduce1 uu___3 in
             (match body with
              | FStar_Pervasives_Native.None -> doc1
              | FStar_Pervasives_Native.Some body1 ->
                  let body2 = forbody body1 in
-                 let uu____2698 =
-                   let uu____2701 = reduce1 [doc1; text "="] in
-                   [uu____2701; body2] in
-                 combine hardline uu____2698) in
+                 let uu___3 =
+                   let uu___4 = reduce1 [doc1; text "="] in [uu___4; body2] in
+                 combine hardline uu___3) in
       let doc1 = FStar_List.map for1 decls in
       let doc2 =
         if (FStar_List.length doc1) > Prims.int_zero
         then
-          let uu____2706 =
-            let uu____2709 =
-              let uu____2712 = combine (text " \n and ") doc1 in [uu____2712] in
-            (text "type") :: uu____2709 in
-          reduce1 uu____2706
+          let uu___ =
+            let uu___1 =
+              let uu___2 = combine (text " \n and ") doc1 in [uu___2] in
+            (text "type") :: uu___1 in
+          reduce1 uu___
         else text "" in
       doc2
 let rec (doc_of_sig1 :
@@ -1192,25 +1154,23 @@ let rec (doc_of_sig1 :
     fun s ->
       match s with
       | FStar_Extraction_ML_Syntax.MLS_Mod (x, subsig) ->
-          let uu____2738 =
-            let uu____2741 = reduce1 [text "module"; text x; text "="] in
-            let uu____2742 =
-              let uu____2745 = doc_of_sig currentModule subsig in
-              let uu____2746 =
-                let uu____2749 = reduce1 [text "end"] in [uu____2749] in
-              uu____2745 :: uu____2746 in
-            uu____2741 :: uu____2742 in
-          combine hardline uu____2738
+          let uu___ =
+            let uu___1 = reduce1 [text "module"; text x; text "="] in
+            let uu___2 =
+              let uu___3 = doc_of_sig currentModule subsig in
+              let uu___4 = let uu___5 = reduce1 [text "end"] in [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
+          combine hardline uu___
       | FStar_Extraction_ML_Syntax.MLS_Exn (x, []) ->
           reduce1 [text "exception"; text x]
       | FStar_Extraction_ML_Syntax.MLS_Exn (x, args) ->
           let args1 =
             FStar_List.map
               (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args in
-          let args2 =
-            let uu____2763 = combine (text " * ") args1 in parens uu____2763 in
+          let args2 = let uu___ = combine (text " * ") args1 in parens uu___ in
           reduce1 [text "exception"; text x; text "of"; args2]
-      | FStar_Extraction_ML_Syntax.MLS_Val (x, (uu____2765, ty)) ->
+      | FStar_Extraction_ML_Syntax.MLS_Val (x, (uu___, ty)) ->
           let ty1 = doc_of_mltype currentModule (min_op_prec, NonAssoc) ty in
           reduce1 [text "val"; text x; text ": "; ty1]
       | FStar_Extraction_ML_Syntax.MLS_Ty decls ->
@@ -1239,25 +1199,24 @@ let (doc_of_mod1 :
           let args2 =
             FStar_List.map
               (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args1 in
-          let args3 =
-            let uu____2825 = combine (text " * ") args2 in parens uu____2825 in
+          let args3 = let uu___ = combine (text " * ") args2 in parens uu___ in
           reduce1 [text "exception"; text x; text "of"; args3]
       | FStar_Extraction_ML_Syntax.MLM_Ty decls ->
           doc_of_mltydecl currentModule decls
       | FStar_Extraction_ML_Syntax.MLM_Let (rec_, lets) ->
           doc_of_lets currentModule (rec_, true, lets)
       | FStar_Extraction_ML_Syntax.MLM_Top e ->
-          let uu____2836 =
-            let uu____2839 =
-              let uu____2842 =
-                let uu____2845 =
-                  let uu____2848 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
                     doc_of_expr currentModule (min_op_prec, NonAssoc) e in
-                  [uu____2848] in
-                (text "=") :: uu____2845 in
-              (text "_") :: uu____2842 in
-            (text "let") :: uu____2839 in
-          reduce1 uu____2836
+                  [uu___4] in
+                (text "=") :: uu___3 in
+              (text "_") :: uu___2 in
+            (text "let") :: uu___1 in
+          reduce1 uu___
       | FStar_Extraction_ML_Syntax.MLM_Loc loc -> doc_of_loc loc
 let (doc_of_mod :
   FStar_Extraction_ML_Syntax.mlsymbol ->
@@ -1271,17 +1230,17 @@ let (doc_of_mod :
              let doc1 = doc_of_mod1 currentModule x in
              [doc1;
              (match x with
-              | FStar_Extraction_ML_Syntax.MLM_Loc uu____2872 -> empty
-              | uu____2873 -> hardline);
+              | FStar_Extraction_ML_Syntax.MLM_Loc uu___ -> empty
+              | uu___ -> hardline);
              hardline]) m in
       reduce (FStar_List.flatten docs)
 let (doc_of_mllib_r :
   FStar_Extraction_ML_Syntax.mllib -> (Prims.string * doc) Prims.list) =
-  fun uu____2884 ->
-    match uu____2884 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Extraction_ML_Syntax.MLLib mllib ->
-        let rec for1_sig uu____2950 =
-          match uu____2950 with
+        let rec for1_sig uu___1 =
+          match uu___1 with
           | (x, sigmod, FStar_Extraction_ML_Syntax.MLLib sub) ->
               let x1 = FStar_Extraction_ML_Util.flatten_mlpath x in
               let head =
@@ -1289,41 +1248,40 @@ let (doc_of_mllib_r :
               let tail = reduce1 [text "end"] in
               let doc1 =
                 FStar_Option.map
-                  (fun uu____3005 ->
-                     match uu____3005 with
-                     | (s, uu____3011) -> doc_of_sig x1 s) sigmod in
+                  (fun uu___2 ->
+                     match uu___2 with | (s, uu___3) -> doc_of_sig x1 s)
+                  sigmod in
               let sub1 = FStar_List.map for1_sig sub in
               let sub2 =
                 FStar_List.map (fun x2 -> reduce [x2; hardline; hardline])
                   sub1 in
-              let uu____3032 =
-                let uu____3035 =
-                  let uu____3038 =
-                    let uu____3041 = reduce sub2 in
-                    [uu____3041; cat tail hardline] in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = reduce sub2 in [uu___5; cat tail hardline] in
                   (match doc1 with
                    | FStar_Pervasives_Native.None -> empty
                    | FStar_Pervasives_Native.Some s -> cat s hardline) ::
-                    uu____3038 in
-                (cat head hardline) :: uu____3035 in
-              reduce uu____3032
-        and for1_mod istop uu____3044 =
-          match uu____3044 with
+                    uu___4 in
+                (cat head hardline) :: uu___3 in
+              reduce uu___2
+        and for1_mod istop uu___1 =
+          match uu___1 with
           | (mod_name, sigmod, FStar_Extraction_ML_Syntax.MLLib sub) ->
               let target_mod_name =
                 FStar_Extraction_ML_Util.flatten_mlpath mod_name in
               let maybe_open_pervasives =
                 match mod_name with
                 | ("FStar"::[], "Pervasives") -> []
-                | uu____3112 ->
+                | uu___2 ->
                     let pervasives =
                       FStar_Extraction_ML_Util.flatten_mlpath
                         (["FStar"], "Pervasives") in
                     [hardline; text (Prims.op_Hat "open " pervasives)] in
               let head =
-                let uu____3123 =
-                  let uu____3126 = FStar_Extraction_ML_Util.codegen_fsharp () in
-                  if uu____3126
+                let uu___2 =
+                  let uu___3 = FStar_Extraction_ML_Util.codegen_fsharp () in
+                  if uu___3
                   then [text "module"; text target_mod_name]
                   else
                     if Prims.op_Negation istop
@@ -1333,54 +1291,51 @@ let (doc_of_mllib_r :
                       text "=";
                       text "struct"]
                     else [] in
-                reduce1 uu____3123 in
+                reduce1 uu___2 in
               let tail =
                 if Prims.op_Negation istop
                 then reduce1 [text "end"]
                 else reduce1 [] in
               let doc1 =
                 FStar_Option.map
-                  (fun uu____3145 ->
-                     match uu____3145 with
-                     | (uu____3150, m) -> doc_of_mod target_mod_name m)
-                  sigmod in
+                  (fun uu___2 ->
+                     match uu___2 with
+                     | (uu___3, m) -> doc_of_mod target_mod_name m) sigmod in
               let sub1 = FStar_List.map (for1_mod false) sub in
               let sub2 =
                 FStar_List.map (fun x -> reduce [x; hardline; hardline]) sub1 in
               let prefix =
-                let uu____3175 = FStar_Extraction_ML_Util.codegen_fsharp () in
-                if uu____3175
-                then [cat (text "#light \"off\"") hardline]
-                else [] in
-              let uu____3179 =
-                let uu____3182 =
-                  let uu____3185 =
-                    let uu____3188 =
-                      let uu____3191 =
-                        let uu____3194 =
-                          let uu____3197 = reduce sub2 in
-                          [uu____3197; cat tail hardline] in
+                let uu___2 = FStar_Extraction_ML_Util.codegen_fsharp () in
+                if uu___2 then [cat (text "#light \"off\"") hardline] else [] in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 = reduce sub2 in
+                          [uu___8; cat tail hardline] in
                         (match doc1 with
                          | FStar_Pervasives_Native.None -> empty
                          | FStar_Pervasives_Native.Some s -> cat s hardline)
-                          :: uu____3194 in
-                      hardline :: uu____3191 in
-                    FStar_List.append maybe_open_pervasives uu____3188 in
+                          :: uu___7 in
+                      hardline :: uu___6 in
+                    FStar_List.append maybe_open_pervasives uu___5 in
                   FStar_List.append [head; hardline; text "open Prims"]
-                    uu____3185 in
-                FStar_List.append prefix uu____3182 in
-              FStar_All.pipe_left reduce uu____3179 in
+                    uu___4 in
+                FStar_List.append prefix uu___3 in
+              FStar_All.pipe_left reduce uu___2 in
         let docs =
           FStar_List.map
-            (fun uu____3236 ->
-               match uu____3236 with
+            (fun uu___1 ->
+               match uu___1 with
                | (x, s, m) ->
-                   let uu____3286 = FStar_Extraction_ML_Util.flatten_mlpath x in
-                   let uu____3287 = for1_mod true (x, s, m) in
-                   (uu____3286, uu____3287)) mllib in
+                   let uu___2 = FStar_Extraction_ML_Util.flatten_mlpath x in
+                   let uu___3 = for1_mod true (x, s, m) in (uu___2, uu___3))
+            mllib in
         docs
 let (pretty : Prims.int -> doc -> Prims.string) =
-  fun sz -> fun uu____3309 -> match uu____3309 with | Doc doc1 -> doc1
+  fun sz -> fun uu___ -> match uu___ with | Doc doc1 -> doc1
 let (doc_of_mllib :
   FStar_Extraction_ML_Syntax.mllib -> (Prims.string * doc) Prims.list) =
   fun mllib -> doc_of_mllib_r mllib
@@ -1391,8 +1346,8 @@ let (string_of_mlexpr :
   fun cmod ->
     fun e ->
       let doc1 =
-        let uu____3333 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
-        doc_of_expr uu____3333 (min_op_prec, NonAssoc) e in
+        let uu___ = FStar_Extraction_ML_Util.flatten_mlpath cmod in
+        doc_of_expr uu___ (min_op_prec, NonAssoc) e in
       pretty Prims.int_zero doc1
 let (string_of_mlty :
   FStar_Extraction_ML_Syntax.mlpath ->
@@ -1401,6 +1356,6 @@ let (string_of_mlty :
   fun cmod ->
     fun e ->
       let doc1 =
-        let uu____3345 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
-        doc_of_mltype uu____3345 (min_op_prec, NonAssoc) e in
+        let uu___ = FStar_Extraction_ML_Util.flatten_mlpath cmod in
+        doc_of_mltype uu___ (min_op_prec, NonAssoc) e in
       pretty Prims.int_zero doc1

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -7,32 +7,32 @@ let (fail_exp :
   =
   fun lid ->
     fun t ->
-      let uu____25 =
-        let uu____26 =
-          let uu____43 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
             FStar_Syntax_Syntax.fvar FStar_Parser_Const.failwith_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-          let uu____46 =
-            let uu____57 = FStar_Syntax_Syntax.iarg t in
-            let uu____66 =
-              let uu____77 =
-                let uu____86 =
-                  let uu____87 =
-                    let uu____88 =
-                      let uu____89 =
-                        let uu____94 =
-                          let uu____95 = FStar_Syntax_Print.lid_to_string lid in
-                          Prims.op_Hat "Not yet implemented:" uu____95 in
-                        (uu____94, FStar_Range.dummyRange) in
-                      FStar_Const.Const_string uu____89 in
-                    FStar_Syntax_Syntax.Tm_constant uu____88 in
-                  FStar_Syntax_Syntax.mk uu____87 FStar_Range.dummyRange in
-                FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____86 in
-              [uu____77] in
-            uu____57 :: uu____66 in
-          (uu____43, uu____46) in
-        FStar_Syntax_Syntax.Tm_app uu____26 in
-      FStar_Syntax_Syntax.mk uu____25 FStar_Range.dummyRange
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Syntax.iarg t in
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        let uu___11 =
+                          let uu___12 = FStar_Syntax_Print.lid_to_string lid in
+                          Prims.op_Hat "Not yet implemented:" uu___12 in
+                        (uu___11, FStar_Range.dummyRange) in
+                      FStar_Const.Const_string uu___10 in
+                    FStar_Syntax_Syntax.Tm_constant uu___9 in
+                  FStar_Syntax_Syntax.mk uu___8 FStar_Range.dummyRange in
+                FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu___7 in
+              [uu___6] in
+            uu___4 :: uu___5 in
+          (uu___2, uu___3) in
+        FStar_Syntax_Syntax.Tm_app uu___1 in
+      FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (always_fail :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -41,27 +41,27 @@ let (always_fail :
   fun lid ->
     fun t ->
       let imp =
-        let uu____157 = FStar_Syntax_Util.arrow_formals t in
-        match uu____157 with
+        let uu___ = FStar_Syntax_Util.arrow_formals t in
+        match uu___ with
         | ([], t1) ->
             let b =
-              let uu____184 =
+              let uu___1 =
                 FStar_Syntax_Syntax.gen_bv "_" FStar_Pervasives_Native.None
                   t1 in
-              FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____184 in
-            let uu____191 = fail_exp lid t1 in
-            FStar_Syntax_Util.abs [b] uu____191 FStar_Pervasives_Native.None
+              FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu___1 in
+            let uu___1 = fail_exp lid t1 in
+            FStar_Syntax_Util.abs [b] uu___1 FStar_Pervasives_Native.None
         | (bs, t1) ->
-            let uu____212 = fail_exp lid t1 in
-            FStar_Syntax_Util.abs bs uu____212 FStar_Pervasives_Native.None in
+            let uu___1 = fail_exp lid t1 in
+            FStar_Syntax_Util.abs bs uu___1 FStar_Pervasives_Native.None in
       let lb =
-        let uu____216 =
-          let uu____221 =
+        let uu___ =
+          let uu___1 =
             FStar_Syntax_Syntax.lid_as_fv lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-          FStar_Util.Inr uu____221 in
+          FStar_Util.Inr uu___1 in
         {
-          FStar_Syntax_Syntax.lbname = uu____216;
+          FStar_Syntax_Syntax.lbname = uu___;
           FStar_Syntax_Syntax.lbunivs = [];
           FStar_Syntax_Syntax.lbtyp = t;
           FStar_Syntax_Syntax.lbeff = FStar_Parser_Const.effect_ML_lid;
@@ -70,39 +70,38 @@ let (always_fail :
           FStar_Syntax_Syntax.lbpos = (imp.FStar_Syntax_Syntax.pos)
         } in
       lb
-let as_pair : 'uuuuuu228 . 'uuuuuu228 Prims.list -> ('uuuuuu228 * 'uuuuuu228)
-  =
-  fun uu___0_239 ->
-    match uu___0_239 with
+let as_pair : 'uuuuu . 'uuuuu Prims.list -> ('uuuuu * 'uuuuu) =
+  fun uu___ ->
+    match uu___ with
     | a::b::[] -> (a, b)
-    | uu____244 -> failwith "Expected a list with 2 elements"
+    | uu___1 -> failwith "Expected a list with 2 elements"
 let (flag_of_qual :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
   =
-  fun uu___1_257 ->
-    match uu___1_257 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Assumption ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Assumed
     | FStar_Syntax_Syntax.Private ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Private
     | FStar_Syntax_Syntax.NoExtract ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.NoExtract
-    | uu____260 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let rec (extract_meta :
   FStar_Syntax_Syntax.term ->
     FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
   =
   fun x ->
-    let uu____268 = FStar_Syntax_Subst.compress x in
-    match uu____268 with
+    let uu___ = FStar_Syntax_Subst.compress x in
+    match uu___ with
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-        FStar_Syntax_Syntax.pos = uu____272;
-        FStar_Syntax_Syntax.vars = uu____273;_} ->
-        let uu____276 =
-          let uu____277 = FStar_Syntax_Syntax.lid_of_fv fv in
-          FStar_Ident.string_of_lid uu____277 in
-        (match uu____276 with
+        FStar_Syntax_Syntax.pos = uu___1;
+        FStar_Syntax_Syntax.vars = uu___2;_} ->
+        let uu___3 =
+          let uu___4 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu___4 in
+        (match uu___3 with
          | "FStar.Pervasives.PpxDerivingShow" ->
              FStar_Pervasives_Native.Some
                FStar_Extraction_ML_Syntax.PpxDerivingShow
@@ -126,24 +125,24 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated "")
-         | uu____280 -> FStar_Pervasives_Native.None)
+         | uu___4 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____282;
-             FStar_Syntax_Syntax.vars = uu____283;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_string (s, uu____285));
-              FStar_Syntax_Syntax.pos = uu____286;
-              FStar_Syntax_Syntax.vars = uu____287;_},
-            uu____288)::[]);
-        FStar_Syntax_Syntax.pos = uu____289;
-        FStar_Syntax_Syntax.vars = uu____290;_} ->
-        let uu____331 =
-          let uu____332 = FStar_Syntax_Syntax.lid_of_fv fv in
-          FStar_Ident.string_of_lid uu____332 in
-        (match uu____331 with
+                (FStar_Const.Const_string (s, uu___3));
+              FStar_Syntax_Syntax.pos = uu___4;
+              FStar_Syntax_Syntax.vars = uu___5;_},
+            uu___6)::[]);
+        FStar_Syntax_Syntax.pos = uu___7;
+        FStar_Syntax_Syntax.vars = uu___8;_} ->
+        let uu___9 =
+          let uu___10 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu___10 in
+        (match uu___9 with
          | "FStar.Pervasives.PpxDerivingShowConstant" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.PpxDerivingShowConstant s)
@@ -165,37 +164,37 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated s)
-         | uu____335 -> FStar_Pervasives_Native.None)
+         | uu___10 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("KremlinPrivate", uu____336));
-        FStar_Syntax_Syntax.pos = uu____337;
-        FStar_Syntax_Syntax.vars = uu____338;_} ->
+          (FStar_Const.Const_string ("KremlinPrivate", uu___1));
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.vars = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Private
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("c_inline", uu____341));
-        FStar_Syntax_Syntax.pos = uu____342;
-        FStar_Syntax_Syntax.vars = uu____343;_} ->
+          (FStar_Const.Const_string ("c_inline", uu___1));
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.vars = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.CInline
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("substitute", uu____346));
-        FStar_Syntax_Syntax.pos = uu____347;
-        FStar_Syntax_Syntax.vars = uu____348;_} ->
+          (FStar_Const.Const_string ("substitute", uu___1));
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.vars = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Substitute
-    | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_meta (x1, uu____352);
-        FStar_Syntax_Syntax.pos = uu____353;
-        FStar_Syntax_Syntax.vars = uu____354;_} -> extract_meta x1
-    | uu____361 -> FStar_Pervasives_Native.None
+    | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_meta (x1, uu___1);
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.vars = uu___3;_} -> extract_meta x1
+    | uu___1 -> FStar_Pervasives_Native.None
 let (extract_metadata :
   FStar_Syntax_Syntax.term Prims.list ->
     FStar_Extraction_ML_Syntax.meta Prims.list)
   = fun metas -> FStar_List.choose extract_meta metas
 let binders_as_mlty_binders :
-  'uuuuuu379 .
+  'uuuuu .
     FStar_Extraction_ML_UEnv.uenv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu379) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
         (FStar_Extraction_ML_UEnv.uenv * FStar_Extraction_ML_Syntax.mlident
           Prims.list)
   =
@@ -203,16 +202,16 @@ let binders_as_mlty_binders :
     fun bs ->
       FStar_Util.fold_map
         (fun env1 ->
-           fun uu____419 ->
-             match uu____419 with
-             | (bv, uu____429) ->
+           fun uu___ ->
+             match uu___ with
+             | (bv, uu___1) ->
                  let env2 = FStar_Extraction_ML_UEnv.extend_ty env1 bv false in
                  let name =
-                   let uu____432 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv in
-                   match uu____432 with
+                   let uu___2 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv in
+                   match uu___2 with
                    | FStar_Util.Inl ty ->
                        ty.FStar_Extraction_ML_UEnv.ty_b_name
-                   | uu____434 -> failwith "Impossible" in
+                   | uu___3 -> failwith "Impossible" in
                  (env2, name)) env bs
 type data_constructor =
   {
@@ -270,22 +269,21 @@ let (__proj__Mkinductive_family__item__imetadata :
     | { ifv; iname; iparams; ityp; idatas; iquals; imetadata;_} -> imetadata
 let (print_ifamily : inductive_family -> unit) =
   fun i ->
-    let uu____623 = FStar_Syntax_Print.lid_to_string i.iname in
-    let uu____624 = FStar_Syntax_Print.binders_to_string " " i.iparams in
-    let uu____625 = FStar_Syntax_Print.term_to_string i.ityp in
-    let uu____626 =
-      let uu____627 =
+    let uu___ = FStar_Syntax_Print.lid_to_string i.iname in
+    let uu___1 = FStar_Syntax_Print.binders_to_string " " i.iparams in
+    let uu___2 = FStar_Syntax_Print.term_to_string i.ityp in
+    let uu___3 =
+      let uu___4 =
         FStar_All.pipe_right i.idatas
           (FStar_List.map
              (fun d ->
-                let uu____638 = FStar_Syntax_Print.lid_to_string d.dname in
-                let uu____639 =
-                  let uu____640 = FStar_Syntax_Print.term_to_string d.dtyp in
-                  Prims.op_Hat " : " uu____640 in
-                Prims.op_Hat uu____638 uu____639)) in
-      FStar_All.pipe_right uu____627 (FStar_String.concat "\n\t\t") in
-    FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____623 uu____624 uu____625
-      uu____626
+                let uu___5 = FStar_Syntax_Print.lid_to_string d.dname in
+                let uu___6 =
+                  let uu___7 = FStar_Syntax_Print.term_to_string d.dtyp in
+                  Prims.op_Hat " : " uu___7 in
+                Prims.op_Hat uu___5 uu___6)) in
+      FStar_All.pipe_right uu___4 (FStar_String.concat "\n\t\t") in
+    FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu___ uu___1 uu___2 uu___3
 let (bundle_as_inductive_families :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -295,18 +293,18 @@ let (bundle_as_inductive_families :
   fun env ->
     fun ses ->
       fun quals ->
-        let uu____678 =
+        let uu___ =
           FStar_Util.fold_map
             (fun env1 ->
                fun se ->
                  match se.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
                      (l, us, bs, t, _mut_i, datas) ->
-                     let uu____731 = FStar_Syntax_Subst.open_univ_vars us t in
-                     (match uu____731 with
+                     let uu___1 = FStar_Syntax_Subst.open_univ_vars us t in
+                     (match uu___1 with
                       | (_us, t1) ->
-                          let uu____744 = FStar_Syntax_Subst.open_term bs t1 in
-                          (match uu____744 with
+                          let uu___2 = FStar_Syntax_Subst.open_term bs t1 in
+                          (match uu___2 with
                            | (bs1, t2) ->
                                let datas1 =
                                  FStar_All.pipe_right ses
@@ -316,89 +314,85 @@ let (bundle_as_inductive_families :
                                          with
                                          | FStar_Syntax_Syntax.Sig_datacon
                                              (d, us1, t3, l', nparams,
-                                              uu____790)
+                                              uu___3)
                                              when FStar_Ident.lid_equals l l'
                                              ->
-                                             let uu____795 =
+                                             let uu___4 =
                                                FStar_Syntax_Subst.open_univ_vars
                                                  us1 t3 in
-                                             (match uu____795 with
+                                             (match uu___4 with
                                               | (_us1, t4) ->
-                                                  let uu____804 =
+                                                  let uu___5 =
                                                     FStar_Syntax_Util.arrow_formals
                                                       t4 in
-                                                  (match uu____804 with
+                                                  (match uu___5 with
                                                    | (bs', body) ->
-                                                       let uu____819 =
+                                                       let uu___6 =
                                                          FStar_Util.first_N
                                                            (FStar_List.length
                                                               bs1) bs' in
-                                                       (match uu____819 with
+                                                       (match uu___6 with
                                                         | (bs_params, rest)
                                                             ->
                                                             let subst =
                                                               FStar_List.map2
-                                                                (fun
-                                                                   uu____910
+                                                                (fun uu___7
                                                                    ->
-                                                                   fun
-                                                                    uu____911
+                                                                   fun uu___8
                                                                     ->
                                                                     match 
-                                                                    (uu____910,
-                                                                    uu____911)
+                                                                    (uu___7,
+                                                                    uu___8)
                                                                     with
                                                                     | 
                                                                     ((b',
-                                                                    uu____937),
+                                                                    uu___9),
                                                                     (b,
-                                                                    uu____939))
+                                                                    uu___10))
                                                                     ->
-                                                                    let uu____960
+                                                                    let uu___11
                                                                     =
-                                                                    let uu____967
+                                                                    let uu___12
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b in
                                                                     (b',
-                                                                    uu____967) in
+                                                                    uu___12) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____960)
+                                                                    uu___11)
                                                                 bs_params bs1 in
                                                             let t5 =
-                                                              let uu____973 =
-                                                                let uu____974
-                                                                  =
+                                                              let uu___7 =
+                                                                let uu___8 =
                                                                   FStar_Syntax_Syntax.mk_Total
                                                                     body in
                                                                 FStar_Syntax_Util.arrow
-                                                                  rest
-                                                                  uu____974 in
+                                                                  rest uu___8 in
                                                               FStar_All.pipe_right
-                                                                uu____973
+                                                                uu___7
                                                                 (FStar_Syntax_Subst.subst
                                                                    subst) in
                                                             [{
                                                                dname = d;
                                                                dtyp = t5
                                                              }])))
-                                         | uu____977 -> [])) in
+                                         | uu___3 -> [])) in
                                let metadata =
-                                 let uu____981 =
+                                 let uu___3 =
                                    extract_metadata
                                      se.FStar_Syntax_Syntax.sigattrs in
-                                 let uu____984 =
+                                 let uu___4 =
                                    FStar_List.choose flag_of_qual quals in
-                                 FStar_List.append uu____981 uu____984 in
+                                 FStar_List.append uu___3 uu___4 in
                                let fv =
                                  FStar_Syntax_Syntax.lid_as_fv l
                                    FStar_Syntax_Syntax.delta_constant
                                    FStar_Pervasives_Native.None in
-                               let uu____988 =
+                               let uu___3 =
                                  FStar_Extraction_ML_UEnv.extend_type_name
                                    env1 fv in
-                               (match uu____988 with
-                                | (uu____999, env2) ->
+                               (match uu___3 with
+                                | (uu___4, env2) ->
                                     (env2,
                                       [{
                                          ifv = fv;
@@ -410,8 +404,8 @@ let (bundle_as_inductive_families :
                                            (se.FStar_Syntax_Syntax.sigquals);
                                          imetadata = metadata
                                        }]))))
-                 | uu____1003 -> (env1, [])) env ses in
-        match uu____678 with
+                 | uu___1 -> (env1, [])) env ses in
+        match uu___ with
         | (env1, ifams) -> (env1, (FStar_List.flatten ifams))
 type iface =
   {
@@ -464,49 +458,49 @@ let (iface_of_bindings :
     -> iface)
   =
   fun fvs ->
-    let uu___221_1205 = empty_iface in
+    let uu___ = empty_iface in
     {
-      iface_module_name = (uu___221_1205.iface_module_name);
+      iface_module_name = (uu___.iface_module_name);
       iface_bindings = fvs;
-      iface_tydefs = (uu___221_1205.iface_tydefs);
-      iface_type_names = (uu___221_1205.iface_type_names)
+      iface_tydefs = (uu___.iface_tydefs);
+      iface_type_names = (uu___.iface_type_names)
     }
 let (iface_of_tydefs : FStar_Extraction_ML_UEnv.tydef Prims.list -> iface) =
   fun tds ->
-    let uu___224_1215 = empty_iface in
-    let uu____1216 =
+    let uu___ = empty_iface in
+    let uu___1 =
       FStar_List.map
         (fun td ->
-           let uu____1231 = FStar_Extraction_ML_UEnv.tydef_fv td in
-           let uu____1232 = FStar_Extraction_ML_UEnv.tydef_mlpath td in
-           (uu____1231, uu____1232)) tds in
+           let uu___2 = FStar_Extraction_ML_UEnv.tydef_fv td in
+           let uu___3 = FStar_Extraction_ML_UEnv.tydef_mlpath td in
+           (uu___2, uu___3)) tds in
     {
-      iface_module_name = (uu___224_1215.iface_module_name);
-      iface_bindings = (uu___224_1215.iface_bindings);
+      iface_module_name = (uu___.iface_module_name);
+      iface_bindings = (uu___.iface_bindings);
       iface_tydefs = tds;
-      iface_type_names = uu____1216
+      iface_type_names = uu___1
     }
 let (iface_of_type_names :
   (FStar_Syntax_Syntax.fv * FStar_Extraction_ML_Syntax.mlpath) Prims.list ->
     iface)
   =
   fun fvs ->
-    let uu___228_1250 = empty_iface in
+    let uu___ = empty_iface in
     {
-      iface_module_name = (uu___228_1250.iface_module_name);
-      iface_bindings = (uu___228_1250.iface_bindings);
-      iface_tydefs = (uu___228_1250.iface_tydefs);
+      iface_module_name = (uu___.iface_module_name);
+      iface_bindings = (uu___.iface_bindings);
+      iface_tydefs = (uu___.iface_tydefs);
       iface_type_names = fvs
     }
 let (iface_union : iface -> iface -> iface) =
   fun if1 ->
     fun if2 ->
-      let uu____1261 =
+      let uu___ =
         if if1.iface_module_name <> if1.iface_module_name
         then failwith "Union not defined"
         else if1.iface_module_name in
       {
-        iface_module_name = uu____1261;
+        iface_module_name = uu___;
         iface_bindings =
           (FStar_List.append if1.iface_bindings if2.iface_bindings);
         iface_tydefs = (FStar_List.append if1.iface_tydefs if2.iface_tydefs);
@@ -521,9 +515,9 @@ let (mlpath_to_string : FStar_Extraction_ML_Syntax.mlpath -> Prims.string) =
       (FStar_List.append (FStar_Pervasives_Native.fst p)
          [FStar_Pervasives_Native.snd p])
 let tscheme_to_string :
-  'uuuuuu1295 .
+  'uuuuu .
     FStar_Extraction_ML_Syntax.mlpath ->
-      ('uuuuuu1295 * FStar_Extraction_ML_Syntax.mlty) -> Prims.string
+      ('uuuuu * FStar_Extraction_ML_Syntax.mlty) -> Prims.string
   =
   fun cm ->
     fun ts ->
@@ -535,73 +529,70 @@ let (print_exp_binding :
   =
   fun cm ->
     fun e ->
-      let uu____1324 =
+      let uu___ =
         FStar_Extraction_ML_Code.string_of_mlexpr cm
           e.FStar_Extraction_ML_UEnv.exp_b_expr in
-      let uu____1325 =
+      let uu___1 =
         tscheme_to_string cm e.FStar_Extraction_ML_UEnv.exp_b_tscheme in
       FStar_Util.format3
         "{\n\texp_b_name = %s\n\texp_b_expr = %s\n\texp_b_tscheme = %s }"
-        e.FStar_Extraction_ML_UEnv.exp_b_name uu____1324 uu____1325
+        e.FStar_Extraction_ML_UEnv.exp_b_name uu___ uu___1
 let (print_binding :
   FStar_Extraction_ML_Syntax.mlpath ->
     (FStar_Syntax_Syntax.fv * FStar_Extraction_ML_UEnv.exp_binding) ->
       Prims.string)
   =
   fun cm ->
-    fun uu____1339 ->
-      match uu____1339 with
+    fun uu___ ->
+      match uu___ with
       | (fv, exp_binding) ->
-          let uu____1346 = FStar_Syntax_Print.fv_to_string fv in
-          let uu____1347 = print_exp_binding cm exp_binding in
-          FStar_Util.format2 "(%s, %s)" uu____1346 uu____1347
+          let uu___1 = FStar_Syntax_Print.fv_to_string fv in
+          let uu___2 = print_exp_binding cm exp_binding in
+          FStar_Util.format2 "(%s, %s)" uu___1 uu___2
 let (print_tydef :
   FStar_Extraction_ML_Syntax.mlpath ->
     FStar_Extraction_ML_UEnv.tydef -> Prims.string)
   =
   fun cm ->
     fun tydef ->
-      let uu____1358 =
-        let uu____1359 = FStar_Extraction_ML_UEnv.tydef_fv tydef in
-        FStar_Syntax_Print.fv_to_string uu____1359 in
-      let uu____1360 =
-        let uu____1361 = FStar_Extraction_ML_UEnv.tydef_def tydef in
-        tscheme_to_string cm uu____1361 in
-      FStar_Util.format2 "(%s, %s)" uu____1358 uu____1360
+      let uu___ =
+        let uu___1 = FStar_Extraction_ML_UEnv.tydef_fv tydef in
+        FStar_Syntax_Print.fv_to_string uu___1 in
+      let uu___1 =
+        let uu___2 = FStar_Extraction_ML_UEnv.tydef_def tydef in
+        tscheme_to_string cm uu___2 in
+      FStar_Util.format2 "(%s, %s)" uu___ uu___1
 let (iface_to_string : iface -> Prims.string) =
   fun iface1 ->
     let cm = iface1.iface_module_name in
-    let print_type_name uu____1381 =
-      match uu____1381 with
-      | (tn, uu____1387) -> FStar_Syntax_Print.fv_to_string tn in
-    let uu____1388 =
-      let uu____1389 =
-        FStar_List.map (print_binding cm) iface1.iface_bindings in
-      FStar_All.pipe_right uu____1389 (FStar_String.concat "\n") in
-    let uu____1398 =
-      let uu____1399 = FStar_List.map (print_tydef cm) iface1.iface_tydefs in
-      FStar_All.pipe_right uu____1399 (FStar_String.concat "\n") in
-    let uu____1404 =
-      let uu____1405 = FStar_List.map print_type_name iface1.iface_type_names in
-      FStar_All.pipe_right uu____1405 (FStar_String.concat "\n") in
+    let print_type_name uu___ =
+      match uu___ with | (tn, uu___1) -> FStar_Syntax_Print.fv_to_string tn in
+    let uu___ =
+      let uu___1 = FStar_List.map (print_binding cm) iface1.iface_bindings in
+      FStar_All.pipe_right uu___1 (FStar_String.concat "\n") in
+    let uu___1 =
+      let uu___2 = FStar_List.map (print_tydef cm) iface1.iface_tydefs in
+      FStar_All.pipe_right uu___2 (FStar_String.concat "\n") in
+    let uu___2 =
+      let uu___3 = FStar_List.map print_type_name iface1.iface_type_names in
+      FStar_All.pipe_right uu___3 (FStar_String.concat "\n") in
     FStar_Util.format4
       "Interface %s = {\niface_bindings=\n%s;\n\niface_tydefs=\n%s;\n\niface_type_names=%s;\n}"
-      (mlpath_to_string iface1.iface_module_name) uu____1388 uu____1398
-      uu____1404
+      (mlpath_to_string iface1.iface_module_name) uu___ uu___1 uu___2
 let (gamma_to_string : FStar_Extraction_ML_UEnv.uenv -> Prims.string) =
   fun env ->
     let cm = FStar_Extraction_ML_UEnv.current_module_of_uenv env in
     let gamma =
-      let uu____1427 = FStar_Extraction_ML_UEnv.bindings_of_uenv env in
+      let uu___ = FStar_Extraction_ML_UEnv.bindings_of_uenv env in
       FStar_List.collect
-        (fun uu___2_1437 ->
-           match uu___2_1437 with
+        (fun uu___1 ->
+           match uu___1 with
            | FStar_Extraction_ML_UEnv.Fv (b, e) -> [(b, e)]
-           | uu____1454 -> []) uu____1427 in
-    let uu____1459 =
-      let uu____1460 = FStar_List.map (print_binding cm) gamma in
-      FStar_All.pipe_right uu____1460 (FStar_String.concat "\n") in
-    FStar_Util.format1 "Gamma = {\n %s }" uu____1459
+           | uu___2 -> []) uu___ in
+    let uu___ =
+      let uu___1 = FStar_List.map (print_binding cm) gamma in
+      FStar_All.pipe_right uu___1 (FStar_String.concat "\n") in
+    FStar_Util.format1 "Gamma = {\n %s }" uu___
 let (extract_typ_abbrev :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -613,16 +604,16 @@ let (extract_typ_abbrev :
     fun quals ->
       fun attrs ->
         fun lb ->
-          let uu____1513 =
-            let uu____1522 =
-              let uu____1531 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-              FStar_TypeChecker_Env.open_universes_in uu____1531
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+              FStar_TypeChecker_Env.open_universes_in uu___2
                 lb.FStar_Syntax_Syntax.lbunivs
                 [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp] in
-            match uu____1522 with
-            | (tcenv, uu____1541, def_typ) ->
-                let uu____1547 = as_pair def_typ in (tcenv, uu____1547) in
-          match uu____1513 with
+            match uu___1 with
+            | (tcenv, uu___2, def_typ) ->
+                let uu___3 = as_pair def_typ in (tcenv, uu___3) in
+          match uu___ with
           | (tcenv, (lbdef, lbtyp)) ->
               let lbtyp1 =
                 FStar_TypeChecker_Normalize.normalize
@@ -637,70 +628,69 @@ let (extract_typ_abbrev :
               let lid =
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
               let def =
-                let uu____1578 =
-                  let uu____1579 = FStar_Syntax_Subst.compress lbdef1 in
-                  FStar_All.pipe_right uu____1579 FStar_Syntax_Util.unmeta in
-                FStar_All.pipe_right uu____1578 FStar_Syntax_Util.un_uinst in
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Subst.compress lbdef1 in
+                  FStar_All.pipe_right uu___2 FStar_Syntax_Util.unmeta in
+                FStar_All.pipe_right uu___1 FStar_Syntax_Util.un_uinst in
               let def1 =
                 match def.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs uu____1587 ->
+                | FStar_Syntax_Syntax.Tm_abs uu___1 ->
                     FStar_Extraction_ML_Term.normalize_abs def
-                | uu____1606 -> def in
-              let uu____1607 =
+                | uu___1 -> def in
+              let uu___1 =
                 match def1.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____1618) ->
+                | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___2) ->
                     FStar_Syntax_Subst.open_term bs body
-                | uu____1643 -> ([], def1) in
-              (match uu____1607 with
+                | uu___2 -> ([], def1) in
+              (match uu___1 with
                | (bs, body) ->
                    let assumed =
                      FStar_Util.for_some
-                       (fun uu___3_1662 ->
-                          match uu___3_1662 with
+                       (fun uu___2 ->
+                          match uu___2 with
                           | FStar_Syntax_Syntax.Assumption -> true
-                          | uu____1663 -> false) quals in
-                   let uu____1664 = binders_as_mlty_binders env bs in
-                   (match uu____1664 with
+                          | uu___3 -> false) quals in
+                   let uu___2 = binders_as_mlty_binders env bs in
+                   (match uu___2 with
                     | (env1, ml_bs) ->
                         let body1 =
-                          let uu____1688 =
+                          let uu___3 =
                             FStar_Extraction_ML_Term.term_as_mlty env1 body in
-                          FStar_All.pipe_right uu____1688
+                          FStar_All.pipe_right uu___3
                             (FStar_Extraction_ML_Util.eraseTypeDeep
                                (FStar_Extraction_ML_Util.udelta_unfold env1)) in
                         let metadata =
-                          let uu____1692 = extract_metadata attrs in
-                          let uu____1695 =
-                            FStar_List.choose flag_of_qual quals in
-                          FStar_List.append uu____1692 uu____1695 in
+                          let uu___3 = extract_metadata attrs in
+                          let uu___4 = FStar_List.choose flag_of_qual quals in
+                          FStar_List.append uu___3 uu___4 in
                         let tyscheme = (ml_bs, body1) in
-                        let uu____1703 =
-                          let uu____1716 =
+                        let uu___3 =
+                          let uu___4 =
                             FStar_All.pipe_right quals
                               (FStar_Util.for_some
-                                 (fun uu___4_1720 ->
-                                    match uu___4_1720 with
+                                 (fun uu___5 ->
+                                    match uu___5 with
                                     | FStar_Syntax_Syntax.Assumption -> true
                                     | FStar_Syntax_Syntax.New -> true
-                                    | uu____1721 -> false)) in
-                          if uu____1716
+                                    | uu___6 -> false)) in
+                          if uu___4
                           then
-                            let uu____1734 =
+                            let uu___5 =
                               FStar_Extraction_ML_UEnv.extend_type_name env
                                 fv in
-                            match uu____1734 with
+                            match uu___5 with
                             | (mlp, env2) ->
                                 (mlp, (iface_of_type_names [(fv, mlp)]),
                                   env2)
                           else
-                            (let uu____1768 =
+                            (let uu___6 =
                                FStar_Extraction_ML_UEnv.extend_tydef env fv
                                  tyscheme in
-                             match uu____1768 with
+                             match uu___6 with
                              | (td, mlp, env2) ->
-                                 let uu____1790 = iface_of_tydefs [td] in
-                                 (mlp, uu____1790, env2)) in
-                        (match uu____1703 with
+                                 let uu___7 = iface_of_tydefs [td] in
+                                 (mlp, uu___7, env2)) in
+                        (match uu___3 with
                          | (mlpath, iface1, env2) ->
                              let td =
                                (assumed,
@@ -711,15 +701,13 @@ let (extract_typ_abbrev :
                                     (FStar_Extraction_ML_Syntax.MLTD_Abbrev
                                        body1))) in
                              let def2 =
-                               let uu____1846 =
-                                 let uu____1847 =
-                                   let uu____1848 =
-                                     FStar_Ident.range_of_lid lid in
+                               let uu___4 =
+                                 let uu___5 =
+                                   let uu___6 = FStar_Ident.range_of_lid lid in
                                    FStar_Extraction_ML_Util.mlloc_of_range
-                                     uu____1848 in
-                                 FStar_Extraction_ML_Syntax.MLM_Loc
-                                   uu____1847 in
-                               [uu____1846;
+                                     uu___6 in
+                                 FStar_Extraction_ML_Syntax.MLM_Loc uu___5 in
+                               [uu___4;
                                FStar_Extraction_ML_Syntax.MLM_Ty [td]] in
                              (env2, iface1, def2))))
 let (extract_let_rec_type :
@@ -734,34 +722,34 @@ let (extract_let_rec_type :
       fun attrs ->
         fun lb ->
           let lbtyp =
-            let uu____1896 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+            let uu___ = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.AllowUnboundUniverses;
               FStar_TypeChecker_Env.EraseUniverses;
               FStar_TypeChecker_Env.UnfoldUntil
                 FStar_Syntax_Syntax.delta_constant;
-              FStar_TypeChecker_Env.ForExtraction] uu____1896
+              FStar_TypeChecker_Env.ForExtraction] uu___
               lb.FStar_Syntax_Syntax.lbtyp in
-          let uu____1897 = FStar_Syntax_Util.arrow_formals lbtyp in
-          match uu____1897 with
-          | (bs, uu____1913) ->
-              let uu____1918 = binders_as_mlty_binders env bs in
-              (match uu____1918 with
+          let uu___ = FStar_Syntax_Util.arrow_formals lbtyp in
+          match uu___ with
+          | (bs, uu___1) ->
+              let uu___2 = binders_as_mlty_binders env bs in
+              (match uu___2 with
                | (env1, ml_bs) ->
                    let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                    let lid =
                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                    let body = FStar_Extraction_ML_Syntax.MLTY_Top in
                    let metadata =
-                     let uu____1947 = extract_metadata attrs in
-                     let uu____1950 = FStar_List.choose flag_of_qual quals in
-                     FStar_List.append uu____1947 uu____1950 in
+                     let uu___3 = extract_metadata attrs in
+                     let uu___4 = FStar_List.choose flag_of_qual quals in
+                     FStar_List.append uu___3 uu___4 in
                    let assumed = false in
                    let tscheme = (ml_bs, body) in
-                   let uu____1959 =
+                   let uu___3 =
                      FStar_Extraction_ML_UEnv.extend_tydef env fv tscheme in
-                   (match uu____1959 with
+                   (match uu___3 with
                     | (tydef, mlp, env2) ->
                         let td =
                           (assumed, (FStar_Pervasives_Native.snd mlp),
@@ -769,14 +757,12 @@ let (extract_let_rec_type :
                             (FStar_Pervasives_Native.Some
                                (FStar_Extraction_ML_Syntax.MLTD_Abbrev body))) in
                         let def =
-                          let uu____2003 =
-                            let uu____2004 =
-                              let uu____2005 = FStar_Ident.range_of_lid lid in
-                              FStar_Extraction_ML_Util.mlloc_of_range
-                                uu____2005 in
-                            FStar_Extraction_ML_Syntax.MLM_Loc uu____2004 in
-                          [uu____2003;
-                          FStar_Extraction_ML_Syntax.MLM_Ty [td]] in
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 = FStar_Ident.range_of_lid lid in
+                              FStar_Extraction_ML_Util.mlloc_of_range uu___6 in
+                            FStar_Extraction_ML_Syntax.MLM_Loc uu___5 in
+                          [uu___4; FStar_Extraction_ML_Syntax.MLM_Ty [td]] in
                         let iface1 = iface_of_tydefs [tydef] in
                         (env2, iface1, def)))
 let (extract_bundle_iface :
@@ -787,47 +773,46 @@ let (extract_bundle_iface :
     fun se ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____2069 =
+          let uu___ =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2069 in
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu___ in
         let tys = (ml_tyvars, mlt) in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____2076 =
-          FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
-        match uu____2076 with | (env2, uu____2092, b) -> (env2, (fvv, b)) in
+        let uu___ = FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
+        match uu___ with | (env2, uu___1, b) -> (env2, (fvv, b)) in
       let extract_one_family env1 ind =
-        let uu____2129 = binders_as_mlty_binders env1 ind.iparams in
-        match uu____2129 with
+        let uu___ = binders_as_mlty_binders env1 ind.iparams in
+        match uu___ with
         | (env_iparams, vars) ->
-            let uu____2154 =
+            let uu___1 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1) in
-            (match uu____2154 with
+            (match uu___1 with
              | (env2, ctors) ->
                  let env3 =
-                   let uu____2206 =
+                   let uu___2 =
                      FStar_Util.find_opt
-                       (fun uu___5_2211 ->
-                          match uu___5_2211 with
-                          | FStar_Syntax_Syntax.RecordType uu____2212 -> true
-                          | uu____2221 -> false) ind.iquals in
-                   match uu____2206 with
+                       (fun uu___3 ->
+                          match uu___3 with
+                          | FStar_Syntax_Syntax.RecordType uu___4 -> true
+                          | uu___4 -> false) ind.iquals in
+                   match uu___2 with
                    | FStar_Pervasives_Native.Some
                        (FStar_Syntax_Syntax.RecordType (ns, ids)) ->
                        let g =
                          FStar_List.fold_right
                            (fun id ->
-                              fun g ->
-                                let uu____2240 =
+                              fun g1 ->
+                                let uu___3 =
                                   FStar_Extraction_ML_UEnv.extend_record_field_name
-                                    g ((ind.iname), id) in
-                                match uu____2240 with
-                                | (uu____2245, g1) -> g1) ids env2 in
+                                    g1 ((ind.iname), id) in
+                                match uu___3 with | (uu___4, g2) -> g2) ids
+                           env2 in
                        g
-                   | uu____2247 -> env2 in
+                   | uu___3 -> env2 in
                  (env3, ctors)) in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -835,45 +820,45 @@ let (extract_bundle_iface :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l, uu____2263, t, uu____2265, uu____2266, uu____2267);
-            FStar_Syntax_Syntax.sigrng = uu____2268;
-            FStar_Syntax_Syntax.sigquals = uu____2269;
-            FStar_Syntax_Syntax.sigmeta = uu____2270;
-            FStar_Syntax_Syntax.sigattrs = uu____2271;
-            FStar_Syntax_Syntax.sigopts = uu____2272;_}::[],
-          uu____2273),
+              (l, uu___, t, uu___1, uu___2, uu___3);
+            FStar_Syntax_Syntax.sigrng = uu___4;
+            FStar_Syntax_Syntax.sigquals = uu___5;
+            FStar_Syntax_Syntax.sigmeta = uu___6;
+            FStar_Syntax_Syntax.sigattrs = uu___7;
+            FStar_Syntax_Syntax.sigopts = uu___8;_}::[],
+          uu___9),
          (FStar_Syntax_Syntax.ExceptionConstructor)::[]) ->
-          let uu____2292 = extract_ctor env [] env { dname = l; dtyp = t } in
-          (match uu____2292 with
+          let uu___10 = extract_ctor env [] env { dname = l; dtyp = t } in
+          (match uu___10 with
            | (env1, ctor) -> (env1, (iface_of_bindings [ctor])))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu____2324), quals) ->
-          let uu____2338 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu___), quals) ->
+          let uu___1 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr in
-          if uu____2338
+          if uu___1
           then (env, empty_iface)
           else
-            (let uu____2344 = bundle_as_inductive_families env ses quals in
-             match uu____2344 with
+            (let uu___3 = bundle_as_inductive_families env ses quals in
+             match uu___3 with
              | (env1, ifams) ->
-                 let uu____2361 =
+                 let uu___4 =
                    FStar_Util.fold_map extract_one_family env1 ifams in
-                 (match uu____2361 with
+                 (match uu___4 with
                   | (env2, td) ->
-                      let uu____2402 =
-                        let uu____2403 =
-                          let uu____2404 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
                             FStar_List.map
                               (fun x ->
-                                 let uu____2418 =
+                                 let uu___8 =
                                    FStar_Extraction_ML_UEnv.mlpath_of_lident
                                      env2 x.iname in
-                                 ((x.ifv), uu____2418)) ifams in
-                          iface_of_type_names uu____2404 in
-                        iface_union uu____2403
+                                 ((x.ifv), uu___8)) ifams in
+                          iface_of_type_names uu___7 in
+                        iface_union uu___6
                           (iface_of_bindings (FStar_List.flatten td)) in
-                      (env2, uu____2402)))
-      | uu____2423 -> failwith "Unexpected signature element"
+                      (env2, uu___5)))
+      | uu___ -> failwith "Unexpected signature element"
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Ident.lident ->
@@ -890,27 +875,27 @@ let (extract_type_declaration :
         fun attrs ->
           fun univs ->
             fun t ->
-              let uu____2496 =
-                let uu____2497 =
+              let uu___ =
+                let uu___1 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2501 ->
-                          match uu___6_2501 with
+                       (fun uu___2 ->
+                          match uu___2 with
                           | FStar_Syntax_Syntax.Assumption -> true
-                          | uu____2502 -> false)) in
-                Prims.op_Negation uu____2497 in
-              if uu____2496
+                          | uu___3 -> false)) in
+                Prims.op_Negation uu___1 in
+              if uu___
               then (g, empty_iface, [])
               else
-                (let uu____2514 = FStar_Syntax_Util.arrow_formals t in
-                 match uu____2514 with
-                 | (bs, uu____2530) ->
+                (let uu___2 = FStar_Syntax_Util.arrow_formals t in
+                 match uu___2 with
+                 | (bs, uu___3) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None in
                      let lb =
-                       let uu____2537 =
+                       let uu___4 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None in
                        {
@@ -919,7 +904,7 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2537;
+                         FStar_Syntax_Syntax.lbdef = uu___4;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
@@ -952,69 +937,66 @@ let (extract_reifiable_effect :
           (FStar_Extraction_ML_Syntax.MLM_Let
              (FStar_Extraction_ML_Syntax.NonRec, [lb]))) in
       let rec extract_fv tm =
-        (let uu____2632 =
-           let uu____2633 =
-             let uu____2638 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_Env.debug uu____2638 in
-           FStar_All.pipe_left uu____2633
-             (FStar_Options.Other "ExtractionReify") in
-         if uu____2632
+        (let uu___1 =
+           let uu___2 =
+             let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+             FStar_TypeChecker_Env.debug uu___3 in
+           FStar_All.pipe_left uu___2 (FStar_Options.Other "ExtractionReify") in
+         if uu___1
          then
-           let uu____2639 = FStar_Syntax_Print.term_to_string tm in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2639
+           let uu___2 = FStar_Syntax_Print.term_to_string tm in
+           FStar_Util.print1 "extract_fv term: %s\n" uu___2
          else ());
-        (let uu____2641 =
-           let uu____2642 = FStar_Syntax_Subst.compress tm in
-           uu____2642.FStar_Syntax_Syntax.n in
-         match uu____2641 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1, uu____2650) -> extract_fv tm1
+        (let uu___1 =
+           let uu___2 = FStar_Syntax_Subst.compress tm in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1, uu___2) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_UEnv.mlpath_of_lident g
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             let uu____2657 = FStar_Extraction_ML_UEnv.lookup_fv g fv in
-             (match uu____2657 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2662;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2663;
+             let uu___2 = FStar_Extraction_ML_UEnv.lookup_fv g fv in
+             (match uu___2 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu___4;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;_} ->
-                  let uu____2665 =
+                  let uu___5 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
-                  (uu____2665, tysc))
-         | uu____2666 ->
-             let uu____2667 =
-               let uu____2668 =
+                  (uu___5, tysc))
+         | uu___2 ->
+             let uu___3 =
+               let uu___4 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos in
-               let uu____2669 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2668 uu____2669 in
-             failwith uu____2667) in
+               let uu___5 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu___4 uu___5 in
+             failwith uu___3) in
       let extract_action g1 a =
-        (let uu____2695 =
-           let uu____2696 =
-             let uu____2701 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
-             FStar_TypeChecker_Env.debug uu____2701 in
-           FStar_All.pipe_left uu____2696
-             (FStar_Options.Other "ExtractionReify") in
-         if uu____2695
+        (let uu___2 =
+           let uu___3 =
+             let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+             FStar_TypeChecker_Env.debug uu___4 in
+           FStar_All.pipe_left uu___3 (FStar_Options.Other "ExtractionReify") in
+         if uu___2
          then
-           let uu____2702 =
+           let uu___3 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ in
-           let uu____2703 =
+           let uu___4 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2702
-             uu____2703
+           FStar_Util.print2 "Action type %s and term %s\n" uu___3 uu___4
          else ());
         (let lbname =
-           let uu____2710 =
+           let uu___2 =
              FStar_Syntax_Syntax.new_bv
                (FStar_Pervasives_Native.Some
                   ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                FStar_Syntax_Syntax.tun in
-           FStar_Util.Inl uu____2710 in
+           FStar_Util.Inl uu___2 in
          let lb =
            FStar_Syntax_Syntax.mk_lb
              (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1028,121 +1010,118 @@ let (extract_reifiable_effect :
              (FStar_Syntax_Syntax.Tm_let
                 (lbs, FStar_Syntax_Util.exp_false_bool))
              (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-         let uu____2736 =
-           FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb in
-         match uu____2736 with
-         | (a_let, uu____2752, ty) ->
-             let uu____2754 =
+         let uu___2 = FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb in
+         match uu___2 with
+         | (a_let, uu___3, ty) ->
+             let uu___4 =
                match a_let.FStar_Extraction_ML_Syntax.expr with
                | FStar_Extraction_ML_Syntax.MLE_Let
-                   ((uu____2771, mllb::[]), uu____2773) ->
+                   ((uu___5, mllb::[]), uu___6) ->
                    (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc with
                     | FStar_Pervasives_Native.Some tysc ->
                         ((mllb.FStar_Extraction_ML_Syntax.mllb_def), tysc)
                     | FStar_Pervasives_Native.None ->
                         failwith "No type scheme")
-               | uu____2803 -> failwith "Impossible" in
-             (match uu____2754 with
+               | uu___5 -> failwith "Impossible" in
+             (match uu___4 with
               | (exp, tysc) ->
-                  let uu____2830 =
+                  let uu___5 =
                     FStar_Extraction_ML_UEnv.extend_with_action_name g1 ed a
                       tysc in
-                  (match uu____2830 with
+                  (match uu___5 with
                    | (a_nm, a_lid, exp_b, g2) ->
-                       ((let uu____2852 =
-                           let uu____2853 =
-                             let uu____2858 =
+                       ((let uu___7 =
+                           let uu___8 =
+                             let uu___9 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu____2858 in
-                           FStar_All.pipe_left uu____2853
+                             FStar_TypeChecker_Env.debug uu___9 in
+                           FStar_All.pipe_left uu___8
                              (FStar_Options.Other "ExtractionReify") in
-                         if uu____2852
+                         if uu___7
                          then
-                           let uu____2859 =
+                           let uu___8 =
                              FStar_Extraction_ML_Code.string_of_mlexpr a_nm
                                a_let in
                            FStar_Util.print1 "Extracted action term: %s\n"
-                             uu____2859
+                             uu___8
                          else ());
-                        (let uu____2862 =
-                           let uu____2863 =
-                             let uu____2868 =
+                        (let uu___8 =
+                           let uu___9 =
+                             let uu___10 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu____2868 in
-                           FStar_All.pipe_left uu____2863
+                             FStar_TypeChecker_Env.debug uu___10 in
+                           FStar_All.pipe_left uu___9
                              (FStar_Options.Other "ExtractionReify") in
-                         if uu____2862
+                         if uu___8
                          then
-                           ((let uu____2870 =
+                           ((let uu___10 =
                                FStar_Extraction_ML_Code.string_of_mlty a_nm
                                  (FStar_Pervasives_Native.snd tysc) in
                              FStar_Util.print1 "Extracted action type: %s\n"
-                               uu____2870);
+                               uu___10);
                             FStar_List.iter
                               (fun x ->
                                  FStar_Util.print1 "and binders: %s\n" x)
                               (FStar_Pervasives_Native.fst tysc))
                          else ());
-                        (let uu____2874 = extend_iface a_lid a_nm exp exp_b in
-                         match uu____2874 with
+                        (let uu___8 = extend_iface a_lid a_nm exp exp_b in
+                         match uu___8 with
                          | (iface1, impl) -> (g2, (iface1, impl))))))) in
-      let uu____2893 =
-        let uu____2900 =
-          let uu____2905 =
-            let uu____2908 =
-              let uu____2917 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_return_repr in
-              FStar_All.pipe_right uu____2917 FStar_Util.must in
-            FStar_All.pipe_right uu____2908 FStar_Pervasives_Native.snd in
-          extract_fv uu____2905 in
-        match uu____2900 with
+              FStar_All.pipe_right uu___4 FStar_Util.must in
+            FStar_All.pipe_right uu___3 FStar_Pervasives_Native.snd in
+          extract_fv uu___2 in
+        match uu___1 with
         | (return_tm, ty_sc) ->
-            let uu____2986 =
+            let uu___2 =
               FStar_Extraction_ML_UEnv.extend_with_monad_op_name g ed
                 "return" ty_sc in
-            (match uu____2986 with
+            (match uu___2 with
              | (return_nm, return_lid, return_b, g1) ->
-                 let uu____3005 =
+                 let uu___3 =
                    extend_iface return_lid return_nm return_tm return_b in
-                 (match uu____3005 with
-                  | (iface1, impl) -> (g1, iface1, impl))) in
-      match uu____2893 with
+                 (match uu___3 with | (iface1, impl) -> (g1, iface1, impl))) in
+      match uu___ with
       | (g1, return_iface, return_decl) ->
-          let uu____3029 =
-            let uu____3036 =
-              let uu____3041 =
-                let uu____3044 =
-                  let uu____3053 =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
                     FStar_All.pipe_right ed FStar_Syntax_Util.get_bind_repr in
-                  FStar_All.pipe_right uu____3053 FStar_Util.must in
-                FStar_All.pipe_right uu____3044 FStar_Pervasives_Native.snd in
-              extract_fv uu____3041 in
-            match uu____3036 with
+                  FStar_All.pipe_right uu___5 FStar_Util.must in
+                FStar_All.pipe_right uu___4 FStar_Pervasives_Native.snd in
+              extract_fv uu___3 in
+            match uu___2 with
             | (bind_tm, ty_sc) ->
-                let uu____3122 =
+                let uu___3 =
                   FStar_Extraction_ML_UEnv.extend_with_monad_op_name g1 ed
                     "bind" ty_sc in
-                (match uu____3122 with
+                (match uu___3 with
                  | (bind_nm, bind_lid, bind_b, g2) ->
-                     let uu____3141 =
+                     let uu___4 =
                        extend_iface bind_lid bind_nm bind_tm bind_b in
-                     (match uu____3141 with
+                     (match uu___4 with
                       | (iface1, impl) -> (g2, iface1, impl))) in
-          (match uu____3029 with
+          (match uu___1 with
            | (g2, bind_iface, bind_decl) ->
-               let uu____3165 =
+               let uu___2 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions in
-               (match uu____3165 with
+               (match uu___2 with
                 | (g3, actions) ->
-                    let uu____3202 = FStar_List.unzip actions in
-                    (match uu____3202 with
+                    let uu___3 = FStar_List.unzip actions in
+                    (match uu___3 with
                      | (actions_iface, actions1) ->
-                         let uu____3229 =
+                         let uu___4 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface) in
-                         (g3, uu____3229, (return_decl :: bind_decl ::
-                           actions1)))))
+                         (g3, uu___4, (return_decl :: bind_decl :: actions1)))))
 let (extract_let_rec_types :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Extraction_ML_UEnv.uenv ->
@@ -1153,48 +1132,48 @@ let (extract_let_rec_types :
   fun se ->
     fun env ->
       fun lbs ->
-        let uu____3259 =
+        let uu___ =
           FStar_Util.for_some
             (fun lb ->
-               let uu____3263 =
+               let uu___1 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp in
-               Prims.op_Negation uu____3263) lbs in
-        if uu____3259
+               Prims.op_Negation uu___1) lbs in
+        if uu___
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3281 =
+          (let uu___2 =
              FStar_List.fold_left
-               (fun uu____3316 ->
+               (fun uu___3 ->
                   fun lb ->
-                    match uu____3316 with
+                    match uu___3 with
                     | (env1, iface_opt, impls) ->
-                        let uu____3357 =
+                        let uu___4 =
                           extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb in
-                        (match uu____3357 with
+                        (match uu___4 with
                          | (env2, iface1, impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3391 = iface_union iface' iface1 in
-                                   FStar_Pervasives_Native.Some uu____3391 in
+                                   let uu___5 = iface_union iface' iface1 in
+                                   FStar_Pervasives_Native.Some uu___5 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs in
-           match uu____3281 with
+           match uu___2 with
            | (env1, iface_opt, impls) ->
-               let uu____3431 = FStar_Option.get iface_opt in
-               let uu____3432 =
+               let uu___3 = FStar_Option.get iface_opt in
+               let uu___4 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten in
-               (env1, uu____3431, uu____3432))
+               (env1, uu___3, uu___4))
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt -> (FStar_Extraction_ML_UEnv.uenv * iface))
@@ -1202,83 +1181,76 @@ let (extract_sigelt_iface :
   fun g ->
     fun se ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3463 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu___ -> extract_bundle_iface g se
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu___ ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3472 ->
-          extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3489 ->
-          extract_bundle_iface g se
+      | FStar_Syntax_Syntax.Sig_datacon uu___ -> extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3507 =
+          let uu___ =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs t in
-          (match uu____3507 with | (env, iface1, uu____3522) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____3528) when
+          (match uu___ with | (env, iface1, uu___1) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3535 =
+          let uu___1 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs lb in
-          (match uu____3535 with | (env, iface1, uu____3550) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____3556) when
+          (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___) when
           FStar_Util.for_some
             (fun lb ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3567 = extract_let_rec_types se g lbs in
-          (match uu____3567 with | (env, iface1, uu____3582) -> (env, iface1))
+          let uu___1 = extract_let_rec_types se g lbs in
+          (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, _univs, t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals in
-          let uu____3593 =
+          let uu___ =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3597 =
-                 let uu____3598 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                 FStar_TypeChecker_Util.must_erase_for_extraction uu____3598
-                   t in
-               Prims.op_Negation uu____3597) in
-          if uu____3593
+              (let uu___1 =
+                 let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                 FStar_TypeChecker_Util.must_erase_for_extraction uu___2 t in
+               Prims.op_Negation uu___1) in
+          if uu___
           then
-            let uu____3603 =
-              let uu____3614 =
-                let uu____3615 =
-                  let uu____3618 = always_fail lid t in [uu____3618] in
-                (false, uu____3615) in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3614 in
-            (match uu____3603 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = always_fail lid t in [uu___4] in
+                (false, uu___3) in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu___2 in
+            (match uu___1 with
              | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu____3641) ->
-          let uu____3646 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
-          (match uu____3646 with
+      | FStar_Syntax_Syntax.Sig_let (lbs, uu___) ->
+          let uu___1 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
+          (match uu___1 with
            | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_assume uu____3675 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3682 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3683 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3696 ->
-          (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____3707 ->
-          (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_assume uu___ -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu___ -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu___ -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___ -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___ -> (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3718 ->
+      | FStar_Syntax_Syntax.Sig_splice uu___ ->
           failwith "impossible: trying to extract splice"
-      | FStar_Syntax_Syntax.Sig_fail uu____3729 ->
+      | FStar_Syntax_Syntax.Sig_fail uu___ ->
           failwith "impossible: trying to extract Sig_fail"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3745 =
-            (let uu____3748 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_Env.is_reifiable_effect uu____3748
+          let uu___ =
+            (let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+             FStar_TypeChecker_Env.is_reifiable_effect uu___1
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders) in
-          if uu____3745
+          if uu___
           then
-            let uu____3759 = extract_reifiable_effect g ed in
-            (match uu____3759 with
-             | (env, iface1, uu____3774) -> (env, iface1))
+            let uu___1 = extract_reifiable_effect g ed in
+            (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
           else (g, empty_iface)
 let (extract_iface' :
   env_t ->
@@ -1286,34 +1258,34 @@ let (extract_iface' :
   =
   fun g ->
     fun modul ->
-      let uu____3794 = FStar_Options.interactive () in
-      if uu____3794
+      let uu___ = FStar_Options.interactive () in
+      if uu___
       then (g, empty_iface)
       else
-        (let uu____3800 = FStar_Options.restore_cmd_line_options true in
+        (let uu___2 = FStar_Options.restore_cmd_line_options true in
          let decls = modul.FStar_Syntax_Syntax.declarations in
          let iface1 =
-           let uu___649_3803 = empty_iface in
-           let uu____3804 = FStar_Extraction_ML_UEnv.current_module_of_uenv g in
+           let uu___3 = empty_iface in
+           let uu___4 = FStar_Extraction_ML_UEnv.current_module_of_uenv g in
            {
-             iface_module_name = uu____3804;
-             iface_bindings = (uu___649_3803.iface_bindings);
-             iface_tydefs = (uu___649_3803.iface_tydefs);
-             iface_type_names = (uu___649_3803.iface_type_names)
+             iface_module_name = uu___4;
+             iface_bindings = (uu___3.iface_bindings);
+             iface_tydefs = (uu___3.iface_tydefs);
+             iface_type_names = (uu___3.iface_type_names)
            } in
          let res =
            FStar_List.fold_left
-             (fun uu____3822 ->
+             (fun uu___3 ->
                 fun se ->
-                  match uu____3822 with
+                  match uu___3 with
                   | (g1, iface2) ->
-                      let uu____3834 = extract_sigelt_iface g1 se in
-                      (match uu____3834 with
+                      let uu___4 = extract_sigelt_iface g1 se in
+                      (match uu___4 with
                        | (g2, iface') ->
-                           let uu____3845 = iface_union iface2 iface' in
-                           (g2, uu____3845))) (g, iface1) decls in
-         (let uu____3847 = FStar_Options.restore_cmd_line_options true in
-          FStar_All.pipe_left (fun uu____3848 -> ()) uu____3847);
+                           let uu___5 = iface_union iface2 iface' in
+                           (g2, uu___5))) (g, iface1) decls in
+         (let uu___4 = FStar_Options.restore_cmd_line_options true in
+          FStar_All.pipe_left (fun uu___5 -> ()) uu___4);
          res)
 let (extract_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1321,23 +1293,23 @@ let (extract_iface :
   =
   fun g ->
     fun modul ->
-      let uu____3863 =
+      let uu___ =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____3875 ->
-             let uu____3876 = FStar_Options.debug_any () in
-             if uu____3876
+          (fun uu___1 ->
+             let uu___2 = FStar_Options.debug_any () in
+             if uu___2
              then
-               let uu____3881 =
-                 let uu____3882 =
+               let uu___3 =
+                 let uu___4 =
                    FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-                 FStar_Util.format1 "Extracted interface of %s" uu____3882 in
-               FStar_Util.measure_execution_time uu____3881
-                 (fun uu____3888 -> extract_iface' g modul)
+                 FStar_Util.format1 "Extracted interface of %s" uu___4 in
+               FStar_Util.measure_execution_time uu___3
+                 (fun uu___4 -> extract_iface' g modul)
              else extract_iface' g modul) in
-      match uu____3863 with
+      match uu___ with
       | (g1, iface1) ->
-          let uu____3896 = FStar_Extraction_ML_UEnv.exit_module g1 in
-          (uu____3896, iface1)
+          let uu___1 = FStar_Extraction_ML_UEnv.exit_module g1 in
+          (uu___1, iface1)
 let (extract_bundle :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1348,10 +1320,10 @@ let (extract_bundle :
     fun se ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____3967 =
+          let uu___ =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3967 in
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu___ in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
           FStar_TypeChecker_Env.UnfoldUntil
@@ -1360,150 +1332,144 @@ let (extract_bundle :
           FStar_TypeChecker_Env.AllowUnboundUniverses;
           FStar_TypeChecker_Env.ForExtraction] in
         let names =
-          let uu____3974 =
-            let uu____3975 =
-              let uu____3978 =
-                let uu____3979 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
                   FStar_Extraction_ML_UEnv.tcenv_of_uenv env_iparams in
-                FStar_TypeChecker_Normalize.normalize steps uu____3979
-                  ctor.dtyp in
-              FStar_Syntax_Subst.compress uu____3978 in
-            uu____3975.FStar_Syntax_Syntax.n in
-          match uu____3974 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs, uu____3983) ->
+                FStar_TypeChecker_Normalize.normalize steps uu___3 ctor.dtyp in
+              FStar_Syntax_Subst.compress uu___2 in
+            uu___1.FStar_Syntax_Syntax.n in
+          match uu___ with
+          | FStar_Syntax_Syntax.Tm_arrow (bs, uu___1) ->
               FStar_List.map
-                (fun uu____4015 ->
-                   match uu____4015 with
+                (fun uu___2 ->
+                   match uu___2 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4023;
-                        FStar_Syntax_Syntax.sort = uu____4024;_},
-                      uu____4025) -> FStar_Ident.string_of_id ppname) bs
-          | uu____4032 -> [] in
+                        FStar_Syntax_Syntax.index = uu___3;
+                        FStar_Syntax_Syntax.sort = uu___4;_},
+                      uu___5) -> FStar_Ident.string_of_id ppname) bs
+          | uu___1 -> [] in
         let tys = (ml_tyvars, mlt) in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____4039 =
-          FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
-        match uu____4039 with
-        | (env2, mls, uu____4062) ->
-            let uu____4063 =
-              let uu____4074 =
-                let uu____4081 = FStar_Extraction_ML_Util.argTypes mlt in
-                FStar_List.zip names uu____4081 in
-              (mls, uu____4074) in
-            (env2, uu____4063) in
+        let uu___ = FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
+        match uu___ with
+        | (env2, mls, uu___1) ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Extraction_ML_Util.argTypes mlt in
+                FStar_List.zip names uu___4 in
+              (mls, uu___3) in
+            (env2, uu___2) in
       let extract_one_family env1 ind =
-        let uu____4133 = binders_as_mlty_binders env1 ind.iparams in
-        match uu____4133 with
+        let uu___ = binders_as_mlty_binders env1 ind.iparams in
+        match uu___ with
         | (env_iparams, vars) ->
-            let uu____4170 =
+            let uu___1 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1) in
-            (match uu____4170 with
+            (match uu___1 with
              | (env2, ctors) ->
-                 let uu____4263 = FStar_Syntax_Util.arrow_formals ind.ityp in
-                 (match uu____4263 with
-                  | (indices, uu____4293) ->
+                 let uu___2 = FStar_Syntax_Util.arrow_formals ind.ityp in
+                 (match uu___2 with
+                  | (indices, uu___3) ->
                       let ml_params =
-                        let uu____4301 =
+                        let uu___4 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i ->
-                                  fun uu____4324 ->
-                                    let uu____4331 =
-                                      FStar_Util.string_of_int i in
-                                    Prims.op_Hat "'dummyV" uu____4331)) in
-                        FStar_List.append vars uu____4301 in
-                      let uu____4332 =
-                        let uu____4339 =
+                                  fun uu___5 ->
+                                    let uu___6 = FStar_Util.string_of_int i in
+                                    Prims.op_Hat "'dummyV" uu___6)) in
+                        FStar_List.append vars uu___4 in
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Util.find_opt
-                            (fun uu___7_4344 ->
-                               match uu___7_4344 with
-                               | FStar_Syntax_Syntax.RecordType uu____4345 ->
+                            (fun uu___6 ->
+                               match uu___6 with
+                               | FStar_Syntax_Syntax.RecordType uu___7 ->
                                    true
-                               | uu____4354 -> false) ind.iquals in
-                        match uu____4339 with
+                               | uu___7 -> false) ind.iquals in
+                        match uu___5 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns, ids)) ->
-                            let uu____4371 = FStar_List.hd ctors in
-                            (match uu____4371 with
-                             | (uu____4398, c_ty) ->
-                                 let uu____4413 =
+                            let uu___6 = FStar_List.hd ctors in
+                            (match uu___6 with
+                             | (uu___7, c_ty) ->
+                                 let uu___9 =
                                    FStar_List.fold_right2
                                      (fun id ->
-                                        fun uu____4449 ->
-                                          fun uu____4450 ->
-                                            match (uu____4449, uu____4450)
-                                            with
-                                            | ((uu____4489, ty), (fields, g))
-                                                ->
-                                                let uu____4519 =
+                                        fun uu___10 ->
+                                          fun uu___11 ->
+                                            match (uu___10, uu___11) with
+                                            | ((uu___12, ty), (fields, g)) ->
+                                                let uu___13 =
                                                   FStar_Extraction_ML_UEnv.extend_record_field_name
                                                     g ((ind.iname), id) in
-                                                (match uu____4519 with
+                                                (match uu___13 with
                                                  | (mlid, g1) ->
                                                      (((mlid, ty) :: fields),
                                                        g1))) ids c_ty
                                      ([], env2) in
-                                 (match uu____4413 with
+                                 (match uu___9 with
                                   | (fields, g) ->
                                       ((FStar_Pervasives_Native.Some
                                           (FStar_Extraction_ML_Syntax.MLTD_Record
                                              fields)), g)))
-                        | uu____4578 when
+                        | uu___6 when
                             (FStar_List.length ctors) = Prims.int_zero ->
                             (FStar_Pervasives_Native.None, env2)
-                        | uu____4593 ->
+                        | uu___6 ->
                             ((FStar_Pervasives_Native.Some
                                 (FStar_Extraction_ML_Syntax.MLTD_DType ctors)),
                               env2) in
-                      (match uu____4332 with
+                      (match uu___4 with
                        | (tbody, env3) ->
-                           let uu____4626 =
-                             let uu____4645 =
-                               let uu____4646 =
+                           let uu___5 =
+                             let uu___6 =
+                               let uu___7 =
                                  FStar_Extraction_ML_UEnv.mlpath_of_lident
                                    env3 ind.iname in
-                               FStar_Pervasives_Native.snd uu____4646 in
-                             (false, uu____4645,
-                               FStar_Pervasives_Native.None, ml_params,
-                               (ind.imetadata), tbody) in
-                           (env3, uu____4626)))) in
+                               FStar_Pervasives_Native.snd uu___7 in
+                             (false, uu___6, FStar_Pervasives_Native.None,
+                               ml_params, (ind.imetadata), tbody) in
+                           (env3, uu___5)))) in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
       with
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l, uu____4688, t, uu____4690, uu____4691, uu____4692);
-            FStar_Syntax_Syntax.sigrng = uu____4693;
-            FStar_Syntax_Syntax.sigquals = uu____4694;
-            FStar_Syntax_Syntax.sigmeta = uu____4695;
-            FStar_Syntax_Syntax.sigattrs = uu____4696;
-            FStar_Syntax_Syntax.sigopts = uu____4697;_}::[],
-          uu____4698),
+              (l, uu___, t, uu___1, uu___2, uu___3);
+            FStar_Syntax_Syntax.sigrng = uu___4;
+            FStar_Syntax_Syntax.sigquals = uu___5;
+            FStar_Syntax_Syntax.sigmeta = uu___6;
+            FStar_Syntax_Syntax.sigattrs = uu___7;
+            FStar_Syntax_Syntax.sigopts = uu___8;_}::[],
+          uu___9),
          (FStar_Syntax_Syntax.ExceptionConstructor)::[]) ->
-          let uu____4717 = extract_ctor env [] env { dname = l; dtyp = t } in
-          (match uu____4717 with
+          let uu___10 = extract_ctor env [] env { dname = l; dtyp = t } in
+          (match uu___10 with
            | (env1, ctor) ->
                (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu____4763), quals) ->
-          let uu____4777 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu___), quals) ->
+          let uu___1 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr in
-          if uu____4777
+          if uu___1
           then (env, [])
           else
-            (let uu____4787 = bundle_as_inductive_families env ses quals in
-             match uu____4787 with
+            (let uu___3 = bundle_as_inductive_families env ses quals in
+             match uu___3 with
              | (env1, ifams) ->
-                 let uu____4806 =
+                 let uu___4 =
                    FStar_Util.fold_map extract_one_family env1 ifams in
-                 (match uu____4806 with
+                 (match uu___4 with
                   | (env2, td) ->
                       (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4899 -> failwith "Unexpected signature element"
+      | uu___ -> failwith "Unexpected signature element"
 let (maybe_register_plugin :
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1517,40 +1483,40 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t ->
-             let uu____4953 = FStar_Syntax_Util.head_and_args t in
-             match uu____4953 with
+             let uu___ = FStar_Syntax_Util.head_and_args t in
+             match uu___ with
              | (head, args) ->
-                 let uu____5000 =
-                   let uu____5001 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head in
-                   Prims.op_Negation uu____5001 in
-                 if uu____5000
+                   Prims.op_Negation uu___2 in
+                 if uu___1
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s, uu____5014));
-                         FStar_Syntax_Syntax.pos = uu____5015;
-                         FStar_Syntax_Syntax.vars = uu____5016;_},
-                       uu____5017)::[] ->
-                        let uu____5054 =
-                          let uu____5057 = FStar_Util.int_of_string s in
-                          FStar_Pervasives_Native.Some uu____5057 in
-                        FStar_Pervasives_Native.Some uu____5054
-                    | uu____5060 ->
+                           (FStar_Const.Const_int (s, uu___3));
+                         FStar_Syntax_Syntax.pos = uu___4;
+                         FStar_Syntax_Syntax.vars = uu___5;_},
+                       uu___6)::[] ->
+                        let uu___7 =
+                          let uu___8 = FStar_Util.int_of_string s in
+                          FStar_Pervasives_Native.Some uu___8 in
+                        FStar_Pervasives_Native.Some uu___7
+                    | uu___3 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None)) in
-      let uu____5073 =
-        let uu____5074 = FStar_Options.codegen () in
-        uu____5074 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin) in
-      if uu____5073
+      let uu___ =
+        let uu___1 = FStar_Options.codegen () in
+        uu___1 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin) in
+      if uu___
       then []
       else
-        (let uu____5082 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs in
-         match uu____5082 with
+        (let uu___2 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs in
+         match uu___2 with
          | FStar_Pervasives_Native.None -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1561,17 +1527,17 @@ let (maybe_register_plugin :
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp in
                     let ml_name_str =
-                      let uu____5120 =
-                        let uu____5121 = FStar_Ident.string_of_lid fv_lid in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5121 in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5120 in
-                    let uu____5122 =
+                      let uu___3 =
+                        let uu___4 = FStar_Ident.string_of_lid fv_lid in
+                        FStar_Extraction_ML_Syntax.MLC_String uu___4 in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu___3 in
+                    let uu___3 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun g
                         fv fv_t arity_opt ml_name_str in
-                    match uu____5122 with
+                    match uu___3 with
                     | FStar_Pervasives_Native.Some
                         (interp, nbe_interp, arity, plugin) ->
-                        let uu____5147 =
+                        let uu___4 =
                           if plugin
                           then
                             ((["FStar_Tactics_Native"], "register_plugin"),
@@ -1579,7 +1545,7 @@ let (maybe_register_plugin :
                           else
                             ((["FStar_Tactics_Native"], "register_tactic"),
                               [interp]) in
-                        (match uu____5147 with
+                        (match uu___4 with
                          | (register, args) ->
                              let h =
                                FStar_All.pipe_left
@@ -1588,15 +1554,13 @@ let (maybe_register_plugin :
                                  (FStar_Extraction_ML_Syntax.MLE_Name
                                     register) in
                              let arity1 =
-                               let uu____5179 =
-                                 let uu____5180 =
-                                   let uu____5191 =
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
                                      FStar_Util.string_of_int arity in
-                                   (uu____5191, FStar_Pervasives_Native.None) in
-                                 FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5180 in
-                               FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5179 in
+                                   (uu___7, FStar_Pervasives_Native.None) in
+                                 FStar_Extraction_ML_Syntax.MLC_Int uu___6 in
+                               FStar_Extraction_ML_Syntax.MLE_Const uu___5 in
                              let app =
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
@@ -1609,7 +1573,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None -> [] in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5215 -> []))
+              | uu___3 -> []))
 let rec (extract_sig :
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1619,376 +1583,366 @@ let rec (extract_sig :
     fun se ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u ->
-           let uu____5242 = FStar_Syntax_Print.sigelt_to_string se in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5242);
+           let uu___1 = FStar_Syntax_Print.sigelt_to_string se in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu___1);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5249 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5258 ->
-           extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5275 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_bundle uu___1 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu___1 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu___1 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
-           let uu____5291 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-           FStar_TypeChecker_Env.is_reifiable_effect uu____5291
+           let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+           FStar_TypeChecker_Env.is_reifiable_effect uu___1
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5292 = extract_reifiable_effect g ed in
-           (match uu____5292 with | (env, _iface, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5316 ->
+           let uu___1 = extract_reifiable_effect g ed in
+           (match uu___1 with | (env, _iface, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu___1 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_fail uu____5329 ->
+       | FStar_Syntax_Syntax.Sig_fail uu___1 ->
            failwith "impossible: trying to extract Sig_fail"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5346 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu___1 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5352 =
+           let uu___1 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs t in
-           (match uu____5352 with | (env, uu____5368, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____5377) when
+           (match uu___1 with | (env, uu___2, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___1) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5384 =
+           let uu___2 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb in
-           (match uu____5384 with | (env, uu____5400, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____5409) when
+           (match uu___2 with | (env, uu___3, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___1) when
            FStar_Util.for_some
              (fun lb ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5420 = extract_let_rec_types se g lbs in
-           (match uu____5420 with | (env, uu____5436, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs, uu____5445) ->
+           let uu___2 = extract_let_rec_types se g lbs in
+           (match uu___2 with | (env, uu___3, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs, uu___1) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs in
            let quals = se.FStar_Syntax_Syntax.sigquals in
-           let uu____5456 =
-             let uu____5465 =
+           let uu___2 =
+             let uu___3 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs in
-             match uu____5465 with
+             match uu___3 with
              | FStar_Pervasives_Native.None ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats, (tau, FStar_Pervasives_Native.None)::uu____5494) ->
+                 (ats, (tau, FStar_Pervasives_Native.None)::uu___4) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats, args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
                     (FStar_Errors.Warning_UnrecognizedAttribute,
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None)) in
-           (match uu____5456 with
+           (match uu___2 with
             | (attrs1, post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
-                    let uu____5578 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Env.postprocess uu____5578 tau
+                    let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Env.postprocess uu___3 tau
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef in
-                  let uu___911_5579 = lb in
+                  let uu___3 = lb in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbname);
+                      (uu___3.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbunivs);
+                      (uu___3.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbtyp);
+                      (uu___3.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbeff);
+                      (uu___3.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbattrs);
+                      (uu___3.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbpos)
+                      (uu___3.FStar_Syntax_Syntax.lbpos)
                   } in
                 let lbs1 =
-                  let uu____5587 =
+                  let uu___3 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
                           (FStar_Pervasives_Native.snd lbs)
                     | FStar_Pervasives_Native.None ->
                         FStar_Pervasives_Native.snd lbs in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5587) in
-                let uu____5601 =
-                  let uu____5608 =
+                  ((FStar_Pervasives_Native.fst lbs), uu___3) in
+                let uu___3 =
+                  let uu___4 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       se.FStar_Syntax_Syntax.sigrng in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5608 in
-                (match uu____5601 with
-                 | (ml_let, uu____5624, uu____5625) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu___4 in
+                (match uu___3 with
+                 | (ml_let, uu___4, uu___5) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor, bindings), uu____5634) ->
+                          ((flavor, bindings), uu___6) ->
                           let flags = FStar_List.choose flag_of_qual quals in
                           let flags' = extract_metadata attrs1 in
-                          let uu____5651 =
+                          let uu___7 =
                             FStar_List.fold_left2
-                              (fun uu____5677 ->
+                              (fun uu___8 ->
                                  fun ml_lb ->
-                                   fun uu____5679 ->
-                                     match (uu____5677, uu____5679) with
+                                   fun uu___9 ->
+                                     match (uu___8, uu___9) with
                                      | ((env, ml_lbs),
                                         {
                                           FStar_Syntax_Syntax.lbname = lbname;
                                           FStar_Syntax_Syntax.lbunivs =
-                                            uu____5701;
+                                            uu___10;
                                           FStar_Syntax_Syntax.lbtyp = t;
-                                          FStar_Syntax_Syntax.lbeff =
-                                            uu____5703;
-                                          FStar_Syntax_Syntax.lbdef =
-                                            uu____5704;
+                                          FStar_Syntax_Syntax.lbeff = uu___11;
+                                          FStar_Syntax_Syntax.lbdef = uu___12;
                                           FStar_Syntax_Syntax.lbattrs =
-                                            uu____5705;
-                                          FStar_Syntax_Syntax.lbpos =
-                                            uu____5706;_})
+                                            uu___13;
+                                          FStar_Syntax_Syntax.lbpos = uu___14;_})
                                          ->
-                                         let uu____5731 =
+                                         let uu___15 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased) in
-                                         if uu____5731
+                                         if uu___15
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5744 =
-                                                let uu____5747 =
+                                              let uu___17 =
+                                                let uu___18 =
                                                   FStar_Util.right lbname in
-                                                uu____5747.FStar_Syntax_Syntax.fv_name in
-                                              uu____5744.FStar_Syntax_Syntax.v in
+                                                uu___18.FStar_Syntax_Syntax.fv_name in
+                                              uu___17.FStar_Syntax_Syntax.v in
                                             let flags'' =
-                                              let uu____5751 =
-                                                let uu____5752 =
+                                              let uu___17 =
+                                                let uu___18 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____5752.FStar_Syntax_Syntax.n in
-                                              match uu____5751 with
+                                                uu___18.FStar_Syntax_Syntax.n in
+                                              match uu___17 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5757,
+                                                  (uu___18,
                                                    {
                                                      FStar_Syntax_Syntax.n =
                                                        FStar_Syntax_Syntax.Comp
                                                        {
                                                          FStar_Syntax_Syntax.comp_univs
-                                                           = uu____5758;
+                                                           = uu___19;
                                                          FStar_Syntax_Syntax.effect_name
                                                            = e;
                                                          FStar_Syntax_Syntax.result_typ
-                                                           = uu____5760;
+                                                           = uu___20;
                                                          FStar_Syntax_Syntax.effect_args
-                                                           = uu____5761;
+                                                           = uu___21;
                                                          FStar_Syntax_Syntax.flags
-                                                           = uu____5762;_};
+                                                           = uu___22;_};
                                                      FStar_Syntax_Syntax.pos
-                                                       = uu____5763;
+                                                       = uu___23;
                                                      FStar_Syntax_Syntax.vars
-                                                       = uu____5764;_})
+                                                       = uu___24;_})
                                                   when
-                                                  let uu____5799 =
+                                                  let uu___25 =
                                                     FStar_Ident.string_of_lid
                                                       e in
-                                                  uu____5799 =
+                                                  uu___25 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5800 -> [] in
+                                              | uu___18 -> [] in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'') in
                                             let ml_lb1 =
-                                              let uu___959_5805 = ml_lb in
+                                              let uu___17 = ml_lb in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___17.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___17.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___17.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___17.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___17.FStar_Extraction_ML_Syntax.print_typ)
                                               } in
-                                            let uu____5806 =
-                                              let uu____5811 =
+                                            let uu___17 =
+                                              let uu___18 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5816 ->
-                                                        match uu___8_5816
-                                                        with
+                                                     (fun uu___19 ->
+                                                        match uu___19 with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5817 ->
-                                                            true
-                                                        | uu____5822 -> false)) in
-                                              if uu____5811
+                                                            uu___20 -> true
+                                                        | uu___20 -> false)) in
+                                              if uu___18
                                               then
-                                                let uu____5827 =
-                                                  let uu____5834 =
+                                                let uu___19 =
+                                                  let uu___20 =
                                                     FStar_Util.right lbname in
-                                                  let uu____5835 =
+                                                  let uu___21 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                   FStar_Extraction_ML_UEnv.extend_fv
-                                                    env uu____5834 uu____5835
+                                                    env uu___20 uu___21
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                match uu____5827 with
-                                                | (env1, mls, uu____5842) ->
+                                                match uu___19 with
+                                                | (env1, mls, uu___20) ->
                                                     (env1,
-                                                      (let uu___971_5844 =
-                                                         ml_lb1 in
+                                                      (let uu___21 = ml_lb1 in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
                                                            = mls;
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___21.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___21.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___21.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___21.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___21.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5846 =
-                                                   let uu____5853 =
+                                                (let uu___20 =
+                                                   let uu___21 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5853
+                                                     env lbname t uu___21
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                 match uu____5846 with
-                                                 | (env1, uu____5859,
-                                                    uu____5860) ->
-                                                     (env1, ml_lb1)) in
-                                            match uu____5806 with
+                                                 match uu___20 with
+                                                 | (env1, uu___21, uu___22)
+                                                     -> (env1, ml_lb1)) in
+                                            match uu___17 with
                                             | (g1, ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1) in
-                          (match uu____5651 with
+                          (match uu___7 with
                            | (g1, ml_lbs') ->
-                               let uu____5887 =
-                                 let uu____5890 =
-                                   let uu____5893 =
-                                     let uu____5894 =
+                               let uu___8 =
+                                 let uu___9 =
+                                   let uu___10 =
+                                     let uu___11 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5894 in
-                                   [uu____5893;
+                                       uu___11 in
+                                   [uu___10;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))] in
-                                 let uu____5897 = maybe_register_plugin g1 se in
-                                 FStar_List.append uu____5890 uu____5897 in
-                               (g1, uu____5887))
-                      | uu____5902 ->
-                          let uu____5903 =
-                            let uu____5904 =
-                              let uu____5905 =
+                                 let uu___10 = maybe_register_plugin g1 se in
+                                 FStar_List.append uu___9 uu___10 in
+                               (g1, uu___8))
+                      | uu___6 ->
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____5905 ml_let in
+                                uu___9 ml_let in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5904 in
-                          failwith uu____5903)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____5913, t) ->
+                              uu___8 in
+                          failwith uu___7)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___1, t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals in
-           let uu____5918 =
+           let uu___2 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____5922 =
-                  let uu____5923 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                  FStar_TypeChecker_Util.must_erase_for_extraction uu____5923
-                    t in
-                Prims.op_Negation uu____5922) in
-           if uu____5918
+               (let uu___3 =
+                  let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  FStar_TypeChecker_Util.must_erase_for_extraction uu___4 t in
+                Prims.op_Negation uu___3) in
+           if uu___2
            then
              let always_fail1 =
-               let uu___991_5931 = se in
-               let uu____5932 =
-                 let uu____5933 =
-                   let uu____5940 =
-                     let uu____5941 =
-                       let uu____5944 = always_fail lid t in [uu____5944] in
-                     (false, uu____5941) in
-                   (uu____5940, []) in
-                 FStar_Syntax_Syntax.Sig_let uu____5933 in
+               let uu___3 = se in
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 = let uu___8 = always_fail lid t in [uu___8] in
+                     (false, uu___7) in
+                   (uu___6, []) in
+                 FStar_Syntax_Syntax.Sig_let uu___5 in
                {
-                 FStar_Syntax_Syntax.sigel = uu____5932;
+                 FStar_Syntax_Syntax.sigel = uu___4;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigrng);
+                   (uu___3.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigquals);
+                   (uu___3.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigopts)
+                   (uu___3.FStar_Syntax_Syntax.sigopts)
                } in
-             let uu____5949 = extract_sig g always_fail1 in
-             (match uu____5949 with
+             let uu___3 = extract_sig g always_fail1 in
+             (match uu___3 with
               | (g1, mlm) ->
-                  let uu____5968 =
+                  let uu___4 =
                     FStar_Util.find_map quals
-                      (fun uu___9_5973 ->
-                         match uu___9_5973 with
+                      (fun uu___5 ->
+                         match uu___5 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____5977 -> FStar_Pervasives_Native.None) in
-                  (match uu____5968 with
+                         | uu___6 -> FStar_Pervasives_Native.None) in
+                  (match uu___4 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____5985 =
-                         let uu____5988 =
-                           let uu____5989 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____5989 in
-                         let uu____5990 =
-                           let uu____5993 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu___7 in
+                         let uu___7 =
+                           let uu___8 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l in
-                           [uu____5993] in
-                         uu____5988 :: uu____5990 in
-                       (g1, uu____5985)
-                   | uu____5996 ->
-                       let uu____5999 =
+                           [uu___8] in
+                         uu___6 :: uu___7 in
+                       (g1, uu___5)
+                   | uu___5 ->
+                       let uu___6 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6005 ->
-                              match uu___10_6005 with
-                              | FStar_Syntax_Syntax.Projector (l, uu____6009)
-                                  -> FStar_Pervasives_Native.Some l
-                              | uu____6010 -> FStar_Pervasives_Native.None) in
-                       (match uu____5999 with
-                        | FStar_Pervasives_Native.Some uu____6017 -> (g1, [])
-                        | uu____6020 -> (g1, mlm))))
+                           (fun uu___7 ->
+                              match uu___7 with
+                              | FStar_Syntax_Syntax.Projector (l, uu___8) ->
+                                  FStar_Pervasives_Native.Some l
+                              | uu___8 -> FStar_Pervasives_Native.None) in
+                       (match uu___6 with
+                        | FStar_Pervasives_Native.Some uu___7 -> (g1, [])
+                        | uu___7 -> (g1, mlm))))
            else (g, [])
-       | FStar_Syntax_Syntax.Sig_assume uu____6028 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6037 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6040 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6055 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____6068 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu___1 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu___1 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu___1 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___1 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___1 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2000,66 +1954,64 @@ let (extract' :
   =
   fun g ->
     fun m ->
-      let uu____6105 = FStar_Options.restore_cmd_line_options true in
-      let uu____6106 =
+      let uu___ = FStar_Options.restore_cmd_line_options true in
+      let uu___1 =
         FStar_Extraction_ML_UEnv.extend_with_module_name g
           m.FStar_Syntax_Syntax.name in
-      match uu____6106 with
+      match uu___1 with
       | (name, g1) ->
           let g2 =
-            let uu____6120 =
-              let uu____6121 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
-              FStar_TypeChecker_Env.set_current_module uu____6121
+            let uu___2 =
+              let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+              FStar_TypeChecker_Env.set_current_module uu___3
                 m.FStar_Syntax_Syntax.name in
-            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6120 in
+            FStar_Extraction_ML_UEnv.set_tcenv g1 uu___2 in
           let g3 = FStar_Extraction_ML_UEnv.set_current_module g2 name in
-          let uu____6123 =
+          let uu___2 =
             FStar_Util.fold_map
               (fun g4 ->
                  fun se ->
-                   let uu____6142 =
-                     let uu____6143 =
+                   let uu___3 =
+                     let uu___4 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                     FStar_Options.debug_module uu____6143 in
-                   if uu____6142
+                     FStar_Options.debug_module uu___4 in
+                   if uu___3
                    then
                      let nm =
-                       let uu____6151 =
+                       let uu___4 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.lids_of_sigelt se)
                            (FStar_List.map FStar_Ident.string_of_lid) in
-                       FStar_All.pipe_right uu____6151
-                         (FStar_String.concat ", ") in
+                       FStar_All.pipe_right uu___4 (FStar_String.concat ", ") in
                      (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                      (let uu____6161 =
-                         FStar_Util.format1 "---Extracted {%s}" nm in
-                       FStar_Util.measure_execution_time uu____6161
-                         (fun uu____6169 -> extract_sig g4 se)))
+                      (let uu___5 = FStar_Util.format1 "---Extracted {%s}" nm in
+                       FStar_Util.measure_execution_time uu___5
+                         (fun uu___6 -> extract_sig g4 se)))
                    else extract_sig g4 se) g3
               m.FStar_Syntax_Syntax.declarations in
-          (match uu____6123 with
+          (match uu___2 with
            | (g4, sigs) ->
                let mlm = FStar_List.flatten sigs in
                let is_kremlin =
-                 let uu____6189 = FStar_Options.codegen () in
-                 uu____6189 =
+                 let uu___3 = FStar_Options.codegen () in
+                 uu___3 =
                    (FStar_Pervasives_Native.Some FStar_Options.Kremlin) in
-               let uu____6194 =
-                 (let uu____6197 =
+               let uu___3 =
+                 (let uu___4 =
                     FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                  uu____6197 <> "Prims") &&
+                  uu___4 <> "Prims") &&
                    (is_kremlin ||
                       (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)) in
-               if uu____6194
+               if uu___3
                then
-                 ((let uu____6205 =
-                     let uu____6206 = FStar_Options.silent () in
-                     Prims.op_Negation uu____6206 in
-                   if uu____6205
+                 ((let uu___5 =
+                     let uu___6 = FStar_Options.silent () in
+                     Prims.op_Negation uu___6 in
+                   if uu___5
                    then
-                     let uu____6207 =
+                     let uu___6 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                     FStar_Util.print1 "Extracted module %s\n" uu____6207
+                     FStar_Util.print1 "Extracted module %s\n" uu___6
                    else ());
                   (g4,
                     (FStar_Pervasives_Native.Some
@@ -2075,45 +2027,43 @@ let (extract :
   =
   fun g ->
     fun m ->
-      (let uu____6277 = FStar_Options.restore_cmd_line_options true in
-       FStar_All.pipe_left (fun uu____6278 -> ()) uu____6277);
-      (let uu____6280 =
-         let uu____6281 =
-           let uu____6282 =
-             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-           FStar_Options.should_extract uu____6282 in
-         Prims.op_Negation uu____6281 in
-       if uu____6280
+      (let uu___1 = FStar_Options.restore_cmd_line_options true in
+       FStar_All.pipe_left (fun uu___2 -> ()) uu___1);
+      (let uu___2 =
+         let uu___3 =
+           let uu___4 = FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+           FStar_Options.should_extract uu___4 in
+         Prims.op_Negation uu___3 in
+       if uu___2
        then
-         let uu____6283 =
-           let uu____6284 =
-             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+         let uu___3 =
+           let uu___4 = FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6284 in
-         failwith uu____6283
+             uu___4 in
+         failwith uu___3
        else ());
-      (let uu____6286 = FStar_Options.interactive () in
-       if uu____6286
+      (let uu___2 = FStar_Options.interactive () in
+       if uu___2
        then (g, FStar_Pervasives_Native.None)
        else
-         (let uu____6296 =
+         (let uu___4 =
             FStar_Syntax_Unionfind.with_uf_enabled
-              (fun uu____6312 ->
-                 let uu____6313 = FStar_Options.debug_any () in
-                 if uu____6313
+              (fun uu___5 ->
+                 let uu___6 = FStar_Options.debug_any () in
+                 if uu___6
                  then
                    let msg =
-                     let uu____6321 =
+                     let uu___7 =
                        FStar_Syntax_Print.lid_to_string
                          m.FStar_Syntax_Syntax.name in
-                     FStar_Util.format1 "Extracting module %s" uu____6321 in
+                     FStar_Util.format1 "Extracting module %s" uu___7 in
                    FStar_Util.measure_execution_time msg
-                     (fun uu____6329 -> extract' g m)
+                     (fun uu___7 -> extract' g m)
                  else extract' g m) in
-          match uu____6296 with
+          match uu___4 with
           | (g1, mllib) ->
-              ((let uu____6344 = FStar_Options.restore_cmd_line_options true in
-                FStar_All.pipe_left (fun uu____6345 -> ()) uu____6344);
-               (let uu____6346 = FStar_Extraction_ML_UEnv.exit_module g1 in
-                (uu____6346, mllib)))))
+              ((let uu___6 = FStar_Options.restore_cmd_line_options true in
+                FStar_All.pipe_left (fun uu___7 -> ()) uu___6);
+               (let uu___6 = FStar_Extraction_ML_UEnv.exit_module g1 in
+                (uu___6, mllib)))))

--- a/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
@@ -2,8 +2,7 @@ open Prims
 type mlsymbol = Prims.string
 type mlident = mlsymbol
 type mlpath = (mlsymbol Prims.list * mlsymbol)
-let kremlin_keywords : 'uuuuuu18 . unit -> 'uuuuuu18 Prims.list =
-  fun uu____22 -> []
+let kremlin_keywords : 'uuuuu . unit -> 'uuuuu Prims.list = fun uu___ -> []
 let (ocamlkeywords : Prims.string Prims.list) =
   ["and";
   "as";
@@ -166,8 +165,8 @@ let (fsharpkeywords : Prims.string Prims.list) =
   "virtual";
   "volatile"]
 let (string_of_mlpath : mlpath -> mlsymbol) =
-  fun uu____31 ->
-    match uu____31 with
+  fun uu___ ->
+    match uu___ with
     | (p, s) -> FStar_String.concat "." (FStar_List.append p [s])
 type mlidents = mlident Prims.list
 type mlsymbols = mlsymbol Prims.list
@@ -176,12 +175,11 @@ type e_tag =
   | E_GHOST 
   | E_IMPURE 
 let (uu___is_E_PURE : e_tag -> Prims.bool) =
-  fun projectee -> match projectee with | E_PURE -> true | uu____47 -> false
+  fun projectee -> match projectee with | E_PURE -> true | uu___ -> false
 let (uu___is_E_GHOST : e_tag -> Prims.bool) =
-  fun projectee -> match projectee with | E_GHOST -> true | uu____53 -> false
+  fun projectee -> match projectee with | E_GHOST -> true | uu___ -> false
 let (uu___is_E_IMPURE : e_tag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | E_IMPURE -> true | uu____59 -> false
+  fun projectee -> match projectee with | E_IMPURE -> true | uu___ -> false
 type mlloc = (Prims.int * Prims.string)
 let (dummy_loc : mlloc) = (Prims.int_zero, "")
 type mlty =
@@ -193,30 +191,29 @@ type mlty =
   | MLTY_Erased 
 let (uu___is_MLTY_Var : mlty -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTY_Var _0 -> true | uu____104 -> false
+    match projectee with | MLTY_Var _0 -> true | uu___ -> false
 let (__proj__MLTY_Var__item___0 : mlty -> mlident) =
   fun projectee -> match projectee with | MLTY_Var _0 -> _0
 let (uu___is_MLTY_Fun : mlty -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTY_Fun _0 -> true | uu____123 -> false
+    match projectee with | MLTY_Fun _0 -> true | uu___ -> false
 let (__proj__MLTY_Fun__item___0 : mlty -> (mlty * e_tag * mlty)) =
   fun projectee -> match projectee with | MLTY_Fun _0 -> _0
 let (uu___is_MLTY_Named : mlty -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTY_Named _0 -> true | uu____160 -> false
+    match projectee with | MLTY_Named _0 -> true | uu___ -> false
 let (__proj__MLTY_Named__item___0 : mlty -> (mlty Prims.list * mlpath)) =
   fun projectee -> match projectee with | MLTY_Named _0 -> _0
 let (uu___is_MLTY_Tuple : mlty -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTY_Tuple _0 -> true | uu____193 -> false
+    match projectee with | MLTY_Tuple _0 -> true | uu___ -> false
 let (__proj__MLTY_Tuple__item___0 : mlty -> mlty Prims.list) =
   fun projectee -> match projectee with | MLTY_Tuple _0 -> _0
 let (uu___is_MLTY_Top : mlty -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLTY_Top -> true | uu____211 -> false
+  fun projectee -> match projectee with | MLTY_Top -> true | uu___ -> false
 let (uu___is_MLTY_Erased : mlty -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTY_Erased -> true | uu____217 -> false
+    match projectee with | MLTY_Erased -> true | uu___ -> false
 type mltyscheme = (mlidents * mlty)
 type mlconstant =
   | MLC_Unit 
@@ -228,16 +225,14 @@ type mlconstant =
   | MLC_String of Prims.string 
   | MLC_Bytes of FStar_BaseTypes.byte Prims.array 
 let (uu___is_MLC_Unit : mlconstant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLC_Unit -> true | uu____269 -> false
+  fun projectee -> match projectee with | MLC_Unit -> true | uu___ -> false
 let (uu___is_MLC_Bool : mlconstant -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLC_Bool _0 -> true | uu____276 -> false
+    match projectee with | MLC_Bool _0 -> true | uu___ -> false
 let (__proj__MLC_Bool__item___0 : mlconstant -> Prims.bool) =
   fun projectee -> match projectee with | MLC_Bool _0 -> _0
 let (uu___is_MLC_Int : mlconstant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLC_Int _0 -> true | uu____299 -> false
+  fun projectee -> match projectee with | MLC_Int _0 -> true | uu___ -> false
 let (__proj__MLC_Int__item___0 :
   mlconstant ->
     (Prims.string * (FStar_Const.signedness * FStar_Const.width)
@@ -245,22 +240,22 @@ let (__proj__MLC_Int__item___0 :
   = fun projectee -> match projectee with | MLC_Int _0 -> _0
 let (uu___is_MLC_Float : mlconstant -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLC_Float _0 -> true | uu____342 -> false
+    match projectee with | MLC_Float _0 -> true | uu___ -> false
 let (__proj__MLC_Float__item___0 : mlconstant -> FStar_BaseTypes.float) =
   fun projectee -> match projectee with | MLC_Float _0 -> _0
 let (uu___is_MLC_Char : mlconstant -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLC_Char _0 -> true | uu____355 -> false
+    match projectee with | MLC_Char _0 -> true | uu___ -> false
 let (__proj__MLC_Char__item___0 : mlconstant -> FStar_BaseTypes.char) =
   fun projectee -> match projectee with | MLC_Char _0 -> _0
 let (uu___is_MLC_String : mlconstant -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLC_String _0 -> true | uu____368 -> false
+    match projectee with | MLC_String _0 -> true | uu___ -> false
 let (__proj__MLC_String__item___0 : mlconstant -> Prims.string) =
   fun projectee -> match projectee with | MLC_String _0 -> _0
 let (uu___is_MLC_Bytes : mlconstant -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLC_Bytes _0 -> true | uu____383 -> false
+    match projectee with | MLC_Bytes _0 -> true | uu___ -> false
 let (__proj__MLC_Bytes__item___0 :
   mlconstant -> FStar_BaseTypes.byte Prims.array) =
   fun projectee -> match projectee with | MLC_Bytes _0 -> _0
@@ -273,38 +268,36 @@ type mlpattern =
   | MLP_Record of (mlsymbol Prims.list * (mlsymbol * mlpattern) Prims.list) 
   | MLP_Tuple of mlpattern Prims.list 
 let (uu___is_MLP_Wild : mlpattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLP_Wild -> true | uu____453 -> false
+  fun projectee -> match projectee with | MLP_Wild -> true | uu___ -> false
 let (uu___is_MLP_Const : mlpattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLP_Const _0 -> true | uu____460 -> false
+    match projectee with | MLP_Const _0 -> true | uu___ -> false
 let (__proj__MLP_Const__item___0 : mlpattern -> mlconstant) =
   fun projectee -> match projectee with | MLP_Const _0 -> _0
 let (uu___is_MLP_Var : mlpattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLP_Var _0 -> true | uu____473 -> false
+  fun projectee -> match projectee with | MLP_Var _0 -> true | uu___ -> false
 let (__proj__MLP_Var__item___0 : mlpattern -> mlident) =
   fun projectee -> match projectee with | MLP_Var _0 -> _0
 let (uu___is_MLP_CTor : mlpattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLP_CTor _0 -> true | uu____492 -> false
+    match projectee with | MLP_CTor _0 -> true | uu___ -> false
 let (__proj__MLP_CTor__item___0 :
   mlpattern -> (mlpath * mlpattern Prims.list)) =
   fun projectee -> match projectee with | MLP_CTor _0 -> _0
 let (uu___is_MLP_Branch : mlpattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLP_Branch _0 -> true | uu____525 -> false
+    match projectee with | MLP_Branch _0 -> true | uu___ -> false
 let (__proj__MLP_Branch__item___0 : mlpattern -> mlpattern Prims.list) =
   fun projectee -> match projectee with | MLP_Branch _0 -> _0
 let (uu___is_MLP_Record : mlpattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLP_Record _0 -> true | uu____556 -> false
+    match projectee with | MLP_Record _0 -> true | uu___ -> false
 let (__proj__MLP_Record__item___0 :
   mlpattern -> (mlsymbol Prims.list * (mlsymbol * mlpattern) Prims.list)) =
   fun projectee -> match projectee with | MLP_Record _0 -> _0
 let (uu___is_MLP_Tuple : mlpattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLP_Tuple _0 -> true | uu____607 -> false
+    match projectee with | MLP_Tuple _0 -> true | uu___ -> false
 let (__proj__MLP_Tuple__item___0 : mlpattern -> mlpattern Prims.list) =
   fun projectee -> match projectee with | MLP_Tuple _0 -> _0
 type meta =
@@ -330,78 +323,68 @@ type meta =
   | CMacro 
   | Deprecated of Prims.string 
 let (uu___is_Mutable : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Mutable -> true | uu____660 -> false
+  fun projectee -> match projectee with | Mutable -> true | uu___ -> false
 let (uu___is_Assumed : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assumed -> true | uu____666 -> false
+  fun projectee -> match projectee with | Assumed -> true | uu___ -> false
 let (uu___is_Private : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Private -> true | uu____672 -> false
+  fun projectee -> match projectee with | Private -> true | uu___ -> false
 let (uu___is_NoExtract : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoExtract -> true | uu____678 -> false
+  fun projectee -> match projectee with | NoExtract -> true | uu___ -> false
 let (uu___is_CInline : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CInline -> true | uu____684 -> false
+  fun projectee -> match projectee with | CInline -> true | uu___ -> false
 let (uu___is_Substitute : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Substitute -> true | uu____690 -> false
+  fun projectee -> match projectee with | Substitute -> true | uu___ -> false
 let (uu___is_GCType : meta -> Prims.bool) =
-  fun projectee -> match projectee with | GCType -> true | uu____696 -> false
+  fun projectee -> match projectee with | GCType -> true | uu___ -> false
 let (uu___is_PpxDerivingShow : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | PpxDerivingShow -> true | uu____702 -> false
+    match projectee with | PpxDerivingShow -> true | uu___ -> false
 let (uu___is_PpxDerivingShowConstant : meta -> Prims.bool) =
   fun projectee ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
-    | uu____709 -> false
+    | uu___ -> false
 let (__proj__PpxDerivingShowConstant__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | PpxDerivingShowConstant _0 -> _0
 let (uu___is_PpxDerivingYoJson : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | PpxDerivingYoJson -> true | uu____721 -> false
+    match projectee with | PpxDerivingYoJson -> true | uu___ -> false
 let (uu___is_Comment : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Comment _0 -> true | uu____728 -> false
+  fun projectee -> match projectee with | Comment _0 -> true | uu___ -> false
 let (__proj__Comment__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | Comment _0 -> _0
 let (uu___is_StackInline : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | StackInline -> true | uu____740 -> false
+    match projectee with | StackInline -> true | uu___ -> false
 let (uu___is_CPrologue : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | CPrologue _0 -> true | uu____747 -> false
+    match projectee with | CPrologue _0 -> true | uu___ -> false
 let (__proj__CPrologue__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | CPrologue _0 -> _0
 let (uu___is_CEpilogue : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | CEpilogue _0 -> true | uu____760 -> false
+    match projectee with | CEpilogue _0 -> true | uu___ -> false
 let (__proj__CEpilogue__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | CEpilogue _0 -> _0
 let (uu___is_CConst : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CConst _0 -> true | uu____773 -> false
+  fun projectee -> match projectee with | CConst _0 -> true | uu___ -> false
 let (__proj__CConst__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | CConst _0 -> _0
 let (uu___is_CCConv : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CCConv _0 -> true | uu____786 -> false
+  fun projectee -> match projectee with | CCConv _0 -> true | uu___ -> false
 let (__proj__CCConv__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | CCConv _0 -> _0
 let (uu___is_Erased : meta -> Prims.bool) =
-  fun projectee -> match projectee with | Erased -> true | uu____798 -> false
+  fun projectee -> match projectee with | Erased -> true | uu___ -> false
 let (uu___is_CAbstract : meta -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CAbstract -> true | uu____804 -> false
+  fun projectee -> match projectee with | CAbstract -> true | uu___ -> false
 let (uu___is_CIfDef : meta -> Prims.bool) =
-  fun projectee -> match projectee with | CIfDef -> true | uu____810 -> false
+  fun projectee -> match projectee with | CIfDef -> true | uu___ -> false
 let (uu___is_CMacro : meta -> Prims.bool) =
-  fun projectee -> match projectee with | CMacro -> true | uu____816 -> false
+  fun projectee -> match projectee with | CMacro -> true | uu___ -> false
 let (uu___is_Deprecated : meta -> Prims.bool) =
   fun projectee ->
-    match projectee with | Deprecated _0 -> true | uu____823 -> false
+    match projectee with | Deprecated _0 -> true | uu___ -> false
 let (__proj__Deprecated__item___0 : meta -> Prims.string) =
   fun projectee -> match projectee with | Deprecated _0 -> _0
 type metadata = meta Prims.list
@@ -409,9 +392,9 @@ type mlletflavor =
   | Rec 
   | NonRec 
 let (uu___is_Rec : mlletflavor -> Prims.bool) =
-  fun projectee -> match projectee with | Rec -> true | uu____837 -> false
+  fun projectee -> match projectee with | Rec -> true | uu___ -> false
 let (uu___is_NonRec : mlletflavor -> Prims.bool) =
-  fun projectee -> match projectee with | NonRec -> true | uu____843 -> false
+  fun projectee -> match projectee with | NonRec -> true | uu___ -> false
 type mlexpr' =
   | MLE_Const of mlconstant 
   | MLE_Var of mlident 
@@ -446,44 +429,40 @@ and mllb =
   print_typ: Prims.bool }
 let (uu___is_MLE_Const : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Const _0 -> true | uu____1088 -> false
+    match projectee with | MLE_Const _0 -> true | uu___ -> false
 let (__proj__MLE_Const__item___0 : mlexpr' -> mlconstant) =
   fun projectee -> match projectee with | MLE_Const _0 -> _0
 let (uu___is_MLE_Var : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_Var _0 -> true | uu____1101 -> false
+  fun projectee -> match projectee with | MLE_Var _0 -> true | uu___ -> false
 let (__proj__MLE_Var__item___0 : mlexpr' -> mlident) =
   fun projectee -> match projectee with | MLE_Var _0 -> _0
 let (uu___is_MLE_Name : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Name _0 -> true | uu____1114 -> false
+    match projectee with | MLE_Name _0 -> true | uu___ -> false
 let (__proj__MLE_Name__item___0 : mlexpr' -> mlpath) =
   fun projectee -> match projectee with | MLE_Name _0 -> _0
 let (uu___is_MLE_Let : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_Let _0 -> true | uu____1137 -> false
+  fun projectee -> match projectee with | MLE_Let _0 -> true | uu___ -> false
 let (__proj__MLE_Let__item___0 :
   mlexpr' -> ((mlletflavor * mllb Prims.list) * mlexpr)) =
   fun projectee -> match projectee with | MLE_Let _0 -> _0
 let (uu___is_MLE_App : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_App _0 -> true | uu____1186 -> false
+  fun projectee -> match projectee with | MLE_App _0 -> true | uu___ -> false
 let (__proj__MLE_App__item___0 : mlexpr' -> (mlexpr * mlexpr Prims.list)) =
   fun projectee -> match projectee with | MLE_App _0 -> _0
 let (uu___is_MLE_TApp : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_TApp _0 -> true | uu____1223 -> false
+    match projectee with | MLE_TApp _0 -> true | uu___ -> false
 let (__proj__MLE_TApp__item___0 : mlexpr' -> (mlexpr * mlty Prims.list)) =
   fun projectee -> match projectee with | MLE_TApp _0 -> _0
 let (uu___is_MLE_Fun : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_Fun _0 -> true | uu____1264 -> false
+  fun projectee -> match projectee with | MLE_Fun _0 -> true | uu___ -> false
 let (__proj__MLE_Fun__item___0 :
   mlexpr' -> ((mlident * mlty) Prims.list * mlexpr)) =
   fun projectee -> match projectee with | MLE_Fun _0 -> _0
 let (uu___is_MLE_Match : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Match _0 -> true | uu____1321 -> false
+    match projectee with | MLE_Match _0 -> true | uu___ -> false
 let (__proj__MLE_Match__item___0 :
   mlexpr' ->
     (mlexpr * (mlpattern * mlexpr FStar_Pervasives_Native.option * mlexpr)
@@ -491,49 +470,46 @@ let (__proj__MLE_Match__item___0 :
   = fun projectee -> match projectee with | MLE_Match _0 -> _0
 let (uu___is_MLE_Coerce : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Coerce _0 -> true | uu____1382 -> false
+    match projectee with | MLE_Coerce _0 -> true | uu___ -> false
 let (__proj__MLE_Coerce__item___0 : mlexpr' -> (mlexpr * mlty * mlty)) =
   fun projectee -> match projectee with | MLE_Coerce _0 -> _0
 let (uu___is_MLE_CTor : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_CTor _0 -> true | uu____1419 -> false
+    match projectee with | MLE_CTor _0 -> true | uu___ -> false
 let (__proj__MLE_CTor__item___0 : mlexpr' -> (mlpath * mlexpr Prims.list)) =
   fun projectee -> match projectee with | MLE_CTor _0 -> _0
 let (uu___is_MLE_Seq : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_Seq _0 -> true | uu____1452 -> false
+  fun projectee -> match projectee with | MLE_Seq _0 -> true | uu___ -> false
 let (__proj__MLE_Seq__item___0 : mlexpr' -> mlexpr Prims.list) =
   fun projectee -> match projectee with | MLE_Seq _0 -> _0
 let (uu___is_MLE_Tuple : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Tuple _0 -> true | uu____1473 -> false
+    match projectee with | MLE_Tuple _0 -> true | uu___ -> false
 let (__proj__MLE_Tuple__item___0 : mlexpr' -> mlexpr Prims.list) =
   fun projectee -> match projectee with | MLE_Tuple _0 -> _0
 let (uu___is_MLE_Record : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Record _0 -> true | uu____1504 -> false
+    match projectee with | MLE_Record _0 -> true | uu___ -> false
 let (__proj__MLE_Record__item___0 :
   mlexpr' -> (mlsymbol Prims.list * (mlsymbol * mlexpr) Prims.list)) =
   fun projectee -> match projectee with | MLE_Record _0 -> _0
 let (uu___is_MLE_Proj : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Proj _0 -> true | uu____1557 -> false
+    match projectee with | MLE_Proj _0 -> true | uu___ -> false
 let (__proj__MLE_Proj__item___0 : mlexpr' -> (mlexpr * mlpath)) =
   fun projectee -> match projectee with | MLE_Proj _0 -> _0
 let (uu___is_MLE_If : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_If _0 -> true | uu____1590 -> false
+  fun projectee -> match projectee with | MLE_If _0 -> true | uu___ -> false
 let (__proj__MLE_If__item___0 :
   mlexpr' -> (mlexpr * mlexpr * mlexpr FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | MLE_If _0 -> _0
 let (uu___is_MLE_Raise : mlexpr' -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLE_Raise _0 -> true | uu____1633 -> false
+    match projectee with | MLE_Raise _0 -> true | uu___ -> false
 let (__proj__MLE_Raise__item___0 : mlexpr' -> (mlpath * mlexpr Prims.list)) =
   fun projectee -> match projectee with | MLE_Raise _0 -> _0
 let (uu___is_MLE_Try : mlexpr' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLE_Try _0 -> true | uu____1678 -> false
+  fun projectee -> match projectee with | MLE_Try _0 -> true | uu___ -> false
 let (__proj__MLE_Try__item___0 :
   mlexpr' ->
     (mlexpr * (mlpattern * mlexpr FStar_Pervasives_Native.option * mlexpr)
@@ -586,18 +562,18 @@ type mltybody =
   | MLTD_DType of (mlsymbol * (mlsymbol * mlty) Prims.list) Prims.list 
 let (uu___is_MLTD_Abbrev : mltybody -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTD_Abbrev _0 -> true | uu____1886 -> false
+    match projectee with | MLTD_Abbrev _0 -> true | uu___ -> false
 let (__proj__MLTD_Abbrev__item___0 : mltybody -> mlty) =
   fun projectee -> match projectee with | MLTD_Abbrev _0 -> _0
 let (uu___is_MLTD_Record : mltybody -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTD_Record _0 -> true | uu____1905 -> false
+    match projectee with | MLTD_Record _0 -> true | uu___ -> false
 let (__proj__MLTD_Record__item___0 :
   mltybody -> (mlsymbol * mlty) Prims.list) =
   fun projectee -> match projectee with | MLTD_Record _0 -> _0
 let (uu___is_MLTD_DType : mltybody -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLTD_DType _0 -> true | uu____1948 -> false
+    match projectee with | MLTD_DType _0 -> true | uu___ -> false
 let (__proj__MLTD_DType__item___0 :
   mltybody -> (mlsymbol * (mlsymbol * mlty) Prims.list) Prims.list) =
   fun projectee -> match projectee with | MLTD_DType _0 -> _0
@@ -612,29 +588,24 @@ type mlmodule1 =
   | MLM_Top of mlexpr 
   | MLM_Loc of mlloc 
 let (uu___is_MLM_Ty : mlmodule1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLM_Ty _0 -> true | uu____2050 -> false
+  fun projectee -> match projectee with | MLM_Ty _0 -> true | uu___ -> false
 let (__proj__MLM_Ty__item___0 : mlmodule1 -> mltydecl) =
   fun projectee -> match projectee with | MLM_Ty _0 -> _0
 let (uu___is_MLM_Let : mlmodule1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLM_Let _0 -> true | uu____2063 -> false
+  fun projectee -> match projectee with | MLM_Let _0 -> true | uu___ -> false
 let (__proj__MLM_Let__item___0 : mlmodule1 -> mlletbinding) =
   fun projectee -> match projectee with | MLM_Let _0 -> _0
 let (uu___is_MLM_Exn : mlmodule1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLM_Exn _0 -> true | uu____2086 -> false
+  fun projectee -> match projectee with | MLM_Exn _0 -> true | uu___ -> false
 let (__proj__MLM_Exn__item___0 :
   mlmodule1 -> (mlsymbol * (mlsymbol * mlty) Prims.list)) =
   fun projectee -> match projectee with | MLM_Exn _0 -> _0
 let (uu___is_MLM_Top : mlmodule1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLM_Top _0 -> true | uu____2129 -> false
+  fun projectee -> match projectee with | MLM_Top _0 -> true | uu___ -> false
 let (__proj__MLM_Top__item___0 : mlmodule1 -> mlexpr) =
   fun projectee -> match projectee with | MLM_Top _0 -> _0
 let (uu___is_MLM_Loc : mlmodule1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLM_Loc _0 -> true | uu____2142 -> false
+  fun projectee -> match projectee with | MLM_Loc _0 -> true | uu___ -> false
 let (__proj__MLM_Loc__item___0 : mlmodule1 -> mlloc) =
   fun projectee -> match projectee with | MLM_Loc _0 -> _0
 type mlmodule = mlmodule1 Prims.list
@@ -644,23 +615,19 @@ type mlsig1 =
   | MLS_Val of (mlsymbol * mltyscheme) 
   | MLS_Exn of (mlsymbol * mlty Prims.list) 
 let (uu___is_MLS_Mod : mlsig1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLS_Mod _0 -> true | uu____2199 -> false
+  fun projectee -> match projectee with | MLS_Mod _0 -> true | uu___ -> false
 let (__proj__MLS_Mod__item___0 : mlsig1 -> (mlsymbol * mlsig1 Prims.list)) =
   fun projectee -> match projectee with | MLS_Mod _0 -> _0
 let (uu___is_MLS_Ty : mlsig1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLS_Ty _0 -> true | uu____2230 -> false
+  fun projectee -> match projectee with | MLS_Ty _0 -> true | uu___ -> false
 let (__proj__MLS_Ty__item___0 : mlsig1 -> mltydecl) =
   fun projectee -> match projectee with | MLS_Ty _0 -> _0
 let (uu___is_MLS_Val : mlsig1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLS_Val _0 -> true | uu____2247 -> false
+  fun projectee -> match projectee with | MLS_Val _0 -> true | uu___ -> false
 let (__proj__MLS_Val__item___0 : mlsig1 -> (mlsymbol * mltyscheme)) =
   fun projectee -> match projectee with | MLS_Val _0 -> _0
 let (uu___is_MLS_Exn : mlsig1 -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLS_Exn _0 -> true | uu____2278 -> false
+  fun projectee -> match projectee with | MLS_Exn _0 -> true | uu___ -> false
 let (__proj__MLS_Exn__item___0 : mlsig1 -> (mlsymbol * mlty Prims.list)) =
   fun projectee -> match projectee with | MLS_Exn _0 -> _0
 type mlsig = mlsig1 Prims.list
@@ -688,27 +655,26 @@ let (apply_obj_repr : mlexpr -> mlty -> mlexpr) =
   fun x ->
     fun t ->
       let obj_ns =
-        let uu____2433 =
-          let uu____2434 = FStar_Options.codegen () in
-          uu____2434 = (FStar_Pervasives_Native.Some FStar_Options.FSharp) in
-        if uu____2433 then "FSharp.Compatibility.OCaml.Obj" else "Obj" in
+        let uu___ =
+          let uu___1 = FStar_Options.codegen () in
+          uu___1 = (FStar_Pervasives_Native.Some FStar_Options.FSharp) in
+        if uu___ then "FSharp.Compatibility.OCaml.Obj" else "Obj" in
       let obj_repr =
         with_ty (MLTY_Fun (t, E_PURE, MLTY_Top))
           (MLE_Name ([obj_ns], "repr")) in
       with_ty_loc MLTY_Top (MLE_App (obj_repr, [x])) x.loc
 let (push_unit : mltyscheme -> mltyscheme) =
   fun ts ->
-    let uu____2450 = ts in
-    match uu____2450 with
-    | (vs, ty) -> (vs, (MLTY_Fun (ml_unit_ty, E_PURE, ty)))
+    let uu___ = ts in
+    match uu___ with | (vs, ty) -> (vs, (MLTY_Fun (ml_unit_ty, E_PURE, ty)))
 let (pop_unit : mltyscheme -> mltyscheme) =
   fun ts ->
-    let uu____2458 = ts in
-    match uu____2458 with
+    let uu___ = ts in
+    match uu___ with
     | (vs, ty) ->
         (match ty with
          | MLTY_Fun (l, E_PURE, t) ->
              if l = ml_unit_ty
              then (vs, t)
              else failwith "unexpected: pop_unit: domain was not unit"
-         | uu____2464 -> failwith "unexpected: pop_unit: not a function type")
+         | uu___1 -> failwith "unexpected: pop_unit: not a function type")

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -2,7 +2,7 @@ open Prims
 exception Un_extractable 
 let (uu___is_Un_extractable : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Un_extractable -> true | uu____5 -> false
+    match projectee with | Un_extractable -> true | uu___ -> false
 let (type_leq :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Extraction_ML_Syntax.mlty ->
@@ -35,80 +35,78 @@ let (eraseTypeDeep :
       FStar_Extraction_ML_Util.eraseTypeDeep
         (FStar_Extraction_ML_Util.udelta_unfold g) t
 let fail :
-  'uuuuuu67 .
-    FStar_Range.range -> (FStar_Errors.raw_error * Prims.string) -> 'uuuuuu67
+  'uuuuu .
+    FStar_Range.range -> (FStar_Errors.raw_error * Prims.string) -> 'uuuuu
   = fun r -> fun err -> FStar_Errors.raise_error err r
 let err_ill_typed_application :
-  'uuuuuu100 'uuuuuu101 .
+  'uuuuu 'uuuuu1 .
     FStar_Extraction_ML_UEnv.uenv ->
       FStar_Syntax_Syntax.term ->
         FStar_Extraction_ML_Syntax.mlexpr ->
-          (FStar_Syntax_Syntax.term * 'uuuuuu100) Prims.list ->
-            FStar_Extraction_ML_Syntax.mlty -> 'uuuuuu101
+          (FStar_Syntax_Syntax.term * 'uuuuu) Prims.list ->
+            FStar_Extraction_ML_Syntax.mlty -> 'uuuuu1
   =
   fun env ->
     fun t ->
       fun mlhead ->
         fun args ->
           fun ty ->
-            let uu____139 =
-              let uu____144 =
-                let uu____145 = FStar_Syntax_Print.term_to_string t in
-                let uu____146 =
-                  let uu____147 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t in
+                let uu___3 =
+                  let uu___4 =
                     FStar_Extraction_ML_UEnv.current_module_of_uenv env in
-                  FStar_Extraction_ML_Code.string_of_mlexpr uu____147 mlhead in
-                let uu____148 =
-                  let uu____149 =
+                  FStar_Extraction_ML_Code.string_of_mlexpr uu___4 mlhead in
+                let uu___4 =
+                  let uu___5 =
                     FStar_Extraction_ML_UEnv.current_module_of_uenv env in
-                  FStar_Extraction_ML_Code.string_of_mlty uu____149 ty in
-                let uu____150 =
-                  let uu____151 =
+                  FStar_Extraction_ML_Code.string_of_mlty uu___5 ty in
+                let uu___5 =
+                  let uu___6 =
                     FStar_All.pipe_right args
                       (FStar_List.map
-                         (fun uu____169 ->
-                            match uu____169 with
-                            | (x, uu____175) ->
+                         (fun uu___7 ->
+                            match uu___7 with
+                            | (x, uu___8) ->
                                 FStar_Syntax_Print.term_to_string x)) in
-                  FStar_All.pipe_right uu____151 (FStar_String.concat " ") in
+                  FStar_All.pipe_right uu___6 (FStar_String.concat " ") in
                 FStar_Util.format4
                   "Ill-typed application: source application is %s \n translated prefix to %s at type %s\n remaining args are %s\n"
-                  uu____145 uu____146 uu____148 uu____150 in
-              (FStar_Errors.Fatal_IllTyped, uu____144) in
-            fail t.FStar_Syntax_Syntax.pos uu____139
+                  uu___2 uu___3 uu___4 uu___5 in
+              (FStar_Errors.Fatal_IllTyped, uu___1) in
+            fail t.FStar_Syntax_Syntax.pos uu___
 let err_ill_typed_erasure :
-  'uuuuuu186 .
+  'uuuuu .
     FStar_Extraction_ML_UEnv.uenv ->
-      FStar_Range.range -> FStar_Extraction_ML_Syntax.mlty -> 'uuuuuu186
+      FStar_Range.range -> FStar_Extraction_ML_Syntax.mlty -> 'uuuuu
   =
   fun env ->
     fun pos ->
       fun ty ->
-        let uu____202 =
-          let uu____207 =
-            let uu____208 =
-              let uu____209 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_Extraction_ML_UEnv.current_module_of_uenv env in
-              FStar_Extraction_ML_Code.string_of_mlty uu____209 ty in
+              FStar_Extraction_ML_Code.string_of_mlty uu___3 ty in
             FStar_Util.format1
               "Erased value found where a value of type %s was expected"
-              uu____208 in
-          (FStar_Errors.Fatal_IllTyped, uu____207) in
-        fail pos uu____202
+              uu___2 in
+          (FStar_Errors.Fatal_IllTyped, uu___1) in
+        fail pos uu___
 let err_value_restriction :
-  'uuuuuu214 .
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuuu214
-  =
+  'uuuuu . FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuu =
   fun t ->
-    let uu____224 =
-      let uu____229 =
-        let uu____230 = FStar_Syntax_Print.tag_of_term t in
-        let uu____231 = FStar_Syntax_Print.term_to_string t in
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Syntax_Print.tag_of_term t in
+        let uu___3 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format2
           "Refusing to generalize because of the value restriction: (%s) %s"
-          uu____230 uu____231 in
-      (FStar_Errors.Fatal_ValueRestriction, uu____229) in
-    fail t.FStar_Syntax_Syntax.pos uu____224
+          uu___2 uu___3 in
+      (FStar_Errors.Fatal_ValueRestriction, uu___1) in
+    fail t.FStar_Syntax_Syntax.pos uu___
 let (err_unexpected_eff :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -121,67 +119,67 @@ let (err_unexpected_eff :
       fun ty ->
         fun f0 ->
           fun f1 ->
-            let uu____261 =
-              let uu____266 =
-                let uu____267 = FStar_Syntax_Print.term_to_string t in
-                let uu____268 =
-                  let uu____269 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t in
+                let uu___3 =
+                  let uu___4 =
                     FStar_Extraction_ML_UEnv.current_module_of_uenv env in
-                  FStar_Extraction_ML_Code.string_of_mlty uu____269 ty in
-                let uu____270 = FStar_Extraction_ML_Util.eff_to_string f0 in
-                let uu____271 = FStar_Extraction_ML_Util.eff_to_string f1 in
+                  FStar_Extraction_ML_Code.string_of_mlty uu___4 ty in
+                let uu___4 = FStar_Extraction_ML_Util.eff_to_string f0 in
+                let uu___5 = FStar_Extraction_ML_Util.eff_to_string f1 in
                 FStar_Util.format4
                   "for expression %s of type %s, Expected effect %s; got effect %s"
-                  uu____267 uu____268 uu____270 uu____271 in
-              (FStar_Errors.Warning_ExtractionUnexpectedEffect, uu____266) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____261
+                  uu___2 uu___3 uu___4 uu___5 in
+              (FStar_Errors.Warning_ExtractionUnexpectedEffect, uu___1) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___
 let (effect_as_etag :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Ident.lident -> FStar_Extraction_ML_Syntax.e_tag)
   =
   let cache = FStar_Util.smap_create (Prims.of_int (20)) in
   let rec delta_norm_eff g l =
-    let uu____294 =
-      let uu____297 = FStar_Ident.string_of_lid l in
-      FStar_Util.smap_try_find cache uu____297 in
-    match uu____294 with
+    let uu___ =
+      let uu___1 = FStar_Ident.string_of_lid l in
+      FStar_Util.smap_try_find cache uu___1 in
+    match uu___ with
     | FStar_Pervasives_Native.Some l1 -> l1
     | FStar_Pervasives_Native.None ->
         let res =
-          let uu____300 =
-            let uu____307 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-            FStar_TypeChecker_Env.lookup_effect_abbrev uu____307
+          let uu___1 =
+            let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+            FStar_TypeChecker_Env.lookup_effect_abbrev uu___2
               [FStar_Syntax_Syntax.U_zero] l in
-          match uu____300 with
+          match uu___1 with
           | FStar_Pervasives_Native.None -> l
-          | FStar_Pervasives_Native.Some (uu____312, c) ->
+          | FStar_Pervasives_Native.Some (uu___2, c) ->
               delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c) in
-        ((let uu____319 = FStar_Ident.string_of_lid l in
-          FStar_Util.smap_add cache uu____319 res);
+        ((let uu___2 = FStar_Ident.string_of_lid l in
+          FStar_Util.smap_add cache uu___2 res);
          res) in
   fun g ->
     fun l ->
       let l1 = delta_norm_eff g l in
-      let uu____323 =
+      let uu___ =
         FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid in
-      if uu____323
+      if uu___
       then FStar_Extraction_ML_Syntax.E_PURE
       else
-        (let uu____325 =
+        (let uu___2 =
            FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid in
-         if uu____325
+         if uu___2
          then FStar_Extraction_ML_Syntax.E_GHOST
          else
            (let ed_opt =
-              let uu____336 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-              FStar_TypeChecker_Env.effect_decl_opt uu____336 l1 in
+              let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+              FStar_TypeChecker_Env.effect_decl_opt uu___4 l1 in
             match ed_opt with
             | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                let uu____349 =
-                  let uu____350 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                  FStar_TypeChecker_Env.is_reifiable_effect uu____350
+                let uu___4 =
+                  let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  FStar_TypeChecker_Env.is_reifiable_effect uu___5
                     ed.FStar_Syntax_Syntax.mname in
-                if uu____349
+                if uu___4
                 then FStar_Extraction_ML_Syntax.E_PURE
                 else FStar_Extraction_ML_Syntax.E_IMPURE
             | FStar_Pervasives_Native.None ->
@@ -191,218 +189,211 @@ let rec (is_arity :
   fun env ->
     fun t ->
       let t1 = FStar_Syntax_Util.unmeta t in
-      let uu____369 =
-        let uu____370 = FStar_Syntax_Subst.compress t1 in
-        uu____370.FStar_Syntax_Syntax.n in
-      match uu____369 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t1 in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____373 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_ascribed uu____388 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_meta uu____415 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_ascribed uu___1 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu___1 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____423 = FStar_Syntax_Util.unfold_lazy i in
-          is_arity env uu____423
-      | FStar_Syntax_Syntax.Tm_uvar uu____424 -> false
-      | FStar_Syntax_Syntax.Tm_constant uu____437 -> false
-      | FStar_Syntax_Syntax.Tm_name uu____438 -> false
-      | FStar_Syntax_Syntax.Tm_quoted uu____439 -> false
-      | FStar_Syntax_Syntax.Tm_bvar uu____446 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____447 -> true
-      | FStar_Syntax_Syntax.Tm_arrow (uu____448, c) ->
+          let uu___1 = FStar_Syntax_Util.unfold_lazy i in is_arity env uu___1
+      | FStar_Syntax_Syntax.Tm_uvar uu___1 -> false
+      | FStar_Syntax_Syntax.Tm_constant uu___1 -> false
+      | FStar_Syntax_Syntax.Tm_name uu___1 -> false
+      | FStar_Syntax_Syntax.Tm_quoted uu___1 -> false
+      | FStar_Syntax_Syntax.Tm_bvar uu___1 -> false
+      | FStar_Syntax_Syntax.Tm_type uu___1 -> true
+      | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
           is_arity env (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let topt =
-            let uu____478 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+            let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
-                 FStar_Syntax_Syntax.delta_constant] uu____478
+                 FStar_Syntax_Syntax.delta_constant] uu___1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match topt with
            | FStar_Pervasives_Native.None -> false
-           | FStar_Pervasives_Native.Some (uu____483, t2) -> is_arity env t2)
-      | FStar_Syntax_Syntax.Tm_app uu____489 ->
-          let uu____506 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____506 with | (head, uu____524) -> is_arity env head)
-      | FStar_Syntax_Syntax.Tm_uinst (head, uu____550) -> is_arity env head
-      | FStar_Syntax_Syntax.Tm_refine (x, uu____556) ->
+           | FStar_Pervasives_Native.Some (uu___1, t2) -> is_arity env t2)
+      | FStar_Syntax_Syntax.Tm_app uu___1 ->
+          let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+          (match uu___2 with | (head, uu___3) -> is_arity env head)
+      | FStar_Syntax_Syntax.Tm_uinst (head, uu___1) -> is_arity env head
+      | FStar_Syntax_Syntax.Tm_refine (x, uu___1) ->
           is_arity env x.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_abs (uu____561, body, uu____563) ->
+      | FStar_Syntax_Syntax.Tm_abs (uu___1, body, uu___2) ->
           is_arity env body
-      | FStar_Syntax_Syntax.Tm_let (uu____588, body) -> is_arity env body
-      | FStar_Syntax_Syntax.Tm_match (uu____606, branches) ->
+      | FStar_Syntax_Syntax.Tm_let (uu___1, body) -> is_arity env body
+      | FStar_Syntax_Syntax.Tm_match (uu___1, branches) ->
           (match branches with
-           | (uu____644, uu____645, e)::uu____647 -> is_arity env e
-           | uu____694 -> false)
+           | (uu___2, uu___3, e)::uu___4 -> is_arity env e
+           | uu___2 -> false)
 let rec (is_type_aux :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env ->
     fun t ->
       let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____722 ->
-          let uu____737 =
-            let uu____738 = FStar_Syntax_Print.tag_of_term t1 in
-            FStar_Util.format1 "Impossible: %s" uu____738 in
-          failwith uu____737
+      | FStar_Syntax_Syntax.Tm_delayed uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.tag_of_term t1 in
+            FStar_Util.format1 "Impossible: %s" uu___2 in
+          failwith uu___1
       | FStar_Syntax_Syntax.Tm_unknown ->
-          let uu____739 =
-            let uu____740 = FStar_Syntax_Print.tag_of_term t1 in
-            FStar_Util.format1 "Impossible: %s" uu____740 in
-          failwith uu____739
+          let uu___ =
+            let uu___1 = FStar_Syntax_Print.tag_of_term t1 in
+            FStar_Util.format1 "Impossible: %s" uu___1 in
+          failwith uu___
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____742 = FStar_Syntax_Util.unfold_lazy i in
-          is_type_aux env uu____742
-      | FStar_Syntax_Syntax.Tm_constant uu____743 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____744 -> true
-      | FStar_Syntax_Syntax.Tm_refine uu____745 -> true
-      | FStar_Syntax_Syntax.Tm_arrow uu____752 -> true
+          let uu___ = FStar_Syntax_Util.unfold_lazy i in
+          is_type_aux env uu___
+      | FStar_Syntax_Syntax.Tm_constant uu___ -> false
+      | FStar_Syntax_Syntax.Tm_type uu___ -> true
+      | FStar_Syntax_Syntax.Tm_refine uu___ -> true
+      | FStar_Syntax_Syntax.Tm_arrow uu___ -> true
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.failwith_lid ->
           false
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Extraction_ML_UEnv.is_type_name env fv
       | FStar_Syntax_Syntax.Tm_uvar
-          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu____769;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____770;
-             FStar_Syntax_Syntax.ctx_uvar_binders = uu____771;
+          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu___;
+             FStar_Syntax_Syntax.ctx_uvar_gamma = uu___1;
+             FStar_Syntax_Syntax.ctx_uvar_binders = uu___2;
              FStar_Syntax_Syntax.ctx_uvar_typ = t2;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu____773;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____774;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu____775;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu____776;_},
+             FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
+             FStar_Syntax_Syntax.ctx_uvar_should_check = uu___4;
+             FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
            s)
           ->
-          let uu____820 = FStar_Syntax_Subst.subst' s t2 in
-          is_arity env uu____820
+          let uu___7 = FStar_Syntax_Subst.subst' s t2 in is_arity env uu___7
       | FStar_Syntax_Syntax.Tm_bvar
-          { FStar_Syntax_Syntax.ppname = uu____821;
-            FStar_Syntax_Syntax.index = uu____822;
+          { FStar_Syntax_Syntax.ppname = uu___;
+            FStar_Syntax_Syntax.index = uu___1;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
       | FStar_Syntax_Syntax.Tm_name
-          { FStar_Syntax_Syntax.ppname = uu____826;
-            FStar_Syntax_Syntax.index = uu____827;
+          { FStar_Syntax_Syntax.ppname = uu___;
+            FStar_Syntax_Syntax.index = uu___1;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____832, uu____833) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) ->
           is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_uinst (t2, uu____875) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____882) ->
-          let uu____907 = FStar_Syntax_Subst.open_term bs body in
-          (match uu____907 with | (uu____912, body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_uinst (t2, uu___) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___) ->
+          let uu___1 = FStar_Syntax_Subst.open_term bs body in
+          (match uu___1 with | (uu___2, body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
           let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-          let uu____929 =
-            let uu____934 =
-              let uu____935 = FStar_Syntax_Syntax.mk_binder x in [uu____935] in
-            FStar_Syntax_Subst.open_term uu____934 body in
-          (match uu____929 with | (uu____954, body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_let ((uu____956, lbs), body) ->
-          let uu____973 = FStar_Syntax_Subst.open_let_rec lbs body in
-          (match uu____973 with | (uu____980, body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_match (uu____986, branches) ->
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Syntax.mk_binder x in [uu___2] in
+            FStar_Syntax_Subst.open_term uu___1 body in
+          (match uu___ with | (uu___1, body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_let ((uu___, lbs), body) ->
+          let uu___1 = FStar_Syntax_Subst.open_let_rec lbs body in
+          (match uu___1 with | (uu___2, body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_match (uu___, branches) ->
           (match branches with
-           | b::uu____1025 ->
-               let uu____1070 = FStar_Syntax_Subst.open_branch b in
-               (match uu____1070 with
-                | (uu____1071, uu____1072, e) -> is_type_aux env e)
-           | uu____1090 -> false)
-      | FStar_Syntax_Syntax.Tm_quoted uu____1107 -> false
-      | FStar_Syntax_Syntax.Tm_meta (t2, uu____1115) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_app (head, uu____1121) -> is_type_aux env head
+           | b::uu___1 ->
+               let uu___2 = FStar_Syntax_Subst.open_branch b in
+               (match uu___2 with | (uu___3, uu___4, e) -> is_type_aux env e)
+           | uu___1 -> false)
+      | FStar_Syntax_Syntax.Tm_quoted uu___ -> false
+      | FStar_Syntax_Syntax.Tm_meta (t2, uu___) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_app (head, uu___) -> is_type_aux env head
 let (is_type :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env ->
     fun t ->
       FStar_Extraction_ML_UEnv.debug env
-        (fun uu____1160 ->
-           let uu____1161 = FStar_Syntax_Print.tag_of_term t in
-           let uu____1162 = FStar_Syntax_Print.term_to_string t in
-           FStar_Util.print2 "checking is_type (%s) %s\n" uu____1161
-             uu____1162);
+        (fun uu___1 ->
+           let uu___2 = FStar_Syntax_Print.tag_of_term t in
+           let uu___3 = FStar_Syntax_Print.term_to_string t in
+           FStar_Util.print2 "checking is_type (%s) %s\n" uu___2 uu___3);
       (let b = is_type_aux env t in
        FStar_Extraction_ML_UEnv.debug env
-         (fun uu____1168 ->
+         (fun uu___2 ->
             if b
             then
-              let uu____1169 = FStar_Syntax_Print.term_to_string t in
-              let uu____1170 = FStar_Syntax_Print.tag_of_term t in
-              FStar_Util.print2 "yes, is_type %s (%s)\n" uu____1169
-                uu____1170
+              let uu___3 = FStar_Syntax_Print.term_to_string t in
+              let uu___4 = FStar_Syntax_Print.tag_of_term t in
+              FStar_Util.print2 "yes, is_type %s (%s)\n" uu___3 uu___4
             else
-              (let uu____1172 = FStar_Syntax_Print.term_to_string t in
-               let uu____1173 = FStar_Syntax_Print.tag_of_term t in
-               FStar_Util.print2 "not a type %s (%s)\n" uu____1172 uu____1173));
+              (let uu___4 = FStar_Syntax_Print.term_to_string t in
+               let uu___5 = FStar_Syntax_Print.tag_of_term t in
+               FStar_Util.print2 "not a type %s (%s)\n" uu___4 uu___5));
        b)
 let is_type_binder :
-  'uuuuuu1180 .
+  'uuuuu .
     FStar_Extraction_ML_UEnv.uenv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu1180) -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuu) -> Prims.bool
   =
   fun env ->
     fun x ->
       is_arity env (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
 let (is_constructor : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1204 =
-      let uu____1205 = FStar_Syntax_Subst.compress t in
-      uu____1205.FStar_Syntax_Syntax.n in
-    match uu____1204 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1208;
-          FStar_Syntax_Syntax.fv_delta = uu____1209;
+        { FStar_Syntax_Syntax.fv_name = uu___1;
+          FStar_Syntax_Syntax.fv_delta = uu___2;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
             (FStar_Syntax_Syntax.Data_ctor);_}
         -> true
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1210;
-          FStar_Syntax_Syntax.fv_delta = uu____1211;
+        { FStar_Syntax_Syntax.fv_name = uu___1;
+          FStar_Syntax_Syntax.fv_delta = uu___2;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-            (FStar_Syntax_Syntax.Record_ctor uu____1212);_}
+            (FStar_Syntax_Syntax.Record_ctor uu___3);_}
         -> true
-    | uu____1219 -> false
+    | uu___1 -> false
 let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1225 =
-      let uu____1226 = FStar_Syntax_Subst.compress t in
-      uu____1226.FStar_Syntax_Syntax.n in
-    match uu____1225 with
-    | FStar_Syntax_Syntax.Tm_constant uu____1229 -> true
-    | FStar_Syntax_Syntax.Tm_bvar uu____1230 -> true
-    | FStar_Syntax_Syntax.Tm_fvar uu____1231 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____1232 -> true
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_constant uu___1 -> true
+    | FStar_Syntax_Syntax.Tm_bvar uu___1 -> true
+    | FStar_Syntax_Syntax.Tm_fvar uu___1 -> true
+    | FStar_Syntax_Syntax.Tm_abs uu___1 -> true
     | FStar_Syntax_Syntax.Tm_app (head, args) ->
-        let uu____1277 = is_constructor head in
-        if uu____1277
+        let uu___1 = is_constructor head in
+        if uu___1
         then
           FStar_All.pipe_right args
             (FStar_List.for_all
-               (fun uu____1295 ->
-                  match uu____1295 with
-                  | (te, uu____1303) -> is_fstar_value te))
+               (fun uu___2 ->
+                  match uu___2 with | (te, uu___3) -> is_fstar_value te))
         else false
-    | FStar_Syntax_Syntax.Tm_meta (t1, uu____1310) -> is_fstar_value t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu____1316, uu____1317) ->
+    | FStar_Syntax_Syntax.Tm_meta (t1, uu___1) -> is_fstar_value t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu___1, uu___2) ->
         is_fstar_value t1
-    | uu____1358 -> false
+    | uu___1 -> false
 let rec (is_ml_value : FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool) =
   fun e ->
     match e.FStar_Extraction_ML_Syntax.expr with
-    | FStar_Extraction_ML_Syntax.MLE_Const uu____1364 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Var uu____1365 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Name uu____1366 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Fun uu____1367 -> true
-    | FStar_Extraction_ML_Syntax.MLE_CTor (uu____1378, exps) ->
+    | FStar_Extraction_ML_Syntax.MLE_Const uu___ -> true
+    | FStar_Extraction_ML_Syntax.MLE_Var uu___ -> true
+    | FStar_Extraction_ML_Syntax.MLE_Name uu___ -> true
+    | FStar_Extraction_ML_Syntax.MLE_Fun uu___ -> true
+    | FStar_Extraction_ML_Syntax.MLE_CTor (uu___, exps) ->
         FStar_Util.for_all is_ml_value exps
     | FStar_Extraction_ML_Syntax.MLE_Tuple exps ->
         FStar_Util.for_all is_ml_value exps
-    | FStar_Extraction_ML_Syntax.MLE_Record (uu____1387, fields) ->
+    | FStar_Extraction_ML_Syntax.MLE_Record (uu___, fields) ->
         FStar_Util.for_all
-          (fun uu____1412 ->
-             match uu____1412 with | (uu____1417, e1) -> is_ml_value e1)
+          (fun uu___1 -> match uu___1 with | (uu___2, e1) -> is_ml_value e1)
           fields
-    | FStar_Extraction_ML_Syntax.MLE_TApp (h, uu____1420) -> is_ml_value h
-    | uu____1425 -> false
+    | FStar_Extraction_ML_Syntax.MLE_TApp (h, uu___) -> is_ml_value h
+    | uu___ -> false
 let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t0 ->
     let rec aux bs t copt =
@@ -410,19 +401,17 @@ let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_abs (bs', body, copt1) ->
           aux (FStar_List.append bs bs') body copt1
-      | uu____1505 ->
+      | uu___ ->
           let e' = FStar_Syntax_Util.unascribe t1 in
-          let uu____1507 = FStar_Syntax_Util.is_fun e' in
-          if uu____1507
-          then aux bs e' copt
-          else FStar_Syntax_Util.abs bs e' copt in
+          let uu___1 = FStar_Syntax_Util.is_fun e' in
+          if uu___1 then aux bs e' copt else FStar_Syntax_Util.abs bs e' copt in
     aux [] t0 FStar_Pervasives_Native.None
 let (unit_binder : unit -> FStar_Syntax_Syntax.binder) =
-  fun uu____1521 ->
-    let uu____1522 =
+  fun uu___ ->
+    let uu___1 =
       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
         FStar_Syntax_Syntax.t_unit in
-    FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1522
+    FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu___1
 let (check_pats_for_ite :
   (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
     FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term) Prims.list ->
@@ -435,12 +424,11 @@ let (check_pats_for_ite :
     if (FStar_List.length l) <> (Prims.of_int (2))
     then def
     else
-      (let uu____1602 = FStar_List.hd l in
-       match uu____1602 with
+      (let uu___1 = FStar_List.hd l in
+       match uu___1 with
        | (p1, w1, e1) ->
-           let uu____1636 =
-             let uu____1645 = FStar_List.tl l in FStar_List.hd uu____1645 in
-           (match uu____1636 with
+           let uu___2 = let uu___3 = FStar_List.tl l in FStar_List.hd uu___3 in
+           (match uu___2 with
             | (p2, w2, e2) ->
                 (match (w1, w2, (p1.FStar_Syntax_Syntax.v),
                          (p2.FStar_Syntax_Syntax.v))
@@ -459,7 +447,7 @@ let (check_pats_for_ite :
                     (FStar_Const.Const_bool (true))) ->
                      (true, (FStar_Pervasives_Native.Some e2),
                        (FStar_Pervasives_Native.Some e1))
-                 | uu____1719 -> def)))
+                 | uu___3 -> def)))
 let (instantiate_tyscheme :
   FStar_Extraction_ML_Syntax.mltyscheme ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
@@ -473,16 +461,16 @@ let (fresh_mlidents :
   =
   fun ts ->
     fun g ->
-      let uu____1780 =
+      let uu___ =
         FStar_List.fold_right
           (fun t ->
-             fun uu____1809 ->
-               match uu____1809 with
+             fun uu___1 ->
+               match uu___1 with
                | (uenv, vs) ->
-                   let uu____1844 = FStar_Extraction_ML_UEnv.new_mlident uenv in
-                   (match uu____1844 with
-                    | (uenv1, v) -> (uenv1, ((v, t) :: vs)))) ts (g, []) in
-      match uu____1780 with | (g1, vs_ts) -> (vs_ts, g1)
+                   let uu___2 = FStar_Extraction_ML_UEnv.new_mlident uenv in
+                   (match uu___2 with | (uenv1, v) -> (uenv1, ((v, t) :: vs))))
+          ts (g, []) in
+      match uu___ with | (g1, vs_ts) -> (vs_ts, g1)
 let (instantiate_maybe_partial :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Extraction_ML_Syntax.mlexpr ->
@@ -496,8 +484,8 @@ let (instantiate_maybe_partial :
     fun e ->
       fun s ->
         fun tyargs ->
-          let uu____1947 = s in
-          match uu____1947 with
+          let uu___ = s in
+          match uu___ with
           | (vars, t) ->
               let n_vars = FStar_List.length vars in
               let n_args = FStar_List.length tyargs in
@@ -508,46 +496,46 @@ let (instantiate_maybe_partial :
                  else
                    (let ts = instantiate_tyscheme (vars, t) tyargs in
                     let tapp =
-                      let uu___372_1973 = e in
+                      let uu___2 = e in
                       {
                         FStar_Extraction_ML_Syntax.expr =
                           (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
                         FStar_Extraction_ML_Syntax.mlty = ts;
                         FStar_Extraction_ML_Syntax.loc =
-                          (uu___372_1973.FStar_Extraction_ML_Syntax.loc)
+                          (uu___2.FStar_Extraction_ML_Syntax.loc)
                       } in
                     (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)))
               else
                 if n_args < n_vars
                 then
                   (let extra_tyargs =
-                     let uu____1986 = FStar_Util.first_N n_args vars in
-                     match uu____1986 with
-                     | (uu____1997, rest_vars) ->
+                     let uu___2 = FStar_Util.first_N n_args vars in
+                     match uu___2 with
+                     | (uu___3, rest_vars) ->
                          FStar_All.pipe_right rest_vars
                            (FStar_List.map
-                              (fun uu____2012 ->
+                              (fun uu___4 ->
                                  FStar_Extraction_ML_Syntax.MLTY_Erased)) in
                    let tyargs1 = FStar_List.append tyargs extra_tyargs in
                    let ts = instantiate_tyscheme (vars, t) tyargs1 in
                    let tapp =
-                     let uu___383_2018 = e in
+                     let uu___2 = e in
                      {
                        FStar_Extraction_ML_Syntax.expr =
                          (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs1));
                        FStar_Extraction_ML_Syntax.mlty = ts;
                        FStar_Extraction_ML_Syntax.loc =
-                         (uu___383_2018.FStar_Extraction_ML_Syntax.loc)
+                         (uu___2.FStar_Extraction_ML_Syntax.loc)
                      } in
                    let t1 =
                      FStar_List.fold_left
                        (fun out ->
-                          fun t1 ->
+                          fun t2 ->
                             FStar_Extraction_ML_Syntax.MLTY_Fun
-                              (t1, FStar_Extraction_ML_Syntax.E_PURE, out))
+                              (t2, FStar_Extraction_ML_Syntax.E_PURE, out))
                        ts extra_tyargs in
-                   let uu____2026 = fresh_mlidents extra_tyargs g in
-                   match uu____2026 with
+                   let uu___2 = fresh_mlidents extra_tyargs g in
+                   match uu___2 with
                    | (vs_ts, g1) ->
                        let f =
                          FStar_All.pipe_left
@@ -565,19 +553,19 @@ let (eta_expand :
   fun g ->
     fun t ->
       fun e ->
-        let uu____2086 = FStar_Extraction_ML_Util.doms_and_cod t in
-        match uu____2086 with
+        let uu___ = FStar_Extraction_ML_Util.doms_and_cod t in
+        match uu___ with
         | (ts, r) ->
             if ts = []
             then e
             else
-              (let uu____2102 = fresh_mlidents ts g in
-               match uu____2102 with
+              (let uu___2 = fresh_mlidents ts g in
+               match uu___2 with
                | (vs_ts, g1) ->
                    let vs_es =
                      FStar_List.map
-                       (fun uu____2137 ->
-                          match uu____2137 with
+                       (fun uu___3 ->
+                          match uu___3 with
                           | (v, t1) ->
                               FStar_Extraction_ML_Syntax.with_ty t1
                                 (FStar_Extraction_ML_Syntax.MLE_Var v)) vs_ts in
@@ -593,15 +581,15 @@ let (default_value_for_ty :
   =
   fun g ->
     fun t ->
-      let uu____2163 = FStar_Extraction_ML_Util.doms_and_cod t in
-      match uu____2163 with
+      let uu___ = FStar_Extraction_ML_Util.doms_and_cod t in
+      match uu___ with
       | (ts, r) ->
           let body r1 =
             let r2 =
-              let uu____2183 = FStar_Extraction_ML_Util.udelta_unfold g r1 in
-              match uu____2183 with
+              let uu___1 = FStar_Extraction_ML_Util.udelta_unfold g r1 in
+              match uu___1 with
               | FStar_Pervasives_Native.None -> r1
-              | FStar_Pervasives_Native.Some r2 -> r2 in
+              | FStar_Pervasives_Native.Some r3 -> r3 in
             match r2 with
             | FStar_Extraction_ML_Syntax.MLTY_Erased ->
                 FStar_Extraction_ML_Syntax.ml_unit
@@ -609,7 +597,7 @@ let (default_value_for_ty :
                 FStar_Extraction_ML_Syntax.apply_obj_repr
                   FStar_Extraction_ML_Syntax.ml_unit
                   FStar_Extraction_ML_Syntax.MLTY_Erased
-            | uu____2187 ->
+            | uu___1 ->
                 FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r2)
                   (FStar_Extraction_ML_Syntax.MLE_Coerce
                      (FStar_Extraction_ML_Syntax.ml_unit,
@@ -617,15 +605,14 @@ let (default_value_for_ty :
           if ts = []
           then body r
           else
-            (let uu____2191 = fresh_mlidents ts g in
-             match uu____2191 with
+            (let uu___2 = fresh_mlidents ts g in
+             match uu___2 with
              | (vs_ts, g1) ->
-                 let uu____2216 =
-                   let uu____2217 =
-                     let uu____2228 = body r in (vs_ts, uu____2228) in
-                   FStar_Extraction_ML_Syntax.MLE_Fun uu____2217 in
+                 let uu___3 =
+                   let uu___4 = let uu___5 = body r in (vs_ts, uu___5) in
+                   FStar_Extraction_ML_Syntax.MLE_Fun uu___4 in
                  FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t)
-                   uu____2216)
+                   uu___3)
 let (maybe_eta_expand :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Extraction_ML_Syntax.mlty ->
@@ -634,12 +621,11 @@ let (maybe_eta_expand :
   fun g ->
     fun expect ->
       fun e ->
-        let uu____2250 =
+        let uu___ =
           (FStar_Options.ml_no_eta_expand_coertions ()) ||
-            (let uu____2252 = FStar_Options.codegen () in
-             uu____2252 =
-               (FStar_Pervasives_Native.Some FStar_Options.Kremlin)) in
-        if uu____2250 then e else eta_expand g expect e
+            (let uu___1 = FStar_Options.codegen () in
+             uu___1 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)) in
+        if uu___ then e else eta_expand g expect e
 let (apply_coercion :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Extraction_ML_Syntax.mlexpr ->
@@ -655,49 +641,48 @@ let (apply_coercion :
             | FStar_Extraction_ML_Syntax.MLE_Fun (binders, body1) ->
                 FStar_Extraction_ML_Syntax.MLE_Fun
                   ((binder :: binders), body1)
-            | uu____2321 ->
-                FStar_Extraction_ML_Syntax.MLE_Fun ([binder], body) in
+            | uu___ -> FStar_Extraction_ML_Syntax.MLE_Fun ([binder], body) in
           let rec aux e1 ty1 expect1 =
-            let coerce_branch uu____2373 =
-              match uu____2373 with
+            let coerce_branch uu___ =
+              match uu___ with
               | (pat, w, b) ->
-                  let uu____2397 = aux b ty1 expect1 in (pat, w, uu____2397) in
+                  let uu___1 = aux b ty1 expect1 in (pat, w, uu___1) in
             match ((e1.FStar_Extraction_ML_Syntax.expr), ty1, expect1) with
             | (FStar_Extraction_ML_Syntax.MLE_Fun (arg::rest, body),
-               FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu____2404, t1),
-               FStar_Extraction_ML_Syntax.MLTY_Fun (s0, uu____2407, s1)) ->
+               FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu___, t1),
+               FStar_Extraction_ML_Syntax.MLTY_Fun (s0, uu___1, s1)) ->
                 let body1 =
                   match rest with
                   | [] -> body
-                  | uu____2434 ->
+                  | uu___2 ->
                       FStar_Extraction_ML_Syntax.with_ty t1
                         (FStar_Extraction_ML_Syntax.MLE_Fun (rest, body)) in
                 let body2 = aux body1 t1 s1 in
-                let uu____2448 = type_leq g s0 t0 in
-                if uu____2448
+                let uu___2 = type_leq g s0 t0 in
+                if uu___2
                 then
                   FStar_Extraction_ML_Syntax.with_ty expect1
                     (mk_fun arg body2)
                 else
                   (let lb =
-                     let uu____2451 =
-                       let uu____2452 =
-                         let uu____2453 =
-                           let uu____2460 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_All.pipe_left
                                (FStar_Extraction_ML_Syntax.with_ty s0)
                                (FStar_Extraction_ML_Syntax.MLE_Var
                                   (FStar_Pervasives_Native.fst arg)) in
-                           (uu____2460, s0, t0) in
-                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2453 in
-                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2452 in
+                           (uu___7, s0, t0) in
+                         FStar_Extraction_ML_Syntax.MLE_Coerce uu___6 in
+                       FStar_Extraction_ML_Syntax.with_ty t0 uu___5 in
                      {
                        FStar_Extraction_ML_Syntax.mllb_name =
                          (FStar_Pervasives_Native.fst arg);
                        FStar_Extraction_ML_Syntax.mllb_tysc =
                          (FStar_Pervasives_Native.Some ([], t0));
                        FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                       FStar_Extraction_ML_Syntax.mllb_def = uu____2451;
+                       FStar_Extraction_ML_Syntax.mllb_def = uu___4;
                        FStar_Extraction_ML_Syntax.mllb_meta = [];
                        FStar_Extraction_ML_Syntax.print_typ = false
                      } in
@@ -708,67 +693,63 @@ let (apply_coercion :
                           ((FStar_Extraction_ML_Syntax.NonRec, [lb]), body2)) in
                    FStar_Extraction_ML_Syntax.with_ty expect1
                      (mk_fun ((FStar_Pervasives_Native.fst arg), s0) body3))
-            | (FStar_Extraction_ML_Syntax.MLE_Let (lbs, body), uu____2472,
-               uu____2473) ->
-                let uu____2486 =
-                  let uu____2487 =
-                    let uu____2498 = aux body ty1 expect1 in
-                    (lbs, uu____2498) in
-                  FStar_Extraction_ML_Syntax.MLE_Let uu____2487 in
+            | (FStar_Extraction_ML_Syntax.MLE_Let (lbs, body), uu___, uu___1)
+                ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = aux body ty1 expect1 in (lbs, uu___4) in
+                  FStar_Extraction_ML_Syntax.MLE_Let uu___3 in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2486
-            | (FStar_Extraction_ML_Syntax.MLE_Match (s, branches),
-               uu____2507, uu____2508) ->
-                let uu____2529 =
-                  let uu____2530 =
-                    let uu____2545 = FStar_List.map coerce_branch branches in
-                    (s, uu____2545) in
-                  FStar_Extraction_ML_Syntax.MLE_Match uu____2530 in
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu___2
+            | (FStar_Extraction_ML_Syntax.MLE_Match (s, branches), uu___,
+               uu___1) ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_List.map coerce_branch branches in
+                    (s, uu___4) in
+                  FStar_Extraction_ML_Syntax.MLE_Match uu___3 in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2529
-            | (FStar_Extraction_ML_Syntax.MLE_If (s, b1, b2_opt), uu____2585,
-               uu____2586) ->
-                let uu____2591 =
-                  let uu____2592 =
-                    let uu____2601 = aux b1 ty1 expect1 in
-                    let uu____2602 =
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu___2
+            | (FStar_Extraction_ML_Syntax.MLE_If (s, b1, b2_opt), uu___,
+               uu___1) ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = aux b1 ty1 expect1 in
+                    let uu___5 =
                       FStar_Util.map_opt b2_opt
                         (fun b2 -> aux b2 ty1 expect1) in
-                    (s, uu____2601, uu____2602) in
-                  FStar_Extraction_ML_Syntax.MLE_If uu____2592 in
+                    (s, uu___4, uu___5) in
+                  FStar_Extraction_ML_Syntax.MLE_If uu___3 in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2591
-            | (FStar_Extraction_ML_Syntax.MLE_Seq es, uu____2610, uu____2611)
-                ->
-                let uu____2614 = FStar_Util.prefix es in
-                (match uu____2614 with
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu___2
+            | (FStar_Extraction_ML_Syntax.MLE_Seq es, uu___, uu___1) ->
+                let uu___2 = FStar_Util.prefix es in
+                (match uu___2 with
                  | (prefix, last) ->
-                     let uu____2627 =
-                       let uu____2628 =
-                         let uu____2631 =
-                           let uu____2634 = aux last ty1 expect1 in
-                           [uu____2634] in
-                         FStar_List.append prefix uu____2631 in
-                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2628 in
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 = aux last ty1 expect1 in [uu___6] in
+                         FStar_List.append prefix uu___5 in
+                       FStar_Extraction_ML_Syntax.MLE_Seq uu___4 in
                      FStar_All.pipe_left
-                       (FStar_Extraction_ML_Syntax.with_ty expect1)
-                       uu____2627)
-            | (FStar_Extraction_ML_Syntax.MLE_Try (s, branches), uu____2637,
-               uu____2638) ->
-                let uu____2659 =
-                  let uu____2660 =
-                    let uu____2675 = FStar_List.map coerce_branch branches in
-                    (s, uu____2675) in
-                  FStar_Extraction_ML_Syntax.MLE_Try uu____2660 in
+                       (FStar_Extraction_ML_Syntax.with_ty expect1) uu___3)
+            | (FStar_Extraction_ML_Syntax.MLE_Try (s, branches), uu___,
+               uu___1) ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_List.map coerce_branch branches in
+                    (s, uu___4) in
+                  FStar_Extraction_ML_Syntax.MLE_Try uu___3 in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2659
-            | uu____2712 ->
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu___2
+            | uu___ ->
                 FStar_Extraction_ML_Syntax.with_ty expect1
                   (FStar_Extraction_ML_Syntax.MLE_Coerce (e1, ty1, expect1)) in
           aux e ty expect
 let maybe_coerce :
-  'uuuuuu2731 .
-    'uuuuuu2731 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_Extraction_ML_UEnv.uenv ->
         FStar_Extraction_ML_Syntax.mlexpr ->
           FStar_Extraction_ML_Syntax.mlty ->
@@ -781,79 +762,79 @@ let maybe_coerce :
         fun ty ->
           fun expect ->
             let ty1 = eraseTypeDeep g ty in
-            let uu____2758 =
+            let uu___ =
               type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect in
-            match uu____2758 with
+            match uu___ with
             | (true, FStar_Pervasives_Native.Some e') -> e'
-            | uu____2768 ->
+            | uu___1 ->
                 (match ty1 with
                  | FStar_Extraction_ML_Syntax.MLTY_Erased ->
                      default_value_for_ty g expect
-                 | uu____2775 ->
-                     let uu____2776 =
-                       let uu____2777 =
+                 | uu___2 ->
+                     let uu___3 =
+                       let uu___4 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            ty1 in
-                       let uu____2778 =
+                       let uu___5 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            expect in
-                       type_leq g uu____2777 uu____2778 in
-                     if uu____2776
+                       type_leq g uu___4 uu___5 in
+                     if uu___3
                      then
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2783 ->
-                             let uu____2784 =
-                               let uu____2785 =
+                          (fun uu___5 ->
+                             let uu___6 =
+                               let uu___7 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g in
                                FStar_Extraction_ML_Code.string_of_mlexpr
-                                 uu____2785 e in
-                             let uu____2786 =
-                               let uu____2787 =
+                                 uu___7 e in
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g in
-                               FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____2787 ty1 in
+                               FStar_Extraction_ML_Code.string_of_mlty uu___8
+                                 ty1 in
                              FStar_Util.print2
                                "\n Effect mismatch on type of %s : %s\n"
-                               uu____2784 uu____2786);
+                               uu___6 uu___7);
                         e)
                      else
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2794 ->
-                             let uu____2795 =
-                               let uu____2796 =
+                          (fun uu___6 ->
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g in
                                FStar_Extraction_ML_Code.string_of_mlexpr
-                                 uu____2796 e in
-                             let uu____2797 =
-                               let uu____2798 =
+                                 uu___8 e in
+                             let uu___8 =
+                               let uu___9 =
+                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
+                                   g in
+                               FStar_Extraction_ML_Code.string_of_mlty uu___9
+                                 ty1 in
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Extraction_ML_UEnv.current_module_of_uenv
                                    g in
                                FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____2798 ty1 in
-                             let uu____2799 =
-                               let uu____2800 =
-                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
-                                   g in
-                               FStar_Extraction_ML_Code.string_of_mlty
-                                 uu____2800 expect in
+                                 uu___10 expect in
                              FStar_Util.print3
                                "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
-                               uu____2795 uu____2797 uu____2799);
-                        (let uu____2801 = apply_coercion g e ty1 expect in
-                         maybe_eta_expand g expect uu____2801)))
+                               uu___7 uu___8 uu___9);
+                        (let uu___6 = apply_coercion g e ty1 expect in
+                         maybe_eta_expand g expect uu___6)))
 let (bv_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty)
   =
   fun g ->
     fun bv ->
-      let uu____2812 = FStar_Extraction_ML_UEnv.lookup_bv g bv in
-      match uu____2812 with
+      let uu___ = FStar_Extraction_ML_UEnv.lookup_bv g bv in
+      match uu___ with
       | FStar_Util.Inl ty_b -> ty_b.FStar_Extraction_ML_UEnv.ty_b_ty
-      | uu____2814 -> FStar_Extraction_ML_Syntax.MLTY_Top
+      | uu___1 -> FStar_Extraction_ML_Syntax.MLTY_Top
 let (extraction_norm_steps_core : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.AllowUnboundUniverses;
   FStar_TypeChecker_Env.EraseUniverses;
@@ -866,51 +847,47 @@ let (extraction_norm_steps_core : FStar_TypeChecker_Env.step Prims.list) =
 let (extraction_norm_steps_nbe : FStar_TypeChecker_Env.step Prims.list) =
   FStar_TypeChecker_Env.NBE :: extraction_norm_steps_core
 let (extraction_norm_steps : unit -> FStar_TypeChecker_Env.step Prims.list) =
-  fun uu____2825 ->
-    let uu____2826 = FStar_Options.use_nbe_for_extraction () in
-    if uu____2826
-    then extraction_norm_steps_nbe
-    else extraction_norm_steps_core
+  fun uu___ ->
+    let uu___1 = FStar_Options.use_nbe_for_extraction () in
+    if uu___1 then extraction_norm_steps_nbe else extraction_norm_steps_core
 let (comp_no_args :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2843 -> c
-    | FStar_Syntax_Syntax.GTotal uu____2852 -> c
+    | FStar_Syntax_Syntax.Total uu___ -> c
+    | FStar_Syntax_Syntax.GTotal uu___ -> c
     | FStar_Syntax_Syntax.Comp ct ->
         let effect_args =
           FStar_List.map
-            (fun uu____2888 ->
-               match uu____2888 with
-               | (uu____2903, aq) -> (FStar_Syntax_Syntax.t_unit, aq))
+            (fun uu___ ->
+               match uu___ with
+               | (uu___1, aq) -> (FStar_Syntax_Syntax.t_unit, aq))
             ct.FStar_Syntax_Syntax.effect_args in
         let ct1 =
-          let uu___550_2916 = ct in
+          let uu___ = ct in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___550_2916.FStar_Syntax_Syntax.comp_univs);
+              (uu___.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___550_2916.FStar_Syntax_Syntax.effect_name);
+              (uu___.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___550_2916.FStar_Syntax_Syntax.result_typ);
+              (uu___.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args = effect_args;
-            FStar_Syntax_Syntax.flags =
-              (uu___550_2916.FStar_Syntax_Syntax.flags)
+            FStar_Syntax_Syntax.flags = (uu___.FStar_Syntax_Syntax.flags)
           } in
         let c1 =
-          let uu___553_2920 = c in
+          let uu___ = c in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-            FStar_Syntax_Syntax.pos = (uu___553_2920.FStar_Syntax_Syntax.pos);
-            FStar_Syntax_Syntax.vars =
-              (uu___553_2920.FStar_Syntax_Syntax.vars)
+            FStar_Syntax_Syntax.pos = (uu___.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
           } in
         c1
 let maybe_reify_comp :
-  'uuuuuu2931 .
-    'uuuuuu2931 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_TypeChecker_Env.env ->
         FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.term
   =
@@ -918,15 +895,15 @@ let maybe_reify_comp :
     fun env ->
       fun c ->
         let c1 = comp_no_args c in
-        let uu____2950 =
-          let uu____2951 =
-            let uu____2952 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_All.pipe_right c1 FStar_Syntax_Util.comp_effect_name in
-            FStar_All.pipe_right uu____2952
+            FStar_All.pipe_right uu___2
               (FStar_TypeChecker_Env.norm_eff_name env) in
-          FStar_All.pipe_right uu____2951
+          FStar_All.pipe_right uu___1
             (FStar_TypeChecker_Env.is_reifiable_effect env) in
-        if uu____2950
+        if uu___
         then
           FStar_TypeChecker_Env.reify_comp env c1
             FStar_Syntax_Syntax.U_unknown
@@ -937,49 +914,49 @@ let rec (translate_term_to_mlty :
   =
   fun g ->
     fun t0 ->
-      let arg_as_mlty g1 uu____3000 =
-        match uu____3000 with
-        | (a, uu____3008) ->
-            let uu____3013 = is_type g1 a in
-            if uu____3013
+      let arg_as_mlty g1 uu___ =
+        match uu___ with
+        | (a, uu___1) ->
+            let uu___2 = is_type g1 a in
+            if uu___2
             then translate_term_to_mlty g1 a
             else FStar_Extraction_ML_Syntax.MLTY_Erased in
       let fv_app_as_mlty g1 fv args =
-        let uu____3031 =
-          let uu____3032 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv in
-          Prims.op_Negation uu____3032 in
-        if uu____3031
+        let uu___ =
+          let uu___1 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv in
+          Prims.op_Negation uu___1 in
+        if uu___
         then FStar_Extraction_ML_Syntax.MLTY_Top
         else
-          (let uu____3034 =
-             let uu____3041 =
-               let uu____3050 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
-               FStar_TypeChecker_Env.lookup_lid uu____3050
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+               FStar_TypeChecker_Env.lookup_lid uu___4
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             match uu____3041 with
-             | ((uu____3057, fvty), uu____3059) ->
+             match uu___3 with
+             | ((uu___4, fvty), uu___5) ->
                  let fvty1 =
-                   let uu____3065 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+                   let uu___6 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
                    FStar_TypeChecker_Normalize.normalize
                      [FStar_TypeChecker_Env.UnfoldUntil
                         FStar_Syntax_Syntax.delta_constant;
-                     FStar_TypeChecker_Env.ForExtraction] uu____3065 fvty in
+                     FStar_TypeChecker_Env.ForExtraction] uu___6 fvty in
                  FStar_Syntax_Util.arrow_formals fvty1 in
-           match uu____3034 with
-           | (formals, uu____3067) ->
+           match uu___2 with
+           | (formals, uu___3) ->
                let mlargs = FStar_List.map (arg_as_mlty g1) args in
                let mlargs1 =
                  let n_args = FStar_List.length args in
                  if (FStar_List.length formals) > n_args
                  then
-                   let uu____3103 = FStar_Util.first_N n_args formals in
-                   match uu____3103 with
-                   | (uu____3132, rest) ->
-                       let uu____3166 =
+                   let uu___4 = FStar_Util.first_N n_args formals in
+                   match uu___4 with
+                   | (uu___5, rest) ->
+                       let uu___6 =
                          FStar_List.map
-                           (fun uu____3176 ->
+                           (fun uu___7 ->
                               FStar_Extraction_ML_Syntax.MLTY_Erased) rest in
-                       FStar_List.append mlargs uu____3166
+                       FStar_List.append mlargs uu___6
                  else mlargs in
                let nm =
                  FStar_Extraction_ML_UEnv.mlpath_of_lident g1
@@ -988,118 +965,118 @@ let rec (translate_term_to_mlty :
       let aux env t =
         let t1 = FStar_Syntax_Subst.compress t in
         match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_type uu____3199 ->
+        | FStar_Syntax_Syntax.Tm_type uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Erased
-        | FStar_Syntax_Syntax.Tm_bvar uu____3200 ->
-            let uu____3201 =
-              let uu____3202 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3202 in
-            failwith uu____3201
-        | FStar_Syntax_Syntax.Tm_delayed uu____3203 ->
-            let uu____3218 =
-              let uu____3219 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3219 in
-            failwith uu____3218
+        | FStar_Syntax_Syntax.Tm_bvar uu___ ->
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu___2 in
+            failwith uu___1
+        | FStar_Syntax_Syntax.Tm_delayed uu___ ->
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu___2 in
+            failwith uu___1
         | FStar_Syntax_Syntax.Tm_unknown ->
-            let uu____3220 =
-              let uu____3221 = FStar_Syntax_Print.term_to_string t1 in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3221 in
-            failwith uu____3220
+            let uu___ =
+              let uu___1 = FStar_Syntax_Print.term_to_string t1 in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu___1 in
+            failwith uu___
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____3223 = FStar_Syntax_Util.unfold_lazy i in
-            translate_term_to_mlty env uu____3223
-        | FStar_Syntax_Syntax.Tm_constant uu____3224 ->
+            let uu___ = FStar_Syntax_Util.unfold_lazy i in
+            translate_term_to_mlty env uu___
+        | FStar_Syntax_Syntax.Tm_constant uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_quoted uu____3225 ->
+        | FStar_Syntax_Syntax.Tm_quoted uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_uvar uu____3232 ->
+        | FStar_Syntax_Syntax.Tm_uvar uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_meta (t2, uu____3246) ->
+        | FStar_Syntax_Syntax.Tm_meta (t2, uu___) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____3251;
-               FStar_Syntax_Syntax.index = uu____3252;
+            ({ FStar_Syntax_Syntax.ppname = uu___;
+               FStar_Syntax_Syntax.index = uu___1;
                FStar_Syntax_Syntax.sort = t2;_},
-             uu____3254)
+             uu___2)
             -> translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2, uu____3262) ->
+        | FStar_Syntax_Syntax.Tm_uinst (t2, uu___) ->
             translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____3268, uu____3269) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
         | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
         | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-            let uu____3342 = FStar_Syntax_Subst.open_comp bs c in
-            (match uu____3342 with
+            let uu___ = FStar_Syntax_Subst.open_comp bs c in
+            (match uu___ with
              | (bs1, c1) ->
-                 let uu____3349 = binders_as_ml_binders env bs1 in
-                 (match uu____3349 with
+                 let uu___1 = binders_as_ml_binders env bs1 in
+                 (match uu___1 with
                   | (mlbs, env1) ->
                       let t_ret =
-                        let uu____3375 =
-                          let uu____3376 =
+                        let uu___2 =
+                          let uu___3 =
                             FStar_Extraction_ML_UEnv.tcenv_of_uenv env1 in
-                          maybe_reify_comp env1 uu____3376 c1 in
-                        translate_term_to_mlty env1 uu____3375 in
+                          maybe_reify_comp env1 uu___3 c1 in
+                        translate_term_to_mlty env1 uu___2 in
                       let erase =
                         effect_as_etag env1
                           (FStar_Syntax_Util.comp_effect_name c1) in
-                      let uu____3378 =
+                      let uu___2 =
                         FStar_List.fold_right
-                          (fun uu____3397 ->
-                             fun uu____3398 ->
-                               match (uu____3397, uu____3398) with
-                               | ((uu____3419, t2), (tag, t')) ->
+                          (fun uu___3 ->
+                             fun uu___4 ->
+                               match (uu___3, uu___4) with
+                               | ((uu___5, t2), (tag, t')) ->
                                    (FStar_Extraction_ML_Syntax.E_PURE,
                                      (FStar_Extraction_ML_Syntax.MLTY_Fun
                                         (t2, tag, t')))) mlbs (erase, t_ret) in
-                      (match uu____3378 with | (uu____3431, t2) -> t2)))
+                      (match uu___2 with | (uu___3, t2) -> t2)))
         | FStar_Syntax_Syntax.Tm_app (head, args) ->
             let res =
-              let uu____3460 =
-                let uu____3461 = FStar_Syntax_Util.un_uinst head in
-                uu____3461.FStar_Syntax_Syntax.n in
-              match uu____3460 with
+              let uu___ =
+                let uu___1 = FStar_Syntax_Util.un_uinst head in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
               | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
               | FStar_Syntax_Syntax.Tm_app (head1, args') ->
-                  let uu____3492 =
+                  let uu___1 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head1, (FStar_List.append args' args)))
                       t1.FStar_Syntax_Syntax.pos in
-                  translate_term_to_mlty env uu____3492
-              | uu____3513 -> FStar_Extraction_ML_Syntax.MLTY_Top in
+                  translate_term_to_mlty env uu___1
+              | uu___1 -> FStar_Extraction_ML_Syntax.MLTY_Top in
             res
-        | FStar_Syntax_Syntax.Tm_abs (bs, ty, uu____3516) ->
-            let uu____3541 = FStar_Syntax_Subst.open_term bs ty in
-            (match uu____3541 with
+        | FStar_Syntax_Syntax.Tm_abs (bs, ty, uu___) ->
+            let uu___1 = FStar_Syntax_Subst.open_term bs ty in
+            (match uu___1 with
              | (bs1, ty1) ->
-                 let uu____3548 = binders_as_ml_binders env bs1 in
-                 (match uu____3548 with
+                 let uu___2 = binders_as_ml_binders env bs1 in
+                 (match uu___2 with
                   | (bts, env1) -> translate_term_to_mlty env1 ty1))
-        | FStar_Syntax_Syntax.Tm_let uu____3573 ->
+        | FStar_Syntax_Syntax.Tm_let uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Top
-        | FStar_Syntax_Syntax.Tm_match uu____3586 ->
+        | FStar_Syntax_Syntax.Tm_match uu___ ->
             FStar_Extraction_ML_Syntax.MLTY_Top in
       let rec is_top_ty t =
         match t with
         | FStar_Extraction_ML_Syntax.MLTY_Top -> true
-        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3615 ->
-            let uu____3622 = FStar_Extraction_ML_Util.udelta_unfold g t in
-            (match uu____3622 with
+        | FStar_Extraction_ML_Syntax.MLTY_Named uu___ ->
+            let uu___1 = FStar_Extraction_ML_Util.udelta_unfold g t in
+            (match uu___1 with
              | FStar_Pervasives_Native.None -> false
              | FStar_Pervasives_Native.Some t1 -> is_top_ty t1)
-        | uu____3626 -> false in
-      let uu____3627 =
-        let uu____3628 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-        FStar_TypeChecker_Util.must_erase_for_extraction uu____3628 t0 in
-      if uu____3627
+        | uu___ -> false in
+      let uu___ =
+        let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+        FStar_TypeChecker_Util.must_erase_for_extraction uu___1 t0 in
+      if uu___
       then FStar_Extraction_ML_Syntax.MLTY_Erased
       else
         (let mlt = aux g t0 in
-         let uu____3631 = is_top_ty mlt in
-         if uu____3631 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
+         let uu___2 = is_top_ty mlt in
+         if uu___2 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
 and (binders_as_ml_binders :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.binders ->
@@ -1108,23 +1085,23 @@ and (binders_as_ml_binders :
   =
   fun g ->
     fun bs ->
-      let uu____3645 =
+      let uu___ =
         FStar_All.pipe_right bs
           (FStar_List.fold_left
-             (fun uu____3699 ->
+             (fun uu___1 ->
                 fun b ->
-                  match uu____3699 with
+                  match uu___1 with
                   | (ml_bs, env) ->
-                      let uu____3741 = is_type_binder g b in
-                      if uu____3741
+                      let uu___2 = is_type_binder g b in
+                      if uu___2
                       then
                         let b1 = FStar_Pervasives_Native.fst b in
                         let env1 =
                           FStar_Extraction_ML_UEnv.extend_ty env b1 true in
                         let ml_b =
-                          let uu____3759 =
+                          let uu___3 =
                             FStar_Extraction_ML_UEnv.lookup_ty env1 b1 in
-                          uu____3759.FStar_Extraction_ML_UEnv.ty_b_name in
+                          uu___3.FStar_Extraction_ML_UEnv.ty_b_name in
                         let ml_b1 =
                           (ml_b, FStar_Extraction_ML_Syntax.ml_unit_ty) in
                         ((ml_b1 :: ml_bs), env1)
@@ -1133,14 +1110,14 @@ and (binders_as_ml_binders :
                          let t =
                            translate_term_to_mlty env
                              b1.FStar_Syntax_Syntax.sort in
-                         let uu____3780 =
+                         let uu___4 =
                            FStar_Extraction_ML_UEnv.extend_bv env b1 
                              ([], t) false false in
-                         match uu____3780 with
-                         | (env1, b2, uu____3799) ->
+                         match uu___4 with
+                         | (env1, b2, uu___5) ->
                              let ml_b = (b2, t) in ((ml_b :: ml_bs), env1)))
              ([], g)) in
-      match uu____3645 with | (ml_bs, env) -> ((FStar_List.rev ml_bs), env)
+      match uu___ with | (ml_bs, env) -> ((FStar_List.rev ml_bs), env)
 let (term_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty)
@@ -1148,9 +1125,9 @@ let (term_as_mlty :
   fun g ->
     fun t0 ->
       let t =
-        let uu____3870 = extraction_norm_steps () in
-        let uu____3871 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-        FStar_TypeChecker_Normalize.normalize uu____3870 uu____3871 t0 in
+        let uu___ = extraction_norm_steps () in
+        let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+        FStar_TypeChecker_Normalize.normalize uu___ uu___1 t0 in
       translate_term_to_mlty g t
 let (mk_MLE_Seq :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -1164,11 +1141,11 @@ let (mk_MLE_Seq :
       | (FStar_Extraction_ML_Syntax.MLE_Seq es1,
          FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 es2)
-      | (FStar_Extraction_ML_Syntax.MLE_Seq es1, uu____3889) ->
+      | (FStar_Extraction_ML_Syntax.MLE_Seq es1, uu___) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 [e2])
-      | (uu____3892, FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
+      | (uu___, FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
-      | uu____3896 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
+      | uu___ -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
 let (mk_MLE_Let :
   Prims.bool ->
     FStar_Extraction_ML_Syntax.mlletbinding ->
@@ -1193,16 +1170,16 @@ let (mk_MLE_Let :
                     | FStar_Extraction_ML_Syntax.MLE_Var x when
                         x = lb.FStar_Extraction_ML_Syntax.mllb_name ->
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                    | uu____3922 when
+                    | uu___1 when
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
                           =
                           FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
                         -> body.FStar_Extraction_ML_Syntax.expr
-                    | uu____3923 ->
+                    | uu___1 ->
                         mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def
                           body)
-             | uu____3924 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
-        | uu____3933 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
+             | uu___ -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
+        | uu___ -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
 let record_fields :
   'a .
     FStar_Extraction_ML_UEnv.uenv ->
@@ -1221,8 +1198,8 @@ let record_fields :
                  FStar_Extraction_ML_UEnv.lookup_record_field_name g (ty, x))
               fns in
           FStar_List.map2
-            (fun uu____4004 ->
-               fun x -> match uu____4004 with | (p, s) -> (s, x)) fns1 xs
+            (fun uu___ -> fun x -> match uu___ with | (p, s) -> (s, x)) fns1
+            xs
 let (resugar_pat :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option ->
@@ -1234,21 +1211,21 @@ let (resugar_pat :
       fun p ->
         match p with
         | FStar_Extraction_ML_Syntax.MLP_CTor (d, pats) ->
-            let uu____4047 = FStar_Extraction_ML_Util.is_xtuple d in
-            (match uu____4047 with
+            let uu___ = FStar_Extraction_ML_Util.is_xtuple d in
+            (match uu___ with
              | FStar_Pervasives_Native.Some n ->
                  FStar_Extraction_ML_Syntax.MLP_Tuple pats
-             | uu____4051 ->
+             | uu___1 ->
                  (match q with
                   | FStar_Pervasives_Native.Some
                       (FStar_Syntax_Syntax.Record_ctor (ty, fns)) ->
                       let path =
-                        let uu____4063 = FStar_Ident.ns_of_lid ty in
-                        FStar_List.map FStar_Ident.string_of_id uu____4063 in
+                        let uu___2 = FStar_Ident.ns_of_lid ty in
+                        FStar_List.map FStar_Ident.string_of_id uu___2 in
                       let fs = record_fields g ty fns pats in
                       FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
-                  | uu____4081 -> p))
-        | uu____4084 -> p
+                  | uu___2 -> p))
+        | uu___ -> p
 let rec (extract_one_pat :
   Prims.bool ->
     FStar_Extraction_ML_UEnv.uenv ->
@@ -1274,216 +1251,211 @@ let rec (extract_one_pat :
               match expected_topt with
               | FStar_Pervasives_Native.None -> true
               | FStar_Pervasives_Native.Some t' ->
-                  let ok = type_leq g t t' in
-                  (if Prims.op_Negation ok
+                  let ok1 = type_leq g t t' in
+                  (if Prims.op_Negation ok1
                    then
                      FStar_Extraction_ML_UEnv.debug g
-                       (fun uu____4176 ->
-                          let uu____4177 =
-                            let uu____4178 =
+                       (fun uu___1 ->
+                          let uu___2 =
+                            let uu___3 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g in
-                            FStar_Extraction_ML_Code.string_of_mlty
-                              uu____4178 t' in
-                          let uu____4179 =
-                            let uu____4180 =
+                            FStar_Extraction_ML_Code.string_of_mlty uu___3 t' in
+                          let uu___3 =
+                            let uu___4 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g in
-                            FStar_Extraction_ML_Code.string_of_mlty
-                              uu____4180 t in
+                            FStar_Extraction_ML_Code.string_of_mlty uu___4 t in
                           FStar_Util.print2
                             "Expected pattern type %s; got pattern type %s\n"
-                            uu____4177 uu____4179)
+                            uu___2 uu___3)
                    else ();
-                   ok) in
+                   ok1) in
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
                 (c, swopt)) when
-                let uu____4210 = FStar_Options.codegen () in
-                uu____4210 <>
-                  (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
+                let uu___ = FStar_Options.codegen () in
+                uu___ <> (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                 ->
-                let uu____4215 =
+                let uu___ =
                   match swopt with
                   | FStar_Pervasives_Native.None ->
-                      let uu____4228 =
-                        let uu____4229 =
-                          let uu____4230 =
+                      let uu___1 =
+                        let uu___2 =
+                          let uu___3 =
                             FStar_Extraction_ML_Util.mlconst_of_const
                               p.FStar_Syntax_Syntax.p
                               (FStar_Const.Const_int
                                  (c, FStar_Pervasives_Native.None)) in
-                          FStar_Extraction_ML_Syntax.MLE_Const uu____4230 in
+                          FStar_Extraction_ML_Syntax.MLE_Const uu___3 in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4229 in
-                      (uu____4228, FStar_Extraction_ML_Syntax.ml_int_ty)
+                             FStar_Extraction_ML_Syntax.ml_int_ty) uu___2 in
+                      (uu___1, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
-                        let uu____4251 =
-                          let uu____4252 =
+                        let uu___1 =
+                          let uu___2 =
                             FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                          uu____4252.FStar_TypeChecker_Env.dsenv in
+                          uu___2.FStar_TypeChecker_Env.dsenv in
                         FStar_ToSyntax_ToSyntax.desugar_machine_integer
-                          uu____4251 c sw FStar_Range.dummyRange in
-                      let uu____4253 = term_as_mlexpr g source_term in
-                      (match uu____4253 with
-                       | (mlterm, uu____4265, mlty) -> (mlterm, mlty)) in
-                (match uu____4215 with
+                          uu___1 c sw FStar_Range.dummyRange in
+                      let uu___1 = term_as_mlexpr g source_term in
+                      (match uu___1 with
+                       | (mlterm, uu___2, mlty) -> (mlterm, mlty)) in
+                (match uu___ with
                  | (mlc, ml_ty) ->
-                     let uu____4283 = FStar_Extraction_ML_UEnv.new_mlident g in
-                     (match uu____4283 with
+                     let uu___1 = FStar_Extraction_ML_UEnv.new_mlident g in
+                     (match uu___1 with
                       | (g1, x) ->
                           let when_clause =
-                            let uu____4305 =
-                              let uu____4306 =
-                                let uu____4313 =
-                                  let uu____4316 =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty
                                          ml_ty)
                                       (FStar_Extraction_ML_Syntax.MLE_Var x) in
-                                  [uu____4316; mlc] in
+                                  [uu___5; mlc] in
                                 (FStar_Extraction_ML_Util.prims_op_equality,
-                                  uu____4313) in
-                              FStar_Extraction_ML_Syntax.MLE_App uu____4306 in
+                                  uu___4) in
+                              FStar_Extraction_ML_Syntax.MLE_App uu___3 in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.ml_bool_ty)
-                              uu____4305 in
-                          let uu____4319 = ok ml_ty in
+                              uu___2 in
+                          let uu___2 = ok ml_ty in
                           (g1,
                             (FStar_Pervasives_Native.Some
                                ((FStar_Extraction_ML_Syntax.MLP_Var x),
-                                 [when_clause])), uu____4319)))
+                                 [when_clause])), uu___2)))
             | FStar_Syntax_Syntax.Pat_constant s ->
                 let t =
-                  let uu____4338 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                  FStar_TypeChecker_TcTerm.tc_constant uu____4338
+                  let uu___ = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  FStar_TypeChecker_TcTerm.tc_constant uu___
                     FStar_Range.dummyRange s in
                 let mlty = term_as_mlty g t in
-                let uu____4340 =
-                  let uu____4349 =
-                    let uu____4356 =
-                      let uu____4357 =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
                         FStar_Extraction_ML_Util.mlconst_of_const
                           p.FStar_Syntax_Syntax.p s in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____4357 in
-                    (uu____4356, []) in
-                  FStar_Pervasives_Native.Some uu____4349 in
-                let uu____4366 = ok mlty in (g, uu____4340, uu____4366)
+                      FStar_Extraction_ML_Syntax.MLP_Const uu___3 in
+                    (uu___2, []) in
+                  FStar_Pervasives_Native.Some uu___1 in
+                let uu___1 = ok mlty in (g, uu___, uu___1)
             | FStar_Syntax_Syntax.Pat_var x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort in
-                let uu____4377 =
+                let uu___ =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false imp in
-                (match uu____4377 with
-                 | (g1, x1, uu____4400) ->
-                     let uu____4401 = ok mlty in
+                (match uu___ with
+                 | (g1, x1, uu___1) ->
+                     let uu___2 = ok mlty in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4401))
+                       uu___2))
             | FStar_Syntax_Syntax.Pat_wild x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort in
-                let uu____4435 =
+                let uu___ =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false imp in
-                (match uu____4435 with
-                 | (g1, x1, uu____4458) ->
-                     let uu____4459 = ok mlty in
+                (match uu___ with
+                 | (g1, x1, uu___1) ->
+                     let uu___2 = ok mlty in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4459))
-            | FStar_Syntax_Syntax.Pat_dot_term uu____4491 ->
+                       uu___2))
+            | FStar_Syntax_Syntax.Pat_dot_term uu___ ->
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f, pats) ->
-                let uu____4530 =
-                  let uu____4539 = FStar_Extraction_ML_UEnv.lookup_fv g f in
-                  match uu____4539 with
-                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____4548;
+                let uu___ =
+                  let uu___1 = FStar_Extraction_ML_UEnv.lookup_fv g f in
+                  match uu___1 with
+                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu___2;
                       FStar_Extraction_ML_UEnv.exp_b_expr =
                         {
                           FStar_Extraction_ML_Syntax.expr =
                             FStar_Extraction_ML_Syntax.MLE_Name n;
-                          FStar_Extraction_ML_Syntax.mlty = uu____4550;
-                          FStar_Extraction_ML_Syntax.loc = uu____4551;_};
+                          FStar_Extraction_ML_Syntax.mlty = uu___3;
+                          FStar_Extraction_ML_Syntax.loc = uu___4;_};
                       FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;_} ->
                       (n, ttys)
-                  | uu____4557 -> failwith "Expected a constructor" in
-                (match uu____4530 with
+                  | uu___2 -> failwith "Expected a constructor" in
+                (match uu___ with
                  | (d, tys) ->
                      let nTyVars =
                        FStar_List.length (FStar_Pervasives_Native.fst tys) in
-                     let uu____4591 = FStar_Util.first_N nTyVars pats in
-                     (match uu____4591 with
+                     let uu___1 = FStar_Util.first_N nTyVars pats in
+                     (match uu___1 with
                       | (tysVarPats, restPats) ->
                           let f_ty_opt =
                             try
-                              (fun uu___852_4687 ->
+                              (fun uu___2 ->
                                  match () with
                                  | () ->
                                      let mlty_args =
                                        FStar_All.pipe_right tysVarPats
                                          (FStar_List.map
-                                            (fun uu____4716 ->
-                                               match uu____4716 with
-                                               | (p1, uu____4722) ->
+                                            (fun uu___3 ->
+                                               match uu___3 with
+                                               | (p1, uu___4) ->
                                                    (match p1.FStar_Syntax_Syntax.v
                                                     with
                                                     | FStar_Syntax_Syntax.Pat_dot_term
-                                                        (uu____4723, t) ->
+                                                        (uu___5, t) ->
                                                         term_as_mlty g t
-                                                    | uu____4729 ->
+                                                    | uu___5 ->
                                                         (FStar_Extraction_ML_UEnv.debug
                                                            g
-                                                           (fun uu____4733 ->
-                                                              let uu____4734
-                                                                =
+                                                           (fun uu___7 ->
+                                                              let uu___8 =
                                                                 FStar_Syntax_Print.pat_to_string
                                                                   p1 in
                                                               FStar_Util.print1
                                                                 "Pattern %s is not extractable"
-                                                                uu____4734);
+                                                                uu___8);
                                                          FStar_Exn.raise
                                                            Un_extractable)))) in
                                      let f_ty =
                                        FStar_Extraction_ML_Util.subst tys
                                          mlty_args in
-                                     let uu____4736 =
+                                     let uu___3 =
                                        FStar_Extraction_ML_Util.uncurry_mlty_fun
                                          f_ty in
-                                     FStar_Pervasives_Native.Some uu____4736)
-                                ()
+                                     FStar_Pervasives_Native.Some uu___3) ()
                             with
                             | Un_extractable -> FStar_Pervasives_Native.None in
-                          let uu____4765 =
+                          let uu___2 =
                             FStar_Util.fold_map
                               (fun g1 ->
-                                 fun uu____4801 ->
-                                   match uu____4801 with
+                                 fun uu___3 ->
+                                   match uu___3 with
                                    | (p1, imp1) ->
-                                       let uu____4820 =
+                                       let uu___4 =
                                          extract_one_pat true g1 p1
                                            FStar_Pervasives_Native.None
                                            term_as_mlexpr in
-                                       (match uu____4820 with
-                                        | (g2, p2, uu____4849) -> (g2, p2)))
-                              g tysVarPats in
-                          (match uu____4765 with
+                                       (match uu___4 with
+                                        | (g2, p2, uu___5) -> (g2, p2))) g
+                              tysVarPats in
+                          (match uu___2 with
                            | (g1, tyMLPats) ->
-                               let uu____4910 =
+                               let uu___3 =
                                  FStar_Util.fold_map
-                                   (fun uu____4974 ->
-                                      fun uu____4975 ->
-                                        match (uu____4974, uu____4975) with
+                                   (fun uu___4 ->
+                                      fun uu___5 ->
+                                        match (uu___4, uu___5) with
                                         | ((g2, f_ty_opt1), (p1, imp1)) ->
-                                            let uu____5068 =
+                                            let uu___6 =
                                               match f_ty_opt1 with
                                               | FStar_Pervasives_Native.Some
                                                   (hd::rest, res) ->
@@ -1491,56 +1463,56 @@ let rec (extract_one_pat :
                                                       (rest, res)),
                                                     (FStar_Pervasives_Native.Some
                                                        hd))
-                                              | uu____5128 ->
+                                              | uu___7 ->
                                                   (FStar_Pervasives_Native.None,
                                                     FStar_Pervasives_Native.None) in
-                                            (match uu____5068 with
+                                            (match uu___6 with
                                              | (f_ty_opt2, expected_ty) ->
-                                                 let uu____5199 =
+                                                 let uu___7 =
                                                    extract_one_pat false g2
                                                      p1 expected_ty
                                                      term_as_mlexpr in
-                                                 (match uu____5199 with
-                                                  | (g3, p2, uu____5240) ->
+                                                 (match uu___7 with
+                                                  | (g3, p2, uu___8) ->
                                                       ((g3, f_ty_opt2), p2))))
                                    (g1, f_ty_opt) restPats in
-                               (match uu____4910 with
+                               (match uu___3 with
                                 | ((g2, f_ty_opt1), restMLPats) ->
-                                    let uu____5358 =
-                                      let uu____5369 =
+                                    let uu___4 =
+                                      let uu___5 =
                                         FStar_All.pipe_right
                                           (FStar_List.append tyMLPats
                                              restMLPats)
                                           (FStar_List.collect
-                                             (fun uu___0_5420 ->
-                                                match uu___0_5420 with
+                                             (fun uu___6 ->
+                                                match uu___6 with
                                                 | FStar_Pervasives_Native.Some
                                                     x -> [x]
-                                                | uu____5462 -> [])) in
-                                      FStar_All.pipe_right uu____5369
+                                                | uu___7 -> [])) in
+                                      FStar_All.pipe_right uu___5
                                         FStar_List.split in
-                                    (match uu____5358 with
+                                    (match uu___4 with
                                      | (mlPats, when_clauses) ->
                                          let pat_ty_compat =
                                            match f_ty_opt1 with
                                            | FStar_Pervasives_Native.Some
                                                ([], t) -> ok t
-                                           | uu____5535 -> false in
-                                         let uu____5544 =
-                                           let uu____5553 =
-                                             let uu____5560 =
+                                           | uu___5 -> false in
+                                         let uu___5 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                resugar_pat g2
                                                  f.FStar_Syntax_Syntax.fv_qual
                                                  (FStar_Extraction_ML_Syntax.MLP_CTor
                                                     (d, mlPats)) in
-                                             let uu____5563 =
+                                             let uu___8 =
                                                FStar_All.pipe_right
                                                  when_clauses
                                                  FStar_List.flatten in
-                                             (uu____5560, uu____5563) in
+                                             (uu___7, uu___8) in
                                            FStar_Pervasives_Native.Some
-                                             uu____5553 in
-                                         (g2, uu____5544, pat_ty_compat))))))
+                                             uu___6 in
+                                         (g2, uu___5, pat_ty_compat))))))
 let (extract_pat :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.pat ->
@@ -1561,22 +1533,21 @@ let (extract_pat :
       fun expected_t ->
         fun term_as_mlexpr ->
           let extract_one_pat1 g1 p1 expected_t1 =
-            let uu____5690 =
+            let uu___ =
               extract_one_pat false g1 p1 expected_t1 term_as_mlexpr in
-            match uu____5690 with
+            match uu___ with
             | (g2, FStar_Pervasives_Native.Some (x, v), b) -> (g2, (x, v), b)
-            | uu____5747 ->
-                failwith "Impossible: Unable to translate pattern" in
+            | uu___1 -> failwith "Impossible: Unable to translate pattern" in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
             | hd::tl ->
-                let uu____5792 =
+                let uu___ =
                   FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd tl in
-                FStar_Pervasives_Native.Some uu____5792 in
-          let uu____5793 =
+                FStar_Pervasives_Native.Some uu___ in
+          let uu___ =
             extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t) in
-          match uu____5793 with
+          match uu___ with
           | (g1, (p1, whens), b) ->
               let when_clause = mk_when_clause whens in
               (g1, [(p1, when_clause)], b)
@@ -1593,68 +1564,68 @@ let (maybe_eta_data_and_project_record :
         fun mlAppExpr ->
           let rec eta_args g1 more_args t =
             match t with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu____5948, t1) ->
-                let uu____5950 = FStar_Extraction_ML_UEnv.new_mlident g1 in
-                (match uu____5950 with
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu___, t1) ->
+                let uu___1 = FStar_Extraction_ML_UEnv.new_mlident g1 in
+                (match uu___1 with
                  | (g2, x) ->
-                     let uu____5971 =
-                       let uu____5982 =
-                         let uu____5991 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_All.pipe_left
                              (FStar_Extraction_ML_Syntax.with_ty t0)
                              (FStar_Extraction_ML_Syntax.MLE_Var x) in
-                         ((x, t0), uu____5991) in
-                       uu____5982 :: more_args in
-                     eta_args g2 uu____5971 t1)
-            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6004, uu____6005)
-                -> ((FStar_List.rev more_args), t)
-            | uu____6028 ->
-                let uu____6029 =
-                  let uu____6030 =
-                    let uu____6031 =
+                         ((x, t0), uu___4) in
+                       uu___3 :: more_args in
+                     eta_args g2 uu___2 t1)
+            | FStar_Extraction_ML_Syntax.MLTY_Named (uu___, uu___1) ->
+                ((FStar_List.rev more_args), t)
+            | uu___ ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
                       FStar_Extraction_ML_UEnv.current_module_of_uenv g1 in
-                    FStar_Extraction_ML_Code.string_of_mlexpr uu____6031
+                    FStar_Extraction_ML_Code.string_of_mlexpr uu___3
                       mlAppExpr in
-                  let uu____6032 =
-                    let uu____6033 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_Extraction_ML_UEnv.current_module_of_uenv g1 in
-                    FStar_Extraction_ML_Code.string_of_mlty uu____6033 t in
+                    FStar_Extraction_ML_Code.string_of_mlty uu___4 t in
                   FStar_Util.format2
-                    "Impossible: Head type is not an arrow: (%s : %s)"
-                    uu____6030 uu____6032 in
-                failwith uu____6029 in
+                    "Impossible: Head type is not an arrow: (%s : %s)" uu___2
+                    uu___3 in
+                failwith uu___1 in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
-            | (FStar_Extraction_ML_Syntax.MLE_CTor (uu____6065, args),
+            | (FStar_Extraction_ML_Syntax.MLE_CTor (uu___, args),
                FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
                (tyname, fields))) ->
                 let path =
-                  let uu____6082 = FStar_Ident.ns_of_lid tyname in
-                  FStar_List.map FStar_Ident.string_of_id uu____6082 in
+                  let uu___1 = FStar_Ident.ns_of_lid tyname in
+                  FStar_List.map FStar_Ident.string_of_id uu___1 in
                 let fields1 = record_fields g tyname fields args in
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      e.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____6100 -> e in
+            | uu___ -> e in
           let resugar_and_maybe_eta qual1 e =
-            let uu____6122 = eta_args g [] residualType in
-            match uu____6122 with
+            let uu___ = eta_args g [] residualType in
+            match uu___ with
             | (eargs, tres) ->
                 (match eargs with
                  | [] ->
-                     let uu____6175 = as_record qual1 e in
-                     FStar_Extraction_ML_Util.resugar_exp uu____6175
-                 | uu____6176 ->
-                     let uu____6187 = FStar_List.unzip eargs in
-                     (match uu____6187 with
+                     let uu___1 = as_record qual1 e in
+                     FStar_Extraction_ML_Util.resugar_exp uu___1
+                 | uu___1 ->
+                     let uu___2 = FStar_List.unzip eargs in
+                     (match uu___2 with
                       | (binders, eargs1) ->
                           (match e.FStar_Extraction_ML_Syntax.expr with
                            | FStar_Extraction_ML_Syntax.MLE_CTor (head, args)
                                ->
                                let body =
-                                 let uu____6229 =
-                                   let uu____6230 =
+                                 let uu___3 =
+                                   let uu___4 =
                                      FStar_All.pipe_left
                                        (FStar_Extraction_ML_Syntax.with_ty
                                           tres)
@@ -1662,49 +1633,47 @@ let (maybe_eta_data_and_project_record :
                                           (head,
                                             (FStar_List.append args eargs1))) in
                                    FStar_All.pipe_left (as_record qual1)
-                                     uu____6230 in
+                                     uu___4 in
                                  FStar_All.pipe_left
                                    FStar_Extraction_ML_Util.resugar_exp
-                                   uu____6229 in
+                                   uu___3 in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     e.FStar_Extraction_ML_Syntax.mlty)
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
-                           | uu____6239 ->
+                           | uu___3 ->
                                failwith "Impossible: Not a constructor"))) in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
-          | (uu____6242, FStar_Pervasives_Native.None) -> mlAppExpr
+          | (uu___, FStar_Pervasives_Native.None) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6246;
-                FStar_Extraction_ML_Syntax.loc = uu____6247;_},
+                FStar_Extraction_ML_Syntax.mlty = uu___;
+                FStar_Extraction_ML_Syntax.loc = uu___1;_},
               mle::args),
              FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname, f))) ->
               let fn =
-                let uu____6259 =
-                  let uu____6264 =
-                    let uu____6265 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Env.typ_of_datacon uu____6265
-                      constrname in
-                  (uu____6264, f) in
-                FStar_Extraction_ML_UEnv.lookup_record_field_name g
-                  uu____6259 in
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Env.typ_of_datacon uu___4 constrname in
+                  (uu___3, f) in
+                FStar_Extraction_ML_UEnv.lookup_record_field_name g uu___2 in
               let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn) in
               let e =
                 match args with
                 | [] -> proj
-                | uu____6268 ->
-                    let uu____6271 =
-                      let uu____6278 =
+                | uu___2 ->
+                    let uu___3 =
+                      let uu___4 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj in
-                      (uu____6278, args) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6271 in
+                      (uu___4, args) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___3 in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -1714,86 +1683,64 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6282;
-                     FStar_Extraction_ML_Syntax.loc = uu____6283;_},
-                   uu____6284);
-                FStar_Extraction_ML_Syntax.mlty = uu____6285;
-                FStar_Extraction_ML_Syntax.loc = uu____6286;_},
+                     FStar_Extraction_ML_Syntax.mlty = uu___;
+                     FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                   uu___2);
+                FStar_Extraction_ML_Syntax.mlty = uu___3;
+                FStar_Extraction_ML_Syntax.loc = uu___4;_},
               mle::args),
              FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname, f))) ->
               let fn =
-                let uu____6302 =
-                  let uu____6307 =
-                    let uu____6308 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Env.typ_of_datacon uu____6308
-                      constrname in
-                  (uu____6307, f) in
-                FStar_Extraction_ML_UEnv.lookup_record_field_name g
-                  uu____6302 in
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Env.typ_of_datacon uu___7 constrname in
+                  (uu___6, f) in
+                FStar_Extraction_ML_UEnv.lookup_record_field_name g uu___5 in
               let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn) in
               let e =
                 match args with
                 | [] -> proj
-                | uu____6311 ->
-                    let uu____6314 =
-                      let uu____6321 =
+                | uu___5 ->
+                    let uu___6 =
+                      let uu___7 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj in
-                      (uu____6321, args) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6314 in
+                      (uu___7, args) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___6 in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6325;
-                FStar_Extraction_ML_Syntax.loc = uu____6326;_},
+                FStar_Extraction_ML_Syntax.mlty = uu___;
+                FStar_Extraction_ML_Syntax.loc = uu___1;_},
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu____6334 =
+              let uu___2 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6334
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___2
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6338;
-                FStar_Extraction_ML_Syntax.loc = uu____6339;_},
+                FStar_Extraction_ML_Syntax.mlty = uu___;
+                FStar_Extraction_ML_Syntax.loc = uu___1;_},
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-             uu____6341)) ->
-              let uu____6354 =
+             uu___2)) ->
+              let uu___3 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6354
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_TApp
-                  ({
-                     FStar_Extraction_ML_Syntax.expr =
-                       FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6358;
-                     FStar_Extraction_ML_Syntax.loc = uu____6359;_},
-                   uu____6360);
-                FStar_Extraction_ML_Syntax.mlty = uu____6361;
-                FStar_Extraction_ML_Syntax.loc = uu____6362;_},
-              mlargs),
-             FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu____6374 =
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6374
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___3
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1801,67 +1748,87 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6378;
-                     FStar_Extraction_ML_Syntax.loc = uu____6379;_},
-                   uu____6380);
-                FStar_Extraction_ML_Syntax.mlty = uu____6381;
-                FStar_Extraction_ML_Syntax.loc = uu____6382;_},
+                     FStar_Extraction_ML_Syntax.mlty = uu___;
+                     FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                   uu___2);
+                FStar_Extraction_ML_Syntax.mlty = uu___3;
+                FStar_Extraction_ML_Syntax.loc = uu___4;_},
               mlargs),
-             FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-             uu____6384)) ->
-              let uu____6401 =
+             FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
+              let uu___5 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6401
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___5
+          | (FStar_Extraction_ML_Syntax.MLE_App
+             ({
+                FStar_Extraction_ML_Syntax.expr =
+                  FStar_Extraction_ML_Syntax.MLE_TApp
+                  ({
+                     FStar_Extraction_ML_Syntax.expr =
+                       FStar_Extraction_ML_Syntax.MLE_Name mlp;
+                     FStar_Extraction_ML_Syntax.mlty = uu___;
+                     FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                   uu___2);
+                FStar_Extraction_ML_Syntax.mlty = uu___3;
+                FStar_Extraction_ML_Syntax.loc = uu___4;_},
+              mlargs),
+             FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
+             uu___5)) ->
+              let uu___6 =
+                FStar_All.pipe_left
+                  (FStar_Extraction_ML_Syntax.with_ty
+                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___6
           | (FStar_Extraction_ML_Syntax.MLE_Name mlp,
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu____6407 =
+              let uu___ =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6407
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___
           | (FStar_Extraction_ML_Syntax.MLE_Name mlp,
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-             uu____6411)) ->
-              let uu____6420 =
+             uu___)) ->
+              let uu___1 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6420
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___1
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6424;
-                FStar_Extraction_ML_Syntax.loc = uu____6425;_},
-              uu____6426),
+                FStar_Extraction_ML_Syntax.mlty = uu___;
+                FStar_Extraction_ML_Syntax.loc = uu___1;_},
+              uu___2),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu____6433 =
+              let uu___3 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6433
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___3
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6437;
-                FStar_Extraction_ML_Syntax.loc = uu____6438;_},
-              uu____6439),
+                FStar_Extraction_ML_Syntax.mlty = uu___;
+                FStar_Extraction_ML_Syntax.loc = uu___1;_},
+              uu___2),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-             uu____6440)) ->
-              let uu____6453 =
+             uu___3)) ->
+              let uu___4 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6453
-          | uu____6456 -> mlAppExpr
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu___4
+          | uu___ -> mlAppExpr
 let (maybe_promote_effect :
   FStar_Extraction_ML_Syntax.mlexpr ->
     FStar_Extraction_ML_Syntax.e_tag ->
@@ -1881,7 +1848,7 @@ let (maybe_promote_effect :
            FStar_Extraction_ML_Syntax.MLTY_Erased) ->
             (FStar_Extraction_ML_Syntax.ml_unit,
               FStar_Extraction_ML_Syntax.E_PURE)
-        | uu____6486 -> (ml_e, tag)
+        | uu___ -> (ml_e, tag)
 let (extract_lb_sig :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.letbindings ->
@@ -1892,25 +1859,24 @@ let (extract_lb_sig :
   =
   fun g ->
     fun lbs ->
-      let maybe_generalize uu____6544 =
-        match uu____6544 with
+      let maybe_generalize uu___ =
+        match uu___ with
         | { FStar_Syntax_Syntax.lbname = lbname_;
-            FStar_Syntax_Syntax.lbunivs = uu____6564;
+            FStar_Syntax_Syntax.lbunivs = uu___1;
             FStar_Syntax_Syntax.lbtyp = lbtyp;
             FStar_Syntax_Syntax.lbeff = lbeff;
             FStar_Syntax_Syntax.lbdef = lbdef;
             FStar_Syntax_Syntax.lbattrs = lbattrs;
-            FStar_Syntax_Syntax.lbpos = uu____6569;_} ->
+            FStar_Syntax_Syntax.lbpos = uu___2;_} ->
             let f_e = effect_as_etag g lbeff in
             let lbtyp1 = FStar_Syntax_Subst.compress lbtyp in
-            let no_gen uu____6647 =
+            let no_gen uu___3 =
               let expected_t = term_as_mlty g lbtyp1 in
               (lbname_, f_e, (lbtyp1, ([], ([], expected_t))), false, lbdef) in
-            let uu____6717 =
-              let uu____6718 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-              FStar_TypeChecker_Util.must_erase_for_extraction uu____6718
-                lbtyp1 in
-            if uu____6717
+            let uu___3 =
+              let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+              FStar_TypeChecker_Util.must_erase_for_extraction uu___4 lbtyp1 in
+            if uu___3
             then
               (lbname_, f_e,
                 (lbtyp1, ([], ([], FStar_Extraction_ML_Syntax.MLTY_Erased))),
@@ -1918,116 +1884,108 @@ let (extract_lb_sig :
             else
               (match lbtyp1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs, c) when
-                   let uu____6796 = FStar_List.hd bs in
-                   FStar_All.pipe_right uu____6796 (is_type_binder g) ->
-                   let uu____6817 = FStar_Syntax_Subst.open_comp bs c in
-                   (match uu____6817 with
+                   let uu___5 = FStar_List.hd bs in
+                   FStar_All.pipe_right uu___5 (is_type_binder g) ->
+                   let uu___5 = FStar_Syntax_Subst.open_comp bs c in
+                   (match uu___5 with
                     | (bs1, c1) ->
-                        let uu____6842 =
-                          let uu____6855 =
+                        let uu___6 =
+                          let uu___7 =
                             FStar_Util.prefix_until
                               (fun x ->
-                                 let uu____6901 = is_type_binder g x in
-                                 Prims.op_Negation uu____6901) bs1 in
-                          match uu____6855 with
+                                 let uu___8 = is_type_binder g x in
+                                 Prims.op_Negation uu___8) bs1 in
+                          match uu___7 with
                           | FStar_Pervasives_Native.None ->
                               (bs1, (FStar_Syntax_Util.comp_result c1))
                           | FStar_Pervasives_Native.Some (bs2, b, rest) ->
-                              let uu____7027 =
+                              let uu___8 =
                                 FStar_Syntax_Util.arrow (b :: rest) c1 in
-                              (bs2, uu____7027) in
-                        (match uu____6842 with
+                              (bs2, uu___8) in
+                        (match uu___6 with
                          | (tbinders, tbody) ->
                              let n_tbinders = FStar_List.length tbinders in
                              let lbdef1 =
-                               let uu____7088 = normalize_abs lbdef in
-                               FStar_All.pipe_right uu____7088
+                               let uu___7 = normalize_abs lbdef in
+                               FStar_All.pipe_right uu___7
                                  FStar_Syntax_Util.unmeta in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs (bs2, body, copt)
                                   ->
-                                  let uu____7136 =
+                                  let uu___7 =
                                     FStar_Syntax_Subst.open_term bs2 body in
-                                  (match uu____7136 with
+                                  (match uu___7 with
                                    | (bs3, body1) ->
                                        if
                                          n_tbinders <=
                                            (FStar_List.length bs3)
                                        then
-                                         let uu____7185 =
+                                         let uu___8 =
                                            FStar_Util.first_N n_tbinders bs3 in
-                                         (match uu____7185 with
+                                         (match uu___8 with
                                           | (targs, rest_args) ->
                                               let expected_source_ty =
                                                 let s =
                                                   FStar_List.map2
-                                                    (fun uu____7287 ->
-                                                       fun uu____7288 ->
-                                                         match (uu____7287,
-                                                                 uu____7288)
+                                                    (fun uu___9 ->
+                                                       fun uu___10 ->
+                                                         match (uu___9,
+                                                                 uu___10)
                                                          with
-                                                         | ((x, uu____7314),
-                                                            (y, uu____7316))
-                                                             ->
-                                                             let uu____7337 =
-                                                               let uu____7344
-                                                                 =
+                                                         | ((x, uu___11),
+                                                            (y, uu___12)) ->
+                                                             let uu___13 =
+                                                               let uu___14 =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    y in
-                                                               (x,
-                                                                 uu____7344) in
+                                                               (x, uu___14) in
                                                              FStar_Syntax_Syntax.NT
-                                                               uu____7337)
+                                                               uu___13)
                                                     tbinders targs in
                                                 FStar_Syntax_Subst.subst s
                                                   tbody in
                                               let env =
                                                 FStar_List.fold_left
-                                                  (fun env ->
-                                                     fun uu____7361 ->
-                                                       match uu____7361 with
-                                                       | (a, uu____7369) ->
+                                                  (fun env1 ->
+                                                     fun uu___9 ->
+                                                       match uu___9 with
+                                                       | (a, uu___10) ->
                                                            FStar_Extraction_ML_UEnv.extend_ty
-                                                             env a false) g
+                                                             env1 a false) g
                                                   targs in
                                               let expected_t =
                                                 term_as_mlty env
                                                   expected_source_ty in
                                               let polytype =
-                                                let uu____7380 =
+                                                let uu___9 =
                                                   FStar_All.pipe_right targs
                                                     (FStar_List.map
-                                                       (fun uu____7399 ->
-                                                          match uu____7399
-                                                          with
-                                                          | (x, uu____7407)
-                                                              ->
-                                                              let uu____7412
-                                                                =
+                                                       (fun uu___10 ->
+                                                          match uu___10 with
+                                                          | (x, uu___11) ->
+                                                              let uu___12 =
                                                                 FStar_Extraction_ML_UEnv.lookup_ty
                                                                   env x in
-                                                              uu____7412.FStar_Extraction_ML_UEnv.ty_b_name)) in
-                                                (uu____7380, expected_t) in
+                                                              uu___12.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                                (uu___9, expected_t) in
                                               let add_unit =
                                                 match rest_args with
                                                 | [] ->
-                                                    (let uu____7422 =
+                                                    (let uu___9 =
                                                        is_fstar_value body1 in
-                                                     Prims.op_Negation
-                                                       uu____7422)
+                                                     Prims.op_Negation uu___9)
                                                       ||
-                                                      (let uu____7424 =
+                                                      (let uu___9 =
                                                          FStar_Syntax_Util.is_pure_comp
                                                            c1 in
                                                        Prims.op_Negation
-                                                         uu____7424)
-                                                | uu____7425 -> false in
+                                                         uu___9)
+                                                | uu___9 -> false in
                                               let rest_args1 =
                                                 if add_unit
                                                 then
-                                                  let uu____7435 =
-                                                    unit_binder () in
-                                                  uu____7435 :: rest_args
+                                                  let uu___9 = unit_binder () in
+                                                  uu___9 :: rest_args
                                                 else rest_args in
                                               let polytype1 =
                                                 if add_unit
@@ -2043,39 +2001,38 @@ let (extract_lb_sig :
                                                 add_unit, body2))
                                        else
                                          failwith "Not enough type binders")
-                              | FStar_Syntax_Syntax.Tm_uinst uu____7485 ->
+                              | FStar_Syntax_Syntax.Tm_uinst uu___7 ->
                                   let env =
                                     FStar_List.fold_left
-                                      (fun env ->
-                                         fun uu____7504 ->
-                                           match uu____7504 with
-                                           | (a, uu____7512) ->
+                                      (fun env1 ->
+                                         fun uu___8 ->
+                                           match uu___8 with
+                                           | (a, uu___9) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
-                                                 env a false) g tbinders in
+                                                 env1 a false) g tbinders in
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
-                                    let uu____7523 =
+                                    let uu___8 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7542 ->
-                                              match uu____7542 with
-                                              | (x, uu____7550) ->
-                                                  let uu____7555 =
+                                           (fun uu___9 ->
+                                              match uu___9 with
+                                              | (x, uu___10) ->
+                                                  let uu___11 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x in
-                                                  uu____7555.FStar_Extraction_ML_UEnv.ty_b_name)) in
-                                    (uu____7523, expected_t) in
+                                                  uu___11.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                    (uu___8, expected_t) in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____7595 ->
-                                            match uu____7595 with
-                                            | (bv, uu____7603) ->
-                                                let uu____7608 =
+                                         (fun uu___8 ->
+                                            match uu___8 with
+                                            | (bv, uu___9) ->
+                                                let uu___10 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv in
-                                                FStar_All.pipe_right
-                                                  uu____7608
+                                                FStar_All.pipe_right uu___10
                                                   FStar_Syntax_Syntax.as_arg)) in
                                   let e =
                                     FStar_Syntax_Syntax.mk
@@ -2084,39 +2041,38 @@ let (extract_lb_sig :
                                       lbdef1.FStar_Syntax_Syntax.pos in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_fvar uu____7636 ->
+                              | FStar_Syntax_Syntax.Tm_fvar uu___7 ->
                                   let env =
                                     FStar_List.fold_left
-                                      (fun env ->
-                                         fun uu____7649 ->
-                                           match uu____7649 with
-                                           | (a, uu____7657) ->
+                                      (fun env1 ->
+                                         fun uu___8 ->
+                                           match uu___8 with
+                                           | (a, uu___9) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
-                                                 env a false) g tbinders in
+                                                 env1 a false) g tbinders in
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
-                                    let uu____7668 =
+                                    let uu___8 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7687 ->
-                                              match uu____7687 with
-                                              | (x, uu____7695) ->
-                                                  let uu____7700 =
+                                           (fun uu___9 ->
+                                              match uu___9 with
+                                              | (x, uu___10) ->
+                                                  let uu___11 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x in
-                                                  uu____7700.FStar_Extraction_ML_UEnv.ty_b_name)) in
-                                    (uu____7668, expected_t) in
+                                                  uu___11.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                    (uu___8, expected_t) in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____7740 ->
-                                            match uu____7740 with
-                                            | (bv, uu____7748) ->
-                                                let uu____7753 =
+                                         (fun uu___8 ->
+                                            match uu___8 with
+                                            | (bv, uu___9) ->
+                                                let uu___10 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv in
-                                                FStar_All.pipe_right
-                                                  uu____7753
+                                                FStar_All.pipe_right uu___10
                                                   FStar_Syntax_Syntax.as_arg)) in
                                   let e =
                                     FStar_Syntax_Syntax.mk
@@ -2125,39 +2081,38 @@ let (extract_lb_sig :
                                       lbdef1.FStar_Syntax_Syntax.pos in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_name uu____7781 ->
+                              | FStar_Syntax_Syntax.Tm_name uu___7 ->
                                   let env =
                                     FStar_List.fold_left
-                                      (fun env ->
-                                         fun uu____7794 ->
-                                           match uu____7794 with
-                                           | (a, uu____7802) ->
+                                      (fun env1 ->
+                                         fun uu___8 ->
+                                           match uu___8 with
+                                           | (a, uu___9) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
-                                                 env a false) g tbinders in
+                                                 env1 a false) g tbinders in
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
-                                    let uu____7813 =
+                                    let uu___8 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7832 ->
-                                              match uu____7832 with
-                                              | (x, uu____7840) ->
-                                                  let uu____7845 =
+                                           (fun uu___9 ->
+                                              match uu___9 with
+                                              | (x, uu___10) ->
+                                                  let uu___11 =
                                                     FStar_Extraction_ML_UEnv.lookup_ty
                                                       env x in
-                                                  uu____7845.FStar_Extraction_ML_UEnv.ty_b_name)) in
-                                    (uu____7813, expected_t) in
+                                                  uu___11.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                    (uu___8, expected_t) in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____7885 ->
-                                            match uu____7885 with
-                                            | (bv, uu____7893) ->
-                                                let uu____7898 =
+                                         (fun uu___8 ->
+                                            match uu___8 with
+                                            | (bv, uu___9) ->
+                                                let uu___10 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv in
-                                                FStar_All.pipe_right
-                                                  uu____7898
+                                                FStar_All.pipe_right uu___10
                                                   FStar_Syntax_Syntax.as_arg)) in
                                   let e =
                                     FStar_Syntax_Syntax.mk
@@ -2166,8 +2121,8 @@ let (extract_lb_sig :
                                       lbdef1.FStar_Syntax_Syntax.pos in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | uu____7926 -> err_value_restriction lbdef1)))
-               | uu____7945 -> no_gen ()) in
+                              | uu___7 -> err_value_restriction lbdef1)))
+               | uu___5 -> no_gen ()) in
       FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
         (FStar_List.map maybe_generalize)
 let (extract_lb_iface :
@@ -2185,19 +2140,19 @@ let (extract_lb_iface :
       let lbs1 = extract_lb_sig g lbs in
       FStar_Util.fold_map
         (fun env ->
-           fun uu____8086 ->
-             match uu____8086 with
+           fun uu___ ->
+             match uu___ with
              | (lbname, e_tag, (typ, (binders, mltyscheme)), add_unit, _body)
                  ->
-                 let uu____8144 =
+                 let uu___1 =
                    FStar_Extraction_ML_UEnv.extend_lb env lbname typ
                      mltyscheme add_unit in
-                 (match uu____8144 with
-                  | (env1, uu____8160, exp_binding) ->
-                      let uu____8162 =
-                        let uu____8167 = FStar_Util.right lbname in
-                        (uu____8167, exp_binding) in
-                      (env1, uu____8162))) g lbs1
+                 (match uu___1 with
+                  | (env1, uu___2, exp_binding) ->
+                      let uu___3 =
+                        let uu___4 = FStar_Util.right lbname in
+                        (uu___4, exp_binding) in
+                      (env1, uu___3))) g lbs1
 let rec (check_term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term ->
@@ -2211,48 +2166,48 @@ let rec (check_term_as_mlexpr :
       fun f ->
         fun ty ->
           FStar_Extraction_ML_UEnv.debug g
-            (fun uu____8233 ->
-               let uu____8234 = FStar_Syntax_Print.term_to_string e in
-               let uu____8235 =
-                 let uu____8236 =
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.term_to_string e in
+               let uu___3 =
+                 let uu___4 =
                    FStar_Extraction_ML_UEnv.current_module_of_uenv g in
-                 FStar_Extraction_ML_Code.string_of_mlty uu____8236 ty in
-               let uu____8237 = FStar_Extraction_ML_Util.eff_to_string f in
-               FStar_Util.print3 "Checking %s at type %s and eff %s\n"
-                 uu____8234 uu____8235 uu____8237);
+                 FStar_Extraction_ML_Code.string_of_mlty uu___4 ty in
+               let uu___4 = FStar_Extraction_ML_Util.eff_to_string f in
+               FStar_Util.print3 "Checking %s at type %s and eff %s\n" uu___2
+                 uu___3 uu___4);
           (match (f, ty) with
-           | (FStar_Extraction_ML_Syntax.E_GHOST, uu____8242) ->
+           | (FStar_Extraction_ML_Syntax.E_GHOST, uu___1) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
            | (FStar_Extraction_ML_Syntax.E_PURE,
               FStar_Extraction_ML_Syntax.MLTY_Erased) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
-           | uu____8243 ->
-               let uu____8248 = term_as_mlexpr g e in
-               (match uu____8248 with
+           | uu___1 ->
+               let uu___2 = term_as_mlexpr g e in
+               (match uu___2 with
                 | (ml_e, tag, t) ->
-                    let uu____8262 = FStar_Extraction_ML_Util.eff_leq tag f in
-                    if uu____8262
+                    let uu___3 = FStar_Extraction_ML_Util.eff_leq tag f in
+                    if uu___3
                     then
-                      let uu____8267 =
+                      let uu___4 =
                         maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e t ty in
-                      (uu____8267, ty)
+                      (uu___4, ty)
                     else
                       (match (tag, f, ty) with
                        | (FStar_Extraction_ML_Syntax.E_GHOST,
                           FStar_Extraction_ML_Syntax.E_PURE,
                           FStar_Extraction_ML_Syntax.MLTY_Erased) ->
-                           let uu____8273 =
+                           let uu___5 =
                              maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e t
                                ty in
-                           (uu____8273, ty)
-                       | uu____8274 ->
+                           (uu___5, ty)
+                       | uu___5 ->
                            (err_unexpected_eff g e ty f tag;
-                            (let uu____8282 =
+                            (let uu___7 =
                                maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e
                                  t ty in
-                             (uu____8282, ty))))))
+                             (uu___7, ty))))))
 and (term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term ->
@@ -2261,11 +2216,11 @@ and (term_as_mlexpr :
   =
   fun g ->
     fun e ->
-      let uu____8291 = term_as_mlexpr' g e in
-      match uu____8291 with
+      let uu___ = term_as_mlexpr' g e in
+      match uu___ with
       | (e1, f, t) ->
-          let uu____8307 = maybe_promote_effect e1 f t in
-          (match uu____8307 with | (e2, f1) -> (e2, f1, t))
+          let uu___1 = maybe_promote_effect e1 f t in
+          (match uu___1 with | (e2, f1) -> (e2, f1, t))
 and (term_as_mlexpr' :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term ->
@@ -2277,250 +2232,245 @@ and (term_as_mlexpr' :
       let top1 = FStar_Syntax_Subst.compress top in
       FStar_Extraction_ML_UEnv.debug g
         (fun u ->
-           let uu____8333 =
-             let uu____8334 =
+           let uu___1 =
+             let uu___2 =
                FStar_Range.string_of_range top1.FStar_Syntax_Syntax.pos in
-             let uu____8335 = FStar_Syntax_Print.tag_of_term top1 in
-             let uu____8336 = FStar_Syntax_Print.term_to_string top1 in
-             FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____8334 uu____8335 uu____8336 in
-           FStar_Util.print_string uu____8333);
+             let uu___3 = FStar_Syntax_Print.tag_of_term top1 in
+             let uu___4 = FStar_Syntax_Print.term_to_string top1 in
+             FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n" uu___2
+               uu___3 uu___4 in
+           FStar_Util.print_string uu___1);
       (let is_match t =
-         let uu____8343 =
-           let uu____8344 =
-             let uu____8347 =
-               FStar_All.pipe_right t FStar_Syntax_Subst.compress in
-             FStar_All.pipe_right uu____8347 FStar_Syntax_Util.unascribe in
-           uu____8344.FStar_Syntax_Syntax.n in
-         match uu____8343 with
-         | FStar_Syntax_Syntax.Tm_match uu____8350 -> true
-         | uu____8373 -> false in
+         let uu___1 =
+           let uu___2 =
+             let uu___3 = FStar_All.pipe_right t FStar_Syntax_Subst.compress in
+             FStar_All.pipe_right uu___3 FStar_Syntax_Util.unascribe in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
+         | FStar_Syntax_Syntax.Tm_match uu___2 -> true
+         | uu___2 -> false in
        let should_apply_to_match_branches =
          FStar_List.for_all
-           (fun uu____8390 ->
-              match uu____8390 with
-              | (t, uu____8398) ->
-                  let uu____8403 =
-                    let uu____8404 =
+           (fun uu___1 ->
+              match uu___1 with
+              | (t, uu___2) ->
+                  let uu___3 =
+                    let uu___4 =
                       FStar_All.pipe_right t FStar_Syntax_Subst.compress in
-                    uu____8404.FStar_Syntax_Syntax.n in
-                  (match uu____8403 with
-                   | FStar_Syntax_Syntax.Tm_name uu____8409 -> true
-                   | FStar_Syntax_Syntax.Tm_fvar uu____8410 -> true
-                   | FStar_Syntax_Syntax.Tm_constant uu____8411 -> true
-                   | uu____8412 -> false)) in
+                    uu___4.FStar_Syntax_Syntax.n in
+                  (match uu___3 with
+                   | FStar_Syntax_Syntax.Tm_name uu___4 -> true
+                   | FStar_Syntax_Syntax.Tm_fvar uu___4 -> true
+                   | FStar_Syntax_Syntax.Tm_constant uu___4 -> true
+                   | uu___4 -> false)) in
        let apply_to_match_branches head args =
-         let uu____8450 =
-           let uu____8451 =
-             let uu____8454 =
+         let uu___1 =
+           let uu___2 =
+             let uu___3 =
                FStar_All.pipe_right head FStar_Syntax_Subst.compress in
-             FStar_All.pipe_right uu____8454 FStar_Syntax_Util.unascribe in
-           uu____8451.FStar_Syntax_Syntax.n in
-         match uu____8450 with
+             FStar_All.pipe_right uu___3 FStar_Syntax_Util.unascribe in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
          | FStar_Syntax_Syntax.Tm_match (scrutinee, branches) ->
              let branches1 =
                FStar_All.pipe_right branches
                  (FStar_List.map
-                    (fun uu____8578 ->
-                       match uu____8578 with
+                    (fun uu___2 ->
+                       match uu___2 with
                        | (pat, when_opt, body) ->
                            (pat, when_opt,
-                             (let uu___1319_8635 = body in
+                             (let uu___3 = body in
                               {
                                 FStar_Syntax_Syntax.n =
                                   (FStar_Syntax_Syntax.Tm_app (body, args));
                                 FStar_Syntax_Syntax.pos =
-                                  (uu___1319_8635.FStar_Syntax_Syntax.pos);
+                                  (uu___3.FStar_Syntax_Syntax.pos);
                                 FStar_Syntax_Syntax.vars =
-                                  (uu___1319_8635.FStar_Syntax_Syntax.vars)
+                                  (uu___3.FStar_Syntax_Syntax.vars)
                               })))) in
-             let uu___1322_8650 = head in
+             let uu___2 = head in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Tm_match (scrutinee, branches1));
-               FStar_Syntax_Syntax.pos =
-                 (uu___1322_8650.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___1322_8650.FStar_Syntax_Syntax.vars)
+               FStar_Syntax_Syntax.pos = (uu___2.FStar_Syntax_Syntax.pos);
+               FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars)
              }
-         | uu____8671 ->
+         | uu___2 ->
              failwith
                "Impossible! cannot apply args to match branches if head is not a match" in
        let t = FStar_Syntax_Subst.compress top1 in
        match t.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_unknown ->
-           let uu____8681 =
-             let uu____8682 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8682 in
-           failwith uu____8681
-       | FStar_Syntax_Syntax.Tm_delayed uu____8689 ->
-           let uu____8704 =
-             let uu____8705 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8705 in
-           failwith uu____8704
-       | FStar_Syntax_Syntax.Tm_uvar uu____8712 ->
-           let uu____8725 =
-             let uu____8726 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8726 in
-           failwith uu____8725
-       | FStar_Syntax_Syntax.Tm_bvar uu____8733 ->
-           let uu____8734 =
-             let uu____8735 = FStar_Syntax_Print.tag_of_term t in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8735 in
-           failwith uu____8734
+           let uu___1 =
+             let uu___2 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu___2 in
+           failwith uu___1
+       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
+           let uu___2 =
+             let uu___3 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu___3 in
+           failwith uu___2
+       | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
+           let uu___2 =
+             let uu___3 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu___3 in
+           failwith uu___2
+       | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
+           let uu___2 =
+             let uu___3 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu___3 in
+           failwith uu___2
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____8743 = FStar_Syntax_Util.unfold_lazy i in
-           term_as_mlexpr g uu____8743
-       | FStar_Syntax_Syntax.Tm_type uu____8744 ->
+           let uu___1 = FStar_Syntax_Util.unfold_lazy i in
+           term_as_mlexpr g uu___1
+       | FStar_Syntax_Syntax.Tm_type uu___1 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_refine uu____8745 ->
+       | FStar_Syntax_Syntax.Tm_refine uu___1 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_arrow uu____8752 ->
+       | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,
             { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
-              FStar_Syntax_Syntax.antiquotes = uu____8768;_})
+              FStar_Syntax_Syntax.antiquotes = uu___1;_})
            ->
-           let uu____8781 =
-             let uu____8782 =
+           let uu___2 =
+             let uu___3 =
                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None in
-             FStar_Extraction_ML_UEnv.lookup_fv g uu____8782 in
-           (match uu____8781 with
-            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____8789;
+             FStar_Extraction_ML_UEnv.lookup_fv g uu___3 in
+           (match uu___2 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
-                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____8791;_} ->
-                let uu____8792 =
-                  let uu____8793 =
-                    let uu____8794 =
-                      let uu____8801 =
-                        let uu____8804 =
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___4;_} ->
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.ml_string_ty)
                             (FStar_Extraction_ML_Syntax.MLE_Const
                                (FStar_Extraction_ML_Syntax.MLC_String
                                   "Cannot evaluate open quotation at runtime")) in
-                        [uu____8804] in
-                      (fw, uu____8801) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____8794 in
+                        [uu___9] in
+                      (fw, uu___8) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___7 in
                   FStar_All.pipe_left
                     (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____8793 in
-                (uu____8792, FStar_Extraction_ML_Syntax.E_PURE,
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___6 in
+                (uu___5, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,
             { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static;
               FStar_Syntax_Syntax.antiquotes = aqs;_})
            ->
-           let uu____8821 = FStar_Reflection_Basic.inspect_ln qt in
-           (match uu____8821 with
+           let uu___1 = FStar_Reflection_Basic.inspect_ln qt in
+           (match uu___1 with
             | FStar_Reflection_Data.Tv_Var bv ->
-                let uu____8829 = FStar_Syntax_Syntax.lookup_aq bv aqs in
-                (match uu____8829 with
+                let uu___2 = FStar_Syntax_Syntax.lookup_aq bv aqs in
+                (match uu___2 with
                  | FStar_Pervasives_Native.Some tm -> term_as_mlexpr g tm
                  | FStar_Pervasives_Native.None ->
                      let tv =
-                       let uu____8840 =
-                         let uu____8847 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_Reflection_Embeddings.e_term_view_aq aqs in
-                         FStar_Syntax_Embeddings.embed uu____8847
+                         FStar_Syntax_Embeddings.embed uu___4
                            (FStar_Reflection_Data.Tv_Var bv) in
-                       uu____8840 t.FStar_Syntax_Syntax.pos
+                       uu___3 t.FStar_Syntax_Syntax.pos
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Embeddings.id_norm_cb in
                      let t1 =
-                       let uu____8855 =
-                         let uu____8866 = FStar_Syntax_Syntax.as_arg tv in
-                         [uu____8866] in
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Syntax.as_arg tv in
+                         [uu___4] in
                        FStar_Syntax_Util.mk_app
                          (FStar_Reflection_Data.refl_constant_term
-                            FStar_Reflection_Data.fstar_refl_pack_ln)
-                         uu____8855 in
+                            FStar_Reflection_Data.fstar_refl_pack_ln) uu___3 in
                      term_as_mlexpr g t1)
             | tv ->
                 let tv1 =
-                  let uu____8893 =
-                    let uu____8900 =
+                  let uu___2 =
+                    let uu___3 =
                       FStar_Reflection_Embeddings.e_term_view_aq aqs in
-                    FStar_Syntax_Embeddings.embed uu____8900 tv in
-                  uu____8893 t.FStar_Syntax_Syntax.pos
+                    FStar_Syntax_Embeddings.embed uu___3 tv in
+                  uu___2 t.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None
                     FStar_Syntax_Embeddings.id_norm_cb in
                 let t1 =
-                  let uu____8908 =
-                    let uu____8919 = FStar_Syntax_Syntax.as_arg tv1 in
-                    [uu____8919] in
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Syntax.as_arg tv1 in [uu___3] in
                   FStar_Syntax_Util.mk_app
                     (FStar_Reflection_Data.refl_constant_term
-                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____8908 in
+                       FStar_Reflection_Data.fstar_refl_pack_ln) uu___2 in
                 term_as_mlexpr g t1)
        | FStar_Syntax_Syntax.Tm_meta
-           (t1, FStar_Syntax_Syntax.Meta_monadic (m, uu____8946)) ->
+           (t1, FStar_Syntax_Syntax.Meta_monadic (m, uu___1)) ->
            let t2 = FStar_Syntax_Subst.compress t1 in
            (match t2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) when
                 FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
-                let uu____8976 =
-                  let uu____8983 =
-                    let uu____8992 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Env.effect_decl_opt uu____8992 m in
-                  FStar_Util.must uu____8983 in
-                (match uu____8976 with
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Env.effect_decl_opt uu___4 m in
+                  FStar_Util.must uu___3 in
+                (match uu___2 with
                  | (ed, qualifiers) ->
-                     let uu____9011 =
-                       let uu____9012 =
-                         let uu____9013 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                         FStar_TypeChecker_Env.is_reifiable_effect uu____9013
+                         FStar_TypeChecker_Env.is_reifiable_effect uu___5
                            ed.FStar_Syntax_Syntax.mname in
-                       Prims.op_Negation uu____9012 in
-                     if uu____9011
+                       Prims.op_Negation uu___4 in
+                     if uu___3
                      then term_as_mlexpr g t2
                      else
                        failwith
                          "This should not happen (should have been handled at Tm_abs level)")
-            | uu____9027 -> term_as_mlexpr g t2)
-       | FStar_Syntax_Syntax.Tm_meta (t1, uu____9029) -> term_as_mlexpr g t1
-       | FStar_Syntax_Syntax.Tm_uinst (t1, uu____9035) -> term_as_mlexpr g t1
+            | uu___2 -> term_as_mlexpr g t2)
+       | FStar_Syntax_Syntax.Tm_meta (t1, uu___1) -> term_as_mlexpr g t1
+       | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____9041 =
-             let uu____9048 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_TcTerm.type_of_tot_term uu____9048 t in
-           (match uu____9041 with
-            | (uu____9055, ty, uu____9057) ->
+           let uu___1 =
+             let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+             FStar_TypeChecker_TcTerm.type_of_tot_term uu___2 t in
+           (match uu___1 with
+            | (uu___2, ty, uu___3) ->
                 let ml_ty = term_as_mlty g ty in
-                let uu____9059 =
-                  let uu____9060 =
+                let uu___4 =
+                  let uu___5 =
                     FStar_Extraction_ML_Util.mlexpr_of_const
                       t.FStar_Syntax_Syntax.pos c in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9060 in
-                (uu____9059, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
-       | FStar_Syntax_Syntax.Tm_name uu____9061 ->
-           let uu____9062 = is_type g t in
-           if uu____9062
+                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu___5 in
+                (uu___4, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
+       | FStar_Syntax_Syntax.Tm_name uu___1 ->
+           let uu___2 = is_type g t in
+           if uu___2
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9070 = FStar_Extraction_ML_UEnv.lookup_term g t in
-              match uu____9070 with
-              | (FStar_Util.Inl uu____9083, uu____9084) ->
+             (let uu___4 = FStar_Extraction_ML_UEnv.lookup_term g t in
+              match uu___4 with
+              | (FStar_Util.Inl uu___5, uu___6) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
               | (FStar_Util.Inr
-                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9089;
+                 { FStar_Extraction_ML_UEnv.exp_b_name = uu___5;
                    FStar_Extraction_ML_UEnv.exp_b_expr = x;
                    FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;_},
                  qual) ->
@@ -2530,149 +2480,147 @@ and (term_as_mlexpr' :
                        (FStar_Extraction_ML_Syntax.ml_unit,
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([], t1) ->
-                       let uu____9105 =
+                       let uu___6 =
                          maybe_eta_data_and_project_record g qual t1 x in
-                       (uu____9105, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | uu____9106 -> instantiate_maybe_partial g x mltys []))
+                       (uu___6, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                   | uu___6 -> instantiate_maybe_partial g x mltys []))
        | FStar_Syntax_Syntax.Tm_fvar fv ->
-           let uu____9108 = is_type g t in
-           if uu____9108
+           let uu___1 = is_type g t in
+           if uu___1
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9116 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv in
-              match uu____9116 with
+             (let uu___3 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv in
+              match uu___3 with
               | FStar_Pervasives_Native.None ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.MLTY_Erased)
               | FStar_Pervasives_Native.Some
-                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9125;
+                  { FStar_Extraction_ML_UEnv.exp_b_name = uu___4;
                     FStar_Extraction_ML_UEnv.exp_b_expr = x;
                     FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;_}
                   ->
                   (FStar_Extraction_ML_UEnv.debug g
-                     (fun uu____9133 ->
-                        let uu____9134 = FStar_Syntax_Print.fv_to_string fv in
-                        let uu____9135 =
-                          let uu____9136 =
+                     (fun uu___6 ->
+                        let uu___7 = FStar_Syntax_Print.fv_to_string fv in
+                        let uu___8 =
+                          let uu___9 =
                             FStar_Extraction_ML_UEnv.current_module_of_uenv g in
-                          FStar_Extraction_ML_Code.string_of_mlexpr
-                            uu____9136 x in
-                        let uu____9137 =
-                          let uu____9138 =
+                          FStar_Extraction_ML_Code.string_of_mlexpr uu___9 x in
+                        let uu___9 =
+                          let uu___10 =
                             FStar_Extraction_ML_UEnv.current_module_of_uenv g in
-                          FStar_Extraction_ML_Code.string_of_mlty uu____9138
+                          FStar_Extraction_ML_Code.string_of_mlty uu___10
                             (FStar_Pervasives_Native.snd mltys) in
                         FStar_Util.print3 "looked up %s: got %s at %s \n"
-                          uu____9134 uu____9135 uu____9137);
+                          uu___7 uu___8 uu___9);
                    (match mltys with
                     | ([], t1) when
                         t1 = FStar_Extraction_ML_Syntax.ml_unit_ty ->
                         (FStar_Extraction_ML_Syntax.ml_unit,
                           FStar_Extraction_ML_Syntax.E_PURE, t1)
                     | ([], t1) ->
-                        let uu____9147 =
+                        let uu___6 =
                           maybe_eta_data_and_project_record g
                             fv.FStar_Syntax_Syntax.fv_qual t1 x in
-                        (uu____9147, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                    | uu____9148 -> instantiate_maybe_partial g x mltys [])))
+                        (uu___6, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                    | uu___6 -> instantiate_maybe_partial g x mltys [])))
        | FStar_Syntax_Syntax.Tm_abs (bs, body, rcopt) ->
-           let uu____9176 = FStar_Syntax_Subst.open_term bs body in
-           (match uu____9176 with
+           let uu___1 = FStar_Syntax_Subst.open_term bs body in
+           (match uu___1 with
             | (bs1, body1) ->
-                let uu____9189 = binders_as_ml_binders g bs1 in
-                (match uu____9189 with
+                let uu___2 = binders_as_ml_binders g bs1 in
+                (match uu___2 with
                  | (ml_bs, env) ->
                      let body2 =
                        match rcopt with
                        | FStar_Pervasives_Native.Some rc ->
-                           let uu____9222 =
-                             let uu____9223 =
+                           let uu___3 =
+                             let uu___4 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-                             FStar_TypeChecker_Env.is_reifiable_rc uu____9223
-                               rc in
-                           if uu____9222
+                             FStar_TypeChecker_Env.is_reifiable_rc uu___4 rc in
+                           if uu___3
                            then
-                             let uu____9224 =
+                             let uu___4 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-                             FStar_TypeChecker_Util.reify_body uu____9224
+                             FStar_TypeChecker_Util.reify_body uu___4
                                [FStar_TypeChecker_Env.Inlining;
                                FStar_TypeChecker_Env.ForExtraction;
                                FStar_TypeChecker_Env.Unascribe] body1
                            else body1
                        | FStar_Pervasives_Native.None ->
                            (FStar_Extraction_ML_UEnv.debug g
-                              (fun uu____9229 ->
-                                 let uu____9230 =
+                              (fun uu___4 ->
+                                 let uu___5 =
                                    FStar_Syntax_Print.term_to_string body1 in
                                  FStar_Util.print1
-                                   "No computation type for: %s\n" uu____9230);
+                                   "No computation type for: %s\n" uu___5);
                             body1) in
-                     let uu____9231 = term_as_mlexpr env body2 in
-                     (match uu____9231 with
+                     let uu___3 = term_as_mlexpr env body2 in
+                     (match uu___3 with
                       | (ml_body, f, t1) ->
-                          let uu____9247 =
+                          let uu___4 =
                             FStar_List.fold_right
-                              (fun uu____9266 ->
-                                 fun uu____9267 ->
-                                   match (uu____9266, uu____9267) with
-                                   | ((uu____9288, targ), (f1, t2)) ->
+                              (fun uu___5 ->
+                                 fun uu___6 ->
+                                   match (uu___5, uu___6) with
+                                   | ((uu___7, targ), (f1, t2)) ->
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
                                             (targ, f1, t2)))) ml_bs (f, t1) in
-                          (match uu____9247 with
+                          (match uu___4 with
                            | (f1, tfun) ->
-                               let uu____9308 =
+                               let uu___5 =
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty tfun)
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
                                       (ml_bs, ml_body)) in
-                               (uu____9308, f1, tfun)))))
+                               (uu___5, f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____9315;
-              FStar_Syntax_Syntax.vars = uu____9316;_},
-            (a1, uu____9318)::[])
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            (a1, uu___3)::[])
            ->
            let ty =
-             let uu____9358 =
+             let uu___4 =
                FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-             term_as_mlty g uu____9358 in
-           let uu____9359 =
-             let uu____9360 =
+             term_as_mlty g uu___4 in
+           let uu___4 =
+             let uu___5 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-               uu____9360 in
-           (uu____9359, FStar_Extraction_ML_Syntax.E_PURE, ty)
+               uu___5 in
+           (uu___4, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____9361;
-              FStar_Syntax_Syntax.vars = uu____9362;_},
-            (t1, uu____9364)::(r, uu____9366)::[])
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            (t1, uu___3)::(r, uu___4)::[])
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____9421);
-              FStar_Syntax_Syntax.pos = uu____9422;
-              FStar_Syntax_Syntax.vars = uu____9423;_},
-            uu____9424)
+                (FStar_Const.Const_reflect uu___1);
+              FStar_Syntax_Syntax.pos = uu___2;
+              FStar_Syntax_Syntax.vars = uu___3;_},
+            uu___4)
            -> failwith "Unreachable? Tm_app Const_reflect"
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (is_match head) &&
              (FStar_All.pipe_right args should_apply_to_match_branches)
            ->
-           let uu____9481 =
+           let uu___1 =
              FStar_All.pipe_right args (apply_to_match_branches head) in
-           FStar_All.pipe_right uu____9481 (term_as_mlexpr g)
+           FStar_All.pipe_right uu___1 (term_as_mlexpr g)
        | FStar_Syntax_Syntax.Tm_app (head, args) ->
            let is_total rc =
              (FStar_Ident.lid_equals rc.FStar_Syntax_Syntax.residual_effect
@@ -2680,49 +2628,49 @@ and (term_as_mlexpr' :
                ||
                (FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                   (FStar_List.existsb
-                     (fun uu___1_9533 ->
-                        match uu___1_9533 with
+                     (fun uu___1 ->
+                        match uu___1 with
                         | FStar_Syntax_Syntax.TOTAL -> true
-                        | uu____9534 -> false))) in
-           let uu____9535 =
-             let uu____9536 =
-               let uu____9539 =
+                        | uu___2 -> false))) in
+           let uu___1 =
+             let uu___2 =
+               let uu___3 =
                  FStar_All.pipe_right head FStar_Syntax_Subst.compress in
-               FStar_All.pipe_right uu____9539 FStar_Syntax_Util.unascribe in
-             uu____9536.FStar_Syntax_Syntax.n in
-           (match uu____9535 with
-            | FStar_Syntax_Syntax.Tm_abs (bs, uu____9549, _rc) ->
-                let uu____9575 =
-                  let uu____9576 =
-                    let uu____9581 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+               FStar_All.pipe_right uu___3 FStar_Syntax_Util.unascribe in
+             uu___2.FStar_Syntax_Syntax.n in
+           (match uu___1 with
+            | FStar_Syntax_Syntax.Tm_abs (bs, uu___2, _rc) ->
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
                     FStar_TypeChecker_Normalize.normalize
                       [FStar_TypeChecker_Env.Beta;
                       FStar_TypeChecker_Env.Iota;
                       FStar_TypeChecker_Env.Zeta;
                       FStar_TypeChecker_Env.EraseUniverses;
                       FStar_TypeChecker_Env.AllowUnboundUniverses;
-                      FStar_TypeChecker_Env.ForExtraction] uu____9581 in
-                  FStar_All.pipe_right t uu____9576 in
-                FStar_All.pipe_right uu____9575 (term_as_mlexpr g)
+                      FStar_TypeChecker_Env.ForExtraction] uu___5 in
+                  FStar_All.pipe_right t uu___4 in
+                FStar_All.pipe_right uu___3 (term_as_mlexpr g)
             | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) ->
                 let e =
-                  let uu____9589 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                  let uu____9590 = FStar_List.hd args in
-                  FStar_TypeChecker_Util.reify_body_with_arg uu____9589
+                  let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  let uu___3 = FStar_List.hd args in
+                  FStar_TypeChecker_Util.reify_body_with_arg uu___2
                     [FStar_TypeChecker_Env.Inlining;
                     FStar_TypeChecker_Env.ForExtraction;
-                    FStar_TypeChecker_Env.Unascribe] head uu____9590 in
+                    FStar_TypeChecker_Env.Unascribe] head uu___3 in
                 let tm =
-                  let uu____9600 = FStar_TypeChecker_Util.remove_reify e in
-                  let uu____9601 = FStar_List.tl args in
-                  FStar_Syntax_Syntax.mk_Tm_app uu____9600 uu____9601
+                  let uu___2 = FStar_TypeChecker_Util.remove_reify e in
+                  let uu___3 = FStar_List.tl args in
+                  FStar_Syntax_Syntax.mk_Tm_app uu___2 uu___3
                     t.FStar_Syntax_Syntax.pos in
                 term_as_mlexpr g tm
-            | uu____9610 ->
-                let rec extract_app is_data uu____9659 uu____9660 restArgs =
-                  match (uu____9659, uu____9660) with
+            | uu___2 ->
+                let rec extract_app is_data uu___3 uu___4 restArgs =
+                  match (uu___3, uu___4) with
                   | ((mlhead, mlargs_f), (f, t1)) ->
-                      let mk_head uu____9741 =
+                      let mk_head uu___5 =
                         let mlargs =
                           FStar_All.pipe_right (FStar_List.rev mlargs_f)
                             (FStar_List.map FStar_Pervasives_Native.fst) in
@@ -2731,81 +2679,81 @@ and (term_as_mlexpr' :
                           (FStar_Extraction_ML_Syntax.MLE_App
                              (mlhead, mlargs)) in
                       (FStar_Extraction_ML_UEnv.debug g
-                         (fun uu____9768 ->
-                            let uu____9769 =
-                              let uu____9770 =
+                         (fun uu___6 ->
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g in
-                              let uu____9771 = mk_head () in
+                              let uu___9 = mk_head () in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____9770 uu____9771 in
-                            let uu____9772 =
-                              let uu____9773 =
+                                uu___8 uu___9 in
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g in
-                              FStar_Extraction_ML_Code.string_of_mlty
-                                uu____9773 t1 in
-                            let uu____9774 =
+                              FStar_Extraction_ML_Code.string_of_mlty uu___9
+                                t1 in
+                            let uu___9 =
                               match restArgs with
                               | [] -> "none"
-                              | (hd, uu____9782)::uu____9783 ->
+                              | (hd, uu___10)::uu___11 ->
                                   FStar_Syntax_Print.term_to_string hd in
                             FStar_Util.print3
                               "extract_app ml_head=%s type of head = %s, next arg = %s\n"
-                              uu____9769 uu____9772 uu____9774);
+                              uu___7 uu___8 uu___9);
                        (match (restArgs, t1) with
-                        | ([], uu____9816) ->
+                        | ([], uu___6) ->
                             let app =
-                              let uu____9832 = mk_head () in
+                              let uu___7 = mk_head () in
                               maybe_eta_data_and_project_record g is_data t1
-                                uu____9832 in
+                                uu___7 in
                             (app, f, t1)
-                        | ((arg, uu____9834)::rest,
+                        | ((arg, uu___6)::rest,
                            FStar_Extraction_ML_Syntax.MLTY_Fun
                            (formal_t, f', t2)) when
                             (is_type g arg) &&
                               (type_leq g formal_t
                                  FStar_Extraction_ML_Syntax.ml_unit_ty)
                             ->
-                            let uu____9865 =
-                              let uu____9870 =
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_Extraction_ML_Util.join
                                   arg.FStar_Syntax_Syntax.pos f f' in
-                              (uu____9870, t2) in
+                              (uu___8, t2) in
                             extract_app is_data
                               (mlhead,
                                 ((FStar_Extraction_ML_Syntax.ml_unit,
                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                mlargs_f)) uu____9865 rest
-                        | ((e0, uu____9882)::rest,
+                                mlargs_f)) uu___7 rest
+                        | ((e0, uu___6)::rest,
                            FStar_Extraction_ML_Syntax.MLTY_Fun
                            (tExpected, f', t2)) ->
                             let r = e0.FStar_Syntax_Syntax.pos in
                             let expected_effect =
-                              let uu____9915 =
+                              let uu___7 =
                                 (FStar_Options.lax ()) &&
                                   (FStar_TypeChecker_Util.short_circuit_head
                                      head) in
-                              if uu____9915
+                              if uu___7
                               then FStar_Extraction_ML_Syntax.E_IMPURE
                               else FStar_Extraction_ML_Syntax.E_PURE in
-                            let uu____9917 =
+                            let uu___7 =
                               check_term_as_mlexpr g e0 expected_effect
                                 tExpected in
-                            (match uu____9917 with
+                            (match uu___7 with
                              | (e01, tInferred) ->
-                                 let uu____9930 =
-                                   let uu____9935 =
+                                 let uu___8 =
+                                   let uu___9 =
                                      FStar_Extraction_ML_Util.join_l r
                                        [f; f'] in
-                                   (uu____9935, t2) in
+                                   (uu___9, t2) in
                                  extract_app is_data
                                    (mlhead, ((e01, expected_effect) ::
-                                     mlargs_f)) uu____9930 rest)
-                        | uu____9946 ->
-                            let uu____9959 =
+                                     mlargs_f)) uu___8 rest)
+                        | uu___6 ->
+                            let uu___7 =
                               FStar_Extraction_ML_Util.udelta_unfold g t1 in
-                            (match uu____9959 with
+                            (match uu___7 with
                              | FStar_Pervasives_Native.Some t2 ->
                                  extract_app is_data (mlhead, mlargs_f)
                                    (f, t2) restArgs
@@ -2818,7 +2766,7 @@ and (term_as_mlexpr' :
                                   | FStar_Extraction_ML_Syntax.MLTY_Top ->
                                       let t2 =
                                         FStar_List.fold_right
-                                          (fun t2 ->
+                                          (fun t3 ->
                                              fun out ->
                                                FStar_Extraction_ML_Syntax.MLTY_Fun
                                                  (FStar_Extraction_ML_Syntax.MLTY_Top,
@@ -2844,7 +2792,7 @@ and (term_as_mlexpr' :
                                           t2 in
                                       extract_app is_data (mlhead1, [])
                                         (f, t2) restArgs
-                                  | uu____10031 ->
+                                  | uu___8 ->
                                       let mlhead1 =
                                         let mlargs =
                                           FStar_All.pipe_right
@@ -2864,117 +2812,113 @@ and (term_as_mlexpr' :
                                           t1 in
                                       err_ill_typed_application g top1
                                         mlhead1 restArgs t1)))) in
-                let extract_app_maybe_projector is_data mlhead uu____10102
-                  args1 =
-                  match uu____10102 with
+                let extract_app_maybe_projector is_data mlhead uu___3 args1 =
+                  match uu___3 with
                   | (f, t1) ->
                       (match is_data with
                        | FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Record_projector uu____10132)
-                           ->
+                           (FStar_Syntax_Syntax.Record_projector uu___4) ->
                            let rec remove_implicits args2 f1 t2 =
                              match (args2, t2) with
                              | ((a0, FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____10216))::args3,
+                                 (FStar_Syntax_Syntax.Implicit uu___5))::args3,
                                 FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____10218, f', t3)) ->
-                                 let uu____10255 =
+                                (uu___6, f', t3)) ->
+                                 let uu___7 =
                                    FStar_Extraction_ML_Util.join
                                      a0.FStar_Syntax_Syntax.pos f1 f' in
-                                 remove_implicits args3 uu____10255 t3
-                             | uu____10256 -> (args2, f1, t2) in
-                           let uu____10281 = remove_implicits args1 f t1 in
-                           (match uu____10281 with
+                                 remove_implicits args3 uu___7 t3
+                             | uu___5 -> (args2, f1, t2) in
+                           let uu___5 = remove_implicits args1 f t1 in
+                           (match uu___5 with
                             | (args2, f1, t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
-                       | uu____10337 ->
+                       | uu___4 ->
                            extract_app is_data (mlhead, []) (f, t1) args1) in
-                let extract_app_with_instantiations uu____10361 =
+                let extract_app_with_instantiations uu___3 =
                   let head1 = FStar_Syntax_Util.un_uinst head in
                   match head1.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_name uu____10369 ->
-                      let uu____10370 =
-                        let uu____10385 =
+                  | FStar_Syntax_Syntax.Tm_name uu___4 ->
+                      let uu___5 =
+                        let uu___6 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1 in
-                        match uu____10385 with
+                        match uu___6 with
                         | (FStar_Util.Inr exp_b, q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____10417 ->
-                                  let uu____10418 =
+                               (fun uu___8 ->
+                                  let uu___9 =
                                     FStar_Syntax_Print.term_to_string head1 in
-                                  let uu____10419 =
-                                    let uu____10420 =
+                                  let uu___10 =
+                                    let uu___11 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____10420
+                                      uu___11
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr in
-                                  let uu____10421 =
-                                    let uu____10422 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____10422
+                                      uu___12
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme) in
                                   FStar_Util.print3
-                                    "@@@looked up %s: got %s at %s\n"
-                                    uu____10418 uu____10419 uu____10421);
+                                    "@@@looked up %s: got %s at %s\n" uu___9
+                                    uu___10 uu___11);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____10437 -> failwith "FIXME Ty" in
-                      (match uu____10370 with
+                        | uu___7 -> failwith "FIXME Ty" in
+                      (match uu___5 with
                        | ((head_ml, (vars, t1)), qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a, uu____10486)::uu____10487 -> is_type g a
-                             | uu____10514 -> false in
-                           let uu____10525 =
+                             | (a, uu___6)::uu___7 -> is_type g a
+                             | uu___6 -> false in
+                           let uu___6 =
                              let n = FStar_List.length vars in
-                             let uu____10541 =
+                             let uu___7 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____10578 =
+                                 let uu___8 =
                                    FStar_List.map
-                                     (fun uu____10590 ->
-                                        match uu____10590 with
-                                        | (x, uu____10598) ->
-                                            term_as_mlty g x) args in
-                                 (uu____10578, [])
+                                     (fun uu___9 ->
+                                        match uu___9 with
+                                        | (x, uu___10) -> term_as_mlty g x)
+                                     args in
+                                 (uu___8, [])
                                else
-                                 (let uu____10620 = FStar_Util.first_N n args in
-                                  match uu____10620 with
+                                 (let uu___9 = FStar_Util.first_N n args in
+                                  match uu___9 with
                                   | (prefix, rest) ->
-                                      let uu____10709 =
+                                      let uu___10 =
                                         FStar_List.map
-                                          (fun uu____10721 ->
-                                             match uu____10721 with
-                                             | (x, uu____10729) ->
+                                          (fun uu___11 ->
+                                             match uu___11 with
+                                             | (x, uu___12) ->
                                                  term_as_mlty g x) prefix in
-                                      (uu____10709, rest)) in
-                             match uu____10541 with
+                                      (uu___10, rest)) in
+                             match uu___7 with
                              | (provided_type_args, rest) ->
-                                 let uu____10780 =
+                                 let uu___8 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____10789 ->
-                                       let uu____10790 =
+                                       uu___9 ->
+                                       let uu___10 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args in
-                                       (match uu____10790 with
-                                        | (head2, uu____10802, t2) ->
-                                            (head2, t2))
+                                       (match uu___10 with
+                                        | (head2, uu___11, t2) -> (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____10804 ->
-                                       let uu____10805 =
+                                       uu___9 ->
+                                       let uu___10 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args in
-                                       (match uu____10805 with
-                                        | (head2, uu____10817, t2) ->
-                                            (head2, t2))
+                                       (match uu___10 with
+                                        | (head2, uu___11, t2) -> (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,
                                         {
@@ -2982,125 +2926,123 @@ and (term_as_mlexpr' :
                                             FStar_Extraction_ML_Syntax.MLE_Const
                                             (FStar_Extraction_ML_Syntax.MLC_Unit);
                                           FStar_Extraction_ML_Syntax.mlty =
-                                            uu____10820;
+                                            uu___9;
                                           FStar_Extraction_ML_Syntax.loc =
-                                            uu____10821;_}::[])
+                                            uu___10;_}::[])
                                        ->
-                                       let uu____10824 =
+                                       let uu___11 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args in
-                                       (match uu____10824 with
-                                        | (head3, uu____10836, t2) ->
-                                            let uu____10838 =
+                                       (match uu___11 with
+                                        | (head3, uu___12, t2) ->
+                                            let uu___13 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
                                                      [FStar_Extraction_ML_Syntax.ml_unit]))
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2) in
-                                            (uu____10838, t2))
-                                   | uu____10841 ->
+                                            (uu___13, t2))
+                                   | uu___9 ->
                                        failwith
                                          "Impossible: Unexpected head term" in
-                                 (match uu____10780 with
+                                 (match uu___8 with
                                   | (head2, t2) -> (head2, t2, rest)) in
-                           (match uu____10525 with
+                           (match uu___6 with
                             | (head_ml1, head_t, args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____10907 =
+                                     let uu___7 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1 in
-                                     (uu____10907,
+                                     (uu___7,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____10908 ->
+                                 | uu___7 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | FStar_Syntax_Syntax.Tm_fvar uu____10917 ->
-                      let uu____10918 =
-                        let uu____10933 =
+                  | FStar_Syntax_Syntax.Tm_fvar uu___4 ->
+                      let uu___5 =
+                        let uu___6 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1 in
-                        match uu____10933 with
+                        match uu___6 with
                         | (FStar_Util.Inr exp_b, q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____10965 ->
-                                  let uu____10966 =
+                               (fun uu___8 ->
+                                  let uu___9 =
                                     FStar_Syntax_Print.term_to_string head1 in
-                                  let uu____10967 =
-                                    let uu____10968 =
+                                  let uu___10 =
+                                    let uu___11 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____10968
+                                      uu___11
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr in
-                                  let uu____10969 =
-                                    let uu____10970 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____10970
+                                      uu___12
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme) in
                                   FStar_Util.print3
-                                    "@@@looked up %s: got %s at %s\n"
-                                    uu____10966 uu____10967 uu____10969);
+                                    "@@@looked up %s: got %s at %s\n" uu___9
+                                    uu___10 uu___11);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____10985 -> failwith "FIXME Ty" in
-                      (match uu____10918 with
+                        | uu___7 -> failwith "FIXME Ty" in
+                      (match uu___5 with
                        | ((head_ml, (vars, t1)), qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a, uu____11034)::uu____11035 -> is_type g a
-                             | uu____11062 -> false in
-                           let uu____11073 =
+                             | (a, uu___6)::uu___7 -> is_type g a
+                             | uu___6 -> false in
+                           let uu___6 =
                              let n = FStar_List.length vars in
-                             let uu____11089 =
+                             let uu___7 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____11126 =
+                                 let uu___8 =
                                    FStar_List.map
-                                     (fun uu____11138 ->
-                                        match uu____11138 with
-                                        | (x, uu____11146) ->
-                                            term_as_mlty g x) args in
-                                 (uu____11126, [])
+                                     (fun uu___9 ->
+                                        match uu___9 with
+                                        | (x, uu___10) -> term_as_mlty g x)
+                                     args in
+                                 (uu___8, [])
                                else
-                                 (let uu____11168 = FStar_Util.first_N n args in
-                                  match uu____11168 with
+                                 (let uu___9 = FStar_Util.first_N n args in
+                                  match uu___9 with
                                   | (prefix, rest) ->
-                                      let uu____11257 =
+                                      let uu___10 =
                                         FStar_List.map
-                                          (fun uu____11269 ->
-                                             match uu____11269 with
-                                             | (x, uu____11277) ->
+                                          (fun uu___11 ->
+                                             match uu___11 with
+                                             | (x, uu___12) ->
                                                  term_as_mlty g x) prefix in
-                                      (uu____11257, rest)) in
-                             match uu____11089 with
+                                      (uu___10, rest)) in
+                             match uu___7 with
                              | (provided_type_args, rest) ->
-                                 let uu____11328 =
+                                 let uu___8 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____11337 ->
-                                       let uu____11338 =
+                                       uu___9 ->
+                                       let uu___10 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args in
-                                       (match uu____11338 with
-                                        | (head2, uu____11350, t2) ->
-                                            (head2, t2))
+                                       (match uu___10 with
+                                        | (head2, uu___11, t2) -> (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____11352 ->
-                                       let uu____11353 =
+                                       uu___9 ->
+                                       let uu___10 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args in
-                                       (match uu____11353 with
-                                        | (head2, uu____11365, t2) ->
-                                            (head2, t2))
+                                       (match uu___10 with
+                                        | (head2, uu___11, t2) -> (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,
                                         {
@@ -3108,120 +3050,119 @@ and (term_as_mlexpr' :
                                             FStar_Extraction_ML_Syntax.MLE_Const
                                             (FStar_Extraction_ML_Syntax.MLC_Unit);
                                           FStar_Extraction_ML_Syntax.mlty =
-                                            uu____11368;
+                                            uu___9;
                                           FStar_Extraction_ML_Syntax.loc =
-                                            uu____11369;_}::[])
+                                            uu___10;_}::[])
                                        ->
-                                       let uu____11372 =
+                                       let uu___11 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args in
-                                       (match uu____11372 with
-                                        | (head3, uu____11384, t2) ->
-                                            let uu____11386 =
+                                       (match uu___11 with
+                                        | (head3, uu___12, t2) ->
+                                            let uu___13 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
                                                      [FStar_Extraction_ML_Syntax.ml_unit]))
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2) in
-                                            (uu____11386, t2))
-                                   | uu____11389 ->
+                                            (uu___13, t2))
+                                   | uu___9 ->
                                        failwith
                                          "Impossible: Unexpected head term" in
-                                 (match uu____11328 with
+                                 (match uu___8 with
                                   | (head2, t2) -> (head2, t2, rest)) in
-                           (match uu____11073 with
+                           (match uu___6 with
                             | (head_ml1, head_t, args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11455 =
+                                     let uu___7 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1 in
-                                     (uu____11455,
+                                     (uu___7,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11456 ->
+                                 | uu___7 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | uu____11465 ->
-                      let uu____11466 = term_as_mlexpr g head1 in
-                      (match uu____11466 with
+                  | uu___4 ->
+                      let uu___5 = term_as_mlexpr g head1 in
+                      (match uu___5 with
                        | (head2, f, t1) ->
                            extract_app_maybe_projector
                              FStar_Pervasives_Native.None head2 (f, t1) args) in
-                let uu____11482 = is_type g t in
-                if uu____11482
+                let uu___3 = is_type g t in
+                if uu___3
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let uu____11490 =
-                     let uu____11491 = FStar_Syntax_Util.un_uinst head in
-                     uu____11491.FStar_Syntax_Syntax.n in
-                   match uu____11490 with
+                  (let uu___5 =
+                     let uu___6 = FStar_Syntax_Util.un_uinst head in
+                     uu___6.FStar_Syntax_Syntax.n in
+                   match uu___5 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                       let uu____11501 =
+                       let uu___6 =
                          FStar_Extraction_ML_UEnv.try_lookup_fv g fv in
-                       (match uu____11501 with
+                       (match uu___6 with
                         | FStar_Pervasives_Native.None ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
                               FStar_Extraction_ML_Syntax.E_PURE,
                               FStar_Extraction_ML_Syntax.MLTY_Erased)
-                        | uu____11510 -> extract_app_with_instantiations ())
-                   | uu____11513 -> extract_app_with_instantiations ()))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0, (tc, uu____11516), f) ->
+                        | uu___7 -> extract_app_with_instantiations ())
+                   | uu___6 -> extract_app_with_instantiations ()))
+       | FStar_Syntax_Syntax.Tm_ascribed (e0, (tc, uu___1), f) ->
            let t1 =
              match tc with
-             | FStar_Util.Inl t1 -> term_as_mlty g t1
+             | FStar_Util.Inl t2 -> term_as_mlty g t2
              | FStar_Util.Inr c ->
-                 let uu____11581 =
-                   let uu____11582 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                   maybe_reify_comp g uu____11582 c in
-                 term_as_mlty g uu____11581 in
+                 let uu___2 =
+                   let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                   maybe_reify_comp g uu___3 c in
+                 term_as_mlty g uu___2 in
            let f1 =
              match f with
              | FStar_Pervasives_Native.None ->
                  failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l in
-           let uu____11585 = check_term_as_mlexpr g e0 f1 t1 in
-           (match uu____11585 with | (e, t2) -> (e, f1, t2))
+           let uu___2 = check_term_as_mlexpr g e0 f1 t1 in
+           (match uu___2 with | (e, t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), e') when
-           (let uu____11614 = FStar_Syntax_Syntax.is_top_level [lb] in
-            Prims.op_Negation uu____11614) &&
-             (let uu____11616 =
+           (let uu___1 = FStar_Syntax_Syntax.is_top_level [lb] in
+            Prims.op_Negation uu___1) &&
+             (let uu___1 =
                 FStar_Syntax_Util.get_attribute
                   FStar_Parser_Const.rename_let_attr
                   lb.FStar_Syntax_Syntax.lbattrs in
-              FStar_Util.is_some uu____11616)
+              FStar_Util.is_some uu___1)
            ->
            let b =
-             let uu____11626 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-             (uu____11626, FStar_Pervasives_Native.None) in
-           let uu____11629 = FStar_Syntax_Subst.open_term_1 b e' in
-           (match uu____11629 with
-            | ((x, uu____11641), body) ->
+             let uu___1 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+             (uu___1, FStar_Pervasives_Native.None) in
+           let uu___1 = FStar_Syntax_Subst.open_term_1 b e' in
+           (match uu___1 with
+            | ((x, uu___2), body) ->
                 let suggested_name =
                   let attr =
                     FStar_Syntax_Util.get_attribute
                       FStar_Parser_Const.rename_let_attr
                       lb.FStar_Syntax_Syntax.lbattrs in
                   match attr with
-                  | FStar_Pervasives_Native.Some ((str, uu____11656)::[]) ->
-                      let uu____11681 =
-                        let uu____11682 = FStar_Syntax_Subst.compress str in
-                        uu____11682.FStar_Syntax_Syntax.n in
-                      (match uu____11681 with
+                  | FStar_Pervasives_Native.Some ((str, uu___3)::[]) ->
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Subst.compress str in
+                        uu___5.FStar_Syntax_Syntax.n in
+                      (match uu___4 with
                        | FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_string (s, uu____11688)) ->
+                           (FStar_Const.Const_string (s, uu___5)) ->
                            let id =
-                             let uu____11690 =
-                               let uu____11695 =
-                                 FStar_Syntax_Syntax.range_of_bv x in
-                               (s, uu____11695) in
-                             FStar_Ident.mk_ident uu____11690 in
+                             let uu___6 =
+                               let uu___7 = FStar_Syntax_Syntax.range_of_bv x in
+                               (s, uu___7) in
+                             FStar_Ident.mk_ident uu___6 in
                            let bv =
                              {
                                FStar_Syntax_Syntax.ppname = id;
@@ -3231,8 +3172,8 @@ and (term_as_mlexpr' :
                              } in
                            let bv1 = FStar_Syntax_Syntax.freshen_bv bv in
                            FStar_Pervasives_Native.Some bv1
-                       | uu____11698 -> FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____11699 ->
+                       | uu___5 -> FStar_Pervasives_Native.None)
+                  | FStar_Pervasives_Native.Some uu___3 ->
                       (FStar_Errors.log_issue top1.FStar_Syntax_Syntax.pos
                          (FStar_Errors.Warning_UnrecognizedAttribute,
                            "Ill-formed application of `rename_let`");
@@ -3240,16 +3181,15 @@ and (term_as_mlexpr' :
                   | FStar_Pervasives_Native.None ->
                       FStar_Pervasives_Native.None in
                 let remove_attr attrs =
-                  let uu____11717 =
+                  let uu___3 =
                     FStar_List.partition
                       (fun attr ->
-                         let uu____11729 =
+                         let uu___4 =
                            FStar_Syntax_Util.get_attribute
                              FStar_Parser_Const.rename_let_attr [attr] in
-                         FStar_Util.is_some uu____11729)
+                         FStar_Util.is_some uu___4)
                       lb.FStar_Syntax_Syntax.lbattrs in
-                  match uu____11717 with
-                  | (uu____11734, other_attrs) -> other_attrs in
+                  match uu___3 with | (uu___4, other_attrs) -> other_attrs in
                 let maybe_rewritten_let =
                   match suggested_name with
                   | FStar_Pervasives_Native.None ->
@@ -3257,149 +3197,142 @@ and (term_as_mlexpr' :
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs in
                       FStar_Syntax_Syntax.Tm_let
                         ((false,
-                           [(let uu___1774_11759 = lb in
+                           [(let uu___3 = lb in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbname);
+                                 (uu___3.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___3.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___3.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbeff);
+                                 (uu___3.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbdef);
+                                 (uu___3.FStar_Syntax_Syntax.lbdef);
                                FStar_Syntax_Syntax.lbattrs = other_attrs;
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1774_11759.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3.FStar_Syntax_Syntax.lbpos)
                              })]), e')
                   | FStar_Pervasives_Native.Some y ->
                       let other_attrs =
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs in
                       let rename =
-                        let uu____11767 =
-                          let uu____11768 =
-                            let uu____11775 =
-                              FStar_Syntax_Syntax.bv_to_name y in
-                            (x, uu____11775) in
-                          FStar_Syntax_Syntax.NT uu____11768 in
-                        [uu____11767] in
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 = FStar_Syntax_Syntax.bv_to_name y in
+                            (x, uu___5) in
+                          FStar_Syntax_Syntax.NT uu___4 in
+                        [uu___3] in
                       let body1 =
-                        let uu____11781 =
-                          FStar_Syntax_Subst.subst rename body in
+                        let uu___3 = FStar_Syntax_Subst.subst rename body in
                         FStar_Syntax_Subst.close
-                          [(y, FStar_Pervasives_Native.None)] uu____11781 in
+                          [(y, FStar_Pervasives_Native.None)] uu___3 in
                       let lb1 =
-                        let uu___1781_11797 = lb in
+                        let uu___3 = lb in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl y);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1781_11797.FStar_Syntax_Syntax.lbunivs);
+                            (uu___3.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp =
-                            (uu___1781_11797.FStar_Syntax_Syntax.lbtyp);
+                            (uu___3.FStar_Syntax_Syntax.lbtyp);
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1781_11797.FStar_Syntax_Syntax.lbeff);
+                            (uu___3.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef =
-                            (uu___1781_11797.FStar_Syntax_Syntax.lbdef);
+                            (uu___3.FStar_Syntax_Syntax.lbdef);
                           FStar_Syntax_Syntax.lbattrs = other_attrs;
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1781_11797.FStar_Syntax_Syntax.lbpos)
+                            (uu___3.FStar_Syntax_Syntax.lbpos)
                         } in
                       FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1) in
                 let top2 =
-                  let uu___1785_11811 = top1 in
+                  let uu___3 = top1 in
                   {
                     FStar_Syntax_Syntax.n = maybe_rewritten_let;
                     FStar_Syntax_Syntax.pos =
-                      (uu___1785_11811.FStar_Syntax_Syntax.pos);
+                      (uu___3.FStar_Syntax_Syntax.pos);
                     FStar_Syntax_Syntax.vars =
-                      (uu___1785_11811.FStar_Syntax_Syntax.vars)
+                      (uu___3.FStar_Syntax_Syntax.vars)
                   } in
                 term_as_mlexpr' g top2)
        | FStar_Syntax_Syntax.Tm_let ((is_rec, lbs), e') ->
            let top_level = FStar_Syntax_Syntax.is_top_level lbs in
-           let uu____11830 =
+           let uu___1 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____11844 = FStar_Syntax_Syntax.is_top_level lbs in
-                if uu____11844
+               (let uu___3 = FStar_Syntax_Syntax.is_top_level lbs in
+                if uu___3
                 then (lbs, e')
                 else
                   (let lb = FStar_List.hd lbs in
                    let x =
-                     let uu____11856 =
+                     let uu___5 =
                        FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                     FStar_Syntax_Syntax.freshen_bv uu____11856 in
+                     FStar_Syntax_Syntax.freshen_bv uu___5 in
                    let lb1 =
-                     let uu___1799_11858 = lb in
+                     let uu___5 = lb in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbunivs);
+                         (uu___5.FStar_Syntax_Syntax.lbunivs);
                        FStar_Syntax_Syntax.lbtyp =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbtyp);
+                         (uu___5.FStar_Syntax_Syntax.lbtyp);
                        FStar_Syntax_Syntax.lbeff =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbeff);
+                         (uu___5.FStar_Syntax_Syntax.lbeff);
                        FStar_Syntax_Syntax.lbdef =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbdef);
+                         (uu___5.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbattrs);
+                         (uu___5.FStar_Syntax_Syntax.lbattrs);
                        FStar_Syntax_Syntax.lbpos =
-                         (uu___1799_11858.FStar_Syntax_Syntax.lbpos)
+                         (uu___5.FStar_Syntax_Syntax.lbpos)
                      } in
                    let e'1 =
                      FStar_Syntax_Subst.subst
                        [FStar_Syntax_Syntax.DB (Prims.int_zero, x)] e' in
                    ([lb1], e'1))) in
-           (match uu____11830 with
+           (match uu___1 with
             | (lbs1, e'1) ->
                 let lbs2 =
                   if top_level
                   then
                     let tcenv =
-                      let uu____11880 =
-                        FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                      let uu____11881 =
-                        let uu____11882 =
-                          let uu____11883 =
-                            let uu____11886 =
+                      let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g in
-                            FStar_Pervasives_Native.fst uu____11886 in
-                          let uu____11895 =
-                            let uu____11898 =
-                              let uu____11899 =
+                            FStar_Pervasives_Native.fst uu___6 in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g in
-                              FStar_Pervasives_Native.snd uu____11899 in
-                            [uu____11898] in
-                          FStar_List.append uu____11883 uu____11895 in
-                        FStar_Ident.lid_of_path uu____11882
-                          FStar_Range.dummyRange in
-                      FStar_TypeChecker_Env.set_current_module uu____11880
-                        uu____11881 in
+                              FStar_Pervasives_Native.snd uu___8 in
+                            [uu___7] in
+                          FStar_List.append uu___5 uu___6 in
+                        FStar_Ident.lid_of_path uu___4 FStar_Range.dummyRange in
+                      FStar_TypeChecker_Env.set_current_module uu___2 uu___3 in
                     FStar_All.pipe_right lbs1
                       (FStar_List.map
                          (fun lb ->
                             let lbdef =
-                              let uu____11919 = FStar_Options.ml_ish () in
-                              if uu____11919
+                              let uu___2 = FStar_Options.ml_ish () in
+                              if uu___2
                               then lb.FStar_Syntax_Syntax.lbdef
                               else
-                                (let norm_call uu____11928 =
-                                   let uu____11929 =
-                                     let uu____11930 =
-                                       let uu____11933 =
-                                         extraction_norm_steps () in
-                                       FStar_TypeChecker_Env.Reify ::
-                                         uu____11933 in
+                                (let norm_call uu___4 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 = extraction_norm_steps () in
+                                       FStar_TypeChecker_Env.Reify :: uu___7 in
                                      FStar_TypeChecker_Env.PureSubtermsWithinComputations
-                                       :: uu____11930 in
+                                       :: uu___6 in
                                    FStar_TypeChecker_Normalize.normalize
-                                     uu____11929 tcenv
+                                     uu___5 tcenv
                                      lb.FStar_Syntax_Syntax.lbdef in
-                                 let uu____11936 =
+                                 let uu___4 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug tcenv)
                                       (FStar_Options.Other "Extraction"))
@@ -3407,67 +3340,65 @@ and (term_as_mlexpr' :
                                      (FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug tcenv)
                                         (FStar_Options.Other "ExtractNorm")) in
-                                 if uu____11936
+                                 if uu___4
                                  then
-                                   ((let uu____11940 =
+                                   ((let uu___6 =
                                        FStar_Syntax_Print.lbname_to_string
                                          lb.FStar_Syntax_Syntax.lbname in
                                      FStar_Util.print1
                                        "Starting to normalize top-level let %s\n"
-                                       uu____11940);
+                                       uu___6);
                                     (let a =
-                                       let uu____11944 =
-                                         let uu____11945 =
+                                       let uu___6 =
+                                         let uu___7 =
                                            FStar_Syntax_Print.lbname_to_string
                                              lb.FStar_Syntax_Syntax.lbname in
                                          FStar_Util.format1
                                            "###(Time to normalize top-level let %s)"
-                                           uu____11945 in
+                                           uu___7 in
                                        FStar_Util.measure_execution_time
-                                         uu____11944 norm_call in
-                                     (let uu____11949 =
+                                         uu___6 norm_call in
+                                     (let uu___7 =
                                         FStar_Syntax_Print.term_to_string a in
                                       FStar_Util.print1 "Normalized to %s\n"
-                                        uu____11949);
+                                        uu___7);
                                      a))
                                  else norm_call ()) in
-                            let uu___1817_11951 = lb in
+                            let uu___2 = lb in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbname);
+                                (uu___2.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbunivs);
+                                (uu___2.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbtyp);
+                                (uu___2.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbeff);
+                                (uu___2.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbattrs);
+                                (uu___2.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1817_11951.FStar_Syntax_Syntax.lbpos)
+                                (uu___2.FStar_Syntax_Syntax.lbpos)
                             }))
                   else lbs1 in
-                let check_lb env uu____12001 =
-                  match uu____12001 with
+                let check_lb env uu___2 =
+                  match uu___2 with
                   | (nm, (_lbname, f, (_t, (targs, polytype)), add_unit, e))
                       ->
                       let env1 =
                         FStar_List.fold_left
-                          (fun env1 ->
-                             fun uu____12150 ->
-                               match uu____12150 with
-                               | (a, uu____12158) ->
-                                   FStar_Extraction_ML_UEnv.extend_ty env1 a
+                          (fun env2 ->
+                             fun uu___3 ->
+                               match uu___3 with
+                               | (a, uu___4) ->
+                                   FStar_Extraction_ML_UEnv.extend_ty env2 a
                                      false) env targs in
                       let expected_t = FStar_Pervasives_Native.snd polytype in
-                      let uu____12164 =
-                        check_term_as_mlexpr env1 e f expected_t in
-                      (match uu____12164 with
+                      let uu___3 = check_term_as_mlexpr env1 e f expected_t in
+                      (match uu___3 with
                        | (e1, ty) ->
-                           let uu____12175 =
-                             maybe_promote_effect e1 f expected_t in
-                           (match uu____12175 with
+                           let uu___4 = maybe_promote_effect e1 f expected_t in
+                           (match uu___4 with
                             | (e2, f1) ->
                                 let meta =
                                   match (f1, ty) with
@@ -3477,7 +3408,7 @@ and (term_as_mlexpr' :
                                   | (FStar_Extraction_ML_Syntax.E_GHOST,
                                      FStar_Extraction_ML_Syntax.MLTY_Erased)
                                       -> [FStar_Extraction_ML_Syntax.Erased]
-                                  | uu____12187 -> [] in
+                                  | uu___5 -> [] in
                                 (f1,
                                   {
                                     FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3492,66 +3423,67 @@ and (term_as_mlexpr' :
                                       true
                                   }))) in
                 let lbs3 = extract_lb_sig g (is_rec, lbs2) in
-                let uu____12215 =
+                let uu___2 =
                   FStar_List.fold_right
                     (fun lb ->
-                       fun uu____12307 ->
-                         match uu____12307 with
-                         | (env, lbs4) ->
-                             let uu____12432 = lb in
-                             (match uu____12432 with
-                              | (lbname, uu____12480,
-                                 (t1, (uu____12482, polytype)), add_unit,
-                                 uu____12485) ->
-                                  let uu____12498 =
+                       fun uu___3 ->
+                         match uu___3 with
+                         | (env, lbs4, env_burn) ->
+                             let uu___4 = lb in
+                             (match uu___4 with
+                              | (lbname, uu___5, (t1, (uu___6, polytype)),
+                                 add_unit, uu___7) ->
+                                  let uu___8 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
                                       lbname t1 polytype add_unit in
-                                  (match uu____12498 with
-                                   | (env1, nm, uu____12535) ->
-                                       (env1, ((nm, lb) :: lbs4))))) lbs3
-                    (g, []) in
-                (match uu____12215 with
-                 | (env_body, lbs4) ->
-                     let env_def = if is_rec then env_body else g in
+                                  (match uu___8 with
+                                   | (env1, nm, uu___9) ->
+                                       let env_burn1 =
+                                         FStar_Extraction_ML_UEnv.burn_name
+                                           env_burn nm in
+                                       (env1, ((nm, lb) :: lbs4), env_burn1))))
+                    lbs3 (g, [], g) in
+                (match uu___2 with
+                 | (env_body, lbs4, env_burn) ->
+                     let env_def = if is_rec then env_body else env_burn in
                      let lbs5 =
                        FStar_All.pipe_right lbs4
                          (FStar_List.map (check_lb env_def)) in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos in
-                     let uu____12792 = term_as_mlexpr env_body e'1 in
-                     (match uu____12792 with
+                     let uu___3 = term_as_mlexpr env_body e'1 in
+                     (match uu___3 with
                       | (e'2, f', t') ->
                           let f =
-                            let uu____12809 =
-                              let uu____12812 =
+                            let uu___4 =
+                              let uu___5 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   lbs5 in
-                              f' :: uu____12812 in
-                            FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____12809 in
+                              f' :: uu___5 in
+                            FStar_Extraction_ML_Util.join_l e'_rng uu___4 in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
                             else FStar_Extraction_ML_Syntax.NonRec in
-                          let uu____12821 =
-                            let uu____12822 =
-                              let uu____12823 =
-                                let uu____12824 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     lbs5 in
-                                (is_rec1, uu____12824) in
-                              mk_MLE_Let top_level uu____12823 e'2 in
-                            let uu____12833 =
+                                (is_rec1, uu___7) in
+                              mk_MLE_Let top_level uu___6 e'2 in
+                            let uu___6 =
                               FStar_Extraction_ML_Util.mlloc_of_range
                                 t.FStar_Syntax_Syntax.pos in
-                            FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____12822 uu____12833 in
-                          (uu____12821, f, t'))))
+                            FStar_Extraction_ML_Syntax.with_ty_loc t' uu___5
+                              uu___6 in
+                          (uu___4, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee, pats) ->
-           let uu____12872 = term_as_mlexpr g scrutinee in
-           (match uu____12872 with
+           let uu___1 = term_as_mlexpr g scrutinee in
+           (match uu___1 with
             | (e, f_e, t_e) ->
-                let uu____12888 = check_pats_for_ite pats in
-                (match uu____12888 with
+                let uu___2 = check_pats_for_ite pats in
+                (match uu___2 with
                  | (b, then_e, else_e) ->
                      let no_lift x t1 = x in
                      if b
@@ -3559,70 +3491,67 @@ and (term_as_mlexpr' :
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some then_e1,
                            FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____12949 = term_as_mlexpr g then_e1 in
-                            (match uu____12949 with
+                            let uu___3 = term_as_mlexpr g then_e1 in
+                            (match uu___3 with
                              | (then_mle, f_then, t_then) ->
-                                 let uu____12965 = term_as_mlexpr g else_e1 in
-                                 (match uu____12965 with
+                                 let uu___4 = term_as_mlexpr g else_e1 in
+                                 (match uu___4 with
                                   | (else_mle, f_else, t_else) ->
-                                      let uu____12981 =
-                                        let uu____12992 =
-                                          type_leq g t_then t_else in
-                                        if uu____12992
+                                      let uu___5 =
+                                        let uu___6 = type_leq g t_then t_else in
+                                        if uu___6
                                         then (t_else, no_lift)
                                         else
-                                          (let uu____13010 =
+                                          (let uu___8 =
                                              type_leq g t_else t_then in
-                                           if uu____13010
+                                           if uu___8
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
                                                FStar_Extraction_ML_Syntax.apply_obj_repr)) in
-                                      (match uu____12981 with
+                                      (match uu___5 with
                                        | (t_branch, maybe_lift) ->
-                                           let uu____13054 =
-                                             let uu____13055 =
-                                               let uu____13056 =
-                                                 let uu____13065 =
+                                           let uu___6 =
+                                             let uu___7 =
+                                               let uu___8 =
+                                                 let uu___9 =
                                                    maybe_lift then_mle t_then in
-                                                 let uu____13066 =
-                                                   let uu____13069 =
+                                                 let uu___10 =
+                                                   let uu___11 =
                                                      maybe_lift else_mle
                                                        t_else in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____13069 in
-                                                 (e, uu____13065,
-                                                   uu____13066) in
+                                                     uu___11 in
+                                                 (e, uu___9, uu___10) in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____13056 in
+                                                 uu___8 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____13055 in
-                                           let uu____13072 =
+                                                  t_branch) uu___7 in
+                                           let uu___7 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
                                                f_then f_else in
-                                           (uu____13054, uu____13072,
-                                             t_branch))))
-                        | uu____13073 ->
+                                           (uu___6, uu___7, t_branch))))
+                        | uu___3 ->
                             failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
-                       (let uu____13089 =
+                       (let uu___4 =
                           FStar_All.pipe_right pats
                             (FStar_Util.fold_map
                                (fun compat ->
                                   fun br ->
-                                    let uu____13184 =
+                                    let uu___5 =
                                       FStar_Syntax_Subst.open_branch br in
-                                    match uu____13184 with
+                                    match uu___5 with
                                     | (pat, when_opt, branch) ->
-                                        let uu____13228 =
+                                        let uu___6 =
                                           extract_pat g pat t_e
                                             term_as_mlexpr in
-                                        (match uu____13228 with
+                                        (match uu___6 with
                                          | (env, p, pat_t_compat) ->
-                                             let uu____13286 =
+                                             let uu___7 =
                                                match when_opt with
                                                | FStar_Pervasives_Native.None
                                                    ->
@@ -3632,9 +3561,9 @@ and (term_as_mlexpr' :
                                                    w ->
                                                    let w_pos =
                                                      w.FStar_Syntax_Syntax.pos in
-                                                   let uu____13309 =
+                                                   let uu___8 =
                                                      term_as_mlexpr env w in
-                                                   (match uu____13309 with
+                                                   (match uu___8 with
                                                     | (w1, f_w, t_w) ->
                                                         let w2 =
                                                           maybe_coerce w_pos
@@ -3642,21 +3571,19 @@ and (term_as_mlexpr' :
                                                             FStar_Extraction_ML_Syntax.ml_bool_ty in
                                                         ((FStar_Pervasives_Native.Some
                                                             w2), f_w)) in
-                                             (match uu____13286 with
+                                             (match uu___7 with
                                               | (when_opt1, f_when) ->
-                                                  let uu____13358 =
+                                                  let uu___8 =
                                                     term_as_mlexpr env branch in
-                                                  (match uu____13358 with
+                                                  (match uu___8 with
                                                    | (mlbranch, f_branch,
                                                       t_branch) ->
-                                                       let uu____13392 =
+                                                       let uu___9 =
                                                          FStar_All.pipe_right
                                                            p
                                                            (FStar_List.map
-                                                              (fun
-                                                                 uu____13469
-                                                                 ->
-                                                                 match uu____13469
+                                                              (fun uu___10 ->
+                                                                 match uu___10
                                                                  with
                                                                  | (p1, wopt)
                                                                     ->
@@ -3673,9 +3600,8 @@ and (term_as_mlexpr' :
                                                                     t_branch)))) in
                                                        ((compat &&
                                                            pat_t_compat),
-                                                         uu____13392)))))
-                               true) in
-                        match uu____13089 with
+                                                         uu___9))))) true) in
+                        match uu___4 with
                         | (pat_t_compat, mlbranches) ->
                             let mlbranches1 = FStar_List.flatten mlbranches in
                             let e1 =
@@ -3683,22 +3609,22 @@ and (term_as_mlexpr' :
                               then e
                               else
                                 (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____13634 ->
-                                      let uu____13635 =
-                                        let uu____13636 =
+                                   (fun uu___7 ->
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g in
                                         FStar_Extraction_ML_Code.string_of_mlexpr
-                                          uu____13636 e in
-                                      let uu____13637 =
-                                        let uu____13638 =
+                                          uu___9 e in
+                                      let uu___9 =
+                                        let uu___10 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g in
                                         FStar_Extraction_ML_Code.string_of_mlty
-                                          uu____13638 t_e in
+                                          uu___10 t_e in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____13635 uu____13637);
+                                        uu___8 uu___9);
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -3706,57 +3632,55 @@ and (term_as_mlexpr' :
                                         FStar_Extraction_ML_Syntax.MLTY_Top))) in
                             (match mlbranches1 with
                              | [] ->
-                                 let uu____13663 =
-                                   let uu____13664 =
+                                 let uu___5 =
+                                   let uu___6 =
                                      FStar_Syntax_Syntax.lid_as_fv
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None in
                                    FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu____13664 in
-                                 (match uu____13663 with
+                                     uu___6 in
+                                 (match uu___5 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =
-                                        uu____13671;
+                                        uu___6;
                                       FStar_Extraction_ML_UEnv.exp_b_expr =
                                         fw;
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
-                                        = uu____13673;_}
+                                        = uu___7;_}
                                       ->
-                                      let uu____13674 =
-                                        let uu____13675 =
-                                          let uu____13676 =
-                                            let uu____13683 =
-                                              let uu____13686 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
+                                              let uu___12 =
                                                 FStar_All.pipe_left
                                                   (FStar_Extraction_ML_Syntax.with_ty
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
                                                   (FStar_Extraction_ML_Syntax.MLE_Const
                                                      (FStar_Extraction_ML_Syntax.MLC_String
                                                         "unreachable")) in
-                                              [uu____13686] in
-                                            (fw, uu____13683) in
+                                              [uu___12] in
+                                            (fw, uu___11) in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____13676 in
+                                            uu___10 in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu____13675 in
-                                      (uu____13674,
+                                          uu___9 in
+                                      (uu___8,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
-                             | (uu____13689, uu____13690,
-                                (uu____13691, f_first, t_first))::rest ->
-                                 let uu____13751 =
+                             | (uu___5, uu___6, (uu___7, f_first, t_first))::rest
+                                 ->
+                                 let uu___8 =
                                    FStar_List.fold_left
-                                     (fun uu____13793 ->
-                                        fun uu____13794 ->
-                                          match (uu____13793, uu____13794)
-                                          with
+                                     (fun uu___9 ->
+                                        fun uu___10 ->
+                                          match (uu___9, uu___10) with
                                           | ((topt, f),
-                                             (uu____13851, uu____13852,
-                                              (uu____13853, f_branch,
-                                               t_branch)))
+                                             (uu___11, uu___12,
+                                              (uu___13, f_branch, t_branch)))
                                               ->
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
@@ -3769,17 +3693,17 @@ and (term_as_mlexpr' :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
-                                                    let uu____13909 =
+                                                    let uu___14 =
                                                       type_leq g t1 t_branch in
-                                                    if uu____13909
+                                                    if uu___14
                                                     then
                                                       FStar_Pervasives_Native.Some
                                                         t_branch
                                                     else
-                                                      (let uu____13913 =
+                                                      (let uu___16 =
                                                          type_leq g t_branch
                                                            t1 in
-                                                       if uu____13913
+                                                       if uu___16
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
@@ -3788,15 +3712,15 @@ and (term_as_mlexpr' :
                                               (topt1, f1))
                                      ((FStar_Pervasives_Native.Some t_first),
                                        f_first) rest in
-                                 (match uu____13751 with
+                                 (match uu___8 with
                                   | (topt, f_match) ->
                                       let mlbranches2 =
                                         FStar_All.pipe_right mlbranches1
                                           (FStar_List.map
-                                             (fun uu____14008 ->
-                                                match uu____14008 with
-                                                | (p, (wopt, uu____14037),
-                                                   (b1, uu____14039, t1)) ->
+                                             (fun uu___9 ->
+                                                match uu___9 with
+                                                | (p, (wopt, uu___10),
+                                                   (b1, uu___11, t1)) ->
                                                     let b2 =
                                                       match topt with
                                                       | FStar_Pervasives_Native.None
@@ -3804,7 +3728,7 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____14058 -> b1 in
+                                                          uu___12 -> b1 in
                                                     (p, wopt, b2))) in
                                       let t_match =
                                         match topt with
@@ -3812,13 +3736,13 @@ and (term_as_mlexpr' :
                                             FStar_Extraction_ML_Syntax.MLTY_Top
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1 in
-                                      let uu____14063 =
+                                      let uu___9 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
                                              (e1, mlbranches2)) in
-                                      (uu____14063, f_match, t_match)))))))
+                                      (uu___9, f_match, t_match)))))))
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Ident.lident ->
@@ -3827,84 +3751,82 @@ let (ind_discriminator_body :
   fun env ->
     fun discName ->
       fun constrName ->
-        let uu____14089 =
-          let uu____14094 =
-            let uu____14103 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-            FStar_TypeChecker_Env.lookup_lid uu____14103 discName in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____14094 in
-        match uu____14089 with
-        | (uu____14120, fstar_disc_type) ->
-            let uu____14122 =
-              let uu____14133 =
-                let uu____14134 = FStar_Syntax_Subst.compress fstar_disc_type in
-                uu____14134.FStar_Syntax_Syntax.n in
-              match uu____14133 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders, uu____14148) ->
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+            FStar_TypeChecker_Env.lookup_lid uu___2 discName in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu___1 in
+        match uu___ with
+        | (uu___1, fstar_disc_type) ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Subst.compress fstar_disc_type in
+                uu___4.FStar_Syntax_Syntax.n in
+              match uu___3 with
+              | FStar_Syntax_Syntax.Tm_arrow (binders, uu___4) ->
                   let binders1 =
                     FStar_All.pipe_right binders
                       (FStar_List.filter
-                         (fun uu___2_14203 ->
-                            match uu___2_14203 with
-                            | (uu____14210, FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____14211)) ->
-                                true
-                            | uu____14214 -> false)) in
+                         (fun uu___5 ->
+                            match uu___5 with
+                            | (uu___6, FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu___7)) -> true
+                            | uu___6 -> false)) in
                   FStar_List.fold_right
-                    (fun uu____14244 ->
-                       fun uu____14245 ->
-                         match uu____14245 with
+                    (fun uu___5 ->
+                       fun uu___6 ->
+                         match uu___6 with
                          | (g, vs) ->
-                             let uu____14286 =
+                             let uu___7 =
                                FStar_Extraction_ML_UEnv.new_mlident g in
-                             (match uu____14286 with
+                             (match uu___7 with
                               | (g1, v) ->
                                   (g1,
                                     ((v, FStar_Extraction_ML_Syntax.MLTY_Top)
                                     :: vs)))) binders1 (env, [])
-              | uu____14323 -> failwith "Discriminator must be a function" in
-            (match uu____14122 with
+              | uu___4 -> failwith "Discriminator must be a function" in
+            (match uu___2 with
              | (g, wildcards) ->
-                 let uu____14348 = FStar_Extraction_ML_UEnv.new_mlident g in
-                 (match uu____14348 with
+                 let uu___3 = FStar_Extraction_ML_UEnv.new_mlident g in
+                 (match uu___3 with
                   | (g1, mlid) ->
                       let targ = FStar_Extraction_ML_Syntax.MLTY_Top in
                       let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top in
                       let discrBody =
-                        let uu____14358 =
-                          let uu____14359 =
-                            let uu____14370 =
-                              let uu____14371 =
-                                let uu____14372 =
-                                  let uu____14387 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
+                                  let uu___9 =
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty
                                          targ)
                                       (FStar_Extraction_ML_Syntax.MLE_Name
                                          ([], mlid)) in
-                                  let uu____14390 =
-                                    let uu____14401 =
-                                      let uu____14410 =
-                                        let uu____14411 =
-                                          let uu____14418 =
+                                  let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
+                                        let uu___13 =
+                                          let uu___14 =
                                             FStar_Extraction_ML_UEnv.mlpath_of_lident
                                               g1 constrName in
-                                          (uu____14418,
+                                          (uu___14,
                                             [FStar_Extraction_ML_Syntax.MLP_Wild]) in
                                         FStar_Extraction_ML_Syntax.MLP_CTor
-                                          uu____14411 in
-                                      let uu____14421 =
+                                          uu___13 in
+                                      let uu___13 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_bool_ty)
                                           (FStar_Extraction_ML_Syntax.MLE_Const
                                              (FStar_Extraction_ML_Syntax.MLC_Bool
                                                 true)) in
-                                      (uu____14410,
-                                        FStar_Pervasives_Native.None,
-                                        uu____14421) in
-                                    let uu____14424 =
-                                      let uu____14435 =
-                                        let uu____14444 =
+                                      (uu___12, FStar_Pervasives_Native.None,
+                                        uu___13) in
+                                    let uu___12 =
+                                      let uu___13 =
+                                        let uu___14 =
                                           FStar_All.pipe_left
                                             (FStar_Extraction_ML_Syntax.with_ty
                                                FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -3913,27 +3835,25 @@ let (ind_discriminator_body :
                                                   false)) in
                                         (FStar_Extraction_ML_Syntax.MLP_Wild,
                                           FStar_Pervasives_Native.None,
-                                          uu____14444) in
-                                      [uu____14435] in
-                                    uu____14401 :: uu____14424 in
-                                  (uu____14387, uu____14390) in
-                                FStar_Extraction_ML_Syntax.MLE_Match
-                                  uu____14372 in
+                                          uu___14) in
+                                      [uu___13] in
+                                    uu___11 :: uu___12 in
+                                  (uu___9, uu___10) in
+                                FStar_Extraction_ML_Syntax.MLE_Match uu___8 in
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                uu____14371 in
+                                uu___7 in
                             ((FStar_List.append wildcards [(mlid, targ)]),
-                              uu____14370) in
-                          FStar_Extraction_ML_Syntax.MLE_Fun uu____14359 in
+                              uu___6) in
+                          FStar_Extraction_ML_Syntax.MLE_Fun uu___5 in
                         FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty disc_ty)
-                          uu____14358 in
-                      let uu____14499 =
+                          (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu___4 in
+                      let uu___4 =
                         FStar_Extraction_ML_UEnv.mlpath_of_lident env
                           discName in
-                      (match uu____14499 with
-                       | (uu____14500, name) ->
+                      (match uu___4 with
+                       | (uu___5, name) ->
                            FStar_Extraction_ML_Syntax.MLM_Let
                              (FStar_Extraction_ML_Syntax.NonRec,
                                [{

--- a/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
@@ -35,12 +35,12 @@ type binding =
   | Bv of (FStar_Syntax_Syntax.bv * ty_or_exp_b) 
   | Fv of (FStar_Syntax_Syntax.fv * exp_binding) 
 let (uu___is_Bv : binding -> Prims.bool) =
-  fun projectee -> match projectee with | Bv _0 -> true | uu____113 -> false
+  fun projectee -> match projectee with | Bv _0 -> true | uu___ -> false
 let (__proj__Bv__item___0 :
   binding -> (FStar_Syntax_Syntax.bv * ty_or_exp_b)) =
   fun projectee -> match projectee with | Bv _0 -> _0
 let (uu___is_Fv : binding -> Prims.bool) =
-  fun projectee -> match projectee with | Fv _0 -> true | uu____142 -> false
+  fun projectee -> match projectee with | Fv _0 -> true | uu___ -> false
 let (__proj__Fv__item___0 :
   binding -> (FStar_Syntax_Syntax.fv * exp_binding)) =
   fun projectee -> match projectee with | Fv _0 -> _0
@@ -154,17 +154,17 @@ let (tcenv_of_uenv : uenv -> FStar_TypeChecker_Env.env) =
 let (set_tcenv : uenv -> FStar_TypeChecker_Env.env -> uenv) =
   fun u ->
     fun t ->
-      let uu___67_650 = u in
+      let uu___ = u in
       {
         env_tcenv = t;
-        env_bindings = (uu___67_650.env_bindings);
-        env_mlident_map = (uu___67_650.env_mlident_map);
-        mlpath_of_lid = (uu___67_650.mlpath_of_lid);
-        env_fieldname_map = (uu___67_650.env_fieldname_map);
-        mlpath_of_fieldname = (uu___67_650.mlpath_of_fieldname);
-        tydefs = (uu___67_650.tydefs);
-        type_names = (uu___67_650.type_names);
-        currentModule = (uu___67_650.currentModule)
+        env_bindings = (uu___.env_bindings);
+        env_mlident_map = (uu___.env_mlident_map);
+        mlpath_of_lid = (uu___.mlpath_of_lid);
+        env_fieldname_map = (uu___.env_fieldname_map);
+        mlpath_of_fieldname = (uu___.mlpath_of_fieldname);
+        tydefs = (uu___.tydefs);
+        type_names = (uu___.type_names);
+        currentModule = (uu___.currentModule)
       }
 let (current_module_of_uenv : uenv -> FStar_Extraction_ML_Syntax.mlpath) =
   fun u -> u.currentModule
@@ -172,16 +172,16 @@ let (set_current_module : uenv -> FStar_Extraction_ML_Syntax.mlpath -> uenv)
   =
   fun u ->
     fun m ->
-      let uu___75_666 = u in
+      let uu___ = u in
       {
-        env_tcenv = (uu___75_666.env_tcenv);
-        env_bindings = (uu___75_666.env_bindings);
-        env_mlident_map = (uu___75_666.env_mlident_map);
-        mlpath_of_lid = (uu___75_666.mlpath_of_lid);
-        env_fieldname_map = (uu___75_666.env_fieldname_map);
-        mlpath_of_fieldname = (uu___75_666.mlpath_of_fieldname);
-        tydefs = (uu___75_666.tydefs);
-        type_names = (uu___75_666.type_names);
+        env_tcenv = (uu___.env_tcenv);
+        env_bindings = (uu___.env_bindings);
+        env_mlident_map = (uu___.env_mlident_map);
+        mlpath_of_lid = (uu___.mlpath_of_lid);
+        env_fieldname_map = (uu___.env_fieldname_map);
+        mlpath_of_fieldname = (uu___.mlpath_of_fieldname);
+        tydefs = (uu___.tydefs);
+        type_names = (uu___.type_names);
         currentModule = m
       }
 let (bindings_of_uenv : uenv -> binding Prims.list) = fun u -> u.env_bindings
@@ -189,9 +189,9 @@ let (debug : uenv -> (unit -> unit) -> unit) =
   fun g ->
     fun f ->
       let c = FStar_Extraction_ML_Syntax.string_of_mlpath g.currentModule in
-      let uu____690 =
+      let uu___ =
         FStar_Options.debug_at_level c (FStar_Options.Other "Extraction") in
-      if uu____690 then f () else ()
+      if uu___ then f () else ()
 let (print_mlpath_map : uenv -> Prims.string) =
   fun g ->
     let string_of_mlpath mlp =
@@ -202,10 +202,10 @@ let (print_mlpath_map : uenv -> Prims.string) =
       FStar_Util.psmap_fold g.mlpath_of_lid
         (fun key ->
            fun value ->
-             fun entries ->
-               let uu____733 =
+             fun entries1 ->
+               let uu___ =
                  FStar_Util.format2 "%s -> %s" key (string_of_mlpath value) in
-               uu____733 :: entries) [] in
+               uu___ :: entries1) [] in
     FStar_String.concat "\n" entries
 let (try_lookup_fv :
   uenv ->
@@ -214,49 +214,49 @@ let (try_lookup_fv :
   fun g ->
     fun fv ->
       FStar_Util.find_map g.env_bindings
-        (fun uu___0_751 ->
-           match uu___0_751 with
+        (fun uu___ ->
+           match uu___ with
            | Fv (fv', t) when FStar_Syntax_Syntax.fv_eq fv fv' ->
                FStar_Pervasives_Native.Some t
-           | uu____756 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (lookup_fv : uenv -> FStar_Syntax_Syntax.fv -> exp_binding) =
   fun g ->
     fun fv ->
-      let uu____767 = try_lookup_fv g fv in
-      match uu____767 with
+      let uu___ = try_lookup_fv g fv in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____770 =
-            let uu____771 =
+          let uu___1 =
+            let uu___2 =
               FStar_Range.string_of_range
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p in
-            let uu____772 =
+            let uu___3 =
               FStar_Syntax_Print.lid_to_string
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            FStar_Util.format2 "(%s) free Variable %s not found\n" uu____771
-              uu____772 in
-          failwith uu____770
+            FStar_Util.format2 "(%s) free Variable %s not found\n" uu___2
+              uu___3 in
+          failwith uu___1
       | FStar_Pervasives_Native.Some y -> y
 let (lookup_bv : uenv -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
   fun g ->
     fun bv ->
       let x =
         FStar_Util.find_map g.env_bindings
-          (fun uu___1_790 ->
-             match uu___1_790 with
+          (fun uu___ ->
+             match uu___ with
              | Bv (bv', r) when FStar_Syntax_Syntax.bv_eq bv bv' ->
                  FStar_Pervasives_Native.Some r
-             | uu____795 -> FStar_Pervasives_Native.None) in
+             | uu___1 -> FStar_Pervasives_Native.None) in
       match x with
       | FStar_Pervasives_Native.None ->
-          let uu____796 =
-            let uu____797 =
-              let uu____798 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
                 FStar_Ident.range_of_id bv.FStar_Syntax_Syntax.ppname in
-              FStar_Range.string_of_range uu____798 in
-            let uu____799 = FStar_Syntax_Print.bv_to_string bv in
-            FStar_Util.format2 "(%s) bound Variable %s not found\n" uu____797
-              uu____799 in
-          failwith uu____796
+              FStar_Range.string_of_range uu___2 in
+            let uu___2 = FStar_Syntax_Print.bv_to_string bv in
+            FStar_Util.format2 "(%s) bound Variable %s not found\n" uu___1
+              uu___2 in
+          failwith uu___
       | FStar_Pervasives_Native.Some y -> y
 let (lookup_term :
   uenv ->
@@ -268,28 +268,26 @@ let (lookup_term :
     fun t ->
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____824 = lookup_bv g x in
-          (uu____824, FStar_Pervasives_Native.None)
+          let uu___ = lookup_bv g x in (uu___, FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar x ->
-          let uu____828 =
-            let uu____829 = lookup_fv g x in FStar_Util.Inr uu____829 in
-          (uu____828, (x.FStar_Syntax_Syntax.fv_qual))
-      | uu____832 -> failwith "Impossible: lookup_term for a non-name"
+          let uu___ = let uu___1 = lookup_fv g x in FStar_Util.Inr uu___1 in
+          (uu___, (x.FStar_Syntax_Syntax.fv_qual))
+      | uu___ -> failwith "Impossible: lookup_term for a non-name"
 let (lookup_ty : uenv -> FStar_Syntax_Syntax.bv -> ty_binding) =
   fun g ->
     fun x ->
-      let uu____849 = lookup_bv g x in
-      match uu____849 with
+      let uu___ = lookup_bv g x in
+      match uu___ with
       | FStar_Util.Inl ty -> ty
-      | uu____851 -> failwith "Expected a type name"
+      | uu___1 -> failwith "Expected a type name"
 let (lookup_tydef :
   uenv ->
     FStar_Extraction_ML_Syntax.mlpath ->
       FStar_Extraction_ML_Syntax.mltyscheme FStar_Pervasives_Native.option)
   =
   fun env ->
-    fun uu____863 ->
-      match uu____863 with
+    fun uu___ ->
+      match uu___ with
       | (module_name, ty_name) ->
           FStar_Util.find_map env.tydefs
             (fun tydef1 ->
@@ -302,30 +300,30 @@ let (mlpath_of_lident :
   uenv -> FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlpath) =
   fun g ->
     fun x ->
-      let uu____891 =
-        let uu____894 = FStar_Ident.string_of_lid x in
-        FStar_Util.psmap_try_find g.mlpath_of_lid uu____894 in
-      match uu____891 with
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_lid x in
+        FStar_Util.psmap_try_find g.mlpath_of_lid uu___1 in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           (debug g
-             (fun uu____899 ->
-                (let uu____901 = FStar_Ident.string_of_lid x in
-                 FStar_Util.print1 "Identifier not found: %s" uu____901);
-                (let uu____902 = print_mlpath_map g in
-                 FStar_Util.print1 "Env is \n%s\n" uu____902));
-           (let uu____903 =
-              let uu____904 = FStar_Ident.string_of_lid x in
-              Prims.op_Hat "Identifier not found: " uu____904 in
-            failwith uu____903))
+             (fun uu___2 ->
+                (let uu___4 = FStar_Ident.string_of_lid x in
+                 FStar_Util.print1 "Identifier not found: %s" uu___4);
+                (let uu___4 = print_mlpath_map g in
+                 FStar_Util.print1 "Env is \n%s\n" uu___4));
+           (let uu___2 =
+              let uu___3 = FStar_Ident.string_of_lid x in
+              Prims.op_Hat "Identifier not found: " uu___3 in
+            failwith uu___2))
       | FStar_Pervasives_Native.Some mlp -> mlp
 let (is_type_name : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g ->
     fun fv ->
       FStar_All.pipe_right g.type_names
         (FStar_Util.for_some
-           (fun uu____929 ->
-              match uu____929 with
-              | (x, uu____935) -> FStar_Syntax_Syntax.fv_eq fv x))
+           (fun uu___ ->
+              match uu___ with
+              | (x, uu___1) -> FStar_Syntax_Syntax.fv_eq fv x))
 let (is_fv_type : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g ->
     fun fv ->
@@ -339,35 +337,35 @@ let (lookup_record_field_name :
       FStar_Extraction_ML_Syntax.mlpath)
   =
   fun g ->
-    fun uu____963 ->
-      match uu____963 with
+    fun uu___ ->
+      match uu___ with
       | (type_name, fn) ->
           let key =
-            let uu____971 =
-              let uu____972 = FStar_Ident.ids_of_lid type_name in
-              FStar_List.append uu____972 [fn] in
-            FStar_Ident.lid_of_ids uu____971 in
-          let uu____975 =
-            let uu____978 = FStar_Ident.string_of_lid key in
-            FStar_Util.psmap_try_find g.mlpath_of_fieldname uu____978 in
-          (match uu____975 with
+            let uu___1 =
+              let uu___2 = FStar_Ident.ids_of_lid type_name in
+              FStar_List.append uu___2 [fn] in
+            FStar_Ident.lid_of_ids uu___1 in
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_lid key in
+            FStar_Util.psmap_try_find g.mlpath_of_fieldname uu___2 in
+          (match uu___1 with
            | FStar_Pervasives_Native.None ->
-               let uu____979 =
-                 let uu____980 = FStar_Ident.string_of_lid key in
-                 Prims.op_Hat "Field name not found: " uu____980 in
-               failwith uu____979
+               let uu___2 =
+                 let uu___3 = FStar_Ident.string_of_lid key in
+                 Prims.op_Hat "Field name not found: " uu___3 in
+               failwith uu___2
            | FStar_Pervasives_Native.Some mlp -> mlp)
 let (initial_mlident_map : unit -> Prims.string FStar_Util.psmap) =
   let map = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-  fun uu____1001 ->
-    let uu____1002 = FStar_ST.op_Bang map in
-    match uu____1002 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang map in
+    match uu___1 with
     | FStar_Pervasives_Native.Some m -> m
     | FStar_Pervasives_Native.None ->
         let m =
-          let uu____1033 =
-            let uu____1036 = FStar_Options.codegen () in
-            match uu____1036 with
+          let uu___2 =
+            let uu___3 = FStar_Options.codegen () in
+            match uu___3 with
             | FStar_Pervasives_Native.Some (FStar_Options.FSharp) ->
                 FStar_Extraction_ML_Syntax.fsharpkeywords
             | FStar_Pervasives_Native.Some (FStar_Options.OCaml) ->
@@ -377,61 +375,52 @@ let (initial_mlident_map : unit -> Prims.string FStar_Util.psmap) =
             | FStar_Pervasives_Native.Some (FStar_Options.Kremlin) ->
                 FStar_Extraction_ML_Syntax.kremlin_keywords ()
             | FStar_Pervasives_Native.None -> [] in
-          let uu____1041 = FStar_Util.psmap_empty () in
+          let uu___3 = FStar_Util.psmap_empty () in
           FStar_List.fold_right
-            (fun x -> fun m -> FStar_Util.psmap_add m x "") uu____1033
-            uu____1041 in
+            (fun x -> fun m1 -> FStar_Util.psmap_add m1 x "") uu___2 uu___3 in
         (FStar_ST.op_Colon_Equals map (FStar_Pervasives_Native.Some m); m)
 let (rename_conventional : Prims.string -> Prims.bool -> Prims.string) =
   fun s ->
     fun is_local_type_variable ->
       let cs = FStar_String.list_of_string s in
-      let sanitize_typ uu____1089 =
+      let sanitize_typ uu___ =
         let valid_rest c = FStar_Util.is_letter_or_digit c in
         let aux cs1 =
           FStar_List.map
-            (fun x ->
-               let uu____1111 = valid_rest x in if uu____1111 then x else 117)
+            (fun x -> let uu___1 = valid_rest x in if uu___1 then x else 117)
             cs1 in
-        let uu____1113 = let uu____1114 = FStar_List.hd cs in uu____1114 = 39 in
-        if uu____1113
+        let uu___1 = let uu___2 = FStar_List.hd cs in uu___2 = 39 in
+        if uu___1
         then
-          let uu____1117 = FStar_List.hd cs in
-          let uu____1118 =
-            let uu____1121 = FStar_List.tail cs in aux uu____1121 in
-          uu____1117 :: uu____1118
-        else (let uu____1125 = aux cs in 39 :: uu____1125) in
-      let sanitize_term uu____1135 =
+          let uu___2 = FStar_List.hd cs in
+          let uu___3 = let uu___4 = FStar_List.tail cs in aux uu___4 in
+          uu___2 :: uu___3
+        else (let uu___3 = aux cs in 39 :: uu___3) in
+      let sanitize_term uu___ =
         let valid c =
           ((FStar_Util.is_letter_or_digit c) || (c = 95)) || (c = 39) in
         let cs' =
           FStar_List.fold_right
             (fun c ->
                fun cs1 ->
-                 let uu____1154 =
-                   let uu____1157 = valid c in
-                   if uu____1157 then [c] else [95; 95] in
-                 FStar_List.append uu____1154 cs1) cs [] in
+                 let uu___1 =
+                   let uu___2 = valid c in if uu___2 then [c] else [95; 95] in
+                 FStar_List.append uu___1 cs1) cs [] in
         match cs' with
         | c::cs1 when (FStar_Util.is_digit c) || (c = 39) -> 95 :: c :: cs1
-        | uu____1167 -> cs in
-      let uu____1170 =
+        | uu___1 -> cs in
+      let uu___ =
         if is_local_type_variable then sanitize_typ () else sanitize_term () in
-      FStar_String.string_of_list uu____1170
+      FStar_String.string_of_list uu___
 let (root_name_of_bv :
   FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlident) =
   fun x ->
-    let uu____1181 =
-      (let uu____1184 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
-       FStar_Util.starts_with uu____1184 FStar_Ident.reserved_prefix) ||
+    let uu___ =
+      (let uu___1 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
+       FStar_Util.starts_with uu___1 FStar_Ident.reserved_prefix) ||
         (FStar_Syntax_Syntax.is_null_bv x) in
-    if uu____1181
-    then
-      let uu____1185 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
-      let uu____1186 =
-        let uu____1187 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
-        Prims.op_Hat "_" uu____1187 in
-      Prims.op_Hat uu____1185 uu____1186
+    if uu___
+    then FStar_Ident.reserved_prefix
     else FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname
 let (find_uniq :
   Prims.string FStar_Util.psmap ->
@@ -446,11 +435,10 @@ let (find_uniq :
             if i = Prims.int_zero
             then root_name1
             else
-              (let uu____1233 = FStar_Util.string_of_int i in
-               Prims.op_Hat root_name1 uu____1233) in
-          let uu____1234 =
-            FStar_Util.psmap_try_find ml_ident_map target_mlident in
-          match uu____1234 with
+              (let uu___1 = FStar_Util.string_of_int i in
+               Prims.op_Hat root_name1 uu___1) in
+          let uu___ = FStar_Util.psmap_try_find ml_ident_map target_mlident in
+          match uu___ with
           | FStar_Pervasives_Native.Some x ->
               aux (i + Prims.int_one) root_name1
           | FStar_Pervasives_Native.None ->
@@ -459,71 +447,69 @@ let (find_uniq :
         let mlident = rename_conventional root_name is_local_type_variable in
         if is_local_type_variable
         then
-          let uu____1256 =
-            let uu____1263 = FStar_Util.substring_from mlident Prims.int_one in
-            aux Prims.int_zero uu____1263 in
-          match uu____1256 with | (nm, map) -> ((Prims.op_Hat "'" nm), map)
+          let uu___ =
+            let uu___1 = FStar_Util.substring_from mlident Prims.int_one in
+            aux Prims.int_zero uu___1 in
+          match uu___ with | (nm, map) -> ((Prims.op_Hat "'" nm), map)
         else aux Prims.int_zero mlident
 let (mlns_of_lid : FStar_Ident.lident -> Prims.string Prims.list) =
   fun x ->
-    let uu____1286 = FStar_Ident.ns_of_lid x in
-    FStar_List.map FStar_Ident.string_of_id uu____1286
+    let uu___ = FStar_Ident.ns_of_lid x in
+    FStar_List.map FStar_Ident.string_of_id uu___
 let (new_mlpath_of_lident :
   uenv -> FStar_Ident.lident -> (FStar_Extraction_ML_Syntax.mlpath * uenv)) =
   fun g ->
     fun x ->
-      let uu____1307 =
-        let uu____1312 =
-          FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid in
-        if uu____1312
+      let uu___ =
+        let uu___1 = FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid in
+        if uu___1
         then
-          let uu____1317 =
-            let uu____1318 =
-              let uu____1319 = FStar_Ident.ident_of_lid x in
-              FStar_Ident.string_of_id uu____1319 in
-            ([], uu____1318) in
-          (uu____1317, g)
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Ident.ident_of_lid x in
+              FStar_Ident.string_of_id uu___4 in
+            ([], uu___3) in
+          (uu___2, g)
         else
-          (let uu____1323 =
-             let uu____1330 =
-               let uu____1331 = FStar_Ident.ident_of_lid x in
-               FStar_Ident.string_of_id uu____1331 in
-             find_uniq g.env_mlident_map uu____1330 false in
-           match uu____1323 with
+          (let uu___3 =
+             let uu___4 =
+               let uu___5 = FStar_Ident.ident_of_lid x in
+               FStar_Ident.string_of_id uu___5 in
+             find_uniq g.env_mlident_map uu___4 false in
+           match uu___3 with
            | (name, map) ->
                let g1 =
-                 let uu___239_1343 = g in
+                 let uu___4 = g in
                  {
-                   env_tcenv = (uu___239_1343.env_tcenv);
-                   env_bindings = (uu___239_1343.env_bindings);
+                   env_tcenv = (uu___4.env_tcenv);
+                   env_bindings = (uu___4.env_bindings);
                    env_mlident_map = map;
-                   mlpath_of_lid = (uu___239_1343.mlpath_of_lid);
-                   env_fieldname_map = (uu___239_1343.env_fieldname_map);
-                   mlpath_of_fieldname = (uu___239_1343.mlpath_of_fieldname);
-                   tydefs = (uu___239_1343.tydefs);
-                   type_names = (uu___239_1343.type_names);
-                   currentModule = (uu___239_1343.currentModule)
+                   mlpath_of_lid = (uu___4.mlpath_of_lid);
+                   env_fieldname_map = (uu___4.env_fieldname_map);
+                   mlpath_of_fieldname = (uu___4.mlpath_of_fieldname);
+                   tydefs = (uu___4.tydefs);
+                   type_names = (uu___4.type_names);
+                   currentModule = (uu___4.currentModule)
                  } in
-               let uu____1344 =
-                 let uu____1345 = mlns_of_lid x in (uu____1345, name) in
-               (uu____1344, g1)) in
-      match uu____1307 with
+               let uu___4 = let uu___5 = mlns_of_lid x in (uu___5, name) in
+               (uu___4, g1)) in
+      match uu___ with
       | (mlp, g1) ->
           let g2 =
-            let uu___245_1357 = g1 in
-            let uu____1358 =
-              let uu____1361 = FStar_Ident.string_of_lid x in
-              FStar_Util.psmap_add g1.mlpath_of_lid uu____1361 mlp in
+            let uu___1 = g1 in
+            let uu___2 =
+              let uu___3 = FStar_Ident.string_of_lid x in
+              FStar_Util.psmap_add g1.mlpath_of_lid uu___3 mlp in
             {
-              env_tcenv = (uu___245_1357.env_tcenv);
-              env_bindings = (uu___245_1357.env_bindings);
-              env_mlident_map = (uu___245_1357.env_mlident_map);
-              mlpath_of_lid = uu____1358;
-              env_fieldname_map = (uu___245_1357.env_fieldname_map);
-              mlpath_of_fieldname = (uu___245_1357.mlpath_of_fieldname);
-              tydefs = (uu___245_1357.tydefs);
-              type_names = (uu___245_1357.type_names);
-              currentModule = (uu___245_1357.currentModule)
+              env_tcenv = (uu___1.env_tcenv);
+              env_bindings = (uu___1.env_bindings);
+              env_mlident_map = (uu___1.env_mlident_map);
+              mlpath_of_lid = uu___2;
+              env_fieldname_map = (uu___1.env_fieldname_map);
+              mlpath_of_fieldname = (uu___1.mlpath_of_fieldname);
+              tydefs = (uu___1.tydefs);
+              type_names = (uu___1.type_names);
+              currentModule = (uu___1.currentModule)
             } in
           (mlp, g2)
 let (extend_ty : uenv -> FStar_Syntax_Syntax.bv -> Prims.bool -> uenv) =
@@ -531,10 +517,10 @@ let (extend_ty : uenv -> FStar_Syntax_Syntax.bv -> Prims.bool -> uenv) =
     fun a ->
       fun map_to_top ->
         let is_local_type_variable = Prims.op_Negation map_to_top in
-        let uu____1378 =
-          let uu____1385 = root_name_of_bv a in
-          find_uniq g.env_mlident_map uu____1385 is_local_type_variable in
-        match uu____1378 with
+        let uu___ =
+          let uu___1 = root_name_of_bv a in
+          find_uniq g.env_mlident_map uu___1 is_local_type_variable in
+        match uu___ with
         | (ml_a, mlident_map) ->
             let mapped_to =
               if map_to_top
@@ -546,17 +532,17 @@ let (extend_ty : uenv -> FStar_Syntax_Syntax.bv -> Prims.bool -> uenv) =
                    (FStar_Util.Inl { ty_b_name = ml_a; ty_b_ty = mapped_to })))
               :: (g.env_bindings) in
             let tcenv = FStar_TypeChecker_Env.push_bv g.env_tcenv a in
-            let uu___262_1398 = g in
+            let uu___1 = g in
             {
               env_tcenv = tcenv;
               env_bindings = gamma;
               env_mlident_map = mlident_map;
-              mlpath_of_lid = (uu___262_1398.mlpath_of_lid);
-              env_fieldname_map = (uu___262_1398.env_fieldname_map);
-              mlpath_of_fieldname = (uu___262_1398.mlpath_of_fieldname);
-              tydefs = (uu___262_1398.tydefs);
-              type_names = (uu___262_1398.type_names);
-              currentModule = (uu___262_1398.currentModule)
+              mlpath_of_lid = (uu___1.mlpath_of_lid);
+              env_fieldname_map = (uu___1.env_fieldname_map);
+              mlpath_of_fieldname = (uu___1.mlpath_of_fieldname);
+              tydefs = (uu___1.tydefs);
+              type_names = (uu___1.type_names);
+              currentModule = (uu___1.currentModule)
             }
 let (extend_bv :
   uenv ->
@@ -574,11 +560,11 @@ let (extend_bv :
             let ml_ty =
               match t_x with
               | ([], t) -> t
-              | uu____1438 -> FStar_Extraction_ML_Syntax.MLTY_Top in
-            let uu____1439 =
-              let uu____1446 = root_name_of_bv x in
-              find_uniq g.env_mlident_map uu____1446 false in
-            match uu____1439 with
+              | uu___ -> FStar_Extraction_ML_Syntax.MLTY_Top in
+            let uu___ =
+              let uu___1 = root_name_of_bv x in
+              find_uniq g.env_mlident_map uu___1 false in
+            match uu___ with
             | (mlident, mlident_map) ->
                 let mlx = FStar_Extraction_ML_Syntax.MLE_Var mlident in
                 let mlx1 =
@@ -608,29 +594,45 @@ let (extend_bv :
                 let gamma = (Bv (x, (FStar_Util.Inr exp_binding1))) ::
                   (g.env_bindings) in
                 let tcenv =
-                  let uu____1472 = FStar_Syntax_Syntax.binders_of_list [x] in
-                  FStar_TypeChecker_Env.push_binders g.env_tcenv uu____1472 in
-                ((let uu___288_1474 = g in
+                  let uu___1 = FStar_Syntax_Syntax.binders_of_list [x] in
+                  FStar_TypeChecker_Env.push_binders g.env_tcenv uu___1 in
+                ((let uu___1 = g in
                   {
                     env_tcenv = tcenv;
                     env_bindings = gamma;
                     env_mlident_map = mlident_map;
-                    mlpath_of_lid = (uu___288_1474.mlpath_of_lid);
-                    env_fieldname_map = (uu___288_1474.env_fieldname_map);
-                    mlpath_of_fieldname = (uu___288_1474.mlpath_of_fieldname);
-                    tydefs = (uu___288_1474.tydefs);
-                    type_names = (uu___288_1474.type_names);
-                    currentModule = (uu___288_1474.currentModule)
+                    mlpath_of_lid = (uu___1.mlpath_of_lid);
+                    env_fieldname_map = (uu___1.env_fieldname_map);
+                    mlpath_of_fieldname = (uu___1.mlpath_of_fieldname);
+                    tydefs = (uu___1.tydefs);
+                    type_names = (uu___1.type_names);
+                    currentModule = (uu___1.currentModule)
                   }), mlident, exp_binding1)
+let (burn_name : uenv -> FStar_Extraction_ML_Syntax.mlident -> uenv) =
+  fun g ->
+    fun i ->
+      let uu___ = g in
+      let uu___1 = FStar_Util.psmap_add g.env_mlident_map i "" in
+      {
+        env_tcenv = (uu___.env_tcenv);
+        env_bindings = (uu___.env_bindings);
+        env_mlident_map = uu___1;
+        mlpath_of_lid = (uu___.mlpath_of_lid);
+        env_fieldname_map = (uu___.env_fieldname_map);
+        mlpath_of_fieldname = (uu___.mlpath_of_fieldname);
+        tydefs = (uu___.tydefs);
+        type_names = (uu___.type_names);
+        currentModule = (uu___.currentModule)
+      }
 let (new_mlident : uenv -> (uenv * FStar_Extraction_ML_Syntax.mlident)) =
   fun g ->
     let ml_ty = FStar_Extraction_ML_Syntax.MLTY_Top in
     let x =
       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
         FStar_Syntax_Syntax.tun in
-    let uu____1490 =
+    let uu___ =
       extend_bv g x ([], FStar_Extraction_ML_Syntax.MLTY_Top) false false in
-    match uu____1490 with | (g1, id, uu____1503) -> (g1, id)
+    match uu___ with | (g1, id, uu___1) -> (g1, id)
 let (extend_fv :
   uenv ->
     FStar_Syntax_Syntax.fv ->
@@ -646,9 +648,8 @@ let (extend_fv :
             match t with
             | FStar_Extraction_ML_Syntax.MLTY_Var x1 -> [x1]
             | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2) ->
-                let uu____1550 = mltyFvars t1 in
-                let uu____1553 = mltyFvars t2 in
-                FStar_List.append uu____1550 uu____1553
+                let uu___ = mltyFvars t1 in
+                let uu___1 = mltyFvars t2 in FStar_List.append uu___ uu___1
             | FStar_Extraction_ML_Syntax.MLTY_Named (args, path) ->
                 FStar_List.collect mltyFvars args
             | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
@@ -660,19 +661,19 @@ let (extend_fv :
             | h::tla -> (FStar_List.contains h lb) && (subsetMlidents tla lb)
             | [] -> true in
           let tySchemeIsClosed tys =
-            let uu____1594 = mltyFvars (FStar_Pervasives_Native.snd tys) in
-            subsetMlidents uu____1594 (FStar_Pervasives_Native.fst tys) in
-          let uu____1597 = tySchemeIsClosed t_x in
-          if uu____1597
+            let uu___ = mltyFvars (FStar_Pervasives_Native.snd tys) in
+            subsetMlidents uu___ (FStar_Pervasives_Native.fst tys) in
+          let uu___ = tySchemeIsClosed t_x in
+          if uu___
           then
             let ml_ty =
               match t_x with
               | ([], t) -> t
-              | uu____1606 -> FStar_Extraction_ML_Syntax.MLTY_Top in
-            let uu____1607 =
+              | uu___1 -> FStar_Extraction_ML_Syntax.MLTY_Top in
+            let uu___1 =
               new_mlpath_of_lident g
                 (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            match uu____1607 with
+            match uu___1 with
             | (mlpath, g1) ->
                 let mlsymbol = FStar_Pervasives_Native.snd mlpath in
                 let mly = FStar_Extraction_ML_Syntax.MLE_Name mlpath in
@@ -700,17 +701,17 @@ let (extend_fv :
                 let gamma = (Fv (x, exp_binding1)) :: (g1.env_bindings) in
                 let mlident_map =
                   FStar_Util.psmap_add g1.env_mlident_map mlsymbol "" in
-                ((let uu___347_1638 = g1 in
+                ((let uu___2 = g1 in
                   {
-                    env_tcenv = (uu___347_1638.env_tcenv);
+                    env_tcenv = (uu___2.env_tcenv);
                     env_bindings = gamma;
                     env_mlident_map = mlident_map;
-                    mlpath_of_lid = (uu___347_1638.mlpath_of_lid);
-                    env_fieldname_map = (uu___347_1638.env_fieldname_map);
-                    mlpath_of_fieldname = (uu___347_1638.mlpath_of_fieldname);
-                    tydefs = (uu___347_1638.tydefs);
-                    type_names = (uu___347_1638.type_names);
-                    currentModule = (uu___347_1638.currentModule)
+                    mlpath_of_lid = (uu___2.mlpath_of_lid);
+                    env_fieldname_map = (uu___2.env_fieldname_map);
+                    mlpath_of_fieldname = (uu___2.mlpath_of_fieldname);
+                    tydefs = (uu___2.tydefs);
+                    type_names = (uu___2.type_names);
+                    currentModule = (uu___2.currentModule)
                   }), mlsymbol, exp_binding1)
           else failwith "freevars found"
 let (extend_lb :
@@ -738,10 +739,10 @@ let (extend_tydef :
   fun g ->
     fun fv ->
       fun ts ->
-        let uu____1712 =
+        let uu___ =
           new_mlpath_of_lident g
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        match uu____1712 with
+        match uu___ with
         | (name, g1) ->
             let tydef1 =
               {
@@ -751,17 +752,17 @@ let (extend_tydef :
                 tydef_def = ts
               } in
             (tydef1, name,
-              (let uu___369_1731 = g1 in
+              (let uu___1 = g1 in
                {
-                 env_tcenv = (uu___369_1731.env_tcenv);
-                 env_bindings = (uu___369_1731.env_bindings);
-                 env_mlident_map = (uu___369_1731.env_mlident_map);
-                 mlpath_of_lid = (uu___369_1731.mlpath_of_lid);
-                 env_fieldname_map = (uu___369_1731.env_fieldname_map);
-                 mlpath_of_fieldname = (uu___369_1731.mlpath_of_fieldname);
+                 env_tcenv = (uu___1.env_tcenv);
+                 env_bindings = (uu___1.env_bindings);
+                 env_mlident_map = (uu___1.env_mlident_map);
+                 mlpath_of_lid = (uu___1.mlpath_of_lid);
+                 env_fieldname_map = (uu___1.env_fieldname_map);
+                 mlpath_of_fieldname = (uu___1.mlpath_of_fieldname);
                  tydefs = (tydef1 :: (g1.tydefs));
                  type_names = ((fv, name) :: (g1.type_names));
-                 currentModule = (uu___369_1731.currentModule)
+                 currentModule = (uu___1.currentModule)
                }))
 let (extend_type_name :
   uenv ->
@@ -769,23 +770,23 @@ let (extend_type_name :
   =
   fun g ->
     fun fv ->
-      let uu____1754 =
+      let uu___ =
         new_mlpath_of_lident g
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      match uu____1754 with
+      match uu___ with
       | (name, g1) ->
           (name,
-            (let uu___376_1766 = g1 in
+            (let uu___1 = g1 in
              {
-               env_tcenv = (uu___376_1766.env_tcenv);
-               env_bindings = (uu___376_1766.env_bindings);
-               env_mlident_map = (uu___376_1766.env_mlident_map);
-               mlpath_of_lid = (uu___376_1766.mlpath_of_lid);
-               env_fieldname_map = (uu___376_1766.env_fieldname_map);
-               mlpath_of_fieldname = (uu___376_1766.mlpath_of_fieldname);
-               tydefs = (uu___376_1766.tydefs);
+               env_tcenv = (uu___1.env_tcenv);
+               env_bindings = (uu___1.env_bindings);
+               env_mlident_map = (uu___1.env_mlident_map);
+               mlpath_of_lid = (uu___1.mlpath_of_lid);
+               env_fieldname_map = (uu___1.env_fieldname_map);
+               mlpath_of_fieldname = (uu___1.mlpath_of_fieldname);
+               tydefs = (uu___1.tydefs);
                type_names = ((fv, name) :: (g1.type_names));
-               currentModule = (uu___376_1766.currentModule)
+               currentModule = (uu___1.currentModule)
              }))
 let (extend_with_monad_op_name :
   uenv ->
@@ -800,19 +801,18 @@ let (extend_with_monad_op_name :
       fun nm ->
         fun ts ->
           let lid =
-            let uu____1800 = FStar_Ident.id_of_text nm in
+            let uu___ = FStar_Ident.id_of_text nm in
             FStar_Syntax_Util.mk_field_projector_name_from_ident
-              ed.FStar_Syntax_Syntax.mname uu____1800 in
-          let uu____1801 =
-            let uu____1808 =
+              ed.FStar_Syntax_Syntax.mname uu___ in
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Syntax.lid_as_fv lid
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
-            extend_fv g uu____1808 ts false in
-          match uu____1801 with
+            extend_fv g uu___1 ts false in
+          match uu___ with
           | (g1, mlid, exp_b) ->
-              let mlp =
-                let uu____1827 = mlns_of_lid lid in (uu____1827, mlid) in
+              let mlp = let uu___1 = mlns_of_lid lid in (uu___1, mlid) in
               (mlp, lid, exp_b, g1)
 let (extend_with_action_name :
   uenv ->
@@ -827,27 +827,25 @@ let (extend_with_action_name :
       fun a ->
         fun ts ->
           let nm =
-            let uu____1861 =
+            let uu___ =
               FStar_Ident.ident_of_lid a.FStar_Syntax_Syntax.action_name in
-            FStar_Ident.string_of_id uu____1861 in
+            FStar_Ident.string_of_id uu___ in
           let module_name =
             FStar_Ident.ns_of_lid ed.FStar_Syntax_Syntax.mname in
           let lid =
-            let uu____1864 =
-              let uu____1865 =
-                let uu____1868 = FStar_Ident.id_of_text nm in [uu____1868] in
-              FStar_List.append module_name uu____1865 in
-            FStar_Ident.lid_of_ids uu____1864 in
-          let uu____1869 =
-            let uu____1876 =
+            let uu___ =
+              let uu___1 = let uu___2 = FStar_Ident.id_of_text nm in [uu___2] in
+              FStar_List.append module_name uu___1 in
+            FStar_Ident.lid_of_ids uu___ in
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Syntax.lid_as_fv lid
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
-            extend_fv g uu____1876 ts false in
-          match uu____1869 with
+            extend_fv g uu___1 ts false in
+          match uu___ with
           | (g1, mlid, exp_b) ->
-              let mlp =
-                let uu____1895 = mlns_of_lid lid in (uu____1895, mlid) in
+              let mlp = let uu___1 = mlns_of_lid lid in (uu___1, mlid) in
               (mlp, lid, exp_b, g1)
 let (extend_record_field_name :
   uenv ->
@@ -855,36 +853,36 @@ let (extend_record_field_name :
       (FStar_Extraction_ML_Syntax.mlident * uenv))
   =
   fun g ->
-    fun uu____1917 ->
-      match uu____1917 with
+    fun uu___ ->
+      match uu___ with
       | (type_name, fn) ->
           let key =
-            let uu____1929 =
-              let uu____1930 = FStar_Ident.ids_of_lid type_name in
-              FStar_List.append uu____1930 [fn] in
-            FStar_Ident.lid_of_ids uu____1929 in
-          let uu____1933 =
-            let uu____1940 = FStar_Ident.string_of_id fn in
-            find_uniq g.env_fieldname_map uu____1940 false in
-          (match uu____1933 with
+            let uu___1 =
+              let uu___2 = FStar_Ident.ids_of_lid type_name in
+              FStar_List.append uu___2 [fn] in
+            FStar_Ident.lid_of_ids uu___1 in
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_id fn in
+            find_uniq g.env_fieldname_map uu___2 false in
+          (match uu___1 with
            | (name, fieldname_map) ->
                let ns = mlns_of_lid type_name in
                let mlp = (ns, name) in
                let g1 =
-                 let uu___410_1964 = g in
-                 let uu____1965 =
-                   let uu____1968 = FStar_Ident.string_of_lid key in
-                   FStar_Util.psmap_add g.mlpath_of_fieldname uu____1968 mlp in
+                 let uu___2 = g in
+                 let uu___3 =
+                   let uu___4 = FStar_Ident.string_of_lid key in
+                   FStar_Util.psmap_add g.mlpath_of_fieldname uu___4 mlp in
                  {
-                   env_tcenv = (uu___410_1964.env_tcenv);
-                   env_bindings = (uu___410_1964.env_bindings);
-                   env_mlident_map = (uu___410_1964.env_mlident_map);
-                   mlpath_of_lid = (uu___410_1964.mlpath_of_lid);
+                   env_tcenv = (uu___2.env_tcenv);
+                   env_bindings = (uu___2.env_bindings);
+                   env_mlident_map = (uu___2.env_mlident_map);
+                   mlpath_of_lid = (uu___2.mlpath_of_lid);
                    env_fieldname_map = fieldname_map;
-                   mlpath_of_fieldname = uu____1965;
-                   tydefs = (uu___410_1964.tydefs);
-                   type_names = (uu___410_1964.type_names);
-                   currentModule = (uu___410_1964.currentModule)
+                   mlpath_of_fieldname = uu___3;
+                   tydefs = (uu___2.tydefs);
+                   type_names = (uu___2.type_names);
+                   currentModule = (uu___2.currentModule)
                  } in
                (name, g1))
 let (extend_with_module_name :
@@ -893,39 +891,39 @@ let (extend_with_module_name :
     fun m ->
       let ns = mlns_of_lid m in
       let p =
-        let uu____1987 = FStar_Ident.ident_of_lid m in
-        FStar_Ident.string_of_id uu____1987 in
+        let uu___ = FStar_Ident.ident_of_lid m in
+        FStar_Ident.string_of_id uu___ in
       ((ns, p), g)
 let (exit_module : uenv -> uenv) =
   fun g ->
-    let uu___418_1995 = g in
-    let uu____1996 = initial_mlident_map () in
-    let uu____1999 = initial_mlident_map () in
+    let uu___ = g in
+    let uu___1 = initial_mlident_map () in
+    let uu___2 = initial_mlident_map () in
     {
-      env_tcenv = (uu___418_1995.env_tcenv);
-      env_bindings = (uu___418_1995.env_bindings);
-      env_mlident_map = uu____1996;
-      mlpath_of_lid = (uu___418_1995.mlpath_of_lid);
-      env_fieldname_map = uu____1999;
-      mlpath_of_fieldname = (uu___418_1995.mlpath_of_fieldname);
-      tydefs = (uu___418_1995.tydefs);
-      type_names = (uu___418_1995.type_names);
-      currentModule = (uu___418_1995.currentModule)
+      env_tcenv = (uu___.env_tcenv);
+      env_bindings = (uu___.env_bindings);
+      env_mlident_map = uu___1;
+      mlpath_of_lid = (uu___.mlpath_of_lid);
+      env_fieldname_map = uu___2;
+      mlpath_of_fieldname = (uu___.mlpath_of_fieldname);
+      tydefs = (uu___.tydefs);
+      type_names = (uu___.type_names);
+      currentModule = (uu___.currentModule)
     }
 let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
   fun e ->
     let env =
-      let uu____2008 = initial_mlident_map () in
-      let uu____2011 = FStar_Util.psmap_empty () in
-      let uu____2014 = initial_mlident_map () in
-      let uu____2017 = FStar_Util.psmap_empty () in
+      let uu___ = initial_mlident_map () in
+      let uu___1 = FStar_Util.psmap_empty () in
+      let uu___2 = initial_mlident_map () in
+      let uu___3 = FStar_Util.psmap_empty () in
       {
         env_tcenv = e;
         env_bindings = [];
-        env_mlident_map = uu____2008;
-        mlpath_of_lid = uu____2011;
-        env_fieldname_map = uu____2014;
-        mlpath_of_fieldname = uu____2017;
+        env_mlident_map = uu___;
+        mlpath_of_lid = uu___1;
+        env_fieldname_map = uu___2;
+        mlpath_of_fieldname = uu___3;
         tydefs = [];
         type_names = [];
         currentModule = ([], "")
@@ -938,11 +936,11 @@ let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
                ([], (["Prims"], "string"))),
              FStar_Extraction_ML_Syntax.E_IMPURE,
              (FStar_Extraction_ML_Syntax.MLTY_Var a)))) in
-    let uu____2036 =
-      let uu____2043 =
-        let uu____2044 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        FStar_Util.Inr uu____2044 in
-      extend_lb env uu____2043 FStar_Syntax_Syntax.tun failwith_ty false in
-    match uu____2036 with | (g, uu____2046, uu____2047) -> g
+        FStar_Util.Inr uu___2 in
+      extend_lb env uu___1 FStar_Syntax_Syntax.tun failwith_ty false in
+    match uu___ with | (g, uu___1, uu___2) -> g

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -1,8 +1,8 @@
 open Prims
 let (codegen_fsharp : unit -> Prims.bool) =
-  fun uu____4 ->
-    let uu____5 = FStar_Options.codegen () in
-    uu____5 = (FStar_Pervasives_Native.Some FStar_Options.FSharp)
+  fun uu___ ->
+    let uu___1 = FStar_Options.codegen () in
+    uu___1 = (FStar_Pervasives_Native.Some FStar_Options.FSharp)
 let pruneNones :
   'a . 'a FStar_Pervasives_Native.option Prims.list -> 'a Prims.list =
   fun l ->
@@ -25,26 +25,26 @@ let (mlconst_of_const' :
   fun sctt ->
     match sctt with
     | FStar_Const.Const_effect -> failwith "Unsupported constant"
-    | FStar_Const.Const_range uu____55 -> FStar_Extraction_ML_Syntax.MLC_Unit
+    | FStar_Const.Const_range uu___ -> FStar_Extraction_ML_Syntax.MLC_Unit
     | FStar_Const.Const_unit -> FStar_Extraction_ML_Syntax.MLC_Unit
     | FStar_Const.Const_char c -> FStar_Extraction_ML_Syntax.MLC_Char c
     | FStar_Const.Const_int (s, i) ->
         FStar_Extraction_ML_Syntax.MLC_Int (s, i)
     | FStar_Const.Const_bool b -> FStar_Extraction_ML_Syntax.MLC_Bool b
     | FStar_Const.Const_float d -> FStar_Extraction_ML_Syntax.MLC_Float d
-    | FStar_Const.Const_bytearray (bytes, uu____80) ->
+    | FStar_Const.Const_bytearray (bytes, uu___) ->
         FStar_Extraction_ML_Syntax.MLC_Bytes bytes
-    | FStar_Const.Const_string (s, uu____86) ->
+    | FStar_Const.Const_string (s, uu___) ->
         FStar_Extraction_ML_Syntax.MLC_String s
     | FStar_Const.Const_range_of ->
         failwith "Unhandled constant: range_of/set_range_of"
     | FStar_Const.Const_set_range_of ->
         failwith "Unhandled constant: range_of/set_range_of"
-    | FStar_Const.Const_real uu____87 ->
+    | FStar_Const.Const_real uu___ ->
         failwith "Unhandled constant: real/reify/reflect"
     | FStar_Const.Const_reify ->
         failwith "Unhandled constant: real/reify/reflect"
-    | FStar_Const.Const_reflect uu____88 ->
+    | FStar_Const.Const_reflect uu___ ->
         failwith "Unhandled constant: real/reify/reflect"
 let (mlconst_of_const :
   FStar_Range.range ->
@@ -52,73 +52,73 @@ let (mlconst_of_const :
   =
   fun p ->
     fun c ->
-      try (fun uu___51_100 -> match () with | () -> mlconst_of_const' c) ()
+      try (fun uu___ -> match () with | () -> mlconst_of_const' c) ()
       with
-      | uu___50_103 ->
-          let uu____104 =
-            let uu____105 = FStar_Range.string_of_range p in
-            let uu____106 = FStar_Syntax_Print.const_to_string c in
-            FStar_Util.format2 "(%s) Failed to translate constant %s "
-              uu____105 uu____106 in
-          failwith uu____104
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Range.string_of_range p in
+            let uu___3 = FStar_Syntax_Print.const_to_string c in
+            FStar_Util.format2 "(%s) Failed to translate constant %s " uu___2
+              uu___3 in
+          failwith uu___1
 let (mlexpr_of_range :
   FStar_Range.range -> FStar_Extraction_ML_Syntax.mlexpr') =
   fun r ->
     let cint i =
-      let uu____118 =
-        let uu____119 =
-          let uu____120 =
-            let uu____131 = FStar_Util.string_of_int i in
-            (uu____131, FStar_Pervasives_Native.None) in
-          FStar_Extraction_ML_Syntax.MLC_Int uu____120 in
-        FStar_All.pipe_right uu____119
-          (fun uu____142 -> FStar_Extraction_ML_Syntax.MLE_Const uu____142) in
-      FStar_All.pipe_right uu____118
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Util.string_of_int i in
+            (uu___3, FStar_Pervasives_Native.None) in
+          FStar_Extraction_ML_Syntax.MLC_Int uu___2 in
+        FStar_All.pipe_right uu___1
+          (fun uu___2 -> FStar_Extraction_ML_Syntax.MLE_Const uu___2) in
+      FStar_All.pipe_right uu___
         (FStar_Extraction_ML_Syntax.with_ty
            FStar_Extraction_ML_Syntax.ml_int_ty) in
     let cstr s =
-      let uu____149 =
+      let uu___ =
         FStar_All.pipe_right (FStar_Extraction_ML_Syntax.MLC_String s)
-          (fun uu____150 -> FStar_Extraction_ML_Syntax.MLE_Const uu____150) in
-      FStar_All.pipe_right uu____149
+          (fun uu___1 -> FStar_Extraction_ML_Syntax.MLE_Const uu___1) in
+      FStar_All.pipe_right uu___
         (FStar_Extraction_ML_Syntax.with_ty
            FStar_Extraction_ML_Syntax.ml_string_ty) in
-    let uu____151 =
-      let uu____158 =
-        let uu____161 =
-          let uu____162 = FStar_Range.file_of_range r in
-          FStar_All.pipe_right uu____162 cstr in
-        let uu____163 =
-          let uu____166 =
-            let uu____167 =
-              let uu____168 = FStar_Range.start_of_range r in
-              FStar_All.pipe_right uu____168 FStar_Range.line_of_pos in
-            FStar_All.pipe_right uu____167 cint in
-          let uu____169 =
-            let uu____172 =
-              let uu____173 =
-                let uu____174 = FStar_Range.start_of_range r in
-                FStar_All.pipe_right uu____174 FStar_Range.col_of_pos in
-              FStar_All.pipe_right uu____173 cint in
-            let uu____175 =
-              let uu____178 =
-                let uu____179 =
-                  let uu____180 = FStar_Range.end_of_range r in
-                  FStar_All.pipe_right uu____180 FStar_Range.line_of_pos in
-                FStar_All.pipe_right uu____179 cint in
-              let uu____181 =
-                let uu____184 =
-                  let uu____185 =
-                    let uu____186 = FStar_Range.end_of_range r in
-                    FStar_All.pipe_right uu____186 FStar_Range.col_of_pos in
-                  FStar_All.pipe_right uu____185 cint in
-                [uu____184] in
-              uu____178 :: uu____181 in
-            uu____172 :: uu____175 in
-          uu____166 :: uu____169 in
-        uu____161 :: uu____163 in
-      (mk_range_mle, uu____158) in
-    FStar_Extraction_ML_Syntax.MLE_App uu____151
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Range.file_of_range r in
+          FStar_All.pipe_right uu___3 cstr in
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Range.start_of_range r in
+              FStar_All.pipe_right uu___6 FStar_Range.line_of_pos in
+            FStar_All.pipe_right uu___5 cint in
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStar_Range.start_of_range r in
+                FStar_All.pipe_right uu___8 FStar_Range.col_of_pos in
+              FStar_All.pipe_right uu___7 cint in
+            let uu___7 =
+              let uu___8 =
+                let uu___9 =
+                  let uu___10 = FStar_Range.end_of_range r in
+                  FStar_All.pipe_right uu___10 FStar_Range.line_of_pos in
+                FStar_All.pipe_right uu___9 cint in
+              let uu___9 =
+                let uu___10 =
+                  let uu___11 =
+                    let uu___12 = FStar_Range.end_of_range r in
+                    FStar_All.pipe_right uu___12 FStar_Range.col_of_pos in
+                  FStar_All.pipe_right uu___11 cint in
+                [uu___10] in
+              uu___8 :: uu___9 in
+            uu___6 :: uu___7 in
+          uu___4 :: uu___5 in
+        uu___2 :: uu___3 in
+      (mk_range_mle, uu___1) in
+    FStar_Extraction_ML_Syntax.MLE_App uu___
 let (mlexpr_of_const :
   FStar_Range.range ->
     FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlexpr')
@@ -127,9 +127,9 @@ let (mlexpr_of_const :
     fun c ->
       match c with
       | FStar_Const.Const_range r -> mlexpr_of_range r
-      | uu____200 ->
-          let uu____201 = mlconst_of_const p c in
-          FStar_Extraction_ML_Syntax.MLE_Const uu____201
+      | uu___ ->
+          let uu___1 = mlconst_of_const p c in
+          FStar_Extraction_ML_Syntax.MLE_Const uu___1
 let rec (subst_aux :
   (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty)
     Prims.list ->
@@ -139,27 +139,26 @@ let rec (subst_aux :
     fun t ->
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Var x ->
-          let uu____225 =
+          let uu___ =
             FStar_Util.find_opt
-              (fun uu____239 ->
-                 match uu____239 with | (y, uu____245) -> y = x) subst in
-          (match uu____225 with
+              (fun uu___1 -> match uu___1 with | (y, uu___2) -> y = x) subst in
+          (match uu___ with
            | FStar_Pervasives_Native.Some ts ->
                FStar_Pervasives_Native.snd ts
            | FStar_Pervasives_Native.None -> t)
       | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2) ->
-          let uu____262 =
-            let uu____269 = subst_aux subst t1 in
-            let uu____270 = subst_aux subst t2 in (uu____269, f, uu____270) in
-          FStar_Extraction_ML_Syntax.MLTY_Fun uu____262
+          let uu___ =
+            let uu___1 = subst_aux subst t1 in
+            let uu___2 = subst_aux subst t2 in (uu___1, f, uu___2) in
+          FStar_Extraction_ML_Syntax.MLTY_Fun uu___
       | FStar_Extraction_ML_Syntax.MLTY_Named (args, path) ->
-          let uu____277 =
-            let uu____284 = FStar_List.map (subst_aux subst) args in
-            (uu____284, path) in
-          FStar_Extraction_ML_Syntax.MLTY_Named uu____277
+          let uu___ =
+            let uu___1 = FStar_List.map (subst_aux subst) args in
+            (uu___1, path) in
+          FStar_Extraction_ML_Syntax.MLTY_Named uu___
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____292 = FStar_List.map (subst_aux subst) ts in
-          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____292
+          let uu___ = FStar_List.map (subst_aux subst) ts in
+          FStar_Extraction_ML_Syntax.MLTY_Tuple uu___
       | FStar_Extraction_ML_Syntax.MLTY_Top -> t
       | FStar_Extraction_ML_Syntax.MLTY_Erased -> t
 let (try_subst :
@@ -167,17 +166,16 @@ let (try_subst :
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
       FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option)
   =
-  fun uu____307 ->
+  fun uu___ ->
     fun args ->
-      match uu____307 with
+      match uu___ with
       | (formals, t) ->
           if (FStar_List.length formals) <> (FStar_List.length args)
           then FStar_Pervasives_Native.None
           else
-            (let uu____318 =
-               let uu____319 = FStar_List.zip formals args in
-               subst_aux uu____319 t in
-             FStar_Pervasives_Native.Some uu____318)
+            (let uu___2 =
+               let uu___3 = FStar_List.zip formals args in subst_aux uu___3 t in
+             FStar_Pervasives_Native.Some uu___2)
 let (subst :
   (FStar_Extraction_ML_Syntax.mlidents * FStar_Extraction_ML_Syntax.mlty) ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
@@ -185,8 +183,8 @@ let (subst :
   =
   fun ts ->
     fun args ->
-      let uu____348 = try_subst ts args in
-      match uu____348 with
+      let uu___ = try_subst ts args in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           failwith
             "Substitution must be fully applied (see GitHub issue #490)"
@@ -197,31 +195,31 @@ let (udelta_unfold :
       FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option)
   =
   fun g ->
-    fun uu___0_363 ->
-      match uu___0_363 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Extraction_ML_Syntax.MLTY_Named (args, n) ->
-          let uu____372 = FStar_Extraction_ML_UEnv.lookup_tydef g n in
-          (match uu____372 with
+          let uu___1 = FStar_Extraction_ML_UEnv.lookup_tydef g n in
+          (match uu___1 with
            | FStar_Pervasives_Native.Some ts ->
-               let uu____378 = try_subst ts args in
-               (match uu____378 with
+               let uu___2 = try_subst ts args in
+               (match uu___2 with
                 | FStar_Pervasives_Native.None ->
-                    let uu____383 =
-                      let uu____384 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Extraction_ML_Syntax.string_of_mlpath n in
-                      let uu____385 =
+                      let uu___5 =
                         FStar_Util.string_of_int (FStar_List.length args) in
-                      let uu____386 =
+                      let uu___6 =
                         FStar_Util.string_of_int
                           (FStar_List.length (FStar_Pervasives_Native.fst ts)) in
                       FStar_Util.format3
                         "Substitution must be fully applied; got an application of %s with %s args whereas %s were expected (see GitHub issue #490)"
-                        uu____384 uu____385 uu____386 in
-                    failwith uu____383
+                        uu___4 uu___5 uu___6 in
+                    failwith uu___3
                 | FStar_Pervasives_Native.Some r ->
                     FStar_Pervasives_Native.Some r)
-           | uu____390 -> FStar_Pervasives_Native.None)
-      | uu____393 -> FStar_Pervasives_Native.None
+           | uu___2 -> FStar_Pervasives_Native.None)
+      | uu___1 -> FStar_Pervasives_Native.None
 let (eff_leq :
   FStar_Extraction_ML_Syntax.e_tag ->
     FStar_Extraction_ML_Syntax.e_tag -> Prims.bool)
@@ -229,15 +227,15 @@ let (eff_leq :
   fun f ->
     fun f' ->
       match (f, f') with
-      | (FStar_Extraction_ML_Syntax.E_PURE, uu____404) -> true
+      | (FStar_Extraction_ML_Syntax.E_PURE, uu___) -> true
       | (FStar_Extraction_ML_Syntax.E_GHOST,
          FStar_Extraction_ML_Syntax.E_GHOST) -> true
       | (FStar_Extraction_ML_Syntax.E_IMPURE,
          FStar_Extraction_ML_Syntax.E_IMPURE) -> true
-      | uu____405 -> false
+      | uu___ -> false
 let (eff_to_string : FStar_Extraction_ML_Syntax.e_tag -> Prims.string) =
-  fun uu___1_414 ->
-    match uu___1_414 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Extraction_ML_Syntax.E_PURE -> "Pure"
     | FStar_Extraction_ML_Syntax.E_GHOST -> "Ghost"
     | FStar_Extraction_ML_Syntax.E_IMPURE -> "Impure"
@@ -271,15 +269,15 @@ let (join :
         | (FStar_Extraction_ML_Syntax.E_PURE,
            FStar_Extraction_ML_Syntax.E_PURE) ->
             FStar_Extraction_ML_Syntax.E_PURE
-        | uu____430 ->
-            let uu____435 =
-              let uu____436 = FStar_Range.string_of_range r in
-              let uu____437 = eff_to_string f in
-              let uu____438 = eff_to_string f' in
+        | uu___ ->
+            let uu___1 =
+              let uu___2 = FStar_Range.string_of_range r in
+              let uu___3 = eff_to_string f in
+              let uu___4 = eff_to_string f' in
               FStar_Util.format3
-                "Impossible (%s): Inconsistent effects %s and %s" uu____436
-                uu____437 uu____438 in
-            failwith uu____435
+                "Impossible (%s): Inconsistent effects %s and %s" uu___2
+                uu___3 uu___4 in
+            failwith uu___1
 let (join_l :
   FStar_Range.range ->
     FStar_Extraction_ML_Syntax.e_tag Prims.list ->
@@ -294,10 +292,10 @@ let (mk_ty_fun :
     FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty)
   =
   FStar_List.fold_right
-    (fun uu____475 ->
+    (fun uu___ ->
        fun t ->
-         match uu____475 with
-         | (uu____481, t0) ->
+         match uu___ with
+         | (uu___1, t0) ->
              FStar_Extraction_ML_Syntax.MLTY_Fun
                (t0, FStar_Extraction_ML_Syntax.E_PURE, t))
 type unfold_t =
@@ -326,41 +324,40 @@ let rec (type_leq_c :
               let mk_fun xs body =
                 match xs with
                 | [] -> body
-                | uu____585 ->
+                | uu___ ->
                     let e1 =
                       match body.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Fun (ys, body1) ->
                           FStar_Extraction_ML_Syntax.MLE_Fun
                             ((FStar_List.append xs ys), body1)
-                      | uu____617 ->
+                      | uu___1 ->
                           FStar_Extraction_ML_Syntax.MLE_Fun (xs, body) in
-                    let uu____624 =
+                    let uu___1 =
                       mk_ty_fun xs body.FStar_Extraction_ML_Syntax.mlty in
-                    FStar_Extraction_ML_Syntax.with_ty uu____624 e1 in
+                    FStar_Extraction_ML_Syntax.with_ty uu___1 e1 in
               (match e with
                | FStar_Pervasives_Native.Some
                    {
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Fun (x::xs, body);
-                     FStar_Extraction_ML_Syntax.mlty = uu____634;
-                     FStar_Extraction_ML_Syntax.loc = uu____635;_}
+                     FStar_Extraction_ML_Syntax.mlty = uu___;
+                     FStar_Extraction_ML_Syntax.loc = uu___1;_}
                    ->
-                   let uu____656 =
-                     (type_leq unfold_ty t1' t1) && (eff_leq f f') in
-                   if uu____656
+                   let uu___2 = (type_leq unfold_ty t1' t1) && (eff_leq f f') in
+                   if uu___2
                    then
                      (if
                         (f = FStar_Extraction_ML_Syntax.E_PURE) &&
                           (f' = FStar_Extraction_ML_Syntax.E_GHOST)
                       then
-                        let uu____669 = type_leq unfold_ty t2 t2' in
-                        (if uu____669
+                        let uu___3 = type_leq unfold_ty t2 t2' in
+                        (if uu___3
                          then
                            let body1 =
-                             let uu____677 =
+                             let uu___4 =
                                type_leq unfold_ty t2
                                  FStar_Extraction_ML_Syntax.ml_unit_ty in
-                             if uu____677
+                             if uu___4
                              then FStar_Extraction_ML_Syntax.ml_unit
                              else
                                FStar_All.pipe_left
@@ -369,89 +366,88 @@ let rec (type_leq_c :
                                     (FStar_Extraction_ML_Syntax.ml_unit,
                                       FStar_Extraction_ML_Syntax.ml_unit_ty,
                                       t2')) in
-                           let uu____679 =
-                             let uu____682 =
-                               let uu____683 =
-                                 let uu____688 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    mk_ty_fun [x]
                                      body1.FStar_Extraction_ML_Syntax.mlty in
-                                 FStar_Extraction_ML_Syntax.with_ty uu____688 in
-                               FStar_All.pipe_left uu____683
+                                 FStar_Extraction_ML_Syntax.with_ty uu___7 in
+                               FStar_All.pipe_left uu___6
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     ([x], body1)) in
-                             FStar_Pervasives_Native.Some uu____682 in
-                           (true, uu____679)
+                             FStar_Pervasives_Native.Some uu___5 in
+                           (true, uu___4)
                          else (false, FStar_Pervasives_Native.None))
                       else
-                        (let uu____717 =
-                           let uu____724 =
-                             let uu____727 = mk_fun xs body in
+                        (let uu___4 =
+                           let uu___5 =
+                             let uu___6 = mk_fun xs body in
                              FStar_All.pipe_left
-                               (fun uu____730 ->
-                                  FStar_Pervasives_Native.Some uu____730)
-                               uu____727 in
-                           type_leq_c unfold_ty uu____724 t2 t2' in
-                         match uu____717 with
+                               (fun uu___7 ->
+                                  FStar_Pervasives_Native.Some uu___7) uu___6 in
+                           type_leq_c unfold_ty uu___5 t2 t2' in
+                         match uu___4 with
                          | (ok, body1) ->
                              let res =
                                match body1 with
                                | FStar_Pervasives_Native.Some body2 ->
-                                   let uu____749 = mk_fun [x] body2 in
-                                   FStar_Pervasives_Native.Some uu____749
-                               | uu____758 -> FStar_Pervasives_Native.None in
+                                   let uu___5 = mk_fun [x] body2 in
+                                   FStar_Pervasives_Native.Some uu___5
+                               | uu___5 -> FStar_Pervasives_Native.None in
                              (ok, res)))
                    else (false, FStar_Pervasives_Native.None)
-               | uu____766 ->
-                   let uu____769 =
+               | uu___ ->
+                   let uu___1 =
                      ((type_leq unfold_ty t1' t1) && (eff_leq f f')) &&
                        (type_leq unfold_ty t2 t2') in
-                   if uu____769
+                   if uu___1
                    then (true, e)
                    else (false, FStar_Pervasives_Native.None))
           | (FStar_Extraction_ML_Syntax.MLTY_Named (args, path),
              FStar_Extraction_ML_Syntax.MLTY_Named (args', path')) ->
               if path = path'
               then
-                let uu____799 =
+                let uu___ =
                   FStar_List.forall2 (type_leq unfold_ty) args args' in
-                (if uu____799
+                (if uu___
                  then (true, e)
                  else (false, FStar_Pervasives_Native.None))
               else
-                (let uu____812 = unfold_ty t in
-                 match uu____812 with
+                (let uu___1 = unfold_ty t in
+                 match uu___1 with
                  | FStar_Pervasives_Native.Some t1 ->
                      type_leq_c unfold_ty e t1 t'
                  | FStar_Pervasives_Native.None ->
-                     let uu____822 = unfold_ty t' in
-                     (match uu____822 with
+                     let uu___2 = unfold_ty t' in
+                     (match uu___2 with
                       | FStar_Pervasives_Native.None ->
                           (false, FStar_Pervasives_Native.None)
                       | FStar_Pervasives_Native.Some t'1 ->
                           type_leq_c unfold_ty e t t'1))
           | (FStar_Extraction_ML_Syntax.MLTY_Tuple ts,
              FStar_Extraction_ML_Syntax.MLTY_Tuple ts') ->
-              let uu____840 = FStar_List.forall2 (type_leq unfold_ty) ts ts' in
-              if uu____840
+              let uu___ = FStar_List.forall2 (type_leq unfold_ty) ts ts' in
+              if uu___
               then (true, e)
               else (false, FStar_Pervasives_Native.None)
           | (FStar_Extraction_ML_Syntax.MLTY_Top,
              FStar_Extraction_ML_Syntax.MLTY_Top) -> (true, e)
-          | (FStar_Extraction_ML_Syntax.MLTY_Named uu____854, uu____855) ->
-              let uu____862 = unfold_ty t in
-              (match uu____862 with
+          | (FStar_Extraction_ML_Syntax.MLTY_Named uu___, uu___1) ->
+              let uu___2 = unfold_ty t in
+              (match uu___2 with
                | FStar_Pervasives_Native.Some t1 ->
                    type_leq_c unfold_ty e t1 t'
-               | uu____872 -> (false, FStar_Pervasives_Native.None))
-          | (uu____877, FStar_Extraction_ML_Syntax.MLTY_Named uu____878) ->
-              let uu____885 = unfold_ty t' in
-              (match uu____885 with
+               | uu___3 -> (false, FStar_Pervasives_Native.None))
+          | (uu___, FStar_Extraction_ML_Syntax.MLTY_Named uu___1) ->
+              let uu___2 = unfold_ty t' in
+              (match uu___2 with
                | FStar_Pervasives_Native.Some t'1 ->
                    type_leq_c unfold_ty e t t'1
-               | uu____895 -> (false, FStar_Pervasives_Native.None))
+               | uu___3 -> (false, FStar_Pervasives_Native.None))
           | (FStar_Extraction_ML_Syntax.MLTY_Erased,
              FStar_Extraction_ML_Syntax.MLTY_Erased) -> (true, e)
-          | uu____902 -> (false, FStar_Pervasives_Native.None)
+          | uu___ -> (false, FStar_Pervasives_Native.None)
 and (type_leq :
   unfold_t ->
     FStar_Extraction_ML_Syntax.mlty ->
@@ -460,69 +456,68 @@ and (type_leq :
   fun g ->
     fun t1 ->
       fun t2 ->
-        let uu____913 = type_leq_c g FStar_Pervasives_Native.None t1 t2 in
-        FStar_All.pipe_right uu____913 FStar_Pervasives_Native.fst
+        let uu___ = type_leq_c g FStar_Pervasives_Native.None t1 t2 in
+        FStar_All.pipe_right uu___ FStar_Pervasives_Native.fst
 let rec (erase_effect_annotations :
   FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty) =
   fun t ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Fun (t1, f, t2) ->
-        let uu____936 =
-          let uu____943 = erase_effect_annotations t1 in
-          let uu____944 = erase_effect_annotations t2 in
-          (uu____943, FStar_Extraction_ML_Syntax.E_PURE, uu____944) in
-        FStar_Extraction_ML_Syntax.MLTY_Fun uu____936
-    | uu____945 -> t
+        let uu___ =
+          let uu___1 = erase_effect_annotations t1 in
+          let uu___2 = erase_effect_annotations t2 in
+          (uu___1, FStar_Extraction_ML_Syntax.E_PURE, uu___2) in
+        FStar_Extraction_ML_Syntax.MLTY_Fun uu___
+    | uu___ -> t
 let is_type_abstraction :
   'a 'b 'c . (('a, 'b) FStar_Util.either * 'c) Prims.list -> Prims.bool =
-  fun uu___2_971 ->
-    match uu___2_971 with
-    | (FStar_Util.Inl uu____982, uu____983)::uu____984 -> true
-    | uu____1007 -> false
+  fun uu___ ->
+    match uu___ with
+    | (FStar_Util.Inl uu___1, uu___2)::uu___3 -> true
+    | uu___1 -> false
 let (is_xtuple :
   (Prims.string Prims.list * Prims.string) ->
     Prims.int FStar_Pervasives_Native.option)
   =
-  fun uu____1030 ->
-    match uu____1030 with
+  fun uu___ ->
+    match uu___ with
     | (ns, n) ->
-        let uu____1045 =
-          let uu____1046 = FStar_Util.concat_l "." (FStar_List.append ns [n]) in
-          FStar_Parser_Const.is_tuple_datacon_string uu____1046 in
-        if uu____1045
+        let uu___1 =
+          let uu___2 = FStar_Util.concat_l "." (FStar_List.append ns [n]) in
+          FStar_Parser_Const.is_tuple_datacon_string uu___2 in
+        if uu___1
         then
-          let uu____1049 =
-            let uu____1050 = FStar_Util.char_at n (Prims.of_int (7)) in
-            FStar_Util.int_of_char uu____1050 in
-          FStar_Pervasives_Native.Some uu____1049
+          let uu___2 =
+            let uu___3 = FStar_Util.char_at n (Prims.of_int (7)) in
+            FStar_Util.int_of_char uu___3 in
+          FStar_Pervasives_Native.Some uu___2
         else FStar_Pervasives_Native.None
 let (resugar_exp :
   FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr) =
   fun e ->
     match e.FStar_Extraction_ML_Syntax.expr with
     | FStar_Extraction_ML_Syntax.MLE_CTor (mlp, args) ->
-        let uu____1063 = is_xtuple mlp in
-        (match uu____1063 with
+        let uu___ = is_xtuple mlp in
+        (match uu___ with
          | FStar_Pervasives_Native.Some n ->
              FStar_All.pipe_left
                (FStar_Extraction_ML_Syntax.with_ty
                   e.FStar_Extraction_ML_Syntax.mlty)
                (FStar_Extraction_ML_Syntax.MLE_Tuple args)
-         | uu____1067 -> e)
-    | uu____1070 -> e
+         | uu___1 -> e)
+    | uu___ -> e
 let (record_field_path :
   FStar_Ident.lident Prims.list -> Prims.string Prims.list) =
-  fun uu___3_1079 ->
-    match uu___3_1079 with
-    | f::uu____1085 ->
-        let uu____1088 =
-          let uu____1095 = FStar_Ident.ns_of_lid f in
-          FStar_Util.prefix uu____1095 in
-        (match uu____1088 with
-         | (ns, uu____1101) ->
+  fun uu___ ->
+    match uu___ with
+    | f::uu___1 ->
+        let uu___2 =
+          let uu___3 = FStar_Ident.ns_of_lid f in FStar_Util.prefix uu___3 in
+        (match uu___2 with
+         | (ns, uu___3) ->
              FStar_All.pipe_right ns
                (FStar_List.map (fun id -> FStar_Ident.string_of_id id)))
-    | uu____1112 -> failwith "impos"
+    | uu___1 -> failwith "impos"
 let record_fields :
   'a .
     FStar_Ident.lident Prims.list ->
@@ -533,64 +528,61 @@ let record_fields :
       FStar_List.map2
         (fun f ->
            fun e ->
-             let uu____1157 =
-               let uu____1158 = FStar_Ident.ident_of_lid f in
-               FStar_Ident.string_of_id uu____1158 in
-             (uu____1157, e)) fs vs
+             let uu___ =
+               let uu___1 = FStar_Ident.ident_of_lid f in
+               FStar_Ident.string_of_id uu___1 in
+             (uu___, e)) fs vs
 let (is_xtuple_ty :
   (Prims.string Prims.list * Prims.string) ->
     Prims.int FStar_Pervasives_Native.option)
   =
-  fun uu____1171 ->
-    match uu____1171 with
+  fun uu___ ->
+    match uu___ with
     | (ns, n) ->
-        let uu____1186 =
-          let uu____1187 = FStar_Util.concat_l "." (FStar_List.append ns [n]) in
-          FStar_Parser_Const.is_tuple_constructor_string uu____1187 in
-        if uu____1186
+        let uu___1 =
+          let uu___2 = FStar_Util.concat_l "." (FStar_List.append ns [n]) in
+          FStar_Parser_Const.is_tuple_constructor_string uu___2 in
+        if uu___1
         then
-          let uu____1190 =
-            let uu____1191 = FStar_Util.char_at n (Prims.of_int (5)) in
-            FStar_Util.int_of_char uu____1191 in
-          FStar_Pervasives_Native.Some uu____1190
+          let uu___2 =
+            let uu___3 = FStar_Util.char_at n (Prims.of_int (5)) in
+            FStar_Util.int_of_char uu___3 in
+          FStar_Pervasives_Native.Some uu___2
         else FStar_Pervasives_Native.None
 let (resugar_mlty :
   FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty) =
   fun t ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Named (args, mlp) ->
-        let uu____1204 = is_xtuple_ty mlp in
-        (match uu____1204 with
+        let uu___ = is_xtuple_ty mlp in
+        (match uu___ with
          | FStar_Pervasives_Native.Some n ->
              FStar_Extraction_ML_Syntax.MLTY_Tuple args
-         | uu____1208 -> t)
-    | uu____1211 -> t
+         | uu___1 -> t)
+    | uu___ -> t
 let (flatten_ns : Prims.string Prims.list -> Prims.string) =
   fun ns ->
-    let uu____1221 = codegen_fsharp () in
-    if uu____1221
-    then FStar_String.concat "." ns
-    else FStar_String.concat "_" ns
+    let uu___ = codegen_fsharp () in
+    if uu___ then FStar_String.concat "." ns else FStar_String.concat "_" ns
 let (flatten_mlpath :
   (Prims.string Prims.list * Prims.string) -> Prims.string) =
-  fun uu____1233 ->
-    match uu____1233 with
+  fun uu___ ->
+    match uu___ with
     | (ns, n) ->
-        let uu____1246 = codegen_fsharp () in
-        if uu____1246
+        let uu___1 = codegen_fsharp () in
+        if uu___1
         then FStar_String.concat "." (FStar_List.append ns [n])
         else FStar_String.concat "_" (FStar_List.append ns [n])
 let (ml_module_name_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l ->
     let mlp =
-      let uu____1260 =
-        let uu____1263 = FStar_All.pipe_right l FStar_Ident.ns_of_lid in
-        FStar_All.pipe_right uu____1263
-          (FStar_List.map FStar_Ident.string_of_id) in
-      let uu____1272 =
-        let uu____1273 = FStar_Ident.ident_of_lid l in
-        FStar_Ident.string_of_id uu____1273 in
-      (uu____1260, uu____1272) in
+      let uu___ =
+        let uu___1 = FStar_All.pipe_right l FStar_Ident.ns_of_lid in
+        FStar_All.pipe_right uu___1 (FStar_List.map FStar_Ident.string_of_id) in
+      let uu___1 =
+        let uu___2 = FStar_Ident.ident_of_lid l in
+        FStar_Ident.string_of_id uu___2 in
+      (uu___, uu___1) in
     flatten_mlpath mlp
 let rec (erasableType :
   unfold_t -> FStar_Extraction_ML_Syntax.mlty -> Prims.bool) =
@@ -602,19 +594,18 @@ let rec (erasableType :
         else
           (match t1 with
            | FStar_Extraction_ML_Syntax.MLTY_Named
-               (uu____1295, ("FStar"::"Ghost"::[], "erased")) -> true
+               (uu___1, ("FStar"::"Ghost"::[], "erased")) -> true
            | FStar_Extraction_ML_Syntax.MLTY_Named
-               (uu____1302, ("FStar"::"Tactics"::"Effect"::[], "tactic")) ->
-               let uu____1309 = FStar_Options.codegen () in
-               uu____1309 <>
-                 (FStar_Pervasives_Native.Some FStar_Options.Plugin)
-           | uu____1314 -> false) in
-      let uu____1315 = erasableTypeNoDelta t in
-      if uu____1315
+               (uu___1, ("FStar"::"Tactics"::"Effect"::[], "tactic")) ->
+               let uu___2 = FStar_Options.codegen () in
+               uu___2 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)
+           | uu___1 -> false) in
+      let uu___ = erasableTypeNoDelta t in
+      if uu___
       then true
       else
-        (let uu____1317 = unfold_ty t in
-         match uu____1317 with
+        (let uu___2 = unfold_ty t in
+         match uu___2 with
          | FStar_Pervasives_Native.Some t1 -> erasableType unfold_ty t1
          | FStar_Pervasives_Native.None -> false)
 let rec (eraseTypeDeep :
@@ -627,38 +618,38 @@ let rec (eraseTypeDeep :
       | FStar_Extraction_ML_Syntax.MLTY_Fun (tyd, etag, tycd) ->
           if etag = FStar_Extraction_ML_Syntax.E_PURE
           then
-            let uu____1336 =
-              let uu____1343 = eraseTypeDeep unfold_ty tyd in
-              let uu____1344 = eraseTypeDeep unfold_ty tycd in
-              (uu____1343, etag, uu____1344) in
-            FStar_Extraction_ML_Syntax.MLTY_Fun uu____1336
+            let uu___ =
+              let uu___1 = eraseTypeDeep unfold_ty tyd in
+              let uu___2 = eraseTypeDeep unfold_ty tycd in
+              (uu___1, etag, uu___2) in
+            FStar_Extraction_ML_Syntax.MLTY_Fun uu___
           else t
       | FStar_Extraction_ML_Syntax.MLTY_Named (lty, mlp) ->
-          let uu____1352 = erasableType unfold_ty t in
-          if uu____1352
+          let uu___ = erasableType unfold_ty t in
+          if uu___
           then FStar_Extraction_ML_Syntax.MLTY_Erased
           else
-            (let uu____1354 =
-               let uu____1361 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
-               (uu____1361, mlp) in
-             FStar_Extraction_ML_Syntax.MLTY_Named uu____1354)
+            (let uu___2 =
+               let uu___3 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
+               (uu___3, mlp) in
+             FStar_Extraction_ML_Syntax.MLTY_Named uu___2)
       | FStar_Extraction_ML_Syntax.MLTY_Tuple lty ->
-          let uu____1369 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
-          FStar_Extraction_ML_Syntax.MLTY_Tuple uu____1369
-      | uu____1372 -> t
+          let uu___ = FStar_List.map (eraseTypeDeep unfold_ty) lty in
+          FStar_Extraction_ML_Syntax.MLTY_Tuple uu___
+      | uu___ -> t
 let (prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr) =
   FStar_All.pipe_left
     (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_Equality"))
 let (prims_op_amp_amp : FStar_Extraction_ML_Syntax.mlexpr) =
-  let uu____1375 =
-    let uu____1380 =
+  let uu___ =
+    let uu___1 =
       mk_ty_fun
         [("x", FStar_Extraction_ML_Syntax.ml_bool_ty);
         ("y", FStar_Extraction_ML_Syntax.ml_bool_ty)]
         FStar_Extraction_ML_Syntax.ml_bool_ty in
-    FStar_Extraction_ML_Syntax.with_ty uu____1380 in
-  FStar_All.pipe_left uu____1375
+    FStar_Extraction_ML_Syntax.with_ty uu___1 in
+  FStar_All.pipe_left uu___
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_AmpAmp"))
 let (conjoin :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -685,13 +676,12 @@ let (conjoin_opt :
       | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some x) ->
           FStar_Pervasives_Native.Some x
       | (FStar_Pervasives_Native.Some x, FStar_Pervasives_Native.Some y) ->
-          let uu____1453 = conjoin x y in
-          FStar_Pervasives_Native.Some uu____1453
+          let uu___ = conjoin x y in FStar_Pervasives_Native.Some uu___
 let (mlloc_of_range : FStar_Range.range -> (Prims.int * Prims.string)) =
   fun r ->
     let pos = FStar_Range.start_of_range r in
     let line = FStar_Range.line_of_pos pos in
-    let uu____1465 = FStar_Range.file_of_range r in (line, uu____1465)
+    let uu___ = FStar_Range.file_of_range r in (line, uu___)
 let rec (doms_and_cod :
   FStar_Extraction_ML_Syntax.mlty ->
     (FStar_Extraction_ML_Syntax.mlty Prims.list *
@@ -699,16 +689,14 @@ let rec (doms_and_cod :
   =
   fun t ->
     match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu____1484, b) ->
-        let uu____1486 = doms_and_cod b in
-        (match uu____1486 with | (ds, c) -> ((a :: ds), c))
-    | uu____1507 -> ([], t)
+    | FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu___, b) ->
+        let uu___1 = doms_and_cod b in
+        (match uu___1 with | (ds, c) -> ((a :: ds), c))
+    | uu___ -> ([], t)
 let (argTypes :
   FStar_Extraction_ML_Syntax.mlty ->
     FStar_Extraction_ML_Syntax.mlty Prims.list)
-  =
-  fun t ->
-    let uu____1519 = doms_and_cod t in FStar_Pervasives_Native.fst uu____1519
+  = fun t -> let uu___ = doms_and_cod t in FStar_Pervasives_Native.fst uu___
 let rec (uncurry_mlty_fun :
   FStar_Extraction_ML_Syntax.mlty ->
     (FStar_Extraction_ML_Syntax.mlty Prims.list *
@@ -716,38 +704,35 @@ let rec (uncurry_mlty_fun :
   =
   fun t ->
     match t with
-    | FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu____1546, b) ->
-        let uu____1548 = uncurry_mlty_fun b in
-        (match uu____1548 with | (args, res) -> ((a :: args), res))
-    | uu____1569 -> ([], t)
+    | FStar_Extraction_ML_Syntax.MLTY_Fun (a, uu___, b) ->
+        let uu___1 = uncurry_mlty_fun b in
+        (match uu___1 with | (args, res) -> ((a :: args), res))
+    | uu___ -> ([], t)
 exception NoTacticEmbedding of Prims.string 
 let (uu___is_NoTacticEmbedding : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | NoTacticEmbedding uu____1581 -> true
-    | uu____1582 -> false
+    match projectee with | NoTacticEmbedding uu___ -> true | uu___ -> false
 let (__proj__NoTacticEmbedding__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee ->
-    match projectee with | NoTacticEmbedding uu____1588 -> uu____1588
+  fun projectee -> match projectee with | NoTacticEmbedding uu___ -> uu___
 let (not_implemented_warning :
   FStar_Range.range -> Prims.string -> Prims.string -> unit) =
   fun r ->
     fun t ->
       fun msg ->
-        let uu____1604 =
-          let uu____1609 =
-            let uu____1610 =
-              let uu____1611 =
-                let uu____1612 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
                   FStar_Errors.lookup
                     FStar_Errors.Warning_PluginNotImplemented in
-                FStar_Errors.error_number uu____1612 in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____1611 in
+                FStar_Errors.error_number uu___4 in
+              FStar_All.pipe_left FStar_Util.string_of_int uu___3 in
             FStar_Util.format3
               "Plugin %s can not run natively because %s (use --warn_error -%s to carry on)."
-              t msg uu____1610 in
-          (FStar_Errors.Warning_PluginNotImplemented, uu____1609) in
-        FStar_Errors.log_issue r uu____1604
+              t msg uu___2 in
+          (FStar_Errors.Warning_PluginNotImplemented, uu___1) in
+        FStar_Errors.log_issue r uu___
 type emb_loc =
   | Syntax_term 
   | Refl_emb 
@@ -755,15 +740,14 @@ type emb_loc =
   | NBERefl_emb 
 let (uu___is_Syntax_term : emb_loc -> Prims.bool) =
   fun projectee ->
-    match projectee with | Syntax_term -> true | uu____1624 -> false
+    match projectee with | Syntax_term -> true | uu___ -> false
 let (uu___is_Refl_emb : emb_loc -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Refl_emb -> true | uu____1630 -> false
+  fun projectee -> match projectee with | Refl_emb -> true | uu___ -> false
 let (uu___is_NBE_t : emb_loc -> Prims.bool) =
-  fun projectee -> match projectee with | NBE_t -> true | uu____1636 -> false
+  fun projectee -> match projectee with | NBE_t -> true | uu___ -> false
 let (uu___is_NBERefl_emb : emb_loc -> Prims.bool) =
   fun projectee ->
-    match projectee with | NBERefl_emb -> true | uu____1642 -> false
+    match projectee with | NBERefl_emb -> true | uu___ -> false
 type wrapped_term =
   (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.mlexpr *
     Prims.int * Prims.bool)
@@ -801,13 +785,12 @@ let (interpret_plugin_as_term_fun :
                    FStar_Extraction_ML_Syntax.MLTY_Top)
                 (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
             let lid_to_name l =
-              let uu____1712 =
-                let uu____1713 =
-                  FStar_Extraction_ML_UEnv.mlpath_of_lident env l in
-                FStar_Extraction_ML_Syntax.MLE_Name uu____1713 in
+              let uu___ =
+                let uu___1 = FStar_Extraction_ML_UEnv.mlpath_of_lident env l in
+                FStar_Extraction_ML_Syntax.MLE_Name uu___1 in
               FStar_All.pipe_left
                 (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____1712 in
+                   FStar_Extraction_ML_Syntax.MLTY_Top) uu___ in
             let str_to_name s = as_name ([], s) in
             let fstar_tc_nbe_prefix s =
               as_name (["FStar_TypeChecker_NBETerm"], s) in
@@ -818,27 +801,27 @@ let (interpret_plugin_as_term_fun :
             let fstar_refl_nbeemb_prefix s =
               as_name (["FStar_Reflection_NBEEmbeddings"], s) in
             let fv_lid_embedded =
-              let uu____1755 =
-                let uu____1756 =
-                  let uu____1763 = as_name (["FStar_Ident"], "lid_of_str") in
-                  let uu____1766 =
-                    let uu____1769 =
-                      let uu____1770 =
-                        let uu____1771 =
-                          let uu____1772 = FStar_Ident.string_of_lid fv_lid in
-                          FStar_Extraction_ML_Syntax.MLC_String uu____1772 in
-                        FStar_Extraction_ML_Syntax.MLE_Const uu____1771 in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = as_name (["FStar_Ident"], "lid_of_str") in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 = FStar_Ident.string_of_lid fv_lid in
+                          FStar_Extraction_ML_Syntax.MLC_String uu___7 in
+                        FStar_Extraction_ML_Syntax.MLE_Const uu___6 in
                       FStar_All.pipe_left
                         (FStar_Extraction_ML_Syntax.with_ty
-                           FStar_Extraction_ML_Syntax.MLTY_Top) uu____1770 in
-                    [uu____1769] in
-                  (uu____1763, uu____1766) in
-                FStar_Extraction_ML_Syntax.MLE_App uu____1756 in
+                           FStar_Extraction_ML_Syntax.MLTY_Top) uu___5 in
+                    [uu___4] in
+                  (uu___2, uu___3) in
+                FStar_Extraction_ML_Syntax.MLE_App uu___1 in
               FStar_All.pipe_left
                 (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu____1755 in
-            let emb_prefix uu___4_1785 =
-              match uu___4_1785 with
+                   FStar_Extraction_ML_Syntax.MLTY_Top) uu___ in
+            let emb_prefix uu___ =
+              match uu___ with
               | Syntax_term -> fstar_syn_emb_prefix
               | Refl_emb -> fstar_refl_emb_prefix
               | NBE_t -> fstar_tc_nbe_prefix
@@ -853,24 +836,24 @@ let (interpret_plugin_as_term_fun :
                 (let idroot =
                    match l with
                    | Syntax_term -> "mk_tactic_interpretation_"
-                   | uu____1802 -> "mk_nbe_tactic_interpretation_" in
-                 let uu____1803 =
-                   let uu____1804 =
-                     let uu____1805 = FStar_Util.string_of_int arity in
-                     Prims.op_Hat idroot uu____1805 in
-                   (["FStar_Tactics_InterpFuns"], uu____1804) in
-                 as_name uu____1803) in
+                   | uu___1 -> "mk_nbe_tactic_interpretation_" in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Util.string_of_int arity in
+                     Prims.op_Hat idroot uu___3 in
+                   (["FStar_Tactics_InterpFuns"], uu___2) in
+                 as_name uu___1) in
             let mk_from_tactic l arity =
               let idroot =
                 match l with
                 | Syntax_term -> "from_tactic_"
-                | uu____1820 -> "from_nbe_tactic_" in
-              let uu____1821 =
-                let uu____1822 =
-                  let uu____1823 = FStar_Util.string_of_int arity in
-                  Prims.op_Hat idroot uu____1823 in
-                (["FStar_Tactics_Native"], uu____1822) in
-              as_name uu____1821 in
+                | uu___ -> "from_nbe_tactic_" in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = FStar_Util.string_of_int arity in
+                  Prims.op_Hat idroot uu___2 in
+                (["FStar_Tactics_Native"], uu___1) in
+              as_name uu___ in
             let mk_basic_embedding l s =
               if s = "norm_step"
               then
@@ -879,412 +862,397 @@ let (interpret_plugin_as_term_fun :
                     as_name (["FStar_Tactics_Builtins"], "e_norm_step'")
                 | NBE_t ->
                     as_name (["FStar_Tactics_Builtins"], "e_norm_step_nbe'")
-                | uu____1841 ->
+                | uu___ ->
                     failwith "impossible: mk_basic_embedding norm_step"
               else emb_prefix l (Prims.op_Hat "e_" s) in
             let mk_arrow_as_prim_step l arity =
-              let uu____1854 =
-                let uu____1855 = FStar_Util.string_of_int arity in
-                Prims.op_Hat "arrow_as_prim_step_" uu____1855 in
-              emb_prefix l uu____1854 in
+              let uu___ =
+                let uu___1 = FStar_Util.string_of_int arity in
+                Prims.op_Hat "arrow_as_prim_step_" uu___1 in
+              emb_prefix l uu___ in
             let mk_any_embedding l s =
-              let uu____1867 =
-                let uu____1868 =
-                  let uu____1875 = emb_prefix l "mk_any_emb" in
-                  let uu____1876 =
-                    let uu____1879 = str_to_name s in [uu____1879] in
-                  (uu____1875, uu____1876) in
-                FStar_Extraction_ML_Syntax.MLE_App uu____1868 in
-              FStar_All.pipe_left w uu____1867 in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = emb_prefix l "mk_any_emb" in
+                  let uu___3 = let uu___4 = str_to_name s in [uu___4] in
+                  (uu___2, uu___3) in
+                FStar_Extraction_ML_Syntax.MLE_App uu___1 in
+              FStar_All.pipe_left w uu___ in
             let mk_lam nm e =
               FStar_All.pipe_left w
                 (FStar_Extraction_ML_Syntax.MLE_Fun
                    ([(nm, FStar_Extraction_ML_Syntax.MLTY_Top)], e)) in
             let emb_arrow l e1 e2 =
-              let uu____1923 =
-                let uu____1924 =
-                  let uu____1931 = emb_prefix l "e_arrow" in
-                  (uu____1931, [e1; e2]) in
-                FStar_Extraction_ML_Syntax.MLE_App uu____1924 in
-              FStar_All.pipe_left w uu____1923 in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = emb_prefix l "e_arrow" in (uu___2, [e1; e2]) in
+                FStar_Extraction_ML_Syntax.MLE_App uu___1 in
+              FStar_All.pipe_left w uu___ in
             let known_type_constructors =
               let term_cs =
-                let uu____1964 =
-                  let uu____1977 =
-                    let uu____1990 =
-                      let uu____2003 =
-                        let uu____2016 =
-                          let uu____2029 =
-                            let uu____2042 =
-                              let uu____2055 =
-                                let uu____2066 =
-                                  let uu____2073 =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
+                                  let uu___9 =
                                     FStar_Parser_Const.mk_tuple_lid
                                       (Prims.of_int (2))
                                       FStar_Range.dummyRange in
-                                  (uu____2073, (Prims.of_int (2)), "tuple2") in
-                                (uu____2066, Syntax_term) in
-                              let uu____2080 =
-                                let uu____2093 =
-                                  let uu____2104 =
-                                    let uu____2111 =
+                                  (uu___9, (Prims.of_int (2)), "tuple2") in
+                                (uu___8, Syntax_term) in
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
+                                    let uu___11 =
                                       FStar_Reflection_Data.fstar_refl_types_lid
                                         "term" in
-                                    (uu____2111, Prims.int_zero, "term") in
-                                  (uu____2104, Refl_emb) in
-                                let uu____2118 =
-                                  let uu____2131 =
-                                    let uu____2142 =
-                                      let uu____2149 =
+                                    (uu___11, Prims.int_zero, "term") in
+                                  (uu___10, Refl_emb) in
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_Reflection_Data.fstar_refl_types_lid
                                           "sigelt" in
-                                      (uu____2149, Prims.int_zero, "sigelt") in
-                                    (uu____2142, Refl_emb) in
-                                  let uu____2156 =
-                                    let uu____2169 =
-                                      let uu____2180 =
-                                        let uu____2187 =
+                                      (uu___13, Prims.int_zero, "sigelt") in
+                                    (uu___12, Refl_emb) in
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
+                                        let uu___15 =
                                           FStar_Reflection_Data.fstar_refl_types_lid
                                             "fv" in
-                                        (uu____2187, Prims.int_zero, "fv") in
-                                      (uu____2180, Refl_emb) in
-                                    let uu____2194 =
-                                      let uu____2207 =
-                                        let uu____2218 =
-                                          let uu____2225 =
+                                        (uu___15, Prims.int_zero, "fv") in
+                                      (uu___14, Refl_emb) in
+                                    let uu___14 =
+                                      let uu___15 =
+                                        let uu___16 =
+                                          let uu___17 =
                                             FStar_Reflection_Data.fstar_refl_types_lid
                                               "binder" in
-                                          (uu____2225, Prims.int_zero,
-                                            "binder") in
-                                        (uu____2218, Refl_emb) in
-                                      let uu____2232 =
-                                        let uu____2245 =
-                                          let uu____2256 =
-                                            let uu____2263 =
+                                          (uu___17, Prims.int_zero, "binder") in
+                                        (uu___16, Refl_emb) in
+                                      let uu___16 =
+                                        let uu___17 =
+                                          let uu___18 =
+                                            let uu___19 =
                                               FStar_Reflection_Data.fstar_refl_syntax_lid
                                                 "binders" in
-                                            (uu____2263, Prims.int_zero,
+                                            (uu___19, Prims.int_zero,
                                               "binders") in
-                                          (uu____2256, Refl_emb) in
-                                        let uu____2270 =
-                                          let uu____2283 =
-                                            let uu____2294 =
-                                              let uu____2301 =
+                                          (uu___18, Refl_emb) in
+                                        let uu___18 =
+                                          let uu___19 =
+                                            let uu___20 =
+                                              let uu___21 =
                                                 FStar_Reflection_Data.fstar_refl_data_lid
                                                   "exp" in
-                                              (uu____2301, Prims.int_zero,
+                                              (uu___21, Prims.int_zero,
                                                 "exp") in
-                                            (uu____2294, Refl_emb) in
-                                          [uu____2283] in
-                                        uu____2245 :: uu____2270 in
-                                      uu____2207 :: uu____2232 in
-                                    uu____2169 :: uu____2194 in
-                                  uu____2131 :: uu____2156 in
-                                uu____2093 :: uu____2118 in
-                              uu____2055 :: uu____2080 in
+                                            (uu___20, Refl_emb) in
+                                          [uu___19] in
+                                        uu___17 :: uu___18 in
+                                      uu___15 :: uu___16 in
+                                    uu___13 :: uu___14 in
+                                  uu___11 :: uu___12 in
+                                uu___9 :: uu___10 in
+                              uu___7 :: uu___8 in
                             ((FStar_Parser_Const.option_lid, Prims.int_one,
                                "option"), Syntax_term)
-                              :: uu____2042 in
+                              :: uu___6 in
                           ((FStar_Parser_Const.list_lid, Prims.int_one,
                              "list"), Syntax_term)
-                            :: uu____2029 in
+                            :: uu___5 in
                         ((FStar_Parser_Const.norm_step_lid, Prims.int_zero,
                            "norm_step"), Syntax_term)
-                          :: uu____2016 in
+                          :: uu___4 in
                       ((FStar_Parser_Const.string_lid, Prims.int_zero,
                          "string"), Syntax_term)
-                        :: uu____2003 in
+                        :: uu___3 in
                     ((FStar_Parser_Const.unit_lid, Prims.int_zero, "unit"),
-                      Syntax_term) :: uu____1990 in
+                      Syntax_term) :: uu___2 in
                   ((FStar_Parser_Const.bool_lid, Prims.int_zero, "bool"),
-                    Syntax_term) :: uu____1977 in
+                    Syntax_term) :: uu___1 in
                 ((FStar_Parser_Const.int_lid, Prims.int_zero, "int"),
-                  Syntax_term) :: uu____1964 in
+                  Syntax_term) :: uu___ in
               let nbe_cs =
                 FStar_List.map
-                  (fun uu___5_2535 ->
-                     match uu___5_2535 with
+                  (fun uu___ ->
+                     match uu___ with
                      | (x, Syntax_term) -> (x, NBE_t)
                      | (x, Refl_emb) -> (x, NBERefl_emb)
-                     | uu____2594 -> failwith "Impossible") term_cs in
-              fun uu___6_2615 ->
-                match uu___6_2615 with
+                     | uu___1 -> failwith "Impossible") term_cs in
+              fun uu___ ->
+                match uu___ with
                 | Syntax_term -> term_cs
                 | Refl_emb -> term_cs
-                | uu____2628 -> nbe_cs in
+                | uu___1 -> nbe_cs in
             let is_known_type_constructor l fv1 n =
               FStar_Util.for_some
-                (fun uu____2660 ->
-                   match uu____2660 with
-                   | ((x, args, uu____2673), uu____2674) ->
+                (fun uu___ ->
+                   match uu___ with
+                   | ((x, args, uu___1), uu___2) ->
                        (FStar_Syntax_Syntax.fv_eq_lid fv1 x) && (n = args))
                 (known_type_constructors l) in
-            let find_env_entry bv uu____2695 =
-              match uu____2695 with
-              | (bv', uu____2701) -> FStar_Syntax_Syntax.bv_eq bv bv' in
+            let find_env_entry bv uu___ =
+              match uu___ with
+              | (bv', uu___1) -> FStar_Syntax_Syntax.bv_eq bv bv' in
             let rec mk_embedding l env1 t2 =
               let t3 =
                 FStar_TypeChecker_Normalize.unfold_whnf'
                   [FStar_TypeChecker_Env.ForExtraction] tcenv t2 in
-              let uu____2731 =
-                let uu____2732 = FStar_Syntax_Subst.compress t3 in
-                uu____2732.FStar_Syntax_Syntax.n in
-              match uu____2731 with
+              let uu___ =
+                let uu___1 = FStar_Syntax_Subst.compress t3 in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
               | FStar_Syntax_Syntax.Tm_name bv when
                   FStar_Util.for_some (find_env_entry bv) env1 ->
-                  let uu____2740 =
-                    let uu____2741 =
-                      let uu____2746 =
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
                         FStar_Util.find_opt (find_env_entry bv) env1 in
-                      FStar_Util.must uu____2746 in
-                    FStar_Pervasives_Native.snd uu____2741 in
-                  FStar_All.pipe_left (mk_any_embedding l) uu____2740
-              | FStar_Syntax_Syntax.Tm_refine (x, uu____2762) ->
+                      FStar_Util.must uu___3 in
+                    FStar_Pervasives_Native.snd uu___2 in
+                  FStar_All.pipe_left (mk_any_embedding l) uu___1
+              | FStar_Syntax_Syntax.Tm_refine (x, uu___1) ->
                   mk_embedding l env1 x.FStar_Syntax_Syntax.sort
-              | FStar_Syntax_Syntax.Tm_ascribed (t4, uu____2768, uu____2769)
-                  -> mk_embedding l env1 t4
+              | FStar_Syntax_Syntax.Tm_ascribed (t4, uu___1, uu___2) ->
+                  mk_embedding l env1 t4
               | FStar_Syntax_Syntax.Tm_arrow (b::[], c) when
                   FStar_Syntax_Util.is_pure_comp c ->
-                  let uu____2842 = FStar_Syntax_Subst.open_comp [b] c in
-                  (match uu____2842 with
+                  let uu___1 = FStar_Syntax_Subst.open_comp [b] c in
+                  (match uu___1 with
                    | (bs, c1) ->
                        let t0 =
-                         let uu____2864 =
-                           let uu____2865 = FStar_List.hd bs in
-                           FStar_Pervasives_Native.fst uu____2865 in
-                         uu____2864.FStar_Syntax_Syntax.sort in
+                         let uu___2 =
+                           let uu___3 = FStar_List.hd bs in
+                           FStar_Pervasives_Native.fst uu___3 in
+                         uu___2.FStar_Syntax_Syntax.sort in
                        let t11 = FStar_Syntax_Util.comp_result c1 in
-                       let uu____2883 = mk_embedding l env1 t0 in
-                       let uu____2884 = mk_embedding l env1 t11 in
-                       emb_arrow l uu____2883 uu____2884)
+                       let uu___2 = mk_embedding l env1 t0 in
+                       let uu___3 = mk_embedding l env1 t11 in
+                       emb_arrow l uu___2 uu___3)
               | FStar_Syntax_Syntax.Tm_arrow (b::more::bs, c) ->
                   let tail =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow ((more :: bs), c))
                       t3.FStar_Syntax_Syntax.pos in
                   let t4 =
-                    let uu____2955 =
-                      let uu____2956 =
-                        let uu____2971 = FStar_Syntax_Syntax.mk_Total tail in
-                        ([b], uu____2971) in
-                      FStar_Syntax_Syntax.Tm_arrow uu____2956 in
-                    FStar_Syntax_Syntax.mk uu____2955
-                      t3.FStar_Syntax_Syntax.pos in
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = FStar_Syntax_Syntax.mk_Total tail in
+                        ([b], uu___3) in
+                      FStar_Syntax_Syntax.Tm_arrow uu___2 in
+                    FStar_Syntax_Syntax.mk uu___1 t3.FStar_Syntax_Syntax.pos in
                   mk_embedding l env1 t4
-              | FStar_Syntax_Syntax.Tm_fvar uu____2996 ->
-                  let uu____2997 = FStar_Syntax_Util.head_and_args t3 in
-                  (match uu____2997 with
+              | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
+                  let uu___2 = FStar_Syntax_Util.head_and_args t3 in
+                  (match uu___2 with
                    | (head, args) ->
                        let n_args = FStar_List.length args in
-                       let uu____3049 =
-                         let uu____3050 = FStar_Syntax_Util.un_uinst head in
-                         uu____3050.FStar_Syntax_Syntax.n in
-                       (match uu____3049 with
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Util.un_uinst head in
+                         uu___4.FStar_Syntax_Syntax.n in
+                       (match uu___3 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____3076 ->
-                                      match uu____3076 with
-                                      | (t4, uu____3084) ->
+                                   (fun uu___4 ->
+                                      match uu___4 with
+                                      | (t4, uu___5) ->
                                           mk_embedding l env1 t4)) in
                             let nm =
-                              let uu____3090 =
+                              let uu___4 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                              FStar_Ident.string_of_id uu____3090 in
-                            let uu____3091 =
-                              let uu____3102 =
+                              FStar_Ident.string_of_id uu___4 in
+                            let uu___4 =
+                              let uu___5 =
                                 FStar_Util.find_opt
-                                  (fun uu____3130 ->
-                                     match uu____3130 with
-                                     | ((x, uu____3142, uu____3143),
-                                        uu____3144) ->
+                                  (fun uu___6 ->
+                                     match uu___6 with
+                                     | ((x, uu___7, uu___8), uu___9) ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l) in
-                              FStar_All.pipe_right uu____3102 FStar_Util.must in
-                            (match uu____3091 with
-                             | ((uu____3183, t_arity, _trepr_head),
+                              FStar_All.pipe_right uu___5 FStar_Util.must in
+                            (match uu___4 with
+                             | ((uu___5, t_arity, _trepr_head),
                                 loc_embedding) ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm in
                                  (match t_arity with
-                                  | uu____3194 when
-                                      uu____3194 = Prims.int_zero -> head1
+                                  | uu___6 when uu___6 = Prims.int_zero ->
+                                      head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____3198 ->
-                            let uu____3199 =
-                              let uu____3200 =
-                                let uu____3201 =
+                        | uu___4 ->
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Print.term_to_string t3 in
                                 Prims.op_Hat
-                                  "Embedding not defined for type "
-                                  uu____3201 in
-                              NoTacticEmbedding uu____3200 in
-                            FStar_Exn.raise uu____3199))
-              | FStar_Syntax_Syntax.Tm_uinst uu____3202 ->
-                  let uu____3209 = FStar_Syntax_Util.head_and_args t3 in
-                  (match uu____3209 with
+                                  "Embedding not defined for type " uu___7 in
+                              NoTacticEmbedding uu___6 in
+                            FStar_Exn.raise uu___5))
+              | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
+                  let uu___2 = FStar_Syntax_Util.head_and_args t3 in
+                  (match uu___2 with
                    | (head, args) ->
                        let n_args = FStar_List.length args in
-                       let uu____3261 =
-                         let uu____3262 = FStar_Syntax_Util.un_uinst head in
-                         uu____3262.FStar_Syntax_Syntax.n in
-                       (match uu____3261 with
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Util.un_uinst head in
+                         uu___4.FStar_Syntax_Syntax.n in
+                       (match uu___3 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____3288 ->
-                                      match uu____3288 with
-                                      | (t4, uu____3296) ->
+                                   (fun uu___4 ->
+                                      match uu___4 with
+                                      | (t4, uu___5) ->
                                           mk_embedding l env1 t4)) in
                             let nm =
-                              let uu____3302 =
+                              let uu___4 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                              FStar_Ident.string_of_id uu____3302 in
-                            let uu____3303 =
-                              let uu____3314 =
+                              FStar_Ident.string_of_id uu___4 in
+                            let uu___4 =
+                              let uu___5 =
                                 FStar_Util.find_opt
-                                  (fun uu____3342 ->
-                                     match uu____3342 with
-                                     | ((x, uu____3354, uu____3355),
-                                        uu____3356) ->
+                                  (fun uu___6 ->
+                                     match uu___6 with
+                                     | ((x, uu___7, uu___8), uu___9) ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l) in
-                              FStar_All.pipe_right uu____3314 FStar_Util.must in
-                            (match uu____3303 with
-                             | ((uu____3395, t_arity, _trepr_head),
+                              FStar_All.pipe_right uu___5 FStar_Util.must in
+                            (match uu___4 with
+                             | ((uu___5, t_arity, _trepr_head),
                                 loc_embedding) ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm in
                                  (match t_arity with
-                                  | uu____3406 when
-                                      uu____3406 = Prims.int_zero -> head1
+                                  | uu___6 when uu___6 = Prims.int_zero ->
+                                      head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____3410 ->
-                            let uu____3411 =
-                              let uu____3412 =
-                                let uu____3413 =
+                        | uu___4 ->
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Print.term_to_string t3 in
                                 Prims.op_Hat
-                                  "Embedding not defined for type "
-                                  uu____3413 in
-                              NoTacticEmbedding uu____3412 in
-                            FStar_Exn.raise uu____3411))
-              | FStar_Syntax_Syntax.Tm_app uu____3414 ->
-                  let uu____3431 = FStar_Syntax_Util.head_and_args t3 in
-                  (match uu____3431 with
+                                  "Embedding not defined for type " uu___7 in
+                              NoTacticEmbedding uu___6 in
+                            FStar_Exn.raise uu___5))
+              | FStar_Syntax_Syntax.Tm_app uu___1 ->
+                  let uu___2 = FStar_Syntax_Util.head_and_args t3 in
+                  (match uu___2 with
                    | (head, args) ->
                        let n_args = FStar_List.length args in
-                       let uu____3483 =
-                         let uu____3484 = FStar_Syntax_Util.un_uinst head in
-                         uu____3484.FStar_Syntax_Syntax.n in
-                       (match uu____3483 with
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Util.un_uinst head in
+                         uu___4.FStar_Syntax_Syntax.n in
+                       (match uu___3 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____3510 ->
-                                      match uu____3510 with
-                                      | (t4, uu____3518) ->
+                                   (fun uu___4 ->
+                                      match uu___4 with
+                                      | (t4, uu___5) ->
                                           mk_embedding l env1 t4)) in
                             let nm =
-                              let uu____3524 =
+                              let uu___4 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                              FStar_Ident.string_of_id uu____3524 in
-                            let uu____3525 =
-                              let uu____3536 =
+                              FStar_Ident.string_of_id uu___4 in
+                            let uu___4 =
+                              let uu___5 =
                                 FStar_Util.find_opt
-                                  (fun uu____3564 ->
-                                     match uu____3564 with
-                                     | ((x, uu____3576, uu____3577),
-                                        uu____3578) ->
+                                  (fun uu___6 ->
+                                     match uu___6 with
+                                     | ((x, uu___7, uu___8), uu___9) ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l) in
-                              FStar_All.pipe_right uu____3536 FStar_Util.must in
-                            (match uu____3525 with
-                             | ((uu____3617, t_arity, _trepr_head),
+                              FStar_All.pipe_right uu___5 FStar_Util.must in
+                            (match uu___4 with
+                             | ((uu___5, t_arity, _trepr_head),
                                 loc_embedding) ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm in
                                  (match t_arity with
-                                  | uu____3628 when
-                                      uu____3628 = Prims.int_zero -> head1
+                                  | uu___6 when uu___6 = Prims.int_zero ->
+                                      head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____3632 ->
-                            let uu____3633 =
-                              let uu____3634 =
-                                let uu____3635 =
+                        | uu___4 ->
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Print.term_to_string t3 in
                                 Prims.op_Hat
-                                  "Embedding not defined for type "
-                                  uu____3635 in
-                              NoTacticEmbedding uu____3634 in
-                            FStar_Exn.raise uu____3633))
-              | uu____3636 ->
-                  let uu____3637 =
-                    let uu____3638 =
-                      let uu____3639 = FStar_Syntax_Print.term_to_string t3 in
-                      Prims.op_Hat "Embedding not defined for type "
-                        uu____3639 in
-                    NoTacticEmbedding uu____3638 in
-                  FStar_Exn.raise uu____3637 in
+                                  "Embedding not defined for type " uu___7 in
+                              NoTacticEmbedding uu___6 in
+                            FStar_Exn.raise uu___5))
+              | uu___1 ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Print.term_to_string t3 in
+                      Prims.op_Hat "Embedding not defined for type " uu___4 in
+                    NoTacticEmbedding uu___3 in
+                  FStar_Exn.raise uu___2 in
             let abstract_tvars tvar_names body =
               match tvar_names with
               | [] ->
                   let body1 =
-                    let uu____3656 =
-                      let uu____3657 =
-                        let uu____3664 =
+                    let uu___ =
+                      let uu___1 =
+                        let uu___2 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap") in
-                        let uu____3667 =
-                          let uu____3670 =
-                            let uu____3671 =
-                              let uu____3672 =
-                                let uu____3673 =
-                                  FStar_Ident.string_of_lid fv_lid in
-                                FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____3673 in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____3672 in
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Ident.string_of_lid fv_lid in
+                                FStar_Extraction_ML_Syntax.MLC_String uu___7 in
+                              FStar_Extraction_ML_Syntax.MLE_Const uu___6 in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____3671 in
-                          let uu____3674 =
-                            let uu____3677 =
-                              let uu____3678 =
-                                let uu____3679 =
-                                  let uu____3680 =
-                                    let uu____3687 =
-                                      let uu____3690 = str_to_name "args" in
-                                      [uu____3690] in
-                                    (body, uu____3687) in
-                                  FStar_Extraction_ML_Syntax.MLE_App
-                                    uu____3680 in
-                                FStar_All.pipe_left w uu____3679 in
-                              mk_lam "_" uu____3678 in
-                            [uu____3677] in
-                          uu____3670 :: uu____3674 in
-                        (uu____3664, uu____3667) in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____3657 in
-                    FStar_All.pipe_left w uu____3656 in
+                                 FStar_Extraction_ML_Syntax.MLTY_Top) uu___5 in
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      let uu___11 = str_to_name "args" in
+                                      [uu___11] in
+                                    (body, uu___10) in
+                                  FStar_Extraction_ML_Syntax.MLE_App uu___9 in
+                                FStar_All.pipe_left w uu___8 in
+                              mk_lam "_" uu___7 in
+                            [uu___6] in
+                          uu___4 :: uu___5 in
+                        (uu___2, uu___3) in
+                      FStar_Extraction_ML_Syntax.MLE_App uu___1 in
+                    FStar_All.pipe_left w uu___ in
                   mk_lam "args" body1
-              | uu____3695 ->
+              | uu___ ->
                   let args_tail =
                     FStar_Extraction_ML_Syntax.MLP_Var "args_tail" in
                   let mk_cons hd_pat tail_pat =
@@ -1299,71 +1267,67 @@ let (interpret_plugin_as_term_fun :
                       (fun hd_var -> mk_cons (fst_pat hd_var)) tvar_names
                       args_tail in
                   let branch =
-                    let uu____3732 =
-                      let uu____3733 =
-                        let uu____3734 =
-                          let uu____3741 =
-                            let uu____3744 = as_name ([], "args") in
-                            [uu____3744] in
-                          (body, uu____3741) in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____3734 in
-                      FStar_All.pipe_left w uu____3733 in
-                    (pattern, FStar_Pervasives_Native.None, uu____3732) in
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 = as_name ([], "args") in [uu___5] in
+                          (body, uu___4) in
+                        FStar_Extraction_ML_Syntax.MLE_App uu___3 in
+                      FStar_All.pipe_left w uu___2 in
+                    (pattern, FStar_Pervasives_Native.None, uu___1) in
                   let default_branch =
-                    let uu____3760 =
-                      let uu____3761 =
-                        let uu____3762 =
-                          let uu____3769 = str_to_name "failwith" in
-                          let uu____3770 =
-                            let uu____3773 =
-                              let uu____3774 =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = str_to_name "failwith" in
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
                                 mlexpr_of_const FStar_Range.dummyRange
                                   (FStar_Const.Const_string
                                      ("arity mismatch",
                                        FStar_Range.dummyRange)) in
-                              FStar_All.pipe_left w uu____3774 in
-                            [uu____3773] in
-                          (uu____3769, uu____3770) in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____3762 in
-                      FStar_All.pipe_left w uu____3761 in
+                              FStar_All.pipe_left w uu___7 in
+                            [uu___6] in
+                          (uu___4, uu___5) in
+                        FStar_Extraction_ML_Syntax.MLE_App uu___3 in
+                      FStar_All.pipe_left w uu___2 in
                     (FStar_Extraction_ML_Syntax.MLP_Wild,
-                      FStar_Pervasives_Native.None, uu____3760) in
+                      FStar_Pervasives_Native.None, uu___1) in
                   let body1 =
-                    let uu____3780 =
-                      let uu____3781 =
-                        let uu____3796 = as_name ([], "args") in
-                        (uu____3796, [branch; default_branch]) in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____3781 in
-                    FStar_All.pipe_left w uu____3780 in
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = as_name ([], "args") in
+                        (uu___3, [branch; default_branch]) in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu___2 in
+                    FStar_All.pipe_left w uu___1 in
                   let body2 =
-                    let uu____3834 =
-                      let uu____3835 =
-                        let uu____3842 =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap") in
-                        let uu____3845 =
-                          let uu____3848 =
-                            let uu____3849 =
-                              let uu____3850 =
-                                let uu____3851 =
-                                  FStar_Ident.string_of_lid fv_lid in
-                                FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____3851 in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____3850 in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Ident.string_of_lid fv_lid in
+                                FStar_Extraction_ML_Syntax.MLC_String uu___8 in
+                              FStar_Extraction_ML_Syntax.MLE_Const uu___7 in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____3849 in
-                          let uu____3852 =
-                            let uu____3855 = mk_lam "_" body1 in [uu____3855] in
-                          uu____3848 :: uu____3852 in
-                        (uu____3842, uu____3845) in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____3835 in
-                    FStar_All.pipe_left w uu____3834 in
+                                 FStar_Extraction_ML_Syntax.MLTY_Top) uu___6 in
+                          let uu___6 =
+                            let uu___7 = mk_lam "_" body1 in [uu___7] in
+                          uu___5 :: uu___6 in
+                        (uu___3, uu___4) in
+                      FStar_Extraction_ML_Syntax.MLE_App uu___2 in
+                    FStar_All.pipe_left w uu___1 in
                   mk_lam "args" body2 in
-            let uu____3858 = FStar_Syntax_Util.arrow_formals_comp t1 in
-            match uu____3858 with
+            let uu___ = FStar_Syntax_Util.arrow_formals_comp t1 in
+            match uu___ with
             | (bs, c) ->
-                let uu____3867 =
+                let uu___1 =
                   match arity_opt with
                   | FStar_Pervasives_Native.None -> (bs, c)
                   | FStar_Pervasives_Native.Some n ->
@@ -1373,49 +1337,47 @@ let (interpret_plugin_as_term_fun :
                       else
                         if n < n_bs
                         then
-                          (let uu____3953 = FStar_Util.first_N n bs in
-                           match uu____3953 with
+                          (let uu___3 = FStar_Util.first_N n bs in
+                           match uu___3 with
                            | (bs1, rest) ->
                                let c1 =
-                                 let uu____4031 =
-                                   FStar_Syntax_Util.arrow rest c in
+                                 let uu___4 = FStar_Syntax_Util.arrow rest c in
                                  FStar_All.pipe_left
-                                   FStar_Syntax_Syntax.mk_Total uu____4031 in
+                                   FStar_Syntax_Syntax.mk_Total uu___4 in
                                (bs1, c1))
                         else
                           (let msg =
-                             let uu____4046 =
-                               FStar_Ident.string_of_lid fv_lid in
-                             let uu____4047 = FStar_Util.string_of_int n in
-                             let uu____4048 = FStar_Util.string_of_int n_bs in
+                             let uu___4 = FStar_Ident.string_of_lid fv_lid in
+                             let uu___5 = FStar_Util.string_of_int n in
+                             let uu___6 = FStar_Util.string_of_int n_bs in
                              FStar_Util.format3
                                "Embedding not defined for %s; expected arity at least %s; got %s"
-                               uu____4046 uu____4047 uu____4048 in
+                               uu___4 uu___5 uu___6 in
                            FStar_Exn.raise (NoTacticEmbedding msg)) in
-                (match uu____3867 with
+                (match uu___1 with
                  | (bs1, c1) ->
                      let result_typ = FStar_Syntax_Util.comp_result c1 in
                      let arity = FStar_List.length bs1 in
-                     let uu____4097 =
-                       let uu____4118 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_Util.prefix_until
-                           (fun uu____4160 ->
-                              match uu____4160 with
-                              | (b, uu____4168) ->
-                                  let uu____4173 =
-                                    let uu____4174 =
+                           (fun uu___4 ->
+                              match uu___4 with
+                              | (b, uu___5) ->
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_Syntax_Subst.compress
                                         b.FStar_Syntax_Syntax.sort in
-                                    uu____4174.FStar_Syntax_Syntax.n in
-                                  (match uu____4173 with
-                                   | FStar_Syntax_Syntax.Tm_type uu____4177
-                                       -> false
-                                   | uu____4178 -> true)) bs1 in
-                       match uu____4118 with
+                                    uu___7.FStar_Syntax_Syntax.n in
+                                  (match uu___6 with
+                                   | FStar_Syntax_Syntax.Tm_type uu___7 ->
+                                       false
+                                   | uu___7 -> true)) bs1 in
+                       match uu___3 with
                        | FStar_Pervasives_Native.None -> (bs1, [])
                        | FStar_Pervasives_Native.Some (tvars, x, rest) ->
                            (tvars, (x :: rest)) in
-                     (match uu____4097 with
+                     (match uu___2 with
                       | (type_vars, bs2) ->
                           let tvar_arity = FStar_List.length type_vars in
                           let non_tvar_arity = FStar_List.length bs2 in
@@ -1423,9 +1385,8 @@ let (interpret_plugin_as_term_fun :
                             FStar_List.mapi
                               (fun i ->
                                  fun tv ->
-                                   let uu____4416 =
-                                     FStar_Util.string_of_int i in
-                                   Prims.op_Hat "tv_" uu____4416) type_vars in
+                                   let uu___3 = FStar_Util.string_of_int i in
+                                   Prims.op_Hat "tv_" uu___3) type_vars in
                           let tvar_context =
                             FStar_List.map2
                               (fun b ->
@@ -1441,40 +1402,39 @@ let (interpret_plugin_as_term_fun :
                                   mk_embedding loc tvar_context result_typ in
                                 let fv_lid1 =
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                let uu____4505 =
+                                let uu___3 =
                                   FStar_Syntax_Util.is_pure_comp c1 in
-                                if uu____4505
+                                if uu___3
                                 then
                                   let cb = str_to_name "cb" in
                                   let embed_fun_N =
                                     mk_arrow_as_prim_step loc non_tvar_arity in
                                   let args =
-                                    let uu____4517 =
-                                      let uu____4520 =
-                                        let uu____4523 = lid_to_name fv_lid1 in
-                                        let uu____4524 =
-                                          let uu____4527 =
-                                            let uu____4528 =
-                                              let uu____4529 =
-                                                let uu____4530 =
-                                                  let uu____4541 =
+                                    let uu___4 =
+                                      let uu___5 =
+                                        let uu___6 = lid_to_name fv_lid1 in
+                                        let uu___7 =
+                                          let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
+                                                let uu___11 =
+                                                  let uu___12 =
                                                     FStar_Util.string_of_int
                                                       tvar_arity in
-                                                  (uu____4541,
+                                                  (uu___12,
                                                     FStar_Pervasives_Native.None) in
                                                 FStar_Extraction_ML_Syntax.MLC_Int
-                                                  uu____4530 in
+                                                  uu___11 in
                                               FStar_Extraction_ML_Syntax.MLE_Const
-                                                uu____4529 in
+                                                uu___10 in
                                             FStar_All.pipe_left
                                               (FStar_Extraction_ML_Syntax.with_ty
                                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                                              uu____4528 in
-                                          [uu____4527; fv_lid_embedded; cb] in
-                                        uu____4523 :: uu____4524 in
-                                      res_embedding :: uu____4520 in
-                                    FStar_List.append arg_unembeddings
-                                      uu____4517 in
+                                              uu___9 in
+                                          [uu___8; fv_lid_embedded; cb] in
+                                        uu___6 :: uu___7 in
+                                      res_embedding :: uu___5 in
+                                    FStar_List.append arg_unembeddings uu___4 in
                                   let fun_embedding =
                                     FStar_All.pipe_left w
                                       (FStar_Extraction_ML_Syntax.MLE_App
@@ -1482,39 +1442,39 @@ let (interpret_plugin_as_term_fun :
                                   let tabs =
                                     abstract_tvars tvar_names fun_embedding in
                                   let cb_tabs = mk_lam "cb" tabs in
-                                  let uu____4557 =
+                                  let uu___4 =
                                     if loc = NBE_t
                                     then cb_tabs
                                     else mk_lam "_psc" cb_tabs in
-                                  (uu____4557, arity, true)
+                                  (uu___4, arity, true)
                                 else
-                                  (let uu____4560 =
-                                     let uu____4561 =
+                                  (let uu___5 =
+                                     let uu___6 =
                                        FStar_TypeChecker_Env.norm_eff_name
                                          tcenv
                                          (FStar_Syntax_Util.comp_effect_name
                                             c1) in
-                                     FStar_Ident.lid_equals uu____4561
+                                     FStar_Ident.lid_equals uu___6
                                        FStar_Parser_Const.effect_TAC_lid in
-                                   if uu____4560
+                                   if uu___5
                                    then
                                      let h =
                                        mk_tactic_interpretation loc
                                          non_tvar_arity in
                                      let tac_fun =
-                                       let uu____4570 =
-                                         let uu____4571 =
-                                           let uu____4578 =
+                                       let uu___6 =
+                                         let uu___7 =
+                                           let uu___8 =
                                              mk_from_tactic loc
                                                non_tvar_arity in
-                                           let uu____4579 =
-                                             let uu____4582 =
+                                           let uu___9 =
+                                             let uu___10 =
                                                lid_to_name fv_lid1 in
-                                             [uu____4582] in
-                                           (uu____4578, uu____4579) in
+                                             [uu___10] in
+                                           (uu___8, uu___9) in
                                          FStar_Extraction_ML_Syntax.MLE_App
-                                           uu____4571 in
-                                       FStar_All.pipe_left w uu____4570 in
+                                           uu___7 in
+                                       FStar_All.pipe_left w uu___6 in
                                      let psc = str_to_name "psc" in
                                      let ncb = str_to_name "ncb" in
                                      let all_args = str_to_name "args" in
@@ -1525,62 +1485,59 @@ let (interpret_plugin_as_term_fun :
                                      let tabs =
                                        match tvar_names with
                                        | [] ->
-                                           let uu____4592 =
+                                           let uu___6 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h,
                                                     (FStar_List.append args
                                                        [all_args]))) in
-                                           mk_lam "args" uu____4592
-                                       | uu____4595 ->
-                                           let uu____4598 =
+                                           mk_lam "args" uu___6
+                                       | uu___6 ->
+                                           let uu___7 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h, args)) in
-                                           abstract_tvars tvar_names
-                                             uu____4598 in
-                                     let uu____4601 =
-                                       let uu____4602 = mk_lam "ncb" tabs in
-                                       mk_lam "psc" uu____4602 in
-                                     (uu____4601, (arity + Prims.int_one),
-                                       false)
+                                           abstract_tvars tvar_names uu___7 in
+                                     let uu___6 =
+                                       let uu___7 = mk_lam "ncb" tabs in
+                                       mk_lam "psc" uu___7 in
+                                     (uu___6, (arity + Prims.int_one), false)
                                    else
-                                     (let uu____4604 =
-                                        let uu____4605 =
-                                          let uu____4606 =
+                                     (let uu___7 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_Syntax_Print.term_to_string
                                               t1 in
                                           Prims.op_Hat
                                             "Plugins not defined for type "
-                                            uu____4606 in
-                                        NoTacticEmbedding uu____4605 in
-                                      FStar_Exn.raise uu____4604))
-                            | (b, uu____4614)::bs4 ->
-                                let uu____4634 =
-                                  let uu____4637 =
+                                            uu___9 in
+                                        NoTacticEmbedding uu___8 in
+                                      FStar_Exn.raise uu___7))
+                            | (b, uu___3)::bs4 ->
+                                let uu___4 =
+                                  let uu___5 =
                                     mk_embedding loc tvar_context
                                       b.FStar_Syntax_Syntax.sort in
-                                  uu____4637 :: accum_embeddings in
-                                aux loc uu____4634 bs4 in
+                                  uu___5 :: accum_embeddings in
+                                aux loc uu___4 bs4 in
                           (try
-                             (fun uu___715_4657 ->
+                             (fun uu___3 ->
                                 match () with
                                 | () ->
-                                    let uu____4668 = aux Syntax_term [] bs2 in
-                                    (match uu____4668 with
+                                    let uu___4 = aux Syntax_term [] bs2 in
+                                    (match uu___4 with
                                      | (w1, a, b) ->
-                                         let uu____4688 = aux NBE_t [] bs2 in
-                                         (match uu____4688 with
-                                          | (w', uu____4706, uu____4707) ->
+                                         let uu___5 = aux NBE_t [] bs2 in
+                                         (match uu___5 with
+                                          | (w', uu___6, uu___7) ->
                                               FStar_Pervasives_Native.Some
                                                 (w1, w', a, b)))) ()
                            with
                            | NoTacticEmbedding msg ->
-                               ((let uu____4732 =
+                               ((let uu___5 =
                                    FStar_Ident.range_of_lid
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                 let uu____4733 =
+                                 let uu___6 =
                                    FStar_Syntax_Print.fv_to_string fv in
-                                 not_implemented_warning uu____4732
-                                   uu____4733 msg);
+                                 not_implemented_warning uu___5 uu___6 msg);
                                 FStar_Pervasives_Native.None))))

--- a/src/ocaml-output/FStar_Ident.ml
+++ b/src/ocaml-output/FStar_Ident.ml
@@ -28,22 +28,20 @@ let (__proj__Mklident__item__str : lident -> Prims.string) =
     match projectee with | { ns; ident = ident1; nsstr; str;_} -> str
 type lid = lident[@@deriving yojson,show]
 let (mk_ident : (Prims.string * FStar_Range.range) -> ident) =
-  fun uu____98 ->
-    match uu____98 with | (text, range) -> { idText = text; idRange = range }
+  fun uu___ ->
+    match uu___ with | (text, range) -> { idText = text; idRange = range }
 let (set_id_range : FStar_Range.range -> ident -> ident) =
-  fun r ->
-    fun i ->
-      let uu___23_115 = i in { idText = (uu___23_115.idText); idRange = r }
+  fun r -> fun i -> let uu___ = i in { idText = (uu___.idText); idRange = r }
 let (reserved_prefix : Prims.string) = "uu___"
 let (_gen : ((unit -> Prims.int) * (unit -> unit))) =
   let x = FStar_Util.mk_ref Prims.int_zero in
-  let next_id uu____134 =
+  let next_id uu___ =
     let v = FStar_ST.read x in FStar_ST.write x (v + Prims.int_one); v in
-  let reset uu____154 = FStar_ST.write x Prims.int_zero in (next_id, reset)
+  let reset uu___ = FStar_ST.write x Prims.int_zero in (next_id, reset)
 let (next_id : unit -> Prims.int) =
-  fun uu____171 -> FStar_Pervasives_Native.fst _gen ()
+  fun uu___ -> FStar_Pervasives_Native.fst _gen ()
 let (reset_gensym : unit -> unit) =
-  fun uu____182 -> FStar_Pervasives_Native.snd _gen ()
+  fun uu___ -> FStar_Pervasives_Native.snd _gen ()
 let (gen' : Prims.string -> FStar_Range.range -> ident) =
   fun s ->
     fun r ->
@@ -70,8 +68,8 @@ let (lid_of_ns_and_id : ipath -> ident -> lident) =
   fun ns ->
     fun id ->
       let nsstr =
-        let uu____266 = FStar_List.map string_of_id ns in
-        FStar_All.pipe_right uu____266 text_of_path in
+        let uu___ = FStar_List.map string_of_id ns in
+        FStar_All.pipe_right uu___ text_of_path in
       {
         ns;
         ident = id;
@@ -83,12 +81,12 @@ let (lid_of_ns_and_id : ipath -> ident -> lident) =
       }
 let (lid_of_ids : ipath -> lident) =
   fun ids ->
-    let uu____273 = FStar_Util.prefix ids in
-    match uu____273 with | (ns, id) -> lid_of_ns_and_id ns id
+    let uu___ = FStar_Util.prefix ids in
+    match uu___ with | (ns, id) -> lid_of_ns_and_id ns id
 let (lid_of_str : Prims.string -> lident) =
   fun str ->
-    let uu____291 = FStar_List.map id_of_text (FStar_Util.split str ".") in
-    lid_of_ids uu____291
+    let uu___ = FStar_List.map id_of_text (FStar_Util.split str ".") in
+    lid_of_ids uu___
 let (lid_of_path : path -> FStar_Range.range -> lident) =
   fun path1 ->
     fun pos ->
@@ -104,32 +102,31 @@ let (range_of_lid : lident -> FStar_Range.range) =
 let (set_lid_range : lident -> FStar_Range.range -> lident) =
   fun l ->
     fun r ->
-      let uu___69_347 = l in
+      let uu___ = l in
       {
-        ns = (uu___69_347.ns);
+        ns = (uu___.ns);
         ident =
-          (let uu___71_349 = l.ident in
-           { idText = (uu___71_349.idText); idRange = r });
-        nsstr = (uu___69_347.nsstr);
-        str = (uu___69_347.str)
+          (let uu___1 = l.ident in { idText = (uu___1.idText); idRange = r });
+        nsstr = (uu___.nsstr);
+        str = (uu___.str)
       }
 let (lid_add_suffix : lident -> Prims.string -> lident) =
   fun l ->
     fun s ->
       let path1 = path_of_lid l in
-      let uu____361 = range_of_lid l in
-      lid_of_path (FStar_List.append path1 [s]) uu____361
+      let uu___ = range_of_lid l in
+      lid_of_path (FStar_List.append path1 [s]) uu___
 let (ml_path_of_lid : lident -> Prims.string) =
   fun lid1 ->
-    let uu____367 =
-      let uu____370 = path_of_ns lid1.ns in
-      let uu____373 = let uu____376 = string_of_id lid1.ident in [uu____376] in
-      FStar_List.append uu____370 uu____373 in
-    FStar_All.pipe_left (FStar_String.concat "_") uu____367
+    let uu___ =
+      let uu___1 = path_of_ns lid1.ns in
+      let uu___2 = let uu___3 = string_of_id lid1.ident in [uu___3] in
+      FStar_List.append uu___1 uu___2 in
+    FStar_All.pipe_left (FStar_String.concat "_") uu___
 let (string_of_lid : lident -> Prims.string) = fun lid1 -> lid1.str
 let (qual_id : lident -> ident -> lident) =
   fun lid1 ->
     fun id ->
-      let uu____394 = lid_of_ids (FStar_List.append lid1.ns [lid1.ident; id]) in
-      let uu____395 = range_of_id id in set_lid_range uu____394 uu____395
+      let uu___ = lid_of_ids (FStar_List.append lid1.ns [lid1.ident; id]) in
+      let uu___1 = range_of_id id in set_lid_range uu___ uu___1
 let (nsstr : lident -> Prims.string) = fun l -> l.nsstr

--- a/src/ocaml-output/FStar_Interactive_CompletionTable.ml
+++ b/src/ocaml-output/FStar_Interactive_CompletionTable.ml
@@ -5,16 +5,15 @@ type 'a heap =
   | EmptyHeap 
   | Heap of ('a * 'a heap Prims.list) 
 let uu___is_EmptyHeap : 'a . 'a heap -> Prims.bool =
-  fun projectee ->
-    match projectee with | EmptyHeap -> true | uu____61 -> false
+  fun projectee -> match projectee with | EmptyHeap -> true | uu___ -> false
 let uu___is_Heap : 'a . 'a heap -> Prims.bool =
-  fun projectee -> match projectee with | Heap _0 -> true | uu____87 -> false
+  fun projectee -> match projectee with | Heap _0 -> true | uu___ -> false
 let __proj__Heap__item___0 : 'a . 'a heap -> ('a * 'a heap Prims.list) =
   fun projectee -> match projectee with | Heap _0 -> _0
 let heap_merge :
-  'uuuuuu129 .
-    ('uuuuuu129 -> 'uuuuuu129 -> Prims.int) ->
-      'uuuuuu129 heap -> 'uuuuuu129 heap -> 'uuuuuu129 heap
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> Prims.int) ->
+      'uuuuu heap -> 'uuuuu heap -> 'uuuuu heap
   =
   fun cmp ->
     fun h1 ->
@@ -23,85 +22,76 @@ let heap_merge :
         | (EmptyHeap, h) -> h
         | (h, EmptyHeap) -> h
         | (Heap (v1, hh1), Heap (v2, hh2)) ->
-            let uu____207 =
-              let uu____208 = cmp v1 v2 in uu____208 < Prims.int_zero in
-            if uu____207
-            then Heap (v1, (h2 :: hh1))
-            else Heap (v2, (h1 :: hh2))
+            let uu___ = let uu___1 = cmp v1 v2 in uu___1 < Prims.int_zero in
+            if uu___ then Heap (v1, (h2 :: hh1)) else Heap (v2, (h1 :: hh2))
 let heap_insert :
-  'uuuuuu232 .
-    ('uuuuuu232 -> 'uuuuuu232 -> Prims.int) ->
-      'uuuuuu232 heap -> 'uuuuuu232 -> 'uuuuuu232 heap
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> Prims.int) -> 'uuuuu heap -> 'uuuuu -> 'uuuuu heap
   = fun cmp -> fun h -> fun v -> heap_merge cmp (Heap (v, [])) h
 let rec heap_merge_pairs :
-  'uuuuuu276 .
-    ('uuuuuu276 -> 'uuuuuu276 -> Prims.int) ->
-      'uuuuuu276 heap Prims.list -> 'uuuuuu276 heap
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> Prims.int) -> 'uuuuu heap Prims.list -> 'uuuuu heap
   =
   fun cmp ->
-    fun uu___0_298 ->
-      match uu___0_298 with
+    fun uu___ ->
+      match uu___ with
       | [] -> EmptyHeap
       | h::[] -> h
       | h1::h2::hh ->
-          let uu____331 = heap_merge cmp h1 h2 in
-          let uu____334 = heap_merge_pairs cmp hh in
-          heap_merge cmp uu____331 uu____334
-let heap_peek :
-  'uuuuuu341 . 'uuuuuu341 heap -> 'uuuuuu341 FStar_Pervasives_Native.option =
-  fun uu___1_350 ->
-    match uu___1_350 with
+          let uu___1 = heap_merge cmp h1 h2 in
+          let uu___2 = heap_merge_pairs cmp hh in
+          heap_merge cmp uu___1 uu___2
+let heap_peek : 'uuuuu . 'uuuuu heap -> 'uuuuu FStar_Pervasives_Native.option
+  =
+  fun uu___ ->
+    match uu___ with
     | EmptyHeap -> FStar_Pervasives_Native.None
-    | Heap (v, uu____354) -> FStar_Pervasives_Native.Some v
+    | Heap (v, uu___1) -> FStar_Pervasives_Native.Some v
 let heap_pop :
-  'uuuuuu369 .
-    ('uuuuuu369 -> 'uuuuuu369 -> Prims.int) ->
-      'uuuuuu369 heap ->
-        ('uuuuuu369 * 'uuuuuu369 heap) FStar_Pervasives_Native.option
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> Prims.int) ->
+      'uuuuu heap -> ('uuuuu * 'uuuuu heap) FStar_Pervasives_Native.option
   =
   fun cmp ->
-    fun uu___2_395 ->
-      match uu___2_395 with
+    fun uu___ ->
+      match uu___ with
       | EmptyHeap -> FStar_Pervasives_Native.None
       | Heap (v, hh) ->
-          let uu____418 =
-            let uu____425 = heap_merge_pairs cmp hh in (v, uu____425) in
-          FStar_Pervasives_Native.Some uu____418
+          let uu___1 = let uu___2 = heap_merge_pairs cmp hh in (v, uu___2) in
+          FStar_Pervasives_Native.Some uu___1
 let heap_from_list :
-  'uuuuuu442 .
-    ('uuuuuu442 -> 'uuuuuu442 -> Prims.int) ->
-      'uuuuuu442 Prims.list -> 'uuuuuu442 heap
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> Prims.int) -> 'uuuuu Prims.list -> 'uuuuu heap
   =
   fun cmp ->
     fun values -> FStar_List.fold_left (heap_insert cmp) EmptyHeap values
 let push_nodup :
-  'uuuuuu479 .
-    ('uuuuuu479 -> Prims.string) ->
-      'uuuuuu479 -> 'uuuuuu479 Prims.list -> 'uuuuuu479 Prims.list
+  'uuuuu .
+    ('uuuuu -> Prims.string) ->
+      'uuuuu -> 'uuuuu Prims.list -> 'uuuuu Prims.list
   =
   fun key_fn ->
     fun x ->
-      fun uu___3_501 ->
-        match uu___3_501 with
+      fun uu___ ->
+        match uu___ with
         | [] -> [x]
         | h::t ->
-            let uu____510 =
-              let uu____511 =
-                let uu____512 = key_fn x in
-                let uu____513 = key_fn h in
-                string_compare uu____512 uu____513 in
-              uu____511 = Prims.int_zero in
-            if uu____510 then h :: t else x :: h :: t
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = key_fn x in
+                let uu___4 = key_fn h in string_compare uu___3 uu___4 in
+              uu___2 = Prims.int_zero in
+            if uu___1 then h :: t else x :: h :: t
 let rec add_priorities :
-  'uuuuuu525 .
+  'uuuuu .
     Prims.int ->
-      (Prims.int * 'uuuuuu525) Prims.list ->
-        'uuuuuu525 Prims.list -> (Prims.int * 'uuuuuu525) Prims.list
+      (Prims.int * 'uuuuu) Prims.list ->
+        'uuuuu Prims.list -> (Prims.int * 'uuuuu) Prims.list
   =
   fun n ->
     fun acc ->
-      fun uu___4_554 ->
-        match uu___4_554 with
+      fun uu___ ->
+        match uu___ with
         | [] -> acc
         | h::t -> add_priorities (n + Prims.int_one) ((n, h) :: acc) t
 let merge_increasing_lists_rev :
@@ -110,64 +100,60 @@ let merge_increasing_lists_rev :
     fun lists ->
       let cmp v1 v2 =
         match (v1, v2) with
-        | ((uu____650, []), uu____651) -> failwith "impossible"
-        | (uu____672, (uu____673, [])) -> failwith "impossible"
-        | ((pr1, h1::uu____696), (pr2, h2::uu____699)) ->
+        | ((uu___, []), uu___1) -> failwith "impossible"
+        | (uu___, (uu___1, [])) -> failwith "impossible"
+        | ((pr1, h1::uu___), (pr2, h2::uu___1)) ->
             let cmp_h =
-              let uu____721 = key_fn h1 in
-              let uu____722 = key_fn h2 in string_compare uu____721 uu____722 in
+              let uu___2 = key_fn h1 in
+              let uu___3 = key_fn h2 in string_compare uu___2 uu___3 in
             if cmp_h <> Prims.int_zero then cmp_h else pr1 - pr2 in
       let rec aux lists1 acc =
-        let uu____757 = heap_pop cmp lists1 in
-        match uu____757 with
+        let uu___ = heap_pop cmp lists1 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> acc
-        | FStar_Pervasives_Native.Some ((pr, []), uu____805) ->
+        | FStar_Pervasives_Native.Some ((pr, []), uu___1) ->
             failwith "impossible"
         | FStar_Pervasives_Native.Some ((pr, v::[]), lists2) ->
-            let uu____895 = push_nodup key_fn v acc in aux lists2 uu____895
+            let uu___1 = push_nodup key_fn v acc in aux lists2 uu___1
         | FStar_Pervasives_Native.Some ((pr, v::tl), lists2) ->
-            let uu____946 = heap_insert cmp lists2 (pr, tl) in
-            let uu____963 = push_nodup key_fn v acc in
-            aux uu____946 uu____963 in
+            let uu___1 = heap_insert cmp lists2 (pr, tl) in
+            let uu___2 = push_nodup key_fn v acc in aux uu___1 uu___2 in
       let lists1 = FStar_List.filter (fun x -> x <> []) lists in
       match lists1 with
       | [] -> []
       | l::[] -> FStar_List.rev l
-      | uu____990 ->
+      | uu___ ->
           let lists2 = add_priorities Prims.int_zero [] lists1 in
-          let uu____1012 = heap_from_list cmp lists2 in aux uu____1012 []
+          let uu___1 = heap_from_list cmp lists2 in aux uu___1 []
 type 'a btree =
   | StrEmpty 
   | StrBranch of (Prims.string * 'a * 'a btree * 'a btree) 
 let uu___is_StrEmpty : 'a . 'a btree -> Prims.bool =
-  fun projectee ->
-    match projectee with | StrEmpty -> true | uu____1065 -> false
+  fun projectee -> match projectee with | StrEmpty -> true | uu___ -> false
 let uu___is_StrBranch : 'a . 'a btree -> Prims.bool =
   fun projectee ->
-    match projectee with | StrBranch _0 -> true | uu____1095 -> false
+    match projectee with | StrBranch _0 -> true | uu___ -> false
 let __proj__StrBranch__item___0 :
   'a . 'a btree -> (Prims.string * 'a * 'a btree * 'a btree) =
   fun projectee -> match projectee with | StrBranch _0 -> _0
 let rec btree_to_list_rev :
-  'uuuuuu1143 .
-    'uuuuuu1143 btree ->
-      (Prims.string * 'uuuuuu1143) Prims.list ->
-        (Prims.string * 'uuuuuu1143) Prims.list
+  'uuuuu .
+    'uuuuu btree ->
+      (Prims.string * 'uuuuu) Prims.list ->
+        (Prims.string * 'uuuuu) Prims.list
   =
   fun btree1 ->
     fun acc ->
       match btree1 with
       | StrEmpty -> acc
       | StrBranch (key, value, lbt, rbt) ->
-          let uu____1188 =
-            let uu____1195 = btree_to_list_rev lbt acc in (key, value) ::
-              uu____1195 in
-          btree_to_list_rev rbt uu____1188
+          let uu___ =
+            let uu___1 = btree_to_list_rev lbt acc in (key, value) :: uu___1 in
+          btree_to_list_rev rbt uu___
 let rec btree_from_list :
-  'uuuuuu1212 .
-    (Prims.string * 'uuuuuu1212) Prims.list ->
-      Prims.int ->
-        ('uuuuuu1212 btree * (Prims.string * 'uuuuuu1212) Prims.list)
+  'uuuuu .
+    (Prims.string * 'uuuuu) Prims.list ->
+      Prims.int -> ('uuuuu btree * (Prims.string * 'uuuuu) Prims.list)
   =
   fun nodes ->
     fun size ->
@@ -176,14 +162,14 @@ let rec btree_from_list :
       else
         (let lbt_size = size / (Prims.of_int (2)) in
          let rbt_size = (size - lbt_size) - Prims.int_one in
-         let uu____1258 = btree_from_list nodes lbt_size in
-         match uu____1258 with
+         let uu___1 = btree_from_list nodes lbt_size in
+         match uu___1 with
          | (lbt, nodes_left) ->
              (match nodes_left with
               | [] -> failwith "Invalid size passed to btree_from_list"
               | (k, v)::nodes_left1 ->
-                  let uu____1342 = btree_from_list nodes_left1 rbt_size in
-                  (match uu____1342 with
+                  let uu___2 = btree_from_list nodes_left1 rbt_size in
+                  (match uu___2 with
                    | (rbt, nodes_left2) ->
                        ((StrBranch (k, v, lbt, rbt)), nodes_left2))))
 let rec btree_insert_replace :
@@ -197,17 +183,17 @@ let rec btree_insert_replace :
             let cmp = string_compare k k' in
             if cmp < Prims.int_zero
             then
-              let uu____1447 =
-                let uu____1460 = btree_insert_replace lbt k v in
-                (k', v', uu____1460, rbt) in
-              StrBranch uu____1447
+              let uu___ =
+                let uu___1 = btree_insert_replace lbt k v in
+                (k', v', uu___1, rbt) in
+              StrBranch uu___
             else
               if cmp > Prims.int_zero
               then
-                (let uu____1470 =
-                   let uu____1483 = btree_insert_replace rbt k v in
-                   (k', v', lbt, uu____1483) in
-                 StrBranch uu____1470)
+                (let uu___1 =
+                   let uu___2 = btree_insert_replace rbt k v in
+                   (k', v', lbt, uu___2) in
+                 StrBranch uu___1)
               else StrBranch (k', v, lbt, rbt)
 let rec btree_find_exact :
   'a . 'a btree -> Prims.string -> 'a FStar_Pervasives_Native.option =
@@ -232,8 +218,7 @@ let rec btree_extract_min :
     | StrEmpty -> FStar_Pervasives_Native.None
     | StrBranch (k, v, StrEmpty, rbt) ->
         FStar_Pervasives_Native.Some (k, v, rbt)
-    | StrBranch (uu____1590, uu____1591, lbt, uu____1593) ->
-        btree_extract_min lbt
+    | StrBranch (uu___, uu___1, lbt, uu___2) -> btree_extract_min lbt
 let rec btree_remove : 'a . 'a btree -> Prims.string -> 'a btree =
   fun bt ->
     fun k ->
@@ -243,22 +228,21 @@ let rec btree_remove : 'a . 'a btree -> Prims.string -> 'a btree =
           let cmp = string_compare k k' in
           if cmp < Prims.int_zero
           then
-            let uu____1641 =
-              let uu____1654 = btree_remove lbt k in (k', v, uu____1654, rbt) in
-            StrBranch uu____1641
+            let uu___ =
+              let uu___1 = btree_remove lbt k in (k', v, uu___1, rbt) in
+            StrBranch uu___
           else
             if cmp > Prims.int_zero
             then
-              (let uu____1664 =
-                 let uu____1677 = btree_remove rbt k in
-                 (k', v, lbt, uu____1677) in
-               StrBranch uu____1664)
+              (let uu___1 =
+                 let uu___2 = btree_remove rbt k in (k', v, lbt, uu___2) in
+               StrBranch uu___1)
             else
               (match lbt with
                | StrEmpty -> bt
-               | uu____1687 ->
-                   let uu____1690 = btree_extract_min rbt in
-                   (match uu____1690 with
+               | uu___2 ->
+                   let uu___3 = btree_extract_min rbt in
+                   (match uu___3 with
                     | FStar_Pervasives_Native.None -> lbt
                     | FStar_Pervasives_Native.Some
                         (rbt_min_k, rbt_min_v, rbt') ->
@@ -321,9 +305,8 @@ let rec btree_fold :
         match bt with
         | StrEmpty -> acc
         | StrBranch (k, v, lbt, rbt) ->
-            let uu____2015 =
-              let uu____2016 = btree_fold rbt f acc in f k v uu____2016 in
-            btree_fold lbt f uu____2015
+            let uu___ = let uu___1 = btree_fold rbt f acc in f k v uu___1 in
+            btree_fold lbt f uu___
 type path = path_elem Prims.list
 type query = Prims.string Prims.list
 let (query_to_string : Prims.string Prims.list -> Prims.string) =
@@ -332,13 +315,12 @@ type 'a name_collection =
   | Names of 'a btree 
   | ImportedNames of (Prims.string * 'a name_collection Prims.list) 
 let uu___is_Names : 'a . 'a name_collection -> Prims.bool =
-  fun projectee ->
-    match projectee with | Names _0 -> true | uu____2074 -> false
+  fun projectee -> match projectee with | Names _0 -> true | uu___ -> false
 let __proj__Names__item___0 : 'a . 'a name_collection -> 'a btree =
   fun projectee -> match projectee with | Names _0 -> _0
 let uu___is_ImportedNames : 'a . 'a name_collection -> Prims.bool =
   fun projectee ->
-    match projectee with | ImportedNames _0 -> true | uu____2119 -> false
+    match projectee with | ImportedNames _0 -> true | uu___ -> false
 let __proj__ImportedNames__item___0 :
   'a . 'a name_collection -> (Prims.string * 'a name_collection Prims.list) =
   fun projectee -> match projectee with | ImportedNames _0 -> _0
@@ -352,27 +334,27 @@ let __proj__Mktrie__item__bindings : 'a . 'a trie -> 'a names =
 let __proj__Mktrie__item__namespaces : 'a . 'a trie -> 'a trie names =
   fun projectee ->
     match projectee with | { bindings; namespaces;_} -> namespaces
-let trie_empty : 'uuuuuu2233 . unit -> 'uuuuuu2233 trie =
-  fun uu____2237 -> { bindings = []; namespaces = [] }
+let trie_empty : 'uuuuu . unit -> 'uuuuu trie =
+  fun uu___ -> { bindings = []; namespaces = [] }
 let rec names_find_exact :
   'a . 'a names -> Prims.string -> 'a FStar_Pervasives_Native.option =
   fun names1 ->
     fun ns ->
-      let uu____2268 =
+      let uu___ =
         match names1 with
         | [] -> (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (Names bt)::names2 ->
-            let uu____2309 = btree_find_exact bt ns in
-            (uu____2309, (FStar_Pervasives_Native.Some names2))
-        | (ImportedNames (uu____2320, names2))::more_names ->
-            let uu____2337 = names_find_exact names2 ns in
-            (uu____2337, (FStar_Pervasives_Native.Some more_names)) in
-      match uu____2268 with
+            let uu___1 = btree_find_exact bt ns in
+            (uu___1, (FStar_Pervasives_Native.Some names2))
+        | (ImportedNames (uu___1, names2))::more_names ->
+            let uu___2 = names_find_exact names2 ns in
+            (uu___2, (FStar_Pervasives_Native.Some more_names)) in
+      match uu___ with
       | (result, names2) ->
           (match (result, names2) with
            | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some
               scopes) -> names_find_exact scopes ns
-           | uu____2383 -> result)
+           | uu___1 -> result)
 let rec trie_descend_exact :
   'a . 'a trie -> query -> 'a trie FStar_Pervasives_Native.option =
   fun tr ->
@@ -380,8 +362,8 @@ let rec trie_descend_exact :
       match query1 with
       | [] -> FStar_Pervasives_Native.Some tr
       | ns::query2 ->
-          let uu____2426 = names_find_exact tr.namespaces ns in
-          FStar_Util.bind_opt uu____2426
+          let uu___ = names_find_exact tr.namespaces ns in
+          FStar_Util.bind_opt uu___
             (fun scope -> trie_descend_exact scope query2)
 let rec trie_find_exact :
   'a . 'a trie -> query -> 'a FStar_Pervasives_Native.option =
@@ -391,23 +373,22 @@ let rec trie_find_exact :
       | [] -> failwith "Empty query in trie_find_exact"
       | name::[] -> names_find_exact tr.bindings name
       | ns::query2 ->
-          let uu____2472 = names_find_exact tr.namespaces ns in
-          FStar_Util.bind_opt uu____2472
+          let uu___ = names_find_exact tr.namespaces ns in
+          FStar_Util.bind_opt uu___
             (fun scope -> trie_find_exact scope query2)
 let names_insert : 'a . 'a names -> Prims.string -> 'a -> 'a names =
   fun name_collections ->
     fun id ->
       fun v ->
-        let uu____2515 =
+        let uu___ =
           match name_collections with
           | (Names bt)::tl -> (bt, tl)
-          | uu____2552 -> (StrEmpty, name_collections) in
-        match uu____2515 with
+          | uu___1 -> (StrEmpty, name_collections) in
+        match uu___ with
         | (bt, name_collections1) ->
-            let uu____2577 =
-              let uu____2580 = btree_insert_replace bt id v in
-              Names uu____2580 in
-            uu____2577 :: name_collections1
+            let uu___1 =
+              let uu___2 = btree_insert_replace bt id v in Names uu___2 in
+            uu___1 :: name_collections1
 let rec namespaces_mutate :
   'a .
     'a trie names ->
@@ -425,10 +406,10 @@ let rec namespaces_mutate :
           fun mut_node ->
             fun mut_leaf ->
               let trie1 =
-                let uu____2774 = names_find_exact namespaces ns in
-                FStar_Util.dflt (trie_empty ()) uu____2774 in
-              let uu____2783 = trie_mutate trie1 q rev_acc mut_node mut_leaf in
-              names_insert namespaces ns uu____2783
+                let uu___ = names_find_exact namespaces ns in
+                FStar_Util.dflt (trie_empty ()) uu___ in
+              let uu___ = trie_mutate trie1 q rev_acc mut_node mut_leaf in
+              names_insert namespaces ns uu___
 and trie_mutate :
   'a .
     'a trie ->
@@ -456,12 +437,12 @@ let trie_mutate_leaf :
     fun query1 ->
       trie_mutate tr query1 []
         (fun tr1 ->
-           fun uu____2875 ->
-             fun uu____2876 ->
-               fun uu____2877 ->
+           fun uu___ ->
+             fun uu___1 ->
+               fun uu___2 ->
                  fun namespaces ->
-                   let uu___379_2885 = tr1 in
-                   { bindings = (uu___379_2885.bindings); namespaces })
+                   let uu___3 = tr1 in
+                   { bindings = (uu___3.bindings); namespaces })
 let trie_insert : 'a . 'a trie -> query -> Prims.string -> 'a -> 'a trie =
   fun tr ->
     fun ns_query ->
@@ -469,13 +450,10 @@ let trie_insert : 'a . 'a trie -> query -> Prims.string -> 'a -> 'a trie =
         fun v ->
           trie_mutate_leaf tr ns_query
             (fun tr1 ->
-               fun uu____2930 ->
-                 let uu___388_2933 = tr1 in
-                 let uu____2936 = names_insert tr1.bindings id v in
-                 {
-                   bindings = uu____2936;
-                   namespaces = (uu___388_2933.namespaces)
-                 })
+               fun uu___ ->
+                 let uu___1 = tr1 in
+                 let uu___2 = names_insert tr1.bindings id v in
+                 { bindings = uu___2; namespaces = (uu___1.namespaces) })
 let trie_import :
   'a .
     'a trie ->
@@ -488,10 +466,10 @@ let trie_import :
         fun mutator ->
           let label = query_to_string included_query in
           let included_trie =
-            let uu____3007 = trie_descend_exact tr included_query in
-            FStar_Util.dflt (trie_empty ()) uu____3007 in
+            let uu___ = trie_descend_exact tr included_query in
+            FStar_Util.dflt (trie_empty ()) uu___ in
           trie_mutate_leaf tr host_query
-            (fun tr1 -> fun uu____3017 -> mutator tr1 included_trie label)
+            (fun tr1 -> fun uu___ -> mutator tr1 included_trie label)
 let trie_include : 'a . 'a trie -> query -> query -> 'a trie =
   fun tr ->
     fun host_query ->
@@ -500,11 +478,11 @@ let trie_include : 'a . 'a trie -> query -> query -> 'a trie =
           (fun tr1 ->
              fun inc ->
                fun label ->
-                 let uu___406_3061 = tr1 in
+                 let uu___ = tr1 in
                  {
                    bindings = ((ImportedNames (label, (inc.bindings))) ::
                      (tr1.bindings));
-                   namespaces = (uu___406_3061.namespaces)
+                   namespaces = (uu___.namespaces)
                  })
 let trie_open_namespace : 'a . 'a trie -> query -> query -> 'a trie =
   fun tr ->
@@ -514,9 +492,9 @@ let trie_open_namespace : 'a . 'a trie -> query -> query -> 'a trie =
           (fun tr1 ->
              fun inc ->
                fun label ->
-                 let uu___415_3111 = tr1 in
+                 let uu___ = tr1 in
                  {
-                   bindings = (uu___415_3111.bindings);
+                   bindings = (uu___.bindings);
                    namespaces = ((ImportedNames (label, (inc.namespaces))) ::
                      (tr1.namespaces))
                  })
@@ -532,7 +510,7 @@ let trie_add_alias :
                  fun label ->
                    trie_mutate_leaf tr1 [key]
                      (fun _ignored_overwritten_trie ->
-                        fun uu____3176 ->
+                        fun uu___ ->
                           {
                             bindings =
                               [ImportedNames (label, (inc.bindings))];
@@ -547,12 +525,11 @@ let names_revmap :
       let rec aux acc imports name_collections1 =
         FStar_List.fold_left
           (fun acc1 ->
-             fun uu___5_3303 ->
-               match uu___5_3303 with
+             fun uu___ ->
+               match uu___ with
                | Names bt ->
-                   let uu____3325 =
-                     let uu____3332 = fn bt in (imports, uu____3332) in
-                   uu____3325 :: acc1
+                   let uu___1 = let uu___2 = fn bt in (imports, uu___2) in
+                   uu___1 :: acc1
                | ImportedNames (nm, name_collections2) ->
                    aux acc1 (nm :: imports) name_collections2) acc
           name_collections1 in
@@ -572,14 +549,12 @@ type name_search_term =
   | NSTNone 
   | NSTPrefix of Prims.string 
 let (uu___is_NSTAll : name_search_term -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NSTAll -> true | uu____3424 -> false
+  fun projectee -> match projectee with | NSTAll -> true | uu___ -> false
 let (uu___is_NSTNone : name_search_term -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NSTNone -> true | uu____3430 -> false
+  fun projectee -> match projectee with | NSTNone -> true | uu___ -> false
 let (uu___is_NSTPrefix : name_search_term -> Prims.bool) =
   fun projectee ->
-    match projectee with | NSTPrefix _0 -> true | uu____3437 -> false
+    match projectee with | NSTPrefix _0 -> true | uu___ -> false
 let (__proj__NSTPrefix__item___0 : name_search_term -> Prims.string) =
   fun projectee -> match projectee with | NSTPrefix _0 -> _0
 let names_find_rev :
@@ -598,18 +573,18 @@ let names_find_rev :
             names_revmap (fun bt -> btree_find_prefix bt id1) names1 in
       let matching_values_per_collection =
         FStar_List.map
-          (fun uu____3565 ->
-             match uu____3565 with
+          (fun uu___ ->
+             match uu___ with
              | (imports, matches) ->
                  FStar_List.map
-                   (fun uu____3613 ->
-                      match uu____3613 with
+                   (fun uu___1 ->
+                      match uu___1 with
                       | (segment, v) -> ((mk_path_el imports segment), v))
                    matches) matching_values_per_collection_with_imports in
       merge_increasing_lists_rev
-        (fun uu____3631 ->
-           match uu____3631 with
-           | (path_el, uu____3637) -> (path_el.segment).completion)
+        (fun uu___ ->
+           match uu___ with
+           | (path_el, uu___1) -> (path_el.segment).completion)
         matching_values_per_collection
 let rec trie_find_prefix' :
   'a .
@@ -620,28 +595,28 @@ let rec trie_find_prefix' :
     fun path_acc ->
       fun query1 ->
         fun acc ->
-          let uu____3691 =
+          let uu___ =
             match query1 with
             | [] -> (NSTAll, NSTAll, [])
             | id::[] -> ((NSTPrefix id), (NSTPrefix id), [])
             | ns::query2 -> ((NSTPrefix ns), NSTNone, query2) in
-          match uu____3691 with
+          match uu___ with
           | (ns_search_term, bindings_search_term, query2) ->
               let matching_namespaces_rev =
                 names_find_rev tr.namespaces ns_search_term in
               let acc_with_recursive_bindings =
                 FStar_List.fold_left
                   (fun acc1 ->
-                     fun uu____3753 ->
-                       match uu____3753 with
+                     fun uu___1 ->
+                       match uu___1 with
                        | (path_el, trie1) ->
                            trie_find_prefix' trie1 (path_el :: path_acc)
                              query2 acc1) acc matching_namespaces_rev in
               let matching_bindings_rev =
                 names_find_rev tr.bindings bindings_search_term in
               FStar_List.rev_map_onto
-                (fun uu____3798 ->
-                   match uu____3798 with
+                (fun uu___1 ->
+                   match uu___1 with
                    | (path_el, v) ->
                        ((FStar_List.rev (path_el :: path_acc)), v))
                 matching_bindings_rev acc_with_recursive_bindings
@@ -674,13 +649,12 @@ type mod_symbol =
   | Module of mod_info 
   | Namespace of ns_info 
 let (uu___is_Module : mod_symbol -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Module _0 -> true | uu____3928 -> false
+  fun projectee -> match projectee with | Module _0 -> true | uu___ -> false
 let (__proj__Module__item___0 : mod_symbol -> mod_info) =
   fun projectee -> match projectee with | Module _0 -> _0
 let (uu___is_Namespace : mod_symbol -> Prims.bool) =
   fun projectee ->
-    match projectee with | Namespace _0 -> true | uu____3941 -> false
+    match projectee with | Namespace _0 -> true | uu___ -> false
 let (__proj__Namespace__item___0 : mod_symbol -> ns_info) =
   fun projectee -> match projectee with | Namespace _0 -> _0
 type lid_symbol = FStar_Ident.lid
@@ -688,13 +662,11 @@ type symbol =
   | ModOrNs of mod_symbol 
   | Lid of lid_symbol 
 let (uu___is_ModOrNs : symbol -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ModOrNs _0 -> true | uu____3964 -> false
+  fun projectee -> match projectee with | ModOrNs _0 -> true | uu___ -> false
 let (__proj__ModOrNs__item___0 : symbol -> mod_symbol) =
   fun projectee -> match projectee with | ModOrNs _0 -> _0
 let (uu___is_Lid : symbol -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lid _0 -> true | uu____3977 -> false
+  fun projectee -> match projectee with | Lid _0 -> true | uu___ -> false
 let (__proj__Lid__item___0 : symbol -> lid_symbol) =
   fun projectee -> match projectee with | Lid _0 -> _0
 type table = {
@@ -711,25 +683,25 @@ let (insert : table -> query -> Prims.string -> lid_symbol -> table) =
     fun host_query ->
       fun id ->
         fun c ->
-          let uu___533_4048 = tbl in
-          let uu____4049 = trie_insert tbl.tbl_lids host_query id c in
-          { tbl_lids = uu____4049; tbl_mods = (uu___533_4048.tbl_mods) }
+          let uu___ = tbl in
+          let uu___1 = trie_insert tbl.tbl_lids host_query id c in
+          { tbl_lids = uu___1; tbl_mods = (uu___.tbl_mods) }
 let (register_alias : table -> Prims.string -> query -> query -> table) =
   fun tbl ->
     fun key ->
       fun host_query ->
         fun included_query ->
-          let uu___543_4072 = tbl in
-          let uu____4073 =
+          let uu___ = tbl in
+          let uu___1 =
             trie_add_alias tbl.tbl_lids key host_query included_query in
-          { tbl_lids = uu____4073; tbl_mods = (uu___543_4072.tbl_mods) }
+          { tbl_lids = uu___1; tbl_mods = (uu___.tbl_mods) }
 let (register_include : table -> query -> query -> table) =
   fun tbl ->
     fun host_query ->
       fun included_query ->
-        let uu___551_4091 = tbl in
-        let uu____4092 = trie_include tbl.tbl_lids host_query included_query in
-        { tbl_lids = uu____4092; tbl_mods = (uu___551_4091.tbl_mods) }
+        let uu___ = tbl in
+        let uu___1 = trie_include tbl.tbl_lids host_query included_query in
+        { tbl_lids = uu___1; tbl_mods = (uu___.tbl_mods) }
 let (register_open : table -> Prims.bool -> query -> query -> table) =
   fun tbl ->
     fun is_module ->
@@ -738,10 +710,10 @@ let (register_open : table -> Prims.bool -> query -> query -> table) =
           if is_module
           then register_include tbl host_query included_query
           else
-            (let uu___562_4116 = tbl in
-             let uu____4117 =
+            (let uu___1 = tbl in
+             let uu___2 =
                trie_open_namespace tbl.tbl_lids host_query included_query in
-             { tbl_lids = uu____4117; tbl_mods = (uu___562_4116.tbl_mods) })
+             { tbl_lids = uu___2; tbl_mods = (uu___1.tbl_mods) })
 let (register_module_path :
   table -> Prims.bool -> Prims.string -> query -> table) =
   fun tbl ->
@@ -749,19 +721,17 @@ let (register_module_path :
       fun path1 ->
         fun mod_query ->
           let ins_ns id bindings full_name loaded1 =
-            let uu____4167 =
-              let uu____4174 = names_find_exact bindings id in
-              (uu____4174, loaded1) in
-            match uu____4167 with
-            | (FStar_Pervasives_Native.None, uu____4181) ->
+            let uu___ =
+              let uu___1 = names_find_exact bindings id in (uu___1, loaded1) in
+            match uu___ with
+            | (FStar_Pervasives_Native.None, uu___1) ->
                 names_insert bindings id
                   (Namespace { ns_name = full_name; ns_loaded = loaded1 })
             | (FStar_Pervasives_Native.Some (Namespace
-               { ns_name = uu____4184; ns_loaded = false;_}), true) ->
+               { ns_name = uu___1; ns_loaded = false;_}), true) ->
                 names_insert bindings id
                   (Namespace { ns_name = full_name; ns_loaded = loaded1 })
-            | (FStar_Pervasives_Native.Some uu____4187, uu____4188) ->
-                bindings in
+            | (FStar_Pervasives_Native.Some uu___1, uu___2) -> bindings in
           let ins_mod id bindings full_name loaded1 =
             names_insert bindings id
               (Module
@@ -776,33 +746,33 @@ let (register_module_path :
             let name = name_of_revq (id :: revq) in
             match q with
             | [] -> ins_mod id bindings name loaded1
-            | uu____4271 -> ins_ns id bindings name loaded1 in
-          let uu___607_4274 = tbl in
-          let uu____4275 =
+            | uu___ -> ins_ns id bindings name loaded1 in
+          let uu___ = tbl in
+          let uu___1 =
             trie_mutate tbl.tbl_mods mod_query []
               (fun tr ->
                  fun id ->
                    fun q ->
                      fun revq ->
                        fun namespaces ->
-                         let uu___616_4296 = tr in
-                         let uu____4299 = ins id q revq tr.bindings loaded in
-                         { bindings = uu____4299; namespaces })
-              (fun tr -> fun uu____4305 -> tr) in
-          { tbl_lids = (uu___607_4274.tbl_lids); tbl_mods = uu____4275 }
+                         let uu___2 = tr in
+                         let uu___3 = ins id q revq tr.bindings loaded in
+                         { bindings = uu___3; namespaces })
+              (fun tr -> fun uu___2 -> tr) in
+          { tbl_lids = (uu___.tbl_lids); tbl_mods = uu___1 }
 let (string_of_path : path -> Prims.string) =
   fun path1 ->
-    let uu____4313 = FStar_List.map (fun el -> (el.segment).completion) path1 in
-    FStar_String.concat "." uu____4313
+    let uu___ = FStar_List.map (fun el -> (el.segment).completion) path1 in
+    FStar_String.concat "." uu___
 let (match_length_of_path : path -> Prims.int) =
   fun path1 ->
-    let uu____4323 =
+    let uu___ =
       FStar_List.fold_left
         (fun acc ->
            fun elem ->
-             let uu____4357 = acc in
-             match uu____4357 with
-             | (acc_len, uu____4375) ->
+             let uu___1 = acc in
+             match uu___1 with
+             | (acc_len, uu___2) ->
                  (match (elem.segment).prefix with
                   | FStar_Pervasives_Native.Some prefix ->
                       let completion_len =
@@ -811,7 +781,7 @@ let (match_length_of_path : path -> Prims.int) =
                         (prefix, completion_len))
                   | FStar_Pervasives_Native.None -> acc))
         (Prims.int_zero, ("", Prims.int_zero)) path1 in
-    match uu____4323 with
+    match uu___ with
     | (length, (last_prefix, last_completion_length)) ->
         ((length - Prims.int_one) - last_completion_length) +
           (FStar_String.length last_prefix)
@@ -820,8 +790,7 @@ let (first_import_of_path :
   fun path1 ->
     match path1 with
     | [] -> FStar_Pervasives_Native.None
-    | { imports; segment = uu____4419;_}::uu____4420 ->
-        FStar_List.last imports
+    | { imports; segment = uu___;_}::uu___1 -> FStar_List.last imports
 let (alist_of_ns_info :
   ns_info -> (Prims.string * FStar_Util.json) Prims.list) =
   fun ns_info1 ->
@@ -862,46 +831,45 @@ let (json_of_completion_result : completion_result -> FStar_Util.json) =
       [FStar_Util.JsonInt (result.completion_match_length);
       FStar_Util.JsonStr (result.completion_annotation);
       FStar_Util.JsonStr (result.completion_candidate)]
-let completion_result_of_lid :
-  'uuuuuu4523 . (path * 'uuuuuu4523) -> completion_result =
-  fun uu____4532 ->
-    match uu____4532 with
+let completion_result_of_lid : 'uuuuu . (path * 'uuuuu) -> completion_result
+  =
+  fun uu___ ->
+    match uu___ with
     | (path1, _lid) ->
-        let uu____4539 = match_length_of_path path1 in
-        let uu____4540 = string_of_path path1 in
-        let uu____4541 =
-          let uu____4542 = first_import_of_path path1 in
-          FStar_Util.dflt "" uu____4542 in
+        let uu___1 = match_length_of_path path1 in
+        let uu___2 = string_of_path path1 in
+        let uu___3 =
+          let uu___4 = first_import_of_path path1 in
+          FStar_Util.dflt "" uu___4 in
         {
-          completion_match_length = uu____4539;
-          completion_candidate = uu____4540;
-          completion_annotation = uu____4541
+          completion_match_length = uu___1;
+          completion_candidate = uu___2;
+          completion_annotation = uu___3
         }
 let (completion_result_of_mod :
   Prims.string -> Prims.bool -> path -> completion_result) =
   fun annot ->
     fun loaded ->
       fun path1 ->
-        let uu____4560 = match_length_of_path path1 in
-        let uu____4561 = string_of_path path1 in
-        let uu____4562 =
+        let uu___ = match_length_of_path path1 in
+        let uu___1 = string_of_path path1 in
+        let uu___2 =
           FStar_Util.format1 (if loaded then " %s " else "(%s)") annot in
         {
-          completion_match_length = uu____4560;
-          completion_candidate = uu____4561;
-          completion_annotation = uu____4562
+          completion_match_length = uu___;
+          completion_candidate = uu___1;
+          completion_annotation = uu___2
         }
 let (completion_result_of_ns_or_mod :
   (path * mod_symbol) -> completion_result) =
-  fun uu____4572 ->
-    match uu____4572 with
+  fun uu___ ->
+    match uu___ with
     | (path1, symb) ->
         (match symb with
          | Module
-             { mod_name = uu____4579; mod_path = uu____4580;
-               mod_loaded = loaded;_}
+             { mod_name = uu___1; mod_path = uu___2; mod_loaded = loaded;_}
              -> completion_result_of_mod "mod" loaded path1
-         | Namespace { ns_name = uu____4582; ns_loaded = loaded;_} ->
+         | Namespace { ns_name = uu___1; ns_loaded = loaded;_} ->
              completion_result_of_mod "ns" loaded path1)
 let (find_module_or_ns :
   table -> query -> mod_symbol FStar_Pervasives_Native.option) =
@@ -909,8 +877,8 @@ let (find_module_or_ns :
 let (autocomplete_lid : table -> query -> completion_result Prims.list) =
   fun tbl ->
     fun query1 ->
-      let uu____4608 = trie_find_prefix tbl.tbl_lids query1 in
-      FStar_List.map completion_result_of_lid uu____4608
+      let uu___ = trie_find_prefix tbl.tbl_lids query1 in
+      FStar_List.map completion_result_of_lid uu___
 let (autocomplete_mod_or_ns :
   table ->
     query ->
@@ -921,8 +889,8 @@ let (autocomplete_mod_or_ns :
   fun tbl ->
     fun query1 ->
       fun filter ->
-        let uu____4661 =
-          let uu____4668 = trie_find_prefix tbl.tbl_mods query1 in
-          FStar_All.pipe_right uu____4668 (FStar_List.filter_map filter) in
-        FStar_All.pipe_right uu____4661
+        let uu___ =
+          let uu___1 = trie_find_prefix tbl.tbl_mods query1 in
+          FStar_All.pipe_right uu___1 (FStar_List.filter_map filter) in
+        FStar_All.pipe_right uu___
           (FStar_List.map completion_result_of_ns_or_mod)

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -1,21 +1,20 @@
 open Prims
 let with_captured_errors' :
-  'uuuuuu28 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
       FStar_Util.sigint_handler ->
-        (FStar_TypeChecker_Env.env ->
-           'uuuuuu28 FStar_Pervasives_Native.option)
-          -> 'uuuuuu28 FStar_Pervasives_Native.option
+        (FStar_TypeChecker_Env.env -> 'uuuuu FStar_Pervasives_Native.option)
+          -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun env ->
     fun sigint_handler ->
       fun f ->
         try
-          (fun uu___11_58 ->
+          (fun uu___ ->
              match () with
              | () ->
                  FStar_Util.with_sigint_handler sigint_handler
-                   (fun uu____64 -> f env)) ()
+                   (fun uu___1 -> f env)) ()
         with
         | FStar_All.Failure msg ->
             let msg1 =
@@ -26,8 +25,8 @@ let with_captured_errors' :
                          (Prims.op_Hat
                             "Please file a bug report, ideally with a "
                             "minimized version of the program that triggered the error.")))) in
-            ((let uu____75 = FStar_TypeChecker_Env.get_range env in
-              FStar_Errors.log_issue uu____75
+            ((let uu___2 = FStar_TypeChecker_Env.get_range env in
+              FStar_Errors.log_issue uu___2
                 (FStar_Errors.Error_IDEAssertionFailure, msg1));
              FStar_Pervasives_Native.None)
         | FStar_Util.SigInt ->
@@ -37,29 +36,26 @@ let with_captured_errors' :
             (FStar_TypeChecker_Err.add_errors env [(e, msg, r)];
              FStar_Pervasives_Native.None)
         | FStar_Errors.Err (e, msg) ->
-            ((let uu____96 =
-                let uu____105 =
-                  let uu____112 = FStar_TypeChecker_Env.get_range env in
-                  (e, msg, uu____112) in
-                [uu____105] in
-              FStar_TypeChecker_Err.add_errors env uu____96);
+            ((let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_TypeChecker_Env.get_range env in
+                  (e, msg, uu___4) in
+                [uu___3] in
+              FStar_TypeChecker_Err.add_errors env uu___2);
              FStar_Pervasives_Native.None)
         | FStar_Errors.Stop -> FStar_Pervasives_Native.None
 let with_captured_errors :
-  'uuuuuu133 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
       FStar_Util.sigint_handler ->
-        (FStar_TypeChecker_Env.env ->
-           'uuuuuu133 FStar_Pervasives_Native.option)
-          -> 'uuuuuu133 FStar_Pervasives_Native.option
+        (FStar_TypeChecker_Env.env -> 'uuuuu FStar_Pervasives_Native.option)
+          -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun env ->
     fun sigint_handler ->
       fun f ->
-        let uu____160 = FStar_Options.trace_error () in
-        if uu____160
-        then f env
-        else with_captured_errors' env sigint_handler f
+        let uu___ = FStar_Options.trace_error () in
+        if uu___ then f env else with_captured_errors' env sigint_handler f
 let (t0 : FStar_Util.time) = FStar_Util.now ()
 let (dummy_tf_of_fname :
   Prims.string -> FStar_Interactive_JsonHelper.timed_fname) =
@@ -70,15 +66,15 @@ let (dummy_tf_of_fname :
     }
 let (string_of_timed_fname :
   FStar_Interactive_JsonHelper.timed_fname -> Prims.string) =
-  fun uu____173 ->
-    match uu____173 with
+  fun uu___ ->
+    match uu___ with
     | { FStar_Interactive_JsonHelper.tf_fname = fname;
         FStar_Interactive_JsonHelper.tf_modtime = modtime;_} ->
         if modtime = t0
         then FStar_Util.format1 "{ %s }" fname
         else
-          (let uu____177 = FStar_Util.string_of_time modtime in
-           FStar_Util.format2 "{ %s; %s }" fname uu____177)
+          (let uu___2 = FStar_Util.string_of_time modtime in
+           FStar_Util.format2 "{ %s; %s }" fname uu___2)
 type push_query =
   {
   push_kind: FStar_Interactive_PushHelper.push_kind ;
@@ -119,26 +115,25 @@ let (repl_current_qid :
 let (nothing_left_to_pop :
   FStar_Interactive_JsonHelper.repl_state -> Prims.bool) =
   fun st ->
-    let uu____264 =
-      let uu____265 =
-        FStar_ST.op_Bang FStar_Interactive_PushHelper.repl_stack in
-      FStar_List.length uu____265 in
-    uu____264 =
+    let uu___ =
+      let uu___1 = FStar_ST.op_Bang FStar_Interactive_PushHelper.repl_stack in
+      FStar_List.length uu___1 in
+    uu___ =
       (FStar_List.length st.FStar_Interactive_JsonHelper.repl_deps_stack)
 let (string_of_repl_task :
   FStar_Interactive_JsonHelper.repl_task -> Prims.string) =
-  fun uu___0_302 ->
-    match uu___0_302 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Interactive_JsonHelper.LDInterleaved (intf, impl) ->
-        let uu____305 = string_of_timed_fname intf in
-        let uu____306 = string_of_timed_fname impl in
-        FStar_Util.format2 "LDInterleaved (%s, %s)" uu____305 uu____306
+        let uu___1 = string_of_timed_fname intf in
+        let uu___2 = string_of_timed_fname impl in
+        FStar_Util.format2 "LDInterleaved (%s, %s)" uu___1 uu___2
     | FStar_Interactive_JsonHelper.LDSingle intf_or_impl ->
-        let uu____308 = string_of_timed_fname intf_or_impl in
-        FStar_Util.format1 "LDSingle %s" uu____308
+        let uu___1 = string_of_timed_fname intf_or_impl in
+        FStar_Util.format1 "LDSingle %s" uu___1
     | FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile intf ->
-        let uu____310 = string_of_timed_fname intf in
-        FStar_Util.format1 "LDInterfaceOfCurrentFile %s" uu____310
+        let uu___1 = string_of_timed_fname intf in
+        FStar_Util.format1 "LDInterfaceOfCurrentFile %s" uu___1
     | FStar_Interactive_JsonHelper.PushFragment frag ->
         FStar_Util.format1 "PushFragment { code = %s }"
           frag.FStar_Parser_ParseIt.frag_text
@@ -157,62 +152,62 @@ let (run_repl_transaction :
           let st1 =
             FStar_Interactive_PushHelper.push_repl "run_repl_transaction"
               push_kind task st in
-          let uu____337 =
+          let uu___ =
             FStar_Interactive_PushHelper.track_name_changes
               st1.FStar_Interactive_JsonHelper.repl_env in
-          match uu____337 with
+          match uu___ with
           | (env, finish_name_tracking) ->
-              let check_success uu____380 =
-                (let uu____383 = FStar_Errors.get_err_count () in
-                 uu____383 = Prims.int_zero) &&
+              let check_success uu___1 =
+                (let uu___2 = FStar_Errors.get_err_count () in
+                 uu___2 = Prims.int_zero) &&
                   (Prims.op_Negation must_rollback) in
-              let uu____384 =
-                let uu____391 =
+              let uu___1 =
+                let uu___2 =
                   with_captured_errors env FStar_Util.sigint_raise
                     (fun env1 ->
-                       let uu____405 =
+                       let uu___3 =
                          FStar_Interactive_PushHelper.run_repl_task
                            st1.FStar_Interactive_JsonHelper.repl_curmod env1
                            task in
                        FStar_All.pipe_left
-                         (fun uu____424 ->
-                            FStar_Pervasives_Native.Some uu____424) uu____405) in
-                match uu____391 with
+                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                         uu___3) in
+                match uu___2 with
                 | FStar_Pervasives_Native.Some (curmod, env1) when
                     check_success () -> (curmod, env1, true)
-                | uu____437 ->
+                | uu___3 ->
                     ((st1.FStar_Interactive_JsonHelper.repl_curmod), env,
                       false) in
-              (match uu____384 with
+              (match uu___1 with
                | (curmod, env1, success) ->
-                   let uu____451 = finish_name_tracking env1 in
-                   (match uu____451 with
+                   let uu___2 = finish_name_tracking env1 in
+                   (match uu___2 with
                     | (env2, name_events) ->
                         let st2 =
                           if success
                           then
-                            let st2 =
-                              let uu___95_470 = st1 in
+                            let st3 =
+                              let uu___3 = st1 in
                               {
                                 FStar_Interactive_JsonHelper.repl_line =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_line);
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_line);
                                 FStar_Interactive_JsonHelper.repl_column =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_column);
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_column);
                                 FStar_Interactive_JsonHelper.repl_fname =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_fname);
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_fname);
                                 FStar_Interactive_JsonHelper.repl_deps_stack
                                   =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_deps_stack);
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_deps_stack);
                                 FStar_Interactive_JsonHelper.repl_curmod =
                                   curmod;
                                 FStar_Interactive_JsonHelper.repl_env = env2;
                                 FStar_Interactive_JsonHelper.repl_stdin =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_stdin);
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_stdin);
                                 FStar_Interactive_JsonHelper.repl_names =
-                                  (uu___95_470.FStar_Interactive_JsonHelper.repl_names)
+                                  (uu___3.FStar_Interactive_JsonHelper.repl_names)
                               } in
                             FStar_Interactive_PushHelper.commit_name_tracking
-                              st2 name_events
+                              st3 name_events
                           else
                             FStar_Interactive_PushHelper.pop_repl
                               "run_repl_transaction" st1 in
@@ -228,14 +223,14 @@ let (run_repl_ld_transactions :
     fun tasks ->
       fun progress_callback ->
         let debug verb task =
-          let uu____511 = FStar_Options.debug_any () in
-          if uu____511
+          let uu___ = FStar_Options.debug_any () in
+          if uu___
           then
-            let uu____512 = string_of_repl_task task in
-            FStar_Util.print2 "%s %s" verb uu____512
+            let uu___1 = string_of_repl_task task in
+            FStar_Util.print2 "%s %s" verb uu___1
           else () in
-        let rec revert_many st1 uu___1_534 =
-          match uu___1_534 with
+        let rec revert_many st1 uu___ =
+          match uu___ with
           | [] -> st1
           | (_id, (task, _st'))::entries ->
               (debug "Reverting" task;
@@ -246,26 +241,26 @@ let (run_repl_ld_transactions :
                   FStar_TypeChecker_Env.dep_graph
                     st1.FStar_Interactive_JsonHelper.repl_env in
                 let st'1 =
-                  let uu___121_585 = st' in
-                  let uu____586 =
+                  let uu___3 = st' in
+                  let uu___4 =
                     FStar_TypeChecker_Env.set_dep_graph
                       st'.FStar_Interactive_JsonHelper.repl_env dep_graph in
                   {
                     FStar_Interactive_JsonHelper.repl_line =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_line);
+                      (uu___3.FStar_Interactive_JsonHelper.repl_line);
                     FStar_Interactive_JsonHelper.repl_column =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_column);
+                      (uu___3.FStar_Interactive_JsonHelper.repl_column);
                     FStar_Interactive_JsonHelper.repl_fname =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_fname);
+                      (uu___3.FStar_Interactive_JsonHelper.repl_fname);
                     FStar_Interactive_JsonHelper.repl_deps_stack =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_deps_stack);
+                      (uu___3.FStar_Interactive_JsonHelper.repl_deps_stack);
                     FStar_Interactive_JsonHelper.repl_curmod =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_curmod);
-                    FStar_Interactive_JsonHelper.repl_env = uu____586;
+                      (uu___3.FStar_Interactive_JsonHelper.repl_curmod);
+                    FStar_Interactive_JsonHelper.repl_env = uu___4;
                     FStar_Interactive_JsonHelper.repl_stdin =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_stdin);
+                      (uu___3.FStar_Interactive_JsonHelper.repl_stdin);
                     FStar_Interactive_JsonHelper.repl_names =
-                      (uu___121_585.FStar_Interactive_JsonHelper.repl_names)
+                      (uu___3.FStar_Interactive_JsonHelper.repl_names)
                   } in
                 revert_many st'1 entries)) in
         let rec aux st1 tasks1 previous =
@@ -274,70 +269,69 @@ let (run_repl_ld_transactions :
           | (task::tasks2, []) ->
               (debug "Loading" task;
                progress_callback task;
-               (let uu____638 = FStar_Options.restore_cmd_line_options false in
-                FStar_All.pipe_right uu____638 (fun uu____639 -> ()));
+               (let uu___3 = FStar_Options.restore_cmd_line_options false in
+                FStar_All.pipe_right uu___3 (fun uu___4 -> ()));
                (let timestamped_task =
                   FStar_Interactive_PushHelper.update_task_timestamps task in
                 let push_kind =
-                  let uu____642 = FStar_Options.lax () in
-                  if uu____642
+                  let uu___3 = FStar_Options.lax () in
+                  if uu___3
                   then FStar_Interactive_PushHelper.LaxCheck
                   else FStar_Interactive_PushHelper.FullCheck in
-                let uu____644 =
+                let uu___3 =
                   run_repl_transaction st1 push_kind false timestamped_task in
-                match uu____644 with
+                match uu___3 with
                 | (success, st2) ->
                     if success
                     then
-                      let uu____659 =
-                        let uu___146_660 = st2 in
-                        let uu____661 =
+                      let uu___4 =
+                        let uu___5 = st2 in
+                        let uu___6 =
                           FStar_ST.op_Bang
                             FStar_Interactive_PushHelper.repl_stack in
                         {
                           FStar_Interactive_JsonHelper.repl_line =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_line);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_line);
                           FStar_Interactive_JsonHelper.repl_column =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_column);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_column);
                           FStar_Interactive_JsonHelper.repl_fname =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_fname);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_fname);
                           FStar_Interactive_JsonHelper.repl_deps_stack =
-                            uu____661;
+                            uu___6;
                           FStar_Interactive_JsonHelper.repl_curmod =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_curmod);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_curmod);
                           FStar_Interactive_JsonHelper.repl_env =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_env);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_env);
                           FStar_Interactive_JsonHelper.repl_stdin =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_stdin);
+                            (uu___5.FStar_Interactive_JsonHelper.repl_stdin);
                           FStar_Interactive_JsonHelper.repl_names =
-                            (uu___146_660.FStar_Interactive_JsonHelper.repl_names)
+                            (uu___5.FStar_Interactive_JsonHelper.repl_names)
                         } in
-                      aux uu____659 tasks2 []
+                      aux uu___4 tasks2 []
                     else FStar_Util.Inr st2))
           | (task::tasks2, prev::previous1) when
-              let uu____691 =
+              let uu___ =
                 FStar_Interactive_PushHelper.update_task_timestamps task in
               (FStar_Pervasives_Native.fst (FStar_Pervasives_Native.snd prev))
-                = uu____691
+                = uu___
               -> (debug "Skipping" task; aux st1 tasks2 previous1)
           | (tasks2, previous1) ->
-              let uu____707 = revert_many st1 previous1 in
-              aux uu____707 tasks2 [] in
+              let uu___ = revert_many st1 previous1 in aux uu___ tasks2 [] in
         aux st tasks
           (FStar_List.rev st.FStar_Interactive_JsonHelper.repl_deps_stack)
 let (js_pushkind : FStar_Util.json -> FStar_Interactive_PushHelper.push_kind)
   =
   fun s ->
-    let uu____721 = FStar_Interactive_JsonHelper.js_str s in
-    match uu____721 with
+    let uu___ = FStar_Interactive_JsonHelper.js_str s in
+    match uu___ with
     | "syntax" -> FStar_Interactive_PushHelper.SyntaxCheck
     | "lax" -> FStar_Interactive_PushHelper.LaxCheck
     | "full" -> FStar_Interactive_PushHelper.FullCheck
-    | uu____722 -> FStar_Interactive_JsonHelper.js_fail "push_kind" s
+    | uu___1 -> FStar_Interactive_JsonHelper.js_fail "push_kind" s
 let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Env.step) =
   fun s ->
-    let uu____728 = FStar_Interactive_JsonHelper.js_str s in
-    match uu____728 with
+    let uu___ = FStar_Interactive_JsonHelper.js_str s in
+    match uu___ with
     | "beta" -> FStar_TypeChecker_Env.Beta
     | "delta" ->
         FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant
@@ -345,23 +339,21 @@ let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Env.step) =
     | "zeta" -> FStar_TypeChecker_Env.Zeta
     | "reify" -> FStar_TypeChecker_Env.Reify
     | "pure-subterms" -> FStar_TypeChecker_Env.PureSubtermsWithinComputations
-    | uu____729 -> FStar_Interactive_JsonHelper.js_fail "reduction rule" s
+    | uu___1 -> FStar_Interactive_JsonHelper.js_fail "reduction rule" s
 type completion_context =
   | CKCode 
   | CKOption of Prims.bool 
   | CKModuleOrNamespace of (Prims.bool * Prims.bool) 
 let (uu___is_CKCode : completion_context -> Prims.bool) =
-  fun projectee -> match projectee with | CKCode -> true | uu____749 -> false
+  fun projectee -> match projectee with | CKCode -> true | uu___ -> false
 let (uu___is_CKOption : completion_context -> Prims.bool) =
   fun projectee ->
-    match projectee with | CKOption _0 -> true | uu____756 -> false
+    match projectee with | CKOption _0 -> true | uu___ -> false
 let (__proj__CKOption__item___0 : completion_context -> Prims.bool) =
   fun projectee -> match projectee with | CKOption _0 -> _0
 let (uu___is_CKModuleOrNamespace : completion_context -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | CKModuleOrNamespace _0 -> true
-    | uu____773 -> false
+    match projectee with | CKModuleOrNamespace _0 -> true | uu___ -> false
 let (__proj__CKModuleOrNamespace__item___0 :
   completion_context -> (Prims.bool * Prims.bool)) =
   fun projectee -> match projectee with | CKModuleOrNamespace _0 -> _0
@@ -371,8 +363,8 @@ let (js_optional_completion_context :
     match k with
     | FStar_Pervasives_Native.None -> CKCode
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____802 = FStar_Interactive_JsonHelper.js_str k1 in
-        (match uu____802 with
+        let uu___ = FStar_Interactive_JsonHelper.js_str k1 in
+        (match uu___ with
          | "symbol" -> CKCode
          | "code" -> CKCode
          | "set-options" -> CKOption false
@@ -381,7 +373,7 @@ let (js_optional_completion_context :
          | "let-open" -> CKModuleOrNamespace (true, true)
          | "include" -> CKModuleOrNamespace (true, false)
          | "module-alias" -> CKModuleOrNamespace (true, false)
-         | uu____803 ->
+         | uu___1 ->
              FStar_Interactive_JsonHelper.js_fail
                "completion context (code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
@@ -392,23 +384,21 @@ type lookup_context =
   | LKCode 
 let (uu___is_LKSymbolOnly : lookup_context -> Prims.bool) =
   fun projectee ->
-    match projectee with | LKSymbolOnly -> true | uu____809 -> false
+    match projectee with | LKSymbolOnly -> true | uu___ -> false
 let (uu___is_LKModule : lookup_context -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LKModule -> true | uu____815 -> false
+  fun projectee -> match projectee with | LKModule -> true | uu___ -> false
 let (uu___is_LKOption : lookup_context -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LKOption -> true | uu____821 -> false
+  fun projectee -> match projectee with | LKOption -> true | uu___ -> false
 let (uu___is_LKCode : lookup_context -> Prims.bool) =
-  fun projectee -> match projectee with | LKCode -> true | uu____827 -> false
+  fun projectee -> match projectee with | LKCode -> true | uu___ -> false
 let (js_optional_lookup_context :
   FStar_Util.json FStar_Pervasives_Native.option -> lookup_context) =
   fun k ->
     match k with
     | FStar_Pervasives_Native.None -> LKSymbolOnly
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____838 = FStar_Interactive_JsonHelper.js_str k1 in
-        (match uu____838 with
+        let uu___ = FStar_Interactive_JsonHelper.js_str k1 in
+        (match uu___ with
          | "symbol-only" -> LKSymbolOnly
          | "code" -> LKCode
          | "set-options" -> LKOption
@@ -417,7 +407,7 @@ let (js_optional_lookup_context :
          | "let-open" -> LKModule
          | "include" -> LKModule
          | "module-alias" -> LKModule
-         | uu____839 ->
+         | uu___1 ->
              FStar_Interactive_JsonHelper.js_fail
                "lookup context (symbol-only, code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
@@ -442,66 +432,60 @@ and query = {
   qq: query' ;
   qid: Prims.string }
 let (uu___is_Exit : query' -> Prims.bool) =
-  fun projectee -> match projectee with | Exit -> true | uu____936 -> false
+  fun projectee -> match projectee with | Exit -> true | uu___ -> false
 let (uu___is_DescribeProtocol : query' -> Prims.bool) =
   fun projectee ->
-    match projectee with | DescribeProtocol -> true | uu____942 -> false
+    match projectee with | DescribeProtocol -> true | uu___ -> false
 let (uu___is_DescribeRepl : query' -> Prims.bool) =
   fun projectee ->
-    match projectee with | DescribeRepl -> true | uu____948 -> false
+    match projectee with | DescribeRepl -> true | uu___ -> false
 let (uu___is_Segment : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Segment _0 -> true | uu____955 -> false
+  fun projectee -> match projectee with | Segment _0 -> true | uu___ -> false
 let (__proj__Segment__item___0 : query' -> Prims.string) =
   fun projectee -> match projectee with | Segment _0 -> _0
 let (uu___is_Pop : query' -> Prims.bool) =
-  fun projectee -> match projectee with | Pop -> true | uu____967 -> false
+  fun projectee -> match projectee with | Pop -> true | uu___ -> false
 let (uu___is_Push : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Push _0 -> true | uu____974 -> false
+  fun projectee -> match projectee with | Push _0 -> true | uu___ -> false
 let (__proj__Push__item___0 : query' -> push_query) =
   fun projectee -> match projectee with | Push _0 -> _0
 let (uu___is_VfsAdd : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VfsAdd _0 -> true | uu____993 -> false
+  fun projectee -> match projectee with | VfsAdd _0 -> true | uu___ -> false
 let (__proj__VfsAdd__item___0 :
   query' -> (Prims.string FStar_Pervasives_Native.option * Prims.string)) =
   fun projectee -> match projectee with | VfsAdd _0 -> _0
 let (uu___is_AutoComplete : query' -> Prims.bool) =
   fun projectee ->
-    match projectee with | AutoComplete _0 -> true | uu____1028 -> false
+    match projectee with | AutoComplete _0 -> true | uu___ -> false
 let (__proj__AutoComplete__item___0 :
   query' -> (Prims.string * completion_context)) =
   fun projectee -> match projectee with | AutoComplete _0 -> _0
 let (uu___is_Lookup : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lookup _0 -> true | uu____1065 -> false
+  fun projectee -> match projectee with | Lookup _0 -> true | uu___ -> false
 let (__proj__Lookup__item___0 :
   query' ->
     (Prims.string * lookup_context * position FStar_Pervasives_Native.option
       * Prims.string Prims.list))
   = fun projectee -> match projectee with | Lookup _0 -> _0
 let (uu___is_Compute : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Compute _0 -> true | uu____1122 -> false
+  fun projectee -> match projectee with | Compute _0 -> true | uu___ -> false
 let (__proj__Compute__item___0 :
   query' ->
     (Prims.string * FStar_TypeChecker_Env.step Prims.list
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | Compute _0 -> _0
 let (uu___is_Search : query' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Search _0 -> true | uu____1159 -> false
+  fun projectee -> match projectee with | Search _0 -> true | uu___ -> false
 let (__proj__Search__item___0 : query' -> Prims.string) =
   fun projectee -> match projectee with | Search _0 -> _0
 let (uu___is_GenericError : query' -> Prims.bool) =
   fun projectee ->
-    match projectee with | GenericError _0 -> true | uu____1172 -> false
+    match projectee with | GenericError _0 -> true | uu___ -> false
 let (__proj__GenericError__item___0 : query' -> Prims.string) =
   fun projectee -> match projectee with | GenericError _0 -> _0
 let (uu___is_ProtocolViolation : query' -> Prims.bool) =
   fun projectee ->
-    match projectee with | ProtocolViolation _0 -> true | uu____1185 -> false
+    match projectee with | ProtocolViolation _0 -> true | uu___ -> false
 let (__proj__ProtocolViolation__item___0 : query' -> Prims.string) =
   fun projectee -> match projectee with | ProtocolViolation _0 -> _0
 let (__proj__Mkquery__item__qq : query -> query') =
@@ -509,26 +493,25 @@ let (__proj__Mkquery__item__qq : query -> query') =
 let (__proj__Mkquery__item__qid : query -> Prims.string) =
   fun projectee -> match projectee with | { qq; qid;_} -> qid
 let (query_needs_current_module : query' -> Prims.bool) =
-  fun uu___2_1210 ->
-    match uu___2_1210 with
+  fun uu___ ->
+    match uu___ with
     | Exit -> false
     | DescribeProtocol -> false
     | DescribeRepl -> false
-    | Segment uu____1211 -> false
+    | Segment uu___1 -> false
     | Pop -> false
     | Push
-        { push_kind = uu____1212; push_code = uu____1213;
-          push_line = uu____1214; push_column = uu____1215;
-          push_peek_only = false;_}
+        { push_kind = uu___1; push_code = uu___2; push_line = uu___3;
+          push_column = uu___4; push_peek_only = false;_}
         -> false
-    | VfsAdd uu____1216 -> false
-    | GenericError uu____1223 -> false
-    | ProtocolViolation uu____1224 -> false
-    | Push uu____1225 -> true
-    | AutoComplete uu____1226 -> true
-    | Lookup uu____1231 -> true
-    | Compute uu____1244 -> true
-    | Search uu____1253 -> true
+    | VfsAdd uu___1 -> false
+    | GenericError uu___1 -> false
+    | ProtocolViolation uu___1 -> false
+    | Push uu___1 -> true
+    | AutoComplete uu___1 -> true
+    | Lookup uu___1 -> true
+    | Compute uu___1 -> true
+    | Search uu___1 -> true
 let (interactive_protocol_vernum : Prims.int) = (Prims.of_int (2))
 let (interactive_protocol_features : Prims.string Prims.list) =
   ["autocomplete";
@@ -557,218 +540,212 @@ type query_status =
   | QueryNOK 
   | QueryViolatesProtocol 
 let (uu___is_QueryOK : query_status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QueryOK -> true | uu____1261 -> false
+  fun projectee -> match projectee with | QueryOK -> true | uu___ -> false
 let (uu___is_QueryNOK : query_status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QueryNOK -> true | uu____1267 -> false
+  fun projectee -> match projectee with | QueryNOK -> true | uu___ -> false
 let (uu___is_QueryViolatesProtocol : query_status -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | QueryViolatesProtocol -> true
-    | uu____1273 -> false
+    match projectee with | QueryViolatesProtocol -> true | uu___ -> false
 let (wrap_js_failure :
   Prims.string -> Prims.string -> FStar_Util.json -> query) =
   fun qid ->
     fun expected ->
       fun got ->
-        let uu____1289 =
-          let uu____1290 =
-            let uu____1291 = FStar_Interactive_JsonHelper.json_debug got in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Interactive_JsonHelper.json_debug got in
             FStar_Util.format2 "JSON decoding failed: expected %s, got %s"
-              expected uu____1291 in
-          ProtocolViolation uu____1290 in
-        { qq = uu____1289; qid }
+              expected uu___2 in
+          ProtocolViolation uu___1 in
+        { qq = uu___; qid }
 let (unpack_interactive_query : FStar_Util.json -> query) =
   fun json ->
     let assoc errloc key a =
-      let uu____1313 = FStar_Interactive_JsonHelper.try_assoc key a in
-      match uu____1313 with
+      let uu___ = FStar_Interactive_JsonHelper.try_assoc key a in
+      match uu___ with
       | FStar_Pervasives_Native.Some v -> v
       | FStar_Pervasives_Native.None ->
-          let uu____1317 =
-            let uu____1318 =
+          let uu___1 =
+            let uu___2 =
               FStar_Util.format2 "Missing key [%s] in %s." key errloc in
-            FStar_Interactive_JsonHelper.InvalidQuery uu____1318 in
-          FStar_Exn.raise uu____1317 in
+            FStar_Interactive_JsonHelper.InvalidQuery uu___2 in
+          FStar_Exn.raise uu___1 in
     let request =
       FStar_All.pipe_right json FStar_Interactive_JsonHelper.js_assoc in
     let qid =
-      let uu____1321 = assoc "query" "query-id" request in
-      FStar_All.pipe_right uu____1321 FStar_Interactive_JsonHelper.js_str in
+      let uu___ = assoc "query" "query-id" request in
+      FStar_All.pipe_right uu___ FStar_Interactive_JsonHelper.js_str in
     try
-      (fun uu___259_1328 ->
+      (fun uu___ ->
          match () with
          | () ->
              let query1 =
-               let uu____1330 = assoc "query" "query" request in
-               FStar_All.pipe_right uu____1330
+               let uu___1 = assoc "query" "query" request in
+               FStar_All.pipe_right uu___1
                  FStar_Interactive_JsonHelper.js_str in
              let args =
-               let uu____1332 = assoc "query" "args" request in
-               FStar_All.pipe_right uu____1332
+               let uu___1 = assoc "query" "args" request in
+               FStar_All.pipe_right uu___1
                  FStar_Interactive_JsonHelper.js_assoc in
              let arg k = assoc "[args]" k args in
              let try_arg k =
-               let uu____1347 = FStar_Interactive_JsonHelper.try_assoc k args in
-               match uu____1347 with
+               let uu___1 = FStar_Interactive_JsonHelper.try_assoc k args in
+               match uu___1 with
                | FStar_Pervasives_Native.Some (FStar_Util.JsonNull) ->
                    FStar_Pervasives_Native.None
                | other -> other in
-             let uu____1355 =
+             let uu___1 =
                match query1 with
                | "exit" -> Exit
                | "pop" -> Pop
                | "describe-protocol" -> DescribeProtocol
                | "describe-repl" -> DescribeRepl
                | "segment" ->
-                   let uu____1356 =
-                     let uu____1357 = arg "code" in
-                     FStar_All.pipe_right uu____1357
+                   let uu___2 =
+                     let uu___3 = arg "code" in
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_str in
-                   Segment uu____1356
+                   Segment uu___2
                | "peek" ->
-                   let uu____1358 =
-                     let uu____1359 =
-                       let uu____1360 = arg "kind" in
-                       FStar_All.pipe_right uu____1360 js_pushkind in
-                     let uu____1361 =
-                       let uu____1362 = arg "code" in
-                       FStar_All.pipe_right uu____1362
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = arg "kind" in
+                       FStar_All.pipe_right uu___4 js_pushkind in
+                     let uu___4 =
+                       let uu___5 = arg "code" in
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_str in
-                     let uu____1363 =
-                       let uu____1364 = arg "line" in
-                       FStar_All.pipe_right uu____1364
+                     let uu___5 =
+                       let uu___6 = arg "line" in
+                       FStar_All.pipe_right uu___6
                          FStar_Interactive_JsonHelper.js_int in
-                     let uu____1365 =
-                       let uu____1366 = arg "column" in
-                       FStar_All.pipe_right uu____1366
+                     let uu___6 =
+                       let uu___7 = arg "column" in
+                       FStar_All.pipe_right uu___7
                          FStar_Interactive_JsonHelper.js_int in
                      {
-                       push_kind = uu____1359;
-                       push_code = uu____1361;
-                       push_line = uu____1363;
-                       push_column = uu____1365;
+                       push_kind = uu___3;
+                       push_code = uu___4;
+                       push_line = uu___5;
+                       push_column = uu___6;
                        push_peek_only = (query1 = "peek")
                      } in
-                   Push uu____1358
+                   Push uu___2
                | "push" ->
-                   let uu____1367 =
-                     let uu____1368 =
-                       let uu____1369 = arg "kind" in
-                       FStar_All.pipe_right uu____1369 js_pushkind in
-                     let uu____1370 =
-                       let uu____1371 = arg "code" in
-                       FStar_All.pipe_right uu____1371
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = arg "kind" in
+                       FStar_All.pipe_right uu___4 js_pushkind in
+                     let uu___4 =
+                       let uu___5 = arg "code" in
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_str in
-                     let uu____1372 =
-                       let uu____1373 = arg "line" in
-                       FStar_All.pipe_right uu____1373
+                     let uu___5 =
+                       let uu___6 = arg "line" in
+                       FStar_All.pipe_right uu___6
                          FStar_Interactive_JsonHelper.js_int in
-                     let uu____1374 =
-                       let uu____1375 = arg "column" in
-                       FStar_All.pipe_right uu____1375
+                     let uu___6 =
+                       let uu___7 = arg "column" in
+                       FStar_All.pipe_right uu___7
                          FStar_Interactive_JsonHelper.js_int in
                      {
-                       push_kind = uu____1368;
-                       push_code = uu____1370;
-                       push_line = uu____1372;
-                       push_column = uu____1374;
+                       push_kind = uu___3;
+                       push_code = uu___4;
+                       push_line = uu___5;
+                       push_column = uu___6;
                        push_peek_only = (query1 = "peek")
                      } in
-                   Push uu____1367
+                   Push uu___2
                | "autocomplete" ->
-                   let uu____1376 =
-                     let uu____1381 =
-                       let uu____1382 = arg "partial-symbol" in
-                       FStar_All.pipe_right uu____1382
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = arg "partial-symbol" in
+                       FStar_All.pipe_right uu___4
                          FStar_Interactive_JsonHelper.js_str in
-                     let uu____1383 =
-                       let uu____1384 = try_arg "context" in
-                       FStar_All.pipe_right uu____1384
+                     let uu___4 =
+                       let uu___5 = try_arg "context" in
+                       FStar_All.pipe_right uu___5
                          js_optional_completion_context in
-                     (uu____1381, uu____1383) in
-                   AutoComplete uu____1376
+                     (uu___3, uu___4) in
+                   AutoComplete uu___2
                | "lookup" ->
-                   let uu____1389 =
-                     let uu____1402 =
-                       let uu____1403 = arg "symbol" in
-                       FStar_All.pipe_right uu____1403
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = arg "symbol" in
+                       FStar_All.pipe_right uu___4
                          FStar_Interactive_JsonHelper.js_str in
-                     let uu____1404 =
-                       let uu____1405 = try_arg "context" in
-                       FStar_All.pipe_right uu____1405
-                         js_optional_lookup_context in
-                     let uu____1410 =
-                       let uu____1413 =
-                         let uu____1416 = try_arg "location" in
-                         FStar_All.pipe_right uu____1416
+                     let uu___4 =
+                       let uu___5 = try_arg "context" in
+                       FStar_All.pipe_right uu___5 js_optional_lookup_context in
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 = try_arg "location" in
+                         FStar_All.pipe_right uu___7
                            (FStar_Util.map_option
                               FStar_Interactive_JsonHelper.js_assoc) in
-                       FStar_All.pipe_right uu____1413
+                       FStar_All.pipe_right uu___6
                          (FStar_Util.map_option
                             (fun loc ->
-                               let uu____1438 =
-                                 let uu____1439 =
+                               let uu___7 =
+                                 let uu___8 =
                                    assoc "[location]" "filename" loc in
-                                 FStar_All.pipe_right uu____1439
+                                 FStar_All.pipe_right uu___8
                                    FStar_Interactive_JsonHelper.js_str in
-                               let uu____1440 =
-                                 let uu____1441 =
-                                   assoc "[location]" "line" loc in
-                                 FStar_All.pipe_right uu____1441
+                               let uu___8 =
+                                 let uu___9 = assoc "[location]" "line" loc in
+                                 FStar_All.pipe_right uu___9
                                    FStar_Interactive_JsonHelper.js_int in
-                               let uu____1442 =
-                                 let uu____1443 =
+                               let uu___9 =
+                                 let uu___10 =
                                    assoc "[location]" "column" loc in
-                                 FStar_All.pipe_right uu____1443
+                                 FStar_All.pipe_right uu___10
                                    FStar_Interactive_JsonHelper.js_int in
-                               (uu____1438, uu____1440, uu____1442))) in
-                     let uu____1444 =
-                       let uu____1447 = arg "requested-info" in
-                       FStar_All.pipe_right uu____1447
+                               (uu___7, uu___8, uu___9))) in
+                     let uu___6 =
+                       let uu___7 = arg "requested-info" in
+                       FStar_All.pipe_right uu___7
                          (FStar_Interactive_JsonHelper.js_list
                             FStar_Interactive_JsonHelper.js_str) in
-                     (uu____1402, uu____1404, uu____1410, uu____1444) in
-                   Lookup uu____1389
+                     (uu___3, uu___4, uu___5, uu___6) in
+                   Lookup uu___2
                | "compute" ->
-                   let uu____1454 =
-                     let uu____1463 =
-                       let uu____1464 = arg "term" in
-                       FStar_All.pipe_right uu____1464
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = arg "term" in
+                       FStar_All.pipe_right uu___4
                          FStar_Interactive_JsonHelper.js_str in
-                     let uu____1465 =
-                       let uu____1470 = try_arg "rules" in
-                       FStar_All.pipe_right uu____1470
+                     let uu___4 =
+                       let uu___5 = try_arg "rules" in
+                       FStar_All.pipe_right uu___5
                          (FStar_Util.map_option
                             (FStar_Interactive_JsonHelper.js_list
                                js_reductionrule)) in
-                     (uu____1463, uu____1465) in
-                   Compute uu____1454
+                     (uu___3, uu___4) in
+                   Compute uu___2
                | "search" ->
-                   let uu____1485 =
-                     let uu____1486 = arg "terms" in
-                     FStar_All.pipe_right uu____1486
+                   let uu___2 =
+                     let uu___3 = arg "terms" in
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_str in
-                   Search uu____1485
+                   Search uu___2
                | "vfs-add" ->
-                   let uu____1487 =
-                     let uu____1494 =
-                       let uu____1497 = try_arg "filename" in
-                       FStar_All.pipe_right uu____1497
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = try_arg "filename" in
+                       FStar_All.pipe_right uu___4
                          (FStar_Util.map_option
                             FStar_Interactive_JsonHelper.js_str) in
-                     let uu____1504 =
-                       let uu____1505 = arg "contents" in
-                       FStar_All.pipe_right uu____1505
+                     let uu___4 =
+                       let uu___5 = arg "contents" in
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_str in
-                     (uu____1494, uu____1504) in
-                   VfsAdd uu____1487
-               | uu____1508 ->
-                   let uu____1509 =
+                     (uu___3, uu___4) in
+                   VfsAdd uu___2
+               | uu___2 ->
+                   let uu___3 =
                      FStar_Util.format1 "Unknown query '%s'" query1 in
-                   ProtocolViolation uu____1509 in
-             { qq = uu____1355; qid }) ()
+                   ProtocolViolation uu___3 in
+             { qq = uu___1; qid }) ()
     with
     | FStar_Interactive_JsonHelper.InvalidQuery msg ->
         { qq = (ProtocolViolation msg); qid }
@@ -777,8 +754,8 @@ let (unpack_interactive_query : FStar_Util.json -> query) =
 let (deserialize_interactive_query : FStar_Util.json -> query) =
   fun js_query ->
     try
-      (fun uu___294_1522 ->
-         match () with | () -> unpack_interactive_query js_query) ()
+      (fun uu___ -> match () with | () -> unpack_interactive_query js_query)
+        ()
     with
     | FStar_Interactive_JsonHelper.InvalidQuery msg ->
         { qq = (ProtocolViolation msg); qid = "?" }
@@ -786,27 +763,27 @@ let (deserialize_interactive_query : FStar_Util.json -> query) =
         wrap_js_failure "?" expected got
 let (parse_interactive_query : Prims.string -> query) =
   fun query_str ->
-    let uu____1534 = FStar_Util.json_of_string query_str in
-    match uu____1534 with
+    let uu___ = FStar_Util.json_of_string query_str in
+    match uu___ with
     | FStar_Pervasives_Native.None ->
         { qq = (ProtocolViolation "Json parsing failed."); qid = "?" }
     | FStar_Pervasives_Native.Some request ->
         deserialize_interactive_query request
 let (read_interactive_query : FStar_Util.stream_reader -> query) =
   fun stream ->
-    let uu____1543 = FStar_Util.read_line stream in
-    match uu____1543 with
+    let uu___ = FStar_Util.read_line stream in
+    match uu___ with
     | FStar_Pervasives_Native.None -> FStar_All.exit Prims.int_zero
     | FStar_Pervasives_Native.Some line -> parse_interactive_query line
 let json_of_opt :
-  'uuuuuu1553 .
-    ('uuuuuu1553 -> FStar_Util.json) ->
-      'uuuuuu1553 FStar_Pervasives_Native.option -> FStar_Util.json
+  'uuuuu .
+    ('uuuuu -> FStar_Util.json) ->
+      'uuuuu FStar_Pervasives_Native.option -> FStar_Util.json
   =
   fun json_of_a ->
     fun opt_a ->
-      let uu____1573 = FStar_Util.map_option json_of_a opt_a in
-      FStar_Util.dflt FStar_Util.JsonNull uu____1573
+      let uu___ = FStar_Util.map_option json_of_a opt_a in
+      FStar_Util.dflt FStar_Util.JsonNull uu___
 let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
   fun i ->
     FStar_Util.JsonStr
@@ -817,103 +794,99 @@ let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
        | FStar_Errors.EError -> "error")
 let (json_of_issue : FStar_Errors.issue -> FStar_Util.json) =
   fun issue ->
-    let uu____1586 =
-      let uu____1593 =
-        let uu____1600 =
-          let uu____1607 =
-            let uu____1614 =
-              let uu____1619 =
-                let uu____1620 =
-                  let uu____1623 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
                     match issue.FStar_Errors.issue_range with
                     | FStar_Pervasives_Native.None -> []
                     | FStar_Pervasives_Native.Some r ->
-                        let uu____1629 = FStar_Range.json_of_use_range r in
-                        [uu____1629] in
-                  let uu____1630 =
+                        let uu___8 = FStar_Range.json_of_use_range r in
+                        [uu___8] in
+                  let uu___8 =
                     match issue.FStar_Errors.issue_range with
                     | FStar_Pervasives_Native.Some r when
-                        let uu____1636 = FStar_Range.def_range r in
-                        let uu____1637 = FStar_Range.use_range r in
-                        uu____1636 <> uu____1637 ->
-                        let uu____1638 = FStar_Range.json_of_def_range r in
-                        [uu____1638]
-                    | uu____1639 -> [] in
-                  FStar_List.append uu____1623 uu____1630 in
-                FStar_Util.JsonList uu____1620 in
-              ("ranges", uu____1619) in
-            [uu____1614] in
+                        let uu___9 = FStar_Range.def_range r in
+                        let uu___10 = FStar_Range.use_range r in
+                        uu___9 <> uu___10 ->
+                        let uu___9 = FStar_Range.json_of_def_range r in
+                        [uu___9]
+                    | uu___9 -> [] in
+                  FStar_List.append uu___7 uu___8 in
+                FStar_Util.JsonList uu___6 in
+              ("ranges", uu___5) in
+            [uu___4] in
           ("message",
             (FStar_Util.JsonStr (issue.FStar_Errors.issue_message))) ::
-            uu____1607 in
+            uu___3 in
         FStar_List.append
           (match issue.FStar_Errors.issue_number with
            | FStar_Pervasives_Native.None -> []
            | FStar_Pervasives_Native.Some n ->
-               [("number", (FStar_Util.JsonInt n))]) uu____1600 in
+               [("number", (FStar_Util.JsonInt n))]) uu___2 in
       FStar_List.append
         [("level", (json_of_issue_level issue.FStar_Errors.issue_level))]
-        uu____1593 in
-    FStar_All.pipe_left (fun uu____1695 -> FStar_Util.JsonAssoc uu____1695)
-      uu____1586
+        uu___1 in
+    FStar_All.pipe_left (fun uu___1 -> FStar_Util.JsonAssoc uu___1) uu___
 let (alist_of_symbol_lookup_result :
   FStar_Interactive_QueryHelper.sl_reponse ->
     (Prims.string * FStar_Util.json) Prims.list)
   =
   fun lr ->
-    let uu____1707 =
-      let uu____1714 =
-        let uu____1719 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           json_of_opt FStar_Range.json_of_def_range
             lr.FStar_Interactive_QueryHelper.slr_def_range in
-        ("defined-at", uu____1719) in
-      let uu____1720 =
-        let uu____1727 =
-          let uu____1732 =
-            json_of_opt (fun uu____1733 -> FStar_Util.JsonStr uu____1733)
+        ("defined-at", uu___2) in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            json_of_opt (fun uu___5 -> FStar_Util.JsonStr uu___5)
               lr.FStar_Interactive_QueryHelper.slr_typ in
-          ("type", uu____1732) in
-        let uu____1734 =
-          let uu____1741 =
-            let uu____1746 =
-              json_of_opt (fun uu____1747 -> FStar_Util.JsonStr uu____1747)
+          ("type", uu___4) in
+        let uu___4 =
+          let uu___5 =
+            let uu___6 =
+              json_of_opt (fun uu___7 -> FStar_Util.JsonStr uu___7)
                 lr.FStar_Interactive_QueryHelper.slr_doc in
-            ("documentation", uu____1746) in
-          let uu____1748 =
-            let uu____1755 =
-              let uu____1760 =
-                json_of_opt (fun uu____1761 -> FStar_Util.JsonStr uu____1761)
+            ("documentation", uu___6) in
+          let uu___6 =
+            let uu___7 =
+              let uu___8 =
+                json_of_opt (fun uu___9 -> FStar_Util.JsonStr uu___9)
                   lr.FStar_Interactive_QueryHelper.slr_def in
-              ("definition", uu____1760) in
-            [uu____1755] in
-          uu____1741 :: uu____1748 in
-        uu____1727 :: uu____1734 in
-      uu____1714 :: uu____1720 in
+              ("definition", uu___8) in
+            [uu___7] in
+          uu___5 :: uu___6 in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     ("name",
       (FStar_Util.JsonStr (lr.FStar_Interactive_QueryHelper.slr_name))) ::
-      uu____1707
+      uu___
 let (alist_of_protocol_info : (Prims.string * FStar_Util.json) Prims.list) =
   let js_version = FStar_Util.JsonInt interactive_protocol_vernum in
   let js_features =
-    let uu____1794 =
-      FStar_List.map (fun uu____1797 -> FStar_Util.JsonStr uu____1797)
+    let uu___ =
+      FStar_List.map (fun uu___1 -> FStar_Util.JsonStr uu___1)
         interactive_protocol_features in
-    FStar_All.pipe_left (fun uu____1800 -> FStar_Util.JsonList uu____1800)
-      uu____1794 in
+    FStar_All.pipe_left (fun uu___1 -> FStar_Util.JsonList uu___1) uu___ in
   [("version", js_version); ("features", js_features)]
 type fstar_option_permission_level =
   | OptSet 
   | OptReadOnly 
 let (uu___is_OptSet : fstar_option_permission_level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | OptSet -> true | uu____1818 -> false
+  fun projectee -> match projectee with | OptSet -> true | uu___ -> false
 let (uu___is_OptReadOnly : fstar_option_permission_level -> Prims.bool) =
   fun projectee ->
-    match projectee with | OptReadOnly -> true | uu____1824 -> false
+    match projectee with | OptReadOnly -> true | uu___ -> false
 let (string_of_option_permission_level :
   fstar_option_permission_level -> Prims.string) =
-  fun uu___3_1829 ->
-    match uu___3_1829 with | OptSet -> "" | OptReadOnly -> "read-only"
+  fun uu___ -> match uu___ with | OptSet -> "" | OptReadOnly -> "read-only"
 type fstar_option =
   {
   opt_name: Prims.string ;
@@ -972,20 +945,20 @@ let (__proj__Mkfstar_option__item__opt_permission_level :
         opt_documentation; opt_permission_level;_} -> opt_permission_level
 let rec (kind_of_fstar_option_type : FStar_Options.opt_type -> Prims.string)
   =
-  fun uu___4_2022 ->
-    match uu___4_2022 with
-    | FStar_Options.Const uu____2023 -> "flag"
-    | FStar_Options.IntStr uu____2024 -> "int"
+  fun uu___ ->
+    match uu___ with
+    | FStar_Options.Const uu___1 -> "flag"
+    | FStar_Options.IntStr uu___1 -> "int"
     | FStar_Options.BoolStr -> "bool"
-    | FStar_Options.PathStr uu____2025 -> "path"
-    | FStar_Options.SimpleStr uu____2026 -> "string"
-    | FStar_Options.EnumStr uu____2027 -> "enum"
-    | FStar_Options.OpenEnumStr uu____2030 -> "open enum"
-    | FStar_Options.PostProcessed (uu____2037, typ) ->
+    | FStar_Options.PathStr uu___1 -> "path"
+    | FStar_Options.SimpleStr uu___1 -> "string"
+    | FStar_Options.EnumStr uu___1 -> "enum"
+    | FStar_Options.OpenEnumStr uu___1 -> "open enum"
+    | FStar_Options.PostProcessed (uu___1, typ) ->
         kind_of_fstar_option_type typ
     | FStar_Options.Accumulated typ -> kind_of_fstar_option_type typ
     | FStar_Options.ReverseAccumulated typ -> kind_of_fstar_option_type typ
-    | FStar_Options.WithSideEffect (uu____2047, typ) ->
+    | FStar_Options.WithSideEffect (uu___1, typ) ->
         kind_of_fstar_option_type typ
 let (snippets_of_fstar_option :
   Prims.string -> FStar_Options.opt_type -> Prims.string Prims.list) =
@@ -999,7 +972,7 @@ let (snippets_of_fstar_option :
              (if argstring <> "" then Prims.op_Hat " " argstring else "")) in
       let rec arg_snippets_of_type typ1 =
         match typ1 with
-        | FStar_Options.Const uu____2095 -> [""]
+        | FStar_Options.Const uu___ -> [""]
         | FStar_Options.BoolStr -> ["true"; "false"]
         | FStar_Options.IntStr desc -> [mk_field desc]
         | FStar_Options.PathStr desc -> [mk_field desc]
@@ -1007,66 +980,65 @@ let (snippets_of_fstar_option :
         | FStar_Options.EnumStr strs -> strs
         | FStar_Options.OpenEnumStr (strs, desc) ->
             FStar_List.append strs [mk_field desc]
-        | FStar_Options.PostProcessed (uu____2108, elem_spec) ->
+        | FStar_Options.PostProcessed (uu___, elem_spec) ->
             arg_snippets_of_type elem_spec
         | FStar_Options.Accumulated elem_spec ->
             arg_snippets_of_type elem_spec
         | FStar_Options.ReverseAccumulated elem_spec ->
             arg_snippets_of_type elem_spec
-        | FStar_Options.WithSideEffect (uu____2118, elem_spec) ->
+        | FStar_Options.WithSideEffect (uu___, elem_spec) ->
             arg_snippets_of_type elem_spec in
-      let uu____2126 = arg_snippets_of_type typ in
-      FStar_List.map (mk_snippet name) uu____2126
+      let uu___ = arg_snippets_of_type typ in
+      FStar_List.map (mk_snippet name) uu___
 let rec (json_of_fstar_option_value :
   FStar_Options.option_val -> FStar_Util.json) =
-  fun uu___5_2133 ->
-    match uu___5_2133 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Options.Bool b -> FStar_Util.JsonBool b
     | FStar_Options.String s -> FStar_Util.JsonStr s
     | FStar_Options.Path s -> FStar_Util.JsonStr s
     | FStar_Options.Int n -> FStar_Util.JsonInt n
     | FStar_Options.List vs ->
-        let uu____2141 = FStar_List.map json_of_fstar_option_value vs in
-        FStar_Util.JsonList uu____2141
+        let uu___1 = FStar_List.map json_of_fstar_option_value vs in
+        FStar_Util.JsonList uu___1
     | FStar_Options.Unset -> FStar_Util.JsonNull
 let (alist_of_fstar_option :
   fstar_option -> (Prims.string * FStar_Util.json) Prims.list) =
   fun opt ->
-    let uu____2155 =
-      let uu____2162 =
-        let uu____2169 =
-          let uu____2174 = json_of_fstar_option_value opt.opt_value in
-          ("value", uu____2174) in
-        let uu____2175 =
-          let uu____2182 =
-            let uu____2187 = json_of_fstar_option_value opt.opt_default in
-            ("default", uu____2187) in
-          let uu____2188 =
-            let uu____2195 =
-              let uu____2200 =
-                json_of_opt (fun uu____2201 -> FStar_Util.JsonStr uu____2201)
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = json_of_fstar_option_value opt.opt_value in
+          ("value", uu___3) in
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = json_of_fstar_option_value opt.opt_default in
+            ("default", uu___5) in
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                json_of_opt (fun uu___8 -> FStar_Util.JsonStr uu___8)
                   opt.opt_documentation in
-              ("documentation", uu____2200) in
-            let uu____2202 =
-              let uu____2209 =
-                let uu____2214 =
-                  let uu____2215 = kind_of_fstar_option_type opt.opt_type in
-                  FStar_Util.JsonStr uu____2215 in
-                ("type", uu____2214) in
-              [uu____2209;
+              ("documentation", uu___7) in
+            let uu___7 =
+              let uu___8 =
+                let uu___9 =
+                  let uu___10 = kind_of_fstar_option_type opt.opt_type in
+                  FStar_Util.JsonStr uu___10 in
+                ("type", uu___9) in
+              [uu___8;
               ("permission-level",
                 (FStar_Util.JsonStr
                    (string_of_option_permission_level
                       opt.opt_permission_level)))] in
-            uu____2195 :: uu____2202 in
-          uu____2182 :: uu____2188 in
-        uu____2169 :: uu____2175 in
-      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu____2162 in
-    ("name", (FStar_Util.JsonStr (opt.opt_name))) :: uu____2155
+            uu___6 :: uu___7 in
+          uu___4 :: uu___5 in
+        uu___2 :: uu___3 in
+      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu___1 in
+    ("name", (FStar_Util.JsonStr (opt.opt_name))) :: uu___
 let (json_of_fstar_option : fstar_option -> FStar_Util.json) =
   fun opt ->
-    let uu____2253 = alist_of_fstar_option opt in
-    FStar_Util.JsonAssoc uu____2253
+    let uu___ = alist_of_fstar_option opt in FStar_Util.JsonAssoc uu___
 let (json_of_response :
   Prims.string -> query_status -> FStar_Util.json -> FStar_Util.json) =
   fun qid ->
@@ -1093,81 +1065,78 @@ let (write_response :
 let (json_of_message : Prims.string -> FStar_Util.json -> FStar_Util.json) =
   fun level ->
     fun js_contents ->
-      let uu____2322 =
-        let uu____2329 =
-          let uu____2336 =
-            let uu____2341 =
-              let uu____2342 = FStar_ST.op_Bang repl_current_qid in
-              json_of_opt (fun uu____2355 -> FStar_Util.JsonStr uu____2355)
-                uu____2342 in
-            ("query-id", uu____2341) in
-          [uu____2336;
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_ST.op_Bang repl_current_qid in
+              json_of_opt (fun uu___5 -> FStar_Util.JsonStr uu___5) uu___4 in
+            ("query-id", uu___3) in
+          [uu___2;
           ("level", (FStar_Util.JsonStr level));
           ("contents", js_contents)] in
-        ("kind", (FStar_Util.JsonStr "message")) :: uu____2329 in
-      FStar_Util.JsonAssoc uu____2322
+        ("kind", (FStar_Util.JsonStr "message")) :: uu___1 in
+      FStar_Util.JsonAssoc uu___
 let forward_message :
-  'uuuuuu2384 .
-    (FStar_Util.json -> 'uuuuuu2384) ->
-      Prims.string -> FStar_Util.json -> 'uuuuuu2384
+  'uuuuu .
+    (FStar_Util.json -> 'uuuuu) -> Prims.string -> FStar_Util.json -> 'uuuuu
   =
   fun callback ->
     fun level ->
       fun contents ->
-        let uu____2405 = json_of_message level contents in
-        callback uu____2405
+        let uu___ = json_of_message level contents in callback uu___
 let (json_of_hello : FStar_Util.json) =
   let js_version = FStar_Util.JsonInt interactive_protocol_vernum in
   let js_features =
-    let uu____2408 =
-      FStar_List.map (fun uu____2411 -> FStar_Util.JsonStr uu____2411)
+    let uu___ =
+      FStar_List.map (fun uu___1 -> FStar_Util.JsonStr uu___1)
         interactive_protocol_features in
-    FStar_Util.JsonList uu____2408 in
+    FStar_Util.JsonList uu___ in
   FStar_Util.JsonAssoc (("kind", (FStar_Util.JsonStr "protocol-info")) ::
     alist_of_protocol_info)
 let (write_hello : unit -> unit) =
-  fun uu____2420 -> FStar_Interactive_JsonHelper.write_json json_of_hello
+  fun uu___ -> FStar_Interactive_JsonHelper.write_json json_of_hello
 let (sig_of_fstar_option :
   Prims.string -> FStar_Options.opt_type -> Prims.string) =
   fun name ->
     fun typ ->
       let flag = Prims.op_Hat "--" name in
-      let uu____2432 = FStar_Options.desc_of_opt_type typ in
-      match uu____2432 with
+      let uu___ = FStar_Options.desc_of_opt_type typ in
+      match uu___ with
       | FStar_Pervasives_Native.None -> flag
       | FStar_Pervasives_Native.Some arg_sig ->
           Prims.op_Hat flag (Prims.op_Hat " " arg_sig)
 let (fstar_options_list_cache : fstar_option Prims.list) =
   let defaults = FStar_Util.smap_of_list FStar_Options.defaults in
-  let uu____2441 =
+  let uu___ =
     FStar_All.pipe_right FStar_Options.all_specs_with_types
       (FStar_List.filter_map
-         (fun uu____2470 ->
-            match uu____2470 with
+         (fun uu___1 ->
+            match uu___1 with
             | (_shortname, name, typ, doc) ->
-                let uu____2485 = FStar_Util.smap_try_find defaults name in
-                FStar_All.pipe_right uu____2485
+                let uu___2 = FStar_Util.smap_try_find defaults name in
+                FStar_All.pipe_right uu___2
                   (FStar_Util.map_option
                      (fun default_value ->
-                        let uu____2497 = sig_of_fstar_option name typ in
-                        let uu____2498 = snippets_of_fstar_option name typ in
-                        let uu____2501 =
-                          let uu____2502 = FStar_Options.settable name in
-                          if uu____2502 then OptSet else OptReadOnly in
+                        let uu___3 = sig_of_fstar_option name typ in
+                        let uu___4 = snippets_of_fstar_option name typ in
+                        let uu___5 =
+                          let uu___6 = FStar_Options.settable name in
+                          if uu___6 then OptSet else OptReadOnly in
                         {
                           opt_name = name;
-                          opt_sig = uu____2497;
+                          opt_sig = uu___3;
                           opt_value = FStar_Options.Unset;
                           opt_default = default_value;
                           opt_type = typ;
-                          opt_snippets = uu____2498;
+                          opt_snippets = uu___4;
                           opt_documentation =
                             (if doc = ""
                              then FStar_Pervasives_Native.None
                              else FStar_Pervasives_Native.Some doc);
-                          opt_permission_level = uu____2501
+                          opt_permission_level = uu___5
                         })))) in
-  FStar_All.pipe_right uu____2441
+  FStar_All.pipe_right uu___
     (FStar_List.sortWith
        (fun o1 ->
           fun o2 ->
@@ -1180,38 +1149,38 @@ let (fstar_options_map_cache : fstar_option FStar_Util.smap) =
   cache
 let (update_option : fstar_option -> fstar_option) =
   fun opt ->
-    let uu___467_2528 = opt in
-    let uu____2529 = FStar_Options.get_option opt.opt_name in
+    let uu___ = opt in
+    let uu___1 = FStar_Options.get_option opt.opt_name in
     {
-      opt_name = (uu___467_2528.opt_name);
-      opt_sig = (uu___467_2528.opt_sig);
-      opt_value = uu____2529;
-      opt_default = (uu___467_2528.opt_default);
-      opt_type = (uu___467_2528.opt_type);
-      opt_snippets = (uu___467_2528.opt_snippets);
-      opt_documentation = (uu___467_2528.opt_documentation);
-      opt_permission_level = (uu___467_2528.opt_permission_level)
+      opt_name = (uu___.opt_name);
+      opt_sig = (uu___.opt_sig);
+      opt_value = uu___1;
+      opt_default = (uu___.opt_default);
+      opt_type = (uu___.opt_type);
+      opt_snippets = (uu___.opt_snippets);
+      opt_documentation = (uu___.opt_documentation);
+      opt_permission_level = (uu___.opt_permission_level)
     }
 let (current_fstar_options :
   (fstar_option -> Prims.bool) -> fstar_option Prims.list) =
   fun filter ->
-    let uu____2542 = FStar_List.filter filter fstar_options_list_cache in
-    FStar_List.map update_option uu____2542
+    let uu___ = FStar_List.filter filter fstar_options_list_cache in
+    FStar_List.map update_option uu___
 let (trim_option_name : Prims.string -> (Prims.string * Prims.string)) =
   fun opt_name ->
     let opt_prefix = "--" in
     if FStar_Util.starts_with opt_name opt_prefix
     then
-      let uu____2559 =
+      let uu___ =
         FStar_Util.substring_from opt_name (FStar_String.length opt_prefix) in
-      (opt_prefix, uu____2559)
+      (opt_prefix, uu___)
     else ("", opt_name)
 let (json_of_repl_state :
   FStar_Interactive_JsonHelper.repl_state -> FStar_Util.json) =
   fun st ->
-    let filenames uu____2581 =
-      match uu____2581 with
-      | (uu____2592, (task, uu____2594)) ->
+    let filenames uu___ =
+      match uu___ with
+      | (uu___1, (task, uu___2)) ->
           (match task with
            | FStar_Interactive_JsonHelper.LDInterleaved (intf, impl) ->
                [intf.FStar_Interactive_JsonHelper.tf_fname;
@@ -1220,61 +1189,58 @@ let (json_of_repl_state :
                [intf_or_impl.FStar_Interactive_JsonHelper.tf_fname]
            | FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile intf ->
                [intf.FStar_Interactive_JsonHelper.tf_fname]
-           | uu____2605 -> []) in
-    let uu____2606 =
-      let uu____2613 =
-        let uu____2618 =
-          let uu____2619 =
-            let uu____2622 =
+           | uu___3 -> []) in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
               FStar_List.concatMap filenames
                 st.FStar_Interactive_JsonHelper.repl_deps_stack in
-            FStar_List.map (fun uu____2633 -> FStar_Util.JsonStr uu____2633)
-              uu____2622 in
-          FStar_Util.JsonList uu____2619 in
-        ("loaded-dependencies", uu____2618) in
-      let uu____2634 =
-        let uu____2641 =
-          let uu____2646 =
-            let uu____2647 =
-              let uu____2650 = current_fstar_options (fun uu____2655 -> true) in
-              FStar_List.map json_of_fstar_option uu____2650 in
-            FStar_Util.JsonList uu____2647 in
-          ("options", uu____2646) in
-        [uu____2641] in
-      uu____2613 :: uu____2634 in
-    FStar_Util.JsonAssoc uu____2606
+            FStar_List.map (fun uu___5 -> FStar_Util.JsonStr uu___5) uu___4 in
+          FStar_Util.JsonList uu___3 in
+        ("loaded-dependencies", uu___2) in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = current_fstar_options (fun uu___7 -> true) in
+              FStar_List.map json_of_fstar_option uu___6 in
+            FStar_Util.JsonList uu___5 in
+          ("options", uu___4) in
+        [uu___3] in
+      uu___1 :: uu___2 in
+    FStar_Util.JsonAssoc uu___
 let run_exit :
-  'uuuuuu2674 'uuuuuu2675 .
-    'uuuuuu2674 ->
-      ((query_status * FStar_Util.json) * ('uuuuuu2675, Prims.int)
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
+      ((query_status * FStar_Util.json) * ('uuuuu1, Prims.int)
         FStar_Util.either)
   =
   fun st -> ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inr Prims.int_zero))
 let run_describe_protocol :
-  'uuuuuu2707 'uuuuuu2708 .
-    'uuuuuu2707 ->
-      ((query_status * FStar_Util.json) * ('uuuuuu2707, 'uuuuuu2708)
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
+      ((query_status * FStar_Util.json) * ('uuuuu, 'uuuuu1)
         FStar_Util.either)
   =
   fun st ->
     ((QueryOK, (FStar_Util.JsonAssoc alist_of_protocol_info)),
       (FStar_Util.Inl st))
 let run_describe_repl :
-  'uuuuuu2738 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       ((query_status * FStar_Util.json) *
-        (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu2738)
-        FStar_Util.either)
+        (FStar_Interactive_JsonHelper.repl_state, 'uuuuu) FStar_Util.either)
   =
   fun st ->
-    let uu____2756 =
-      let uu____2761 = json_of_repl_state st in (QueryOK, uu____2761) in
-    (uu____2756, (FStar_Util.Inl st))
+    let uu___ = let uu___1 = json_of_repl_state st in (QueryOK, uu___1) in
+    (uu___, (FStar_Util.Inl st))
 let run_protocol_violation :
-  'uuuuuu2778 'uuuuuu2779 .
-    'uuuuuu2778 ->
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
       Prims.string ->
-        ((query_status * FStar_Util.json) * ('uuuuuu2778, 'uuuuuu2779)
+        ((query_status * FStar_Util.json) * ('uuuuu, 'uuuuu1)
           FStar_Util.either)
   =
   fun st ->
@@ -1282,24 +1248,24 @@ let run_protocol_violation :
       ((QueryViolatesProtocol, (FStar_Util.JsonStr message)),
         (FStar_Util.Inl st))
 let run_generic_error :
-  'uuuuuu2818 'uuuuuu2819 .
-    'uuuuuu2818 ->
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
       Prims.string ->
-        ((query_status * FStar_Util.json) * ('uuuuuu2818, 'uuuuuu2819)
+        ((query_status * FStar_Util.json) * ('uuuuu, 'uuuuu1)
           FStar_Util.either)
   =
   fun st ->
     fun message ->
       ((QueryNOK, (FStar_Util.JsonStr message)), (FStar_Util.Inl st))
 let (collect_errors : unit -> FStar_Errors.issue Prims.list) =
-  fun uu____2856 ->
+  fun uu___ ->
     let errors = FStar_Errors.report_all () in FStar_Errors.clear (); errors
 let run_segment :
-  'uuuuuu2867 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu2867)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
@@ -1311,52 +1277,51 @@ let run_segment :
           FStar_Parser_ParseIt.frag_line = Prims.int_one;
           FStar_Parser_ParseIt.frag_col = Prims.int_zero
         } in
-      let collect_decls uu____2898 =
-        let uu____2899 = FStar_Parser_Driver.parse_fragment frag in
-        match uu____2899 with
+      let collect_decls uu___ =
+        let uu___1 = FStar_Parser_Driver.parse_fragment frag in
+        match uu___1 with
         | FStar_Parser_Driver.Empty -> []
         | FStar_Parser_Driver.Decls decls -> decls
-        | FStar_Parser_Driver.Modul (FStar_Parser_AST.Module
-            (uu____2905, decls)) -> decls
+        | FStar_Parser_Driver.Modul (FStar_Parser_AST.Module (uu___2, decls))
+            -> decls
         | FStar_Parser_Driver.Modul (FStar_Parser_AST.Interface
-            (uu____2911, decls, uu____2913)) -> decls in
-      let uu____2918 =
+            (uu___2, decls, uu___3)) -> decls in
+      let uu___ =
         with_captured_errors st.FStar_Interactive_JsonHelper.repl_env
           FStar_Util.sigint_ignore
-          (fun uu____2927 ->
-             let uu____2928 = collect_decls () in
+          (fun uu___1 ->
+             let uu___2 = collect_decls () in
              FStar_All.pipe_left
-               (fun uu____2939 -> FStar_Pervasives_Native.Some uu____2939)
-               uu____2928) in
-      match uu____2918 with
+               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2) in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           let errors =
-            let uu____2957 = collect_errors () in
-            FStar_All.pipe_right uu____2957 (FStar_List.map json_of_issue) in
+            let uu___1 = collect_errors () in
+            FStar_All.pipe_right uu___1 (FStar_List.map json_of_issue) in
           ((QueryNOK, (FStar_Util.JsonList errors)), (FStar_Util.Inl st))
       | FStar_Pervasives_Native.Some decls ->
           let json_of_decl decl =
-            let uu____2983 =
-              let uu____2990 =
-                let uu____2995 =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
                   FStar_Range.json_of_def_range
                     (FStar_Parser_AST.decl_drange decl) in
-                ("def_range", uu____2995) in
-              [uu____2990] in
-            FStar_Util.JsonAssoc uu____2983 in
+                ("def_range", uu___3) in
+              [uu___2] in
+            FStar_Util.JsonAssoc uu___1 in
           let js_decls =
-            let uu____3005 = FStar_List.map json_of_decl decls in
-            FStar_All.pipe_left
-              (fun uu____3010 -> FStar_Util.JsonList uu____3010) uu____3005 in
+            let uu___1 = FStar_List.map json_of_decl decls in
+            FStar_All.pipe_left (fun uu___2 -> FStar_Util.JsonList uu___2)
+              uu___1 in
           ((QueryOK, (FStar_Util.JsonAssoc [("decls", js_decls)])),
             (FStar_Util.Inl st))
 let run_vfs_add :
-  'uuuuuu3035 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string FStar_Pervasives_Native.option ->
         Prims.string ->
           ((query_status * FStar_Util.json) *
-            (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu3035)
+            (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
             FStar_Util.either)
   =
   fun st ->
@@ -1368,15 +1333,14 @@ let run_vfs_add :
         FStar_Parser_ParseIt.add_vfs_entry fname contents;
         ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inl st))
 let run_pop :
-  'uuuuuu3081 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       ((query_status * FStar_Util.json) *
-        (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu3081)
-        FStar_Util.either)
+        (FStar_Interactive_JsonHelper.repl_state, 'uuuuu) FStar_Util.either)
   =
   fun st ->
-    let uu____3099 = nothing_left_to_pop st in
-    if uu____3099
+    let uu___ = nothing_left_to_pop st in
+    if uu___
     then
       ((QueryNOK, (FStar_Util.JsonStr "Too many pops")), (FStar_Util.Inl st))
     else
@@ -1393,14 +1357,14 @@ let (write_progress :
         | FStar_Pervasives_Native.Some s -> FStar_Util.JsonStr s
         | FStar_Pervasives_Native.None -> FStar_Util.JsonNull in
       let js_contents = ("stage", stage1) :: contents_alist in
-      let uu____3169 =
+      let uu___ =
         json_of_message "progress" (FStar_Util.JsonAssoc js_contents) in
-      FStar_Interactive_JsonHelper.write_json uu____3169
+      FStar_Interactive_JsonHelper.write_json uu___
 let (write_repl_ld_task_progress :
   FStar_Interactive_JsonHelper.repl_task -> unit) =
   fun task ->
     match task with
-    | FStar_Interactive_JsonHelper.LDInterleaved (uu____3175, tf) ->
+    | FStar_Interactive_JsonHelper.LDInterleaved (uu___, tf) ->
         let modname =
           FStar_Parser_Dep.module_name_of_file
             tf.FStar_Interactive_JsonHelper.tf_fname in
@@ -1418,51 +1382,50 @@ let (write_repl_ld_task_progress :
             tf.FStar_Interactive_JsonHelper.tf_fname in
         write_progress (FStar_Pervasives_Native.Some "loading-dependency")
           [("modname", (FStar_Util.JsonStr modname))]
-    | uu____3206 -> ()
+    | uu___ -> ()
 let (load_deps :
   FStar_Interactive_JsonHelper.repl_state ->
     ((FStar_Interactive_JsonHelper.repl_state * Prims.string Prims.list),
       FStar_Interactive_JsonHelper.repl_state) FStar_Util.either)
   =
   fun st ->
-    let uu____3222 =
+    let uu___ =
       with_captured_errors st.FStar_Interactive_JsonHelper.repl_env
         FStar_Util.sigint_ignore
         (fun _env ->
-           let uu____3248 =
+           let uu___1 =
              FStar_Interactive_PushHelper.deps_and_repl_ld_tasks_of_our_file
                st.FStar_Interactive_JsonHelper.repl_fname in
            FStar_All.pipe_left
-             (fun uu____3291 -> FStar_Pervasives_Native.Some uu____3291)
-             uu____3248) in
-    match uu____3222 with
+             (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) uu___1) in
+    match uu___ with
     | FStar_Pervasives_Native.None -> FStar_Util.Inr st
     | FStar_Pervasives_Native.Some (deps, tasks, dep_graph) ->
         let st1 =
-          let uu___557_3340 = st in
-          let uu____3341 =
+          let uu___1 = st in
+          let uu___2 =
             FStar_TypeChecker_Env.set_dep_graph
               st.FStar_Interactive_JsonHelper.repl_env dep_graph in
           {
             FStar_Interactive_JsonHelper.repl_line =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_line);
+              (uu___1.FStar_Interactive_JsonHelper.repl_line);
             FStar_Interactive_JsonHelper.repl_column =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_column);
+              (uu___1.FStar_Interactive_JsonHelper.repl_column);
             FStar_Interactive_JsonHelper.repl_fname =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_fname);
+              (uu___1.FStar_Interactive_JsonHelper.repl_fname);
             FStar_Interactive_JsonHelper.repl_deps_stack =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_deps_stack);
+              (uu___1.FStar_Interactive_JsonHelper.repl_deps_stack);
             FStar_Interactive_JsonHelper.repl_curmod =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_curmod);
-            FStar_Interactive_JsonHelper.repl_env = uu____3341;
+              (uu___1.FStar_Interactive_JsonHelper.repl_curmod);
+            FStar_Interactive_JsonHelper.repl_env = uu___2;
             FStar_Interactive_JsonHelper.repl_stdin =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_stdin);
+              (uu___1.FStar_Interactive_JsonHelper.repl_stdin);
             FStar_Interactive_JsonHelper.repl_names =
-              (uu___557_3340.FStar_Interactive_JsonHelper.repl_names)
+              (uu___1.FStar_Interactive_JsonHelper.repl_names)
           } in
-        let uu____3342 =
+        let uu___1 =
           run_repl_ld_transactions st1 tasks write_repl_ld_task_progress in
-        (match uu____3342 with
+        (match uu___1 with
          | FStar_Util.Inr st2 ->
              (write_progress FStar_Pervasives_Native.None [];
               FStar_Util.Inr st2)
@@ -1471,143 +1434,141 @@ let (load_deps :
               FStar_Util.Inl (st2, deps)))
 let (rephrase_dependency_error : FStar_Errors.issue -> FStar_Errors.issue) =
   fun issue ->
-    let uu___567_3388 = issue in
-    let uu____3389 =
+    let uu___ = issue in
+    let uu___1 =
       FStar_Util.format1 "Error while computing or loading dependencies:\n%s"
         issue.FStar_Errors.issue_message in
     {
-      FStar_Errors.issue_message = uu____3389;
-      FStar_Errors.issue_level = (uu___567_3388.FStar_Errors.issue_level);
-      FStar_Errors.issue_range = (uu___567_3388.FStar_Errors.issue_range);
-      FStar_Errors.issue_number = (uu___567_3388.FStar_Errors.issue_number)
+      FStar_Errors.issue_message = uu___1;
+      FStar_Errors.issue_level = (uu___.FStar_Errors.issue_level);
+      FStar_Errors.issue_range = (uu___.FStar_Errors.issue_range);
+      FStar_Errors.issue_number = (uu___.FStar_Errors.issue_number)
     }
 let run_push_without_deps :
-  'uuuuuu3396 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       push_query ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu3396)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
     fun query1 ->
       let set_nosynth_flag st1 flag =
-        let uu___574_3430 = st1 in
+        let uu___ = st1 in
         {
           FStar_Interactive_JsonHelper.repl_line =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_line);
+            (uu___.FStar_Interactive_JsonHelper.repl_line);
           FStar_Interactive_JsonHelper.repl_column =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_column);
+            (uu___.FStar_Interactive_JsonHelper.repl_column);
           FStar_Interactive_JsonHelper.repl_fname =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_fname);
+            (uu___.FStar_Interactive_JsonHelper.repl_fname);
           FStar_Interactive_JsonHelper.repl_deps_stack =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_deps_stack);
+            (uu___.FStar_Interactive_JsonHelper.repl_deps_stack);
           FStar_Interactive_JsonHelper.repl_curmod =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_curmod);
+            (uu___.FStar_Interactive_JsonHelper.repl_curmod);
           FStar_Interactive_JsonHelper.repl_env =
-            (let uu___576_3432 = st1.FStar_Interactive_JsonHelper.repl_env in
+            (let uu___1 = st1.FStar_Interactive_JsonHelper.repl_env in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___576_3432.FStar_TypeChecker_Env.solver);
+                 (uu___1.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___576_3432.FStar_TypeChecker_Env.range);
+                 (uu___1.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___576_3432.FStar_TypeChecker_Env.curmodule);
+                 (uu___1.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___576_3432.FStar_TypeChecker_Env.gamma);
+                 (uu___1.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___576_3432.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___1.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___576_3432.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___1.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___576_3432.FStar_TypeChecker_Env.modules);
+                 (uu___1.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___576_3432.FStar_TypeChecker_Env.expected_typ);
+                 (uu___1.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___576_3432.FStar_TypeChecker_Env.sigtab);
+                 (uu___1.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___576_3432.FStar_TypeChecker_Env.attrtab);
+                 (uu___1.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___576_3432.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___576_3432.FStar_TypeChecker_Env.effects);
+                 (uu___1.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___576_3432.FStar_TypeChecker_Env.generalize);
+                 (uu___1.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___576_3432.FStar_TypeChecker_Env.letrecs);
+                 (uu___1.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___576_3432.FStar_TypeChecker_Env.top_level);
+                 (uu___1.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___576_3432.FStar_TypeChecker_Env.check_uvars);
+                 (uu___1.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq =
-                 (uu___576_3432.FStar_TypeChecker_Env.use_eq);
+                 (uu___1.FStar_TypeChecker_Env.use_eq);
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___576_3432.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___576_3432.FStar_TypeChecker_Env.is_iface);
+                 (uu___1.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___576_3432.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax =
-                 (uu___576_3432.FStar_TypeChecker_Env.lax);
+                 (uu___1.FStar_TypeChecker_Env.admit);
+               FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___576_3432.FStar_TypeChecker_Env.lax_universes);
+                 (uu___1.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___576_3432.FStar_TypeChecker_Env.phase1);
+                 (uu___1.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___576_3432.FStar_TypeChecker_Env.failhard);
+                 (uu___1.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth = flag;
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___576_3432.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___576_3432.FStar_TypeChecker_Env.tc_term);
+                 (uu___1.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___576_3432.FStar_TypeChecker_Env.type_of);
+                 (uu___1.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___576_3432.FStar_TypeChecker_Env.universe_of);
+                 (uu___1.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___576_3432.FStar_TypeChecker_Env.check_type_of);
+                 (uu___1.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___576_3432.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___576_3432.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___576_3432.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___576_3432.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___576_3432.FStar_TypeChecker_Env.proof_ns);
+                 (uu___1.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___576_3432.FStar_TypeChecker_Env.synth_hook);
+                 (uu___1.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___576_3432.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___576_3432.FStar_TypeChecker_Env.splice);
+                 (uu___1.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___576_3432.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___1.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___576_3432.FStar_TypeChecker_Env.postprocess);
+                 (uu___1.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___576_3432.FStar_TypeChecker_Env.identifier_info);
+                 (uu___1.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___576_3432.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___1.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___576_3432.FStar_TypeChecker_Env.dsenv);
-               FStar_TypeChecker_Env.nbe =
-                 (uu___576_3432.FStar_TypeChecker_Env.nbe);
+                 (uu___1.FStar_TypeChecker_Env.dsenv);
+               FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___576_3432.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___576_3432.FStar_TypeChecker_Env.erasable_types_tab);
+                 (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                FStar_TypeChecker_Env.enable_defer_to_tac =
-                 (uu___576_3432.FStar_TypeChecker_Env.enable_defer_to_tac)
+                 (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
              });
           FStar_Interactive_JsonHelper.repl_stdin =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_stdin);
+            (uu___.FStar_Interactive_JsonHelper.repl_stdin);
           FStar_Interactive_JsonHelper.repl_names =
-            (uu___574_3430.FStar_Interactive_JsonHelper.repl_names)
+            (uu___.FStar_Interactive_JsonHelper.repl_names)
         } in
-      let uu____3433 = query1 in
-      match uu____3433 with
+      let uu___ = query1 in
+      match uu___ with
       | { push_kind; push_code = text; push_line = line;
           push_column = column; push_peek_only = peek_only;_} ->
           let frag =
@@ -1620,106 +1581,106 @@ let run_push_without_deps :
           (FStar_TypeChecker_Env.toggle_id_info
              st.FStar_Interactive_JsonHelper.repl_env true;
            (let st1 = set_nosynth_flag st peek_only in
-            let uu____3454 =
+            let uu___2 =
               run_repl_transaction st1 push_kind peek_only
                 (FStar_Interactive_JsonHelper.PushFragment frag) in
-            match uu____3454 with
+            match uu___2 with
             | (success, st2) ->
                 let st3 = set_nosynth_flag st2 false in
                 let status =
                   if success || peek_only then QueryOK else QueryNOK in
                 let json_errors =
-                  let uu____3477 =
-                    let uu____3480 = collect_errors () in
-                    FStar_All.pipe_right uu____3480
+                  let uu___3 =
+                    let uu___4 = collect_errors () in
+                    FStar_All.pipe_right uu___4
                       (FStar_List.map json_of_issue) in
-                  FStar_Util.JsonList uu____3477 in
+                  FStar_Util.JsonList uu___3 in
                 let st4 =
                   if success
                   then
-                    let uu___595_3488 = st3 in
+                    let uu___3 = st3 in
                     {
                       FStar_Interactive_JsonHelper.repl_line = line;
                       FStar_Interactive_JsonHelper.repl_column = column;
                       FStar_Interactive_JsonHelper.repl_fname =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_fname);
+                        (uu___3.FStar_Interactive_JsonHelper.repl_fname);
                       FStar_Interactive_JsonHelper.repl_deps_stack =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_deps_stack);
+                        (uu___3.FStar_Interactive_JsonHelper.repl_deps_stack);
                       FStar_Interactive_JsonHelper.repl_curmod =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_curmod);
+                        (uu___3.FStar_Interactive_JsonHelper.repl_curmod);
                       FStar_Interactive_JsonHelper.repl_env =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_env);
+                        (uu___3.FStar_Interactive_JsonHelper.repl_env);
                       FStar_Interactive_JsonHelper.repl_stdin =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_stdin);
+                        (uu___3.FStar_Interactive_JsonHelper.repl_stdin);
                       FStar_Interactive_JsonHelper.repl_names =
-                        (uu___595_3488.FStar_Interactive_JsonHelper.repl_names)
+                        (uu___3.FStar_Interactive_JsonHelper.repl_names)
                     }
                   else st3 in
                 ((status, json_errors), (FStar_Util.Inl st4))))
 let run_push_with_deps :
-  'uuuuuu3504 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       push_query ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu3504)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
     fun query1 ->
-      (let uu____3528 = FStar_Options.debug_any () in
-       if uu____3528
+      (let uu___1 = FStar_Options.debug_any () in
+       if uu___1
        then FStar_Util.print_string "Reloading dependencies"
        else ());
       FStar_TypeChecker_Env.toggle_id_info
         st.FStar_Interactive_JsonHelper.repl_env false;
-      (let uu____3531 = load_deps st in
-       match uu____3531 with
+      (let uu___2 = load_deps st in
+       match uu___2 with
        | FStar_Util.Inr st1 ->
            let errors =
-             let uu____3564 = collect_errors () in
-             FStar_List.map rephrase_dependency_error uu____3564 in
+             let uu___3 = collect_errors () in
+             FStar_List.map rephrase_dependency_error uu___3 in
            let js_errors =
              FStar_All.pipe_right errors (FStar_List.map json_of_issue) in
            ((QueryNOK, (FStar_Util.JsonList js_errors)),
              (FStar_Util.Inl st1))
        | FStar_Util.Inl (st1, deps) ->
-           ((let uu____3595 = FStar_Options.restore_cmd_line_options false in
-             FStar_All.pipe_right uu____3595 (fun uu____3596 -> ()));
+           ((let uu___4 = FStar_Options.restore_cmd_line_options false in
+             FStar_All.pipe_right uu___4 (fun uu___5 -> ()));
             (let names =
                FStar_Interactive_PushHelper.add_module_completions
                  st1.FStar_Interactive_JsonHelper.repl_fname deps
                  st1.FStar_Interactive_JsonHelper.repl_names in
              run_push_without_deps
-               (let uu___613_3599 = st1 in
+               (let uu___4 = st1 in
                 {
                   FStar_Interactive_JsonHelper.repl_line =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_line);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_line);
                   FStar_Interactive_JsonHelper.repl_column =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_column);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_column);
                   FStar_Interactive_JsonHelper.repl_fname =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_fname);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_fname);
                   FStar_Interactive_JsonHelper.repl_deps_stack =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_deps_stack);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_deps_stack);
                   FStar_Interactive_JsonHelper.repl_curmod =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_curmod);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_curmod);
                   FStar_Interactive_JsonHelper.repl_env =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_env);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_env);
                   FStar_Interactive_JsonHelper.repl_stdin =
-                    (uu___613_3599.FStar_Interactive_JsonHelper.repl_stdin);
+                    (uu___4.FStar_Interactive_JsonHelper.repl_stdin);
                   FStar_Interactive_JsonHelper.repl_names = names
                 }) query1)))
 let run_push :
-  'uuuuuu3606 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       push_query ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu3606)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
     fun query1 ->
-      let uu____3629 = nothing_left_to_pop st in
-      if uu____3629
+      let uu___ = nothing_left_to_pop st in
+      if uu___
       then run_push_with_deps st query1
       else run_push_without_deps st query1
 let (run_symbol_lookup :
@@ -1736,17 +1697,17 @@ let (run_symbol_lookup :
     fun symbol ->
       fun pos_opt ->
         fun requested_info ->
-          let uu____3685 =
+          let uu___ =
             FStar_Interactive_QueryHelper.symlookup
               st.FStar_Interactive_JsonHelper.repl_env symbol pos_opt
               requested_info in
-          match uu____3685 with
+          match uu___ with
           | FStar_Pervasives_Native.None -> FStar_Util.Inl "Symbol not found"
           | FStar_Pervasives_Native.Some result ->
-              let uu____3713 =
-                let uu____3724 = alist_of_symbol_lookup_result result in
-                ("symbol", uu____3724) in
-              FStar_Util.Inr uu____3713
+              let uu___1 =
+                let uu___2 = alist_of_symbol_lookup_result result in
+                ("symbol", uu___2) in
+              FStar_Util.Inr uu___1
 let (run_option_lookup :
   Prims.string ->
     (Prims.string,
@@ -1754,21 +1715,21 @@ let (run_option_lookup :
       FStar_Util.either)
   =
   fun opt_name ->
-    let uu____3766 = trim_option_name opt_name in
-    match uu____3766 with
-    | (uu____3785, trimmed_name) ->
-        let uu____3787 =
+    let uu___ = trim_option_name opt_name in
+    match uu___ with
+    | (uu___1, trimmed_name) ->
+        let uu___2 =
           FStar_Util.smap_try_find fstar_options_map_cache trimmed_name in
-        (match uu____3787 with
+        (match uu___2 with
          | FStar_Pervasives_Native.None ->
              FStar_Util.Inl (Prims.op_Hat "Unknown option:" opt_name)
          | FStar_Pervasives_Native.Some opt ->
-             let uu____3815 =
-               let uu____3826 =
-                 let uu____3833 = update_option opt in
-                 alist_of_fstar_option uu____3833 in
-               ("option", uu____3826) in
-             FStar_Util.Inr uu____3815)
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 = update_option opt in
+                 alist_of_fstar_option uu___5 in
+               ("option", uu___4) in
+             FStar_Util.Inr uu___3)
 let (run_module_lookup :
   FStar_Interactive_JsonHelper.repl_state ->
     Prims.string ->
@@ -1779,26 +1740,26 @@ let (run_module_lookup :
   fun st ->
     fun symbol ->
       let query1 = FStar_Util.split symbol "." in
-      let uu____3877 =
+      let uu___ =
         FStar_Interactive_CompletionTable.find_module_or_ns
           st.FStar_Interactive_JsonHelper.repl_names query1 in
-      match uu____3877 with
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           FStar_Util.Inl "No such module or namespace"
       | FStar_Pervasives_Native.Some
           (FStar_Interactive_CompletionTable.Module mod_info) ->
-          let uu____3905 =
-            let uu____3916 =
+          let uu___1 =
+            let uu___2 =
               FStar_Interactive_CompletionTable.alist_of_mod_info mod_info in
-            ("module", uu____3916) in
-          FStar_Util.Inr uu____3905
+            ("module", uu___2) in
+          FStar_Util.Inr uu___1
       | FStar_Pervasives_Native.Some
           (FStar_Interactive_CompletionTable.Namespace ns_info) ->
-          let uu____3940 =
-            let uu____3951 =
+          let uu___1 =
+            let uu___2 =
               FStar_Interactive_CompletionTable.alist_of_ns_info ns_info in
-            ("namespace", uu____3951) in
-          FStar_Util.Inr uu____3940
+            ("namespace", uu___2) in
+          FStar_Util.Inr uu___1
 let (run_code_lookup :
   FStar_Interactive_JsonHelper.repl_state ->
     Prims.string ->
@@ -1813,12 +1774,12 @@ let (run_code_lookup :
     fun symbol ->
       fun pos_opt ->
         fun requested_info ->
-          let uu____4016 = run_symbol_lookup st symbol pos_opt requested_info in
-          match uu____4016 with
+          let uu___ = run_symbol_lookup st symbol pos_opt requested_info in
+          match uu___ with
           | FStar_Util.Inr alist -> FStar_Util.Inr alist
-          | FStar_Util.Inl uu____4076 ->
-              let uu____4087 = run_module_lookup st symbol in
-              (match uu____4087 with
+          | FStar_Util.Inl uu___1 ->
+              let uu___2 = run_module_lookup st symbol in
+              (match uu___2 with
                | FStar_Util.Inr alist -> FStar_Util.Inr alist
                | FStar_Util.Inl err_msg ->
                    FStar_Util.Inl "No such symbol, module, or namespace.")
@@ -1845,7 +1806,7 @@ let (run_lookup' :
             | LKOption -> run_option_lookup symbol
             | LKCode -> run_code_lookup st symbol pos_opt requested_info
 let run_lookup :
-  'uuuuuu4241 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         lookup_context ->
@@ -1853,7 +1814,7 @@ let run_lookup :
             FStar_Pervasives_Native.option ->
             Prims.string Prims.list ->
               ((query_status * FStar_Util.json) *
-                (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu4241)
+                (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
                 FStar_Util.either)
   =
   fun st ->
@@ -1861,9 +1822,8 @@ let run_lookup :
       fun context ->
         fun pos_opt ->
           fun requested_info ->
-            let uu____4287 =
-              run_lookup' st symbol context pos_opt requested_info in
-            match uu____4287 with
+            let uu___ = run_lookup' st symbol context pos_opt requested_info in
+            match uu___ with
             | FStar_Util.Inl err_msg ->
                 ((QueryNOK, (FStar_Util.JsonStr err_msg)),
                   (FStar_Util.Inl st))
@@ -1872,11 +1832,11 @@ let run_lookup :
                    (FStar_Util.JsonAssoc (("kind", (FStar_Util.JsonStr kind))
                       :: info))), (FStar_Util.Inl st))
 let run_code_autocomplete :
-  'uuuuuu4375 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu4375)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
@@ -1887,13 +1847,13 @@ let run_code_autocomplete :
           FStar_Interactive_CompletionTable.json_of_completion_result result in
       ((QueryOK, (FStar_Util.JsonList js)), (FStar_Util.Inl st))
 let run_module_autocomplete :
-  'uuuuuu4426 'uuuuuu4427 'uuuuuu4428 .
+  'uuuuu 'uuuuu1 'uuuuu2 .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
-        'uuuuuu4426 ->
-          'uuuuuu4427 ->
+        'uuuuu ->
+          'uuuuu1 ->
             ((query_status * FStar_Util.json) *
-              (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu4428)
+              (FStar_Interactive_JsonHelper.repl_state, 'uuuuu2)
               FStar_Util.either)
   =
   fun st ->
@@ -1904,27 +1864,27 @@ let run_module_autocomplete :
           let mods_and_nss =
             FStar_Interactive_CompletionTable.autocomplete_mod_or_ns
               st.FStar_Interactive_JsonHelper.repl_names needle
-              (fun uu____4471 -> FStar_Pervasives_Native.Some uu____4471) in
+              (fun uu___ -> FStar_Pervasives_Native.Some uu___) in
           let json =
             FStar_List.map
               FStar_Interactive_CompletionTable.json_of_completion_result
               mods_and_nss in
           ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
 let candidates_of_fstar_option :
-  'uuuuuu4491 .
+  'uuuuu .
     Prims.int ->
-      'uuuuuu4491 ->
+      'uuuuu ->
         fstar_option ->
           FStar_Interactive_CompletionTable.completion_result Prims.list
   =
   fun match_len ->
     fun is_reset ->
       fun opt ->
-        let uu____4509 =
+        let uu___ =
           match opt.opt_permission_level with
           | OptSet -> (true, "")
           | OptReadOnly -> (false, "read-only") in
-        match uu____4509 with
+        match uu___ with
         | (may_set, explanation) ->
             let opt_type = kind_of_fstar_option_type opt.opt_type in
             let annot =
@@ -1946,18 +1906,18 @@ let candidates_of_fstar_option :
                         = annot
                     }))
 let run_option_autocomplete :
-  'uuuuuu4543 'uuuuuu4544 'uuuuuu4545 .
-    'uuuuuu4543 ->
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    'uuuuu ->
       Prims.string ->
-        'uuuuuu4544 ->
-          ((query_status * FStar_Util.json) * ('uuuuuu4543, 'uuuuuu4545)
+        'uuuuu1 ->
+          ((query_status * FStar_Util.json) * ('uuuuu, 'uuuuu2)
             FStar_Util.either)
   =
   fun st ->
     fun search_term ->
       fun is_reset ->
-        let uu____4573 = trim_option_name search_term in
-        match uu____4573 with
+        let uu___ = trim_option_name search_term in
+        match uu___ with
         | ("--", trimmed_name) ->
             let matcher opt =
               FStar_Util.starts_with opt.opt_name trimmed_name in
@@ -1971,17 +1931,17 @@ let run_option_autocomplete :
                 FStar_Interactive_CompletionTable.json_of_completion_result
                 results in
             ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
-        | (uu____4622, uu____4623) ->
+        | (uu___1, uu___2) ->
             ((QueryNOK,
                (FStar_Util.JsonStr "Options should start with '--'")),
               (FStar_Util.Inl st))
 let run_autocomplete :
-  'uuuuuu4640 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         completion_context ->
           ((query_status * FStar_Util.json) *
-            (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu4640)
+            (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
             FStar_Util.either)
   =
   fun st ->
@@ -1994,12 +1954,12 @@ let run_autocomplete :
         | CKModuleOrNamespace (modules, namespaces) ->
             run_module_autocomplete st search_term modules namespaces
 let run_and_rewind :
-  'uuuuuu4681 'uuuuuu4682 .
+  'uuuuu 'uuuuu1 .
     FStar_Interactive_JsonHelper.repl_state ->
-      'uuuuuu4681 ->
-        (FStar_Interactive_JsonHelper.repl_state -> 'uuuuuu4681) ->
-          ('uuuuuu4681 * (FStar_Interactive_JsonHelper.repl_state,
-            'uuuuuu4682) FStar_Util.either)
+      'uuuuu ->
+        (FStar_Interactive_JsonHelper.repl_state -> 'uuuuu) ->
+          ('uuuuu * (FStar_Interactive_JsonHelper.repl_state, 'uuuuu1)
+            FStar_Util.either)
   =
   fun st ->
     fun sigint_default ->
@@ -2010,15 +1970,14 @@ let run_and_rewind :
             FStar_Interactive_JsonHelper.Noop st in
         let results =
           try
-            (fun uu___728_4722 ->
+            (fun uu___ ->
                match () with
                | () ->
                    FStar_Util.with_sigint_handler FStar_Util.sigint_raise
-                     (fun uu____4733 ->
-                        let uu____4734 = task st1 in
+                     (fun uu___1 ->
+                        let uu___2 = task st1 in
                         FStar_All.pipe_left
-                          (fun uu____4739 -> FStar_Util.Inl uu____4739)
-                          uu____4734)) ()
+                          (fun uu___3 -> FStar_Util.Inl uu___3) uu___2)) ()
           with | FStar_Util.SigInt -> FStar_Util.Inl sigint_default
           | e -> FStar_Util.Inr e in
         let st2 = FStar_Interactive_PushHelper.pop_repl "run_and_rewind" st1 in
@@ -2026,16 +1985,16 @@ let run_and_rewind :
         | FStar_Util.Inl results1 -> (results1, (FStar_Util.Inl st2))
         | FStar_Util.Inr e -> FStar_Exn.raise e
 let run_with_parsed_and_tc_term :
-  'uuuuuu4786 'uuuuuu4787 'uuuuuu4788 .
+  'uuuuu 'uuuuu1 'uuuuu2 .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
-        'uuuuuu4786 ->
-          'uuuuuu4787 ->
+        'uuuuu ->
+          'uuuuu1 ->
             (FStar_TypeChecker_Env.env ->
                FStar_Syntax_Syntax.term -> (query_status * FStar_Util.json))
               ->
               ((query_status * FStar_Util.json) *
-                (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu4788)
+                (FStar_Interactive_JsonHelper.repl_state, 'uuuuu2)
                 FStar_Util.either)
   =
   fun st ->
@@ -2056,52 +2015,51 @@ let run_with_parsed_and_tc_term :
               match ses with
               | {
                   FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                    ((uu____4881,
-                      { FStar_Syntax_Syntax.lbname = uu____4882;
+                    ((uu___,
+                      { FStar_Syntax_Syntax.lbname = uu___1;
                         FStar_Syntax_Syntax.lbunivs = univs;
-                        FStar_Syntax_Syntax.lbtyp = uu____4884;
-                        FStar_Syntax_Syntax.lbeff = uu____4885;
+                        FStar_Syntax_Syntax.lbtyp = uu___2;
+                        FStar_Syntax_Syntax.lbeff = uu___3;
                         FStar_Syntax_Syntax.lbdef = def;
-                        FStar_Syntax_Syntax.lbattrs = uu____4887;
-                        FStar_Syntax_Syntax.lbpos = uu____4888;_}::[]),
-                     uu____4889);
-                  FStar_Syntax_Syntax.sigrng = uu____4890;
-                  FStar_Syntax_Syntax.sigquals = uu____4891;
-                  FStar_Syntax_Syntax.sigmeta = uu____4892;
-                  FStar_Syntax_Syntax.sigattrs = uu____4893;
-                  FStar_Syntax_Syntax.sigopts = uu____4894;_}::[] ->
+                        FStar_Syntax_Syntax.lbattrs = uu___4;
+                        FStar_Syntax_Syntax.lbpos = uu___5;_}::[]),
+                     uu___6);
+                  FStar_Syntax_Syntax.sigrng = uu___7;
+                  FStar_Syntax_Syntax.sigquals = uu___8;
+                  FStar_Syntax_Syntax.sigmeta = uu___9;
+                  FStar_Syntax_Syntax.sigattrs = uu___10;
+                  FStar_Syntax_Syntax.sigopts = uu___11;_}::[] ->
                   FStar_Pervasives_Native.Some (univs, def)
-              | uu____4933 -> FStar_Pervasives_Native.None in
+              | uu___ -> FStar_Pervasives_Native.None in
             let parse frag =
-              let uu____4954 =
+              let uu___ =
                 FStar_Parser_ParseIt.parse
                   (FStar_Parser_ParseIt.Toplevel frag) in
-              match uu____4954 with
+              match uu___ with
               | FStar_Parser_ParseIt.ASTFragment
-                  (FStar_Util.Inr decls, uu____4960) ->
+                  (FStar_Util.Inr decls, uu___1) ->
                   FStar_Pervasives_Native.Some decls
-              | uu____4979 -> FStar_Pervasives_Native.None in
+              | uu___1 -> FStar_Pervasives_Native.None in
             let desugar env decls =
-              let uu____4997 =
-                let uu____5002 =
-                  FStar_ToSyntax_ToSyntax.decls_to_sigelts decls in
-                uu____5002 env.FStar_TypeChecker_Env.dsenv in
-              FStar_Pervasives_Native.fst uu____4997 in
+              let uu___ =
+                let uu___1 = FStar_ToSyntax_ToSyntax.decls_to_sigelts decls in
+                uu___1 env.FStar_TypeChecker_Env.dsenv in
+              FStar_Pervasives_Native.fst uu___ in
             let typecheck tcenv decls =
-              let uu____5024 = FStar_TypeChecker_Tc.tc_decls tcenv decls in
-              match uu____5024 with | (ses, uu____5034) -> ses in
+              let uu___ = FStar_TypeChecker_Tc.tc_decls tcenv decls in
+              match uu___ with | (ses, uu___1) -> ses in
             run_and_rewind st
               (QueryNOK, (FStar_Util.JsonStr "Computation interrupted"))
               (fun st1 ->
                  let tcenv = st1.FStar_Interactive_JsonHelper.repl_env in
                  let frag = dummy_let_fragment term in
-                 let uu____5050 = parse frag in
-                 match uu____5050 with
+                 let uu___ = parse frag in
+                 match uu___ with
                  | FStar_Pervasives_Native.None ->
                      (QueryNOK,
                        (FStar_Util.JsonStr "Could not parse this term"))
                  | FStar_Pervasives_Native.Some decls ->
-                     let aux uu____5075 =
+                     let aux uu___1 =
                        let decls1 = desugar tcenv decls in
                        let ses = typecheck tcenv decls1 in
                        match find_let_body ses with
@@ -2110,42 +2068,39 @@ let run_with_parsed_and_tc_term :
                              (FStar_Util.JsonStr
                                 "Typechecking yielded an unexpected term"))
                        | FStar_Pervasives_Native.Some (univs, def) ->
-                           let uu____5110 =
+                           let uu___2 =
                              FStar_Syntax_Subst.open_univ_vars univs def in
-                           (match uu____5110 with
+                           (match uu___2 with
                             | (univs1, def1) ->
                                 let tcenv1 =
                                   FStar_TypeChecker_Env.push_univ_vars tcenv
                                     univs1 in
                                 continuation tcenv1 def1) in
-                     let uu____5122 = FStar_Options.trace_error () in
-                     if uu____5122
+                     let uu___1 = FStar_Options.trace_error () in
+                     if uu___1
                      then aux ()
                      else
-                       (try
-                          (fun uu___811_5133 -> match () with | () -> aux ())
-                            ()
+                       (try (fun uu___3 -> match () with | () -> aux ()) ()
                         with
-                        | uu___810_5142 ->
-                            let uu____5147 =
-                              FStar_Errors.issue_of_exn uu___810_5142 in
-                            (match uu____5147 with
+                        | uu___3 ->
+                            let uu___4 = FStar_Errors.issue_of_exn uu___3 in
+                            (match uu___4 with
                              | FStar_Pervasives_Native.Some issue ->
-                                 let uu____5155 =
-                                   let uu____5156 =
+                                 let uu___5 =
+                                   let uu___6 =
                                      FStar_Errors.format_issue issue in
-                                   FStar_Util.JsonStr uu____5156 in
-                                 (QueryNOK, uu____5155)
+                                   FStar_Util.JsonStr uu___6 in
+                                 (QueryNOK, uu___5)
                              | FStar_Pervasives_Native.None ->
-                                 FStar_Exn.raise uu___810_5142)))
+                                 FStar_Exn.raise uu___3)))
 let run_compute :
-  'uuuuuu5169 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         FStar_TypeChecker_Env.step Prims.list FStar_Pervasives_Native.option
           ->
           ((query_status * FStar_Util.json) *
-            (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu5169)
+            (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
             FStar_Util.either)
   =
   fun st ->
@@ -2154,7 +2109,7 @@ let run_compute :
         let rules1 =
           FStar_List.append
             (match rules with
-             | FStar_Pervasives_Native.Some rules1 -> rules1
+             | FStar_Pervasives_Native.Some rules2 -> rules2
              | FStar_Pervasives_Native.None ->
                  [FStar_TypeChecker_Env.Beta;
                  FStar_TypeChecker_Env.Iota;
@@ -2171,12 +2126,12 @@ let run_compute :
           (fun tcenv ->
              fun def ->
                let normalized = normalize_term tcenv rules1 def in
-               let uu____5241 =
-                 let uu____5242 =
+               let uu___ =
+                 let uu___1 =
                    FStar_Interactive_QueryHelper.term_to_string tcenv
                      normalized in
-                 FStar_Util.JsonStr uu____5242 in
-               (QueryOK, uu____5241))
+                 FStar_Util.JsonStr uu___1 in
+               (QueryOK, uu___))
 type search_term' =
   | NameContainsStr of Prims.string 
   | TypeContainsLid of FStar_Ident.lid 
@@ -2185,12 +2140,12 @@ and search_term = {
   st_term: search_term' }
 let (uu___is_NameContainsStr : search_term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | NameContainsStr _0 -> true | uu____5269 -> false
+    match projectee with | NameContainsStr _0 -> true | uu___ -> false
 let (__proj__NameContainsStr__item___0 : search_term' -> Prims.string) =
   fun projectee -> match projectee with | NameContainsStr _0 -> _0
 let (uu___is_TypeContainsLid : search_term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TypeContainsLid _0 -> true | uu____5282 -> false
+    match projectee with | TypeContainsLid _0 -> true | uu___ -> false
 let (__proj__TypeContainsLid__item___0 : search_term' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | TypeContainsLid _0 -> _0
 let (__proj__Mksearch_term__item__st_negate : search_term -> Prims.bool) =
@@ -2199,8 +2154,8 @@ let (__proj__Mksearch_term__item__st_negate : search_term -> Prims.bool) =
 let (__proj__Mksearch_term__item__st_term : search_term -> search_term') =
   fun projectee -> match projectee with | { st_negate; st_term;_} -> st_term
 let (st_cost : search_term' -> Prims.int) =
-  fun uu___6_5307 ->
-    match uu___6_5307 with
+  fun uu___ ->
+    match uu___ with
     | NameContainsStr str -> - (FStar_String.length str)
     | TypeContainsLid lid -> Prims.int_one
 type search_candidate =
@@ -2230,26 +2185,24 @@ let (__proj__Mksearch_candidate__item__sc_fvars :
     match projectee with | { sc_lid; sc_typ; sc_fvars;_} -> sc_fvars
 let (sc_of_lid : FStar_Ident.lid -> search_candidate) =
   fun lid ->
-    let uu____5418 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-    let uu____5425 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-    { sc_lid = lid; sc_typ = uu____5418; sc_fvars = uu____5425 }
+    let uu___ = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+    let uu___1 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+    { sc_lid = lid; sc_typ = uu___; sc_fvars = uu___1 }
 let (sc_typ :
   FStar_TypeChecker_Env.env -> search_candidate -> FStar_Syntax_Syntax.typ) =
   fun tcenv ->
     fun sc ->
-      let uu____5448 = FStar_ST.op_Bang sc.sc_typ in
-      match uu____5448 with
+      let uu___ = FStar_ST.op_Bang sc.sc_typ in
+      match uu___ with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None ->
           let typ =
-            let uu____5463 =
-              FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid in
-            match uu____5463 with
+            let uu___1 = FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid in
+            match uu___1 with
             | FStar_Pervasives_Native.None ->
                 FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
                   FStar_Range.dummyRange
-            | FStar_Pervasives_Native.Some ((uu____5482, typ), uu____5484) ->
-                typ in
+            | FStar_Pervasives_Native.Some ((uu___2, typ1), uu___3) -> typ1 in
           (FStar_ST.op_Colon_Equals sc.sc_typ
              (FStar_Pervasives_Native.Some typ);
            typ)
@@ -2259,13 +2212,12 @@ let (sc_fvars :
   =
   fun tcenv ->
     fun sc ->
-      let uu____5520 = FStar_ST.op_Bang sc.sc_fvars in
-      match uu____5520 with
+      let uu___ = FStar_ST.op_Bang sc.sc_fvars in
+      match uu___ with
       | FStar_Pervasives_Native.Some fv -> fv
       | FStar_Pervasives_Native.None ->
           let fv =
-            let uu____5551 = sc_typ tcenv sc in
-            FStar_Syntax_Free.fvars uu____5551 in
+            let uu___1 = sc_typ tcenv sc in FStar_Syntax_Free.fvars uu___1 in
           (FStar_ST.op_Colon_Equals sc.sc_fvars
              (FStar_Pervasives_Native.Some fv);
            fv)
@@ -2274,35 +2226,32 @@ let (json_of_search_result :
   fun tcenv ->
     fun sc ->
       let typ_str =
-        let uu____5580 = sc_typ tcenv sc in
-        FStar_Interactive_QueryHelper.term_to_string tcenv uu____5580 in
-      let uu____5581 =
-        let uu____5588 =
-          let uu____5593 =
-            let uu____5594 =
-              let uu____5595 =
+        let uu___ = sc_typ tcenv sc in
+        FStar_Interactive_QueryHelper.term_to_string tcenv uu___ in
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_Syntax_DsEnv.shorten_lid
                   tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid in
-              FStar_Ident.string_of_lid uu____5595 in
-            FStar_Util.JsonStr uu____5594 in
-          ("lid", uu____5593) in
-        [uu____5588; ("type", (FStar_Util.JsonStr typ_str))] in
-      FStar_Util.JsonAssoc uu____5581
+              FStar_Ident.string_of_lid uu___4 in
+            FStar_Util.JsonStr uu___3 in
+          ("lid", uu___2) in
+        [uu___1; ("type", (FStar_Util.JsonStr typ_str))] in
+      FStar_Util.JsonAssoc uu___
 exception InvalidSearch of Prims.string 
 let (uu___is_InvalidSearch : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | InvalidSearch uu____5617 -> true
-    | uu____5618 -> false
+    match projectee with | InvalidSearch uu___ -> true | uu___ -> false
 let (__proj__InvalidSearch__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee ->
-    match projectee with | InvalidSearch uu____5624 -> uu____5624
+  fun projectee -> match projectee with | InvalidSearch uu___ -> uu___
 let run_search :
-  'uuuuuu5631 .
+  'uuuuu .
     FStar_Interactive_JsonHelper.repl_state ->
       Prims.string ->
         ((query_status * FStar_Util.json) *
-          (FStar_Interactive_JsonHelper.repl_state, 'uuuuuu5631)
+          (FStar_Interactive_JsonHelper.repl_state, 'uuuuu)
           FStar_Util.either)
   =
   fun st ->
@@ -2313,11 +2262,11 @@ let run_search :
         let found =
           match term.st_term with
           | NameContainsStr str ->
-              let uu____5671 = FStar_Ident.string_of_lid candidate.sc_lid in
-              FStar_Util.contains uu____5671 str
+              let uu___ = FStar_Ident.string_of_lid candidate.sc_lid in
+              FStar_Util.contains uu___ str
           | TypeContainsLid lid ->
-              let uu____5673 = sc_fvars tcenv candidate in
-              FStar_Util.set_mem lid uu____5673 in
+              let uu___ = sc_fvars tcenv candidate in
+              FStar_Util.set_mem lid uu___ in
         found <> term.st_negate in
       let parse search_str1 =
         let parse_one term =
@@ -2337,29 +2286,28 @@ let run_search :
           let parsed =
             if beg_quote <> end_quote
             then
-              let uu____5703 =
-                let uu____5704 =
+              let uu___ =
+                let uu___1 =
                   FStar_Util.format1 "Improperly quoted search term: %s"
                     term1 in
-                InvalidSearch uu____5704 in
-              FStar_Exn.raise uu____5703
+                InvalidSearch uu___1 in
+              FStar_Exn.raise uu___
             else
               if beg_quote
               then
-                (let uu____5706 = strip_quotes term1 in
-                 NameContainsStr uu____5706)
+                (let uu___1 = strip_quotes term1 in NameContainsStr uu___1)
               else
                 (let lid = FStar_Ident.lid_of_str term1 in
-                 let uu____5709 =
+                 let uu___2 =
                    FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                      tcenv.FStar_TypeChecker_Env.dsenv lid in
-                 match uu____5709 with
+                 match uu___2 with
                  | FStar_Pervasives_Native.None ->
-                     let uu____5712 =
-                       let uu____5713 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_Util.format1 "Unknown identifier: %s" term1 in
-                       InvalidSearch uu____5713 in
-                     FStar_Exn.raise uu____5712
+                       InvalidSearch uu___4 in
+                     FStar_Exn.raise uu___3
                  | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1) in
           { st_negate = negate; st_term = parsed } in
         let terms =
@@ -2367,16 +2315,16 @@ let run_search :
         let cmp x y = (st_cost x.st_term) - (st_cost y.st_term) in
         FStar_Util.sort_with cmp terms in
       let pprint_one term =
-        let uu____5735 =
+        let uu___ =
           match term.st_term with
           | NameContainsStr s -> FStar_Util.format1 "\"%s\"" s
           | TypeContainsLid l ->
-              let uu____5738 = FStar_Ident.string_of_lid l in
-              FStar_Util.format1 "%s" uu____5738 in
-        Prims.op_Hat (if term.st_negate then "-" else "") uu____5735 in
+              let uu___1 = FStar_Ident.string_of_lid l in
+              FStar_Util.format1 "%s" uu___1 in
+        Prims.op_Hat (if term.st_negate then "-" else "") uu___ in
       let results =
         try
-          (fun uu___924_5760 ->
+          (fun uu___ ->
              match () with
              | () ->
                  let terms = parse search_str in
@@ -2385,24 +2333,24 @@ let run_search :
                  let matches_all candidate =
                    FStar_List.for_all (st_matches candidate) terms in
                  let cmp r1 r2 =
-                   let uu____5791 = FStar_Ident.string_of_lid r1.sc_lid in
-                   let uu____5792 = FStar_Ident.string_of_lid r2.sc_lid in
-                   FStar_Util.compare uu____5791 uu____5792 in
-                 let results = FStar_List.filter matches_all all_candidates in
-                 let sorted = FStar_Util.sort_with cmp results in
+                   let uu___1 = FStar_Ident.string_of_lid r1.sc_lid in
+                   let uu___2 = FStar_Ident.string_of_lid r2.sc_lid in
+                   FStar_Util.compare uu___1 uu___2 in
+                 let results1 = FStar_List.filter matches_all all_candidates in
+                 let sorted = FStar_Util.sort_with cmp results1 in
                  let js = FStar_List.map (json_of_search_result tcenv) sorted in
-                 (match results with
+                 (match results1 with
                   | [] ->
                       let kwds =
-                        let uu____5807 = FStar_List.map pprint_one terms in
-                        FStar_Util.concat_l " " uu____5807 in
-                      let uu____5810 =
-                        let uu____5811 =
+                        let uu___1 = FStar_List.map pprint_one terms in
+                        FStar_Util.concat_l " " uu___1 in
+                      let uu___1 =
+                        let uu___2 =
                           FStar_Util.format1
                             "No results found for query [%s]" kwds in
-                        InvalidSearch uu____5811 in
-                      FStar_Exn.raise uu____5810
-                  | uu____5816 -> (QueryOK, (FStar_Util.JsonList js)))) ()
+                        InvalidSearch uu___2 in
+                      FStar_Exn.raise uu___1
+                  | uu___1 -> (QueryOK, (FStar_Util.JsonList js)))) ()
         with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s)) in
       (results, (FStar_Util.Inl st))
 let (run_query :
@@ -2437,8 +2385,8 @@ let (validate_query :
       match q.qq with
       | Push
           { push_kind = FStar_Interactive_PushHelper.SyntaxCheck;
-            push_code = uu____5914; push_line = uu____5915;
-            push_column = uu____5916; push_peek_only = false;_}
+            push_code = uu___; push_line = uu___1; push_column = uu___2;
+            push_peek_only = false;_}
           ->
           {
             qq =
@@ -2446,12 +2394,12 @@ let (validate_query :
                  "Cannot use 'kind': 'syntax' with 'query': 'push'");
             qid = (q.qid)
           }
-      | uu____5917 ->
+      | uu___ ->
           (match st.FStar_Interactive_JsonHelper.repl_curmod with
            | FStar_Pervasives_Native.None when
                query_needs_current_module q.qq ->
                { qq = (GenericError "Current module unset"); qid = (q.qid) }
-           | uu____5918 -> q)
+           | uu___1 -> q)
 let (validate_and_run_query :
   FStar_Interactive_JsonHelper.repl_state ->
     query ->
@@ -2473,8 +2421,8 @@ let (js_repl_eval :
   =
   fun st ->
     fun query1 ->
-      let uu____5971 = validate_and_run_query st query1 in
-      match uu____5971 with
+      let uu___ = validate_and_run_query st query1 in
+      match uu___ with
       | ((status, response), st_opt) ->
           let js_response = json_of_response query1.qid status response in
           (js_response, st_opt)
@@ -2486,8 +2434,8 @@ let (js_repl_eval_js :
   =
   fun st ->
     fun query_js ->
-      let uu____6030 = deserialize_interactive_query query_js in
-      js_repl_eval st uu____6030
+      let uu___ = deserialize_interactive_query query_js in
+      js_repl_eval st uu___
 let (js_repl_eval_str :
   FStar_Interactive_JsonHelper.repl_state ->
     Prims.string ->
@@ -2496,17 +2444,17 @@ let (js_repl_eval_str :
   =
   fun st ->
     fun query_str ->
-      let uu____6049 =
-        let uu____6058 = parse_interactive_query query_str in
-        js_repl_eval st uu____6058 in
-      match uu____6049 with
+      let uu___ =
+        let uu___1 = parse_interactive_query query_str in
+        js_repl_eval st uu___1 in
+      match uu___ with
       | (js_response, st_opt) ->
-          let uu____6077 = FStar_Util.string_of_json js_response in
-          (uu____6077, st_opt)
+          let uu___1 = FStar_Util.string_of_json js_response in
+          (uu___1, st_opt)
 let (js_repl_init_opts : unit -> unit) =
-  fun uu____6086 ->
-    let uu____6087 = FStar_Options.parse_cmd_line () in
-    match uu____6087 with
+  fun uu___ ->
+    let uu___1 = FStar_Options.parse_cmd_line () in
+    match uu___1 with
     | (res, fnames) ->
         (match res with
          | FStar_Getopt.Error msg ->
@@ -2517,16 +2465,16 @@ let (js_repl_init_opts : unit -> unit) =
               | [] ->
                   failwith
                     "repl_init: No file name given in --ide invocation"
-              | h::uu____6102::uu____6103 ->
+              | h::uu___2::uu___3 ->
                   failwith
                     "repl_init: Too many file names given in --ide invocation"
-              | uu____6106 -> ()))
+              | uu___2 -> ()))
 let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
   fun st ->
     let query1 =
       read_interactive_query st.FStar_Interactive_JsonHelper.repl_stdin in
-    let uu____6115 = validate_and_run_query st query1 in
-    match uu____6115 with
+    let uu___ = validate_and_run_query st query1 in
+    match uu___ with
     | ((status, response), state_opt) ->
         (write_response query1.qid status response;
          (match state_opt with
@@ -2535,23 +2483,22 @@ let rec (go : FStar_Interactive_JsonHelper.repl_state -> Prims.int) =
 let (interactive_error_handler : FStar_Errors.error_handler) =
   let issues = FStar_Util.mk_ref [] in
   let add_one e =
-    let uu____6159 =
-      let uu____6162 = FStar_ST.op_Bang issues in e :: uu____6162 in
-    FStar_ST.op_Colon_Equals issues uu____6159 in
-  let count_errors uu____6190 =
+    let uu___ = let uu___1 = FStar_ST.op_Bang issues in e :: uu___1 in
+    FStar_ST.op_Colon_Equals issues uu___ in
+  let count_errors uu___ =
     let issues1 =
-      let uu____6194 = FStar_ST.op_Bang issues in
-      FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu____6194 in
-    let uu____6211 =
+      let uu___1 = FStar_ST.op_Bang issues in
+      FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu___1 in
+    let uu___1 =
       FStar_List.filter
         (fun e -> e.FStar_Errors.issue_level = FStar_Errors.EError) issues1 in
-    FStar_List.length uu____6211 in
-  let report uu____6223 =
-    let uu____6224 =
-      let uu____6227 = FStar_ST.op_Bang issues in
-      FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu____6227 in
-    FStar_List.sortWith FStar_Errors.compare_issues uu____6224 in
-  let clear uu____6249 = FStar_ST.op_Colon_Equals issues [] in
+    FStar_List.length uu___1 in
+  let report uu___ =
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang issues in
+      FStar_Util.remove_dups (fun i0 -> fun i1 -> i0 = i1) uu___2 in
+    FStar_List.sortWith FStar_Errors.compare_issues uu___1 in
+  let clear uu___ = FStar_ST.op_Colon_Equals issues [] in
   {
     FStar_Errors.eh_add_one = add_one;
     FStar_Errors.eh_count_errors = count_errors;
@@ -2571,23 +2518,22 @@ let (interactive_printer : (FStar_Util.json -> unit) -> FStar_Util.printer) =
         (fun label ->
            fun get_string ->
              fun get_json ->
-               let uu____6288 = get_json () in
-               forward_message printer label uu____6288)
+               let uu___ = get_json () in forward_message printer label uu___)
     }
 let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
   fun printer ->
     FStar_Util.set_printer (interactive_printer printer);
     FStar_Errors.set_handler interactive_error_handler
 let (initial_range : FStar_Range.range) =
-  let uu____6300 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-  let uu____6301 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-  FStar_Range.mk_range "<input>" uu____6300 uu____6301
+  let uu___ = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+  let uu___1 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+  FStar_Range.mk_range "<input>" uu___ uu___1
 let (build_initial_repl_state :
   Prims.string -> FStar_Interactive_JsonHelper.repl_state) =
   fun filename ->
     let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps in
     let env1 = FStar_TypeChecker_Env.set_range env initial_range in
-    let uu____6309 = FStar_Util.open_stdin () in
+    let uu___ = FStar_Util.open_stdin () in
     {
       FStar_Interactive_JsonHelper.repl_line = Prims.int_one;
       FStar_Interactive_JsonHelper.repl_column = Prims.int_zero;
@@ -2595,47 +2541,43 @@ let (build_initial_repl_state :
       FStar_Interactive_JsonHelper.repl_deps_stack = [];
       FStar_Interactive_JsonHelper.repl_curmod = FStar_Pervasives_Native.None;
       FStar_Interactive_JsonHelper.repl_env = env1;
-      FStar_Interactive_JsonHelper.repl_stdin = uu____6309;
+      FStar_Interactive_JsonHelper.repl_stdin = uu___;
       FStar_Interactive_JsonHelper.repl_names =
         FStar_Interactive_CompletionTable.empty
     }
 let interactive_mode' :
-  'uuuuuu6322 . FStar_Interactive_JsonHelper.repl_state -> 'uuuuuu6322 =
+  'uuuuu . FStar_Interactive_JsonHelper.repl_state -> 'uuuuu =
   fun init_st ->
     write_hello ();
     (let exit_code =
-       let uu____6330 =
+       let uu___1 =
          (FStar_Options.record_hints ()) || (FStar_Options.use_hints ()) in
-       if uu____6330
+       if uu___1
        then
-         let uu____6331 =
-           let uu____6332 = FStar_Options.file_list () in
-           FStar_List.hd uu____6332 in
-         FStar_SMTEncoding_Solver.with_hints_db uu____6331
-           (fun uu____6336 -> go init_st)
+         let uu___2 =
+           let uu___3 = FStar_Options.file_list () in FStar_List.hd uu___3 in
+         FStar_SMTEncoding_Solver.with_hints_db uu___2
+           (fun uu___3 -> go init_st)
        else go init_st in
      FStar_All.exit exit_code)
 let (interactive_mode : Prims.string -> unit) =
   fun filename ->
     install_ide_mode_hooks FStar_Interactive_JsonHelper.write_json;
     FStar_Util.set_sigint_handler FStar_Util.sigint_ignore;
-    (let uu____6346 =
-       let uu____6347 = FStar_Options.codegen () in
-       FStar_Option.isSome uu____6347 in
-     if uu____6346
+    (let uu___3 =
+       let uu___4 = FStar_Options.codegen () in FStar_Option.isSome uu___4 in
+     if uu___3
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen")
      else ());
     (let init = build_initial_repl_state filename in
-     let uu____6352 = FStar_Options.trace_error () in
-     if uu____6352
+     let uu___3 = FStar_Options.trace_error () in
+     if uu___3
      then interactive_mode' init
      else
-       (try
-          (fun uu___1077_6355 -> match () with | () -> interactive_mode' init)
-            ()
+       (try (fun uu___5 -> match () with | () -> interactive_mode' init) ()
         with
-        | uu___1076_6358 ->
+        | uu___5 ->
             (FStar_Errors.set_handler FStar_Errors.default_handler;
-             FStar_Exn.raise uu___1076_6358)))
+             FStar_Exn.raise uu___5)))

--- a/src/ocaml-output/FStar_Interactive_JsonHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_JsonHelper.ml
@@ -4,124 +4,118 @@ let (try_assoc :
   Prims.string -> assoct -> FStar_Util.json FStar_Pervasives_Native.option) =
   fun key ->
     fun d ->
-      let uu____47 =
+      let uu___ =
         FStar_Util.try_find
-          (fun uu____61 -> match uu____61 with | (k, uu____67) -> k = key) d in
-      FStar_Util.map_option FStar_Pervasives_Native.snd uu____47
+          (fun uu___1 -> match uu___1 with | (k, uu___2) -> k = key) d in
+      FStar_Util.map_option FStar_Pervasives_Native.snd uu___
 exception MissingKey of Prims.string 
 let (uu___is_MissingKey : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | MissingKey uu____81 -> true | uu____82 -> false
+    match projectee with | MissingKey uu___ -> true | uu___ -> false
 let (__proj__MissingKey__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee -> match projectee with | MissingKey uu____88 -> uu____88
+  fun projectee -> match projectee with | MissingKey uu___ -> uu___
 exception InvalidQuery of Prims.string 
 let (uu___is_InvalidQuery : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | InvalidQuery uu____98 -> true | uu____99 -> false
+    match projectee with | InvalidQuery uu___ -> true | uu___ -> false
 let (__proj__InvalidQuery__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee -> match projectee with | InvalidQuery uu____105 -> uu____105
+  fun projectee -> match projectee with | InvalidQuery uu___ -> uu___
 exception UnexpectedJsonType of (Prims.string * FStar_Util.json) 
 let (uu___is_UnexpectedJsonType : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | UnexpectedJsonType uu____119 -> true
-    | uu____124 -> false
+    match projectee with | UnexpectedJsonType uu___ -> true | uu___ -> false
 let (__proj__UnexpectedJsonType__item__uu___ :
   Prims.exn -> (Prims.string * FStar_Util.json)) =
-  fun projectee ->
-    match projectee with | UnexpectedJsonType uu____138 -> uu____138
+  fun projectee -> match projectee with | UnexpectedJsonType uu___ -> uu___
 exception MalformedHeader 
 let (uu___is_MalformedHeader : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | MalformedHeader -> true | uu____148 -> false
+    match projectee with | MalformedHeader -> true | uu___ -> false
 exception InputExhausted 
 let (uu___is_InputExhausted : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | InputExhausted -> true | uu____154 -> false
+    match projectee with | InputExhausted -> true | uu___ -> false
 let (assoc : Prims.string -> assoct -> FStar_Util.json) =
   fun key ->
     fun a ->
-      let uu____165 = try_assoc key a in
-      match uu____165 with
+      let uu___ = try_assoc key a in
+      match uu___ with
       | FStar_Pervasives_Native.Some v -> v
       | FStar_Pervasives_Native.None ->
-          let uu____169 =
-            let uu____170 = FStar_Util.format1 "Missing key [%s]" key in
-            MissingKey uu____170 in
-          FStar_Exn.raise uu____169
+          let uu___1 =
+            let uu___2 = FStar_Util.format1 "Missing key [%s]" key in
+            MissingKey uu___2 in
+          FStar_Exn.raise uu___1
 let (write_json : FStar_Util.json -> unit) =
   fun js ->
-    (let uu____177 = FStar_Util.string_of_json js in
-     FStar_Util.print_raw uu____177);
+    (let uu___1 = FStar_Util.string_of_json js in FStar_Util.print_raw uu___1);
     FStar_Util.print_raw "\n"
 let (write_jsonrpc : FStar_Util.json -> unit) =
   fun js ->
     let js_str = FStar_Util.string_of_json js in
     let len = FStar_Util.string_of_int (FStar_String.length js_str) in
-    let uu____185 =
-      FStar_Util.format2 "Content-Length: %s\r\n\r\n%s" len js_str in
-    FStar_Util.print_raw uu____185
+    let uu___ = FStar_Util.format2 "Content-Length: %s\r\n\r\n%s" len js_str in
+    FStar_Util.print_raw uu___
 let js_fail : 'a . Prims.string -> FStar_Util.json -> 'a =
   fun expected ->
     fun got -> FStar_Exn.raise (UnexpectedJsonType (expected, got))
 let (js_int : FStar_Util.json -> Prims.int) =
-  fun uu___0_210 ->
-    match uu___0_210 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonInt i -> i
     | other -> js_fail "int" other
 let (js_str : FStar_Util.json -> Prims.string) =
-  fun uu___1_220 ->
-    match uu___1_220 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonStr s -> s
     | other -> js_fail "string" other
 let js_list :
   'a . (FStar_Util.json -> 'a) -> FStar_Util.json -> 'a Prims.list =
   fun k ->
-    fun uu___2_244 ->
-      match uu___2_244 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Util.JsonList l -> FStar_List.map k l
       | other -> js_fail "list" other
 let (js_assoc : FStar_Util.json -> assoct) =
-  fun uu___3_260 ->
-    match uu___3_260 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonAssoc a -> a
     | other -> js_fail "dictionary" other
 let (js_str_int : FStar_Util.json -> Prims.int) =
-  fun uu___4_276 ->
-    match uu___4_276 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonInt i -> i
     | FStar_Util.JsonStr s -> FStar_Util.int_of_string s
     | other -> js_fail "string or int" other
 let (arg : Prims.string -> assoct -> FStar_Util.json) =
   fun k ->
     fun r ->
-      let uu____290 =
-        let uu____291 = assoc "params" r in
-        FStar_All.pipe_right uu____291 js_assoc in
-      assoc k uu____290
+      let uu___ =
+        let uu___1 = assoc "params" r in FStar_All.pipe_right uu___1 js_assoc in
+      assoc k uu___
 let (uri_to_path : Prims.string -> Prims.string) =
   fun u ->
-    let uu____297 =
-      let uu____298 =
+    let uu___ =
+      let uu___1 =
         FStar_Util.substring u (Prims.of_int (9)) (Prims.of_int (3)) in
-      uu____298 = "%3A" in
-    if uu____297
+      uu___1 = "%3A" in
+    if uu___
     then
-      let uu____299 = FStar_Util.substring u (Prims.of_int (8)) Prims.int_one in
-      let uu____300 = FStar_Util.substring_from u (Prims.of_int (12)) in
-      FStar_Util.format2 "%s:%s" uu____299 uu____300
+      let uu___1 = FStar_Util.substring u (Prims.of_int (8)) Prims.int_one in
+      let uu___2 = FStar_Util.substring_from u (Prims.of_int (12)) in
+      FStar_Util.format2 "%s:%s" uu___1 uu___2
     else FStar_Util.substring_from u (Prims.of_int (7))
 let (path_to_uri : Prims.string -> Prims.string) =
   fun u ->
-    let uu____307 =
-      let uu____308 = FStar_Util.char_at u Prims.int_one in uu____308 = 58 in
-    if uu____307
+    let uu___ =
+      let uu___1 = FStar_Util.char_at u Prims.int_one in uu___1 = 58 in
+    if uu___
     then
       let rest =
-        let uu____310 = FStar_Util.substring_from u (Prims.of_int (2)) in
-        FStar_Util.replace_char uu____310 92 47 in
-      let uu____311 = FStar_Util.substring u Prims.int_zero Prims.int_one in
-      FStar_Util.format2 "file:///%s%3A%s" uu____311 rest
+        let uu___1 = FStar_Util.substring_from u (Prims.of_int (2)) in
+        FStar_Util.replace_char uu___1 92 47 in
+      let uu___1 = FStar_Util.substring u Prims.int_zero Prims.int_one in
+      FStar_Util.format2 "file:///%s%3A%s" uu___1 rest
     else FStar_Util.format1 "file://%s" u
 type completion_context =
   {
@@ -136,16 +130,16 @@ let (__proj__Mkcompletion_context__item__trigger_char :
   fun projectee ->
     match projectee with | { trigger_kind; trigger_char;_} -> trigger_char
 let (js_compl_context : FStar_Util.json -> completion_context) =
-  fun uu___5_354 ->
-    match uu___5_354 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonAssoc a ->
-        let uu____362 =
-          let uu____363 = assoc "triggerKind" a in
-          FStar_All.pipe_right uu____363 js_int in
-        let uu____364 =
-          let uu____367 = try_assoc "triggerChar" a in
-          FStar_All.pipe_right uu____367 (FStar_Util.map_option js_str) in
-        { trigger_kind = uu____362; trigger_char = uu____364 }
+        let uu___1 =
+          let uu___2 = assoc "triggerKind" a in
+          FStar_All.pipe_right uu___2 js_int in
+        let uu___2 =
+          let uu___3 = try_assoc "triggerChar" a in
+          FStar_All.pipe_right uu___3 (FStar_Util.map_option js_str) in
+        { trigger_kind = uu___1; trigger_char = uu___2 }
     | other -> js_fail "dictionary" other
 type txdoc_item =
   {
@@ -166,30 +160,22 @@ let (__proj__Mktxdoc_item__item__text : txdoc_item -> Prims.string) =
   fun projectee ->
     match projectee with | { fname; langId; version; text;_} -> text
 let (js_txdoc_item : FStar_Util.json -> txdoc_item) =
-  fun uu___6_438 ->
-    match uu___6_438 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonAssoc a ->
         let arg1 k = assoc k a in
-        let uu____452 =
-          let uu____453 =
-            let uu____454 = arg1 "uri" in
-            FStar_All.pipe_right uu____454 js_str in
-          uri_to_path uu____453 in
-        let uu____455 =
-          let uu____456 = arg1 "languageId" in
-          FStar_All.pipe_right uu____456 js_str in
-        let uu____457 =
-          let uu____458 = arg1 "version" in
-          FStar_All.pipe_right uu____458 js_int in
-        let uu____459 =
-          let uu____460 = arg1 "text" in
-          FStar_All.pipe_right uu____460 js_str in
-        {
-          fname = uu____452;
-          langId = uu____455;
-          version = uu____457;
-          text = uu____459
-        }
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = arg1 "uri" in FStar_All.pipe_right uu___3 js_str in
+          uri_to_path uu___2 in
+        let uu___2 =
+          let uu___3 = arg1 "languageId" in
+          FStar_All.pipe_right uu___3 js_str in
+        let uu___3 =
+          let uu___4 = arg1 "version" in FStar_All.pipe_right uu___4 js_int in
+        let uu___4 =
+          let uu___5 = arg1 "text" in FStar_All.pipe_right uu___5 js_str in
+        { fname = uu___1; langId = uu___2; version = uu___3; text = uu___4 }
     | other -> js_fail "dictionary" other
 type txdoc_pos = {
   path: Prims.string ;
@@ -203,27 +189,25 @@ let (__proj__Mktxdoc_pos__item__col : txdoc_pos -> Prims.int) =
   fun projectee -> match projectee with | { path; line; col;_} -> col
 let (js_txdoc_id : assoct -> Prims.string) =
   fun r ->
-    let uu____512 =
-      let uu____513 =
-        let uu____514 =
-          let uu____515 = arg "textDocument" r in
-          FStar_All.pipe_right uu____515 js_assoc in
-        assoc "uri" uu____514 in
-      FStar_All.pipe_right uu____513 js_str in
-    uri_to_path uu____512
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = arg "textDocument" r in
+          FStar_All.pipe_right uu___3 js_assoc in
+        assoc "uri" uu___2 in
+      FStar_All.pipe_right uu___1 js_str in
+    uri_to_path uu___
 let (js_txdoc_pos : assoct -> txdoc_pos) =
   fun r ->
     let pos =
-      let uu____528 = arg "position" r in
-      FStar_All.pipe_right uu____528 js_assoc in
-    let uu____529 = js_txdoc_id r in
-    let uu____530 =
-      let uu____531 = assoc "line" pos in
-      FStar_All.pipe_right uu____531 js_int in
-    let uu____532 =
-      let uu____533 = assoc "character" pos in
-      FStar_All.pipe_right uu____533 js_int in
-    { path = uu____529; line = uu____530; col = uu____532 }
+      let uu___ = arg "position" r in FStar_All.pipe_right uu___ js_assoc in
+    let uu___ = js_txdoc_id r in
+    let uu___1 =
+      let uu___2 = assoc "line" pos in FStar_All.pipe_right uu___2 js_int in
+    let uu___2 =
+      let uu___3 = assoc "character" pos in
+      FStar_All.pipe_right uu___3 js_int in
+    { path = uu___; line = uu___1; col = uu___2 }
 type workspace_folder = {
   wk_uri: Prims.string ;
   wk_name: Prims.string }
@@ -241,45 +225,45 @@ let (__proj__Mkwsch_event__item__added : wsch_event -> workspace_folder) =
 let (__proj__Mkwsch_event__item__removed : wsch_event -> workspace_folder) =
   fun projectee -> match projectee with | { added; removed;_} -> removed
 let (js_wsch_event : FStar_Util.json -> wsch_event) =
-  fun uu___7_589 ->
-    match uu___7_589 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonAssoc a ->
         let added' =
-          let uu____598 = assoc "added" a in
-          FStar_All.pipe_right uu____598 js_assoc in
+          let uu___1 = assoc "added" a in
+          FStar_All.pipe_right uu___1 js_assoc in
         let removed' =
-          let uu____600 = assoc "removed" a in
-          FStar_All.pipe_right uu____600 js_assoc in
-        let uu____601 =
-          let uu____602 =
-            let uu____603 = assoc "uri" added' in
-            FStar_All.pipe_right uu____603 js_str in
-          let uu____604 =
-            let uu____605 = assoc "name" added' in
-            FStar_All.pipe_right uu____605 js_str in
-          { wk_uri = uu____602; wk_name = uu____604 } in
-        let uu____606 =
-          let uu____607 =
-            let uu____608 = assoc "uri" removed' in
-            FStar_All.pipe_right uu____608 js_str in
-          let uu____609 =
-            let uu____610 = assoc "name" removed' in
-            FStar_All.pipe_right uu____610 js_str in
-          { wk_uri = uu____607; wk_name = uu____609 } in
-        { added = uu____601; removed = uu____606 }
+          let uu___1 = assoc "removed" a in
+          FStar_All.pipe_right uu___1 js_assoc in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = assoc "uri" added' in
+            FStar_All.pipe_right uu___3 js_str in
+          let uu___3 =
+            let uu___4 = assoc "name" added' in
+            FStar_All.pipe_right uu___4 js_str in
+          { wk_uri = uu___2; wk_name = uu___3 } in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = assoc "uri" removed' in
+            FStar_All.pipe_right uu___4 js_str in
+          let uu___4 =
+            let uu___5 = assoc "name" removed' in
+            FStar_All.pipe_right uu___5 js_str in
+          { wk_uri = uu___3; wk_name = uu___4 } in
+        { added = uu___1; removed = uu___2 }
     | other -> js_fail "dictionary" other
 let (js_contentch : FStar_Util.json -> Prims.string) =
-  fun uu___8_619 ->
-    match uu___8_619 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonList l ->
-        let uu____623 =
+        let uu___1 =
           FStar_List.map
-            (fun uu____629 ->
-               match uu____629 with
+            (fun uu___2 ->
+               match uu___2 with
                | FStar_Util.JsonAssoc a ->
-                   let uu____637 = assoc "text" a in
-                   FStar_All.pipe_right uu____637 js_str) l in
-        FStar_List.hd uu____623
+                   let uu___3 = assoc "text" a in
+                   FStar_All.pipe_right uu___3 js_str) l in
+        FStar_List.hd uu___1
     | other -> js_fail "dictionary" other
 type rng =
   {
@@ -291,35 +275,34 @@ let (__proj__Mkrng__item__rng_start : rng -> (Prims.int * Prims.int)) =
 let (__proj__Mkrng__item__rng_end : rng -> (Prims.int * Prims.int)) =
   fun projectee -> match projectee with | { rng_start; rng_end;_} -> rng_end
 let (js_rng : FStar_Util.json -> rng) =
-  fun uu___9_707 ->
-    match uu___9_707 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonAssoc a ->
         let st = assoc "start" a in
         let fin = assoc "end" a in
         let l = assoc "line" in
         let c = assoc "character" in
-        let uu____727 =
-          let uu____732 =
-            let uu____733 =
-              let uu____734 = FStar_All.pipe_right st js_assoc in l uu____734 in
-            FStar_All.pipe_right uu____733 js_int in
-          let uu____735 =
-            let uu____736 =
-              let uu____737 = FStar_All.pipe_right st js_assoc in c uu____737 in
-            FStar_All.pipe_right uu____736 js_int in
-          (uu____732, uu____735) in
-        let uu____738 =
-          let uu____743 =
-            let uu____744 =
-              let uu____745 = FStar_All.pipe_right fin js_assoc in
-              l uu____745 in
-            FStar_All.pipe_right uu____744 js_int in
-          let uu____746 =
-            let uu____747 =
-              let uu____748 = FStar_All.pipe_right st js_assoc in c uu____748 in
-            FStar_All.pipe_right uu____747 js_int in
-          (uu____743, uu____746) in
-        { rng_start = uu____727; rng_end = uu____738 }
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_All.pipe_right st js_assoc in l uu___4 in
+            FStar_All.pipe_right uu___3 js_int in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_All.pipe_right st js_assoc in c uu___5 in
+            FStar_All.pipe_right uu___4 js_int in
+          (uu___2, uu___3) in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_All.pipe_right fin js_assoc in l uu___5 in
+            FStar_All.pipe_right uu___4 js_int in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_All.pipe_right st js_assoc in c uu___6 in
+            FStar_All.pipe_right uu___5 js_int in
+          (uu___3, uu___4) in
+        { rng_start = uu___1; rng_end = uu___2 }
     | other -> js_fail "dictionary" other
 type lquery =
   | Initialize of (Prims.int * Prims.string) 
@@ -365,167 +348,155 @@ type lquery =
   | BadProtocolMsg of Prims.string 
 let (uu___is_Initialize : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Initialize _0 -> true | uu____881 -> false
+    match projectee with | Initialize _0 -> true | uu___ -> false
 let (__proj__Initialize__item___0 : lquery -> (Prims.int * Prims.string)) =
   fun projectee -> match projectee with | Initialize _0 -> _0
 let (uu___is_Initialized : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Initialized -> true | uu____905 -> false
+    match projectee with | Initialized -> true | uu___ -> false
 let (uu___is_Shutdown : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Shutdown -> true | uu____911 -> false
+  fun projectee -> match projectee with | Shutdown -> true | uu___ -> false
 let (uu___is_Exit : lquery -> Prims.bool) =
-  fun projectee -> match projectee with | Exit -> true | uu____917 -> false
+  fun projectee -> match projectee with | Exit -> true | uu___ -> false
 let (uu___is_Cancel : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Cancel _0 -> true | uu____924 -> false
+  fun projectee -> match projectee with | Cancel _0 -> true | uu___ -> false
 let (__proj__Cancel__item___0 : lquery -> Prims.int) =
   fun projectee -> match projectee with | Cancel _0 -> _0
 let (uu___is_FolderChange : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | FolderChange _0 -> true | uu____937 -> false
+    match projectee with | FolderChange _0 -> true | uu___ -> false
 let (__proj__FolderChange__item___0 : lquery -> wsch_event) =
   fun projectee -> match projectee with | FolderChange _0 -> _0
 let (uu___is_ChangeConfig : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | ChangeConfig -> true | uu____949 -> false
+    match projectee with | ChangeConfig -> true | uu___ -> false
 let (uu___is_ChangeWatch : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | ChangeWatch -> true | uu____955 -> false
+    match projectee with | ChangeWatch -> true | uu___ -> false
 let (uu___is_Symbol : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Symbol _0 -> true | uu____962 -> false
+  fun projectee -> match projectee with | Symbol _0 -> true | uu___ -> false
 let (__proj__Symbol__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | Symbol _0 -> _0
 let (uu___is_ExecCommand : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | ExecCommand _0 -> true | uu____975 -> false
+    match projectee with | ExecCommand _0 -> true | uu___ -> false
 let (__proj__ExecCommand__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | ExecCommand _0 -> _0
 let (uu___is_DidOpen : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | DidOpen _0 -> true | uu____988 -> false
+  fun projectee -> match projectee with | DidOpen _0 -> true | uu___ -> false
 let (__proj__DidOpen__item___0 : lquery -> txdoc_item) =
   fun projectee -> match projectee with | DidOpen _0 -> _0
 let (uu___is_DidChange : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DidChange _0 -> true | uu____1005 -> false
+    match projectee with | DidChange _0 -> true | uu___ -> false
 let (__proj__DidChange__item___0 : lquery -> (Prims.string * Prims.string)) =
   fun projectee -> match projectee with | DidChange _0 -> _0
 let (uu___is_WillSave : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | WillSave _0 -> true | uu____1030 -> false
+    match projectee with | WillSave _0 -> true | uu___ -> false
 let (__proj__WillSave__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | WillSave _0 -> _0
 let (uu___is_WillSaveWait : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | WillSaveWait _0 -> true | uu____1043 -> false
+    match projectee with | WillSaveWait _0 -> true | uu___ -> false
 let (__proj__WillSaveWait__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | WillSaveWait _0 -> _0
 let (uu___is_DidSave : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | DidSave _0 -> true | uu____1060 -> false
+  fun projectee -> match projectee with | DidSave _0 -> true | uu___ -> false
 let (__proj__DidSave__item___0 : lquery -> (Prims.string * Prims.string)) =
   fun projectee -> match projectee with | DidSave _0 -> _0
 let (uu___is_DidClose : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DidClose _0 -> true | uu____1085 -> false
+    match projectee with | DidClose _0 -> true | uu___ -> false
 let (__proj__DidClose__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | DidClose _0 -> _0
 let (uu___is_Completion : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Completion _0 -> true | uu____1102 -> false
+    match projectee with | Completion _0 -> true | uu___ -> false
 let (__proj__Completion__item___0 :
   lquery -> (txdoc_pos * completion_context)) =
   fun projectee -> match projectee with | Completion _0 -> _0
 let (uu___is_Resolve : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Resolve -> true | uu____1126 -> false
+  fun projectee -> match projectee with | Resolve -> true | uu___ -> false
 let (uu___is_Hover : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Hover _0 -> true | uu____1133 -> false
+  fun projectee -> match projectee with | Hover _0 -> true | uu___ -> false
 let (__proj__Hover__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | Hover _0 -> _0
 let (uu___is_SignatureHelp : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | SignatureHelp _0 -> true | uu____1146 -> false
+    match projectee with | SignatureHelp _0 -> true | uu___ -> false
 let (__proj__SignatureHelp__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | SignatureHelp _0 -> _0
 let (uu___is_Declaration : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Declaration _0 -> true | uu____1159 -> false
+    match projectee with | Declaration _0 -> true | uu___ -> false
 let (__proj__Declaration__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | Declaration _0 -> _0
 let (uu___is_Definition : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Definition _0 -> true | uu____1172 -> false
+    match projectee with | Definition _0 -> true | uu___ -> false
 let (__proj__Definition__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | Definition _0 -> _0
 let (uu___is_TypeDefinition : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | TypeDefinition _0 -> true | uu____1185 -> false
+    match projectee with | TypeDefinition _0 -> true | uu___ -> false
 let (__proj__TypeDefinition__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | TypeDefinition _0 -> _0
 let (uu___is_Implementation : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | Implementation _0 -> true | uu____1198 -> false
+    match projectee with | Implementation _0 -> true | uu___ -> false
 let (__proj__Implementation__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | Implementation _0 -> _0
 let (uu___is_References : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | References -> true | uu____1210 -> false
+  fun projectee -> match projectee with | References -> true | uu___ -> false
 let (uu___is_DocumentHighlight : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DocumentHighlight _0 -> true | uu____1217 -> false
+    match projectee with | DocumentHighlight _0 -> true | uu___ -> false
 let (__proj__DocumentHighlight__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | DocumentHighlight _0 -> _0
 let (uu___is_DocumentSymbol : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DocumentSymbol -> true | uu____1229 -> false
+    match projectee with | DocumentSymbol -> true | uu___ -> false
 let (uu___is_CodeAction : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CodeAction -> true | uu____1235 -> false
+  fun projectee -> match projectee with | CodeAction -> true | uu___ -> false
 let (uu___is_CodeLens : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CodeLens -> true | uu____1241 -> false
+  fun projectee -> match projectee with | CodeLens -> true | uu___ -> false
 let (uu___is_CodeLensResolve : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | CodeLensResolve -> true | uu____1247 -> false
+    match projectee with | CodeLensResolve -> true | uu___ -> false
 let (uu___is_DocumentLink : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DocumentLink -> true | uu____1253 -> false
+    match projectee with | DocumentLink -> true | uu___ -> false
 let (uu___is_DocumentLinkResolve : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DocumentLinkResolve -> true | uu____1259 -> false
+    match projectee with | DocumentLinkResolve -> true | uu___ -> false
 let (uu___is_DocumentColor : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | DocumentColor -> true | uu____1265 -> false
+    match projectee with | DocumentColor -> true | uu___ -> false
 let (uu___is_ColorPresentation : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | ColorPresentation -> true | uu____1271 -> false
+    match projectee with | ColorPresentation -> true | uu___ -> false
 let (uu___is_Formatting : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Formatting -> true | uu____1277 -> false
+  fun projectee -> match projectee with | Formatting -> true | uu___ -> false
 let (uu___is_RangeFormatting : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | RangeFormatting -> true | uu____1283 -> false
+    match projectee with | RangeFormatting -> true | uu___ -> false
 let (uu___is_TypeFormatting : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | TypeFormatting -> true | uu____1289 -> false
+    match projectee with | TypeFormatting -> true | uu___ -> false
 let (uu___is_Rename : lquery -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Rename -> true | uu____1295 -> false
+  fun projectee -> match projectee with | Rename -> true | uu___ -> false
 let (uu___is_PrepareRename : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | PrepareRename _0 -> true | uu____1302 -> false
+    match projectee with | PrepareRename _0 -> true | uu___ -> false
 let (__proj__PrepareRename__item___0 : lquery -> txdoc_pos) =
   fun projectee -> match projectee with | PrepareRename _0 -> _0
 let (uu___is_FoldingRange : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | FoldingRange -> true | uu____1314 -> false
+    match projectee with | FoldingRange -> true | uu___ -> false
 let (uu___is_BadProtocolMsg : lquery -> Prims.bool) =
   fun projectee ->
-    match projectee with | BadProtocolMsg _0 -> true | uu____1321 -> false
+    match projectee with | BadProtocolMsg _0 -> true | uu___ -> false
 let (__proj__BadProtocolMsg__item___0 : lquery -> Prims.string) =
   fun projectee -> match projectee with | BadProtocolMsg _0 -> _0
 type lsp_query =
@@ -557,30 +528,30 @@ type repl_task =
   | Noop 
 let (uu___is_LDInterleaved : repl_task -> Prims.bool) =
   fun projectee ->
-    match projectee with | LDInterleaved _0 -> true | uu____1426 -> false
+    match projectee with | LDInterleaved _0 -> true | uu___ -> false
 let (__proj__LDInterleaved__item___0 :
   repl_task -> (timed_fname * timed_fname)) =
   fun projectee -> match projectee with | LDInterleaved _0 -> _0
 let (uu___is_LDSingle : repl_task -> Prims.bool) =
   fun projectee ->
-    match projectee with | LDSingle _0 -> true | uu____1451 -> false
+    match projectee with | LDSingle _0 -> true | uu___ -> false
 let (__proj__LDSingle__item___0 : repl_task -> timed_fname) =
   fun projectee -> match projectee with | LDSingle _0 -> _0
 let (uu___is_LDInterfaceOfCurrentFile : repl_task -> Prims.bool) =
   fun projectee ->
     match projectee with
     | LDInterfaceOfCurrentFile _0 -> true
-    | uu____1464 -> false
+    | uu___ -> false
 let (__proj__LDInterfaceOfCurrentFile__item___0 : repl_task -> timed_fname) =
   fun projectee -> match projectee with | LDInterfaceOfCurrentFile _0 -> _0
 let (uu___is_PushFragment : repl_task -> Prims.bool) =
   fun projectee ->
-    match projectee with | PushFragment _0 -> true | uu____1477 -> false
+    match projectee with | PushFragment _0 -> true | uu___ -> false
 let (__proj__PushFragment__item___0 :
   repl_task -> FStar_Parser_ParseIt.input_frag) =
   fun projectee -> match projectee with | PushFragment _0 -> _0
 let (uu___is_Noop : repl_task -> Prims.bool) =
-  fun projectee -> match projectee with | Noop -> true | uu____1489 -> false
+  fun projectee -> match projectee with | Noop -> true | uu___ -> false
 type repl_state =
   {
   repl_line: Prims.int ;
@@ -662,41 +633,40 @@ type error_code =
   | RequestCancelled 
   | ContentModified 
 let (uu___is_ParseError : error_code -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ParseError -> true | uu____1801 -> false
+  fun projectee -> match projectee with | ParseError -> true | uu___ -> false
 let (uu___is_InvalidRequest : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | InvalidRequest -> true | uu____1807 -> false
+    match projectee with | InvalidRequest -> true | uu___ -> false
 let (uu___is_MethodNotFound : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | MethodNotFound -> true | uu____1813 -> false
+    match projectee with | MethodNotFound -> true | uu___ -> false
 let (uu___is_InvalidParams : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | InvalidParams -> true | uu____1819 -> false
+    match projectee with | InvalidParams -> true | uu___ -> false
 let (uu___is_InternalError : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | InternalError -> true | uu____1825 -> false
+    match projectee with | InternalError -> true | uu___ -> false
 let (uu___is_ServerErrorStart : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | ServerErrorStart -> true | uu____1831 -> false
+    match projectee with | ServerErrorStart -> true | uu___ -> false
 let (uu___is_ServerErrorEnd : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | ServerErrorEnd -> true | uu____1837 -> false
+    match projectee with | ServerErrorEnd -> true | uu___ -> false
 let (uu___is_ServerNotInitialized : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | ServerNotInitialized -> true | uu____1843 -> false
+    match projectee with | ServerNotInitialized -> true | uu___ -> false
 let (uu___is_UnknownErrorCode : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnknownErrorCode -> true | uu____1849 -> false
+    match projectee with | UnknownErrorCode -> true | uu___ -> false
 let (uu___is_RequestCancelled : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | RequestCancelled -> true | uu____1855 -> false
+    match projectee with | RequestCancelled -> true | uu___ -> false
 let (uu___is_ContentModified : error_code -> Prims.bool) =
   fun projectee ->
-    match projectee with | ContentModified -> true | uu____1861 -> false
+    match projectee with | ContentModified -> true | uu___ -> false
 let (errorcode_to_int : error_code -> Prims.int) =
-  fun uu___10_1869 ->
-    match uu___10_1869 with
+  fun uu___ ->
+    match uu___ with
     | ParseError -> ~- (Prims.of_int (32700))
     | InvalidRequest -> ~- (Prims.of_int (32600))
     | MethodNotFound -> ~- (Prims.of_int (32601))
@@ -709,17 +679,17 @@ let (errorcode_to_int : error_code -> Prims.int) =
     | RequestCancelled -> ~- (Prims.of_int (32800))
     | ContentModified -> ~- (Prims.of_int (32801))
 let (json_debug : FStar_Util.json -> Prims.string) =
-  fun uu___11_1874 ->
-    match uu___11_1874 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.JsonNull -> "null"
     | FStar_Util.JsonBool b ->
         FStar_Util.format1 "bool (%s)" (if b then "true" else "false")
     | FStar_Util.JsonInt i ->
-        let uu____1878 = FStar_Util.string_of_int i in
-        FStar_Util.format1 "int (%s)" uu____1878
+        let uu___1 = FStar_Util.string_of_int i in
+        FStar_Util.format1 "int (%s)" uu___1
     | FStar_Util.JsonStr s -> FStar_Util.format1 "string (%s)" s
-    | FStar_Util.JsonList uu____1880 -> "list (...)"
-    | FStar_Util.JsonAssoc uu____1883 -> "dictionary (...)"
+    | FStar_Util.JsonList uu___1 -> "list (...)"
+    | FStar_Util.JsonAssoc uu___1 -> "dictionary (...)"
 let (wrap_jsfail :
   Prims.int FStar_Pervasives_Native.option ->
     Prims.string -> FStar_Util.json -> lsp_query)
@@ -727,13 +697,13 @@ let (wrap_jsfail :
   fun qid ->
     fun expected ->
       fun got ->
-        let uu____1909 =
-          let uu____1910 =
-            let uu____1911 = json_debug got in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = json_debug got in
             FStar_Util.format2 "JSON decoding failed: expected %s, got %s"
-              expected uu____1911 in
-          BadProtocolMsg uu____1910 in
-        { query_id = qid; q = uu____1909 }
+              expected uu___2 in
+          BadProtocolMsg uu___1 in
+        { query_id = qid; q = uu___ }
 let (resultResponse :
   FStar_Util.json -> assoct FStar_Pervasives_Native.option) =
   fun r -> FStar_Pervasives_Native.Some [("result", r)]
@@ -759,14 +729,13 @@ let (json_of_response :
 let (js_resperr : error_code -> Prims.string -> FStar_Util.json) =
   fun err ->
     fun msg ->
-      let uu____2003 =
-        let uu____2010 =
-          let uu____2015 =
-            let uu____2016 = errorcode_to_int err in
-            FStar_Util.JsonInt uu____2016 in
-          ("code", uu____2015) in
-        [uu____2010; ("message", (FStar_Util.JsonStr msg))] in
-      FStar_Util.JsonAssoc uu____2003
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = errorcode_to_int err in FStar_Util.JsonInt uu___3 in
+          ("code", uu___2) in
+        [uu___1; ("message", (FStar_Util.JsonStr msg))] in
+      FStar_Util.JsonAssoc uu___
 let (wrap_content_szerr : Prims.string -> lsp_query) =
   fun m ->
     { query_id = FStar_Pervasives_Native.None; q = (BadProtocolMsg m) }
@@ -795,38 +764,37 @@ let (js_servcap : FStar_Util.json) =
           ("codeActionProvider", (FStar_Util.JsonBool false))]))]
 let (js_pos : FStar_Range.pos -> FStar_Util.json) =
   fun p ->
-    let uu____2135 =
-      let uu____2142 =
-        let uu____2147 =
-          let uu____2148 =
-            let uu____2149 = FStar_Range.line_of_pos p in
-            uu____2149 - Prims.int_one in
-          FStar_Util.JsonInt uu____2148 in
-        ("line", uu____2147) in
-      let uu____2150 =
-        let uu____2157 =
-          let uu____2162 =
-            let uu____2163 = FStar_Range.col_of_pos p in
-            FStar_Util.JsonInt uu____2163 in
-          ("character", uu____2162) in
-        [uu____2157] in
-      uu____2142 :: uu____2150 in
-    FStar_Util.JsonAssoc uu____2135
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Range.line_of_pos p in uu___4 - Prims.int_one in
+          FStar_Util.JsonInt uu___3 in
+        ("line", uu___2) in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = FStar_Range.col_of_pos p in
+            FStar_Util.JsonInt uu___5 in
+          ("character", uu___4) in
+        [uu___3] in
+      uu___1 :: uu___2 in
+    FStar_Util.JsonAssoc uu___
 let (js_range : FStar_Range.range -> FStar_Util.json) =
   fun r ->
-    let uu____2181 =
-      let uu____2188 =
-        let uu____2193 =
-          let uu____2194 = FStar_Range.start_of_range r in js_pos uu____2194 in
-        ("start", uu____2193) in
-      let uu____2195 =
-        let uu____2202 =
-          let uu____2207 =
-            let uu____2208 = FStar_Range.end_of_range r in js_pos uu____2208 in
-          ("end", uu____2207) in
-        [uu____2202] in
-      uu____2188 :: uu____2195 in
-    FStar_Util.JsonAssoc uu____2181
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Range.start_of_range r in js_pos uu___3 in
+        ("start", uu___2) in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = FStar_Range.end_of_range r in js_pos uu___5 in
+          ("end", uu___4) in
+        [uu___3] in
+      uu___1 :: uu___2 in
+    FStar_Util.JsonAssoc uu___
 let (js_dummyrange : FStar_Util.json) =
   FStar_Util.JsonAssoc
     [("start",
@@ -840,20 +808,20 @@ let (js_dummyrange : FStar_Util.json) =
 let (js_loclink : FStar_Range.range -> FStar_Util.json) =
   fun r ->
     let s = js_range r in
-    let uu____2263 =
-      let uu____2266 =
-        let uu____2267 =
-          let uu____2274 =
-            let uu____2279 =
-              let uu____2280 =
-                let uu____2281 = FStar_Range.file_of_range r in
-                path_to_uri uu____2281 in
-              FStar_Util.JsonStr uu____2280 in
-            ("targetUri", uu____2279) in
-          [uu____2274; ("targetRange", s); ("targetSelectionRange", s)] in
-        FStar_Util.JsonAssoc uu____2267 in
-      [uu____2266] in
-    FStar_Util.JsonList uu____2263
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_Range.file_of_range r in
+                path_to_uri uu___6 in
+              FStar_Util.JsonStr uu___5 in
+            ("targetUri", uu___4) in
+          [uu___3; ("targetRange", s); ("targetSelectionRange", s)] in
+        FStar_Util.JsonAssoc uu___2 in
+      [uu___1] in
+    FStar_Util.JsonList uu___
 let (pos_munge : txdoc_pos -> (Prims.string * Prims.int * Prims.int)) =
   fun pos -> ((pos.path), (pos.line + Prims.int_one), (pos.col))
 let (js_diag :
@@ -873,35 +841,34 @@ let (js_diag :
             (FStar_Util.JsonList
                [FStar_Util.JsonAssoc
                   [("range", r'); ("message", (FStar_Util.JsonStr msg))]])) in
-        let uu____2347 =
-          let uu____2354 =
-            let uu____2359 =
-              let uu____2360 =
-                let uu____2367 =
-                  let uu____2372 =
-                    let uu____2373 = path_to_uri fname in
-                    FStar_Util.JsonStr uu____2373 in
-                  ("uri", uu____2372) in
-                [uu____2367; ds] in
-              FStar_Util.JsonAssoc uu____2360 in
-            ("params", uu____2359) in
-          [uu____2354] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = path_to_uri fname in
+                    FStar_Util.JsonStr uu___6 in
+                  ("uri", uu___5) in
+                [uu___4; ds] in
+              FStar_Util.JsonAssoc uu___3 in
+            ("params", uu___2) in
+          [uu___1] in
         ("method", (FStar_Util.JsonStr "textDocument/publishDiagnostics")) ::
-          uu____2347
+          uu___
 let (js_diag_clear : Prims.string -> assoct) =
   fun fname ->
-    let uu____2403 =
-      let uu____2410 =
-        let uu____2415 =
-          let uu____2416 =
-            let uu____2423 =
-              let uu____2428 =
-                let uu____2429 = path_to_uri fname in
-                FStar_Util.JsonStr uu____2429 in
-              ("uri", uu____2428) in
-            [uu____2423; ("diagnostics", (FStar_Util.JsonList []))] in
-          FStar_Util.JsonAssoc uu____2416 in
-        ("params", uu____2415) in
-      [uu____2410] in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = path_to_uri fname in FStar_Util.JsonStr uu___6 in
+              ("uri", uu___5) in
+            [uu___4; ("diagnostics", (FStar_Util.JsonList []))] in
+          FStar_Util.JsonAssoc uu___3 in
+        ("params", uu___2) in
+      [uu___1] in
     ("method", (FStar_Util.JsonStr "textDocument/publishDiagnostics")) ::
-      uu____2403
+      uu___

--- a/src/ocaml-output/FStar_Interactive_Legacy.ml
+++ b/src/ocaml-output/FStar_Interactive_Legacy.ml
@@ -7,29 +7,29 @@ let (tc_one_file :
   =
   fun remaining ->
     fun env ->
-      let uu____32 =
+      let uu___ =
         match remaining with
         | intf::impl::remaining1 when
             FStar_Universal.needs_interleaving intf impl ->
-            let uu____66 =
+            let uu___1 =
               FStar_Universal.tc_one_file_for_ide env
                 (FStar_Pervasives_Native.Some intf) impl
                 FStar_Parser_Dep.empty_parsing_data in
-            (match uu____66 with
-             | (uu____85, env1) ->
+            (match uu___1 with
+             | (uu___2, env1) ->
                  (((FStar_Pervasives_Native.Some intf), impl), env1,
                    remaining1))
         | intf_or_impl::remaining1 ->
-            let uu____101 =
+            let uu___1 =
               FStar_Universal.tc_one_file_for_ide env
                 FStar_Pervasives_Native.None intf_or_impl
                 FStar_Parser_Dep.empty_parsing_data in
-            (match uu____101 with
-             | (uu____120, env1) ->
+            (match uu___1 with
+             | (uu___2, env1) ->
                  ((FStar_Pervasives_Native.None, intf_or_impl), env1,
                    remaining1))
         | [] -> failwith "Impossible" in
-      match uu____32 with
+      match uu___ with
       | ((intf, impl), env1, remaining1) -> ((intf, impl), env1, remaining1)
 type env_t = FStar_TypeChecker_Env.env
 type modul_t = FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option
@@ -37,7 +37,7 @@ type stack_t = (env_t * modul_t) Prims.list
 let (pop : FStar_TypeChecker_Env.env -> Prims.string -> unit) =
   fun env ->
     fun msg ->
-      (let uu____207 = FStar_TypeChecker_Tc.pop_context env msg in ());
+      (let uu___1 = FStar_TypeChecker_Tc.pop_context env msg in ());
       FStar_Options.pop ()
 let (push_with_kind :
   FStar_TypeChecker_Env.env ->
@@ -48,108 +48,107 @@ let (push_with_kind :
       fun restore_cmd_line_options ->
         fun msg ->
           let env1 =
-            let uu___30_229 = env in
+            let uu___ = env in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___30_229.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___30_229.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___30_229.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___30_229.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___30_229.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___30_229.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___30_229.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___30_229.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___30_229.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___30_229.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___30_229.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___30_229.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___30_229.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___30_229.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___30_229.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___30_229.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___30_229.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___30_229.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___30_229.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___30_229.FStar_TypeChecker_Env.admit);
+                (uu___.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax = lax;
               FStar_TypeChecker_Env.lax_universes =
-                (uu___30_229.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___30_229.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___30_229.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___30_229.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___30_229.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___30_229.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___30_229.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___30_229.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___30_229.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___30_229.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___30_229.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___30_229.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___30_229.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___30_229.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___30_229.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___30_229.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___30_229.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___30_229.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___30_229.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___30_229.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___30_229.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___30_229.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___30_229.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___30_229.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___30_229.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___30_229.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
           let res = FStar_TypeChecker_Tc.push_context env1 msg in
           FStar_Options.push ();
           if restore_cmd_line_options
           then
-            (let uu____233 = FStar_Options.restore_cmd_line_options false in
-             FStar_All.pipe_right uu____233 (fun uu____234 -> ()))
+            (let uu___2 = FStar_Options.restore_cmd_line_options false in
+             FStar_All.pipe_right uu___2 (fun uu___3 -> ()))
           else ();
           res
 let (check_frag :
@@ -164,37 +163,36 @@ let (check_frag :
     fun curmod ->
       fun frag ->
         try
-          (fun uu___41_280 ->
+          (fun uu___ ->
              match () with
              | () ->
-                 let uu____291 =
-                   FStar_Universal.tc_one_fragment curmod env frag in
-                 (match uu____291 with
+                 let uu___1 = FStar_Universal.tc_one_fragment curmod env frag in
+                 (match uu___1 with
                   | (m, env1) ->
-                      let uu____314 =
-                        let uu____323 = FStar_Errors.get_err_count () in
-                        (m, env1, uu____323) in
-                      FStar_Pervasives_Native.Some uu____314)) ()
+                      let uu___2 =
+                        let uu___3 = FStar_Errors.get_err_count () in
+                        (m, env1, uu___3) in
+                      FStar_Pervasives_Native.Some uu___2)) ()
         with
         | FStar_Errors.Error (e, msg, r) when
-            let uu____353 = FStar_Options.trace_error () in
-            Prims.op_Negation uu____353 ->
+            let uu___1 = FStar_Options.trace_error () in
+            Prims.op_Negation uu___1 ->
             (FStar_TypeChecker_Err.add_errors env [(e, msg, r)];
              FStar_Pervasives_Native.None)
         | FStar_Errors.Err (e, msg) when
-            let uu____377 = FStar_Options.trace_error () in
-            Prims.op_Negation uu____377 ->
-            ((let uu____379 =
-                let uu____388 =
-                  let uu____395 = FStar_TypeChecker_Env.get_range env in
-                  (e, msg, uu____395) in
-                [uu____388] in
-              FStar_TypeChecker_Err.add_errors env uu____379);
+            let uu___1 = FStar_Options.trace_error () in
+            Prims.op_Negation uu___1 ->
+            ((let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_TypeChecker_Env.get_range env in
+                  (e, msg, uu___4) in
+                [uu___3] in
+              FStar_TypeChecker_Err.add_errors env uu___2);
              FStar_Pervasives_Native.None)
 let (report_fail : unit -> unit) =
-  fun uu____420 ->
-    (let uu____422 = FStar_Errors.report_all () in
-     FStar_All.pipe_right uu____422 (fun uu____427 -> ()));
+  fun uu___ ->
+    (let uu___2 = FStar_Errors.report_all () in
+     FStar_All.pipe_right uu___2 (fun uu___3 -> ()));
     FStar_Errors.clear ()
 type input_chunks =
   | Push of (Prims.bool * Prims.int * Prims.int) 
@@ -204,24 +202,21 @@ type input_chunks =
   Prims.int) FStar_Pervasives_Native.option) 
   | Completions of Prims.string 
 let (uu___is_Push : input_chunks -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Push _0 -> true | uu____493 -> false
+  fun projectee -> match projectee with | Push _0 -> true | uu___ -> false
 let (__proj__Push__item___0 :
   input_chunks -> (Prims.bool * Prims.int * Prims.int)) =
   fun projectee -> match projectee with | Push _0 -> _0
 let (uu___is_Pop : input_chunks -> Prims.bool) =
-  fun projectee -> match projectee with | Pop _0 -> true | uu____524 -> false
+  fun projectee -> match projectee with | Pop _0 -> true | uu___ -> false
 let (__proj__Pop__item___0 : input_chunks -> Prims.string) =
   fun projectee -> match projectee with | Pop _0 -> _0
 let (uu___is_Code : input_chunks -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Code _0 -> true | uu____545 -> false
+  fun projectee -> match projectee with | Code _0 -> true | uu___ -> false
 let (__proj__Code__item___0 :
   input_chunks -> (Prims.string * (Prims.string * Prims.string))) =
   fun projectee -> match projectee with | Code _0 -> _0
 let (uu___is_Info : input_chunks -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Info _0 -> true | uu____596 -> false
+  fun projectee -> match projectee with | Info _0 -> true | uu___ -> false
 let (__proj__Info__item___0 :
   input_chunks ->
     (Prims.string * Prims.bool * (Prims.string * Prims.int * Prims.int)
@@ -229,7 +224,7 @@ let (__proj__Info__item___0 :
   = fun projectee -> match projectee with | Info _0 -> _0
 let (uu___is_Completions : input_chunks -> Prims.bool) =
   fun projectee ->
-    match projectee with | Completions _0 -> true | uu____651 -> false
+    match projectee with | Completions _0 -> true | uu___ -> false
 let (__proj__Completions__item___0 : input_chunks -> Prims.string) =
   fun projectee -> match projectee with | Completions _0 -> _0
 type interactive_state =
@@ -259,43 +254,42 @@ let (__proj__Mkinteractive_state__item__log :
   fun projectee ->
     match projectee with | { chunk; stdin; buffer; log;_} -> log
 let (the_interactive_state : interactive_state) =
-  let uu____804 = FStar_Util.new_string_builder () in
-  let uu____805 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-  let uu____812 = FStar_Util.mk_ref [] in
-  let uu____819 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-  { chunk = uu____804; stdin = uu____805; buffer = uu____812; log = uu____819
-  }
+  let uu___ = FStar_Util.new_string_builder () in
+  let uu___1 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+  let uu___2 = FStar_Util.mk_ref [] in
+  let uu___3 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+  { chunk = uu___; stdin = uu___1; buffer = uu___2; log = uu___3 }
 let rec (read_chunk : unit -> input_chunks) =
-  fun uu____830 ->
+  fun uu___ ->
     let s = the_interactive_state in
     let log =
-      let uu____837 = FStar_Options.debug_any () in
-      if uu____837
+      let uu___1 = FStar_Options.debug_any () in
+      if uu___1
       then
         let transcript =
-          let uu____842 = FStar_ST.op_Bang s.log in
-          match uu____842 with
-          | FStar_Pervasives_Native.Some transcript -> transcript
+          let uu___2 = FStar_ST.op_Bang s.log in
+          match uu___2 with
+          | FStar_Pervasives_Native.Some transcript1 -> transcript1
           | FStar_Pervasives_Native.None ->
-              let transcript = FStar_Util.open_file_for_writing "transcript" in
+              let transcript1 = FStar_Util.open_file_for_writing "transcript" in
               (FStar_ST.op_Colon_Equals s.log
-                 (FStar_Pervasives_Native.Some transcript);
-               transcript) in
+                 (FStar_Pervasives_Native.Some transcript1);
+               transcript1) in
         fun line ->
           (FStar_Util.append_to_file transcript line;
            FStar_Util.flush_file transcript)
-      else (fun uu____871 -> ()) in
+      else (fun uu___3 -> ()) in
     let stdin =
-      let uu____873 = FStar_ST.op_Bang s.stdin in
-      match uu____873 with
+      let uu___1 = FStar_ST.op_Bang s.stdin in
+      match uu___1 with
       | FStar_Pervasives_Native.Some i -> i
       | FStar_Pervasives_Native.None ->
           let i = FStar_Util.open_stdin () in
           (FStar_ST.op_Colon_Equals s.stdin (FStar_Pervasives_Native.Some i);
            i) in
     let line =
-      let uu____900 = FStar_Util.read_line stdin in
-      match uu____900 with
+      let uu___1 = FStar_Util.read_line stdin in
+      match uu___1 with
       | FStar_Pervasives_Native.None -> FStar_All.exit Prims.int_zero
       | FStar_Pervasives_Native.Some l -> l in
     log line;
@@ -304,8 +298,8 @@ let rec (read_chunk : unit -> input_chunks) =
      then
        let responses =
          match FStar_Util.split l " " with
-         | uu____915::ok::fail::[] -> (ok, fail)
-         | uu____918 -> ("ok", "fail") in
+         | uu___2::ok::fail::[] -> (ok, fail)
+         | uu___2 -> ("ok", "fail") in
        let str = FStar_Util.string_of_string_builder s.chunk in
        (FStar_Util.clear_string_builder s.chunk; Code (str, responses))
      else
@@ -316,20 +310,20 @@ let rec (read_chunk : unit -> input_chunks) =
          then
            (FStar_Util.clear_string_builder s.chunk;
             (let lc_lax =
-               let uu____932 =
+               let uu___5 =
                  FStar_Util.substring_from l (FStar_String.length "#push") in
-               FStar_Util.trim_string uu____932 in
+               FStar_Util.trim_string uu___5 in
              let lc =
                match FStar_Util.split lc_lax " " with
                | l1::c::"#lax"::[] ->
-                   let uu____948 = FStar_Util.int_of_string l1 in
-                   let uu____949 = FStar_Util.int_of_string c in
-                   (true, uu____948, uu____949)
+                   let uu___5 = FStar_Util.int_of_string l1 in
+                   let uu___6 = FStar_Util.int_of_string c in
+                   (true, uu___5, uu___6)
                | l1::c::[] ->
-                   let uu____952 = FStar_Util.int_of_string l1 in
-                   let uu____953 = FStar_Util.int_of_string c in
-                   (false, uu____952, uu____953)
-               | uu____954 ->
+                   let uu___5 = FStar_Util.int_of_string l1 in
+                   let uu___6 = FStar_Util.int_of_string c in
+                   (false, uu___5, uu___6)
+               | uu___5 ->
                    (FStar_Errors.log_issue FStar_Range.dummyRange
                       (FStar_Errors.Warning_WrongErrorLocation,
                         (Prims.op_Hat
@@ -341,21 +335,21 @@ let rec (read_chunk : unit -> input_chunks) =
            if FStar_Util.starts_with l "#info "
            then
              (match FStar_Util.split l " " with
-              | uu____959::symbol::[] ->
+              | uu___5::symbol::[] ->
                   (FStar_Util.clear_string_builder s.chunk;
                    Info (symbol, true, FStar_Pervasives_Native.None))
-              | uu____976::symbol::file::row::col::[] ->
+              | uu___5::symbol::file::row::col::[] ->
                   (FStar_Util.clear_string_builder s.chunk;
-                   (let uu____982 =
-                      let uu____997 =
-                        let uu____1006 =
-                          let uu____1013 = FStar_Util.int_of_string row in
-                          let uu____1014 = FStar_Util.int_of_string col in
-                          (file, uu____1013, uu____1014) in
-                        FStar_Pervasives_Native.Some uu____1006 in
-                      (symbol, false, uu____997) in
-                    Info uu____982))
-              | uu____1029 ->
+                   (let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 = FStar_Util.int_of_string row in
+                          let uu___11 = FStar_Util.int_of_string col in
+                          (file, uu___10, uu___11) in
+                        FStar_Pervasives_Native.Some uu___9 in
+                      (symbol, false, uu___8) in
+                    Info uu___7))
+              | uu___5 ->
                   (FStar_Errors.log_issue FStar_Range.dummyRange
                      (FStar_Errors.Error_IDEUnrecognized,
                        (Prims.op_Hat "Unrecognized \"#info\" request: " l));
@@ -364,10 +358,10 @@ let rec (read_chunk : unit -> input_chunks) =
              if FStar_Util.starts_with l "#completions "
              then
                (match FStar_Util.split l " " with
-                | uu____1034::prefix::"#"::[] ->
+                | uu___6::prefix::"#"::[] ->
                     (FStar_Util.clear_string_builder s.chunk;
                      Completions prefix)
-                | uu____1037 ->
+                | uu___6 ->
                     (FStar_Errors.log_issue FStar_Range.dummyRange
                        (FStar_Errors.Error_IDEUnrecognized,
                          (Prims.op_Hat
@@ -381,70 +375,68 @@ let rec (read_chunk : unit -> input_chunks) =
                   FStar_Util.string_builder_append s.chunk "\n";
                   read_chunk ()))
 let (shift_chunk : unit -> input_chunks) =
-  fun uu____1049 ->
+  fun uu___ ->
     let s = the_interactive_state in
-    let uu____1051 = FStar_ST.op_Bang s.buffer in
-    match uu____1051 with
+    let uu___1 = FStar_ST.op_Bang s.buffer in
+    match uu___1 with
     | [] -> read_chunk ()
     | chunk::chunks -> (FStar_ST.op_Colon_Equals s.buffer chunks; chunk)
 let (fill_buffer : unit -> unit) =
-  fun uu____1083 ->
+  fun uu___ ->
     let s = the_interactive_state in
-    let uu____1085 =
-      let uu____1088 = FStar_ST.op_Bang s.buffer in
-      let uu____1101 = let uu____1104 = read_chunk () in [uu____1104] in
-      FStar_List.append uu____1088 uu____1101 in
-    FStar_ST.op_Colon_Equals s.buffer uu____1085
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang s.buffer in
+      let uu___3 = let uu___4 = read_chunk () in [uu___4] in
+      FStar_List.append uu___2 uu___3 in
+    FStar_ST.op_Colon_Equals s.buffer uu___1
 let (deps_of_our_file :
   Prims.string ->
     (Prims.string Prims.list * Prims.string FStar_Pervasives_Native.option *
       FStar_Parser_Dep.deps))
   =
   fun filename ->
-    let uu____1130 =
+    let uu___ =
       FStar_Dependencies.find_deps_if_needed [filename]
         FStar_CheckedFiles.load_parsing_data_from_cache in
-    match uu____1130 with
+    match uu___ with
     | (deps, dep_graph) ->
-        let uu____1153 =
+        let uu___1 =
           FStar_List.partition
             (fun x ->
-               let uu____1166 = FStar_Parser_Dep.lowercase_module_name x in
-               let uu____1167 =
-                 FStar_Parser_Dep.lowercase_module_name filename in
-               uu____1166 <> uu____1167) deps in
-        (match uu____1153 with
+               let uu___2 = FStar_Parser_Dep.lowercase_module_name x in
+               let uu___3 = FStar_Parser_Dep.lowercase_module_name filename in
+               uu___2 <> uu___3) deps in
+        (match uu___1 with
          | (deps1, same_name) ->
              let maybe_intf =
                match same_name with
                | intf::impl::[] ->
-                   ((let uu____1196 =
-                       (let uu____1199 = FStar_Parser_Dep.is_interface intf in
-                        Prims.op_Negation uu____1199) ||
-                         (let uu____1201 =
+                   ((let uu___3 =
+                       (let uu___4 = FStar_Parser_Dep.is_interface intf in
+                        Prims.op_Negation uu___4) ||
+                         (let uu___4 =
                             FStar_Parser_Dep.is_implementation impl in
-                          Prims.op_Negation uu____1201) in
-                     if uu____1196
+                          Prims.op_Negation uu___4) in
+                     if uu___3
                      then
-                       let uu____1202 =
-                         let uu____1207 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Util.format2
                              "Found %s and %s but not an interface + implementation"
                              intf impl in
                          (FStar_Errors.Warning_MissingInterfaceOrImplementation,
-                           uu____1207) in
-                       FStar_Errors.log_issue FStar_Range.dummyRange
-                         uu____1202
+                           uu___5) in
+                       FStar_Errors.log_issue FStar_Range.dummyRange uu___4
                      else ());
                     FStar_Pervasives_Native.Some intf)
                | impl::[] -> FStar_Pervasives_Native.None
-               | uu____1210 ->
-                   ((let uu____1214 =
-                       let uu____1219 =
+               | uu___2 ->
+                   ((let uu___4 =
+                       let uu___5 =
                          FStar_Util.format1 "Unexpected: ended up with %s"
                            (FStar_String.concat " " same_name) in
-                       (FStar_Errors.Warning_UnexpectedFile, uu____1219) in
-                     FStar_Errors.log_issue FStar_Range.dummyRange uu____1214);
+                       (FStar_Errors.Warning_UnexpectedFile, uu___5) in
+                     FStar_Errors.log_issue FStar_Range.dummyRange uu___4);
                     FStar_Pervasives_Native.None) in
              (deps1, maybe_intf, dep_graph))
 type m_timestamps =
@@ -466,29 +458,29 @@ let rec (tc_deps :
           fun ts ->
             match remaining with
             | [] -> (stack, env, ts)
-            | uu____1279 ->
+            | uu___ ->
                 let stack1 = (env, m) :: stack in
                 let env1 =
-                  let uu____1294 = FStar_Options.lax () in
-                  push_with_kind env uu____1294 true "typecheck_modul" in
-                let uu____1295 = tc_one_file remaining env1 in
-                (match uu____1295 with
+                  let uu___1 = FStar_Options.lax () in
+                  push_with_kind env uu___1 true "typecheck_modul" in
+                let uu___1 = tc_one_file remaining env1 in
+                (match uu___1 with
                  | ((intf, impl), env2, remaining1) ->
-                     let uu____1334 =
+                     let uu___2 =
                        let intf_t =
                          match intf with
                          | FStar_Pervasives_Native.Some intf1 ->
-                             let uu____1347 =
+                             let uu___3 =
                                FStar_Parser_ParseIt.get_file_last_modification_time
                                  intf1 in
-                             FStar_Pervasives_Native.Some uu____1347
+                             FStar_Pervasives_Native.Some uu___3
                          | FStar_Pervasives_Native.None ->
                              FStar_Pervasives_Native.None in
                        let impl_t =
                          FStar_Parser_ParseIt.get_file_last_modification_time
                            impl in
                        (intf_t, impl_t) in
-                     (match uu____1334 with
+                     (match uu___2 with
                       | (intf_t, impl_t) ->
                           tc_deps m stack1 env2 remaining1
                             ((intf, impl, intf_t, impl_t) :: ts)))
@@ -515,7 +507,7 @@ let (update_deps :
                      FStar_Util.is_before intf_t1 intf_mt
                  | (FStar_Pervasives_Native.None,
                     FStar_Pervasives_Native.None) -> false
-                 | (uu____1464, uu____1465) ->
+                 | (uu___, uu___1) ->
                      failwith
                        "Impossible, if the interface is None, the timestamp entry should also be None") in
             let rec iterate depnames st env' ts1 good_stack good_ts =
@@ -527,56 +519,55 @@ let (update_deps :
                          if dep = impl
                          then (true, depnames')
                          else (false, depnames1)
-                     | uu____1578 -> (false, depnames1))
+                     | uu___ -> (false, depnames1))
                 | FStar_Pervasives_Native.Some intf1 ->
                     (match depnames1 with
                      | depintf::dep::depnames' ->
                          if (depintf = intf1) && (dep = impl)
                          then (true, depnames')
                          else (false, depnames1)
-                     | uu____1606 -> (false, depnames1)) in
+                     | uu___ -> (false, depnames1)) in
               let rec pop_tc_and_stack env1 stack ts2 =
                 match ts2 with
                 | [] -> env1
-                | uu____1679::ts3 ->
+                | uu___::ts3 ->
                     (pop env1 "";
-                     (let uu____1720 =
-                        let uu____1735 = FStar_List.hd stack in
-                        let uu____1744 = FStar_List.tl stack in
-                        (uu____1735, uu____1744) in
-                      match uu____1720 with
-                      | ((env2, uu____1766), stack1) ->
+                     (let uu___2 =
+                        let uu___3 = FStar_List.hd stack in
+                        let uu___4 = FStar_List.tl stack in (uu___3, uu___4) in
+                      match uu___2 with
+                      | ((env2, uu___3), stack1) ->
                           pop_tc_and_stack env2 stack1 ts3)) in
               match ts1 with
               | ts_elt::ts' ->
-                  let uu____1830 = ts_elt in
-                  (match uu____1830 with
+                  let uu___ = ts_elt in
+                  (match uu___ with
                    | (intf, impl, intf_t, impl_t) ->
-                       let uu____1861 = match_dep depnames intf impl in
-                       (match uu____1861 with
+                       let uu___1 = match_dep depnames intf impl in
+                       (match uu___1 with
                         | (b, depnames') ->
-                            let uu____1880 =
+                            let uu___2 =
                               (Prims.op_Negation b) ||
                                 (is_stale intf impl intf_t impl_t) in
-                            if uu____1880
+                            if uu___2
                             then
                               let env1 =
                                 pop_tc_and_stack env'
                                   (FStar_List.rev_append st []) ts1 in
                               tc_deps m good_stack env1 depnames good_ts
                             else
-                              (let uu____1897 =
-                                 let uu____1906 = FStar_List.hd st in
-                                 let uu____1915 = FStar_List.tl st in
-                                 (uu____1906, uu____1915) in
-                               match uu____1897 with
+                              (let uu___4 =
+                                 let uu___5 = FStar_List.hd st in
+                                 let uu___6 = FStar_List.tl st in
+                                 (uu___5, uu___6) in
+                               match uu___4 with
                                | (stack_elt, st') ->
                                    iterate depnames' st' env' ts' (stack_elt
                                      :: good_stack) (ts_elt :: good_ts))))
               | [] -> tc_deps m good_stack env' depnames good_ts in
-            let uu____1968 = deps_of_our_file filename in
-            match uu____1968 with
-            | (filenames, uu____1986, dep_graph) ->
+            let uu___ = deps_of_our_file filename in
+            match uu___ with
+            | (filenames, uu___1, dep_graph) ->
                 iterate filenames (FStar_List.rev_append stk []) env
                   (FStar_List.rev_append ts []) [] []
 let (format_info :
@@ -591,16 +582,15 @@ let (format_info :
       fun typ ->
         fun range ->
           fun doc ->
-            let uu____2073 = FStar_Range.string_of_range range in
-            let uu____2074 =
-              FStar_TypeChecker_Normalize.term_to_string env typ in
-            let uu____2075 =
+            let uu___ = FStar_Range.string_of_range range in
+            let uu___1 = FStar_TypeChecker_Normalize.term_to_string env typ in
+            let uu___2 =
               match doc with
               | FStar_Pervasives_Native.Some docstring ->
                   FStar_Util.format1 "#doc %s" docstring
               | FStar_Pervasives_Native.None -> "" in
-            FStar_Util.format4 "(defined at %s) %s: %s%s" uu____2073 name
-              uu____2074 uu____2075
+            FStar_Util.format4 "(defined at %s) %s: %s%s" uu___ name uu___1
+              uu___2
 let rec (go :
   (Prims.int * Prims.int) ->
     Prims.string -> stack_t -> modul_t -> env_t -> m_timestamps -> unit)
@@ -611,8 +601,8 @@ let rec (go :
         fun curmod ->
           fun env ->
             fun ts ->
-              let uu____2115 = shift_chunk () in
-              match uu____2115 with
+              let uu___ = shift_chunk () in
+              match uu___ with
               | Info (symbol, fqn_only, pos_opt) ->
                   let info_at_pos_opt =
                     match pos_opt with
@@ -622,58 +612,56 @@ let rec (go :
                         FStar_TypeChecker_Err.info_at_pos env file row col in
                   let info_opt =
                     match info_at_pos_opt with
-                    | FStar_Pervasives_Native.Some uu____2210 ->
-                        info_at_pos_opt
+                    | FStar_Pervasives_Native.Some uu___1 -> info_at_pos_opt
                     | FStar_Pervasives_Native.None ->
                         if symbol = ""
                         then FStar_Pervasives_Native.None
                         else
                           (let lid =
-                             let uu____2265 =
+                             let uu___2 =
                                FStar_List.map FStar_Ident.id_of_text
                                  (FStar_Util.split symbol ".") in
-                             FStar_Ident.lid_of_ids uu____2265 in
+                             FStar_Ident.lid_of_ids uu___2 in
                            let lid1 =
                              if fqn_only
                              then lid
                              else
-                               (let uu____2268 =
+                               (let uu___3 =
                                   FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                                     env.FStar_TypeChecker_Env.dsenv lid in
-                                match uu____2268 with
+                                match uu___3 with
                                 | FStar_Pervasives_Native.None -> lid
-                                | FStar_Pervasives_Native.Some lid1 -> lid1) in
-                           let uu____2272 =
+                                | FStar_Pervasives_Native.Some lid2 -> lid2) in
+                           let uu___2 =
                              FStar_TypeChecker_Env.try_lookup_lid env lid1 in
-                           FStar_All.pipe_right uu____2272
+                           FStar_All.pipe_right uu___2
                              (FStar_Util.map_option
-                                (fun uu____2327 ->
-                                   match uu____2327 with
-                                   | ((uu____2346, typ), r) ->
+                                (fun uu___3 ->
+                                   match uu___3 with
+                                   | ((uu___4, typ), r) ->
                                        ((FStar_Util.Inr lid1), typ, r)))) in
                   ((match info_opt with
                     | FStar_Pervasives_Native.None ->
                         FStar_Util.print_string "\n#done-nok\n"
                     | FStar_Pervasives_Native.Some (name_or_lid, typ, rng) ->
-                        let uu____2389 =
+                        let uu___2 =
                           match name_or_lid with
                           | FStar_Util.Inl name ->
                               (name, FStar_Pervasives_Native.None)
                           | FStar_Util.Inr lid ->
-                              let uu____2406 = FStar_Ident.string_of_lid lid in
-                              (uu____2406, FStar_Pervasives_Native.None) in
-                        (match uu____2389 with
+                              let uu___3 = FStar_Ident.string_of_lid lid in
+                              (uu___3, FStar_Pervasives_Native.None) in
+                        (match uu___2 with
                          | (name, doc) ->
-                             let uu____2415 =
-                               format_info env name typ rng doc in
-                             FStar_Util.print1 "%s\n#done-ok\n" uu____2415));
+                             let uu___3 = format_info env name typ rng doc in
+                             FStar_Util.print1 "%s\n#done-ok\n" uu___3));
                    go line_col filename stack curmod env ts)
               | Completions search_term ->
                   let rec measure_anchored_match search_term1 candidate =
                     match (search_term1, candidate) with
-                    | ([], uu____2456) ->
+                    | ([], uu___1) ->
                         FStar_Pervasives_Native.Some ([], Prims.int_zero)
-                    | (uu____2471, []) -> FStar_Pervasives_Native.None
+                    | (uu___1, []) -> FStar_Pervasives_Native.None
                     | (hs::ts1, hc::tc) ->
                         let hc_text = FStar_Ident.string_of_id hc in
                         if FStar_Util.starts_with hc_text hs
@@ -682,12 +670,12 @@ let rec (go :
                            | [] ->
                                FStar_Pervasives_Native.Some
                                  (candidate, (FStar_String.length hs))
-                           | uu____2521 ->
-                               let uu____2524 = measure_anchored_match ts1 tc in
-                               FStar_All.pipe_right uu____2524
+                           | uu___1 ->
+                               let uu___2 = measure_anchored_match ts1 tc in
+                               FStar_All.pipe_right uu___2
                                  (FStar_Util.map_option
-                                    (fun uu____2564 ->
-                                       match uu____2564 with
+                                    (fun uu___3 ->
+                                       match uu___3 with
                                        | (matched, len) ->
                                            ((hc :: matched),
                                              (((FStar_String.length hc_text)
@@ -695,52 +683,51 @@ let rec (go :
                                                 + len)))))
                         else FStar_Pervasives_Native.None in
                   let rec locate_match needle candidate =
-                    let uu____2623 = measure_anchored_match needle candidate in
-                    match uu____2623 with
+                    let uu___1 = measure_anchored_match needle candidate in
+                    match uu___1 with
                     | FStar_Pervasives_Native.Some (matched, n) ->
                         FStar_Pervasives_Native.Some ([], matched, n)
                     | FStar_Pervasives_Native.None ->
                         (match candidate with
                          | [] -> FStar_Pervasives_Native.None
                          | hc::tc ->
-                             let uu____2702 = locate_match needle tc in
-                             FStar_All.pipe_right uu____2702
+                             let uu___2 = locate_match needle tc in
+                             FStar_All.pipe_right uu___2
                                (FStar_Util.map_option
-                                  (fun uu____2763 ->
-                                     match uu____2763 with
+                                  (fun uu___3 ->
+                                     match uu___3 with
                                      | (prefix, matched, len) ->
                                          ((hc :: prefix), matched, len)))) in
                   let str_of_ids ids =
-                    let uu____2809 =
-                      FStar_List.map FStar_Ident.string_of_id ids in
-                    FStar_Util.concat_l "." uu____2809 in
+                    let uu___1 = FStar_List.map FStar_Ident.string_of_id ids in
+                    FStar_Util.concat_l "." uu___1 in
                   let match_lident_against needle lident =
-                    let uu____2839 =
-                      let uu____2842 = FStar_Ident.ns_of_lid lident in
-                      let uu____2845 =
-                        let uu____2848 = FStar_Ident.ident_of_lid lident in
-                        [uu____2848] in
-                      FStar_List.append uu____2842 uu____2845 in
-                    locate_match needle uu____2839 in
-                  let shorten_namespace uu____2872 =
-                    match uu____2872 with
+                    let uu___1 =
+                      let uu___2 = FStar_Ident.ns_of_lid lident in
+                      let uu___3 =
+                        let uu___4 = FStar_Ident.ident_of_lid lident in
+                        [uu___4] in
+                      FStar_List.append uu___2 uu___3 in
+                    locate_match needle uu___1 in
+                  let shorten_namespace uu___1 =
+                    match uu___1 with
                     | (prefix, matched, match_len) ->
                         let naked_match =
                           match matched with
-                          | uu____2903::[] -> true
-                          | uu____2904 -> false in
-                        let uu____2907 =
+                          | uu___2::[] -> true
+                          | uu___2 -> false in
+                        let uu___2 =
                           FStar_Syntax_DsEnv.shorten_module_path
                             env.FStar_TypeChecker_Env.dsenv prefix
                             naked_match in
-                        (match uu____2907 with
+                        (match uu___2 with
                          | (stripped_ns, shortened) ->
-                             let uu____2934 = str_of_ids shortened in
-                             let uu____2935 = str_of_ids matched in
-                             let uu____2936 = str_of_ids stripped_ns in
-                             (uu____2934, uu____2935, uu____2936, match_len)) in
-                  let prepare_candidate uu____2956 =
-                    match uu____2956 with
+                             let uu___3 = str_of_ids shortened in
+                             let uu___4 = str_of_ids matched in
+                             let uu___5 = str_of_ids stripped_ns in
+                             (uu___3, uu___4, uu___5, match_len)) in
+                  let prepare_candidate uu___1 =
+                    match uu___1 with
                     | (prefix, matched, stripped_ns, match_len) ->
                         if prefix = ""
                         then (matched, stripped_ns, match_len)
@@ -769,64 +756,59 @@ let rec (go :
                               if FStar_Util.starts_with n id
                               then
                                 let lid =
-                                  let uu____3090 = FStar_Ident.ids_of_lid m in
-                                  let uu____3091 = FStar_Ident.id_of_text n in
-                                  FStar_Ident.lid_of_ns_and_id uu____3090
-                                    uu____3091 in
-                                let uu____3092 =
+                                  let uu___1 = FStar_Ident.ids_of_lid m in
+                                  let uu___2 = FStar_Ident.id_of_text n in
+                                  FStar_Ident.lid_of_ns_and_id uu___1 uu___2 in
+                                let uu___1 =
                                   FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                                     env.FStar_TypeChecker_Env.dsenv lid in
                                 FStar_Option.map
                                   (fun fqn ->
-                                     let uu____3108 =
-                                       let uu____3111 =
+                                     let uu___2 =
+                                       let uu___3 =
                                          FStar_List.map
                                            FStar_Ident.id_of_text orig_ns in
-                                       let uu____3114 =
-                                         let uu____3117 =
+                                       let uu___4 =
+                                         let uu___5 =
                                            FStar_Ident.ident_of_lid fqn in
-                                         [uu____3117] in
-                                       FStar_List.append uu____3111
-                                         uu____3114 in
-                                     ([], uu____3108, matched_length))
-                                  uu____3092
+                                         [uu___5] in
+                                       FStar_List.append uu___3 uu___4 in
+                                     ([], uu___2, matched_length)) uu___1
                               else FStar_Pervasives_Native.None)) in
-                    let case_b_find_matches_in_env uu____3150 =
-                      let matches =
+                    let case_b_find_matches_in_env uu___1 =
+                      let matches1 =
                         FStar_List.filter_map (match_lident_against needle)
                           all_lidents_in_env in
-                      FStar_All.pipe_right matches
+                      FStar_All.pipe_right matches1
                         (FStar_List.filter
-                           (fun uu____3225 ->
-                              match uu____3225 with
-                              | (ns, id, uu____3238) ->
-                                  let uu____3247 =
-                                    let uu____3250 =
-                                      FStar_Ident.lid_of_ids id in
+                           (fun uu___2 ->
+                              match uu___2 with
+                              | (ns, id, uu___3) ->
+                                  let uu___4 =
+                                    let uu___5 = FStar_Ident.lid_of_ids id in
                                     FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
-                                      env.FStar_TypeChecker_Env.dsenv
-                                      uu____3250 in
-                                  (match uu____3247 with
+                                      env.FStar_TypeChecker_Env.dsenv uu___5 in
+                                  (match uu___4 with
                                    | FStar_Pervasives_Native.None -> false
                                    | FStar_Pervasives_Native.Some l ->
-                                       let uu____3252 =
+                                       let uu___5 =
                                          FStar_Ident.lid_of_ids
                                            (FStar_List.append ns id) in
-                                       FStar_Ident.lid_equals l uu____3252))) in
-                    let uu____3253 = FStar_Util.prefix needle in
-                    match uu____3253 with
+                                       FStar_Ident.lid_equals l uu___5))) in
+                    let uu___1 = FStar_Util.prefix needle in
+                    match uu___1 with
                     | (ns, id) ->
                         let matched_ids =
                           match ns with
                           | [] -> case_b_find_matches_in_env ()
-                          | uu____3299 ->
+                          | uu___2 ->
                               let l =
                                 FStar_Ident.lid_of_path ns
                                   FStar_Range.dummyRange in
-                              let uu____3303 =
+                              let uu___3 =
                                 FStar_Syntax_DsEnv.resolve_module_name
                                   env.FStar_TypeChecker_Env.dsenv l true in
-                              (match uu____3303 with
+                              (match uu___3 with
                                | FStar_Pervasives_Native.None ->
                                    case_b_find_matches_in_env ()
                                | FStar_Pervasives_Native.Some m ->
@@ -834,33 +816,30 @@ let rec (go :
                         FStar_All.pipe_right matched_ids
                           (FStar_List.map
                              (fun x ->
-                                let uu____3368 = shorten_namespace x in
-                                prepare_candidate uu____3368)) in
-                  ((let uu____3378 =
+                                let uu___2 = shorten_namespace x in
+                                prepare_candidate uu___2)) in
+                  ((let uu___2 =
                       FStar_Util.sort_with
-                        (fun uu____3401 ->
-                           fun uu____3402 ->
-                             match (uu____3401, uu____3402) with
-                             | ((cd1, ns1, uu____3429),
-                                (cd2, ns2, uu____3432)) ->
+                        (fun uu___3 ->
+                           fun uu___4 ->
+                             match (uu___3, uu___4) with
+                             | ((cd1, ns1, uu___5), (cd2, ns2, uu___6)) ->
                                  (match FStar_String.compare cd1 cd2 with
-                                  | uu____3445 when
-                                      uu____3445 = Prims.int_zero ->
+                                  | uu___7 when uu___7 = Prims.int_zero ->
                                       FStar_String.compare ns1 ns2
                                   | n -> n)) matches in
                     FStar_List.iter
-                      (fun uu____3458 ->
-                         match uu____3458 with
+                      (fun uu___3 ->
+                         match uu___3 with
                          | (candidate, ns, match_len) ->
-                             let uu____3468 =
-                               FStar_Util.string_of_int match_len in
-                             FStar_Util.print3 "%s %s %s \n" uu____3468 ns
-                               candidate) uu____3378);
+                             let uu___4 = FStar_Util.string_of_int match_len in
+                             FStar_Util.print3 "%s %s %s \n" uu___4 ns
+                               candidate) uu___2);
                    FStar_Util.print_string "#done-ok\n";
                    go line_col filename stack curmod env ts)
               | Pop msg ->
                   (pop env msg;
-                   (let uu____3472 =
+                   (let uu___2 =
                       match stack with
                       | [] ->
                           (FStar_Errors.log_issue FStar_Range.dummyRange
@@ -868,18 +847,17 @@ let rec (go :
                                "too many pops");
                            FStar_All.exit Prims.int_one)
                       | hd::tl -> (hd, tl) in
-                    match uu____3472 with
+                    match uu___2 with
                     | ((env1, curmod1), stack1) ->
                         go line_col filename stack1 curmod1 env1 ts))
               | Push (lax, l, c) ->
-                  let uu____3532 =
+                  let uu___1 =
                     if (FStar_List.length stack) = (FStar_List.length ts)
                     then
-                      let uu____3569 =
-                        update_deps filename curmod stack env ts in
-                      (true, uu____3569)
+                      let uu___2 = update_deps filename curmod stack env ts in
+                      (true, uu___2)
                     else (false, (stack, env, ts)) in
-                  (match uu____3532 with
+                  (match uu___1 with
                    | (restore_cmd_line_options, (stack1, env1, ts1)) ->
                        let stack2 = (env1, curmod) :: stack1 in
                        let env2 =
@@ -908,48 +886,45 @@ let rec (go :
                          (FStar_Util.print1 "\n%s\n" ok;
                           go line_col filename stack curmod1 env1 ts)
                        else fail1 curmod1 env1
-                   | uu____3660 -> fail1 curmod env)
+                   | uu___1 -> fail1 curmod env)
 let (interactive_mode : Prims.string -> unit) =
   fun filename ->
-    (let uu____3677 =
-       let uu____3678 = FStar_Options.codegen () in
-       FStar_Option.isSome uu____3678 in
-     if uu____3677
+    (let uu___1 =
+       let uu___2 = FStar_Options.codegen () in FStar_Option.isSome uu___2 in
+     if uu___1
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen,
            "code-generation is not supported in interactive mode, ignoring the codegen flag")
      else ());
-    (let uu____3682 = deps_of_our_file filename in
-     match uu____3682 with
+    (let uu___1 = deps_of_our_file filename in
+     match uu___1 with
      | (filenames, maybe_intf, dep_graph) ->
          let env = FStar_Universal.init_env dep_graph in
-         let uu____3705 =
+         let uu___2 =
            tc_deps FStar_Pervasives_Native.None [] env filenames [] in
-         (match uu____3705 with
+         (match uu___2 with
           | (stack, env1, ts) ->
               let initial_range =
-                let uu____3732 =
-                  FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-                let uu____3733 =
-                  FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-                FStar_Range.mk_range filename uu____3732 uu____3733 in
+                let uu___3 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+                let uu___4 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+                FStar_Range.mk_range filename uu___3 uu___4 in
               let env2 = FStar_TypeChecker_Env.set_range env1 initial_range in
               let env3 =
                 match maybe_intf with
                 | FStar_Pervasives_Native.Some intf ->
                     FStar_Universal.load_interface_decls env2 intf
                 | FStar_Pervasives_Native.None -> env2 in
-              let uu____3737 =
+              let uu___3 =
                 (FStar_Options.record_hints ()) ||
                   (FStar_Options.use_hints ()) in
-              if uu____3737
+              if uu___3
               then
-                let uu____3738 =
-                  let uu____3739 = FStar_Options.file_list () in
-                  FStar_List.hd uu____3739 in
-                FStar_SMTEncoding_Solver.with_hints_db uu____3738
-                  (fun uu____3743 ->
+                let uu___4 =
+                  let uu___5 = FStar_Options.file_list () in
+                  FStar_List.hd uu___5 in
+                FStar_SMTEncoding_Solver.with_hints_db uu___4
+                  (fun uu___5 ->
                      go (Prims.int_one, Prims.int_zero) filename stack
                        FStar_Pervasives_Native.None env3 ts)
               else

--- a/src/ocaml-output/FStar_Interactive_Lsp.ml
+++ b/src/ocaml-output/FStar_Interactive_Lsp.ml
@@ -5,141 +5,135 @@ let (unpack_lsp_query :
   =
   fun r ->
     let qid =
-      let uu____20 = FStar_Interactive_JsonHelper.try_assoc "id" r in
-      FStar_All.pipe_right uu____20
+      let uu___ = FStar_Interactive_JsonHelper.try_assoc "id" r in
+      FStar_All.pipe_right uu___
         (FStar_Util.map_option FStar_Interactive_JsonHelper.js_str_int) in
     try
-      (fun uu___3_30 ->
+      (fun uu___ ->
          match () with
          | () ->
              let method1 =
-               let uu____32 = FStar_Interactive_JsonHelper.assoc "method" r in
-               FStar_All.pipe_right uu____32
+               let uu___1 = FStar_Interactive_JsonHelper.assoc "method" r in
+               FStar_All.pipe_right uu___1
                  FStar_Interactive_JsonHelper.js_str in
-             let uu____33 =
+             let uu___1 =
                match method1 with
                | "initialize" ->
-                   let uu____34 =
-                     let uu____39 =
-                       let uu____40 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_Interactive_JsonHelper.arg "processId" r in
-                       FStar_All.pipe_right uu____40
+                       FStar_All.pipe_right uu___4
                          FStar_Interactive_JsonHelper.js_int in
-                     let uu____41 =
-                       let uu____42 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Interactive_JsonHelper.arg "rootUri" r in
-                       FStar_All.pipe_right uu____42
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_str in
-                     (uu____39, uu____41) in
-                   FStar_Interactive_JsonHelper.Initialize uu____34
+                     (uu___3, uu___4) in
+                   FStar_Interactive_JsonHelper.Initialize uu___2
                | "initialized" -> FStar_Interactive_JsonHelper.Initialized
                | "shutdown" -> FStar_Interactive_JsonHelper.Shutdown
                | "exit" -> FStar_Interactive_JsonHelper.Exit
                | "$/cancelRequest" ->
-                   let uu____43 =
-                     let uu____44 = FStar_Interactive_JsonHelper.arg "id" r in
-                     FStar_All.pipe_right uu____44
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.arg "id" r in
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_str_int in
-                   FStar_Interactive_JsonHelper.Cancel uu____43
+                   FStar_Interactive_JsonHelper.Cancel uu___2
                | "workspace/didChangeWorkspaceFolders" ->
-                   let uu____45 =
-                     let uu____46 =
-                       FStar_Interactive_JsonHelper.arg "event" r in
-                     FStar_All.pipe_right uu____46
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.arg "event" r in
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_wsch_event in
-                   FStar_Interactive_JsonHelper.FolderChange uu____45
+                   FStar_Interactive_JsonHelper.FolderChange uu___2
                | "workspace/didChangeConfiguration" ->
                    FStar_Interactive_JsonHelper.ChangeConfig
                | "workspace/didChangeWatchedFiles" ->
                    FStar_Interactive_JsonHelper.ChangeWatch
                | "workspace/symbol" ->
-                   let uu____47 =
-                     let uu____48 =
-                       FStar_Interactive_JsonHelper.arg "query" r in
-                     FStar_All.pipe_right uu____48
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.arg "query" r in
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_str in
-                   FStar_Interactive_JsonHelper.Symbol uu____47
+                   FStar_Interactive_JsonHelper.Symbol uu___2
                | "workspace/executeCommand" ->
-                   let uu____49 =
-                     let uu____50 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Interactive_JsonHelper.arg "command" r in
-                     FStar_All.pipe_right uu____50
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_str in
-                   FStar_Interactive_JsonHelper.ExecCommand uu____49
+                   FStar_Interactive_JsonHelper.ExecCommand uu___2
                | "textDocument/didOpen" ->
-                   let uu____51 =
-                     let uu____52 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Interactive_JsonHelper.arg "textDocument" r in
-                     FStar_All.pipe_right uu____52
+                     FStar_All.pipe_right uu___3
                        FStar_Interactive_JsonHelper.js_txdoc_item in
-                   FStar_Interactive_JsonHelper.DidOpen uu____51
+                   FStar_Interactive_JsonHelper.DidOpen uu___2
                | "textDocument/didChange" ->
-                   let uu____53 =
-                     let uu____58 =
-                       FStar_Interactive_JsonHelper.js_txdoc_id r in
-                     let uu____59 =
-                       let uu____60 =
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.js_txdoc_id r in
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Interactive_JsonHelper.arg "contentChanges" r in
-                       FStar_All.pipe_right uu____60
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_contentch in
-                     (uu____58, uu____59) in
-                   FStar_Interactive_JsonHelper.DidChange uu____53
+                     (uu___3, uu___4) in
+                   FStar_Interactive_JsonHelper.DidChange uu___2
                | "textDocument/willSave" ->
-                   let uu____61 = FStar_Interactive_JsonHelper.js_txdoc_id r in
-                   FStar_Interactive_JsonHelper.WillSave uu____61
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_id r in
+                   FStar_Interactive_JsonHelper.WillSave uu___2
                | "textDocument/willSaveWaitUntil" ->
-                   let uu____62 = FStar_Interactive_JsonHelper.js_txdoc_id r in
-                   FStar_Interactive_JsonHelper.WillSaveWait uu____62
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_id r in
+                   FStar_Interactive_JsonHelper.WillSaveWait uu___2
                | "textDocument/didSave" ->
-                   let uu____63 =
-                     let uu____68 =
-                       FStar_Interactive_JsonHelper.js_txdoc_id r in
-                     let uu____69 =
-                       let uu____70 =
-                         FStar_Interactive_JsonHelper.arg "text" r in
-                       FStar_All.pipe_right uu____70
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.js_txdoc_id r in
+                     let uu___4 =
+                       let uu___5 = FStar_Interactive_JsonHelper.arg "text" r in
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_str in
-                     (uu____68, uu____69) in
-                   FStar_Interactive_JsonHelper.DidSave uu____63
+                     (uu___3, uu___4) in
+                   FStar_Interactive_JsonHelper.DidSave uu___2
                | "textDocument/didClose" ->
-                   let uu____71 = FStar_Interactive_JsonHelper.js_txdoc_id r in
-                   FStar_Interactive_JsonHelper.DidClose uu____71
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_id r in
+                   FStar_Interactive_JsonHelper.DidClose uu___2
                | "textDocument/completion" ->
-                   let uu____72 =
-                     let uu____77 =
-                       FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                     let uu____78 =
-                       let uu____79 =
+                   let uu___2 =
+                     let uu___3 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Interactive_JsonHelper.arg "context" r in
-                       FStar_All.pipe_right uu____79
+                       FStar_All.pipe_right uu___5
                          FStar_Interactive_JsonHelper.js_compl_context in
-                     (uu____77, uu____78) in
-                   FStar_Interactive_JsonHelper.Completion uu____72
+                     (uu___3, uu___4) in
+                   FStar_Interactive_JsonHelper.Completion uu___2
                | "completionItem/resolve" ->
                    FStar_Interactive_JsonHelper.Resolve
                | "textDocument/hover" ->
-                   let uu____80 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.Hover uu____80
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.Hover uu___2
                | "textDocument/signatureHelp" ->
-                   let uu____81 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.SignatureHelp uu____81
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.SignatureHelp uu___2
                | "textDocument/declaration" ->
-                   let uu____82 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.Declaration uu____82
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.Declaration uu___2
                | "textDocument/definition" ->
-                   let uu____83 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.Definition uu____83
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.Definition uu___2
                | "textDocument/typeDefinition" ->
-                   let uu____84 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.TypeDefinition uu____84
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.TypeDefinition uu___2
                | "textDocument/implementation" ->
-                   let uu____85 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.Implementation uu____85
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.Implementation uu___2
                | "textDocument/references" ->
                    FStar_Interactive_JsonHelper.References
                | "textDocument/documentHighlight" ->
-                   let uu____86 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.DocumentHighlight uu____86
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.DocumentHighlight uu___2
                | "textDocument/documentSymbol" ->
                    FStar_Interactive_JsonHelper.DocumentSymbol
                | "textDocument/codeAction" ->
@@ -164,16 +158,16 @@ let (unpack_lsp_query :
                    FStar_Interactive_JsonHelper.TypeFormatting
                | "textDocument/rename" -> FStar_Interactive_JsonHelper.Rename
                | "textDocument/prepareRename" ->
-                   let uu____87 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
-                   FStar_Interactive_JsonHelper.PrepareRename uu____87
+                   let uu___2 = FStar_Interactive_JsonHelper.js_txdoc_pos r in
+                   FStar_Interactive_JsonHelper.PrepareRename uu___2
                | "textDocument/foldingRange" ->
                    FStar_Interactive_JsonHelper.FoldingRange
                | m ->
-                   let uu____89 = FStar_Util.format1 "Unknown method '%s'" m in
-                   FStar_Interactive_JsonHelper.BadProtocolMsg uu____89 in
+                   let uu___2 = FStar_Util.format1 "Unknown method '%s'" m in
+                   FStar_Interactive_JsonHelper.BadProtocolMsg uu___2 in
              {
                FStar_Interactive_JsonHelper.query_id = qid;
-               FStar_Interactive_JsonHelper.q = uu____33
+               FStar_Interactive_JsonHelper.q = uu___1
              }) ()
     with
     | FStar_Interactive_JsonHelper.MissingKey msg ->
@@ -188,13 +182,13 @@ let (deserialize_lsp_query :
   FStar_Util.json -> FStar_Interactive_JsonHelper.lsp_query) =
   fun js_query ->
     try
-      (fun uu___57_103 ->
+      (fun uu___ ->
          match () with
          | () ->
-             let uu____104 =
+             let uu___1 =
                FStar_All.pipe_right js_query
                  FStar_Interactive_JsonHelper.js_assoc in
-             unpack_lsp_query uu____104) ()
+             unpack_lsp_query uu___1) ()
     with
     | FStar_Interactive_JsonHelper.UnexpectedJsonType (expected, got) ->
         FStar_Interactive_JsonHelper.wrap_jsfail FStar_Pervasives_Native.None
@@ -202,8 +196,8 @@ let (deserialize_lsp_query :
 let (parse_lsp_query :
   Prims.string -> FStar_Interactive_JsonHelper.lsp_query) =
   fun query_str ->
-    let uu____129 = FStar_Util.json_of_string query_str in
-    match uu____129 with
+    let uu___1 = FStar_Util.json_of_string query_str in
+    match uu___1 with
     | FStar_Pervasives_Native.None ->
         {
           FStar_Interactive_JsonHelper.query_id =
@@ -217,12 +211,12 @@ let (repl_state_init :
   Prims.string -> FStar_Interactive_JsonHelper.repl_state) =
   fun fname ->
     let intial_range =
-      let uu____139 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-      let uu____140 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
-      FStar_Range.mk_range fname uu____139 uu____140 in
+      let uu___ = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+      let uu___1 = FStar_Range.mk_pos Prims.int_one Prims.int_zero in
+      FStar_Range.mk_range fname uu___ uu___1 in
     let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps in
     let env1 = FStar_TypeChecker_Env.set_range env intial_range in
-    let uu____143 = FStar_Util.open_stdin () in
+    let uu___ = FStar_Util.open_stdin () in
     {
       FStar_Interactive_JsonHelper.repl_line = Prims.int_one;
       FStar_Interactive_JsonHelper.repl_column = Prims.int_zero;
@@ -230,7 +224,7 @@ let (repl_state_init :
       FStar_Interactive_JsonHelper.repl_deps_stack = [];
       FStar_Interactive_JsonHelper.repl_curmod = FStar_Pervasives_Native.None;
       FStar_Interactive_JsonHelper.repl_env = env1;
-      FStar_Interactive_JsonHelper.repl_stdin = uu____143;
+      FStar_Interactive_JsonHelper.repl_stdin = uu___;
       FStar_Interactive_JsonHelper.repl_names =
         FStar_Interactive_CompletionTable.empty
     }
@@ -247,12 +241,12 @@ let (invoke_full_lax :
     fun fname ->
       fun text ->
         fun force ->
-          let aux uu____201 =
+          let aux uu___ =
             FStar_Parser_ParseIt.add_vfs_entry fname text;
-            (let uu____203 =
-               let uu____210 = repl_state_init fname in
-               FStar_Interactive_PushHelper.full_lax text uu____210 in
-             match uu____203 with
+            (let uu___2 =
+               let uu___3 = repl_state_init fname in
+               FStar_Interactive_PushHelper.full_lax text uu___3 in
+             match uu___2 with
              | (diag, st') ->
                  let repls =
                    FStar_Util.psmap_add
@@ -261,22 +255,22 @@ let (invoke_full_lax :
                    if FStar_Util.is_some diag
                    then diag
                    else
-                     (let uu____236 =
+                     (let uu___4 =
                         FStar_Interactive_JsonHelper.js_diag_clear fname in
-                      FStar_Pervasives_Native.Some uu____236) in
+                      FStar_Pervasives_Native.Some uu___4) in
                  (diag1,
                    (FStar_Util.Inl
-                      (let uu___88_244 = gst in
+                      (let uu___3 = gst in
                        {
                          FStar_Interactive_JsonHelper.grepl_repls = repls;
                          FStar_Interactive_JsonHelper.grepl_stdin =
-                           (uu___88_244.FStar_Interactive_JsonHelper.grepl_stdin)
+                           (uu___3.FStar_Interactive_JsonHelper.grepl_stdin)
                        })))) in
-          let uu____245 =
+          let uu___ =
             FStar_Util.psmap_try_find
               gst.FStar_Interactive_JsonHelper.grepl_repls fname in
-          match uu____245 with
-          | FStar_Pervasives_Native.Some uu____252 ->
+          match uu___ with
+          | FStar_Pervasives_Native.Some uu___1 ->
               if force
               then aux ()
               else (FStar_Pervasives_Native.None, (FStar_Util.Inl gst))
@@ -288,11 +282,11 @@ let (run_query :
   fun gst ->
     fun q ->
       match q with
-      | FStar_Interactive_JsonHelper.Initialize (uu____276, uu____277) ->
-          let uu____278 =
+      | FStar_Interactive_JsonHelper.Initialize (uu___, uu___1) ->
+          let uu___2 =
             FStar_Interactive_JsonHelper.resultResponse
               FStar_Interactive_JsonHelper.js_servcap in
-          (uu____278, (FStar_Util.Inl gst))
+          (uu___2, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.Initialized ->
           (FStar_Pervasives_Native.None, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.Shutdown ->
@@ -313,8 +307,8 @@ let (run_query :
           (FStar_Interactive_JsonHelper.nullResponse, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.DidOpen
           { FStar_Interactive_JsonHelper.fname = f;
-            FStar_Interactive_JsonHelper.langId = uu____284;
-            FStar_Interactive_JsonHelper.version = uu____285;
+            FStar_Interactive_JsonHelper.langId = uu___;
+            FStar_Interactive_JsonHelper.version = uu___1;
             FStar_Interactive_JsonHelper.text = t;_}
           -> invoke_full_lax gst f t false
       | FStar_Interactive_JsonHelper.DidChange (txid, content) ->
@@ -329,31 +323,30 @@ let (run_query :
       | FStar_Interactive_JsonHelper.DidClose txid ->
           (FStar_Pervasives_Native.None, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.Completion (txpos, ctx) ->
-          let uu____297 =
+          let uu___ =
             FStar_Util.psmap_try_find
               gst.FStar_Interactive_JsonHelper.grepl_repls
               txpos.FStar_Interactive_JsonHelper.path in
-          (match uu____297 with
+          (match uu___ with
            | FStar_Pervasives_Native.Some st ->
-               let uu____305 =
-                 FStar_Interactive_QueryHelper.complookup st txpos in
-               (uu____305, (FStar_Util.Inl gst))
+               let uu___1 = FStar_Interactive_QueryHelper.complookup st txpos in
+               (uu___1, (FStar_Util.Inl gst))
            | FStar_Pervasives_Native.None ->
                (FStar_Interactive_JsonHelper.nullResponse,
                  (FStar_Util.Inl gst)))
       | FStar_Interactive_JsonHelper.Resolve ->
           (FStar_Interactive_JsonHelper.nullResponse, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.Hover txpos ->
-          let uu____307 =
+          let uu___ =
             FStar_Util.psmap_try_find
               gst.FStar_Interactive_JsonHelper.grepl_repls
               txpos.FStar_Interactive_JsonHelper.path in
-          (match uu____307 with
+          (match uu___ with
            | FStar_Pervasives_Native.Some st ->
-               let uu____315 =
+               let uu___1 =
                  FStar_Interactive_QueryHelper.hoverlookup
                    st.FStar_Interactive_JsonHelper.repl_env txpos in
-               (uu____315, (FStar_Util.Inl gst))
+               (uu___1, (FStar_Util.Inl gst))
            | FStar_Pervasives_Native.None ->
                (FStar_Interactive_JsonHelper.nullResponse,
                  (FStar_Util.Inl gst)))
@@ -362,16 +355,16 @@ let (run_query :
       | FStar_Interactive_JsonHelper.Declaration txpos ->
           (FStar_Interactive_JsonHelper.nullResponse, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.Definition txpos ->
-          let uu____319 =
+          let uu___ =
             FStar_Util.psmap_try_find
               gst.FStar_Interactive_JsonHelper.grepl_repls
               txpos.FStar_Interactive_JsonHelper.path in
-          (match uu____319 with
+          (match uu___ with
            | FStar_Pervasives_Native.Some st ->
-               let uu____327 =
+               let uu___1 =
                  FStar_Interactive_QueryHelper.deflookup
                    st.FStar_Interactive_JsonHelper.repl_env txpos in
-               (uu____327, (FStar_Util.Inl gst))
+               (uu___1, (FStar_Util.Inl gst))
            | FStar_Pervasives_Native.None ->
                (FStar_Interactive_JsonHelper.nullResponse,
                  (FStar_Util.Inl gst)))
@@ -412,25 +405,25 @@ let (run_query :
       | FStar_Interactive_JsonHelper.FoldingRange ->
           (FStar_Interactive_JsonHelper.nullResponse, (FStar_Util.Inl gst))
       | FStar_Interactive_JsonHelper.BadProtocolMsg msg ->
-          let uu____333 =
-            let uu____334 =
+          let uu___ =
+            let uu___1 =
               FStar_Interactive_JsonHelper.js_resperr
                 FStar_Interactive_JsonHelper.MethodNotFound msg in
-            FStar_Interactive_JsonHelper.errorResponse uu____334 in
-          (uu____333, (FStar_Util.Inl gst))
+            FStar_Interactive_JsonHelper.errorResponse uu___1 in
+          (uu___, (FStar_Util.Inl gst))
 let rec (parse_header_len :
   FStar_Util.stream_reader -> Prims.int -> Prims.int) =
   fun stream ->
     fun len ->
-      let uu____345 = FStar_Util.read_line stream in
-      match uu____345 with
+      let uu___ = FStar_Util.read_line stream in
+      match uu___ with
       | FStar_Pervasives_Native.Some s ->
           if FStar_Util.starts_with s "Content-Length: "
           then
-            let uu____349 =
-              let uu____350 = FStar_Util.substring_from s (Prims.of_int (16)) in
-              FStar_Util.int_of_string uu____350 in
-            parse_header_len stream uu____349
+            let uu___1 =
+              let uu___2 = FStar_Util.substring_from s (Prims.of_int (16)) in
+              FStar_Util.int_of_string uu___2 in
+            parse_header_len stream uu___1
           else
             if FStar_Util.starts_with s "Content-Type: "
             then parse_header_len stream len
@@ -445,19 +438,18 @@ let rec (read_lsp_query :
   FStar_Util.stream_reader -> FStar_Interactive_JsonHelper.lsp_query) =
   fun stream ->
     try
-      (fun uu___190_363 ->
+      (fun uu___ ->
          match () with
          | () ->
              let n = parse_header_len stream Prims.int_zero in
-             let uu____365 = FStar_Util.nread stream n in
-             (match uu____365 with
+             let uu___1 = FStar_Util.nread stream n in
+             (match uu___1 with
               | FStar_Pervasives_Native.Some s -> parse_lsp_query s
               | FStar_Pervasives_Native.None ->
-                  let uu____369 =
-                    let uu____370 = FStar_Util.string_of_int n in
-                    FStar_Util.format1 "Could not read %s bytes" uu____370 in
-                  FStar_Interactive_JsonHelper.wrap_content_szerr uu____369))
-        ()
+                  let uu___2 =
+                    let uu___3 = FStar_Util.string_of_int n in
+                    FStar_Util.format1 "Could not read %s bytes" uu___3 in
+                  FStar_Interactive_JsonHelper.wrap_content_szerr uu___2)) ()
     with
     | FStar_Interactive_JsonHelper.MalformedHeader ->
         (FStar_Util.print_error "[E] Malformed Content Header\n";
@@ -466,8 +458,8 @@ let rec (read_lsp_query :
 let rec (go : FStar_Interactive_JsonHelper.grepl_state -> Prims.int) =
   fun gst ->
     let query = read_lsp_query gst.FStar_Interactive_JsonHelper.grepl_stdin in
-    let uu____381 = run_query gst query.FStar_Interactive_JsonHelper.q in
-    match uu____381 with
+    let uu___ = run_query gst query.FStar_Interactive_JsonHelper.q in
+    match uu___ with
     | (r, state_opt) ->
         ((match r with
           | FStar_Pervasives_Native.Some response ->
@@ -476,8 +468,8 @@ let rec (go : FStar_Interactive_JsonHelper.grepl_state -> Prims.int) =
                   query.FStar_Interactive_JsonHelper.query_id response in
               (if false
                then
-                 (let uu____392 = FStar_Util.string_of_json response' in
-                  FStar_Util.print1_error "<<< %s\n" uu____392)
+                 (let uu___3 = FStar_Util.string_of_json response' in
+                  FStar_Util.print1_error "<<< %s\n" uu___3)
                else ();
                FStar_Interactive_JsonHelper.write_jsonrpc response')
           | FStar_Pervasives_Native.None -> ());
@@ -485,14 +477,14 @@ let rec (go : FStar_Interactive_JsonHelper.grepl_state -> Prims.int) =
           | FStar_Util.Inl gst' -> go gst'
           | FStar_Util.Inr exitcode -> exitcode))
 let (start_server : unit -> unit) =
-  fun uu____400 ->
-    let uu____401 =
-      let uu____402 =
-        let uu____403 = FStar_Util.psmap_empty () in
-        let uu____406 = FStar_Util.open_stdin () in
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 =
+        let uu___3 = FStar_Util.psmap_empty () in
+        let uu___4 = FStar_Util.open_stdin () in
         {
-          FStar_Interactive_JsonHelper.grepl_repls = uu____403;
-          FStar_Interactive_JsonHelper.grepl_stdin = uu____406
+          FStar_Interactive_JsonHelper.grepl_repls = uu___3;
+          FStar_Interactive_JsonHelper.grepl_stdin = uu___4
         } in
-      go uu____402 in
-    FStar_All.exit uu____401
+      go uu___2 in
+    FStar_All.exit uu___1

--- a/src/ocaml-output/FStar_Interactive_PushHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_PushHelper.ml
@@ -5,13 +5,11 @@ type push_kind =
   | FullCheck 
 let (uu___is_SyntaxCheck : push_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | SyntaxCheck -> true | uu____5 -> false
+    match projectee with | SyntaxCheck -> true | uu___ -> false
 let (uu___is_LaxCheck : push_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LaxCheck -> true | uu____11 -> false
+  fun projectee -> match projectee with | LaxCheck -> true | uu___ -> false
 let (uu___is_FullCheck : push_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FullCheck -> true | uu____17 -> false
+  fun projectee -> match projectee with | FullCheck -> true | uu___ -> false
 type ctx_depth_t =
   (Prims.int * Prims.int * FStar_TypeChecker_Env.solver_depth_t * Prims.int)
 type deps_t = FStar_Parser_Dep.deps
@@ -24,99 +22,87 @@ let (set_check_kind :
   FStar_TypeChecker_Env.env_t -> push_kind -> FStar_TypeChecker_Env.env_t) =
   fun env ->
     fun check_kind ->
-      let uu___4_52 = env in
-      let uu____53 =
+      let uu___ = env in
+      let uu___1 =
         FStar_Syntax_DsEnv.set_syntax_only env.FStar_TypeChecker_Env.dsenv
           (check_kind = SyntaxCheck) in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___4_52.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range = (uu___4_52.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___4_52.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma = (uu___4_52.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___4_52.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___4_52.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___4_52.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___4_52.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___4_52.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___4_52.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___4_52.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___4_52.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___4_52.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___4_52.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___4_52.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___4_52.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___4_52.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___4_52.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___4_52.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit = (uu___4_52.FStar_TypeChecker_Env.admit);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
         FStar_TypeChecker_Env.lax = (check_kind = LaxCheck);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___4_52.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___4_52.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___4_52.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___4_52.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___4_52.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___4_52.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___4_52.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___4_52.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___4_52.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___4_52.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___4_52.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___4_52.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___4_52.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___4_52.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___4_52.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___4_52.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___4_52.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___4_52.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___4_52.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___4_52.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___4_52.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv = uu____53;
-        FStar_TypeChecker_Env.nbe = (uu___4_52.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = uu___1;
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___4_52.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___4_52.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___4_52.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       }
 let (repl_ld_tasks_of_deps :
   Prims.string Prims.list ->
@@ -126,26 +112,26 @@ let (repl_ld_tasks_of_deps :
   fun deps ->
     fun final_tasks ->
       let wrap fname =
-        let uu____80 = FStar_Util.now () in
+        let uu___ = FStar_Util.now () in
         {
           FStar_Interactive_JsonHelper.tf_fname = fname;
-          FStar_Interactive_JsonHelper.tf_modtime = uu____80
+          FStar_Interactive_JsonHelper.tf_modtime = uu___
         } in
       let rec aux deps1 final_tasks1 =
         match deps1 with
         | intf::impl::deps' when FStar_Universal.needs_interleaving intf impl
             ->
-            let uu____109 =
-              let uu____110 =
-                let uu____115 = wrap intf in
-                let uu____116 = wrap impl in (uu____115, uu____116) in
-              FStar_Interactive_JsonHelper.LDInterleaved uu____110 in
-            let uu____117 = aux deps' final_tasks1 in uu____109 :: uu____117
+            let uu___ =
+              let uu___1 =
+                let uu___2 = wrap intf in
+                let uu___3 = wrap impl in (uu___2, uu___3) in
+              FStar_Interactive_JsonHelper.LDInterleaved uu___1 in
+            let uu___1 = aux deps' final_tasks1 in uu___ :: uu___1
         | intf_or_impl::deps' ->
-            let uu____124 =
-              let uu____125 = wrap intf_or_impl in
-              FStar_Interactive_JsonHelper.LDSingle uu____125 in
-            let uu____126 = aux deps' final_tasks1 in uu____124 :: uu____126
+            let uu___ =
+              let uu___1 = wrap intf_or_impl in
+              FStar_Interactive_JsonHelper.LDSingle uu___1 in
+            let uu___1 = aux deps' final_tasks1 in uu___ :: uu___1
         | [] -> final_tasks1 in
       aux deps final_tasks
 let (deps_and_repl_ld_tasks_of_our_file :
@@ -157,65 +143,61 @@ let (deps_and_repl_ld_tasks_of_our_file :
     let get_mod_name fname = FStar_Parser_Dep.lowercase_module_name fname in
     let our_mod_name = get_mod_name filename in
     let has_our_mod_name f =
-      let uu____167 = get_mod_name f in uu____167 = our_mod_name in
+      let uu___ = get_mod_name f in uu___ = our_mod_name in
     let parse_data_cache = FStar_CheckedFiles.load_parsing_data_from_cache in
-    let uu____175 =
+    let uu___ =
       FStar_Dependencies.find_deps_if_needed [filename] parse_data_cache in
-    match uu____175 with
+    match uu___ with
     | (deps, dep_graph) ->
-        let uu____198 = FStar_List.partition has_our_mod_name deps in
-        (match uu____198 with
+        let uu___1 = FStar_List.partition has_our_mod_name deps in
+        (match uu___1 with
          | (same_name, real_deps) ->
              let intf_tasks =
                match same_name with
                | intf::impl::[] ->
-                   ((let uu____235 =
-                       let uu____236 = FStar_Parser_Dep.is_interface intf in
-                       Prims.op_Negation uu____236 in
-                     if uu____235
+                   ((let uu___3 =
+                       let uu___4 = FStar_Parser_Dep.is_interface intf in
+                       Prims.op_Negation uu___4 in
+                     if uu___3
                      then
-                       let uu____237 =
-                         let uu____242 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Util.format1
                              "Expecting an interface, got %s" intf in
-                         (FStar_Errors.Fatal_MissingInterface, uu____242) in
-                       FStar_Errors.raise_err uu____237
+                         (FStar_Errors.Fatal_MissingInterface, uu___5) in
+                       FStar_Errors.raise_err uu___4
                      else ());
-                    (let uu____245 =
-                       let uu____246 =
-                         FStar_Parser_Dep.is_implementation impl in
-                       Prims.op_Negation uu____246 in
-                     if uu____245
+                    (let uu___4 =
+                       let uu___5 = FStar_Parser_Dep.is_implementation impl in
+                       Prims.op_Negation uu___5 in
+                     if uu___4
                      then
-                       let uu____247 =
-                         let uu____252 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_Util.format1
                              "Expecting an implementation, got %s" impl in
-                         (FStar_Errors.Fatal_MissingImplementation,
-                           uu____252) in
-                       FStar_Errors.raise_err uu____247
+                         (FStar_Errors.Fatal_MissingImplementation, uu___6) in
+                       FStar_Errors.raise_err uu___5
                      else ());
-                    (let uu____254 =
-                       let uu____255 =
-                         let uu____256 = FStar_Util.now () in
+                    (let uu___4 =
+                       let uu___5 =
+                         let uu___6 = FStar_Util.now () in
                          {
                            FStar_Interactive_JsonHelper.tf_fname = intf;
-                           FStar_Interactive_JsonHelper.tf_modtime =
-                             uu____256
+                           FStar_Interactive_JsonHelper.tf_modtime = uu___6
                          } in
                        FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile
-                         uu____255 in
-                     [uu____254]))
+                         uu___5 in
+                     [uu___4]))
                | impl::[] -> []
-               | uu____258 ->
+               | uu___2 ->
                    let mods_str = FStar_String.concat " " same_name in
                    let message = "Too many or too few files matching %s: %s" in
-                   ((let uu____264 =
-                       let uu____269 =
+                   ((let uu___4 =
+                       let uu___5 =
                          FStar_Util.format message [our_mod_name; mods_str] in
-                       (FStar_Errors.Fatal_TooManyOrTooFewFileMatch,
-                         uu____269) in
-                     FStar_Errors.raise_err uu____264);
+                       (FStar_Errors.Fatal_TooManyOrTooFewFileMatch, uu___5) in
+                     FStar_Errors.raise_err uu___4);
                     []) in
              let tasks = repl_ld_tasks_of_deps real_deps intf_tasks in
              (real_deps, tasks, dep_graph))
@@ -227,11 +209,11 @@ let (snapshot_env :
   =
   fun env ->
     fun msg ->
-      let uu____295 = FStar_TypeChecker_Tc.snapshot_context env msg in
-      match uu____295 with
+      let uu___ = FStar_TypeChecker_Tc.snapshot_context env msg in
+      match uu___ with
       | (ctx_depth, env1) ->
-          let uu____330 = FStar_Options.snapshot () in
-          (match uu____330 with
+          let uu___1 = FStar_Options.snapshot () in
+          (match uu___1 with
            | (opt_depth, ()) -> ((ctx_depth, opt_depth), env1))
 let (push_repl :
   Prims.string ->
@@ -244,32 +226,32 @@ let (push_repl :
     fun push_kind1 ->
       fun task ->
         fun st ->
-          let uu____360 =
+          let uu___ =
             snapshot_env st.FStar_Interactive_JsonHelper.repl_env msg in
-          match uu____360 with
+          match uu___ with
           | (depth, env) ->
-              ((let uu____368 =
-                  let uu____369 = FStar_ST.op_Bang repl_stack in
-                  (depth, (task, st)) :: uu____369 in
-                FStar_ST.op_Colon_Equals repl_stack uu____368);
-               (let uu___66_404 = st in
-                let uu____405 = set_check_kind env push_kind1 in
+              ((let uu___2 =
+                  let uu___3 = FStar_ST.op_Bang repl_stack in
+                  (depth, (task, st)) :: uu___3 in
+                FStar_ST.op_Colon_Equals repl_stack uu___2);
+               (let uu___2 = st in
+                let uu___3 = set_check_kind env push_kind1 in
                 {
                   FStar_Interactive_JsonHelper.repl_line =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_line);
+                    (uu___2.FStar_Interactive_JsonHelper.repl_line);
                   FStar_Interactive_JsonHelper.repl_column =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_column);
+                    (uu___2.FStar_Interactive_JsonHelper.repl_column);
                   FStar_Interactive_JsonHelper.repl_fname =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_fname);
+                    (uu___2.FStar_Interactive_JsonHelper.repl_fname);
                   FStar_Interactive_JsonHelper.repl_deps_stack =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_deps_stack);
+                    (uu___2.FStar_Interactive_JsonHelper.repl_deps_stack);
                   FStar_Interactive_JsonHelper.repl_curmod =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_curmod);
-                  FStar_Interactive_JsonHelper.repl_env = uu____405;
+                    (uu___2.FStar_Interactive_JsonHelper.repl_curmod);
+                  FStar_Interactive_JsonHelper.repl_env = uu___3;
                   FStar_Interactive_JsonHelper.repl_stdin =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_stdin);
+                    (uu___2.FStar_Interactive_JsonHelper.repl_stdin);
                   FStar_Interactive_JsonHelper.repl_names =
-                    (uu___66_404.FStar_Interactive_JsonHelper.repl_names)
+                    (uu___2.FStar_Interactive_JsonHelper.repl_names)
                 }))
 let (rollback_env :
   FStar_TypeChecker_Env.solver_t ->
@@ -279,8 +261,8 @@ let (rollback_env :
   =
   fun solver ->
     fun msg ->
-      fun uu____432 ->
-        match uu____432 with
+      fun uu___ ->
+        match uu___ with
         | (ctx_depth, opt_depth) ->
             let env =
               FStar_TypeChecker_Tc.rollback_context solver msg
@@ -294,19 +276,19 @@ let (pop_repl :
   =
   fun msg ->
     fun st ->
-      let uu____483 = FStar_ST.op_Bang repl_stack in
-      match uu____483 with
+      let uu___ = FStar_ST.op_Bang repl_stack in
+      match uu___ with
       | [] -> failwith "Too many pops"
-      | (depth, (uu____499, st'))::stack_tl ->
+      | (depth, (uu___1, st'))::stack_tl ->
           let env =
             rollback_env
               (st.FStar_Interactive_JsonHelper.repl_env).FStar_TypeChecker_Env.solver
               msg depth in
           (FStar_ST.op_Colon_Equals repl_stack stack_tl;
-           (let uu____533 =
+           (let uu___4 =
               FStar_Util.physical_equality env
                 st'.FStar_Interactive_JsonHelper.repl_env in
-            FStar_Common.runtime_assert uu____533 "Inconsistent stack state");
+            FStar_Common.runtime_assert uu___4 "Inconsistent stack state");
            st')
 let (tc_one :
   FStar_TypeChecker_Env.env_t ->
@@ -317,13 +299,13 @@ let (tc_one :
     fun intf_opt ->
       fun modf ->
         let parse_data =
-          let uu____554 =
-            let uu____559 = FStar_TypeChecker_Env.dep_graph env in
-            FStar_Parser_Dep.parsing_data_of uu____559 in
-          FStar_All.pipe_right modf uu____554 in
-        let uu____560 =
+          let uu___ =
+            let uu___1 = FStar_TypeChecker_Env.dep_graph env in
+            FStar_Parser_Dep.parsing_data_of uu___1 in
+          FStar_All.pipe_right modf uu___ in
+        let uu___ =
           FStar_Universal.tc_one_file_for_ide env intf_opt modf parse_data in
-        match uu____560 with | (uu____565, env1) -> env1
+        match uu___ with | (uu___1, env1) -> env1
 let (run_repl_task :
   FStar_Interactive_JsonHelper.optmod_t ->
     FStar_TypeChecker_Env.env_t ->
@@ -335,22 +317,22 @@ let (run_repl_task :
       fun task ->
         match task with
         | FStar_Interactive_JsonHelper.LDInterleaved (intf, impl) ->
-            let uu____592 =
+            let uu___ =
               tc_one env
                 (FStar_Pervasives_Native.Some
                    (intf.FStar_Interactive_JsonHelper.tf_fname))
                 impl.FStar_Interactive_JsonHelper.tf_fname in
-            (curmod, uu____592)
+            (curmod, uu___)
         | FStar_Interactive_JsonHelper.LDSingle intf_or_impl ->
-            let uu____594 =
+            let uu___ =
               tc_one env FStar_Pervasives_Native.None
                 intf_or_impl.FStar_Interactive_JsonHelper.tf_fname in
-            (curmod, uu____594)
+            (curmod, uu___)
         | FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile intf ->
-            let uu____596 =
+            let uu___ =
               FStar_Universal.load_interface_decls env
                 intf.FStar_Interactive_JsonHelper.tf_fname in
-            (curmod, uu____596)
+            (curmod, uu___)
         | FStar_Interactive_JsonHelper.PushFragment frag ->
             FStar_Universal.tc_one_fragment curmod env frag
         | FStar_Interactive_JsonHelper.Noop -> (curmod, env)
@@ -362,28 +344,26 @@ type name_tracking_event =
   | NTBinding of (FStar_Syntax_Syntax.binding,
   FStar_TypeChecker_Env.sig_binding) FStar_Util.either 
 let (uu___is_NTAlias : name_tracking_event -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NTAlias _0 -> true | uu____648 -> false
+  fun projectee -> match projectee with | NTAlias _0 -> true | uu___ -> false
 let (__proj__NTAlias__item___0 :
   name_tracking_event ->
     (FStar_Ident.lid * FStar_Ident.ident * FStar_Ident.lid))
   = fun projectee -> match projectee with | NTAlias _0 -> _0
 let (uu___is_NTOpen : name_tracking_event -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NTOpen _0 -> true | uu____683 -> false
+  fun projectee -> match projectee with | NTOpen _0 -> true | uu___ -> false
 let (__proj__NTOpen__item___0 :
   name_tracking_event ->
     (FStar_Ident.lid * FStar_Syntax_DsEnv.open_module_or_namespace))
   = fun projectee -> match projectee with | NTOpen _0 -> _0
 let (uu___is_NTInclude : name_tracking_event -> Prims.bool) =
   fun projectee ->
-    match projectee with | NTInclude _0 -> true | uu____712 -> false
+    match projectee with | NTInclude _0 -> true | uu___ -> false
 let (__proj__NTInclude__item___0 :
   name_tracking_event -> (FStar_Ident.lid * FStar_Ident.lid)) =
   fun projectee -> match projectee with | NTInclude _0 -> _0
 let (uu___is_NTBinding : name_tracking_event -> Prims.bool) =
   fun projectee ->
-    match projectee with | NTBinding _0 -> true | uu____741 -> false
+    match projectee with | NTBinding _0 -> true | uu___ -> false
 let (__proj__NTBinding__item___0 :
   name_tracking_event ->
     (FStar_Syntax_Syntax.binding, FStar_TypeChecker_Env.sig_binding)
@@ -395,12 +375,11 @@ let (query_of_ids :
 let (query_of_lid :
   FStar_Ident.lident -> FStar_Interactive_CompletionTable.query) =
   fun lid ->
-    let uu____774 =
-      let uu____777 = FStar_Ident.ns_of_lid lid in
-      let uu____780 =
-        let uu____783 = FStar_Ident.ident_of_lid lid in [uu____783] in
-      FStar_List.append uu____777 uu____780 in
-    query_of_ids uu____774
+    let uu___ =
+      let uu___1 = FStar_Ident.ns_of_lid lid in
+      let uu___2 = let uu___3 = FStar_Ident.ident_of_lid lid in [uu___3] in
+      FStar_List.append uu___1 uu___2 in
+    query_of_ids uu___
 let (update_names_from_event :
   Prims.string ->
     FStar_Interactive_CompletionTable.table ->
@@ -410,57 +389,56 @@ let (update_names_from_event :
     fun table ->
       fun evt ->
         let is_cur_mod lid =
-          let uu____805 = FStar_Ident.string_of_lid lid in
-          uu____805 = cur_mod_str in
+          let uu___ = FStar_Ident.string_of_lid lid in uu___ = cur_mod_str in
         match evt with
         | NTAlias (host, id, included) ->
-            let uu____809 = is_cur_mod host in
-            if uu____809
+            let uu___ = is_cur_mod host in
+            if uu___
             then
-              let uu____810 = FStar_Ident.string_of_id id in
-              let uu____811 = query_of_lid included in
-              FStar_Interactive_CompletionTable.register_alias table
-                uu____810 [] uu____811
+              let uu___1 = FStar_Ident.string_of_id id in
+              let uu___2 = query_of_lid included in
+              FStar_Interactive_CompletionTable.register_alias table uu___1
+                [] uu___2
             else table
         | NTOpen (host, (included, kind)) ->
-            let uu____816 = is_cur_mod host in
-            if uu____816
+            let uu___ = is_cur_mod host in
+            if uu___
             then
-              let uu____817 = query_of_lid included in
+              let uu___1 = query_of_lid included in
               FStar_Interactive_CompletionTable.register_open table
-                (kind = FStar_Syntax_DsEnv.Open_module) [] uu____817
+                (kind = FStar_Syntax_DsEnv.Open_module) [] uu___1
             else table
         | NTInclude (host, included) ->
-            let uu____821 =
-              let uu____822 = is_cur_mod host in
-              if uu____822 then [] else query_of_lid host in
-            let uu____824 = query_of_lid included in
-            FStar_Interactive_CompletionTable.register_include table
-              uu____821 uu____824
+            let uu___ =
+              let uu___1 = is_cur_mod host in
+              if uu___1 then [] else query_of_lid host in
+            let uu___1 = query_of_lid included in
+            FStar_Interactive_CompletionTable.register_include table uu___
+              uu___1
         | NTBinding binding ->
             let lids =
               match binding with
-              | FStar_Util.Inl (FStar_Syntax_Syntax.Binding_lid
-                  (lid, uu____836)) -> [lid]
-              | FStar_Util.Inr (lids, uu____850) -> lids
-              | uu____855 -> [] in
+              | FStar_Util.Inl (FStar_Syntax_Syntax.Binding_lid (lid, uu___))
+                  -> [lid]
+              | FStar_Util.Inr (lids1, uu___) -> lids1
+              | uu___ -> [] in
             FStar_List.fold_left
               (fun tbl ->
                  fun lid ->
                    let ns_query =
-                     let uu____867 =
-                       let uu____868 = FStar_Ident.nsstr lid in
-                       uu____868 = cur_mod_str in
-                     if uu____867
+                     let uu___ =
+                       let uu___1 = FStar_Ident.nsstr lid in
+                       uu___1 = cur_mod_str in
+                     if uu___
                      then []
                      else
-                       (let uu____870 = FStar_Ident.ns_of_lid lid in
-                        query_of_ids uu____870) in
-                   let uu____873 =
-                     let uu____874 = FStar_Ident.ident_of_lid lid in
-                     FStar_Ident.string_of_id uu____874 in
+                       (let uu___2 = FStar_Ident.ns_of_lid lid in
+                        query_of_ids uu___2) in
+                   let uu___ =
+                     let uu___1 = FStar_Ident.ident_of_lid lid in
+                     FStar_Ident.string_of_id uu___1 in
                    FStar_Interactive_CompletionTable.insert tbl ns_query
-                     uu____873 lid) table lids
+                     uu___ lid) table lids
 let (commit_name_tracking' :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Interactive_CompletionTable.table ->
@@ -474,8 +452,8 @@ let (commit_name_tracking' :
           match cur_mod with
           | FStar_Pervasives_Native.None -> ""
           | FStar_Pervasives_Native.Some md ->
-              let uu____900 = FStar_Syntax_Syntax.mod_name md in
-              FStar_Ident.string_of_lid uu____900 in
+              let uu___ = FStar_Syntax_Syntax.mod_name md in
+              FStar_Ident.string_of_lid uu___ in
         let updater = update_names_from_event cur_mod_str in
         FStar_List.fold_left updater names name_events
 let (commit_name_tracking :
@@ -487,22 +465,22 @@ let (commit_name_tracking :
       let names =
         commit_name_tracking' st.FStar_Interactive_JsonHelper.repl_curmod
           st.FStar_Interactive_JsonHelper.repl_names name_events in
-      let uu___166_925 = st in
+      let uu___ = st in
       {
         FStar_Interactive_JsonHelper.repl_line =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_line);
+          (uu___.FStar_Interactive_JsonHelper.repl_line);
         FStar_Interactive_JsonHelper.repl_column =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_column);
+          (uu___.FStar_Interactive_JsonHelper.repl_column);
         FStar_Interactive_JsonHelper.repl_fname =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_fname);
+          (uu___.FStar_Interactive_JsonHelper.repl_fname);
         FStar_Interactive_JsonHelper.repl_deps_stack =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_deps_stack);
+          (uu___.FStar_Interactive_JsonHelper.repl_deps_stack);
         FStar_Interactive_JsonHelper.repl_curmod =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_curmod);
+          (uu___.FStar_Interactive_JsonHelper.repl_curmod);
         FStar_Interactive_JsonHelper.repl_env =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_env);
+          (uu___.FStar_Interactive_JsonHelper.repl_env);
         FStar_Interactive_JsonHelper.repl_stdin =
-          (uu___166_925.FStar_Interactive_JsonHelper.repl_stdin);
+          (uu___.FStar_Interactive_JsonHelper.repl_stdin);
         FStar_Interactive_JsonHelper.repl_names = names
       }
 let (fresh_name_tracking_hooks :
@@ -510,46 +488,45 @@ let (fresh_name_tracking_hooks :
     (name_tracking_event Prims.list FStar_ST.ref *
       FStar_Syntax_DsEnv.dsenv_hooks * FStar_TypeChecker_Env.tcenv_hooks))
   =
-  fun uu____940 ->
+  fun uu___ ->
     let events = FStar_Util.mk_ref [] in
     let push_event evt =
-      let uu____954 =
-        let uu____957 = FStar_ST.op_Bang events in evt :: uu____957 in
-      FStar_ST.op_Colon_Equals events uu____954 in
+      let uu___1 = let uu___2 = FStar_ST.op_Bang events in evt :: uu___2 in
+      FStar_ST.op_Colon_Equals events uu___1 in
     (events,
       {
         FStar_Syntax_DsEnv.ds_push_open_hook =
           (fun dsenv ->
              fun op ->
-               let uu____992 =
-                 let uu____993 =
-                   let uu____998 = FStar_Syntax_DsEnv.current_module dsenv in
-                   (uu____998, op) in
-                 NTOpen uu____993 in
-               push_event uu____992);
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_DsEnv.current_module dsenv in
+                   (uu___3, op) in
+                 NTOpen uu___2 in
+               push_event uu___1);
         FStar_Syntax_DsEnv.ds_push_include_hook =
           (fun dsenv ->
              fun ns ->
-               let uu____1004 =
-                 let uu____1005 =
-                   let uu____1010 = FStar_Syntax_DsEnv.current_module dsenv in
-                   (uu____1010, ns) in
-                 NTInclude uu____1005 in
-               push_event uu____1004);
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_DsEnv.current_module dsenv in
+                   (uu___3, ns) in
+                 NTInclude uu___2 in
+               push_event uu___1);
         FStar_Syntax_DsEnv.ds_push_module_abbrev_hook =
           (fun dsenv ->
              fun x ->
                fun l ->
-                 let uu____1018 =
-                   let uu____1019 =
-                     let uu____1026 = FStar_Syntax_DsEnv.current_module dsenv in
-                     (uu____1026, x, l) in
-                   NTAlias uu____1019 in
-                 push_event uu____1018)
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_DsEnv.current_module dsenv in
+                     (uu___3, x, l) in
+                   NTAlias uu___2 in
+                 push_event uu___1)
       },
       {
         FStar_TypeChecker_Env.tc_push_in_gamma_hook =
-          (fun uu____1031 -> fun s -> push_event (NTBinding s))
+          (fun uu___1 -> fun s -> push_event (NTBinding s))
       })
 let (track_name_changes :
   FStar_TypeChecker_Env.env_t ->
@@ -559,31 +536,30 @@ let (track_name_changes :
   =
   fun env ->
     let set_hooks dshooks tchooks env1 =
-      let uu____1084 =
+      let uu___ =
         FStar_Universal.with_dsenv_of_tcenv env1
           (fun dsenv ->
-             let uu____1092 = FStar_Syntax_DsEnv.set_ds_hooks dsenv dshooks in
-             ((), uu____1092)) in
-      match uu____1084 with
+             let uu___1 = FStar_Syntax_DsEnv.set_ds_hooks dsenv dshooks in
+             ((), uu___1)) in
+      match uu___ with
       | ((), tcenv') -> FStar_TypeChecker_Env.set_tc_hooks tcenv' tchooks in
-    let uu____1094 =
-      let uu____1099 =
+    let uu___ =
+      let uu___1 =
         FStar_Syntax_DsEnv.ds_hooks env.FStar_TypeChecker_Env.dsenv in
-      let uu____1100 = FStar_TypeChecker_Env.tc_hooks env in
-      (uu____1099, uu____1100) in
-    match uu____1094 with
+      let uu___2 = FStar_TypeChecker_Env.tc_hooks env in (uu___1, uu___2) in
+    match uu___ with
     | (old_dshooks, old_tchooks) ->
-        let uu____1116 = fresh_name_tracking_hooks () in
-        (match uu____1116 with
+        let uu___1 = fresh_name_tracking_hooks () in
+        (match uu___1 with
          | (events, new_dshooks, new_tchooks) ->
-             let uu____1151 = set_hooks new_dshooks new_tchooks env in
-             (uu____1151,
+             let uu___2 = set_hooks new_dshooks new_tchooks env in
+             (uu___2,
                ((fun env1 ->
-                   let uu____1165 = set_hooks old_dshooks old_tchooks env1 in
-                   let uu____1166 =
-                     let uu____1169 = FStar_ST.op_Bang events in
-                     FStar_List.rev uu____1169 in
-                   (uu____1165, uu____1166)))))
+                   let uu___3 = set_hooks old_dshooks old_tchooks env1 in
+                   let uu___4 =
+                     let uu___5 = FStar_ST.op_Bang events in
+                     FStar_List.rev uu___5 in
+                   (uu___3, uu___4)))))
 let (repl_tx :
   FStar_Interactive_JsonHelper.repl_state ->
     push_kind ->
@@ -595,109 +571,104 @@ let (repl_tx :
     fun push_kind1 ->
       fun task ->
         try
-          (fun uu___202_1224 ->
+          (fun uu___ ->
              match () with
              | () ->
                  let st1 = push_repl "repl_tx" push_kind1 task st in
-                 let uu____1232 =
+                 let uu___1 =
                    track_name_changes
                      st1.FStar_Interactive_JsonHelper.repl_env in
-                 (match uu____1232 with
+                 (match uu___1 with
                   | (env, finish_name_tracking) ->
-                      let uu____1272 =
+                      let uu___2 =
                         run_repl_task
                           st1.FStar_Interactive_JsonHelper.repl_curmod env
                           task in
-                      (match uu____1272 with
+                      (match uu___2 with
                        | (curmod, env1) ->
                            let st2 =
-                             let uu___228_1286 = st1 in
+                             let uu___3 = st1 in
                              {
                                FStar_Interactive_JsonHelper.repl_line =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_line);
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_line);
                                FStar_Interactive_JsonHelper.repl_column =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_column);
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_column);
                                FStar_Interactive_JsonHelper.repl_fname =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_fname);
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_fname);
                                FStar_Interactive_JsonHelper.repl_deps_stack =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_deps_stack);
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_deps_stack);
                                FStar_Interactive_JsonHelper.repl_curmod =
                                  curmod;
                                FStar_Interactive_JsonHelper.repl_env = env1;
                                FStar_Interactive_JsonHelper.repl_stdin =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_stdin);
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_stdin);
                                FStar_Interactive_JsonHelper.repl_names =
-                                 (uu___228_1286.FStar_Interactive_JsonHelper.repl_names)
+                                 (uu___3.FStar_Interactive_JsonHelper.repl_names)
                              } in
-                           let uu____1287 = finish_name_tracking env1 in
-                           (match uu____1287 with
+                           let uu___3 = finish_name_tracking env1 in
+                           (match uu___3 with
                             | (env2, name_events) ->
-                                let uu____1306 =
+                                let uu___4 =
                                   commit_name_tracking st2 name_events in
-                                (FStar_Pervasives_Native.None, uu____1306)))))
-            ()
+                                (FStar_Pervasives_Native.None, uu___4))))) ()
         with
         | FStar_All.Failure msg ->
-            let uu____1320 =
-              let uu____1323 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   FStar_Pervasives_Native.None in
-              FStar_Pervasives_Native.Some uu____1323 in
-            (uu____1320, st)
+              FStar_Pervasives_Native.Some uu___2 in
+            (uu___1, st)
         | FStar_Util.SigInt ->
             (FStar_Util.print_error "[E] Interrupt";
              (FStar_Pervasives_Native.None, st))
         | FStar_Errors.Error (e, msg, r) ->
-            let uu____1332 =
-              let uu____1335 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   (FStar_Pervasives_Native.Some r) in
-              FStar_Pervasives_Native.Some uu____1335 in
-            (uu____1332, st)
+              FStar_Pervasives_Native.Some uu___2 in
+            (uu___1, st)
         | FStar_Errors.Err (e, msg) ->
-            let uu____1340 =
-              let uu____1343 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Interactive_JsonHelper.js_diag
                   st.FStar_Interactive_JsonHelper.repl_fname msg
                   FStar_Pervasives_Native.None in
-              FStar_Pervasives_Native.Some uu____1343 in
-            (uu____1340, st)
+              FStar_Pervasives_Native.Some uu___2 in
+            (uu___1, st)
         | FStar_Errors.Stop ->
             (FStar_Util.print_error "[E] Stop";
              (FStar_Pervasives_Native.None, st))
 let (tf_of_fname : Prims.string -> FStar_Interactive_JsonHelper.timed_fname)
   =
   fun fname ->
-    let uu____1354 =
-      FStar_Parser_ParseIt.get_file_last_modification_time fname in
+    let uu___ = FStar_Parser_ParseIt.get_file_last_modification_time fname in
     {
       FStar_Interactive_JsonHelper.tf_fname = fname;
-      FStar_Interactive_JsonHelper.tf_modtime = uu____1354
+      FStar_Interactive_JsonHelper.tf_modtime = uu___
     }
 let (update_task_timestamps :
   FStar_Interactive_JsonHelper.repl_task ->
     FStar_Interactive_JsonHelper.repl_task)
   =
-  fun uu___0_1359 ->
-    match uu___0_1359 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Interactive_JsonHelper.LDInterleaved (intf, impl) ->
-        let uu____1362 =
-          let uu____1367 =
-            tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname in
-          let uu____1368 =
-            tf_of_fname impl.FStar_Interactive_JsonHelper.tf_fname in
-          (uu____1367, uu____1368) in
-        FStar_Interactive_JsonHelper.LDInterleaved uu____1362
+        let uu___1 =
+          let uu___2 = tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname in
+          let uu___3 = tf_of_fname impl.FStar_Interactive_JsonHelper.tf_fname in
+          (uu___2, uu___3) in
+        FStar_Interactive_JsonHelper.LDInterleaved uu___1
     | FStar_Interactive_JsonHelper.LDSingle intf_or_impl ->
-        let uu____1370 =
+        let uu___1 =
           tf_of_fname intf_or_impl.FStar_Interactive_JsonHelper.tf_fname in
-        FStar_Interactive_JsonHelper.LDSingle uu____1370
+        FStar_Interactive_JsonHelper.LDSingle uu___1
     | FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile intf ->
-        let uu____1372 =
-          tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname in
-        FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile uu____1372
+        let uu___1 = tf_of_fname intf.FStar_Interactive_JsonHelper.tf_fname in
+        FStar_Interactive_JsonHelper.LDInterfaceOfCurrentFile uu___1
     | other -> other
 let (repl_ldtx :
   FStar_Interactive_JsonHelper.repl_state ->
@@ -705,8 +676,8 @@ let (repl_ldtx :
   =
   fun st ->
     fun tasks ->
-      let rec revert_many st1 uu___1_1408 =
-        match uu___1_1408 with
+      let rec revert_many st1 uu___ =
+        match uu___ with
         | [] -> st1
         | (_id, (task, _st'))::entries ->
             let st' = pop_repl "repl_ldtx" st1 in
@@ -714,26 +685,26 @@ let (repl_ldtx :
               FStar_TypeChecker_Env.dep_graph
                 st1.FStar_Interactive_JsonHelper.repl_env in
             let st'1 =
-              let uu___260_1456 = st' in
-              let uu____1457 =
+              let uu___1 = st' in
+              let uu___2 =
                 FStar_TypeChecker_Env.set_dep_graph
                   st'.FStar_Interactive_JsonHelper.repl_env dep_graph in
               {
                 FStar_Interactive_JsonHelper.repl_line =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_line);
+                  (uu___1.FStar_Interactive_JsonHelper.repl_line);
                 FStar_Interactive_JsonHelper.repl_column =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_column);
+                  (uu___1.FStar_Interactive_JsonHelper.repl_column);
                 FStar_Interactive_JsonHelper.repl_fname =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_fname);
+                  (uu___1.FStar_Interactive_JsonHelper.repl_fname);
                 FStar_Interactive_JsonHelper.repl_deps_stack =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_deps_stack);
+                  (uu___1.FStar_Interactive_JsonHelper.repl_deps_stack);
                 FStar_Interactive_JsonHelper.repl_curmod =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_curmod);
-                FStar_Interactive_JsonHelper.repl_env = uu____1457;
+                  (uu___1.FStar_Interactive_JsonHelper.repl_curmod);
+                FStar_Interactive_JsonHelper.repl_env = uu___2;
                 FStar_Interactive_JsonHelper.repl_stdin =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_stdin);
+                  (uu___1.FStar_Interactive_JsonHelper.repl_stdin);
                 FStar_Interactive_JsonHelper.repl_names =
-                  (uu___260_1456.FStar_Interactive_JsonHelper.repl_names)
+                  (uu___1.FStar_Interactive_JsonHelper.repl_names)
               } in
             revert_many st'1 entries in
       let rec aux st1 tasks1 previous =
@@ -741,42 +712,40 @@ let (repl_ldtx :
         | ([], []) -> FStar_Util.Inl st1
         | (task::tasks2, []) ->
             let timestamped_task = update_task_timestamps task in
-            let uu____1507 = repl_tx st1 LaxCheck timestamped_task in
-            (match uu____1507 with
+            let uu___ = repl_tx st1 LaxCheck timestamped_task in
+            (match uu___ with
              | (diag, st2) ->
                  if Prims.op_Negation (FStar_Util.is_some diag)
                  then
-                   let uu____1528 =
-                     let uu___280_1529 = st2 in
-                     let uu____1530 = FStar_ST.op_Bang repl_stack in
+                   let uu___1 =
+                     let uu___2 = st2 in
+                     let uu___3 = FStar_ST.op_Bang repl_stack in
                      {
                        FStar_Interactive_JsonHelper.repl_line =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_line);
+                         (uu___2.FStar_Interactive_JsonHelper.repl_line);
                        FStar_Interactive_JsonHelper.repl_column =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_column);
+                         (uu___2.FStar_Interactive_JsonHelper.repl_column);
                        FStar_Interactive_JsonHelper.repl_fname =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_fname);
-                       FStar_Interactive_JsonHelper.repl_deps_stack =
-                         uu____1530;
+                         (uu___2.FStar_Interactive_JsonHelper.repl_fname);
+                       FStar_Interactive_JsonHelper.repl_deps_stack = uu___3;
                        FStar_Interactive_JsonHelper.repl_curmod =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_curmod);
+                         (uu___2.FStar_Interactive_JsonHelper.repl_curmod);
                        FStar_Interactive_JsonHelper.repl_env =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_env);
+                         (uu___2.FStar_Interactive_JsonHelper.repl_env);
                        FStar_Interactive_JsonHelper.repl_stdin =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_stdin);
+                         (uu___2.FStar_Interactive_JsonHelper.repl_stdin);
                        FStar_Interactive_JsonHelper.repl_names =
-                         (uu___280_1529.FStar_Interactive_JsonHelper.repl_names)
+                         (uu___2.FStar_Interactive_JsonHelper.repl_names)
                      } in
-                   aux uu____1528 tasks2 []
+                   aux uu___1 tasks2 []
                  else FStar_Util.Inr st2)
         | (task::tasks2, prev::previous1) when
-            let uu____1560 = update_task_timestamps task in
+            let uu___ = update_task_timestamps task in
             (FStar_Pervasives_Native.fst (FStar_Pervasives_Native.snd prev))
-              = uu____1560
+              = uu___
             -> aux st1 tasks2 previous1
         | (tasks2, previous1) ->
-            let uu____1575 = revert_many st1 previous1 in
-            aux uu____1575 tasks2 [] in
+            let uu___ = revert_many st1 previous1 in aux uu___ tasks2 [] in
       aux st tasks
         (FStar_List.rev st.FStar_Interactive_JsonHelper.repl_deps_stack)
 let (ld_deps :
@@ -786,42 +755,42 @@ let (ld_deps :
   =
   fun st ->
     try
-      (fun uu___294_1617 ->
+      (fun uu___ ->
          match () with
          | () ->
-             let uu____1628 =
+             let uu___1 =
                deps_and_repl_ld_tasks_of_our_file
                  st.FStar_Interactive_JsonHelper.repl_fname in
-             (match uu____1628 with
+             (match uu___1 with
               | (deps, tasks, dep_graph) ->
                   let st1 =
-                    let uu___304_1661 = st in
-                    let uu____1662 =
+                    let uu___2 = st in
+                    let uu___3 =
                       FStar_TypeChecker_Env.set_dep_graph
                         st.FStar_Interactive_JsonHelper.repl_env dep_graph in
                     {
                       FStar_Interactive_JsonHelper.repl_line =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_line);
+                        (uu___2.FStar_Interactive_JsonHelper.repl_line);
                       FStar_Interactive_JsonHelper.repl_column =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_column);
+                        (uu___2.FStar_Interactive_JsonHelper.repl_column);
                       FStar_Interactive_JsonHelper.repl_fname =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_fname);
+                        (uu___2.FStar_Interactive_JsonHelper.repl_fname);
                       FStar_Interactive_JsonHelper.repl_deps_stack =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_deps_stack);
+                        (uu___2.FStar_Interactive_JsonHelper.repl_deps_stack);
                       FStar_Interactive_JsonHelper.repl_curmod =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_curmod);
-                      FStar_Interactive_JsonHelper.repl_env = uu____1662;
+                        (uu___2.FStar_Interactive_JsonHelper.repl_curmod);
+                      FStar_Interactive_JsonHelper.repl_env = uu___3;
                       FStar_Interactive_JsonHelper.repl_stdin =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_stdin);
+                        (uu___2.FStar_Interactive_JsonHelper.repl_stdin);
                       FStar_Interactive_JsonHelper.repl_names =
-                        (uu___304_1661.FStar_Interactive_JsonHelper.repl_names)
+                        (uu___2.FStar_Interactive_JsonHelper.repl_names)
                     } in
-                  let uu____1663 = repl_ldtx st1 tasks in
-                  (match uu____1663 with
+                  let uu___2 = repl_ldtx st1 tasks in
+                  (match uu___2 with
                    | FStar_Util.Inr st2 -> FStar_Util.Inr st2
                    | FStar_Util.Inl st2 -> FStar_Util.Inl (st2, deps)))) ()
     with
-    | uu___293_1692 ->
+    | uu___ ->
         (FStar_Util.print_error "[E] Failed to load deps"; FStar_Util.Inr st)
 let (add_module_completions :
   Prims.string ->
@@ -838,39 +807,37 @@ let (add_module_completions :
           else
             (let first =
                FStar_String.substring str Prims.int_zero Prims.int_one in
-             let uu____1737 =
+             let uu___1 =
                FStar_String.substring str Prims.int_one
                  ((FStar_String.length str) - Prims.int_one) in
-             Prims.op_Hat (FStar_String.uppercase first) uu____1737) in
+             Prims.op_Hat (FStar_String.uppercase first) uu___1) in
         let mods = FStar_Parser_Dep.build_inclusion_candidates_list () in
         let loaded_mods_set =
-          let uu____1748 = FStar_Util.psmap_empty () in
-          let uu____1751 =
-            let uu____1754 = FStar_Options.prims () in uu____1754 :: deps in
+          let uu___ = FStar_Util.psmap_empty () in
+          let uu___1 = let uu___2 = FStar_Options.prims () in uu___2 :: deps in
           FStar_List.fold_left
             (fun acc ->
                fun dep ->
-                 let uu____1764 = FStar_Parser_Dep.lowercase_module_name dep in
-                 FStar_Util.psmap_add acc uu____1764 true) uu____1748
-            uu____1751 in
+                 let uu___2 = FStar_Parser_Dep.lowercase_module_name dep in
+                 FStar_Util.psmap_add acc uu___2 true) uu___ uu___1 in
         let loaded modname =
           FStar_Util.psmap_find_default loaded_mods_set modname false in
         let this_mod_key = FStar_Parser_Dep.lowercase_module_name this_fname in
         FStar_List.fold_left
           (fun table1 ->
-             fun uu____1782 ->
-               match uu____1782 with
+             fun uu___ ->
+               match uu___ with
                | (modname, mod_path) ->
                    let mod_key = FStar_String.lowercase modname in
                    if this_mod_key = mod_key
                    then table1
                    else
                      (let ns_query =
-                        let uu____1794 = capitalize modname in
-                        FStar_Util.split uu____1794 "." in
-                      let uu____1795 = loaded mod_key in
+                        let uu___2 = capitalize modname in
+                        FStar_Util.split uu___2 "." in
+                      let uu___2 = loaded mod_key in
                       FStar_Interactive_CompletionTable.register_module_path
-                        table1 uu____1795 mod_path ns_query)) table
+                        table1 uu___2 mod_path ns_query)) table
           (FStar_List.rev mods)
 let (full_lax :
   Prims.string ->
@@ -890,30 +857,30 @@ let (full_lax :
            FStar_Parser_ParseIt.frag_line = Prims.int_one;
            FStar_Parser_ParseIt.frag_col = Prims.int_zero
          } in
-       let uu____1818 = ld_deps st in
-       match uu____1818 with
+       let uu___1 = ld_deps st in
+       match uu___1 with
        | FStar_Util.Inl (st1, deps) ->
            let names =
              add_module_completions
                st1.FStar_Interactive_JsonHelper.repl_fname deps
                st1.FStar_Interactive_JsonHelper.repl_names in
            repl_tx
-             (let uu___341_1850 = st1 in
+             (let uu___2 = st1 in
               {
                 FStar_Interactive_JsonHelper.repl_line =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_line);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_line);
                 FStar_Interactive_JsonHelper.repl_column =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_column);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_column);
                 FStar_Interactive_JsonHelper.repl_fname =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_fname);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_fname);
                 FStar_Interactive_JsonHelper.repl_deps_stack =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_deps_stack);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_deps_stack);
                 FStar_Interactive_JsonHelper.repl_curmod =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_curmod);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_curmod);
                 FStar_Interactive_JsonHelper.repl_env =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_env);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_env);
                 FStar_Interactive_JsonHelper.repl_stdin =
-                  (uu___341_1850.FStar_Interactive_JsonHelper.repl_stdin);
+                  (uu___2.FStar_Interactive_JsonHelper.repl_stdin);
                 FStar_Interactive_JsonHelper.repl_names = names
               }) LaxCheck (FStar_Interactive_JsonHelper.PushFragment frag)
        | FStar_Util.Inr st1 -> (FStar_Pervasives_Native.None, st1))

--- a/src/ocaml-output/FStar_Interactive_QueryHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_QueryHelper.ml
@@ -32,11 +32,10 @@ let (__proj__Mksl_reponse__item__slr_def :
   fun projectee ->
     match projectee with
     | { slr_name; slr_def_range; slr_typ; slr_doc; slr_def;_} -> slr_def
-let with_printed_effect_args :
-  'uuuuuu154 . (unit -> 'uuuuuu154) -> 'uuuuuu154 =
+let with_printed_effect_args : 'uuuuu . (unit -> 'uuuuu) -> 'uuuuu =
   fun k ->
     FStar_Options.with_saved_options
-      (fun uu____167 ->
+      (fun uu___ ->
          FStar_Options.set_option "print_effect_args"
            (FStar_Options.Bool true);
          k ())
@@ -45,11 +44,11 @@ let (term_to_string :
   fun tcenv ->
     fun t ->
       with_printed_effect_args
-        (fun uu____180 -> FStar_TypeChecker_Normalize.term_to_string tcenv t)
+        (fun uu___ -> FStar_TypeChecker_Normalize.term_to_string tcenv t)
 let (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun se ->
     with_printed_effect_args
-      (fun uu____187 -> FStar_Syntax_Print.sigelt_to_string se)
+      (fun uu___ -> FStar_Syntax_Print.sigelt_to_string se)
 let (symlookup :
   FStar_TypeChecker_Env.env ->
     Prims.string ->
@@ -62,41 +61,40 @@ let (symlookup :
         fun requested_info ->
           let info_of_lid_str lid_str =
             let lid =
-              let uu____237 =
+              let uu___ =
                 FStar_List.map FStar_Ident.id_of_text
                   (FStar_Util.split lid_str ".") in
-              FStar_Ident.lid_of_ids uu____237 in
+              FStar_Ident.lid_of_ids uu___ in
             let lid1 =
-              let uu____239 =
+              let uu___ =
                 FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                   tcenv.FStar_TypeChecker_Env.dsenv lid in
-              FStar_All.pipe_left (FStar_Util.dflt lid) uu____239 in
-            let uu____244 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1 in
-            FStar_All.pipe_right uu____244
+              FStar_All.pipe_left (FStar_Util.dflt lid) uu___ in
+            let uu___ = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1 in
+            FStar_All.pipe_right uu___
               (FStar_Util.map_option
-                 (fun uu____299 ->
-                    match uu____299 with
-                    | ((uu____318, typ), r) ->
-                        ((FStar_Util.Inr lid1), typ, r))) in
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | ((uu___2, typ), r) -> ((FStar_Util.Inr lid1), typ, r))) in
           let docs_of_lid lid = FStar_Pervasives_Native.None in
           let def_of_lid lid =
-            let uu____345 = FStar_TypeChecker_Env.lookup_qname tcenv lid in
-            FStar_Util.bind_opt uu____345
-              (fun uu___0_389 ->
-                 match uu___0_389 with
-                 | (FStar_Util.Inr (se, uu____411), uu____412) ->
-                     let uu____441 = sigelt_to_string se in
-                     FStar_Pervasives_Native.Some uu____441
-                 | uu____442 -> FStar_Pervasives_Native.None) in
+            let uu___ = FStar_TypeChecker_Env.lookup_qname tcenv lid in
+            FStar_Util.bind_opt uu___
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (FStar_Util.Inr (se, uu___2), uu___3) ->
+                     let uu___4 = sigelt_to_string se in
+                     FStar_Pervasives_Native.Some uu___4
+                 | uu___2 -> FStar_Pervasives_Native.None) in
           let info_at_pos_opt =
             FStar_Util.bind_opt pos_opt
-              (fun uu____488 ->
-                 match uu____488 with
+              (fun uu___ ->
+                 match uu___ with
                  | (file, row, col) ->
                      FStar_TypeChecker_Err.info_at_pos tcenv file row col) in
           let info_opt =
             match info_at_pos_opt with
-            | FStar_Pervasives_Native.Some uu____529 -> info_at_pos_opt
+            | FStar_Pervasives_Native.Some uu___ -> info_at_pos_opt
             | FStar_Pervasives_Native.None ->
                 if symbol = ""
                 then FStar_Pervasives_Native.None
@@ -106,26 +104,26 @@ let (symlookup :
           | FStar_Pervasives_Native.Some (name_or_lid, typ, rng) ->
               let name =
                 match name_or_lid with
-                | FStar_Util.Inl name -> name
+                | FStar_Util.Inl name1 -> name1
                 | FStar_Util.Inr lid -> FStar_Ident.string_of_lid lid in
               let typ_str =
                 if FStar_List.mem "type" requested_info
                 then
-                  let uu____624 = term_to_string tcenv typ in
-                  FStar_Pervasives_Native.Some uu____624
+                  let uu___ = term_to_string tcenv typ in
+                  FStar_Pervasives_Native.Some uu___
                 else FStar_Pervasives_Native.None in
               let doc_str =
                 match name_or_lid with
                 | FStar_Util.Inr lid when
                     FStar_List.mem "documentation" requested_info ->
                     docs_of_lid lid
-                | uu____632 -> FStar_Pervasives_Native.None in
+                | uu___ -> FStar_Pervasives_Native.None in
               let def_str =
                 match name_or_lid with
                 | FStar_Util.Inr lid when
                     FStar_List.mem "definition" requested_info ->
                     def_of_lid lid
-                | uu____643 -> FStar_Pervasives_Native.None in
+                | uu___ -> FStar_Pervasives_Native.None in
               let def_range =
                 if FStar_List.mem "defined-at" requested_info
                 then FStar_Pervasives_Native.Some rng
@@ -139,38 +137,38 @@ let (symlookup :
                   slr_def = def_str
                 }
 let mod_filter :
-  'uuuuuu658 .
-    ('uuuuuu658 * FStar_Interactive_CompletionTable.mod_symbol) ->
-      ('uuuuuu658 * FStar_Interactive_CompletionTable.mod_symbol)
+  'uuuuu .
+    ('uuuuu * FStar_Interactive_CompletionTable.mod_symbol) ->
+      ('uuuuu * FStar_Interactive_CompletionTable.mod_symbol)
         FStar_Pervasives_Native.option
   =
-  fun uu___1_673 ->
-    match uu___1_673 with
-    | (uu____678, FStar_Interactive_CompletionTable.Namespace uu____679) ->
+  fun uu___ ->
+    match uu___ with
+    | (uu___1, FStar_Interactive_CompletionTable.Namespace uu___2) ->
         FStar_Pervasives_Native.None
-    | (uu____684, FStar_Interactive_CompletionTable.Module
-       { FStar_Interactive_CompletionTable.mod_name = uu____685;
-         FStar_Interactive_CompletionTable.mod_path = uu____686;
+    | (uu___1, FStar_Interactive_CompletionTable.Module
+       { FStar_Interactive_CompletionTable.mod_name = uu___2;
+         FStar_Interactive_CompletionTable.mod_path = uu___3;
          FStar_Interactive_CompletionTable.mod_loaded = true;_})
         -> FStar_Pervasives_Native.None
     | (pth, FStar_Interactive_CompletionTable.Module md) ->
-        let uu____693 =
-          let uu____698 =
-            let uu____699 =
-              let uu___99_700 = md in
-              let uu____701 =
-                let uu____702 = FStar_Interactive_CompletionTable.mod_name md in
-                Prims.op_Hat uu____702 "." in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = md in
+              let uu___5 =
+                let uu___6 = FStar_Interactive_CompletionTable.mod_name md in
+                Prims.op_Hat uu___6 "." in
               {
-                FStar_Interactive_CompletionTable.mod_name = uu____701;
+                FStar_Interactive_CompletionTable.mod_name = uu___5;
                 FStar_Interactive_CompletionTable.mod_path =
-                  (uu___99_700.FStar_Interactive_CompletionTable.mod_path);
+                  (uu___4.FStar_Interactive_CompletionTable.mod_path);
                 FStar_Interactive_CompletionTable.mod_loaded =
-                  (uu___99_700.FStar_Interactive_CompletionTable.mod_loaded)
+                  (uu___4.FStar_Interactive_CompletionTable.mod_loaded)
               } in
-            FStar_Interactive_CompletionTable.Module uu____699 in
-          (pth, uu____698) in
-        FStar_Pervasives_Native.Some uu____693
+            FStar_Interactive_CompletionTable.Module uu___3 in
+          (pth, uu___2) in
+        FStar_Pervasives_Native.Some uu___1
 let (ck_completion :
   FStar_Interactive_JsonHelper.repl_state ->
     Prims.string ->
@@ -193,20 +191,20 @@ let (deflookup :
   =
   fun env ->
     fun pos ->
-      let uu____744 =
-        let uu____747 =
-          let uu____750 = FStar_Interactive_JsonHelper.pos_munge pos in
-          FStar_Pervasives_Native.Some uu____750 in
-        symlookup env "" uu____747 ["defined-at"] in
-      match uu____744 with
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Interactive_JsonHelper.pos_munge pos in
+          FStar_Pervasives_Native.Some uu___2 in
+        symlookup env "" uu___1 ["defined-at"] in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          { slr_name = uu____753;
-            slr_def_range = FStar_Pervasives_Native.Some r;
-            slr_typ = uu____755; slr_doc = uu____756; slr_def = uu____757;_}
+          { slr_name = uu___1;
+            slr_def_range = FStar_Pervasives_Native.Some r; slr_typ = uu___2;
+            slr_doc = uu___3; slr_def = uu___4;_}
           ->
-          let uu____764 = FStar_Interactive_JsonHelper.js_loclink r in
-          FStar_Interactive_JsonHelper.resultResponse uu____764
-      | uu____765 -> FStar_Interactive_JsonHelper.nullResponse
+          let uu___5 = FStar_Interactive_JsonHelper.js_loclink r in
+          FStar_Interactive_JsonHelper.resultResponse uu___5
+      | uu___1 -> FStar_Interactive_JsonHelper.nullResponse
 let (hoverlookup :
   FStar_TypeChecker_Env.env ->
     FStar_Interactive_JsonHelper.txdoc_pos ->
@@ -214,15 +212,15 @@ let (hoverlookup :
   =
   fun env ->
     fun pos ->
-      let uu____782 =
-        let uu____785 =
-          let uu____788 = FStar_Interactive_JsonHelper.pos_munge pos in
-          FStar_Pervasives_Native.Some uu____788 in
-        symlookup env "" uu____785 ["type"; "definition"] in
-      match uu____782 with
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Interactive_JsonHelper.pos_munge pos in
+          FStar_Pervasives_Native.Some uu___2 in
+        symlookup env "" uu___1 ["type"; "definition"] in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          { slr_name = n; slr_def_range = uu____792;
-            slr_typ = FStar_Pervasives_Native.Some t; slr_doc = uu____794;
+          { slr_name = n; slr_def_range = uu___1;
+            slr_typ = FStar_Pervasives_Native.Some t; slr_doc = uu___2;
             slr_def = FStar_Pervasives_Native.Some d;_}
           ->
           let hovertxt =
@@ -234,7 +232,7 @@ let (hoverlookup :
                   (FStar_Util.JsonAssoc
                      [("kind", (FStar_Util.JsonStr "markdown"));
                      ("value", (FStar_Util.JsonStr hovertxt))]))])
-      | uu____821 -> FStar_Interactive_JsonHelper.nullResponse
+      | uu___1 -> FStar_Interactive_JsonHelper.nullResponse
 let (complookup :
   FStar_Interactive_JsonHelper.repl_state ->
     FStar_Interactive_JsonHelper.txdoc_pos ->
@@ -242,12 +240,12 @@ let (complookup :
   =
   fun st ->
     fun pos ->
-      let uu____838 = FStar_Interactive_JsonHelper.pos_munge pos in
-      match uu____838 with
+      let uu___ = FStar_Interactive_JsonHelper.pos_munge pos in
+      match uu___ with
       | (file, row, current_col) ->
-          let uu____850 = FStar_Parser_ParseIt.read_vfs_entry file in
-          (match uu____850 with
-           | FStar_Pervasives_Native.Some (uu____859, text) ->
+          let uu___1 = FStar_Parser_ParseIt.read_vfs_entry file in
+          (match uu___1 with
+           | FStar_Pervasives_Native.Some (uu___2, text) ->
                let rec find_col l =
                  match l with
                  | [] -> Prims.int_zero
@@ -263,15 +261,14 @@ let (complookup :
                    if i < Prims.int_zero
                    then l
                    else
-                     (let uu____909 =
-                        let uu____912 = FStar_String.get s i in uu____912 ::
-                          l in
-                      exp (i - Prims.int_one) uu____909) in
+                     (let uu___4 =
+                        let uu___5 = FStar_String.get s i in uu___5 :: l in
+                      exp (i - Prims.int_one) uu___4) in
                  exp ((FStar_String.length s) - Prims.int_one) [] in
                let begin_col =
-                 let uu____914 =
-                   let uu____917 = explode str in FStar_List.rev uu____917 in
-                 find_col uu____914 in
+                 let uu___3 =
+                   let uu___4 = explode str in FStar_List.rev uu___4 in
+                 find_col uu___3 in
                let term =
                  FStar_Util.substring str begin_col (current_col - begin_col) in
                let items = ck_completion st term in

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -2,8 +2,8 @@ open Prims
 let (uu___0 : unit) = FStar_Version.dummy ()
 let (process_args :
   unit -> (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list)) =
-  fun uu____10 -> FStar_Options.parse_cmd_line ()
-let (cleanup : unit -> unit) = fun uu____21 -> FStar_Util.kill_all ()
+  fun uu___ -> FStar_Options.parse_cmd_line ()
+let (cleanup : unit -> unit) = fun uu___ -> FStar_Util.kill_all ()
 let (finished_message :
   (Prims.bool * FStar_Ident.lident) Prims.list -> Prims.int -> unit) =
   fun fmods ->
@@ -12,156 +12,153 @@ let (finished_message :
         if errs > Prims.int_zero
         then FStar_Util.print_error
         else FStar_Util.print_string in
-      let uu____53 =
-        let uu____54 = FStar_Options.silent () in Prims.op_Negation uu____54 in
-      if uu____53
+      let uu___ =
+        let uu___1 = FStar_Options.silent () in Prims.op_Negation uu___1 in
+      if uu___
       then
         (FStar_All.pipe_right fmods
            (FStar_List.iter
-              (fun uu____72 ->
-                 match uu____72 with
+              (fun uu___2 ->
+                 match uu___2 with
                  | (iface, name) ->
                      let tag =
                        if iface then "i'face (or impl+i'face)" else "module" in
-                     let uu____81 =
-                       let uu____82 = FStar_Ident.string_of_lid name in
-                       FStar_Options.should_print_message uu____82 in
-                     if uu____81
+                     let uu___3 =
+                       let uu___4 = FStar_Ident.string_of_lid name in
+                       FStar_Options.should_print_message uu___4 in
+                     if uu___3
                      then
-                       let uu____83 =
-                         let uu____84 = FStar_Ident.string_of_lid name in
-                         FStar_Util.format2 "Verified %s: %s\n" tag uu____84 in
-                       print_to uu____83
+                       let uu___4 =
+                         let uu___5 = FStar_Ident.string_of_lid name in
+                         FStar_Util.format2 "Verified %s: %s\n" tag uu___5 in
+                       print_to uu___4
                      else ()));
          if errs > Prims.int_zero
          then
            (if errs = Prims.int_one
             then FStar_Util.print_error "1 error was reported (see above)\n"
             else
-              (let uu____87 = FStar_Util.string_of_int errs in
+              (let uu___3 = FStar_Util.string_of_int errs in
                FStar_Util.print1_error
-                 "%s errors were reported (see above)\n" uu____87))
+                 "%s errors were reported (see above)\n" uu___3))
          else
-           (let uu____89 =
+           (let uu___3 =
               FStar_Util.colorize_bold
                 "All verification conditions discharged successfully" in
-            FStar_Util.print1 "%s\n" uu____89))
+            FStar_Util.print1 "%s\n" uu___3))
       else ()
 let (report_errors : (Prims.bool * FStar_Ident.lident) Prims.list -> unit) =
   fun fmods ->
-    (let uu____109 = FStar_Errors.report_all () in
-     FStar_All.pipe_right uu____109 (fun uu____114 -> ()));
+    (let uu___1 = FStar_Errors.report_all () in
+     FStar_All.pipe_right uu___1 (fun uu___2 -> ()));
     (let nerrs = FStar_Errors.get_err_count () in
      if nerrs > Prims.int_zero
      then (finished_message fmods nerrs; FStar_All.exit Prims.int_one)
      else ())
 let (load_native_tactics : unit -> unit) =
-  fun uu____122 ->
+  fun uu___ ->
     let modules_to_load =
-      let uu____126 = FStar_Options.load () in
-      FStar_All.pipe_right uu____126 (FStar_List.map FStar_Ident.lid_of_str) in
+      let uu___1 = FStar_Options.load () in
+      FStar_All.pipe_right uu___1 (FStar_List.map FStar_Ident.lid_of_str) in
     let ml_module_name m = FStar_Extraction_ML_Util.ml_module_name_of_lid m in
     let ml_file m =
-      let uu____145 = ml_module_name m in Prims.op_Hat uu____145 ".ml" in
+      let uu___1 = ml_module_name m in Prims.op_Hat uu___1 ".ml" in
     let cmxs_file m =
-      let cmxs =
-        let uu____153 = ml_module_name m in Prims.op_Hat uu____153 ".cmxs" in
-      let uu____154 =
-        let uu____157 =
+      let cmxs = let uu___1 = ml_module_name m in Prims.op_Hat uu___1 ".cmxs" in
+      let uu___1 =
+        let uu___2 =
           FStar_All.pipe_right cmxs FStar_Options.prepend_output_dir in
-        FStar_Options.find_file uu____157 in
-      match uu____154 with
+        FStar_Options.find_file uu___2 in
+      match uu___1 with
       | FStar_Pervasives_Native.Some f -> f
       | FStar_Pervasives_Native.None ->
-          let uu____159 =
-            let uu____162 =
-              let uu____163 = ml_file m in
-              FStar_All.pipe_right uu____163 FStar_Options.prepend_output_dir in
-            FStar_Options.find_file uu____162 in
-          (match uu____159 with
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = ml_file m in
+              FStar_All.pipe_right uu___4 FStar_Options.prepend_output_dir in
+            FStar_Options.find_file uu___3 in
+          (match uu___2 with
            | FStar_Pervasives_Native.None ->
-               let uu____164 =
-                 let uu____169 =
-                   let uu____170 = ml_file m in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = ml_file m in
                    FStar_Util.format1
                      "Failed to compile native tactic; extracted module %s not found"
-                     uu____170 in
-                 (FStar_Errors.Fatal_FailToCompileNativeTactic, uu____169) in
-               FStar_Errors.raise_err uu____164
+                     uu___5 in
+                 (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___4) in
+               FStar_Errors.raise_err uu___3
            | FStar_Pervasives_Native.Some ml ->
                let dir = FStar_Util.dirname ml in
-               ((let uu____174 =
-                   let uu____177 = ml_module_name m in [uu____177] in
-                 FStar_Tactics_Load.compile_modules dir uu____174);
-                (let uu____178 = FStar_Options.find_file cmxs in
-                 match uu____178 with
+               ((let uu___4 = let uu___5 = ml_module_name m in [uu___5] in
+                 FStar_Tactics_Load.compile_modules dir uu___4);
+                (let uu___4 = FStar_Options.find_file cmxs in
+                 match uu___4 with
                  | FStar_Pervasives_Native.None ->
-                     let uu____181 =
-                       let uu____186 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_Util.format1
                            "Failed to compile native tactic; compiled object %s not found"
                            cmxs in
-                       (FStar_Errors.Fatal_FailToCompileNativeTactic,
-                         uu____186) in
-                     FStar_Errors.raise_err uu____181
+                       (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___6) in
+                     FStar_Errors.raise_err uu___5
                  | FStar_Pervasives_Native.Some f -> f))) in
     let cmxs_files =
       FStar_All.pipe_right modules_to_load (FStar_List.map cmxs_file) in
     FStar_List.iter (fun x -> FStar_Util.print1 "cmxs file: %s\n" x)
       cmxs_files;
-    (let uu____199 =
-       (let uu____202 = FStar_Options.no_load_fstartaclib () in
-        Prims.op_Negation uu____202) &&
+    (let uu___3 =
+       (let uu___4 = FStar_Options.no_load_fstartaclib () in
+        Prims.op_Negation uu___4) &&
          (Prims.op_Negation (FStar_Platform.system = FStar_Platform.Windows)) in
-     if uu____199 then FStar_Tactics_Load.try_load_lib () else ());
+     if uu___3 then FStar_Tactics_Load.try_load_lib () else ());
     FStar_Tactics_Load.load_tactics cmxs_files;
-    (let uu____206 = FStar_Options.use_native_tactics () in
-     FStar_Util.iter_opt uu____206 FStar_Tactics_Load.load_tactics_dir)
+    (let uu___5 = FStar_Options.use_native_tactics () in
+     FStar_Util.iter_opt uu___5 FStar_Tactics_Load.load_tactics_dir)
 let (fstar_files :
   Prims.string Prims.list FStar_Pervasives_Native.option FStar_ST.ref) =
   FStar_Util.mk_ref FStar_Pervasives_Native.None
-let go : 'uuuuuu225 . 'uuuuuu225 -> unit =
-  fun uu____230 ->
-    let uu____231 = process_args () in
-    match uu____231 with
+let go : 'uuuuu . 'uuuuu -> unit =
+  fun uu___ ->
+    let uu___1 = process_args () in
+    match uu___1 with
     | (res, filenames) ->
         (match res with
          | FStar_Getopt.Help ->
              (FStar_Options.display_usage (); FStar_All.exit Prims.int_zero)
          | FStar_Getopt.Error msg ->
              (FStar_Util.print_error msg; FStar_All.exit Prims.int_one)
-         | uu____247 when FStar_Options.print_cache_version () ->
-             ((let uu____249 =
+         | uu___2 when FStar_Options.print_cache_version () ->
+             ((let uu___4 =
                  FStar_Util.string_of_int
                    FStar_CheckedFiles.cache_version_number in
-               FStar_Util.print1 "F* cache version number: %s\n" uu____249);
+               FStar_Util.print1 "F* cache version number: %s\n" uu___4);
               FStar_All.exit Prims.int_zero)
          | FStar_Getopt.Success ->
              (FStar_ST.op_Colon_Equals fstar_files
                 (FStar_Pervasives_Native.Some filenames);
               FStar_Syntax_Unionfind.set_ro ();
-              (let uu____268 =
-                 let uu____269 = FStar_Options.dep () in
-                 uu____269 <> FStar_Pervasives_Native.None in
-               if uu____268
+              (let uu___4 =
+                 let uu___5 = FStar_Options.dep () in
+                 uu___5 <> FStar_Pervasives_Native.None in
+               if uu___4
                then
-                 let uu____274 =
+                 let uu___5 =
                    FStar_Parser_Dep.collect filenames
                      FStar_CheckedFiles.load_parsing_data_from_cache in
-                 match uu____274 with
-                 | (uu____281, deps) ->
+                 match uu___5 with
+                 | (uu___6, deps) ->
                      (FStar_Parser_Dep.print deps; report_errors [])
                else
-                 (let uu____293 =
+                 (let uu___6 =
                     (FStar_Options.print ()) ||
                       (FStar_Options.print_in_place ()) in
-                  if uu____293
+                  if uu___6
                   then
                     (if FStar_Platform.is_fstar_compiler_using_ocaml
                      then
                        let printing_mode =
-                         let uu____295 = FStar_Options.print () in
-                         if uu____295
+                         let uu___7 = FStar_Options.print () in
+                         if uu___7
                          then FStar_Prettyprint.FromTempToStdout
                          else FStar_Prettyprint.FromTempToFile in
                        FStar_Prettyprint.generate printing_mode filenames
@@ -169,13 +166,13 @@ let go : 'uuuuuu225 . 'uuuuuu225 -> unit =
                        failwith
                          "You seem to be using the F#-generated version ofthe compiler ; \\o\n                         reindenting is not known to work yet with this version")
                   else
-                    (let uu____299 = FStar_Options.lsp_server () in
-                     if uu____299
+                    (let uu___8 = FStar_Options.lsp_server () in
+                     if uu___8
                      then FStar_Interactive_Lsp.start_server ()
                      else
                        (load_native_tactics ();
-                        (let uu____302 = FStar_Options.interactive () in
-                         if uu____302
+                        (let uu___11 = FStar_Options.interactive () in
+                         if uu___11
                          then
                            (FStar_Syntax_Unionfind.set_rw ();
                             (match filenames with
@@ -185,16 +182,16 @@ let go : 'uuuuuu225 . 'uuuuuu225 -> unit =
                                     (FStar_Errors.Error_MissingFileName,
                                       "--ide: Name of current file missing in command line invocation\n");
                                   FStar_All.exit Prims.int_one)
-                             | uu____305::uu____306::uu____307 ->
+                             | uu___13::uu___14::uu___15 ->
                                  (FStar_Errors.log_issue
                                     FStar_Range.dummyRange
                                     (FStar_Errors.Error_TooManyFiles,
                                       "--ide: Too many files in command line invocation\n");
                                   FStar_All.exit Prims.int_one)
                              | filename::[] ->
-                                 let uu____312 =
+                                 let uu___13 =
                                    FStar_Options.legacy_interactive () in
-                                 if uu____312
+                                 if uu___13
                                  then
                                    FStar_Interactive_Legacy.interactive_mode
                                      filename
@@ -204,18 +201,18 @@ let go : 'uuuuuu225 . 'uuuuuu225 -> unit =
                          else
                            if (FStar_List.length filenames) >= Prims.int_one
                            then
-                             (let uu____315 =
+                             (let uu___13 =
                                 FStar_Dependencies.find_deps_if_needed
                                   filenames
                                   FStar_CheckedFiles.load_parsing_data_from_cache in
-                              match uu____315 with
+                              match uu___13 with
                               | (filenames1, dep_graph) ->
-                                  let uu____328 =
+                                  let uu___14 =
                                     FStar_Universal.batch_mode_tc filenames1
                                       dep_graph in
-                                  (match uu____328 with
+                                  (match uu___14 with
                                    | (tcrs, env, cleanup1) ->
-                                       ((let uu____354 = cleanup1 env in ());
+                                       ((let uu___16 = cleanup1 env in ());
                                         (let module_names =
                                            FStar_All.pipe_right tcrs
                                              (FStar_List.map
@@ -258,10 +255,9 @@ let (lazy_chooser :
           FStar_Tactics_Embedding.unfold_lazy_goal i
       | FStar_Syntax_Syntax.Lazy_uvar ->
           FStar_Syntax_Util.exp_string "((uvar))"
-      | FStar_Syntax_Syntax.Lazy_embedding (uu____394, t) ->
-          FStar_Thunk.force t
+      | FStar_Syntax_Syntax.Lazy_embedding (uu___, t) -> FStar_Thunk.force t
 let (setup_hooks : unit -> unit) =
-  fun uu____410 ->
+  fun uu___ ->
     FStar_Errors.set_parse_warn_error FStar_Parser_ParseIt.parse_warn_error;
     FStar_ST.op_Colon_Equals FStar_Syntax_Syntax.lazy_chooser
       (FStar_Pervasives_Native.Some lazy_chooser);
@@ -274,45 +270,42 @@ let (setup_hooks : unit -> unit) =
 let (handle_error : Prims.exn -> unit) =
   fun e ->
     if FStar_Errors.handleable e then FStar_Errors.err_exn e else ();
-    (let uu____503 = FStar_Options.trace_error () in
-     if uu____503
+    (let uu___2 = FStar_Options.trace_error () in
+     if uu___2
      then
-       let uu____504 = FStar_Util.message_of_exn e in
-       let uu____505 = FStar_Util.trace_of_exn e in
-       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____504
-         uu____505
+       let uu___3 = FStar_Util.message_of_exn e in
+       let uu___4 = FStar_Util.trace_of_exn e in
+       FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu___3 uu___4
      else
        if Prims.op_Negation (FStar_Errors.handleable e)
        then
-         (let uu____507 = FStar_Util.message_of_exn e in
+         (let uu___4 = FStar_Util.message_of_exn e in
           FStar_Util.print1_error
             "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n"
-            uu____507)
+            uu___4)
        else ());
     cleanup ();
     report_errors []
-let main : 'uuuuuu518 . unit -> 'uuuuuu518 =
-  fun uu____523 ->
+let main : 'uuuuu . unit -> 'uuuuu =
+  fun uu___ ->
     try
-      (fun uu___131_531 ->
+      (fun uu___1 ->
          match () with
          | () ->
              (setup_hooks ();
-              (let uu____533 = FStar_Util.record_time go in
-               match uu____533 with
-               | (uu____538, time) ->
-                   ((let uu____541 = FStar_Options.query_stats () in
-                     if uu____541
+              (let uu___3 = FStar_Util.record_time go in
+               match uu___3 with
+               | (uu___4, time) ->
+                   ((let uu___6 = FStar_Options.query_stats () in
+                     if uu___6
                      then
-                       let uu____542 = FStar_Util.string_of_int time in
-                       let uu____543 =
-                         let uu____544 = FStar_Getopt.cmdline () in
-                         FStar_String.concat " " uu____544 in
+                       let uu___7 = FStar_Util.string_of_int time in
+                       let uu___8 =
+                         let uu___9 = FStar_Getopt.cmdline () in
+                         FStar_String.concat " " uu___9 in
                        FStar_Util.print2_error "TOTAL TIME %s ms: %s\n"
-                         uu____542 uu____543
+                         uu___7 uu___8
                      else ());
                     cleanup ();
                     FStar_All.exit Prims.int_zero)))) ()
-    with
-    | uu___130_551 ->
-        (handle_error uu___130_551; FStar_All.exit Prims.int_one)
+    with | uu___1 -> (handle_error uu___1; FStar_All.exit Prims.int_one)

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -8,16 +8,15 @@ type debug_level_t =
   | Extreme 
   | Other of Prims.string 
 let (uu___is_Low : debug_level_t -> Prims.bool) =
-  fun projectee -> match projectee with | Low -> true | uu____14 -> false
+  fun projectee -> match projectee with | Low -> true | uu___ -> false
 let (uu___is_Medium : debug_level_t -> Prims.bool) =
-  fun projectee -> match projectee with | Medium -> true | uu____20 -> false
+  fun projectee -> match projectee with | Medium -> true | uu___ -> false
 let (uu___is_High : debug_level_t -> Prims.bool) =
-  fun projectee -> match projectee with | High -> true | uu____26 -> false
+  fun projectee -> match projectee with | High -> true | uu___ -> false
 let (uu___is_Extreme : debug_level_t -> Prims.bool) =
-  fun projectee -> match projectee with | Extreme -> true | uu____32 -> false
+  fun projectee -> match projectee with | Extreme -> true | uu___ -> false
 let (uu___is_Other : debug_level_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Other _0 -> true | uu____39 -> false
+  fun projectee -> match projectee with | Other _0 -> true | uu___ -> false
 let (__proj__Other__item___0 : debug_level_t -> Prims.string) =
   fun projectee -> match projectee with | Other _0 -> _0
 type option_val =
@@ -28,161 +27,146 @@ type option_val =
   | List of option_val Prims.list 
   | Unset 
 let (uu___is_Bool : option_val -> Prims.bool) =
-  fun projectee -> match projectee with | Bool _0 -> true | uu____79 -> false
+  fun projectee -> match projectee with | Bool _0 -> true | uu___ -> false
 let (__proj__Bool__item___0 : option_val -> Prims.bool) =
   fun projectee -> match projectee with | Bool _0 -> _0
 let (uu___is_String : option_val -> Prims.bool) =
-  fun projectee ->
-    match projectee with | String _0 -> true | uu____92 -> false
+  fun projectee -> match projectee with | String _0 -> true | uu___ -> false
 let (__proj__String__item___0 : option_val -> Prims.string) =
   fun projectee -> match projectee with | String _0 -> _0
 let (uu___is_Path : option_val -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Path _0 -> true | uu____105 -> false
+  fun projectee -> match projectee with | Path _0 -> true | uu___ -> false
 let (__proj__Path__item___0 : option_val -> Prims.string) =
   fun projectee -> match projectee with | Path _0 -> _0
 let (uu___is_Int : option_val -> Prims.bool) =
-  fun projectee -> match projectee with | Int _0 -> true | uu____118 -> false
+  fun projectee -> match projectee with | Int _0 -> true | uu___ -> false
 let (__proj__Int__item___0 : option_val -> Prims.int) =
   fun projectee -> match projectee with | Int _0 -> _0
 let (uu___is_List : option_val -> Prims.bool) =
-  fun projectee ->
-    match projectee with | List _0 -> true | uu____133 -> false
+  fun projectee -> match projectee with | List _0 -> true | uu___ -> false
 let (__proj__List__item___0 : option_val -> option_val Prims.list) =
   fun projectee -> match projectee with | List _0 -> _0
 let (uu___is_Unset : option_val -> Prims.bool) =
-  fun projectee -> match projectee with | Unset -> true | uu____151 -> false
+  fun projectee -> match projectee with | Unset -> true | uu___ -> false
 let (__unit_tests__ : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false
 let (__unit_tests : unit -> Prims.bool) =
-  fun uu____158 -> FStar_ST.op_Bang __unit_tests__
+  fun uu___ -> FStar_ST.op_Bang __unit_tests__
 let (__set_unit_tests : unit -> unit) =
-  fun uu____169 -> FStar_ST.op_Colon_Equals __unit_tests__ true
+  fun uu___ -> FStar_ST.op_Colon_Equals __unit_tests__ true
 let (__clear_unit_tests : unit -> unit) =
-  fun uu____180 -> FStar_ST.op_Colon_Equals __unit_tests__ false
+  fun uu___ -> FStar_ST.op_Colon_Equals __unit_tests__ false
 let (as_bool : option_val -> Prims.bool) =
-  fun uu___0_191 ->
-    match uu___0_191 with
+  fun uu___ ->
+    match uu___ with
     | Bool b -> b
-    | uu____193 -> failwith "Impos: expected Bool"
+    | uu___1 -> failwith "Impos: expected Bool"
 let (as_int : option_val -> Prims.int) =
-  fun uu___1_198 ->
-    match uu___1_198 with
-    | Int b -> b
-    | uu____200 -> failwith "Impos: expected Int"
+  fun uu___ ->
+    match uu___ with | Int b -> b | uu___1 -> failwith "Impos: expected Int"
 let (as_string : option_val -> Prims.string) =
-  fun uu___2_205 ->
-    match uu___2_205 with
+  fun uu___ ->
+    match uu___ with
     | String b -> b
     | Path b -> FStar_Common.try_convert_file_name_to_mixed b
-    | uu____208 -> failwith "Impos: expected String"
+    | uu___1 -> failwith "Impos: expected String"
 let (as_list' : option_val -> option_val Prims.list) =
-  fun uu___3_215 ->
-    match uu___3_215 with
+  fun uu___ ->
+    match uu___ with
     | List ts -> ts
-    | uu____221 -> failwith "Impos: expected List"
+    | uu___1 -> failwith "Impos: expected List"
 let as_list :
-  'uuuuuu230 .
-    (option_val -> 'uuuuuu230) -> option_val -> 'uuuuuu230 Prims.list
-  =
+  'uuuuu . (option_val -> 'uuuuu) -> option_val -> 'uuuuu Prims.list =
   fun as_t ->
     fun x ->
-      let uu____248 = as_list' x in
-      FStar_All.pipe_right uu____248 (FStar_List.map as_t)
+      let uu___ = as_list' x in
+      FStar_All.pipe_right uu___ (FStar_List.map as_t)
 let as_option :
-  'uuuuuu261 .
-    (option_val -> 'uuuuuu261) ->
-      option_val -> 'uuuuuu261 FStar_Pervasives_Native.option
+  'uuuuu .
+    (option_val -> 'uuuuu) ->
+      option_val -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun as_t ->
-    fun uu___4_276 ->
-      match uu___4_276 with
+    fun uu___ ->
+      match uu___ with
       | Unset -> FStar_Pervasives_Native.None
-      | v -> let uu____280 = as_t v in FStar_Pervasives_Native.Some uu____280
+      | v -> let uu___1 = as_t v in FStar_Pervasives_Native.Some uu___1
 let (as_comma_string_list : option_val -> Prims.string Prims.list) =
-  fun uu___5_287 ->
-    match uu___5_287 with
+  fun uu___ ->
+    match uu___ with
     | List ls ->
-        let uu____293 =
+        let uu___1 =
           FStar_List.map
-            (fun l ->
-               let uu____303 = as_string l in FStar_Util.split uu____303 ",")
+            (fun l -> let uu___2 = as_string l in FStar_Util.split uu___2 ",")
             ls in
-        FStar_All.pipe_left FStar_List.flatten uu____293
-    | uu____310 -> failwith "Impos: expected String (comma list)"
+        FStar_All.pipe_left FStar_List.flatten uu___1
+    | uu___1 -> failwith "Impos: expected String (comma list)"
 type optionstate = option_val FStar_Util.smap
 let copy_optionstate :
-  'uuuuuu319 . 'uuuuuu319 FStar_Util.smap -> 'uuuuuu319 FStar_Util.smap =
+  'uuuuu . 'uuuuu FStar_Util.smap -> 'uuuuu FStar_Util.smap =
   fun m -> FStar_Util.smap_copy m
 let (fstar_options : optionstate Prims.list Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (internal_peek : unit -> optionstate) =
-  fun uu____347 ->
-    let uu____348 =
-      let uu____351 = FStar_ST.op_Bang fstar_options in
-      FStar_List.hd uu____351 in
-    FStar_List.hd uu____348
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang fstar_options in FStar_List.hd uu___2 in
+    FStar_List.hd uu___1
 let (peek : unit -> optionstate) =
-  fun uu____376 ->
-    let uu____377 = internal_peek () in copy_optionstate uu____377
+  fun uu___ -> let uu___1 = internal_peek () in copy_optionstate uu___1
 let (pop : unit -> unit) =
-  fun uu____384 ->
-    let uu____385 = FStar_ST.op_Bang fstar_options in
-    match uu____385 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang fstar_options in
+    match uu___1 with
     | [] -> failwith "TOO MANY POPS!"
-    | uu____406::[] -> failwith "TOO MANY POPS!"
-    | uu____413::tl -> FStar_ST.op_Colon_Equals fstar_options tl
+    | uu___2::[] -> failwith "TOO MANY POPS!"
+    | uu___2::tl -> FStar_ST.op_Colon_Equals fstar_options tl
 let (push : unit -> unit) =
-  fun uu____441 ->
-    let uu____442 =
-      let uu____447 =
-        let uu____450 =
-          let uu____453 = FStar_ST.op_Bang fstar_options in
-          FStar_List.hd uu____453 in
-        FStar_List.map copy_optionstate uu____450 in
-      let uu____474 = FStar_ST.op_Bang fstar_options in uu____447 ::
-        uu____474 in
-    FStar_ST.op_Colon_Equals fstar_options uu____442
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 = FStar_ST.op_Bang fstar_options in FStar_List.hd uu___4 in
+        FStar_List.map copy_optionstate uu___3 in
+      let uu___3 = FStar_ST.op_Bang fstar_options in uu___2 :: uu___3 in
+    FStar_ST.op_Colon_Equals fstar_options uu___1
 let (internal_pop : unit -> Prims.bool) =
-  fun uu____513 ->
+  fun uu___ ->
     let curstack =
-      let uu____517 = FStar_ST.op_Bang fstar_options in
-      FStar_List.hd uu____517 in
+      let uu___1 = FStar_ST.op_Bang fstar_options in FStar_List.hd uu___1 in
     match curstack with
     | [] -> failwith "impossible: empty current option stack"
-    | uu____538::[] -> false
-    | uu____539::tl ->
-        ((let uu____544 =
-            let uu____549 =
-              let uu____554 = FStar_ST.op_Bang fstar_options in
-              FStar_List.tl uu____554 in
-            tl :: uu____549 in
-          FStar_ST.op_Colon_Equals fstar_options uu____544);
+    | uu___1::[] -> false
+    | uu___1::tl ->
+        ((let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_ST.op_Bang fstar_options in
+              FStar_List.tl uu___5 in
+            tl :: uu___4 in
+          FStar_ST.op_Colon_Equals fstar_options uu___3);
          true)
 let (internal_push : unit -> unit) =
-  fun uu____595 ->
+  fun uu___ ->
     let curstack =
-      let uu____599 = FStar_ST.op_Bang fstar_options in
-      FStar_List.hd uu____599 in
+      let uu___1 = FStar_ST.op_Bang fstar_options in FStar_List.hd uu___1 in
     let stack' =
-      let uu____623 =
-        let uu____624 = FStar_List.hd curstack in copy_optionstate uu____624 in
-      uu____623 :: curstack in
-    let uu____627 =
-      let uu____632 =
-        let uu____637 = FStar_ST.op_Bang fstar_options in
-        FStar_List.tl uu____637 in
-      stack' :: uu____632 in
-    FStar_ST.op_Colon_Equals fstar_options uu____627
+      let uu___1 =
+        let uu___2 = FStar_List.hd curstack in copy_optionstate uu___2 in
+      uu___1 :: curstack in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 = FStar_ST.op_Bang fstar_options in FStar_List.tl uu___3 in
+      stack' :: uu___2 in
+    FStar_ST.op_Colon_Equals fstar_options uu___1
 let (set : optionstate -> unit) =
   fun o ->
-    let uu____679 = FStar_ST.op_Bang fstar_options in
-    match uu____679 with
+    let uu___ = FStar_ST.op_Bang fstar_options in
+    match uu___ with
     | [] -> failwith "set on empty option stack"
-    | []::uu____700 -> failwith "set on empty current option stack"
-    | (uu____707::tl)::os ->
+    | []::uu___1 -> failwith "set on empty current option stack"
+    | (uu___1::tl)::os ->
         FStar_ST.op_Colon_Equals fstar_options ((o :: tl) :: os)
 let (snapshot : unit -> (Prims.int * unit)) =
-  fun uu____742 -> FStar_Common.snapshot push fstar_options ()
+  fun uu___ -> FStar_Common.snapshot push fstar_options ()
 let (rollback : Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth -> FStar_Common.rollback pop fstar_options depth
 let (set_option : Prims.string -> option_val -> unit) =
@@ -191,23 +175,22 @@ let (set_option : Prims.string -> option_val -> unit) =
       let map = internal_peek () in
       if k = "report_assumes"
       then
-        let uu____767 = FStar_Util.smap_try_find map k in
-        match uu____767 with
+        let uu___ = FStar_Util.smap_try_find map k in
+        match uu___ with
         | FStar_Pervasives_Native.Some (String "error") -> ()
-        | uu____770 -> FStar_Util.smap_add map k v
+        | uu___1 -> FStar_Util.smap_add map k v
       else FStar_Util.smap_add map k v
 let (set_option' : (Prims.string * option_val) -> unit) =
-  fun uu____782 -> match uu____782 with | (k, v) -> set_option k v
+  fun uu___ -> match uu___ with | (k, v) -> set_option k v
 let (set_admit_smt_queries : Prims.bool -> unit) =
   fun b -> set_option "admit_smt_queries" (Bool b)
 let (light_off_files : Prims.string Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (add_light_off_file : Prims.string -> unit) =
   fun filename ->
-    let uu____805 =
-      let uu____808 = FStar_ST.op_Bang light_off_files in filename ::
-        uu____808 in
-    FStar_ST.op_Colon_Equals light_off_files uu____805
+    let uu___ =
+      let uu___1 = FStar_ST.op_Bang light_off_files in filename :: uu___1 in
+    FStar_ST.op_Colon_Equals light_off_files uu___
 let (defaults : (Prims.string * option_val) Prims.list) =
   [("__temp_no_proj", (List []));
   ("__temp_fast_implicits", (Bool false));
@@ -333,12 +316,12 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("profile_component", Unset);
   ("profile", Unset)]
 let (init : unit -> unit) =
-  fun uu____1337 ->
+  fun uu___ ->
     let o = internal_peek () in
     FStar_Util.smap_clear o;
     FStar_All.pipe_right defaults (FStar_List.iter set_option')
 let (clear : unit -> unit) =
-  fun uu____1354 ->
+  fun uu___ ->
     let o = FStar_Util.smap_create (Prims.of_int (50)) in
     FStar_ST.op_Colon_Equals fstar_options [[o]];
     FStar_ST.op_Colon_Equals light_off_files [];
@@ -346,271 +329,257 @@ let (clear : unit -> unit) =
 let (_run : unit) = clear ()
 let (get_option : Prims.string -> option_val) =
   fun s ->
-    let uu____1393 =
-      let uu____1396 = internal_peek () in
-      FStar_Util.smap_try_find uu____1396 s in
-    match uu____1393 with
+    let uu___ =
+      let uu___1 = internal_peek () in FStar_Util.smap_try_find uu___1 s in
+    match uu___ with
     | FStar_Pervasives_Native.None ->
-        let uu____1399 =
-          let uu____1400 = FStar_String.op_Hat s " not found" in
-          FStar_String.op_Hat "Impossible: option " uu____1400 in
-        failwith uu____1399
+        let uu___1 =
+          let uu___2 = FStar_String.op_Hat s " not found" in
+          FStar_String.op_Hat "Impossible: option " uu___2 in
+        failwith uu___1
     | FStar_Pervasives_Native.Some s1 -> s1
-let lookup_opt :
-  'uuuuuu1408 . Prims.string -> (option_val -> 'uuuuuu1408) -> 'uuuuuu1408 =
-  fun s -> fun c -> let uu____1424 = get_option s in c uu____1424
+let lookup_opt : 'uuuuu . Prims.string -> (option_val -> 'uuuuu) -> 'uuuuu =
+  fun s -> fun c -> let uu___ = get_option s in c uu___
 let (get_abort_on : unit -> Prims.int) =
-  fun uu____1429 -> lookup_opt "abort_on" as_int
+  fun uu___ -> lookup_opt "abort_on" as_int
 let (get_admit_smt_queries : unit -> Prims.bool) =
-  fun uu____1434 -> lookup_opt "admit_smt_queries" as_bool
+  fun uu___ -> lookup_opt "admit_smt_queries" as_bool
 let (get_admit_except : unit -> Prims.string FStar_Pervasives_Native.option)
-  = fun uu____1441 -> lookup_opt "admit_except" (as_option as_string)
+  = fun uu___ -> lookup_opt "admit_except" (as_option as_string)
 let (get_already_cached :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____1452 ->
-    lookup_opt "already_cached" (as_option (as_list as_string))
+  fun uu___ -> lookup_opt "already_cached" (as_option (as_list as_string))
 let (get_cache_checked_modules : unit -> Prims.bool) =
-  fun uu____1463 -> lookup_opt "cache_checked_modules" as_bool
+  fun uu___ -> lookup_opt "cache_checked_modules" as_bool
 let (get_cache_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1470 -> lookup_opt "cache_dir" (as_option as_string)
+  fun uu___ -> lookup_opt "cache_dir" (as_option as_string)
 let (get_cache_off : unit -> Prims.bool) =
-  fun uu____1477 -> lookup_opt "cache_off" as_bool
+  fun uu___ -> lookup_opt "cache_off" as_bool
 let (get_print_cache_version : unit -> Prims.bool) =
-  fun uu____1482 -> lookup_opt "print_cache_version" as_bool
-let (get_cmi : unit -> Prims.bool) =
-  fun uu____1487 -> lookup_opt "cmi" as_bool
+  fun uu___ -> lookup_opt "print_cache_version" as_bool
+let (get_cmi : unit -> Prims.bool) = fun uu___ -> lookup_opt "cmi" as_bool
 let (get_codegen : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1494 -> lookup_opt "codegen" (as_option as_string)
+  fun uu___ -> lookup_opt "codegen" (as_option as_string)
 let (get_codegen_lib : unit -> Prims.string Prims.list) =
-  fun uu____1503 -> lookup_opt "codegen-lib" (as_list as_string)
+  fun uu___ -> lookup_opt "codegen-lib" (as_list as_string)
 let (get_debug : unit -> Prims.string Prims.list) =
-  fun uu____1512 -> lookup_opt "debug" as_comma_string_list
+  fun uu___ -> lookup_opt "debug" as_comma_string_list
 let (get_debug_level : unit -> Prims.string Prims.list) =
-  fun uu____1521 -> lookup_opt "debug_level" as_comma_string_list
+  fun uu___ -> lookup_opt "debug_level" as_comma_string_list
 let (get_defensive : unit -> Prims.string) =
-  fun uu____1528 -> lookup_opt "defensive" as_string
+  fun uu___ -> lookup_opt "defensive" as_string
 let (get_dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1535 -> lookup_opt "dep" (as_option as_string)
+  fun uu___ -> lookup_opt "dep" (as_option as_string)
 let (get_detail_errors : unit -> Prims.bool) =
-  fun uu____1542 -> lookup_opt "detail_errors" as_bool
+  fun uu___ -> lookup_opt "detail_errors" as_bool
 let (get_detail_hint_replay : unit -> Prims.bool) =
-  fun uu____1547 -> lookup_opt "detail_hint_replay" as_bool
+  fun uu___ -> lookup_opt "detail_hint_replay" as_bool
 let (get_dump_module : unit -> Prims.string Prims.list) =
-  fun uu____1554 -> lookup_opt "dump_module" (as_list as_string)
+  fun uu___ -> lookup_opt "dump_module" (as_list as_string)
 let (get_eager_subtyping : unit -> Prims.bool) =
-  fun uu____1561 -> lookup_opt "eager_subtyping" as_bool
+  fun uu___ -> lookup_opt "eager_subtyping" as_bool
 let (get_expose_interfaces : unit -> Prims.bool) =
-  fun uu____1566 -> lookup_opt "expose_interfaces" as_bool
+  fun uu___ -> lookup_opt "expose_interfaces" as_bool
 let (get_extract :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____1575 -> lookup_opt "extract" (as_option (as_list as_string))
+  fun uu___ -> lookup_opt "extract" (as_option (as_list as_string))
 let (get_extract_module : unit -> Prims.string Prims.list) =
-  fun uu____1588 -> lookup_opt "extract_module" (as_list as_string)
+  fun uu___ -> lookup_opt "extract_module" (as_list as_string)
 let (get_extract_namespace : unit -> Prims.string Prims.list) =
-  fun uu____1597 -> lookup_opt "extract_namespace" (as_list as_string)
+  fun uu___ -> lookup_opt "extract_namespace" (as_list as_string)
 let (get_force : unit -> Prims.bool) =
-  fun uu____1604 -> lookup_opt "force" as_bool
+  fun uu___ -> lookup_opt "force" as_bool
 let (get_fs_typ_app : unit -> Prims.bool) =
-  fun uu____1609 -> lookup_opt "fs_typ_app" as_bool
+  fun uu___ -> lookup_opt "fs_typ_app" as_bool
 let (get_hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____1614 -> lookup_opt "hide_uvar_nums" as_bool
+  fun uu___ -> lookup_opt "hide_uvar_nums" as_bool
 let (get_hint_info : unit -> Prims.bool) =
-  fun uu____1619 -> lookup_opt "hint_info" as_bool
+  fun uu___ -> lookup_opt "hint_info" as_bool
 let (get_hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1626 -> lookup_opt "hint_dir" (as_option as_string)
+  fun uu___ -> lookup_opt "hint_dir" (as_option as_string)
 let (get_hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1635 -> lookup_opt "hint_file" (as_option as_string)
-let (get_in : unit -> Prims.bool) = fun uu____1642 -> lookup_opt "in" as_bool
-let (get_ide : unit -> Prims.bool) =
-  fun uu____1647 -> lookup_opt "ide" as_bool
-let (get_lsp : unit -> Prims.bool) =
-  fun uu____1652 -> lookup_opt "lsp" as_bool
+  fun uu___ -> lookup_opt "hint_file" (as_option as_string)
+let (get_in : unit -> Prims.bool) = fun uu___ -> lookup_opt "in" as_bool
+let (get_ide : unit -> Prims.bool) = fun uu___ -> lookup_opt "ide" as_bool
+let (get_lsp : unit -> Prims.bool) = fun uu___ -> lookup_opt "lsp" as_bool
 let (get_include : unit -> Prims.string Prims.list) =
-  fun uu____1659 -> lookup_opt "include" (as_list as_string)
+  fun uu___ -> lookup_opt "include" (as_list as_string)
 let (get_print : unit -> Prims.bool) =
-  fun uu____1666 -> lookup_opt "print" as_bool
+  fun uu___ -> lookup_opt "print" as_bool
 let (get_print_in_place : unit -> Prims.bool) =
-  fun uu____1671 -> lookup_opt "print_in_place" as_bool
+  fun uu___ -> lookup_opt "print_in_place" as_bool
 let (get_initial_fuel : unit -> Prims.int) =
-  fun uu____1676 -> lookup_opt "initial_fuel" as_int
+  fun uu___ -> lookup_opt "initial_fuel" as_int
 let (get_initial_ifuel : unit -> Prims.int) =
-  fun uu____1681 -> lookup_opt "initial_ifuel" as_int
+  fun uu___ -> lookup_opt "initial_ifuel" as_int
 let (get_keep_query_captions : unit -> Prims.bool) =
-  fun uu____1686 -> lookup_opt "keep_query_captions" as_bool
-let (get_lax : unit -> Prims.bool) =
-  fun uu____1691 -> lookup_opt "lax" as_bool
+  fun uu___ -> lookup_opt "keep_query_captions" as_bool
+let (get_lax : unit -> Prims.bool) = fun uu___ -> lookup_opt "lax" as_bool
 let (get_load : unit -> Prims.string Prims.list) =
-  fun uu____1698 -> lookup_opt "load" (as_list as_string)
+  fun uu___ -> lookup_opt "load" (as_list as_string)
 let (get_log_queries : unit -> Prims.bool) =
-  fun uu____1705 -> lookup_opt "log_queries" as_bool
+  fun uu___ -> lookup_opt "log_queries" as_bool
 let (get_log_types : unit -> Prims.bool) =
-  fun uu____1710 -> lookup_opt "log_types" as_bool
+  fun uu___ -> lookup_opt "log_types" as_bool
 let (get_max_fuel : unit -> Prims.int) =
-  fun uu____1715 -> lookup_opt "max_fuel" as_int
+  fun uu___ -> lookup_opt "max_fuel" as_int
 let (get_max_ifuel : unit -> Prims.int) =
-  fun uu____1720 -> lookup_opt "max_ifuel" as_int
+  fun uu___ -> lookup_opt "max_ifuel" as_int
 let (get_min_fuel : unit -> Prims.int) =
-  fun uu____1725 -> lookup_opt "min_fuel" as_int
+  fun uu___ -> lookup_opt "min_fuel" as_int
 let (get_MLish : unit -> Prims.bool) =
-  fun uu____1730 -> lookup_opt "MLish" as_bool
+  fun uu___ -> lookup_opt "MLish" as_bool
 let (get_no_default_includes : unit -> Prims.bool) =
-  fun uu____1735 -> lookup_opt "no_default_includes" as_bool
+  fun uu___ -> lookup_opt "no_default_includes" as_bool
 let (get_no_extract : unit -> Prims.string Prims.list) =
-  fun uu____1742 -> lookup_opt "no_extract" (as_list as_string)
+  fun uu___ -> lookup_opt "no_extract" (as_list as_string)
 let (get_no_load_fstartaclib : unit -> Prims.bool) =
-  fun uu____1749 -> lookup_opt "no_load_fstartaclib" as_bool
+  fun uu___ -> lookup_opt "no_load_fstartaclib" as_bool
 let (get_no_location_info : unit -> Prims.bool) =
-  fun uu____1754 -> lookup_opt "no_location_info" as_bool
+  fun uu___ -> lookup_opt "no_location_info" as_bool
 let (get_no_plugins : unit -> Prims.bool) =
-  fun uu____1759 -> lookup_opt "no_plugins" as_bool
+  fun uu___ -> lookup_opt "no_plugins" as_bool
 let (get_no_smt : unit -> Prims.bool) =
-  fun uu____1764 -> lookup_opt "no_smt" as_bool
+  fun uu___ -> lookup_opt "no_smt" as_bool
 let (get_normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____1769 -> lookup_opt "normalize_pure_terms_for_extraction" as_bool
+  fun uu___ -> lookup_opt "normalize_pure_terms_for_extraction" as_bool
 let (get_odir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1776 -> lookup_opt "odir" (as_option as_string)
-let (get_ugly : unit -> Prims.bool) =
-  fun uu____1783 -> lookup_opt "ugly" as_bool
+  fun uu___ -> lookup_opt "odir" (as_option as_string)
+let (get_ugly : unit -> Prims.bool) = fun uu___ -> lookup_opt "ugly" as_bool
 let (get_prims : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1790 -> lookup_opt "prims" (as_option as_string)
+  fun uu___ -> lookup_opt "prims" (as_option as_string)
 let (get_print_bound_var_types : unit -> Prims.bool) =
-  fun uu____1797 -> lookup_opt "print_bound_var_types" as_bool
+  fun uu___ -> lookup_opt "print_bound_var_types" as_bool
 let (get_print_effect_args : unit -> Prims.bool) =
-  fun uu____1802 -> lookup_opt "print_effect_args" as_bool
+  fun uu___ -> lookup_opt "print_effect_args" as_bool
 let (get_print_expected_failures : unit -> Prims.bool) =
-  fun uu____1807 -> lookup_opt "print_expected_failures" as_bool
+  fun uu___ -> lookup_opt "print_expected_failures" as_bool
 let (get_print_full_names : unit -> Prims.bool) =
-  fun uu____1812 -> lookup_opt "print_full_names" as_bool
+  fun uu___ -> lookup_opt "print_full_names" as_bool
 let (get_print_implicits : unit -> Prims.bool) =
-  fun uu____1817 -> lookup_opt "print_implicits" as_bool
+  fun uu___ -> lookup_opt "print_implicits" as_bool
 let (get_print_universes : unit -> Prims.bool) =
-  fun uu____1822 -> lookup_opt "print_universes" as_bool
+  fun uu___ -> lookup_opt "print_universes" as_bool
 let (get_print_z3_statistics : unit -> Prims.bool) =
-  fun uu____1827 -> lookup_opt "print_z3_statistics" as_bool
-let (get_prn : unit -> Prims.bool) =
-  fun uu____1832 -> lookup_opt "prn" as_bool
+  fun uu___ -> lookup_opt "print_z3_statistics" as_bool
+let (get_prn : unit -> Prims.bool) = fun uu___ -> lookup_opt "prn" as_bool
 let (get_quake_lo : unit -> Prims.int) =
-  fun uu____1837 -> lookup_opt "quake_lo" as_int
+  fun uu___ -> lookup_opt "quake_lo" as_int
 let (get_quake_hi : unit -> Prims.int) =
-  fun uu____1842 -> lookup_opt "quake_hi" as_int
+  fun uu___ -> lookup_opt "quake_hi" as_int
 let (get_quake_keep : unit -> Prims.bool) =
-  fun uu____1847 -> lookup_opt "quake_keep" as_bool
+  fun uu___ -> lookup_opt "quake_keep" as_bool
 let (get_query_stats : unit -> Prims.bool) =
-  fun uu____1852 -> lookup_opt "query_stats" as_bool
+  fun uu___ -> lookup_opt "query_stats" as_bool
 let (get_record_hints : unit -> Prims.bool) =
-  fun uu____1857 -> lookup_opt "record_hints" as_bool
+  fun uu___ -> lookup_opt "record_hints" as_bool
 let (get_record_options : unit -> Prims.bool) =
-  fun uu____1862 -> lookup_opt "record_options" as_bool
+  fun uu___ -> lookup_opt "record_options" as_bool
 let (get_retry : unit -> Prims.bool) =
-  fun uu____1867 -> lookup_opt "retry" as_bool
+  fun uu___ -> lookup_opt "retry" as_bool
 let (get_reuse_hint_for :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1874 -> lookup_opt "reuse_hint_for" (as_option as_string)
+  fun uu___ -> lookup_opt "reuse_hint_for" (as_option as_string)
 let (get_report_assumes :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1883 -> lookup_opt "report_assumes" (as_option as_string)
+  fun uu___ -> lookup_opt "report_assumes" (as_option as_string)
 let (get_silent : unit -> Prims.bool) =
-  fun uu____1890 -> lookup_opt "silent" as_bool
+  fun uu___ -> lookup_opt "silent" as_bool
 let (get_smt : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1897 -> lookup_opt "smt" (as_option as_string)
+  fun uu___ -> lookup_opt "smt" (as_option as_string)
 let (get_smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____1904 -> lookup_opt "smtencoding.elim_box" as_bool
+  fun uu___ -> lookup_opt "smtencoding.elim_box" as_bool
 let (get_smtencoding_nl_arith_repr : unit -> Prims.string) =
-  fun uu____1909 -> lookup_opt "smtencoding.nl_arith_repr" as_string
+  fun uu___ -> lookup_opt "smtencoding.nl_arith_repr" as_string
 let (get_smtencoding_l_arith_repr : unit -> Prims.string) =
-  fun uu____1914 -> lookup_opt "smtencoding.l_arith_repr" as_string
+  fun uu___ -> lookup_opt "smtencoding.l_arith_repr" as_string
 let (get_smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____1919 -> lookup_opt "smtencoding.valid_intro" as_bool
+  fun uu___ -> lookup_opt "smtencoding.valid_intro" as_bool
 let (get_smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____1924 -> lookup_opt "smtencoding.valid_elim" as_bool
+  fun uu___ -> lookup_opt "smtencoding.valid_elim" as_bool
 let (get_tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____1929 -> lookup_opt "tactic_raw_binders" as_bool
+  fun uu___ -> lookup_opt "tactic_raw_binders" as_bool
 let (get_tactics_failhard : unit -> Prims.bool) =
-  fun uu____1934 -> lookup_opt "tactics_failhard" as_bool
+  fun uu___ -> lookup_opt "tactics_failhard" as_bool
 let (get_tactics_info : unit -> Prims.bool) =
-  fun uu____1939 -> lookup_opt "tactics_info" as_bool
+  fun uu___ -> lookup_opt "tactics_info" as_bool
 let (get_tactic_trace : unit -> Prims.bool) =
-  fun uu____1944 -> lookup_opt "tactic_trace" as_bool
+  fun uu___ -> lookup_opt "tactic_trace" as_bool
 let (get_tactic_trace_d : unit -> Prims.int) =
-  fun uu____1949 -> lookup_opt "tactic_trace_d" as_int
+  fun uu___ -> lookup_opt "tactic_trace_d" as_int
 let (get_tactics_nbe : unit -> Prims.bool) =
-  fun uu____1954 -> lookup_opt "__tactics_nbe" as_bool
+  fun uu___ -> lookup_opt "__tactics_nbe" as_bool
 let (get_tcnorm : unit -> Prims.bool) =
-  fun uu____1959 -> lookup_opt "tcnorm" as_bool
+  fun uu___ -> lookup_opt "tcnorm" as_bool
 let (get_timing : unit -> Prims.bool) =
-  fun uu____1964 -> lookup_opt "timing" as_bool
+  fun uu___ -> lookup_opt "timing" as_bool
 let (get_trace_error : unit -> Prims.bool) =
-  fun uu____1969 -> lookup_opt "trace_error" as_bool
+  fun uu___ -> lookup_opt "trace_error" as_bool
 let (get_unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____1974 -> lookup_opt "unthrottle_inductives" as_bool
+  fun uu___ -> lookup_opt "unthrottle_inductives" as_bool
 let (get_unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____1979 -> lookup_opt "unsafe_tactic_exec" as_bool
+  fun uu___ -> lookup_opt "unsafe_tactic_exec" as_bool
 let (get_use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____1984 -> lookup_opt "use_eq_at_higher_order" as_bool
+  fun uu___ -> lookup_opt "use_eq_at_higher_order" as_bool
 let (get_use_hints : unit -> Prims.bool) =
-  fun uu____1989 -> lookup_opt "use_hints" as_bool
+  fun uu___ -> lookup_opt "use_hints" as_bool
 let (get_use_hint_hashes : unit -> Prims.bool) =
-  fun uu____1994 -> lookup_opt "use_hint_hashes" as_bool
+  fun uu___ -> lookup_opt "use_hint_hashes" as_bool
 let (get_use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2001 -> lookup_opt "use_native_tactics" (as_option as_string)
+  fun uu___ -> lookup_opt "use_native_tactics" (as_option as_string)
 let (get_use_tactics : unit -> Prims.bool) =
-  fun uu____2008 ->
-    let uu____2009 = lookup_opt "no_tactics" as_bool in
-    Prims.op_Negation uu____2009
+  fun uu___ ->
+    let uu___1 = lookup_opt "no_tactics" as_bool in Prims.op_Negation uu___1
 let (get_using_facts_from :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2018 ->
-    lookup_opt "using_facts_from" (as_option (as_list as_string))
+  fun uu___ -> lookup_opt "using_facts_from" (as_option (as_list as_string))
 let (get_vcgen_optimize_bind_as_seq :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____2031 ->
-    lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
+  fun uu___ -> lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
 let (get_verify_module : unit -> Prims.string Prims.list) =
-  fun uu____2040 -> lookup_opt "verify_module" (as_list as_string)
+  fun uu___ -> lookup_opt "verify_module" (as_list as_string)
 let (get___temp_no_proj : unit -> Prims.string Prims.list) =
-  fun uu____2049 -> lookup_opt "__temp_no_proj" (as_list as_string)
+  fun uu___ -> lookup_opt "__temp_no_proj" (as_list as_string)
 let (get_version : unit -> Prims.bool) =
-  fun uu____2056 -> lookup_opt "version" as_bool
+  fun uu___ -> lookup_opt "version" as_bool
 let (get_warn_default_effects : unit -> Prims.bool) =
-  fun uu____2061 -> lookup_opt "warn_default_effects" as_bool
+  fun uu___ -> lookup_opt "warn_default_effects" as_bool
 let (get_z3cliopt : unit -> Prims.string Prims.list) =
-  fun uu____2068 -> lookup_opt "z3cliopt" (as_list as_string)
+  fun uu___ -> lookup_opt "z3cliopt" (as_list as_string)
 let (get_z3refresh : unit -> Prims.bool) =
-  fun uu____2075 -> lookup_opt "z3refresh" as_bool
+  fun uu___ -> lookup_opt "z3refresh" as_bool
 let (get_z3rlimit : unit -> Prims.int) =
-  fun uu____2080 -> lookup_opt "z3rlimit" as_int
+  fun uu___ -> lookup_opt "z3rlimit" as_int
 let (get_z3rlimit_factor : unit -> Prims.int) =
-  fun uu____2085 -> lookup_opt "z3rlimit_factor" as_int
+  fun uu___ -> lookup_opt "z3rlimit_factor" as_int
 let (get_z3seed : unit -> Prims.int) =
-  fun uu____2090 -> lookup_opt "z3seed" as_int
+  fun uu___ -> lookup_opt "z3seed" as_int
 let (get_use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____2095 -> lookup_opt "use_two_phase_tc" as_bool
+  fun uu___ -> lookup_opt "use_two_phase_tc" as_bool
 let (get_no_positivity : unit -> Prims.bool) =
-  fun uu____2100 -> lookup_opt "__no_positivity" as_bool
+  fun uu___ -> lookup_opt "__no_positivity" as_bool
 let (get_ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____2105 -> lookup_opt "__ml_no_eta_expand_coertions" as_bool
+  fun uu___ -> lookup_opt "__ml_no_eta_expand_coertions" as_bool
 let (get_warn_error : unit -> Prims.string Prims.list) =
-  fun uu____2112 -> lookup_opt "warn_error" (as_list as_string)
+  fun uu___ -> lookup_opt "warn_error" (as_list as_string)
 let (get_use_nbe : unit -> Prims.bool) =
-  fun uu____2119 -> lookup_opt "use_nbe" as_bool
+  fun uu___ -> lookup_opt "use_nbe" as_bool
 let (get_use_nbe_for_extraction : unit -> Prims.bool) =
-  fun uu____2124 -> lookup_opt "use_nbe_for_extraction" as_bool
+  fun uu___ -> lookup_opt "use_nbe_for_extraction" as_bool
 let (get_trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____2129 ->
-    lookup_opt "trivial_pre_for_unannotated_effectful_fns" as_bool
+  fun uu___ -> lookup_opt "trivial_pre_for_unannotated_effectful_fns" as_bool
 let (get_profile :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2138 -> lookup_opt "profile" (as_option (as_list as_string))
+  fun uu___ -> lookup_opt "profile" (as_option (as_list as_string))
 let (get_profile_group_by_decl : unit -> Prims.bool) =
-  fun uu____2149 -> lookup_opt "profile_group_by_decl" as_bool
+  fun uu___ -> lookup_opt "profile_group_by_decl" as_bool
 let (get_profile_component :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____2158 ->
-    lookup_opt "profile_component" (as_option (as_list as_string))
+  fun uu___ -> lookup_opt "profile_component" (as_option (as_list as_string))
 let (dlevel : Prims.string -> debug_level_t) =
-  fun uu___6_2169 ->
-    match uu___6_2169 with
+  fun uu___ ->
+    match uu___ with
     | "Low" -> Low
     | "Medium" -> Medium
     | "High" -> High
@@ -620,7 +589,7 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
   fun l1 ->
     fun l2 ->
       match l1 with
-      | Other uu____2181 -> l1 = l2
+      | Other uu___ -> l1 = l2
       | Low -> l1 = l2
       | Medium -> (l2 = Low) || (l2 = Medium)
       | High -> ((l2 = Low) || (l2 = Medium)) || (l2 = High)
@@ -628,121 +597,116 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
           (((l2 = Low) || (l2 = Medium)) || (l2 = High)) || (l2 = Extreme)
 let (debug_level_geq : debug_level_t -> Prims.bool) =
   fun l2 ->
-    let uu____2187 = get_debug_level () in
-    FStar_All.pipe_right uu____2187
+    let uu___ = get_debug_level () in
+    FStar_All.pipe_right uu___
       (FStar_Util.for_some (fun l1 -> one_debug_level_geq (dlevel l1) l2))
 let (universe_include_path_base_dirs : Prims.string Prims.list) =
   let sub_dirs = ["legacy"; "experimental"; ".cache"] in
   FStar_All.pipe_right ["/ulib"; "/lib/fstar"]
     (FStar_List.collect
        (fun d ->
-          let uu____2206 =
+          let uu___ =
             FStar_All.pipe_right sub_dirs
               (FStar_List.map
                  (fun s ->
-                    let uu____2216 = FStar_String.op_Hat "/" s in
-                    FStar_String.op_Hat d uu____2216)) in
-          d :: uu____2206))
+                    let uu___1 = FStar_String.op_Hat "/" s in
+                    FStar_String.op_Hat d uu___1)) in
+          d :: uu___))
 let (_version : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (_platform : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (_compiler : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (_date : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "<not set>"
 let (_commit : Prims.string FStar_ST.ref) = FStar_Util.mk_ref ""
 let (display_version : unit -> unit) =
-  fun uu____2231 ->
-    let uu____2232 =
-      let uu____2233 = FStar_ST.op_Bang _version in
-      let uu____2240 = FStar_ST.op_Bang _platform in
-      let uu____2247 = FStar_ST.op_Bang _compiler in
-      let uu____2254 = FStar_ST.op_Bang _date in
-      let uu____2261 = FStar_ST.op_Bang _commit in
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang _version in
+      let uu___3 = FStar_ST.op_Bang _platform in
+      let uu___4 = FStar_ST.op_Bang _compiler in
+      let uu___5 = FStar_ST.op_Bang _date in
+      let uu___6 = FStar_ST.op_Bang _commit in
       FStar_Util.format5
-        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____2233
-        uu____2240 uu____2247 uu____2254 uu____2261 in
-    FStar_Util.print_string uu____2232
+        "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu___2 uu___3
+        uu___4 uu___5 uu___6 in
+    FStar_Util.print_string uu___1
 let display_usage_aux :
-  'uuuuuu2274 'uuuuuu2275 .
-    ('uuuuuu2274 * Prims.string * 'uuuuuu2275 FStar_Getopt.opt_variant *
-      Prims.string) Prims.list -> unit
+  'uuuuu 'uuuuu1 .
+    ('uuuuu * Prims.string * 'uuuuu1 FStar_Getopt.opt_variant * Prims.string)
+      Prims.list -> unit
   =
   fun specs ->
     FStar_Util.print_string "fstar.exe [options] file[s]\n";
     FStar_List.iter
-      (fun uu____2323 ->
-         match uu____2323 with
-         | (uu____2334, flag, p, doc) ->
+      (fun uu___1 ->
+         match uu___1 with
+         | (uu___2, flag, p, doc) ->
              (match p with
               | FStar_Getopt.ZeroArgs ig ->
                   if doc = ""
                   then
-                    let uu____2346 =
-                      let uu____2347 = FStar_Util.colorize_bold flag in
-                      FStar_Util.format1 "  --%s\n" uu____2347 in
-                    FStar_Util.print_string uu____2346
+                    let uu___3 =
+                      let uu___4 = FStar_Util.colorize_bold flag in
+                      FStar_Util.format1 "  --%s\n" uu___4 in
+                    FStar_Util.print_string uu___3
                   else
-                    (let uu____2349 =
-                       let uu____2350 = FStar_Util.colorize_bold flag in
-                       FStar_Util.format2 "  --%s  %s\n" uu____2350 doc in
-                     FStar_Util.print_string uu____2349)
-              | FStar_Getopt.OneArg (uu____2351, argname) ->
+                    (let uu___4 =
+                       let uu___5 = FStar_Util.colorize_bold flag in
+                       FStar_Util.format2 "  --%s  %s\n" uu___5 doc in
+                     FStar_Util.print_string uu___4)
+              | FStar_Getopt.OneArg (uu___3, argname) ->
                   if doc = ""
                   then
-                    let uu____2359 =
-                      let uu____2360 = FStar_Util.colorize_bold flag in
-                      let uu____2361 = FStar_Util.colorize_bold argname in
-                      FStar_Util.format2 "  --%s %s\n" uu____2360 uu____2361 in
-                    FStar_Util.print_string uu____2359
+                    let uu___4 =
+                      let uu___5 = FStar_Util.colorize_bold flag in
+                      let uu___6 = FStar_Util.colorize_bold argname in
+                      FStar_Util.format2 "  --%s %s\n" uu___5 uu___6 in
+                    FStar_Util.print_string uu___4
                   else
-                    (let uu____2363 =
-                       let uu____2364 = FStar_Util.colorize_bold flag in
-                       let uu____2365 = FStar_Util.colorize_bold argname in
-                       FStar_Util.format3 "  --%s %s  %s\n" uu____2364
-                         uu____2365 doc in
-                     FStar_Util.print_string uu____2363))) specs
+                    (let uu___5 =
+                       let uu___6 = FStar_Util.colorize_bold flag in
+                       let uu___7 = FStar_Util.colorize_bold argname in
+                       FStar_Util.format3 "  --%s %s  %s\n" uu___6 uu___7 doc in
+                     FStar_Util.print_string uu___5))) specs
 let (mk_spec :
   (FStar_BaseTypes.char * Prims.string * option_val FStar_Getopt.opt_variant
     * Prims.string) -> FStar_Getopt.opt)
   =
   fun o ->
-    let uu____2391 = o in
-    match uu____2391 with
+    let uu___ = o in
+    match uu___ with
     | (ns, name, arg, desc) ->
         let arg1 =
           match arg with
           | FStar_Getopt.ZeroArgs f ->
-              let g uu____2424 =
-                let uu____2425 = f () in set_option name uu____2425 in
+              let g uu___1 = let uu___2 = f () in set_option name uu___2 in
               FStar_Getopt.ZeroArgs g
           | FStar_Getopt.OneArg (f, d) ->
-              let g x = let uu____2440 = f x in set_option name uu____2440 in
+              let g x = let uu___1 = f x in set_option name uu___1 in
               FStar_Getopt.OneArg (g, d) in
         (ns, name, arg1, desc)
 let (accumulated_option : Prims.string -> option_val -> option_val) =
   fun name ->
     fun value ->
       let prev_values =
-        let uu____2459 = lookup_opt name (as_option as_list') in
-        FStar_Util.dflt [] uu____2459 in
+        let uu___ = lookup_opt name (as_option as_list') in
+        FStar_Util.dflt [] uu___ in
       List (value :: prev_values)
 let (reverse_accumulated_option : Prims.string -> option_val -> option_val) =
   fun name ->
     fun value ->
       let prev_values =
-        let uu____2485 = lookup_opt name (as_option as_list') in
-        FStar_Util.dflt [] uu____2485 in
+        let uu___ = lookup_opt name (as_option as_list') in
+        FStar_Util.dflt [] uu___ in
       List (FStar_List.append prev_values [value])
 let accumulate_string :
-  'uuuuuu2506 .
-    Prims.string -> ('uuuuuu2506 -> Prims.string) -> 'uuuuuu2506 -> unit
-  =
+  'uuuuu . Prims.string -> ('uuuuu -> Prims.string) -> 'uuuuu -> unit =
   fun name ->
     fun post_processor ->
       fun value ->
-        let uu____2527 =
-          let uu____2528 =
-            let uu____2529 = post_processor value in String uu____2529 in
-          accumulated_option name uu____2528 in
-        set_option name uu____2527
+        let uu___ =
+          let uu___1 = let uu___2 = post_processor value in String uu___2 in
+          accumulated_option name uu___1 in
+        set_option name uu___
 let (add_extract_module : Prims.string -> unit) =
   fun s -> accumulate_string "extract_module" FStar_String.lowercase s
 let (add_extract_namespace : Prims.string -> unit) =
@@ -762,109 +726,98 @@ type opt_type =
   | ReverseAccumulated of opt_type 
   | WithSideEffect of ((unit -> unit) * opt_type) 
 let (uu___is_Const : opt_type -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Const _0 -> true | uu____2625 -> false
+  fun projectee -> match projectee with | Const _0 -> true | uu___ -> false
 let (__proj__Const__item___0 : opt_type -> option_val) =
   fun projectee -> match projectee with | Const _0 -> _0
 let (uu___is_IntStr : opt_type -> Prims.bool) =
-  fun projectee ->
-    match projectee with | IntStr _0 -> true | uu____2638 -> false
+  fun projectee -> match projectee with | IntStr _0 -> true | uu___ -> false
 let (__proj__IntStr__item___0 : opt_type -> Prims.string) =
   fun projectee -> match projectee with | IntStr _0 -> _0
 let (uu___is_BoolStr : opt_type -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BoolStr -> true | uu____2650 -> false
+  fun projectee -> match projectee with | BoolStr -> true | uu___ -> false
 let (uu___is_PathStr : opt_type -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PathStr _0 -> true | uu____2657 -> false
+  fun projectee -> match projectee with | PathStr _0 -> true | uu___ -> false
 let (__proj__PathStr__item___0 : opt_type -> Prims.string) =
   fun projectee -> match projectee with | PathStr _0 -> _0
 let (uu___is_SimpleStr : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | SimpleStr _0 -> true | uu____2670 -> false
+    match projectee with | SimpleStr _0 -> true | uu___ -> false
 let (__proj__SimpleStr__item___0 : opt_type -> Prims.string) =
   fun projectee -> match projectee with | SimpleStr _0 -> _0
 let (uu___is_EnumStr : opt_type -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EnumStr _0 -> true | uu____2685 -> false
+  fun projectee -> match projectee with | EnumStr _0 -> true | uu___ -> false
 let (__proj__EnumStr__item___0 : opt_type -> Prims.string Prims.list) =
   fun projectee -> match projectee with | EnumStr _0 -> _0
 let (uu___is_OpenEnumStr : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | OpenEnumStr _0 -> true | uu____2710 -> false
+    match projectee with | OpenEnumStr _0 -> true | uu___ -> false
 let (__proj__OpenEnumStr__item___0 :
   opt_type -> (Prims.string Prims.list * Prims.string)) =
   fun projectee -> match projectee with | OpenEnumStr _0 -> _0
 let (uu___is_PostProcessed : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | PostProcessed _0 -> true | uu____2748 -> false
+    match projectee with | PostProcessed _0 -> true | uu___ -> false
 let (__proj__PostProcessed__item___0 :
   opt_type -> ((option_val -> option_val) * opt_type)) =
   fun projectee -> match projectee with | PostProcessed _0 -> _0
 let (uu___is_Accumulated : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | Accumulated _0 -> true | uu____2782 -> false
+    match projectee with | Accumulated _0 -> true | uu___ -> false
 let (__proj__Accumulated__item___0 : opt_type -> opt_type) =
   fun projectee -> match projectee with | Accumulated _0 -> _0
 let (uu___is_ReverseAccumulated : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | ReverseAccumulated _0 -> true
-    | uu____2795 -> false
+    match projectee with | ReverseAccumulated _0 -> true | uu___ -> false
 let (__proj__ReverseAccumulated__item___0 : opt_type -> opt_type) =
   fun projectee -> match projectee with | ReverseAccumulated _0 -> _0
 let (uu___is_WithSideEffect : opt_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | WithSideEffect _0 -> true | uu____2815 -> false
+    match projectee with | WithSideEffect _0 -> true | uu___ -> false
 let (__proj__WithSideEffect__item___0 :
   opt_type -> ((unit -> unit) * opt_type)) =
   fun projectee -> match projectee with | WithSideEffect _0 -> _0
 exception InvalidArgument of Prims.string 
 let (uu___is_InvalidArgument : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | InvalidArgument uu____2852 -> true
-    | uu____2853 -> false
+    match projectee with | InvalidArgument uu___ -> true | uu___ -> false
 let (__proj__InvalidArgument__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee ->
-    match projectee with | InvalidArgument uu____2859 -> uu____2859
+  fun projectee -> match projectee with | InvalidArgument uu___ -> uu___
 let rec (parse_opt_val :
   Prims.string -> opt_type -> Prims.string -> option_val) =
   fun opt_name ->
     fun typ ->
       fun str_val ->
         try
-          (fun uu___310_2877 ->
+          (fun uu___ ->
              match () with
              | () ->
                  (match typ with
                   | Const c -> c
-                  | IntStr uu____2879 ->
-                      let uu____2880 = FStar_Util.safe_int_of_string str_val in
-                      (match uu____2880 with
+                  | IntStr uu___1 ->
+                      let uu___2 = FStar_Util.safe_int_of_string str_val in
+                      (match uu___2 with
                        | FStar_Pervasives_Native.Some v -> Int v
                        | FStar_Pervasives_Native.None ->
                            FStar_Exn.raise (InvalidArgument opt_name))
                   | BoolStr ->
-                      let uu____2884 =
+                      let uu___1 =
                         if str_val = "true"
                         then true
                         else
                           if str_val = "false"
                           then false
                           else FStar_Exn.raise (InvalidArgument opt_name) in
-                      Bool uu____2884
-                  | PathStr uu____2887 -> Path str_val
-                  | SimpleStr uu____2888 -> String str_val
+                      Bool uu___1
+                  | PathStr uu___1 -> Path str_val
+                  | SimpleStr uu___1 -> String str_val
                   | EnumStr strs ->
                       if FStar_List.mem str_val strs
                       then String str_val
                       else FStar_Exn.raise (InvalidArgument opt_name)
-                  | OpenEnumStr uu____2893 -> String str_val
+                  | OpenEnumStr uu___1 -> String str_val
                   | PostProcessed (pp, elem_spec) ->
-                      let uu____2908 =
-                        parse_opt_val opt_name elem_spec str_val in
-                      pp uu____2908
+                      let uu___1 = parse_opt_val opt_name elem_spec str_val in
+                      pp uu___1
                   | Accumulated elem_spec ->
                       let v = parse_opt_val opt_name elem_spec str_val in
                       accumulated_option opt_name v
@@ -876,18 +829,17 @@ let rec (parse_opt_val :
                        parse_opt_val opt_name elem_spec str_val))) ()
         with
         | InvalidArgument opt_name1 ->
-            let uu____2927 =
+            let uu___1 =
               FStar_Util.format1 "Invalid argument to --%s" opt_name1 in
-            failwith uu____2927
+            failwith uu___1
 let rec (desc_of_opt_type :
   opt_type -> Prims.string FStar_Pervasives_Native.option) =
   fun typ ->
     let desc_of_enum cases =
-      let uu____2949 =
-        let uu____2950 =
-          FStar_String.op_Hat (FStar_String.concat "|" cases) "]" in
-        FStar_String.op_Hat "[" uu____2950 in
-      FStar_Pervasives_Native.Some uu____2949 in
+      let uu___ =
+        let uu___1 = FStar_String.op_Hat (FStar_String.concat "|" cases) "]" in
+        FStar_String.op_Hat "[" uu___1 in
+      FStar_Pervasives_Native.Some uu___ in
     match typ with
     | Const c -> FStar_Pervasives_Native.None
     | IntStr desc -> FStar_Pervasives_Native.Some desc
@@ -897,28 +849,27 @@ let rec (desc_of_opt_type :
     | EnumStr strs -> desc_of_enum strs
     | OpenEnumStr (strs, desc) ->
         desc_of_enum (FStar_List.append strs [desc])
-    | PostProcessed (uu____2966, elem_spec) -> desc_of_opt_type elem_spec
+    | PostProcessed (uu___, elem_spec) -> desc_of_opt_type elem_spec
     | Accumulated elem_spec -> desc_of_opt_type elem_spec
     | ReverseAccumulated elem_spec -> desc_of_opt_type elem_spec
-    | WithSideEffect (uu____2976, elem_spec) -> desc_of_opt_type elem_spec
+    | WithSideEffect (uu___, elem_spec) -> desc_of_opt_type elem_spec
 let (arg_spec_of_opt_type :
   Prims.string -> opt_type -> option_val FStar_Getopt.opt_variant) =
   fun opt_name ->
     fun typ ->
       let parser = parse_opt_val opt_name typ in
-      let uu____3003 = desc_of_opt_type typ in
-      match uu____3003 with
+      let uu___ = desc_of_opt_type typ in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          FStar_Getopt.ZeroArgs ((fun uu____3009 -> parser ""))
+          FStar_Getopt.ZeroArgs ((fun uu___1 -> parser ""))
       | FStar_Pervasives_Native.Some desc ->
           FStar_Getopt.OneArg (parser, desc)
 let (pp_validate_dir : option_val -> option_val) =
   fun p -> let pp = as_string p in FStar_Util.mkdir false pp; p
 let (pp_lowercase : option_val -> option_val) =
   fun s ->
-    let uu____3026 =
-      let uu____3027 = as_string s in FStar_String.lowercase uu____3027 in
-    String uu____3026
+    let uu___ = let uu___1 = as_string s in FStar_String.lowercase uu___1 in
+    String uu___
 let (abort_counter : Prims.int FStar_ST.ref) =
   FStar_Util.mk_ref Prims.int_zero
 let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
@@ -927,41 +878,38 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
     let ios = FStar_Util.int_of_string in
     match FStar_Util.split s "/" with
     | f::[] ->
-        let uu____3061 = ios f in
-        let uu____3062 = ios f in (uu____3061, uu____3062, false)
+        let uu___ = ios f in let uu___1 = ios f in (uu___, uu___1, false)
     | f1::f2::[] ->
         if f2 = "k"
         then
-          let uu____3071 = ios f1 in
-          let uu____3072 = ios f1 in (uu____3071, uu____3072, true)
+          let uu___ = ios f1 in let uu___1 = ios f1 in (uu___, uu___1, true)
         else
-          (let uu____3074 = ios f1 in
-           let uu____3075 = ios f2 in (uu____3074, uu____3075, false))
+          (let uu___1 = ios f1 in
+           let uu___2 = ios f2 in (uu___1, uu___2, false))
     | f1::f2::k::[] ->
         if k = "k"
         then
-          let uu____3085 = ios f1 in
-          let uu____3086 = ios f2 in (uu____3085, uu____3086, true)
+          let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
-    | uu____3094 -> failwith "unexpected value for --quake"
+    | uu___ -> failwith "unexpected value for --quake"
 let (uu___402 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f = FStar_ST.op_Colon_Equals cb (FStar_Pervasives_Native.Some f) in
   let call msg =
-    let uu____3168 = FStar_ST.op_Bang cb in
-    match uu____3168 with
+    let uu___ = FStar_ST.op_Bang cb in
+    match uu___ with
     | FStar_Pervasives_Native.None -> ()
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
   match uu___402 with
-  | (set_option_warning_callback_aux, option_warning_callback) ->
-      set_option_warning_callback_aux
+  | (set_option_warning_callback_aux1, option_warning_callback) ->
+      set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
   match uu___402 with
-  | (set_option_warning_callback_aux1, option_warning_callback) ->
-      option_warning_callback
+  | (set_option_warning_callback_aux1, option_warning_callback1) ->
+      option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
   fun f -> set_option_warning_callback_aux f
 let rec (specs_with_types :
@@ -972,21 +920,21 @@ let rec (specs_with_types :
   fun warn_unsafe ->
     [(FStar_Getopt.noshort, "abort_on",
        (PostProcessed
-          (((fun uu___7_3324 ->
-               match uu___7_3324 with
+          (((fun uu___ ->
+               match uu___ with
                | Int x -> (FStar_ST.op_Colon_Equals abort_counter x; Int x)
                | x -> failwith "?")), (IntStr "non-negative integer"))),
        "Abort on the n-th error or warning raised. Useful in combination with --trace_error. Count starts at 1, use 0 to disable. (default 0)");
     (FStar_Getopt.noshort, "admit_smt_queries",
       (WithSideEffect
-         (((fun uu____3346 ->
+         (((fun uu___ ->
               if warn_unsafe
               then option_warning_callback "admit_smt_queries"
               else ())), BoolStr)),
       "Admit SMT queries, unsafe! (default 'false')");
     (FStar_Getopt.noshort, "admit_except",
       (WithSideEffect
-         (((fun uu____3360 ->
+         (((fun uu___ ->
               if warn_unsafe
               then option_warning_callback "admit_except"
               else ())), (SimpleStr "[symbol|(symbol, id)]"))),
@@ -1070,48 +1018,44 @@ let rec (specs_with_types :
       "Force checking the files given as arguments even if they have valid checked files");
     (FStar_Getopt.noshort, "fuel",
       (PostProcessed
-         (((fun uu___8_3640 ->
-              match uu___8_3640 with
+         (((fun uu___ ->
+              match uu___ with
               | String s ->
                   let p f =
-                    let uu____3648 = FStar_Util.int_of_string f in
-                    Int uu____3648 in
-                  let uu____3649 =
+                    let uu___1 = FStar_Util.int_of_string f in Int uu___1 in
+                  let uu___1 =
                     match FStar_Util.split s "," with
                     | f::[] -> (f, f)
                     | f1::f2::[] -> (f1, f2)
-                    | uu____3661 -> failwith "unexpected value for --fuel" in
-                  (match uu____3649 with
+                    | uu___2 -> failwith "unexpected value for --fuel" in
+                  (match uu___1 with
                    | (min, max) ->
-                       ((let uu____3671 = p min in
-                         set_option "initial_fuel" uu____3671);
-                        (let uu____3673 = p max in
-                         set_option "max_fuel" uu____3673);
+                       ((let uu___3 = p min in
+                         set_option "initial_fuel" uu___3);
+                        (let uu___4 = p max in set_option "max_fuel" uu___4);
                         String s))
-              | uu____3674 -> failwith "impos")),
+              | uu___1 -> failwith "impos")),
            (SimpleStr "non-negative integer or pair of non-negative integers"))),
       "Set initial_fuel and max_fuel at once");
     (FStar_Getopt.noshort, "ifuel",
       (PostProcessed
-         (((fun uu___9_3694 ->
-              match uu___9_3694 with
+         (((fun uu___ ->
+              match uu___ with
               | String s ->
                   let p f =
-                    let uu____3702 = FStar_Util.int_of_string f in
-                    Int uu____3702 in
-                  let uu____3703 =
+                    let uu___1 = FStar_Util.int_of_string f in Int uu___1 in
+                  let uu___1 =
                     match FStar_Util.split s "," with
                     | f::[] -> (f, f)
                     | f1::f2::[] -> (f1, f2)
-                    | uu____3715 -> failwith "unexpected value for --ifuel" in
-                  (match uu____3703 with
+                    | uu___2 -> failwith "unexpected value for --ifuel" in
+                  (match uu___1 with
                    | (min, max) ->
-                       ((let uu____3725 = p min in
-                         set_option "initial_ifuel" uu____3725);
-                        (let uu____3727 = p max in
-                         set_option "max_ifuel" uu____3727);
+                       ((let uu___3 = p min in
+                         set_option "initial_ifuel" uu___3);
+                        (let uu___4 = p max in set_option "max_ifuel" uu___4);
                         String s))
-              | uu____3728 -> failwith "impos")),
+              | uu___1 -> failwith "impos")),
            (SimpleStr "non-negative integer or pair of non-negative integers"))),
       "Set initial_ifuel and max_ifuel at once");
     (FStar_Getopt.noshort, "initial_fuel", (IntStr "non-negative integer"),
@@ -1122,7 +1066,7 @@ let rec (specs_with_types :
       "Retain comments in the logged SMT queries (requires --log_queries; default true)");
     (FStar_Getopt.noshort, "lax",
       (WithSideEffect
-         (((fun uu____3765 ->
+         (((fun uu___ ->
               if warn_unsafe then option_warning_callback "lax" else ())),
            (Const (Bool true)))),
       "Run the lax-type checker only (admit all verification conditions)");
@@ -1176,18 +1120,18 @@ let rec (specs_with_types :
       "Print full names (deprecated; use --print_full_names instead)");
     (FStar_Getopt.noshort, "quake",
       (PostProcessed
-         (((fun uu___10_3975 ->
-              match uu___10_3975 with
+         (((fun uu___ ->
+              match uu___ with
               | String s ->
-                  let uu____3977 = interp_quake_arg s in
-                  (match uu____3977 with
+                  let uu___1 = interp_quake_arg s in
+                  (match uu___1 with
                    | (min, max, k) ->
                        (set_option "quake_lo" (Int min);
                         set_option "quake_hi" (Int max);
                         set_option "quake_keep" (Bool k);
                         set_option "retry" (Bool false);
                         String s))
-              | uu____3991 -> failwith "impos")),
+              | uu___1 -> failwith "impos")),
            (SimpleStr "positive integer or pair of positive integers"))),
       "Repeats SMT queries to check for robustness\n\t\t--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible\n\t\t--quake N/M/k works as above, except it will unconditionally run M times\n\t\t--quake N is an alias for --quake N/N\n\t\t--quake N/k is an alias for --quake N/N/k\n\tUsing --quake disables --retry.");
     (FStar_Getopt.noshort, "query_stats", (Const (Bool true)),
@@ -1198,16 +1142,15 @@ let rec (specs_with_types :
       "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming");
     (FStar_Getopt.noshort, "retry",
       (PostProcessed
-         (((fun uu___11_4033 ->
-              match uu___11_4033 with
+         (((fun uu___ ->
+              match uu___ with
               | Int i ->
                   (set_option "quake_lo" (Int Prims.int_one);
                    set_option "quake_hi" (Int i);
                    set_option "quake_keep" (Bool false);
                    set_option "retry" (Bool true);
                    Bool true)
-              | uu____4039 -> failwith "impos")),
-           (IntStr "positive integer"))),
+              | uu___1 -> failwith "impos")), (IntStr "positive integer"))),
       "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake.");
     (FStar_Getopt.noshort, "reuse_hint_for", (SimpleStr "toplevel_name"),
       "Optimistically, attempt using the recorded hint for <toplevel_name> (a top-level name in the current module) when trying to verify some other term 'g'");
@@ -1280,8 +1223,7 @@ let rec (specs_with_types :
       "Don't use this option yet");
     (118, "version",
       (WithSideEffect
-         (((fun uu____4301 ->
-              display_version (); FStar_All.exit Prims.int_zero)),
+         (((fun uu___ -> display_version (); FStar_All.exit Prims.int_zero)),
            (Const (Bool true)))), "Display version number");
     (FStar_Getopt.noshort, "warn_default_effects", (Const (Bool true)),
       "Warn when (a -> b) is desugared to (a -> Tot b)");
@@ -1312,12 +1254,12 @@ let rec (specs_with_types :
       "Enforce trivial preconditions for unannotated effectful functions (default 'true')");
     (FStar_Getopt.noshort, "__debug_embedding",
       (WithSideEffect
-         (((fun uu____4419 -> FStar_ST.op_Colon_Equals debug_embedding true)),
+         (((fun uu___ -> FStar_ST.op_Colon_Equals debug_embedding true)),
            (Const (Bool true)))),
       "Debug messages for embeddings/unembeddings of natively compiled terms");
     (FStar_Getopt.noshort, "eager_embedding",
       (WithSideEffect
-         (((fun uu____4438 -> FStar_ST.op_Colon_Equals eager_embedding true)),
+         (((fun uu___ -> FStar_ST.op_Colon_Equals eager_embedding true)),
            (Const (Bool true)))),
       "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking");
     (FStar_Getopt.noshort, "profile_group_by_decl", (Const (Bool true)),
@@ -1334,25 +1276,24 @@ let rec (specs_with_types :
       "\n\tProfiling can be enabled when the compiler is processing a given set of source modules.\n\tPass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives.\n\tThis option is a module or namespace selector, like many other options (e.g., `--extract`)");
     (104, "help",
       (WithSideEffect
-         (((fun uu____4482 ->
-              (let uu____4484 = specs warn_unsafe in
-               display_usage_aux uu____4484);
+         (((fun uu___ ->
+              (let uu___2 = specs warn_unsafe in display_usage_aux uu___2);
               FStar_All.exit Prims.int_zero)), (Const (Bool true)))),
       "Display this information")]
 and (specs : Prims.bool -> FStar_Getopt.opt Prims.list) =
   fun warn_unsafe ->
-    let uu____4508 = specs_with_types warn_unsafe in
+    let uu___ = specs_with_types warn_unsafe in
     FStar_List.map
-      (fun uu____4533 ->
-         match uu____4533 with
+      (fun uu___1 ->
+         match uu___1 with
          | (short, long, typ, doc) ->
-             let uu____4546 =
-               let uu____4557 = arg_spec_of_opt_type long typ in
-               (short, long, uu____4557, doc) in
-             mk_spec uu____4546) uu____4508
+             let uu___2 =
+               let uu___3 = arg_spec_of_opt_type long typ in
+               (short, long, uu___3, doc) in
+             mk_spec uu___2) uu___
 let (settable : Prims.string -> Prims.bool) =
-  fun uu___12_4566 ->
-    match uu___12_4566 with
+  fun uu___ ->
+    match uu___ with
     | "abort_on" -> true
     | "admit_except" -> true
     | "admit_smt_queries" -> true
@@ -1432,7 +1373,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "profile_group_by_decl" -> true
     | "profile_component" -> true
     | "profile" -> true
-    | uu____4567 -> false
+    | uu___1 -> false
 let (all_specs : FStar_Getopt.opt Prims.list) = specs true
 let (all_specs_with_types :
   (FStar_BaseTypes.char * Prims.string * opt_type * Prims.string) Prims.list)
@@ -1443,9 +1384,8 @@ let (settable_specs :
   =
   FStar_All.pipe_right all_specs
     (FStar_List.filter
-       (fun uu____4631 ->
-          match uu____4631 with
-          | (uu____4642, x, uu____4644, uu____4645) -> settable x))
+       (fun uu___ ->
+          match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
 let (uu___582 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
@@ -1453,9 +1393,9 @@ let (uu___582 :
   let callback = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
     FStar_ST.op_Colon_Equals callback (FStar_Pervasives_Native.Some f) in
-  let call uu____4714 =
-    let uu____4715 = FStar_ST.op_Bang callback in
-    match uu____4715 with
+  let call uu___ =
+    let uu___1 = FStar_ST.op_Bang callback in
+    match uu___1 with
     | FStar_Pervasives_Native.None ->
         failwith "Error flags callback not yet set"
     | FStar_Pervasives_Native.Some f -> f () in
@@ -1463,65 +1403,63 @@ let (uu___582 :
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
   match uu___582 with
-  | (set_error_flags_callback_aux, set_error_flags) ->
-      set_error_flags_callback_aux
+  | (set_error_flags_callback_aux1, set_error_flags) ->
+      set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
   match uu___582 with
-  | (set_error_flags_callback_aux1, set_error_flags) -> set_error_flags
+  | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
   set_error_flags_callback_aux
-let (display_usage : unit -> unit) =
-  fun uu____4827 -> display_usage_aux all_specs
+let (display_usage : unit -> unit) = fun uu___ -> display_usage_aux all_specs
 let (fstar_bin_directory : Prims.string) = FStar_Util.get_exec_dir ()
 let (file_list_ : Prims.string Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (parse_cmd_line :
   unit -> (FStar_Getopt.parse_cmdline_res * Prims.string Prims.list)) =
-  fun uu____4844 ->
+  fun uu___ ->
     let res =
       FStar_Getopt.parse_cmdline all_specs
         (fun i ->
-           let uu____4849 =
-             let uu____4852 = FStar_ST.op_Bang file_list_ in
-             FStar_List.append uu____4852 [i] in
-           FStar_ST.op_Colon_Equals file_list_ uu____4849) in
+           let uu___1 =
+             let uu___2 = FStar_ST.op_Bang file_list_ in
+             FStar_List.append uu___2 [i] in
+           FStar_ST.op_Colon_Equals file_list_ uu___1) in
     let res1 = if res = FStar_Getopt.Success then set_error_flags () else res in
-    let uu____4877 =
-      let uu____4880 = FStar_ST.op_Bang file_list_ in
-      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____4880 in
-    (res1, uu____4877)
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang file_list_ in
+      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu___2 in
+    (res1, uu___1)
 let (file_list : unit -> Prims.string Prims.list) =
-  fun uu____4901 -> FStar_ST.op_Bang file_list_
+  fun uu___ -> FStar_ST.op_Bang file_list_
 let (restore_cmd_line_options : Prims.bool -> FStar_Getopt.parse_cmdline_res)
   =
   fun should_clear ->
     let old_verify_module = get_verify_module () in
     if should_clear then clear () else init ();
     (let r =
-       let uu____4923 = specs false in
-       FStar_Getopt.parse_cmdline uu____4923 (fun x -> ()) in
-     (let uu____4929 =
-        let uu____4934 =
-          let uu____4935 =
-            FStar_List.map (fun uu____4938 -> String uu____4938)
-              old_verify_module in
-          List uu____4935 in
-        ("verify_module", uu____4934) in
-      set_option' uu____4929);
+       let uu___1 = specs false in
+       FStar_Getopt.parse_cmdline uu___1 (fun x -> ()) in
+     (let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            FStar_List.map (fun uu___5 -> String uu___5) old_verify_module in
+          List uu___4 in
+        ("verify_module", uu___3) in
+      set_option' uu___2);
      r)
 let (module_name_of_file_name : Prims.string -> Prims.string) =
   fun f ->
     let f1 = FStar_Util.basename f in
     let f2 =
-      let uu____4946 =
-        let uu____4947 =
-          let uu____4948 =
-            let uu____4949 = FStar_Util.get_file_extension f1 in
-            FStar_String.length uu____4949 in
-          (FStar_String.length f1) - uu____4948 in
-        uu____4947 - Prims.int_one in
-      FStar_String.substring f1 Prims.int_zero uu____4946 in
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Util.get_file_extension f1 in
+            FStar_String.length uu___3 in
+          (FStar_String.length f1) - uu___2 in
+        uu___1 - Prims.int_one in
+      FStar_String.substring f1 Prims.int_zero uu___ in
     FStar_String.lowercase f2
 let (should_check : Prims.string -> Prims.bool) =
   fun m ->
@@ -1529,80 +1467,72 @@ let (should_check : Prims.string -> Prims.bool) =
     FStar_List.contains (FStar_String.lowercase m) l
 let (should_verify : Prims.string -> Prims.bool) =
   fun m ->
-    (let uu____4965 = get_lax () in Prims.op_Negation uu____4965) &&
-      (should_check m)
+    (let uu___ = get_lax () in Prims.op_Negation uu___) && (should_check m)
 let (should_check_file : Prims.string -> Prims.bool) =
-  fun fn ->
-    let uu____4971 = module_name_of_file_name fn in should_check uu____4971
+  fun fn -> let uu___ = module_name_of_file_name fn in should_check uu___
 let (should_verify_file : Prims.string -> Prims.bool) =
-  fun fn ->
-    let uu____4977 = module_name_of_file_name fn in should_verify uu____4977
+  fun fn -> let uu___ = module_name_of_file_name fn in should_verify uu___
 let (module_name_eq : Prims.string -> Prims.string -> Prims.bool) =
   fun m1 ->
     fun m2 -> (FStar_String.lowercase m1) = (FStar_String.lowercase m2)
 let (dont_gen_projectors : Prims.string -> Prims.bool) =
   fun m ->
-    let uu____4993 = get___temp_no_proj () in
-    FStar_All.pipe_right uu____4993 (FStar_List.existsb (module_name_eq m))
+    let uu___ = get___temp_no_proj () in
+    FStar_All.pipe_right uu___ (FStar_List.existsb (module_name_eq m))
 let (should_print_message : Prims.string -> Prims.bool) =
   fun m ->
-    let uu____5003 = should_verify m in
-    if uu____5003 then m <> "Prims" else false
+    let uu___ = should_verify m in if uu___ then m <> "Prims" else false
 let (include_path : unit -> Prims.string Prims.list) =
-  fun uu____5011 ->
+  fun uu___ ->
     let cache_dir =
-      let uu____5015 = get_cache_dir () in
-      match uu____5015 with
+      let uu___1 = get_cache_dir () in
+      match uu___1 with
       | FStar_Pervasives_Native.None -> []
       | FStar_Pervasives_Native.Some c -> [c] in
-    let uu____5021 = get_no_default_includes () in
-    if uu____5021
-    then
-      let uu____5024 = get_include () in
-      FStar_List.append cache_dir uu____5024
+    let uu___1 = get_no_default_includes () in
+    if uu___1
+    then let uu___2 = get_include () in FStar_List.append cache_dir uu___2
     else
       (let lib_paths =
-         let uu____5031 = FStar_Util.expand_environment_variable "FSTAR_LIB" in
-         match uu____5031 with
+         let uu___3 = FStar_Util.expand_environment_variable "FSTAR_LIB" in
+         match uu___3 with
          | FStar_Pervasives_Native.None ->
              let fstar_home = FStar_String.op_Hat fstar_bin_directory "/.." in
              let defs = universe_include_path_base_dirs in
-             let uu____5040 =
+             let uu___4 =
                FStar_All.pipe_right defs
                  (FStar_List.map (fun x -> FStar_String.op_Hat fstar_home x)) in
-             FStar_All.pipe_right uu____5040
+             FStar_All.pipe_right uu___4
                (FStar_List.filter FStar_Util.file_exists)
          | FStar_Pervasives_Native.Some s -> [s] in
-       let uu____5054 =
-         let uu____5057 =
-           let uu____5060 = get_include () in
-           FStar_List.append uu____5060 ["."] in
-         FStar_List.append lib_paths uu____5057 in
-       FStar_List.append cache_dir uu____5054)
+       let uu___3 =
+         let uu___4 =
+           let uu___5 = get_include () in FStar_List.append uu___5 ["."] in
+         FStar_List.append lib_paths uu___4 in
+       FStar_List.append cache_dir uu___3)
 let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
   =
   let file_map = FStar_Util.smap_create (Prims.of_int (100)) in
   fun filename ->
-    let uu____5077 = FStar_Util.smap_try_find file_map filename in
-    match uu____5077 with
+    let uu___ = FStar_Util.smap_try_find file_map filename in
+    match uu___ with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None ->
         let result =
           try
-            (fun uu___643_5100 ->
+            (fun uu___1 ->
                match () with
                | () ->
-                   let uu____5103 = FStar_Util.is_path_absolute filename in
-                   if uu____5103
+                   let uu___2 = FStar_Util.is_path_absolute filename in
+                   if uu___2
                    then
                      (if FStar_Util.file_exists filename
                       then FStar_Pervasives_Native.Some filename
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____5110 =
-                        let uu____5113 = include_path () in
-                        FStar_List.rev uu____5113 in
-                      FStar_Util.find_map uu____5110
+                     (let uu___4 =
+                        let uu___5 = include_path () in FStar_List.rev uu___5 in
+                      FStar_Util.find_map uu___4
                         (fun p ->
                            let path =
                              if p = "."
@@ -1611,71 +1541,69 @@ let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
                            if FStar_Util.file_exists path
                            then FStar_Pervasives_Native.Some path
                            else FStar_Pervasives_Native.None))) ()
-          with | uu___642_5125 -> FStar_Pervasives_Native.None in
+          with | uu___1 -> FStar_Pervasives_Native.None in
         (if FStar_Option.isSome result
          then FStar_Util.smap_add file_map filename result
          else ();
          result)
 let (prims : unit -> Prims.string) =
-  fun uu____5136 ->
-    let uu____5137 = get_prims () in
-    match uu____5137 with
+  fun uu___ ->
+    let uu___1 = get_prims () in
+    match uu___1 with
     | FStar_Pervasives_Native.None ->
         let filename = "prims.fst" in
-        let uu____5141 = find_file filename in
-        (match uu____5141 with
+        let uu___2 = find_file filename in
+        (match uu___2 with
          | FStar_Pervasives_Native.Some result -> result
          | FStar_Pervasives_Native.None ->
-             let uu____5145 =
+             let uu___3 =
                FStar_Util.format1
                  "unable to find required file \"%s\" in the module search path.\n"
                  filename in
-             failwith uu____5145)
+             failwith uu___3)
     | FStar_Pervasives_Native.Some x -> x
 let (prims_basename : unit -> Prims.string) =
-  fun uu____5151 ->
-    let uu____5152 = prims () in FStar_Util.basename uu____5152
+  fun uu___ -> let uu___1 = prims () in FStar_Util.basename uu___1
 let (pervasives : unit -> Prims.string) =
-  fun uu____5157 ->
+  fun uu___ ->
     let filename = "FStar.Pervasives.fsti" in
-    let uu____5159 = find_file filename in
-    match uu____5159 with
+    let uu___1 = find_file filename in
+    match uu___1 with
     | FStar_Pervasives_Native.Some result -> result
     | FStar_Pervasives_Native.None ->
-        let uu____5163 =
+        let uu___2 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename in
-        failwith uu____5163
+        failwith uu___2
 let (pervasives_basename : unit -> Prims.string) =
-  fun uu____5168 ->
-    let uu____5169 = pervasives () in FStar_Util.basename uu____5169
+  fun uu___ -> let uu___1 = pervasives () in FStar_Util.basename uu___1
 let (pervasives_native_basename : unit -> Prims.string) =
-  fun uu____5174 ->
+  fun uu___ ->
     let filename = "FStar.Pervasives.Native.fst" in
-    let uu____5176 = find_file filename in
-    match uu____5176 with
+    let uu___1 = find_file filename in
+    match uu___1 with
     | FStar_Pervasives_Native.Some result -> FStar_Util.basename result
     | FStar_Pervasives_Native.None ->
-        let uu____5180 =
+        let uu___2 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
             filename in
-        failwith uu____5180
+        failwith uu___2
 let (prepend_output_dir : Prims.string -> Prims.string) =
   fun fname ->
-    let uu____5186 = get_odir () in
-    match uu____5186 with
+    let uu___ = get_odir () in
+    match uu___ with
     | FStar_Pervasives_Native.None -> fname
     | FStar_Pervasives_Native.Some x -> FStar_Util.join_paths x fname
 let (prepend_cache_dir : Prims.string -> Prims.string) =
   fun fpath ->
-    let uu____5195 = get_cache_dir () in
-    match uu____5195 with
+    let uu___ = get_cache_dir () in
+    match uu___ with
     | FStar_Pervasives_Native.None -> fpath
     | FStar_Pervasives_Native.Some x ->
-        let uu____5199 = FStar_Util.basename fpath in
-        FStar_Util.join_paths x uu____5199
+        let uu___1 = FStar_Util.basename fpath in
+        FStar_Util.join_paths x uu___1
 let (path_of_text : Prims.string -> Prims.string Prims.list) =
   fun text -> FStar_String.split [46] text
 let (parse_settings :
@@ -1685,8 +1613,8 @@ let (parse_settings :
   fun ns ->
     let cache = FStar_Util.smap_create (Prims.of_int (31)) in
     let with_cache f s =
-      let uu____5291 = FStar_Util.smap_try_find cache s in
-      match uu____5291 with
+      let uu___ = FStar_Util.smap_try_find cache s in
+      match uu___ with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None ->
           let res = f s in (FStar_Util.smap_add cache s res; res) in
@@ -1700,8 +1628,8 @@ let (parse_settings :
           if FStar_Util.starts_with s "-"
           then
             (let path =
-               let uu____5400 = FStar_Util.substring_from s Prims.int_one in
-               path_of_text uu____5400 in
+               let uu___2 = FStar_Util.substring_from s Prims.int_one in
+               path_of_text uu___2 in
              (path, false))
           else
             (let s1 =
@@ -1709,7 +1637,7 @@ let (parse_settings :
                then FStar_Util.substring_from s Prims.int_one
                else s in
              ((path_of_text s1), true)) in
-    let uu____5408 =
+    let uu___ =
       FStar_All.pipe_right ns
         (FStar_List.collect
            (fun s ->
@@ -1720,312 +1648,296 @@ let (parse_settings :
                 with_cache
                   (fun s2 ->
                      let s3 = FStar_Util.replace_char s2 32 44 in
-                     let uu____5460 =
-                       let uu____5463 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_All.pipe_right (FStar_Util.splitlines s3)
                            (FStar_List.concatMap
                               (fun s4 -> FStar_Util.split s4 ",")) in
-                       FStar_All.pipe_right uu____5463
+                       FStar_All.pipe_right uu___3
                          (FStar_List.filter (fun s4 -> s4 <> "")) in
-                     FStar_All.pipe_right uu____5460
+                     FStar_All.pipe_right uu___2
                        (FStar_List.map parse_one_setting)) s1)) in
-    FStar_All.pipe_right uu____5408 FStar_List.rev
+    FStar_All.pipe_right uu___ FStar_List.rev
 let (__temp_no_proj : Prims.string -> Prims.bool) =
   fun s ->
-    let uu____5521 = get___temp_no_proj () in
-    FStar_All.pipe_right uu____5521 (FStar_List.contains s)
+    let uu___ = get___temp_no_proj () in
+    FStar_All.pipe_right uu___ (FStar_List.contains s)
 let (__temp_fast_implicits : unit -> Prims.bool) =
-  fun uu____5530 -> lookup_opt "__temp_fast_implicits" as_bool
+  fun uu___ -> lookup_opt "__temp_fast_implicits" as_bool
 let (admit_smt_queries : unit -> Prims.bool) =
-  fun uu____5535 -> get_admit_smt_queries ()
+  fun uu___ -> get_admit_smt_queries ()
 let (admit_except : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5542 -> get_admit_except ()
+  fun uu___ -> get_admit_except ()
 let (cache_checked_modules : unit -> Prims.bool) =
-  fun uu____5547 -> get_cache_checked_modules ()
-let (cache_off : unit -> Prims.bool) = fun uu____5552 -> get_cache_off ()
+  fun uu___ -> get_cache_checked_modules ()
+let (cache_off : unit -> Prims.bool) = fun uu___ -> get_cache_off ()
 let (print_cache_version : unit -> Prims.bool) =
-  fun uu____5557 -> get_print_cache_version ()
-let (cmi : unit -> Prims.bool) = fun uu____5562 -> get_cmi ()
+  fun uu___ -> get_print_cache_version ()
+let (cmi : unit -> Prims.bool) = fun uu___ -> get_cmi ()
 type codegen_t =
   | OCaml 
   | FSharp 
   | Kremlin 
   | Plugin 
 let (uu___is_OCaml : codegen_t -> Prims.bool) =
-  fun projectee -> match projectee with | OCaml -> true | uu____5568 -> false
+  fun projectee -> match projectee with | OCaml -> true | uu___ -> false
 let (uu___is_FSharp : codegen_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FSharp -> true | uu____5574 -> false
+  fun projectee -> match projectee with | FSharp -> true | uu___ -> false
 let (uu___is_Kremlin : codegen_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Kremlin -> true | uu____5580 -> false
+  fun projectee -> match projectee with | Kremlin -> true | uu___ -> false
 let (uu___is_Plugin : codegen_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Plugin -> true | uu____5586 -> false
+  fun projectee -> match projectee with | Plugin -> true | uu___ -> false
 let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
-  fun uu____5593 ->
-    let uu____5594 = get_codegen () in
-    FStar_Util.map_opt uu____5594
-      (fun uu___13_5598 ->
-         match uu___13_5598 with
+  fun uu___ ->
+    let uu___1 = get_codegen () in
+    FStar_Util.map_opt uu___1
+      (fun uu___2 ->
+         match uu___2 with
          | "OCaml" -> OCaml
          | "FSharp" -> FSharp
          | "Kremlin" -> Kremlin
          | "Plugin" -> Plugin
-         | uu____5599 -> failwith "Impossible")
+         | uu___3 -> failwith "Impossible")
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
-  fun uu____5608 ->
-    let uu____5609 = get_codegen_lib () in
-    FStar_All.pipe_right uu____5609
+  fun uu___ ->
+    let uu___1 = get_codegen_lib () in
+    FStar_All.pipe_right uu___1
       (FStar_List.map (fun x -> FStar_Util.split x "."))
 let (debug_any : unit -> Prims.bool) =
-  fun uu____5626 -> let uu____5627 = get_debug () in uu____5627 <> []
+  fun uu___ -> let uu___1 = get_debug () in uu___1 <> []
 let (debug_module : Prims.string -> Prims.bool) =
   fun modul ->
-    let uu____5637 = get_debug () in
-    FStar_All.pipe_right uu____5637
-      (FStar_List.existsb (module_name_eq modul))
+    let uu___ = get_debug () in
+    FStar_All.pipe_right uu___ (FStar_List.existsb (module_name_eq modul))
 let (debug_at_level_no_module : debug_level_t -> Prims.bool) =
   fun level -> debug_level_geq level
 let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
   fun modul ->
     fun level -> (debug_module modul) && (debug_at_level_no_module level)
 let (profile_group_by_decls : unit -> Prims.bool) =
-  fun uu____5661 -> get_profile_group_by_decl ()
+  fun uu___ -> get_profile_group_by_decl ()
 let (defensive : unit -> Prims.bool) =
-  fun uu____5666 -> let uu____5667 = get_defensive () in uu____5667 <> "no"
+  fun uu___ -> let uu___1 = get_defensive () in uu___1 <> "no"
 let (defensive_error : unit -> Prims.bool) =
-  fun uu____5672 -> let uu____5673 = get_defensive () in uu____5673 = "error"
+  fun uu___ -> let uu___1 = get_defensive () in uu___1 = "error"
 let (defensive_abort : unit -> Prims.bool) =
-  fun uu____5678 -> let uu____5679 = get_defensive () in uu____5679 = "abort"
+  fun uu___ -> let uu___1 = get_defensive () in uu___1 = "abort"
 let (dep : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5686 -> get_dep ()
-let (detail_errors : unit -> Prims.bool) =
-  fun uu____5691 -> get_detail_errors ()
+  fun uu___ -> get_dep ()
+let (detail_errors : unit -> Prims.bool) = fun uu___ -> get_detail_errors ()
 let (detail_hint_replay : unit -> Prims.bool) =
-  fun uu____5696 -> get_detail_hint_replay ()
+  fun uu___ -> get_detail_hint_replay ()
 let (dump_module : Prims.string -> Prims.bool) =
   fun s ->
-    let uu____5702 = get_dump_module () in
-    FStar_All.pipe_right uu____5702 (FStar_List.existsb (module_name_eq s))
+    let uu___ = get_dump_module () in
+    FStar_All.pipe_right uu___ (FStar_List.existsb (module_name_eq s))
 let (eager_subtyping : unit -> Prims.bool) =
-  fun uu____5711 -> get_eager_subtyping ()
+  fun uu___ -> get_eager_subtyping ()
 let (expose_interfaces : unit -> Prims.bool) =
-  fun uu____5716 -> get_expose_interfaces ()
-let (force : unit -> Prims.bool) = fun uu____5721 -> get_force ()
+  fun uu___ -> get_expose_interfaces ()
+let (force : unit -> Prims.bool) = fun uu___ -> get_force ()
 let (fs_typ_app : Prims.string -> Prims.bool) =
   fun filename ->
-    let uu____5727 = FStar_ST.op_Bang light_off_files in
-    FStar_List.contains filename uu____5727
-let (full_context_dependency : unit -> Prims.bool) = fun uu____5744 -> true
+    let uu___ = FStar_ST.op_Bang light_off_files in
+    FStar_List.contains filename uu___
+let (full_context_dependency : unit -> Prims.bool) = fun uu___ -> true
 let (hide_uvar_nums : unit -> Prims.bool) =
-  fun uu____5749 -> get_hide_uvar_nums ()
+  fun uu___ -> get_hide_uvar_nums ()
 let (hint_info : unit -> Prims.bool) =
-  fun uu____5754 -> (get_hint_info ()) || (get_query_stats ())
+  fun uu___ -> (get_hint_info ()) || (get_query_stats ())
 let (hint_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5761 -> get_hint_dir ()
+  fun uu___ -> get_hint_dir ()
 let (hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5768 -> get_hint_file ()
+  fun uu___ -> get_hint_file ()
 let (hint_file_for_src : Prims.string -> Prims.string) =
   fun src_filename ->
-    let uu____5774 = hint_file () in
-    match uu____5774 with
+    let uu___ = hint_file () in
+    match uu___ with
     | FStar_Pervasives_Native.Some fn -> fn
     | FStar_Pervasives_Native.None ->
         let file_name =
-          let uu____5779 = hint_dir () in
-          match uu____5779 with
+          let uu___1 = hint_dir () in
+          match uu___1 with
           | FStar_Pervasives_Native.Some dir ->
-              let uu____5783 = FStar_Util.basename src_filename in
-              FStar_Util.concat_dir_filename dir uu____5783
-          | uu____5784 -> src_filename in
+              let uu___2 = FStar_Util.basename src_filename in
+              FStar_Util.concat_dir_filename dir uu___2
+          | uu___2 -> src_filename in
         FStar_Util.format1 "%s.hints" file_name
-let (ide : unit -> Prims.bool) = fun uu____5791 -> get_ide ()
-let (print : unit -> Prims.bool) = fun uu____5796 -> get_print ()
+let (ide : unit -> Prims.bool) = fun uu___ -> get_ide ()
+let (print : unit -> Prims.bool) = fun uu___ -> get_print ()
 let (print_in_place : unit -> Prims.bool) =
-  fun uu____5801 -> get_print_in_place ()
+  fun uu___ -> get_print_in_place ()
 let (initial_fuel : unit -> Prims.int) =
-  fun uu____5806 ->
-    let uu____5807 = get_initial_fuel () in
-    let uu____5808 = get_max_fuel () in Prims.min uu____5807 uu____5808
+  fun uu___ ->
+    let uu___1 = get_initial_fuel () in
+    let uu___2 = get_max_fuel () in Prims.min uu___1 uu___2
 let (initial_ifuel : unit -> Prims.int) =
-  fun uu____5813 ->
-    let uu____5814 = get_initial_ifuel () in
-    let uu____5815 = get_max_ifuel () in Prims.min uu____5814 uu____5815
+  fun uu___ ->
+    let uu___1 = get_initial_ifuel () in
+    let uu___2 = get_max_ifuel () in Prims.min uu___1 uu___2
 let (interactive : unit -> Prims.bool) =
-  fun uu____5820 -> (get_in ()) || (get_ide ())
-let (lax : unit -> Prims.bool) = fun uu____5825 -> get_lax ()
-let (load : unit -> Prims.string Prims.list) = fun uu____5832 -> get_load ()
-let (legacy_interactive : unit -> Prims.bool) = fun uu____5837 -> get_in ()
-let (lsp_server : unit -> Prims.bool) = fun uu____5842 -> get_lsp ()
-let (log_queries : unit -> Prims.bool) = fun uu____5847 -> get_log_queries ()
+  fun uu___ -> (get_in ()) || (get_ide ())
+let (lax : unit -> Prims.bool) = fun uu___ -> get_lax ()
+let (load : unit -> Prims.string Prims.list) = fun uu___ -> get_load ()
+let (legacy_interactive : unit -> Prims.bool) = fun uu___ -> get_in ()
+let (lsp_server : unit -> Prims.bool) = fun uu___ -> get_lsp ()
+let (log_queries : unit -> Prims.bool) = fun uu___ -> get_log_queries ()
 let (keep_query_captions : unit -> Prims.bool) =
-  fun uu____5852 -> (log_queries ()) && (get_keep_query_captions ())
-let (log_types : unit -> Prims.bool) = fun uu____5857 -> get_log_types ()
-let (max_fuel : unit -> Prims.int) = fun uu____5862 -> get_max_fuel ()
-let (max_ifuel : unit -> Prims.int) = fun uu____5867 -> get_max_ifuel ()
-let (min_fuel : unit -> Prims.int) = fun uu____5872 -> get_min_fuel ()
-let (ml_ish : unit -> Prims.bool) = fun uu____5877 -> get_MLish ()
-let (set_ml_ish : unit -> unit) =
-  fun uu____5882 -> set_option "MLish" (Bool true)
+  fun uu___ -> (log_queries ()) && (get_keep_query_captions ())
+let (log_types : unit -> Prims.bool) = fun uu___ -> get_log_types ()
+let (max_fuel : unit -> Prims.int) = fun uu___ -> get_max_fuel ()
+let (max_ifuel : unit -> Prims.int) = fun uu___ -> get_max_ifuel ()
+let (min_fuel : unit -> Prims.int) = fun uu___ -> get_min_fuel ()
+let (ml_ish : unit -> Prims.bool) = fun uu___ -> get_MLish ()
+let (set_ml_ish : unit -> unit) = fun uu___ -> set_option "MLish" (Bool true)
 let (no_default_includes : unit -> Prims.bool) =
-  fun uu____5887 -> get_no_default_includes ()
+  fun uu___ -> get_no_default_includes ()
 let (no_extract : Prims.string -> Prims.bool) =
   fun s ->
-    let uu____5893 = get_no_extract () in
-    FStar_All.pipe_right uu____5893 (FStar_List.existsb (module_name_eq s))
+    let uu___ = get_no_extract () in
+    FStar_All.pipe_right uu___ (FStar_List.existsb (module_name_eq s))
 let (normalize_pure_terms_for_extraction : unit -> Prims.bool) =
-  fun uu____5902 -> get_normalize_pure_terms_for_extraction ()
+  fun uu___ -> get_normalize_pure_terms_for_extraction ()
 let (no_load_fstartaclib : unit -> Prims.bool) =
-  fun uu____5907 -> get_no_load_fstartaclib ()
+  fun uu___ -> get_no_load_fstartaclib ()
 let (no_location_info : unit -> Prims.bool) =
-  fun uu____5912 -> get_no_location_info ()
-let (no_plugins : unit -> Prims.bool) = fun uu____5917 -> get_no_plugins ()
-let (no_smt : unit -> Prims.bool) = fun uu____5922 -> get_no_smt ()
+  fun uu___ -> get_no_location_info ()
+let (no_plugins : unit -> Prims.bool) = fun uu___ -> get_no_plugins ()
+let (no_smt : unit -> Prims.bool) = fun uu___ -> get_no_smt ()
 let (output_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5929 -> get_odir ()
-let (ugly : unit -> Prims.bool) = fun uu____5934 -> get_ugly ()
+  fun uu___ -> get_odir ()
+let (ugly : unit -> Prims.bool) = fun uu___ -> get_ugly ()
 let (print_bound_var_types : unit -> Prims.bool) =
-  fun uu____5939 -> get_print_bound_var_types ()
+  fun uu___ -> get_print_bound_var_types ()
 let (print_effect_args : unit -> Prims.bool) =
-  fun uu____5944 -> get_print_effect_args ()
+  fun uu___ -> get_print_effect_args ()
 let (print_expected_failures : unit -> Prims.bool) =
-  fun uu____5949 -> get_print_expected_failures ()
+  fun uu___ -> get_print_expected_failures ()
 let (print_implicits : unit -> Prims.bool) =
-  fun uu____5954 -> get_print_implicits ()
+  fun uu___ -> get_print_implicits ()
 let (print_real_names : unit -> Prims.bool) =
-  fun uu____5959 -> (get_prn ()) || (get_print_full_names ())
+  fun uu___ -> (get_prn ()) || (get_print_full_names ())
 let (print_universes : unit -> Prims.bool) =
-  fun uu____5964 -> get_print_universes ()
+  fun uu___ -> get_print_universes ()
 let (print_z3_statistics : unit -> Prims.bool) =
-  fun uu____5969 -> get_print_z3_statistics ()
-let (quake_lo : unit -> Prims.int) = fun uu____5974 -> get_quake_lo ()
-let (quake_hi : unit -> Prims.int) = fun uu____5979 -> get_quake_hi ()
-let (quake_keep : unit -> Prims.bool) = fun uu____5984 -> get_quake_keep ()
-let (query_stats : unit -> Prims.bool) = fun uu____5989 -> get_query_stats ()
-let (record_hints : unit -> Prims.bool) =
-  fun uu____5994 -> get_record_hints ()
+  fun uu___ -> get_print_z3_statistics ()
+let (quake_lo : unit -> Prims.int) = fun uu___ -> get_quake_lo ()
+let (quake_hi : unit -> Prims.int) = fun uu___ -> get_quake_hi ()
+let (quake_keep : unit -> Prims.bool) = fun uu___ -> get_quake_keep ()
+let (query_stats : unit -> Prims.bool) = fun uu___ -> get_query_stats ()
+let (record_hints : unit -> Prims.bool) = fun uu___ -> get_record_hints ()
 let (record_options : unit -> Prims.bool) =
-  fun uu____5999 -> get_record_options ()
-let (retry : unit -> Prims.bool) = fun uu____6004 -> get_retry ()
+  fun uu___ -> get_record_options ()
+let (retry : unit -> Prims.bool) = fun uu___ -> get_retry ()
 let (reuse_hint_for : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____6011 -> get_reuse_hint_for ()
+  fun uu___ -> get_reuse_hint_for ()
 let (report_assumes : unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____6018 -> get_report_assumes ()
-let (silent : unit -> Prims.bool) = fun uu____6023 -> get_silent ()
+  fun uu___ -> get_report_assumes ()
+let (silent : unit -> Prims.bool) = fun uu___ -> get_silent ()
 let (smtencoding_elim_box : unit -> Prims.bool) =
-  fun uu____6028 -> get_smtencoding_elim_box ()
+  fun uu___ -> get_smtencoding_elim_box ()
 let (smtencoding_nl_arith_native : unit -> Prims.bool) =
-  fun uu____6033 ->
-    let uu____6034 = get_smtencoding_nl_arith_repr () in
-    uu____6034 = "native"
+  fun uu___ ->
+    let uu___1 = get_smtencoding_nl_arith_repr () in uu___1 = "native"
 let (smtencoding_nl_arith_wrapped : unit -> Prims.bool) =
-  fun uu____6039 ->
-    let uu____6040 = get_smtencoding_nl_arith_repr () in
-    uu____6040 = "wrapped"
+  fun uu___ ->
+    let uu___1 = get_smtencoding_nl_arith_repr () in uu___1 = "wrapped"
 let (smtencoding_nl_arith_default : unit -> Prims.bool) =
-  fun uu____6045 ->
-    let uu____6046 = get_smtencoding_nl_arith_repr () in
-    uu____6046 = "boxwrap"
+  fun uu___ ->
+    let uu___1 = get_smtencoding_nl_arith_repr () in uu___1 = "boxwrap"
 let (smtencoding_l_arith_native : unit -> Prims.bool) =
-  fun uu____6051 ->
-    let uu____6052 = get_smtencoding_l_arith_repr () in uu____6052 = "native"
+  fun uu___ ->
+    let uu___1 = get_smtencoding_l_arith_repr () in uu___1 = "native"
 let (smtencoding_l_arith_default : unit -> Prims.bool) =
-  fun uu____6057 ->
-    let uu____6058 = get_smtencoding_l_arith_repr () in
-    uu____6058 = "boxwrap"
+  fun uu___ ->
+    let uu___1 = get_smtencoding_l_arith_repr () in uu___1 = "boxwrap"
 let (smtencoding_valid_intro : unit -> Prims.bool) =
-  fun uu____6063 -> get_smtencoding_valid_intro ()
+  fun uu___ -> get_smtencoding_valid_intro ()
 let (smtencoding_valid_elim : unit -> Prims.bool) =
-  fun uu____6068 -> get_smtencoding_valid_elim ()
+  fun uu___ -> get_smtencoding_valid_elim ()
 let (tactic_raw_binders : unit -> Prims.bool) =
-  fun uu____6073 -> get_tactic_raw_binders ()
+  fun uu___ -> get_tactic_raw_binders ()
 let (tactics_failhard : unit -> Prims.bool) =
-  fun uu____6078 -> get_tactics_failhard ()
-let (tactics_info : unit -> Prims.bool) =
-  fun uu____6083 -> get_tactics_info ()
-let (tactic_trace : unit -> Prims.bool) =
-  fun uu____6088 -> get_tactic_trace ()
-let (tactic_trace_d : unit -> Prims.int) =
-  fun uu____6093 -> get_tactic_trace_d ()
-let (tactics_nbe : unit -> Prims.bool) = fun uu____6098 -> get_tactics_nbe ()
-let (tcnorm : unit -> Prims.bool) = fun uu____6103 -> get_tcnorm ()
-let (timing : unit -> Prims.bool) = fun uu____6108 -> get_timing ()
-let (trace_error : unit -> Prims.bool) = fun uu____6113 -> get_trace_error ()
+  fun uu___ -> get_tactics_failhard ()
+let (tactics_info : unit -> Prims.bool) = fun uu___ -> get_tactics_info ()
+let (tactic_trace : unit -> Prims.bool) = fun uu___ -> get_tactic_trace ()
+let (tactic_trace_d : unit -> Prims.int) = fun uu___ -> get_tactic_trace_d ()
+let (tactics_nbe : unit -> Prims.bool) = fun uu___ -> get_tactics_nbe ()
+let (tcnorm : unit -> Prims.bool) = fun uu___ -> get_tcnorm ()
+let (timing : unit -> Prims.bool) = fun uu___ -> get_timing ()
+let (trace_error : unit -> Prims.bool) = fun uu___ -> get_trace_error ()
 let (unthrottle_inductives : unit -> Prims.bool) =
-  fun uu____6118 -> get_unthrottle_inductives ()
+  fun uu___ -> get_unthrottle_inductives ()
 let (unsafe_tactic_exec : unit -> Prims.bool) =
-  fun uu____6123 -> get_unsafe_tactic_exec ()
+  fun uu___ -> get_unsafe_tactic_exec ()
 let (use_eq_at_higher_order : unit -> Prims.bool) =
-  fun uu____6128 -> get_use_eq_at_higher_order ()
-let (use_hints : unit -> Prims.bool) = fun uu____6133 -> get_use_hints ()
+  fun uu___ -> get_use_eq_at_higher_order ()
+let (use_hints : unit -> Prims.bool) = fun uu___ -> get_use_hints ()
 let (use_hint_hashes : unit -> Prims.bool) =
-  fun uu____6138 -> get_use_hint_hashes ()
+  fun uu___ -> get_use_hint_hashes ()
 let (use_native_tactics :
   unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____6145 -> get_use_native_tactics ()
-let (use_tactics : unit -> Prims.bool) = fun uu____6150 -> get_use_tactics ()
+  fun uu___ -> get_use_native_tactics ()
+let (use_tactics : unit -> Prims.bool) = fun uu___ -> get_use_tactics ()
 let (using_facts_from :
   unit -> (Prims.string Prims.list * Prims.bool) Prims.list) =
-  fun uu____6163 ->
-    let uu____6164 = get_using_facts_from () in
-    match uu____6164 with
+  fun uu___ ->
+    let uu___1 = get_using_facts_from () in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
 let (vcgen_optimize_bind_as_seq : unit -> Prims.bool) =
-  fun uu____6202 ->
-    let uu____6203 = get_vcgen_optimize_bind_as_seq () in
-    FStar_Option.isSome uu____6203
+  fun uu___ ->
+    let uu___1 = get_vcgen_optimize_bind_as_seq () in
+    FStar_Option.isSome uu___1
 let (vcgen_decorate_with_type : unit -> Prims.bool) =
-  fun uu____6210 ->
-    let uu____6211 = get_vcgen_optimize_bind_as_seq () in
-    match uu____6211 with
+  fun uu___ ->
+    let uu___1 = get_vcgen_optimize_bind_as_seq () in
+    match uu___1 with
     | FStar_Pervasives_Native.Some "with_type" -> true
-    | uu____6214 -> false
+    | uu___2 -> false
 let (warn_default_effects : unit -> Prims.bool) =
-  fun uu____6221 -> get_warn_default_effects ()
+  fun uu___ -> get_warn_default_effects ()
 let (warn_error : unit -> Prims.string) =
-  fun uu____6226 ->
-    let uu____6227 = get_warn_error () in FStar_String.concat " " uu____6227
+  fun uu___ ->
+    let uu___1 = get_warn_error () in FStar_String.concat " " uu___1
 let (z3_exe : unit -> Prims.string) =
-  fun uu____6234 ->
-    let uu____6235 = get_smt () in
-    match uu____6235 with
+  fun uu___ ->
+    let uu___1 = get_smt () in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> FStar_Platform.exe "z3"
     | FStar_Pervasives_Native.Some s -> s
 let (z3_cliopt : unit -> Prims.string Prims.list) =
-  fun uu____6245 -> get_z3cliopt ()
-let (z3_refresh : unit -> Prims.bool) = fun uu____6250 -> get_z3refresh ()
-let (z3_rlimit : unit -> Prims.int) = fun uu____6255 -> get_z3rlimit ()
+  fun uu___ -> get_z3cliopt ()
+let (z3_refresh : unit -> Prims.bool) = fun uu___ -> get_z3refresh ()
+let (z3_rlimit : unit -> Prims.int) = fun uu___ -> get_z3rlimit ()
 let (z3_rlimit_factor : unit -> Prims.int) =
-  fun uu____6260 -> get_z3rlimit_factor ()
-let (z3_seed : unit -> Prims.int) = fun uu____6265 -> get_z3seed ()
+  fun uu___ -> get_z3rlimit_factor ()
+let (z3_seed : unit -> Prims.int) = fun uu___ -> get_z3seed ()
 let (use_two_phase_tc : unit -> Prims.bool) =
-  fun uu____6270 ->
+  fun uu___ ->
     (get_use_two_phase_tc ()) &&
-      (let uu____6272 = lax () in Prims.op_Negation uu____6272)
-let (no_positivity : unit -> Prims.bool) =
-  fun uu____6277 -> get_no_positivity ()
+      (let uu___1 = lax () in Prims.op_Negation uu___1)
+let (no_positivity : unit -> Prims.bool) = fun uu___ -> get_no_positivity ()
 let (ml_no_eta_expand_coertions : unit -> Prims.bool) =
-  fun uu____6282 -> get_ml_no_eta_expand_coertions ()
-let (use_nbe : unit -> Prims.bool) = fun uu____6287 -> get_use_nbe ()
+  fun uu___ -> get_ml_no_eta_expand_coertions ()
+let (use_nbe : unit -> Prims.bool) = fun uu___ -> get_use_nbe ()
 let (use_nbe_for_extraction : unit -> Prims.bool) =
-  fun uu____6292 -> get_use_nbe_for_extraction ()
+  fun uu___ -> get_use_nbe_for_extraction ()
 let (trivial_pre_for_unannotated_effectful_fns : unit -> Prims.bool) =
-  fun uu____6297 -> get_trivial_pre_for_unannotated_effectful_fns ()
+  fun uu___ -> get_trivial_pre_for_unannotated_effectful_fns ()
 let with_saved_options : 'a . (unit -> 'a) -> 'a =
   fun f ->
-    let uu____6313 =
-      let uu____6314 = trace_error () in Prims.op_Negation uu____6314 in
-    if uu____6313
+    let uu___ = let uu___1 = trace_error () in Prims.op_Negation uu___1 in
+    if uu___
     then
       (push ();
        (let r =
           try
-            (fun uu___857_6327 ->
+            (fun uu___2 ->
                match () with
-               | () -> let uu____6332 = f () in FStar_Util.Inr uu____6332) ()
-          with | uu___856_6334 -> FStar_Util.Inl uu___856_6334 in
+               | () -> let uu___3 = f () in FStar_Util.Inr uu___3) ()
+          with | uu___2 -> FStar_Util.Inl uu___2 in
         pop ();
         (match r with
          | FStar_Util.Inr v -> v
@@ -2040,50 +1952,49 @@ let (module_matches_namespace_filter :
       let m_components = path_of_text m1 in
       let rec matches_path m_components1 path =
         match (m_components1, path) with
-        | (uu____6396, []) -> true
+        | (uu___, []) -> true
         | (m2::ms, p::ps) ->
             (m2 = (FStar_String.lowercase p)) && (matches_path ms ps)
-        | uu____6415 -> false in
-      let uu____6424 =
+        | uu___ -> false in
+      let uu___ =
         FStar_All.pipe_right setting
           (FStar_Util.try_find
-             (fun uu____6458 ->
-                match uu____6458 with
-                | (path, uu____6466) -> matches_path m_components path)) in
-      match uu____6424 with
+             (fun uu___1 ->
+                match uu___1 with
+                | (path, uu___2) -> matches_path m_components path)) in
+      match uu___ with
       | FStar_Pervasives_Native.None -> false
-      | FStar_Pervasives_Native.Some (uu____6477, flag) -> flag
+      | FStar_Pervasives_Native.Some (uu___1, flag) -> flag
 let (matches_namespace_filter_opt :
   Prims.string ->
     Prims.string Prims.list FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun m ->
-    fun uu___14_6502 ->
-      match uu___14_6502 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.None -> false
       | FStar_Pervasives_Native.Some filter ->
           module_matches_namespace_filter m filter
 let (should_extract : Prims.string -> Prims.bool) =
   fun m ->
     let m1 = FStar_String.lowercase m in
-    let uu____6520 = get_extract () in
-    match uu____6520 with
+    let uu___ = get_extract () in
+    match uu___ with
     | FStar_Pervasives_Native.Some extract_setting ->
-        ((let uu____6531 =
-            let uu____6544 = get_no_extract () in
-            let uu____6547 = get_extract_namespace () in
-            let uu____6550 = get_extract_module () in
-            (uu____6544, uu____6547, uu____6550) in
-          match uu____6531 with
+        ((let uu___2 =
+            let uu___3 = get_no_extract () in
+            let uu___4 = get_extract_namespace () in
+            let uu___5 = get_extract_module () in (uu___3, uu___4, uu___5) in
+          match uu___2 with
           | ([], [], []) -> ()
-          | uu____6565 ->
+          | uu___3 ->
               failwith
                 "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
          module_matches_namespace_filter m1 extract_setting)
     | FStar_Pervasives_Native.None ->
         let should_extract_namespace m2 =
-          let uu____6586 = get_extract_namespace () in
-          match uu____6586 with
+          let uu___1 = get_extract_namespace () in
+          match uu___1 with
           | [] -> false
           | ns ->
               FStar_All.pipe_right ns
@@ -2091,26 +2002,25 @@ let (should_extract : Prims.string -> Prims.bool) =
                    (fun n ->
                       FStar_Util.starts_with m2 (FStar_String.lowercase n))) in
         let should_extract_module m2 =
-          let uu____6602 = get_extract_module () in
-          match uu____6602 with
+          let uu___1 = get_extract_module () in
+          match uu___1 with
           | [] -> false
           | l ->
               FStar_All.pipe_right l
                 (FStar_Util.for_some
                    (fun n -> (FStar_String.lowercase n) = m2)) in
-        (let uu____6614 = no_extract m1 in Prims.op_Negation uu____6614) &&
-          (let uu____6616 =
-             let uu____6625 = get_extract_namespace () in
-             let uu____6628 = get_extract_module () in
-             (uu____6625, uu____6628) in
-           (match uu____6616 with
+        (let uu___1 = no_extract m1 in Prims.op_Negation uu___1) &&
+          (let uu___1 =
+             let uu___2 = get_extract_namespace () in
+             let uu___3 = get_extract_module () in (uu___2, uu___3) in
+           (match uu___1 with
             | ([], []) -> true
-            | uu____6639 ->
+            | uu___2 ->
                 (should_extract_namespace m1) || (should_extract_module m1)))
 let (should_be_already_cached : Prims.string -> Prims.bool) =
   fun m ->
-    let uu____6653 = get_already_cached () in
-    match uu____6653 with
+    let uu___ = get_already_cached () in
+    match uu___ with
     | FStar_Pervasives_Native.None -> false
     | FStar_Pervasives_Native.Some already_cached_setting ->
         module_matches_namespace_filter m already_cached_setting
@@ -2121,26 +2031,23 @@ let (profile_enabled :
     fun phase ->
       match modul_opt with
       | FStar_Pervasives_Native.None ->
-          let uu____6679 = get_profile_component () in
-          matches_namespace_filter_opt phase uu____6679
+          let uu___ = get_profile_component () in
+          matches_namespace_filter_opt phase uu___
       | FStar_Pervasives_Native.Some modul ->
-          (let uu____6687 = get_profile () in
-           matches_namespace_filter_opt modul uu____6687) &&
-            (let uu____6693 = get_profile_component () in
-             matches_namespace_filter_opt phase uu____6693)
+          (let uu___ = get_profile () in
+           matches_namespace_filter_opt modul uu___) &&
+            (let uu___ = get_profile_component () in
+             matches_namespace_filter_opt phase uu___)
 exception File_argument of Prims.string 
 let (uu___is_File_argument : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | File_argument uu____6707 -> true
-    | uu____6708 -> false
+    match projectee with | File_argument uu___ -> true | uu___ -> false
 let (__proj__File_argument__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee ->
-    match projectee with | File_argument uu____6714 -> uu____6714
+  fun projectee -> match projectee with | File_argument uu___ -> uu___
 let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
   fun s ->
     try
-      (fun uu___942_6721 ->
+      (fun uu___ ->
          match () with
          | () ->
              if s = ""
@@ -2154,6 +2061,5 @@ let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
                 else res)) ()
     with
     | File_argument s1 ->
-        let uu____6734 =
-          FStar_Util.format1 "File %s is not a valid option" s1 in
-        FStar_Getopt.Error uu____6734
+        let uu___1 = FStar_Util.format1 "File %s is not a valid option" s1 in
+        FStar_Getopt.Error uu___1

--- a/src/ocaml-output/FStar_Order.ml
+++ b/src/ocaml-output/FStar_Order.ml
@@ -4,11 +4,11 @@ type order =
   | Eq 
   | Gt 
 let (uu___is_Lt : order -> Prims.bool) =
-  fun projectee -> match projectee with | Lt -> true | uu____5 -> false
+  fun projectee -> match projectee with | Lt -> true | uu___ -> false
 let (uu___is_Eq : order -> Prims.bool) =
-  fun projectee -> match projectee with | Eq -> true | uu____11 -> false
+  fun projectee -> match projectee with | Eq -> true | uu___ -> false
 let (uu___is_Gt : order -> Prims.bool) =
-  fun projectee -> match projectee with | Gt -> true | uu____17 -> false
+  fun projectee -> match projectee with | Gt -> true | uu___ -> false
 let (ge : order -> Prims.bool) = fun o -> o <> Lt
 let (le : order -> Prims.bool) = fun o -> o <> Gt
 let (ne : order -> Prims.bool) = fun o -> o <> Eq
@@ -19,9 +19,9 @@ let (lex : order -> (unit -> order) -> order) =
   fun o1 ->
     fun o2 ->
       match (o1, o2) with
-      | (Lt, uu____66) -> Lt
-      | (Eq, uu____73) -> o2 ()
-      | (Gt, uu____80) -> Gt
+      | (Lt, uu___) -> Lt
+      | (Eq, uu___) -> o2 ()
+      | (Gt, uu___) -> Gt
 let (order_from_int : Prims.int -> order) =
   fun i ->
     if i < Prims.int_zero then Lt else if i = Prims.int_zero then Eq else Gt
@@ -34,11 +34,11 @@ let rec compare_list :
       fun l2 ->
         match (l1, l2) with
         | ([], []) -> Eq
-        | ([], uu____155) -> Lt
-        | (uu____162, []) -> Gt
+        | ([], uu___) -> Lt
+        | (uu___, []) -> Gt
         | (x::xs, y::ys) ->
-            let uu____181 = f x y in
-            lex uu____181 (fun uu____183 -> compare_list f xs ys)
+            let uu___ = f x y in
+            lex uu___ (fun uu___1 -> compare_list f xs ys)
 let compare_option :
   'a .
     ('a -> 'a -> order) ->
@@ -50,9 +50,9 @@ let compare_option :
       fun y ->
         match (x, y) with
         | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) -> Eq
-        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some
-           uu____234) -> Lt
-        | (FStar_Pervasives_Native.Some uu____239,
-           FStar_Pervasives_Native.None) -> Gt
+        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some uu___)
+            -> Lt
+        | (FStar_Pervasives_Native.Some uu___, FStar_Pervasives_Native.None)
+            -> Gt
         | (FStar_Pervasives_Native.Some x1, FStar_Pervasives_Native.Some y1)
             -> f x1 y1

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -6,31 +6,30 @@ type level =
   | Kind 
   | Formula 
 let (uu___is_Un : level -> Prims.bool) =
-  fun projectee -> match projectee with | Un -> true | uu____22 -> false
+  fun projectee -> match projectee with | Un -> true | uu___ -> false
 let (uu___is_Expr : level -> Prims.bool) =
-  fun projectee -> match projectee with | Expr -> true | uu____28 -> false
+  fun projectee -> match projectee with | Expr -> true | uu___ -> false
 let (uu___is_Type_level : level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Type_level -> true | uu____34 -> false
+  fun projectee -> match projectee with | Type_level -> true | uu___ -> false
 let (uu___is_Kind : level -> Prims.bool) =
-  fun projectee -> match projectee with | Kind -> true | uu____40 -> false
+  fun projectee -> match projectee with | Kind -> true | uu___ -> false
 let (uu___is_Formula : level -> Prims.bool) =
-  fun projectee -> match projectee with | Formula -> true | uu____46 -> false
+  fun projectee -> match projectee with | Formula -> true | uu___ -> false
 type let_qualifier =
   | NoLetQualifier 
   | Rec 
 let (uu___is_NoLetQualifier : let_qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | NoLetQualifier -> true | uu____52 -> false
+    match projectee with | NoLetQualifier -> true | uu___ -> false
 let (uu___is_Rec : let_qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Rec -> true | uu____58 -> false
+  fun projectee -> match projectee with | Rec -> true | uu___ -> false
 type quote_kind =
   | Static 
   | Dynamic 
 let (uu___is_Static : quote_kind -> Prims.bool) =
-  fun projectee -> match projectee with | Static -> true | uu____64 -> false
+  fun projectee -> match projectee with | Static -> true | uu___ -> false
 let (uu___is_Dynamic : quote_kind -> Prims.bool) =
-  fun projectee -> match projectee with | Dynamic -> true | uu____70 -> false
+  fun projectee -> match projectee with | Dynamic -> true | uu___ -> false
 type term' =
   | Wild 
   | Const of FStar_Const.sconst 
@@ -126,92 +125,83 @@ and imp =
   | Infix 
   | Nothing 
 let (uu___is_Wild : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Wild -> true | uu____689 -> false
+  fun projectee -> match projectee with | Wild -> true | uu___ -> false
 let (uu___is_Const : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Const _0 -> true | uu____696 -> false
+  fun projectee -> match projectee with | Const _0 -> true | uu___ -> false
 let (__proj__Const__item___0 : term' -> FStar_Const.sconst) =
   fun projectee -> match projectee with | Const _0 -> _0
 let (uu___is_Op : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Op _0 -> true | uu____715 -> false
+  fun projectee -> match projectee with | Op _0 -> true | uu___ -> false
 let (__proj__Op__item___0 : term' -> (FStar_Ident.ident * term Prims.list)) =
   fun projectee -> match projectee with | Op _0 -> _0
 let (uu___is_Tvar : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tvar _0 -> true | uu____746 -> false
+  fun projectee -> match projectee with | Tvar _0 -> true | uu___ -> false
 let (__proj__Tvar__item___0 : term' -> FStar_Ident.ident) =
   fun projectee -> match projectee with | Tvar _0 -> _0
 let (uu___is_Uvar : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Uvar _0 -> true | uu____759 -> false
+  fun projectee -> match projectee with | Uvar _0 -> true | uu___ -> false
 let (__proj__Uvar__item___0 : term' -> FStar_Ident.ident) =
   fun projectee -> match projectee with | Uvar _0 -> _0
 let (uu___is_Var : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Var _0 -> true | uu____772 -> false
+  fun projectee -> match projectee with | Var _0 -> true | uu___ -> false
 let (__proj__Var__item___0 : term' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Var _0 -> _0
 let (uu___is_Name : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Name _0 -> true | uu____785 -> false
+  fun projectee -> match projectee with | Name _0 -> true | uu___ -> false
 let (__proj__Name__item___0 : term' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Name _0 -> _0
 let (uu___is_Projector : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Projector _0 -> true | uu____802 -> false
+    match projectee with | Projector _0 -> true | uu___ -> false
 let (__proj__Projector__item___0 :
   term' -> (FStar_Ident.lid * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Projector _0 -> _0
 let (uu___is_Construct : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Construct _0 -> true | uu____837 -> false
+    match projectee with | Construct _0 -> true | uu___ -> false
 let (__proj__Construct__item___0 :
   term' -> (FStar_Ident.lid * (term * imp) Prims.list)) =
   fun projectee -> match projectee with | Construct _0 -> _0
 let (uu___is_Abs : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Abs _0 -> true | uu____886 -> false
+  fun projectee -> match projectee with | Abs _0 -> true | uu___ -> false
 let (__proj__Abs__item___0 : term' -> (pattern Prims.list * term)) =
   fun projectee -> match projectee with | Abs _0 -> _0
 let (uu___is_App : term' -> Prims.bool) =
-  fun projectee -> match projectee with | App _0 -> true | uu____923 -> false
+  fun projectee -> match projectee with | App _0 -> true | uu___ -> false
 let (__proj__App__item___0 : term' -> (term * term * imp)) =
   fun projectee -> match projectee with | App _0 -> _0
 let (uu___is_Let : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Let _0 -> true | uu____974 -> false
+  fun projectee -> match projectee with | Let _0 -> true | uu___ -> false
 let (__proj__Let__item___0 :
   term' ->
     (let_qualifier * (term Prims.list FStar_Pervasives_Native.option *
       (pattern * term)) Prims.list * term))
   = fun projectee -> match projectee with | Let _0 -> _0
 let (uu___is_LetOpen : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LetOpen _0 -> true | uu____1051 -> false
+  fun projectee -> match projectee with | LetOpen _0 -> true | uu___ -> false
 let (__proj__LetOpen__item___0 : term' -> (FStar_Ident.lid * term)) =
   fun projectee -> match projectee with | LetOpen _0 -> _0
 let (uu___is_Seq : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Seq _0 -> true | uu____1080 -> false
+  fun projectee -> match projectee with | Seq _0 -> true | uu___ -> false
 let (__proj__Seq__item___0 : term' -> (term * term)) =
   fun projectee -> match projectee with | Seq _0 -> _0
 let (uu___is_Bind : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Bind _0 -> true | uu____1111 -> false
+  fun projectee -> match projectee with | Bind _0 -> true | uu___ -> false
 let (__proj__Bind__item___0 : term' -> (FStar_Ident.ident * term * term)) =
   fun projectee -> match projectee with | Bind _0 -> _0
 let (uu___is_If : term' -> Prims.bool) =
-  fun projectee -> match projectee with | If _0 -> true | uu____1148 -> false
+  fun projectee -> match projectee with | If _0 -> true | uu___ -> false
 let (__proj__If__item___0 : term' -> (term * term * term)) =
   fun projectee -> match projectee with | If _0 -> _0
 let (uu___is_Match : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Match _0 -> true | uu____1193 -> false
+  fun projectee -> match projectee with | Match _0 -> true | uu___ -> false
 let (__proj__Match__item___0 :
   term' ->
     (term * (pattern * term FStar_Pervasives_Native.option * term)
       Prims.list))
   = fun projectee -> match projectee with | Match _0 -> _0
 let (uu___is_TryWith : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TryWith _0 -> true | uu____1262 -> false
+  fun projectee -> match projectee with | TryWith _0 -> true | uu___ -> false
 let (__proj__TryWith__item___0 :
   term' ->
     (term * (pattern * term FStar_Pervasives_Native.option * term)
@@ -219,110 +209,97 @@ let (__proj__TryWith__item___0 :
   = fun projectee -> match projectee with | TryWith _0 -> _0
 let (uu___is_Ascribed : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Ascribed _0 -> true | uu____1325 -> false
+    match projectee with | Ascribed _0 -> true | uu___ -> false
 let (__proj__Ascribed__item___0 :
   term' -> (term * term * term FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Ascribed _0 -> _0
 let (uu___is_Record : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Record _0 -> true | uu____1374 -> false
+  fun projectee -> match projectee with | Record _0 -> true | uu___ -> false
 let (__proj__Record__item___0 :
   term' ->
     (term FStar_Pervasives_Native.option * (FStar_Ident.lid * term)
       Prims.list))
   = fun projectee -> match projectee with | Record _0 -> _0
 let (uu___is_Project : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Project _0 -> true | uu____1427 -> false
+  fun projectee -> match projectee with | Project _0 -> true | uu___ -> false
 let (__proj__Project__item___0 : term' -> (term * FStar_Ident.lid)) =
   fun projectee -> match projectee with | Project _0 -> _0
 let (uu___is_Product : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Product _0 -> true | uu____1458 -> false
+  fun projectee -> match projectee with | Product _0 -> true | uu___ -> false
 let (__proj__Product__item___0 : term' -> (binder Prims.list * term)) =
   fun projectee -> match projectee with | Product _0 -> _0
 let (uu___is_Sum : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Sum _0 -> true | uu____1499 -> false
+  fun projectee -> match projectee with | Sum _0 -> true | uu___ -> false
 let (__proj__Sum__item___0 :
   term' -> ((binder, term) FStar_Util.either Prims.list * term)) =
   fun projectee -> match projectee with | Sum _0 -> _0
 let (uu___is_QForall : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QForall _0 -> true | uu____1560 -> false
+  fun projectee -> match projectee with | QForall _0 -> true | uu___ -> false
 let (__proj__QForall__item___0 :
   term' ->
     (binder Prims.list * (FStar_Ident.ident Prims.list * term Prims.list
       Prims.list) * term))
   = fun projectee -> match projectee with | QForall _0 -> _0
 let (uu___is_QExists : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QExists _0 -> true | uu____1645 -> false
+  fun projectee -> match projectee with | QExists _0 -> true | uu___ -> false
 let (__proj__QExists__item___0 :
   term' ->
     (binder Prims.list * (FStar_Ident.ident Prims.list * term Prims.list
       Prims.list) * term))
   = fun projectee -> match projectee with | QExists _0 -> _0
 let (uu___is_Refine : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Refine _0 -> true | uu____1716 -> false
+  fun projectee -> match projectee with | Refine _0 -> true | uu___ -> false
 let (__proj__Refine__item___0 : term' -> (binder * term)) =
   fun projectee -> match projectee with | Refine _0 -> _0
 let (uu___is_NamedTyp : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | NamedTyp _0 -> true | uu____1745 -> false
+    match projectee with | NamedTyp _0 -> true | uu___ -> false
 let (__proj__NamedTyp__item___0 : term' -> (FStar_Ident.ident * term)) =
   fun projectee -> match projectee with | NamedTyp _0 -> _0
 let (uu___is_Paren : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Paren _0 -> true | uu____1770 -> false
+  fun projectee -> match projectee with | Paren _0 -> true | uu___ -> false
 let (__proj__Paren__item___0 : term' -> term) =
   fun projectee -> match projectee with | Paren _0 -> _0
 let (uu___is_Requires : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Requires _0 -> true | uu____1789 -> false
+    match projectee with | Requires _0 -> true | uu___ -> false
 let (__proj__Requires__item___0 :
   term' -> (term * Prims.string FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Requires _0 -> _0
 let (uu___is_Ensures : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Ensures _0 -> true | uu____1826 -> false
+  fun projectee -> match projectee with | Ensures _0 -> true | uu___ -> false
 let (__proj__Ensures__item___0 :
   term' -> (term * Prims.string FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Ensures _0 -> _0
 let (uu___is_Labeled : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Labeled _0 -> true | uu____1863 -> false
+  fun projectee -> match projectee with | Labeled _0 -> true | uu___ -> false
 let (__proj__Labeled__item___0 : term' -> (term * Prims.string * Prims.bool))
   = fun projectee -> match projectee with | Labeled _0 -> _0
 let (uu___is_Discrim : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Discrim _0 -> true | uu____1894 -> false
+  fun projectee -> match projectee with | Discrim _0 -> true | uu___ -> false
 let (__proj__Discrim__item___0 : term' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Discrim _0 -> _0
 let (uu___is_Attributes : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Attributes _0 -> true | uu____1909 -> false
+    match projectee with | Attributes _0 -> true | uu___ -> false
 let (__proj__Attributes__item___0 : term' -> term Prims.list) =
   fun projectee -> match projectee with | Attributes _0 -> _0
 let (uu___is_Antiquote : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Antiquote _0 -> true | uu____1928 -> false
+    match projectee with | Antiquote _0 -> true | uu___ -> false
 let (__proj__Antiquote__item___0 : term' -> term) =
   fun projectee -> match projectee with | Antiquote _0 -> _0
 let (uu___is_Quote : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Quote _0 -> true | uu____1945 -> false
+  fun projectee -> match projectee with | Quote _0 -> true | uu___ -> false
 let (__proj__Quote__item___0 : term' -> (term * quote_kind)) =
   fun projectee -> match projectee with | Quote _0 -> _0
 let (uu___is_VQuote : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VQuote _0 -> true | uu____1970 -> false
+  fun projectee -> match projectee with | VQuote _0 -> true | uu___ -> false
 let (__proj__VQuote__item___0 : term' -> term) =
   fun projectee -> match projectee with | VQuote _0 -> _0
 let (uu___is_CalcProof : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | CalcProof _0 -> true | uu____1991 -> false
+    match projectee with | CalcProof _0 -> true | uu___ -> false
 let (__proj__CalcProof__item___0 :
   term' -> (term * term * calc_step Prims.list)) =
   fun projectee -> match projectee with | CalcProof _0 -> _0
@@ -340,27 +317,26 @@ let (__proj__CalcStep__item___0 : calc_step -> (term * term * term)) =
   fun projectee -> match projectee with | CalcStep _0 -> _0
 let (uu___is_Variable : binder' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Variable _0 -> true | uu____2081 -> false
+    match projectee with | Variable _0 -> true | uu___ -> false
 let (__proj__Variable__item___0 : binder' -> FStar_Ident.ident) =
   fun projectee -> match projectee with | Variable _0 -> _0
 let (uu___is_TVariable : binder' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TVariable _0 -> true | uu____2094 -> false
+    match projectee with | TVariable _0 -> true | uu___ -> false
 let (__proj__TVariable__item___0 : binder' -> FStar_Ident.ident) =
   fun projectee -> match projectee with | TVariable _0 -> _0
 let (uu___is_Annotated : binder' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Annotated _0 -> true | uu____2111 -> false
+    match projectee with | Annotated _0 -> true | uu___ -> false
 let (__proj__Annotated__item___0 : binder' -> (FStar_Ident.ident * term)) =
   fun projectee -> match projectee with | Annotated _0 -> _0
 let (uu___is_TAnnotated : binder' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TAnnotated _0 -> true | uu____2140 -> false
+    match projectee with | TAnnotated _0 -> true | uu___ -> false
 let (__proj__TAnnotated__item___0 : binder' -> (FStar_Ident.ident * term)) =
   fun projectee -> match projectee with | TAnnotated _0 -> _0
 let (uu___is_NoName : binder' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoName _0 -> true | uu____2165 -> false
+  fun projectee -> match projectee with | NoName _0 -> true | uu___ -> false
 let (__proj__NoName__item___0 : binder' -> term) =
   fun projectee -> match projectee with | NoName _0 -> _0
 let (__proj__Mkbinder__item__b : binder -> binder') =
@@ -376,71 +352,63 @@ let (__proj__Mkbinder__item__aqual :
   fun projectee ->
     match projectee with | { b; brange; blevel; aqual;_} -> aqual
 let (uu___is_PatWild : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatWild _0 -> true | uu____2228 -> false
+  fun projectee -> match projectee with | PatWild _0 -> true | uu___ -> false
 let (__proj__PatWild__item___0 :
   pattern' -> arg_qualifier FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | PatWild _0 -> _0
 let (uu___is_PatConst : pattern' -> Prims.bool) =
   fun projectee ->
-    match projectee with | PatConst _0 -> true | uu____2247 -> false
+    match projectee with | PatConst _0 -> true | uu___ -> false
 let (__proj__PatConst__item___0 : pattern' -> FStar_Const.sconst) =
   fun projectee -> match projectee with | PatConst _0 -> _0
 let (uu___is_PatApp : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatApp _0 -> true | uu____2266 -> false
+  fun projectee -> match projectee with | PatApp _0 -> true | uu___ -> false
 let (__proj__PatApp__item___0 : pattern' -> (pattern * pattern Prims.list)) =
   fun projectee -> match projectee with | PatApp _0 -> _0
 let (uu___is_PatVar : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatVar _0 -> true | uu____2303 -> false
+  fun projectee -> match projectee with | PatVar _0 -> true | uu___ -> false
 let (__proj__PatVar__item___0 :
   pattern' ->
     (FStar_Ident.ident * arg_qualifier FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | PatVar _0 -> _0
 let (uu___is_PatName : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatName _0 -> true | uu____2334 -> false
+  fun projectee -> match projectee with | PatName _0 -> true | uu___ -> false
 let (__proj__PatName__item___0 : pattern' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | PatName _0 -> _0
 let (uu___is_PatTvar : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatTvar _0 -> true | uu____2353 -> false
+  fun projectee -> match projectee with | PatTvar _0 -> true | uu___ -> false
 let (__proj__PatTvar__item___0 :
   pattern' ->
     (FStar_Ident.ident * arg_qualifier FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | PatTvar _0 -> _0
 let (uu___is_PatList : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatList _0 -> true | uu____2386 -> false
+  fun projectee -> match projectee with | PatList _0 -> true | uu___ -> false
 let (__proj__PatList__item___0 : pattern' -> pattern Prims.list) =
   fun projectee -> match projectee with | PatList _0 -> _0
 let (uu___is_PatTuple : pattern' -> Prims.bool) =
   fun projectee ->
-    match projectee with | PatTuple _0 -> true | uu____2411 -> false
+    match projectee with | PatTuple _0 -> true | uu___ -> false
 let (__proj__PatTuple__item___0 :
   pattern' -> (pattern Prims.list * Prims.bool)) =
   fun projectee -> match projectee with | PatTuple _0 -> _0
 let (uu___is_PatRecord : pattern' -> Prims.bool) =
   fun projectee ->
-    match projectee with | PatRecord _0 -> true | uu____2448 -> false
+    match projectee with | PatRecord _0 -> true | uu___ -> false
 let (__proj__PatRecord__item___0 :
   pattern' -> (FStar_Ident.lid * pattern) Prims.list) =
   fun projectee -> match projectee with | PatRecord _0 -> _0
 let (uu___is_PatAscribed : pattern' -> Prims.bool) =
   fun projectee ->
-    match projectee with | PatAscribed _0 -> true | uu____2489 -> false
+    match projectee with | PatAscribed _0 -> true | uu___ -> false
 let (__proj__PatAscribed__item___0 :
   pattern' -> (pattern * (term * term FStar_Pervasives_Native.option))) =
   fun projectee -> match projectee with | PatAscribed _0 -> _0
 let (uu___is_PatOr : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatOr _0 -> true | uu____2534 -> false
+  fun projectee -> match projectee with | PatOr _0 -> true | uu___ -> false
 let (__proj__PatOr__item___0 : pattern' -> pattern Prims.list) =
   fun projectee -> match projectee with | PatOr _0 -> _0
 let (uu___is_PatOp : pattern' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PatOp _0 -> true | uu____2553 -> false
+  fun projectee -> match projectee with | PatOp _0 -> true | uu___ -> false
 let (__proj__PatOp__item___0 : pattern' -> FStar_Ident.ident) =
   fun projectee -> match projectee with | PatOp _0 -> _0
 let (__proj__Mkpattern__item__pat : pattern -> pattern') =
@@ -448,49 +416,41 @@ let (__proj__Mkpattern__item__pat : pattern -> pattern') =
 let (__proj__Mkpattern__item__prange : pattern -> FStar_Range.range) =
   fun projectee -> match projectee with | { pat; prange;_} -> prange
 let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Implicit -> true | uu____2579 -> false
+  fun projectee -> match projectee with | Implicit -> true | uu___ -> false
 let (uu___is_Equality : arg_qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Equality -> true | uu____2585 -> false
+  fun projectee -> match projectee with | Equality -> true | uu___ -> false
 let (uu___is_Meta : arg_qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Meta _0 -> true | uu____2592 -> false
+  fun projectee -> match projectee with | Meta _0 -> true | uu___ -> false
 let (__proj__Meta__item___0 : arg_qualifier -> arg_qualifier_meta_t) =
   fun projectee -> match projectee with | Meta _0 -> _0
 let (uu___is_Arg_qualifier_meta_tac : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Arg_qualifier_meta_tac _0 -> true
-    | uu____2605 -> false
+    match projectee with | Arg_qualifier_meta_tac _0 -> true | uu___ -> false
 let (__proj__Arg_qualifier_meta_tac__item___0 : arg_qualifier_meta_t -> term)
   = fun projectee -> match projectee with | Arg_qualifier_meta_tac _0 -> _0
 let (uu___is_Arg_qualifier_meta_attr : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Arg_qualifier_meta_attr _0 -> true
-    | uu____2618 -> false
+    | uu___ -> false
 let (__proj__Arg_qualifier_meta_attr__item___0 :
   arg_qualifier_meta_t -> term) =
   fun projectee -> match projectee with | Arg_qualifier_meta_attr _0 -> _0
 let (uu___is_FsTypApp : imp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FsTypApp -> true | uu____2630 -> false
+  fun projectee -> match projectee with | FsTypApp -> true | uu___ -> false
 let (uu___is_Hash : imp -> Prims.bool) =
-  fun projectee -> match projectee with | Hash -> true | uu____2636 -> false
+  fun projectee -> match projectee with | Hash -> true | uu___ -> false
 let (uu___is_UnivApp : imp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UnivApp -> true | uu____2642 -> false
+  fun projectee -> match projectee with | UnivApp -> true | uu___ -> false
 let (uu___is_HashBrace : imp -> Prims.bool) =
   fun projectee ->
-    match projectee with | HashBrace _0 -> true | uu____2649 -> false
+    match projectee with | HashBrace _0 -> true | uu___ -> false
 let (__proj__HashBrace__item___0 : imp -> term) =
   fun projectee -> match projectee with | HashBrace _0 -> _0
 let (uu___is_Infix : imp -> Prims.bool) =
-  fun projectee -> match projectee with | Infix -> true | uu____2661 -> false
+  fun projectee -> match projectee with | Infix -> true | uu___ -> false
 let (uu___is_Nothing : imp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Nothing -> true | uu____2667 -> false
+  fun projectee -> match projectee with | Nothing -> true | uu___ -> false
 type patterns = (FStar_Ident.ident Prims.list * term Prims.list Prims.list)
 type attributes_ = term Prims.list
 type branch = (pattern * term FStar_Pervasives_Native.option * term)
@@ -510,7 +470,7 @@ type tycon =
   FStar_Pervasives_Native.option * Prims.bool) Prims.list) 
 let (uu___is_TyconAbstract : tycon -> Prims.bool) =
   fun projectee ->
-    match projectee with | TyconAbstract _0 -> true | uu____2788 -> false
+    match projectee with | TyconAbstract _0 -> true | uu___ -> false
 let (__proj__TyconAbstract__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
@@ -518,7 +478,7 @@ let (__proj__TyconAbstract__item___0 :
   = fun projectee -> match projectee with | TyconAbstract _0 -> _0
 let (uu___is_TyconAbbrev : tycon -> Prims.bool) =
   fun projectee ->
-    match projectee with | TyconAbbrev _0 -> true | uu____2843 -> false
+    match projectee with | TyconAbbrev _0 -> true | uu___ -> false
 let (__proj__TyconAbbrev__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
@@ -526,7 +486,7 @@ let (__proj__TyconAbbrev__item___0 :
   = fun projectee -> match projectee with | TyconAbbrev _0 -> _0
 let (uu___is_TyconRecord : tycon -> Prims.bool) =
   fun projectee ->
-    match projectee with | TyconRecord _0 -> true | uu____2910 -> false
+    match projectee with | TyconRecord _0 -> true | uu___ -> false
 let (__proj__TyconRecord__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
@@ -534,7 +494,7 @@ let (__proj__TyconRecord__item___0 :
   = fun projectee -> match projectee with | TyconRecord _0 -> _0
 let (uu___is_TyconVariant : tycon -> Prims.bool) =
   fun projectee ->
-    match projectee with | TyconVariant _0 -> true | uu____2999 -> false
+    match projectee with | TyconVariant _0 -> true | uu___ -> false
 let (__proj__TyconVariant__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
@@ -561,72 +521,62 @@ type qualifier =
   | Opaque 
   | Logic 
 let (uu___is_Private : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Private -> true | uu____3077 -> false
+  fun projectee -> match projectee with | Private -> true | uu___ -> false
 let (uu___is_Noeq : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Noeq -> true | uu____3083 -> false
+  fun projectee -> match projectee with | Noeq -> true | uu___ -> false
 let (uu___is_Unopteq : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unopteq -> true | uu____3089 -> false
+  fun projectee -> match projectee with | Unopteq -> true | uu___ -> false
 let (uu___is_Assumption : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assumption -> true | uu____3095 -> false
+  fun projectee -> match projectee with | Assumption -> true | uu___ -> false
 let (uu___is_DefaultEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | DefaultEffect -> true | uu____3101 -> false
+    match projectee with | DefaultEffect -> true | uu___ -> false
 let (uu___is_TotalEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | TotalEffect -> true | uu____3107 -> false
+    match projectee with | TotalEffect -> true | uu___ -> false
 let (uu___is_Effect_qual : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Effect_qual -> true | uu____3113 -> false
+    match projectee with | Effect_qual -> true | uu___ -> false
 let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | New -> true | uu____3119 -> false
+  fun projectee -> match projectee with | New -> true | uu___ -> false
 let (uu___is_Inline : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Inline -> true | uu____3125 -> false
+  fun projectee -> match projectee with | Inline -> true | uu___ -> false
 let (uu___is_Visible : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Visible -> true | uu____3131 -> false
+  fun projectee -> match projectee with | Visible -> true | uu___ -> false
 let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Unfold_for_unification_and_vcgen -> true
-    | uu____3137 -> false
+    | uu___ -> false
 let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Inline_for_extraction -> true
-    | uu____3143 -> false
+    match projectee with | Inline_for_extraction -> true | uu___ -> false
 let (uu___is_Irreducible : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Irreducible -> true | uu____3149 -> false
+    match projectee with | Irreducible -> true | uu___ -> false
 let (uu___is_NoExtract : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoExtract -> true | uu____3155 -> false
+  fun projectee -> match projectee with | NoExtract -> true | uu___ -> false
 let (uu___is_Reifiable : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Reifiable -> true | uu____3161 -> false
+  fun projectee -> match projectee with | Reifiable -> true | uu___ -> false
 let (uu___is_Reflectable : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Reflectable -> true | uu____3167 -> false
+    match projectee with | Reflectable -> true | uu___ -> false
 let (uu___is_Opaque : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Opaque -> true | uu____3173 -> false
+  fun projectee -> match projectee with | Opaque -> true | uu___ -> false
 let (uu___is_Logic : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Logic -> true | uu____3179 -> false
+  fun projectee -> match projectee with | Logic -> true | uu___ -> false
 type qualifiers = qualifier Prims.list
 type decoration =
   | Qualifier of qualifier 
   | DeclAttributes of term Prims.list 
 let (uu___is_Qualifier : decoration -> Prims.bool) =
   fun projectee ->
-    match projectee with | Qualifier _0 -> true | uu____3200 -> false
+    match projectee with | Qualifier _0 -> true | uu___ -> false
 let (__proj__Qualifier__item___0 : decoration -> qualifier) =
   fun projectee -> match projectee with | Qualifier _0 -> _0
 let (uu___is_DeclAttributes : decoration -> Prims.bool) =
   fun projectee ->
-    match projectee with | DeclAttributes _0 -> true | uu____3215 -> false
+    match projectee with | DeclAttributes _0 -> true | uu___ -> false
 let (__proj__DeclAttributes__item___0 : decoration -> term Prims.list) =
   fun projectee -> match projectee with | DeclAttributes _0 -> _0
 type lift_op =
@@ -635,17 +585,17 @@ type lift_op =
   | LiftForFree of term 
 let (uu___is_NonReifiableLift : lift_op -> Prims.bool) =
   fun projectee ->
-    match projectee with | NonReifiableLift _0 -> true | uu____3253 -> false
+    match projectee with | NonReifiableLift _0 -> true | uu___ -> false
 let (__proj__NonReifiableLift__item___0 : lift_op -> term) =
   fun projectee -> match projectee with | NonReifiableLift _0 -> _0
 let (uu___is_ReifiableLift : lift_op -> Prims.bool) =
   fun projectee ->
-    match projectee with | ReifiableLift _0 -> true | uu____3270 -> false
+    match projectee with | ReifiableLift _0 -> true | uu___ -> false
 let (__proj__ReifiableLift__item___0 : lift_op -> (term * term)) =
   fun projectee -> match projectee with | ReifiableLift _0 -> _0
 let (uu___is_LiftForFree : lift_op -> Prims.bool) =
   fun projectee ->
-    match projectee with | LiftForFree _0 -> true | uu____3295 -> false
+    match projectee with | LiftForFree _0 -> true | uu___ -> false
 let (__proj__LiftForFree__item___0 : lift_op -> term) =
   fun projectee -> match projectee with | LiftForFree _0 -> _0
 type lift =
@@ -672,30 +622,28 @@ type pragma =
   | LightOff 
 let (uu___is_SetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | SetOptions _0 -> true | uu____3366 -> false
+    match projectee with | SetOptions _0 -> true | uu___ -> false
 let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
   fun projectee -> match projectee with | SetOptions _0 -> _0
 let (uu___is_ResetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | ResetOptions _0 -> true | uu____3381 -> false
+    match projectee with | ResetOptions _0 -> true | uu___ -> false
 let (__proj__ResetOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | ResetOptions _0 -> _0
 let (uu___is_PushOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | PushOptions _0 -> true | uu____3402 -> false
+    match projectee with | PushOptions _0 -> true | uu___ -> false
 let (__proj__PushOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | PushOptions _0 -> _0
 let (uu___is_PopOptions : pragma -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PopOptions -> true | uu____3420 -> false
+  fun projectee -> match projectee with | PopOptions -> true | uu___ -> false
 let (uu___is_RestartSolver : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | RestartSolver -> true | uu____3426 -> false
+    match projectee with | RestartSolver -> true | uu___ -> false
 let (uu___is_LightOff : pragma -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LightOff -> true | uu____3432 -> false
+  fun projectee -> match projectee with | LightOff -> true | uu___ -> false
 type decl' =
   | TopLevelModule of FStar_Ident.lid 
   | Open of FStar_Ident.lid 
@@ -727,95 +675,85 @@ and effect_decl =
   | RedefineEffect of (FStar_Ident.ident * binder Prims.list * term) 
 let (uu___is_TopLevelModule : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TopLevelModule _0 -> true | uu____3630 -> false
+    match projectee with | TopLevelModule _0 -> true | uu___ -> false
 let (__proj__TopLevelModule__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | TopLevelModule _0 -> _0
 let (uu___is_Open : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Open _0 -> true | uu____3643 -> false
+  fun projectee -> match projectee with | Open _0 -> true | uu___ -> false
 let (__proj__Open__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Open _0 -> _0
 let (uu___is_Friend : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Friend _0 -> true | uu____3656 -> false
+  fun projectee -> match projectee with | Friend _0 -> true | uu___ -> false
 let (__proj__Friend__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Friend _0 -> _0
 let (uu___is_Include : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Include _0 -> true | uu____3669 -> false
+  fun projectee -> match projectee with | Include _0 -> true | uu___ -> false
 let (__proj__Include__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Include _0 -> _0
 let (uu___is_ModuleAbbrev : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | ModuleAbbrev _0 -> true | uu____3686 -> false
+    match projectee with | ModuleAbbrev _0 -> true | uu___ -> false
 let (__proj__ModuleAbbrev__item___0 :
   decl' -> (FStar_Ident.ident * FStar_Ident.lid)) =
   fun projectee -> match projectee with | ModuleAbbrev _0 -> _0
 let (uu___is_TopLevelLet : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TopLevelLet _0 -> true | uu____3721 -> false
+    match projectee with | TopLevelLet _0 -> true | uu___ -> false
 let (__proj__TopLevelLet__item___0 :
   decl' -> (let_qualifier * (pattern * term) Prims.list)) =
   fun projectee -> match projectee with | TopLevelLet _0 -> _0
 let (uu___is_Tycon : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tycon _0 -> true | uu____3772 -> false
+  fun projectee -> match projectee with | Tycon _0 -> true | uu___ -> false
 let (__proj__Tycon__item___0 :
   decl' -> (Prims.bool * Prims.bool * tycon Prims.list)) =
   fun projectee -> match projectee with | Tycon _0 -> _0
 let (uu___is_Val : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Val _0 -> true | uu____3813 -> false
+  fun projectee -> match projectee with | Val _0 -> true | uu___ -> false
 let (__proj__Val__item___0 : decl' -> (FStar_Ident.ident * term)) =
   fun projectee -> match projectee with | Val _0 -> _0
 let (uu___is_Exception : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Exception _0 -> true | uu____3844 -> false
+    match projectee with | Exception _0 -> true | uu___ -> false
 let (__proj__Exception__item___0 :
   decl' -> (FStar_Ident.ident * term FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Exception _0 -> _0
 let (uu___is_NewEffect : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | NewEffect _0 -> true | uu____3875 -> false
+    match projectee with | NewEffect _0 -> true | uu___ -> false
 let (__proj__NewEffect__item___0 : decl' -> effect_decl) =
   fun projectee -> match projectee with | NewEffect _0 -> _0
 let (uu___is_LayeredEffect : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | LayeredEffect _0 -> true | uu____3888 -> false
+    match projectee with | LayeredEffect _0 -> true | uu___ -> false
 let (__proj__LayeredEffect__item___0 : decl' -> effect_decl) =
   fun projectee -> match projectee with | LayeredEffect _0 -> _0
 let (uu___is_SubEffect : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | SubEffect _0 -> true | uu____3901 -> false
+    match projectee with | SubEffect _0 -> true | uu___ -> false
 let (__proj__SubEffect__item___0 : decl' -> lift) =
   fun projectee -> match projectee with | SubEffect _0 -> _0
 let (uu___is_Polymonadic_bind : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Polymonadic_bind _0 -> true | uu____3922 -> false
+    match projectee with | Polymonadic_bind _0 -> true | uu___ -> false
 let (__proj__Polymonadic_bind__item___0 :
   decl' -> (FStar_Ident.lid * FStar_Ident.lid * FStar_Ident.lid * term)) =
   fun projectee -> match projectee with | Polymonadic_bind _0 -> _0
 let (uu___is_Polymonadic_subcomp : decl' -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Polymonadic_subcomp _0 -> true
-    | uu____3965 -> false
+    match projectee with | Polymonadic_subcomp _0 -> true | uu___ -> false
 let (__proj__Polymonadic_subcomp__item___0 :
   decl' -> (FStar_Ident.lid * FStar_Ident.lid * term)) =
   fun projectee -> match projectee with | Polymonadic_subcomp _0 -> _0
 let (uu___is_Pragma : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Pragma _0 -> true | uu____3996 -> false
+  fun projectee -> match projectee with | Pragma _0 -> true | uu___ -> false
 let (__proj__Pragma__item___0 : decl' -> pragma) =
   fun projectee -> match projectee with | Pragma _0 -> _0
 let (uu___is_Assume : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assume _0 -> true | uu____4013 -> false
+  fun projectee -> match projectee with | Assume _0 -> true | uu___ -> false
 let (__proj__Assume__item___0 : decl' -> (FStar_Ident.ident * term)) =
   fun projectee -> match projectee with | Assume _0 -> _0
 let (uu___is_Splice : decl' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Splice _0 -> true | uu____4044 -> false
+  fun projectee -> match projectee with | Splice _0 -> true | uu___ -> false
 let (__proj__Splice__item___0 :
   decl' -> (FStar_Ident.ident Prims.list * term)) =
   fun projectee -> match projectee with | Splice _0 -> _0
@@ -832,14 +770,14 @@ let (__proj__Mkdecl__item__attrs : decl -> attributes_) =
     match projectee with | { d; drange; quals; attrs;_} -> attrs
 let (uu___is_DefineEffect : effect_decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DefineEffect _0 -> true | uu____4123 -> false
+    match projectee with | DefineEffect _0 -> true | uu___ -> false
 let (__proj__DefineEffect__item___0 :
   effect_decl ->
     (FStar_Ident.ident * binder Prims.list * term * decl Prims.list))
   = fun projectee -> match projectee with | DefineEffect _0 -> _0
 let (uu___is_RedefineEffect : effect_decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | RedefineEffect _0 -> true | uu____4180 -> false
+    match projectee with | RedefineEffect _0 -> true | uu___ -> false
 let (__proj__RedefineEffect__item___0 :
   effect_decl -> (FStar_Ident.ident * binder Prims.list * term)) =
   fun projectee -> match projectee with | RedefineEffect _0 -> _0
@@ -847,13 +785,12 @@ type modul =
   | Module of (FStar_Ident.lid * decl Prims.list) 
   | Interface of (FStar_Ident.lid * decl Prims.list * Prims.bool) 
 let (uu___is_Module : modul -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Module _0 -> true | uu____4247 -> false
+  fun projectee -> match projectee with | Module _0 -> true | uu___ -> false
 let (__proj__Module__item___0 : modul -> (FStar_Ident.lid * decl Prims.list))
   = fun projectee -> match projectee with | Module _0 -> _0
 let (uu___is_Interface : modul -> Prims.bool) =
   fun projectee ->
-    match projectee with | Interface _0 -> true | uu____4286 -> false
+    match projectee with | Interface _0 -> true | uu___ -> false
 let (__proj__Interface__item___0 :
   modul -> (FStar_Ident.lid * decl Prims.list * Prims.bool)) =
   fun projectee -> match projectee with | Interface _0 -> _0
@@ -863,25 +800,25 @@ let (decl_drange : decl -> FStar_Range.range) = fun decl1 -> decl1.drange
 let (check_id : FStar_Ident.ident -> unit) =
   fun id ->
     let first_char =
-      let uu____4334 = FStar_Ident.string_of_id id in
-      FStar_String.substring uu____4334 Prims.int_zero Prims.int_one in
+      let uu___ = FStar_Ident.string_of_id id in
+      FStar_String.substring uu___ Prims.int_zero Prims.int_one in
     if (FStar_String.lowercase first_char) = first_char
     then ()
     else
-      (let uu____4336 =
-         let uu____4341 =
-           let uu____4342 = FStar_Ident.string_of_id id in
+      (let uu___1 =
+         let uu___2 =
+           let uu___3 = FStar_Ident.string_of_id id in
            FStar_Util.format1
              "Invalid identifer '%s'; expected a symbol that begins with a lower-case character"
-             uu____4342 in
-         (FStar_Errors.Fatal_InvalidIdentifier, uu____4341) in
-       let uu____4343 = FStar_Ident.range_of_id id in
-       FStar_Errors.raise_error uu____4336 uu____4343)
+             uu___3 in
+         (FStar_Errors.Fatal_InvalidIdentifier, uu___2) in
+       let uu___2 = FStar_Ident.range_of_id id in
+       FStar_Errors.raise_error uu___1 uu___2)
 let at_most_one :
-  'uuuuuu4352 .
+  'uuuuu .
     Prims.string ->
       FStar_Range.range ->
-        'uuuuuu4352 Prims.list -> 'uuuuuu4352 FStar_Pervasives_Native.option
+        'uuuuu Prims.list -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun s ->
     fun r ->
@@ -889,32 +826,32 @@ let at_most_one :
         match l with
         | x::[] -> FStar_Pervasives_Native.Some x
         | [] -> FStar_Pervasives_Native.None
-        | uu____4375 ->
-            let uu____4378 =
-              let uu____4383 =
+        | uu___ ->
+            let uu___1 =
+              let uu___2 =
                 FStar_Util.format1
                   "At most one %s is allowed on declarations" s in
-              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu____4383) in
-            FStar_Errors.raise_error uu____4378 r
+              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu___2) in
+            FStar_Errors.raise_error uu___1 r
 let (mk_decl : decl' -> FStar_Range.range -> decoration Prims.list -> decl) =
   fun d ->
     fun r ->
       fun decorations ->
         let attributes_1 =
-          let uu____4410 =
+          let uu___ =
             FStar_List.choose
-              (fun uu___0_4419 ->
-                 match uu___0_4419 with
+              (fun uu___1 ->
+                 match uu___1 with
                  | DeclAttributes a -> FStar_Pervasives_Native.Some a
-                 | uu____4429 -> FStar_Pervasives_Native.None) decorations in
-          at_most_one "attribute set" r uu____4410 in
+                 | uu___2 -> FStar_Pervasives_Native.None) decorations in
+          at_most_one "attribute set" r uu___ in
         let attributes_2 = FStar_Util.dflt [] attributes_1 in
         let qualifiers1 =
           FStar_List.choose
-            (fun uu___1_4444 ->
-               match uu___1_4444 with
+            (fun uu___ ->
+               match uu___ with
                | Qualifier q -> FStar_Pervasives_Native.Some q
-               | uu____4448 -> FStar_Pervasives_Native.None) decorations in
+               | uu___1 -> FStar_Pervasives_Native.None) decorations in
         { d; drange = r; quals = qualifiers1; attrs = attributes_2 }
 let (mk_binder :
   binder' ->
@@ -941,11 +878,11 @@ let (mk_uminus :
                      ((Prims.op_Hat "-" s),
                        (FStar_Pervasives_Native.Some
                           (FStar_Const.Signed, width))))
-            | uu____4531 ->
-                let uu____4532 =
-                  let uu____4539 = FStar_Ident.mk_ident ("-", rminus) in
-                  (uu____4539, [t]) in
-                Op uu____4532 in
+            | uu___ ->
+                let uu___1 =
+                  let uu___2 = FStar_Ident.mk_ident ("-", rminus) in
+                  (uu___2, [t]) in
+                Op uu___1 in
           mk_term t1 r l
 let (mk_pattern : pattern' -> FStar_Range.range -> pattern) =
   fun p -> fun r -> { pat = p; prange = r }
@@ -954,7 +891,7 @@ let (un_curry_abs : pattern Prims.list -> term -> term') =
     fun body ->
       match body.tm with
       | Abs (p', body') -> Abs ((FStar_List.append ps p'), body')
-      | uu____4574 -> Abs (ps, body)
+      | uu___ -> Abs (ps, body)
 let (mk_function :
   (pattern * term FStar_Pervasives_Native.option * term) Prims.list ->
     FStar_Range.range -> FStar_Range.range -> term)
@@ -963,38 +900,37 @@ let (mk_function :
     fun r1 ->
       fun r2 ->
         let x = FStar_Ident.gen r1 in
-        let uu____4613 =
-          let uu____4614 =
-            let uu____4621 =
-              let uu____4622 =
-                let uu____4623 =
-                  let uu____4638 =
-                    let uu____4639 =
-                      let uu____4640 = FStar_Ident.lid_of_ids [x] in
-                      Var uu____4640 in
-                    mk_term uu____4639 r1 Expr in
-                  (uu____4638, branches) in
-                Match uu____4623 in
-              mk_term uu____4622 r2 Expr in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 =
+                      let uu___7 = FStar_Ident.lid_of_ids [x] in Var uu___7 in
+                    mk_term uu___6 r1 Expr in
+                  (uu___5, branches) in
+                Match uu___4 in
+              mk_term uu___3 r2 Expr in
             ([mk_pattern (PatVar (x, FStar_Pervasives_Native.None)) r1],
-              uu____4621) in
-          Abs uu____4614 in
-        mk_term uu____4613 r2 Expr
+              uu___2) in
+          Abs uu___1 in
+        mk_term uu___ r2 Expr
 let (un_function :
   pattern -> term -> (pattern * term) FStar_Pervasives_Native.option) =
   fun p ->
     fun tm ->
       match ((p.pat), (tm.tm)) with
-      | (PatVar uu____4677, Abs (pats, body)) ->
+      | (PatVar uu___, Abs (pats, body)) ->
           FStar_Pervasives_Native.Some
             ((mk_pattern (PatApp (p, pats)) p.prange), body)
-      | uu____4696 -> FStar_Pervasives_Native.None
+      | uu___ -> FStar_Pervasives_Native.None
 let (lid_with_range :
   FStar_Ident.lident -> FStar_Range.range -> FStar_Ident.lident) =
   fun lid ->
     fun r ->
-      let uu____4715 = FStar_Ident.path_of_lid lid in
-      FStar_Ident.lid_of_path uu____4715 r
+      let uu___ = FStar_Ident.path_of_lid lid in
+      FStar_Ident.lid_of_path uu___ r
 let (consPat : FStar_Range.range -> pattern -> pattern -> pattern') =
   fun r ->
     fun hd ->
@@ -1042,44 +978,44 @@ let (mkApp : term -> (term * imp) Prims.list -> FStar_Range.range -> term) =
       fun r ->
         match args with
         | [] -> t
-        | uu____4902 ->
+        | uu___ ->
             (match t.tm with
              | Name s -> mk_term (Construct (s, args)) r Un
-             | uu____4916 ->
+             | uu___1 ->
                  FStar_List.fold_left
                    (fun t1 ->
-                      fun uu____4926 ->
-                        match uu____4926 with
+                      fun uu___2 ->
+                        match uu___2 with
                         | (a, imp1) -> mk_term (App (t1, a, imp1)) r Un) t
                    args)
 let (mkRefSet : FStar_Range.range -> term Prims.list -> term) =
   fun r ->
     fun elts ->
-      let uu____4947 =
+      let uu___ =
         (FStar_Parser_Const.set_empty, FStar_Parser_Const.set_singleton,
           FStar_Parser_Const.set_union, FStar_Parser_Const.heap_addr_of_lid) in
-      match uu____4947 with
+      match uu___ with
       | (empty_lid, singleton_lid, union_lid, addr_of_lid) ->
           let empty =
-            let uu____4961 =
-              let uu____4962 = FStar_Ident.set_lid_range empty_lid r in
-              Var uu____4962 in
-            mk_term uu____4961 r Expr in
+            let uu___1 =
+              let uu___2 = FStar_Ident.set_lid_range empty_lid r in
+              Var uu___2 in
+            mk_term uu___1 r Expr in
           let addr_of =
-            let uu____4964 =
-              let uu____4965 = FStar_Ident.set_lid_range addr_of_lid r in
-              Var uu____4965 in
-            mk_term uu____4964 r Expr in
+            let uu___1 =
+              let uu___2 = FStar_Ident.set_lid_range addr_of_lid r in
+              Var uu___2 in
+            mk_term uu___1 r Expr in
           let singleton =
-            let uu____4967 =
-              let uu____4968 = FStar_Ident.set_lid_range singleton_lid r in
-              Var uu____4968 in
-            mk_term uu____4967 r Expr in
+            let uu___1 =
+              let uu___2 = FStar_Ident.set_lid_range singleton_lid r in
+              Var uu___2 in
+            mk_term uu___1 r Expr in
           let union =
-            let uu____4970 =
-              let uu____4971 = FStar_Ident.set_lid_range union_lid r in
-              Var uu____4971 in
-            mk_term uu____4970 r Expr in
+            let uu___1 =
+              let uu___2 = FStar_Ident.set_lid_range union_lid r in
+              Var uu___2 in
+            mk_term uu___1 r Expr in
           FStar_List.fold_right
             (fun e ->
                fun tl ->
@@ -1093,17 +1029,16 @@ let (mkExplicitApp : term -> term Prims.list -> FStar_Range.range -> term) =
       fun r ->
         match args with
         | [] -> t
-        | uu____5027 ->
+        | uu___ ->
             (match t.tm with
              | Name s ->
-                 let uu____5031 =
-                   let uu____5032 =
-                     let uu____5043 =
-                       FStar_List.map (fun a -> (a, Nothing)) args in
-                     (s, uu____5043) in
-                   Construct uu____5032 in
-                 mk_term uu____5031 r Un
-             | uu____5062 ->
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_List.map (fun a -> (a, Nothing)) args in
+                     (s, uu___3) in
+                   Construct uu___2 in
+                 mk_term uu___1 r Un
+             | uu___1 ->
                  FStar_List.fold_left
                    (fun t1 -> fun a -> mk_term (App (t1, a, Nothing)) r Un) t
                    args)
@@ -1113,37 +1048,36 @@ let (mkAdmitMagic : FStar_Range.range -> term) =
   fun r ->
     let admit =
       let admit_name =
-        let uu____5079 =
-          let uu____5080 =
+        let uu___ =
+          let uu___1 =
             FStar_Ident.set_lid_range FStar_Parser_Const.admit_lid r in
-          Var uu____5080 in
-        mk_term uu____5079 r Expr in
+          Var uu___1 in
+        mk_term uu___ r Expr in
       mkExplicitApp admit_name [unit_const r] r in
     let magic =
       let magic_name =
-        let uu____5083 =
-          let uu____5084 =
+        let uu___ =
+          let uu___1 =
             FStar_Ident.set_lid_range FStar_Parser_Const.magic_lid r in
-          Var uu____5084 in
-        mk_term uu____5083 r Expr in
+          Var uu___1 in
+        mk_term uu___ r Expr in
       mkExplicitApp magic_name [unit_const r] r in
     let admit_magic = mk_term (Seq (admit, magic)) r Expr in admit_magic
 let mkWildAdmitMagic :
-  'uuuuuu5090 .
+  'uuuuu .
     FStar_Range.range ->
-      (pattern * 'uuuuuu5090 FStar_Pervasives_Native.option * term)
+      (pattern * 'uuuuu FStar_Pervasives_Native.option * term)
   =
   fun r ->
-    let uu____5104 = mkAdmitMagic r in
+    let uu___ = mkAdmitMagic r in
     ((mk_pattern (PatWild FStar_Pervasives_Native.None) r),
-      FStar_Pervasives_Native.None, uu____5104)
+      FStar_Pervasives_Native.None, uu___)
 let focusBranches :
-  'uuuuuu5113 .
-    (Prims.bool * (pattern * 'uuuuuu5113 FStar_Pervasives_Native.option *
-      term)) Prims.list ->
+  'uuuuu .
+    (Prims.bool * (pattern * 'uuuuu FStar_Pervasives_Native.option * term))
+      Prims.list ->
       FStar_Range.range ->
-        (pattern * 'uuuuuu5113 FStar_Pervasives_Native.option * term)
-          Prims.list
+        (pattern * 'uuuuu FStar_Pervasives_Native.option * term) Prims.list
   =
   fun branches ->
     fun r ->
@@ -1154,20 +1088,19 @@ let focusBranches :
         (FStar_Errors.log_issue r
            (FStar_Errors.Warning_Filtered, "Focusing on only some cases");
          (let focussed =
-            let uu____5205 =
+            let uu___1 =
               FStar_List.filter FStar_Pervasives_Native.fst branches in
-            FStar_All.pipe_right uu____5205
+            FStar_All.pipe_right uu___1
               (FStar_List.map FStar_Pervasives_Native.snd) in
-          let uu____5292 =
-            let uu____5303 = mkWildAdmitMagic r in [uu____5303] in
-          FStar_List.append focussed uu____5292))
+          let uu___1 = let uu___2 = mkWildAdmitMagic r in [uu___2] in
+          FStar_List.append focussed uu___1))
       else
         FStar_All.pipe_right branches
           (FStar_List.map FStar_Pervasives_Native.snd)
 let focusLetBindings :
-  'uuuuuu5395 .
-    (Prims.bool * ('uuuuuu5395 * term)) Prims.list ->
-      FStar_Range.range -> ('uuuuuu5395 * term) Prims.list
+  'uuuuu .
+    (Prims.bool * ('uuuuu * term)) Prims.list ->
+      FStar_Range.range -> ('uuuuu * term) Prims.list
   =
   fun lbs ->
     fun r ->
@@ -1178,27 +1111,26 @@ let focusLetBindings :
            (FStar_Errors.Warning_Filtered,
              "Focusing on only some cases in this (mutually) recursive definition");
          FStar_List.map
-           (fun uu____5467 ->
-              match uu____5467 with
+           (fun uu___1 ->
+              match uu___1 with
               | (f, lb) ->
                   if f
                   then lb
                   else
-                    (let uu____5495 = mkAdmitMagic r in
-                     ((FStar_Pervasives_Native.fst lb), uu____5495))) lbs)
+                    (let uu___3 = mkAdmitMagic r in
+                     ((FStar_Pervasives_Native.fst lb), uu___3))) lbs)
       else
         FStar_All.pipe_right lbs (FStar_List.map FStar_Pervasives_Native.snd)
 let focusAttrLetBindings :
-  'uuuuuu5537 'uuuuuu5538 .
-    ('uuuuuu5537 * (Prims.bool * ('uuuuuu5538 * term))) Prims.list ->
-      FStar_Range.range -> ('uuuuuu5537 * ('uuuuuu5538 * term)) Prims.list
+  'uuuuu 'uuuuu1 .
+    ('uuuuu * (Prims.bool * ('uuuuu1 * term))) Prims.list ->
+      FStar_Range.range -> ('uuuuu * ('uuuuu1 * term)) Prims.list
   =
   fun lbs ->
     fun r ->
       let should_filter =
         FStar_Util.for_some
-          (fun uu____5604 ->
-             match uu____5604 with | (attr, (focus, uu____5619)) -> focus)
+          (fun uu___ -> match uu___ with | (attr, (focus, uu___1)) -> focus)
           lbs in
       if should_filter
       then
@@ -1206,42 +1138,41 @@ let focusAttrLetBindings :
            (FStar_Errors.Warning_Filtered,
              "Focusing on only some cases in this (mutually) recursive definition");
          FStar_List.map
-           (fun uu____5671 ->
-              match uu____5671 with
+           (fun uu___1 ->
+              match uu___1 with
               | (attr, (f, lb)) ->
                   if f
                   then (attr, lb)
                   else
-                    (let uu____5724 =
-                       let uu____5729 = mkAdmitMagic r in
-                       ((FStar_Pervasives_Native.fst lb), uu____5729) in
-                     (attr, uu____5724))) lbs)
+                    (let uu___3 =
+                       let uu___4 = mkAdmitMagic r in
+                       ((FStar_Pervasives_Native.fst lb), uu___4) in
+                     (attr, uu___3))) lbs)
       else
         FStar_All.pipe_right lbs
           (FStar_List.map
-             (fun uu____5783 ->
-                match uu____5783 with
-                | (attr, (uu____5805, lb)) -> (attr, lb)))
+             (fun uu___1 ->
+                match uu___1 with | (attr, (uu___2, lb)) -> (attr, lb)))
 let (mkFsTypApp : term -> term Prims.list -> FStar_Range.range -> term) =
   fun t ->
     fun args ->
       fun r ->
-        let uu____5846 = FStar_List.map (fun a -> (a, FsTypApp)) args in
-        mkApp t uu____5846 r
+        let uu___ = FStar_List.map (fun a -> (a, FsTypApp)) args in
+        mkApp t uu___ r
 let (mkTuple : term Prims.list -> FStar_Range.range -> term) =
   fun args ->
     fun r ->
       let cons =
         FStar_Parser_Const.mk_tuple_data_lid (FStar_List.length args) r in
-      let uu____5874 = FStar_List.map (fun x -> (x, Nothing)) args in
-      mkApp (mk_term (Name cons) r Expr) uu____5874 r
+      let uu___ = FStar_List.map (fun x -> (x, Nothing)) args in
+      mkApp (mk_term (Name cons) r Expr) uu___ r
 let (mkDTuple : term Prims.list -> FStar_Range.range -> term) =
   fun args ->
     fun r ->
       let cons =
         FStar_Parser_Const.mk_dtuple_data_lid (FStar_List.length args) r in
-      let uu____5902 = FStar_List.map (fun x -> (x, Nothing)) args in
-      mkApp (mk_term (Name cons) r Expr) uu____5902 r
+      let uu___ = FStar_List.map (fun x -> (x, Nothing)) args in
+      mkApp (mk_term (Name cons) r Expr) uu___ r
 let (mkRefinedBinder :
   FStar_Ident.ident ->
     term ->
@@ -1294,34 +1225,34 @@ let (mkRefinedPattern :
                     if should_bind_pat
                     then
                       (match pat.pat with
-                       | PatVar (x, uu____5995) ->
+                       | PatVar (x, uu___) ->
                            mk_term
                              (Refine
                                 ((mk_binder (Annotated (x, t)) t_range
                                     Type_level FStar_Pervasives_Native.None),
                                   phi)) range Type_level
-                       | uu____6000 ->
+                       | uu___ ->
                            let x = FStar_Ident.gen t_range in
                            let phi1 =
                              let x_var =
-                               let uu____6004 =
-                                 let uu____6005 = FStar_Ident.lid_of_ids [x] in
-                                 Var uu____6005 in
-                               mk_term uu____6004 phi.range Formula in
+                               let uu___1 =
+                                 let uu___2 = FStar_Ident.lid_of_ids [x] in
+                                 Var uu___2 in
+                               mk_term uu___1 phi.range Formula in
                              let pat_branch =
                                (pat, FStar_Pervasives_Native.None, phi) in
                              let otherwise_branch =
-                               let uu____6026 =
-                                 let uu____6027 =
-                                   let uu____6028 =
+                               let uu___1 =
+                                 let uu___2 =
+                                   let uu___3 =
                                      FStar_Ident.lid_of_path ["False"]
                                        phi.range in
-                                   Name uu____6028 in
-                                 mk_term uu____6027 phi.range Formula in
+                                   Name uu___3 in
+                                 mk_term uu___2 phi.range Formula in
                                ((mk_pattern
                                    (PatWild FStar_Pervasives_Native.None)
                                    phi.range), FStar_Pervasives_Native.None,
-                                 uu____6026) in
+                                 uu___1) in
                              mk_term
                                (Match (x_var, [pat_branch; otherwise_branch]))
                                phi.range Formula in
@@ -1349,20 +1280,20 @@ let rec (extract_named_refinement :
     | NamedTyp (x, t) ->
         FStar_Pervasives_Native.Some (x, t, FStar_Pervasives_Native.None)
     | Refine
-        ({ b = Annotated (x, t); brange = uu____6114; blevel = uu____6115;
-           aqual = uu____6116;_},
+        ({ b = Annotated (x, t); brange = uu___; blevel = uu___1;
+           aqual = uu___2;_},
          t')
         ->
         FStar_Pervasives_Native.Some
           (x, t, (FStar_Pervasives_Native.Some t'))
     | Paren t -> extract_named_refinement t
-    | uu____6131 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let rec (as_mlist :
   ((FStar_Ident.lid * decl) * decl Prims.list) -> decl Prims.list -> modul) =
   fun cur ->
     fun ds ->
-      let uu____6174 = cur in
-      match uu____6174 with
+      let uu___ = cur in
+      match uu___ with
       | ((m_name, m_decl), cur1) ->
           (match ds with
            | [] -> Module (m_name, (m_decl :: (FStar_List.rev cur1)))
@@ -1372,47 +1303,46 @@ let rec (as_mlist :
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_UnexpectedModuleDeclaration,
                         "Unexpected module declaration") d.drange
-                | uu____6203 -> as_mlist ((m_name, m_decl), (d :: cur1)) ds1))
+                | uu___1 -> as_mlist ((m_name, m_decl), (d :: cur1)) ds1))
 let (as_frag :
   Prims.bool -> FStar_Range.range -> decl Prims.list -> inputFragment) =
   fun is_light ->
     fun light_range ->
       fun ds ->
-        let uu____6229 =
+        let uu___ =
           match ds with
           | d::ds1 -> (d, ds1)
           | [] -> FStar_Exn.raise FStar_Errors.Empty_frag in
-        match uu____6229 with
+        match uu___ with
         | (d, ds1) ->
             (match d.d with
              | TopLevelModule m ->
                  let ds2 =
                    if is_light
                    then
-                     let uu____6266 =
-                       mk_decl (Pragma LightOff) light_range [] in
-                     uu____6266 :: ds1
+                     let uu___1 = mk_decl (Pragma LightOff) light_range [] in
+                     uu___1 :: ds1
                    else ds1 in
                  let m1 = as_mlist ((m, d), []) ds2 in FStar_Util.Inl m1
-             | uu____6277 ->
+             | uu___1 ->
                  let ds2 = d :: ds1 in
                  (FStar_List.iter
-                    (fun uu___2_6287 ->
-                       match uu___2_6287 with
-                       | { d = TopLevelModule uu____6288; drange = r;
-                           quals = uu____6290; attrs = uu____6291;_} ->
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | { d = TopLevelModule uu___4; drange = r;
+                           quals = uu___5; attrs = uu___6;_} ->
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_UnexpectedModuleDeclaration,
                                "Unexpected module declaration") r
-                       | uu____6292 -> ()) ds2;
+                       | uu___4 -> ()) ds2;
                   FStar_Util.Inr ds2))
 let (compile_op :
   Prims.int -> Prims.string -> FStar_Range.range -> Prims.string) =
   fun arity ->
     fun s ->
       fun r ->
-        let name_of_char uu___3_6315 =
-          match uu___3_6315 with
+        let name_of_char uu___ =
+          match uu___ with
           | 38 -> "Amp"
           | 64 -> "At"
           | 43 -> "Plus"
@@ -1448,223 +1378,217 @@ let (compile_op :
         | ".()" -> "op_Array_Access"
         | ".[||]" -> "op_Brack_Lens_Access"
         | ".(||)" -> "op_Lens_Access"
-        | uu____6317 ->
-            let uu____6318 =
-              let uu____6319 =
-                let uu____6322 = FStar_String.list_of_string s in
-                FStar_List.map name_of_char uu____6322 in
-              FStar_String.concat "_" uu____6319 in
-            Prims.op_Hat "op_" uu____6318
+        | uu___ ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_String.list_of_string s in
+                FStar_List.map name_of_char uu___3 in
+              FStar_String.concat "_" uu___2 in
+            Prims.op_Hat "op_" uu___1
 let (compile_op' : Prims.string -> FStar_Range.range -> Prims.string) =
   fun s -> fun r -> compile_op (~- Prims.int_one) s r
 let (string_of_fsdoc :
   (Prims.string * (Prims.string * Prims.string) Prims.list) -> Prims.string)
   =
-  fun uu____6349 ->
-    match uu____6349 with
+  fun uu___ ->
+    match uu___ with
     | (comment, keywords) ->
-        let uu____6374 =
-          let uu____6375 =
+        let uu___1 =
+          let uu___2 =
             FStar_List.map
-              (fun uu____6385 ->
-                 match uu____6385 with
+              (fun uu___3 ->
+                 match uu___3 with
                  | (k, v) -> Prims.op_Hat k (Prims.op_Hat "->" v)) keywords in
-          FStar_String.concat "," uu____6375 in
-        Prims.op_Hat comment uu____6374
+          FStar_String.concat "," uu___2 in
+        Prims.op_Hat comment uu___1
 let (string_of_let_qualifier : let_qualifier -> Prims.string) =
-  fun uu___4_6396 ->
-    match uu___4_6396 with | NoLetQualifier -> "" | Rec -> "rec"
+  fun uu___ -> match uu___ with | NoLetQualifier -> "" | Rec -> "rec"
 let to_string_l :
-  'uuuuuu6405 .
+  'uuuuu .
     Prims.string ->
-      ('uuuuuu6405 -> Prims.string) -> 'uuuuuu6405 Prims.list -> Prims.string
+      ('uuuuu -> Prims.string) -> 'uuuuu Prims.list -> Prims.string
   =
   fun sep ->
     fun f ->
       fun l ->
-        let uu____6430 = FStar_List.map f l in
-        FStar_String.concat sep uu____6430
+        let uu___ = FStar_List.map f l in FStar_String.concat sep uu___
 let (imp_to_string : imp -> Prims.string) =
-  fun uu___5_6437 -> match uu___5_6437 with | Hash -> "#" | uu____6438 -> ""
+  fun uu___ -> match uu___ with | Hash -> "#" | uu___1 -> ""
 let rec (term_to_string : term -> Prims.string) =
   fun x ->
     match x.tm with
     | Wild -> "_"
-    | Requires (t, uu____6471) ->
-        let uu____6476 = term_to_string t in
-        FStar_Util.format1 "(requires %s)" uu____6476
-    | Ensures (t, uu____6478) ->
-        let uu____6483 = term_to_string t in
-        FStar_Util.format1 "(ensures %s)" uu____6483
-    | Labeled (t, l, uu____6486) ->
-        let uu____6487 = term_to_string t in
-        FStar_Util.format2 "(labeled %s %s)" l uu____6487
+    | Requires (t, uu___) ->
+        let uu___1 = term_to_string t in
+        FStar_Util.format1 "(requires %s)" uu___1
+    | Ensures (t, uu___) ->
+        let uu___1 = term_to_string t in
+        FStar_Util.format1 "(ensures %s)" uu___1
+    | Labeled (t, l, uu___) ->
+        let uu___1 = term_to_string t in
+        FStar_Util.format2 "(labeled %s %s)" l uu___1
     | Const c -> FStar_Parser_Const.const_to_string c
     | Op (s, xs) ->
-        let uu____6495 = FStar_Ident.string_of_id s in
-        let uu____6496 =
-          let uu____6497 =
+        let uu___ = FStar_Ident.string_of_id s in
+        let uu___1 =
+          let uu___2 =
             FStar_List.map (fun x1 -> FStar_All.pipe_right x1 term_to_string)
               xs in
-          FStar_String.concat ", " uu____6497 in
-        FStar_Util.format2 "%s(%s)" uu____6495 uu____6496
+          FStar_String.concat ", " uu___2 in
+        FStar_Util.format2 "%s(%s)" uu___ uu___1
     | Tvar id -> FStar_Ident.string_of_id id
     | Uvar id -> FStar_Ident.string_of_id id
     | Var l -> FStar_Ident.string_of_lid l
     | Name l -> FStar_Ident.string_of_lid l
     | Projector (rec_lid, field_id) ->
-        let uu____6508 = FStar_Ident.string_of_lid rec_lid in
-        let uu____6509 = FStar_Ident.string_of_id field_id in
-        FStar_Util.format2 "%s?.%s" uu____6508 uu____6509
+        let uu___ = FStar_Ident.string_of_lid rec_lid in
+        let uu___1 = FStar_Ident.string_of_id field_id in
+        FStar_Util.format2 "%s?.%s" uu___ uu___1
     | Construct (l, args) ->
-        let uu____6524 = FStar_Ident.string_of_lid l in
-        let uu____6525 =
+        let uu___ = FStar_Ident.string_of_lid l in
+        let uu___1 =
           to_string_l " "
-            (fun uu____6534 ->
-               match uu____6534 with
+            (fun uu___2 ->
+               match uu___2 with
                | (a, imp1) ->
-                   let uu____6541 = term_to_string a in
-                   FStar_Util.format2 "%s%s" (imp_to_string imp1) uu____6541)
+                   let uu___3 = term_to_string a in
+                   FStar_Util.format2 "%s%s" (imp_to_string imp1) uu___3)
             args in
-        FStar_Util.format2 "(%s %s)" uu____6524 uu____6525
+        FStar_Util.format2 "(%s %s)" uu___ uu___1
     | Abs (pats, t) ->
-        let uu____6548 = to_string_l " " pat_to_string pats in
-        let uu____6549 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "(fun %s -> %s)" uu____6548 uu____6549
+        let uu___ = to_string_l " " pat_to_string pats in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "(fun %s -> %s)" uu___ uu___1
     | App (t1, t2, imp1) ->
-        let uu____6553 = FStar_All.pipe_right t1 term_to_string in
-        let uu____6554 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format3 "%s %s%s" uu____6553 (imp_to_string imp1)
-          uu____6554
+        let uu___ = FStar_All.pipe_right t1 term_to_string in
+        let uu___1 = FStar_All.pipe_right t2 term_to_string in
+        FStar_Util.format3 "%s %s%s" uu___ (imp_to_string imp1) uu___1
     | Let (Rec, (a, (p, b))::lbs, body) ->
-        let uu____6612 = attrs_opt_to_string a in
-        let uu____6613 =
-          let uu____6614 = FStar_All.pipe_right p pat_to_string in
-          let uu____6615 = FStar_All.pipe_right b term_to_string in
-          FStar_Util.format2 "%s=%s" uu____6614 uu____6615 in
-        let uu____6616 =
+        let uu___ = attrs_opt_to_string a in
+        let uu___1 =
+          let uu___2 = FStar_All.pipe_right p pat_to_string in
+          let uu___3 = FStar_All.pipe_right b term_to_string in
+          FStar_Util.format2 "%s=%s" uu___2 uu___3 in
+        let uu___2 =
           to_string_l " "
-            (fun uu____6636 ->
-               match uu____6636 with
+            (fun uu___3 ->
+               match uu___3 with
                | (a1, (p1, b1)) ->
-                   let uu____6664 = attrs_opt_to_string a1 in
-                   let uu____6665 = FStar_All.pipe_right p1 pat_to_string in
-                   let uu____6666 = FStar_All.pipe_right b1 term_to_string in
-                   FStar_Util.format3 "%sand %s=%s" uu____6664 uu____6665
-                     uu____6666) lbs in
-        let uu____6667 = FStar_All.pipe_right body term_to_string in
-        FStar_Util.format4 "%slet rec %s%s in %s" uu____6612 uu____6613
-          uu____6616 uu____6667
+                   let uu___4 = attrs_opt_to_string a1 in
+                   let uu___5 = FStar_All.pipe_right p1 pat_to_string in
+                   let uu___6 = FStar_All.pipe_right b1 term_to_string in
+                   FStar_Util.format3 "%sand %s=%s" uu___4 uu___5 uu___6) lbs in
+        let uu___3 = FStar_All.pipe_right body term_to_string in
+        FStar_Util.format4 "%slet rec %s%s in %s" uu___ uu___1 uu___2 uu___3
     | Let (q, (attrs, (pat, tm))::[], body) ->
-        let uu____6723 = attrs_opt_to_string attrs in
-        let uu____6724 = FStar_All.pipe_right pat pat_to_string in
-        let uu____6725 = FStar_All.pipe_right tm term_to_string in
-        let uu____6726 = FStar_All.pipe_right body term_to_string in
-        FStar_Util.format5 "%slet %s %s = %s in %s" uu____6723
-          (string_of_let_qualifier q) uu____6724 uu____6725 uu____6726
-    | Let (uu____6727, uu____6728, uu____6729) ->
+        let uu___ = attrs_opt_to_string attrs in
+        let uu___1 = FStar_All.pipe_right pat pat_to_string in
+        let uu___2 = FStar_All.pipe_right tm term_to_string in
+        let uu___3 = FStar_All.pipe_right body term_to_string in
+        FStar_Util.format5 "%slet %s %s = %s in %s" uu___
+          (string_of_let_qualifier q) uu___1 uu___2 uu___3
+    | Let (uu___, uu___1, uu___2) ->
         FStar_Errors.raise_error
           (FStar_Errors.Fatal_EmptySurfaceLet,
             "Internal error: found an invalid surface Let") x.range
     | LetOpen (lid, t) ->
-        let uu____6760 = FStar_Ident.string_of_lid lid in
-        let uu____6761 = term_to_string t in
-        FStar_Util.format2 "let open %s in %s" uu____6760 uu____6761
+        let uu___ = FStar_Ident.string_of_lid lid in
+        let uu___1 = term_to_string t in
+        FStar_Util.format2 "let open %s in %s" uu___ uu___1
     | Seq (t1, t2) ->
-        let uu____6764 = FStar_All.pipe_right t1 term_to_string in
-        let uu____6765 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format2 "%s; %s" uu____6764 uu____6765
+        let uu___ = FStar_All.pipe_right t1 term_to_string in
+        let uu___1 = FStar_All.pipe_right t2 term_to_string in
+        FStar_Util.format2 "%s; %s" uu___ uu___1
     | Bind (id, t1, t2) ->
-        let uu____6769 = FStar_Ident.string_of_id id in
-        let uu____6770 = term_to_string t1 in
-        let uu____6771 = term_to_string t2 in
-        FStar_Util.format3 "%s <- %s; %s" uu____6769 uu____6770 uu____6771
+        let uu___ = FStar_Ident.string_of_id id in
+        let uu___1 = term_to_string t1 in
+        let uu___2 = term_to_string t2 in
+        FStar_Util.format3 "%s <- %s; %s" uu___ uu___1 uu___2
     | If (t1, t2, t3) ->
-        let uu____6775 = FStar_All.pipe_right t1 term_to_string in
-        let uu____6776 = FStar_All.pipe_right t2 term_to_string in
-        let uu____6777 = FStar_All.pipe_right t3 term_to_string in
-        FStar_Util.format3 "if %s then %s else %s" uu____6775 uu____6776
-          uu____6777
+        let uu___ = FStar_All.pipe_right t1 term_to_string in
+        let uu___1 = FStar_All.pipe_right t2 term_to_string in
+        let uu___2 = FStar_All.pipe_right t3 term_to_string in
+        FStar_Util.format3 "if %s then %s else %s" uu___ uu___1 uu___2
     | Match (t, branches) ->
         let s =
           match x.tm with
-          | Match uu____6801 -> "match"
-          | TryWith uu____6816 -> "try"
-          | uu____6831 -> failwith "impossible" in
-        let uu____6832 = FStar_All.pipe_right t term_to_string in
-        let uu____6833 =
+          | Match uu___ -> "match"
+          | TryWith uu___ -> "try"
+          | uu___ -> failwith "impossible" in
+        let uu___ = FStar_All.pipe_right t term_to_string in
+        let uu___1 =
           to_string_l " | "
-            (fun uu____6849 ->
-               match uu____6849 with
+            (fun uu___2 ->
+               match uu___2 with
                | (p, w, e) ->
-                   let uu____6865 = FStar_All.pipe_right p pat_to_string in
-                   let uu____6866 =
+                   let uu___3 = FStar_All.pipe_right p pat_to_string in
+                   let uu___4 =
                      match w with
                      | FStar_Pervasives_Native.None -> ""
                      | FStar_Pervasives_Native.Some e1 ->
-                         let uu____6868 = term_to_string e1 in
-                         FStar_Util.format1 "when %s" uu____6868 in
-                   let uu____6869 = FStar_All.pipe_right e term_to_string in
-                   FStar_Util.format3 "%s %s -> %s" uu____6865 uu____6866
-                     uu____6869) branches in
-        FStar_Util.format3 "%s %s with %s" s uu____6832 uu____6833
+                         let uu___5 = term_to_string e1 in
+                         FStar_Util.format1 "when %s" uu___5 in
+                   let uu___5 = FStar_All.pipe_right e term_to_string in
+                   FStar_Util.format3 "%s %s -> %s" uu___3 uu___4 uu___5)
+            branches in
+        FStar_Util.format3 "%s %s with %s" s uu___ uu___1
     | TryWith (t, branches) ->
         let s =
           match x.tm with
-          | Match uu____6893 -> "match"
-          | TryWith uu____6908 -> "try"
-          | uu____6923 -> failwith "impossible" in
-        let uu____6924 = FStar_All.pipe_right t term_to_string in
-        let uu____6925 =
+          | Match uu___ -> "match"
+          | TryWith uu___ -> "try"
+          | uu___ -> failwith "impossible" in
+        let uu___ = FStar_All.pipe_right t term_to_string in
+        let uu___1 =
           to_string_l " | "
-            (fun uu____6941 ->
-               match uu____6941 with
+            (fun uu___2 ->
+               match uu___2 with
                | (p, w, e) ->
-                   let uu____6957 = FStar_All.pipe_right p pat_to_string in
-                   let uu____6958 =
+                   let uu___3 = FStar_All.pipe_right p pat_to_string in
+                   let uu___4 =
                      match w with
                      | FStar_Pervasives_Native.None -> ""
                      | FStar_Pervasives_Native.Some e1 ->
-                         let uu____6960 = term_to_string e1 in
-                         FStar_Util.format1 "when %s" uu____6960 in
-                   let uu____6961 = FStar_All.pipe_right e term_to_string in
-                   FStar_Util.format3 "%s %s -> %s" uu____6957 uu____6958
-                     uu____6961) branches in
-        FStar_Util.format3 "%s %s with %s" s uu____6924 uu____6925
+                         let uu___5 = term_to_string e1 in
+                         FStar_Util.format1 "when %s" uu___5 in
+                   let uu___5 = FStar_All.pipe_right e term_to_string in
+                   FStar_Util.format3 "%s %s -> %s" uu___3 uu___4 uu___5)
+            branches in
+        FStar_Util.format3 "%s %s with %s" s uu___ uu___1
     | Ascribed (t1, t2, FStar_Pervasives_Native.None) ->
-        let uu____6966 = FStar_All.pipe_right t1 term_to_string in
-        let uu____6967 = FStar_All.pipe_right t2 term_to_string in
-        FStar_Util.format2 "(%s : %s)" uu____6966 uu____6967
+        let uu___ = FStar_All.pipe_right t1 term_to_string in
+        let uu___1 = FStar_All.pipe_right t2 term_to_string in
+        FStar_Util.format2 "(%s : %s)" uu___ uu___1
     | Ascribed (t1, t2, FStar_Pervasives_Native.Some tac) ->
-        let uu____6973 = FStar_All.pipe_right t1 term_to_string in
-        let uu____6974 = FStar_All.pipe_right t2 term_to_string in
-        let uu____6975 = FStar_All.pipe_right tac term_to_string in
-        FStar_Util.format3 "(%s : %s by %s)" uu____6973 uu____6974 uu____6975
+        let uu___ = FStar_All.pipe_right t1 term_to_string in
+        let uu___1 = FStar_All.pipe_right t2 term_to_string in
+        let uu___2 = FStar_All.pipe_right tac term_to_string in
+        FStar_Util.format3 "(%s : %s by %s)" uu___ uu___1 uu___2
     | Record (FStar_Pervasives_Native.Some e, fields) ->
-        let uu____6992 = FStar_All.pipe_right e term_to_string in
-        let uu____6993 =
+        let uu___ = FStar_All.pipe_right e term_to_string in
+        let uu___1 =
           to_string_l " "
-            (fun uu____7003 ->
-               match uu____7003 with
+            (fun uu___2 ->
+               match uu___2 with
                | (l, e1) ->
-                   let uu____7010 = FStar_Ident.string_of_lid l in
-                   let uu____7011 = FStar_All.pipe_right e1 term_to_string in
-                   FStar_Util.format2 "%s=%s" uu____7010 uu____7011) fields in
-        FStar_Util.format2 "{%s with %s}" uu____6992 uu____6993
+                   let uu___3 = FStar_Ident.string_of_lid l in
+                   let uu___4 = FStar_All.pipe_right e1 term_to_string in
+                   FStar_Util.format2 "%s=%s" uu___3 uu___4) fields in
+        FStar_Util.format2 "{%s with %s}" uu___ uu___1
     | Record (FStar_Pervasives_Native.None, fields) ->
-        let uu____7027 =
+        let uu___ =
           to_string_l " "
-            (fun uu____7037 ->
-               match uu____7037 with
+            (fun uu___1 ->
+               match uu___1 with
                | (l, e) ->
-                   let uu____7044 = FStar_Ident.string_of_lid l in
-                   let uu____7045 = FStar_All.pipe_right e term_to_string in
-                   FStar_Util.format2 "%s=%s" uu____7044 uu____7045) fields in
-        FStar_Util.format1 "{%s}" uu____7027
+                   let uu___2 = FStar_Ident.string_of_lid l in
+                   let uu___3 = FStar_All.pipe_right e term_to_string in
+                   FStar_Util.format2 "%s=%s" uu___2 uu___3) fields in
+        FStar_Util.format1 "{%s}" uu___
     | Project (e, l) ->
-        let uu____7048 = FStar_All.pipe_right e term_to_string in
-        let uu____7049 = FStar_Ident.string_of_lid l in
-        FStar_Util.format2 "%s.%s" uu____7048 uu____7049
+        let uu___ = FStar_All.pipe_right e term_to_string in
+        let uu___1 = FStar_Ident.string_of_lid l in
+        FStar_Util.format2 "%s.%s" uu___ uu___1
     | Product ([], t) -> term_to_string t
     | Product (b::hd::tl, t) ->
         term_to_string
@@ -1673,303 +1597,283 @@ let rec (term_to_string : term -> Prims.string) =
                 ([b], (mk_term (Product ((hd :: tl), t)) x.range x.level)))
              x.range x.level)
     | Product (b::[], t) when x.level = Type_level ->
-        let uu____7069 = FStar_All.pipe_right b binder_to_string in
-        let uu____7070 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s -> %s" uu____7069 uu____7070
+        let uu___ = FStar_All.pipe_right b binder_to_string in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "%s -> %s" uu___ uu___1
     | Product (b::[], t) when x.level = Kind ->
-        let uu____7075 = FStar_All.pipe_right b binder_to_string in
-        let uu____7076 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s => %s" uu____7075 uu____7076
+        let uu___ = FStar_All.pipe_right b binder_to_string in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "%s => %s" uu___ uu___1
     | Sum (binders, t) ->
-        let uu____7091 =
+        let uu___ =
           FStar_All.pipe_right (FStar_List.append binders [FStar_Util.Inr t])
             (FStar_List.map
-               (fun uu___6_7120 ->
-                  match uu___6_7120 with
+               (fun uu___1 ->
+                  match uu___1 with
                   | FStar_Util.Inl b -> binder_to_string b
                   | FStar_Util.Inr t1 -> term_to_string t1)) in
-        FStar_All.pipe_right uu____7091 (FStar_String.concat " & ")
-    | QForall (bs, (uu____7130, pats), t) ->
-        let uu____7159 = to_string_l " " binder_to_string bs in
-        let uu____7160 =
+        FStar_All.pipe_right uu___ (FStar_String.concat " & ")
+    | QForall (bs, (uu___, pats), t) ->
+        let uu___1 = to_string_l " " binder_to_string bs in
+        let uu___2 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu____7163 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____7159 uu____7160
-          uu____7163
-    | QExists (bs, (uu____7165, pats), t) ->
-        let uu____7194 = to_string_l " " binder_to_string bs in
-        let uu____7195 =
+        let uu___3 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format3 "forall %s.{:pattern %s} %s" uu___1 uu___2 uu___3
+    | QExists (bs, (uu___, pats), t) ->
+        let uu___1 = to_string_l " " binder_to_string bs in
+        let uu___2 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu____7198 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____7194 uu____7195
-          uu____7198
+        let uu___3 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format3 "exists %s.{:pattern %s} %s" uu___1 uu___2 uu___3
     | Refine (b, t) ->
-        let uu____7201 = FStar_All.pipe_right b binder_to_string in
-        let uu____7202 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s:{%s}" uu____7201 uu____7202
+        let uu___ = FStar_All.pipe_right b binder_to_string in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "%s:{%s}" uu___ uu___1
     | NamedTyp (x1, t) ->
-        let uu____7205 = FStar_Ident.string_of_id x1 in
-        let uu____7206 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "%s:%s" uu____7205 uu____7206
+        let uu___ = FStar_Ident.string_of_id x1 in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "%s:%s" uu___ uu___1
     | Paren t ->
-        let uu____7208 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format1 "(%s)" uu____7208
+        let uu___ = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format1 "(%s)" uu___
     | Product (bs, t) ->
-        let uu____7215 =
-          let uu____7216 =
+        let uu___ =
+          let uu___1 =
             FStar_All.pipe_right bs (FStar_List.map binder_to_string) in
-          FStar_All.pipe_right uu____7216 (FStar_String.concat ",") in
-        let uu____7225 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "Unidentified product: [%s] %s" uu____7215
-          uu____7225
+          FStar_All.pipe_right uu___1 (FStar_String.concat ",") in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "Unidentified product: [%s] %s" uu___ uu___1
     | Discrim lid ->
-        let uu____7227 = FStar_Ident.string_of_lid lid in
-        FStar_Util.format1 "%s?" uu____7227
+        let uu___ = FStar_Ident.string_of_lid lid in
+        FStar_Util.format1 "%s?" uu___
     | Attributes ts ->
-        let uu____7231 =
-          let uu____7232 = FStar_List.map term_to_string ts in
-          FStar_All.pipe_left (FStar_String.concat " ") uu____7232 in
-        FStar_Util.format1 "(attributes %s)" uu____7231
+        let uu___ =
+          let uu___1 = FStar_List.map term_to_string ts in
+          FStar_All.pipe_left (FStar_String.concat " ") uu___1 in
+        FStar_Util.format1 "(attributes %s)" uu___
     | Antiquote t ->
-        let uu____7238 = term_to_string t in
-        FStar_Util.format1 "(`#%s)" uu____7238
+        let uu___ = term_to_string t in FStar_Util.format1 "(`#%s)" uu___
     | Quote (t, Static) ->
-        let uu____7240 = term_to_string t in
-        FStar_Util.format1 "(`(%s))" uu____7240
+        let uu___ = term_to_string t in FStar_Util.format1 "(`(%s))" uu___
     | Quote (t, Dynamic) ->
-        let uu____7242 = term_to_string t in
-        FStar_Util.format1 "quote (%s)" uu____7242
+        let uu___ = term_to_string t in FStar_Util.format1 "quote (%s)" uu___
     | VQuote t ->
-        let uu____7244 = term_to_string t in
-        FStar_Util.format1 "`%%%s" uu____7244
+        let uu___ = term_to_string t in FStar_Util.format1 "`%%%s" uu___
     | CalcProof (rel, init, steps) ->
-        let uu____7252 = term_to_string rel in
-        let uu____7253 = term_to_string init in
-        let uu____7254 =
-          let uu____7255 = FStar_List.map calc_step_to_string steps in
-          FStar_All.pipe_left (FStar_String.concat " ") uu____7255 in
-        FStar_Util.format3 "calc (%s) { %s %s }" uu____7252 uu____7253
-          uu____7254
+        let uu___ = term_to_string rel in
+        let uu___1 = term_to_string init in
+        let uu___2 =
+          let uu___3 = FStar_List.map calc_step_to_string steps in
+          FStar_All.pipe_left (FStar_String.concat " ") uu___3 in
+        FStar_Util.format3 "calc (%s) { %s %s }" uu___ uu___1 uu___2
 and (calc_step_to_string : calc_step -> Prims.string) =
-  fun uu____7260 ->
-    match uu____7260 with
+  fun uu___ ->
+    match uu___ with
     | CalcStep (rel, just, next) ->
-        let uu____7264 = term_to_string rel in
-        let uu____7265 = term_to_string just in
-        let uu____7266 = term_to_string next in
-        FStar_Util.format3 "%s{ %s } %s" uu____7264 uu____7265 uu____7266
+        let uu___1 = term_to_string rel in
+        let uu___2 = term_to_string just in
+        let uu___3 = term_to_string next in
+        FStar_Util.format3 "%s{ %s } %s" uu___1 uu___2 uu___3
 and (binder_to_string : binder -> Prims.string) =
   fun x ->
     let s =
       match x.b with
       | Variable i -> FStar_Ident.string_of_id i
       | TVariable i ->
-          let uu____7271 = FStar_Ident.string_of_id i in
-          FStar_Util.format1 "%s:_" uu____7271
+          let uu___ = FStar_Ident.string_of_id i in
+          FStar_Util.format1 "%s:_" uu___
       | TAnnotated (i, t) ->
-          let uu____7274 = FStar_Ident.string_of_id i in
-          let uu____7275 = FStar_All.pipe_right t term_to_string in
-          FStar_Util.format2 "%s:%s" uu____7274 uu____7275
+          let uu___ = FStar_Ident.string_of_id i in
+          let uu___1 = FStar_All.pipe_right t term_to_string in
+          FStar_Util.format2 "%s:%s" uu___ uu___1
       | Annotated (i, t) ->
-          let uu____7278 = FStar_Ident.string_of_id i in
-          let uu____7279 = FStar_All.pipe_right t term_to_string in
-          FStar_Util.format2 "%s:%s" uu____7278 uu____7279
+          let uu___ = FStar_Ident.string_of_id i in
+          let uu___1 = FStar_All.pipe_right t term_to_string in
+          FStar_Util.format2 "%s:%s" uu___ uu___1
       | NoName t -> FStar_All.pipe_right t term_to_string in
-    let uu____7281 = aqual_to_string x.aqual in
-    FStar_Util.format2 "%s%s" uu____7281 s
+    let uu___ = aqual_to_string x.aqual in FStar_Util.format2 "%s%s" uu___ s
 and (aqual_to_string :
   arg_qualifier FStar_Pervasives_Native.option -> Prims.string) =
-  fun uu___7_7282 ->
-    match uu___7_7282 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.Some (Equality) -> "$"
     | FStar_Pervasives_Native.Some (Implicit) -> "#"
-    | uu____7285 -> ""
+    | uu___1 -> ""
 and (pat_to_string : pattern -> Prims.string) =
   fun x ->
     match x.pat with
     | PatWild (FStar_Pervasives_Native.None) -> "_"
-    | PatWild uu____7289 -> "#_"
+    | PatWild uu___ -> "#_"
     | PatConst c -> FStar_Parser_Const.const_to_string c
     | PatApp (p, ps) ->
-        let uu____7299 = FStar_All.pipe_right p pat_to_string in
-        let uu____7300 = to_string_l " " pat_to_string ps in
-        FStar_Util.format2 "(%s %s)" uu____7299 uu____7300
+        let uu___ = FStar_All.pipe_right p pat_to_string in
+        let uu___1 = to_string_l " " pat_to_string ps in
+        FStar_Util.format2 "(%s %s)" uu___ uu___1
     | PatTvar (i, aq) ->
-        let uu____7307 = aqual_to_string aq in
-        let uu____7308 = FStar_Ident.string_of_id i in
-        FStar_Util.format2 "%s%s" uu____7307 uu____7308
+        let uu___ = aqual_to_string aq in
+        let uu___1 = FStar_Ident.string_of_id i in
+        FStar_Util.format2 "%s%s" uu___ uu___1
     | PatVar (i, aq) ->
-        let uu____7315 = aqual_to_string aq in
-        let uu____7316 = FStar_Ident.string_of_id i in
-        FStar_Util.format2 "%s%s" uu____7315 uu____7316
+        let uu___ = aqual_to_string aq in
+        let uu___1 = FStar_Ident.string_of_id i in
+        FStar_Util.format2 "%s%s" uu___ uu___1
     | PatName l -> FStar_Ident.string_of_lid l
     | PatList l ->
-        let uu____7321 = to_string_l "; " pat_to_string l in
-        FStar_Util.format1 "[%s]" uu____7321
+        let uu___ = to_string_l "; " pat_to_string l in
+        FStar_Util.format1 "[%s]" uu___
     | PatTuple (l, false) ->
-        let uu____7327 = to_string_l ", " pat_to_string l in
-        FStar_Util.format1 "(%s)" uu____7327
+        let uu___ = to_string_l ", " pat_to_string l in
+        FStar_Util.format1 "(%s)" uu___
     | PatTuple (l, true) ->
-        let uu____7333 = to_string_l ", " pat_to_string l in
-        FStar_Util.format1 "(|%s|)" uu____7333
+        let uu___ = to_string_l ", " pat_to_string l in
+        FStar_Util.format1 "(|%s|)" uu___
     | PatRecord l ->
-        let uu____7341 =
+        let uu___ =
           to_string_l "; "
-            (fun uu____7351 ->
-               match uu____7351 with
+            (fun uu___1 ->
+               match uu___1 with
                | (f, e) ->
-                   let uu____7358 = FStar_Ident.string_of_lid f in
-                   let uu____7359 = FStar_All.pipe_right e pat_to_string in
-                   FStar_Util.format2 "%s=%s" uu____7358 uu____7359) l in
-        FStar_Util.format1 "{%s}" uu____7341
+                   let uu___2 = FStar_Ident.string_of_lid f in
+                   let uu___3 = FStar_All.pipe_right e pat_to_string in
+                   FStar_Util.format2 "%s=%s" uu___2 uu___3) l in
+        FStar_Util.format1 "{%s}" uu___
     | PatOr l -> to_string_l "|\n " pat_to_string l
     | PatOp op ->
-        let uu____7364 = FStar_Ident.string_of_id op in
-        FStar_Util.format1 "(%s)" uu____7364
+        let uu___ = FStar_Ident.string_of_id op in
+        FStar_Util.format1 "(%s)" uu___
     | PatAscribed (p, (t, FStar_Pervasives_Native.None)) ->
-        let uu____7375 = FStar_All.pipe_right p pat_to_string in
-        let uu____7376 = FStar_All.pipe_right t term_to_string in
-        FStar_Util.format2 "(%s:%s)" uu____7375 uu____7376
+        let uu___ = FStar_All.pipe_right p pat_to_string in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        FStar_Util.format2 "(%s:%s)" uu___ uu___1
     | PatAscribed (p, (t, FStar_Pervasives_Native.Some tac)) ->
-        let uu____7388 = FStar_All.pipe_right p pat_to_string in
-        let uu____7389 = FStar_All.pipe_right t term_to_string in
-        let uu____7390 = FStar_All.pipe_right tac term_to_string in
-        FStar_Util.format3 "(%s:%s by %s)" uu____7388 uu____7389 uu____7390
+        let uu___ = FStar_All.pipe_right p pat_to_string in
+        let uu___1 = FStar_All.pipe_right t term_to_string in
+        let uu___2 = FStar_All.pipe_right tac term_to_string in
+        FStar_Util.format3 "(%s:%s by %s)" uu___ uu___1 uu___2
 and (attrs_opt_to_string :
   term Prims.list FStar_Pervasives_Native.option -> Prims.string) =
-  fun uu___8_7391 ->
-    match uu___8_7391 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> ""
     | FStar_Pervasives_Native.Some attrs ->
-        let uu____7403 =
-          let uu____7404 = FStar_List.map term_to_string attrs in
-          FStar_All.pipe_right uu____7404 (FStar_String.concat "; ") in
-        FStar_Util.format1 "[@ %s]" uu____7403
+        let uu___1 =
+          let uu___2 = FStar_List.map term_to_string attrs in
+          FStar_All.pipe_right uu___2 (FStar_String.concat "; ") in
+        FStar_Util.format1 "[@ %s]" uu___1
 let rec (head_id_of_pat : pattern -> FStar_Ident.lident Prims.list) =
   fun p ->
     match p.pat with
     | PatName l -> [l]
-    | PatVar (i, uu____7420) ->
-        let uu____7425 = FStar_Ident.lid_of_ids [i] in [uu____7425]
-    | PatApp (p1, uu____7427) -> head_id_of_pat p1
-    | PatAscribed (p1, uu____7433) -> head_id_of_pat p1
-    | uu____7446 -> []
+    | PatVar (i, uu___) ->
+        let uu___1 = FStar_Ident.lid_of_ids [i] in [uu___1]
+    | PatApp (p1, uu___) -> head_id_of_pat p1
+    | PatAscribed (p1, uu___) -> head_id_of_pat p1
+    | uu___ -> []
 let lids_of_let :
-  'uuuuuu7451 .
-    (pattern * 'uuuuuu7451) Prims.list -> FStar_Ident.lident Prims.list
-  =
+  'uuuuu . (pattern * 'uuuuu) Prims.list -> FStar_Ident.lident Prims.list =
   fun defs ->
     FStar_All.pipe_right defs
       (FStar_List.collect
-         (fun uu____7486 ->
-            match uu____7486 with | (p, uu____7494) -> head_id_of_pat p))
+         (fun uu___ -> match uu___ with | (p, uu___1) -> head_id_of_pat p))
 let (id_of_tycon : tycon -> Prims.string) =
-  fun uu___9_7499 ->
-    match uu___9_7499 with
-    | TyconAbstract (i, uu____7501, uu____7502) -> FStar_Ident.string_of_id i
-    | TyconAbbrev (i, uu____7512, uu____7513, uu____7514) ->
-        FStar_Ident.string_of_id i
-    | TyconRecord (i, uu____7524, uu____7525, uu____7526) ->
-        FStar_Ident.string_of_id i
-    | TyconVariant (i, uu____7548, uu____7549, uu____7550) ->
-        FStar_Ident.string_of_id i
+  fun uu___ ->
+    match uu___ with
+    | TyconAbstract (i, uu___1, uu___2) -> FStar_Ident.string_of_id i
+    | TyconAbbrev (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
+    | TyconRecord (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
+    | TyconVariant (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
 let (decl_to_string : decl -> Prims.string) =
   fun d ->
     match d.d with
     | TopLevelModule l ->
-        let uu____7585 = FStar_Ident.string_of_lid l in
-        Prims.op_Hat "module " uu____7585
+        let uu___ = FStar_Ident.string_of_lid l in
+        Prims.op_Hat "module " uu___
     | Open l ->
-        let uu____7587 = FStar_Ident.string_of_lid l in
-        Prims.op_Hat "open " uu____7587
+        let uu___ = FStar_Ident.string_of_lid l in Prims.op_Hat "open " uu___
     | Friend l ->
-        let uu____7589 = FStar_Ident.string_of_lid l in
-        Prims.op_Hat "friend " uu____7589
+        let uu___ = FStar_Ident.string_of_lid l in
+        Prims.op_Hat "friend " uu___
     | Include l ->
-        let uu____7591 = FStar_Ident.string_of_lid l in
-        Prims.op_Hat "include " uu____7591
+        let uu___ = FStar_Ident.string_of_lid l in
+        Prims.op_Hat "include " uu___
     | ModuleAbbrev (i, l) ->
-        let uu____7594 = FStar_Ident.string_of_id i in
-        let uu____7595 = FStar_Ident.string_of_lid l in
-        FStar_Util.format2 "module %s = %s" uu____7594 uu____7595
-    | TopLevelLet (uu____7596, pats) ->
-        let uu____7610 =
-          let uu____7611 =
-            let uu____7614 = lids_of_let pats in
-            FStar_All.pipe_right uu____7614
+        let uu___ = FStar_Ident.string_of_id i in
+        let uu___1 = FStar_Ident.string_of_lid l in
+        FStar_Util.format2 "module %s = %s" uu___ uu___1
+    | TopLevelLet (uu___, pats) ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = lids_of_let pats in
+            FStar_All.pipe_right uu___3
               (FStar_List.map (fun l -> FStar_Ident.string_of_lid l)) in
-          FStar_All.pipe_right uu____7611 (FStar_String.concat ", ") in
-        Prims.op_Hat "let " uu____7610
-    | Assume (i, uu____7626) ->
-        let uu____7627 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "assume " uu____7627
-    | Tycon (uu____7628, uu____7629, tys) ->
-        let uu____7635 =
-          let uu____7636 =
-            FStar_All.pipe_right tys (FStar_List.map id_of_tycon) in
-          FStar_All.pipe_right uu____7636 (FStar_String.concat ", ") in
-        Prims.op_Hat "type " uu____7635
-    | Val (i, uu____7646) ->
-        let uu____7647 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "val " uu____7647
-    | Exception (i, uu____7649) ->
-        let uu____7654 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "exception " uu____7654
-    | NewEffect (DefineEffect (i, uu____7656, uu____7657, uu____7658)) ->
-        let uu____7667 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "new_effect " uu____7667
-    | NewEffect (RedefineEffect (i, uu____7669, uu____7670)) ->
-        let uu____7675 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "new_effect " uu____7675
-    | LayeredEffect (DefineEffect (i, uu____7677, uu____7678, uu____7679)) ->
-        let uu____7688 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "layered_effect " uu____7688
-    | LayeredEffect (RedefineEffect (i, uu____7690, uu____7691)) ->
-        let uu____7696 = FStar_Ident.string_of_id i in
-        Prims.op_Hat "layered_effect " uu____7696
-    | Polymonadic_bind (l1, l2, l3, uu____7700) ->
-        let uu____7701 = FStar_Ident.string_of_lid l1 in
-        let uu____7702 = FStar_Ident.string_of_lid l2 in
-        let uu____7703 = FStar_Ident.string_of_lid l3 in
-        FStar_Util.format3 "polymonadic_bind (%s, %s) |> %s" uu____7701
-          uu____7702 uu____7703
-    | Polymonadic_subcomp (l1, l2, uu____7706) ->
-        let uu____7707 = FStar_Ident.string_of_lid l1 in
-        let uu____7708 = FStar_Ident.string_of_lid l2 in
-        FStar_Util.format2 "polymonadic_subcomp %s <: %s" uu____7707
-          uu____7708
+          FStar_All.pipe_right uu___2 (FStar_String.concat ", ") in
+        Prims.op_Hat "let " uu___1
+    | Assume (i, uu___) ->
+        let uu___1 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "assume " uu___1
+    | Tycon (uu___, uu___1, tys) ->
+        let uu___2 =
+          let uu___3 = FStar_All.pipe_right tys (FStar_List.map id_of_tycon) in
+          FStar_All.pipe_right uu___3 (FStar_String.concat ", ") in
+        Prims.op_Hat "type " uu___2
+    | Val (i, uu___) ->
+        let uu___1 = FStar_Ident.string_of_id i in Prims.op_Hat "val " uu___1
+    | Exception (i, uu___) ->
+        let uu___1 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "exception " uu___1
+    | NewEffect (DefineEffect (i, uu___, uu___1, uu___2)) ->
+        let uu___3 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "new_effect " uu___3
+    | NewEffect (RedefineEffect (i, uu___, uu___1)) ->
+        let uu___2 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "new_effect " uu___2
+    | LayeredEffect (DefineEffect (i, uu___, uu___1, uu___2)) ->
+        let uu___3 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "layered_effect " uu___3
+    | LayeredEffect (RedefineEffect (i, uu___, uu___1)) ->
+        let uu___2 = FStar_Ident.string_of_id i in
+        Prims.op_Hat "layered_effect " uu___2
+    | Polymonadic_bind (l1, l2, l3, uu___) ->
+        let uu___1 = FStar_Ident.string_of_lid l1 in
+        let uu___2 = FStar_Ident.string_of_lid l2 in
+        let uu___3 = FStar_Ident.string_of_lid l3 in
+        FStar_Util.format3 "polymonadic_bind (%s, %s) |> %s" uu___1 uu___2
+          uu___3
+    | Polymonadic_subcomp (l1, l2, uu___) ->
+        let uu___1 = FStar_Ident.string_of_lid l1 in
+        let uu___2 = FStar_Ident.string_of_lid l2 in
+        FStar_Util.format2 "polymonadic_subcomp %s <: %s" uu___1 uu___2
     | Splice (ids, t) ->
-        let uu____7715 =
-          let uu____7716 =
-            let uu____7717 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_List.map (fun i -> FStar_Ident.string_of_id i) ids in
-            FStar_All.pipe_left (FStar_String.concat ";") uu____7717 in
-          let uu____7724 =
-            let uu____7725 =
-              let uu____7726 = term_to_string t in
-              Prims.op_Hat uu____7726 ")" in
-            Prims.op_Hat "] (" uu____7725 in
-          Prims.op_Hat uu____7716 uu____7724 in
-        Prims.op_Hat "splice[" uu____7715
-    | SubEffect uu____7727 -> "sub_effect"
-    | Pragma uu____7728 -> "pragma"
+            FStar_All.pipe_left (FStar_String.concat ";") uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = term_to_string t in Prims.op_Hat uu___4 ")" in
+            Prims.op_Hat "] (" uu___3 in
+          Prims.op_Hat uu___1 uu___2 in
+        Prims.op_Hat "splice[" uu___
+    | SubEffect uu___ -> "sub_effect"
+    | Pragma uu___ -> "pragma"
 let (modul_to_string : modul -> Prims.string) =
   fun m ->
     match m with
-    | Module (uu____7734, decls) ->
-        let uu____7740 =
+    | Module (uu___, decls) ->
+        let uu___1 =
           FStar_All.pipe_right decls (FStar_List.map decl_to_string) in
-        FStar_All.pipe_right uu____7740 (FStar_String.concat "\n")
-    | Interface (uu____7749, decls, uu____7751) ->
-        let uu____7756 =
+        FStar_All.pipe_right uu___1 (FStar_String.concat "\n")
+    | Interface (uu___, decls, uu___1) ->
+        let uu___2 =
           FStar_All.pipe_right decls (FStar_List.map decl_to_string) in
-        FStar_All.pipe_right uu____7756 (FStar_String.concat "\n")
+        FStar_All.pipe_right uu___2 (FStar_String.concat "\n")
 let (decl_is_val : FStar_Ident.ident -> decl -> Prims.bool) =
   fun id ->
     fun decl1 ->
       match decl1.d with
-      | Val (id', uu____7776) -> FStar_Ident.ident_equals id id'
-      | uu____7777 -> false
+      | Val (id', uu___) -> FStar_Ident.ident_equals id id'
+      | uu___ -> false
 let (thunk : term -> term) =
   fun ens ->
     let wildpat = mk_pattern (PatWild FStar_Pervasives_Native.None) ens.range in
@@ -1984,9 +1888,9 @@ let (idents_of_binders :
               match b.b with
               | Variable i -> i
               | TVariable i -> i
-              | Annotated (i, uu____7812) -> i
-              | TAnnotated (i, uu____7814) -> i
-              | NoName uu____7815 ->
+              | Annotated (i, uu___) -> i
+              | TAnnotated (i, uu___) -> i
+              | NoName uu___ ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_MissingQuantifierBinder,
                       "Wildcard binders in quantifiers are not allowed") r))

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -284,17 +284,17 @@ let (allow_informative_binders_attr : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "allow_informative_binders"]
 let (gen_reset : ((unit -> Prims.int) * (unit -> unit))) =
   let x = FStar_Util.mk_ref Prims.int_zero in
-  let gen uu____53 = FStar_Util.incr x; FStar_Util.read x in
-  let reset uu____60 = FStar_Util.write x Prims.int_zero in (gen, reset)
+  let gen uu___ = FStar_Util.incr x; FStar_Util.read x in
+  let reset uu___ = FStar_Util.write x Prims.int_zero in (gen, reset)
 let (next_id : unit -> Prims.int) = FStar_Pervasives_Native.fst gen_reset
 let (sli : FStar_Ident.lident -> Prims.string) =
   fun l ->
-    let uu____82 = FStar_Options.print_real_names () in
-    if uu____82
+    let uu___ = FStar_Options.print_real_names () in
+    if uu___
     then FStar_Ident.string_of_lid l
     else
-      (let uu____84 = FStar_Ident.ident_of_lid l in
-       FStar_Ident.string_of_id uu____84)
+      (let uu___2 = FStar_Ident.ident_of_lid l in
+       FStar_Ident.string_of_id uu___2)
 let (const_to_string : FStar_Const.sconst -> Prims.string) =
   fun x ->
     match x with
@@ -303,94 +303,91 @@ let (const_to_string : FStar_Const.sconst -> Prims.string) =
     | FStar_Const.Const_bool b -> if b then "true" else "false"
     | FStar_Const.Const_real r -> FStar_String.op_Hat r "R"
     | FStar_Const.Const_float x1 -> FStar_Util.string_of_float x1
-    | FStar_Const.Const_string (s, uu____95) -> FStar_Util.format1 "\"%s\"" s
-    | FStar_Const.Const_bytearray uu____96 -> "<bytearray>"
-    | FStar_Const.Const_int (x1, uu____104) -> x1
+    | FStar_Const.Const_string (s, uu___) -> FStar_Util.format1 "\"%s\"" s
+    | FStar_Const.Const_bytearray uu___ -> "<bytearray>"
+    | FStar_Const.Const_int (x1, uu___) -> x1
     | FStar_Const.Const_char c ->
-        let uu____118 = FStar_String.op_Hat (FStar_Util.string_of_char c) "'" in
-        FStar_String.op_Hat "'" uu____118
+        let uu___ = FStar_String.op_Hat (FStar_Util.string_of_char c) "'" in
+        FStar_String.op_Hat "'" uu___
     | FStar_Const.Const_range r -> FStar_Range.string_of_range r
     | FStar_Const.Const_range_of -> "range_of"
     | FStar_Const.Const_set_range_of -> "set_range_of"
     | FStar_Const.Const_reify -> "reify"
     | FStar_Const.Const_reflect l ->
-        let uu____121 = sli l in
-        FStar_Util.format1 "[[%s.reflect]]" uu____121
+        let uu___ = sli l in FStar_Util.format1 "[[%s.reflect]]" uu___
 let (mk_tuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n ->
     fun r ->
       let t =
-        let uu____133 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "tuple%s" uu____133 in
-      let uu____134 = psnconst t in FStar_Ident.set_lid_range uu____134 r
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "tuple%s" uu___ in
+      let uu___ = psnconst t in FStar_Ident.set_lid_range uu___ r
 let (lid_tuple2 : FStar_Ident.lident) =
   mk_tuple_lid (Prims.of_int (2)) FStar_Range.dummyRange
 let (is_tuple_constructor_string : Prims.string -> Prims.bool) =
   fun s -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple"
 let (is_tuple_constructor_id : FStar_Ident.ident -> Prims.bool) =
   fun id ->
-    let uu____145 = FStar_Ident.string_of_id id in
-    is_tuple_constructor_string uu____145
+    let uu___ = FStar_Ident.string_of_id id in
+    is_tuple_constructor_string uu___
 let (is_tuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
-    let uu____151 = FStar_Ident.string_of_lid lid in
-    is_tuple_constructor_string uu____151
+    let uu___ = FStar_Ident.string_of_lid lid in
+    is_tuple_constructor_string uu___
 let (mk_tuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n ->
     fun r ->
       let t =
-        let uu____163 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "Mktuple%s" uu____163 in
-      let uu____164 = psnconst t in FStar_Ident.set_lid_range uu____164 r
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "Mktuple%s" uu___ in
+      let uu___ = psnconst t in FStar_Ident.set_lid_range uu___ r
 let (lid_Mktuple2 : FStar_Ident.lident) =
   mk_tuple_data_lid (Prims.of_int (2)) FStar_Range.dummyRange
 let (is_tuple_datacon_string : Prims.string -> Prims.bool) =
   fun s -> FStar_Util.starts_with s "FStar.Pervasives.Native.Mktuple"
 let (is_tuple_datacon_id : FStar_Ident.ident -> Prims.bool) =
   fun id ->
-    let uu____175 = FStar_Ident.string_of_id id in
-    is_tuple_datacon_string uu____175
+    let uu___ = FStar_Ident.string_of_id id in is_tuple_datacon_string uu___
 let (is_tuple_datacon_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
-    let uu____181 = FStar_Ident.string_of_lid lid in
-    is_tuple_datacon_string uu____181
+    let uu___ = FStar_Ident.string_of_lid lid in
+    is_tuple_datacon_string uu___
 let (is_tuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f ->
     fun n ->
-      let uu____192 = mk_tuple_data_lid n FStar_Range.dummyRange in
-      FStar_Ident.lid_equals f uu____192
+      let uu___ = mk_tuple_data_lid n FStar_Range.dummyRange in
+      FStar_Ident.lid_equals f uu___
 let (is_tuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f ->
-    let uu____198 = FStar_Ident.string_of_lid f in
-    is_tuple_datacon_string uu____198
+    let uu___ = FStar_Ident.string_of_lid f in is_tuple_datacon_string uu___
 let (mod_prefix_dtuple : Prims.int -> Prims.string -> FStar_Ident.lident) =
   fun n -> if n = (Prims.of_int (2)) then pconst else psconst
 let (mk_dtuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n ->
     fun r ->
       let t =
-        let uu____225 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "dtuple%s" uu____225 in
-      let uu____226 = let uu____227 = mod_prefix_dtuple n in uu____227 t in
-      FStar_Ident.set_lid_range uu____226 r
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "dtuple%s" uu___ in
+      let uu___ = let uu___1 = mod_prefix_dtuple n in uu___1 t in
+      FStar_Ident.set_lid_range uu___ r
 let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
   fun s ->
     (s = "Prims.dtuple2") ||
       (FStar_Util.starts_with s "FStar.Pervasives.dtuple")
 let (is_dtuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
-    let uu____242 = FStar_Ident.string_of_lid lid in
-    is_dtuple_constructor_string uu____242
+    let uu___ = FStar_Ident.string_of_lid lid in
+    is_dtuple_constructor_string uu___
 let (mk_dtuple_data_lid :
   Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
   fun n ->
     fun r ->
       let t =
-        let uu____254 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "Mkdtuple%s" uu____254 in
-      let uu____255 = let uu____256 = mod_prefix_dtuple n in uu____256 t in
-      FStar_Ident.set_lid_range uu____255 r
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "Mkdtuple%s" uu___ in
+      let uu___ = let uu___1 = mod_prefix_dtuple n in uu___1 t in
+      FStar_Ident.set_lid_range uu___ r
 let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
   fun s ->
     (s = "Prims.Mkdtuple2") ||
@@ -398,19 +395,18 @@ let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
 let (is_dtuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
   fun f ->
     fun n ->
-      let uu____276 = mk_dtuple_data_lid n FStar_Range.dummyRange in
-      FStar_Ident.lid_equals f uu____276
+      let uu___ = mk_dtuple_data_lid n FStar_Range.dummyRange in
+      FStar_Ident.lid_equals f uu___
 let (is_dtuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
   fun f ->
-    let uu____282 = FStar_Ident.string_of_lid f in
-    is_dtuple_datacon_string uu____282
+    let uu___ = FStar_Ident.string_of_lid f in is_dtuple_datacon_string uu___
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
     let c =
-      let uu____289 =
-        let uu____290 = FStar_Ident.ident_of_lid lid in
-        FStar_Ident.string_of_id uu____290 in
-      FStar_Util.char_at uu____289 Prims.int_zero in
+      let uu___ =
+        let uu___1 = FStar_Ident.ident_of_lid lid in
+        FStar_Ident.string_of_id uu___1 in
+      FStar_Util.char_at uu___ Prims.int_zero in
     FStar_Util.is_upper c
 let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
   fun s ->

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1,19 +1,18 @@
 open Prims
-let profile : 'uuuuuu16 . (unit -> 'uuuuuu16) -> Prims.string -> 'uuuuuu16 =
+let profile : 'uuuuu . (unit -> 'uuuuu) -> Prims.string -> 'uuuuu =
   fun f -> fun c -> FStar_Profiling.profile f FStar_Pervasives_Native.None c
 type verify_mode =
   | VerifyAll 
   | VerifyUserList 
   | VerifyFigureItOut 
 let (uu___is_VerifyAll : verify_mode -> Prims.bool) =
-  fun projectee ->
-    match projectee with | VerifyAll -> true | uu____37 -> false
+  fun projectee -> match projectee with | VerifyAll -> true | uu___ -> false
 let (uu___is_VerifyUserList : verify_mode -> Prims.bool) =
   fun projectee ->
-    match projectee with | VerifyUserList -> true | uu____43 -> false
+    match projectee with | VerifyUserList -> true | uu___ -> false
 let (uu___is_VerifyFigureItOut : verify_mode -> Prims.bool) =
   fun projectee ->
-    match projectee with | VerifyFigureItOut -> true | uu____49 -> false
+    match projectee with | VerifyFigureItOut -> true | uu___ -> false
 type files_for_module_name =
   (Prims.string FStar_Pervasives_Native.option * Prims.string
     FStar_Pervasives_Native.option) FStar_Util.smap
@@ -22,20 +21,20 @@ type color =
   | Gray 
   | Black 
 let (uu___is_White : color -> Prims.bool) =
-  fun projectee -> match projectee with | White -> true | uu____65 -> false
+  fun projectee -> match projectee with | White -> true | uu___ -> false
 let (uu___is_Gray : color -> Prims.bool) =
-  fun projectee -> match projectee with | Gray -> true | uu____71 -> false
+  fun projectee -> match projectee with | Gray -> true | uu___ -> false
 let (uu___is_Black : color -> Prims.bool) =
-  fun projectee -> match projectee with | Black -> true | uu____77 -> false
+  fun projectee -> match projectee with | Black -> true | uu___ -> false
 type open_kind =
   | Open_module 
   | Open_namespace 
 let (uu___is_Open_module : open_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Open_module -> true | uu____83 -> false
+    match projectee with | Open_module -> true | uu___ -> false
 let (uu___is_Open_namespace : open_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Open_namespace -> true | uu____89 -> false
+    match projectee with | Open_namespace -> true | uu___ -> false
 let (check_and_strip_suffix :
   Prims.string -> Prims.string FStar_Pervasives_Native.option) =
   fun f ->
@@ -45,72 +44,66 @@ let (check_and_strip_suffix :
         (fun ext ->
            let lext = FStar_String.length ext in
            let l = FStar_String.length f in
-           let uu____117 =
+           let uu___ =
              (l > lext) &&
-               (let uu____119 = FStar_String.substring f (l - lext) lext in
-                uu____119 = ext) in
-           if uu____117
+               (let uu___1 = FStar_String.substring f (l - lext) lext in
+                uu___1 = ext) in
+           if uu___
            then
-             let uu____122 =
-               FStar_String.substring f Prims.int_zero (l - lext) in
-             FStar_Pervasives_Native.Some uu____122
+             let uu___1 = FStar_String.substring f Prims.int_zero (l - lext) in
+             FStar_Pervasives_Native.Some uu___1
            else FStar_Pervasives_Native.None) suffixes in
-    let uu____124 = FStar_List.filter FStar_Util.is_some matches in
-    match uu____124 with
-    | (FStar_Pervasives_Native.Some m)::uu____134 ->
+    let uu___ = FStar_List.filter FStar_Util.is_some matches in
+    match uu___ with
+    | (FStar_Pervasives_Native.Some m)::uu___1 ->
         FStar_Pervasives_Native.Some m
-    | uu____141 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_interface : Prims.string -> Prims.bool) =
   fun f ->
-    let uu____151 =
-      FStar_String.get f ((FStar_String.length f) - Prims.int_one) in
-    uu____151 = 105
+    let uu___ = FStar_String.get f ((FStar_String.length f) - Prims.int_one) in
+    uu___ = 105
 let (is_implementation : Prims.string -> Prims.bool) =
-  fun f -> let uu____157 = is_interface f in Prims.op_Negation uu____157
+  fun f -> let uu___ = is_interface f in Prims.op_Negation uu___
 let list_of_option :
-  'uuuuuu162 .
-    'uuuuuu162 FStar_Pervasives_Native.option -> 'uuuuuu162 Prims.list
-  =
-  fun uu___0_171 ->
-    match uu___0_171 with
+  'uuuuu . 'uuuuu FStar_Pervasives_Native.option -> 'uuuuu Prims.list =
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.Some x -> [x]
     | FStar_Pervasives_Native.None -> []
 let list_of_pair :
-  'uuuuuu179 .
-    ('uuuuuu179 FStar_Pervasives_Native.option * 'uuuuuu179
-      FStar_Pervasives_Native.option) -> 'uuuuuu179 Prims.list
+  'uuuuu .
+    ('uuuuu FStar_Pervasives_Native.option * 'uuuuu
+      FStar_Pervasives_Native.option) -> 'uuuuu Prims.list
   =
-  fun uu____194 ->
-    match uu____194 with
+  fun uu___ ->
+    match uu___ with
     | (intf, impl) ->
         FStar_List.append (list_of_option intf) (list_of_option impl)
 let (module_name_of_file : Prims.string -> Prims.string) =
   fun f ->
-    let uu____218 =
-      let uu____221 = FStar_Util.basename f in
-      check_and_strip_suffix uu____221 in
-    match uu____218 with
+    let uu___ =
+      let uu___1 = FStar_Util.basename f in check_and_strip_suffix uu___1 in
+    match uu___ with
     | FStar_Pervasives_Native.Some longname -> longname
     | FStar_Pervasives_Native.None ->
-        let uu____223 =
-          let uu____228 = FStar_Util.format1 "not a valid FStar file: %s" f in
-          (FStar_Errors.Fatal_NotValidFStarFile, uu____228) in
-        FStar_Errors.raise_err uu____223
+        let uu___1 =
+          let uu___2 = FStar_Util.format1 "not a valid FStar file: %s" f in
+          (FStar_Errors.Fatal_NotValidFStarFile, uu___2) in
+        FStar_Errors.raise_err uu___1
 let (lowercase_module_name : Prims.string -> Prims.string) =
-  fun f ->
-    let uu____234 = module_name_of_file f in FStar_String.lowercase uu____234
+  fun f -> let uu___ = module_name_of_file f in FStar_String.lowercase uu___
 let (namespace_of_module :
   Prims.string -> FStar_Ident.lident FStar_Pervasives_Native.option) =
   fun f ->
     let lid =
-      let uu____243 = FStar_Ident.path_of_text f in
-      FStar_Ident.lid_of_path uu____243 FStar_Range.dummyRange in
-    let uu____244 = FStar_Ident.ns_of_lid lid in
-    match uu____244 with
+      let uu___ = FStar_Ident.path_of_text f in
+      FStar_Ident.lid_of_path uu___ FStar_Range.dummyRange in
+    let uu___ = FStar_Ident.ns_of_lid lid in
+    match uu___ with
     | [] -> FStar_Pervasives_Native.None
     | ns ->
-        let uu____248 = FStar_Ident.lid_of_ids ns in
-        FStar_Pervasives_Native.Some uu____248
+        let uu___1 = FStar_Ident.lid_of_ids ns in
+        FStar_Pervasives_Native.Some uu___1
 type file_name = Prims.string
 type module_name = Prims.string
 type dependence =
@@ -120,36 +113,33 @@ type dependence =
   | FriendImplementation of module_name 
 let (uu___is_UseInterface : dependence -> Prims.bool) =
   fun projectee ->
-    match projectee with | UseInterface _0 -> true | uu____275 -> false
+    match projectee with | UseInterface _0 -> true | uu___ -> false
 let (__proj__UseInterface__item___0 : dependence -> module_name) =
   fun projectee -> match projectee with | UseInterface _0 -> _0
 let (uu___is_PreferInterface : dependence -> Prims.bool) =
   fun projectee ->
-    match projectee with | PreferInterface _0 -> true | uu____288 -> false
+    match projectee with | PreferInterface _0 -> true | uu___ -> false
 let (__proj__PreferInterface__item___0 : dependence -> module_name) =
   fun projectee -> match projectee with | PreferInterface _0 -> _0
 let (uu___is_UseImplementation : dependence -> Prims.bool) =
   fun projectee ->
-    match projectee with | UseImplementation _0 -> true | uu____301 -> false
+    match projectee with | UseImplementation _0 -> true | uu___ -> false
 let (__proj__UseImplementation__item___0 : dependence -> module_name) =
   fun projectee -> match projectee with | UseImplementation _0 -> _0
 let (uu___is_FriendImplementation : dependence -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | FriendImplementation _0 -> true
-    | uu____314 -> false
+    match projectee with | FriendImplementation _0 -> true | uu___ -> false
 let (__proj__FriendImplementation__item___0 : dependence -> module_name) =
   fun projectee -> match projectee with | FriendImplementation _0 -> _0
 let (dep_to_string : dependence -> Prims.string) =
-  fun uu___1_325 ->
-    match uu___1_325 with
+  fun uu___ ->
+    match uu___ with
     | UseInterface f -> FStar_String.op_Hat "UseInterface " f
     | PreferInterface f -> FStar_String.op_Hat "PreferInterface " f
     | UseImplementation f -> FStar_String.op_Hat "UseImplementation " f
     | FriendImplementation f -> FStar_String.op_Hat "FriendImplementation " f
 type dependences = dependence Prims.list
-let empty_dependences : 'uuuuuu334 . unit -> 'uuuuuu334 Prims.list =
-  fun uu____338 -> []
+let empty_dependences : 'uuuuu . unit -> 'uuuuu Prims.list = fun uu___ -> []
 type dep_node = {
   edges: dependences ;
   color: color }
@@ -173,13 +163,12 @@ type parsing_data_elt =
   | P_inline_for_extraction 
 let (uu___is_P_begin_module : parsing_data_elt -> Prims.bool) =
   fun projectee ->
-    match projectee with | P_begin_module _0 -> true | uu____439 -> false
+    match projectee with | P_begin_module _0 -> true | uu___ -> false
 let (__proj__P_begin_module__item___0 :
   parsing_data_elt -> FStar_Ident.lident) =
   fun projectee -> match projectee with | P_begin_module _0 -> _0
 let (uu___is_P_open : parsing_data_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | P_open _0 -> true | uu____456 -> false
+  fun projectee -> match projectee with | P_open _0 -> true | uu___ -> false
 let (__proj__P_open__item___0 :
   parsing_data_elt -> (Prims.bool * FStar_Ident.lident)) =
   fun projectee -> match projectee with | P_open _0 -> _0
@@ -187,32 +176,27 @@ let (uu___is_P_open_module_or_namespace : parsing_data_elt -> Prims.bool) =
   fun projectee ->
     match projectee with
     | P_open_module_or_namespace _0 -> true
-    | uu____485 -> false
+    | uu___ -> false
 let (__proj__P_open_module_or_namespace__item___0 :
   parsing_data_elt -> (open_kind * FStar_Ident.lid)) =
   fun projectee -> match projectee with | P_open_module_or_namespace _0 -> _0
 let (uu___is_P_dep : parsing_data_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | P_dep _0 -> true | uu____514 -> false
+  fun projectee -> match projectee with | P_dep _0 -> true | uu___ -> false
 let (__proj__P_dep__item___0 :
   parsing_data_elt -> (Prims.bool * FStar_Ident.lident)) =
   fun projectee -> match projectee with | P_dep _0 -> _0
 let (uu___is_P_alias : parsing_data_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | P_alias _0 -> true | uu____543 -> false
+  fun projectee -> match projectee with | P_alias _0 -> true | uu___ -> false
 let (__proj__P_alias__item___0 :
   parsing_data_elt -> (FStar_Ident.ident * FStar_Ident.lident)) =
   fun projectee -> match projectee with | P_alias _0 -> _0
 let (uu___is_P_lid : parsing_data_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | P_lid _0 -> true | uu____568 -> false
+  fun projectee -> match projectee with | P_lid _0 -> true | uu___ -> false
 let (__proj__P_lid__item___0 : parsing_data_elt -> FStar_Ident.lident) =
   fun projectee -> match projectee with | P_lid _0 -> _0
 let (uu___is_P_inline_for_extraction : parsing_data_elt -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | P_inline_for_extraction -> true
-    | uu____580 -> false
+    match projectee with | P_inline_for_extraction -> true | uu___ -> false
 type parsing_data =
   | Mk_pd of parsing_data_elt Prims.list 
 let (uu___is_Mk_pd : parsing_data -> Prims.bool) = fun projectee -> true
@@ -220,74 +204,74 @@ let (__proj__Mk_pd__item___0 : parsing_data -> parsing_data_elt Prims.list) =
   fun projectee -> match projectee with | Mk_pd _0 -> _0
 let (str_of_parsing_data_elt : parsing_data_elt -> Prims.string) =
   fun elt ->
-    let str_of_open_kind uu___2_615 =
-      match uu___2_615 with
+    let str_of_open_kind uu___ =
+      match uu___ with
       | Open_module -> "P_open_module"
       | Open_namespace -> "P_open_namespace" in
     match elt with
     | P_begin_module lid ->
-        let uu____617 =
-          let uu____618 = FStar_Ident.string_of_lid lid in
-          FStar_String.op_Hat uu____618 ")" in
-        FStar_String.op_Hat "P_begin_module (" uu____617
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid lid in
+          FStar_String.op_Hat uu___1 ")" in
+        FStar_String.op_Hat "P_begin_module (" uu___
     | P_open (b, lid) ->
-        let uu____621 =
-          let uu____622 = FStar_Util.string_of_bool b in
-          let uu____623 =
-            let uu____624 =
-              let uu____625 = FStar_Ident.string_of_lid lid in
-              FStar_String.op_Hat uu____625 ")" in
-            FStar_String.op_Hat ", " uu____624 in
-          FStar_String.op_Hat uu____622 uu____623 in
-        FStar_String.op_Hat "P_open (" uu____621
+        let uu___ =
+          let uu___1 = FStar_Util.string_of_bool b in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Ident.string_of_lid lid in
+              FStar_String.op_Hat uu___4 ")" in
+            FStar_String.op_Hat ", " uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "P_open (" uu___
     | P_open_module_or_namespace (k, lid) ->
-        let uu____628 =
-          let uu____629 =
-            let uu____630 =
-              let uu____631 = FStar_Ident.string_of_lid lid in
-              FStar_String.op_Hat uu____631 ")" in
-            FStar_String.op_Hat ", " uu____630 in
-          FStar_String.op_Hat (str_of_open_kind k) uu____629 in
-        FStar_String.op_Hat "P_open_module_or_namespace (" uu____628
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Ident.string_of_lid lid in
+              FStar_String.op_Hat uu___3 ")" in
+            FStar_String.op_Hat ", " uu___2 in
+          FStar_String.op_Hat (str_of_open_kind k) uu___1 in
+        FStar_String.op_Hat "P_open_module_or_namespace (" uu___
     | P_dep (b, lid) ->
-        let uu____634 =
-          let uu____635 = FStar_Ident.string_of_lid lid in
-          let uu____636 =
-            let uu____637 =
-              let uu____638 = FStar_Util.string_of_bool b in
-              FStar_String.op_Hat uu____638 ")" in
-            FStar_String.op_Hat ", " uu____637 in
-          FStar_String.op_Hat uu____635 uu____636 in
-        FStar_String.op_Hat "P_dep (" uu____634
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid lid in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Util.string_of_bool b in
+              FStar_String.op_Hat uu___4 ")" in
+            FStar_String.op_Hat ", " uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "P_dep (" uu___
     | P_alias (id, lid) ->
-        let uu____641 =
-          let uu____642 = FStar_Ident.string_of_id id in
-          let uu____643 =
-            let uu____644 =
-              let uu____645 = FStar_Ident.string_of_lid lid in
-              FStar_String.op_Hat uu____645 ")" in
-            FStar_String.op_Hat ", " uu____644 in
-          FStar_String.op_Hat uu____642 uu____643 in
-        FStar_String.op_Hat "P_alias (" uu____641
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_id id in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Ident.string_of_lid lid in
+              FStar_String.op_Hat uu___4 ")" in
+            FStar_String.op_Hat ", " uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "P_alias (" uu___
     | P_lid lid ->
-        let uu____647 =
-          let uu____648 = FStar_Ident.string_of_lid lid in
-          FStar_String.op_Hat uu____648 ")" in
-        FStar_String.op_Hat "P_lid (" uu____647
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid lid in
+          FStar_String.op_Hat uu___1 ")" in
+        FStar_String.op_Hat "P_lid (" uu___
     | P_inline_for_extraction -> "P_inline_for_extraction"
 let (str_of_parsing_data : parsing_data -> Prims.string) =
-  fun uu___3_653 ->
-    match uu___3_653 with
+  fun uu___ ->
+    match uu___ with
     | Mk_pd l ->
         FStar_All.pipe_right l
           (FStar_List.fold_left
              (fun s ->
                 fun elt ->
-                  let uu____664 =
-                    let uu____665 =
+                  let uu___1 =
+                    let uu___2 =
                       FStar_All.pipe_right elt str_of_parsing_data_elt in
-                    FStar_String.op_Hat "; " uu____665 in
-                  FStar_String.op_Hat s uu____664) "")
+                    FStar_String.op_Hat "; " uu___2 in
+                  FStar_String.op_Hat s uu___1) "")
 let (parsing_data_elt_eq :
   parsing_data_elt -> parsing_data_elt -> Prims.bool) =
   fun e1 ->
@@ -302,12 +286,12 @@ let (parsing_data_elt_eq :
       | (P_dep (b1, l1), P_dep (b2, l2)) ->
           (b1 = b2) && (FStar_Ident.lid_equals l1 l2)
       | (P_alias (i1, l1), P_alias (i2, l2)) ->
-          (let uu____698 = FStar_Ident.string_of_id i1 in
-           let uu____699 = FStar_Ident.string_of_id i2 in
-           uu____698 = uu____699) && (FStar_Ident.lid_equals l1 l2)
+          (let uu___ = FStar_Ident.string_of_id i1 in
+           let uu___1 = FStar_Ident.string_of_id i2 in uu___ = uu___1) &&
+            (FStar_Ident.lid_equals l1 l2)
       | (P_lid l1, P_lid l2) -> FStar_Ident.lid_equals l1 l2
       | (P_inline_for_extraction, P_inline_for_extraction) -> true
-      | (uu____702, uu____703) -> false
+      | (uu___, uu___1) -> false
 let (empty_parsing_data : parsing_data) = Mk_pd []
 type deps =
   {
@@ -353,18 +337,16 @@ let (__proj__Mkdeps__item__parse_results :
 let (deps_try_find :
   dependence_graph -> Prims.string -> dep_node FStar_Pervasives_Native.option)
   =
-  fun uu____882 ->
-    fun k -> match uu____882 with | Deps m -> FStar_Util.smap_try_find m k
+  fun uu___ ->
+    fun k -> match uu___ with | Deps m -> FStar_Util.smap_try_find m k
 let (deps_add_dep : dependence_graph -> Prims.string -> dep_node -> unit) =
-  fun uu____901 ->
-    fun k ->
-      fun v -> match uu____901 with | Deps m -> FStar_Util.smap_add m k v
+  fun uu___ ->
+    fun k -> fun v -> match uu___ with | Deps m -> FStar_Util.smap_add m k v
 let (deps_keys : dependence_graph -> Prims.string Prims.list) =
-  fun uu____913 -> match uu____913 with | Deps m -> FStar_Util.smap_keys m
+  fun uu___ -> match uu___ with | Deps m -> FStar_Util.smap_keys m
 let (deps_empty : unit -> dependence_graph) =
-  fun uu____923 ->
-    let uu____924 = FStar_Util.smap_create (Prims.of_int (41)) in
-    Deps uu____924
+  fun uu___ ->
+    let uu___1 = FStar_Util.smap_create (Prims.of_int (41)) in Deps uu___1
 let (mk_deps :
   dependence_graph ->
     files_for_module_name ->
@@ -387,13 +369,13 @@ let (mk_deps :
                 parse_results = pr
               }
 let (empty_deps : deps) =
-  let uu____973 = deps_empty () in
-  let uu____974 = FStar_Util.smap_create Prims.int_zero in
-  let uu____983 = FStar_Util.smap_create Prims.int_zero in
-  mk_deps uu____973 uu____974 [] [] [] uu____983
+  let uu___ = deps_empty () in
+  let uu___1 = FStar_Util.smap_create Prims.int_zero in
+  let uu___2 = FStar_Util.smap_create Prims.int_zero in
+  mk_deps uu___ uu___1 [] [] [] uu___2
 let (module_name_of_dep : dependence -> module_name) =
-  fun uu___4_990 ->
-    match uu___4_990 with
+  fun uu___ ->
+    match uu___ with
     | UseInterface m -> m
     | PreferInterface m -> m
     | UseImplementation m -> m
@@ -404,41 +386,41 @@ let (resolve_module_name :
   =
   fun file_system_map ->
     fun key ->
-      let uu____1009 = FStar_Util.smap_try_find file_system_map key in
-      match uu____1009 with
+      let uu___ = FStar_Util.smap_try_find file_system_map key in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          (FStar_Pervasives_Native.Some fn, uu____1031) ->
-          let uu____1046 = lowercase_module_name fn in
-          FStar_Pervasives_Native.Some uu____1046
+          (FStar_Pervasives_Native.Some fn, uu___1) ->
+          let uu___2 = lowercase_module_name fn in
+          FStar_Pervasives_Native.Some uu___2
       | FStar_Pervasives_Native.Some
-          (uu____1047, FStar_Pervasives_Native.Some fn) ->
-          let uu____1063 = lowercase_module_name fn in
-          FStar_Pervasives_Native.Some uu____1063
-      | uu____1064 -> FStar_Pervasives_Native.None
+          (uu___1, FStar_Pervasives_Native.Some fn) ->
+          let uu___2 = lowercase_module_name fn in
+          FStar_Pervasives_Native.Some uu___2
+      | uu___1 -> FStar_Pervasives_Native.None
 let (interface_of_internal :
   files_for_module_name ->
     module_name -> file_name FStar_Pervasives_Native.option)
   =
   fun file_system_map ->
     fun key ->
-      let uu____1089 = FStar_Util.smap_try_find file_system_map key in
-      match uu____1089 with
+      let uu___ = FStar_Util.smap_try_find file_system_map key in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          (FStar_Pervasives_Native.Some iface, uu____1111) ->
+          (FStar_Pervasives_Native.Some iface, uu___1) ->
           FStar_Pervasives_Native.Some iface
-      | uu____1126 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (implementation_of_internal :
   files_for_module_name ->
     module_name -> file_name FStar_Pervasives_Native.option)
   =
   fun file_system_map ->
     fun key ->
-      let uu____1151 = FStar_Util.smap_try_find file_system_map key in
-      match uu____1151 with
+      let uu___ = FStar_Util.smap_try_find file_system_map key in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          (uu____1172, FStar_Pervasives_Native.Some impl) ->
+          (uu___1, FStar_Pervasives_Native.Some impl) ->
           FStar_Pervasives_Native.Some impl
-      | uu____1188 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (interface_of :
   deps -> Prims.string -> Prims.string FStar_Pervasives_Native.option) =
   fun deps1 -> fun key -> interface_of_internal deps1.file_system_map key
@@ -449,14 +431,14 @@ let (implementation_of :
 let (has_interface : files_for_module_name -> module_name -> Prims.bool) =
   fun file_system_map ->
     fun key ->
-      let uu____1233 = interface_of_internal file_system_map key in
-      FStar_Option.isSome uu____1233
+      let uu___ = interface_of_internal file_system_map key in
+      FStar_Option.isSome uu___
 let (has_implementation : files_for_module_name -> module_name -> Prims.bool)
   =
   fun file_system_map ->
     fun key ->
-      let uu____1246 = implementation_of_internal file_system_map key in
-      FStar_Option.isSome uu____1246
+      let uu___ = implementation_of_internal file_system_map key in
+      FStar_Option.isSome uu___
 let (cache_file_name : Prims.string -> Prims.string) =
   let checked_file_and_exists_flag fn =
     let lax = FStar_Options.lax () in
@@ -465,56 +447,56 @@ let (cache_file_name : Prims.string -> Prims.string) =
       then FStar_String.op_Hat fn ".checked.lax"
       else FStar_String.op_Hat fn ".checked" in
     let mname = FStar_All.pipe_right fn module_name_of_file in
-    let uu____1263 =
-      let uu____1266 = FStar_All.pipe_right cache_fn FStar_Util.basename in
-      FStar_Options.find_file uu____1266 in
-    match uu____1263 with
+    let uu___ =
+      let uu___1 = FStar_All.pipe_right cache_fn FStar_Util.basename in
+      FStar_Options.find_file uu___1 in
+    match uu___ with
     | FStar_Pervasives_Native.Some path ->
         let expected_cache_file = FStar_Options.prepend_cache_dir cache_fn in
-        ((let uu____1270 =
-            ((let uu____1273 = FStar_Options.dep () in
-              FStar_Option.isSome uu____1273) &&
-               (let uu____1277 = FStar_Options.should_be_already_cached mname in
-                Prims.op_Negation uu____1277))
+        ((let uu___2 =
+            ((let uu___3 = FStar_Options.dep () in FStar_Option.isSome uu___3)
+               &&
+               (let uu___3 = FStar_Options.should_be_already_cached mname in
+                Prims.op_Negation uu___3))
               &&
               ((Prims.op_Negation
                   (FStar_Util.file_exists expected_cache_file))
                  ||
-                 (let uu____1279 =
+                 (let uu___3 =
                     FStar_Util.paths_to_same_file path expected_cache_file in
-                  Prims.op_Negation uu____1279)) in
-          if uu____1270
+                  Prims.op_Negation uu___3)) in
+          if uu___2
           then
-            let uu____1280 =
-              let uu____1285 =
-                let uu____1286 = FStar_Options.prepend_cache_dir cache_fn in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Options.prepend_cache_dir cache_fn in
                 FStar_Util.format3
                   "Did not expect %s to be already checked, but found it in an unexpected location %s instead of %s"
-                  mname path uu____1286 in
-              (FStar_Errors.Warning_UnexpectedCheckedFile, uu____1285) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1280
+                  mname path uu___5 in
+              (FStar_Errors.Warning_UnexpectedCheckedFile, uu___4) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___3
           else ());
-         (let uu____1288 =
+         (let uu___2 =
             (FStar_Util.file_exists expected_cache_file) &&
               (FStar_Util.paths_to_same_file path expected_cache_file) in
-          if uu____1288 then expected_cache_file else path))
+          if uu___2 then expected_cache_file else path))
     | FStar_Pervasives_Native.None ->
-        let uu____1290 =
+        let uu___1 =
           FStar_All.pipe_right mname FStar_Options.should_be_already_cached in
-        if uu____1290
+        if uu___1
         then
-          let uu____1291 =
-            let uu____1296 =
+          let uu___2 =
+            let uu___3 =
               FStar_Util.format1
                 "Expected %s to be already checked but could not find it"
                 mname in
-            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu____1296) in
-          FStar_Errors.raise_err uu____1291
+            (FStar_Errors.Error_AlreadyCachedAssertionFailure, uu___3) in
+          FStar_Errors.raise_err uu___2
         else FStar_Options.prepend_cache_dir cache_fn in
   let memo = FStar_Util.smap_create (Prims.of_int (100)) in
   let memo1 f x =
-    let uu____1317 = FStar_Util.smap_try_find memo x in
-    match uu____1317 with
+    let uu___ = FStar_Util.smap_try_find memo x in
+    match uu___ with
     | FStar_Pervasives_Native.Some res -> res
     | FStar_Pervasives_Native.None ->
         let res = f x in (FStar_Util.smap_add memo x res; res) in
@@ -522,8 +504,8 @@ let (cache_file_name : Prims.string -> Prims.string) =
 let (parsing_data_of : deps -> Prims.string -> parsing_data) =
   fun deps1 ->
     fun fn ->
-      let uu____1333 = FStar_Util.smap_try_find deps1.parse_results fn in
-      FStar_All.pipe_right uu____1333 FStar_Util.must
+      let uu___ = FStar_Util.smap_try_find deps1.parse_results fn in
+      FStar_All.pipe_right uu___ FStar_Util.must
 let (file_of_dep_aux :
   Prims.bool ->
     files_for_module_name -> file_name Prims.list -> dependence -> file_name)
@@ -537,95 +519,94 @@ let (file_of_dep_aux :
               (FStar_Util.for_some
                  (fun fn ->
                     (is_implementation fn) &&
-                      (let uu____1373 = lowercase_module_name fn in
-                       key = uu____1373))) in
+                      (let uu___ = lowercase_module_name fn in key = uu___))) in
           let maybe_use_cache_of f =
             if use_checked_file then cache_file_name f else f in
           match d with
           | UseInterface key ->
-              let uu____1382 = interface_of_internal file_system_map key in
-              (match uu____1382 with
+              let uu___ = interface_of_internal file_system_map key in
+              (match uu___ with
                | FStar_Pervasives_Native.None ->
-                   let uu____1386 =
-                     let uu____1391 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Util.format1
                          "Expected an interface for module %s, but couldn't find one"
                          key in
-                     (FStar_Errors.Fatal_MissingInterface, uu____1391) in
-                   FStar_Errors.raise_err uu____1386
+                     (FStar_Errors.Fatal_MissingInterface, uu___3) in
+                   FStar_Errors.raise_err uu___2
                | FStar_Pervasives_Native.Some f -> f)
           | PreferInterface key when has_interface file_system_map key ->
-              let uu____1394 =
+              let uu___ =
                 (cmd_line_has_impl key) &&
-                  (let uu____1396 = FStar_Options.dep () in
-                   FStar_Option.isNone uu____1396) in
-              if uu____1394
+                  (let uu___1 = FStar_Options.dep () in
+                   FStar_Option.isNone uu___1) in
+              if uu___
               then
-                let uu____1399 = FStar_Options.expose_interfaces () in
-                (if uu____1399
+                let uu___1 = FStar_Options.expose_interfaces () in
+                (if uu___1
                  then
-                   let uu____1400 =
-                     let uu____1401 =
+                   let uu___2 =
+                     let uu___3 =
                        implementation_of_internal file_system_map key in
-                     FStar_Option.get uu____1401 in
-                   maybe_use_cache_of uu____1400
+                     FStar_Option.get uu___3 in
+                   maybe_use_cache_of uu___2
                  else
-                   (let uu____1405 =
-                      let uu____1410 =
-                        let uu____1411 =
-                          let uu____1412 =
+                   (let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
                             implementation_of_internal file_system_map key in
-                          FStar_Option.get uu____1412 in
-                        let uu____1415 =
-                          let uu____1416 =
+                          FStar_Option.get uu___6 in
+                        let uu___6 =
+                          let uu___7 =
                             interface_of_internal file_system_map key in
-                          FStar_Option.get uu____1416 in
+                          FStar_Option.get uu___7 in
                         FStar_Util.format3
                           "You may have a cyclic dependence on module %s: use --dep full to confirm. Alternatively, invoking fstar with %s on the command line breaks the abstraction imposed by its interface %s; if you really want this behavior add the option '--expose_interfaces'"
-                          key uu____1411 uu____1415 in
+                          key uu___5 uu___6 in
                       (FStar_Errors.Fatal_MissingExposeInterfacesOption,
-                        uu____1410) in
-                    FStar_Errors.raise_err uu____1405))
+                        uu___4) in
+                    FStar_Errors.raise_err uu___3))
               else
-                (let uu____1420 =
-                   let uu____1421 = interface_of_internal file_system_map key in
-                   FStar_Option.get uu____1421 in
-                 maybe_use_cache_of uu____1420)
+                (let uu___2 =
+                   let uu___3 = interface_of_internal file_system_map key in
+                   FStar_Option.get uu___3 in
+                 maybe_use_cache_of uu___2)
           | PreferInterface key ->
-              let uu____1425 = implementation_of_internal file_system_map key in
-              (match uu____1425 with
+              let uu___ = implementation_of_internal file_system_map key in
+              (match uu___ with
                | FStar_Pervasives_Native.None ->
-                   let uu____1428 =
-                     let uu____1433 =
+                   let uu___1 =
+                     let uu___2 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____1433) in
-                   FStar_Errors.raise_err uu____1428
+                     (FStar_Errors.Fatal_MissingImplementation, uu___2) in
+                   FStar_Errors.raise_err uu___1
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | UseImplementation key ->
-              let uu____1436 = implementation_of_internal file_system_map key in
-              (match uu____1436 with
+              let uu___ = implementation_of_internal file_system_map key in
+              (match uu___ with
                | FStar_Pervasives_Native.None ->
-                   let uu____1439 =
-                     let uu____1444 =
+                   let uu___1 =
+                     let uu___2 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____1444) in
-                   FStar_Errors.raise_err uu____1439
+                     (FStar_Errors.Fatal_MissingImplementation, uu___2) in
+                   FStar_Errors.raise_err uu___1
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
           | FriendImplementation key ->
-              let uu____1447 = implementation_of_internal file_system_map key in
-              (match uu____1447 with
+              let uu___ = implementation_of_internal file_system_map key in
+              (match uu___ with
                | FStar_Pervasives_Native.None ->
-                   let uu____1450 =
-                     let uu____1455 =
+                   let uu___1 =
+                     let uu___2 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
                          key in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____1455) in
-                   FStar_Errors.raise_err uu____1450
+                     (FStar_Errors.Fatal_MissingImplementation, uu___2) in
+                   FStar_Errors.raise_err uu___1
                | FStar_Pervasives_Native.Some f -> maybe_use_cache_of f)
 let (file_of_dep :
   files_for_module_name -> file_name Prims.list -> dependence -> file_name) =
@@ -639,15 +620,15 @@ let (dependences_of :
     fun deps1 ->
       fun all_cmd_line_files ->
         fun fn ->
-          let uu____1499 = deps_try_find deps1 fn in
-          match uu____1499 with
+          let uu___ = deps_try_find deps1 fn in
+          match uu___ with
           | FStar_Pervasives_Native.None -> empty_dependences ()
-          | FStar_Pervasives_Native.Some
-              { edges = deps2; color = uu____1505;_} ->
-              let uu____1506 =
+          | FStar_Pervasives_Native.Some { edges = deps2; color = uu___1;_}
+              ->
+              let uu___2 =
                 FStar_List.map
                   (file_of_dep file_system_map all_cmd_line_files) deps2 in
-              FStar_All.pipe_right uu____1506
+              FStar_All.pipe_right uu___2
                 (FStar_List.filter (fun k -> k <> fn))
 let (print_graph : dependence_graph -> unit) =
   fun graph ->
@@ -657,42 +638,40 @@ let (print_graph : dependence_graph -> unit) =
       "With GraphViz installed, try: fdp -Tpng -odep.png dep.graph";
     FStar_Util.print_endline
       "Hint: cat dep.graph | grep -v _ | grep -v prims";
-    (let uu____1523 =
-       let uu____1524 =
-         let uu____1525 =
-           let uu____1526 =
-             let uu____1529 =
-               let uu____1532 = deps_keys graph in
-               FStar_List.unique uu____1532 in
+    (let uu___3 =
+       let uu___4 =
+         let uu___5 =
+           let uu___6 =
+             let uu___7 =
+               let uu___8 = deps_keys graph in FStar_List.unique uu___8 in
              FStar_List.collect
                (fun k ->
                   let deps1 =
-                    let uu____1541 =
-                      let uu____1542 = deps_try_find graph k in
-                      FStar_Util.must uu____1542 in
-                    uu____1541.edges in
+                    let uu___8 =
+                      let uu___9 = deps_try_find graph k in
+                      FStar_Util.must uu___9 in
+                    uu___8.edges in
                   let r s = FStar_Util.replace_char s 46 95 in
                   let print dep =
-                    let uu____1557 =
-                      let uu____1558 = lowercase_module_name k in
-                      r uu____1558 in
-                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu____1557
+                    let uu___8 =
+                      let uu___9 = lowercase_module_name k in r uu___9 in
+                    FStar_Util.format2 "  \"%s\" -> \"%s\"" uu___8
                       (r (module_name_of_dep dep)) in
-                  FStar_List.map print deps1) uu____1529 in
-           FStar_String.concat "\n" uu____1526 in
-         FStar_String.op_Hat uu____1525 "\n}\n" in
-       FStar_String.op_Hat "digraph {\n" uu____1524 in
-     FStar_Util.write_file "dep.graph" uu____1523)
+                  FStar_List.map print deps1) uu___7 in
+           FStar_String.concat "\n" uu___6 in
+         FStar_String.op_Hat uu___5 "\n}\n" in
+       FStar_String.op_Hat "digraph {\n" uu___4 in
+     FStar_Util.write_file "dep.graph" uu___3)
 let (build_inclusion_candidates_list :
   unit -> (Prims.string * Prims.string) Prims.list) =
-  fun uu____1569 ->
+  fun uu___ ->
     let include_directories = FStar_Options.include_path () in
     let include_directories1 =
       FStar_List.map FStar_Util.normalize_file_path include_directories in
     let include_directories2 = FStar_List.unique include_directories1 in
     let cwd =
-      let uu____1586 = FStar_Util.getcwd () in
-      FStar_Util.normalize_file_path uu____1586 in
+      let uu___1 = FStar_Util.getcwd () in
+      FStar_Util.normalize_file_path uu___1 in
     FStar_List.concatMap
       (fun d ->
          if FStar_Util.is_directory d
@@ -701,28 +680,28 @@ let (build_inclusion_candidates_list :
            FStar_List.filter_map
              (fun f ->
                 let f1 = FStar_Util.basename f in
-                let uu____1612 = check_and_strip_suffix f1 in
-                FStar_All.pipe_right uu____1612
+                let uu___1 = check_and_strip_suffix f1 in
+                FStar_All.pipe_right uu___1
                   (FStar_Util.map_option
                      (fun longname ->
                         let full_path =
                           if d = cwd then f1 else FStar_Util.join_paths d f1 in
                         (longname, full_path)))) files
          else
-           (let uu____1633 =
-              let uu____1638 =
+           (let uu___2 =
+              let uu___3 =
                 FStar_Util.format1 "not a valid include directory: %s\n" d in
-              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____1638) in
-            FStar_Errors.raise_err uu____1633)) include_directories2
+              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu___3) in
+            FStar_Errors.raise_err uu___2)) include_directories2
 let (build_map : Prims.string Prims.list -> files_for_module_name) =
   fun filenames ->
     let map = FStar_Util.smap_create (Prims.of_int (41)) in
     let add_entry key full_path =
-      let uu____1684 = FStar_Util.smap_try_find map key in
-      match uu____1684 with
+      let uu___ = FStar_Util.smap_try_find map key in
+      match uu___ with
       | FStar_Pervasives_Native.Some (intf, impl) ->
-          let uu____1721 = is_interface full_path in
-          if uu____1721
+          let uu___1 = is_interface full_path in
+          if uu___1
           then
             FStar_Util.smap_add map key
               ((FStar_Pervasives_Native.Some full_path), impl)
@@ -730,8 +709,8 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
             FStar_Util.smap_add map key
               (intf, (FStar_Pervasives_Native.Some full_path))
       | FStar_Pervasives_Native.None ->
-          let uu____1755 = is_interface full_path in
-          if uu____1755
+          let uu___1 = is_interface full_path in
+          if uu___1
           then
             FStar_Util.smap_add map key
               ((FStar_Pervasives_Native.Some full_path),
@@ -740,16 +719,14 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
             FStar_Util.smap_add map key
               (FStar_Pervasives_Native.None,
                 (FStar_Pervasives_Native.Some full_path)) in
-    (let uu____1782 = build_inclusion_candidates_list () in
+    (let uu___1 = build_inclusion_candidates_list () in
      FStar_List.iter
-       (fun uu____1796 ->
-          match uu____1796 with
+       (fun uu___2 ->
+          match uu___2 with
           | (longname, full_path) ->
-              add_entry (FStar_String.lowercase longname) full_path)
-       uu____1782);
+              add_entry (FStar_String.lowercase longname) full_path) uu___1);
     FStar_List.iter
-      (fun f ->
-         let uu____1807 = lowercase_module_name f in add_entry uu____1807 f)
+      (fun f -> let uu___2 = lowercase_module_name f in add_entry uu___2 f)
       filenames;
     map
 let (enter_namespace :
@@ -763,15 +740,15 @@ let (enter_namespace :
         let prefix1 = FStar_String.op_Hat prefix "." in
         FStar_Util.smap_iter original_map
           (fun k ->
-             fun uu____1842 ->
+             fun uu___1 ->
                if FStar_Util.starts_with k prefix1
                then
                  let suffix =
                    FStar_String.substring k (FStar_String.length prefix1)
                      ((FStar_String.length k) - (FStar_String.length prefix1)) in
                  let filename =
-                   let uu____1861 = FStar_Util.smap_try_find original_map k in
-                   FStar_Util.must uu____1861 in
+                   let uu___2 = FStar_Util.smap_try_find original_map k in
+                   FStar_Util.must uu___2 in
                  (FStar_Util.smap_add working_map suffix filename;
                   FStar_ST.op_Colon_Equals found true)
                else ());
@@ -782,87 +759,85 @@ let (string_of_lid : FStar_Ident.lident -> Prims.bool -> Prims.string) =
       let suffix =
         if last
         then
-          let uu____1925 =
-            let uu____1926 = FStar_Ident.ident_of_lid l in
-            FStar_Ident.string_of_id uu____1926 in
-          [uu____1925]
+          let uu___ =
+            let uu___1 = FStar_Ident.ident_of_lid l in
+            FStar_Ident.string_of_id uu___1 in
+          [uu___]
         else [] in
       let names =
-        let uu____1931 =
-          let uu____1934 = FStar_Ident.ns_of_lid l in
-          FStar_List.map (fun x -> FStar_Ident.string_of_id x) uu____1934 in
-        FStar_List.append uu____1931 suffix in
+        let uu___ =
+          let uu___1 = FStar_Ident.ns_of_lid l in
+          FStar_List.map (fun x -> FStar_Ident.string_of_id x) uu___1 in
+        FStar_List.append uu___ suffix in
       FStar_String.concat "." names
 let (lowercase_join_longident :
   FStar_Ident.lident -> Prims.bool -> Prims.string) =
   fun l ->
     fun last ->
-      let uu____1949 = string_of_lid l last in
-      FStar_String.lowercase uu____1949
+      let uu___ = string_of_lid l last in FStar_String.lowercase uu___
 let (namespace_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l ->
-    let uu____1955 =
-      let uu____1958 = FStar_Ident.ns_of_lid l in
-      FStar_List.map FStar_Ident.string_of_id uu____1958 in
-    FStar_String.concat "_" uu____1955
+    let uu___ =
+      let uu___1 = FStar_Ident.ns_of_lid l in
+      FStar_List.map FStar_Ident.string_of_id uu___1 in
+    FStar_String.concat "_" uu___
 let (check_module_declaration_against_filename :
   FStar_Ident.lident -> Prims.string -> unit) =
   fun lid ->
     fun filename ->
       let k' = lowercase_join_longident lid true in
-      let uu____1972 =
-        let uu____1973 =
-          let uu____1974 =
-            let uu____1975 =
-              let uu____1978 = FStar_Util.basename filename in
-              check_and_strip_suffix uu____1978 in
-            FStar_Util.must uu____1975 in
-          FStar_String.lowercase uu____1974 in
-        uu____1973 <> k' in
-      if uu____1972
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Util.basename filename in
+              check_and_strip_suffix uu___4 in
+            FStar_Util.must uu___3 in
+          FStar_String.lowercase uu___2 in
+        uu___1 <> k' in
+      if uu___
       then
-        let uu____1979 = FStar_Ident.range_of_lid lid in
-        let uu____1980 =
-          let uu____1985 =
-            let uu____1986 = string_of_lid lid true in
+        let uu___1 = FStar_Ident.range_of_lid lid in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = string_of_lid lid true in
             FStar_Util.format2
               "The module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect and the module will not be verified.\n"
-              uu____1986 filename in
-          (FStar_Errors.Error_ModuleFileNameMismatch, uu____1985) in
-        FStar_Errors.log_issue uu____1979 uu____1980
+              uu___4 filename in
+          (FStar_Errors.Error_ModuleFileNameMismatch, uu___3) in
+        FStar_Errors.log_issue uu___1 uu___2
       else ()
 exception Exit 
 let (uu___is_Exit : Prims.exn -> Prims.bool) =
-  fun projectee -> match projectee with | Exit -> true | uu____1993 -> false
+  fun projectee -> match projectee with | Exit -> true | uu___ -> false
 let (core_modules : Prims.string Prims.list) =
-  let uu____1996 =
-    let uu____1999 = FStar_Options.prims_basename () in
-    let uu____2000 =
-      let uu____2003 = FStar_Options.pervasives_basename () in
-      let uu____2004 =
-        let uu____2007 = FStar_Options.pervasives_native_basename () in
-        [uu____2007] in
-      uu____2003 :: uu____2004 in
-    uu____1999 :: uu____2000 in
-  FStar_All.pipe_right uu____1996 (FStar_List.map module_name_of_file)
+  let uu___ =
+    let uu___1 = FStar_Options.prims_basename () in
+    let uu___2 =
+      let uu___3 = FStar_Options.pervasives_basename () in
+      let uu___4 =
+        let uu___5 = FStar_Options.pervasives_native_basename () in [uu___5] in
+      uu___3 :: uu___4 in
+    uu___1 :: uu___2 in
+  FStar_All.pipe_right uu___ (FStar_List.map module_name_of_file)
 let (hard_coded_dependencies :
   Prims.string -> (FStar_Ident.lident * open_kind) Prims.list) =
   fun full_filename ->
     let filename = FStar_Util.basename full_filename in
-    let uu____2024 =
-      let uu____2025 = module_name_of_file filename in
-      FStar_List.mem uu____2025 core_modules in
-    if uu____2024
+    let uu___ =
+      let uu___1 = module_name_of_file filename in
+      FStar_List.mem uu___1 core_modules in
+    if uu___
     then []
     else
       (let implicit_deps =
          [(FStar_Parser_Const.fstar_ns_lid, Open_namespace);
          (FStar_Parser_Const.prims_lid, Open_module);
          (FStar_Parser_Const.pervasives_lid, Open_module)] in
-       let uu____2060 =
-         let uu____2063 = lowercase_module_name full_filename in
-         namespace_of_module uu____2063 in
-       match uu____2060 with
+       let uu___2 =
+         let uu___3 = lowercase_module_name full_filename in
+         namespace_of_module uu___3 in
+       match uu___2 with
        | FStar_Pervasives_Native.None -> implicit_deps
        | FStar_Pervasives_Native.Some ns ->
            FStar_List.append implicit_deps [(ns, Open_namespace)])
@@ -871,7 +846,7 @@ let (dep_subsumed_by : dependence -> dependence -> Prims.bool) =
     fun d' ->
       match (d, d') with
       | (PreferInterface l', FriendImplementation l) -> l = l'
-      | uu____2095 -> d = d'
+      | uu___ -> d = d'
 let (collect_one :
   files_for_module_name ->
     Prims.string ->
@@ -887,34 +862,33 @@ let (collect_one :
           let has_inline_for_extraction = FStar_Util.mk_ref false in
           let mo_roots =
             let mname = lowercase_module_name filename1 in
-            let uu____2198 =
+            let uu___ =
               (is_interface filename1) &&
                 (has_implementation original_map1 mname) in
-            if uu____2198 then [UseImplementation mname] else [] in
+            if uu___ then [UseImplementation mname] else [] in
           let auto_open =
-            let uu____2205 = hard_coded_dependencies filename1 in
-            FStar_All.pipe_right uu____2205
+            let uu___ = hard_coded_dependencies filename1 in
+            FStar_All.pipe_right uu___
               (FStar_List.map
-                 (fun uu____2227 ->
-                    match uu____2227 with
+                 (fun uu___1 ->
+                    match uu___1 with
                     | (lid, k) -> P_open_module_or_namespace (k, lid))) in
           let working_map = FStar_Util.smap_copy original_map1 in
-          let set_interface_inlining uu____2258 =
-            let uu____2259 = is_interface filename1 in
-            if uu____2259
+          let set_interface_inlining uu___ =
+            let uu___1 = is_interface filename1 in
+            if uu___1
             then FStar_ST.op_Colon_Equals has_inline_for_extraction true
             else () in
           let add_dep deps2 d =
-            let uu____2310 =
-              let uu____2311 =
-                let uu____2312 = FStar_ST.op_Bang deps2 in
-                FStar_List.existsML (dep_subsumed_by d) uu____2312 in
-              Prims.op_Negation uu____2311 in
-            if uu____2310
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_ST.op_Bang deps2 in
+                FStar_List.existsML (dep_subsumed_by d) uu___2 in
+              Prims.op_Negation uu___1 in
+            if uu___
             then
-              let uu____2325 =
-                let uu____2328 = FStar_ST.op_Bang deps2 in d :: uu____2328 in
-              FStar_ST.op_Colon_Equals deps2 uu____2325
+              let uu___1 = let uu___2 = FStar_ST.op_Bang deps2 in d :: uu___2 in
+              FStar_ST.op_Colon_Equals deps2 uu___1
             else () in
           let dep_edge module_name1 is_friend =
             if is_friend
@@ -922,29 +896,29 @@ let (collect_one :
             else PreferInterface module_name1 in
           let add_dependence_edge original_or_working_map lid is_friend =
             let key = lowercase_join_longident lid true in
-            let uu____2381 = resolve_module_name original_or_working_map key in
-            match uu____2381 with
+            let uu___ = resolve_module_name original_or_working_map key in
+            match uu___ with
             | FStar_Pervasives_Native.Some module_name1 ->
                 (add_dep deps1 (dep_edge module_name1 is_friend); true)
-            | uu____2386 -> false in
+            | uu___1 -> false in
           let record_open_module let_open lid =
-            let uu____2400 =
+            let uu___ =
               (let_open && (add_dependence_edge working_map lid false)) ||
                 ((Prims.op_Negation let_open) &&
                    (add_dependence_edge original_map1 lid false)) in
-            if uu____2400
+            if uu___
             then true
             else
               (if let_open
                then
-                 (let uu____2403 = FStar_Ident.range_of_lid lid in
-                  let uu____2404 =
-                    let uu____2409 =
-                      let uu____2410 = string_of_lid lid true in
-                      FStar_Util.format1 "Module not found: %s" uu____2410 in
+                 (let uu___3 = FStar_Ident.range_of_lid lid in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = string_of_lid lid true in
+                      FStar_Util.format1 "Module not found: %s" uu___6 in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____2409) in
-                  FStar_Errors.log_issue uu____2403 uu____2404)
+                      uu___5) in
+                  FStar_Errors.log_issue uu___3 uu___4)
                else ();
                false) in
           let record_open_namespace lid =
@@ -952,94 +926,92 @@ let (collect_one :
             let r = enter_namespace original_map1 working_map key in
             if Prims.op_Negation r
             then
-              let uu____2420 = FStar_Ident.range_of_lid lid in
-              let uu____2421 =
-                let uu____2426 =
-                  let uu____2427 = string_of_lid lid true in
+              let uu___ = FStar_Ident.range_of_lid lid in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = string_of_lid lid true in
                   FStar_Util.format1
                     "No modules in namespace %s and no file with that name either"
-                    uu____2427 in
-                (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                  uu____2426) in
-              FStar_Errors.log_issue uu____2420 uu____2421
+                    uu___3 in
+                (FStar_Errors.Warning_ModuleOrFileNotFoundWarning, uu___2) in
+              FStar_Errors.log_issue uu___ uu___1
             else () in
           let record_open let_open lid =
-            let uu____2440 = record_open_module let_open lid in
-            if uu____2440
+            let uu___ = record_open_module let_open lid in
+            if uu___
             then ()
             else
               if Prims.op_Negation let_open
               then record_open_namespace lid
               else () in
-          let record_open_module_or_namespace uu____2452 =
-            match uu____2452 with
+          let record_open_module_or_namespace uu___ =
+            match uu___ with
             | (lid, kind) ->
                 (match kind with
                  | Open_namespace -> record_open_namespace lid
                  | Open_module ->
-                     let uu____2459 = record_open_module false lid in ()) in
+                     let uu___1 = record_open_module false lid in ()) in
           let record_module_alias ident lid =
             let key =
-              let uu____2472 = FStar_Ident.string_of_id ident in
-              FStar_String.lowercase uu____2472 in
+              let uu___ = FStar_Ident.string_of_id ident in
+              FStar_String.lowercase uu___ in
             let alias = lowercase_join_longident lid true in
-            let uu____2474 = FStar_Util.smap_try_find original_map1 alias in
-            match uu____2474 with
+            let uu___ = FStar_Util.smap_try_find original_map1 alias in
+            match uu___ with
             | FStar_Pervasives_Native.Some deps_of_aliased_module ->
                 (FStar_Util.smap_add working_map key deps_of_aliased_module;
-                 (let uu____2520 =
-                    let uu____2521 = lowercase_join_longident lid true in
-                    dep_edge uu____2521 false in
-                  add_dep deps1 uu____2520);
+                 (let uu___3 =
+                    let uu___4 = lowercase_join_longident lid true in
+                    dep_edge uu___4 false in
+                  add_dep deps1 uu___3);
                  true)
             | FStar_Pervasives_Native.None ->
-                ((let uu____2531 = FStar_Ident.range_of_lid lid in
-                  let uu____2532 =
-                    let uu____2537 =
+                ((let uu___2 = FStar_Ident.range_of_lid lid in
+                  let uu___3 =
+                    let uu___4 =
                       FStar_Util.format1
                         "module not found in search path: %s\n" alias in
                     (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                      uu____2537) in
-                  FStar_Errors.log_issue uu____2531 uu____2532);
+                      uu___4) in
+                  FStar_Errors.log_issue uu___2 uu___3);
                  false) in
           let add_dep_on_module module_name1 is_friend =
-            let uu____2549 =
+            let uu___ =
               add_dependence_edge working_map module_name1 is_friend in
-            if uu____2549
+            if uu___
             then ()
             else
-              (let uu____2551 =
+              (let uu___2 =
                  FStar_Options.debug_at_level_no_module
                    (FStar_Options.Other "Dep") in
-               if uu____2551
+               if uu___2
                then
-                 let uu____2552 = FStar_Ident.range_of_lid module_name1 in
-                 let uu____2553 =
-                   let uu____2558 =
-                     let uu____2559 = FStar_Ident.string_of_lid module_name1 in
-                     FStar_Util.format1 "Unbound module reference %s"
-                       uu____2559 in
-                   (FStar_Errors.Warning_UnboundModuleReference, uu____2558) in
-                 FStar_Errors.log_issue uu____2552 uu____2553
+                 let uu___3 = FStar_Ident.range_of_lid module_name1 in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Ident.string_of_lid module_name1 in
+                     FStar_Util.format1 "Unbound module reference %s" uu___6 in
+                   (FStar_Errors.Warning_UnboundModuleReference, uu___5) in
+                 FStar_Errors.log_issue uu___3 uu___4
                else ()) in
           let record_lid lid =
-            let uu____2567 = FStar_Ident.ns_of_lid lid in
-            match uu____2567 with
+            let uu___ = FStar_Ident.ns_of_lid lid in
+            match uu___ with
             | [] -> ()
             | ns ->
                 let module_name1 = FStar_Ident.lid_of_ids ns in
                 add_dep_on_module module_name1 false in
           let begin_module lid =
-            let uu____2576 =
-              let uu____2577 =
-                let uu____2578 = FStar_Ident.ns_of_lid lid in
-                FStar_List.length uu____2578 in
-              uu____2577 > Prims.int_zero in
-            if uu____2576
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Ident.ns_of_lid lid in
+                FStar_List.length uu___2 in
+              uu___1 > Prims.int_zero in
+            if uu___
             then
-              let uu____2581 =
-                let uu____2582 = namespace_of_lid lid in
-                enter_namespace original_map1 working_map uu____2582 in
+              let uu___1 =
+                let uu___2 = namespace_of_lid lid in
+                enter_namespace original_map1 working_map uu___2 in
               ()
             else () in
           (match pd with
@@ -1054,59 +1026,57 @@ let (collect_one :
                            record_open_module_or_namespace (lid, k)
                        | P_dep (b, lid) -> add_dep_on_module lid b
                        | P_alias (id, lid) ->
-                           let uu____2602 = record_module_alias id lid in ()
+                           let uu___1 = record_module_alias id lid in ()
                        | P_lid lid -> record_lid lid
                        | P_inline_for_extraction -> set_interface_inlining ())));
-          (let uu____2604 = FStar_ST.op_Bang deps1 in
-           let uu____2617 = FStar_ST.op_Bang has_inline_for_extraction in
-           (uu____2604, uu____2617, mo_roots)) in
+          (let uu___1 = FStar_ST.op_Bang deps1 in
+           let uu___2 = FStar_ST.op_Bang has_inline_for_extraction in
+           (uu___1, uu___2, mo_roots)) in
         let data_from_cache =
           FStar_All.pipe_right filename get_parsing_data_from_cache in
-        let uu____2633 =
-          FStar_All.pipe_right data_from_cache FStar_Util.is_some in
-        if uu____2633
+        let uu___ = FStar_All.pipe_right data_from_cache FStar_Util.is_some in
+        if uu___
         then
-          ((let uu____2649 =
+          ((let uu___2 =
               FStar_Options.debug_at_level_no_module
                 (FStar_Options.Other "Dep") in
-            if uu____2649
+            if uu___2
             then
               FStar_Util.print1
                 "Reading the parsing data for %s from its checked file\n"
                 filename
             else ());
-           (let uu____2651 =
-              let uu____2662 =
+           (let uu___2 =
+              let uu___3 =
                 FStar_All.pipe_right data_from_cache FStar_Util.must in
-              from_parsing_data uu____2662 original_map filename in
-            match uu____2651 with
+              from_parsing_data uu___3 original_map filename in
+            match uu___2 with
             | (deps1, has_inline_for_extraction, mo_roots) ->
-                let uu____2688 =
+                let uu___3 =
                   FStar_All.pipe_right data_from_cache FStar_Util.must in
-                (uu____2688, deps1, has_inline_for_extraction, mo_roots)))
+                (uu___3, deps1, has_inline_for_extraction, mo_roots)))
         else
           (let num_of_toplevelmods = FStar_Util.mk_ref Prims.int_zero in
            let pd = FStar_Util.mk_ref [] in
            let add_to_parsing_data elt =
-             let uu____2712 =
-               let uu____2713 =
-                 let uu____2714 = FStar_ST.op_Bang pd in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_ST.op_Bang pd in
                  FStar_List.existsML (fun e -> parsing_data_elt_eq e elt)
-                   uu____2714 in
-               Prims.op_Negation uu____2713 in
-             if uu____2712
+                   uu___4 in
+               Prims.op_Negation uu___3 in
+             if uu___2
              then
-               let uu____2729 =
-                 let uu____2732 = FStar_ST.op_Bang pd in elt :: uu____2732 in
-               FStar_ST.op_Colon_Equals pd uu____2729
+               let uu___3 = let uu___4 = FStar_ST.op_Bang pd in elt :: uu___4 in
+               FStar_ST.op_Colon_Equals pd uu___3
              else () in
-           let rec collect_module uu___5_2862 =
-             match uu___5_2862 with
+           let rec collect_module uu___2 =
+             match uu___2 with
              | FStar_Parser_AST.Module (lid, decls) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
-             | FStar_Parser_AST.Interface (lid, decls, uu____2873) ->
+             | FStar_Parser_AST.Interface (lid, decls, uu___3) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
@@ -1116,12 +1086,12 @@ let (collect_one :
                   collect_decl x.FStar_Parser_AST.d;
                   FStar_List.iter collect_term x.FStar_Parser_AST.attrs;
                   (match x.FStar_Parser_AST.d with
-                   | FStar_Parser_AST.Val uu____2890 when
+                   | FStar_Parser_AST.Val uu___4 when
                        FStar_List.contains
                          FStar_Parser_AST.Inline_for_extraction
                          x.FStar_Parser_AST.quals
                        -> add_to_parsing_data P_inline_for_extraction
-                   | uu____2895 -> ())) decls
+                   | uu___4 -> ())) decls
            and collect_decl d =
              match d with
              | FStar_Parser_AST.Include lid ->
@@ -1129,108 +1099,107 @@ let (collect_one :
              | FStar_Parser_AST.Open lid ->
                  add_to_parsing_data (P_open (false, lid))
              | FStar_Parser_AST.Friend lid ->
-                 let uu____2900 =
-                   let uu____2901 =
-                     let uu____2906 =
-                       let uu____2907 = lowercase_join_longident lid true in
-                       FStar_All.pipe_right uu____2907 FStar_Ident.lid_of_str in
-                     (true, uu____2906) in
-                   P_dep uu____2901 in
-                 add_to_parsing_data uu____2900
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = lowercase_join_longident lid true in
+                       FStar_All.pipe_right uu___5 FStar_Ident.lid_of_str in
+                     (true, uu___4) in
+                   P_dep uu___3 in
+                 add_to_parsing_data uu___2
              | FStar_Parser_AST.ModuleAbbrev (ident, lid) ->
                  add_to_parsing_data (P_alias (ident, lid))
-             | FStar_Parser_AST.TopLevelLet (uu____2910, patterms) ->
+             | FStar_Parser_AST.TopLevelLet (uu___2, patterms) ->
                  FStar_List.iter
-                   (fun uu____2932 ->
-                      match uu____2932 with
+                   (fun uu___3 ->
+                      match uu___3 with
                       | (pat, t) -> (collect_pattern pat; collect_term t))
                    patterms
-             | FStar_Parser_AST.Splice (uu____2940, t) -> collect_term t
-             | FStar_Parser_AST.Assume (uu____2946, t) -> collect_term t
+             | FStar_Parser_AST.Splice (uu___2, t) -> collect_term t
+             | FStar_Parser_AST.Assume (uu___2, t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____2948;
-                   FStar_Parser_AST.mdest = uu____2949;
+                 { FStar_Parser_AST.msource = uu___2;
+                   FStar_Parser_AST.mdest = uu___3;
                    FStar_Parser_AST.lift_op =
                      FStar_Parser_AST.NonReifiableLift t;_}
                  -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____2951;
-                   FStar_Parser_AST.mdest = uu____2952;
+                 { FStar_Parser_AST.msource = uu___2;
+                   FStar_Parser_AST.mdest = uu___3;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree t;_}
                  -> collect_term t
-             | FStar_Parser_AST.Val (uu____2954, t) -> collect_term t
+             | FStar_Parser_AST.Val (uu___2, t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu____2956;
-                   FStar_Parser_AST.mdest = uu____2957;
+                 { FStar_Parser_AST.msource = uu___2;
+                   FStar_Parser_AST.mdest = uu___3;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.ReifiableLift
                      (t0, t1);_}
                  -> (collect_term t0; collect_term t1)
-             | FStar_Parser_AST.Tycon (uu____2961, tc, ts) ->
+             | FStar_Parser_AST.Tycon (uu___2, tc, ts) ->
                  (if tc
                   then
                     add_to_parsing_data
                       (P_lid FStar_Parser_Const.mk_class_lid)
                   else ();
                   FStar_List.iter collect_tycon ts)
-             | FStar_Parser_AST.Exception (uu____2970, t) ->
+             | FStar_Parser_AST.Exception (uu___2, t) ->
                  FStar_Util.iter_opt t collect_term
              | FStar_Parser_AST.NewEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.LayeredEffect ed -> collect_effect_decl ed
-             | FStar_Parser_AST.Polymonadic_bind
-                 (uu____2978, uu____2979, uu____2980, t) -> collect_term t
-             | FStar_Parser_AST.Polymonadic_subcomp
-                 (uu____2982, uu____2983, t) -> collect_term t
-             | FStar_Parser_AST.Pragma uu____2985 -> ()
+             | FStar_Parser_AST.Polymonadic_bind (uu___2, uu___3, uu___4, t)
+                 -> collect_term t
+             | FStar_Parser_AST.Polymonadic_subcomp (uu___2, uu___3, t) ->
+                 collect_term t
+             | FStar_Parser_AST.Pragma uu___2 -> ()
              | FStar_Parser_AST.TopLevelModule lid ->
                  (FStar_Util.incr num_of_toplevelmods;
-                  (let uu____2988 =
-                     let uu____2989 = FStar_ST.op_Bang num_of_toplevelmods in
-                     uu____2989 > Prims.int_one in
-                   if uu____2988
+                  (let uu___3 =
+                     let uu___4 = FStar_ST.op_Bang num_of_toplevelmods in
+                     uu___4 > Prims.int_one in
+                   if uu___3
                    then
-                     let uu____2996 =
-                       let uu____3001 =
-                         let uu____3002 = string_of_lid lid true in
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 = string_of_lid lid true in
                          FStar_Util.format1
                            "Automatic dependency analysis demands one module per file (module %s not supported)"
-                           uu____3002 in
-                       (FStar_Errors.Fatal_OneModulePerFile, uu____3001) in
-                     let uu____3003 = FStar_Ident.range_of_lid lid in
-                     FStar_Errors.raise_error uu____2996 uu____3003
+                           uu___6 in
+                       (FStar_Errors.Fatal_OneModulePerFile, uu___5) in
+                     let uu___5 = FStar_Ident.range_of_lid lid in
+                     FStar_Errors.raise_error uu___4 uu___5
                    else ()))
-           and collect_tycon uu___6_3005 =
-             match uu___6_3005 with
-             | FStar_Parser_AST.TyconAbstract (uu____3006, binders, k) ->
+           and collect_tycon uu___2 =
+             match uu___2 with
+             | FStar_Parser_AST.TyconAbstract (uu___3, binders, k) ->
                  (collect_binders binders; FStar_Util.iter_opt k collect_term)
-             | FStar_Parser_AST.TyconAbbrev (uu____3018, binders, k, t) ->
+             | FStar_Parser_AST.TyconAbbrev (uu___3, binders, k, t) ->
                  (collect_binders binders;
                   FStar_Util.iter_opt k collect_term;
                   collect_term t)
-             | FStar_Parser_AST.TyconRecord
-                 (uu____3032, binders, k, identterms) ->
-                 (collect_binders binders;
-                  FStar_Util.iter_opt k collect_term;
-                  FStar_List.iter
-                    (fun uu____3065 ->
-                       match uu____3065 with
-                       | (uu____3070, t) -> collect_term t) identterms)
-             | FStar_Parser_AST.TyconVariant
-                 (uu____3072, binders, k, identterms) ->
-                 (collect_binders binders;
-                  FStar_Util.iter_opt k collect_term;
-                  FStar_List.iter
-                    (fun uu____3118 ->
-                       match uu____3118 with
-                       | (uu____3127, t, uu____3129) ->
-                           FStar_Util.iter_opt t collect_term) identterms)
-           and collect_effect_decl uu___7_3134 =
-             match uu___7_3134 with
-             | FStar_Parser_AST.DefineEffect (uu____3135, binders, t, decls)
+             | FStar_Parser_AST.TyconRecord (uu___3, binders, k, identterms)
                  ->
+                 (collect_binders binders;
+                  FStar_Util.iter_opt k collect_term;
+                  FStar_List.iter
+                    (fun uu___6 ->
+                       match uu___6 with | (uu___7, t) -> collect_term t)
+                    identterms)
+             | FStar_Parser_AST.TyconVariant (uu___3, binders, k, identterms)
+                 ->
+                 (collect_binders binders;
+                  FStar_Util.iter_opt k collect_term;
+                  FStar_List.iter
+                    (fun uu___6 ->
+                       match uu___6 with
+                       | (uu___7, t, uu___8) ->
+                           FStar_Util.iter_opt t collect_term) identterms)
+           and collect_effect_decl uu___2 =
+             match uu___2 with
+             | FStar_Parser_AST.DefineEffect (uu___3, binders, t, decls) ->
                  (collect_binders binders;
                   collect_term t;
                   collect_decls decls)
-             | FStar_Parser_AST.RedefineEffect (uu____3149, binders, t) ->
+             | FStar_Parser_AST.RedefineEffect (uu___3, binders, t) ->
                  (collect_binders binders; collect_term t)
            and collect_binders binders =
              FStar_List.iter collect_binder binders
@@ -1238,37 +1207,35 @@ let (collect_one :
              collect_aqual b.FStar_Parser_AST.aqual;
              (match b with
               | {
-                  FStar_Parser_AST.b = FStar_Parser_AST.Annotated
-                    (uu____3162, t);
-                  FStar_Parser_AST.brange = uu____3164;
-                  FStar_Parser_AST.blevel = uu____3165;
-                  FStar_Parser_AST.aqual = uu____3166;_} -> collect_term t
+                  FStar_Parser_AST.b = FStar_Parser_AST.Annotated (uu___3, t);
+                  FStar_Parser_AST.brange = uu___4;
+                  FStar_Parser_AST.blevel = uu___5;
+                  FStar_Parser_AST.aqual = uu___6;_} -> collect_term t
               | {
                   FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated
-                    (uu____3169, t);
-                  FStar_Parser_AST.brange = uu____3171;
-                  FStar_Parser_AST.blevel = uu____3172;
-                  FStar_Parser_AST.aqual = uu____3173;_} -> collect_term t
+                    (uu___3, t);
+                  FStar_Parser_AST.brange = uu___4;
+                  FStar_Parser_AST.blevel = uu___5;
+                  FStar_Parser_AST.aqual = uu___6;_} -> collect_term t
               | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
-                  FStar_Parser_AST.brange = uu____3177;
-                  FStar_Parser_AST.blevel = uu____3178;
-                  FStar_Parser_AST.aqual = uu____3179;_} -> collect_term t
-              | uu____3182 -> ())
-           and collect_aqual uu___8_3183 =
-             match uu___8_3183 with
+                  FStar_Parser_AST.brange = uu___3;
+                  FStar_Parser_AST.blevel = uu___4;
+                  FStar_Parser_AST.aqual = uu___5;_} -> collect_term t
+              | uu___3 -> ())
+           and collect_aqual uu___2 =
+             match uu___2 with
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
                  (FStar_Parser_AST.Arg_qualifier_meta_tac t)) ->
                  collect_term t
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
                  (FStar_Parser_AST.Arg_qualifier_meta_attr t)) ->
                  collect_term t
-             | uu____3188 -> ()
+             | uu___3 -> ()
            and collect_term t = collect_term' t.FStar_Parser_AST.tm
-           and collect_constant uu___9_3192 =
-             match uu___9_3192 with
+           and collect_constant uu___2 =
+             match uu___2 with
              | FStar_Const.Const_int
-                 (uu____3193, FStar_Pervasives_Native.Some
-                  (signedness, width))
+                 (uu___3, FStar_Pervasives_Native.Some (signedness, width))
                  ->
                  let u =
                    match signedness with
@@ -1280,59 +1247,57 @@ let (collect_one :
                    | FStar_Const.Int16 -> "16"
                    | FStar_Const.Int32 -> "32"
                    | FStar_Const.Int64 -> "64" in
-                 let uu____3208 =
-                   let uu____3209 =
-                     let uu____3214 =
-                       let uu____3215 =
-                         FStar_Util.format2 "fstar.%sint%s" u w in
-                       FStar_All.pipe_right uu____3215 FStar_Ident.lid_of_str in
-                     (false, uu____3214) in
-                   P_dep uu____3209 in
-                 add_to_parsing_data uu____3208
-             | FStar_Const.Const_char uu____3216 ->
-                 let uu____3217 =
-                   let uu____3218 =
-                     let uu____3223 =
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Util.format2 "fstar.%sint%s" u w in
+                       FStar_All.pipe_right uu___7 FStar_Ident.lid_of_str in
+                     (false, uu___6) in
+                   P_dep uu___5 in
+                 add_to_parsing_data uu___4
+             | FStar_Const.Const_char uu___3 ->
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
                        FStar_All.pipe_right "fstar.char"
                          FStar_Ident.lid_of_str in
-                     (false, uu____3223) in
-                   P_dep uu____3218 in
-                 add_to_parsing_data uu____3217
-             | FStar_Const.Const_float uu____3224 ->
-                 let uu____3225 =
-                   let uu____3226 =
-                     let uu____3231 =
+                     (false, uu___6) in
+                   P_dep uu___5 in
+                 add_to_parsing_data uu___4
+             | FStar_Const.Const_float uu___3 ->
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
                        FStar_All.pipe_right "fstar.float"
                          FStar_Ident.lid_of_str in
-                     (false, uu____3231) in
-                   P_dep uu____3226 in
-                 add_to_parsing_data uu____3225
-             | uu____3232 -> ()
-           and collect_term' uu___12_3233 =
-             match uu___12_3233 with
+                     (false, uu___6) in
+                   P_dep uu___5 in
+                 add_to_parsing_data uu___4
+             | uu___3 -> ()
+           and collect_term' uu___2 =
+             match uu___2 with
              | FStar_Parser_AST.Wild -> ()
              | FStar_Parser_AST.Const c -> collect_constant c
              | FStar_Parser_AST.Op (s, ts) ->
-                 ((let uu____3242 =
-                     let uu____3243 = FStar_Ident.string_of_id s in
-                     uu____3243 = "@" in
-                   if uu____3242
+                 ((let uu___4 =
+                     let uu___5 = FStar_Ident.string_of_id s in uu___5 = "@" in
+                   if uu___4
                    then
-                     let uu____3244 =
-                       let uu____3245 =
-                         let uu____3246 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_Ident.path_of_text
                              "FStar.List.Tot.Base.append" in
-                         FStar_Ident.lid_of_path uu____3246
+                         FStar_Ident.lid_of_path uu___7
                            FStar_Range.dummyRange in
-                       FStar_Parser_AST.Name uu____3245 in
-                     collect_term' uu____3244
+                       FStar_Parser_AST.Name uu___6 in
+                     collect_term' uu___5
                    else ());
                   FStar_List.iter collect_term ts)
-             | FStar_Parser_AST.Tvar uu____3248 -> ()
-             | FStar_Parser_AST.Uvar uu____3249 -> ()
+             | FStar_Parser_AST.Tvar uu___3 -> ()
+             | FStar_Parser_AST.Uvar uu___3 -> ()
              | FStar_Parser_AST.Var lid -> add_to_parsing_data (P_lid lid)
-             | FStar_Parser_AST.Projector (lid, uu____3252) ->
+             | FStar_Parser_AST.Projector (lid, uu___3) ->
                  add_to_parsing_data (P_lid lid)
              | FStar_Parser_AST.Discrim lid ->
                  add_to_parsing_data (P_lid lid)
@@ -1340,19 +1305,19 @@ let (collect_one :
              | FStar_Parser_AST.Construct (lid, termimps) ->
                  (add_to_parsing_data (P_lid lid);
                   FStar_List.iter
-                    (fun uu____3277 ->
-                       match uu____3277 with
-                       | (t, uu____3283) -> collect_term t) termimps)
+                    (fun uu___4 ->
+                       match uu___4 with | (t, uu___5) -> collect_term t)
+                    termimps)
              | FStar_Parser_AST.Abs (pats, t) ->
                  (collect_patterns pats; collect_term t)
-             | FStar_Parser_AST.App (t1, t2, uu____3293) ->
+             | FStar_Parser_AST.App (t1, t2, uu___3) ->
                  (collect_term t1; collect_term t2)
-             | FStar_Parser_AST.Let (uu____3295, patterms, t) ->
+             | FStar_Parser_AST.Let (uu___3, patterms, t) ->
                  (FStar_List.iter
-                    (fun uu____3345 ->
-                       match uu____3345 with
+                    (fun uu___5 ->
+                       match uu___5 with
                        | (attrs_opt, (pat, t1)) ->
-                           ((let uu____3374 =
+                           ((let uu___7 =
                                FStar_Util.map_opt attrs_opt
                                  (FStar_List.iter collect_term) in
                              ());
@@ -1361,7 +1326,7 @@ let (collect_one :
                   collect_term t)
              | FStar_Parser_AST.LetOpen (lid, t) ->
                  (add_to_parsing_data (P_open (true, lid)); collect_term t)
-             | FStar_Parser_AST.Bind (uu____3383, t1, t2) ->
+             | FStar_Parser_AST.Bind (uu___3, t1, t2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Seq (t1, t2) ->
                  (collect_term t1; collect_term t2)
@@ -1380,79 +1345,76 @@ let (collect_one :
              | FStar_Parser_AST.Record (t, idterms) ->
                  (FStar_Util.iter_opt t collect_term;
                   FStar_List.iter
-                    (fun uu____3479 ->
-                       match uu____3479 with
-                       | (uu____3484, t1) -> collect_term t1) idterms)
-             | FStar_Parser_AST.Project (t, uu____3487) -> collect_term t
+                    (fun uu___4 ->
+                       match uu___4 with | (uu___5, t1) -> collect_term t1)
+                    idterms)
+             | FStar_Parser_AST.Project (t, uu___3) -> collect_term t
              | FStar_Parser_AST.Product (binders, t) ->
                  (collect_binders binders; collect_term t)
              | FStar_Parser_AST.Sum (binders, t) ->
                  (FStar_List.iter
-                    (fun uu___10_3516 ->
-                       match uu___10_3516 with
+                    (fun uu___4 ->
+                       match uu___4 with
                        | FStar_Util.Inl b -> collect_binder b
                        | FStar_Util.Inr t1 -> collect_term t1) binders;
                   collect_term t)
-             | FStar_Parser_AST.QForall (binders, (uu____3524, ts), t) ->
+             | FStar_Parser_AST.QForall (binders, (uu___3, ts), t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
-             | FStar_Parser_AST.QExists (binders, (uu____3558, ts), t) ->
+             | FStar_Parser_AST.QExists (binders, (uu___3, ts), t) ->
                  (collect_binders binders;
                   FStar_List.iter (FStar_List.iter collect_term) ts;
                   collect_term t)
              | FStar_Parser_AST.Refine (binder, t) ->
                  (collect_binder binder; collect_term t)
-             | FStar_Parser_AST.NamedTyp (uu____3594, t) -> collect_term t
+             | FStar_Parser_AST.NamedTyp (uu___3, t) -> collect_term t
              | FStar_Parser_AST.Paren t -> collect_term t
-             | FStar_Parser_AST.Requires (t, uu____3598) -> collect_term t
-             | FStar_Parser_AST.Ensures (t, uu____3604) -> collect_term t
-             | FStar_Parser_AST.Labeled (t, uu____3610, uu____3611) ->
-                 collect_term t
-             | FStar_Parser_AST.Quote (t, uu____3613) -> collect_term t
+             | FStar_Parser_AST.Requires (t, uu___3) -> collect_term t
+             | FStar_Parser_AST.Ensures (t, uu___3) -> collect_term t
+             | FStar_Parser_AST.Labeled (t, uu___3, uu___4) -> collect_term t
+             | FStar_Parser_AST.Quote (t, uu___3) -> collect_term t
              | FStar_Parser_AST.Antiquote t -> collect_term t
              | FStar_Parser_AST.VQuote t -> collect_term t
              | FStar_Parser_AST.Attributes cattributes ->
                  FStar_List.iter collect_term cattributes
              | FStar_Parser_AST.CalcProof (rel, init, steps) ->
-                 ((let uu____3627 =
-                     let uu____3628 =
-                       let uu____3633 = FStar_Ident.lid_of_str "FStar.Calc" in
-                       (false, uu____3633) in
-                     P_dep uu____3628 in
-                   add_to_parsing_data uu____3627);
+                 ((let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_Ident.lid_of_str "FStar.Calc" in
+                       (false, uu___6) in
+                     P_dep uu___5 in
+                   add_to_parsing_data uu___4);
                   collect_term rel;
                   collect_term init;
                   FStar_List.iter
-                    (fun uu___11_3642 ->
-                       match uu___11_3642 with
+                    (fun uu___6 ->
+                       match uu___6 with
                        | FStar_Parser_AST.CalcStep (rel1, just, next) ->
                            (collect_term rel1;
                             collect_term just;
                             collect_term next)) steps)
            and collect_patterns ps = FStar_List.iter collect_pattern ps
            and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
-           and collect_pattern' uu___13_3652 =
-             match uu___13_3652 with
-             | FStar_Parser_AST.PatVar (uu____3653, aqual) ->
-                 collect_aqual aqual
-             | FStar_Parser_AST.PatTvar (uu____3659, aqual) ->
+           and collect_pattern' uu___2 =
+             match uu___2 with
+             | FStar_Parser_AST.PatVar (uu___3, aqual) -> collect_aqual aqual
+             | FStar_Parser_AST.PatTvar (uu___3, aqual) ->
                  collect_aqual aqual
              | FStar_Parser_AST.PatWild aqual -> collect_aqual aqual
-             | FStar_Parser_AST.PatOp uu____3668 -> ()
-             | FStar_Parser_AST.PatConst uu____3669 -> ()
+             | FStar_Parser_AST.PatOp uu___3 -> ()
+             | FStar_Parser_AST.PatConst uu___3 -> ()
              | FStar_Parser_AST.PatApp (p, ps) ->
                  (collect_pattern p; collect_patterns ps)
-             | FStar_Parser_AST.PatName uu____3677 -> ()
+             | FStar_Parser_AST.PatName uu___3 -> ()
              | FStar_Parser_AST.PatList ps -> collect_patterns ps
              | FStar_Parser_AST.PatOr ps -> collect_patterns ps
-             | FStar_Parser_AST.PatTuple (ps, uu____3685) ->
-                 collect_patterns ps
+             | FStar_Parser_AST.PatTuple (ps, uu___3) -> collect_patterns ps
              | FStar_Parser_AST.PatRecord lidpats ->
                  FStar_List.iter
-                   (fun uu____3704 ->
-                      match uu____3704 with
-                      | (uu____3709, p) -> collect_pattern p) lidpats
+                   (fun uu___3 ->
+                      match uu___3 with | (uu___4, p) -> collect_pattern p)
+                   lidpats
              | FStar_Parser_AST.PatAscribed
                  (p, (t, FStar_Pervasives_Native.None)) ->
                  (collect_pattern p; collect_term t)
@@ -1460,40 +1422,40 @@ let (collect_one :
                  (p, (t, FStar_Pervasives_Native.Some tac)) ->
                  (collect_pattern p; collect_term t; collect_term tac)
            and collect_branches bs = FStar_List.iter collect_branch bs
-           and collect_branch uu____3754 =
-             match uu____3754 with
+           and collect_branch uu___2 =
+             match uu___2 with
              | (pat, t1, t2) ->
                  (collect_pattern pat;
                   FStar_Util.iter_opt t1 collect_term;
                   collect_term t2) in
-           let uu____3772 = FStar_Parser_Driver.parse_file filename in
-           match uu____3772 with
-           | (ast, uu____3796) ->
+           let uu___2 = FStar_Parser_Driver.parse_file filename in
+           match uu___2 with
+           | (ast, uu___3) ->
                (collect_module ast;
                 (let pd1 =
-                   let uu____3811 =
-                     let uu____3814 = FStar_ST.op_Bang pd in
-                     FStar_List.rev uu____3814 in
-                   Mk_pd uu____3811 in
-                 let uu____3827 = from_parsing_data pd1 original_map filename in
-                 match uu____3827 with
+                   let uu___5 =
+                     let uu___6 = FStar_ST.op_Bang pd in
+                     FStar_List.rev uu___6 in
+                   Mk_pd uu___5 in
+                 let uu___5 = from_parsing_data pd1 original_map filename in
+                 match uu___5 with
                  | (deps1, has_inline_for_extraction, mo_roots) ->
                      (pd1, deps1, has_inline_for_extraction, mo_roots))))
 let (collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap FStar_ST.ref)
   =
-  let uu____3879 = FStar_Util.smap_create Prims.int_zero in
-  FStar_Util.mk_ref uu____3879
+  let uu___ = FStar_Util.smap_create Prims.int_zero in
+  FStar_Util.mk_ref uu___
 let (set_collect_one_cache :
   (dependence Prims.list * dependence Prims.list * Prims.bool)
     FStar_Util.smap -> unit)
   = fun cache -> FStar_ST.op_Colon_Equals collect_one_cache cache
 let (dep_graph_copy : dependence_graph -> dependence_graph) =
   fun dep_graph ->
-    let uu____3978 = dep_graph in
-    match uu____3978 with
-    | Deps g -> let uu____3982 = FStar_Util.smap_copy g in Deps uu____3982
+    let uu___ = dep_graph in
+    match uu___ with
+    | Deps g -> let uu___1 = FStar_Util.smap_copy g in Deps uu___1
 let (widen_deps :
   module_name Prims.list ->
     dependence_graph ->
@@ -1504,11 +1466,11 @@ let (widen_deps :
       fun file_system_map ->
         fun widened ->
           let widened1 = FStar_Util.mk_ref widened in
-          let uu____4016 = dep_graph in
-          match uu____4016 with
+          let uu___ = dep_graph in
+          match uu___ with
           | Deps dg ->
-              let uu____4024 = deps_empty () in
-              (match uu____4024 with
+              let uu___1 = deps_empty () in
+              (match uu___1 with
                | Deps dg' ->
                    let widen_one deps1 =
                      FStar_All.pipe_right deps1
@@ -1521,18 +1483,18 @@ let (widen_deps :
                                  ->
                                  (FStar_ST.op_Colon_Equals widened1 true;
                                   FriendImplementation m)
-                             | uu____4060 -> d)) in
+                             | uu___2 -> d)) in
                    (FStar_Util.smap_fold dg
                       (fun filename ->
                          fun dep_node1 ->
-                           fun uu____4068 ->
-                             let uu____4069 =
-                               let uu___992_4070 = dep_node1 in
-                               let uu____4071 = widen_one dep_node1.edges in
-                               { edges = uu____4071; color = White } in
-                             FStar_Util.smap_add dg' filename uu____4069) ();
-                    (let uu____4072 = FStar_ST.op_Bang widened1 in
-                     (uu____4072, (Deps dg')))))
+                           fun uu___3 ->
+                             let uu___4 =
+                               let uu___5 = dep_node1 in
+                               let uu___6 = widen_one dep_node1.edges in
+                               { edges = uu___6; color = White } in
+                             FStar_Util.smap_add dg' filename uu___4) ();
+                    (let uu___3 = FStar_ST.op_Bang widened1 in
+                     (uu___3, (Deps dg')))))
 let (topological_dependences_of' :
   files_for_module_name ->
     dependence_graph ->
@@ -1545,107 +1507,104 @@ let (topological_dependences_of' :
       fun interfaces_needing_inlining ->
         fun root_files ->
           fun widened ->
-            let rec all_friend_deps_1 dep_graph1 cycle uu____4198 filename =
-              match uu____4198 with
+            let rec all_friend_deps_1 dep_graph1 cycle uu___ filename =
+              match uu___ with
               | (all_friends, all_files) ->
                   let dep_node1 =
-                    let uu____4229 = deps_try_find dep_graph1 filename in
-                    FStar_Util.must uu____4229 in
+                    let uu___1 = deps_try_find dep_graph1 filename in
+                    FStar_Util.must uu___1 in
                   (match dep_node1.color with
                    | Gray ->
                        failwith
                          "Impossible: cycle detected after cycle detection has passed"
                    | Black -> (all_friends, all_files)
                    | White ->
-                       ((let uu____4253 =
+                       ((let uu___2 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep") in
-                         if uu____4253
+                         if uu___2
                          then
-                           let uu____4254 =
-                             let uu____4255 =
+                           let uu___3 =
+                             let uu___4 =
                                FStar_List.map dep_to_string dep_node1.edges in
-                             FStar_String.concat ", " uu____4255 in
+                             FStar_String.concat ", " uu___4 in
                            FStar_Util.print2
                              "Visiting %s: direct deps are %s\n" filename
-                             uu____4254
+                             uu___3
                          else ());
                         deps_add_dep dep_graph1 filename
-                          (let uu___1014_4261 = dep_node1 in
-                           { edges = (uu___1014_4261.edges); color = Gray });
-                        (let uu____4262 =
-                           let uu____4271 =
+                          (let uu___3 = dep_node1 in
+                           { edges = (uu___3.edges); color = Gray });
+                        (let uu___3 =
+                           let uu___4 =
                              dependences_of file_system_map dep_graph1
                                root_files filename in
                            all_friend_deps dep_graph1 cycle
-                             (all_friends, all_files) uu____4271 in
-                         match uu____4262 with
+                             (all_friends, all_files) uu___4 in
+                         match uu___3 with
                          | (all_friends1, all_files1) ->
                              (deps_add_dep dep_graph1 filename
-                                (let uu___1020_4298 = dep_node1 in
-                                 {
-                                   edges = (uu___1020_4298.edges);
-                                   color = Black
-                                 });
-                              (let uu____4300 =
+                                (let uu___5 = dep_node1 in
+                                 { edges = (uu___5.edges); color = Black });
+                              (let uu___6 =
                                  FStar_Options.debug_at_level_no_module
                                    (FStar_Options.Other "Dep") in
-                               if uu____4300
+                               if uu___6
                                then FStar_Util.print1 "Adding %s\n" filename
                                else ());
-                              (let uu____4302 =
-                                 let uu____4305 =
+                              (let uu___6 =
+                                 let uu___7 =
                                    FStar_List.collect
-                                     (fun uu___14_4310 ->
-                                        match uu___14_4310 with
+                                     (fun uu___8 ->
+                                        match uu___8 with
                                         | FriendImplementation m -> [m]
                                         | d -> []) dep_node1.edges in
-                                 FStar_List.append uu____4305 all_friends1 in
-                               (uu____4302, (filename :: all_files1)))))))
+                                 FStar_List.append uu___7 all_friends1 in
+                               (uu___6, (filename :: all_files1)))))))
             and all_friend_deps dep_graph1 cycle all_friends filenames =
               FStar_List.fold_left
                 (fun all_friends1 ->
                    fun k ->
                      all_friend_deps_1 dep_graph1 (k :: cycle) all_friends1 k)
                 all_friends filenames in
-            let uu____4355 = all_friend_deps dep_graph [] ([], []) root_files in
-            match uu____4355 with
+            let uu___ = all_friend_deps dep_graph [] ([], []) root_files in
+            match uu___ with
             | (friends, all_files_0) ->
-                ((let uu____4385 =
+                ((let uu___2 =
                     FStar_Options.debug_at_level_no_module
                       (FStar_Options.Other "Dep") in
-                  if uu____4385
+                  if uu___2
                   then
-                    let uu____4386 =
-                      let uu____4387 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Util.remove_dups (fun x -> fun y -> x = y)
                           friends in
-                      FStar_String.concat ", " uu____4387 in
+                      FStar_String.concat ", " uu___4 in
                     FStar_Util.print3
                       "Phase1 complete:\n\tall_files = %s\n\tall_friends=%s\n\tinterfaces_with_inlining=%s\n"
-                      (FStar_String.concat ", " all_files_0) uu____4386
+                      (FStar_String.concat ", " all_files_0) uu___3
                       (FStar_String.concat ", " interfaces_needing_inlining)
                   else ());
-                 (let uu____4395 =
+                 (let uu___2 =
                     widen_deps friends dep_graph file_system_map widened in
-                  match uu____4395 with
+                  match uu___2 with
                   | (widened1, dep_graph1) ->
-                      let uu____4408 =
-                        (let uu____4418 =
+                      let uu___3 =
+                        (let uu___5 =
                            FStar_Options.debug_at_level_no_module
                              (FStar_Options.Other "Dep") in
-                         if uu____4418
+                         if uu___5
                          then
                            FStar_Util.print_string
                              "==============Phase2==================\n"
                          else ());
                         all_friend_deps dep_graph1 [] ([], []) root_files in
-                      (match uu____4408 with
-                       | (uu____4430, all_files) ->
-                           ((let uu____4441 =
+                      (match uu___3 with
+                       | (uu___4, all_files) ->
+                           ((let uu___6 =
                                FStar_Options.debug_at_level_no_module
                                  (FStar_Options.Other "Dep") in
-                             if uu____4441
+                             if uu___6
                              then
                                FStar_Util.print1
                                  "Phase2 complete: all_files = %s\n"
@@ -1661,17 +1620,17 @@ let (phase1 :
     fun dep_graph ->
       fun interfaces_needing_inlining ->
         fun for_extraction ->
-          (let uu____4474 =
+          (let uu___1 =
              FStar_Options.debug_at_level_no_module
                (FStar_Options.Other "Dep") in
-           if uu____4474
+           if uu___1
            then
              FStar_Util.print_string
                "==============Phase1==================\n"
            else ());
           (let widened = false in
-           let uu____4477 = (FStar_Options.cmi ()) && for_extraction in
-           if uu____4477
+           let uu___1 = (FStar_Options.cmi ()) && for_extraction in
+           if uu___1
            then
              widen_deps interfaces_needing_inlining dep_graph file_system_map
                widened
@@ -1688,10 +1647,10 @@ let (topological_dependences_of :
       fun interfaces_needing_inlining ->
         fun root_files ->
           fun for_extraction ->
-            let uu____4528 =
+            let uu___ =
               phase1 file_system_map dep_graph interfaces_needing_inlining
                 for_extraction in
-            match uu____4528 with
+            match uu___ with
             | (widened, dep_graph1) ->
                 topological_dependences_of' file_system_map dep_graph1
                   interfaces_needing_inlining root_files widened
@@ -1706,47 +1665,47 @@ let (collect :
         FStar_All.pipe_right all_cmd_line_files
           (FStar_List.map
              (fun fn ->
-                let uu____4587 = FStar_Options.find_file fn in
-                match uu____4587 with
+                let uu___ = FStar_Options.find_file fn in
+                match uu___ with
                 | FStar_Pervasives_Native.None ->
-                    let uu____4590 =
-                      let uu____4595 =
+                    let uu___1 =
+                      let uu___2 =
                         FStar_Util.format1 "File %s could not be found\n" fn in
-                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____4595) in
-                    FStar_Errors.raise_err uu____4590
+                      (FStar_Errors.Fatal_ModuleOrFileNotFound, uu___2) in
+                    FStar_Errors.raise_err uu___1
                 | FStar_Pervasives_Native.Some fn1 -> fn1)) in
       let dep_graph = deps_empty () in
       let file_system_map = build_map all_cmd_line_files1 in
       let interfaces_needing_inlining = FStar_Util.mk_ref [] in
       let add_interface_for_inlining l =
         let l1 = lowercase_module_name l in
-        let uu____4613 =
-          let uu____4616 = FStar_ST.op_Bang interfaces_needing_inlining in l1
-            :: uu____4616 in
-        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu____4613 in
+        let uu___ =
+          let uu___1 = FStar_ST.op_Bang interfaces_needing_inlining in l1 ::
+            uu___1 in
+        FStar_ST.op_Colon_Equals interfaces_needing_inlining uu___ in
       let parse_results = FStar_Util.smap_create (Prims.of_int (40)) in
       let rec discover_one file_name1 =
-        let uu____4648 =
-          let uu____4649 = deps_try_find dep_graph file_name1 in
-          uu____4649 = FStar_Pervasives_Native.None in
-        if uu____4648
+        let uu___ =
+          let uu___1 = deps_try_find dep_graph file_name1 in
+          uu___1 = FStar_Pervasives_Native.None in
+        if uu___
         then
-          let uu____4654 =
-            let uu____4669 =
-              let uu____4682 = FStar_ST.op_Bang collect_one_cache in
-              FStar_Util.smap_try_find uu____4682 file_name1 in
-            match uu____4669 with
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_ST.op_Bang collect_one_cache in
+              FStar_Util.smap_try_find uu___3 file_name1 in
+            match uu___2 with
             | FStar_Pervasives_Native.Some cached -> ((Mk_pd []), cached)
             | FStar_Pervasives_Native.None ->
-                let uu____4790 =
+                let uu___3 =
                   collect_one file_system_map file_name1
                     get_parsing_data_from_cache in
-                (match uu____4790 with
+                (match uu___3 with
                  | (parsing_data1, deps1, needs_interface_inlining,
                     additional_roots) ->
                      (parsing_data1,
                        (deps1, additional_roots, needs_interface_inlining))) in
-          match uu____4654 with
+          match uu___1 with
           | (parsing_data1, (deps1, mo_roots, needs_interface_inlining)) ->
               (if needs_interface_inlining
                then add_interface_for_inlining file_name1
@@ -1754,24 +1713,24 @@ let (collect :
                FStar_Util.smap_add parse_results file_name1 parsing_data1;
                (let deps2 =
                   let module_name1 = lowercase_module_name file_name1 in
-                  let uu____4872 =
+                  let uu___4 =
                     (is_implementation file_name1) &&
                       (has_interface file_system_map module_name1) in
-                  if uu____4872
+                  if uu___4
                   then FStar_List.append deps1 [UseInterface module_name1]
                   else deps1 in
                 let dep_node1 =
-                  let uu____4877 = FStar_List.unique deps2 in
-                  { edges = uu____4877; color = White } in
+                  let uu___4 = FStar_List.unique deps2 in
+                  { edges = uu___4; color = White } in
                 deps_add_dep dep_graph file_name1 dep_node1;
-                (let uu____4879 =
+                (let uu___5 =
                    FStar_List.map
                      (file_of_dep file_system_map all_cmd_line_files1)
                      (FStar_List.append deps2 mo_roots) in
-                 FStar_List.iter discover_one uu____4879)))
+                 FStar_List.iter discover_one uu___5)))
         else () in
       profile
-        (fun uu____4885 -> FStar_List.iter discover_one all_cmd_line_files1)
+        (fun uu___1 -> FStar_List.iter discover_one all_cmd_line_files1)
         "FStar.Parser.Dep.discover";
       (let cycle_detected dep_graph1 cycle filename =
          FStar_Util.print1
@@ -1779,82 +1738,81 @@ let (collect :
            (FStar_String.concat "\n`used by` " cycle);
          print_graph dep_graph1;
          FStar_Util.print_string "\n";
-         (let uu____4909 =
-            let uu____4914 =
+         (let uu___4 =
+            let uu___5 =
               FStar_Util.format1 "Recursive dependency on module %s\n"
                 filename in
-            (FStar_Errors.Fatal_CyclicDependence, uu____4914) in
-          FStar_Errors.raise_err uu____4909) in
+            (FStar_Errors.Fatal_CyclicDependence, uu___5) in
+          FStar_Errors.raise_err uu___4) in
        let full_cycle_detection all_command_line_files file_system_map1 =
          let dep_graph1 = dep_graph_copy dep_graph in
          let mo_files = FStar_Util.mk_ref [] in
          let rec aux cycle filename =
            let node =
-             let uu____4954 = deps_try_find dep_graph1 filename in
-             match uu____4954 with
-             | FStar_Pervasives_Native.Some node -> node
+             let uu___1 = deps_try_find dep_graph1 filename in
+             match uu___1 with
+             | FStar_Pervasives_Native.Some node1 -> node1
              | FStar_Pervasives_Native.None ->
-                 let uu____4958 =
+                 let uu___2 =
                    FStar_Util.format1
                      "Impossible: Failed to find dependencies of %s" filename in
-                 failwith uu____4958 in
+                 failwith uu___2 in
            let direct_deps =
              FStar_All.pipe_right node.edges
                (FStar_List.collect
                   (fun x ->
                      match x with
                      | UseInterface f ->
-                         let uu____4969 =
+                         let uu___1 =
                            implementation_of_internal file_system_map1 f in
-                         (match uu____4969 with
+                         (match uu___1 with
                           | FStar_Pervasives_Native.None -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____4975 -> [x; UseImplementation f])
+                          | uu___2 -> [x; UseImplementation f])
                      | PreferInterface f ->
-                         let uu____4979 =
+                         let uu___1 =
                            implementation_of_internal file_system_map1 f in
-                         (match uu____4979 with
+                         (match uu___1 with
                           | FStar_Pervasives_Native.None -> [x]
                           | FStar_Pervasives_Native.Some fn when
                               fn = filename -> [x]
-                          | uu____4985 -> [x; UseImplementation f])
-                     | uu____4988 -> [x])) in
+                          | uu___2 -> [x; UseImplementation f])
+                     | uu___1 -> [x])) in
            match node.color with
            | Gray -> cycle_detected dep_graph1 cycle filename
            | Black -> ()
            | White ->
                (deps_add_dep dep_graph1 filename
-                  (let uu___1141_4991 = node in
-                   { edges = direct_deps; color = Gray });
-                (let uu____4993 =
+                  (let uu___2 = node in { edges = direct_deps; color = Gray });
+                (let uu___3 =
                    dependences_of file_system_map1 dep_graph1
                      all_command_line_files filename in
-                 FStar_List.iter (fun k -> aux (k :: cycle) k) uu____4993);
+                 FStar_List.iter (fun k -> aux (k :: cycle) k) uu___3);
                 deps_add_dep dep_graph1 filename
-                  (let uu___1146_5000 = node in
+                  (let uu___4 = node in
                    { edges = direct_deps; color = Black });
-                (let uu____5001 = is_interface filename in
-                 if uu____5001
+                (let uu___4 = is_interface filename in
+                 if uu___4
                  then
-                   let uu____5002 =
-                     let uu____5005 = lowercase_module_name filename in
-                     implementation_of_internal file_system_map1 uu____5005 in
-                   FStar_Util.iter_opt uu____5002
+                   let uu___5 =
+                     let uu___6 = lowercase_module_name filename in
+                     implementation_of_internal file_system_map1 uu___6 in
+                   FStar_Util.iter_opt uu___5
                      (fun impl ->
                         if
                           Prims.op_Negation
                             (FStar_List.contains impl all_command_line_files)
                         then
-                          let uu____5009 =
-                            let uu____5012 = FStar_ST.op_Bang mo_files in
-                            impl :: uu____5012 in
-                          FStar_ST.op_Colon_Equals mo_files uu____5009
+                          let uu___6 =
+                            let uu___7 = FStar_ST.op_Bang mo_files in impl ::
+                              uu___7 in
+                          FStar_ST.op_Colon_Equals mo_files uu___6
                         else ())
                  else ())) in
          FStar_List.iter (aux []) all_command_line_files;
-         (let uu____5038 = FStar_ST.op_Bang mo_files in
-          FStar_List.iter (aux []) uu____5038) in
+         (let uu___2 = FStar_ST.op_Bang mo_files in
+          FStar_List.iter (aux []) uu___2) in
        full_cycle_detection all_cmd_line_files1 file_system_map;
        FStar_All.pipe_right all_cmd_line_files1
          (FStar_List.iter
@@ -1862,21 +1820,21 @@ let (collect :
                let m = lowercase_module_name f in
                FStar_Options.add_verify_module m));
        (let inlining_ifaces = FStar_ST.op_Bang interfaces_needing_inlining in
-        let uu____5072 =
+        let uu___3 =
           profile
-            (fun uu____5087 ->
-               let uu____5088 =
-                 let uu____5089 = FStar_Options.codegen () in
-                 uu____5089 <> FStar_Pervasives_Native.None in
+            (fun uu___4 ->
+               let uu___5 =
+                 let uu___6 = FStar_Options.codegen () in
+                 uu___6 <> FStar_Pervasives_Native.None in
                topological_dependences_of file_system_map dep_graph
-                 inlining_ifaces all_cmd_line_files1 uu____5088)
+                 inlining_ifaces all_cmd_line_files1 uu___5)
             "FStar.Parser.Dep.topological_dependences_of" in
-        match uu____5072 with
-        | (all_files, uu____5101) ->
-            ((let uu____5107 =
+        match uu___3 with
+        | (all_files, uu___4) ->
+            ((let uu___6 =
                 FStar_Options.debug_at_level_no_module
                   (FStar_Options.Other "Dep") in
-              if uu____5107
+              if uu___6
               then
                 FStar_Util.print1 "Interfaces needing inlining: %s\n"
                   (FStar_String.concat ", " inlining_ifaces)
@@ -1892,15 +1850,15 @@ let (deps_of : deps -> Prims.string -> Prims.string Prims.list) =
 let (print_digest : (Prims.string * Prims.string) Prims.list -> Prims.string)
   =
   fun dig ->
-    let uu____5142 =
+    let uu___ =
       FStar_All.pipe_right dig
         (FStar_List.map
-           (fun uu____5161 ->
-              match uu____5161 with
+           (fun uu___1 ->
+              match uu___1 with
               | (m, d) ->
-                  let uu____5168 = FStar_Util.base64_encode d in
-                  FStar_Util.format2 "%s:%s" m uu____5168)) in
-    FStar_All.pipe_right uu____5142 (FStar_String.concat "\n")
+                  let uu___2 = FStar_Util.base64_encode d in
+                  FStar_Util.format2 "%s:%s" m uu___2)) in
+    FStar_All.pipe_right uu___ (FStar_String.concat "\n")
 let (print_make : deps -> unit) =
   fun deps1 ->
     let file_system_map = deps1.file_system_map in
@@ -1911,8 +1869,8 @@ let (print_make : deps -> unit) =
       (FStar_List.iter
          (fun f ->
             let dep_node1 =
-              let uu____5192 = deps_try_find deps2 f in
-              FStar_All.pipe_right uu____5192 FStar_Option.get in
+              let uu___ = deps_try_find deps2 f in
+              FStar_All.pipe_right uu___ FStar_Option.get in
             let files =
               FStar_List.map (file_of_dep file_system_map all_cmd_line_files)
                 dep_node1.edges in
@@ -1922,25 +1880,25 @@ let (print_make : deps -> unit) =
             FStar_Util.print2 "%s: %s\n\n" f (FStar_String.concat " " files1)))
 let (print_raw : deps -> unit) =
   fun deps1 ->
-    let uu____5210 = deps1.dep_graph in
-    match uu____5210 with
+    let uu___ = deps1.dep_graph in
+    match uu___ with
     | Deps deps2 ->
-        let uu____5214 =
-          let uu____5215 =
+        let uu___1 =
+          let uu___2 =
             FStar_Util.smap_fold deps2
               (fun k ->
                  fun dep_node1 ->
                    fun out ->
-                     let uu____5229 =
-                       let uu____5230 =
-                         let uu____5231 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_List.map dep_to_string dep_node1.edges in
-                         FStar_All.pipe_right uu____5231
+                         FStar_All.pipe_right uu___5
                            (FStar_String.concat ";\n\t") in
-                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu____5230 in
-                     uu____5229 :: out) [] in
-          FStar_All.pipe_right uu____5215 (FStar_String.concat ";;\n") in
-        FStar_All.pipe_right uu____5214 FStar_Util.print_endline
+                       FStar_Util.format2 "%s -> [\n\t%s\n] " k uu___4 in
+                     uu___3 :: out) [] in
+          FStar_All.pipe_right uu___2 (FStar_String.concat ";;\n") in
+        FStar_All.pipe_right uu___1 FStar_Util.print_endline
 let (print_full : deps -> unit) =
   fun deps1 ->
     let sort_output_files orig_output_file_map =
@@ -1948,12 +1906,12 @@ let (print_full : deps -> unit) =
       let remaining_output_files = FStar_Util.smap_copy orig_output_file_map in
       let visited_other_modules = FStar_Util.smap_create (Prims.of_int (41)) in
       let should_visit lc_module_name =
-        (let uu____5276 =
+        (let uu___ =
            FStar_Util.smap_try_find remaining_output_files lc_module_name in
-         FStar_Option.isSome uu____5276) ||
-          (let uu____5280 =
+         FStar_Option.isSome uu___) ||
+          (let uu___ =
              FStar_Util.smap_try_find visited_other_modules lc_module_name in
-           FStar_Option.isNone uu____5280) in
+           FStar_Option.isNone uu___) in
       let mark_visiting lc_module_name =
         let ml_file_opt =
           FStar_Util.smap_try_find remaining_output_files lc_module_name in
@@ -1964,129 +1922,123 @@ let (print_full : deps -> unit) =
         match ml_file_opt with
         | FStar_Pervasives_Native.None -> ()
         | FStar_Pervasives_Native.Some ml_file ->
-            let uu____5307 =
-              let uu____5310 = FStar_ST.op_Bang order in ml_file ::
-                uu____5310 in
-            FStar_ST.op_Colon_Equals order uu____5307 in
-      let rec aux uu___15_5340 =
-        match uu___15_5340 with
+            let uu___ =
+              let uu___1 = FStar_ST.op_Bang order in ml_file :: uu___1 in
+            FStar_ST.op_Colon_Equals order uu___ in
+      let rec aux uu___ =
+        match uu___ with
         | [] -> ()
         | lc_module_name::modules_to_extract ->
             let visit_file file_opt =
               match file_opt with
               | FStar_Pervasives_Native.None -> ()
               | FStar_Pervasives_Native.Some file_name1 ->
-                  let uu____5358 = deps_try_find deps1.dep_graph file_name1 in
-                  (match uu____5358 with
+                  let uu___1 = deps_try_find deps1.dep_graph file_name1 in
+                  (match uu___1 with
                    | FStar_Pervasives_Native.None ->
-                       let uu____5361 =
+                       let uu___2 =
                          FStar_Util.format2
                            "Impossible: module %s: %s not found"
                            lc_module_name file_name1 in
-                       failwith uu____5361
+                       failwith uu___2
                    | FStar_Pervasives_Native.Some
-                       { edges = immediate_deps; color = uu____5363;_} ->
+                       { edges = immediate_deps; color = uu___2;_} ->
                        let immediate_deps1 =
                          FStar_List.map
                            (fun x ->
                               FStar_String.lowercase (module_name_of_dep x))
                            immediate_deps in
                        aux immediate_deps1) in
-            ((let uu____5370 = should_visit lc_module_name in
-              if uu____5370
+            ((let uu___2 = should_visit lc_module_name in
+              if uu___2
               then
                 let ml_file_opt = mark_visiting lc_module_name in
-                ((let uu____5375 = implementation_of deps1 lc_module_name in
-                  visit_file uu____5375);
-                 (let uu____5379 = interface_of deps1 lc_module_name in
-                  visit_file uu____5379);
+                ((let uu___4 = implementation_of deps1 lc_module_name in
+                  visit_file uu___4);
+                 (let uu___5 = interface_of deps1 lc_module_name in
+                  visit_file uu___5);
                  emit_output_file_opt ml_file_opt)
               else ());
              aux modules_to_extract) in
       let all_extracted_modules = FStar_Util.smap_keys orig_output_file_map in
       aux all_extracted_modules;
-      (let uu____5387 = FStar_ST.op_Bang order in FStar_List.rev uu____5387) in
+      (let uu___1 = FStar_ST.op_Bang order in FStar_List.rev uu___1) in
     let sb =
-      let uu____5401 = FStar_BigInt.of_int_fs (Prims.of_int (10000)) in
-      FStar_StringBuffer.create uu____5401 in
+      let uu___ = FStar_BigInt.of_int_fs (Prims.of_int (10000)) in
+      FStar_StringBuffer.create uu___ in
     let pr str =
-      let uu____5408 = FStar_StringBuffer.add str sb in
-      FStar_All.pipe_left (fun uu____5409 -> ()) uu____5408 in
+      let uu___ = FStar_StringBuffer.add str sb in
+      FStar_All.pipe_left (fun uu___1 -> ()) uu___ in
     let print_entry target first_dep all_deps =
       pr target; pr ": "; pr first_dep; pr "\\\n\t"; pr all_deps; pr "\n\n" in
     let keys = deps_keys deps1.dep_graph in
     let output_file ext fst_file =
       let ml_base_name =
-        let uu____5446 =
-          let uu____5447 =
-            let uu____5450 = FStar_Util.basename fst_file in
-            check_and_strip_suffix uu____5450 in
-          FStar_Option.get uu____5447 in
-        FStar_Util.replace_chars uu____5446 46 "_" in
-      let uu____5451 = FStar_String.op_Hat ml_base_name ext in
-      FStar_Options.prepend_output_dir uu____5451 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Util.basename fst_file in
+            check_and_strip_suffix uu___2 in
+          FStar_Option.get uu___1 in
+        FStar_Util.replace_chars uu___ 46 "_" in
+      let uu___ = FStar_String.op_Hat ml_base_name ext in
+      FStar_Options.prepend_output_dir uu___ in
     let norm_path s =
       FStar_Util.replace_chars (FStar_Util.replace_chars s 92 "/") 32 "\\ " in
-    let output_ml_file f =
-      let uu____5464 = output_file ".ml" f in norm_path uu____5464 in
+    let output_ml_file f = let uu___ = output_file ".ml" f in norm_path uu___ in
     let output_krml_file f =
-      let uu____5471 = output_file ".krml" f in norm_path uu____5471 in
+      let uu___ = output_file ".krml" f in norm_path uu___ in
     let output_cmx_file f =
-      let uu____5478 = output_file ".cmx" f in norm_path uu____5478 in
-    let cache_file f =
-      let uu____5485 = cache_file_name f in norm_path uu____5485 in
-    let uu____5486 =
+      let uu___ = output_file ".cmx" f in norm_path uu___ in
+    let cache_file f = let uu___ = cache_file_name f in norm_path uu___ in
+    let uu___ =
       phase1 deps1.file_system_map deps1.dep_graph
         deps1.interfaces_with_inlining true in
-    match uu____5486 with
+    match uu___ with
     | (widened, dep_graph) ->
         let all_checked_files =
           FStar_All.pipe_right keys
             (FStar_List.fold_left
-               (fun all_checked_files ->
+               (fun all_checked_files1 ->
                   fun file_name1 ->
-                    let process_one_key uu____5516 =
+                    let process_one_key uu___1 =
                       let dep_node1 =
-                        let uu____5518 =
-                          deps_try_find deps1.dep_graph file_name1 in
-                        FStar_All.pipe_right uu____5518 FStar_Option.get in
-                      let uu____5523 =
-                        let uu____5534 = is_interface file_name1 in
-                        if uu____5534
+                        let uu___2 = deps_try_find deps1.dep_graph file_name1 in
+                        FStar_All.pipe_right uu___2 FStar_Option.get in
+                      let uu___2 =
+                        let uu___3 = is_interface file_name1 in
+                        if uu___3
                         then
                           (FStar_Pervasives_Native.None,
                             FStar_Pervasives_Native.None)
                         else
-                          (let uu____5554 =
-                             let uu____5557 =
-                               lowercase_module_name file_name1 in
-                             interface_of deps1 uu____5557 in
-                           match uu____5554 with
+                          (let uu___5 =
+                             let uu___6 = lowercase_module_name file_name1 in
+                             interface_of deps1 uu___6 in
+                           match uu___5 with
                            | FStar_Pervasives_Native.None ->
                                (FStar_Pervasives_Native.None,
                                  FStar_Pervasives_Native.None)
                            | FStar_Pervasives_Native.Some iface ->
-                               let uu____5577 =
-                                 let uu____5582 =
-                                   let uu____5585 =
-                                     let uu____5586 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        deps_try_find deps1.dep_graph iface in
-                                     FStar_Option.get uu____5586 in
-                                   uu____5585.edges in
-                                 FStar_Pervasives_Native.Some uu____5582 in
-                               ((FStar_Pervasives_Native.Some iface),
-                                 uu____5577)) in
-                      match uu____5523 with
+                                     FStar_Option.get uu___9 in
+                                   uu___8.edges in
+                                 FStar_Pervasives_Native.Some uu___7 in
+                               ((FStar_Pervasives_Native.Some iface), uu___6)) in
+                      match uu___2 with
                       | (iface_fn, iface_deps) ->
                           let iface_deps1 =
                             FStar_Util.map_opt iface_deps
                               (FStar_List.filter
                                  (fun iface_dep ->
-                                    let uu____5625 =
+                                    let uu___3 =
                                       FStar_Util.for_some
                                         (dep_subsumed_by iface_dep)
                                         dep_node1.edges in
-                                    Prims.op_Negation uu____5625)) in
+                                    Prims.op_Negation uu___3)) in
                           let norm_f = norm_path file_name1 in
                           let files =
                             FStar_List.map
@@ -2105,49 +2057,47 @@ let (print_full : deps -> unit) =
                                   (fun x -> fun y -> x = y)
                                   (FStar_List.append files iface_files) in
                           let files2 =
-                            let uu____5652 =
+                            let uu___3 =
                               FStar_All.pipe_right iface_fn
                                 FStar_Util.is_some in
-                            if uu____5652
+                            if uu___3
                             then
                               let iface_fn1 =
                                 FStar_All.pipe_right iface_fn FStar_Util.must in
-                              let uu____5660 =
+                              let uu___4 =
                                 FStar_All.pipe_right files1
                                   (FStar_List.filter
                                      (fun f -> f <> iface_fn1)) in
-                              FStar_All.pipe_right uu____5660
-                                (fun files2 ->
-                                   let uu____5678 = cache_file_name iface_fn1 in
-                                   uu____5678 :: files2)
+                              FStar_All.pipe_right uu___4
+                                (fun files3 ->
+                                   let uu___5 = cache_file_name iface_fn1 in
+                                   uu___5 :: files3)
                             else files1 in
                           let files3 = FStar_List.map norm_path files2 in
                           let files4 = FStar_String.concat "\\\n\t" files3 in
                           let cache_file_name1 = cache_file file_name1 in
-                          let all_checked_files1 =
-                            let uu____5688 =
-                              let uu____5689 =
-                                let uu____5690 =
-                                  module_name_of_file file_name1 in
-                                FStar_Options.should_be_already_cached
-                                  uu____5690 in
-                              Prims.op_Negation uu____5689 in
-                            if uu____5688
+                          let all_checked_files2 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 = module_name_of_file file_name1 in
+                                FStar_Options.should_be_already_cached uu___5 in
+                              Prims.op_Negation uu___4 in
+                            if uu___3
                             then
                               (print_entry cache_file_name1 norm_f files4;
                                cache_file_name1
                                ::
-                               all_checked_files)
-                            else all_checked_files in
-                          let uu____5695 =
-                            let uu____5702 = FStar_Options.cmi () in
-                            if uu____5702
+                               all_checked_files1)
+                            else all_checked_files1 in
+                          let uu___3 =
+                            let uu___4 = FStar_Options.cmi () in
+                            if uu___4
                             then
                               profile
-                                (fun uu____5717 ->
-                                   let uu____5718 = dep_graph_copy dep_graph in
+                                (fun uu___5 ->
+                                   let uu___6 = dep_graph_copy dep_graph in
                                    topological_dependences_of'
-                                     deps1.file_system_map uu____5718
+                                     deps1.file_system_map uu___6
                                      deps1.interfaces_with_inlining
                                      [file_name1] widened)
                                 "FStar.Parser.Dep.topological_dependences_of_2"
@@ -2165,13 +2115,13 @@ let (print_full : deps -> unit) =
                                  | FStar_Pervasives_Native.None -> []
                                  | FStar_Pervasives_Native.Some iface_deps2
                                      -> maybe_widen_deps iface_deps2 in
-                               let uu____5745 =
+                               let uu___6 =
                                  FStar_Util.remove_dups
                                    (fun x -> fun y -> x = y)
                                    (FStar_List.append fst_files
                                       fst_files_from_iface) in
-                               (uu____5745, false)) in
-                          (match uu____5695 with
+                               (uu___6, false)) in
+                          (match uu___3 with
                            | (all_fst_files_dep, widened1) ->
                                let all_checked_fst_dep_files =
                                  FStar_All.pipe_right all_fst_files_dep
@@ -2179,110 +2129,102 @@ let (print_full : deps -> unit) =
                                let all_checked_fst_dep_files_string =
                                  FStar_String.concat " \\\n\t"
                                    all_checked_fst_dep_files in
-                               ((let uu____5771 =
-                                   is_implementation file_name1 in
-                                 if uu____5771
+                               ((let uu___5 = is_implementation file_name1 in
+                                 if uu___5
                                  then
-                                   ((let uu____5773 =
+                                   ((let uu___7 =
                                        (FStar_Options.cmi ()) && widened1 in
-                                     if uu____5773
+                                     if uu___7
                                      then
-                                       ((let uu____5775 =
+                                       ((let uu___9 =
                                            output_ml_file file_name1 in
-                                         print_entry uu____5775
-                                           cache_file_name1
+                                         print_entry uu___9 cache_file_name1
                                            all_checked_fst_dep_files_string);
-                                        (let uu____5776 =
+                                        (let uu___9 =
                                            output_krml_file file_name1 in
-                                         print_entry uu____5776
-                                           cache_file_name1
+                                         print_entry uu___9 cache_file_name1
                                            all_checked_fst_dep_files_string))
                                      else
-                                       ((let uu____5779 =
+                                       ((let uu___10 =
                                            output_ml_file file_name1 in
-                                         print_entry uu____5779
-                                           cache_file_name1 "");
-                                        (let uu____5780 =
+                                         print_entry uu___10 cache_file_name1
+                                           "");
+                                        (let uu___10 =
                                            output_krml_file file_name1 in
-                                         print_entry uu____5780
-                                           cache_file_name1 "")));
+                                         print_entry uu___10 cache_file_name1
+                                           "")));
                                     (let cmx_files =
                                        let extracted_fst_files =
                                          FStar_All.pipe_right
                                            all_fst_files_dep
                                            (FStar_List.filter
                                               (fun df ->
-                                                 (let uu____5797 =
+                                                 (let uu___7 =
                                                     lowercase_module_name df in
-                                                  let uu____5798 =
+                                                  let uu___8 =
                                                     lowercase_module_name
                                                       file_name1 in
-                                                  uu____5797 <> uu____5798)
-                                                   &&
-                                                   (let uu____5800 =
+                                                  uu___7 <> uu___8) &&
+                                                   (let uu___7 =
                                                       lowercase_module_name
                                                         df in
                                                     FStar_Options.should_extract
-                                                      uu____5800))) in
+                                                      uu___7))) in
                                        FStar_All.pipe_right
                                          extracted_fst_files
                                          (FStar_List.map output_cmx_file) in
-                                     let uu____5805 =
-                                       let uu____5806 =
+                                     let uu___7 =
+                                       let uu___8 =
                                          lowercase_module_name file_name1 in
-                                       FStar_Options.should_extract
-                                         uu____5806 in
-                                     if uu____5805
+                                       FStar_Options.should_extract uu___8 in
+                                     if uu___7
                                      then
                                        let cmx_files1 =
                                          FStar_String.concat "\\\n\t"
                                            cmx_files in
-                                       let uu____5808 =
+                                       let uu___8 =
                                          output_cmx_file file_name1 in
-                                       let uu____5809 =
-                                         output_ml_file file_name1 in
-                                       print_entry uu____5808 uu____5809
-                                         cmx_files1
+                                       let uu___9 = output_ml_file file_name1 in
+                                       print_entry uu___8 uu___9 cmx_files1
                                      else ()))
                                  else
-                                   (let uu____5812 =
-                                      (let uu____5815 =
-                                         let uu____5816 =
+                                   (let uu___7 =
+                                      (let uu___8 =
+                                         let uu___9 =
                                            lowercase_module_name file_name1 in
                                          has_implementation
-                                           deps1.file_system_map uu____5816 in
-                                       Prims.op_Negation uu____5815) &&
+                                           deps1.file_system_map uu___9 in
+                                       Prims.op_Negation uu___8) &&
                                         (is_interface file_name1) in
-                                    if uu____5812
+                                    if uu___7
                                     then
-                                      let uu____5817 =
+                                      let uu___8 =
                                         (FStar_Options.cmi ()) &&
                                           (widened1 || true) in
-                                      (if uu____5817
+                                      (if uu___8
                                        then
-                                         let uu____5818 =
+                                         let uu___9 =
                                            output_krml_file file_name1 in
-                                         print_entry uu____5818
-                                           cache_file_name1
+                                         print_entry uu___9 cache_file_name1
                                            all_checked_fst_dep_files_string
                                        else
-                                         (let uu____5820 =
+                                         (let uu___10 =
                                             output_krml_file file_name1 in
-                                          print_entry uu____5820
+                                          print_entry uu___10
                                             cache_file_name1 ""))
                                     else ()));
-                                all_checked_files1)) in
+                                all_checked_files2)) in
                     profile process_one_key
                       "FStar.Parser.Dep.process_one_key") []) in
         let all_fst_files =
-          let uu____5827 =
+          let uu___1 =
             FStar_All.pipe_right keys (FStar_List.filter is_implementation) in
-          FStar_All.pipe_right uu____5827
+          FStar_All.pipe_right uu___1
             (FStar_Util.sort_with FStar_String.compare) in
         let all_fsti_files =
-          let uu____5841 =
+          let uu___1 =
             FStar_All.pipe_right keys (FStar_List.filter is_interface) in
-          FStar_All.pipe_right uu____5841
+          FStar_All.pipe_right uu___1
             (FStar_Util.sort_with FStar_String.compare) in
         let all_ml_files =
           let ml_file_map = FStar_Util.smap_create (Prims.of_int (41)) in
@@ -2290,11 +2232,11 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file ->
                   let mname = lowercase_module_name fst_file in
-                  let uu____5867 = FStar_Options.should_extract mname in
-                  if uu____5867
+                  let uu___2 = FStar_Options.should_extract mname in
+                  if uu___2
                   then
-                    let uu____5868 = output_ml_file fst_file in
-                    FStar_Util.smap_add ml_file_map mname uu____5868
+                    let uu___3 = output_ml_file fst_file in
+                    FStar_Util.smap_add ml_file_map mname uu___3
                   else ()));
           sort_output_files ml_file_map in
         let all_krml_files =
@@ -2303,8 +2245,8 @@ let (print_full : deps -> unit) =
             (FStar_List.iter
                (fun fst_file ->
                   let mname = lowercase_module_name fst_file in
-                  let uu____5884 = output_krml_file fst_file in
-                  FStar_Util.smap_add krml_file_map mname uu____5884));
+                  let uu___2 = output_krml_file fst_file in
+                  FStar_Util.smap_add krml_file_map mname uu___2));
           sort_output_files krml_file_map in
         let print_all tag files =
           pr tag;
@@ -2319,23 +2261,22 @@ let (print_full : deps -> unit) =
                    let r =
                      FStar_Range.set_file_of_range FStar_Range.dummyRange
                        fsti1 in
-                   let uu____5925 = FStar_Range.def_range r in
-                   FStar_Range.set_use_range r uu____5925 in
-                 let uu____5926 =
-                   let uu____5927 =
-                     has_implementation deps1.file_system_map mn in
-                   Prims.op_Negation uu____5927 in
-                 if uu____5926
+                   let uu___2 = FStar_Range.def_range r in
+                   FStar_Range.set_use_range r uu___2 in
+                 let uu___2 =
+                   let uu___3 = has_implementation deps1.file_system_map mn in
+                   Prims.op_Negation uu___3 in
+                 if uu___2
                  then
-                   let uu____5928 = range_of_file fsti in
-                   let uu____5929 =
-                     let uu____5934 =
-                       let uu____5935 = module_name_of_file fsti in
+                   let uu___3 = range_of_file fsti in
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = module_name_of_file fsti in
                        FStar_Util.format1
                          "Interface %s is admitted without an implementation"
-                         uu____5935 in
-                     (FStar_Errors.Warning_WarnOnUse, uu____5934) in
-                   FStar_Errors.log_issue uu____5928 uu____5929
+                         uu___6 in
+                     (FStar_Errors.Warning_WarnOnUse, uu___5) in
+                   FStar_Errors.log_issue uu___3 uu___4
                  else ()));
          print_all "ALL_FST_FILES" all_fst_files;
          print_all "ALL_FSTI_FILES" all_fsti_files;
@@ -2345,15 +2286,15 @@ let (print_full : deps -> unit) =
          FStar_StringBuffer.output_channel FStar_Util.stdout sb)
 let (print : deps -> unit) =
   fun deps1 ->
-    let uu____5947 = FStar_Options.dep () in
-    match uu____5947 with
+    let uu___ = FStar_Options.dep () in
+    match uu___ with
     | FStar_Pervasives_Native.Some "make" -> print_make deps1
     | FStar_Pervasives_Native.Some "full" ->
-        profile (fun uu____5951 -> print_full deps1)
+        profile (fun uu___1 -> print_full deps1)
           "FStar.Parser.Deps.print_full_deps"
     | FStar_Pervasives_Native.Some "graph" -> print_graph deps1.dep_graph
     | FStar_Pervasives_Native.Some "raw" -> print_raw deps1
-    | FStar_Pervasives_Native.Some uu____5952 ->
+    | FStar_Pervasives_Native.Some uu___1 ->
         FStar_Errors.raise_err
           (FStar_Errors.Fatal_UnknownToolForDep, "unknown tool for --dep\n")
     | FStar_Pervasives_Native.None -> ()
@@ -2364,34 +2305,34 @@ let (print_fsmap :
   fun fsmap ->
     FStar_Util.smap_fold fsmap
       (fun k ->
-         fun uu____5993 ->
+         fun uu___ ->
            fun s ->
-             match uu____5993 with
+             match uu___ with
              | (v0, v1) ->
-                 let uu____6013 =
-                   let uu____6014 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_Util.format3 "%s -> (%s, %s)" k
                        (FStar_Util.dflt "_" v0) (FStar_Util.dflt "_" v1) in
-                   FStar_String.op_Hat "; " uu____6014 in
-                 FStar_String.op_Hat s uu____6013) ""
+                   FStar_String.op_Hat "; " uu___2 in
+                 FStar_String.op_Hat s uu___1) ""
 let (module_has_interface : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps1 ->
     fun module_name1 ->
-      let uu____6025 =
-        let uu____6026 = FStar_Ident.string_of_lid module_name1 in
-        FStar_String.lowercase uu____6026 in
-      has_interface deps1.file_system_map uu____6025
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_lid module_name1 in
+        FStar_String.lowercase uu___1 in
+      has_interface deps1.file_system_map uu___
 let (deps_has_implementation : deps -> FStar_Ident.lident -> Prims.bool) =
   fun deps1 ->
     fun module_name1 ->
       let m =
-        let uu____6038 = FStar_Ident.string_of_lid module_name1 in
-        FStar_String.lowercase uu____6038 in
+        let uu___ = FStar_Ident.string_of_lid module_name1 in
+        FStar_String.lowercase uu___ in
       FStar_All.pipe_right deps1.all_files
         (FStar_Util.for_some
            (fun f ->
               (is_implementation f) &&
-                (let uu____6044 =
-                   let uu____6045 = module_name_of_file f in
-                   FStar_String.lowercase uu____6045 in
-                 uu____6044 = m)))
+                (let uu___ =
+                   let uu___1 = module_name_of_file f in
+                   FStar_String.lowercase uu___1 in
+                 uu___ = m)))

--- a/src/ocaml-output/FStar_Parser_Driver.ml
+++ b/src/ocaml-output/FStar_Parser_Driver.ml
@@ -1,36 +1,33 @@
 open Prims
 let (is_cache_file : Prims.string -> Prims.bool) =
-  fun fn ->
-    let uu____5 = FStar_Util.get_file_extension fn in uu____5 = ".cache"
+  fun fn -> let uu___ = FStar_Util.get_file_extension fn in uu___ = ".cache"
 type fragment =
   | Empty 
   | Modul of FStar_Parser_AST.modul 
   | Decls of FStar_Parser_AST.decl Prims.list 
 let (uu___is_Empty : fragment -> Prims.bool) =
-  fun projectee -> match projectee with | Empty -> true | uu____23 -> false
+  fun projectee -> match projectee with | Empty -> true | uu___ -> false
 let (uu___is_Modul : fragment -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Modul _0 -> true | uu____30 -> false
+  fun projectee -> match projectee with | Modul _0 -> true | uu___ -> false
 let (__proj__Modul__item___0 : fragment -> FStar_Parser_AST.modul) =
   fun projectee -> match projectee with | Modul _0 -> _0
 let (uu___is_Decls : fragment -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Decls _0 -> true | uu____45 -> false
+  fun projectee -> match projectee with | Decls _0 -> true | uu___ -> false
 let (__proj__Decls__item___0 : fragment -> FStar_Parser_AST.decl Prims.list)
   = fun projectee -> match projectee with | Decls _0 -> _0
 let (parse_fragment : FStar_Parser_ParseIt.input_frag -> fragment) =
   fun frag ->
-    let uu____63 =
+    let uu___ =
       FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Toplevel frag) in
-    match uu____63 with
-    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl modul, uu____65) ->
+    match uu___ with
+    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl modul, uu___1) ->
         Modul modul
-    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr [], uu____80) -> Empty
-    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr decls, uu____96) ->
+    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr [], uu___1) -> Empty
+    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr decls, uu___1) ->
         Decls decls
     | FStar_Parser_ParseIt.ParseError (e, msg, r) ->
         FStar_Errors.raise_error (e, msg) r
-    | FStar_Parser_ParseIt.Term uu____116 ->
+    | FStar_Parser_ParseIt.Term uu___1 ->
         failwith
           "Impossible: parsing a Toplevel always results in an ASTFragment"
 let (parse_file :
@@ -38,18 +35,16 @@ let (parse_file :
     (FStar_Parser_AST.file * (Prims.string * FStar_Range.range) Prims.list))
   =
   fun fn ->
-    let uu____132 =
-      FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename fn) in
-    match uu____132 with
+    let uu___ = FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename fn) in
+    match uu___ with
     | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl ast, comments) ->
         (ast, comments)
-    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu____165, uu____166)
-        ->
+    | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu___1, uu___2) ->
         let msg = FStar_Util.format1 "%s: expected a module\n" fn in
         let r = FStar_Range.dummyRange in
         FStar_Errors.raise_error (FStar_Errors.Fatal_ModuleExpected, msg) r
     | FStar_Parser_ParseIt.ParseError (e, msg, r) ->
         FStar_Errors.raise_error (e, msg) r
-    | FStar_Parser_ParseIt.Term uu____208 ->
+    | FStar_Parser_ParseIt.Term uu___1 ->
         failwith
           "Impossible: parsing a Filename always results in an ASTFragment"

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -2,8 +2,8 @@ open Prims
 let (maybe_unthunk : FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun t ->
     match t.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Abs (uu____8::[], body) -> body
-    | uu____12 -> t
+    | FStar_Parser_AST.Abs (uu___::[], body) -> body
+    | uu___ -> t
 let (min : Prims.int -> Prims.int -> Prims.int) =
   fun x -> fun y -> if x > y then y else x
 let (max : Prims.int -> Prims.int -> Prims.int) =
@@ -15,8 +15,7 @@ let map_rev : 'a 'b . ('a -> 'b) -> 'a Prims.list -> 'b Prims.list =
         match l1 with
         | [] -> acc
         | x::xs ->
-            let uu____93 = let uu____96 = f x in uu____96 :: acc in
-            aux xs uu____93 in
+            let uu___ = let uu___1 = f x in uu___1 :: acc in aux xs uu___ in
       aux l []
 let map_if_all :
   'a 'b .
@@ -29,8 +28,8 @@ let map_if_all :
         match l1 with
         | [] -> acc
         | x::xs ->
-            let uu____161 = f x in
-            (match uu____161 with
+            let uu___ = f x in
+            (match uu___ with
              | FStar_Pervasives_Native.Some r -> aux xs (r :: acc)
              | FStar_Pervasives_Native.None -> []) in
       let r = aux l [] in
@@ -42,23 +41,21 @@ let rec all : 'a . ('a -> Prims.bool) -> 'a Prims.list -> Prims.bool =
     fun l ->
       match l with
       | [] -> true
-      | x::xs -> let uu____210 = f x in if uu____210 then all f xs else false
+      | x::xs -> let uu___ = f x in if uu___ then all f xs else false
 let (all1_explicit :
   (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list -> Prims.bool) =
   fun args ->
     (Prims.op_Negation (FStar_List.isEmpty args)) &&
       (FStar_Util.for_all
-         (fun uu___0_239 ->
-            match uu___0_239 with
-            | (uu____244, FStar_Parser_AST.Nothing) -> true
-            | uu____245 -> false) args)
+         (fun uu___ ->
+            match uu___ with
+            | (uu___1, FStar_Parser_AST.Nothing) -> true
+            | uu___1 -> false) args)
 let (should_print_fs_typ_app : Prims.bool FStar_ST.ref) =
   FStar_Util.mk_ref false
 let (unfold_tuples : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref true
 let with_fs_typ_app :
-  'uuuuuu264 'uuuuuu265 .
-    Prims.bool -> ('uuuuuu264 -> 'uuuuuu265) -> 'uuuuuu264 -> 'uuuuuu265
-  =
+  'uuuuu 'uuuuu1 . Prims.bool -> ('uuuuu -> 'uuuuu1) -> 'uuuuu -> 'uuuuu1 =
   fun b ->
     fun printer ->
       fun t ->
@@ -69,10 +66,9 @@ let with_fs_typ_app :
 let (str : Prims.string -> FStar_Pprint.document) =
   fun s -> FStar_Pprint.doc_of_string s
 let default_or_map :
-  'uuuuuu323 'uuuuuu324 .
-    'uuuuuu323 ->
-      ('uuuuuu324 -> 'uuuuuu323) ->
-        'uuuuuu324 FStar_Pervasives_Native.option -> 'uuuuuu323
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
+      ('uuuuu1 -> 'uuuuu) -> 'uuuuu1 FStar_Pervasives_Native.option -> 'uuuuu
   =
   fun n ->
     fun f ->
@@ -105,61 +101,59 @@ let (infix0 :
   = FStar_Pprint.infix Prims.int_zero Prims.int_one
 let (break1 : FStar_Pprint.document) = FStar_Pprint.break_ Prims.int_one
 let separate_break_map :
-  'uuuuuu418 .
+  'uuuuu .
     FStar_Pprint.document ->
-      ('uuuuuu418 -> FStar_Pprint.document) ->
-        'uuuuuu418 Prims.list -> FStar_Pprint.document
+      ('uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
       fun l ->
-        let uu____443 =
-          let uu____444 =
-            let uu____445 = FStar_Pprint.op_Hat_Hat sep break1 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____445 in
-          FStar_Pprint.separate_map uu____444 f l in
-        FStar_Pprint.group uu____443
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Pprint.op_Hat_Hat sep break1 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+          FStar_Pprint.separate_map uu___1 f l in
+        FStar_Pprint.group uu___
 let precede_break_separate_map :
-  'uuuuuu456 .
+  'uuuuu .
     FStar_Pprint.document ->
       FStar_Pprint.document ->
-        ('uuuuuu456 -> FStar_Pprint.document) ->
-          'uuuuuu456 Prims.list -> FStar_Pprint.document
+        ('uuuuu -> FStar_Pprint.document) ->
+          'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun prec ->
     fun sep ->
       fun f ->
         fun l ->
-          let uu____486 =
-            let uu____487 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space in
-            let uu____488 =
-              let uu____489 = FStar_List.hd l in
-              FStar_All.pipe_right uu____489 f in
-            FStar_Pprint.precede uu____487 uu____488 in
-          let uu____490 =
-            let uu____491 = FStar_List.tl l in
+          let uu___ =
+            let uu___1 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space in
+            let uu___2 =
+              let uu___3 = FStar_List.hd l in FStar_All.pipe_right uu___3 f in
+            FStar_Pprint.precede uu___1 uu___2 in
+          let uu___1 =
+            let uu___2 = FStar_List.tl l in
             FStar_Pprint.concat_map
               (fun x ->
-                 let uu____497 =
-                   let uu____498 =
-                     let uu____499 = f x in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____499 in
-                   FStar_Pprint.op_Hat_Hat sep uu____498 in
-                 FStar_Pprint.op_Hat_Hat break1 uu____497) uu____491 in
-          FStar_Pprint.op_Hat_Hat uu____486 uu____490
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = f x in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
+                   FStar_Pprint.op_Hat_Hat sep uu___4 in
+                 FStar_Pprint.op_Hat_Hat break1 uu___3) uu___2 in
+          FStar_Pprint.op_Hat_Hat uu___ uu___1
 let concat_break_map :
-  'uuuuuu506 .
-    ('uuuuuu506 -> FStar_Pprint.document) ->
-      'uuuuuu506 Prims.list -> FStar_Pprint.document
+  'uuuuu .
+    ('uuuuu -> FStar_Pprint.document) ->
+      'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun f ->
     fun l ->
-      let uu____526 =
+      let uu___ =
         FStar_Pprint.concat_map
-          (fun x ->
-             let uu____530 = f x in FStar_Pprint.op_Hat_Hat uu____530 break1)
+          (fun x -> let uu___1 = f x in FStar_Pprint.op_Hat_Hat uu___1 break1)
           l in
-      FStar_Pprint.group uu____526
+      FStar_Pprint.group uu___
 let (parens_with_nesting : FStar_Pprint.document -> FStar_Pprint.document) =
   fun contents ->
     FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero
@@ -196,15 +190,15 @@ let (soft_brackets_with_nesting :
 let (soft_begin_end_with_nesting :
   FStar_Pprint.document -> FStar_Pprint.document) =
   fun contents ->
-    let uu____571 = str "begin" in
-    let uu____572 = str "end" in
-    FStar_Pprint.soft_surround (Prims.of_int (2)) Prims.int_one uu____571
-      contents uu____572
+    let uu___ = str "begin" in
+    let uu___1 = str "end" in
+    FStar_Pprint.soft_surround (Prims.of_int (2)) Prims.int_one uu___
+      contents uu___1
 let separate_map_last :
-  'uuuuuu581 .
+  'uuuuu .
     FStar_Pprint.document ->
-      (Prims.bool -> 'uuuuuu581 -> FStar_Pprint.document) ->
-        'uuuuuu581 Prims.list -> FStar_Pprint.document
+      (Prims.bool -> 'uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
@@ -215,25 +209,25 @@ let separate_map_last :
             es in
         FStar_Pprint.separate sep es1
 let separate_break_map_last :
-  'uuuuuu627 .
+  'uuuuu .
     FStar_Pprint.document ->
-      (Prims.bool -> 'uuuuuu627 -> FStar_Pprint.document) ->
-        'uuuuuu627 Prims.list -> FStar_Pprint.document
+      (Prims.bool -> 'uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
       fun l ->
-        let uu____657 =
-          let uu____658 =
-            let uu____659 = FStar_Pprint.op_Hat_Hat sep break1 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____659 in
-          separate_map_last uu____658 f l in
-        FStar_Pprint.group uu____657
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Pprint.op_Hat_Hat sep break1 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+          separate_map_last uu___1 f l in
+        FStar_Pprint.group uu___
 let separate_map_or_flow :
-  'uuuuuu668 .
+  'uuuuu .
     FStar_Pprint.document ->
-      ('uuuuuu668 -> FStar_Pprint.document) ->
-        'uuuuuu668 Prims.list -> FStar_Pprint.document
+      ('uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
@@ -242,10 +236,10 @@ let separate_map_or_flow :
         then FStar_Pprint.separate_map sep f l
         else FStar_Pprint.flow_map sep f l
 let flow_map_last :
-  'uuuuuu702 .
+  'uuuuu .
     FStar_Pprint.document ->
-      (Prims.bool -> 'uuuuuu702 -> FStar_Pprint.document) ->
-        'uuuuuu702 Prims.list -> FStar_Pprint.document
+      (Prims.bool -> 'uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
@@ -256,10 +250,10 @@ let flow_map_last :
             es in
         FStar_Pprint.flow sep es1
 let separate_map_or_flow_last :
-  'uuuuuu748 .
+  'uuuuu .
     FStar_Pprint.document ->
-      (Prims.bool -> 'uuuuuu748 -> FStar_Pprint.document) ->
-        'uuuuuu748 Prims.list -> FStar_Pprint.document
+      (Prims.bool -> 'uuuuu -> FStar_Pprint.document) ->
+        'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun sep ->
     fun f ->
@@ -285,19 +279,19 @@ let (surround_maybe_empty :
           fun doc3 ->
             if doc2 = FStar_Pprint.empty
             then
-              let uu____818 = FStar_Pprint.op_Hat_Slash_Hat doc1 doc3 in
-              FStar_Pprint.group uu____818
+              let uu___ = FStar_Pprint.op_Hat_Slash_Hat doc1 doc3 in
+              FStar_Pprint.group uu___
             else FStar_Pprint.surround n b doc1 doc2 doc3
 let soft_surround_separate_map :
-  'uuuuuu838 .
+  'uuuuu .
     Prims.int ->
       Prims.int ->
         FStar_Pprint.document ->
           FStar_Pprint.document ->
             FStar_Pprint.document ->
               FStar_Pprint.document ->
-                ('uuuuuu838 -> FStar_Pprint.document) ->
-                  'uuuuuu838 Prims.list -> FStar_Pprint.document
+                ('uuuuu -> FStar_Pprint.document) ->
+                  'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun n ->
     fun b ->
@@ -310,18 +304,18 @@ let soft_surround_separate_map :
                   if xs = []
                   then void_
                   else
-                    (let uu____891 = FStar_Pprint.separate_map sep f xs in
-                     FStar_Pprint.soft_surround n b opening uu____891 closing)
+                    (let uu___1 = FStar_Pprint.separate_map sep f xs in
+                     FStar_Pprint.soft_surround n b opening uu___1 closing)
 let soft_surround_map_or_flow :
-  'uuuuuu910 .
+  'uuuuu .
     Prims.int ->
       Prims.int ->
         FStar_Pprint.document ->
           FStar_Pprint.document ->
             FStar_Pprint.document ->
               FStar_Pprint.document ->
-                ('uuuuuu910 -> FStar_Pprint.document) ->
-                  'uuuuuu910 Prims.list -> FStar_Pprint.document
+                ('uuuuu -> FStar_Pprint.document) ->
+                  'uuuuu Prims.list -> FStar_Pprint.document
   =
   fun n ->
     fun b ->
@@ -334,23 +328,22 @@ let soft_surround_map_or_flow :
                   if xs = []
                   then void_
                   else
-                    (let uu____963 = separate_map_or_flow sep f xs in
-                     FStar_Pprint.soft_surround n b opening uu____963 closing)
+                    (let uu___1 = separate_map_or_flow sep f xs in
+                     FStar_Pprint.soft_surround n b opening uu___1 closing)
 let (is_unit : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Const (FStar_Const.Const_unit) -> true
-    | uu____969 -> false
+    | uu___ -> false
 let (matches_var : FStar_Parser_AST.term -> FStar_Ident.ident -> Prims.bool)
   =
   fun t ->
     fun x ->
       match t.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Var y ->
-          let uu____981 = FStar_Ident.string_of_id x in
-          let uu____982 = FStar_Ident.string_of_lid y in
-          uu____981 = uu____982
-      | uu____983 -> false
+          let uu___ = FStar_Ident.string_of_id x in
+          let uu___1 = FStar_Ident.string_of_lid y in uu___ = uu___1
+      | uu___ -> false
 let (is_tuple_constructor : FStar_Ident.lident -> Prims.bool) =
   FStar_Parser_Const.is_tuple_data_lid'
 let (is_dtuple_constructor : FStar_Ident.lident -> Prims.bool) =
@@ -365,9 +358,9 @@ let (is_list_structure :
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Construct (lid, []) ->
             FStar_Ident.lid_equals lid nil_lid
-        | FStar_Parser_AST.Construct (lid, uu____1025::(e2, uu____1027)::[])
-            -> (FStar_Ident.lid_equals lid cons_lid) && (aux e2)
-        | uu____1050 -> false in
+        | FStar_Parser_AST.Construct (lid, uu___::(e2, uu___1)::[]) ->
+            (FStar_Ident.lid_equals lid cons_lid) && (aux e2)
+        | uu___ -> false in
       aux
 let (is_list : FStar_Parser_AST.term -> Prims.bool) =
   is_list_structure FStar_Parser_Const.cons_lid FStar_Parser_Const.nil_lid
@@ -378,28 +371,27 @@ let rec (extract_from_list :
   FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
   fun e ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Construct (uu____1068, []) -> []
+    | FStar_Parser_AST.Construct (uu___, []) -> []
     | FStar_Parser_AST.Construct
-        (uu____1079,
+        (uu___,
          (e1, FStar_Parser_AST.Nothing)::(e2, FStar_Parser_AST.Nothing)::[])
-        -> let uu____1100 = extract_from_list e2 in e1 :: uu____1100
-    | uu____1103 ->
-        let uu____1104 =
-          let uu____1105 = FStar_Parser_AST.term_to_string e in
-          FStar_Util.format1 "Not a list %s" uu____1105 in
-        failwith uu____1104
+        -> let uu___1 = extract_from_list e2 in e1 :: uu___1
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Parser_AST.term_to_string e in
+          FStar_Util.format1 "Not a list %s" uu___2 in
+        failwith uu___1
 let (is_array : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.App
         ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var lid;
-           FStar_Parser_AST.range = uu____1114;
-           FStar_Parser_AST.level = uu____1115;_},
+           FStar_Parser_AST.range = uu___; FStar_Parser_AST.level = uu___1;_},
          l, FStar_Parser_AST.Nothing)
         ->
         (FStar_Ident.lid_equals lid FStar_Parser_Const.array_of_list_lid) &&
           (is_list l)
-    | uu____1117 -> false
+    | uu___ -> false
 let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     match e.FStar_Parser_AST.tm with
@@ -407,16 +399,15 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
         FStar_Ident.lid_equals maybe_empty_lid FStar_Parser_Const.set_empty
     | FStar_Parser_AST.App
         ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_singleton_lid;
-           FStar_Parser_AST.range = uu____1125;
-           FStar_Parser_AST.level = uu____1126;_},
+           FStar_Parser_AST.range = uu___; FStar_Parser_AST.level = uu___1;_},
          {
            FStar_Parser_AST.tm = FStar_Parser_AST.App
              ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_addr_of_lid;
-                FStar_Parser_AST.range = uu____1128;
-                FStar_Parser_AST.level = uu____1129;_},
+                FStar_Parser_AST.range = uu___2;
+                FStar_Parser_AST.level = uu___3;_},
               e1, FStar_Parser_AST.Nothing);
-           FStar_Parser_AST.range = uu____1131;
-           FStar_Parser_AST.level = uu____1132;_},
+           FStar_Parser_AST.range = uu___4;
+           FStar_Parser_AST.level = uu___5;_},
          FStar_Parser_AST.Nothing)
         ->
         (FStar_Ident.lid_equals maybe_singleton_lid
@@ -428,71 +419,69 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
         ({
            FStar_Parser_AST.tm = FStar_Parser_AST.App
              ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var maybe_union_lid;
-                FStar_Parser_AST.range = uu____1134;
-                FStar_Parser_AST.level = uu____1135;_},
+                FStar_Parser_AST.range = uu___;
+                FStar_Parser_AST.level = uu___1;_},
               e1, FStar_Parser_AST.Nothing);
-           FStar_Parser_AST.range = uu____1137;
-           FStar_Parser_AST.level = uu____1138;_},
+           FStar_Parser_AST.range = uu___2;
+           FStar_Parser_AST.level = uu___3;_},
          e2, FStar_Parser_AST.Nothing)
         ->
         ((FStar_Ident.lid_equals maybe_union_lid FStar_Parser_Const.set_union)
            && (is_ref_set e1))
           && (is_ref_set e2)
-    | uu____1140 -> false
+    | uu___ -> false
 let rec (extract_from_ref_set :
   FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
   fun e ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Var uu____1150 -> []
+    | FStar_Parser_AST.Var uu___ -> []
     | FStar_Parser_AST.App
-        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1151;
-           FStar_Parser_AST.range = uu____1152;
-           FStar_Parser_AST.level = uu____1153;_},
+        ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu___;
+           FStar_Parser_AST.range = uu___1;
+           FStar_Parser_AST.level = uu___2;_},
          {
            FStar_Parser_AST.tm = FStar_Parser_AST.App
-             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1154;
-                FStar_Parser_AST.range = uu____1155;
-                FStar_Parser_AST.level = uu____1156;_},
+             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu___3;
+                FStar_Parser_AST.range = uu___4;
+                FStar_Parser_AST.level = uu___5;_},
               e1, FStar_Parser_AST.Nothing);
-           FStar_Parser_AST.range = uu____1158;
-           FStar_Parser_AST.level = uu____1159;_},
+           FStar_Parser_AST.range = uu___6;
+           FStar_Parser_AST.level = uu___7;_},
          FStar_Parser_AST.Nothing)
         -> [e1]
     | FStar_Parser_AST.App
         ({
            FStar_Parser_AST.tm = FStar_Parser_AST.App
-             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu____1160;
-                FStar_Parser_AST.range = uu____1161;
-                FStar_Parser_AST.level = uu____1162;_},
+             ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var uu___;
+                FStar_Parser_AST.range = uu___1;
+                FStar_Parser_AST.level = uu___2;_},
               e1, FStar_Parser_AST.Nothing);
-           FStar_Parser_AST.range = uu____1164;
-           FStar_Parser_AST.level = uu____1165;_},
+           FStar_Parser_AST.range = uu___3;
+           FStar_Parser_AST.level = uu___4;_},
          e2, FStar_Parser_AST.Nothing)
         ->
-        let uu____1167 = extract_from_ref_set e1 in
-        let uu____1170 = extract_from_ref_set e2 in
-        FStar_List.append uu____1167 uu____1170
-    | uu____1173 ->
-        let uu____1174 =
-          let uu____1175 = FStar_Parser_AST.term_to_string e in
-          FStar_Util.format1 "Not a ref set %s" uu____1175 in
-        failwith uu____1174
+        let uu___5 = extract_from_ref_set e1 in
+        let uu___6 = extract_from_ref_set e2 in
+        FStar_List.append uu___5 uu___6
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Parser_AST.term_to_string e in
+          FStar_Util.format1 "Not a ref set %s" uu___2 in
+        failwith uu___1
 let (is_general_application : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
-    let uu____1183 = (is_array e) || (is_ref_set e) in
-    Prims.op_Negation uu____1183
+    let uu___ = (is_array e) || (is_ref_set e) in Prims.op_Negation uu___
 let (is_general_construction : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
-    let uu____1189 = (is_list e) || (is_lex_list e) in
-    Prims.op_Negation uu____1189
+    let uu___ = (is_list e) || (is_lex_list e) in Prims.op_Negation uu___
 let (is_general_prefix_op : FStar_Ident.ident -> Prims.bool) =
   fun op ->
     let op_starting_char =
-      let uu____1196 = FStar_Ident.string_of_id op in
-      FStar_Util.char_at uu____1196 Prims.int_zero in
+      let uu___ = FStar_Ident.string_of_id op in
+      FStar_Util.char_at uu___ Prims.int_zero in
     ((op_starting_char = 33) || (op_starting_char = 63)) ||
       ((op_starting_char = 126) &&
-         (let uu____1198 = FStar_Ident.string_of_id op in uu____1198 <> "~"))
+         (let uu___ = FStar_Ident.string_of_id op in uu___ <> "~"))
 let (head_and_args :
   FStar_Parser_AST.term ->
     (FStar_Parser_AST.term * (FStar_Parser_AST.term * FStar_Parser_AST.imp)
@@ -502,25 +491,24 @@ let (head_and_args :
     let rec aux e1 acc =
       match e1.FStar_Parser_AST.tm with
       | FStar_Parser_AST.App (head, arg, imp) -> aux head ((arg, imp) :: acc)
-      | uu____1264 -> (e1, acc) in
+      | uu___ -> (e1, acc) in
     aux e []
 type associativity =
   | Left 
   | Right 
   | NonAssoc 
 let (uu___is_Left : associativity -> Prims.bool) =
-  fun projectee -> match projectee with | Left -> true | uu____1280 -> false
+  fun projectee -> match projectee with | Left -> true | uu___ -> false
 let (uu___is_Right : associativity -> Prims.bool) =
-  fun projectee -> match projectee with | Right -> true | uu____1286 -> false
+  fun projectee -> match projectee with | Right -> true | uu___ -> false
 let (uu___is_NonAssoc : associativity -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NonAssoc -> true | uu____1292 -> false
+  fun projectee -> match projectee with | NonAssoc -> true | uu___ -> false
 type token = (FStar_Char.char, Prims.string) FStar_Util.either
 type associativity_level = (associativity * token Prims.list)
 let (token_to_string :
   (FStar_BaseTypes.char, Prims.string) FStar_Util.either -> Prims.string) =
-  fun uu___1_1311 ->
-    match uu___1_1311 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.Inl c -> Prims.op_Hat (FStar_Util.string_of_char c) ".*"
     | FStar_Util.Inr s -> s
 let (matches_token :
@@ -528,24 +516,23 @@ let (matches_token :
     (FStar_Char.char, Prims.string) FStar_Util.either -> Prims.bool)
   =
   fun s ->
-    fun uu___2_1331 ->
-      match uu___2_1331 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Util.Inl c ->
-          let uu____1337 = FStar_String.get s Prims.int_zero in
-          uu____1337 = c
+          let uu___1 = FStar_String.get s Prims.int_zero in uu___1 = c
       | FStar_Util.Inr s' -> s = s'
 let matches_level :
-  'uuuuuu1345 .
+  'uuuuu .
     Prims.string ->
-      ('uuuuuu1345 * (FStar_Char.char, Prims.string) FStar_Util.either
-        Prims.list) -> Prims.bool
+      ('uuuuu * (FStar_Char.char, Prims.string) FStar_Util.either Prims.list)
+        -> Prims.bool
   =
   fun s ->
-    fun uu____1365 ->
-      match uu____1365 with
+    fun uu___ ->
+      match uu___ with
       | (assoc_levels, tokens) ->
-          let uu____1390 = FStar_List.tryFind (matches_token s) tokens in
-          uu____1390 <> FStar_Pervasives_Native.None
+          let uu___1 = FStar_List.tryFind (matches_token s) tokens in
+          uu___1 <> FStar_Pervasives_Native.None
 let (opinfix4 : associativity_level) = (Right, [FStar_Util.Inr "**"])
 let (opinfix3 : associativity_level) =
   (Left, [FStar_Util.Inl 42; FStar_Util.Inl 47; FStar_Util.Inl 37])
@@ -579,15 +566,15 @@ let (level_associativity_spec : associativity_level Prims.list) =
   colon_colon]
 let (level_table :
   ((Prims.int * Prims.int * Prims.int) * token Prims.list) Prims.list) =
-  let levels_from_associativity l uu___3_1471 =
-    match uu___3_1471 with
+  let levels_from_associativity l uu___ =
+    match uu___ with
     | Left -> (l, l, (l - Prims.int_one))
     | Right -> ((l - Prims.int_one), l, l)
     | NonAssoc -> ((l - Prims.int_one), l, (l - Prims.int_one)) in
   FStar_List.mapi
     (fun i ->
-       fun uu____1501 ->
-         match uu____1501 with
+       fun uu___ ->
+         match uu___ with
          | (assoc, tokens) -> ((levels_from_associativity i assoc), tokens))
     level_associativity_spec
 let (assign_levels :
@@ -596,38 +583,37 @@ let (assign_levels :
   =
   fun token_associativity_spec ->
     fun s ->
-      let uu____1560 = FStar_List.tryFind (matches_level s) level_table in
-      match uu____1560 with
-      | FStar_Pervasives_Native.Some (assoc_levels, uu____1600) ->
-          assoc_levels
-      | uu____1629 -> failwith (Prims.op_Hat "Unrecognized operator " s)
-let max_level :
-  'uuuuuu1654 . ('uuuuuu1654 * token Prims.list) Prims.list -> Prims.int =
+      let uu___ = FStar_List.tryFind (matches_level s) level_table in
+      match uu___ with
+      | FStar_Pervasives_Native.Some (assoc_levels, uu___1) -> assoc_levels
+      | uu___1 -> failwith (Prims.op_Hat "Unrecognized operator " s)
+let max_level : 'uuuuu . ('uuuuu * token Prims.list) Prims.list -> Prims.int
+  =
   fun l ->
     let find_level_and_max n level =
-      let uu____1699 =
+      let uu___ =
         FStar_List.tryFind
-          (fun uu____1729 ->
-             match uu____1729 with
-             | (uu____1742, tokens) ->
+          (fun uu___1 ->
+             match uu___1 with
+             | (uu___2, tokens) ->
                  tokens = (FStar_Pervasives_Native.snd level)) level_table in
-      match uu____1699 with
-      | FStar_Pervasives_Native.Some
-          ((uu____1764, l1, uu____1766), uu____1767) -> max n l1
+      match uu___ with
+      | FStar_Pervasives_Native.Some ((uu___1, l1, uu___2), uu___3) ->
+          max n l1
       | FStar_Pervasives_Native.None ->
-          let uu____1802 =
-            let uu____1803 =
-              let uu____1804 =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_List.map token_to_string
                   (FStar_Pervasives_Native.snd level) in
-              FStar_String.concat "," uu____1804 in
-            FStar_Util.format1 "Undefined associativity level %s" uu____1803 in
-          failwith uu____1802 in
+              FStar_String.concat "," uu___3 in
+            FStar_Util.format1 "Undefined associativity level %s" uu___2 in
+          failwith uu___1 in
     FStar_List.fold_left find_level_and_max Prims.int_zero l
 let (levels : Prims.string -> (Prims.int * Prims.int * Prims.int)) =
   fun op ->
-    let uu____1826 = assign_levels level_associativity_spec op in
-    match uu____1826 with
+    let uu___ = assign_levels level_associativity_spec op in
+    match uu___ with
     | (left, mine, right) ->
         if op = "*"
         then ((left - Prims.int_one), mine, right)
@@ -636,88 +622,85 @@ let (operatorInfix0ad12 : associativity_level Prims.list) =
   [opinfix0a; opinfix0b; opinfix0c; opinfix0d; opinfix1; opinfix2]
 let (is_operatorInfix0ad12 : FStar_Ident.ident -> Prims.bool) =
   fun op ->
-    let uu____1856 =
-      let uu____1859 =
-        let uu____1864 = FStar_Ident.string_of_id op in
-        FStar_All.pipe_left matches_level uu____1864 in
-      FStar_List.tryFind uu____1859 operatorInfix0ad12 in
-    uu____1856 <> FStar_Pervasives_Native.None
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Ident.string_of_id op in
+        FStar_All.pipe_left matches_level uu___2 in
+      FStar_List.tryFind uu___1 operatorInfix0ad12 in
+    uu___ <> FStar_Pervasives_Native.None
 let (is_operatorInfix34 : FStar_Ident.ident -> Prims.bool) =
   let opinfix34 = [opinfix3; opinfix4] in
   fun op ->
-    let uu____1918 =
-      let uu____1931 =
-        let uu____1946 = FStar_Ident.string_of_id op in
-        FStar_All.pipe_left matches_level uu____1946 in
-      FStar_List.tryFind uu____1931 opinfix34 in
-    uu____1918 <> FStar_Pervasives_Native.None
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Ident.string_of_id op in
+        FStar_All.pipe_left matches_level uu___2 in
+      FStar_List.tryFind uu___1 opinfix34 in
+    uu___ <> FStar_Pervasives_Native.None
 let (handleable_args_length : FStar_Ident.ident -> Prims.int) =
   fun op ->
     let op_s = FStar_Ident.string_of_id op in
-    let uu____1998 =
-      (is_general_prefix_op op) || (FStar_List.mem op_s ["-"; "~"]) in
-    if uu____1998
+    let uu___ = (is_general_prefix_op op) || (FStar_List.mem op_s ["-"; "~"]) in
+    if uu___
     then Prims.int_one
     else
-      (let uu____2000 =
+      (let uu___2 =
          ((is_operatorInfix0ad12 op) || (is_operatorInfix34 op)) ||
            (FStar_List.mem op_s
               ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"]) in
-       if uu____2000
+       if uu___2
        then (Prims.of_int (2))
        else
          if FStar_List.mem op_s [".()<-"; ".[]<-"]
          then (Prims.of_int (3))
          else Prims.int_zero)
 let handleable_op :
-  'uuuuuu2009 . FStar_Ident.ident -> 'uuuuuu2009 Prims.list -> Prims.bool =
+  'uuuuu . FStar_Ident.ident -> 'uuuuu Prims.list -> Prims.bool =
   fun op ->
     fun args ->
       match FStar_List.length args with
-      | uu____2024 when uu____2024 = Prims.int_zero -> true
-      | uu____2025 when uu____2025 = Prims.int_one ->
+      | uu___ when uu___ = Prims.int_zero -> true
+      | uu___ when uu___ = Prims.int_one ->
           (is_general_prefix_op op) ||
-            (let uu____2027 = FStar_Ident.string_of_id op in
-             FStar_List.mem uu____2027 ["-"; "~"])
-      | uu____2028 when uu____2028 = (Prims.of_int (2)) ->
+            (let uu___1 = FStar_Ident.string_of_id op in
+             FStar_List.mem uu___1 ["-"; "~"])
+      | uu___ when uu___ = (Prims.of_int (2)) ->
           ((is_operatorInfix0ad12 op) || (is_operatorInfix34 op)) ||
-            (let uu____2030 = FStar_Ident.string_of_id op in
-             FStar_List.mem uu____2030
+            (let uu___1 = FStar_Ident.string_of_id op in
+             FStar_List.mem uu___1
                ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"])
-      | uu____2031 when uu____2031 = (Prims.of_int (3)) ->
-          let uu____2032 = FStar_Ident.string_of_id op in
-          FStar_List.mem uu____2032 [".()<-"; ".[]<-"]
-      | uu____2033 -> false
+      | uu___ when uu___ = (Prims.of_int (3)) ->
+          let uu___1 = FStar_Ident.string_of_id op in
+          FStar_List.mem uu___1 [".()<-"; ".[]<-"]
+      | uu___ -> false
 type annotation_style =
   | Binders of (Prims.int * Prims.int * Prims.bool) 
   | Arrows of (Prims.int * Prims.int) 
 let (uu___is_Binders : annotation_style -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Binders _0 -> true | uu____2066 -> false
+  fun projectee -> match projectee with | Binders _0 -> true | uu___ -> false
 let (__proj__Binders__item___0 :
   annotation_style -> (Prims.int * Prims.int * Prims.bool)) =
   fun projectee -> match projectee with | Binders _0 -> _0
 let (uu___is_Arrows : annotation_style -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Arrows _0 -> true | uu____2101 -> false
+  fun projectee -> match projectee with | Arrows _0 -> true | uu___ -> false
 let (__proj__Arrows__item___0 : annotation_style -> (Prims.int * Prims.int))
   = fun projectee -> match projectee with | Arrows _0 -> _0
 let (all_binders_annot : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     let is_binder_annot b =
       match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Annotated uu____2131 -> true
-      | uu____2136 -> false in
+      | FStar_Parser_AST.Annotated uu___ -> true
+      | uu___ -> false in
     let rec all_binders e1 l =
       match e1.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (bs, tgt) ->
-          let uu____2162 = FStar_List.for_all is_binder_annot bs in
-          if uu____2162
+          let uu___ = FStar_List.for_all is_binder_annot bs in
+          if uu___
           then all_binders tgt (l + (FStar_List.length bs))
           else (false, Prims.int_zero)
-      | uu____2168 -> (true, (l + Prims.int_one)) in
-    let uu____2169 = all_binders e Prims.int_zero in
-    match uu____2169 with
+      | uu___ -> (true, (l + Prims.int_one)) in
+    let uu___ = all_binders e Prims.int_zero in
+    match uu___ with
     | (b, l) -> if b && (l > Prims.int_one) then true else false
 type catf =
   FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document
@@ -725,8 +708,8 @@ let (cat_with_colon :
   FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document) =
   fun x ->
     fun y ->
-      let uu____2193 = FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon y in
-      FStar_Pprint.op_Hat_Hat x uu____2193
+      let uu___ = FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon y in
+      FStar_Pprint.op_Hat_Hat x uu___
 let (comment_stack :
   (Prims.string * FStar_Range.range) Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
@@ -745,99 +728,98 @@ let (__proj__Mkdecl_meta__item__has_attrs : decl_meta -> Prims.bool) =
 let (dummy_meta : decl_meta) =
   { r = FStar_Range.dummyRange; has_qs = false; has_attrs = false }
 let with_comment :
-  'uuuuuu2259 .
-    ('uuuuuu2259 -> FStar_Pprint.document) ->
-      'uuuuuu2259 -> FStar_Range.range -> FStar_Pprint.document
+  'uuuuu .
+    ('uuuuu -> FStar_Pprint.document) ->
+      'uuuuu -> FStar_Range.range -> FStar_Pprint.document
   =
   fun printer ->
     fun tm ->
       fun tmrange ->
         let rec comments_before_pos acc print_pos lookahead_pos =
-          let uu____2300 = FStar_ST.op_Bang comment_stack in
-          match uu____2300 with
+          let uu___ = FStar_ST.op_Bang comment_stack in
+          match uu___ with
           | [] -> (acc, false)
           | (c, crange)::cs ->
               let comment =
-                let uu____2347 = str c in
-                FStar_Pprint.op_Hat_Hat uu____2347 FStar_Pprint.hardline in
-              let uu____2348 = FStar_Range.range_before_pos crange print_pos in
-              if uu____2348
+                let uu___1 = str c in
+                FStar_Pprint.op_Hat_Hat uu___1 FStar_Pprint.hardline in
+              let uu___1 = FStar_Range.range_before_pos crange print_pos in
+              if uu___1
               then
                 (FStar_ST.op_Colon_Equals comment_stack cs;
-                 (let uu____2372 = FStar_Pprint.op_Hat_Hat acc comment in
-                  comments_before_pos uu____2372 print_pos lookahead_pos))
+                 (let uu___3 = FStar_Pprint.op_Hat_Hat acc comment in
+                  comments_before_pos uu___3 print_pos lookahead_pos))
               else
-                (let uu____2374 =
+                (let uu___3 =
                    FStar_Range.range_before_pos crange lookahead_pos in
-                 (acc, uu____2374)) in
-        let uu____2375 =
-          let uu____2380 =
-            let uu____2381 = FStar_Range.start_of_range tmrange in
-            FStar_Range.end_of_line uu____2381 in
-          let uu____2382 = FStar_Range.end_of_range tmrange in
-          comments_before_pos FStar_Pprint.empty uu____2380 uu____2382 in
-        match uu____2375 with
+                 (acc, uu___3)) in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Range.start_of_range tmrange in
+            FStar_Range.end_of_line uu___2 in
+          let uu___2 = FStar_Range.end_of_range tmrange in
+          comments_before_pos FStar_Pprint.empty uu___1 uu___2 in
+        match uu___ with
         | (comments, has_lookahead) ->
             let printed_e = printer tm in
             let comments1 =
               if has_lookahead
               then
                 let pos = FStar_Range.end_of_range tmrange in
-                let uu____2388 = comments_before_pos comments pos pos in
-                FStar_Pervasives_Native.fst uu____2388
+                let uu___1 = comments_before_pos comments pos pos in
+                FStar_Pervasives_Native.fst uu___1
               else comments in
             if comments1 = FStar_Pprint.empty
             then printed_e
             else
-              (let uu____2395 = FStar_Pprint.op_Hat_Hat comments1 printed_e in
-               FStar_Pprint.group uu____2395)
+              (let uu___2 = FStar_Pprint.op_Hat_Hat comments1 printed_e in
+               FStar_Pprint.group uu___2)
 let with_comment_sep :
-  'uuuuuu2406 'uuuuuu2407 .
-    ('uuuuuu2406 -> 'uuuuuu2407) ->
-      'uuuuuu2406 ->
-        FStar_Range.range -> (FStar_Pprint.document * 'uuuuuu2407)
+  'uuuuu 'uuuuu1 .
+    ('uuuuu -> 'uuuuu1) ->
+      'uuuuu -> FStar_Range.range -> (FStar_Pprint.document * 'uuuuu1)
   =
   fun printer ->
     fun tm ->
       fun tmrange ->
         let rec comments_before_pos acc print_pos lookahead_pos =
-          let uu____2452 = FStar_ST.op_Bang comment_stack in
-          match uu____2452 with
+          let uu___ = FStar_ST.op_Bang comment_stack in
+          match uu___ with
           | [] -> (acc, false)
           | (c, crange)::cs ->
               let comment = str c in
-              let uu____2499 = FStar_Range.range_before_pos crange print_pos in
-              if uu____2499
+              let uu___1 = FStar_Range.range_before_pos crange print_pos in
+              if uu___1
               then
                 (FStar_ST.op_Colon_Equals comment_stack cs;
-                 (let uu____2523 =
+                 (let uu___3 =
                     if acc = FStar_Pprint.empty
                     then comment
                     else
-                      (let uu____2525 =
+                      (let uu___5 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
                            comment in
-                       FStar_Pprint.op_Hat_Hat acc uu____2525) in
-                  comments_before_pos uu____2523 print_pos lookahead_pos))
+                       FStar_Pprint.op_Hat_Hat acc uu___5) in
+                  comments_before_pos uu___3 print_pos lookahead_pos))
               else
-                (let uu____2527 =
+                (let uu___3 =
                    FStar_Range.range_before_pos crange lookahead_pos in
-                 (acc, uu____2527)) in
-        let uu____2528 =
-          let uu____2533 =
-            let uu____2534 = FStar_Range.start_of_range tmrange in
-            FStar_Range.end_of_line uu____2534 in
-          let uu____2535 = FStar_Range.end_of_range tmrange in
-          comments_before_pos FStar_Pprint.empty uu____2533 uu____2535 in
-        match uu____2528 with
+                 (acc, uu___3)) in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Range.start_of_range tmrange in
+            FStar_Range.end_of_line uu___2 in
+          let uu___2 = FStar_Range.end_of_range tmrange in
+          comments_before_pos FStar_Pprint.empty uu___1 uu___2 in
+        match uu___ with
         | (comments, has_lookahead) ->
             let printed_e = printer tm in
             let comments1 =
               if has_lookahead
               then
                 let pos = FStar_Range.end_of_range tmrange in
-                let uu____2545 = comments_before_pos comments pos pos in
-                FStar_Pervasives_Native.fst uu____2545
+                let uu___1 = comments_before_pos comments pos pos in
+                FStar_Pervasives_Native.fst uu___1
               else comments in
             (comments1, printed_e)
 let rec (place_comments_until_pos :
@@ -855,39 +837,38 @@ let rec (place_comments_until_pos :
           fun doc ->
             fun r ->
               fun init ->
-                let uu____2586 = FStar_ST.op_Bang comment_stack in
-                match uu____2586 with
+                let uu___ = FStar_ST.op_Bang comment_stack in
+                match uu___ with
                 | (comment, crange)::cs when
                     FStar_Range.range_before_pos crange pos ->
                     (FStar_ST.op_Colon_Equals comment_stack cs;
                      (let lnum =
-                        let uu____2644 =
-                          let uu____2645 =
-                            let uu____2646 =
-                              FStar_Range.start_of_range crange in
-                            FStar_Range.line_of_pos uu____2646 in
-                          uu____2645 - lbegin in
-                        max k uu____2644 in
+                        let uu___2 =
+                          let uu___3 =
+                            let uu___4 = FStar_Range.start_of_range crange in
+                            FStar_Range.line_of_pos uu___4 in
+                          uu___3 - lbegin in
+                        max k uu___2 in
                       let lnum1 = min (Prims.of_int (2)) lnum in
                       let doc1 =
-                        let uu____2649 =
-                          let uu____2650 =
+                        let uu___2 =
+                          let uu___3 =
                             FStar_Pprint.repeat lnum1 FStar_Pprint.hardline in
-                          let uu____2651 = str comment in
-                          FStar_Pprint.op_Hat_Hat uu____2650 uu____2651 in
-                        FStar_Pprint.op_Hat_Hat doc uu____2649 in
-                      let uu____2652 =
-                        let uu____2653 = FStar_Range.end_of_range crange in
-                        FStar_Range.line_of_pos uu____2653 in
-                      place_comments_until_pos Prims.int_one uu____2652 pos
+                          let uu___4 = str comment in
+                          FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                        FStar_Pprint.op_Hat_Hat doc uu___2 in
+                      let uu___2 =
+                        let uu___3 = FStar_Range.end_of_range crange in
+                        FStar_Range.line_of_pos uu___3 in
+                      place_comments_until_pos Prims.int_one uu___2 pos
                         meta_decl doc1 true init))
-                | uu____2654 ->
+                | uu___1 ->
                     if doc = FStar_Pprint.empty
                     then FStar_Pprint.empty
                     else
                       (let lnum =
-                         let uu____2663 = FStar_Range.line_of_pos pos in
-                         uu____2663 - lbegin in
+                         let uu___3 = FStar_Range.line_of_pos pos in
+                         uu___3 - lbegin in
                        let lnum1 = min (Prims.of_int (3)) lnum in
                        let lnum2 =
                          if meta_decl.has_qs || meta_decl.has_attrs
@@ -899,163 +880,158 @@ let rec (place_comments_until_pos :
                          then (Prims.of_int (2))
                          else lnum3 in
                        let lnum5 = if init then (Prims.of_int (2)) else lnum4 in
-                       let uu____2672 =
+                       let uu___3 =
                          FStar_Pprint.repeat lnum5 FStar_Pprint.hardline in
-                       FStar_Pprint.op_Hat_Hat doc uu____2672)
+                       FStar_Pprint.op_Hat_Hat doc uu___3)
 let separate_map_with_comments :
-  'uuuuuu2685 .
+  'uuuuu .
     FStar_Pprint.document ->
       FStar_Pprint.document ->
-        ('uuuuuu2685 -> FStar_Pprint.document) ->
-          'uuuuuu2685 Prims.list ->
-            ('uuuuuu2685 -> decl_meta) -> FStar_Pprint.document
+        ('uuuuu -> FStar_Pprint.document) ->
+          'uuuuu Prims.list -> ('uuuuu -> decl_meta) -> FStar_Pprint.document
   =
   fun prefix ->
     fun sep ->
       fun f ->
         fun xs ->
           fun extract_meta ->
-            let fold_fun uu____2742 x =
-              match uu____2742 with
+            let fold_fun uu___ x =
+              match uu___ with
               | (last_line, doc) ->
                   let meta_decl = extract_meta x in
                   let r = meta_decl.r in
                   let doc1 =
-                    let uu____2757 = FStar_Range.start_of_range r in
-                    place_comments_until_pos Prims.int_one last_line
-                      uu____2757 meta_decl doc false false in
-                  let uu____2758 =
-                    let uu____2759 = FStar_Range.end_of_range r in
-                    FStar_Range.line_of_pos uu____2759 in
-                  let uu____2760 =
-                    let uu____2761 =
-                      let uu____2762 = f x in
-                      FStar_Pprint.op_Hat_Hat sep uu____2762 in
-                    FStar_Pprint.op_Hat_Hat doc1 uu____2761 in
-                  (uu____2758, uu____2760) in
-            let uu____2763 =
-              let uu____2770 = FStar_List.hd xs in
-              let uu____2771 = FStar_List.tl xs in (uu____2770, uu____2771) in
-            match uu____2763 with
+                    let uu___1 = FStar_Range.start_of_range r in
+                    place_comments_until_pos Prims.int_one last_line uu___1
+                      meta_decl doc false false in
+                  let uu___1 =
+                    let uu___2 = FStar_Range.end_of_range r in
+                    FStar_Range.line_of_pos uu___2 in
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = f x in FStar_Pprint.op_Hat_Hat sep uu___4 in
+                    FStar_Pprint.op_Hat_Hat doc1 uu___3 in
+                  (uu___1, uu___2) in
+            let uu___ =
+              let uu___1 = FStar_List.hd xs in
+              let uu___2 = FStar_List.tl xs in (uu___1, uu___2) in
+            match uu___ with
             | (x, xs1) ->
                 let init =
                   let meta_decl = extract_meta x in
-                  let uu____2788 =
-                    let uu____2789 = FStar_Range.end_of_range meta_decl.r in
-                    FStar_Range.line_of_pos uu____2789 in
-                  let uu____2790 =
-                    let uu____2791 = f x in
-                    FStar_Pprint.op_Hat_Hat prefix uu____2791 in
-                  (uu____2788, uu____2790) in
-                let uu____2792 = FStar_List.fold_left fold_fun init xs1 in
-                FStar_Pervasives_Native.snd uu____2792
+                  let uu___1 =
+                    let uu___2 = FStar_Range.end_of_range meta_decl.r in
+                    FStar_Range.line_of_pos uu___2 in
+                  let uu___2 =
+                    let uu___3 = f x in FStar_Pprint.op_Hat_Hat prefix uu___3 in
+                  (uu___1, uu___2) in
+                let uu___1 = FStar_List.fold_left fold_fun init xs1 in
+                FStar_Pervasives_Native.snd uu___1
 let separate_map_with_comments_kw :
-  'uuuuuu2815 'uuuuuu2816 .
-    'uuuuuu2815 ->
-      'uuuuuu2815 ->
-        ('uuuuuu2815 -> 'uuuuuu2816 -> FStar_Pprint.document) ->
-          'uuuuuu2816 Prims.list ->
-            ('uuuuuu2816 -> decl_meta) -> FStar_Pprint.document
+  'uuuuu 'uuuuu1 .
+    'uuuuu ->
+      'uuuuu ->
+        ('uuuuu -> 'uuuuu1 -> FStar_Pprint.document) ->
+          'uuuuu1 Prims.list ->
+            ('uuuuu1 -> decl_meta) -> FStar_Pprint.document
   =
   fun prefix ->
     fun sep ->
       fun f ->
         fun xs ->
           fun extract_meta ->
-            let fold_fun uu____2878 x =
-              match uu____2878 with
+            let fold_fun uu___ x =
+              match uu___ with
               | (last_line, doc) ->
                   let meta_decl = extract_meta x in
                   let r = meta_decl.r in
                   let doc1 =
-                    let uu____2893 = FStar_Range.start_of_range r in
-                    place_comments_until_pos Prims.int_one last_line
-                      uu____2893 meta_decl doc false false in
-                  let uu____2894 =
-                    let uu____2895 = FStar_Range.end_of_range r in
-                    FStar_Range.line_of_pos uu____2895 in
-                  let uu____2896 =
-                    let uu____2897 = f sep x in
-                    FStar_Pprint.op_Hat_Hat doc1 uu____2897 in
-                  (uu____2894, uu____2896) in
-            let uu____2898 =
-              let uu____2905 = FStar_List.hd xs in
-              let uu____2906 = FStar_List.tl xs in (uu____2905, uu____2906) in
-            match uu____2898 with
+                    let uu___1 = FStar_Range.start_of_range r in
+                    place_comments_until_pos Prims.int_one last_line uu___1
+                      meta_decl doc false false in
+                  let uu___1 =
+                    let uu___2 = FStar_Range.end_of_range r in
+                    FStar_Range.line_of_pos uu___2 in
+                  let uu___2 =
+                    let uu___3 = f sep x in
+                    FStar_Pprint.op_Hat_Hat doc1 uu___3 in
+                  (uu___1, uu___2) in
+            let uu___ =
+              let uu___1 = FStar_List.hd xs in
+              let uu___2 = FStar_List.tl xs in (uu___1, uu___2) in
+            match uu___ with
             | (x, xs1) ->
                 let init =
                   let meta_decl = extract_meta x in
-                  let uu____2923 =
-                    let uu____2924 = FStar_Range.end_of_range meta_decl.r in
-                    FStar_Range.line_of_pos uu____2924 in
-                  let uu____2925 = f prefix x in (uu____2923, uu____2925) in
-                let uu____2926 = FStar_List.fold_left fold_fun init xs1 in
-                FStar_Pervasives_Native.snd uu____2926
+                  let uu___1 =
+                    let uu___2 = FStar_Range.end_of_range meta_decl.r in
+                    FStar_Range.line_of_pos uu___2 in
+                  let uu___2 = f prefix x in (uu___1, uu___2) in
+                let uu___1 = FStar_List.fold_left fold_fun init xs1 in
+                FStar_Pervasives_Native.snd uu___1
 let rec (p_decl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d ->
     let qualifiers =
       match ((d.FStar_Parser_AST.quals), (d.FStar_Parser_AST.d)) with
       | ((FStar_Parser_AST.Assumption)::[], FStar_Parser_AST.Assume
-         (id, uu____3831)) ->
-          let uu____3834 =
-            let uu____3835 =
-              let uu____3836 = FStar_Ident.string_of_id id in
-              FStar_Util.char_at uu____3836 Prims.int_zero in
-            FStar_All.pipe_right uu____3835 FStar_Util.is_upper in
-          if uu____3834
+         (id, uu___)) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Ident.string_of_id id in
+              FStar_Util.char_at uu___3 Prims.int_zero in
+            FStar_All.pipe_right uu___2 FStar_Util.is_upper in
+          if uu___1
           then
-            let uu____3837 = p_qualifier FStar_Parser_AST.Assumption in
-            FStar_Pprint.op_Hat_Hat uu____3837 FStar_Pprint.space
+            let uu___2 = p_qualifier FStar_Parser_AST.Assumption in
+            FStar_Pprint.op_Hat_Hat uu___2 FStar_Pprint.space
           else p_qualifiers d.FStar_Parser_AST.quals
-      | uu____3839 -> p_qualifiers d.FStar_Parser_AST.quals in
-    let uu____3846 = p_attributes d.FStar_Parser_AST.attrs in
-    let uu____3847 =
-      let uu____3848 = p_rawDecl d in
-      FStar_Pprint.op_Hat_Hat qualifiers uu____3848 in
-    FStar_Pprint.op_Hat_Hat uu____3846 uu____3847
+      | uu___ -> p_qualifiers d.FStar_Parser_AST.quals in
+    let uu___ = p_attributes d.FStar_Parser_AST.attrs in
+    let uu___1 =
+      let uu___2 = p_rawDecl d in FStar_Pprint.op_Hat_Hat qualifiers uu___2 in
+    FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_attributes : FStar_Parser_AST.attributes_ -> FStar_Pprint.document) =
   fun attrs ->
     match attrs with
     | [] -> FStar_Pprint.empty
-    | uu____3850 ->
-        let uu____3851 =
-          let uu____3852 = str "@@ " in
-          let uu____3853 =
-            let uu____3854 =
-              let uu____3855 =
-                let uu____3856 =
-                  let uu____3857 = str "; " in
-                  let uu____3858 =
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = str "@@ " in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = str "; " in
+                  let uu___8 =
                     FStar_List.map (p_noSeqTermAndComment false false) attrs in
-                  FStar_Pprint.flow uu____3857 uu____3858 in
-                FStar_Pprint.op_Hat_Hat uu____3856 FStar_Pprint.rbracket in
-              FStar_Pprint.align uu____3855 in
-            FStar_Pprint.op_Hat_Hat uu____3854 FStar_Pprint.hardline in
-          FStar_Pprint.op_Hat_Hat uu____3852 uu____3853 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____3851
+                  FStar_Pprint.flow uu___7 uu___8 in
+                FStar_Pprint.op_Hat_Hat uu___6 FStar_Pprint.rbracket in
+              FStar_Pprint.align uu___5 in
+            FStar_Pprint.op_Hat_Hat uu___4 FStar_Pprint.hardline in
+          FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu___1
 and (p_justSig : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Val (lid, t) ->
-        let uu____3864 =
-          let uu____3865 = str "val" in
-          let uu____3866 =
-            let uu____3867 =
-              let uu____3868 = p_lident lid in
-              let uu____3869 =
+        let uu___ =
+          let uu___1 = str "val" in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = p_lident lid in
+              let uu___5 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
-              FStar_Pprint.op_Hat_Hat uu____3868 uu____3869 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3867 in
-          FStar_Pprint.op_Hat_Hat uu____3865 uu____3866 in
-        let uu____3870 = p_typ false false t in
-        FStar_Pprint.op_Hat_Hat uu____3864 uu____3870
-    | FStar_Parser_AST.TopLevelLet (uu____3871, lbs) ->
+              FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        let uu___1 = p_typ false false t in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
+    | FStar_Parser_AST.TopLevelLet (uu___, lbs) ->
         FStar_Pprint.separate_map FStar_Pprint.hardline
           (fun lb ->
-             let uu____3896 =
-               let uu____3897 = str "let" in p_letlhs uu____3897 lb false in
-             FStar_Pprint.group uu____3896) lbs
-    | uu____3898 -> FStar_Pprint.empty
+             let uu___1 = let uu___2 = str "let" in p_letlhs uu___2 lb false in
+             FStar_Pprint.group uu___1) lbs
+    | uu___ -> FStar_Pprint.empty
 and (p_list :
   (FStar_Ident.ident -> FStar_Pprint.document) ->
     FStar_Pprint.document ->
@@ -1064,247 +1040,237 @@ and (p_list :
   fun f ->
     fun sep ->
       fun l ->
-        let rec p_list' uu___4_3913 =
-          match uu___4_3913 with
+        let rec p_list' uu___ =
+          match uu___ with
           | [] -> FStar_Pprint.empty
           | x::[] -> f x
           | x::xs ->
-              let uu____3921 = f x in
-              let uu____3922 =
-                let uu____3923 = p_list' xs in
-                FStar_Pprint.op_Hat_Hat sep uu____3923 in
-              FStar_Pprint.op_Hat_Hat uu____3921 uu____3922 in
-        let uu____3924 = str "[" in
-        let uu____3925 =
-          let uu____3926 = p_list' l in
-          let uu____3927 = str "]" in
-          FStar_Pprint.op_Hat_Hat uu____3926 uu____3927 in
-        FStar_Pprint.op_Hat_Hat uu____3924 uu____3925
+              let uu___1 = f x in
+              let uu___2 =
+                let uu___3 = p_list' xs in FStar_Pprint.op_Hat_Hat sep uu___3 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        let uu___ = str "[" in
+        let uu___1 =
+          let uu___2 = p_list' l in
+          let uu___3 = str "]" in FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Open uid ->
-        let uu____3930 =
-          let uu____3931 = str "open" in
-          let uu____3932 = p_quident uid in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3931 uu____3932 in
-        FStar_Pprint.group uu____3930
+        let uu___ =
+          let uu___1 = str "open" in
+          let uu___2 = p_quident uid in
+          FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.Include uid ->
-        let uu____3934 =
-          let uu____3935 = str "include" in
-          let uu____3936 = p_quident uid in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3935 uu____3936 in
-        FStar_Pprint.group uu____3934
+        let uu___ =
+          let uu___1 = str "include" in
+          let uu___2 = p_quident uid in
+          FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.Friend uid ->
-        let uu____3938 =
-          let uu____3939 = str "friend" in
-          let uu____3940 = p_quident uid in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3939 uu____3940 in
-        FStar_Pprint.group uu____3938
+        let uu___ =
+          let uu___1 = str "friend" in
+          let uu___2 = p_quident uid in
+          FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.ModuleAbbrev (uid1, uid2) ->
-        let uu____3943 =
-          let uu____3944 = str "module" in
-          let uu____3945 =
-            let uu____3946 =
-              let uu____3947 = p_uident uid1 in
-              let uu____3948 =
+        let uu___ =
+          let uu___1 = str "module" in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = p_uident uid1 in
+              let uu___5 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                   FStar_Pprint.equals in
-              FStar_Pprint.op_Hat_Hat uu____3947 uu____3948 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3946 in
-          FStar_Pprint.op_Hat_Hat uu____3944 uu____3945 in
-        let uu____3949 = p_quident uid2 in
-        op_Hat_Slash_Plus_Hat uu____3943 uu____3949
+              FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        let uu___1 = p_quident uid2 in op_Hat_Slash_Plus_Hat uu___ uu___1
     | FStar_Parser_AST.TopLevelModule uid ->
-        let uu____3951 =
-          let uu____3952 = str "module" in
-          let uu____3953 =
-            let uu____3954 = p_quident uid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3954 in
-          FStar_Pprint.op_Hat_Hat uu____3952 uu____3953 in
-        FStar_Pprint.group uu____3951
+        let uu___ =
+          let uu___1 = str "module" in
+          let uu___2 =
+            let uu___3 = p_quident uid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.Tycon
-        (true, uu____3955, (FStar_Parser_AST.TyconAbbrev
+        (true, uu___, (FStar_Parser_AST.TyconAbbrev
          (uid, tpars, FStar_Pervasives_Native.None, t))::[])
         ->
         let effect_prefix_doc =
-          let uu____3968 = str "effect" in
-          let uu____3969 =
-            let uu____3970 = p_uident uid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3970 in
-          FStar_Pprint.op_Hat_Hat uu____3968 uu____3969 in
-        let uu____3971 =
-          let uu____3972 = p_typars tpars in
+          let uu___1 = str "effect" in
+          let uu___2 =
+            let uu___3 = p_uident uid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        let uu___1 =
+          let uu___2 = p_typars tpars in
           FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-            effect_prefix_doc uu____3972 FStar_Pprint.equals in
-        let uu____3973 = p_typ false false t in
-        op_Hat_Slash_Plus_Hat uu____3971 uu____3973
+            effect_prefix_doc uu___2 FStar_Pprint.equals in
+        let uu___2 = p_typ false false t in
+        op_Hat_Slash_Plus_Hat uu___1 uu___2
     | FStar_Parser_AST.Tycon (false, tc, tcdefs) ->
         let s = if tc then str "class" else str "type" in
-        let uu____3982 =
-          let uu____3983 = FStar_List.hd tcdefs in
-          p_typeDeclWithKw s uu____3983 in
-        let uu____3984 =
-          let uu____3985 = FStar_List.tl tcdefs in
+        let uu___ =
+          let uu___1 = FStar_List.hd tcdefs in p_typeDeclWithKw s uu___1 in
+        let uu___1 =
+          let uu___2 = FStar_List.tl tcdefs in
           FStar_All.pipe_left
             (FStar_Pprint.concat_map
                (fun x ->
-                  let uu____3993 =
-                    let uu____3994 = str "and" in
-                    p_typeDeclWithKw uu____3994 x in
-                  FStar_Pprint.op_Hat_Hat break1 uu____3993)) uu____3985 in
-        FStar_Pprint.op_Hat_Hat uu____3982 uu____3984
+                  let uu___3 =
+                    let uu___4 = str "and" in p_typeDeclWithKw uu___4 x in
+                  FStar_Pprint.op_Hat_Hat break1 uu___3)) uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.TopLevelLet (q, lbs) ->
         let let_doc =
-          let uu____4010 = str "let" in
-          let uu____4011 = p_letqualifier q in
-          FStar_Pprint.op_Hat_Hat uu____4010 uu____4011 in
-        let uu____4012 = str "and" in
-        separate_map_with_comments_kw let_doc uu____4012 p_letbinding lbs
-          (fun uu____4021 ->
-             match uu____4021 with
+          let uu___ = str "let" in
+          let uu___1 = p_letqualifier q in
+          FStar_Pprint.op_Hat_Hat uu___ uu___1 in
+        let uu___ = str "and" in
+        separate_map_with_comments_kw let_doc uu___ p_letbinding lbs
+          (fun uu___1 ->
+             match uu___1 with
              | (p, t) ->
-                 let uu____4028 =
+                 let uu___2 =
                    FStar_Range.union_ranges p.FStar_Parser_AST.prange
                      t.FStar_Parser_AST.range in
-                 { r = uu____4028; has_qs = false; has_attrs = false })
+                 { r = uu___2; has_qs = false; has_attrs = false })
     | FStar_Parser_AST.Val (lid, t) ->
-        let uu____4031 =
-          let uu____4032 = str "val" in
-          let uu____4033 =
-            let uu____4034 =
-              let uu____4035 = p_lident lid in
-              let uu____4036 = sig_as_binders_if_possible t false in
-              FStar_Pprint.op_Hat_Hat uu____4035 uu____4036 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4034 in
-          FStar_Pprint.op_Hat_Hat uu____4032 uu____4033 in
-        FStar_All.pipe_left FStar_Pprint.group uu____4031
+        let uu___ =
+          let uu___1 = str "val" in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = p_lident lid in
+              let uu___5 = sig_as_binders_if_possible t false in
+              FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        FStar_All.pipe_left FStar_Pprint.group uu___
     | FStar_Parser_AST.Assume (id, t) ->
         let decl_keyword =
-          let uu____4040 =
-            let uu____4041 =
-              let uu____4042 = FStar_Ident.string_of_id id in
-              FStar_Util.char_at uu____4042 Prims.int_zero in
-            FStar_All.pipe_right uu____4041 FStar_Util.is_upper in
-          if uu____4040
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Ident.string_of_id id in
+              FStar_Util.char_at uu___2 Prims.int_zero in
+            FStar_All.pipe_right uu___1 FStar_Util.is_upper in
+          if uu___
           then FStar_Pprint.empty
           else
-            (let uu____4044 = str "val" in
-             FStar_Pprint.op_Hat_Hat uu____4044 FStar_Pprint.space) in
-        let uu____4045 =
-          let uu____4046 = p_ident id in
-          let uu____4047 =
-            let uu____4048 =
-              let uu____4049 =
-                let uu____4050 = p_typ false false t in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4050 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4049 in
-            FStar_Pprint.group uu____4048 in
-          FStar_Pprint.op_Hat_Hat uu____4046 uu____4047 in
-        FStar_Pprint.op_Hat_Hat decl_keyword uu____4045
+            (let uu___2 = str "val" in
+             FStar_Pprint.op_Hat_Hat uu___2 FStar_Pprint.space) in
+        let uu___ =
+          let uu___1 = p_ident id in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = p_typ false false t in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___4 in
+            FStar_Pprint.group uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        FStar_Pprint.op_Hat_Hat decl_keyword uu___
     | FStar_Parser_AST.Exception (uid, t_opt) ->
-        let uu____4057 = str "exception" in
-        let uu____4058 =
-          let uu____4059 =
-            let uu____4060 = p_uident uid in
-            let uu____4061 =
+        let uu___ = str "exception" in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = p_uident uid in
+            let uu___4 =
               FStar_Pprint.optional
                 (fun t ->
-                   let uu____4065 =
-                     let uu____4066 = str "of" in
-                     let uu____4067 = p_typ false false t in
-                     op_Hat_Slash_Plus_Hat uu____4066 uu____4067 in
-                   FStar_Pprint.op_Hat_Hat break1 uu____4065) t_opt in
-            FStar_Pprint.op_Hat_Hat uu____4060 uu____4061 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4059 in
-        FStar_Pprint.op_Hat_Hat uu____4057 uu____4058
+                   let uu___5 =
+                     let uu___6 = str "of" in
+                     let uu___7 = p_typ false false t in
+                     op_Hat_Slash_Plus_Hat uu___6 uu___7 in
+                   FStar_Pprint.op_Hat_Hat break1 uu___5) t_opt in
+            FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.NewEffect ne ->
-        let uu____4069 = str "new_effect" in
-        let uu____4070 =
-          let uu____4071 = p_newEffect ne in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4071 in
-        FStar_Pprint.op_Hat_Hat uu____4069 uu____4070
+        let uu___ = str "new_effect" in
+        let uu___1 =
+          let uu___2 = p_newEffect ne in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.SubEffect se ->
-        let uu____4073 = str "sub_effect" in
-        let uu____4074 =
-          let uu____4075 = p_subEffect se in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4075 in
-        FStar_Pprint.op_Hat_Hat uu____4073 uu____4074
+        let uu___ = str "sub_effect" in
+        let uu___1 =
+          let uu___2 = p_subEffect se in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.LayeredEffect ne ->
-        let uu____4077 = str "layered_effect" in
-        let uu____4078 =
-          let uu____4079 = p_newEffect ne in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4079 in
-        FStar_Pprint.op_Hat_Hat uu____4077 uu____4078
+        let uu___ = str "layered_effect" in
+        let uu___1 =
+          let uu___2 = p_newEffect ne in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Polymonadic_bind (l1, l2, l3, t) ->
-        let uu____4084 = str "polymonadic_bind" in
-        let uu____4085 =
-          let uu____4086 =
-            let uu____4087 = p_quident l1 in
-            let uu____4088 =
-              let uu____4089 =
-                let uu____4090 =
-                  let uu____4091 = p_quident l2 in
-                  let uu____4092 =
-                    let uu____4093 =
-                      let uu____4094 = str "|>" in
-                      let uu____4095 =
-                        let uu____4096 = p_quident l3 in
-                        let uu____4097 =
-                          let uu____4098 = p_simpleTerm false false t in
-                          FStar_Pprint.op_Hat_Hat FStar_Pprint.equals
-                            uu____4098 in
-                        FStar_Pprint.op_Hat_Hat uu____4096 uu____4097 in
-                      FStar_Pprint.op_Hat_Hat uu____4094 uu____4095 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen uu____4093 in
-                  FStar_Pprint.op_Hat_Hat uu____4091 uu____4092 in
-                FStar_Pprint.op_Hat_Hat break1 uu____4090 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.comma uu____4089 in
-            FStar_Pprint.op_Hat_Hat uu____4087 uu____4088 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4086 in
-        FStar_Pprint.op_Hat_Hat uu____4084 uu____4085
+        let uu___ = str "polymonadic_bind" in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = p_quident l1 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = p_quident l2 in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = str "|>" in
+                      let uu___11 =
+                        let uu___12 = p_quident l3 in
+                        let uu___13 =
+                          let uu___14 = p_simpleTerm false false t in
+                          FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu___14 in
+                        FStar_Pprint.op_Hat_Hat uu___12 uu___13 in
+                      FStar_Pprint.op_Hat_Hat uu___10 uu___11 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen uu___9 in
+                  FStar_Pprint.op_Hat_Hat uu___7 uu___8 in
+                FStar_Pprint.op_Hat_Hat break1 uu___6 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.comma uu___5 in
+            FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Pragma p -> p_pragma p
-    | FStar_Parser_AST.Tycon (true, uu____4100, uu____4101) ->
+    | FStar_Parser_AST.Tycon (true, uu___, uu___1) ->
         failwith
           "Effect abbreviation is expected to be defined by an abbreviation"
     | FStar_Parser_AST.Splice (ids, t) ->
-        let uu____4112 = str "%splice" in
-        let uu____4113 =
-          let uu____4114 =
-            let uu____4115 = str ";" in p_list p_uident uu____4115 ids in
-          let uu____4116 =
-            let uu____4117 = p_term false false t in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4117 in
-          FStar_Pprint.op_Hat_Hat uu____4114 uu____4116 in
-        FStar_Pprint.op_Hat_Hat uu____4112 uu____4113
+        let uu___ = str "%splice" in
+        let uu___1 =
+          let uu___2 = let uu___3 = str ";" in p_list p_uident uu___3 ids in
+          let uu___3 =
+            let uu___4 = p_term false false t in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___4 in
+          FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_pragma : FStar_Parser_AST.pragma -> FStar_Pprint.document) =
-  fun uu___5_4118 ->
-    match uu___5_4118 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.SetOptions s ->
-        let uu____4120 = str "#set-options" in
-        let uu____4121 =
-          let uu____4122 =
-            let uu____4123 = str s in FStar_Pprint.dquotes uu____4123 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4122 in
-        FStar_Pprint.op_Hat_Hat uu____4120 uu____4121
+        let uu___1 = str "#set-options" in
+        let uu___2 =
+          let uu___3 = let uu___4 = str s in FStar_Pprint.dquotes uu___4 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
     | FStar_Parser_AST.ResetOptions s_opt ->
-        let uu____4127 = str "#reset-options" in
-        let uu____4128 =
+        let uu___1 = str "#reset-options" in
+        let uu___2 =
           FStar_Pprint.optional
             (fun s ->
-               let uu____4132 =
-                 let uu____4133 = str s in FStar_Pprint.dquotes uu____4133 in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4132) s_opt in
-        FStar_Pprint.op_Hat_Hat uu____4127 uu____4128
+               let uu___3 = let uu___4 = str s in FStar_Pprint.dquotes uu___4 in
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3) s_opt in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
     | FStar_Parser_AST.PushOptions s_opt ->
-        let uu____4137 = str "#push-options" in
-        let uu____4138 =
+        let uu___1 = str "#push-options" in
+        let uu___2 =
           FStar_Pprint.optional
             (fun s ->
-               let uu____4142 =
-                 let uu____4143 = str s in FStar_Pprint.dquotes uu____4143 in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4142) s_opt in
-        FStar_Pprint.op_Hat_Hat uu____4137 uu____4138
+               let uu___3 = let uu___4 = str s in FStar_Pprint.dquotes uu___4 in
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3) s_opt in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
     | FStar_Parser_AST.PopOptions -> str "#pop-options"
     | FStar_Parser_AST.RestartSolver -> str "#restart-solver"
     | FStar_Parser_AST.LightOff ->
@@ -1316,32 +1282,30 @@ and (p_typeDeclWithKw :
   FStar_Pprint.document -> FStar_Parser_AST.tycon -> FStar_Pprint.document) =
   fun kw ->
     fun typedecl ->
-      let uu____4156 = p_typeDecl kw typedecl in
-      match uu____4156 with
+      let uu___ = p_typeDecl kw typedecl in
+      match uu___ with
       | (comm, decl, body, pre) ->
           if comm = FStar_Pprint.empty
-          then
-            let uu____4178 = pre body in
-            FStar_Pprint.op_Hat_Hat decl uu____4178
+          then let uu___1 = pre body in FStar_Pprint.op_Hat_Hat decl uu___1
           else
-            (let uu____4180 =
-               let uu____4181 =
-                 let uu____4182 =
-                   let uu____4183 = pre body in
-                   FStar_Pprint.op_Hat_Slash_Hat uu____4183 comm in
-                 FStar_Pprint.op_Hat_Hat decl uu____4182 in
-               let uu____4184 =
-                 let uu____4185 =
-                   let uu____4186 =
-                     let uu____4187 =
-                       let uu____4188 =
+            (let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = pre body in
+                   FStar_Pprint.op_Hat_Slash_Hat uu___5 comm in
+                 FStar_Pprint.op_Hat_Hat decl uu___4 in
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 =
+                       let uu___8 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline body in
-                       FStar_Pprint.op_Hat_Hat comm uu____4188 in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____4187 in
-                   FStar_Pprint.nest (Prims.of_int (2)) uu____4186 in
-                 FStar_Pprint.op_Hat_Hat decl uu____4185 in
-               FStar_Pprint.ifflat uu____4181 uu____4184 in
-             FStar_All.pipe_left FStar_Pprint.group uu____4180)
+                       FStar_Pprint.op_Hat_Hat comm uu___8 in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___7 in
+                   FStar_Pprint.nest (Prims.of_int (2)) uu___6 in
+                 FStar_Pprint.op_Hat_Hat decl uu___5 in
+               FStar_Pprint.ifflat uu___3 uu___4 in
+             FStar_All.pipe_left FStar_Pprint.group uu___2)
 and (p_typeDecl :
   FStar_Pprint.document ->
     FStar_Parser_AST.tycon ->
@@ -1349,65 +1313,64 @@ and (p_typeDecl :
         * (FStar_Pprint.document -> FStar_Pprint.document)))
   =
   fun pre ->
-    fun uu___6_4190 ->
-      match uu___6_4190 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Parser_AST.TyconAbstract (lid, bs, typ_opt) ->
-          let uu____4213 = p_typeDeclPrefix pre false lid bs typ_opt in
-          (FStar_Pprint.empty, uu____4213, FStar_Pprint.empty,
+          let uu___1 = p_typeDeclPrefix pre false lid bs typ_opt in
+          (FStar_Pprint.empty, uu___1, FStar_Pprint.empty,
             FStar_Pervasives.id)
       | FStar_Parser_AST.TyconAbbrev (lid, bs, typ_opt, t) ->
-          let uu____4229 = p_typ_sep false false t in
-          (match uu____4229 with
+          let uu___1 = p_typ_sep false false t in
+          (match uu___1 with
            | (comm, doc) ->
-               let uu____4247 = p_typeDeclPrefix pre true lid bs typ_opt in
-               (comm, uu____4247, doc, jump2))
+               let uu___2 = p_typeDeclPrefix pre true lid bs typ_opt in
+               (comm, uu___2, doc, jump2))
       | FStar_Parser_AST.TyconRecord (lid, bs, typ_opt, record_field_decls)
           ->
-          let p_recordField ps uu____4289 =
-            match uu____4289 with
+          let p_recordField ps uu___1 =
+            match uu___1 with
             | (lid1, t) ->
-                let uu____4296 =
-                  let uu____4301 =
+                let uu___2 =
+                  let uu___3 =
                     FStar_Range.extend_to_end_of_line
                       t.FStar_Parser_AST.range in
-                  with_comment_sep (p_recordFieldDecl ps) (lid1, t)
-                    uu____4301 in
-                (match uu____4296 with
+                  with_comment_sep (p_recordFieldDecl ps) (lid1, t) uu___3 in
+                (match uu___2 with
                  | (comm, field) ->
                      let sep =
                        if ps then FStar_Pprint.semi else FStar_Pprint.empty in
                      inline_comment_or_above comm field sep) in
           let p_fields =
-            let uu____4311 =
+            let uu___1 =
               separate_map_last FStar_Pprint.hardline p_recordField
                 record_field_decls in
-            braces_with_nesting uu____4311 in
-          let uu____4316 = p_typeDeclPrefix pre true lid bs typ_opt in
-          (FStar_Pprint.empty, uu____4316, p_fields,
+            braces_with_nesting uu___1 in
+          let uu___1 = p_typeDeclPrefix pre true lid bs typ_opt in
+          (FStar_Pprint.empty, uu___1, p_fields,
             ((fun d -> FStar_Pprint.op_Hat_Hat FStar_Pprint.space d)))
       | FStar_Parser_AST.TyconVariant (lid, bs, typ_opt, ct_decls) ->
-          let p_constructorBranchAndComments uu____4367 =
-            match uu____4367 with
+          let p_constructorBranchAndComments uu___1 =
+            match uu___1 with
             | (uid, t_opt, use_of) ->
                 let range =
-                  let uu____4384 =
-                    let uu____4385 = FStar_Ident.range_of_id uid in
-                    let uu____4386 =
+                  let uu___2 =
+                    let uu___3 = FStar_Ident.range_of_id uid in
+                    let uu___4 =
                       FStar_Util.map_opt t_opt
                         (fun t -> t.FStar_Parser_AST.range) in
-                    FStar_Util.dflt uu____4385 uu____4386 in
-                  FStar_Range.extend_to_end_of_line uu____4384 in
-                let uu____4391 =
+                    FStar_Util.dflt uu___3 uu___4 in
+                  FStar_Range.extend_to_end_of_line uu___2 in
+                let uu___2 =
                   with_comment_sep p_constructorBranch (uid, t_opt, use_of)
                     range in
-                (match uu____4391 with
+                (match uu___2 with
                  | (comm, ctor) ->
                      inline_comment_or_above comm ctor FStar_Pprint.empty) in
           let datacon_doc =
             FStar_Pprint.separate_map FStar_Pprint.hardline
               p_constructorBranchAndComments ct_decls in
-          let uu____4417 = p_typeDeclPrefix pre true lid bs typ_opt in
-          (FStar_Pprint.empty, uu____4417, datacon_doc, jump2)
+          let uu___1 = p_typeDeclPrefix pre true lid bs typ_opt in
+          (FStar_Pprint.empty, uu___1, datacon_doc, jump2)
 and (p_typeDeclPrefix :
   FStar_Pprint.document ->
     Prims.bool ->
@@ -1424,8 +1387,8 @@ and (p_typeDeclPrefix :
             let with_kw cont =
               let lid_doc = p_ident lid in
               let kw_lid =
-                let uu____4443 = FStar_Pprint.op_Hat_Slash_Hat kw lid_doc in
-                FStar_Pprint.group uu____4443 in
+                let uu___ = FStar_Pprint.op_Hat_Slash_Hat kw lid_doc in
+                FStar_Pprint.group uu___ in
               cont kw_lid in
             let typ =
               let maybe_eq =
@@ -1433,75 +1396,75 @@ and (p_typeDeclPrefix :
               match typ_opt with
               | FStar_Pervasives_Native.None -> maybe_eq
               | FStar_Pervasives_Native.Some t ->
-                  let uu____4448 =
-                    let uu____4449 =
-                      let uu____4450 = p_typ false false t in
-                      FStar_Pprint.op_Hat_Slash_Hat uu____4450 maybe_eq in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4449 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4448 in
+                  let uu___ =
+                    let uu___1 =
+                      let uu___2 = p_typ false false t in
+                      FStar_Pprint.op_Hat_Slash_Hat uu___2 maybe_eq in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___1 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___ in
             if bs = []
             then with_kw (fun n -> prefix2 n typ)
             else
               (let binders = p_binders_list true bs in
                with_kw
                  (fun n ->
-                    let uu____4465 =
-                      let uu____4466 = FStar_Pprint.flow break1 binders in
-                      prefix2 n uu____4466 in
-                    prefix2 uu____4465 typ))
+                    let uu___1 =
+                      let uu___2 = FStar_Pprint.flow break1 binders in
+                      prefix2 n uu___2 in
+                    prefix2 uu___1 typ))
 and (p_recordFieldDecl :
   Prims.bool ->
     (FStar_Ident.ident * FStar_Parser_AST.term) -> FStar_Pprint.document)
   =
   fun ps ->
-    fun uu____4468 ->
-      match uu____4468 with
+    fun uu___ ->
+      match uu___ with
       | (lid, t) ->
-          let uu____4475 =
-            let uu____4476 = p_lident lid in
-            let uu____4477 =
-              let uu____4478 = p_typ ps false t in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4478 in
-            FStar_Pprint.op_Hat_Hat uu____4476 uu____4477 in
-          FStar_Pprint.group uu____4475
+          let uu___1 =
+            let uu___2 = p_lident lid in
+            let uu___3 =
+              let uu___4 = p_typ ps false t in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___4 in
+            FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+          FStar_Pprint.group uu___1
 and (p_constructorBranch :
   (FStar_Ident.ident * FStar_Parser_AST.term FStar_Pervasives_Native.option *
     Prims.bool) -> FStar_Pprint.document)
   =
-  fun uu____4479 ->
-    match uu____4479 with
+  fun uu___ ->
+    match uu___ with
     | (uid, t_opt, use_of) ->
         let sep = if use_of then str "of" else FStar_Pprint.colon in
         let uid_doc =
-          let uu____4498 =
-            let uu____4499 =
-              let uu____4500 = p_uident uid in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4500 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____4499 in
-          FStar_Pprint.group uu____4498 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = p_uident uid in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
+          FStar_Pprint.group uu___1 in
         default_or_map uid_doc
           (fun t ->
-             let uu____4504 =
-               let uu____4505 =
-                 let uu____4506 =
-                   let uu____4507 =
-                     let uu____4508 = p_typ false false t in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4508 in
-                   FStar_Pprint.op_Hat_Hat sep uu____4507 in
-                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4506 in
-               FStar_Pprint.op_Hat_Hat uid_doc uu____4505 in
-             FStar_Pprint.group uu____4504) t_opt
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = p_typ false false t in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
+                   FStar_Pprint.op_Hat_Hat sep uu___4 in
+                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+               FStar_Pprint.op_Hat_Hat uid_doc uu___2 in
+             FStar_Pprint.group uu___1) t_opt
 and (p_letlhs :
   FStar_Pprint.document ->
     (FStar_Parser_AST.pattern * FStar_Parser_AST.term) ->
       Prims.bool -> FStar_Pprint.document)
   =
   fun kw ->
-    fun uu____4510 ->
+    fun uu___ ->
       fun inner_let ->
-        match uu____4510 with
-        | (pat, uu____4517) ->
-            let uu____4518 =
+        match uu___ with
+        | (pat, uu___1) ->
+            let uu___2 =
               match pat.FStar_Parser_AST.pat with
               | FStar_Parser_AST.PatAscribed
                   (pat1, (t, FStar_Pervasives_Native.None)) ->
@@ -1509,125 +1472,121 @@ and (p_letlhs :
                     (FStar_Pervasives_Native.Some (t, FStar_Pprint.empty)))
               | FStar_Parser_AST.PatAscribed
                   (pat1, (t, FStar_Pervasives_Native.Some tac)) ->
-                  let uu____4570 =
-                    let uu____4577 =
-                      let uu____4582 =
-                        let uu____4583 =
-                          let uu____4584 =
-                            let uu____4585 = str "by" in
-                            let uu____4586 =
-                              let uu____4587 =
-                                p_atomicTerm (maybe_unthunk tac) in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 = str "by" in
+                            let uu___9 =
+                              let uu___10 = p_atomicTerm (maybe_unthunk tac) in
                               FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                                uu____4587 in
-                            FStar_Pprint.op_Hat_Hat uu____4585 uu____4586 in
-                          FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                            uu____4584 in
-                        FStar_Pprint.group uu____4583 in
-                      (t, uu____4582) in
-                    FStar_Pervasives_Native.Some uu____4577 in
-                  (pat1, uu____4570)
-              | uu____4598 -> (pat, FStar_Pervasives_Native.None) in
-            (match uu____4518 with
+                                uu___10 in
+                            FStar_Pprint.op_Hat_Hat uu___8 uu___9 in
+                          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___7 in
+                        FStar_Pprint.group uu___6 in
+                      (t, uu___5) in
+                    FStar_Pervasives_Native.Some uu___4 in
+                  (pat1, uu___3)
+              | uu___3 -> (pat, FStar_Pervasives_Native.None) in
+            (match uu___2 with
              | (pat1, ascr) ->
                  (match pat1.FStar_Parser_AST.pat with
                   | FStar_Parser_AST.PatApp
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           (lid, uu____4624);
-                         FStar_Parser_AST.prange = uu____4625;_},
+                           (lid, uu___3);
+                         FStar_Parser_AST.prange = uu___4;_},
                        pats)
                       ->
                       let ascr_doc =
                         match ascr with
                         | FStar_Pervasives_Native.Some (t, tac) ->
-                            let uu____4642 =
-                              sig_as_binders_if_possible t true in
-                            FStar_Pprint.op_Hat_Hat uu____4642 tac
+                            let uu___5 = sig_as_binders_if_possible t true in
+                            FStar_Pprint.op_Hat_Hat uu___5 tac
                         | FStar_Pervasives_Native.None -> FStar_Pprint.empty in
-                      let uu____4647 =
+                      let uu___5 =
                         if inner_let
                         then
-                          let uu____4660 = pats_as_binders_if_possible pats in
-                          match uu____4660 with
+                          let uu___6 = pats_as_binders_if_possible pats in
+                          match uu___6 with
                           | (bs, style) ->
                               ((FStar_List.append bs [ascr_doc]), style)
                         else
-                          (let uu____4682 = pats_as_binders_if_possible pats in
-                           match uu____4682 with
+                          (let uu___7 = pats_as_binders_if_possible pats in
+                           match uu___7 with
                            | (bs, style) ->
                                ((FStar_List.append bs [ascr_doc]), style)) in
-                      (match uu____4647 with
+                      (match uu___5 with
                        | (terms, style) ->
-                           let uu____4709 =
-                             let uu____4710 =
-                               let uu____4711 =
-                                 let uu____4712 = p_lident lid in
-                                 let uu____4713 =
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = p_lident lid in
+                                 let uu___10 =
                                    format_sig style terms true true in
-                                 FStar_Pprint.op_Hat_Hat uu____4712
-                                   uu____4713 in
+                                 FStar_Pprint.op_Hat_Hat uu___9 uu___10 in
                                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                                 uu____4711 in
-                             FStar_Pprint.op_Hat_Hat kw uu____4710 in
-                           FStar_All.pipe_left FStar_Pprint.group uu____4709)
-                  | uu____4714 ->
+                                 uu___8 in
+                             FStar_Pprint.op_Hat_Hat kw uu___7 in
+                           FStar_All.pipe_left FStar_Pprint.group uu___6)
+                  | uu___3 ->
                       let ascr_doc =
                         match ascr with
                         | FStar_Pervasives_Native.Some (t, tac) ->
-                            let uu____4722 =
-                              let uu____4723 =
-                                let uu____4724 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
                                   p_typ_top
                                     (Arrows
                                        ((Prims.of_int (2)),
                                          (Prims.of_int (2)))) false false t in
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
-                                  uu____4724 in
-                              FStar_Pprint.group uu____4723 in
-                            FStar_Pprint.op_Hat_Hat uu____4722 tac
+                                  uu___6 in
+                              FStar_Pprint.group uu___5 in
+                            FStar_Pprint.op_Hat_Hat uu___4 tac
                         | FStar_Pervasives_Native.None -> FStar_Pprint.empty in
-                      let uu____4729 =
-                        let uu____4730 =
-                          let uu____4731 =
-                            let uu____4732 = p_tuplePattern pat1 in
-                            FStar_Pprint.op_Hat_Slash_Hat kw uu____4732 in
-                          FStar_Pprint.group uu____4731 in
-                        FStar_Pprint.op_Hat_Hat uu____4730 ascr_doc in
-                      FStar_Pprint.group uu____4729))
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 = p_tuplePattern pat1 in
+                            FStar_Pprint.op_Hat_Slash_Hat kw uu___7 in
+                          FStar_Pprint.group uu___6 in
+                        FStar_Pprint.op_Hat_Hat uu___5 ascr_doc in
+                      FStar_Pprint.group uu___4))
 and (p_letbinding :
   FStar_Pprint.document ->
     (FStar_Parser_AST.pattern * FStar_Parser_AST.term) ->
       FStar_Pprint.document)
   =
   fun kw ->
-    fun uu____4734 ->
-      match uu____4734 with
+    fun uu___ ->
+      match uu___ with
       | (pat, e) ->
           let doc_pat = p_letlhs kw (pat, e) false in
-          let uu____4742 = p_term_sep false false e in
-          (match uu____4742 with
+          let uu___1 = p_term_sep false false e in
+          (match uu___1 with
            | (comm, doc_expr) ->
                let doc_expr1 =
                  inline_comment_or_above comm doc_expr FStar_Pprint.empty in
-               let uu____4750 =
-                 let uu____4751 =
+               let uu___2 =
+                 let uu___3 =
                    FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals
                      doc_expr1 in
-                 FStar_Pprint.op_Hat_Slash_Hat doc_pat uu____4751 in
-               let uu____4752 =
-                 let uu____4753 =
-                   let uu____4754 =
-                     let uu____4755 =
-                       let uu____4756 = jump2 doc_expr1 in
-                       FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____4756 in
-                     FStar_Pprint.group uu____4755 in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4754 in
-                 FStar_Pprint.op_Hat_Hat doc_pat uu____4753 in
-               FStar_Pprint.ifflat uu____4750 uu____4752)
+                 FStar_Pprint.op_Hat_Slash_Hat doc_pat uu___3 in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = jump2 doc_expr1 in
+                       FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu___7 in
+                     FStar_Pprint.group uu___6 in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
+                 FStar_Pprint.op_Hat_Hat doc_pat uu___4 in
+               FStar_Pprint.ifflat uu___2 uu___3)
 and (p_newEffect : FStar_Parser_AST.effect_decl -> FStar_Pprint.document) =
-  fun uu___7_4757 ->
-    match uu___7_4757 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.RedefineEffect (lid, bs, t) ->
         p_effectRedefinition lid bs t
     | FStar_Parser_AST.DefineEffect (lid, bs, t, eff_decls) ->
@@ -1640,13 +1599,13 @@ and (p_effectRedefinition :
   fun uid ->
     fun bs ->
       fun t ->
-        let uu____4782 = p_uident uid in
-        let uu____4783 = p_binders true bs in
-        let uu____4784 =
-          let uu____4785 = p_simpleTerm false false t in
-          prefix2 FStar_Pprint.equals uu____4785 in
-        surround_maybe_empty (Prims.of_int (2)) Prims.int_one uu____4782
-          uu____4783 uu____4784
+        let uu___ = p_uident uid in
+        let uu___1 = p_binders true bs in
+        let uu___2 =
+          let uu___3 = p_simpleTerm false false t in
+          prefix2 FStar_Pprint.equals uu___3 in
+        surround_maybe_empty (Prims.of_int (2)) Prims.int_one uu___ uu___1
+          uu___2
 and (p_effectDefinition :
   FStar_Ident.ident ->
     FStar_Parser_AST.binder Prims.list ->
@@ -1658,59 +1617,57 @@ and (p_effectDefinition :
       fun t ->
         fun eff_decls ->
           let binders = p_binders true bs in
-          let uu____4795 =
-            let uu____4796 =
-              let uu____4797 =
-                let uu____4798 = p_uident uid in
-                let uu____4799 = p_binders true bs in
-                let uu____4800 =
-                  let uu____4801 = p_typ false false t in
-                  prefix2 FStar_Pprint.colon uu____4801 in
-                surround_maybe_empty (Prims.of_int (2)) Prims.int_one
-                  uu____4798 uu____4799 uu____4800 in
-              FStar_Pprint.group uu____4797 in
-            let uu____4802 =
-              let uu____4803 = str "with" in
-              let uu____4804 =
-                let uu____4805 =
-                  let uu____4806 =
-                    let uu____4807 =
-                      let uu____4808 =
-                        let uu____4809 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = p_uident uid in
+                let uu___4 = p_binders true bs in
+                let uu___5 =
+                  let uu___6 = p_typ false false t in
+                  prefix2 FStar_Pprint.colon uu___6 in
+                surround_maybe_empty (Prims.of_int (2)) Prims.int_one uu___3
+                  uu___4 uu___5 in
+              FStar_Pprint.group uu___2 in
+            let uu___2 =
+              let uu___3 = str "with" in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.semi
                             FStar_Pprint.space in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                          uu____4809 in
-                      separate_map_last uu____4808 p_effectDecl eff_decls in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4807 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4806 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____4805 in
-              FStar_Pprint.op_Hat_Hat uu____4803 uu____4804 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____4796 uu____4802 in
-          braces_with_nesting uu____4795
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___9 in
+                      separate_map_last uu___8 p_effectDecl eff_decls in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___7 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___6 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___5 in
+              FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+            FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+          braces_with_nesting uu___
 and (p_effectDecl :
   Prims.bool -> FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun ps ->
     fun d ->
       match d.FStar_Parser_AST.d with
       | FStar_Parser_AST.Tycon
-          (false, uu____4812, (FStar_Parser_AST.TyconAbbrev
+          (false, uu___, (FStar_Parser_AST.TyconAbbrev
            (lid, [], FStar_Pervasives_Native.None, e))::[])
           ->
-          let uu____4821 =
-            let uu____4822 = p_lident lid in
-            let uu____4823 =
+          let uu___1 =
+            let uu___2 = p_lident lid in
+            let uu___3 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals in
-            FStar_Pprint.op_Hat_Hat uu____4822 uu____4823 in
-          let uu____4824 = p_simpleTerm ps false e in
-          prefix2 uu____4821 uu____4824
-      | uu____4825 ->
-          let uu____4826 =
-            let uu____4827 = FStar_Parser_AST.decl_to_string d in
+            FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+          let uu___2 = p_simpleTerm ps false e in prefix2 uu___1 uu___2
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Parser_AST.decl_to_string d in
             FStar_Util.format1
               "Not a declaration of an effect member... or at least I hope so : %s"
-              uu____4827 in
-          failwith uu____4826
+              uu___2 in
+          failwith uu___1
 and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
   fun lift ->
     let lift_op_doc =
@@ -1720,34 +1677,33 @@ and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
         | FStar_Parser_AST.ReifiableLift (t1, t2) ->
             [("lift_wp", t1); ("lift", t2)]
         | FStar_Parser_AST.LiftForFree t -> [("lift", t)] in
-      let p_lift ps uu____4889 =
-        match uu____4889 with
+      let p_lift ps uu___ =
+        match uu___ with
         | (kwd, t) ->
-            let uu____4896 =
-              let uu____4897 = str kwd in
-              let uu____4898 =
+            let uu___1 =
+              let uu___2 = str kwd in
+              let uu___3 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                   FStar_Pprint.equals in
-              FStar_Pprint.op_Hat_Hat uu____4897 uu____4898 in
-            let uu____4899 = p_simpleTerm ps false t in
-            prefix2 uu____4896 uu____4899 in
+              FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+            let uu___2 = p_simpleTerm ps false t in prefix2 uu___1 uu___2 in
       separate_break_map_last FStar_Pprint.semi p_lift lifts in
-    let uu____4904 =
-      let uu____4905 =
-        let uu____4906 = p_quident lift.FStar_Parser_AST.msource in
-        let uu____4907 =
-          let uu____4908 = str "~>" in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4908 in
-        FStar_Pprint.op_Hat_Hat uu____4906 uu____4907 in
-      let uu____4909 = p_quident lift.FStar_Parser_AST.mdest in
-      prefix2 uu____4905 uu____4909 in
-    let uu____4910 =
-      let uu____4911 = braces_with_nesting lift_op_doc in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4911 in
-    FStar_Pprint.op_Hat_Hat uu____4904 uu____4910
+    let uu___ =
+      let uu___1 =
+        let uu___2 = p_quident lift.FStar_Parser_AST.msource in
+        let uu___3 =
+          let uu___4 = str "~>" in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___4 in
+        FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+      let uu___2 = p_quident lift.FStar_Parser_AST.mdest in
+      prefix2 uu___1 uu___2 in
+    let uu___1 =
+      let uu___2 = braces_with_nesting lift_op_doc in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+    FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_qualifier : FStar_Parser_AST.qualifier -> FStar_Pprint.document) =
-  fun uu___8_4912 ->
-    match uu___8_4912 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.Private -> str "private"
     | FStar_Parser_AST.Noeq -> str "noeq"
     | FStar_Parser_AST.Unopteq -> str "unopteq"
@@ -1771,101 +1727,97 @@ and (p_qualifiers : FStar_Parser_AST.qualifiers -> FStar_Pprint.document) =
     match qs with
     | [] -> FStar_Pprint.empty
     | q::[] ->
-        let uu____4915 = p_qualifier q in
-        FStar_Pprint.op_Hat_Hat uu____4915 FStar_Pprint.hardline
-    | uu____4916 ->
-        let uu____4917 =
-          let uu____4918 = FStar_List.map p_qualifier qs in
-          FStar_Pprint.flow break1 uu____4918 in
-        FStar_Pprint.op_Hat_Hat uu____4917 FStar_Pprint.hardline
+        let uu___ = p_qualifier q in
+        FStar_Pprint.op_Hat_Hat uu___ FStar_Pprint.hardline
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_List.map p_qualifier qs in
+          FStar_Pprint.flow break1 uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___1 FStar_Pprint.hardline
 and (p_letqualifier :
   FStar_Parser_AST.let_qualifier -> FStar_Pprint.document) =
-  fun uu___9_4921 ->
-    match uu___9_4921 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.Rec ->
-        let uu____4922 = str "rec" in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4922
+        let uu___1 = str "rec" in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___1
     | FStar_Parser_AST.NoLetQualifier -> FStar_Pprint.empty
 and (p_aqual : FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document) =
-  fun uu___10_4923 ->
-    match uu___10_4923 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.Implicit -> str "#"
     | FStar_Parser_AST.Equality -> str "$"
     | FStar_Parser_AST.Meta (FStar_Parser_AST.Arg_qualifier_meta_tac t) ->
         let t1 =
           match t.FStar_Parser_AST.tm with
-          | FStar_Parser_AST.Abs (uu____4926, e) -> e
-          | uu____4932 ->
+          | FStar_Parser_AST.Abs (uu___1, e) -> e
+          | uu___1 ->
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.App
                    (t,
                      (FStar_Parser_AST.unit_const t.FStar_Parser_AST.range),
                      FStar_Parser_AST.Nothing)) t.FStar_Parser_AST.range
                 FStar_Parser_AST.Expr in
-        let uu____4933 = str "#[" in
-        let uu____4934 =
-          let uu____4935 = p_term false false t1 in
-          let uu____4936 =
-            let uu____4937 = str "]" in
-            FStar_Pprint.op_Hat_Hat uu____4937 break1 in
-          FStar_Pprint.op_Hat_Hat uu____4935 uu____4936 in
-        FStar_Pprint.op_Hat_Hat uu____4933 uu____4934
+        let uu___1 = str "#[" in
+        let uu___2 =
+          let uu___3 = p_term false false t1 in
+          let uu___4 =
+            let uu___5 = str "]" in FStar_Pprint.op_Hat_Hat uu___5 break1 in
+          FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
     | FStar_Parser_AST.Meta (FStar_Parser_AST.Arg_qualifier_meta_attr t) ->
-        let uu____4939 = str "#[@" in
-        let uu____4940 =
-          let uu____4941 = p_term false false t in
-          let uu____4942 =
-            let uu____4943 = str "]" in
-            FStar_Pprint.op_Hat_Hat uu____4943 break1 in
-          FStar_Pprint.op_Hat_Hat uu____4941 uu____4942 in
-        FStar_Pprint.op_Hat_Hat uu____4939 uu____4940
+        let uu___1 = str "#[@" in
+        let uu___2 =
+          let uu___3 = p_term false false t in
+          let uu___4 =
+            let uu___5 = str "]" in FStar_Pprint.op_Hat_Hat uu___5 break1 in
+          FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
 and (p_disjunctivePattern :
   FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatOr pats ->
-        let uu____4948 =
-          let uu____4949 =
-            let uu____4950 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space in
-            FStar_Pprint.op_Hat_Hat break1 uu____4950 in
-          FStar_Pprint.separate_map uu____4949 p_tuplePattern pats in
-        FStar_Pprint.group uu____4948
-    | uu____4951 -> p_tuplePattern p
+            FStar_Pprint.op_Hat_Hat break1 uu___2 in
+          FStar_Pprint.separate_map uu___1 p_tuplePattern pats in
+        FStar_Pprint.group uu___
+    | uu___ -> p_tuplePattern p
 and (p_tuplePattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatTuple (pats, false) ->
-        let uu____4958 =
-          let uu____4959 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          FStar_Pprint.separate_map uu____4959 p_constructorPattern pats in
-        FStar_Pprint.group uu____4958
-    | uu____4960 -> p_constructorPattern p
+        let uu___ =
+          let uu___1 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          FStar_Pprint.separate_map uu___1 p_constructorPattern pats in
+        FStar_Pprint.group uu___
+    | uu___ -> p_constructorPattern p
 and (p_constructorPattern :
   FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName maybe_cons_lid;
-           FStar_Parser_AST.prange = uu____4963;_},
+           FStar_Parser_AST.prange = uu___;_},
          hd::tl::[])
         when
         FStar_Ident.lid_equals maybe_cons_lid FStar_Parser_Const.cons_lid ->
-        let uu____4968 =
+        let uu___1 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon in
-        let uu____4969 = p_constructorPattern hd in
-        let uu____4970 = p_constructorPattern tl in
-        infix0 uu____4968 uu____4969 uu____4970
+        let uu___2 = p_constructorPattern hd in
+        let uu___3 = p_constructorPattern tl in infix0 uu___1 uu___2 uu___3
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uid;
-           FStar_Parser_AST.prange = uu____4972;_},
+           FStar_Parser_AST.prange = uu___;_},
          pats)
         ->
-        let uu____4978 = p_quident uid in
-        let uu____4979 =
-          FStar_Pprint.separate_map break1 p_atomicPattern pats in
-        prefix2 uu____4978 uu____4979
-    | uu____4980 -> p_atomicPattern p
+        let uu___1 = p_quident uid in
+        let uu___2 = FStar_Pprint.separate_map break1 p_atomicPattern pats in
+        prefix2 uu___1 uu___2
+    | uu___ -> p_atomicPattern p
 and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p ->
     match p.FStar_Parser_AST.pat with
@@ -1874,114 +1826,105 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
         (match ((pat.FStar_Parser_AST.pat), (t.FStar_Parser_AST.tm)) with
          | (FStar_Parser_AST.PatVar (lid, aqual), FStar_Parser_AST.Refine
             ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1);
-               FStar_Parser_AST.brange = uu____4996;
-               FStar_Parser_AST.blevel = uu____4997;
-               FStar_Parser_AST.aqual = uu____4998;_},
+               FStar_Parser_AST.brange = uu___;
+               FStar_Parser_AST.blevel = uu___1;
+               FStar_Parser_AST.aqual = uu___2;_},
              phi)) when
-             let uu____5006 = FStar_Ident.string_of_id lid in
-             let uu____5007 = FStar_Ident.string_of_id lid' in
-             uu____5006 = uu____5007 ->
-             let uu____5008 =
-               let uu____5009 = p_ident lid in
-               p_refinement aqual uu____5009 t1 phi in
-             soft_parens_with_nesting uu____5008
+             let uu___3 = FStar_Ident.string_of_id lid in
+             let uu___4 = FStar_Ident.string_of_id lid' in uu___3 = uu___4 ->
+             let uu___3 =
+               let uu___4 = p_ident lid in p_refinement aqual uu___4 t1 phi in
+             soft_parens_with_nesting uu___3
          | (FStar_Parser_AST.PatWild aqual, FStar_Parser_AST.Refine
             ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-               FStar_Parser_AST.brange = uu____5012;
-               FStar_Parser_AST.blevel = uu____5013;
-               FStar_Parser_AST.aqual = uu____5014;_},
+               FStar_Parser_AST.brange = uu___;
+               FStar_Parser_AST.blevel = uu___1;
+               FStar_Parser_AST.aqual = uu___2;_},
              phi)) ->
-             let uu____5020 =
-               p_refinement aqual FStar_Pprint.underscore t1 phi in
-             soft_parens_with_nesting uu____5020
-         | uu____5021 ->
-             let uu____5026 =
-               let uu____5027 = p_tuplePattern pat in
-               let uu____5028 =
-                 let uu____5029 = p_tmEqNoRefinement t in
-                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____5029 in
-               FStar_Pprint.op_Hat_Hat uu____5027 uu____5028 in
-             soft_parens_with_nesting uu____5026)
+             let uu___3 = p_refinement aqual FStar_Pprint.underscore t1 phi in
+             soft_parens_with_nesting uu___3
+         | uu___ ->
+             let uu___1 =
+               let uu___2 = p_tuplePattern pat in
+               let uu___3 =
+                 let uu___4 = p_tmEqNoRefinement t in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___4 in
+               FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+             soft_parens_with_nesting uu___1)
     | FStar_Parser_AST.PatList pats ->
-        let uu____5033 =
-          separate_break_map FStar_Pprint.semi p_tuplePattern pats in
+        let uu___ = separate_break_map FStar_Pprint.semi p_tuplePattern pats in
         FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero
-          FStar_Pprint.lbracket uu____5033 FStar_Pprint.rbracket
+          FStar_Pprint.lbracket uu___ FStar_Pprint.rbracket
     | FStar_Parser_AST.PatRecord pats ->
-        let p_recordFieldPat uu____5050 =
-          match uu____5050 with
+        let p_recordFieldPat uu___ =
+          match uu___ with
           | (lid, pat) ->
-              let uu____5057 = p_qlident lid in
-              let uu____5058 = p_tuplePattern pat in
-              infix2 FStar_Pprint.equals uu____5057 uu____5058 in
-        let uu____5059 =
+              let uu___1 = p_qlident lid in
+              let uu___2 = p_tuplePattern pat in
+              infix2 FStar_Pprint.equals uu___1 uu___2 in
+        let uu___ =
           separate_break_map FStar_Pprint.semi p_recordFieldPat pats in
-        soft_braces_with_nesting uu____5059
+        soft_braces_with_nesting uu___
     | FStar_Parser_AST.PatTuple (pats, true) ->
-        let uu____5069 =
+        let uu___ =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
-        let uu____5070 =
+        let uu___1 =
           separate_break_map FStar_Pprint.comma p_constructorPattern pats in
-        let uu____5071 =
+        let uu___2 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____5069
-          uu____5070 uu____5071
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu___ uu___1
+          uu___2
     | FStar_Parser_AST.PatTvar (tv, arg_qualifier_opt) -> p_tvar tv
     | FStar_Parser_AST.PatOp op ->
-        let uu____5080 =
-          let uu____5081 =
-            let uu____5082 =
-              let uu____5083 = FStar_Ident.string_of_id op in str uu____5083 in
-            let uu____5084 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Ident.string_of_id op in str uu___3 in
+            let uu___3 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
-            FStar_Pprint.op_Hat_Hat uu____5082 uu____5084 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5081 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5080
+            FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___1 in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___
     | FStar_Parser_AST.PatWild aqual ->
-        let uu____5088 = FStar_Pprint.optional p_aqual aqual in
-        FStar_Pprint.op_Hat_Hat uu____5088 FStar_Pprint.underscore
+        let uu___ = FStar_Pprint.optional p_aqual aqual in
+        FStar_Pprint.op_Hat_Hat uu___ FStar_Pprint.underscore
     | FStar_Parser_AST.PatConst c -> p_constant c
     | FStar_Parser_AST.PatVar (lid, aqual) ->
-        let uu____5096 = FStar_Pprint.optional p_aqual aqual in
-        let uu____5097 = p_lident lid in
-        FStar_Pprint.op_Hat_Hat uu____5096 uu____5097
+        let uu___ = FStar_Pprint.optional p_aqual aqual in
+        let uu___1 = p_lident lid in FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.PatName uid -> p_quident uid
-    | FStar_Parser_AST.PatOr uu____5099 -> failwith "Inner or pattern !"
+    | FStar_Parser_AST.PatOr uu___ -> failwith "Inner or pattern !"
     | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu____5102;
-           FStar_Parser_AST.prange = uu____5103;_},
-         uu____5104)
-        ->
-        let uu____5109 = p_tuplePattern p in
-        soft_parens_with_nesting uu____5109
-    | FStar_Parser_AST.PatTuple (uu____5110, false) ->
-        let uu____5115 = p_tuplePattern p in
-        soft_parens_with_nesting uu____5115
-    | uu____5116 ->
-        let uu____5117 =
-          let uu____5118 = FStar_Parser_AST.pat_to_string p in
-          FStar_Util.format1 "Invalid pattern %s" uu____5118 in
-        failwith uu____5117
+        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu___;
+           FStar_Parser_AST.prange = uu___1;_},
+         uu___2)
+        -> let uu___3 = p_tuplePattern p in soft_parens_with_nesting uu___3
+    | FStar_Parser_AST.PatTuple (uu___, false) ->
+        let uu___1 = p_tuplePattern p in soft_parens_with_nesting uu___1
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Parser_AST.pat_to_string p in
+          FStar_Util.format1 "Invalid pattern %s" uu___2 in
+        failwith uu___1
 and (is_typ_tuple : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.Op (id, uu____5121) when
-        let uu____5126 = FStar_Ident.string_of_id id in uu____5126 = "*" ->
-        true
-    | uu____5127 -> false
+    | FStar_Parser_AST.Op (id, uu___) when
+        let uu___1 = FStar_Ident.string_of_id id in uu___1 = "*" -> true
+    | uu___ -> false
 and (is_meta_qualifier :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option -> Prims.bool)
   =
   fun aq ->
     match aq with
-    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu____5131) -> true
-    | uu____5132 -> false
+    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu___) -> true
+    | uu___ -> false
 and (p_binder :
   Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document) =
   fun is_atomic ->
     fun b ->
-      let uu____5137 = p_binder' is_atomic b in
-      match uu____5137 with
+      let uu___ = p_binder' is_atomic b in
+      match uu___ with
       | (b', t', catf1) ->
           (match t' with
            | FStar_Pervasives_Native.Some typ -> catf1 b' typ
@@ -1996,93 +1939,90 @@ and (p_binder' :
     fun b ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Variable lid ->
-          let uu____5173 =
-            let uu____5174 =
+          let uu___ =
+            let uu___1 =
               FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-            let uu____5175 = p_lident lid in
-            FStar_Pprint.op_Hat_Hat uu____5174 uu____5175 in
-          (uu____5173, FStar_Pervasives_Native.None, cat_with_colon)
+            let uu___2 = p_lident lid in
+            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+          (uu___, FStar_Pervasives_Native.None, cat_with_colon)
       | FStar_Parser_AST.TVariable lid ->
-          let uu____5181 = p_lident lid in
-          (uu____5181, FStar_Pervasives_Native.None, cat_with_colon)
+          let uu___ = p_lident lid in
+          (uu___, FStar_Pervasives_Native.None, cat_with_colon)
       | FStar_Parser_AST.Annotated (lid, t) ->
-          let uu____5188 =
+          let uu___ =
             match t.FStar_Parser_AST.tm with
             | FStar_Parser_AST.Refine
                 ({
                    FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1);
-                   FStar_Parser_AST.brange = uu____5199;
-                   FStar_Parser_AST.blevel = uu____5200;
-                   FStar_Parser_AST.aqual = uu____5201;_},
+                   FStar_Parser_AST.brange = uu___1;
+                   FStar_Parser_AST.blevel = uu___2;
+                   FStar_Parser_AST.aqual = uu___3;_},
                  phi)
                 when
-                let uu____5205 = FStar_Ident.string_of_id lid in
-                let uu____5206 = FStar_Ident.string_of_id lid' in
-                uu____5205 = uu____5206 ->
-                let uu____5207 = p_lident lid in
-                p_refinement' b.FStar_Parser_AST.aqual uu____5207 t1 phi
-            | uu____5208 ->
+                let uu___4 = FStar_Ident.string_of_id lid in
+                let uu___5 = FStar_Ident.string_of_id lid' in uu___4 = uu___5
+                ->
+                let uu___4 = p_lident lid in
+                p_refinement' b.FStar_Parser_AST.aqual uu___4 t1 phi
+            | uu___1 ->
                 let t' =
-                  let uu____5210 = is_typ_tuple t in
-                  if uu____5210
+                  let uu___2 = is_typ_tuple t in
+                  if uu___2
                   then
-                    let uu____5211 = p_tmFormula t in
-                    soft_parens_with_nesting uu____5211
+                    let uu___3 = p_tmFormula t in
+                    soft_parens_with_nesting uu___3
                   else p_tmFormula t in
-                let uu____5213 =
-                  let uu____5214 =
+                let uu___2 =
+                  let uu___3 =
                     FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-                  let uu____5215 = p_lident lid in
-                  FStar_Pprint.op_Hat_Hat uu____5214 uu____5215 in
-                (uu____5213, t') in
-          (match uu____5188 with
+                  let uu___4 = p_lident lid in
+                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                (uu___2, t') in
+          (match uu___ with
            | (b', t') ->
                let catf1 =
-                 let uu____5233 =
+                 let uu___1 =
                    is_atomic || (is_meta_qualifier b.FStar_Parser_AST.aqual) in
-                 if uu____5233
+                 if uu___1
                  then
                    fun x ->
                      fun y ->
-                       let uu____5238 =
-                         let uu____5239 =
-                           let uu____5240 = cat_with_colon x y in
-                           FStar_Pprint.op_Hat_Hat uu____5240
-                             FStar_Pprint.rparen in
-                         FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen
-                           uu____5239 in
-                       FStar_Pprint.group uu____5238
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 = cat_with_colon x y in
+                           FStar_Pprint.op_Hat_Hat uu___4 FStar_Pprint.rparen in
+                         FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___3 in
+                       FStar_Pprint.group uu___2
                  else
                    (fun x ->
                       fun y ->
-                        let uu____5244 = cat_with_colon x y in
-                        FStar_Pprint.group uu____5244) in
+                        let uu___3 = cat_with_colon x y in
+                        FStar_Pprint.group uu___3) in
                (b', (FStar_Pervasives_Native.Some t'), catf1))
-      | FStar_Parser_AST.TAnnotated uu____5249 ->
-          failwith "Is this still used ?"
+      | FStar_Parser_AST.TAnnotated uu___ -> failwith "Is this still used ?"
       | FStar_Parser_AST.NoName t ->
           (match t.FStar_Parser_AST.tm with
            | FStar_Parser_AST.Refine
                ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-                  FStar_Parser_AST.brange = uu____5276;
-                  FStar_Parser_AST.blevel = uu____5277;
-                  FStar_Parser_AST.aqual = uu____5278;_},
+                  FStar_Parser_AST.brange = uu___;
+                  FStar_Parser_AST.blevel = uu___1;
+                  FStar_Parser_AST.aqual = uu___2;_},
                 phi)
                ->
-               let uu____5282 =
+               let uu___3 =
                  p_refinement' b.FStar_Parser_AST.aqual
                    FStar_Pprint.underscore t1 phi in
-               (match uu____5282 with
+               (match uu___3 with
                 | (b', t') ->
                     (b', (FStar_Pervasives_Native.Some t'), cat_with_colon))
-           | uu____5303 ->
+           | uu___ ->
                if is_atomic
                then
-                 let uu____5314 = p_atomicTerm t in
-                 (uu____5314, FStar_Pervasives_Native.None, cat_with_colon)
+                 let uu___1 = p_atomicTerm t in
+                 (uu___1, FStar_Pervasives_Native.None, cat_with_colon)
                else
-                 (let uu____5320 = p_appTerm t in
-                  (uu____5320, FStar_Pervasives_Native.None, cat_with_colon)))
+                 (let uu___2 = p_appTerm t in
+                  (uu___2, FStar_Pervasives_Native.None, cat_with_colon)))
 and (p_refinement :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Pprint.document ->
@@ -2092,8 +2032,8 @@ and (p_refinement :
     fun binder ->
       fun t ->
         fun phi ->
-          let uu____5331 = p_refinement' aqual_opt binder t phi in
-          match uu____5331 with | (b, typ) -> cat_with_colon b typ
+          let uu___ = p_refinement' aqual_opt binder t phi in
+          match uu___ with | (b, typ) -> cat_with_colon b typ
 and (p_refinement' :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Pprint.document ->
@@ -2107,37 +2047,37 @@ and (p_refinement' :
         fun phi ->
           let is_t_atomic =
             match t.FStar_Parser_AST.tm with
-            | FStar_Parser_AST.Construct uu____5345 -> false
-            | FStar_Parser_AST.App uu____5356 -> false
-            | FStar_Parser_AST.Op uu____5363 -> false
-            | uu____5370 -> true in
-          let uu____5371 = p_noSeqTerm false false phi in
-          match uu____5371 with
+            | FStar_Parser_AST.Construct uu___ -> false
+            | FStar_Parser_AST.App uu___ -> false
+            | FStar_Parser_AST.Op uu___ -> false
+            | uu___ -> true in
+          let uu___ = p_noSeqTerm false false phi in
+          match uu___ with
           | (comm, phi1) ->
               let phi2 =
                 if comm = FStar_Pprint.empty
                 then phi1
                 else
-                  (let uu____5384 =
+                  (let uu___2 =
                      FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline phi1 in
-                   FStar_Pprint.op_Hat_Hat comm uu____5384) in
+                   FStar_Pprint.op_Hat_Hat comm uu___2) in
               let jump_break =
                 if is_t_atomic then Prims.int_zero else Prims.int_one in
-              let uu____5387 =
-                let uu____5388 = FStar_Pprint.optional p_aqual aqual_opt in
-                FStar_Pprint.op_Hat_Hat uu____5388 binder in
-              let uu____5389 =
-                let uu____5390 = p_appTerm t in
-                let uu____5391 =
-                  let uu____5392 =
-                    let uu____5393 =
-                      let uu____5394 = soft_braces_with_nesting_tight phi2 in
-                      let uu____5395 = soft_braces_with_nesting phi2 in
-                      FStar_Pprint.ifflat uu____5394 uu____5395 in
-                    FStar_Pprint.group uu____5393 in
-                  FStar_Pprint.jump (Prims.of_int (2)) jump_break uu____5392 in
-                FStar_Pprint.op_Hat_Hat uu____5390 uu____5391 in
-              (uu____5387, uu____5389)
+              let uu___1 =
+                let uu___2 = FStar_Pprint.optional p_aqual aqual_opt in
+                FStar_Pprint.op_Hat_Hat uu___2 binder in
+              let uu___2 =
+                let uu___3 = p_appTerm t in
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 =
+                      let uu___7 = soft_braces_with_nesting_tight phi2 in
+                      let uu___8 = soft_braces_with_nesting phi2 in
+                      FStar_Pprint.ifflat uu___7 uu___8 in
+                    FStar_Pprint.group uu___6 in
+                  FStar_Pprint.jump (Prims.of_int (2)) jump_break uu___5 in
+                FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+              (uu___1, uu___2)
 and (p_binders_list :
   Prims.bool ->
     FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document Prims.list)
@@ -2147,32 +2087,32 @@ and (p_binders :
   =
   fun is_atomic ->
     fun bs ->
-      let uu____5406 = p_binders_list is_atomic bs in
-      separate_or_flow break1 uu____5406
+      let uu___ = p_binders_list is_atomic bs in
+      separate_or_flow break1 uu___
 and (string_of_id_or_underscore : FStar_Ident.ident -> FStar_Pprint.document)
   =
   fun lid ->
-    let uu____5410 =
-      (let uu____5413 = FStar_Ident.string_of_id lid in
-       FStar_Util.starts_with uu____5413 FStar_Ident.reserved_prefix) &&
-        (let uu____5415 = FStar_Options.print_real_names () in
-         Prims.op_Negation uu____5415) in
-    if uu____5410
+    let uu___ =
+      (let uu___1 = FStar_Ident.string_of_id lid in
+       FStar_Util.starts_with uu___1 FStar_Ident.reserved_prefix) &&
+        (let uu___1 = FStar_Options.print_real_names () in
+         Prims.op_Negation uu___1) in
+    if uu___
     then FStar_Pprint.underscore
-    else (let uu____5417 = FStar_Ident.string_of_id lid in str uu____5417)
+    else (let uu___2 = FStar_Ident.string_of_id lid in str uu___2)
 and (text_of_lid_or_underscore : FStar_Ident.lident -> FStar_Pprint.document)
   =
   fun lid ->
-    let uu____5419 =
-      (let uu____5422 =
-         let uu____5423 = FStar_Ident.ident_of_lid lid in
-         FStar_Ident.string_of_id uu____5423 in
-       FStar_Util.starts_with uu____5422 FStar_Ident.reserved_prefix) &&
-        (let uu____5425 = FStar_Options.print_real_names () in
-         Prims.op_Negation uu____5425) in
-    if uu____5419
+    let uu___ =
+      (let uu___1 =
+         let uu___2 = FStar_Ident.ident_of_lid lid in
+         FStar_Ident.string_of_id uu___2 in
+       FStar_Util.starts_with uu___1 FStar_Ident.reserved_prefix) &&
+        (let uu___1 = FStar_Options.print_real_names () in
+         Prims.op_Negation uu___1) in
+    if uu___
     then FStar_Pprint.underscore
-    else (let uu____5427 = FStar_Ident.string_of_lid lid in str uu____5427)
+    else (let uu___2 = FStar_Ident.string_of_lid lid in str uu___2)
 and (p_qlident : FStar_Ident.lid -> FStar_Pprint.document) =
   fun lid -> text_of_lid_or_underscore lid
 and (p_quident : FStar_Ident.lid -> FStar_Pprint.document) =
@@ -2196,24 +2136,24 @@ and (inline_comment_or_above :
       fun sep ->
         if comm = FStar_Pprint.empty
         then
-          let uu____5443 = FStar_Pprint.op_Hat_Hat doc sep in
-          FStar_Pprint.group uu____5443
+          let uu___ = FStar_Pprint.op_Hat_Hat doc sep in
+          FStar_Pprint.group uu___
         else
-          (let uu____5445 =
-             let uu____5446 =
-               let uu____5447 =
-                 let uu____5448 =
-                   let uu____5449 = FStar_Pprint.op_Hat_Hat break1 comm in
-                   FStar_Pprint.op_Hat_Hat sep uu____5449 in
-                 FStar_Pprint.op_Hat_Hat doc uu____5448 in
-               FStar_Pprint.group uu____5447 in
-             let uu____5450 =
-               let uu____5451 =
-                 let uu____5452 = FStar_Pprint.op_Hat_Hat doc sep in
-                 FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5452 in
-               FStar_Pprint.op_Hat_Hat comm uu____5451 in
-             FStar_Pprint.ifflat uu____5446 uu____5450 in
-           FStar_All.pipe_left FStar_Pprint.group uu____5445)
+          (let uu___1 =
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = FStar_Pprint.op_Hat_Hat break1 comm in
+                   FStar_Pprint.op_Hat_Hat sep uu___5 in
+                 FStar_Pprint.op_Hat_Hat doc uu___4 in
+               FStar_Pprint.group uu___3 in
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 = FStar_Pprint.op_Hat_Hat doc sep in
+                 FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___5 in
+               FStar_Pprint.op_Hat_Hat comm uu___4 in
+             FStar_Pprint.ifflat uu___2 uu___3 in
+           FStar_All.pipe_left FStar_Pprint.group uu___1)
 and (p_term :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -2222,37 +2162,37 @@ and (p_term :
       fun e ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Seq (e1, e2) ->
-            let uu____5458 = p_noSeqTerm true false e1 in
-            (match uu____5458 with
+            let uu___ = p_noSeqTerm true false e1 in
+            (match uu___ with
              | (comm, t1) ->
-                 let uu____5465 =
+                 let uu___1 =
                    inline_comment_or_above comm t1 FStar_Pprint.semi in
-                 let uu____5466 =
-                   let uu____5467 = p_term ps pb e2 in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5467 in
-                 FStar_Pprint.op_Hat_Hat uu____5465 uu____5466)
+                 let uu___2 =
+                   let uu___3 = p_term ps pb e2 in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___3 in
+                 FStar_Pprint.op_Hat_Hat uu___1 uu___2)
         | FStar_Parser_AST.Bind (x, e1, e2) ->
-            let uu____5471 =
-              let uu____5472 =
-                let uu____5473 =
-                  let uu____5474 = p_lident x in
-                  let uu____5475 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = p_lident x in
+                  let uu___4 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.long_left_arrow in
-                  FStar_Pprint.op_Hat_Hat uu____5474 uu____5475 in
-                let uu____5476 =
-                  let uu____5477 = p_noSeqTermAndComment true false e1 in
-                  let uu____5478 =
+                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                let uu___3 =
+                  let uu___4 = p_noSeqTermAndComment true false e1 in
+                  let uu___5 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.semi in
-                  FStar_Pprint.op_Hat_Hat uu____5477 uu____5478 in
-                op_Hat_Slash_Plus_Hat uu____5473 uu____5476 in
-              FStar_Pprint.group uu____5472 in
-            let uu____5479 = p_term ps pb e2 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____5471 uu____5479
-        | uu____5480 ->
-            let uu____5481 = p_noSeqTermAndComment ps pb e in
-            FStar_Pprint.group uu____5481
+                  FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+                op_Hat_Slash_Plus_Hat uu___2 uu___3 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = p_term ps pb e2 in
+            FStar_Pprint.op_Hat_Slash_Hat uu___ uu___1
+        | uu___ ->
+            let uu___1 = p_noSeqTermAndComment ps pb e in
+            FStar_Pprint.group uu___1
 and (p_term_sep :
   Prims.bool ->
     Prims.bool ->
@@ -2264,41 +2204,41 @@ and (p_term_sep :
       fun e ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Seq (e1, e2) ->
-            let uu____5491 = p_noSeqTerm true false e1 in
-            (match uu____5491 with
+            let uu___ = p_noSeqTerm true false e1 in
+            (match uu___ with
              | (comm, t1) ->
-                 let uu____5502 =
-                   let uu____5503 =
-                     let uu____5504 =
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Pprint.op_Hat_Hat t1 FStar_Pprint.semi in
-                     FStar_Pprint.group uu____5504 in
-                   let uu____5505 =
-                     let uu____5506 = p_term ps pb e2 in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5506 in
-                   FStar_Pprint.op_Hat_Hat uu____5503 uu____5505 in
-                 (comm, uu____5502))
+                     FStar_Pprint.group uu___3 in
+                   let uu___3 =
+                     let uu___4 = p_term ps pb e2 in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___4 in
+                   FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+                 (comm, uu___1))
         | FStar_Parser_AST.Bind (x, e1, e2) ->
-            let uu____5510 =
-              let uu____5511 =
-                let uu____5512 =
-                  let uu____5513 =
-                    let uu____5514 = p_lident x in
-                    let uu____5515 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = p_lident x in
+                    let uu___5 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                         FStar_Pprint.long_left_arrow in
-                    FStar_Pprint.op_Hat_Hat uu____5514 uu____5515 in
-                  let uu____5516 =
-                    let uu____5517 = p_noSeqTermAndComment true false e1 in
-                    let uu____5518 =
+                    FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+                  let uu___4 =
+                    let uu___5 = p_noSeqTermAndComment true false e1 in
+                    let uu___6 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                         FStar_Pprint.semi in
-                    FStar_Pprint.op_Hat_Hat uu____5517 uu____5518 in
-                  op_Hat_Slash_Plus_Hat uu____5513 uu____5516 in
-                FStar_Pprint.group uu____5512 in
-              let uu____5519 = p_term ps pb e2 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5511 uu____5519 in
-            (FStar_Pprint.empty, uu____5510)
-        | uu____5520 -> p_noSeqTerm ps pb e
+                    FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
+                  op_Hat_Slash_Plus_Hat uu___3 uu___4 in
+                FStar_Pprint.group uu___2 in
+              let uu___2 = p_term ps pb e2 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+            (FStar_Pprint.empty, uu___)
+        | uu___ -> p_noSeqTerm ps pb e
 and (p_noSeqTerm :
   Prims.bool ->
     Prims.bool ->
@@ -2323,219 +2263,214 @@ and (p_noSeqTerm' :
       fun e ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Ascribed (e1, t, FStar_Pervasives_Native.None) ->
-            let uu____5534 =
-              let uu____5535 = p_tmIff e1 in
-              let uu____5536 =
-                let uu____5537 =
-                  let uu____5538 = p_typ ps pb t in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____5538 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____5537 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5535 uu____5536 in
-            FStar_Pprint.group uu____5534
+            let uu___ =
+              let uu___1 = p_tmIff e1 in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = p_typ ps pb t in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___4 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu___3 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Ascribed (e1, t, FStar_Pervasives_Native.Some tac)
             ->
-            let uu____5544 =
-              let uu____5545 = p_tmIff e1 in
-              let uu____5546 =
-                let uu____5547 =
-                  let uu____5548 =
-                    let uu____5549 = p_typ false false t in
-                    let uu____5550 =
-                      let uu____5551 = str "by" in
-                      let uu____5552 = p_typ ps pb (maybe_unthunk tac) in
-                      FStar_Pprint.op_Hat_Slash_Hat uu____5551 uu____5552 in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____5549 uu____5550 in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____5548 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____5547 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5545 uu____5546 in
-            FStar_Pprint.group uu____5544
+            let uu___ =
+              let uu___1 = p_tmIff e1 in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = p_typ false false t in
+                    let uu___6 =
+                      let uu___7 = str "by" in
+                      let uu___8 = p_typ ps pb (maybe_unthunk tac) in
+                      FStar_Pprint.op_Hat_Slash_Hat uu___7 uu___8 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu___5 uu___6 in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___4 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu___3 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Op (id, e1::e2::e3::[]) when
-            let uu____5559 = FStar_Ident.string_of_id id in
-            uu____5559 = ".()<-" ->
-            let uu____5560 =
-              let uu____5561 =
-                let uu____5562 =
-                  let uu____5563 = p_atomicTermNotQUident e1 in
-                  let uu____5564 =
-                    let uu____5565 =
-                      let uu____5566 =
-                        let uu____5567 = p_term false false e2 in
-                        soft_parens_with_nesting uu____5567 in
-                      let uu____5568 =
+            let uu___ = FStar_Ident.string_of_id id in uu___ = ".()<-" ->
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = p_atomicTermNotQUident e1 in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 = p_term false false e2 in
+                        soft_parens_with_nesting uu___7 in
+                      let uu___7 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                           FStar_Pprint.larrow in
-                      FStar_Pprint.op_Hat_Hat uu____5566 uu____5568 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5565 in
-                  FStar_Pprint.op_Hat_Hat uu____5563 uu____5564 in
-                FStar_Pprint.group uu____5562 in
-              let uu____5569 =
-                let uu____5570 = p_noSeqTermAndComment ps pb e3 in
-                jump2 uu____5570 in
-              FStar_Pprint.op_Hat_Hat uu____5561 uu____5569 in
-            FStar_Pprint.group uu____5560
+                      FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___5 in
+                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                FStar_Pprint.group uu___2 in
+              let uu___2 =
+                let uu___3 = p_noSeqTermAndComment ps pb e3 in jump2 uu___3 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Op (id, e1::e2::e3::[]) when
-            let uu____5577 = FStar_Ident.string_of_id id in
-            uu____5577 = ".[]<-" ->
-            let uu____5578 =
-              let uu____5579 =
-                let uu____5580 =
-                  let uu____5581 = p_atomicTermNotQUident e1 in
-                  let uu____5582 =
-                    let uu____5583 =
-                      let uu____5584 =
-                        let uu____5585 = p_term false false e2 in
-                        soft_brackets_with_nesting uu____5585 in
-                      let uu____5586 =
+            let uu___ = FStar_Ident.string_of_id id in uu___ = ".[]<-" ->
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = p_atomicTermNotQUident e1 in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 = p_term false false e2 in
+                        soft_brackets_with_nesting uu___7 in
+                      let uu___7 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                           FStar_Pprint.larrow in
-                      FStar_Pprint.op_Hat_Hat uu____5584 uu____5586 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5583 in
-                  FStar_Pprint.op_Hat_Hat uu____5581 uu____5582 in
-                FStar_Pprint.group uu____5580 in
-              let uu____5587 =
-                let uu____5588 = p_noSeqTermAndComment ps pb e3 in
-                jump2 uu____5588 in
-              FStar_Pprint.op_Hat_Hat uu____5579 uu____5587 in
-            FStar_Pprint.group uu____5578
+                      FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___5 in
+                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                FStar_Pprint.group uu___2 in
+              let uu___2 =
+                let uu___3 = p_noSeqTermAndComment ps pb e3 in jump2 uu___3 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Requires (e1, wtf) ->
-            let uu____5596 =
-              let uu____5597 = str "requires" in
-              let uu____5598 = p_typ ps pb e1 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5597 uu____5598 in
-            FStar_Pprint.group uu____5596
+            let uu___1 =
+              let uu___2 = str "requires" in
+              let uu___3 = p_typ ps pb e1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+            FStar_Pprint.group uu___1
         | FStar_Parser_AST.Ensures (e1, wtf) ->
-            let uu____5606 =
-              let uu____5607 = str "ensures" in
-              let uu____5608 = p_typ ps pb e1 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5607 uu____5608 in
-            FStar_Pprint.group uu____5606
+            let uu___1 =
+              let uu___2 = str "ensures" in
+              let uu___3 = p_typ ps pb e1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+            FStar_Pprint.group uu___1
         | FStar_Parser_AST.Attributes es ->
-            let uu____5612 =
-              let uu____5613 = str "attributes" in
-              let uu____5614 =
-                FStar_Pprint.separate_map break1 p_atomicTerm es in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5613 uu____5614 in
-            FStar_Pprint.group uu____5612
+            let uu___ =
+              let uu___1 = str "attributes" in
+              let uu___2 = FStar_Pprint.separate_map break1 p_atomicTerm es in
+              FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.If (e1, e2, e3) ->
             if is_unit e3
             then
-              let uu____5618 =
-                let uu____5619 =
-                  let uu____5620 = str "if" in
-                  let uu____5621 = p_noSeqTermAndComment false false e1 in
-                  op_Hat_Slash_Plus_Hat uu____5620 uu____5621 in
-                let uu____5622 =
-                  let uu____5623 = str "then" in
-                  let uu____5624 = p_noSeqTermAndComment ps pb e2 in
-                  op_Hat_Slash_Plus_Hat uu____5623 uu____5624 in
-                FStar_Pprint.op_Hat_Slash_Hat uu____5619 uu____5622 in
-              FStar_Pprint.group uu____5618
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = str "if" in
+                  let uu___3 = p_noSeqTermAndComment false false e1 in
+                  op_Hat_Slash_Plus_Hat uu___2 uu___3 in
+                let uu___2 =
+                  let uu___3 = str "then" in
+                  let uu___4 = p_noSeqTermAndComment ps pb e2 in
+                  op_Hat_Slash_Plus_Hat uu___3 uu___4 in
+                FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+              FStar_Pprint.group uu___
             else
               (let e2_doc =
                  match e2.FStar_Parser_AST.tm with
-                 | FStar_Parser_AST.If (uu____5627, uu____5628, e31) when
-                     is_unit e31 ->
-                     let uu____5630 = p_noSeqTermAndComment false false e2 in
-                     soft_parens_with_nesting uu____5630
-                 | uu____5631 -> p_noSeqTermAndComment false false e2 in
-               let uu____5632 =
-                 let uu____5633 =
-                   let uu____5634 = str "if" in
-                   let uu____5635 = p_noSeqTermAndComment false false e1 in
-                   op_Hat_Slash_Plus_Hat uu____5634 uu____5635 in
-                 let uu____5636 =
-                   let uu____5637 =
-                     let uu____5638 = str "then" in
-                     op_Hat_Slash_Plus_Hat uu____5638 e2_doc in
-                   let uu____5639 =
-                     let uu____5640 = str "else" in
-                     let uu____5641 = p_noSeqTermAndComment ps pb e3 in
-                     op_Hat_Slash_Plus_Hat uu____5640 uu____5641 in
-                   FStar_Pprint.op_Hat_Slash_Hat uu____5637 uu____5639 in
-                 FStar_Pprint.op_Hat_Slash_Hat uu____5633 uu____5636 in
-               FStar_Pprint.group uu____5632)
+                 | FStar_Parser_AST.If (uu___1, uu___2, e31) when is_unit e31
+                     ->
+                     let uu___3 = p_noSeqTermAndComment false false e2 in
+                     soft_parens_with_nesting uu___3
+                 | uu___1 -> p_noSeqTermAndComment false false e2 in
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = str "if" in
+                   let uu___4 = p_noSeqTermAndComment false false e1 in
+                   op_Hat_Slash_Plus_Hat uu___3 uu___4 in
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = str "then" in
+                     op_Hat_Slash_Plus_Hat uu___5 e2_doc in
+                   let uu___5 =
+                     let uu___6 = str "else" in
+                     let uu___7 = p_noSeqTermAndComment ps pb e3 in
+                     op_Hat_Slash_Plus_Hat uu___6 uu___7 in
+                   FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                 FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+               FStar_Pprint.group uu___1)
         | FStar_Parser_AST.TryWith (e1, branches) ->
-            let uu____5664 =
-              let uu____5665 =
-                let uu____5666 =
-                  let uu____5667 = str "try" in
-                  let uu____5668 = p_noSeqTermAndComment false false e1 in
-                  prefix2 uu____5667 uu____5668 in
-                let uu____5669 =
-                  let uu____5670 = str "with" in
-                  let uu____5671 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = str "try" in
+                  let uu___4 = p_noSeqTermAndComment false false e1 in
+                  prefix2 uu___3 uu___4 in
+                let uu___3 =
+                  let uu___4 = str "with" in
+                  let uu___5 =
                     separate_map_last FStar_Pprint.hardline p_patternBranch
                       branches in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____5670 uu____5671 in
-                FStar_Pprint.op_Hat_Slash_Hat uu____5666 uu____5669 in
-              FStar_Pprint.group uu____5665 in
-            let uu____5680 = paren_if (ps || pb) in uu____5680 uu____5664
+                  FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = paren_if (ps || pb) in uu___1 uu___
         | FStar_Parser_AST.Match (e1, branches) ->
-            let uu____5707 =
-              let uu____5708 =
-                let uu____5709 =
-                  let uu____5710 = str "match" in
-                  let uu____5711 = p_noSeqTermAndComment false false e1 in
-                  let uu____5712 = str "with" in
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = str "match" in
+                  let uu___4 = p_noSeqTermAndComment false false e1 in
+                  let uu___5 = str "with" in
                   FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-                    uu____5710 uu____5711 uu____5712 in
-                let uu____5713 =
+                    uu___3 uu___4 uu___5 in
+                let uu___3 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
                     branches in
-                FStar_Pprint.op_Hat_Slash_Hat uu____5709 uu____5713 in
-              FStar_Pprint.group uu____5708 in
-            let uu____5722 = paren_if (ps || pb) in uu____5722 uu____5707
+                FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = paren_if (ps || pb) in uu___1 uu___
         | FStar_Parser_AST.LetOpen (uid, e1) ->
-            let uu____5729 =
-              let uu____5730 =
-                let uu____5731 =
-                  let uu____5732 = str "let open" in
-                  let uu____5733 = p_quident uid in
-                  let uu____5734 = str "in" in
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = str "let open" in
+                  let uu___4 = p_quident uid in
+                  let uu___5 = str "in" in
                   FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-                    uu____5732 uu____5733 uu____5734 in
-                let uu____5735 = p_term false pb e1 in
-                FStar_Pprint.op_Hat_Slash_Hat uu____5731 uu____5735 in
-              FStar_Pprint.group uu____5730 in
-            let uu____5736 = paren_if ps in uu____5736 uu____5729
+                    uu___3 uu___4 uu___5 in
+                let uu___3 = p_term false pb e1 in
+                FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = paren_if ps in uu___1 uu___
         | FStar_Parser_AST.Let (q, lbs, e1) ->
-            let p_lb q1 uu____5800 is_last =
-              match uu____5800 with
+            let p_lb q1 uu___ is_last =
+              match uu___ with
               | (a, (pat, e2)) ->
                   let attrs = p_attrs_opt a in
                   let doc_let_or_and =
                     match q1 with
                     | FStar_Pervasives_Native.Some (FStar_Parser_AST.Rec) ->
-                        let uu____5833 =
-                          let uu____5834 = str "let" in
-                          let uu____5835 = str "rec" in
-                          FStar_Pprint.op_Hat_Slash_Hat uu____5834 uu____5835 in
-                        FStar_Pprint.group uu____5833
+                        let uu___1 =
+                          let uu___2 = str "let" in
+                          let uu___3 = str "rec" in
+                          FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+                        FStar_Pprint.group uu___1
                     | FStar_Pervasives_Native.Some
                         (FStar_Parser_AST.NoLetQualifier) -> str "let"
-                    | uu____5836 -> str "and" in
+                    | uu___1 -> str "and" in
                   let doc_pat = p_letlhs doc_let_or_and (pat, e2) true in
-                  let uu____5840 = p_term_sep false false e2 in
-                  (match uu____5840 with
+                  let uu___1 = p_term_sep false false e2 in
+                  (match uu___1 with
                    | (comm, doc_expr) ->
                        let doc_expr1 =
                          inline_comment_or_above comm doc_expr
                            FStar_Pprint.empty in
-                       let uu____5848 =
+                       let uu___2 =
                          if is_last
                          then
-                           let uu____5849 =
+                           let uu___3 =
                              FStar_Pprint.flow break1
                                [doc_pat; FStar_Pprint.equals] in
-                           let uu____5850 = str "in" in
+                           let uu___4 = str "in" in
                            FStar_Pprint.surround (Prims.of_int (2))
-                             Prims.int_one uu____5849 doc_expr1 uu____5850
+                             Prims.int_one uu___3 doc_expr1 uu___4
                          else
-                           (let uu____5852 =
+                           (let uu___4 =
                               FStar_Pprint.flow break1
                                 [doc_pat; FStar_Pprint.equals; doc_expr1] in
-                            FStar_Pprint.hang (Prims.of_int (2)) uu____5852) in
-                       FStar_Pprint.op_Hat_Hat attrs uu____5848) in
+                            FStar_Pprint.hang (Prims.of_int (2)) uu___4) in
+                       FStar_Pprint.op_Hat_Hat attrs uu___2) in
             let l = FStar_List.length lbs in
             let lbs_docs =
               FStar_List.mapi
@@ -2543,165 +2478,162 @@ and (p_noSeqTerm' :
                    fun lb ->
                      if i = Prims.int_zero
                      then
-                       let uu____5898 =
+                       let uu___ =
                          p_lb (FStar_Pervasives_Native.Some q) lb
                            (i = (l - Prims.int_one)) in
-                       FStar_Pprint.group uu____5898
+                       FStar_Pprint.group uu___
                      else
-                       (let uu____5900 =
+                       (let uu___1 =
                           p_lb FStar_Pervasives_Native.None lb
                             (i = (l - Prims.int_one)) in
-                        FStar_Pprint.group uu____5900)) lbs in
+                        FStar_Pprint.group uu___1)) lbs in
             let lbs_doc =
-              let uu____5902 = FStar_Pprint.separate break1 lbs_docs in
-              FStar_Pprint.group uu____5902 in
-            let uu____5903 =
-              let uu____5904 =
-                let uu____5905 =
-                  let uu____5906 = p_term false pb e1 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____5906 in
-                FStar_Pprint.op_Hat_Hat lbs_doc uu____5905 in
-              FStar_Pprint.group uu____5904 in
-            let uu____5907 = paren_if ps in uu____5907 uu____5903
+              let uu___ = FStar_Pprint.separate break1 lbs_docs in
+              FStar_Pprint.group uu___ in
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = p_term false pb e1 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___3 in
+                FStar_Pprint.op_Hat_Hat lbs_doc uu___2 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = paren_if ps in uu___1 uu___
         | FStar_Parser_AST.Abs
             ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, typ_opt);
-               FStar_Parser_AST.prange = uu____5914;_}::[],
+               FStar_Parser_AST.prange = uu___;_}::[],
              {
                FStar_Parser_AST.tm = FStar_Parser_AST.Match
                  (maybe_x, branches);
-               FStar_Parser_AST.range = uu____5917;
-               FStar_Parser_AST.level = uu____5918;_})
+               FStar_Parser_AST.range = uu___1;
+               FStar_Parser_AST.level = uu___2;_})
             when matches_var maybe_x x ->
-            let uu____5945 =
-              let uu____5946 =
-                let uu____5947 = str "function" in
-                let uu____5948 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = str "function" in
+                let uu___6 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
                     branches in
-                FStar_Pprint.op_Hat_Slash_Hat uu____5947 uu____5948 in
-              FStar_Pprint.group uu____5946 in
-            let uu____5957 = paren_if (ps || pb) in uu____5957 uu____5945
+                FStar_Pprint.op_Hat_Slash_Hat uu___5 uu___6 in
+              FStar_Pprint.group uu___4 in
+            let uu___4 = paren_if (ps || pb) in uu___4 uu___3
         | FStar_Parser_AST.Quote (e1, FStar_Parser_AST.Dynamic) ->
-            let uu____5963 =
-              let uu____5964 = str "quote" in
-              let uu____5965 = p_noSeqTermAndComment ps pb e1 in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5964 uu____5965 in
-            FStar_Pprint.group uu____5963
+            let uu___ =
+              let uu___1 = str "quote" in
+              let uu___2 = p_noSeqTermAndComment ps pb e1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Quote (e1, FStar_Parser_AST.Static) ->
-            let uu____5967 =
-              let uu____5968 = str "`" in
-              let uu____5969 = p_noSeqTermAndComment ps pb e1 in
-              FStar_Pprint.op_Hat_Hat uu____5968 uu____5969 in
-            FStar_Pprint.group uu____5967
+            let uu___ =
+              let uu___1 = str "`" in
+              let uu___2 = p_noSeqTermAndComment ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.VQuote e1 ->
-            let uu____5971 =
-              let uu____5972 = str "`%" in
-              let uu____5973 = p_noSeqTermAndComment ps pb e1 in
-              FStar_Pprint.op_Hat_Hat uu____5972 uu____5973 in
-            FStar_Pprint.group uu____5971
+            let uu___ =
+              let uu___1 = str "`%" in
+              let uu___2 = p_noSeqTermAndComment ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Antiquote
             {
               FStar_Parser_AST.tm = FStar_Parser_AST.Quote
                 (e1, FStar_Parser_AST.Dynamic);
-              FStar_Parser_AST.range = uu____5975;
-              FStar_Parser_AST.level = uu____5976;_}
+              FStar_Parser_AST.range = uu___;
+              FStar_Parser_AST.level = uu___1;_}
             ->
-            let uu____5977 =
-              let uu____5978 = str "`@" in
-              let uu____5979 = p_noSeqTermAndComment ps pb e1 in
-              FStar_Pprint.op_Hat_Hat uu____5978 uu____5979 in
-            FStar_Pprint.group uu____5977
+            let uu___2 =
+              let uu___3 = str "`@" in
+              let uu___4 = p_noSeqTermAndComment ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+            FStar_Pprint.group uu___2
         | FStar_Parser_AST.Antiquote e1 ->
-            let uu____5981 =
-              let uu____5982 = str "`#" in
-              let uu____5983 = p_noSeqTermAndComment ps pb e1 in
-              FStar_Pprint.op_Hat_Hat uu____5982 uu____5983 in
-            FStar_Pprint.group uu____5981
+            let uu___ =
+              let uu___1 = str "`#" in
+              let uu___2 = p_noSeqTermAndComment ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.CalcProof (rel, init, steps) ->
             let head =
-              let uu____5992 = str "calc" in
-              let uu____5993 =
-                let uu____5994 =
-                  let uu____5995 = p_noSeqTermAndComment false false rel in
-                  let uu____5996 =
+              let uu___ = str "calc" in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = p_noSeqTermAndComment false false rel in
+                  let uu___4 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                       FStar_Pprint.lbrace in
-                  FStar_Pprint.op_Hat_Hat uu____5995 uu____5996 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5994 in
-              FStar_Pprint.op_Hat_Hat uu____5992 uu____5993 in
+                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+              FStar_Pprint.op_Hat_Hat uu___ uu___1 in
             let bot = FStar_Pprint.rbrace in
-            let uu____5998 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline bot in
-            let uu____5999 =
-              let uu____6000 =
-                let uu____6001 =
-                  let uu____6002 = p_noSeqTermAndComment false false init in
-                  let uu____6003 =
-                    let uu____6004 = str ";" in
-                    let uu____6005 =
-                      let uu____6006 =
+            let uu___ = FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline bot in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = p_noSeqTermAndComment false false init in
+                  let uu___5 =
+                    let uu___6 = str ";" in
+                    let uu___7 =
+                      let uu___8 =
                         separate_map_last FStar_Pprint.hardline p_calcStep
                           steps in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                        uu____6006 in
-                    FStar_Pprint.op_Hat_Hat uu____6004 uu____6005 in
-                  FStar_Pprint.op_Hat_Hat uu____6002 uu____6003 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____6001 in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___8 in
+                    FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
+                  FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___3 in
               FStar_All.pipe_left (FStar_Pprint.nest (Prims.of_int (2)))
-                uu____6000 in
-            FStar_Pprint.enclose head uu____5998 uu____5999
-        | uu____6007 -> p_typ ps pb e
+                uu___2 in
+            FStar_Pprint.enclose head uu___ uu___1
+        | uu___ -> p_typ ps pb e
 and (p_calcStep :
   Prims.bool -> FStar_Parser_AST.calc_step -> FStar_Pprint.document) =
-  fun uu____6008 ->
-    fun uu____6009 ->
-      match uu____6009 with
+  fun uu___ ->
+    fun uu___1 ->
+      match uu___1 with
       | FStar_Parser_AST.CalcStep (rel, just, next) ->
-          let uu____6013 =
-            let uu____6014 = p_noSeqTermAndComment false false rel in
-            let uu____6015 =
-              let uu____6016 =
-                let uu____6017 =
-                  let uu____6018 =
-                    let uu____6019 = p_noSeqTermAndComment false false just in
-                    let uu____6020 =
-                      let uu____6021 =
-                        let uu____6022 =
-                          let uu____6023 =
-                            let uu____6024 =
+          let uu___2 =
+            let uu___3 = p_noSeqTermAndComment false false rel in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 = p_noSeqTermAndComment false false just in
+                    let uu___9 =
+                      let uu___10 =
+                        let uu___11 =
+                          let uu___12 =
+                            let uu___13 =
                               p_noSeqTermAndComment false false next in
-                            let uu____6025 = str ";" in
-                            FStar_Pprint.op_Hat_Hat uu____6024 uu____6025 in
+                            let uu___14 = str ";" in
+                            FStar_Pprint.op_Hat_Hat uu___13 uu___14 in
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                            uu____6023 in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace
-                          uu____6022 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6021 in
-                    FStar_Pprint.op_Hat_Hat uu____6019 uu____6020 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6018 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____6017 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6016 in
-            FStar_Pprint.op_Hat_Hat uu____6014 uu____6015 in
-          FStar_Pprint.group uu____6013
+                            uu___12 in
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace uu___11 in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___10 in
+                    FStar_Pprint.op_Hat_Hat uu___8 uu___9 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___7 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu___6 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
+            FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+          FStar_Pprint.group uu___2
 and (p_attrs_opt :
   FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option ->
     FStar_Pprint.document)
   =
-  fun uu___11_6026 ->
-    match uu___11_6026 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> FStar_Pprint.empty
     | FStar_Pervasives_Native.Some terms ->
-        let uu____6038 =
-          let uu____6039 = str "[@@" in
-          let uu____6040 =
-            let uu____6041 =
-              let uu____6042 = str "; " in
-              FStar_Pprint.separate_map uu____6042
+        let uu___1 =
+          let uu___2 = str "[@@" in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = str "; " in
+              FStar_Pprint.separate_map uu___5
                 (p_noSeqTermAndComment false false) terms in
-            let uu____6043 = str "]" in
-            FStar_Pprint.op_Hat_Slash_Hat uu____6041 uu____6043 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____6039 uu____6040 in
-        FStar_Pprint.group uu____6038
+            let uu___5 = str "]" in
+            FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+          FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+        FStar_Pprint.group uu___1
 and (p_typ :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -2723,61 +2655,55 @@ and (p_typ' :
     fun pb ->
       fun e ->
         match e.FStar_Parser_AST.tm with
-        | FStar_Parser_AST.QForall (bs, (uu____6054, trigger), e1) ->
+        | FStar_Parser_AST.QForall (bs, (uu___, trigger), e1) ->
             let binders_doc = p_binders true bs in
             let term_doc = p_noSeqTermAndComment ps pb e1 in
             (match trigger with
              | [] ->
-                 let uu____6087 =
-                   let uu____6088 =
-                     let uu____6089 = p_quantifier e in
-                     FStar_Pprint.op_Hat_Hat uu____6089 FStar_Pprint.space in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = p_quantifier e in
+                     FStar_Pprint.op_Hat_Hat uu___3 FStar_Pprint.space in
                    FStar_Pprint.soft_surround (Prims.of_int (2))
-                     Prims.int_zero uu____6088 binders_doc FStar_Pprint.dot in
-                 prefix2 uu____6087 term_doc
+                     Prims.int_zero uu___2 binders_doc FStar_Pprint.dot in
+                 prefix2 uu___1 term_doc
              | pats ->
-                 let uu____6095 =
-                   let uu____6096 =
-                     let uu____6097 =
-                       let uu____6098 =
-                         let uu____6099 = p_quantifier e in
-                         FStar_Pprint.op_Hat_Hat uu____6099
-                           FStar_Pprint.space in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = p_quantifier e in
+                         FStar_Pprint.op_Hat_Hat uu___5 FStar_Pprint.space in
                        FStar_Pprint.soft_surround (Prims.of_int (2))
-                         Prims.int_zero uu____6098 binders_doc
-                         FStar_Pprint.dot in
-                     let uu____6100 = p_trigger trigger in
-                     prefix2 uu____6097 uu____6100 in
-                   FStar_Pprint.group uu____6096 in
-                 prefix2 uu____6095 term_doc)
-        | FStar_Parser_AST.QExists (bs, (uu____6102, trigger), e1) ->
+                         Prims.int_zero uu___4 binders_doc FStar_Pprint.dot in
+                     let uu___4 = p_trigger trigger in prefix2 uu___3 uu___4 in
+                   FStar_Pprint.group uu___2 in
+                 prefix2 uu___1 term_doc)
+        | FStar_Parser_AST.QExists (bs, (uu___, trigger), e1) ->
             let binders_doc = p_binders true bs in
             let term_doc = p_noSeqTermAndComment ps pb e1 in
             (match trigger with
              | [] ->
-                 let uu____6135 =
-                   let uu____6136 =
-                     let uu____6137 = p_quantifier e in
-                     FStar_Pprint.op_Hat_Hat uu____6137 FStar_Pprint.space in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = p_quantifier e in
+                     FStar_Pprint.op_Hat_Hat uu___3 FStar_Pprint.space in
                    FStar_Pprint.soft_surround (Prims.of_int (2))
-                     Prims.int_zero uu____6136 binders_doc FStar_Pprint.dot in
-                 prefix2 uu____6135 term_doc
+                     Prims.int_zero uu___2 binders_doc FStar_Pprint.dot in
+                 prefix2 uu___1 term_doc
              | pats ->
-                 let uu____6143 =
-                   let uu____6144 =
-                     let uu____6145 =
-                       let uu____6146 =
-                         let uu____6147 = p_quantifier e in
-                         FStar_Pprint.op_Hat_Hat uu____6147
-                           FStar_Pprint.space in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = p_quantifier e in
+                         FStar_Pprint.op_Hat_Hat uu___5 FStar_Pprint.space in
                        FStar_Pprint.soft_surround (Prims.of_int (2))
-                         Prims.int_zero uu____6146 binders_doc
-                         FStar_Pprint.dot in
-                     let uu____6148 = p_trigger trigger in
-                     prefix2 uu____6145 uu____6148 in
-                   FStar_Pprint.group uu____6144 in
-                 prefix2 uu____6143 term_doc)
-        | uu____6149 -> p_simpleTerm ps pb e
+                         Prims.int_zero uu___4 binders_doc FStar_Pprint.dot in
+                     let uu___4 = p_trigger trigger in prefix2 uu___3 uu___4 in
+                   FStar_Pprint.group uu___2 in
+                 prefix2 uu___1 term_doc)
+        | uu___ -> p_simpleTerm ps pb e
 and (p_typ_top :
   annotation_style ->
     Prims.bool ->
@@ -2800,56 +2726,56 @@ and (sig_as_binders_if_possible :
   fun t ->
     fun extra_space ->
       let s = if extra_space then FStar_Pprint.space else FStar_Pprint.empty in
-      let uu____6162 = all_binders_annot t in
-      if uu____6162
+      let uu___ = all_binders_annot t in
+      if uu___
       then
-        let uu____6163 =
+        let uu___1 =
           p_typ_top (Binders ((Prims.of_int (4)), Prims.int_zero, true))
             false false t in
-        FStar_Pprint.op_Hat_Hat s uu____6163
+        FStar_Pprint.op_Hat_Hat s uu___1
       else
-        (let uu____6165 =
-           let uu____6166 =
-             let uu____6167 =
+        (let uu___2 =
+           let uu___3 =
+             let uu___4 =
                p_typ_top (Arrows ((Prims.of_int (2)), (Prims.of_int (2))))
                  false false t in
-             FStar_Pprint.op_Hat_Hat s uu____6167 in
-           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____6166 in
-         FStar_Pprint.group uu____6165)
+             FStar_Pprint.op_Hat_Hat s uu___4 in
+           FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___3 in
+         FStar_Pprint.group uu___2)
 and (collapse_pats :
   (FStar_Pprint.document * FStar_Pprint.document) Prims.list ->
     FStar_Pprint.document Prims.list)
   =
   fun pats ->
     let fold_fun bs x =
-      let uu____6220 = x in
-      match uu____6220 with
+      let uu___ = x in
+      match uu___ with
       | (b1, t1) ->
           (match bs with
            | [] -> [([b1], t1)]
            | hd::tl ->
-               let uu____6285 = hd in
-               (match uu____6285 with
+               let uu___1 = hd in
+               (match uu___1 with
                 | (b2s, t2) ->
                     if t1 = t2
                     then ((FStar_List.append b2s [b1]), t1) :: tl
                     else ([b1], t1) :: hd :: tl)) in
     let p_collapsed_binder cb =
-      let uu____6355 = cb in
-      match uu____6355 with
+      let uu___ = cb in
+      match uu___ with
       | (bs, typ) ->
           (match bs with
            | [] -> failwith "Impossible"
            | b::[] -> cat_with_colon b typ
            | hd::tl ->
-               let uu____6373 =
+               let uu___1 =
                  FStar_List.fold_left
                    (fun x ->
                       fun y ->
-                        let uu____6379 =
+                        let uu___2 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space y in
-                        FStar_Pprint.op_Hat_Hat x uu____6379) hd tl in
-               cat_with_colon uu____6373 typ) in
+                        FStar_Pprint.op_Hat_Hat x uu___2) hd tl in
+               cat_with_colon uu___1 typ) in
     let binders = FStar_List.fold_left fold_fun [] (FStar_List.rev pats) in
     map_rev p_collapsed_binder binders
 and (pats_as_binders_if_possible :
@@ -2864,79 +2790,77 @@ and (pats_as_binders_if_possible :
           (match ((pat.FStar_Parser_AST.pat), (t.FStar_Parser_AST.tm)) with
            | (FStar_Parser_AST.PatVar (lid, aqual), FStar_Parser_AST.Refine
               ({ FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1);
-                 FStar_Parser_AST.brange = uu____6458;
-                 FStar_Parser_AST.blevel = uu____6459;
-                 FStar_Parser_AST.aqual = uu____6460;_},
+                 FStar_Parser_AST.brange = uu___;
+                 FStar_Parser_AST.blevel = uu___1;
+                 FStar_Parser_AST.aqual = uu___2;_},
                phi)) when
-               let uu____6468 = FStar_Ident.string_of_id lid in
-               let uu____6469 = FStar_Ident.string_of_id lid' in
-               uu____6468 = uu____6469 ->
-               let uu____6470 =
-                 let uu____6475 = p_ident lid in
-                 p_refinement' aqual uu____6475 t1 phi in
-               FStar_Pervasives_Native.Some uu____6470
-           | (FStar_Parser_AST.PatVar (lid, aqual), uu____6482) ->
-               let uu____6487 =
-                 let uu____6492 =
-                   let uu____6493 = FStar_Pprint.optional p_aqual aqual in
-                   let uu____6494 = p_ident lid in
-                   FStar_Pprint.op_Hat_Hat uu____6493 uu____6494 in
-                 let uu____6495 = p_tmEqNoRefinement t in
-                 (uu____6492, uu____6495) in
-               FStar_Pervasives_Native.Some uu____6487
-           | uu____6500 -> FStar_Pervasives_Native.None)
-      | uu____6509 -> FStar_Pervasives_Native.None in
+               let uu___3 = FStar_Ident.string_of_id lid in
+               let uu___4 = FStar_Ident.string_of_id lid' in uu___3 = uu___4
+               ->
+               let uu___3 =
+                 let uu___4 = p_ident lid in
+                 p_refinement' aqual uu___4 t1 phi in
+               FStar_Pervasives_Native.Some uu___3
+           | (FStar_Parser_AST.PatVar (lid, aqual), uu___) ->
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Pprint.optional p_aqual aqual in
+                   let uu___4 = p_ident lid in
+                   FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                 let uu___3 = p_tmEqNoRefinement t in (uu___2, uu___3) in
+               FStar_Pervasives_Native.Some uu___1
+           | uu___ -> FStar_Pervasives_Native.None)
+      | uu___ -> FStar_Pervasives_Native.None in
     let all_unbound p =
       match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatAscribed uu____6520 -> false
-      | uu____6531 -> true in
-    let uu____6532 = map_if_all all_binders pats in
-    match uu____6532 with
+      | FStar_Parser_AST.PatAscribed uu___ -> false
+      | uu___ -> true in
+    let uu___ = map_if_all all_binders pats in
+    match uu___ with
     | FStar_Pervasives_Native.Some bs ->
-        let uu____6564 = collapse_pats bs in
-        (uu____6564, (Binders ((Prims.of_int (4)), Prims.int_zero, true)))
+        let uu___1 = collapse_pats bs in
+        (uu___1, (Binders ((Prims.of_int (4)), Prims.int_zero, true)))
     | FStar_Pervasives_Native.None ->
-        let uu____6575 = FStar_List.map p_atomicPattern pats in
-        (uu____6575, (Binders ((Prims.of_int (4)), Prims.int_zero, false)))
+        let uu___1 = FStar_List.map p_atomicPattern pats in
+        (uu___1, (Binders ((Prims.of_int (4)), Prims.int_zero, false)))
 and (p_quantifier : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.QForall uu____6581 -> str "forall"
-    | FStar_Parser_AST.QExists uu____6600 -> str "exists"
-    | uu____6619 ->
+    | FStar_Parser_AST.QForall uu___ -> str "forall"
+    | FStar_Parser_AST.QExists uu___ -> str "exists"
+    | uu___ ->
         failwith "Imposible : p_quantifier called on a non-quantifier term"
 and (p_trigger :
   FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
-  fun uu___12_6620 ->
-    match uu___12_6620 with
+  fun uu___ ->
+    match uu___ with
     | [] -> FStar_Pprint.empty
     | pats ->
-        let uu____6632 =
-          let uu____6633 =
-            let uu____6634 =
-              let uu____6635 = str "pattern" in
-              let uu____6636 =
-                let uu____6637 =
-                  let uu____6638 = p_disjunctivePats pats in
-                  FStar_Pprint.jump (Prims.of_int (2)) Prims.int_zero
-                    uu____6638 in
-                FStar_Pprint.op_Hat_Hat uu____6637 FStar_Pprint.rbrace in
-              FStar_Pprint.op_Hat_Slash_Hat uu____6635 uu____6636 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____6634 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____6633 in
-        FStar_Pprint.group uu____6632
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = str "pattern" in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = p_disjunctivePats pats in
+                  FStar_Pprint.jump (Prims.of_int (2)) Prims.int_zero uu___7 in
+                FStar_Pprint.op_Hat_Hat uu___6 FStar_Pprint.rbrace in
+              FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu___2 in
+        FStar_Pprint.group uu___1
 and (p_disjunctivePats :
   FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
   fun pats ->
-    let uu____6644 = str "\\/" in
-    FStar_Pprint.separate_map uu____6644 p_conjunctivePats pats
+    let uu___ = str "\\/" in
+    FStar_Pprint.separate_map uu___ p_conjunctivePats pats
 and (p_conjunctivePats :
   FStar_Parser_AST.term Prims.list -> FStar_Pprint.document) =
   fun pats ->
-    let uu____6650 =
-      let uu____6651 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-      FStar_Pprint.separate_map uu____6651 p_appTerm pats in
-    FStar_Pprint.group uu____6650
+    let uu___ =
+      let uu___1 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+      FStar_Pprint.separate_map uu___1 p_appTerm pats in
+    FStar_Pprint.group uu___
 and (p_simpleTerm :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -2945,33 +2869,31 @@ and (p_simpleTerm :
       fun e ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Abs (pats, e1) ->
-            let uu____6661 = p_term_sep false pb e1 in
-            (match uu____6661 with
+            let uu___ = p_term_sep false pb e1 in
+            (match uu___ with
              | (comm, doc) ->
                  let prefix =
-                   let uu____6669 = str "fun" in
-                   let uu____6670 =
-                     let uu____6671 =
+                   let uu___1 = str "fun" in
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Pprint.separate_map break1 p_atomicPattern pats in
-                     FStar_Pprint.op_Hat_Slash_Hat uu____6671
-                       FStar_Pprint.rarrow in
-                   op_Hat_Slash_Plus_Hat uu____6669 uu____6670 in
-                 let uu____6672 =
+                     FStar_Pprint.op_Hat_Slash_Hat uu___3 FStar_Pprint.rarrow in
+                   op_Hat_Slash_Plus_Hat uu___1 uu___2 in
+                 let uu___1 =
                    if comm <> FStar_Pprint.empty
                    then
-                     let uu____6673 =
-                       let uu____6674 =
-                         let uu____6675 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc in
-                         FStar_Pprint.op_Hat_Hat comm uu____6675 in
-                       FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline
-                         uu____6674 in
-                     FStar_Pprint.op_Hat_Hat prefix uu____6673
+                         FStar_Pprint.op_Hat_Hat comm uu___4 in
+                       FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___3 in
+                     FStar_Pprint.op_Hat_Hat prefix uu___2
                    else
-                     (let uu____6677 = op_Hat_Slash_Plus_Hat prefix doc in
-                      FStar_Pprint.group uu____6677) in
-                 let uu____6678 = paren_if ps in uu____6678 uu____6672)
-        | uu____6683 -> p_tmIff e
+                     (let uu___3 = op_Hat_Slash_Plus_Hat prefix doc in
+                      FStar_Pprint.group uu___3) in
+                 let uu___2 = paren_if ps in uu___2 uu___1)
+        | uu___ -> p_tmIff e
 and (p_maybeFocusArrow : Prims.bool -> FStar_Pprint.document) =
   fun b -> if b then str "~>" else FStar_Pprint.rarrow
 and (p_patternBranch :
@@ -2981,128 +2903,124 @@ and (p_patternBranch :
       FStar_Pprint.document)
   =
   fun pb ->
-    fun uu____6687 ->
-      match uu____6687 with
+    fun uu___ ->
+      match uu___ with
       | (pat, when_opt, e) ->
           let one_pattern_branch p =
             let branch =
               match when_opt with
               | FStar_Pervasives_Native.None ->
-                  let uu____6710 =
-                    let uu____6711 =
-                      let uu____6712 =
-                        let uu____6713 = p_tuplePattern p in
-                        let uu____6714 =
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = p_tuplePattern p in
+                        let uu___5 =
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                             FStar_Pprint.rarrow in
-                        FStar_Pprint.op_Hat_Hat uu____6713 uu____6714 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6712 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____6711 in
-                  FStar_Pprint.group uu____6710
+                        FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
+                  FStar_Pprint.group uu___1
               | FStar_Pervasives_Native.Some f ->
-                  let uu____6716 =
-                    let uu____6717 =
-                      let uu____6718 =
-                        let uu____6719 =
-                          let uu____6720 =
-                            let uu____6721 = p_tuplePattern p in
-                            let uu____6722 = str "when" in
-                            FStar_Pprint.op_Hat_Slash_Hat uu____6721
-                              uu____6722 in
-                          FStar_Pprint.group uu____6720 in
-                        let uu____6723 =
-                          let uu____6724 =
-                            let uu____6727 = p_tmFormula f in
-                            [uu____6727; FStar_Pprint.rarrow] in
-                          FStar_Pprint.flow break1 uu____6724 in
-                        FStar_Pprint.op_Hat_Slash_Hat uu____6719 uu____6723 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6718 in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____6717 in
-                  FStar_Pprint.hang (Prims.of_int (2)) uu____6716 in
-            let uu____6728 = p_term_sep false pb e in
-            match uu____6728 with
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = p_tuplePattern p in
+                            let uu___7 = str "when" in
+                            FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7 in
+                          FStar_Pprint.group uu___5 in
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 = p_tmFormula f in
+                            [uu___7; FStar_Pprint.rarrow] in
+                          FStar_Pprint.flow break1 uu___6 in
+                        FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
+                  FStar_Pprint.hang (Prims.of_int (2)) uu___1 in
+            let uu___1 = p_term_sep false pb e in
+            match uu___1 with
             | (comm, doc) ->
                 if pb
                 then
                   (if comm = FStar_Pprint.empty
                    then
-                     let uu____6735 = op_Hat_Slash_Plus_Hat branch doc in
-                     FStar_Pprint.group uu____6735
+                     let uu___2 = op_Hat_Slash_Plus_Hat branch doc in
+                     FStar_Pprint.group uu___2
                    else
-                     (let uu____6737 =
-                        let uu____6738 =
-                          let uu____6739 =
-                            let uu____6740 =
-                              let uu____6741 =
+                     (let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
                                 FStar_Pprint.op_Hat_Hat break1 comm in
-                              FStar_Pprint.op_Hat_Hat doc uu____6741 in
-                            op_Hat_Slash_Plus_Hat branch uu____6740 in
-                          FStar_Pprint.group uu____6739 in
-                        let uu____6742 =
-                          let uu____6743 =
-                            let uu____6744 =
+                              FStar_Pprint.op_Hat_Hat doc uu___7 in
+                            op_Hat_Slash_Plus_Hat branch uu___6 in
+                          FStar_Pprint.group uu___5 in
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
                               inline_comment_or_above comm doc
                                 FStar_Pprint.empty in
-                            jump2 uu____6744 in
-                          FStar_Pprint.op_Hat_Hat branch uu____6743 in
-                        FStar_Pprint.ifflat uu____6738 uu____6742 in
-                      FStar_Pprint.group uu____6737))
+                            jump2 uu___7 in
+                          FStar_Pprint.op_Hat_Hat branch uu___6 in
+                        FStar_Pprint.ifflat uu___4 uu___5 in
+                      FStar_Pprint.group uu___3))
                 else
                   if comm <> FStar_Pprint.empty
                   then
-                    (let uu____6746 =
-                       let uu____6747 =
+                    (let uu___3 =
+                       let uu___4 =
                          FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc in
-                       FStar_Pprint.op_Hat_Hat comm uu____6747 in
-                     op_Hat_Slash_Plus_Hat branch uu____6746)
+                       FStar_Pprint.op_Hat_Hat comm uu___4 in
+                     op_Hat_Slash_Plus_Hat branch uu___3)
                   else op_Hat_Slash_Plus_Hat branch doc in
           (match pat.FStar_Parser_AST.pat with
            | FStar_Parser_AST.PatOr pats ->
                (match FStar_List.rev pats with
                 | hd::tl ->
                     let last_pat_branch = one_pattern_branch hd in
-                    let uu____6757 =
-                      let uu____6758 =
-                        let uu____6759 =
-                          let uu____6760 =
-                            let uu____6761 =
-                              let uu____6762 =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.bar
                                   FStar_Pprint.space in
-                              FStar_Pprint.op_Hat_Hat break1 uu____6762 in
-                            FStar_Pprint.separate_map uu____6761
-                              p_tuplePattern (FStar_List.rev tl) in
-                          FStar_Pprint.op_Hat_Slash_Hat uu____6760
+                              FStar_Pprint.op_Hat_Hat break1 uu___6 in
+                            FStar_Pprint.separate_map uu___5 p_tuplePattern
+                              (FStar_List.rev tl) in
+                          FStar_Pprint.op_Hat_Slash_Hat uu___4
                             last_pat_branch in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6759 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____6758 in
-                    FStar_Pprint.group uu____6757
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
+                    FStar_Pprint.group uu___1
                 | [] ->
                     failwith "Impossible: disjunctive pattern can't be empty")
-           | uu____6763 -> one_pattern_branch pat)
+           | uu___1 -> one_pattern_branch pat)
 and (p_tmIff : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op (id, e1::e2::[]) when
-        let uu____6770 = FStar_Ident.string_of_id id in uu____6770 = "<==>"
-        ->
-        let uu____6771 = str "<==>" in
-        let uu____6772 = p_tmImplies e1 in
-        let uu____6773 = p_tmIff e2 in
-        infix0 uu____6771 uu____6772 uu____6773
-    | uu____6774 -> p_tmImplies e
+        let uu___ = FStar_Ident.string_of_id id in uu___ = "<==>" ->
+        let uu___ = str "<==>" in
+        let uu___1 = p_tmImplies e1 in
+        let uu___2 = p_tmIff e2 in infix0 uu___ uu___1 uu___2
+    | uu___ -> p_tmImplies e
 and (p_tmImplies : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op (id, e1::e2::[]) when
-        let uu____6781 = FStar_Ident.string_of_id id in uu____6781 = "==>" ->
-        let uu____6782 = str "==>" in
-        let uu____6783 =
+        let uu___ = FStar_Ident.string_of_id id in uu___ = "==>" ->
+        let uu___ = str "==>" in
+        let uu___1 =
           p_tmArrow (Arrows ((Prims.of_int (2)), (Prims.of_int (2)))) false
             p_tmFormula e1 in
-        let uu____6784 = p_tmImplies e2 in
-        infix0 uu____6782 uu____6783 uu____6784
-    | uu____6785 ->
+        let uu___2 = p_tmImplies e2 in infix0 uu___ uu___1 uu___2
+    | uu___ ->
         p_tmArrow (Arrows ((Prims.of_int (2)), (Prims.of_int (2)))) false
           p_tmFormula e
 and (format_sig :
@@ -3114,32 +3032,32 @@ and (format_sig :
     fun terms ->
       fun no_last_op ->
         fun flat_space ->
-          let uu____6792 =
+          let uu___ =
             FStar_List.splitAt ((FStar_List.length terms) - Prims.int_one)
               terms in
-          match uu____6792 with
+          match uu___ with
           | (terms', last) ->
-              let uu____6811 =
+              let uu___1 =
                 match style with
                 | Arrows (n, ln) ->
-                    let uu____6838 =
-                      let uu____6839 =
+                    let uu___2 =
+                      let uu___3 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____6839 in
-                    let uu____6840 =
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                    let uu___3 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow
                         FStar_Pprint.space in
-                    (n, ln, terms', uu____6838, uu____6840)
+                    (n, ln, terms', uu___2, uu___3)
                 | Binders (n, ln, parens) ->
-                    let uu____6846 =
+                    let uu___2 =
                       if parens
                       then FStar_List.map soft_parens_with_nesting terms'
                       else terms' in
-                    let uu____6852 =
+                    let uu___3 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
                         FStar_Pprint.space in
-                    (n, ln, uu____6846, break1, uu____6852) in
-              (match uu____6811 with
+                    (n, ln, uu___2, break1, uu___3) in
+              (match uu___1 with
                | (n, last_n, terms'1, sep, last_op) ->
                    let last1 = FStar_List.hd last in
                    let last_op1 =
@@ -3161,59 +3079,55 @@ and (format_sig :
                      then FStar_Pprint.space
                      else FStar_Pprint.empty in
                    (match FStar_List.length terms with
-                    | uu____6872 when uu____6872 = Prims.int_one ->
+                    | uu___2 when uu___2 = Prims.int_one ->
                         FStar_List.hd terms
-                    | uu____6873 ->
-                        let uu____6874 =
-                          let uu____6875 =
-                            let uu____6876 =
-                              let uu____6877 =
-                                FStar_Pprint.separate sep terms'1 in
-                              let uu____6878 =
-                                let uu____6879 =
+                    | uu___2 ->
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 = FStar_Pprint.separate sep terms'1 in
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_Pprint.op_Hat_Hat last_op1 last1 in
-                                FStar_Pprint.op_Hat_Hat one_line_space
-                                  uu____6879 in
-                              FStar_Pprint.op_Hat_Hat uu____6877 uu____6878 in
-                            FStar_Pprint.op_Hat_Hat fs uu____6876 in
-                          let uu____6880 =
-                            let uu____6881 =
-                              let uu____6882 =
-                                let uu____6883 =
-                                  let uu____6884 =
+                                FStar_Pprint.op_Hat_Hat one_line_space uu___8 in
+                              FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
+                            FStar_Pprint.op_Hat_Hat fs uu___5 in
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
+                                  let uu___9 =
                                     FStar_Pprint.separate sep terms'1 in
-                                  FStar_Pprint.op_Hat_Hat fs uu____6884 in
-                                let uu____6885 =
-                                  let uu____6886 =
-                                    let uu____6887 =
-                                      let uu____6888 =
+                                  FStar_Pprint.op_Hat_Hat fs uu___9 in
+                                let uu___9 =
+                                  let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Pprint.op_Hat_Hat sep
                                           single_line_arg_indent in
-                                      let uu____6889 =
+                                      let uu___13 =
                                         FStar_List.map
                                           (fun x ->
-                                             let uu____6895 =
+                                             let uu___14 =
                                                FStar_Pprint.hang
                                                  (Prims.of_int (2)) x in
-                                             FStar_Pprint.align uu____6895)
+                                             FStar_Pprint.align uu___14)
                                           terms'1 in
-                                      FStar_Pprint.separate uu____6888
-                                        uu____6889 in
+                                      FStar_Pprint.separate uu___12 uu___13 in
                                     FStar_Pprint.op_Hat_Hat
-                                      single_line_arg_indent uu____6887 in
-                                  jump2 uu____6886 in
-                                FStar_Pprint.ifflat uu____6883 uu____6885 in
-                              FStar_Pprint.group uu____6882 in
-                            let uu____6896 =
-                              let uu____6897 =
-                                let uu____6898 =
+                                      single_line_arg_indent uu___11 in
+                                  jump2 uu___10 in
+                                FStar_Pprint.ifflat uu___8 uu___9 in
+                              FStar_Pprint.group uu___7 in
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
                                   FStar_Pprint.op_Hat_Hat last_op1 last1 in
-                                FStar_Pprint.hang last_n uu____6898 in
-                              FStar_Pprint.align uu____6897 in
-                            FStar_Pprint.prefix n Prims.int_one uu____6881
-                              uu____6896 in
-                          FStar_Pprint.ifflat uu____6875 uu____6880 in
-                        FStar_Pprint.group uu____6874))
+                                FStar_Pprint.hang last_n uu___9 in
+                              FStar_Pprint.align uu___8 in
+                            FStar_Pprint.prefix n Prims.int_one uu___6 uu___7 in
+                          FStar_Pprint.ifflat uu___4 uu___5 in
+                        FStar_Pprint.group uu___3))
 and (p_tmArrow :
   annotation_style ->
     Prims.bool ->
@@ -3226,8 +3140,8 @@ and (p_tmArrow :
         fun e ->
           let terms =
             match style with
-            | Arrows uu____6910 -> p_tmArrow' p_Tm e
-            | Binders uu____6915 -> collapse_binders p_Tm e in
+            | Arrows uu___ -> p_tmArrow' p_Tm e
+            | Binders uu___ -> collapse_binders p_Tm e in
           format_sig style terms false flat_space
 and (p_tmArrow' :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
@@ -3237,10 +3151,9 @@ and (p_tmArrow' :
     fun e ->
       match e.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (bs, tgt) ->
-          let uu____6934 = FStar_List.map (fun b -> p_binder false b) bs in
-          let uu____6939 = p_tmArrow' p_Tm tgt in
-          FStar_List.append uu____6934 uu____6939
-      | uu____6942 -> let uu____6943 = p_Tm e in [uu____6943]
+          let uu___ = FStar_List.map (fun b -> p_binder false b) bs in
+          let uu___1 = p_tmArrow' p_Tm tgt in FStar_List.append uu___ uu___1
+      | uu___ -> let uu___1 = p_Tm e in [uu___1]
 and (collapse_binders :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
     FStar_Parser_AST.term -> FStar_Pprint.document Prims.list)
@@ -3250,69 +3163,67 @@ and (collapse_binders :
       let rec accumulate_binders p_Tm1 e1 =
         match e1.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Product (bs, tgt) ->
-            let uu____6996 = FStar_List.map (fun b -> p_binder' false b) bs in
-            let uu____7021 = accumulate_binders p_Tm1 tgt in
-            FStar_List.append uu____6996 uu____7021
-        | uu____7044 ->
-            let uu____7045 =
-              let uu____7056 = p_Tm1 e1 in
-              (uu____7056, FStar_Pervasives_Native.None, cat_with_colon) in
-            [uu____7045] in
+            let uu___ = FStar_List.map (fun b -> p_binder' false b) bs in
+            let uu___1 = accumulate_binders p_Tm1 tgt in
+            FStar_List.append uu___ uu___1
+        | uu___ ->
+            let uu___1 =
+              let uu___2 = p_Tm1 e1 in
+              (uu___2, FStar_Pervasives_Native.None, cat_with_colon) in
+            [uu___1] in
       let fold_fun bs x =
-        let uu____7154 = x in
-        match uu____7154 with
+        let uu___ = x in
+        match uu___ with
         | (b1, t1, f1) ->
             (match bs with
              | [] -> [([b1], t1, f1)]
              | hd::tl ->
-                 let uu____7286 = hd in
-                 (match uu____7286 with
-                  | (b2s, t2, uu____7315) ->
+                 let uu___1 = hd in
+                 (match uu___1 with
+                  | (b2s, t2, uu___2) ->
                       (match (t1, t2) with
                        | (FStar_Pervasives_Native.Some typ1,
                           FStar_Pervasives_Native.Some typ2) ->
                            if typ1 = typ2
                            then ((FStar_List.append b2s [b1]), t1, f1) :: tl
                            else ([b1], t1, f1) :: hd :: tl
-                       | uu____7415 -> ([b1], t1, f1) :: bs))) in
+                       | uu___3 -> ([b1], t1, f1) :: bs))) in
       let p_collapsed_binder cb =
-        let uu____7472 = cb in
-        match uu____7472 with
+        let uu___ = cb in
+        match uu___ with
         | (bs, t, f) ->
             (match t with
              | FStar_Pervasives_Native.None ->
                  (match bs with
                   | b::[] -> b
-                  | uu____7501 -> failwith "Impossible")
+                  | uu___1 -> failwith "Impossible")
              | FStar_Pervasives_Native.Some typ ->
                  (match bs with
                   | [] -> failwith "Impossible"
                   | b::[] -> f b typ
                   | hd::tl ->
-                      let uu____7510 =
+                      let uu___1 =
                         FStar_List.fold_left
                           (fun x ->
                              fun y ->
-                               let uu____7516 =
+                               let uu___2 =
                                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space y in
-                               FStar_Pprint.op_Hat_Hat x uu____7516) hd tl in
-                      f uu____7510 typ)) in
+                               FStar_Pprint.op_Hat_Hat x uu___2) hd tl in
+                      f uu___1 typ)) in
       let binders =
-        let uu____7532 = accumulate_binders p_Tm e in
-        FStar_List.fold_left fold_fun [] uu____7532 in
+        let uu___ = accumulate_binders p_Tm e in
+        FStar_List.fold_left fold_fun [] uu___ in
       map_rev p_collapsed_binder binders
 and (p_tmFormula : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     let conj =
-      let uu____7595 =
-        let uu____7596 = str "/\\" in
-        FStar_Pprint.op_Hat_Hat uu____7596 break1 in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7595 in
+      let uu___ =
+        let uu___1 = str "/\\" in FStar_Pprint.op_Hat_Hat uu___1 break1 in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___ in
     let disj =
-      let uu____7598 =
-        let uu____7599 = str "\\/" in
-        FStar_Pprint.op_Hat_Hat uu____7599 break1 in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7598 in
+      let uu___ =
+        let uu___1 = str "\\/" in FStar_Pprint.op_Hat_Hat uu___1 break1 in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___ in
     let formula = p_tmDisjunction e in
     FStar_Pprint.flow_map disj
       (fun d -> FStar_Pprint.flow_map conj (fun x -> FStar_Pprint.group x) d)
@@ -3322,21 +3233,21 @@ and (p_tmDisjunction :
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op (id, e1::e2::[]) when
-        let uu____7623 = FStar_Ident.string_of_id id in uu____7623 = "\\/" ->
-        let uu____7624 = p_tmDisjunction e1 in
-        let uu____7629 = let uu____7634 = p_tmConjunction e2 in [uu____7634] in
-        FStar_List.append uu____7624 uu____7629
-    | uu____7643 -> let uu____7644 = p_tmConjunction e in [uu____7644]
+        let uu___ = FStar_Ident.string_of_id id in uu___ = "\\/" ->
+        let uu___ = p_tmDisjunction e1 in
+        let uu___1 = let uu___2 = p_tmConjunction e2 in [uu___2] in
+        FStar_List.append uu___ uu___1
+    | uu___ -> let uu___1 = p_tmConjunction e in [uu___1]
 and (p_tmConjunction :
   FStar_Parser_AST.term -> FStar_Pprint.document Prims.list) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op (id, e1::e2::[]) when
-        let uu____7659 = FStar_Ident.string_of_id id in uu____7659 = "/\\" ->
-        let uu____7660 = p_tmConjunction e1 in
-        let uu____7663 = let uu____7666 = p_tmTuple e2 in [uu____7666] in
-        FStar_List.append uu____7660 uu____7663
-    | uu____7667 -> let uu____7668 = p_tmTuple e in [uu____7668]
+        let uu___ = FStar_Ident.string_of_id id in uu___ = "/\\" ->
+        let uu___ = p_tmConjunction e1 in
+        let uu___1 = let uu___2 = p_tmTuple e2 in [uu___2] in
+        FStar_List.append uu___ uu___1
+    | uu___ -> let uu___1 = p_tmTuple e in [uu___1]
 and (p_tmTuple : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e -> with_comment p_tmTuple' e e.FStar_Parser_AST.range
 and (p_tmTuple' : FStar_Parser_AST.term -> FStar_Pprint.document) =
@@ -3344,11 +3255,10 @@ and (p_tmTuple' : FStar_Parser_AST.term -> FStar_Pprint.document) =
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Construct (lid, args) when
         (is_tuple_constructor lid) && (all1_explicit args) ->
-        let uu____7685 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-        FStar_Pprint.separate_map uu____7685
-          (fun uu____7693 ->
-             match uu____7693 with | (e1, uu____7699) -> p_tmEq e1) args
-    | uu____7700 -> p_tmEq e
+        let uu___ = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+        FStar_Pprint.separate_map uu___
+          (fun uu___1 -> match uu___1 with | (e1, uu___2) -> p_tmEq e1) args
+    | uu___ -> p_tmEq e
 and (paren_if_gt :
   Prims.int -> Prims.int -> FStar_Pprint.document -> FStar_Pprint.document) =
   fun curr ->
@@ -3357,10 +3267,10 @@ and (paren_if_gt :
         if mine <= curr
         then doc
         else
-          (let uu____7705 =
-             let uu____7706 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____7706 in
-           FStar_Pprint.group uu____7705)
+          (let uu___1 =
+             let uu___2 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen in
+             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___2 in
+           FStar_Pprint.group uu___1)
 and (p_tmEqWith :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
     FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -3380,52 +3290,46 @@ and (p_tmEqWith' :
       fun e ->
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Op (op, e1::e2::[]) when
-            (let uu____7724 =
-               (let uu____7727 = FStar_Ident.string_of_id op in
-                uu____7727 = "==>") ||
-                 (let uu____7729 = FStar_Ident.string_of_id op in
-                  uu____7729 = "<==>") in
-             Prims.op_Negation uu____7724) &&
-              (((is_operatorInfix0ad12 op) ||
-                  (let uu____7731 = FStar_Ident.string_of_id op in
-                   uu____7731 = "="))
+            (let uu___ =
+               (let uu___1 = FStar_Ident.string_of_id op in uu___1 = "==>")
                  ||
-                 (let uu____7733 = FStar_Ident.string_of_id op in
-                  uu____7733 = "|>"))
+                 (let uu___1 = FStar_Ident.string_of_id op in uu___1 = "<==>") in
+             Prims.op_Negation uu___) &&
+              (((is_operatorInfix0ad12 op) ||
+                  (let uu___ = FStar_Ident.string_of_id op in uu___ = "="))
+                 || (let uu___ = FStar_Ident.string_of_id op in uu___ = "|>"))
             ->
             let op1 = FStar_Ident.string_of_id op in
-            let uu____7735 = levels op1 in
-            (match uu____7735 with
+            let uu___ = levels op1 in
+            (match uu___ with
              | (left, mine, right) ->
-                 let uu____7745 =
-                   let uu____7746 = FStar_All.pipe_left str op1 in
-                   let uu____7747 = p_tmEqWith' p_X left e1 in
-                   let uu____7748 = p_tmEqWith' p_X right e2 in
-                   infix0 uu____7746 uu____7747 uu____7748 in
-                 paren_if_gt curr mine uu____7745)
+                 let uu___1 =
+                   let uu___2 = FStar_All.pipe_left str op1 in
+                   let uu___3 = p_tmEqWith' p_X left e1 in
+                   let uu___4 = p_tmEqWith' p_X right e2 in
+                   infix0 uu___2 uu___3 uu___4 in
+                 paren_if_gt curr mine uu___1)
         | FStar_Parser_AST.Op (id, e1::e2::[]) when
-            let uu____7754 = FStar_Ident.string_of_id id in uu____7754 = ":="
-            ->
-            let uu____7755 =
-              let uu____7756 = p_tmEqWith p_X e1 in
-              let uu____7757 =
-                let uu____7758 =
-                  let uu____7759 =
-                    let uu____7760 = p_tmEqWith p_X e2 in
-                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____7760 in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____7759 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____7758 in
-              FStar_Pprint.op_Hat_Hat uu____7756 uu____7757 in
-            FStar_Pprint.group uu____7755
+            let uu___ = FStar_Ident.string_of_id id in uu___ = ":=" ->
+            let uu___ =
+              let uu___1 = p_tmEqWith p_X e1 in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = p_tmEqWith p_X e2 in
+                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu___5 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___4 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            FStar_Pprint.group uu___
         | FStar_Parser_AST.Op (id, e1::[]) when
-            let uu____7765 = FStar_Ident.string_of_id id in uu____7765 = "-"
-            ->
-            let uu____7766 = levels "-" in
-            (match uu____7766 with
+            let uu___ = FStar_Ident.string_of_id id in uu___ = "-" ->
+            let uu___ = levels "-" in
+            (match uu___ with
              | (left, mine, right) ->
-                 let uu____7776 = p_tmEqWith' p_X mine e1 in
-                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____7776)
-        | uu____7777 -> p_tmNoEqWith p_X e
+                 let uu___1 = p_tmEqWith' p_X mine e1 in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu___1)
+        | uu___ -> p_tmNoEqWith p_X e
 and (p_tmNoEqWith :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
     FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -3444,120 +3348,115 @@ and (p_tmNoEqWith' :
       fun curr ->
         fun e ->
           match e.FStar_Parser_AST.tm with
-          | FStar_Parser_AST.Construct
-              (lid, (e1, uu____7821)::(e2, uu____7823)::[]) when
+          | FStar_Parser_AST.Construct (lid, (e1, uu___)::(e2, uu___1)::[])
+              when
               (FStar_Ident.lid_equals lid FStar_Parser_Const.cons_lid) &&
-                (let uu____7843 = is_list e in Prims.op_Negation uu____7843)
+                (let uu___2 = is_list e in Prims.op_Negation uu___2)
               ->
               let op = "::" in
-              let uu____7845 = levels op in
-              (match uu____7845 with
+              let uu___2 = levels op in
+              (match uu___2 with
                | (left, mine, right) ->
-                   let uu____7855 =
-                     let uu____7856 = str op in
-                     let uu____7857 = p_tmNoEqWith' false p_X left e1 in
-                     let uu____7858 = p_tmNoEqWith' false p_X right e2 in
-                     infix0 uu____7856 uu____7857 uu____7858 in
-                   paren_if_gt curr mine uu____7855)
+                   let uu___3 =
+                     let uu___4 = str op in
+                     let uu___5 = p_tmNoEqWith' false p_X left e1 in
+                     let uu___6 = p_tmNoEqWith' false p_X right e2 in
+                     infix0 uu___4 uu___5 uu___6 in
+                   paren_if_gt curr mine uu___3)
           | FStar_Parser_AST.Sum (binders, res) ->
               let op = "&" in
-              let uu____7874 = levels op in
-              (match uu____7874 with
+              let uu___ = levels op in
+              (match uu___ with
                | (left, mine, right) ->
                    let p_dsumfst bt =
                      match bt with
                      | FStar_Util.Inl b ->
-                         let uu____7899 = p_binder false b in
-                         let uu____7900 =
-                           let uu____7901 =
-                             let uu____7902 = str op in
-                             FStar_Pprint.op_Hat_Hat uu____7902 break1 in
-                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                             uu____7901 in
-                         FStar_Pprint.op_Hat_Hat uu____7899 uu____7900
+                         let uu___1 = p_binder false b in
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = str op in
+                             FStar_Pprint.op_Hat_Hat uu___4 break1 in
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                         FStar_Pprint.op_Hat_Hat uu___1 uu___2
                      | FStar_Util.Inr t ->
-                         let uu____7904 = p_tmNoEqWith' false p_X left t in
-                         let uu____7905 =
-                           let uu____7906 =
-                             let uu____7907 = str op in
-                             FStar_Pprint.op_Hat_Hat uu____7907 break1 in
-                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                             uu____7906 in
-                         FStar_Pprint.op_Hat_Hat uu____7904 uu____7905 in
-                   let uu____7908 =
-                     let uu____7909 =
-                       FStar_Pprint.concat_map p_dsumfst binders in
-                     let uu____7914 = p_tmNoEqWith' false p_X right res in
-                     FStar_Pprint.op_Hat_Hat uu____7909 uu____7914 in
-                   paren_if_gt curr mine uu____7908)
+                         let uu___1 = p_tmNoEqWith' false p_X left t in
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = str op in
+                             FStar_Pprint.op_Hat_Hat uu___4 break1 in
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+                         FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+                   let uu___1 =
+                     let uu___2 = FStar_Pprint.concat_map p_dsumfst binders in
+                     let uu___3 = p_tmNoEqWith' false p_X right res in
+                     FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+                   paren_if_gt curr mine uu___1)
           | FStar_Parser_AST.Op (id, e1::e2::[]) when
-              (let uu____7922 = FStar_Ident.string_of_id id in
-               uu____7922 = "*") && (FStar_ST.op_Bang unfold_tuples)
+              (let uu___ = FStar_Ident.string_of_id id in uu___ = "*") &&
+                (FStar_ST.op_Bang unfold_tuples)
               ->
               let op = "*" in
-              let uu____7930 = levels op in
-              (match uu____7930 with
+              let uu___ = levels op in
+              (match uu___ with
                | (left, mine, right) ->
                    if inside_tuple
                    then
-                     let uu____7940 = str op in
-                     let uu____7941 = p_tmNoEqWith' true p_X left e1 in
-                     let uu____7942 = p_tmNoEqWith' true p_X right e2 in
-                     infix0 uu____7940 uu____7941 uu____7942
+                     let uu___1 = str op in
+                     let uu___2 = p_tmNoEqWith' true p_X left e1 in
+                     let uu___3 = p_tmNoEqWith' true p_X right e2 in
+                     infix0 uu___1 uu___2 uu___3
                    else
-                     (let uu____7944 =
-                        let uu____7945 = str op in
-                        let uu____7946 = p_tmNoEqWith' true p_X left e1 in
-                        let uu____7947 = p_tmNoEqWith' true p_X right e2 in
-                        infix0 uu____7945 uu____7946 uu____7947 in
-                      paren_if_gt curr mine uu____7944))
+                     (let uu___2 =
+                        let uu___3 = str op in
+                        let uu___4 = p_tmNoEqWith' true p_X left e1 in
+                        let uu___5 = p_tmNoEqWith' true p_X right e2 in
+                        infix0 uu___3 uu___4 uu___5 in
+                      paren_if_gt curr mine uu___2))
           | FStar_Parser_AST.Op (op, e1::e2::[]) when is_operatorInfix34 op
               ->
               let op1 = FStar_Ident.string_of_id op in
-              let uu____7954 = levels op1 in
-              (match uu____7954 with
+              let uu___ = levels op1 in
+              (match uu___ with
                | (left, mine, right) ->
-                   let uu____7964 =
-                     let uu____7965 = str op1 in
-                     let uu____7966 = p_tmNoEqWith' false p_X left e1 in
-                     let uu____7967 = p_tmNoEqWith' false p_X right e2 in
-                     infix0 uu____7965 uu____7966 uu____7967 in
-                   paren_if_gt curr mine uu____7964)
+                   let uu___1 =
+                     let uu___2 = str op1 in
+                     let uu___3 = p_tmNoEqWith' false p_X left e1 in
+                     let uu___4 = p_tmNoEqWith' false p_X right e2 in
+                     infix0 uu___2 uu___3 uu___4 in
+                   paren_if_gt curr mine uu___1)
           | FStar_Parser_AST.Record (with_opt, record_fields) ->
-              let uu____7986 =
-                let uu____7987 =
+              let uu___ =
+                let uu___1 =
                   default_or_map FStar_Pprint.empty p_with_clause with_opt in
-                let uu____7988 =
-                  let uu____7989 =
+                let uu___2 =
+                  let uu___3 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-                  separate_map_last uu____7989 p_simpleDef record_fields in
-                FStar_Pprint.op_Hat_Hat uu____7987 uu____7988 in
-              braces_with_nesting uu____7986
+                  separate_map_last uu___3 p_simpleDef record_fields in
+                FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+              braces_with_nesting uu___
           | FStar_Parser_AST.Op (id, e1::[]) when
-              let uu____7998 = FStar_Ident.string_of_id id in
-              uu____7998 = "~" ->
-              let uu____7999 =
-                let uu____8000 = str "~" in
-                let uu____8001 = p_atomicTerm e1 in
-                FStar_Pprint.op_Hat_Hat uu____8000 uu____8001 in
-              FStar_Pprint.group uu____7999
+              let uu___ = FStar_Ident.string_of_id id in uu___ = "~" ->
+              let uu___ =
+                let uu___1 = str "~" in
+                let uu___2 = p_atomicTerm e1 in
+                FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+              FStar_Pprint.group uu___
           | FStar_Parser_AST.Paren p when inside_tuple ->
               (match p.FStar_Parser_AST.tm with
                | FStar_Parser_AST.Op (id, e1::e2::[]) when
-                   let uu____8008 = FStar_Ident.string_of_id id in
-                   uu____8008 = "*" ->
+                   let uu___ = FStar_Ident.string_of_id id in uu___ = "*" ->
                    let op = "*" in
-                   let uu____8010 = levels op in
-                   (match uu____8010 with
+                   let uu___ = levels op in
+                   (match uu___ with
                     | (left, mine, right) ->
-                        let uu____8020 =
-                          let uu____8021 = str op in
-                          let uu____8022 = p_tmNoEqWith' true p_X left e1 in
-                          let uu____8023 = p_tmNoEqWith' true p_X right e2 in
-                          infix0 uu____8021 uu____8022 uu____8023 in
-                        paren_if_gt curr mine uu____8020)
-               | uu____8024 -> p_X e)
-          | uu____8025 -> p_X e
+                        let uu___1 =
+                          let uu___2 = str op in
+                          let uu___3 = p_tmNoEqWith' true p_X left e1 in
+                          let uu___4 = p_tmNoEqWith' true p_X right e2 in
+                          infix0 uu___2 uu___3 uu___4 in
+                        paren_if_gt curr mine uu___1)
+               | uu___ -> p_X e)
+          | uu___ -> p_X e
 and (p_tmEqNoRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e -> p_tmEqWith p_appTerm e
 and (p_tmEq : FStar_Parser_AST.term -> FStar_Pprint.document) =
@@ -3568,24 +3467,23 @@ and (p_tmRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.NamedTyp (lid, e1) ->
-        let uu____8032 =
-          let uu____8033 = p_lident lid in
-          let uu____8034 =
-            let uu____8035 = p_appTerm e1 in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____8035 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____8033 uu____8034 in
-        FStar_Pprint.group uu____8032
+        let uu___ =
+          let uu___1 = p_lident lid in
+          let uu___2 =
+            let uu___3 = p_appTerm e1 in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___3 in
+          FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.Refine (b, phi) -> p_refinedBinder b phi
-    | uu____8038 -> p_appTerm e
+    | uu___ -> p_appTerm e
 and (p_with_clause : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
-    let uu____8040 = p_appTerm e in
-    let uu____8041 =
-      let uu____8042 =
-        let uu____8043 = str "with" in
-        FStar_Pprint.op_Hat_Hat uu____8043 break1 in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8042 in
-    FStar_Pprint.op_Hat_Hat uu____8040 uu____8041
+    let uu___ = p_appTerm e in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 = str "with" in FStar_Pprint.op_Hat_Hat uu___3 break1 in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+    FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_refinedBinder :
   FStar_Parser_AST.binder -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -3593,138 +3491,129 @@ and (p_refinedBinder :
     fun phi ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Annotated (lid, t) ->
-          let uu____8048 = p_lident lid in
-          p_refinement b.FStar_Parser_AST.aqual uu____8048 t phi
-      | FStar_Parser_AST.TAnnotated uu____8049 ->
-          failwith "Is this still used ?"
-      | FStar_Parser_AST.Variable uu____8054 ->
-          let uu____8055 =
-            let uu____8056 = FStar_Parser_AST.binder_to_string b in
+          let uu___ = p_lident lid in
+          p_refinement b.FStar_Parser_AST.aqual uu___ t phi
+      | FStar_Parser_AST.TAnnotated uu___ -> failwith "Is this still used ?"
+      | FStar_Parser_AST.Variable uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
-              "Imposible : a refined binder ought to be annotated %s"
-              uu____8056 in
-          failwith uu____8055
-      | FStar_Parser_AST.TVariable uu____8057 ->
-          let uu____8058 =
-            let uu____8059 = FStar_Parser_AST.binder_to_string b in
+              "Imposible : a refined binder ought to be annotated %s" uu___2 in
+          failwith uu___1
+      | FStar_Parser_AST.TVariable uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
-              "Imposible : a refined binder ought to be annotated %s"
-              uu____8059 in
-          failwith uu____8058
-      | FStar_Parser_AST.NoName uu____8060 ->
-          let uu____8061 =
-            let uu____8062 = FStar_Parser_AST.binder_to_string b in
+              "Imposible : a refined binder ought to be annotated %s" uu___2 in
+          failwith uu___1
+      | FStar_Parser_AST.NoName uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
-              "Imposible : a refined binder ought to be annotated %s"
-              uu____8062 in
-          failwith uu____8061
+              "Imposible : a refined binder ought to be annotated %s" uu___2 in
+          failwith uu___1
 and (p_simpleDef :
   Prims.bool ->
     (FStar_Ident.lid * FStar_Parser_AST.term) -> FStar_Pprint.document)
   =
   fun ps ->
-    fun uu____8064 ->
-      match uu____8064 with
+    fun uu___ ->
+      match uu___ with
       | (lid, e) ->
-          let uu____8071 =
-            let uu____8072 = p_qlident lid in
-            let uu____8073 =
-              let uu____8074 = p_noSeqTermAndComment ps false e in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____8074 in
-            FStar_Pprint.op_Hat_Slash_Hat uu____8072 uu____8073 in
-          FStar_Pprint.group uu____8071
+          let uu___1 =
+            let uu___2 = p_qlident lid in
+            let uu___3 =
+              let uu___4 = p_noSeqTermAndComment ps false e in
+              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu___4 in
+            FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+          FStar_Pprint.group uu___1
 and (p_appTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
-    | FStar_Parser_AST.App uu____8076 when is_general_application e ->
-        let uu____8083 = head_and_args e in
-        (match uu____8083 with
+    | FStar_Parser_AST.App uu___ when is_general_application e ->
+        let uu___1 = head_and_args e in
+        (match uu___1 with
          | (head, args) ->
              (match args with
               | e1::e2::[] when
                   (FStar_Pervasives_Native.snd e1) = FStar_Parser_AST.Infix
                   ->
-                  let uu____8130 = p_argTerm e1 in
-                  let uu____8131 =
-                    let uu____8132 =
-                      let uu____8133 =
-                        let uu____8134 = str "`" in
-                        let uu____8135 =
-                          let uu____8136 = p_indexingTerm head in
-                          let uu____8137 = str "`" in
-                          FStar_Pprint.op_Hat_Hat uu____8136 uu____8137 in
-                        FStar_Pprint.op_Hat_Hat uu____8134 uu____8135 in
-                      FStar_Pprint.group uu____8133 in
-                    let uu____8138 = p_argTerm e2 in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____8132 uu____8138 in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____8130 uu____8131
-              | uu____8139 ->
-                  let uu____8146 =
-                    let uu____8157 = FStar_ST.op_Bang should_print_fs_typ_app in
-                    if uu____8157
+                  let uu___2 = p_argTerm e1 in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = str "`" in
+                        let uu___7 =
+                          let uu___8 = p_indexingTerm head in
+                          let uu___9 = str "`" in
+                          FStar_Pprint.op_Hat_Hat uu___8 uu___9 in
+                        FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
+                      FStar_Pprint.group uu___5 in
+                    let uu___5 = p_argTerm e2 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                  FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3
+              | uu___2 ->
+                  let uu___3 =
+                    let uu___4 = FStar_ST.op_Bang should_print_fs_typ_app in
+                    if uu___4
                     then
-                      let uu____8174 =
+                      let uu___5 =
                         FStar_Util.take
-                          (fun uu____8198 ->
-                             match uu____8198 with
-                             | (uu____8203, aq) ->
-                                 aq = FStar_Parser_AST.FsTypApp) args in
-                      match uu____8174 with
+                          (fun uu___6 ->
+                             match uu___6 with
+                             | (uu___7, aq) -> aq = FStar_Parser_AST.FsTypApp)
+                          args in
+                      match uu___5 with
                       | (fs_typ_args, args1) ->
-                          let uu____8241 =
-                            let uu____8242 = p_indexingTerm head in
-                            let uu____8243 =
-                              let uu____8244 =
+                          let uu___6 =
+                            let uu___7 = p_indexingTerm head in
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.comma
                                   break1 in
                               soft_surround_map_or_flow (Prims.of_int (2))
                                 Prims.int_zero FStar_Pprint.empty
-                                FStar_Pprint.langle uu____8244
+                                FStar_Pprint.langle uu___9
                                 FStar_Pprint.rangle p_fsTypArg fs_typ_args in
-                            FStar_Pprint.op_Hat_Hat uu____8242 uu____8243 in
-                          (uu____8241, args1)
-                    else
-                      (let uu____8256 = p_indexingTerm head in
-                       (uu____8256, args)) in
-                  (match uu____8146 with
+                            FStar_Pprint.op_Hat_Hat uu___7 uu___8 in
+                          (uu___6, args1)
+                    else (let uu___6 = p_indexingTerm head in (uu___6, args)) in
+                  (match uu___3 with
                    | (head_doc, args1) ->
-                       let uu____8277 =
-                         let uu____8278 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Pprint.op_Hat_Hat head_doc
                              FStar_Pprint.space in
                          soft_surround_map_or_flow (Prims.of_int (2))
-                           Prims.int_zero head_doc uu____8278 break1
+                           Prims.int_zero head_doc uu___5 break1
                            FStar_Pprint.empty p_argTerm args1 in
-                       FStar_Pprint.group uu____8277)))
+                       FStar_Pprint.group uu___4)))
     | FStar_Parser_AST.Construct (lid, args) when
         (is_general_construction e) &&
-          (let uu____8298 =
-             (is_dtuple_constructor lid) && (all1_explicit args) in
-           Prims.op_Negation uu____8298)
+          (let uu___ = (is_dtuple_constructor lid) && (all1_explicit args) in
+           Prims.op_Negation uu___)
         ->
         (match args with
          | [] -> p_quident lid
          | arg::[] ->
-             let uu____8316 =
-               let uu____8317 = p_quident lid in
-               let uu____8318 = p_argTerm arg in
-               FStar_Pprint.op_Hat_Slash_Hat uu____8317 uu____8318 in
-             FStar_Pprint.group uu____8316
+             let uu___ =
+               let uu___1 = p_quident lid in
+               let uu___2 = p_argTerm arg in
+               FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+             FStar_Pprint.group uu___
          | hd::tl ->
-             let uu____8335 =
-               let uu____8336 =
-                 let uu____8337 =
-                   let uu____8338 = p_quident lid in
-                   let uu____8339 = p_argTerm hd in
-                   prefix2 uu____8338 uu____8339 in
-                 FStar_Pprint.group uu____8337 in
-               let uu____8340 =
-                 let uu____8341 =
-                   FStar_Pprint.separate_map break1 p_argTerm tl in
-                 jump2 uu____8341 in
-               FStar_Pprint.op_Hat_Hat uu____8336 uu____8340 in
-             FStar_Pprint.group uu____8335)
-    | uu____8346 -> p_indexingTerm e
+             let uu___ =
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = p_quident lid in
+                   let uu___4 = p_argTerm hd in prefix2 uu___3 uu___4 in
+                 FStar_Pprint.group uu___2 in
+               let uu___2 =
+                 let uu___3 = FStar_Pprint.separate_map break1 p_argTerm tl in
+                 jump2 uu___3 in
+               FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+             FStar_Pprint.group uu___)
+    | uu___ -> p_indexingTerm e
 and (p_argTerm :
   (FStar_Parser_AST.term * FStar_Parser_AST.imp) -> FStar_Pprint.document) =
   fun arg_imp ->
@@ -3734,29 +3623,27 @@ and (p_argTerm :
         (FStar_Errors.log_issue e.FStar_Parser_AST.range
            (FStar_Errors.Warning_UnexpectedFsTypApp,
              "Unexpected FsTypApp, output might not be formatted correctly.");
-         (let uu____8355 = p_indexingTerm e in
+         (let uu___1 = p_indexingTerm e in
           FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
-            FStar_Pprint.langle uu____8355 FStar_Pprint.rangle))
+            FStar_Pprint.langle uu___1 FStar_Pprint.rangle))
     | (e, FStar_Parser_AST.Hash) ->
-        let uu____8357 = str "#" in
-        let uu____8358 = p_indexingTerm e in
-        FStar_Pprint.op_Hat_Hat uu____8357 uu____8358
+        let uu___ = str "#" in
+        let uu___1 = p_indexingTerm e in FStar_Pprint.op_Hat_Hat uu___ uu___1
     | (e, FStar_Parser_AST.HashBrace t) ->
-        let uu____8361 = str "#[" in
-        let uu____8362 =
-          let uu____8363 = p_indexingTerm t in
-          let uu____8364 =
-            let uu____8365 = str "]" in
-            let uu____8366 = p_indexingTerm e in
-            FStar_Pprint.op_Hat_Hat uu____8365 uu____8366 in
-          FStar_Pprint.op_Hat_Hat uu____8363 uu____8364 in
-        FStar_Pprint.op_Hat_Hat uu____8361 uu____8362
+        let uu___ = str "#[" in
+        let uu___1 =
+          let uu___2 = p_indexingTerm t in
+          let uu___3 =
+            let uu___4 = str "]" in
+            let uu___5 = p_indexingTerm e in
+            FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+          FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | (e, FStar_Parser_AST.Infix) -> p_indexingTerm e
     | (e, FStar_Parser_AST.Nothing) -> p_indexingTerm e
 and (p_fsTypArg :
   (FStar_Parser_AST.term * FStar_Parser_AST.imp) -> FStar_Pprint.document) =
-  fun uu____8369 ->
-    match uu____8369 with | (e, uu____8375) -> p_indexingTerm e
+  fun uu___ -> match uu___ with | (e, uu___1) -> p_indexingTerm e
 and (p_indexingTerm_aux :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
     FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -3765,50 +3652,46 @@ and (p_indexingTerm_aux :
     fun e ->
       match e.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Op (id, e1::e2::[]) when
-          let uu____8385 = FStar_Ident.string_of_id id in uu____8385 = ".()"
-          ->
-          let uu____8386 =
-            let uu____8387 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
-            let uu____8388 =
-              let uu____8389 =
-                let uu____8390 = p_term false false e2 in
-                soft_parens_with_nesting uu____8390 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8389 in
-            FStar_Pprint.op_Hat_Hat uu____8387 uu____8388 in
-          FStar_Pprint.group uu____8386
+          let uu___ = FStar_Ident.string_of_id id in uu___ = ".()" ->
+          let uu___ =
+            let uu___1 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = p_term false false e2 in
+                soft_parens_with_nesting uu___4 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___3 in
+            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+          FStar_Pprint.group uu___
       | FStar_Parser_AST.Op (id, e1::e2::[]) when
-          let uu____8396 = FStar_Ident.string_of_id id in uu____8396 = ".[]"
-          ->
-          let uu____8397 =
-            let uu____8398 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
-            let uu____8399 =
-              let uu____8400 =
-                let uu____8401 = p_term false false e2 in
-                soft_brackets_with_nesting uu____8401 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8400 in
-            FStar_Pprint.op_Hat_Hat uu____8398 uu____8399 in
-          FStar_Pprint.group uu____8397
-      | uu____8402 -> exit e
+          let uu___ = FStar_Ident.string_of_id id in uu___ = ".[]" ->
+          let uu___ =
+            let uu___1 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = p_term false false e2 in
+                soft_brackets_with_nesting uu___4 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___3 in
+            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+          FStar_Pprint.group uu___
+      | uu___ -> exit e
 and (p_indexingTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e -> p_indexingTerm_aux p_atomicTerm e
 and (p_atomicTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.LetOpen (lid, e1) ->
-        let uu____8407 = p_quident lid in
-        let uu____8408 =
-          let uu____8409 =
-            let uu____8410 = p_term false false e1 in
-            soft_parens_with_nesting uu____8410 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8409 in
-        FStar_Pprint.op_Hat_Hat uu____8407 uu____8408
+        let uu___ = p_quident lid in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = p_term false false e1 in
+            soft_parens_with_nesting uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Name lid -> p_quident lid
     | FStar_Parser_AST.Op (op, e1::[]) when is_general_prefix_op op ->
-        let uu____8416 =
-          let uu____8417 = FStar_Ident.string_of_id op in str uu____8417 in
-        let uu____8418 = p_atomicTerm e1 in
-        FStar_Pprint.op_Hat_Hat uu____8416 uu____8418
-    | uu____8419 -> p_atomicTermNotQUident e
+        let uu___ = let uu___1 = FStar_Ident.string_of_id op in str uu___1 in
+        let uu___1 = p_atomicTerm e1 in FStar_Pprint.op_Hat_Hat uu___ uu___1
+    | uu___ -> p_atomicTermNotQUident e
 and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
   =
   fun e ->
@@ -3824,328 +3707,289 @@ and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
     | FStar_Parser_AST.Const c ->
         (match c with
          | FStar_Const.Const_char x when x = 10 -> str "0x0Az"
-         | uu____8426 -> p_constant c)
+         | uu___ -> p_constant c)
     | FStar_Parser_AST.Name lid when
         FStar_Ident.lid_equals lid FStar_Parser_Const.true_lid -> str "True"
     | FStar_Parser_AST.Name lid when
         FStar_Ident.lid_equals lid FStar_Parser_Const.false_lid ->
         str "False"
     | FStar_Parser_AST.Op (op, e1::[]) when is_general_prefix_op op ->
-        let uu____8433 =
-          let uu____8434 = FStar_Ident.string_of_id op in str uu____8434 in
-        let uu____8435 = p_atomicTermNotQUident e1 in
-        FStar_Pprint.op_Hat_Hat uu____8433 uu____8435
+        let uu___ = let uu___1 = FStar_Ident.string_of_id op in str uu___1 in
+        let uu___1 = p_atomicTermNotQUident e1 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Op (op, []) ->
-        let uu____8439 =
-          let uu____8440 =
-            let uu____8441 =
-              let uu____8442 = FStar_Ident.string_of_id op in str uu____8442 in
-            let uu____8443 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Ident.string_of_id op in str uu___3 in
+            let uu___3 =
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
-            FStar_Pprint.op_Hat_Hat uu____8441 uu____8443 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____8440 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____8439
+            FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___1 in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___
     | FStar_Parser_AST.Construct (lid, args) when
         (is_dtuple_constructor lid) && (all1_explicit args) ->
-        let uu____8458 =
+        let uu___ =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
-        let uu____8459 =
-          let uu____8460 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          FStar_Pprint.separate_map uu____8460
-            (fun uu____8468 ->
-               match uu____8468 with | (e1, uu____8474) -> p_tmEq e1) args in
-        let uu____8475 =
+        let uu___1 =
+          let uu___2 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          FStar_Pprint.separate_map uu___2
+            (fun uu___3 -> match uu___3 with | (e1, uu___4) -> p_tmEq e1)
+            args in
+        let uu___2 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____8458
-          uu____8459 uu____8475
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu___ uu___1
+          uu___2
     | FStar_Parser_AST.Project (e1, lid) ->
-        let uu____8478 =
-          let uu____8479 = p_atomicTermNotQUident e1 in
-          let uu____8480 =
-            let uu____8481 = p_qlident lid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8481 in
-          FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_zero uu____8479
-            uu____8480 in
-        FStar_Pprint.group uu____8478
-    | uu____8482 -> p_projectionLHS e
+        let uu___ =
+          let uu___1 = p_atomicTermNotQUident e1 in
+          let uu___2 =
+            let uu___3 = p_qlident lid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___3 in
+          FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_zero uu___1 uu___2 in
+        FStar_Pprint.group uu___
+    | uu___ -> p_projectionLHS e
 and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Var lid -> p_qlident lid
     | FStar_Parser_AST.Projector (constr_lid, field_lid) ->
-        let uu____8487 = p_quident constr_lid in
-        let uu____8488 =
-          let uu____8489 =
-            let uu____8490 = p_lident field_lid in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8490 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____8489 in
-        FStar_Pprint.op_Hat_Hat uu____8487 uu____8488
+        let uu___ = p_quident constr_lid in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = p_lident field_lid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu___2 in
+        FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Discrim constr_lid ->
-        let uu____8492 = p_quident constr_lid in
-        FStar_Pprint.op_Hat_Hat uu____8492 FStar_Pprint.qmark
+        let uu___ = p_quident constr_lid in
+        FStar_Pprint.op_Hat_Hat uu___ FStar_Pprint.qmark
     | FStar_Parser_AST.Paren e1 ->
-        let uu____8494 = p_term_sep false false e1 in
-        (match uu____8494 with
+        let uu___ = p_term_sep false false e1 in
+        (match uu___ with
          | (comm, t) ->
              let doc = soft_parens_with_nesting t in
              if comm = FStar_Pprint.empty
              then doc
              else
-               (let uu____8503 =
+               (let uu___2 =
                   FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline doc in
-                FStar_Pprint.op_Hat_Hat comm uu____8503))
-    | uu____8504 when is_array e ->
+                FStar_Pprint.op_Hat_Hat comm uu___2))
+    | uu___ when is_array e ->
         let es = extract_from_list e in
-        let uu____8508 =
+        let uu___1 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar in
-        let uu____8509 =
-          let uu____8510 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          separate_map_or_flow_last uu____8510
+        let uu___2 =
+          let uu___3 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+          separate_map_or_flow_last uu___3
             (fun ps -> p_noSeqTermAndComment ps false) es in
-        let uu____8513 =
+        let uu___3 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____8508
-          uu____8509 uu____8513
-    | uu____8514 when is_list e ->
-        let uu____8515 =
-          let uu____8516 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          let uu____8517 = extract_from_list e in
-          separate_map_or_flow_last uu____8516
-            (fun ps -> p_noSeqTermAndComment ps false) uu____8517 in
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu___1 uu___2
+          uu___3
+    | uu___ when is_list e ->
+        let uu___1 =
+          let uu___2 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+          let uu___3 = extract_from_list e in
+          separate_map_or_flow_last uu___2
+            (fun ps -> p_noSeqTermAndComment ps false) uu___3 in
         FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero
-          FStar_Pprint.lbracket uu____8515 FStar_Pprint.rbracket
-    | uu____8522 when is_lex_list e ->
-        let uu____8523 =
+          FStar_Pprint.lbracket uu___1 FStar_Pprint.rbracket
+    | uu___ when is_lex_list e ->
+        let uu___1 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket in
-        let uu____8524 =
-          let uu____8525 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
-          let uu____8526 = extract_from_list e in
-          separate_map_or_flow_last uu____8525
-            (fun ps -> p_noSeqTermAndComment ps false) uu____8526 in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu____8523
-          uu____8524 FStar_Pprint.rbracket
-    | uu____8531 when is_ref_set e ->
+        let uu___2 =
+          let uu___3 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+          let uu___4 = extract_from_list e in
+          separate_map_or_flow_last uu___3
+            (fun ps -> p_noSeqTermAndComment ps false) uu___4 in
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu___1 uu___2
+          FStar_Pprint.rbracket
+    | uu___ when is_ref_set e ->
         let es = extract_from_ref_set e in
-        let uu____8535 =
+        let uu___1 =
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace in
-        let uu____8536 =
-          let uu____8537 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
-          separate_map_or_flow uu____8537 p_appTerm es in
-        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu____8535
-          uu____8536 FStar_Pprint.rbrace
+        let uu___2 =
+          let uu___3 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          separate_map_or_flow uu___3 p_appTerm es in
+        FStar_Pprint.surround (Prims.of_int (2)) Prims.int_zero uu___1 uu___2
+          FStar_Pprint.rbrace
     | FStar_Parser_AST.Labeled (e1, s, b) ->
-        let uu____8541 = str (Prims.op_Hat "(*" (Prims.op_Hat s "*)")) in
-        let uu____8542 = p_term false false e1 in
-        FStar_Pprint.op_Hat_Slash_Hat uu____8541 uu____8542
+        let uu___ = str (Prims.op_Hat "(*" (Prims.op_Hat s "*)")) in
+        let uu___1 = p_term false false e1 in
+        FStar_Pprint.op_Hat_Slash_Hat uu___ uu___1
     | FStar_Parser_AST.Op (op, args) when
-        let uu____8549 = handleable_op op args in
-        Prims.op_Negation uu____8549 ->
-        let uu____8550 =
-          let uu____8551 =
-            let uu____8552 = FStar_Ident.string_of_id op in
-            let uu____8553 =
-              let uu____8554 =
-                let uu____8555 =
+        let uu___ = handleable_op op args in Prims.op_Negation uu___ ->
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_id op in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
                   FStar_Util.string_of_int (FStar_List.length args) in
-                Prims.op_Hat uu____8555
+                Prims.op_Hat uu___5
                   " arguments couldn't be handled by the pretty printer" in
-              Prims.op_Hat " with " uu____8554 in
-            Prims.op_Hat uu____8552 uu____8553 in
-          Prims.op_Hat "Operation " uu____8551 in
-        failwith uu____8550
+              Prims.op_Hat " with " uu___4 in
+            Prims.op_Hat uu___2 uu___3 in
+          Prims.op_Hat "Operation " uu___1 in
+        failwith uu___
     | FStar_Parser_AST.Uvar id ->
         failwith "Unexpected universe variable out of universe context"
     | FStar_Parser_AST.Wild ->
-        let uu____8557 = p_term false false e in
-        soft_parens_with_nesting uu____8557
-    | FStar_Parser_AST.Const uu____8558 ->
-        let uu____8559 = p_term false false e in
-        soft_parens_with_nesting uu____8559
-    | FStar_Parser_AST.Op uu____8560 ->
-        let uu____8567 = p_term false false e in
-        soft_parens_with_nesting uu____8567
-    | FStar_Parser_AST.Tvar uu____8568 ->
-        let uu____8569 = p_term false false e in
-        soft_parens_with_nesting uu____8569
-    | FStar_Parser_AST.Var uu____8570 ->
-        let uu____8571 = p_term false false e in
-        soft_parens_with_nesting uu____8571
-    | FStar_Parser_AST.Name uu____8572 ->
-        let uu____8573 = p_term false false e in
-        soft_parens_with_nesting uu____8573
-    | FStar_Parser_AST.Construct uu____8574 ->
-        let uu____8585 = p_term false false e in
-        soft_parens_with_nesting uu____8585
-    | FStar_Parser_AST.Abs uu____8586 ->
-        let uu____8593 = p_term false false e in
-        soft_parens_with_nesting uu____8593
-    | FStar_Parser_AST.App uu____8594 ->
-        let uu____8601 = p_term false false e in
-        soft_parens_with_nesting uu____8601
-    | FStar_Parser_AST.Let uu____8602 ->
-        let uu____8623 = p_term false false e in
-        soft_parens_with_nesting uu____8623
-    | FStar_Parser_AST.LetOpen uu____8624 ->
-        let uu____8629 = p_term false false e in
-        soft_parens_with_nesting uu____8629
-    | FStar_Parser_AST.Seq uu____8630 ->
-        let uu____8635 = p_term false false e in
-        soft_parens_with_nesting uu____8635
-    | FStar_Parser_AST.Bind uu____8636 ->
-        let uu____8643 = p_term false false e in
-        soft_parens_with_nesting uu____8643
-    | FStar_Parser_AST.If uu____8644 ->
-        let uu____8651 = p_term false false e in
-        soft_parens_with_nesting uu____8651
-    | FStar_Parser_AST.Match uu____8652 ->
-        let uu____8667 = p_term false false e in
-        soft_parens_with_nesting uu____8667
-    | FStar_Parser_AST.TryWith uu____8668 ->
-        let uu____8683 = p_term false false e in
-        soft_parens_with_nesting uu____8683
-    | FStar_Parser_AST.Ascribed uu____8684 ->
-        let uu____8693 = p_term false false e in
-        soft_parens_with_nesting uu____8693
-    | FStar_Parser_AST.Record uu____8694 ->
-        let uu____8707 = p_term false false e in
-        soft_parens_with_nesting uu____8707
-    | FStar_Parser_AST.Project uu____8708 ->
-        let uu____8713 = p_term false false e in
-        soft_parens_with_nesting uu____8713
-    | FStar_Parser_AST.Product uu____8714 ->
-        let uu____8721 = p_term false false e in
-        soft_parens_with_nesting uu____8721
-    | FStar_Parser_AST.Sum uu____8722 ->
-        let uu____8733 = p_term false false e in
-        soft_parens_with_nesting uu____8733
-    | FStar_Parser_AST.QForall uu____8734 ->
-        let uu____8753 = p_term false false e in
-        soft_parens_with_nesting uu____8753
-    | FStar_Parser_AST.QExists uu____8754 ->
-        let uu____8773 = p_term false false e in
-        soft_parens_with_nesting uu____8773
-    | FStar_Parser_AST.Refine uu____8774 ->
-        let uu____8779 = p_term false false e in
-        soft_parens_with_nesting uu____8779
-    | FStar_Parser_AST.NamedTyp uu____8780 ->
-        let uu____8785 = p_term false false e in
-        soft_parens_with_nesting uu____8785
-    | FStar_Parser_AST.Requires uu____8786 ->
-        let uu____8793 = p_term false false e in
-        soft_parens_with_nesting uu____8793
-    | FStar_Parser_AST.Ensures uu____8794 ->
-        let uu____8801 = p_term false false e in
-        soft_parens_with_nesting uu____8801
-    | FStar_Parser_AST.Attributes uu____8802 ->
-        let uu____8805 = p_term false false e in
-        soft_parens_with_nesting uu____8805
-    | FStar_Parser_AST.Quote uu____8806 ->
-        let uu____8811 = p_term false false e in
-        soft_parens_with_nesting uu____8811
-    | FStar_Parser_AST.VQuote uu____8812 ->
-        let uu____8813 = p_term false false e in
-        soft_parens_with_nesting uu____8813
-    | FStar_Parser_AST.Antiquote uu____8814 ->
-        let uu____8815 = p_term false false e in
-        soft_parens_with_nesting uu____8815
-    | FStar_Parser_AST.CalcProof uu____8816 ->
-        let uu____8825 = p_term false false e in
-        soft_parens_with_nesting uu____8825
+        let uu___ = p_term false false e in soft_parens_with_nesting uu___
+    | FStar_Parser_AST.Const uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Op uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Tvar uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Var uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Name uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Construct uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Abs uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.App uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Let uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.LetOpen uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Seq uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Bind uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.If uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Match uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.TryWith uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Ascribed uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Record uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Project uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Product uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Sum uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.QForall uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.QExists uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Refine uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.NamedTyp uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Requires uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Ensures uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Attributes uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Quote uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.VQuote uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Antiquote uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.CalcProof uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
 and (p_constant : FStar_Const.sconst -> FStar_Pprint.document) =
-  fun uu___15_8826 ->
-    match uu___15_8826 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Const.Const_effect -> str "Effect"
     | FStar_Const.Const_unit -> str "()"
     | FStar_Const.Const_bool b -> FStar_Pprint.doc_of_bool b
     | FStar_Const.Const_real r -> str (Prims.op_Hat r "R")
     | FStar_Const.Const_float x -> str (FStar_Util.string_of_float x)
     | FStar_Const.Const_char x -> FStar_Pprint.doc_of_char x
-    | FStar_Const.Const_string (s, uu____8832) ->
-        let uu____8833 = str (FStar_String.escaped s) in
-        FStar_Pprint.dquotes uu____8833
-    | FStar_Const.Const_bytearray (bytes, uu____8835) ->
-        let uu____8840 =
-          let uu____8841 = str (FStar_Util.string_of_bytes bytes) in
-          FStar_Pprint.dquotes uu____8841 in
-        let uu____8842 = str "B" in
-        FStar_Pprint.op_Hat_Hat uu____8840 uu____8842
+    | FStar_Const.Const_string (s, uu___1) ->
+        let uu___2 = str (FStar_String.escaped s) in
+        FStar_Pprint.dquotes uu___2
+    | FStar_Const.Const_bytearray (bytes, uu___1) ->
+        let uu___2 =
+          let uu___3 = str (FStar_Util.string_of_bytes bytes) in
+          FStar_Pprint.dquotes uu___3 in
+        let uu___3 = str "B" in FStar_Pprint.op_Hat_Hat uu___2 uu___3
     | FStar_Const.Const_int (repr, sign_width_opt) ->
-        let signedness uu___13_8862 =
-          match uu___13_8862 with
+        let signedness uu___1 =
+          match uu___1 with
           | FStar_Const.Unsigned -> str "u"
           | FStar_Const.Signed -> FStar_Pprint.empty in
-        let width uu___14_8868 =
-          match uu___14_8868 with
+        let width uu___1 =
+          match uu___1 with
           | FStar_Const.Int8 -> str "y"
           | FStar_Const.Int16 -> str "s"
           | FStar_Const.Int32 -> str "l"
           | FStar_Const.Int64 -> str "L" in
         let ending =
           default_or_map FStar_Pprint.empty
-            (fun uu____8879 ->
-               match uu____8879 with
+            (fun uu___1 ->
+               match uu___1 with
                | (s, w) ->
-                   let uu____8886 = signedness s in
-                   let uu____8887 = width w in
-                   FStar_Pprint.op_Hat_Hat uu____8886 uu____8887)
-            sign_width_opt in
-        let uu____8888 = str repr in
-        FStar_Pprint.op_Hat_Hat uu____8888 ending
+                   let uu___2 = signedness s in
+                   let uu___3 = width w in
+                   FStar_Pprint.op_Hat_Hat uu___2 uu___3) sign_width_opt in
+        let uu___1 = str repr in FStar_Pprint.op_Hat_Hat uu___1 ending
     | FStar_Const.Const_range_of -> str "range_of"
     | FStar_Const.Const_set_range_of -> str "set_range_of"
     | FStar_Const.Const_range r ->
-        let uu____8890 = FStar_Range.string_of_range r in str uu____8890
+        let uu___1 = FStar_Range.string_of_range r in str uu___1
     | FStar_Const.Const_reify -> str "reify"
     | FStar_Const.Const_reflect lid ->
-        let uu____8892 = p_quident lid in
-        let uu____8893 =
-          let uu____8894 =
-            let uu____8895 = str "reflect" in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____8895 in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____8894 in
-        FStar_Pprint.op_Hat_Hat uu____8892 uu____8893
+        let uu___1 = p_quident lid in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = str "reflect" in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu___4 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu___3 in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
 and (p_universe : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u ->
-    let uu____8897 = str "u#" in
-    let uu____8898 = p_atomicUniverse u in
-    FStar_Pprint.op_Hat_Hat uu____8897 uu____8898
+    let uu___ = str "u#" in
+    let uu___1 = p_atomicUniverse u in FStar_Pprint.op_Hat_Hat uu___ uu___1
 and (p_universeFrom : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u ->
     match u.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op (id, u1::u2::[]) when
-        let uu____8905 = FStar_Ident.string_of_id id in uu____8905 = "+" ->
-        let uu____8906 =
-          let uu____8907 = p_universeFrom u1 in
-          let uu____8908 =
-            let uu____8909 = p_universeFrom u2 in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____8909 in
-          FStar_Pprint.op_Hat_Slash_Hat uu____8907 uu____8908 in
-        FStar_Pprint.group uu____8906
-    | FStar_Parser_AST.App uu____8910 ->
-        let uu____8917 = head_and_args u in
-        (match uu____8917 with
+        let uu___ = FStar_Ident.string_of_id id in uu___ = "+" ->
+        let uu___ =
+          let uu___1 = p_universeFrom u1 in
+          let uu___2 =
+            let uu___3 = p_universeFrom u2 in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu___3 in
+          FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+        FStar_Pprint.group uu___
+    | FStar_Parser_AST.App uu___ ->
+        let uu___1 = head_and_args u in
+        (match uu___1 with
          | (head, args) ->
              (match head.FStar_Parser_AST.tm with
               | FStar_Parser_AST.Var maybe_max_lid when
                   FStar_Ident.lid_equals maybe_max_lid
                     FStar_Parser_Const.max_lid
                   ->
-                  let uu____8943 =
-                    let uu____8944 = p_qlident FStar_Parser_Const.max_lid in
-                    let uu____8945 =
+                  let uu___2 =
+                    let uu___3 = p_qlident FStar_Parser_Const.max_lid in
+                    let uu___4 =
                       FStar_Pprint.separate_map FStar_Pprint.space
-                        (fun uu____8953 ->
-                           match uu____8953 with
-                           | (u1, uu____8959) -> p_atomicUniverse u1) args in
-                    op_Hat_Slash_Plus_Hat uu____8944 uu____8945 in
-                  FStar_Pprint.group uu____8943
-              | uu____8960 ->
-                  let uu____8961 =
-                    let uu____8962 = FStar_Parser_AST.term_to_string u in
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (u1, uu___6) -> p_atomicUniverse u1) args in
+                    op_Hat_Slash_Plus_Hat uu___3 uu___4 in
+                  FStar_Pprint.group uu___2
+              | uu___2 ->
+                  let uu___3 =
+                    let uu___4 = FStar_Parser_AST.term_to_string u in
                     FStar_Util.format1 "Invalid term in universe context %s"
-                      uu____8962 in
-                  failwith uu____8961))
-    | uu____8963 -> p_atomicUniverse u
+                      uu___4 in
+                  failwith uu___3))
+    | uu___ -> p_atomicUniverse u
 and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u ->
     match u.FStar_Parser_AST.tm with
@@ -4153,22 +3997,19 @@ and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
     | FStar_Parser_AST.Const (FStar_Const.Const_int (r, sw)) ->
         p_constant (FStar_Const.Const_int (r, sw))
     | FStar_Parser_AST.Uvar id ->
-        let uu____8986 = FStar_Ident.string_of_id id in str uu____8986
+        let uu___ = FStar_Ident.string_of_id id in str uu___
     | FStar_Parser_AST.Paren u1 ->
-        let uu____8988 = p_universeFrom u1 in
-        soft_parens_with_nesting uu____8988
-    | FStar_Parser_AST.App uu____8989 ->
-        let uu____8996 = p_universeFrom u in
-        soft_parens_with_nesting uu____8996
-    | FStar_Parser_AST.Op (id, uu____8998::uu____8999::[]) when
-        let uu____9002 = FStar_Ident.string_of_id id in uu____9002 = "+" ->
-        let uu____9003 = p_universeFrom u in
-        soft_parens_with_nesting uu____9003
-    | uu____9004 ->
-        let uu____9005 =
-          let uu____9006 = FStar_Parser_AST.term_to_string u in
-          FStar_Util.format1 "Invalid term in universe context %s" uu____9006 in
-        failwith uu____9005
+        let uu___ = p_universeFrom u1 in soft_parens_with_nesting uu___
+    | FStar_Parser_AST.App uu___ ->
+        let uu___1 = p_universeFrom u in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.Op (id, uu___::uu___1::[]) when
+        let uu___2 = FStar_Ident.string_of_id id in uu___2 = "+" ->
+        let uu___2 = p_universeFrom u in soft_parens_with_nesting uu___2
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Parser_AST.term_to_string u in
+          FStar_Util.format1 "Invalid term in universe context %s" uu___2 in
+        failwith uu___1
 let (term_to_document : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e -> FStar_ST.op_Colon_Equals unfold_tuples false; p_term false false e
 let (signature_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document)
@@ -4184,31 +4025,31 @@ let (modul_to_document : FStar_Parser_AST.modul -> FStar_Pprint.document) =
     FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
     (let res =
        match m with
-       | FStar_Parser_AST.Module (uu____9052, decls) ->
-           let uu____9058 =
+       | FStar_Parser_AST.Module (uu___1, decls) ->
+           let uu___2 =
              FStar_All.pipe_right decls (FStar_List.map decl_to_document) in
-           FStar_All.pipe_right uu____9058
+           FStar_All.pipe_right uu___2
              (FStar_Pprint.separate FStar_Pprint.hardline)
-       | FStar_Parser_AST.Interface (uu____9067, decls, uu____9069) ->
-           let uu____9074 =
+       | FStar_Parser_AST.Interface (uu___1, decls, uu___2) ->
+           let uu___3 =
              FStar_All.pipe_right decls (FStar_List.map decl_to_document) in
-           FStar_All.pipe_right uu____9074
+           FStar_All.pipe_right uu___3
              (FStar_Pprint.separate FStar_Pprint.hardline) in
      FStar_ST.op_Colon_Equals should_print_fs_typ_app false; res)
 let (comments_to_document :
   (Prims.string * FStar_Range.range) Prims.list -> FStar_Pprint.document) =
   fun comments ->
     FStar_Pprint.separate_map FStar_Pprint.hardline
-      (fun uu____9114 ->
-         match uu____9114 with | (comment, range) -> str comment) comments
+      (fun uu___ -> match uu___ with | (comment, range) -> str comment)
+      comments
 let (extract_decl_range : FStar_Parser_AST.decl -> decl_meta) =
   fun d ->
     let has_qs =
       match ((d.FStar_Parser_AST.quals), (d.FStar_Parser_AST.d)) with
       | ((FStar_Parser_AST.Assumption)::[], FStar_Parser_AST.Assume
-         (id, uu____9130)) -> false
-      | ([], uu____9133) -> false
-      | uu____9136 -> true in
+         (id, uu___)) -> false
+      | ([], uu___) -> false
+      | uu___ -> true in
     {
       r = (d.FStar_Parser_AST.drange);
       has_qs;
@@ -4224,40 +4065,38 @@ let (modul_with_comments_to_document :
     fun comments ->
       let decls =
         match m with
-        | FStar_Parser_AST.Module (uu____9180, decls) -> decls
-        | FStar_Parser_AST.Interface (uu____9186, decls, uu____9188) -> decls in
+        | FStar_Parser_AST.Module (uu___, decls1) -> decls1
+        | FStar_Parser_AST.Interface (uu___, decls1, uu___1) -> decls1 in
       FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
       (match decls with
        | [] -> (FStar_Pprint.empty, comments)
        | d::ds ->
-           let uu____9220 =
+           let uu___1 =
              match ds with
              | {
                  FStar_Parser_AST.d = FStar_Parser_AST.Pragma
                    (FStar_Parser_AST.LightOff);
-                 FStar_Parser_AST.drange = uu____9233;
-                 FStar_Parser_AST.quals = uu____9234;
-                 FStar_Parser_AST.attrs = uu____9235;_}::uu____9236 ->
+                 FStar_Parser_AST.drange = uu___2;
+                 FStar_Parser_AST.quals = uu___3;
+                 FStar_Parser_AST.attrs = uu___4;_}::uu___5 ->
                  let d0 = FStar_List.hd ds in
-                 let uu____9240 =
-                   let uu____9243 =
-                     let uu____9246 = FStar_List.tl ds in d :: uu____9246 in
-                   d0 :: uu____9243 in
-                 (uu____9240, (d0.FStar_Parser_AST.drange))
-             | uu____9251 -> ((d :: ds), (d.FStar_Parser_AST.drange)) in
-           (match uu____9220 with
+                 let uu___6 =
+                   let uu___7 = let uu___8 = FStar_List.tl ds in d :: uu___8 in
+                   d0 :: uu___7 in
+                 (uu___6, (d0.FStar_Parser_AST.drange))
+             | uu___2 -> ((d :: ds), (d.FStar_Parser_AST.drange)) in
+           (match uu___1 with
             | (decls1, first_range) ->
                 (FStar_ST.op_Colon_Equals comment_stack comments;
                  (let initial_comment =
-                    let uu____9292 = FStar_Range.start_of_range first_range in
+                    let uu___3 = FStar_Range.start_of_range first_range in
                     place_comments_until_pos Prims.int_zero Prims.int_one
-                      uu____9292 dummy_meta FStar_Pprint.empty false true in
+                      uu___3 dummy_meta FStar_Pprint.empty false true in
                   let doc =
                     separate_map_with_comments FStar_Pprint.empty
                       FStar_Pprint.empty p_decl decls1 extract_decl_range in
                   let comments1 = FStar_ST.op_Bang comment_stack in
                   FStar_ST.op_Colon_Equals comment_stack [];
                   FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
-                  (let uu____9349 =
-                     FStar_Pprint.op_Hat_Hat initial_comment doc in
-                   (uu____9349, comments1))))))
+                  (let uu___5 = FStar_Pprint.op_Hat_Hat initial_comment doc in
+                   (uu___5, comments1))))))

--- a/src/ocaml-output/FStar_Pervasives.ml
+++ b/src/ocaml-output/FStar_Pervasives.ml
@@ -5,14 +5,14 @@ type pattern = unit
 type 'p spinoff = 'p
 
 let id : 'a . 'a -> 'a = fun x -> x
-type ('a, 'uuuuuu50) trivial_pure_post = unit
-type ('uuuuuu57, 'uuuuuu58) ambient = unit
+type ('a, 'uuuuu) trivial_pure_post = unit
+type ('uuuuu, 'uuuuu1) ambient = unit
 
 type 'heap st_pre_h = unit
 type ('heap, 'a, 'pre) st_post_h' = unit
 type ('heap, 'a) st_post_h = unit
 type ('heap, 'a) st_wp_h = unit
-type ('heap, 'a, 'x, 'p, 'uuuuu0u116) st_return = 'p
+type ('heap, 'a, 'x, 'p, 'uuuuu) st_return = 'p
 type ('heap, 'r1, 'a, 'b, 'wp1, 'wp2, 'p, 'h0) st_bind_wp = 'wp1
 type ('heap, 'a, 'p, 'wputhen, 'wpuelse, 'post, 'h0) st_if_then_else = unit
 type ('heap, 'a, 'wp, 'post, 'h0) st_ite_wp = unit
@@ -24,16 +24,15 @@ type 'a result =
   | E of Prims.exn 
   | Err of Prims.string 
 let uu___is_V : 'a . 'a result -> Prims.bool =
-  fun projectee -> match projectee with | V v -> true | uu____346 -> false
+  fun projectee -> match projectee with | V v -> true | uu___ -> false
 let __proj__V__item__v : 'a . 'a result -> 'a =
   fun projectee -> match projectee with | V v -> v
 let uu___is_E : 'a . 'a result -> Prims.bool =
-  fun projectee -> match projectee with | E e -> true | uu____379 -> false
+  fun projectee -> match projectee with | E e -> true | uu___ -> false
 let __proj__E__item__e : 'a . 'a result -> Prims.exn =
   fun projectee -> match projectee with | E e -> e
 let uu___is_Err : 'a . 'a result -> Prims.bool =
-  fun projectee ->
-    match projectee with | Err msg -> true | uu____412 -> false
+  fun projectee -> match projectee with | Err msg -> true | uu___ -> false
 let __proj__Err__item__msg : 'a . 'a result -> Prims.string =
   fun projectee -> match projectee with | Err msg -> msg
 type ex_pre = unit
@@ -52,25 +51,25 @@ type 'h all_pre_h = unit
 type ('h, 'a, 'pre) all_post_h' = unit
 type ('h, 'a) all_post_h = unit
 type ('h, 'a) all_wp_h = unit
-type ('heap, 'a, 'x, 'p, 'uuuuu3u662) all_return = 'p
+type ('heap, 'a, 'x, 'p, 'uuuuu) all_return = 'p
 type ('heap, 'r1, 'a, 'b, 'wp1, 'wp2, 'p, 'h0) all_bind_wp = 'wp1
 type ('heap, 'a, 'p, 'wputhen, 'wpuelse, 'post, 'h0) all_if_then_else = unit
 type ('heap, 'a, 'wp, 'post, 'h0) all_ite_wp = unit
 type ('heap, 'a, 'wp1, 'wp2) all_stronger = unit
 type ('heap, 'a, 'b, 'wp, 'p, 'h) all_close_wp = unit
 type ('heap, 'a, 'wp) all_trivial = unit
-type 'uuuuuu858 inversion = unit
+type 'uuuuu inversion = unit
 
 
 type ('a, 'b) either =
   | Inl of 'a 
   | Inr of 'b 
 let uu___is_Inl : 'a 'b . ('a, 'b) either -> Prims.bool =
-  fun projectee -> match projectee with | Inl v -> true | uu____905 -> false
+  fun projectee -> match projectee with | Inl v -> true | uu___ -> false
 let __proj__Inl__item__v : 'a 'b . ('a, 'b) either -> 'a =
   fun projectee -> match projectee with | Inl v -> v
 let uu___is_Inr : 'a 'b . ('a, 'b) either -> Prims.bool =
-  fun projectee -> match projectee with | Inr v -> true | uu____954 -> false
+  fun projectee -> match projectee with | Inr v -> true | uu___ -> false
 let __proj__Inr__item__v : 'a 'b . ('a, 'b) either -> 'b =
   fun projectee -> match projectee with | Inr v -> v
 let dfst : 'a 'b . ('a, 'b) Prims.dtuple2 -> 'a =
@@ -104,8 +103,7 @@ let __proj__Mkdtuple4__item___4 :
   'a 'b 'c 'd . ('a, 'b, 'c, 'd) dtuple4 -> 'd =
   fun projectee -> match projectee with | Mkdtuple4 (_1, _2, _3, _4) -> _4
 
-let rec false_elim : 'uuuuuu1500 . unit -> 'uuuuuu1500 =
-  fun uu____1505 -> false_elim ()
+let rec false_elim : 'uuuuu . unit -> 'uuuuu = fun uu___ -> false_elim ()
 type __internal_ocaml_attributes =
   | PpxDerivingShow 
   | PpxDerivingShowConstant of Prims.string 
@@ -123,63 +121,56 @@ type __internal_ocaml_attributes =
   | CMacro 
 let (uu___is_PpxDerivingShow : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
-    match projectee with | PpxDerivingShow -> true | uu____1541 -> false
+    match projectee with | PpxDerivingShow -> true | uu___ -> false
 let (uu___is_PpxDerivingShowConstant :
   __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
-    | uu____1548 -> false
+    | uu___ -> false
 let (__proj__PpxDerivingShowConstant__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee -> match projectee with | PpxDerivingShowConstant _0 -> _0
 let (uu___is_PpxDerivingYoJson : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
-    match projectee with | PpxDerivingYoJson -> true | uu____1560 -> false
+    match projectee with | PpxDerivingYoJson -> true | uu___ -> false
 let (uu___is_CInline : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CInline -> true | uu____1566 -> false
+  fun projectee -> match projectee with | CInline -> true | uu___ -> false
 let (uu___is_Substitute : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Substitute -> true | uu____1572 -> false
+  fun projectee -> match projectee with | Substitute -> true | uu___ -> false
 let (uu___is_Gc : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee -> match projectee with | Gc -> true | uu____1578 -> false
+  fun projectee -> match projectee with | Gc -> true | uu___ -> false
 let (uu___is_Comment : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Comment _0 -> true | uu____1585 -> false
+  fun projectee -> match projectee with | Comment _0 -> true | uu___ -> false
 let (__proj__Comment__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee -> match projectee with | Comment _0 -> _0
 let (uu___is_CPrologue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
-    match projectee with | CPrologue _0 -> true | uu____1598 -> false
+    match projectee with | CPrologue _0 -> true | uu___ -> false
 let (__proj__CPrologue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee -> match projectee with | CPrologue _0 -> _0
 let (uu___is_CEpilogue : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
-    match projectee with | CEpilogue _0 -> true | uu____1611 -> false
+    match projectee with | CEpilogue _0 -> true | uu___ -> false
 let (__proj__CEpilogue__item___0 :
   __internal_ocaml_attributes -> Prims.string) =
   fun projectee -> match projectee with | CEpilogue _0 -> _0
 let (uu___is_CConst : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CConst _0 -> true | uu____1624 -> false
+  fun projectee -> match projectee with | CConst _0 -> true | uu___ -> false
 let (__proj__CConst__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee -> match projectee with | CConst _0 -> _0
 let (uu___is_CCConv : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CCConv _0 -> true | uu____1637 -> false
+  fun projectee -> match projectee with | CCConv _0 -> true | uu___ -> false
 let (__proj__CCConv__item___0 : __internal_ocaml_attributes -> Prims.string)
   = fun projectee -> match projectee with | CCConv _0 -> _0
 let (uu___is_CAbstractStruct : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee ->
-    match projectee with | CAbstractStruct -> true | uu____1649 -> false
+    match projectee with | CAbstractStruct -> true | uu___ -> false
 let (uu___is_CIfDef : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CIfDef -> true | uu____1655 -> false
+  fun projectee -> match projectee with | CIfDef -> true | uu___ -> false
 let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CMacro -> true | uu____1661 -> false
+  fun projectee -> match projectee with | CMacro -> true | uu___ -> false
 
 
 
@@ -196,7 +187,7 @@ let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
 
 
 
-let normalize_term : 'uuuuuu1666 . 'uuuuuu1666 -> 'uuuuuu1666 = fun x -> x
+let normalize_term : 'uuuuu . 'uuuuu -> 'uuuuu = fun x -> x
 type 'a normalize = 'a
 type norm_step =
   | Simpl 
@@ -213,40 +204,38 @@ type norm_step =
   | UnfoldFully of Prims.string Prims.list 
   | UnfoldAttr of Prims.string Prims.list 
 let (uu___is_Simpl : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Simpl -> true | uu____1702 -> false
+  fun projectee -> match projectee with | Simpl -> true | uu___ -> false
 let (uu___is_Weak : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Weak -> true | uu____1708 -> false
+  fun projectee -> match projectee with | Weak -> true | uu___ -> false
 let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | HNF -> true | uu____1714 -> false
+  fun projectee -> match projectee with | HNF -> true | uu___ -> false
 let (uu___is_Primops : norm_step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Primops -> true | uu____1720 -> false
+  fun projectee -> match projectee with | Primops -> true | uu___ -> false
 let (uu___is_Delta : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Delta -> true | uu____1726 -> false
+  fun projectee -> match projectee with | Delta -> true | uu___ -> false
 let (uu___is_Zeta : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Zeta -> true | uu____1732 -> false
+  fun projectee -> match projectee with | Zeta -> true | uu___ -> false
 let (uu___is_ZetaFull : norm_step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ZetaFull -> true | uu____1738 -> false
+  fun projectee -> match projectee with | ZetaFull -> true | uu___ -> false
 let (uu___is_Iota : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Iota -> true | uu____1744 -> false
+  fun projectee -> match projectee with | Iota -> true | uu___ -> false
 let (uu___is_NBE : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | NBE -> true | uu____1750 -> false
+  fun projectee -> match projectee with | NBE -> true | uu___ -> false
 let (uu___is_Reify : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Reify -> true | uu____1756 -> false
+  fun projectee -> match projectee with | Reify -> true | uu___ -> false
 let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldOnly _0 -> true | uu____1765 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu___ -> false
 let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldOnly _0 -> _0
 let (uu___is_UnfoldFully : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldFully _0 -> true | uu____1786 -> false
+    match projectee with | UnfoldFully _0 -> true | uu___ -> false
 let (__proj__UnfoldFully__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldFully _0 -> _0
 let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldAttr _0 -> true | uu____1807 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu___ -> false
 let (__proj__UnfoldAttr__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldAttr _0 -> _0
 let (simplify : norm_step) = Simpl
@@ -266,12 +255,12 @@ let (delta_fully : Prims.string Prims.list -> norm_step) =
 let (delta_attr : Prims.string Prims.list -> norm_step) =
   fun s -> UnfoldAttr s
 let (norm : norm_step Prims.list -> unit -> Obj.t -> Obj.t) =
-  fun uu____1861 -> fun uu____1862 -> fun x -> x
+  fun uu___ -> fun uu___1 -> fun x -> x
 
 
 
 
 
-let singleton : 'uuuuuu1870 . 'uuuuuu1870 -> 'uuuuuu1870 = fun x -> x
-let with_type : 'uuuuuu1880 . 'uuuuuu1880 -> 'uuuuuu1880 = fun e -> e
+let singleton : 'uuuuu . 'uuuuu -> 'uuuuu = fun x -> x
+let with_type : 'uuuuu . 'uuuuu -> 'uuuuu = fun e -> e
 type 'a eqtype_as_type = 'a

--- a/src/ocaml-output/FStar_Prettyprint.ml
+++ b/src/ocaml-output/FStar_Prettyprint.ml
@@ -4,49 +4,48 @@ type printing_mode =
   | FromTempToStdout 
   | FromTempToFile 
 let (uu___is_ToTempFile : printing_mode -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ToTempFile -> true | uu____5 -> false
+  fun projectee -> match projectee with | ToTempFile -> true | uu___ -> false
 let (uu___is_FromTempToStdout : printing_mode -> Prims.bool) =
   fun projectee ->
-    match projectee with | FromTempToStdout -> true | uu____11 -> false
+    match projectee with | FromTempToStdout -> true | uu___ -> false
 let (uu___is_FromTempToFile : printing_mode -> Prims.bool) =
   fun projectee ->
-    match projectee with | FromTempToFile -> true | uu____17 -> false
+    match projectee with | FromTempToFile -> true | uu___ -> false
 let (temp_file_name : Prims.string -> Prims.string) =
   fun f -> FStar_Util.format1 "%s.print_.fst" f
 let (generate : printing_mode -> Prims.string Prims.list -> unit) =
   fun m ->
     fun filenames ->
       let parse_and_prettyprint m1 filename =
-        let uu____48 = FStar_Parser_Driver.parse_file filename in
-        match uu____48 with
+        let uu___ = FStar_Parser_Driver.parse_file filename in
+        match uu___ with
         | (modul, comments) ->
             let outf =
               match m1 with
               | FromTempToStdout -> FStar_Pervasives_Native.None
               | FromTempToFile ->
-                  let outf = FStar_Util.open_file_for_writing filename in
-                  FStar_Pervasives_Native.Some outf
+                  let outf1 = FStar_Util.open_file_for_writing filename in
+                  FStar_Pervasives_Native.Some outf1
               | ToTempFile ->
-                  let outf =
-                    let uu____80 = temp_file_name filename in
-                    FStar_Util.open_file_for_writing uu____80 in
-                  FStar_Pervasives_Native.Some outf in
+                  let outf1 =
+                    let uu___1 = temp_file_name filename in
+                    FStar_Util.open_file_for_writing uu___1 in
+                  FStar_Pervasives_Native.Some outf1 in
             let leftover_comments =
               let comments1 = FStar_List.rev comments in
-              let uu____99 =
+              let uu___1 =
                 FStar_Parser_ToDocument.modul_with_comments_to_document modul
                   comments1 in
-              match uu____99 with
+              match uu___1 with
               | (doc, comments2) ->
                   ((match outf with
                     | FStar_Pervasives_Native.Some f ->
-                        let uu____132 =
+                        let uu___3 =
                           FStar_Pprint.pretty_string
                             (FStar_Util.float_of_string "1.0")
                             (Prims.of_int (100)) doc in
                         FStar_All.pipe_left (FStar_Util.append_to_file f)
-                          uu____132
+                          uu___3
                     | FStar_Pervasives_Native.None ->
                         FStar_Pprint.pretty_out_channel
                           (FStar_Util.float_of_string "1.0")
@@ -55,16 +54,16 @@ let (generate : printing_mode -> Prims.string Prims.list -> unit) =
             let left_over_doc =
               if Prims.op_Negation (FStar_List.isEmpty leftover_comments)
               then
-                let uu____138 =
-                  let uu____141 =
-                    let uu____144 =
-                      let uu____147 =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Parser_ToDocument.comments_to_document
                           leftover_comments in
-                      [uu____147] in
-                    FStar_Pprint.hardline :: uu____144 in
-                  FStar_Pprint.hardline :: uu____141 in
-                FStar_Pprint.concat uu____138
+                      [uu___4] in
+                    FStar_Pprint.hardline :: uu___3 in
+                  FStar_Pprint.hardline :: uu___2 in
+                FStar_Pprint.concat uu___1
               else
                 if m1 = FromTempToStdout
                 then
@@ -77,11 +76,11 @@ let (generate : printing_mode -> Prims.string Prims.list -> unit) =
                    (FStar_Util.float_of_string "1.0") (Prims.of_int (100))
                    left_over_doc FStar_Util.stdout
              | FStar_Pervasives_Native.Some outf1 ->
-                 ((let uu____152 =
+                 ((let uu___2 =
                      FStar_Pprint.pretty_string
                        (FStar_Util.float_of_string "1.0")
                        (Prims.of_int (100)) left_over_doc in
                    FStar_All.pipe_left (FStar_Util.append_to_file outf1)
-                     uu____152);
+                     uu___2);
                   FStar_Util.close_file outf1)) in
       FStar_List.iter (parse_and_prettyprint m) filenames

--- a/src/ocaml-output/FStar_Profiling.ml
+++ b/src/ocaml-output/FStar_Profiling.ml
@@ -24,21 +24,16 @@ let (__proj__Mkcounter__item__undercount :
     | { cid; total_time; running; undercount;_} -> undercount
 let (new_counter : Prims.string -> counter) =
   fun cid ->
-    let uu____113 = FStar_Util.mk_ref Prims.int_zero in
-    let uu____116 = FStar_Util.mk_ref false in
-    let uu____119 = FStar_Util.mk_ref false in
-    {
-      cid;
-      total_time = uu____113;
-      running = uu____116;
-      undercount = uu____119
-    }
+    let uu___ = FStar_Util.mk_ref Prims.int_zero in
+    let uu___1 = FStar_Util.mk_ref false in
+    let uu___2 = FStar_Util.mk_ref false in
+    { cid; total_time = uu___; running = uu___1; undercount = uu___2 }
 let (all_counters : counter FStar_Util.smap) =
   FStar_Util.smap_create (Prims.of_int (20))
 let (create_or_lookup_counter : Prims.string -> counter) =
   fun cid ->
-    let uu____129 = FStar_Util.smap_try_find all_counters cid in
-    match uu____129 with
+    let uu___ = FStar_Util.smap_try_find all_counters cid in
+    match uu___ with
     | FStar_Pervasives_Native.Some c -> c
     | FStar_Pervasives_Native.None ->
         let c = new_counter cid in
@@ -51,64 +46,62 @@ let profile :
   fun f ->
     fun module_name ->
       fun cid ->
-        let uu____168 = FStar_Options.profile_enabled module_name cid in
-        if uu____168
+        let uu___ = FStar_Options.profile_enabled module_name cid in
+        if uu___
         then
           let c = create_or_lookup_counter cid in
-          let uu____170 = FStar_ST.op_Bang c.running in
-          (if uu____170
+          let uu___1 = FStar_ST.op_Bang c.running in
+          (if uu___1
            then f ()
            else
              (try
-                (fun uu___31_185 ->
+                (fun uu___3 ->
                    match () with
                    | () ->
                        (FStar_ST.op_Colon_Equals c.running true;
-                        (let uu____193 = FStar_Util.record_time f in
-                         match uu____193 with
+                        (let uu___5 = FStar_Util.record_time f in
+                         match uu___5 with
                          | (res, elapsed) ->
-                             ((let uu____201 =
-                                 let uu____202 =
-                                   FStar_ST.op_Bang c.total_time in
-                                 uu____202 + elapsed in
-                               FStar_ST.op_Colon_Equals c.total_time
-                                 uu____201);
+                             ((let uu___7 =
+                                 let uu___8 = FStar_ST.op_Bang c.total_time in
+                                 uu___8 + elapsed in
+                               FStar_ST.op_Colon_Equals c.total_time uu___7);
                               FStar_ST.op_Colon_Equals c.running false;
                               res)))) ()
               with
-              | uu___30_225 ->
+              | uu___3 ->
                   (FStar_ST.op_Colon_Equals c.running false;
                    FStar_ST.op_Colon_Equals c.undercount true;
-                   FStar_Exn.raise uu___30_225)))
+                   FStar_Exn.raise uu___3)))
         else f ()
 let (report_and_clear : Prims.string -> unit) =
   fun tag ->
     let ctrs =
       FStar_Util.smap_fold all_counters
-        (fun uu____254 -> fun v -> fun l -> v :: l) [] in
+        (fun uu___ -> fun v -> fun l -> v :: l) [] in
     FStar_Util.smap_clear all_counters;
     (let ctrs1 =
        FStar_Util.sort_with
          (fun c1 ->
             fun c2 ->
-              let uu____269 = FStar_ST.op_Bang c2.total_time in
-              let uu____276 = FStar_ST.op_Bang c1.total_time in
-              uu____269 - uu____276) ctrs in
+              let uu___1 = FStar_ST.op_Bang c2.total_time in
+              let uu___2 = FStar_ST.op_Bang c1.total_time in uu___1 - uu___2)
+         ctrs in
      FStar_All.pipe_right ctrs1
        (FStar_List.iter
           (fun c ->
              let warn =
-               let uu____290 = FStar_ST.op_Bang c.running in
-               if uu____290
+               let uu___1 = FStar_ST.op_Bang c.running in
+               if uu___1
                then " (Warning, this counter is still running)"
                else
-                 (let uu____298 = FStar_ST.op_Bang c.undercount in
-                  if uu____298
+                 (let uu___3 = FStar_ST.op_Bang c.undercount in
+                  if uu___3
                   then
                     " (Warning, some operations raised exceptions and we not accounted for)"
                   else "") in
-             let uu____306 =
-               let uu____307 = FStar_ST.op_Bang c.total_time in
-               FStar_Util.string_of_int uu____307 in
+             let uu___1 =
+               let uu___2 = FStar_ST.op_Bang c.total_time in
+               FStar_Util.string_of_int uu___2 in
              FStar_Util.print4 "%s, profiled %s:\t %s ms%s\n" tag c.cid
-               uu____306 warn)))
+               uu___1 warn)))

--- a/src/ocaml-output/FStar_Range.ml
+++ b/src/ocaml-output/FStar_Range.ml
@@ -51,16 +51,16 @@ let (set_use_range : range -> rng -> range) =
     fun use_rng ->
       if use_rng <> dummy_rng
       then
-        let uu___35_145 = r2 in
-        { def_range = (uu___35_145.def_range); use_range = use_rng }
+        let uu___ = r2 in
+        { def_range = (uu___.def_range); use_range = use_rng }
       else r2
 let (set_def_range : range -> rng -> range) =
   fun r2 ->
     fun def_rng ->
       if def_rng <> dummy_rng
       then
-        let uu___40_157 = r2 in
-        { def_range = def_rng; use_range = (uu___40_157.use_range) }
+        let uu___ = r2 in
+        { def_range = def_rng; use_range = (uu___.use_range) }
       else r2
 let (mk_pos : Prims.int -> Prims.int -> pos) =
   fun l ->
@@ -87,9 +87,9 @@ let (union_rng : rng -> rng -> rng) =
 let (union_ranges : range -> range -> range) =
   fun r1 ->
     fun r2 ->
-      let uu____225 = union_rng r1.def_range r2.def_range in
-      let uu____226 = union_rng r1.use_range r2.use_range in
-      { def_range = uu____225; use_range = uu____226 }
+      let uu___ = union_rng r1.def_range r2.def_range in
+      let uu___1 = union_rng r1.use_range r2.use_range in
+      { def_range = uu___; use_range = uu___1 }
 let (rng_included : rng -> rng -> Prims.bool) =
   fun r1 ->
     fun r2 ->
@@ -100,49 +100,49 @@ let (rng_included : rng -> rng -> Prims.bool) =
           (pos_geq r2.end_pos r1.end_pos)
 let (string_of_pos : pos -> Prims.string) =
   fun pos1 ->
-    let uu____243 = FStar_Util.string_of_int pos1.line in
-    let uu____244 = FStar_Util.string_of_int pos1.col in
-    FStar_Util.format2 "%s,%s" uu____243 uu____244
+    let uu___ = FStar_Util.string_of_int pos1.line in
+    let uu___1 = FStar_Util.string_of_int pos1.col in
+    FStar_Util.format2 "%s,%s" uu___ uu___1
 let (string_of_file_name : Prims.string -> Prims.string) =
   fun f ->
-    let uu____250 = FStar_Options.ide () in
-    if uu____250
+    let uu___ = FStar_Options.ide () in
+    if uu___
     then
       try
-        (fun uu___67_253 ->
+        (fun uu___1 ->
            match () with
            | () ->
-               let uu____254 =
-                 let uu____257 = FStar_Util.basename f in
-                 FStar_Options.find_file uu____257 in
-               (match uu____254 with
+               let uu___2 =
+                 let uu___3 = FStar_Util.basename f in
+                 FStar_Options.find_file uu___3 in
+               (match uu___2 with
                 | FStar_Pervasives_Native.None -> f
                 | FStar_Pervasives_Native.Some absolute_path -> absolute_path))
           ()
-      with | uu___66_260 -> f
+      with | uu___1 -> f
     else f
 let (file_of_range : range -> Prims.string) =
   fun r -> let f = (r.def_range).file_name in string_of_file_name f
 let (set_file_of_range : range -> Prims.string -> range) =
   fun r ->
     fun f ->
-      let uu___79_278 = r in
+      let uu___ = r in
       {
         def_range =
-          (let uu___81_281 = r.def_range in
+          (let uu___1 = r.def_range in
            {
              file_name = f;
-             start_pos = (uu___81_281.start_pos);
-             end_pos = (uu___81_281.end_pos)
+             start_pos = (uu___1.start_pos);
+             end_pos = (uu___1.end_pos)
            });
-        use_range = (uu___79_278.use_range)
+        use_range = (uu___.use_range)
       }
 let (string_of_rng : rng -> Prims.string) =
   fun r ->
-    let uu____287 = string_of_file_name r.file_name in
-    let uu____288 = string_of_pos r.start_pos in
-    let uu____289 = string_of_pos r.end_pos in
-    FStar_Util.format3 "%s(%s-%s)" uu____287 uu____288 uu____289
+    let uu___ = string_of_file_name r.file_name in
+    let uu___1 = string_of_pos r.start_pos in
+    let uu___2 = string_of_pos r.end_pos in
+    FStar_Util.format3 "%s(%s-%s)" uu___ uu___1 uu___2
 let (string_of_def_range : range -> Prims.string) =
   fun r -> string_of_rng r.def_range
 let (string_of_use_range : range -> Prims.string) =
@@ -177,31 +177,29 @@ let (compare : range -> range -> Prims.int) =
 let (compare_use_range : range -> range -> Prims.int) =
   fun r1 -> fun r2 -> compare_rng r1.use_range r2.use_range
 let (range_before_pos : range -> pos -> Prims.bool) =
-  fun m1 -> fun p -> let uu____391 = end_of_range m1 in pos_geq p uu____391
+  fun m1 -> fun p -> let uu___ = end_of_range m1 in pos_geq p uu___
 let (end_of_line : pos -> pos) =
-  fun p ->
-    let uu___110_397 = p in
-    { line = (uu___110_397.line); col = FStar_Util.max_int }
+  fun p -> let uu___ = p in { line = (uu___.line); col = FStar_Util.max_int }
 let (extend_to_end_of_line : range -> range) =
   fun r ->
-    let uu____403 = file_of_range r in
-    let uu____404 = start_of_range r in
-    let uu____405 = let uu____406 = end_of_range r in end_of_line uu____406 in
-    mk_range uu____403 uu____404 uu____405
+    let uu___ = file_of_range r in
+    let uu___1 = start_of_range r in
+    let uu___2 = let uu___3 = end_of_range r in end_of_line uu___3 in
+    mk_range uu___ uu___1 uu___2
 let (prims_to_fstar_range :
   ((Prims.string * (Prims.int * Prims.int) * (Prims.int * Prims.int)) *
     (Prims.string * (Prims.int * Prims.int) * (Prims.int * Prims.int))) ->
     range)
   =
   fun r ->
-    let uu____476 = r in
-    match uu____476 with
+    let uu___ = r in
+    match uu___ with
     | (r1, r2) ->
-        let uu____567 = r1 in
-        (match uu____567 with
+        let uu___1 = r1 in
+        (match uu___1 with
          | (f1, s1, e1) ->
-             let uu____601 = r2 in
-             (match uu____601 with
+             let uu___2 = r2 in
+             (match uu___2 with
               | (f2, s2, e2) ->
                   let s11 =
                     mk_pos (FStar_Pervasives_Native.fst s1)
@@ -220,39 +218,35 @@ let (prims_to_fstar_range :
                   { def_range = r11; use_range = r21 }))
 let (json_of_pos : pos -> FStar_Util.json) =
   fun pos1 ->
-    let uu____646 =
-      let uu____649 =
-        let uu____650 = line_of_pos pos1 in FStar_Util.JsonInt uu____650 in
-      let uu____651 =
-        let uu____654 =
-          let uu____655 = col_of_pos pos1 in FStar_Util.JsonInt uu____655 in
-        [uu____654] in
-      uu____649 :: uu____651 in
-    FStar_Util.JsonList uu____646
+    let uu___ =
+      let uu___1 = let uu___2 = line_of_pos pos1 in FStar_Util.JsonInt uu___2 in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 = col_of_pos pos1 in FStar_Util.JsonInt uu___4 in
+        [uu___3] in
+      uu___1 :: uu___2 in
+    FStar_Util.JsonList uu___
 let (json_of_range_fields : Prims.string -> pos -> pos -> FStar_Util.json) =
   fun file ->
     fun b ->
       fun e ->
-        let uu____671 =
-          let uu____678 =
-            let uu____685 =
-              let uu____690 = json_of_pos b in ("beg", uu____690) in
-            let uu____691 =
-              let uu____698 =
-                let uu____703 = json_of_pos e in ("end", uu____703) in
-              [uu____698] in
-            uu____685 :: uu____691 in
-          ("fname", (FStar_Util.JsonStr file)) :: uu____678 in
-        FStar_Util.JsonAssoc uu____671
+        let uu___ =
+          let uu___1 =
+            let uu___2 = let uu___3 = json_of_pos b in ("beg", uu___3) in
+            let uu___3 =
+              let uu___4 = let uu___5 = json_of_pos e in ("end", uu___5) in
+              [uu___4] in
+            uu___2 :: uu___3 in
+          ("fname", (FStar_Util.JsonStr file)) :: uu___1 in
+        FStar_Util.JsonAssoc uu___
 let (json_of_use_range : range -> FStar_Util.json) =
   fun r ->
-    let uu____725 = file_of_use_range r in
-    let uu____726 = start_of_use_range r in
-    let uu____727 = end_of_use_range r in
-    json_of_range_fields uu____725 uu____726 uu____727
+    let uu___ = file_of_use_range r in
+    let uu___1 = start_of_use_range r in
+    let uu___2 = end_of_use_range r in
+    json_of_range_fields uu___ uu___1 uu___2
 let (json_of_def_range : range -> FStar_Util.json) =
   fun r ->
-    let uu____733 = file_of_range r in
-    let uu____734 = start_of_range r in
-    let uu____735 = end_of_range r in
-    json_of_range_fields uu____733 uu____734 uu____735
+    let uu___ = file_of_range r in
+    let uu___1 = start_of_range r in
+    let uu___2 = end_of_range r in json_of_range_fields uu___ uu___1 uu___2

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -1,9 +1,9 @@
 open Prims
 let (get_env : unit -> FStar_TypeChecker_Env.env) =
-  fun uu____4 ->
-    let uu____5 =
+  fun uu___ ->
+    let uu___1 =
       FStar_ST.op_Bang FStar_TypeChecker_Normalize.reflection_env_hook in
-    match uu____5 with
+    match uu___1 with
     | FStar_Pervasives_Native.None ->
         failwith "impossible: env_hook unset in reflection"
     | FStar_Pervasives_Native.Some e -> e
@@ -11,7 +11,7 @@ let (inspect_aqual :
   FStar_Syntax_Syntax.aqual -> FStar_Reflection_Data.aqualv) =
   fun aq ->
     match aq with
-    | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit uu____24) ->
+    | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit uu___) ->
         FStar_Reflection_Data.Q_Implicit
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
         (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
@@ -39,85 +39,83 @@ let (pack_aqual : FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.aqual)
              (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t))
 let (inspect_fv : FStar_Syntax_Syntax.fv -> Prims.string Prims.list) =
   fun fv ->
-    let uu____47 = FStar_Syntax_Syntax.lid_of_fv fv in
-    FStar_Ident.path_of_lid uu____47
+    let uu___ = FStar_Syntax_Syntax.lid_of_fv fv in
+    FStar_Ident.path_of_lid uu___
 let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
   fun ns ->
     let lid = FStar_Parser_Const.p2l ns in
-    let fallback uu____63 =
+    let fallback uu___ =
       let quals =
-        let uu____67 = FStar_Ident.lid_equals lid FStar_Parser_Const.cons_lid in
-        if uu____67
+        let uu___1 = FStar_Ident.lid_equals lid FStar_Parser_Const.cons_lid in
+        if uu___1
         then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
         else
-          (let uu____71 =
-             FStar_Ident.lid_equals lid FStar_Parser_Const.nil_lid in
-           if uu____71
+          (let uu___3 = FStar_Ident.lid_equals lid FStar_Parser_Const.nil_lid in
+           if uu___3
            then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
            else
-             (let uu____75 =
+             (let uu___5 =
                 FStar_Ident.lid_equals lid FStar_Parser_Const.some_lid in
-              if uu____75
+              if uu___5
               then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
               else
-                (let uu____79 =
+                (let uu___7 =
                    FStar_Ident.lid_equals lid FStar_Parser_Const.none_lid in
-                 if uu____79
+                 if uu___7
                  then
                    FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
                  else FStar_Pervasives_Native.None))) in
-      let uu____83 = FStar_Parser_Const.p2l ns in
-      FStar_Syntax_Syntax.lid_as_fv uu____83
+      let uu___1 = FStar_Parser_Const.p2l ns in
+      FStar_Syntax_Syntax.lid_as_fv uu___1
         (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
         quals in
-    let uu____84 =
+    let uu___ =
       FStar_ST.op_Bang FStar_TypeChecker_Normalize.reflection_env_hook in
-    match uu____84 with
+    match uu___ with
     | FStar_Pervasives_Native.None -> fallback ()
     | FStar_Pervasives_Native.Some env ->
         let qninfo = FStar_TypeChecker_Env.lookup_qname env lid in
         (match qninfo with
          | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, _us), _rng) ->
              let quals = FStar_Syntax_DsEnv.fv_qual_of_se se in
-             let uu____151 = FStar_Parser_Const.p2l ns in
-             FStar_Syntax_Syntax.lid_as_fv uu____151
+             let uu___1 = FStar_Parser_Const.p2l ns in
+             FStar_Syntax_Syntax.lid_as_fv uu___1
                (FStar_Syntax_Syntax.Delta_constant_at_level
                   (Prims.of_int (999))) quals
-         | uu____152 -> fallback ())
+         | uu___1 -> fallback ())
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____169::xs -> last xs
+    | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____197 = init xs in x :: uu____197
+    | x::xs -> let uu___ = init xs in x :: uu___
 let (inspect_const :
   FStar_Syntax_Syntax.sconst -> FStar_Reflection_Data.vconst) =
   fun c ->
     match c with
     | FStar_Const.Const_unit -> FStar_Reflection_Data.C_Unit
-    | FStar_Const.Const_int (s, uu____206) ->
-        let uu____219 = FStar_BigInt.big_int_of_string s in
-        FStar_Reflection_Data.C_Int uu____219
+    | FStar_Const.Const_int (s, uu___) ->
+        let uu___1 = FStar_BigInt.big_int_of_string s in
+        FStar_Reflection_Data.C_Int uu___1
     | FStar_Const.Const_bool (true) -> FStar_Reflection_Data.C_True
     | FStar_Const.Const_bool (false) -> FStar_Reflection_Data.C_False
-    | FStar_Const.Const_string (s, uu____221) ->
-        FStar_Reflection_Data.C_String s
+    | FStar_Const.Const_string (s, uu___) -> FStar_Reflection_Data.C_String s
     | FStar_Const.Const_range r -> FStar_Reflection_Data.C_Range r
     | FStar_Const.Const_reify -> FStar_Reflection_Data.C_Reify
     | FStar_Const.Const_reflect l ->
-        let uu____224 = FStar_Ident.path_of_lid l in
-        FStar_Reflection_Data.C_Reflect uu____224
-    | uu____225 ->
-        let uu____226 =
-          let uu____227 = FStar_Syntax_Print.const_to_string c in
-          FStar_Util.format1 "unknown constant: %s" uu____227 in
-        failwith uu____226
+        let uu___ = FStar_Ident.path_of_lid l in
+        FStar_Reflection_Data.C_Reflect uu___
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Print.const_to_string c in
+          FStar_Util.format1 "unknown constant: %s" uu___2 in
+        failwith uu___1
 let rec (inspect_ln :
   FStar_Syntax_Syntax.term -> FStar_Reflection_Data.term_view) =
   fun t ->
@@ -125,24 +123,23 @@ let rec (inspect_ln :
     let t2 = FStar_Syntax_Util.un_uinst t1 in
     let t3 = FStar_Syntax_Util.unlazy_emb t2 in
     match t3.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_meta (t4, uu____237) -> inspect_ln t4
+    | FStar_Syntax_Syntax.Tm_meta (t4, uu___) -> inspect_ln t4
     | FStar_Syntax_Syntax.Tm_name bv -> FStar_Reflection_Data.Tv_Var bv
     | FStar_Syntax_Syntax.Tm_bvar bv -> FStar_Reflection_Data.Tv_BVar bv
     | FStar_Syntax_Syntax.Tm_fvar fv -> FStar_Reflection_Data.Tv_FVar fv
     | FStar_Syntax_Syntax.Tm_app (hd, []) ->
         failwith "inspect_ln: empty arguments on Tm_app"
     | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-        let uu____294 = last args in
-        (match uu____294 with
+        let uu___ = last args in
+        (match uu___ with
          | (a, q) ->
              let q' = inspect_aqual q in
-             let uu____322 =
-               let uu____327 =
-                 let uu____328 = init args in
-                 FStar_Syntax_Util.mk_app hd uu____328 in
-               (uu____327, (a, q')) in
-             FStar_Reflection_Data.Tv_App uu____322)
-    | FStar_Syntax_Syntax.Tm_abs ([], uu____347, uu____348) ->
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 = init args in FStar_Syntax_Util.mk_app hd uu___3 in
+               (uu___2, (a, q')) in
+             FStar_Reflection_Data.Tv_App uu___1)
+    | FStar_Syntax_Syntax.Tm_abs ([], uu___, uu___1) ->
         failwith "inspect_ln: empty arguments on Tm_abs"
     | FStar_Syntax_Syntax.Tm_abs (b::bs, t4, k) ->
         let body =
@@ -153,36 +150,34 @@ let rec (inspect_ln :
                 (FStar_Syntax_Syntax.Tm_abs (bs1, t4, k))
                 t4.FStar_Syntax_Syntax.pos in
         FStar_Reflection_Data.Tv_Abs (b, body)
-    | FStar_Syntax_Syntax.Tm_type uu____439 ->
-        FStar_Reflection_Data.Tv_Type ()
+    | FStar_Syntax_Syntax.Tm_type uu___ -> FStar_Reflection_Data.Tv_Type ()
     | FStar_Syntax_Syntax.Tm_arrow ([], k) ->
         failwith "inspect_ln: empty binders on arrow"
-    | FStar_Syntax_Syntax.Tm_arrow uu____459 ->
-        let uu____474 = FStar_Syntax_Util.arrow_one_ln t3 in
-        (match uu____474 with
+    | FStar_Syntax_Syntax.Tm_arrow uu___ ->
+        let uu___1 = FStar_Syntax_Util.arrow_one_ln t3 in
+        (match uu___1 with
          | FStar_Pervasives_Native.Some (b, c) ->
              FStar_Reflection_Data.Tv_Arrow (b, c)
          | FStar_Pervasives_Native.None -> failwith "impossible")
     | FStar_Syntax_Syntax.Tm_refine (bv, t4) ->
         FStar_Reflection_Data.Tv_Refine (bv, t4)
     | FStar_Syntax_Syntax.Tm_constant c ->
-        let uu____498 = inspect_const c in
-        FStar_Reflection_Data.Tv_Const uu____498
+        let uu___ = inspect_const c in FStar_Reflection_Data.Tv_Const uu___
     | FStar_Syntax_Syntax.Tm_uvar (ctx_u, s) ->
-        let uu____517 =
-          let uu____522 =
-            let uu____523 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_Syntax_Unionfind.uvar_id
                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-            FStar_BigInt.of_int_fs uu____523 in
-          (uu____522, (ctx_u, s)) in
-        FStar_Reflection_Data.Tv_Uvar uu____517
+            FStar_BigInt.of_int_fs uu___2 in
+          (uu___1, (ctx_u, s)) in
+        FStar_Reflection_Data.Tv_Uvar uu___
     | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), t21) ->
         if lb.FStar_Syntax_Syntax.lbunivs <> []
         then FStar_Reflection_Data.Tv_Unknown
         else
           (match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inr uu____549 -> FStar_Reflection_Data.Tv_Unknown
+           | FStar_Util.Inr uu___1 -> FStar_Reflection_Data.Tv_Unknown
            | FStar_Util.Inl bv ->
                FStar_Reflection_Data.Tv_Let
                  (false, (lb.FStar_Syntax_Syntax.lbattrs), bv,
@@ -192,7 +187,7 @@ let rec (inspect_ln :
         then FStar_Reflection_Data.Tv_Unknown
         else
           (match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inr uu____570 -> FStar_Reflection_Data.Tv_Unknown
+           | FStar_Util.Inr uu___1 -> FStar_Reflection_Data.Tv_Unknown
            | FStar_Util.Inl bv ->
                FStar_Reflection_Data.Tv_Let
                  (true, (lb.FStar_Syntax_Syntax.lbattrs), bv,
@@ -201,19 +196,18 @@ let rec (inspect_ln :
         let rec inspect_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_constant c ->
-              let uu____623 = inspect_const c in
-              FStar_Reflection_Data.Pat_Constant uu____623
+              let uu___ = inspect_const c in
+              FStar_Reflection_Data.Pat_Constant uu___
           | FStar_Syntax_Syntax.Pat_cons (fv, ps) ->
-              let uu____642 =
-                let uu____653 =
+              let uu___ =
+                let uu___1 =
                   FStar_List.map
-                    (fun uu____674 ->
-                       match uu____674 with
+                    (fun uu___2 ->
+                       match uu___2 with
                        | (p1, b) ->
-                           let uu____691 = inspect_pat p1 in (uu____691, b))
-                    ps in
-                (fv, uu____653) in
-              FStar_Reflection_Data.Pat_Cons uu____642
+                           let uu___3 = inspect_pat p1 in (uu___3, b)) ps in
+                (fv, uu___1) in
+              FStar_Reflection_Data.Pat_Cons uu___
           | FStar_Syntax_Syntax.Pat_var bv ->
               FStar_Reflection_Data.Pat_Var bv
           | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -222,87 +216,85 @@ let rec (inspect_ln :
               FStar_Reflection_Data.Pat_Dot_Term (bv, t5) in
         let brs1 =
           FStar_List.map
-            (fun uu___0_740 ->
-               match uu___0_740 with
-               | (pat, uu____762, t5) ->
-                   let uu____780 = inspect_pat pat in (uu____780, t5)) brs in
+            (fun uu___ ->
+               match uu___ with
+               | (pat, uu___1, t5) ->
+                   let uu___2 = inspect_pat pat in (uu___2, t5)) brs in
         FStar_Reflection_Data.Tv_Match (t4, brs1)
     | FStar_Syntax_Syntax.Tm_unknown -> FStar_Reflection_Data.Tv_Unknown
-    | uu____785 ->
-        ((let uu____787 =
-            let uu____792 =
-              let uu____793 = FStar_Syntax_Print.tag_of_term t3 in
-              let uu____794 = FStar_Syntax_Print.term_to_string t3 in
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Syntax_Print.tag_of_term t3 in
+              let uu___5 = FStar_Syntax_Print.term_to_string t3 in
               FStar_Util.format2
-                "inspect_ln: outside of expected syntax (%s, %s)\n" uu____793
-                uu____794 in
-            (FStar_Errors.Warning_CantInspect, uu____792) in
-          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____787);
+                "inspect_ln: outside of expected syntax (%s, %s)\n" uu___4
+                uu___5 in
+            (FStar_Errors.Warning_CantInspect, uu___3) in
+          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu___2);
          FStar_Reflection_Data.Tv_Unknown)
 let (inspect_comp :
   FStar_Syntax_Syntax.comp -> FStar_Reflection_Data.comp_view) =
   fun c ->
     let get_dec flags =
-      let uu____814 =
+      let uu___ =
         FStar_List.tryFind
-          (fun uu___1_819 ->
-             match uu___1_819 with
-             | FStar_Syntax_Syntax.DECREASES uu____820 -> true
-             | uu____823 -> false) flags in
-      match uu____814 with
+          (fun uu___1 ->
+             match uu___1 with
+             | FStar_Syntax_Syntax.DECREASES uu___2 -> true
+             | uu___2 -> false) flags in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES t) ->
           FStar_Pervasives_Native.Some t
-      | uu____829 -> failwith "impossible" in
+      | uu___1 -> failwith "impossible" in
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t, uu____835) ->
+    | FStar_Syntax_Syntax.Total (t, uu___) ->
         FStar_Reflection_Data.C_Total (t, FStar_Pervasives_Native.None)
-    | FStar_Syntax_Syntax.GTotal (t, uu____847) ->
+    | FStar_Syntax_Syntax.GTotal (t, uu___) ->
         FStar_Reflection_Data.C_GTotal (t, FStar_Pervasives_Native.None)
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____859 =
+        let uu___ =
           FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
             FStar_Parser_Const.effect_Lemma_lid in
-        if uu____859
+        if uu___
         then
           (match ct.FStar_Syntax_Syntax.effect_args with
-           | (pre, uu____861)::(post, uu____863)::(pats, uu____865)::uu____866
-               -> FStar_Reflection_Data.C_Lemma (pre, post, pats)
-           | uu____925 ->
+           | (pre, uu___1)::(post, uu___2)::(pats, uu___3)::uu___4 ->
+               FStar_Reflection_Data.C_Lemma (pre, post, pats)
+           | uu___1 ->
                failwith "inspect_comp: Lemma does not have enough arguments?")
         else
-          (let uu____937 =
+          (let uu___2 =
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Tot_lid in
-           if uu____937
+           if uu___2
            then
              let md = get_dec ct.FStar_Syntax_Syntax.flags in
              FStar_Reflection_Data.C_Total
                ((ct.FStar_Syntax_Syntax.result_typ), md)
            else
-             (let uu____944 =
+             (let uu___4 =
                 FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_GTot_lid in
-              if uu____944
+              if uu___4
               then
                 let md = get_dec ct.FStar_Syntax_Syntax.flags in
                 FStar_Reflection_Data.C_GTotal
                   ((ct.FStar_Syntax_Syntax.result_typ), md)
               else
-                (let inspect_arg uu____968 =
-                   match uu____968 with
-                   | (a, q) ->
-                       let uu____987 = inspect_aqual q in (a, uu____987) in
-                 let uu____990 =
-                   let uu____1003 =
+                (let inspect_arg uu___6 =
+                   match uu___6 with
+                   | (a, q) -> let uu___7 = inspect_aqual q in (a, uu___7) in
+                 let uu___6 =
+                   let uu___7 =
                      FStar_Ident.path_of_lid
                        ct.FStar_Syntax_Syntax.effect_name in
-                   let uu____1004 =
+                   let uu___8 =
                      FStar_List.map inspect_arg
                        ct.FStar_Syntax_Syntax.effect_args in
-                   ([], uu____1003, (ct.FStar_Syntax_Syntax.result_typ),
-                     uu____1004) in
-                 FStar_Reflection_Data.C_Eff uu____990)))
+                   ([], uu___7, (ct.FStar_Syntax_Syntax.result_typ), uu___8) in
+                 FStar_Reflection_Data.C_Eff uu___6)))
 let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
   =
   fun cv ->
@@ -335,36 +327,35 @@ let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
         FStar_Syntax_Syntax.mk_Comp ct
     | FStar_Reflection_Data.C_Lemma (pre, post, pats) ->
         let ct =
-          let uu____1060 =
-            let uu____1071 = FStar_Syntax_Syntax.as_arg pre in
-            let uu____1080 =
-              let uu____1091 = FStar_Syntax_Syntax.as_arg post in
-              let uu____1100 =
-                let uu____1111 = FStar_Syntax_Syntax.as_arg pats in
-                [uu____1111] in
-              uu____1091 :: uu____1100 in
-            uu____1071 :: uu____1080 in
+          let uu___ =
+            let uu___1 = FStar_Syntax_Syntax.as_arg pre in
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.as_arg post in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg pats in [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           {
             FStar_Syntax_Syntax.comp_univs = [];
             FStar_Syntax_Syntax.effect_name =
               FStar_Parser_Const.effect_Lemma_lid;
             FStar_Syntax_Syntax.result_typ = FStar_Syntax_Syntax.t_unit;
-            FStar_Syntax_Syntax.effect_args = uu____1060;
+            FStar_Syntax_Syntax.effect_args = uu___;
             FStar_Syntax_Syntax.flags = []
           } in
         FStar_Syntax_Syntax.mk_Comp ct
     | FStar_Reflection_Data.C_Eff (us, ef, res, args) ->
-        let pack_arg uu____1181 =
-          match uu____1181 with
-          | (a, q) -> let uu____1200 = pack_aqual q in (a, uu____1200) in
+        let pack_arg uu___ =
+          match uu___ with
+          | (a, q) -> let uu___1 = pack_aqual q in (a, uu___1) in
         let ct =
-          let uu____1204 = FStar_Ident.lid_of_path ef FStar_Range.dummyRange in
-          let uu____1205 = FStar_List.map pack_arg args in
+          let uu___ = FStar_Ident.lid_of_path ef FStar_Range.dummyRange in
+          let uu___1 = FStar_List.map pack_arg args in
           {
             FStar_Syntax_Syntax.comp_univs = [];
-            FStar_Syntax_Syntax.effect_name = uu____1204;
+            FStar_Syntax_Syntax.effect_name = uu___;
             FStar_Syntax_Syntax.result_typ = res;
-            FStar_Syntax_Syntax.effect_args = uu____1205;
+            FStar_Syntax_Syntax.effect_args = uu___1;
             FStar_Syntax_Syntax.flags = []
           } in
         FStar_Syntax_Syntax.mk_Comp ct
@@ -374,10 +365,10 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     match c with
     | FStar_Reflection_Data.C_Unit -> FStar_Const.Const_unit
     | FStar_Reflection_Data.C_Int i ->
-        let uu____1230 =
-          let uu____1241 = FStar_BigInt.string_of_big_int i in
-          (uu____1241, FStar_Pervasives_Native.None) in
-        FStar_Const.Const_int uu____1230
+        let uu___ =
+          let uu___1 = FStar_BigInt.string_of_big_int i in
+          (uu___1, FStar_Pervasives_Native.None) in
+        FStar_Const.Const_int uu___
     | FStar_Reflection_Data.C_True -> FStar_Const.Const_bool true
     | FStar_Reflection_Data.C_False -> FStar_Const.Const_bool false
     | FStar_Reflection_Data.C_String s ->
@@ -385,8 +376,8 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     | FStar_Reflection_Data.C_Range r -> FStar_Const.Const_range r
     | FStar_Reflection_Data.C_Reify -> FStar_Const.Const_reify
     | FStar_Reflection_Data.C_Reflect ns ->
-        let uu____1255 = FStar_Ident.lid_of_path ns FStar_Range.dummyRange in
-        FStar_Const.Const_reflect uu____1255
+        let uu___ = FStar_Ident.lid_of_path ns FStar_Range.dummyRange in
+        FStar_Const.Const_reflect uu___
 let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
   fun tv ->
     match tv with
@@ -407,10 +398,9 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (bv, t))
           t.FStar_Syntax_Syntax.pos
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____1343 =
-          let uu____1344 = pack_const c in
-          FStar_Syntax_Syntax.Tm_constant uu____1344 in
-        FStar_Syntax_Syntax.mk uu____1343 FStar_Range.dummyRange
+        let uu___ =
+          let uu___1 = pack_const c in FStar_Syntax_Syntax.Tm_constant uu___1 in
+        FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Uvar (u, ctx_u_s) ->
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
           FStar_Range.dummyRange
@@ -439,23 +429,22 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____1406 =
-                let uu____1407 = pack_const c in
-                FStar_Syntax_Syntax.Pat_constant uu____1407 in
-              FStar_All.pipe_left wrap uu____1406
+              let uu___ =
+                let uu___1 = pack_const c in
+                FStar_Syntax_Syntax.Pat_constant uu___1 in
+              FStar_All.pipe_left wrap uu___
           | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-              let uu____1422 =
-                let uu____1423 =
-                  let uu____1436 =
+              let uu___ =
+                let uu___1 =
+                  let uu___2 =
                     FStar_List.map
-                      (fun uu____1457 ->
-                         match uu____1457 with
-                         | (p1, b) ->
-                             let uu____1468 = pack_pat p1 in (uu____1468, b))
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | (p1, b) -> let uu___4 = pack_pat p1 in (uu___4, b))
                       ps in
-                  (fv, uu____1436) in
-                FStar_Syntax_Syntax.Pat_cons uu____1423 in
-              FStar_All.pipe_left wrap uu____1422
+                  (fv, uu___2) in
+                FStar_Syntax_Syntax.Pat_cons uu___1 in
+              FStar_All.pipe_left wrap uu___
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -465,11 +454,11 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
                 (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
         let brs1 =
           FStar_List.map
-            (fun uu___2_1514 ->
-               match uu___2_1514 with
+            (fun uu___ ->
+               match uu___ with
                | (pat, t1) ->
-                   let uu____1531 = pack_pat pat in
-                   (uu____1531, FStar_Pervasives_Native.None, t1)) brs in
+                   let uu___1 = pack_pat pat in
+                   (uu___1, FStar_Pervasives_Native.None, t1)) brs in
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs1))
           FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_AscribedT (e, t, tacopt) ->
@@ -502,60 +491,60 @@ let (lookup_attr :
   =
   fun attr ->
     fun env ->
-      let uu____1679 =
-        let uu____1680 = FStar_Syntax_Subst.compress attr in
-        uu____1680.FStar_Syntax_Syntax.n in
-      match uu____1679 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress attr in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let ses =
-            let uu____1689 =
-              let uu____1690 = FStar_Syntax_Syntax.lid_of_fv fv in
-              FStar_Ident.string_of_lid uu____1690 in
-            FStar_TypeChecker_Env.lookup_attr env uu____1689 in
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
+              FStar_Ident.string_of_lid uu___2 in
+            FStar_TypeChecker_Env.lookup_attr env uu___1 in
           FStar_List.concatMap
             (fun se ->
-               let uu____1694 = FStar_Syntax_Util.lid_of_sigelt se in
-               match uu____1694 with
+               let uu___1 = FStar_Syntax_Util.lid_of_sigelt se in
+               match uu___1 with
                | FStar_Pervasives_Native.None -> []
                | FStar_Pervasives_Native.Some l ->
-                   let uu____1700 =
+                   let uu___2 =
                      FStar_Syntax_Syntax.lid_as_fv l
                        (FStar_Syntax_Syntax.Delta_constant_at_level
                           (Prims.of_int (999))) FStar_Pervasives_Native.None in
-                   [uu____1700]) ses
-      | uu____1701 -> []
+                   [uu___2]) ses
+      | uu___1 -> []
 let (all_defs_in_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.fv Prims.list) =
   fun env ->
-    let uu____1711 = FStar_TypeChecker_Env.lidents env in
+    let uu___ = FStar_TypeChecker_Env.lidents env in
     FStar_List.map
       (fun l ->
          FStar_Syntax_Syntax.lid_as_fv l
            (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
-           FStar_Pervasives_Native.None) uu____1711
+           FStar_Pervasives_Native.None) uu___
 let (defs_in_module :
   FStar_TypeChecker_Env.env ->
     FStar_Reflection_Data.name -> FStar_Syntax_Syntax.fv Prims.list)
   =
   fun env ->
     fun modul ->
-      let uu____1730 = FStar_TypeChecker_Env.lidents env in
+      let uu___ = FStar_TypeChecker_Env.lidents env in
       FStar_List.concatMap
         (fun l ->
            let ns =
-             let uu____1738 =
-               let uu____1741 = FStar_Ident.ids_of_lid l in
-               FStar_All.pipe_right uu____1741 init in
-             FStar_All.pipe_right uu____1738
+             let uu___1 =
+               let uu___2 = FStar_Ident.ids_of_lid l in
+               FStar_All.pipe_right uu___2 init in
+             FStar_All.pipe_right uu___1
                (FStar_List.map FStar_Ident.string_of_id) in
            if ns = modul
            then
-             let uu____1752 =
+             let uu___1 =
                FStar_Syntax_Syntax.lid_as_fv l
                  (FStar_Syntax_Syntax.Delta_constant_at_level
                     (Prims.of_int (999))) FStar_Pervasives_Native.None in
-             [uu____1752]
-           else []) uu____1730
+             [uu___1]
+           else []) uu___
 let (lookup_typ :
   FStar_TypeChecker_Env.env ->
     Prims.string Prims.list ->
@@ -574,23 +563,19 @@ let (set_sigelt_attrs :
   =
   fun attrs ->
     fun se ->
-      let uu___427_1796 = se in
+      let uu___ = se in
       {
-        FStar_Syntax_Syntax.sigel = (uu___427_1796.FStar_Syntax_Syntax.sigel);
-        FStar_Syntax_Syntax.sigrng =
-          (uu___427_1796.FStar_Syntax_Syntax.sigrng);
-        FStar_Syntax_Syntax.sigquals =
-          (uu___427_1796.FStar_Syntax_Syntax.sigquals);
-        FStar_Syntax_Syntax.sigmeta =
-          (uu___427_1796.FStar_Syntax_Syntax.sigmeta);
+        FStar_Syntax_Syntax.sigel = (uu___.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
+        FStar_Syntax_Syntax.sigquals = (uu___.FStar_Syntax_Syntax.sigquals);
+        FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = attrs;
-        FStar_Syntax_Syntax.sigopts =
-          (uu___427_1796.FStar_Syntax_Syntax.sigopts)
+        FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
       }
 let (rd_to_syntax_qual :
   FStar_Reflection_Data.qualifier -> FStar_Syntax_Syntax.qualifier) =
-  fun uu___3_1801 ->
-    match uu___3_1801 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Reflection_Data.Assumption -> FStar_Syntax_Syntax.Assumption
     | FStar_Reflection_Data.New -> FStar_Syntax_Syntax.New
     | FStar_Reflection_Data.Private -> FStar_Syntax_Syntax.Private
@@ -626,8 +611,8 @@ let (rd_to_syntax_qual :
     | FStar_Reflection_Data.OnlyName -> FStar_Syntax_Syntax.OnlyName
 let (syntax_to_rd_qual :
   FStar_Syntax_Syntax.qualifier -> FStar_Reflection_Data.qualifier) =
-  fun uu___4_1839 ->
-    match uu___4_1839 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Assumption -> FStar_Reflection_Data.Assumption
     | FStar_Syntax_Syntax.New -> FStar_Reflection_Data.New
     | FStar_Syntax_Syntax.Private -> FStar_Reflection_Data.Private
@@ -672,19 +657,15 @@ let (set_sigelt_quals :
   =
   fun quals ->
     fun se ->
-      let uu___504_1900 = se in
-      let uu____1901 = FStar_List.map rd_to_syntax_qual quals in
+      let uu___ = se in
+      let uu___1 = FStar_List.map rd_to_syntax_qual quals in
       {
-        FStar_Syntax_Syntax.sigel = (uu___504_1900.FStar_Syntax_Syntax.sigel);
-        FStar_Syntax_Syntax.sigrng =
-          (uu___504_1900.FStar_Syntax_Syntax.sigrng);
-        FStar_Syntax_Syntax.sigquals = uu____1901;
-        FStar_Syntax_Syntax.sigmeta =
-          (uu___504_1900.FStar_Syntax_Syntax.sigmeta);
-        FStar_Syntax_Syntax.sigattrs =
-          (uu___504_1900.FStar_Syntax_Syntax.sigattrs);
-        FStar_Syntax_Syntax.sigopts =
-          (uu___504_1900.FStar_Syntax_Syntax.sigopts)
+        FStar_Syntax_Syntax.sigel = (uu___.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
+        FStar_Syntax_Syntax.sigquals = uu___1;
+        FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
+        FStar_Syntax_Syntax.sigattrs = (uu___.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
       }
 let (e_optionstate_hook :
   FStar_Options.optionstate FStar_Syntax_Embeddings.embedding
@@ -698,28 +679,28 @@ let (sigelt_opts :
     match se.FStar_Syntax_Syntax.sigopts with
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
     | FStar_Pervasives_Native.Some o ->
-        let uu____1932 =
-          let uu____1933 =
-            let uu____1940 =
-              let uu____1943 = FStar_ST.op_Bang e_optionstate_hook in
-              FStar_All.pipe_right uu____1943 FStar_Util.must in
-            FStar_Syntax_Embeddings.embed uu____1940 o in
-          uu____1933 FStar_Range.dummyRange FStar_Pervasives_Native.None
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_ST.op_Bang e_optionstate_hook in
+              FStar_All.pipe_right uu___3 FStar_Util.must in
+            FStar_Syntax_Embeddings.embed uu___2 o in
+          uu___1 FStar_Range.dummyRange FStar_Pervasives_Native.None
             FStar_Syntax_Embeddings.id_norm_cb in
-        FStar_Pervasives_Native.Some uu____1932
+        FStar_Pervasives_Native.Some uu___
 let (inspect_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_Data.sigelt_view) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let ((r, lb::[]), uu____1979) ->
+    | FStar_Syntax_Syntax.Sig_let ((r, lb::[]), uu___) ->
         let fv =
           match lb.FStar_Syntax_Syntax.lbname with
-          | FStar_Util.Inr fv -> fv
-          | FStar_Util.Inl uu____1988 ->
+          | FStar_Util.Inr fv1 -> fv1
+          | FStar_Util.Inl uu___1 ->
               failwith "impossible: global Sig_let has bv" in
-        let uu____1989 =
+        let uu___1 =
           FStar_Syntax_Subst.univ_var_opening lb.FStar_Syntax_Syntax.lbunivs in
-        (match uu____1989 with
+        (match uu___1 with
          | (s, us) ->
              let typ =
                FStar_Syntax_Subst.subst s lb.FStar_Syntax_Syntax.lbtyp in
@@ -729,47 +710,47 @@ let (inspect_sigelt :
     | FStar_Syntax_Syntax.Sig_inductive_typ
         (lid, us, param_bs, ty, _mutual, c_lids) ->
         let nm = FStar_Ident.path_of_lid lid in
-        let uu____2027 = FStar_Syntax_Subst.univ_var_opening us in
-        (match uu____2027 with
+        let uu___ = FStar_Syntax_Subst.univ_var_opening us in
+        (match uu___ with
          | (s, us1) ->
              let param_bs1 = FStar_Syntax_Subst.subst_binders s param_bs in
              let ty1 = FStar_Syntax_Subst.subst s ty in
-             let uu____2048 = FStar_Syntax_Subst.open_term param_bs1 ty1 in
-             (match uu____2048 with
+             let uu___1 = FStar_Syntax_Subst.open_term param_bs1 ty1 in
+             (match uu___1 with
               | (param_bs2, ty2) ->
                   let inspect_ctor c_lid =
-                    let uu____2061 =
-                      let uu____2064 = get_env () in
-                      FStar_TypeChecker_Env.lookup_sigelt uu____2064 c_lid in
-                    match uu____2061 with
+                    let uu___2 =
+                      let uu___3 = get_env () in
+                      FStar_TypeChecker_Env.lookup_sigelt uu___3 c_lid in
+                    match uu___2 with
                     | FStar_Pervasives_Native.Some
                         {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_datacon
                             (lid1, us2, cty, _ty_lid_, nparam, _mutual1);
-                          FStar_Syntax_Syntax.sigrng = uu____2071;
-                          FStar_Syntax_Syntax.sigquals = uu____2072;
-                          FStar_Syntax_Syntax.sigmeta = uu____2073;
-                          FStar_Syntax_Syntax.sigattrs = uu____2074;
-                          FStar_Syntax_Syntax.sigopts = uu____2075;_}
+                          FStar_Syntax_Syntax.sigrng = uu___3;
+                          FStar_Syntax_Syntax.sigquals = uu___4;
+                          FStar_Syntax_Syntax.sigmeta = uu___5;
+                          FStar_Syntax_Syntax.sigattrs = uu___6;
+                          FStar_Syntax_Syntax.sigopts = uu___7;_}
                         ->
                         let cty1 = FStar_Syntax_Subst.subst s cty in
-                        let uu____2087 =
-                          let uu____2094 = get_env () in
-                          FStar_TypeChecker_Normalize.get_n_binders
-                            uu____2094 nparam cty1 in
-                        (match uu____2087 with
+                        let uu___8 =
+                          let uu___9 = get_env () in
+                          FStar_TypeChecker_Normalize.get_n_binders uu___9
+                            nparam cty1 in
+                        (match uu___8 with
                          | (param_ctor_bs, c) ->
                              (if (FStar_List.length param_ctor_bs) <> nparam
                               then
                                 failwith
                                   "impossible: inspect_sigelt: could not obtain sufficient ctor param binders"
                               else ();
-                              (let uu____2104 =
-                                 let uu____2105 =
+                              (let uu___11 =
+                                 let uu___12 =
                                    FStar_Syntax_Util.is_total_comp c in
-                                 Prims.op_Negation uu____2105 in
-                               if uu____2104
+                                 Prims.op_Negation uu___12 in
+                               if uu___11
                                then
                                  failwith
                                    "impossible: inspect_sigelt: removed parameters and got an effectful comp"
@@ -779,26 +760,26 @@ let (inspect_sigelt :
                                  FStar_List.map2
                                    (fun b1 ->
                                       fun b2 ->
-                                        let uu____2142 =
-                                          let uu____2149 =
+                                        let uu___11 =
+                                          let uu___12 =
                                             FStar_Syntax_Syntax.bv_to_name
                                               (FStar_Pervasives_Native.fst b2) in
                                           ((FStar_Pervasives_Native.fst b1),
-                                            uu____2149) in
-                                        FStar_Syntax_Syntax.NT uu____2142)
+                                            uu___12) in
+                                        FStar_Syntax_Syntax.NT uu___11)
                                    param_ctor_bs param_bs2 in
                                let cty3 = FStar_Syntax_Subst.subst s' cty2 in
                                let cty4 = FStar_Syntax_Util.remove_inacc cty3 in
-                               let uu____2160 = FStar_Ident.path_of_lid lid1 in
-                               (uu____2160, cty4))))
-                    | uu____2161 ->
+                               let uu___11 = FStar_Ident.path_of_lid lid1 in
+                               (uu___11, cty4))))
+                    | uu___3 ->
                         failwith
                           "impossible: inspect_sigelt: did not find ctor" in
-                  let uu____2164 =
-                    let uu____2181 = FStar_List.map inspect_ctor c_lids in
-                    (nm, us1, param_bs2, ty2, uu____2181) in
-                  FStar_Reflection_Data.Sg_Inductive uu____2164))
-    | uu____2190 -> FStar_Reflection_Data.Unk
+                  let uu___2 =
+                    let uu___3 = FStar_List.map inspect_ctor c_lids in
+                    (nm, us1, param_bs2, ty2, uu___3) in
+                  FStar_Reflection_Data.Sg_Inductive uu___2))
+    | uu___ -> FStar_Reflection_Data.Unk
 let (pack_sigelt :
   FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.sigelt) =
   fun sv ->
@@ -811,27 +792,26 @@ let (pack_sigelt :
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inr fv) univs typ1
             FStar_Parser_Const.effect_Tot_lid def1 []
             def1.FStar_Syntax_Syntax.pos in
-        let uu____2213 =
-          let uu____2214 =
-            let uu____2221 =
-              let uu____2224 = FStar_Syntax_Syntax.lid_of_fv fv in
-              [uu____2224] in
-            ((r, [lb]), uu____2221) in
-          FStar_Syntax_Syntax.Sig_let uu____2214 in
-        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____2213
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.lid_of_fv fv in [uu___3] in
+            ((r, [lb]), uu___2) in
+          FStar_Syntax_Syntax.Sig_let uu___1 in
+        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu___
     | FStar_Reflection_Data.Sg_Inductive (nm, us_names, param_bs, ty, ctors)
         ->
         let ind_lid = FStar_Ident.lid_of_path nm FStar_Range.dummyRange in
         let s = FStar_Syntax_Subst.univ_var_closing us_names in
         let nparam = FStar_List.length param_bs in
         let pack_ctor c =
-          let uu____2257 = c in
-          match uu____2257 with
+          let uu___ = c in
+          match uu___ with
           | (nm1, ty1) ->
               let lid = FStar_Ident.lid_of_path nm1 FStar_Range.dummyRange in
               let ty2 =
-                let uu____2264 = FStar_Syntax_Syntax.mk_Total ty1 in
-                FStar_Syntax_Util.arrow param_bs uu____2264 in
+                let uu___1 = FStar_Syntax_Syntax.mk_Total ty1 in
+                FStar_Syntax_Util.arrow param_bs uu___1 in
               let ty3 = FStar_Syntax_Subst.subst s ty2 in
               FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt
                 (FStar_Syntax_Syntax.Sig_datacon
@@ -840,8 +820,8 @@ let (pack_sigelt :
         let c_lids =
           FStar_List.map
             (fun se ->
-               let uu____2279 = FStar_Syntax_Util.lid_of_sigelt se in
-               FStar_Util.must uu____2279) ctor_ses in
+               let uu___ = FStar_Syntax_Util.lid_of_sigelt se in
+               FStar_Util.must uu___) ctor_ses in
         let ind_se =
           let param_bs1 = FStar_Syntax_Subst.close_binders param_bs in
           let ty1 = FStar_Syntax_Subst.close param_bs1 ty in
@@ -854,41 +834,35 @@ let (pack_sigelt :
           FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt
             (FStar_Syntax_Syntax.Sig_bundle
                ((ind_se :: ctor_ses), (ind_lid :: c_lids))) in
-        let uu___617_2296 = se in
+        let uu___ = se in
         {
-          FStar_Syntax_Syntax.sigel =
-            (uu___617_2296.FStar_Syntax_Syntax.sigel);
-          FStar_Syntax_Syntax.sigrng =
-            (uu___617_2296.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigel = (uu___.FStar_Syntax_Syntax.sigel);
+          FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals = (FStar_Syntax_Syntax.Noeq ::
             (se.FStar_Syntax_Syntax.sigquals));
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___617_2296.FStar_Syntax_Syntax.sigmeta);
-          FStar_Syntax_Syntax.sigattrs =
-            (uu___617_2296.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___617_2296.FStar_Syntax_Syntax.sigopts)
+          FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
+          FStar_Syntax_Syntax.sigattrs = (uu___.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Reflection_Data.Unk -> failwith "packing Unk, sorry"
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_Data.bv_view) =
   fun bv ->
-    let uu____2302 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
-    let uu____2303 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
+    let uu___ = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+    let uu___1 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
     {
-      FStar_Reflection_Data.bv_ppname = uu____2302;
-      FStar_Reflection_Data.bv_index = uu____2303;
+      FStar_Reflection_Data.bv_ppname = uu___;
+      FStar_Reflection_Data.bv_index = uu___1;
       FStar_Reflection_Data.bv_sort = (bv.FStar_Syntax_Syntax.sort)
     }
 let (pack_bv : FStar_Reflection_Data.bv_view -> FStar_Syntax_Syntax.bv) =
   fun bvv ->
-    let uu____2309 =
+    let uu___ =
       FStar_Ident.mk_ident
         ((bvv.FStar_Reflection_Data.bv_ppname), FStar_Range.dummyRange) in
-    let uu____2310 =
-      FStar_BigInt.to_int_fs bvv.FStar_Reflection_Data.bv_index in
+    let uu___1 = FStar_BigInt.to_int_fs bvv.FStar_Reflection_Data.bv_index in
     {
-      FStar_Syntax_Syntax.ppname = uu____2309;
-      FStar_Syntax_Syntax.index = uu____2310;
+      FStar_Syntax_Syntax.ppname = uu___;
+      FStar_Syntax_Syntax.index = uu___1;
       FStar_Syntax_Syntax.sort = (bvv.FStar_Reflection_Data.bv_sort)
     }
 let (inspect_binder :
@@ -896,26 +870,25 @@ let (inspect_binder :
     (FStar_Syntax_Syntax.bv * FStar_Reflection_Data.aqualv))
   =
   fun b ->
-    let uu____2324 = b in
-    match uu____2324 with
-    | (bv, aq) -> let uu____2335 = inspect_aqual aq in (bv, uu____2335)
+    let uu___ = b in
+    match uu___ with
+    | (bv, aq) -> let uu___1 = inspect_aqual aq in (bv, uu___1)
 let (pack_binder :
   FStar_Syntax_Syntax.bv ->
     FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.binder)
-  = fun bv -> fun aqv -> let uu____2346 = pack_aqual aqv in (bv, uu____2346)
+  = fun bv -> fun aqv -> let uu___ = pack_aqual aqv in (bv, uu___)
 let (moduleof : FStar_TypeChecker_Env.env -> Prims.string Prims.list) =
   fun e -> FStar_Ident.path_of_lid e.FStar_TypeChecker_Env.curmodule
 let (env_open_modules :
   FStar_TypeChecker_Env.env -> FStar_Reflection_Data.name Prims.list) =
   fun e ->
-    let uu____2369 =
-      FStar_Syntax_DsEnv.open_modules e.FStar_TypeChecker_Env.dsenv in
+    let uu___ = FStar_Syntax_DsEnv.open_modules e.FStar_TypeChecker_Env.dsenv in
     FStar_List.map
-      (fun uu____2386 ->
-         match uu____2386 with
+      (fun uu___1 ->
+         match uu___1 with
          | (l, m) ->
-             let uu____2395 = FStar_Ident.ids_of_lid l in
-             FStar_List.map FStar_Ident.string_of_id uu____2395) uu____2369
+             let uu___2 = FStar_Ident.ids_of_lid l in
+             FStar_List.map FStar_Ident.string_of_id uu___2) uu___
 let (binders_of_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders) =
   fun e -> FStar_TypeChecker_Env.all_binders e
@@ -923,9 +896,9 @@ let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1 ->
     fun t2 ->
-      let uu____2413 = FStar_Syntax_Util.un_uinst t1 in
-      let uu____2414 = FStar_Syntax_Util.un_uinst t2 in
-      FStar_Syntax_Util.term_eq uu____2413 uu____2414
+      let uu___ = FStar_Syntax_Util.un_uinst t1 in
+      let uu___1 = FStar_Syntax_Util.un_uinst t2 in
+      FStar_Syntax_Util.term_eq uu___ uu___1
 let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t -> FStar_Syntax_Print.term_to_string t
 let (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -12,31 +12,29 @@ type vconst =
   | C_Reify 
   | C_Reflect of name 
 let (uu___is_C_Unit : vconst -> Prims.bool) =
-  fun projectee -> match projectee with | C_Unit -> true | uu____35 -> false
+  fun projectee -> match projectee with | C_Unit -> true | uu___ -> false
 let (uu___is_C_Int : vconst -> Prims.bool) =
-  fun projectee ->
-    match projectee with | C_Int _0 -> true | uu____42 -> false
+  fun projectee -> match projectee with | C_Int _0 -> true | uu___ -> false
 let (__proj__C_Int__item___0 : vconst -> FStar_BigInt.t) =
   fun projectee -> match projectee with | C_Int _0 -> _0
 let (uu___is_C_True : vconst -> Prims.bool) =
-  fun projectee -> match projectee with | C_True -> true | uu____54 -> false
+  fun projectee -> match projectee with | C_True -> true | uu___ -> false
 let (uu___is_C_False : vconst -> Prims.bool) =
-  fun projectee -> match projectee with | C_False -> true | uu____60 -> false
+  fun projectee -> match projectee with | C_False -> true | uu___ -> false
 let (uu___is_C_String : vconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | C_String _0 -> true | uu____67 -> false
+    match projectee with | C_String _0 -> true | uu___ -> false
 let (__proj__C_String__item___0 : vconst -> Prims.string) =
   fun projectee -> match projectee with | C_String _0 -> _0
 let (uu___is_C_Range : vconst -> Prims.bool) =
-  fun projectee ->
-    match projectee with | C_Range _0 -> true | uu____80 -> false
+  fun projectee -> match projectee with | C_Range _0 -> true | uu___ -> false
 let (__proj__C_Range__item___0 : vconst -> FStar_Range.range) =
   fun projectee -> match projectee with | C_Range _0 -> _0
 let (uu___is_C_Reify : vconst -> Prims.bool) =
-  fun projectee -> match projectee with | C_Reify -> true | uu____92 -> false
+  fun projectee -> match projectee with | C_Reify -> true | uu___ -> false
 let (uu___is_C_Reflect : vconst -> Prims.bool) =
   fun projectee ->
-    match projectee with | C_Reflect _0 -> true | uu____99 -> false
+    match projectee with | C_Reflect _0 -> true | uu___ -> false
 let (__proj__C_Reflect__item___0 : vconst -> name) =
   fun projectee -> match projectee with | C_Reflect _0 -> _0
 type pattern =
@@ -48,28 +46,27 @@ type pattern =
   | Pat_Dot_Term of (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) 
 let (uu___is_Pat_Constant : pattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_Constant _0 -> true | uu____151 -> false
+    match projectee with | Pat_Constant _0 -> true | uu___ -> false
 let (__proj__Pat_Constant__item___0 : pattern -> vconst) =
   fun projectee -> match projectee with | Pat_Constant _0 -> _0
 let (uu___is_Pat_Cons : pattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_Cons _0 -> true | uu____174 -> false
+    match projectee with | Pat_Cons _0 -> true | uu___ -> false
 let (__proj__Pat_Cons__item___0 :
   pattern -> (FStar_Syntax_Syntax.fv * (pattern * Prims.bool) Prims.list)) =
   fun projectee -> match projectee with | Pat_Cons _0 -> _0
 let (uu___is_Pat_Var : pattern -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Pat_Var _0 -> true | uu____217 -> false
+  fun projectee -> match projectee with | Pat_Var _0 -> true | uu___ -> false
 let (__proj__Pat_Var__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
   fun projectee -> match projectee with | Pat_Var _0 -> _0
 let (uu___is_Pat_Wild : pattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_Wild _0 -> true | uu____230 -> false
+    match projectee with | Pat_Wild _0 -> true | uu___ -> false
 let (__proj__Pat_Wild__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
   fun projectee -> match projectee with | Pat_Wild _0 -> _0
 let (uu___is_Pat_Dot_Term : pattern -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_Dot_Term _0 -> true | uu____247 -> false
+    match projectee with | Pat_Dot_Term _0 -> true | uu___ -> false
 let (__proj__Pat_Dot_Term__item___0 :
   pattern -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
   fun projectee -> match projectee with | Pat_Dot_Term _0 -> _0
@@ -80,19 +77,16 @@ type aqualv =
   | Q_Meta of FStar_Syntax_Syntax.term 
   | Q_Meta_attr of FStar_Syntax_Syntax.term 
 let (uu___is_Q_Implicit : aqualv -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Q_Implicit -> true | uu____285 -> false
+  fun projectee -> match projectee with | Q_Implicit -> true | uu___ -> false
 let (uu___is_Q_Explicit : aqualv -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Q_Explicit -> true | uu____291 -> false
+  fun projectee -> match projectee with | Q_Explicit -> true | uu___ -> false
 let (uu___is_Q_Meta : aqualv -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Q_Meta _0 -> true | uu____298 -> false
+  fun projectee -> match projectee with | Q_Meta _0 -> true | uu___ -> false
 let (__proj__Q_Meta__item___0 : aqualv -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Q_Meta _0 -> _0
 let (uu___is_Q_Meta_attr : aqualv -> Prims.bool) =
   fun projectee ->
-    match projectee with | Q_Meta_attr _0 -> true | uu____311 -> false
+    match projectee with | Q_Meta_attr _0 -> true | uu___ -> false
 let (__proj__Q_Meta_attr__item___0 : aqualv -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Q_Meta_attr _0 -> _0
 type argv = (FStar_Syntax_Syntax.term * aqualv)
@@ -117,62 +111,54 @@ type term_view =
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option) 
   | Tv_Unknown 
 let (uu___is_Tv_Var : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Var _0 -> true | uu____452 -> false
+  fun projectee -> match projectee with | Tv_Var _0 -> true | uu___ -> false
 let (__proj__Tv_Var__item___0 : term_view -> FStar_Syntax_Syntax.bv) =
   fun projectee -> match projectee with | Tv_Var _0 -> _0
 let (uu___is_Tv_BVar : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_BVar _0 -> true | uu____465 -> false
+  fun projectee -> match projectee with | Tv_BVar _0 -> true | uu___ -> false
 let (__proj__Tv_BVar__item___0 : term_view -> FStar_Syntax_Syntax.bv) =
   fun projectee -> match projectee with | Tv_BVar _0 -> _0
 let (uu___is_Tv_FVar : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_FVar _0 -> true | uu____478 -> false
+  fun projectee -> match projectee with | Tv_FVar _0 -> true | uu___ -> false
 let (__proj__Tv_FVar__item___0 : term_view -> FStar_Syntax_Syntax.fv) =
   fun projectee -> match projectee with | Tv_FVar _0 -> _0
 let (uu___is_Tv_App : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_App _0 -> true | uu____495 -> false
+  fun projectee -> match projectee with | Tv_App _0 -> true | uu___ -> false
 let (__proj__Tv_App__item___0 :
   term_view -> (FStar_Syntax_Syntax.term * argv)) =
   fun projectee -> match projectee with | Tv_App _0 -> _0
 let (uu___is_Tv_Abs : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Abs _0 -> true | uu____524 -> false
+  fun projectee -> match projectee with | Tv_Abs _0 -> true | uu___ -> false
 let (__proj__Tv_Abs__item___0 :
   term_view -> (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.term)) =
   fun projectee -> match projectee with | Tv_Abs _0 -> _0
 let (uu___is_Tv_Arrow : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Arrow _0 -> true | uu____553 -> false
+    match projectee with | Tv_Arrow _0 -> true | uu___ -> false
 let (__proj__Tv_Arrow__item___0 :
   term_view -> (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.comp)) =
   fun projectee -> match projectee with | Tv_Arrow _0 -> _0
 let (uu___is_Tv_Type : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Type _0 -> true | uu____578 -> false
+  fun projectee -> match projectee with | Tv_Type _0 -> true | uu___ -> false
 
 let (uu___is_Tv_Refine : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Refine _0 -> true | uu____589 -> false
+    match projectee with | Tv_Refine _0 -> true | uu___ -> false
 let (__proj__Tv_Refine__item___0 :
   term_view -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
   fun projectee -> match projectee with | Tv_Refine _0 -> _0
 let (uu___is_Tv_Const : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Const _0 -> true | uu____614 -> false
+    match projectee with | Tv_Const _0 -> true | uu___ -> false
 let (__proj__Tv_Const__item___0 : term_view -> vconst) =
   fun projectee -> match projectee with | Tv_Const _0 -> _0
 let (uu___is_Tv_Uvar : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Uvar _0 -> true | uu____631 -> false
+  fun projectee -> match projectee with | Tv_Uvar _0 -> true | uu___ -> false
 let (__proj__Tv_Uvar__item___0 :
   term_view -> (FStar_BigInt.t * FStar_Syntax_Syntax.ctx_uvar_and_subst)) =
   fun projectee -> match projectee with | Tv_Uvar _0 -> _0
 let (uu___is_Tv_Let : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Let _0 -> true | uu____668 -> false
+  fun projectee -> match projectee with | Tv_Let _0 -> true | uu___ -> false
 let (__proj__Tv_Let__item___0 :
   term_view ->
     (Prims.bool * FStar_Syntax_Syntax.term Prims.list *
@@ -181,13 +167,13 @@ let (__proj__Tv_Let__item___0 :
   = fun projectee -> match projectee with | Tv_Let _0 -> _0
 let (uu___is_Tv_Match : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Match _0 -> true | uu____723 -> false
+    match projectee with | Tv_Match _0 -> true | uu___ -> false
 let (__proj__Tv_Match__item___0 :
   term_view -> (FStar_Syntax_Syntax.term * branch Prims.list)) =
   fun projectee -> match projectee with | Tv_Match _0 -> _0
 let (uu___is_Tv_AscribedT : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_AscribedT _0 -> true | uu____762 -> false
+    match projectee with | Tv_AscribedT _0 -> true | uu___ -> false
 let (__proj__Tv_AscribedT__item___0 :
   term_view ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term *
@@ -195,15 +181,14 @@ let (__proj__Tv_AscribedT__item___0 :
   = fun projectee -> match projectee with | Tv_AscribedT _0 -> _0
 let (uu___is_Tv_AscribedC : term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_AscribedC _0 -> true | uu____807 -> false
+    match projectee with | Tv_AscribedC _0 -> true | uu___ -> false
 let (__proj__Tv_AscribedC__item___0 :
   term_view ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.comp *
       FStar_Syntax_Syntax.term FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | Tv_AscribedC _0 -> _0
 let (uu___is_Tv_Unknown : term_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tv_Unknown -> true | uu____843 -> false
+  fun projectee -> match projectee with | Tv_Unknown -> true | uu___ -> false
 type qualifier =
   | Assumption 
   | New 
@@ -231,88 +216,80 @@ type qualifier =
   | Effect 
   | OnlyName 
 let (uu___is_Assumption : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assumption -> true | uu____899 -> false
+  fun projectee -> match projectee with | Assumption -> true | uu___ -> false
 let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | New -> true | uu____905 -> false
+  fun projectee -> match projectee with | New -> true | uu___ -> false
 let (uu___is_Private : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Private -> true | uu____911 -> false
+  fun projectee -> match projectee with | Private -> true | uu___ -> false
 let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Unfold_for_unification_and_vcgen -> true
-    | uu____917 -> false
+    | uu___ -> false
 let (uu___is_Visible_default : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Visible_default -> true | uu____923 -> false
+    match projectee with | Visible_default -> true | uu___ -> false
 let (uu___is_Irreducible : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Irreducible -> true | uu____929 -> false
+    match projectee with | Irreducible -> true | uu___ -> false
 let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Inline_for_extraction -> true | uu____935 -> false
+    match projectee with | Inline_for_extraction -> true | uu___ -> false
 let (uu___is_NoExtract : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoExtract -> true | uu____941 -> false
+  fun projectee -> match projectee with | NoExtract -> true | uu___ -> false
 let (uu___is_Noeq : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Noeq -> true | uu____947 -> false
+  fun projectee -> match projectee with | Noeq -> true | uu___ -> false
 let (uu___is_Unopteq : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unopteq -> true | uu____953 -> false
+  fun projectee -> match projectee with | Unopteq -> true | uu___ -> false
 let (uu___is_TotalEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | TotalEffect -> true | uu____959 -> false
+    match projectee with | TotalEffect -> true | uu___ -> false
 let (uu___is_Logic : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Logic -> true | uu____965 -> false
+  fun projectee -> match projectee with | Logic -> true | uu___ -> false
 let (uu___is_Reifiable : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Reifiable -> true | uu____971 -> false
+  fun projectee -> match projectee with | Reifiable -> true | uu___ -> false
 let (uu___is_Reflectable : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Reflectable _0 -> true | uu____978 -> false
+    match projectee with | Reflectable _0 -> true | uu___ -> false
 let (__proj__Reflectable__item___0 : qualifier -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Reflectable _0 -> _0
 let (uu___is_Discriminator : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Discriminator _0 -> true | uu____991 -> false
+    match projectee with | Discriminator _0 -> true | uu___ -> false
 let (__proj__Discriminator__item___0 : qualifier -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Discriminator _0 -> _0
 let (uu___is_Projector : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Projector _0 -> true | uu____1008 -> false
+    match projectee with | Projector _0 -> true | uu___ -> false
 let (__proj__Projector__item___0 :
   qualifier -> (FStar_Ident.lid * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Projector _0 -> _0
 let (uu___is_RecordType : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordType _0 -> true | uu____1041 -> false
+    match projectee with | RecordType _0 -> true | uu___ -> false
 let (__proj__RecordType__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordType _0 -> _0
 let (uu___is_RecordConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordConstructor _0 -> true | uu____1086 -> false
+    match projectee with | RecordConstructor _0 -> true | uu___ -> false
 let (__proj__RecordConstructor__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordConstructor _0 -> _0
 let (uu___is_Action : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Action _0 -> true | uu____1123 -> false
+  fun projectee -> match projectee with | Action _0 -> true | uu___ -> false
 let (__proj__Action__item___0 : qualifier -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Action _0 -> _0
 let (uu___is_ExceptionConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | ExceptionConstructor -> true | uu____1135 -> false
+    match projectee with | ExceptionConstructor -> true | uu___ -> false
 let (uu___is_HasMaskedEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | HasMaskedEffect -> true | uu____1141 -> false
+    match projectee with | HasMaskedEffect -> true | uu___ -> false
 let (uu___is_Effect : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Effect -> true | uu____1147 -> false
+  fun projectee -> match projectee with | Effect -> true | uu___ -> false
 let (uu___is_OnlyName : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | OnlyName -> true | uu____1153 -> false
+  fun projectee -> match projectee with | OnlyName -> true | uu___ -> false
 type bv_view =
   {
   bv_ppname: Prims.string ;
@@ -338,30 +315,27 @@ type comp_view =
   | C_Eff of (unit Prims.list * name * FStar_Syntax_Syntax.term * argv
   Prims.list) 
 let (uu___is_C_Total : comp_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | C_Total _0 -> true | uu____1259 -> false
+  fun projectee -> match projectee with | C_Total _0 -> true | uu___ -> false
 let (__proj__C_Total__item___0 :
   comp_view ->
     (typ * FStar_Syntax_Syntax.term FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | C_Total _0 -> _0
 let (uu___is_C_GTotal : comp_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | C_GTotal _0 -> true | uu____1296 -> false
+    match projectee with | C_GTotal _0 -> true | uu___ -> false
 let (__proj__C_GTotal__item___0 :
   comp_view ->
     (typ * FStar_Syntax_Syntax.term FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | C_GTotal _0 -> _0
 let (uu___is_C_Lemma : comp_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | C_Lemma _0 -> true | uu____1333 -> false
+  fun projectee -> match projectee with | C_Lemma _0 -> true | uu___ -> false
 let (__proj__C_Lemma__item___0 :
   comp_view ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term *
       FStar_Syntax_Syntax.term))
   = fun projectee -> match projectee with | C_Lemma _0 -> _0
 let (uu___is_C_Eff : comp_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | C_Eff _0 -> true | uu____1376 -> false
+  fun projectee -> match projectee with | C_Eff _0 -> true | uu___ -> false
 let (__proj__C_Eff__item___0 :
   comp_view ->
     (unit Prims.list * name * FStar_Syntax_Syntax.term * argv Prims.list))
@@ -375,8 +349,7 @@ type sigelt_view =
   FStar_Syntax_Syntax.binder Prims.list * typ * ctor Prims.list) 
   | Unk 
 let (uu___is_Sg_Let : sigelt_view -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Sg_Let _0 -> true | uu____1479 -> false
+  fun projectee -> match projectee with | Sg_Let _0 -> true | uu___ -> false
 let (__proj__Sg_Let__item___0 :
   sigelt_view ->
     (Prims.bool * FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.univ_name
@@ -384,29 +357,27 @@ let (__proj__Sg_Let__item___0 :
   = fun projectee -> match projectee with | Sg_Let _0 -> _0
 let (uu___is_Sg_Inductive : sigelt_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sg_Inductive _0 -> true | uu____1544 -> false
+    match projectee with | Sg_Inductive _0 -> true | uu___ -> false
 let (__proj__Sg_Inductive__item___0 :
   sigelt_view ->
     (name * FStar_Syntax_Syntax.univ_name Prims.list *
       FStar_Syntax_Syntax.binder Prims.list * typ * ctor Prims.list))
   = fun projectee -> match projectee with | Sg_Inductive _0 -> _0
 let (uu___is_Unk : sigelt_view -> Prims.bool) =
-  fun projectee -> match projectee with | Unk -> true | uu____1604 -> false
+  fun projectee -> match projectee with | Unk -> true | uu___ -> false
 type var = FStar_BigInt.t
 type exp =
   | Unit 
   | Var of var 
   | Mult of (exp * exp) 
 let (uu___is_Unit : exp -> Prims.bool) =
-  fun projectee -> match projectee with | Unit -> true | uu____1624 -> false
+  fun projectee -> match projectee with | Unit -> true | uu___ -> false
 let (uu___is_Var : exp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Var _0 -> true | uu____1631 -> false
+  fun projectee -> match projectee with | Var _0 -> true | uu___ -> false
 let (__proj__Var__item___0 : exp -> var) =
   fun projectee -> match projectee with | Var _0 -> _0
 let (uu___is_Mult : exp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Mult _0 -> true | uu____1648 -> false
+  fun projectee -> match projectee with | Mult _0 -> true | uu___ -> false
 let (__proj__Mult__item___0 : exp -> (exp * exp)) =
   fun projectee -> match projectee with | Mult _0 -> _0
 type refl_constant =
@@ -440,35 +411,29 @@ let (fstar_refl_data_lid : Prims.string -> FStar_Ident.lident) =
 let (fstar_refl_data_const : Prims.string -> refl_constant) =
   fun s ->
     let lid = fstar_refl_data_lid s in
-    let uu____1751 =
+    let uu___ =
       FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
         (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
-    let uu____1752 = FStar_Syntax_Syntax.tdataconstr lid in
-    { lid; fv = uu____1751; t = uu____1752 }
+    let uu___1 = FStar_Syntax_Syntax.tdataconstr lid in
+    { lid; fv = uu___; t = uu___1 }
 let (mk_refl_types_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s ->
-    let uu____1758 = fstar_refl_types_lid s in
-    FStar_Syntax_Syntax.tconst uu____1758
+    let uu___ = fstar_refl_types_lid s in FStar_Syntax_Syntax.tconst uu___
 let (mk_refl_types_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s ->
-    let uu____1764 = fstar_refl_types_lid s in
-    FStar_Syntax_Syntax.fvconst uu____1764
+    let uu___ = fstar_refl_types_lid s in FStar_Syntax_Syntax.fvconst uu___
 let (mk_refl_syntax_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s ->
-    let uu____1770 = fstar_refl_syntax_lid s in
-    FStar_Syntax_Syntax.tconst uu____1770
+    let uu___ = fstar_refl_syntax_lid s in FStar_Syntax_Syntax.tconst uu___
 let (mk_refl_syntax_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s ->
-    let uu____1776 = fstar_refl_syntax_lid s in
-    FStar_Syntax_Syntax.fvconst uu____1776
+    let uu___ = fstar_refl_syntax_lid s in FStar_Syntax_Syntax.fvconst uu___
 let (mk_refl_data_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s ->
-    let uu____1782 = fstar_refl_data_lid s in
-    FStar_Syntax_Syntax.tconst uu____1782
+    let uu___ = fstar_refl_data_lid s in FStar_Syntax_Syntax.tconst uu___
 let (mk_refl_data_lid_as_fv : Prims.string -> FStar_Syntax_Syntax.fv) =
   fun s ->
-    let uu____1788 = fstar_refl_data_lid s in
-    FStar_Syntax_Syntax.fvconst uu____1788
+    let uu___ = fstar_refl_data_lid s in FStar_Syntax_Syntax.fvconst uu___
 let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
   =
   fun s ->
@@ -483,62 +448,63 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
         (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
         FStar_Pervasives_Native.None in
     let inspect =
-      let uu____1803 = FStar_Syntax_Syntax.fv_to_tm inspect_fv in
-      { lid = inspect_lid; fv = inspect_fv; t = uu____1803 } in
+      let uu___ = FStar_Syntax_Syntax.fv_to_tm inspect_fv in
+      { lid = inspect_lid; fv = inspect_fv; t = uu___ } in
     let pack =
-      let uu____1805 = FStar_Syntax_Syntax.fv_to_tm pack_fv in
-      { lid = pack_lid; fv = pack_fv; t = uu____1805 } in
+      let uu___ = FStar_Syntax_Syntax.fv_to_tm pack_fv in
+      { lid = pack_lid; fv = pack_fv; t = uu___ } in
     (inspect, pack)
 let (uu___79 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_ln"
 let (fstar_refl_inspect_ln : refl_constant) =
   match uu___79 with
-  | (fstar_refl_inspect_ln, fstar_refl_pack_ln) -> fstar_refl_inspect_ln
+  | (fstar_refl_inspect_ln1, fstar_refl_pack_ln) -> fstar_refl_inspect_ln1
 let (fstar_refl_pack_ln : refl_constant) =
   match uu___79 with
-  | (fstar_refl_inspect_ln1, fstar_refl_pack_ln) -> fstar_refl_pack_ln
+  | (fstar_refl_inspect_ln1, fstar_refl_pack_ln1) -> fstar_refl_pack_ln1
 let (uu___86 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_fv"
 let (fstar_refl_inspect_fv : refl_constant) =
   match uu___86 with
-  | (fstar_refl_inspect_fv, fstar_refl_pack_fv) -> fstar_refl_inspect_fv
+  | (fstar_refl_inspect_fv1, fstar_refl_pack_fv) -> fstar_refl_inspect_fv1
 let (fstar_refl_pack_fv : refl_constant) =
   match uu___86 with
-  | (fstar_refl_inspect_fv1, fstar_refl_pack_fv) -> fstar_refl_pack_fv
+  | (fstar_refl_inspect_fv1, fstar_refl_pack_fv1) -> fstar_refl_pack_fv1
 let (uu___93 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_bv"
 let (fstar_refl_inspect_bv : refl_constant) =
   match uu___93 with
-  | (fstar_refl_inspect_bv, fstar_refl_pack_bv) -> fstar_refl_inspect_bv
+  | (fstar_refl_inspect_bv1, fstar_refl_pack_bv) -> fstar_refl_inspect_bv1
 let (fstar_refl_pack_bv : refl_constant) =
   match uu___93 with
-  | (fstar_refl_inspect_bv1, fstar_refl_pack_bv) -> fstar_refl_pack_bv
+  | (fstar_refl_inspect_bv1, fstar_refl_pack_bv1) -> fstar_refl_pack_bv1
 let (uu___100 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_binder"
 let (fstar_refl_inspect_binder : refl_constant) =
   match uu___100 with
-  | (fstar_refl_inspect_binder, fstar_refl_pack_binder) ->
-      fstar_refl_inspect_binder
+  | (fstar_refl_inspect_binder1, fstar_refl_pack_binder) ->
+      fstar_refl_inspect_binder1
 let (fstar_refl_pack_binder : refl_constant) =
   match uu___100 with
-  | (fstar_refl_inspect_binder1, fstar_refl_pack_binder) ->
-      fstar_refl_pack_binder
+  | (fstar_refl_inspect_binder1, fstar_refl_pack_binder1) ->
+      fstar_refl_pack_binder1
 let (uu___107 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_comp"
 let (fstar_refl_inspect_comp : refl_constant) =
   match uu___107 with
-  | (fstar_refl_inspect_comp, fstar_refl_pack_comp) ->
-      fstar_refl_inspect_comp
+  | (fstar_refl_inspect_comp1, fstar_refl_pack_comp) ->
+      fstar_refl_inspect_comp1
 let (fstar_refl_pack_comp : refl_constant) =
   match uu___107 with
-  | (fstar_refl_inspect_comp1, fstar_refl_pack_comp) -> fstar_refl_pack_comp
+  | (fstar_refl_inspect_comp1, fstar_refl_pack_comp1) ->
+      fstar_refl_pack_comp1
 let (uu___114 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_sigelt"
 let (fstar_refl_inspect_sigelt : refl_constant) =
   match uu___114 with
-  | (fstar_refl_inspect_sigelt, fstar_refl_pack_sigelt) ->
-      fstar_refl_inspect_sigelt
+  | (fstar_refl_inspect_sigelt1, fstar_refl_pack_sigelt) ->
+      fstar_refl_inspect_sigelt1
 let (fstar_refl_pack_sigelt : refl_constant) =
   match uu___114 with
-  | (fstar_refl_inspect_sigelt1, fstar_refl_pack_sigelt) ->
-      fstar_refl_pack_sigelt
+  | (fstar_refl_inspect_sigelt1, fstar_refl_pack_sigelt1) ->
+      fstar_refl_pack_sigelt1
 let (fstar_refl_env : FStar_Syntax_Syntax.term) =
   mk_refl_types_lid_as_term "env"
 let (fstar_refl_env_fv : FStar_Syntax_Syntax.fv) =
@@ -622,27 +588,26 @@ let (fstar_refl_qualifier_fv : FStar_Syntax_Syntax.fv) =
 let (ref_Mk_bv : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbv_view" in
   let attr =
-    let uu____1856 =
-      let uu____1863 = fstar_refl_data_lid "bv_view" in
-      let uu____1864 =
-        let uu____1867 =
+    let uu___ =
+      let uu___1 = fstar_refl_data_lid "bv_view" in
+      let uu___2 =
+        let uu___3 =
           FStar_Ident.mk_ident ("bv_ppname", FStar_Range.dummyRange) in
-        let uu____1868 =
-          let uu____1871 =
+        let uu___4 =
+          let uu___5 =
             FStar_Ident.mk_ident ("bv_index", FStar_Range.dummyRange) in
-          let uu____1872 =
-            let uu____1875 =
+          let uu___6 =
+            let uu___7 =
               FStar_Ident.mk_ident ("bv_sort", FStar_Range.dummyRange) in
-            [uu____1875] in
-          uu____1871 :: uu____1872 in
-        uu____1867 :: uu____1868 in
-      (uu____1863, uu____1864) in
-    FStar_Syntax_Syntax.Record_ctor uu____1856 in
+            [uu___7] in
+          uu___5 :: uu___6 in
+        uu___3 :: uu___4 in
+      (uu___1, uu___2) in
+    FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
     FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
       (FStar_Pervasives_Native.Some attr) in
-  let uu____1879 = FStar_Syntax_Syntax.fv_to_tm fv in
-  { lid; fv; t = uu____1879 }
+  let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit"
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit"
 let (ref_Q_Meta : refl_constant) = fstar_refl_data_const "Q_Meta"
@@ -721,10 +686,10 @@ let (ref_E_Unit : refl_constant) = fstar_refl_data_const "Unit"
 let (ref_E_Var : refl_constant) = fstar_refl_data_const "Var"
 let (ref_E_Mult : refl_constant) = fstar_refl_data_const "Mult"
 let (t_exp : FStar_Syntax_Syntax.term) =
-  let uu____1880 =
+  let uu___ =
     FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Data"; "exp"]
       FStar_Range.dummyRange in
-  FStar_Syntax_Syntax.tconst uu____1880
+  FStar_Syntax_Syntax.tconst uu___
 let (ord_Lt_lid : FStar_Ident.lident) =
   FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange
 let (ord_Eq_lid : FStar_Ident.lident) =

--- a/src/ocaml-output/FStar_Reflection_Embeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_Embeddings.ml
@@ -1,68 +1,66 @@
 open Prims
 let mk_emb :
-  'uuuuuu8 .
-    (FStar_Range.range -> 'uuuuuu8 -> FStar_Syntax_Syntax.term) ->
+  'uuuuu .
+    (FStar_Range.range -> 'uuuuu -> FStar_Syntax_Syntax.term) ->
       (Prims.bool ->
-         FStar_Syntax_Syntax.term -> 'uuuuuu8 FStar_Pervasives_Native.option)
+         FStar_Syntax_Syntax.term -> 'uuuuu FStar_Pervasives_Native.option)
         ->
-        FStar_Syntax_Syntax.term ->
-          'uuuuuu8 FStar_Syntax_Embeddings.embedding
+        FStar_Syntax_Syntax.term -> 'uuuuu FStar_Syntax_Embeddings.embedding
   =
   fun f ->
     fun g ->
       fun t ->
-        let uu____50 = FStar_Syntax_Embeddings.term_as_fv t in
+        let uu___ = FStar_Syntax_Embeddings.term_as_fv t in
         FStar_Syntax_Embeddings.mk_emb
           (fun x -> fun r -> fun _topt -> fun _norm -> f r x)
-          (fun x -> fun w -> fun _norm -> g w x) uu____50
+          (fun x -> fun w -> fun _norm -> g w x) uu___
 let embed :
-  'uuuuuu75 .
-    'uuuuuu75 FStar_Syntax_Embeddings.embedding ->
-      FStar_Range.range -> 'uuuuuu75 -> FStar_Syntax_Syntax.term
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
+      FStar_Range.range -> 'uuuuu -> FStar_Syntax_Syntax.term
   =
   fun e ->
     fun r ->
       fun x ->
-        let uu____95 = FStar_Syntax_Embeddings.embed e x in
-        uu____95 r FStar_Pervasives_Native.None
+        let uu___ = FStar_Syntax_Embeddings.embed e x in
+        uu___ r FStar_Pervasives_Native.None
           FStar_Syntax_Embeddings.id_norm_cb
 let unembed' :
-  'uuuuuu112 .
+  'uuuuu .
     Prims.bool ->
-      'uuuuuu112 FStar_Syntax_Embeddings.embedding ->
-        FStar_Syntax_Syntax.term -> 'uuuuuu112 FStar_Pervasives_Native.option
+      'uuuuu FStar_Syntax_Embeddings.embedding ->
+        FStar_Syntax_Syntax.term -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun w ->
     fun e ->
       fun x ->
-        let uu____134 = FStar_Syntax_Embeddings.unembed e x in
-        uu____134 w FStar_Syntax_Embeddings.id_norm_cb
+        let uu___ = FStar_Syntax_Embeddings.unembed e x in
+        uu___ w FStar_Syntax_Embeddings.id_norm_cb
 let (e_bv : FStar_Syntax_Syntax.bv FStar_Syntax_Embeddings.embedding) =
   let embed_bv rng bv =
     FStar_Syntax_Util.mk_lazy bv FStar_Reflection_Data.fstar_refl_bv
       FStar_Syntax_Syntax.Lazy_bv (FStar_Pervasives_Native.Some rng) in
   let unembed_bv w t =
-    let uu____169 =
-      let uu____170 = FStar_Syntax_Subst.compress t in
-      uu____170.FStar_Syntax_Syntax.n in
-    match uu____169 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_bv;
-          FStar_Syntax_Syntax.ltyp = uu____176;
-          FStar_Syntax_Syntax.rng = uu____177;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____180 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____180
-    | uu____181 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____183 =
-              let uu____188 =
-                let uu____189 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded bv: %s" uu____189 in
-              (FStar_Errors.Warning_NotEmbedded, uu____188) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____183)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded bv: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_bv unembed_bv FStar_Reflection_Data.fstar_refl_bv
@@ -72,27 +70,26 @@ let (e_binder : FStar_Syntax_Syntax.binder FStar_Syntax_Embeddings.embedding)
     FStar_Syntax_Util.mk_lazy b FStar_Reflection_Data.fstar_refl_binder
       FStar_Syntax_Syntax.Lazy_binder (FStar_Pervasives_Native.Some rng) in
   let unembed_binder w t =
-    let uu____219 =
-      let uu____220 = FStar_Syntax_Subst.compress t in
-      uu____220.FStar_Syntax_Syntax.n in
-    match uu____219 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_binder;
-          FStar_Syntax_Syntax.ltyp = uu____226;
-          FStar_Syntax_Syntax.rng = uu____227;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____230 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____230
-    | uu____231 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____233 =
-              let uu____238 =
-                let uu____239 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded binder: %s" uu____239 in
-              (FStar_Errors.Warning_NotEmbedded, uu____238) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____233)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded binder: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_binder unembed_binder FStar_Reflection_Data.fstar_refl_binder
@@ -102,28 +99,26 @@ let (e_optionstate :
     FStar_Syntax_Util.mk_lazy b FStar_Reflection_Data.fstar_refl_optionstate
       FStar_Syntax_Syntax.Lazy_optionstate (FStar_Pervasives_Native.Some rng) in
   let unembed_optionstate w t =
-    let uu____269 =
-      let uu____270 = FStar_Syntax_Subst.compress t in
-      uu____270.FStar_Syntax_Syntax.n in
-    match uu____269 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_optionstate;
-          FStar_Syntax_Syntax.ltyp = uu____276;
-          FStar_Syntax_Syntax.rng = uu____277;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____280 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____280
-    | uu____281 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____283 =
-              let uu____288 =
-                let uu____289 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded optionstate: %s"
-                  uu____289 in
-              (FStar_Errors.Warning_NotEmbedded, uu____288) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____283)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded optionstate: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_optionstate unembed_optionstate
@@ -141,11 +136,11 @@ let rec mapM_opt :
       match l with
       | [] -> FStar_Pervasives_Native.Some []
       | x::xs ->
-          let uu____352 = f x in
-          FStar_Util.bind_opt uu____352
+          let uu___ = f x in
+          FStar_Util.bind_opt uu___
             (fun x1 ->
-               let uu____360 = mapM_opt f xs in
-               FStar_Util.bind_opt uu____360
+               let uu___1 = mapM_opt f xs in
+               FStar_Util.bind_opt uu___1
                  (fun xs1 -> FStar_Pervasives_Native.Some (x1 :: xs1)))
 let (e_term_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -161,36 +156,36 @@ let (e_term_aq :
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (t, qi)) rng in
     let rec unembed_term w t =
       let apply_antiquotes t1 aq1 =
-        let uu____426 =
+        let uu___ =
           mapM_opt
-            (fun uu____439 ->
-               match uu____439 with
+            (fun uu___1 ->
+               match uu___1 with
                | (bv, e) ->
-                   let uu____448 = unembed_term w e in
-                   FStar_Util.bind_opt uu____448
+                   let uu___2 = unembed_term w e in
+                   FStar_Util.bind_opt uu___2
                      (fun e1 ->
                         FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.NT (bv, e1)))) aq1 in
-        FStar_Util.bind_opt uu____426
+        FStar_Util.bind_opt uu___
           (fun s ->
-             let uu____462 = FStar_Syntax_Subst.subst s t1 in
-             FStar_Pervasives_Native.Some uu____462) in
+             let uu___1 = FStar_Syntax_Subst.subst s t1 in
+             FStar_Pervasives_Native.Some uu___1) in
       let t1 = FStar_Syntax_Util.unmeta t in
-      let uu____464 =
-        let uu____465 = FStar_Syntax_Subst.compress t1 in
-        uu____465.FStar_Syntax_Syntax.n in
-      match uu____464 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t1 in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
           apply_antiquotes tm qi.FStar_Syntax_Syntax.antiquotes
-      | uu____476 ->
+      | uu___1 ->
           (if w
            then
-             (let uu____478 =
-                let uu____483 =
-                  let uu____484 = FStar_Syntax_Print.term_to_string t1 in
-                  FStar_Util.format1 "Not an embedded term: %s" uu____484 in
-                (FStar_Errors.Warning_NotEmbedded, uu____483) in
-              FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____478)
+             (let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                  FStar_Util.format1 "Not an embedded term: %s" uu___5 in
+                (FStar_Errors.Warning_NotEmbedded, uu___4) in
+              FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___3)
            else ();
            FStar_Pervasives_Native.None) in
     mk_emb embed_term unembed_term FStar_Syntax_Syntax.t_term
@@ -206,40 +201,40 @@ let (e_aqualv :
       | FStar_Reflection_Data.Q_Implicit ->
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Q_Meta t ->
-          let uu____513 =
-            let uu____514 =
-              let uu____523 = embed e_term rng t in
-              FStar_Syntax_Syntax.as_arg uu____523 in
-            [uu____514] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_term rng t in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.t
-            uu____513 FStar_Range.dummyRange
+            FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange
       | FStar_Reflection_Data.Q_Meta_attr t ->
-          let uu____541 =
-            let uu____542 =
-              let uu____551 = embed e_term rng t in
-              FStar_Syntax_Syntax.as_arg uu____551 in
-            [uu____542] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_term rng t in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Q_Meta_attr.FStar_Reflection_Data.t
-            uu____541 FStar_Range.dummyRange in
-    let uu___106_568 = r in
+            uu___ FStar_Range.dummyRange in
+    let uu___ = r in
     {
-      FStar_Syntax_Syntax.n = (uu___106_568.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___106_568.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let unembed_aqualv w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____587 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____587 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____632 =
-          let uu____647 =
-            let uu____648 = FStar_Syntax_Util.un_uinst hd in
-            uu____648.FStar_Syntax_Syntax.n in
-          (uu____647, args) in
-        (match uu____632 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Explicit.FStar_Reflection_Data.lid
@@ -248,34 +243,33 @@ let (e_aqualv :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Q_Implicit
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu____703)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.lid
              ->
-             let uu____738 = unembed' w e_term t2 in
-             FStar_Util.bind_opt uu____738
+             let uu___3 = unembed' w e_term t2 in
+             FStar_Util.bind_opt uu___3
                (fun t3 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.Q_Meta t3))
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu____745)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Meta_attr.FStar_Reflection_Data.lid
              ->
-             let uu____780 = unembed' w e_term t2 in
-             FStar_Util.bind_opt uu____780
+             let uu___3 = unembed' w e_term t2 in
+             FStar_Util.bind_opt uu___3
                (fun t3 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.Q_Meta_attr t3))
-         | uu____785 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____801 =
-                   let uu____806 =
-                     let uu____807 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not an embedded aqualv: %s"
-                       uu____807 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____806) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____801)
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not an embedded aqualv: %s" uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_aqualv unembed_aqualv FStar_Reflection_Data.fstar_refl_aqualv
@@ -287,27 +281,26 @@ let (e_fv : FStar_Syntax_Syntax.fv FStar_Syntax_Embeddings.embedding) =
     FStar_Syntax_Util.mk_lazy fv FStar_Reflection_Data.fstar_refl_fv
       FStar_Syntax_Syntax.Lazy_fvar (FStar_Pervasives_Native.Some rng) in
   let unembed_fv w t =
-    let uu____839 =
-      let uu____840 = FStar_Syntax_Subst.compress t in
-      uu____840.FStar_Syntax_Syntax.n in
-    match uu____839 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar;
-          FStar_Syntax_Syntax.ltyp = uu____846;
-          FStar_Syntax_Syntax.rng = uu____847;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____850 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____850
-    | uu____851 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____853 =
-              let uu____858 =
-                let uu____859 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded fvar: %s" uu____859 in
-              (FStar_Errors.Warning_NotEmbedded, uu____858) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____853)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded fvar: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_fv unembed_fv FStar_Reflection_Data.fstar_refl_fv
@@ -316,27 +309,26 @@ let (e_comp : FStar_Syntax_Syntax.comp FStar_Syntax_Embeddings.embedding) =
     FStar_Syntax_Util.mk_lazy c FStar_Reflection_Data.fstar_refl_comp
       FStar_Syntax_Syntax.Lazy_comp (FStar_Pervasives_Native.Some rng) in
   let unembed_comp w t =
-    let uu____889 =
-      let uu____890 = FStar_Syntax_Subst.compress t in
-      uu____890.FStar_Syntax_Syntax.n in
-    match uu____889 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp;
-          FStar_Syntax_Syntax.ltyp = uu____896;
-          FStar_Syntax_Syntax.rng = uu____897;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____900 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____900
-    | uu____901 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____903 =
-              let uu____908 =
-                let uu____909 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded comp: %s" uu____909 in
-              (FStar_Errors.Warning_NotEmbedded, uu____908) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____903)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded comp: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_comp unembed_comp FStar_Reflection_Data.fstar_refl_comp
@@ -345,27 +337,26 @@ let (e_env : FStar_TypeChecker_Env.env FStar_Syntax_Embeddings.embedding) =
     FStar_Syntax_Util.mk_lazy e FStar_Reflection_Data.fstar_refl_env
       FStar_Syntax_Syntax.Lazy_env (FStar_Pervasives_Native.Some rng) in
   let unembed_env w t =
-    let uu____939 =
-      let uu____940 = FStar_Syntax_Subst.compress t in
-      uu____940.FStar_Syntax_Syntax.n in
-    match uu____939 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env;
-          FStar_Syntax_Syntax.ltyp = uu____946;
-          FStar_Syntax_Syntax.rng = uu____947;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____950 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____950
-    | uu____951 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____953 =
-              let uu____958 =
-                let uu____959 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded env: %s" uu____959 in
-              (FStar_Errors.Warning_NotEmbedded, uu____958) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____953)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded env: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_env unembed_env FStar_Reflection_Data.fstar_refl_env
@@ -381,63 +372,62 @@ let (e_const :
       | FStar_Reflection_Data.C_False ->
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Int i ->
-          let uu____980 =
-            let uu____981 =
-              let uu____990 =
-                let uu____991 = FStar_BigInt.string_of_big_int i in
-                FStar_Syntax_Util.exp_int uu____991 in
-              FStar_Syntax_Syntax.as_arg uu____990 in
-            [uu____981] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_BigInt.string_of_big_int i in
+                FStar_Syntax_Util.exp_int uu___3 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.t uu____980
+            FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.t uu___
             FStar_Range.dummyRange
       | FStar_Reflection_Data.C_String s ->
-          let uu____1009 =
-            let uu____1010 =
-              let uu____1019 = embed FStar_Syntax_Embeddings.e_string rng s in
-              FStar_Syntax_Syntax.as_arg uu____1019 in
-            [uu____1010] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_string rng s in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.t
-            uu____1009 FStar_Range.dummyRange
-      | FStar_Reflection_Data.C_Range r ->
-          let uu____1037 =
-            let uu____1038 =
-              let uu____1047 = embed FStar_Syntax_Embeddings.e_range rng r in
-              FStar_Syntax_Syntax.as_arg uu____1047 in
-            [uu____1038] in
+            FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange
+      | FStar_Reflection_Data.C_Range r1 ->
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_range rng r1 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.t
-            uu____1037 FStar_Range.dummyRange
+            FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange
       | FStar_Reflection_Data.C_Reify ->
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Reflect ns ->
-          let uu____1065 =
-            let uu____1066 =
-              let uu____1075 =
-                embed FStar_Syntax_Embeddings.e_string_list rng ns in
-              FStar_Syntax_Syntax.as_arg uu____1075 in
-            [uu____1066] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_string_list rng ns in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.t
-            uu____1065 FStar_Range.dummyRange in
-    let uu___203_1094 = r in
+            FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange in
+    let uu___ = r in
     {
-      FStar_Syntax_Syntax.n = (uu___203_1094.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___203_1094.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let unembed_const w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____1113 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____1113 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____1158 =
-          let uu____1173 =
-            let uu____1174 = FStar_Syntax_Util.un_uinst hd in
-            uu____1174.FStar_Syntax_Syntax.n in
-          (uu____1173, args) in
-        (match uu____1158 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Unit.FStar_Reflection_Data.lid
@@ -450,230 +440,218 @@ let (e_const :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_False
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (i, uu____1248)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (i, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.lid
              ->
-             let uu____1283 = unembed' w FStar_Syntax_Embeddings.e_int i in
-             FStar_Util.bind_opt uu____1283
+             let uu___3 = unembed' w FStar_Syntax_Embeddings.e_int i in
+             FStar_Util.bind_opt uu___3
                (fun i1 ->
                   FStar_All.pipe_left
-                    (fun uu____1290 ->
-                       FStar_Pervasives_Native.Some uu____1290)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.C_Int i1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (s, uu____1293)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (s, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.lid
              ->
-             let uu____1328 = unembed' w FStar_Syntax_Embeddings.e_string s in
-             FStar_Util.bind_opt uu____1328
+             let uu___3 = unembed' w FStar_Syntax_Embeddings.e_string s in
+             FStar_Util.bind_opt uu___3
                (fun s1 ->
                   FStar_All.pipe_left
-                    (fun uu____1335 ->
-                       FStar_Pervasives_Native.Some uu____1335)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.C_String s1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (r, uu____1338)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (r, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.lid
              ->
-             let uu____1373 = unembed' w FStar_Syntax_Embeddings.e_range r in
-             FStar_Util.bind_opt uu____1373
+             let uu___3 = unembed' w FStar_Syntax_Embeddings.e_range r in
+             FStar_Util.bind_opt uu___3
                (fun r1 ->
                   FStar_All.pipe_left
-                    (fun uu____1380 ->
-                       FStar_Pervasives_Native.Some uu____1380)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.C_Range r1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.lid
              ->
              FStar_All.pipe_left
-               (fun uu____1402 -> FStar_Pervasives_Native.Some uu____1402)
+               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                FStar_Reflection_Data.C_Reify
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (ns, uu____1405)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (ns, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.lid
              ->
-             let uu____1440 =
-               unembed' w FStar_Syntax_Embeddings.e_string_list ns in
-             FStar_Util.bind_opt uu____1440
+             let uu___3 = unembed' w FStar_Syntax_Embeddings.e_string_list ns in
+             FStar_Util.bind_opt uu___3
                (fun ns1 ->
                   FStar_All.pipe_left
-                    (fun uu____1455 ->
-                       FStar_Pervasives_Native.Some uu____1455)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.C_Reflect ns1))
-         | uu____1456 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____1472 =
-                   let uu____1477 =
-                     let uu____1478 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not an embedded vconst: %s"
-                       uu____1478 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____1477) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1472)
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not an embedded vconst: %s" uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_const unembed_const FStar_Reflection_Data.fstar_refl_vconst
 let rec (e_pattern' :
   unit -> FStar_Reflection_Data.pattern FStar_Syntax_Embeddings.embedding) =
-  fun uu____1486 ->
+  fun uu___ ->
     let rec embed_pattern rng p =
       match p with
       | FStar_Reflection_Data.Pat_Constant c ->
-          let uu____1499 =
-            let uu____1500 =
-              let uu____1509 = embed e_const rng c in
-              FStar_Syntax_Syntax.as_arg uu____1509 in
-            [uu____1500] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = embed e_const rng c in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            [uu___2] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.t
-            uu____1499 rng
+            uu___1 rng
       | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-          let uu____1540 =
-            let uu____1541 =
-              let uu____1550 = embed e_fv rng fv in
-              FStar_Syntax_Syntax.as_arg uu____1550 in
-            let uu____1551 =
-              let uu____1562 =
-                let uu____1571 =
-                  let uu____1572 =
-                    let uu____1581 =
-                      let uu____1588 = e_pattern' () in
-                      FStar_Syntax_Embeddings.e_tuple2 uu____1588
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = embed e_fv rng fv in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_pattern' () in
+                      FStar_Syntax_Embeddings.e_tuple2 uu___8
                         FStar_Syntax_Embeddings.e_bool in
-                    FStar_Syntax_Embeddings.e_list uu____1581 in
-                  embed uu____1572 rng ps in
-                FStar_Syntax_Syntax.as_arg uu____1571 in
-              [uu____1562] in
-            uu____1541 :: uu____1551 in
+                    FStar_Syntax_Embeddings.e_list uu___7 in
+                  embed uu___6 rng ps in
+                FStar_Syntax_Syntax.as_arg uu___5 in
+              [uu___4] in
+            uu___2 :: uu___3 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t
-            uu____1540 rng
+            FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t uu___1
+            rng
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1626 =
-            let uu____1627 =
-              let uu____1636 = embed e_bv rng bv in
-              FStar_Syntax_Syntax.as_arg uu____1636 in
-            [uu____1627] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = embed e_bv rng bv in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            [uu___2] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t
-            uu____1626 rng
+            FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t uu___1
+            rng
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1654 =
-            let uu____1655 =
-              let uu____1664 = embed e_bv rng bv in
-              FStar_Syntax_Syntax.as_arg uu____1664 in
-            [uu____1655] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = embed e_bv rng bv in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            [uu___2] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
-            uu____1654 rng
+            FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t uu___1
+            rng
       | FStar_Reflection_Data.Pat_Dot_Term (bv, t) ->
-          let uu____1683 =
-            let uu____1684 =
-              let uu____1693 = embed e_bv rng bv in
-              FStar_Syntax_Syntax.as_arg uu____1693 in
-            let uu____1694 =
-              let uu____1705 =
-                let uu____1714 = embed e_term rng t in
-                FStar_Syntax_Syntax.as_arg uu____1714 in
-              [uu____1705] in
-            uu____1684 :: uu____1694 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = embed e_bv rng bv in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = embed e_term rng t in
+                FStar_Syntax_Syntax.as_arg uu___5 in
+              [uu___4] in
+            uu___2 :: uu___3 in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
-            uu____1683 rng in
+            uu___1 rng in
     let rec unembed_pattern w t =
       let t1 = FStar_Syntax_Util.unascribe t in
-      let uu____1755 = FStar_Syntax_Util.head_and_args t1 in
-      match uu____1755 with
+      let uu___1 = FStar_Syntax_Util.head_and_args t1 in
+      match uu___1 with
       | (hd, args) ->
-          let uu____1800 =
-            let uu____1813 =
-              let uu____1814 = FStar_Syntax_Util.un_uinst hd in
-              uu____1814.FStar_Syntax_Syntax.n in
-            (uu____1813, args) in
-          (match uu____1800 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (c, uu____1829)::[]) when
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Syntax_Util.un_uinst hd in
+              uu___4.FStar_Syntax_Syntax.n in
+            (uu___3, args) in
+          (match uu___2 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (c, uu___3)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
                ->
-               let uu____1854 = unembed' w e_const c in
-               FStar_Util.bind_opt uu____1854
+               let uu___4 = unembed' w e_const c in
+               FStar_Util.bind_opt uu___4
                  (fun c1 ->
                     FStar_All.pipe_left
-                      (fun uu____1861 ->
-                         FStar_Pervasives_Native.Some uu____1861)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Constant c1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (f, uu____1864)::(ps, uu____1866)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (f, uu___3)::(ps, uu___4)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
                ->
-               let uu____1901 = unembed' w e_fv f in
-               FStar_Util.bind_opt uu____1901
+               let uu___5 = unembed' w e_fv f in
+               FStar_Util.bind_opt uu___5
                  (fun f1 ->
-                    let uu____1907 =
-                      let uu____1916 =
-                        let uu____1925 =
-                          let uu____1932 = e_pattern' () in
-                          FStar_Syntax_Embeddings.e_tuple2 uu____1932
+                    let uu___6 =
+                      let uu___7 =
+                        let uu___8 =
+                          let uu___9 = e_pattern' () in
+                          FStar_Syntax_Embeddings.e_tuple2 uu___9
                             FStar_Syntax_Embeddings.e_bool in
-                        FStar_Syntax_Embeddings.e_list uu____1925 in
-                      unembed' w uu____1916 ps in
-                    FStar_Util.bind_opt uu____1907
+                        FStar_Syntax_Embeddings.e_list uu___8 in
+                      unembed' w uu___7 ps in
+                    FStar_Util.bind_opt uu___6
                       (fun ps1 ->
                          FStar_All.pipe_left
-                           (fun uu____1961 ->
-                              FStar_Pervasives_Native.Some uu____1961)
+                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                            (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu____1970)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu___3)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
                ->
-               let uu____1995 = unembed' w e_bv bv in
-               FStar_Util.bind_opt uu____1995
+               let uu___4 = unembed' w e_bv bv in
+               FStar_Util.bind_opt uu___4
                  (fun bv1 ->
                     FStar_All.pipe_left
-                      (fun uu____2002 ->
-                         FStar_Pervasives_Native.Some uu____2002)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Var bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu____2005)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu___3)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
                ->
-               let uu____2030 = unembed' w e_bv bv in
-               FStar_Util.bind_opt uu____2030
+               let uu___4 = unembed' w e_bv bv in
+               FStar_Util.bind_opt uu___4
                  (fun bv1 ->
                     FStar_All.pipe_left
-                      (fun uu____2037 ->
-                         FStar_Pervasives_Native.Some uu____2037)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Wild bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (bv, uu____2040)::(t2, uu____2042)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu___3)::(t2, uu___4)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
                ->
-               let uu____2077 = unembed' w e_bv bv in
-               FStar_Util.bind_opt uu____2077
+               let uu___5 = unembed' w e_bv bv in
+               FStar_Util.bind_opt uu___5
                  (fun bv1 ->
-                    let uu____2083 = unembed' w e_term t2 in
-                    FStar_Util.bind_opt uu____2083
+                    let uu___6 = unembed' w e_term t2 in
+                    FStar_Util.bind_opt uu___6
                       (fun t3 ->
                          FStar_All.pipe_left
-                           (fun uu____2090 ->
-                              FStar_Pervasives_Native.Some uu____2090)
+                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                            (FStar_Reflection_Data.Pat_Dot_Term (bv1, t3))))
-           | uu____2091 ->
+           | uu___3 ->
                (if w
                 then
-                  (let uu____2105 =
-                     let uu____2110 =
-                       let uu____2111 = FStar_Syntax_Print.term_to_string t1 in
+                  (let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Print.term_to_string t1 in
                        FStar_Util.format1 "Not an embedded pattern: %s"
-                         uu____2111 in
-                     (FStar_Errors.Warning_NotEmbedded, uu____2110) in
-                   FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos
-                     uu____2105)
+                         uu___7 in
+                     (FStar_Errors.Warning_NotEmbedded, uu___6) in
+                   FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___5)
                 else ();
                 FStar_Pervasives_Native.None)) in
     mk_emb embed_pattern unembed_pattern
@@ -695,16 +673,16 @@ let (e_branch_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq ->
-    let uu____2134 = e_term_aq aq in
-    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2134
+    let uu___ = e_term_aq aq in
+    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu___
 let (e_argv_aq :
   FStar_Syntax_Syntax.antiquotations ->
     (FStar_Syntax_Syntax.term * FStar_Reflection_Data.aqualv)
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq ->
-    let uu____2148 = e_term_aq aq in
-    FStar_Syntax_Embeddings.e_tuple2 uu____2148 e_aqualv
+    let uu___ = e_term_aq aq in
+    FStar_Syntax_Embeddings.e_tuple2 uu___ e_aqualv
 let (e_term_view_aq :
   FStar_Syntax_Syntax.antiquotations ->
     FStar_Reflection_Data.term_view FStar_Syntax_Embeddings.embedding)
@@ -713,471 +691,446 @@ let (e_term_view_aq :
     let embed_term_view rng t =
       match t with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____2170 =
-            let uu____2171 =
-              let uu____2180 = embed e_fv rng fv in
-              FStar_Syntax_Syntax.as_arg uu____2180 in
-            [uu____2171] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_fv rng fv in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t
-            uu____2170 rng
+            FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_BVar fv ->
-          let uu____2198 =
-            let uu____2199 =
-              let uu____2208 = embed e_bv rng fv in
-              FStar_Syntax_Syntax.as_arg uu____2208 in
-            [uu____2199] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_bv rng fv in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t
-            uu____2198 rng
+            FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____2226 =
-            let uu____2227 =
-              let uu____2236 = embed e_bv rng bv in
-              FStar_Syntax_Syntax.as_arg uu____2236 in
-            [uu____2227] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_bv rng bv in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t
-            uu____2226 rng
+            FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_App (hd, a) ->
-          let uu____2255 =
-            let uu____2256 =
-              let uu____2265 =
-                let uu____2266 = e_term_aq aq in embed uu____2266 rng hd in
-              FStar_Syntax_Syntax.as_arg uu____2265 in
-            let uu____2269 =
-              let uu____2280 =
-                let uu____2289 =
-                  let uu____2290 = e_argv_aq aq in embed uu____2290 rng a in
-                FStar_Syntax_Syntax.as_arg uu____2289 in
-              [uu____2280] in
-            uu____2256 :: uu____2269 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = let uu___3 = e_term_aq aq in embed uu___3 rng hd in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = let uu___5 = e_argv_aq aq in embed uu___5 rng a in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t
-            uu____2255 rng
+            FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Abs (b, t1) ->
-          let uu____2327 =
-            let uu____2328 =
-              let uu____2337 = embed e_binder rng b in
-              FStar_Syntax_Syntax.as_arg uu____2337 in
-            let uu____2338 =
-              let uu____2349 =
-                let uu____2358 =
-                  let uu____2359 = e_term_aq aq in embed uu____2359 rng t1 in
-                FStar_Syntax_Syntax.as_arg uu____2358 in
-              [uu____2349] in
-            uu____2328 :: uu____2338 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_binder rng b in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = let uu___5 = e_term_aq aq in embed uu___5 rng t1 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t
-            uu____2327 rng
+            FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Arrow (b, c) ->
-          let uu____2388 =
-            let uu____2389 =
-              let uu____2398 = embed e_binder rng b in
-              FStar_Syntax_Syntax.as_arg uu____2398 in
-            let uu____2399 =
-              let uu____2410 =
-                let uu____2419 = embed e_comp rng c in
-                FStar_Syntax_Syntax.as_arg uu____2419 in
-              [uu____2410] in
-            uu____2389 :: uu____2399 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_binder rng b in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = embed e_comp rng c in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t
-            uu____2388 rng
+            FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____2445 =
-            let uu____2446 =
-              let uu____2455 = embed FStar_Syntax_Embeddings.e_unit rng () in
-              FStar_Syntax_Syntax.as_arg uu____2455 in
-            [uu____2446] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_unit rng () in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t
-            uu____2445 rng
+            FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Refine (bv, t1) ->
-          let uu____2474 =
-            let uu____2475 =
-              let uu____2484 = embed e_bv rng bv in
-              FStar_Syntax_Syntax.as_arg uu____2484 in
-            let uu____2485 =
-              let uu____2496 =
-                let uu____2505 =
-                  let uu____2506 = e_term_aq aq in embed uu____2506 rng t1 in
-                FStar_Syntax_Syntax.as_arg uu____2505 in
-              [uu____2496] in
-            uu____2475 :: uu____2485 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_bv rng bv in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = let uu___5 = e_term_aq aq in embed uu___5 rng t1 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t
-            uu____2474 rng
+            FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2534 =
-            let uu____2535 =
-              let uu____2544 = embed e_const rng c in
-              FStar_Syntax_Syntax.as_arg uu____2544 in
-            [uu____2535] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_const rng c in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t
-            uu____2534 rng
+            FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Uvar (u, d) ->
-          let uu____2563 =
-            let uu____2564 =
-              let uu____2573 = embed FStar_Syntax_Embeddings.e_int rng u in
-              FStar_Syntax_Syntax.as_arg uu____2573 in
-            let uu____2574 =
-              let uu____2585 =
-                let uu____2594 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_int rng u in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
                   FStar_Syntax_Util.mk_lazy (u, d)
                     FStar_Syntax_Util.t_ctx_uvar_and_sust
                     FStar_Syntax_Syntax.Lazy_uvar
                     FStar_Pervasives_Native.None in
-                FStar_Syntax_Syntax.as_arg uu____2594 in
-              [uu____2585] in
-            uu____2564 :: uu____2574 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t
-            uu____2563 rng
+            FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Let (r, attrs, b, t1, t2) ->
-          let uu____2632 =
-            let uu____2633 =
-              let uu____2642 = embed FStar_Syntax_Embeddings.e_bool rng r in
-              FStar_Syntax_Syntax.as_arg uu____2642 in
-            let uu____2643 =
-              let uu____2654 =
-                let uu____2663 =
-                  let uu____2664 = FStar_Syntax_Embeddings.e_list e_term in
-                  embed uu____2664 rng attrs in
-                FStar_Syntax_Syntax.as_arg uu____2663 in
-              let uu____2671 =
-                let uu____2682 =
-                  let uu____2691 = embed e_bv rng b in
-                  FStar_Syntax_Syntax.as_arg uu____2691 in
-                let uu____2692 =
-                  let uu____2703 =
-                    let uu____2712 =
-                      let uu____2713 = e_term_aq aq in
-                      embed uu____2713 rng t1 in
-                    FStar_Syntax_Syntax.as_arg uu____2712 in
-                  let uu____2716 =
-                    let uu____2727 =
-                      let uu____2736 =
-                        let uu____2737 = e_term_aq aq in
-                        embed uu____2737 rng t2 in
-                      FStar_Syntax_Syntax.as_arg uu____2736 in
-                    [uu____2727] in
-                  uu____2703 :: uu____2716 in
-                uu____2682 :: uu____2692 in
-              uu____2654 :: uu____2671 in
-            uu____2633 :: uu____2643 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed FStar_Syntax_Embeddings.e_bool rng r in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Embeddings.e_list e_term in
+                  embed uu___5 rng attrs in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 = embed e_bv rng b in
+                  FStar_Syntax_Syntax.as_arg uu___6 in
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 = e_term_aq aq in embed uu___9 rng t1 in
+                    FStar_Syntax_Syntax.as_arg uu___8 in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        let uu___11 = e_term_aq aq in embed uu___11 rng t2 in
+                      FStar_Syntax_Syntax.as_arg uu___10 in
+                    [uu___9] in
+                  uu___7 :: uu___8 in
+                uu___5 :: uu___6 in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t
-            uu____2632 rng
+            FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Match (t1, brs) ->
-          let uu____2794 =
-            let uu____2795 =
-              let uu____2804 =
-                let uu____2805 = e_term_aq aq in embed uu____2805 rng t1 in
-              FStar_Syntax_Syntax.as_arg uu____2804 in
-            let uu____2808 =
-              let uu____2819 =
-                let uu____2828 =
-                  let uu____2829 =
-                    let uu____2838 = e_branch_aq aq in
-                    FStar_Syntax_Embeddings.e_list uu____2838 in
-                  embed uu____2829 rng brs in
-                FStar_Syntax_Syntax.as_arg uu____2828 in
-              [uu____2819] in
-            uu____2795 :: uu____2808 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = let uu___3 = e_term_aq aq in embed uu___3 rng t1 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = e_branch_aq aq in
+                    FStar_Syntax_Embeddings.e_list uu___6 in
+                  embed uu___5 rng brs in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t
-            uu____2794 rng
+            FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_AscribedT (e, t1, tacopt) ->
-          let uu____2886 =
-            let uu____2887 =
-              let uu____2896 =
-                let uu____2897 = e_term_aq aq in embed uu____2897 rng e in
-              FStar_Syntax_Syntax.as_arg uu____2896 in
-            let uu____2900 =
-              let uu____2911 =
-                let uu____2920 =
-                  let uu____2921 = e_term_aq aq in embed uu____2921 rng t1 in
-                FStar_Syntax_Syntax.as_arg uu____2920 in
-              let uu____2924 =
-                let uu____2935 =
-                  let uu____2944 =
-                    let uu____2945 =
-                      let uu____2950 = e_term_aq aq in
-                      FStar_Syntax_Embeddings.e_option uu____2950 in
-                    embed uu____2945 rng tacopt in
-                  FStar_Syntax_Syntax.as_arg uu____2944 in
-                [uu____2935] in
-              uu____2911 :: uu____2924 in
-            uu____2887 :: uu____2900 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = let uu___3 = e_term_aq aq in embed uu___3 rng e in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = let uu___5 = e_term_aq aq in embed uu___5 rng t1 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_term_aq aq in
+                      FStar_Syntax_Embeddings.e_option uu___8 in
+                    embed uu___7 rng tacopt in
+                  FStar_Syntax_Syntax.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t
-            uu____2886 rng
+            FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_AscribedC (e, c, tacopt) ->
-          let uu____2994 =
-            let uu____2995 =
-              let uu____3004 =
-                let uu____3005 = e_term_aq aq in embed uu____3005 rng e in
-              FStar_Syntax_Syntax.as_arg uu____3004 in
-            let uu____3008 =
-              let uu____3019 =
-                let uu____3028 = embed e_comp rng c in
-                FStar_Syntax_Syntax.as_arg uu____3028 in
-              let uu____3029 =
-                let uu____3040 =
-                  let uu____3049 =
-                    let uu____3050 =
-                      let uu____3055 = e_term_aq aq in
-                      FStar_Syntax_Embeddings.e_option uu____3055 in
-                    embed uu____3050 rng tacopt in
-                  FStar_Syntax_Syntax.as_arg uu____3049 in
-                [uu____3040] in
-              uu____3019 :: uu____3029 in
-            uu____2995 :: uu____3008 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = let uu___3 = e_term_aq aq in embed uu___3 rng e in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = embed e_comp rng c in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_term_aq aq in
+                      FStar_Syntax_Embeddings.e_option uu___8 in
+                    embed uu___7 rng tacopt in
+                  FStar_Syntax_Syntax.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t
-            uu____2994 rng
+            FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t uu___
+            rng
       | FStar_Reflection_Data.Tv_Unknown ->
-          let uu___397_3092 =
+          let uu___ =
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.t in
           {
-            FStar_Syntax_Syntax.n = (uu___397_3092.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
-            FStar_Syntax_Syntax.vars =
-              (uu___397_3092.FStar_Syntax_Syntax.vars)
+            FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
           } in
     let unembed_term_view w t =
-      let uu____3108 = FStar_Syntax_Util.head_and_args t in
-      match uu____3108 with
+      let uu___ = FStar_Syntax_Util.head_and_args t in
+      match uu___ with
       | (hd, args) ->
-          let uu____3153 =
-            let uu____3166 =
-              let uu____3167 = FStar_Syntax_Util.un_uinst hd in
-              uu____3167.FStar_Syntax_Syntax.n in
-            (uu____3166, args) in
-          (match uu____3153 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu____3182)::[]) when
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Util.un_uinst hd in
+              uu___3.FStar_Syntax_Syntax.n in
+            (uu___2, args) in
+          (match uu___1 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
                ->
-               let uu____3207 = unembed' w e_bv b in
-               FStar_Util.bind_opt uu____3207
+               let uu___3 = unembed' w e_bv b in
+               FStar_Util.bind_opt uu___3
                  (fun b1 ->
                     FStar_All.pipe_left
-                      (fun uu____3214 ->
-                         FStar_Pervasives_Native.Some uu____3214)
+                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                       (FStar_Reflection_Data.Tv_Var b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu____3217)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
                ->
-               let uu____3242 = unembed' w e_bv b in
-               FStar_Util.bind_opt uu____3242
+               let uu___3 = unembed' w e_bv b in
+               FStar_Util.bind_opt uu___3
                  (fun b1 ->
                     FStar_All.pipe_left
-                      (fun uu____3249 ->
-                         FStar_Pervasives_Native.Some uu____3249)
+                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                       (FStar_Reflection_Data.Tv_BVar b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (f, uu____3252)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (f, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
                ->
-               let uu____3277 = unembed' w e_fv f in
-               FStar_Util.bind_opt uu____3277
+               let uu___3 = unembed' w e_fv f in
+               FStar_Util.bind_opt uu___3
                  (fun f1 ->
                     FStar_All.pipe_left
-                      (fun uu____3284 ->
-                         FStar_Pervasives_Native.Some uu____3284)
+                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                       (FStar_Reflection_Data.Tv_FVar f1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (l, uu____3287)::(r, uu____3289)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::(r, uu___3)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
                ->
-               let uu____3324 = unembed' w e_term l in
-               FStar_Util.bind_opt uu____3324
+               let uu___4 = unembed' w e_term l in
+               FStar_Util.bind_opt uu___4
                  (fun l1 ->
-                    let uu____3330 = unembed' w e_argv r in
-                    FStar_Util.bind_opt uu____3330
+                    let uu___5 = unembed' w e_argv r in
+                    FStar_Util.bind_opt uu___5
                       (fun r1 ->
                          FStar_All.pipe_left
-                           (fun uu____3337 ->
-                              FStar_Pervasives_Native.Some uu____3337)
+                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                            (FStar_Reflection_Data.Tv_App (l1, r1))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (b, uu____3340)::(t1, uu____3342)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::(t1, uu___3)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
                ->
-               let uu____3377 = unembed' w e_binder b in
-               FStar_Util.bind_opt uu____3377
+               let uu___4 = unembed' w e_binder b in
+               FStar_Util.bind_opt uu___4
                  (fun b1 ->
-                    let uu____3383 = unembed' w e_term t1 in
-                    FStar_Util.bind_opt uu____3383
+                    let uu___5 = unembed' w e_term t1 in
+                    FStar_Util.bind_opt uu___5
                       (fun t2 ->
                          FStar_All.pipe_left
-                           (fun uu____3390 ->
-                              FStar_Pervasives_Native.Some uu____3390)
+                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                            (FStar_Reflection_Data.Tv_Abs (b1, t2))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (b, uu____3393)::(t1, uu____3395)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::(t1, uu___3)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
                ->
-               let uu____3430 = unembed' w e_binder b in
-               FStar_Util.bind_opt uu____3430
+               let uu___4 = unembed' w e_binder b in
+               FStar_Util.bind_opt uu___4
                  (fun b1 ->
-                    let uu____3436 = unembed' w e_comp t1 in
-                    FStar_Util.bind_opt uu____3436
+                    let uu___5 = unembed' w e_comp t1 in
+                    FStar_Util.bind_opt uu___5
                       (fun c ->
                          FStar_All.pipe_left
-                           (fun uu____3443 ->
-                              FStar_Pervasives_Native.Some uu____3443)
+                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                            (FStar_Reflection_Data.Tv_Arrow (b1, c))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu____3446)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
                ->
-               let uu____3471 = unembed' w FStar_Syntax_Embeddings.e_unit u in
-               FStar_Util.bind_opt uu____3471
+               let uu___3 = unembed' w FStar_Syntax_Embeddings.e_unit u in
+               FStar_Util.bind_opt uu___3
                  (fun u1 ->
                     FStar_All.pipe_left
-                      (fun uu____3478 ->
-                         FStar_Pervasives_Native.Some uu____3478)
+                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                       (FStar_Reflection_Data.Tv_Type ()))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (b, uu____3481)::(t1, uu____3483)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::(t1, uu___3)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
                ->
-               let uu____3518 = unembed' w e_bv b in
-               FStar_Util.bind_opt uu____3518
+               let uu___4 = unembed' w e_bv b in
+               FStar_Util.bind_opt uu___4
                  (fun b1 ->
-                    let uu____3524 = unembed' w e_term t1 in
-                    FStar_Util.bind_opt uu____3524
+                    let uu___5 = unembed' w e_term t1 in
+                    FStar_Util.bind_opt uu___5
                       (fun t2 ->
                          FStar_All.pipe_left
-                           (fun uu____3531 ->
-                              FStar_Pervasives_Native.Some uu____3531)
+                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                            (FStar_Reflection_Data.Tv_Refine (b1, t2))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (c, uu____3534)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (c, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
                ->
-               let uu____3559 = unembed' w e_const c in
-               FStar_Util.bind_opt uu____3559
+               let uu___3 = unembed' w e_const c in
+               FStar_Util.bind_opt uu___3
                  (fun c1 ->
                     FStar_All.pipe_left
-                      (fun uu____3566 ->
-                         FStar_Pervasives_Native.Some uu____3566)
+                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                       (FStar_Reflection_Data.Tv_Const c1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (u, uu____3569)::(l, uu____3571)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu___2)::(l, uu___3)::[])
+               when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
                ->
-               let uu____3606 = unembed' w FStar_Syntax_Embeddings.e_int u in
-               FStar_Util.bind_opt uu____3606
+               let uu___4 = unembed' w FStar_Syntax_Embeddings.e_int u in
+               FStar_Util.bind_opt uu___4
                  (fun u1 ->
                     let ctx_u_s =
                       FStar_Syntax_Util.unlazy_as_t
                         FStar_Syntax_Syntax.Lazy_uvar l in
                     FStar_All.pipe_left
-                      (fun uu____3615 ->
-                         FStar_Pervasives_Native.Some uu____3615)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (r, uu____3618)::(attrs, uu____3620)::(b, uu____3622)::
-              (t1, uu____3624)::(t2, uu____3626)::[]) when
+              (r, uu___2)::(attrs, uu___3)::(b, uu___4)::(t1, uu___5)::
+              (t2, uu___6)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
                ->
-               let uu____3691 = unembed' w FStar_Syntax_Embeddings.e_bool r in
-               FStar_Util.bind_opt uu____3691
+               let uu___7 = unembed' w FStar_Syntax_Embeddings.e_bool r in
+               FStar_Util.bind_opt uu___7
                  (fun r1 ->
-                    let uu____3697 =
-                      let uu____3702 = FStar_Syntax_Embeddings.e_list e_term in
-                      unembed' w uu____3702 attrs in
-                    FStar_Util.bind_opt uu____3697
+                    let uu___8 =
+                      let uu___9 = FStar_Syntax_Embeddings.e_list e_term in
+                      unembed' w uu___9 attrs in
+                    FStar_Util.bind_opt uu___8
                       (fun attrs1 ->
-                         let uu____3716 = unembed' w e_bv b in
-                         FStar_Util.bind_opt uu____3716
+                         let uu___9 = unembed' w e_bv b in
+                         FStar_Util.bind_opt uu___9
                            (fun b1 ->
-                              let uu____3722 = unembed' w e_term t1 in
-                              FStar_Util.bind_opt uu____3722
+                              let uu___10 = unembed' w e_term t1 in
+                              FStar_Util.bind_opt uu___10
                                 (fun t11 ->
-                                   let uu____3728 = unembed' w e_term t2 in
-                                   FStar_Util.bind_opt uu____3728
+                                   let uu___11 = unembed' w e_term t2 in
+                                   FStar_Util.bind_opt uu___11
                                      (fun t21 ->
                                         FStar_All.pipe_left
-                                          (fun uu____3735 ->
+                                          (fun uu___12 ->
                                              FStar_Pervasives_Native.Some
-                                               uu____3735)
+                                               uu___12)
                                           (FStar_Reflection_Data.Tv_Let
                                              (r1, attrs1, b1, t11, t21)))))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (t1, uu____3740)::(brs, uu____3742)::[]) when
+              (t1, uu___2)::(brs, uu___3)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
                ->
-               let uu____3777 = unembed' w e_term t1 in
-               FStar_Util.bind_opt uu____3777
+               let uu___4 = unembed' w e_term t1 in
+               FStar_Util.bind_opt uu___4
                  (fun t2 ->
-                    let uu____3783 =
-                      let uu____3788 =
-                        FStar_Syntax_Embeddings.e_list e_branch in
-                      unembed' w uu____3788 brs in
-                    FStar_Util.bind_opt uu____3783
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Embeddings.e_list e_branch in
+                      unembed' w uu___6 brs in
+                    FStar_Util.bind_opt uu___5
                       (fun brs1 ->
                          FStar_All.pipe_left
-                           (fun uu____3803 ->
-                              FStar_Pervasives_Native.Some uu____3803)
+                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                            (FStar_Reflection_Data.Tv_Match (t2, brs1))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (e, uu____3808)::(t1, uu____3810)::(tacopt, uu____3812)::[])
-               when
+              (e, uu___2)::(t1, uu___3)::(tacopt, uu___4)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
                ->
-               let uu____3857 = unembed' w e_term e in
-               FStar_Util.bind_opt uu____3857
+               let uu___5 = unembed' w e_term e in
+               FStar_Util.bind_opt uu___5
                  (fun e1 ->
-                    let uu____3863 = unembed' w e_term t1 in
-                    FStar_Util.bind_opt uu____3863
+                    let uu___6 = unembed' w e_term t1 in
+                    FStar_Util.bind_opt uu___6
                       (fun t2 ->
-                         let uu____3869 =
-                           let uu____3874 =
+                         let uu___7 =
+                           let uu___8 =
                              FStar_Syntax_Embeddings.e_option e_term in
-                           unembed' w uu____3874 tacopt in
-                         FStar_Util.bind_opt uu____3869
+                           unembed' w uu___8 tacopt in
+                         FStar_Util.bind_opt uu___7
                            (fun tacopt1 ->
                               FStar_All.pipe_left
-                                (fun uu____3889 ->
-                                   FStar_Pervasives_Native.Some uu____3889)
+                                (fun uu___8 ->
+                                   FStar_Pervasives_Native.Some uu___8)
                                 (FStar_Reflection_Data.Tv_AscribedT
                                    (e1, t2, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
-              (e, uu____3894)::(c, uu____3896)::(tacopt, uu____3898)::[])
-               when
+              (e, uu___2)::(c, uu___3)::(tacopt, uu___4)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
                ->
-               let uu____3943 = unembed' w e_term e in
-               FStar_Util.bind_opt uu____3943
+               let uu___5 = unembed' w e_term e in
+               FStar_Util.bind_opt uu___5
                  (fun e1 ->
-                    let uu____3949 = unembed' w e_comp c in
-                    FStar_Util.bind_opt uu____3949
+                    let uu___6 = unembed' w e_comp c in
+                    FStar_Util.bind_opt uu___6
                       (fun c1 ->
-                         let uu____3955 =
-                           let uu____3960 =
+                         let uu___7 =
+                           let uu___8 =
                              FStar_Syntax_Embeddings.e_option e_term in
-                           unembed' w uu____3960 tacopt in
-                         FStar_Util.bind_opt uu____3955
+                           unembed' w uu___8 tacopt in
+                         FStar_Util.bind_opt uu___7
                            (fun tacopt1 ->
                               FStar_All.pipe_left
-                                (fun uu____3975 ->
-                                   FStar_Pervasives_Native.Some uu____3975)
+                                (fun uu___8 ->
+                                   FStar_Pervasives_Native.Some uu___8)
                                 (FStar_Reflection_Data.Tv_AscribedC
                                    (e1, c1, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
@@ -1185,19 +1138,18 @@ let (e_term_view_aq :
                  FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
                ->
                FStar_All.pipe_left
-                 (fun uu____3995 -> FStar_Pervasives_Native.Some uu____3995)
+                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____3996 ->
+           | uu___2 ->
                (if w
                 then
-                  (let uu____4010 =
-                     let uu____4015 =
-                       let uu____4016 = FStar_Syntax_Print.term_to_string t in
+                  (let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_Syntax_Print.term_to_string t in
                        FStar_Util.format1 "Not an embedded term_view: %s"
-                         uu____4016 in
-                     (FStar_Errors.Warning_NotEmbedded, uu____4015) in
-                   FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
-                     uu____4010)
+                         uu___6 in
+                     (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                   FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___4)
                 else ();
                 FStar_Pervasives_Native.None)) in
     mk_emb embed_term_view unembed_term_view
@@ -1207,86 +1159,83 @@ let (e_term_view :
   e_term_view_aq []
 let (e_lid : FStar_Ident.lid FStar_Syntax_Embeddings.embedding) =
   let embed1 rng lid =
-    let uu____4039 = FStar_Ident.path_of_lid lid in
-    embed FStar_Syntax_Embeddings.e_string_list rng uu____4039 in
+    let uu___ = FStar_Ident.path_of_lid lid in
+    embed FStar_Syntax_Embeddings.e_string_list rng uu___ in
   let unembed w t =
-    let uu____4063 = unembed' w FStar_Syntax_Embeddings.e_string_list t in
-    FStar_Util.map_opt uu____4063
+    let uu___ = unembed' w FStar_Syntax_Embeddings.e_string_list t in
+    FStar_Util.map_opt uu___
       (fun p -> FStar_Ident.lid_of_path p t.FStar_Syntax_Syntax.pos) in
-  let uu____4076 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string in
+  let uu___ = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string in
   FStar_Syntax_Embeddings.mk_emb_full
-    (fun x -> fun r -> fun uu____4083 -> fun uu____4084 -> embed1 r x)
-    (fun x -> fun w -> fun uu____4091 -> unembed w x) uu____4076
+    (fun x -> fun r -> fun uu___1 -> fun uu___2 -> embed1 r x)
+    (fun x -> fun w -> fun uu___1 -> unembed w x) uu___
     FStar_Ident.string_of_lid FStar_Syntax_Syntax.ET_abstract
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_Syntax_Embeddings.embedding) =
   let embed_bv_view rng bvv =
-    let uu____4106 =
-      let uu____4107 =
-        let uu____4116 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           embed FStar_Syntax_Embeddings.e_string rng
             bvv.FStar_Reflection_Data.bv_ppname in
-        FStar_Syntax_Syntax.as_arg uu____4116 in
-      let uu____4117 =
-        let uu____4128 =
-          let uu____4137 =
+        FStar_Syntax_Syntax.as_arg uu___2 in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
             embed FStar_Syntax_Embeddings.e_int rng
               bvv.FStar_Reflection_Data.bv_index in
-          FStar_Syntax_Syntax.as_arg uu____4137 in
-        let uu____4138 =
-          let uu____4149 =
-            let uu____4158 =
-              embed e_term rng bvv.FStar_Reflection_Data.bv_sort in
-            FStar_Syntax_Syntax.as_arg uu____4158 in
-          [uu____4149] in
-        uu____4128 :: uu____4138 in
-      uu____4107 :: uu____4117 in
+          FStar_Syntax_Syntax.as_arg uu___4 in
+        let uu___4 =
+          let uu___5 =
+            let uu___6 = embed e_term rng bvv.FStar_Reflection_Data.bv_sort in
+            FStar_Syntax_Syntax.as_arg uu___6 in
+          [uu___5] in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     FStar_Syntax_Syntax.mk_Tm_app
-      FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4106 rng in
+      FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu___ rng in
   let unembed_bv_view w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____4207 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____4207 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____4252 =
-          let uu____4265 =
-            let uu____4266 = FStar_Syntax_Util.un_uinst hd in
-            uu____4266.FStar_Syntax_Syntax.n in
-          (uu____4265, args) in
-        (match uu____4252 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (nm, uu____4281)::(idx, uu____4283)::(s, uu____4285)::[]) when
+            (nm, uu___2)::(idx, uu___3)::(s, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
              ->
-             let uu____4330 = unembed' w FStar_Syntax_Embeddings.e_string nm in
-             FStar_Util.bind_opt uu____4330
+             let uu___5 = unembed' w FStar_Syntax_Embeddings.e_string nm in
+             FStar_Util.bind_opt uu___5
                (fun nm1 ->
-                  let uu____4336 =
-                    unembed' w FStar_Syntax_Embeddings.e_int idx in
-                  FStar_Util.bind_opt uu____4336
+                  let uu___6 = unembed' w FStar_Syntax_Embeddings.e_int idx in
+                  FStar_Util.bind_opt uu___6
                     (fun idx1 ->
-                       let uu____4342 = unembed' w e_term s in
-                       FStar_Util.bind_opt uu____4342
+                       let uu___7 = unembed' w e_term s in
+                       FStar_Util.bind_opt uu___7
                          (fun s1 ->
                             FStar_All.pipe_left
-                              (fun uu____4349 ->
-                                 FStar_Pervasives_Native.Some uu____4349)
+                              (fun uu___8 ->
+                                 FStar_Pervasives_Native.Some uu___8)
                               {
                                 FStar_Reflection_Data.bv_ppname = nm1;
                                 FStar_Reflection_Data.bv_index = idx1;
                                 FStar_Reflection_Data.bv_sort = s1
                               })))
-         | uu____4350 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____4364 =
-                   let uu____4369 =
-                     let uu____4370 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not an embedded bv_view: %s"
-                       uu____4370 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4369) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4364)
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not an embedded bv_view: %s" uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_bv_view unembed_bv_view
@@ -1296,186 +1245,179 @@ let (e_comp_view :
   let embed_comp_view rng cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t, md) ->
-        let uu____4391 =
-          let uu____4392 =
-            let uu____4401 = embed e_term rng t in
-            FStar_Syntax_Syntax.as_arg uu____4401 in
-          let uu____4402 =
-            let uu____4413 =
-              let uu____4422 =
-                let uu____4423 = FStar_Syntax_Embeddings.e_option e_term in
-                embed uu____4423 rng md in
-              FStar_Syntax_Syntax.as_arg uu____4422 in
-            [uu____4413] in
-          uu____4392 :: uu____4402 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed e_term rng t in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Embeddings.e_option e_term in
+                embed uu___5 rng md in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
-          FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t
-          uu____4391 rng
+          FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t uu___ rng
     | FStar_Reflection_Data.C_GTotal (t, md) ->
-        let uu____4460 =
-          let uu____4461 =
-            let uu____4470 = embed e_term rng t in
-            FStar_Syntax_Syntax.as_arg uu____4470 in
-          let uu____4471 =
-            let uu____4482 =
-              let uu____4491 =
-                let uu____4492 = FStar_Syntax_Embeddings.e_option e_term in
-                embed uu____4492 rng md in
-              FStar_Syntax_Syntax.as_arg uu____4491 in
-            [uu____4482] in
-          uu____4461 :: uu____4471 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed e_term rng t in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Embeddings.e_option e_term in
+                embed uu___5 rng md in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
-          FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.t
-          uu____4460 rng
+          FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.t uu___
+          rng
     | FStar_Reflection_Data.C_Lemma (pre, post, pats) ->
-        let uu____4526 =
-          let uu____4527 =
-            let uu____4536 = embed e_term rng pre in
-            FStar_Syntax_Syntax.as_arg uu____4536 in
-          let uu____4537 =
-            let uu____4548 =
-              let uu____4557 = embed e_term rng post in
-              FStar_Syntax_Syntax.as_arg uu____4557 in
-            let uu____4558 =
-              let uu____4569 =
-                let uu____4578 = embed e_term rng pats in
-                FStar_Syntax_Syntax.as_arg uu____4578 in
-              [uu____4569] in
-            uu____4548 :: uu____4558 in
-          uu____4527 :: uu____4537 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed e_term rng pre in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = embed e_term rng post in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = embed e_term rng pats in
+                FStar_Syntax_Syntax.as_arg uu___6 in
+              [uu___5] in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
-          FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t
-          uu____4526 rng
+          FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t uu___ rng
     | FStar_Reflection_Data.C_Eff (us, eff, res, args) ->
-        let uu____4623 =
-          let uu____4624 =
-            let uu____4633 = embed FStar_Syntax_Embeddings.e_unit rng () in
-            FStar_Syntax_Syntax.as_arg uu____4633 in
-          let uu____4634 =
-            let uu____4645 =
-              let uu____4654 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed FStar_Syntax_Embeddings.e_unit rng () in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 embed FStar_Syntax_Embeddings.e_string_list rng eff in
-              FStar_Syntax_Syntax.as_arg uu____4654 in
-            let uu____4657 =
-              let uu____4668 =
-                let uu____4677 = embed e_term rng res in
-                FStar_Syntax_Syntax.as_arg uu____4677 in
-              let uu____4678 =
-                let uu____4689 =
-                  let uu____4698 =
-                    let uu____4699 = FStar_Syntax_Embeddings.e_list e_argv in
-                    embed uu____4699 rng args in
-                  FStar_Syntax_Syntax.as_arg uu____4698 in
-                [uu____4689] in
-              uu____4668 :: uu____4678 in
-            uu____4645 :: uu____4657 in
-          uu____4624 :: uu____4634 in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = embed e_term rng res in
+                FStar_Syntax_Syntax.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 = FStar_Syntax_Embeddings.e_list e_argv in
+                    embed uu___9 rng args in
+                  FStar_Syntax_Syntax.as_arg uu___8 in
+                [uu___7] in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
-          FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.t uu____4623
-          rng in
+          FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.t uu___ rng in
   let unembed_comp_view w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____4762 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____4762 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____4807 =
-          let uu____4820 =
-            let uu____4821 = FStar_Syntax_Util.un_uinst hd in
-            uu____4821.FStar_Syntax_Syntax.n in
-          (uu____4820, args) in
-        (match uu____4807 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (t2, uu____4836)::(md, uu____4838)::[]) when
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu___2)::(md, uu___3)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
              ->
-             let uu____4873 = unembed' w e_term t2 in
-             FStar_Util.bind_opt uu____4873
+             let uu___4 = unembed' w e_term t2 in
+             FStar_Util.bind_opt uu___4
                (fun t3 ->
-                  let uu____4879 =
-                    let uu____4884 = FStar_Syntax_Embeddings.e_option e_term in
-                    unembed' w uu____4884 md in
-                  FStar_Util.bind_opt uu____4879
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Embeddings.e_option e_term in
+                    unembed' w uu___6 md in
+                  FStar_Util.bind_opt uu___5
                     (fun md1 ->
                        FStar_All.pipe_left
-                         (fun uu____4899 ->
-                            FStar_Pervasives_Native.Some uu____4899)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.C_Total (t3, md1))))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (t2, uu____4904)::(md, uu____4906)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu___2)::(md, uu___3)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.lid
              ->
-             let uu____4941 = unembed' w e_term t2 in
-             FStar_Util.bind_opt uu____4941
+             let uu___4 = unembed' w e_term t2 in
+             FStar_Util.bind_opt uu___4
                (fun t3 ->
-                  let uu____4947 =
-                    let uu____4952 = FStar_Syntax_Embeddings.e_option e_term in
-                    unembed' w uu____4952 md in
-                  FStar_Util.bind_opt uu____4947
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Embeddings.e_option e_term in
+                    unembed' w uu___6 md in
+                  FStar_Util.bind_opt uu___5
                     (fun md1 ->
                        FStar_All.pipe_left
-                         (fun uu____4967 ->
-                            FStar_Pervasives_Native.Some uu____4967)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.C_GTotal (t3, md1))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (pre, uu____4972)::(post, uu____4974)::(pats, uu____4976)::[])
-             when
+            (pre, uu___2)::(post, uu___3)::(pats, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
              ->
-             let uu____5021 = unembed' w e_term pre in
-             FStar_Util.bind_opt uu____5021
+             let uu___5 = unembed' w e_term pre in
+             FStar_Util.bind_opt uu___5
                (fun pre1 ->
-                  let uu____5027 = unembed' w e_term post in
-                  FStar_Util.bind_opt uu____5027
+                  let uu___6 = unembed' w e_term post in
+                  FStar_Util.bind_opt uu___6
                     (fun post1 ->
-                       let uu____5033 = unembed' w e_term pats in
-                       FStar_Util.bind_opt uu____5033
+                       let uu___7 = unembed' w e_term pats in
+                       FStar_Util.bind_opt uu___7
                          (fun pats1 ->
                             FStar_All.pipe_left
-                              (fun uu____5040 ->
-                                 FStar_Pervasives_Native.Some uu____5040)
+                              (fun uu___8 ->
+                                 FStar_Pervasives_Native.Some uu___8)
                               (FStar_Reflection_Data.C_Lemma
                                  (pre1, post1, pats1)))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (us, uu____5043)::(eff, uu____5045)::(res, uu____5047)::(args1,
-                                                                    uu____5049)::[])
+            (us, uu___2)::(eff, uu___3)::(res, uu___4)::(args1, uu___5)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.lid
              ->
-             let uu____5104 = unembed' w FStar_Syntax_Embeddings.e_unit us in
-             FStar_Util.bind_opt uu____5104
+             let uu___6 = unembed' w FStar_Syntax_Embeddings.e_unit us in
+             FStar_Util.bind_opt uu___6
                (fun us1 ->
-                  let uu____5110 =
+                  let uu___7 =
                     unembed' w FStar_Syntax_Embeddings.e_string_list eff in
-                  FStar_Util.bind_opt uu____5110
+                  FStar_Util.bind_opt uu___7
                     (fun eff1 ->
-                       let uu____5124 = unembed' w e_term res in
-                       FStar_Util.bind_opt uu____5124
+                       let uu___8 = unembed' w e_term res in
+                       FStar_Util.bind_opt uu___8
                          (fun res1 ->
-                            let uu____5130 =
-                              let uu____5135 =
+                            let uu___9 =
+                              let uu___10 =
                                 FStar_Syntax_Embeddings.e_list e_argv in
-                              unembed' w uu____5135 args1 in
-                            FStar_Util.bind_opt uu____5130
+                              unembed' w uu___10 args1 in
+                            FStar_Util.bind_opt uu___9
                               (fun args2 ->
                                  FStar_All.pipe_left
-                                   (fun uu____5150 ->
-                                      FStar_Pervasives_Native.Some uu____5150)
+                                   (fun uu___10 ->
+                                      FStar_Pervasives_Native.Some uu___10)
                                    (FStar_Reflection_Data.C_Eff
                                       ([], eff1, res1, args2))))))
-         | uu____5155 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____5169 =
-                   let uu____5174 =
-                     let uu____5175 = FStar_Syntax_Print.term_to_string t1 in
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.format1 "Not an embedded comp_view: %s"
-                       uu____5175 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____5174) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5169)
+                       uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_comp_view unembed_comp_view
@@ -1487,23 +1429,23 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
       | FStar_Order.Lt -> FStar_Reflection_Data.ord_Lt
       | FStar_Order.Eq -> FStar_Reflection_Data.ord_Eq
       | FStar_Order.Gt -> FStar_Reflection_Data.ord_Gt in
-    let uu___722_5195 = r in
+    let uu___ = r in
     {
-      FStar_Syntax_Syntax.n = (uu___722_5195.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___722_5195.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let unembed_order w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____5214 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____5214 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____5259 =
-          let uu____5274 =
-            let uu____5275 = FStar_Syntax_Util.un_uinst hd in
-            uu____5275.FStar_Syntax_Syntax.n in
-          (uu____5274, args) in
-        (match uu____5259 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Lt_lid
@@ -1516,16 +1458,15 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Gt_lid
              -> FStar_Pervasives_Native.Some FStar_Order.Gt
-         | uu____5347 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____5363 =
-                   let uu____5368 =
-                     let uu____5369 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not an embedded order: %s"
-                       uu____5369 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____5368) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5363)
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not an embedded order: %s" uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_order unembed_order FStar_Syntax_Syntax.t_order
@@ -1535,27 +1476,26 @@ let (e_sigelt : FStar_Syntax_Syntax.sigelt FStar_Syntax_Embeddings.embedding)
     FStar_Syntax_Util.mk_lazy se FStar_Reflection_Data.fstar_refl_sigelt
       FStar_Syntax_Syntax.Lazy_sigelt (FStar_Pervasives_Native.Some rng) in
   let unembed_sigelt w t =
-    let uu____5399 =
-      let uu____5400 = FStar_Syntax_Subst.compress t in
-      uu____5400.FStar_Syntax_Syntax.n in
-    match uu____5399 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt;
-          FStar_Syntax_Syntax.ltyp = uu____5406;
-          FStar_Syntax_Syntax.rng = uu____5407;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____5410 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____5410
-    | uu____5411 ->
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____5413 =
-              let uu____5418 =
-                let uu____5419 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5419 in
-              (FStar_Errors.Warning_NotEmbedded, uu____5418) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5413)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded sigelt: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_sigelt unembed_sigelt FStar_Reflection_Data.fstar_refl_sigelt
@@ -1565,8 +1505,8 @@ let (e_ident : FStar_Ident.ident FStar_Syntax_Embeddings.embedding) =
       FStar_Syntax_Embeddings.e_range in
   FStar_Syntax_Embeddings.embed_as repr FStar_Ident.mk_ident
     (fun i ->
-       let uu____5440 = FStar_Ident.string_of_id i in
-       let uu____5441 = FStar_Ident.range_of_id i in (uu____5440, uu____5441))
+       let uu___ = FStar_Ident.string_of_id i in
+       let uu___1 = FStar_Ident.range_of_id i in (uu___, uu___1))
     (FStar_Pervasives_Native.Some FStar_Reflection_Data.fstar_refl_ident)
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_Syntax_Embeddings.embedding) =
@@ -1586,158 +1526,154 @@ let (e_sigelt_view :
   let embed_sigelt_view rng sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r, fv, univs, ty, t) ->
-        let uu____5480 =
-          let uu____5481 =
-            let uu____5490 = embed FStar_Syntax_Embeddings.e_bool rng r in
-            FStar_Syntax_Syntax.as_arg uu____5490 in
-          let uu____5491 =
-            let uu____5502 =
-              let uu____5511 = embed e_fv rng fv in
-              FStar_Syntax_Syntax.as_arg uu____5511 in
-            let uu____5512 =
-              let uu____5523 =
-                let uu____5532 = embed e_univ_names rng univs in
-                FStar_Syntax_Syntax.as_arg uu____5532 in
-              let uu____5535 =
-                let uu____5546 =
-                  let uu____5555 = embed e_term rng ty in
-                  FStar_Syntax_Syntax.as_arg uu____5555 in
-                let uu____5556 =
-                  let uu____5567 =
-                    let uu____5576 = embed e_term rng t in
-                    FStar_Syntax_Syntax.as_arg uu____5576 in
-                  [uu____5567] in
-                uu____5546 :: uu____5556 in
-              uu____5523 :: uu____5535 in
-            uu____5502 :: uu____5512 in
-          uu____5481 :: uu____5491 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed FStar_Syntax_Embeddings.e_bool rng r in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = embed e_fv rng fv in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = embed e_univ_names rng univs in
+                FStar_Syntax_Syntax.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 = embed e_term rng ty in
+                  FStar_Syntax_Syntax.as_arg uu___8 in
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 = embed e_term rng t in
+                    FStar_Syntax_Syntax.as_arg uu___10 in
+                  [uu___9] in
+                uu___7 :: uu___8 in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
-          FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t uu____5480
-          rng
+          FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t uu___ rng
     | FStar_Reflection_Data.Sg_Inductive (nm, univs, bs, t, dcs) ->
-        let uu____5642 =
-          let uu____5643 =
-            let uu____5652 =
-              embed FStar_Syntax_Embeddings.e_string_list rng nm in
-            FStar_Syntax_Syntax.as_arg uu____5652 in
-          let uu____5655 =
-            let uu____5666 =
-              let uu____5675 = embed e_univ_names rng univs in
-              FStar_Syntax_Syntax.as_arg uu____5675 in
-            let uu____5678 =
-              let uu____5689 =
-                let uu____5698 = embed e_binders rng bs in
-                FStar_Syntax_Syntax.as_arg uu____5698 in
-              let uu____5699 =
-                let uu____5710 =
-                  let uu____5719 = embed e_term rng t in
-                  FStar_Syntax_Syntax.as_arg uu____5719 in
-                let uu____5720 =
-                  let uu____5731 =
-                    let uu____5740 =
-                      let uu____5741 = FStar_Syntax_Embeddings.e_list e_ctor in
-                      embed uu____5741 rng dcs in
-                    FStar_Syntax_Syntax.as_arg uu____5740 in
-                  [uu____5731] in
-                uu____5710 :: uu____5720 in
-              uu____5689 :: uu____5699 in
-            uu____5666 :: uu____5678 in
-          uu____5643 :: uu____5655 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed FStar_Syntax_Embeddings.e_string_list rng nm in
+            FStar_Syntax_Syntax.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = embed e_univ_names rng univs in
+              FStar_Syntax_Syntax.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = embed e_binders rng bs in
+                FStar_Syntax_Syntax.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 = embed e_term rng t in
+                  FStar_Syntax_Syntax.as_arg uu___8 in
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 = FStar_Syntax_Embeddings.e_list e_ctor in
+                      embed uu___11 rng dcs in
+                    FStar_Syntax_Syntax.as_arg uu___10 in
+                  [uu___9] in
+                uu___7 :: uu___8 in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         FStar_Syntax_Syntax.mk_Tm_app
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.t
-          uu____5642 rng
+          uu___ rng
     | FStar_Reflection_Data.Unk ->
-        let uu___781_5814 =
-          FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.t in
+        let uu___ = FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.t in
         {
-          FStar_Syntax_Syntax.n = (uu___781_5814.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___781_5814.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
         } in
   let unembed_sigelt_view w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____5831 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____5831 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____5876 =
-          let uu____5889 =
-            let uu____5890 = FStar_Syntax_Util.un_uinst hd in
-            uu____5890.FStar_Syntax_Syntax.n in
-          (uu____5889, args) in
-        (match uu____5876 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (nm, uu____5905)::(us, uu____5907)::(bs, uu____5909)::(t2,
-                                                                   uu____5911)::
-            (dcs, uu____5913)::[]) when
+            (nm, uu___2)::(us, uu___3)::(bs, uu___4)::(t2, uu___5)::(dcs,
+                                                                    uu___6)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
              ->
-             let uu____5978 =
-               unembed' w FStar_Syntax_Embeddings.e_string_list nm in
-             FStar_Util.bind_opt uu____5978
+             let uu___7 = unembed' w FStar_Syntax_Embeddings.e_string_list nm in
+             FStar_Util.bind_opt uu___7
                (fun nm1 ->
-                  let uu____5992 = unembed' w e_univ_names us in
-                  FStar_Util.bind_opt uu____5992
+                  let uu___8 = unembed' w e_univ_names us in
+                  FStar_Util.bind_opt uu___8
                     (fun us1 ->
-                       let uu____6006 = unembed' w e_binders bs in
-                       FStar_Util.bind_opt uu____6006
+                       let uu___9 = unembed' w e_binders bs in
+                       FStar_Util.bind_opt uu___9
                          (fun bs1 ->
-                            let uu____6012 = unembed' w e_term t2 in
-                            FStar_Util.bind_opt uu____6012
+                            let uu___10 = unembed' w e_term t2 in
+                            FStar_Util.bind_opt uu___10
                               (fun t3 ->
-                                 let uu____6018 =
-                                   let uu____6029 =
+                                 let uu___11 =
+                                   let uu___12 =
                                      FStar_Syntax_Embeddings.e_list e_ctor in
-                                   unembed' w uu____6029 dcs in
-                                 FStar_Util.bind_opt uu____6018
+                                   unembed' w uu___12 dcs in
+                                 FStar_Util.bind_opt uu___11
                                    (fun dcs1 ->
                                       FStar_All.pipe_left
-                                        (fun uu____6074 ->
+                                        (fun uu___12 ->
                                            FStar_Pervasives_Native.Some
-                                             uu____6074)
+                                             uu___12)
                                         (FStar_Reflection_Data.Sg_Inductive
                                            (nm1, us1, bs1, t3, dcs1)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (r, uu____6083)::(fvar, uu____6085)::(univs, uu____6087)::
-            (ty, uu____6089)::(t2, uu____6091)::[]) when
+            (r, uu___2)::(fvar, uu___3)::(univs, uu___4)::(ty, uu___5)::
+            (t2, uu___6)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
              ->
-             let uu____6156 = unembed' w FStar_Syntax_Embeddings.e_bool r in
-             FStar_Util.bind_opt uu____6156
+             let uu___7 = unembed' w FStar_Syntax_Embeddings.e_bool r in
+             FStar_Util.bind_opt uu___7
                (fun r1 ->
-                  let uu____6162 = unembed' w e_fv fvar in
-                  FStar_Util.bind_opt uu____6162
+                  let uu___8 = unembed' w e_fv fvar in
+                  FStar_Util.bind_opt uu___8
                     (fun fvar1 ->
-                       let uu____6168 = unembed' w e_univ_names univs in
-                       FStar_Util.bind_opt uu____6168
+                       let uu___9 = unembed' w e_univ_names univs in
+                       FStar_Util.bind_opt uu___9
                          (fun univs1 ->
-                            let uu____6182 = unembed' w e_term ty in
-                            FStar_Util.bind_opt uu____6182
+                            let uu___10 = unembed' w e_term ty in
+                            FStar_Util.bind_opt uu___10
                               (fun ty1 ->
-                                 let uu____6188 = unembed' w e_term t2 in
-                                 FStar_Util.bind_opt uu____6188
+                                 let uu___11 = unembed' w e_term t2 in
+                                 FStar_Util.bind_opt uu___11
                                    (fun t3 ->
                                       FStar_All.pipe_left
-                                        (fun uu____6195 ->
+                                        (fun uu___12 ->
                                            FStar_Pervasives_Native.Some
-                                             uu____6195)
+                                             uu___12)
                                         (FStar_Reflection_Data.Sg_Let
                                            (r1, fvar1, univs1, ty1, t3)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-         | uu____6213 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____6227 =
-                   let uu____6232 =
-                     let uu____6233 = FStar_Syntax_Print.term_to_string t1 in
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.format1 "Not an embedded sigelt_view: %s"
-                       uu____6233 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6232) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6227)
+                       uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_sigelt_view unembed_sigelt_view
@@ -1749,86 +1685,84 @@ let (e_exp : FStar_Reflection_Data.exp FStar_Syntax_Embeddings.embedding) =
       | FStar_Reflection_Data.Unit ->
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Var i ->
-          let uu____6254 =
-            let uu____6255 =
-              let uu____6264 =
-                let uu____6265 = FStar_BigInt.string_of_big_int i in
-                FStar_Syntax_Util.exp_int uu____6265 in
-              FStar_Syntax_Syntax.as_arg uu____6264 in
-            [uu____6255] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_BigInt.string_of_big_int i in
+                FStar_Syntax_Util.exp_int uu___3 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t
-            uu____6254 FStar_Range.dummyRange
+            FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange
       | FStar_Reflection_Data.Mult (e1, e2) ->
-          let uu____6284 =
-            let uu____6285 =
-              let uu____6294 = embed_exp rng e1 in
-              FStar_Syntax_Syntax.as_arg uu____6294 in
-            let uu____6295 =
-              let uu____6306 =
-                let uu____6315 = embed_exp rng e2 in
-                FStar_Syntax_Syntax.as_arg uu____6315 in
-              [uu____6306] in
-            uu____6285 :: uu____6295 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed_exp rng e1 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = embed_exp rng e2 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t
-            uu____6284 FStar_Range.dummyRange in
-    let uu___856_6340 = r in
+            FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t uu___
+            FStar_Range.dummyRange in
+    let uu___ = r in
     {
-      FStar_Syntax_Syntax.n = (uu___856_6340.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___856_6340.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let rec unembed_exp w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____6359 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____6359 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____6404 =
-          let uu____6417 =
-            let uu____6418 = FStar_Syntax_Util.un_uinst hd in
-            uu____6418.FStar_Syntax_Syntax.n in
-          (uu____6417, args) in
-        (match uu____6404 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (i, uu____6448)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (i, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
              ->
-             let uu____6473 = unembed' w FStar_Syntax_Embeddings.e_int i in
-             FStar_Util.bind_opt uu____6473
+             let uu___3 = unembed' w FStar_Syntax_Embeddings.e_int i in
+             FStar_Util.bind_opt uu___3
                (fun i1 ->
                   FStar_All.pipe_left
-                    (fun uu____6480 ->
-                       FStar_Pervasives_Native.Some uu____6480)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.Var i1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (e1, uu____6483)::(e2, uu____6485)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (e1, uu___2)::(e2, uu___3)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
              ->
-             let uu____6520 = unembed_exp w e1 in
-             FStar_Util.bind_opt uu____6520
+             let uu___4 = unembed_exp w e1 in
+             FStar_Util.bind_opt uu___4
                (fun e11 ->
-                  let uu____6526 = unembed_exp w e2 in
-                  FStar_Util.bind_opt uu____6526
+                  let uu___5 = unembed_exp w e2 in
+                  FStar_Util.bind_opt uu___5
                     (fun e21 ->
                        FStar_All.pipe_left
-                         (fun uu____6533 ->
-                            FStar_Pervasives_Native.Some uu____6533)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.Mult (e11, e21))))
-         | uu____6534 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____6548 =
-                   let uu____6553 =
-                     let uu____6554 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not an embedded exp: %s" uu____6554 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6553) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6548)
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not an embedded exp: %s" uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed_exp unembed_exp FStar_Reflection_Data.fstar_refl_exp
@@ -1880,99 +1814,99 @@ let (e_qualifier :
       | FStar_Reflection_Data.OnlyName ->
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Reflectable l ->
-          let uu____6583 =
-            let uu____6584 =
-              let uu____6593 = embed e_lid rng l in
-              FStar_Syntax_Syntax.as_arg uu____6593 in
-            [uu____6584] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_lid rng l in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.t
-            uu____6583 FStar_Range.dummyRange
+            uu___ FStar_Range.dummyRange
       | FStar_Reflection_Data.Discriminator l ->
-          let uu____6611 =
-            let uu____6612 =
-              let uu____6621 = embed e_lid rng l in
-              FStar_Syntax_Syntax.as_arg uu____6621 in
-            [uu____6612] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_lid rng l in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.t
-            uu____6611 FStar_Range.dummyRange
+            uu___ FStar_Range.dummyRange
       | FStar_Reflection_Data.Action l ->
-          let uu____6639 =
-            let uu____6640 =
-              let uu____6649 = embed e_lid rng l in
-              FStar_Syntax_Syntax.as_arg uu____6649 in
-            [uu____6640] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_lid rng l in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            [uu___1] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.t
-            uu____6639 FStar_Range.dummyRange
+            uu___ FStar_Range.dummyRange
       | FStar_Reflection_Data.Projector (l, i) ->
-          let uu____6668 =
-            let uu____6669 =
-              let uu____6678 = embed e_lid rng l in
-              FStar_Syntax_Syntax.as_arg uu____6678 in
-            let uu____6679 =
-              let uu____6690 =
-                let uu____6699 = embed e_ident rng i in
-                FStar_Syntax_Syntax.as_arg uu____6699 in
-              [uu____6690] in
-            uu____6669 :: uu____6679 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = embed e_lid rng l in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = embed e_ident rng i in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
-            uu____6668 FStar_Range.dummyRange
+            uu___ FStar_Range.dummyRange
       | FStar_Reflection_Data.RecordType (ids1, ids2) ->
-          let uu____6734 =
-            let uu____6735 =
-              let uu____6744 =
-                let uu____6745 = FStar_Syntax_Embeddings.e_list e_ident in
-                embed uu____6745 rng ids1 in
-              FStar_Syntax_Syntax.as_arg uu____6744 in
-            let uu____6752 =
-              let uu____6763 =
-                let uu____6772 =
-                  let uu____6773 = FStar_Syntax_Embeddings.e_list e_ident in
-                  embed uu____6773 rng ids2 in
-                FStar_Syntax_Syntax.as_arg uu____6772 in
-              [uu____6763] in
-            uu____6735 :: uu____6752 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Embeddings.e_list e_ident in
+                embed uu___3 rng ids1 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Embeddings.e_list e_ident in
+                  embed uu___5 rng ids2 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.t
-            uu____6734 FStar_Range.dummyRange
+            uu___ FStar_Range.dummyRange
       | FStar_Reflection_Data.RecordConstructor (ids1, ids2) ->
-          let uu____6814 =
-            let uu____6815 =
-              let uu____6824 =
-                let uu____6825 = FStar_Syntax_Embeddings.e_list e_ident in
-                embed uu____6825 rng ids1 in
-              FStar_Syntax_Syntax.as_arg uu____6824 in
-            let uu____6832 =
-              let uu____6843 =
-                let uu____6852 =
-                  let uu____6853 = FStar_Syntax_Embeddings.e_list e_ident in
-                  embed uu____6853 rng ids2 in
-                FStar_Syntax_Syntax.as_arg uu____6852 in
-              [uu____6843] in
-            uu____6815 :: uu____6832 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Embeddings.e_list e_ident in
+                embed uu___3 rng ids1 in
+              FStar_Syntax_Syntax.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Embeddings.e_list e_ident in
+                  embed uu___5 rng ids2 in
+                FStar_Syntax_Syntax.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.t
-            uu____6814 FStar_Range.dummyRange in
-    let uu___931_6884 = r in
+            uu___ FStar_Range.dummyRange in
+    let uu___ = r in
     {
-      FStar_Syntax_Syntax.n = (uu___931_6884.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___931_6884.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let unembed w t =
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____6903 = FStar_Syntax_Util.head_and_args t1 in
-    match uu____6903 with
+    let uu___ = FStar_Syntax_Util.head_and_args t1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____6948 =
-          let uu____6961 =
-            let uu____6962 = FStar_Syntax_Util.un_uinst hd in
-            uu____6962.FStar_Syntax_Syntax.n in
-          (uu____6961, args) in
-        (match uu____6948 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Assumption.FStar_Reflection_Data.lid
@@ -2053,103 +1987,97 @@ let (e_qualifier :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.OnlyName
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____7232)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
              ->
-             let uu____7257 = unembed' w e_lid l in
-             FStar_Util.bind_opt uu____7257
+             let uu___3 = unembed' w e_lid l in
+             FStar_Util.bind_opt uu___3
                (fun l1 ->
                   FStar_All.pipe_left
-                    (fun uu____7264 ->
-                       FStar_Pervasives_Native.Some uu____7264)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.Reflectable l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____7267)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
              ->
-             let uu____7292 = unembed' w e_lid l in
-             FStar_Util.bind_opt uu____7292
+             let uu___3 = unembed' w e_lid l in
+             FStar_Util.bind_opt uu___3
                (fun l1 ->
                   FStar_All.pipe_left
-                    (fun uu____7299 ->
-                       FStar_Pervasives_Native.Some uu____7299)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.Discriminator l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____7302)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
              ->
-             let uu____7327 = unembed' w e_lid l in
-             FStar_Util.bind_opt uu____7327
+             let uu___3 = unembed' w e_lid l in
+             FStar_Util.bind_opt uu___3
                (fun l1 ->
                   FStar_All.pipe_left
-                    (fun uu____7334 ->
-                       FStar_Pervasives_Native.Some uu____7334)
+                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                     (FStar_Reflection_Data.Action l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (l, uu____7337)::(i, uu____7339)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::(i, uu___3)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
              ->
-             let uu____7374 = unembed' w e_lid l in
-             FStar_Util.bind_opt uu____7374
+             let uu___4 = unembed' w e_lid l in
+             FStar_Util.bind_opt uu___4
                (fun l1 ->
-                  let uu____7380 = unembed' w e_ident i in
-                  FStar_Util.bind_opt uu____7380
+                  let uu___5 = unembed' w e_ident i in
+                  FStar_Util.bind_opt uu___5
                     (fun i1 ->
                        FStar_All.pipe_left
-                         (fun uu____7387 ->
-                            FStar_Pervasives_Native.Some uu____7387)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.Projector (l1, i1))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (ids1, uu____7390)::(ids2, uu____7392)::[]) when
+            (ids1, uu___2)::(ids2, uu___3)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
              ->
-             let uu____7427 =
-               let uu____7432 = FStar_Syntax_Embeddings.e_list e_ident in
-               unembed' w uu____7432 ids1 in
-             FStar_Util.bind_opt uu____7427
+             let uu___4 =
+               let uu___5 = FStar_Syntax_Embeddings.e_list e_ident in
+               unembed' w uu___5 ids1 in
+             FStar_Util.bind_opt uu___4
                (fun ids11 ->
-                  let uu____7446 =
-                    let uu____7451 = FStar_Syntax_Embeddings.e_list e_ident in
-                    unembed' w uu____7451 ids2 in
-                  FStar_Util.bind_opt uu____7446
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Embeddings.e_list e_ident in
+                    unembed' w uu___6 ids2 in
+                  FStar_Util.bind_opt uu___5
                     (fun ids21 ->
                        FStar_All.pipe_left
-                         (fun uu____7466 ->
-                            FStar_Pervasives_Native.Some uu____7466)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.RecordType (ids11, ids21))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            (ids1, uu____7473)::(ids2, uu____7475)::[]) when
+            (ids1, uu___2)::(ids2, uu___3)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
              ->
-             let uu____7510 =
-               let uu____7515 = FStar_Syntax_Embeddings.e_list e_ident in
-               unembed' w uu____7515 ids1 in
-             FStar_Util.bind_opt uu____7510
+             let uu___4 =
+               let uu___5 = FStar_Syntax_Embeddings.e_list e_ident in
+               unembed' w uu___5 ids1 in
+             FStar_Util.bind_opt uu___4
                (fun ids11 ->
-                  let uu____7529 =
-                    let uu____7534 = FStar_Syntax_Embeddings.e_list e_ident in
-                    unembed' w uu____7534 ids2 in
-                  FStar_Util.bind_opt uu____7529
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Embeddings.e_list e_ident in
+                    unembed' w uu___6 ids2 in
+                  FStar_Util.bind_opt uu___5
                     (fun ids21 ->
                        FStar_All.pipe_left
-                         (fun uu____7549 ->
-                            FStar_Pervasives_Native.Some uu____7549)
+                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
                          (FStar_Reflection_Data.RecordConstructor
                             (ids11, ids21))))
-         | uu____7554 ->
+         | uu___2 ->
              (if w
               then
-                (let uu____7568 =
-                   let uu____7573 =
-                     let uu____7574 = FStar_Syntax_Print.term_to_string t1 in
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.format1 "Not an embedded qualifier: %s"
-                       uu____7574 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____7573) in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7568)
+                       uu___6 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___5) in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu___4)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb embed1 unembed FStar_Reflection_Data.fstar_refl_qualifier
@@ -2161,66 +2089,66 @@ let (unfold_lazy_bv :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i ->
     let bv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob in
-    let uu____7586 =
-      let uu____7587 =
-        let uu____7596 =
-          let uu____7597 = FStar_Reflection_Basic.inspect_bv bv in
-          embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7597 in
-        FStar_Syntax_Syntax.as_arg uu____7596 in
-      [uu____7587] in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Reflection_Basic.inspect_bv bv in
+          embed e_bv_view i.FStar_Syntax_Syntax.rng uu___3 in
+        FStar_Syntax_Syntax.as_arg uu___2 in
+      [uu___1] in
     FStar_Syntax_Syntax.mk_Tm_app
-      FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t
-      uu____7586 i.FStar_Syntax_Syntax.rng
+      FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t uu___
+      i.FStar_Syntax_Syntax.rng
 let (unfold_lazy_binder :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i ->
     let binder = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob in
-    let uu____7620 = FStar_Reflection_Basic.inspect_binder binder in
-    match uu____7620 with
+    let uu___ = FStar_Reflection_Basic.inspect_binder binder in
+    match uu___ with
     | (bv, aq) ->
-        let uu____7627 =
-          let uu____7628 =
-            let uu____7637 = embed e_bv i.FStar_Syntax_Syntax.rng bv in
-            FStar_Syntax_Syntax.as_arg uu____7637 in
-          let uu____7638 =
-            let uu____7649 =
-              let uu____7658 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq in
-              FStar_Syntax_Syntax.as_arg uu____7658 in
-            [uu____7649] in
-          uu____7628 :: uu____7638 in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = embed e_bv i.FStar_Syntax_Syntax.rng bv in
+            FStar_Syntax_Syntax.as_arg uu___3 in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq in
+              FStar_Syntax_Syntax.as_arg uu___5 in
+            [uu___4] in
+          uu___2 :: uu___3 in
         FStar_Syntax_Syntax.mk_Tm_app
           FStar_Reflection_Data.fstar_refl_pack_binder.FStar_Reflection_Data.t
-          uu____7627 i.FStar_Syntax_Syntax.rng
+          uu___1 i.FStar_Syntax_Syntax.rng
 let (unfold_lazy_fvar :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i ->
     let fv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob in
-    let uu____7689 =
-      let uu____7690 =
-        let uu____7699 =
-          let uu____7700 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
             FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string in
-          let uu____7705 = FStar_Reflection_Basic.inspect_fv fv in
-          embed uu____7700 i.FStar_Syntax_Syntax.rng uu____7705 in
-        FStar_Syntax_Syntax.as_arg uu____7699 in
-      [uu____7690] in
+          let uu___4 = FStar_Reflection_Basic.inspect_fv fv in
+          embed uu___3 i.FStar_Syntax_Syntax.rng uu___4 in
+        FStar_Syntax_Syntax.as_arg uu___2 in
+      [uu___1] in
     FStar_Syntax_Syntax.mk_Tm_app
-      FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t
-      uu____7689 i.FStar_Syntax_Syntax.rng
+      FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t uu___
+      i.FStar_Syntax_Syntax.rng
 let (unfold_lazy_comp :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i ->
     let comp = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob in
-    let uu____7732 =
-      let uu____7733 =
-        let uu____7742 =
-          let uu____7743 = FStar_Reflection_Basic.inspect_comp comp in
-          embed e_comp_view i.FStar_Syntax_Syntax.rng uu____7743 in
-        FStar_Syntax_Syntax.as_arg uu____7742 in
-      [uu____7733] in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Reflection_Basic.inspect_comp comp in
+          embed e_comp_view i.FStar_Syntax_Syntax.rng uu___3 in
+        FStar_Syntax_Syntax.as_arg uu___2 in
+      [uu___1] in
     FStar_Syntax_Syntax.mk_Tm_app
       FStar_Reflection_Data.fstar_refl_pack_comp.FStar_Reflection_Data.t
-      uu____7732 i.FStar_Syntax_Syntax.rng
+      uu___ i.FStar_Syntax_Syntax.rng
 let (unfold_lazy_env :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i -> FStar_Syntax_Util.exp_unit
@@ -2231,13 +2159,13 @@ let (unfold_lazy_sigelt :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i ->
     let sigelt = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob in
-    let uu____7776 =
-      let uu____7777 =
-        let uu____7786 =
-          let uu____7787 = FStar_Reflection_Basic.inspect_sigelt sigelt in
-          embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____7787 in
-        FStar_Syntax_Syntax.as_arg uu____7786 in
-      [uu____7777] in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Reflection_Basic.inspect_sigelt sigelt in
+          embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu___3 in
+        FStar_Syntax_Syntax.as_arg uu___2 in
+      [uu___1] in
     FStar_Syntax_Syntax.mk_Tm_app
       FStar_Reflection_Data.fstar_refl_pack_sigelt.FStar_Reflection_Data.t
-      uu____7776 i.FStar_Syntax_Syntax.rng
+      uu___ i.FStar_Syntax_Syntax.rng

--- a/src/ocaml-output/FStar_Reflection_Interpreter.ml
+++ b/src/ocaml-output/FStar_Reflection_Interpreter.ml
@@ -1,41 +1,40 @@
 open Prims
 let unembed :
-  'uuuuuu8 .
-    'uuuuuu8 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Embeddings.norm_cb ->
-          'uuuuuu8 FStar_Pervasives_Native.option
+          'uuuuu FStar_Pervasives_Native.option
   =
   fun ea ->
     fun a ->
       fun norm_cb ->
-        let uu____32 = FStar_Syntax_Embeddings.unembed ea a in
-        uu____32 true norm_cb
+        let uu___ = FStar_Syntax_Embeddings.unembed ea a in
+        uu___ true norm_cb
 let try_unembed :
-  'uuuuuu47 .
-    'uuuuuu47 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Embeddings.norm_cb ->
-          'uuuuuu47 FStar_Pervasives_Native.option
+          'uuuuu FStar_Pervasives_Native.option
   =
   fun ea ->
     fun a ->
       fun norm_cb ->
-        let uu____71 = FStar_Syntax_Embeddings.unembed ea a in
-        uu____71 false norm_cb
+        let uu___ = FStar_Syntax_Embeddings.unembed ea a in
+        uu___ false norm_cb
 let embed :
-  'uuuuuu88 .
-    'uuuuuu88 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Range.range ->
-        'uuuuuu88 ->
-          FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
+        'uuuuu -> FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
   =
   fun ea ->
     fun r ->
       fun x ->
         fun norm_cb ->
-          let uu____115 = FStar_Syntax_Embeddings.embed ea x in
-          uu____115 r FStar_Pervasives_Native.None norm_cb
+          let uu___ = FStar_Syntax_Embeddings.embed ea x in
+          uu___ r FStar_Pervasives_Native.None norm_cb
 let int1 :
   'a 'r .
     FStar_Ident.lid ->
@@ -55,17 +54,15 @@ let int1 :
             fun n ->
               fun args ->
                 match args with
-                | (a1, uu____197)::[] ->
-                    let uu____222 = try_unembed ea a1 n in
-                    FStar_Util.bind_opt uu____222
+                | (a1, uu___)::[] ->
+                    let uu___1 = try_unembed ea a1 n in
+                    FStar_Util.bind_opt uu___1
                       (fun a2 ->
-                         let uu____228 =
-                           let uu____229 =
-                             FStar_TypeChecker_Cfg.psc_range psc in
-                           let uu____230 = f a2 in
-                           embed er uu____229 uu____230 n in
-                         FStar_Pervasives_Native.Some uu____228)
-                | uu____231 -> FStar_Pervasives_Native.None
+                         let uu___2 =
+                           let uu___3 = FStar_TypeChecker_Cfg.psc_range psc in
+                           let uu___4 = f a2 in embed er uu___3 uu___4 n in
+                         FStar_Pervasives_Native.Some uu___2)
+                | uu___ -> FStar_Pervasives_Native.None
 let int2 :
   'a 'b 'r .
     FStar_Ident.lid ->
@@ -87,20 +84,20 @@ let int2 :
               fun n ->
                 fun args ->
                   match args with
-                  | (a1, uu____324)::(b1, uu____326)::[] ->
-                      let uu____367 = try_unembed ea a1 n in
-                      FStar_Util.bind_opt uu____367
+                  | (a1, uu___)::(b1, uu___1)::[] ->
+                      let uu___2 = try_unembed ea a1 n in
+                      FStar_Util.bind_opt uu___2
                         (fun a2 ->
-                           let uu____373 = try_unembed eb b1 n in
-                           FStar_Util.bind_opt uu____373
+                           let uu___3 = try_unembed eb b1 n in
+                           FStar_Util.bind_opt uu___3
                              (fun b2 ->
-                                let uu____379 =
-                                  let uu____380 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_TypeChecker_Cfg.psc_range psc in
-                                  let uu____381 = f a2 b2 in
-                                  embed er uu____380 uu____381 n in
-                                FStar_Pervasives_Native.Some uu____379))
-                  | uu____382 -> FStar_Pervasives_Native.None
+                                  let uu___6 = f a2 b2 in
+                                  embed er uu___5 uu___6 n in
+                                FStar_Pervasives_Native.Some uu___4))
+                  | uu___ -> FStar_Pervasives_Native.None
 let nbe_int1 :
   'a 'r .
     FStar_Ident.lid ->
@@ -118,15 +115,15 @@ let nbe_int1 :
           fun cb ->
             fun args ->
               match args with
-              | (a1, uu____447)::[] ->
-                  let uu____456 = FStar_TypeChecker_NBETerm.unembed ea cb a1 in
-                  FStar_Util.bind_opt uu____456
+              | (a1, uu___)::[] ->
+                  let uu___1 = FStar_TypeChecker_NBETerm.unembed ea cb a1 in
+                  FStar_Util.bind_opt uu___1
                     (fun a2 ->
-                       let uu____462 =
-                         let uu____463 = f a2 in
-                         FStar_TypeChecker_NBETerm.embed er cb uu____463 in
-                       FStar_Pervasives_Native.Some uu____462)
-              | uu____464 -> FStar_Pervasives_Native.None
+                       let uu___2 =
+                         let uu___3 = f a2 in
+                         FStar_TypeChecker_NBETerm.embed er cb uu___3 in
+                       FStar_Pervasives_Native.Some uu___2)
+              | uu___ -> FStar_Pervasives_Native.None
 let nbe_int2 :
   'a 'b 'r .
     FStar_Ident.lid ->
@@ -146,21 +143,19 @@ let nbe_int2 :
             fun cb ->
               fun args ->
                 match args with
-                | (a1, uu____548)::(b1, uu____550)::[] ->
-                    let uu____563 =
-                      FStar_TypeChecker_NBETerm.unembed ea cb a1 in
-                    FStar_Util.bind_opt uu____563
+                | (a1, uu___)::(b1, uu___1)::[] ->
+                    let uu___2 = FStar_TypeChecker_NBETerm.unembed ea cb a1 in
+                    FStar_Util.bind_opt uu___2
                       (fun a2 ->
-                         let uu____569 =
+                         let uu___3 =
                            FStar_TypeChecker_NBETerm.unembed eb cb b1 in
-                         FStar_Util.bind_opt uu____569
+                         FStar_Util.bind_opt uu___3
                            (fun b2 ->
-                              let uu____575 =
-                                let uu____576 = f a2 b2 in
-                                FStar_TypeChecker_NBETerm.embed er cb
-                                  uu____576 in
-                              FStar_Pervasives_Native.Some uu____575))
-                | uu____577 -> FStar_Pervasives_Native.None
+                              let uu___4 =
+                                let uu___5 = f a2 b2 in
+                                FStar_TypeChecker_NBETerm.embed er cb uu___5 in
+                              FStar_Pervasives_Native.Some uu___4))
+                | uu___ -> FStar_Pervasives_Native.None
 let (mklid : Prims.string -> FStar_Ident.lid) =
   fun nm -> FStar_Reflection_Data.fstar_refl_builtins_lid nm
 let (mk :
@@ -236,96 +231,96 @@ let mk2 :
                     mk l (Prims.of_int (2)) (int2 l f ea eb er)
                       (nbe_int2 l nf ena enb enr)
 let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
-  let uu____856 =
+  let uu___ =
     mk1 "inspect_ln" FStar_Reflection_Basic.inspect_ln
       FStar_Reflection_Embeddings.e_term
       FStar_Reflection_Embeddings.e_term_view
       FStar_Reflection_Basic.inspect_ln FStar_Reflection_NBEEmbeddings.e_term
       FStar_Reflection_NBEEmbeddings.e_term_view in
-  let uu____857 =
-    let uu____860 =
+  let uu___1 =
+    let uu___2 =
       mk1 "pack_ln" FStar_Reflection_Basic.pack_ln
         FStar_Reflection_Embeddings.e_term_view
         FStar_Reflection_Embeddings.e_term FStar_Reflection_Basic.pack_ln
         FStar_Reflection_NBEEmbeddings.e_term_view
         FStar_Reflection_NBEEmbeddings.e_term in
-    let uu____861 =
-      let uu____864 =
+    let uu___3 =
+      let uu___4 =
         mk1 "inspect_fv" FStar_Reflection_Basic.inspect_fv
           FStar_Reflection_Embeddings.e_fv
           FStar_Syntax_Embeddings.e_string_list
           FStar_Reflection_Basic.inspect_fv
           FStar_Reflection_NBEEmbeddings.e_fv
           FStar_TypeChecker_NBETerm.e_string_list in
-      let uu____869 =
-        let uu____872 =
+      let uu___5 =
+        let uu___6 =
           mk1 "pack_fv" FStar_Reflection_Basic.pack_fv
             FStar_Syntax_Embeddings.e_string_list
             FStar_Reflection_Embeddings.e_fv FStar_Reflection_Basic.pack_fv
             FStar_TypeChecker_NBETerm.e_string_list
             FStar_Reflection_NBEEmbeddings.e_fv in
-        let uu____877 =
-          let uu____880 =
+        let uu___7 =
+          let uu___8 =
             mk1 "inspect_comp" FStar_Reflection_Basic.inspect_comp
               FStar_Reflection_Embeddings.e_comp
               FStar_Reflection_Embeddings.e_comp_view
               FStar_Reflection_Basic.inspect_comp
               FStar_Reflection_NBEEmbeddings.e_comp
               FStar_Reflection_NBEEmbeddings.e_comp_view in
-          let uu____881 =
-            let uu____884 =
+          let uu___9 =
+            let uu___10 =
               mk1 "pack_comp" FStar_Reflection_Basic.pack_comp
                 FStar_Reflection_Embeddings.e_comp_view
                 FStar_Reflection_Embeddings.e_comp
                 FStar_Reflection_Basic.pack_comp
                 FStar_Reflection_NBEEmbeddings.e_comp_view
                 FStar_Reflection_NBEEmbeddings.e_comp in
-            let uu____885 =
-              let uu____888 =
+            let uu___11 =
+              let uu___12 =
                 mk1 "inspect_sigelt" FStar_Reflection_Basic.inspect_sigelt
                   FStar_Reflection_Embeddings.e_sigelt
                   FStar_Reflection_Embeddings.e_sigelt_view
                   FStar_Reflection_Basic.inspect_sigelt
                   FStar_Reflection_NBEEmbeddings.e_sigelt
                   FStar_Reflection_NBEEmbeddings.e_sigelt_view in
-              let uu____889 =
-                let uu____892 =
+              let uu___13 =
+                let uu___14 =
                   mk1 "pack_sigelt" FStar_Reflection_Basic.pack_sigelt
                     FStar_Reflection_Embeddings.e_sigelt_view
                     FStar_Reflection_Embeddings.e_sigelt
                     FStar_Reflection_Basic.pack_sigelt
                     FStar_Reflection_NBEEmbeddings.e_sigelt_view
                     FStar_Reflection_NBEEmbeddings.e_sigelt in
-                let uu____893 =
-                  let uu____896 =
+                let uu___15 =
+                  let uu___16 =
                     mk1 "inspect_bv" FStar_Reflection_Basic.inspect_bv
                       FStar_Reflection_Embeddings.e_bv
                       FStar_Reflection_Embeddings.e_bv_view
                       FStar_Reflection_Basic.inspect_bv
                       FStar_Reflection_NBEEmbeddings.e_bv
                       FStar_Reflection_NBEEmbeddings.e_bv_view in
-                  let uu____897 =
-                    let uu____900 =
+                  let uu___17 =
+                    let uu___18 =
                       mk1 "pack_bv" FStar_Reflection_Basic.pack_bv
                         FStar_Reflection_Embeddings.e_bv_view
                         FStar_Reflection_Embeddings.e_bv
                         FStar_Reflection_Basic.pack_bv
                         FStar_Reflection_NBEEmbeddings.e_bv_view
                         FStar_Reflection_NBEEmbeddings.e_bv in
-                    let uu____901 =
-                      let uu____904 =
-                        let uu____905 =
+                    let uu___19 =
+                      let uu___20 =
+                        let uu___21 =
                           FStar_Syntax_Embeddings.e_option
                             FStar_Reflection_Embeddings.e_term in
-                        let uu____910 =
+                        let uu___22 =
                           FStar_TypeChecker_NBETerm.e_option
                             FStar_Reflection_NBEEmbeddings.e_term in
                         mk1 "sigelt_opts" FStar_Reflection_Basic.sigelt_opts
-                          FStar_Reflection_Embeddings.e_sigelt uu____905
+                          FStar_Reflection_Embeddings.e_sigelt uu___21
                           FStar_Reflection_Basic.sigelt_opts
-                          FStar_Reflection_NBEEmbeddings.e_sigelt uu____910 in
-                      let uu____919 =
-                        let uu____922 =
+                          FStar_Reflection_NBEEmbeddings.e_sigelt uu___22 in
+                      let uu___21 =
+                        let uu___22 =
                           mk1 "sigelt_attrs"
                             FStar_Reflection_Basic.sigelt_attrs
                             FStar_Reflection_Embeddings.e_sigelt
@@ -333,8 +328,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                             FStar_Reflection_Basic.sigelt_attrs
                             FStar_Reflection_NBEEmbeddings.e_sigelt
                             FStar_Reflection_NBEEmbeddings.e_attributes in
-                        let uu____927 =
-                          let uu____930 =
+                        let uu___23 =
+                          let uu___24 =
                             mk2 "set_sigelt_attrs"
                               FStar_Reflection_Basic.set_sigelt_attrs
                               FStar_Reflection_Embeddings.e_attributes
@@ -344,8 +339,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                               FStar_Reflection_NBEEmbeddings.e_attributes
                               FStar_Reflection_NBEEmbeddings.e_sigelt
                               FStar_Reflection_NBEEmbeddings.e_sigelt in
-                          let uu____935 =
-                            let uu____938 =
+                          let uu___25 =
+                            let uu___26 =
                               mk1 "sigelt_quals"
                                 FStar_Reflection_Basic.sigelt_quals
                                 FStar_Reflection_Embeddings.e_sigelt
@@ -353,8 +348,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                 FStar_Reflection_Basic.sigelt_quals
                                 FStar_Reflection_NBEEmbeddings.e_sigelt
                                 FStar_Reflection_NBEEmbeddings.e_qualifiers in
-                            let uu____943 =
-                              let uu____946 =
+                            let uu___27 =
+                              let uu___28 =
                                 mk2 "set_sigelt_quals"
                                   FStar_Reflection_Basic.set_sigelt_quals
                                   FStar_Reflection_Embeddings.e_qualifiers
@@ -364,8 +359,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                   FStar_Reflection_NBEEmbeddings.e_qualifiers
                                   FStar_Reflection_NBEEmbeddings.e_sigelt
                                   FStar_Reflection_NBEEmbeddings.e_sigelt in
-                              let uu____951 =
-                                let uu____954 =
+                              let uu___29 =
+                                let uu___30 =
                                   mk1 "inspect_binder"
                                     FStar_Reflection_Basic.inspect_binder
                                     FStar_Reflection_Embeddings.e_binder
@@ -373,8 +368,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                     FStar_Reflection_Basic.inspect_binder
                                     FStar_Reflection_NBEEmbeddings.e_binder
                                     FStar_Reflection_NBEEmbeddings.e_binder_view in
-                                let uu____955 =
-                                  let uu____958 =
+                                let uu___31 =
+                                  let uu___32 =
                                     mk2 "pack_binder"
                                       FStar_Reflection_Basic.pack_binder
                                       FStar_Reflection_Embeddings.e_bv
@@ -384,8 +379,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                       FStar_Reflection_NBEEmbeddings.e_bv
                                       FStar_Reflection_NBEEmbeddings.e_aqualv
                                       FStar_Reflection_NBEEmbeddings.e_binder in
-                                  let uu____959 =
-                                    let uu____962 =
+                                  let uu___33 =
+                                    let uu___34 =
                                       mk2 "compare_bv"
                                         FStar_Reflection_Basic.compare_bv
                                         FStar_Reflection_Embeddings.e_bv
@@ -395,8 +390,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                         FStar_Reflection_NBEEmbeddings.e_bv
                                         FStar_Reflection_NBEEmbeddings.e_bv
                                         FStar_Reflection_NBEEmbeddings.e_order in
-                                    let uu____963 =
-                                      let uu____966 =
+                                    let uu___35 =
+                                      let uu___36 =
                                         mk2 "is_free"
                                           FStar_Reflection_Basic.is_free
                                           FStar_Reflection_Embeddings.e_bv
@@ -406,57 +401,57 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                           FStar_Reflection_NBEEmbeddings.e_bv
                                           FStar_Reflection_NBEEmbeddings.e_term
                                           FStar_TypeChecker_NBETerm.e_bool in
-                                      let uu____967 =
-                                        let uu____970 =
-                                          let uu____971 =
+                                      let uu___37 =
+                                        let uu___38 =
+                                          let uu___39 =
                                             FStar_Syntax_Embeddings.e_list
                                               FStar_Reflection_Embeddings.e_fv in
-                                          let uu____976 =
+                                          let uu___40 =
                                             FStar_TypeChecker_NBETerm.e_list
                                               FStar_Reflection_NBEEmbeddings.e_fv in
                                           mk2 "lookup_attr"
                                             FStar_Reflection_Basic.lookup_attr
                                             FStar_Reflection_Embeddings.e_term
                                             FStar_Reflection_Embeddings.e_env
-                                            uu____971
+                                            uu___39
                                             FStar_Reflection_Basic.lookup_attr
                                             FStar_Reflection_NBEEmbeddings.e_term
                                             FStar_Reflection_NBEEmbeddings.e_env
-                                            uu____976 in
-                                        let uu____985 =
-                                          let uu____988 =
-                                            let uu____989 =
+                                            uu___40 in
+                                        let uu___39 =
+                                          let uu___40 =
+                                            let uu___41 =
                                               FStar_Syntax_Embeddings.e_list
                                                 FStar_Reflection_Embeddings.e_fv in
-                                            let uu____994 =
+                                            let uu___42 =
                                               FStar_TypeChecker_NBETerm.e_list
                                                 FStar_Reflection_NBEEmbeddings.e_fv in
                                             mk1 "all_defs_in_env"
                                               FStar_Reflection_Basic.all_defs_in_env
                                               FStar_Reflection_Embeddings.e_env
-                                              uu____989
+                                              uu___41
                                               FStar_Reflection_Basic.all_defs_in_env
                                               FStar_Reflection_NBEEmbeddings.e_env
-                                              uu____994 in
-                                          let uu____1003 =
-                                            let uu____1006 =
-                                              let uu____1007 =
+                                              uu___42 in
+                                          let uu___41 =
+                                            let uu___42 =
+                                              let uu___43 =
                                                 FStar_Syntax_Embeddings.e_list
                                                   FStar_Reflection_Embeddings.e_fv in
-                                              let uu____1012 =
+                                              let uu___44 =
                                                 FStar_TypeChecker_NBETerm.e_list
                                                   FStar_Reflection_NBEEmbeddings.e_fv in
                                               mk2 "defs_in_module"
                                                 FStar_Reflection_Basic.defs_in_module
                                                 FStar_Reflection_Embeddings.e_env
                                                 FStar_Syntax_Embeddings.e_string_list
-                                                uu____1007
+                                                uu___43
                                                 FStar_Reflection_Basic.defs_in_module
                                                 FStar_Reflection_NBEEmbeddings.e_env
                                                 FStar_TypeChecker_NBETerm.e_string_list
-                                                uu____1012 in
-                                            let uu____1025 =
-                                              let uu____1028 =
+                                                uu___44 in
+                                            let uu___43 =
+                                              let uu___44 =
                                                 mk2 "term_eq"
                                                   FStar_Reflection_Basic.term_eq
                                                   FStar_Reflection_Embeddings.e_term
@@ -466,8 +461,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                   FStar_Reflection_NBEEmbeddings.e_term
                                                   FStar_Reflection_NBEEmbeddings.e_term
                                                   FStar_TypeChecker_NBETerm.e_bool in
-                                              let uu____1029 =
-                                                let uu____1032 =
+                                              let uu___45 =
+                                                let uu___46 =
                                                   mk1 "moduleof"
                                                     FStar_Reflection_Basic.moduleof
                                                     FStar_Reflection_Embeddings.e_env
@@ -475,8 +470,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                     FStar_Reflection_Basic.moduleof
                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                     FStar_TypeChecker_NBETerm.e_string_list in
-                                                let uu____1037 =
-                                                  let uu____1040 =
+                                                let uu___47 =
+                                                  let uu___48 =
                                                     mk1 "term_to_string"
                                                       FStar_Reflection_Basic.term_to_string
                                                       FStar_Reflection_Embeddings.e_term
@@ -484,8 +479,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                       FStar_Reflection_Basic.term_to_string
                                                       FStar_Reflection_NBEEmbeddings.e_term
                                                       FStar_TypeChecker_NBETerm.e_string in
-                                                  let uu____1041 =
-                                                    let uu____1044 =
+                                                  let uu___49 =
+                                                    let uu___50 =
                                                       mk1 "comp_to_string"
                                                         FStar_Reflection_Basic.comp_to_string
                                                         FStar_Reflection_Embeddings.e_comp
@@ -493,8 +488,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                         FStar_Reflection_Basic.comp_to_string
                                                         FStar_Reflection_NBEEmbeddings.e_comp
                                                         FStar_TypeChecker_NBETerm.e_string in
-                                                    let uu____1045 =
-                                                      let uu____1048 =
+                                                    let uu___51 =
+                                                      let uu___52 =
                                                         mk1 "binders_of_env"
                                                           FStar_Reflection_Basic.binders_of_env
                                                           FStar_Reflection_Embeddings.e_env
@@ -502,41 +497,41 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                           FStar_Reflection_Basic.binders_of_env
                                                           FStar_Reflection_NBEEmbeddings.e_env
                                                           FStar_Reflection_NBEEmbeddings.e_binders in
-                                                      let uu____1049 =
-                                                        let uu____1052 =
-                                                          let uu____1053 =
+                                                      let uu___53 =
+                                                        let uu___54 =
+                                                          let uu___55 =
                                                             FStar_Syntax_Embeddings.e_option
                                                               FStar_Reflection_Embeddings.e_sigelt in
-                                                          let uu____1058 =
+                                                          let uu___56 =
                                                             FStar_TypeChecker_NBETerm.e_option
                                                               FStar_Reflection_NBEEmbeddings.e_sigelt in
                                                           mk2 "lookup_typ"
                                                             FStar_Reflection_Basic.lookup_typ
                                                             FStar_Reflection_Embeddings.e_env
                                                             FStar_Syntax_Embeddings.e_string_list
-                                                            uu____1053
+                                                            uu___55
                                                             FStar_Reflection_Basic.lookup_typ
                                                             FStar_Reflection_NBEEmbeddings.e_env
                                                             FStar_TypeChecker_NBETerm.e_string_list
-                                                            uu____1058 in
-                                                        let uu____1071 =
-                                                          let uu____1074 =
-                                                            let uu____1075 =
+                                                            uu___56 in
+                                                        let uu___55 =
+                                                          let uu___56 =
+                                                            let uu___57 =
                                                               FStar_Syntax_Embeddings.e_list
                                                                 FStar_Syntax_Embeddings.e_string_list in
-                                                            let uu____1084 =
+                                                            let uu___58 =
                                                               FStar_TypeChecker_NBETerm.e_list
                                                                 FStar_TypeChecker_NBETerm.e_string_list in
                                                             mk1
                                                               "env_open_modules"
                                                               FStar_Reflection_Basic.env_open_modules
                                                               FStar_Reflection_Embeddings.e_env
-                                                              uu____1075
+                                                              uu___57
                                                               FStar_Reflection_Basic.env_open_modules
                                                               FStar_Reflection_NBEEmbeddings.e_env
-                                                              uu____1084 in
-                                                          let uu____1101 =
-                                                            let uu____1104 =
+                                                              uu___58 in
+                                                          let uu___57 =
+                                                            let uu___58 =
                                                               mk1
                                                                 "implode_qn"
                                                                 FStar_Reflection_Basic.implode_qn
@@ -545,9 +540,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                                 FStar_Reflection_Basic.implode_qn
                                                                 FStar_TypeChecker_NBETerm.e_string_list
                                                                 FStar_TypeChecker_NBETerm.e_string in
-                                                            let uu____1109 =
-                                                              let uu____1112
-                                                                =
+                                                            let uu___59 =
+                                                              let uu___60 =
                                                                 mk1
                                                                   "explode_qn"
                                                                   FStar_Reflection_Basic.explode_qn
@@ -556,10 +550,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                                   FStar_Reflection_Basic.explode_qn
                                                                   FStar_TypeChecker_NBETerm.e_string
                                                                   FStar_TypeChecker_NBETerm.e_string_list in
-                                                              let uu____1117
-                                                                =
-                                                                let uu____1120
-                                                                  =
+                                                              let uu___61 =
+                                                                let uu___62 =
                                                                   mk2
                                                                     "compare_string"
                                                                     FStar_Reflection_Basic.compare_string
@@ -570,9 +562,8 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_int in
-                                                                let uu____1121
-                                                                  =
-                                                                  let uu____1124
+                                                                let uu___63 =
+                                                                  let uu___64
                                                                     =
                                                                     mk2
                                                                     "push_binder"
@@ -584,45 +575,42 @@ let (reflection_primops : FStar_TypeChecker_Cfg.primitive_step Prims.list) =
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_binder
                                                                     FStar_Reflection_NBEEmbeddings.e_env in
-                                                                  [uu____1124] in
-                                                                uu____1120 ::
-                                                                  uu____1121 in
-                                                              uu____1112 ::
-                                                                uu____1117 in
-                                                            uu____1104 ::
-                                                              uu____1109 in
-                                                          uu____1074 ::
-                                                            uu____1101 in
-                                                        uu____1052 ::
-                                                          uu____1071 in
-                                                      uu____1048 ::
-                                                        uu____1049 in
-                                                    uu____1044 :: uu____1045 in
-                                                  uu____1040 :: uu____1041 in
-                                                uu____1032 :: uu____1037 in
-                                              uu____1028 :: uu____1029 in
-                                            uu____1006 :: uu____1025 in
-                                          uu____988 :: uu____1003 in
-                                        uu____970 :: uu____985 in
-                                      uu____966 :: uu____967 in
-                                    uu____962 :: uu____963 in
-                                  uu____958 :: uu____959 in
-                                uu____954 :: uu____955 in
-                              uu____946 :: uu____951 in
-                            uu____938 :: uu____943 in
-                          uu____930 :: uu____935 in
-                        uu____922 :: uu____927 in
-                      uu____904 :: uu____919 in
-                    uu____900 :: uu____901 in
-                  uu____896 :: uu____897 in
-                uu____892 :: uu____893 in
-              uu____888 :: uu____889 in
-            uu____884 :: uu____885 in
-          uu____880 :: uu____881 in
-        uu____872 :: uu____877 in
-      uu____864 :: uu____869 in
-    uu____860 :: uu____861 in
-  uu____856 :: uu____857
+                                                                  [uu___64] in
+                                                                uu___62 ::
+                                                                  uu___63 in
+                                                              uu___60 ::
+                                                                uu___61 in
+                                                            uu___58 ::
+                                                              uu___59 in
+                                                          uu___56 :: uu___57 in
+                                                        uu___54 :: uu___55 in
+                                                      uu___52 :: uu___53 in
+                                                    uu___50 :: uu___51 in
+                                                  uu___48 :: uu___49 in
+                                                uu___46 :: uu___47 in
+                                              uu___44 :: uu___45 in
+                                            uu___42 :: uu___43 in
+                                          uu___40 :: uu___41 in
+                                        uu___38 :: uu___39 in
+                                      uu___36 :: uu___37 in
+                                    uu___34 :: uu___35 in
+                                  uu___32 :: uu___33 in
+                                uu___30 :: uu___31 in
+                              uu___28 :: uu___29 in
+                            uu___26 :: uu___27 in
+                          uu___24 :: uu___25 in
+                        uu___22 :: uu___23 in
+                      uu___20 :: uu___21 in
+                    uu___18 :: uu___19 in
+                  uu___16 :: uu___17 in
+                uu___14 :: uu___15 in
+              uu___12 :: uu___13 in
+            uu___10 :: uu___11 in
+          uu___8 :: uu___9 in
+        uu___6 :: uu___7 in
+      uu___4 :: uu___5 in
+    uu___2 :: uu___3 in
+  uu___ :: uu___1
 let (uu___113 : unit) =
   FStar_List.iter FStar_TypeChecker_Cfg.register_extra_step
     reflection_primops

--- a/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
@@ -23,34 +23,32 @@ let (mkConstruct :
           (FStar_List.rev ts)
 let (fv_as_emb_typ : FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.emb_typ) =
   fun fv ->
-    let uu____75 =
-      let uu____82 =
+    let uu___ =
+      let uu___1 =
         FStar_Ident.string_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      (uu____82, []) in
-    FStar_Syntax_Syntax.ET_app uu____75
+      (uu___1, []) in
+    FStar_Syntax_Syntax.ET_app uu___
 let mk_emb' :
-  'uuuuuu93 .
+  'uuuuu .
     (FStar_TypeChecker_NBETerm.nbe_cbs ->
-       'uuuuuu93 -> FStar_TypeChecker_NBETerm.t)
+       'uuuuu -> FStar_TypeChecker_NBETerm.t)
       ->
       (FStar_TypeChecker_NBETerm.nbe_cbs ->
-         FStar_TypeChecker_NBETerm.t ->
-           'uuuuuu93 FStar_Pervasives_Native.option)
+         FStar_TypeChecker_NBETerm.t -> 'uuuuu FStar_Pervasives_Native.option)
         ->
-        FStar_Syntax_Syntax.fv ->
-          'uuuuuu93 FStar_TypeChecker_NBETerm.embedding
+        FStar_Syntax_Syntax.fv -> 'uuuuu FStar_TypeChecker_NBETerm.embedding
   =
   fun x ->
     fun y ->
       fun fv ->
-        let uu____135 = mkFV fv [] [] in
-        let uu____140 = fv_as_emb_typ fv in
-        FStar_TypeChecker_NBETerm.mk_emb x y uu____135 uu____140
+        let uu___ = mkFV fv [] [] in
+        let uu___1 = fv_as_emb_typ fv in
+        FStar_TypeChecker_NBETerm.mk_emb x y uu___ uu___1
 let mk_lazy :
-  'uuuuuu151 .
+  'uuuuu .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
-      'uuuuuu151 ->
+      'uuuuu ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.lazy_kind -> FStar_TypeChecker_NBETerm.t
   =
@@ -59,18 +57,18 @@ let mk_lazy :
       fun ty ->
         fun kind ->
           let li =
-            let uu____177 = FStar_Dyn.mkdyn obj in
+            let uu___ = FStar_Dyn.mkdyn obj in
             {
-              FStar_Syntax_Syntax.blob = uu____177;
+              FStar_Syntax_Syntax.blob = uu___;
               FStar_Syntax_Syntax.lkind = kind;
               FStar_Syntax_Syntax.ltyp = ty;
               FStar_Syntax_Syntax.rng = FStar_Range.dummyRange
             } in
           let thunk =
             FStar_Thunk.mk
-              (fun uu____183 ->
-                 let uu____184 = FStar_Syntax_Util.unfold_lazy li in
-                 FStar_TypeChecker_NBETerm.translate_cb cb uu____184) in
+              (fun uu___ ->
+                 let uu___1 = FStar_Syntax_Util.unfold_lazy li in
+                 FStar_TypeChecker_NBETerm.translate_cb cb uu___1) in
           FStar_TypeChecker_NBETerm.mk_t
             (FStar_TypeChecker_NBETerm.Lazy ((FStar_Util.Inl li), thunk))
 let (e_bv : FStar_Syntax_Syntax.bv FStar_TypeChecker_NBETerm.embedding) =
@@ -83,20 +81,20 @@ let (e_bv : FStar_Syntax_Syntax.bv FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_bv;
-           FStar_Syntax_Syntax.ltyp = uu____228;
-           FStar_Syntax_Syntax.rng = uu____229;_},
-         uu____230)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____249 = FStar_Dyn.undyn b in
+        let uu___3 = FStar_Dyn.undyn b in
         FStar_All.pipe_left
-          (fun uu____252 -> FStar_Pervasives_Native.Some uu____252) uu____249
-    | uu____253 ->
-        ((let uu____255 =
-            let uu____260 =
-              let uu____261 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded bv: %s" uu____261 in
-            (FStar_Errors.Warning_NotEmbedded, uu____260) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____255);
+          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded bv: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_bv unembed_bv FStar_Reflection_Data.fstar_refl_bv_fv
 let (e_binder :
@@ -110,19 +108,18 @@ let (e_binder :
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_binder;
-           FStar_Syntax_Syntax.ltyp = uu____291;
-           FStar_Syntax_Syntax.rng = uu____292;_},
-         uu____293)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____312 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____312
-    | uu____313 ->
-        ((let uu____315 =
-            let uu____320 =
-              let uu____321 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded binder: %s" uu____321 in
-            (FStar_Errors.Warning_NotEmbedded, uu____320) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____315);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded binder: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_binder unembed_binder
     FStar_Reflection_Data.fstar_refl_binder_fv
@@ -137,19 +134,18 @@ let (e_optionstate :
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_optionstate;
-           FStar_Syntax_Syntax.ltyp = uu____351;
-           FStar_Syntax_Syntax.rng = uu____352;_},
-         uu____353)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____372 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____372
-    | uu____373 ->
-        ((let uu____375 =
-            let uu____380 =
-              let uu____381 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded optionstate: %s" uu____381 in
-            (FStar_Errors.Warning_NotEmbedded, uu____380) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____375);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded optionstate: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_optionstate unembed_optionstate
     FStar_Reflection_Data.fstar_refl_optionstate_fv
@@ -163,11 +159,11 @@ let rec mapM_opt :
       match l with
       | [] -> FStar_Pervasives_Native.Some []
       | x::xs ->
-          let uu____427 = f x in
-          FStar_Util.bind_opt uu____427
+          let uu___ = f x in
+          FStar_Util.bind_opt uu___
             (fun x1 ->
-               let uu____435 = mapM_opt f xs in
-               FStar_Util.bind_opt uu____435
+               let uu___1 = mapM_opt f xs in
+               FStar_Util.bind_opt uu___1
                  (fun xs1 -> FStar_Pervasives_Native.Some (x1 :: xs1)))
 let (e_term_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
@@ -187,14 +183,14 @@ let (e_term_aq :
       match t.FStar_TypeChecker_NBETerm.nbe_t with
       | FStar_TypeChecker_NBETerm.Quote (tm, qi) ->
           FStar_Pervasives_Native.Some tm
-      | uu____504 -> FStar_Pervasives_Native.None in
-    let uu____505 = mkFV FStar_Reflection_Data.fstar_refl_term_fv [] [] in
-    let uu____510 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_term_fv in
+      | uu___ -> FStar_Pervasives_Native.None in
+    let uu___ = mkFV FStar_Reflection_Data.fstar_refl_term_fv [] [] in
+    let uu___1 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_term_fv in
     {
       FStar_TypeChecker_NBETerm.em = embed_term;
       FStar_TypeChecker_NBETerm.un = unembed_term;
-      FStar_TypeChecker_NBETerm.typ = uu____505;
-      FStar_TypeChecker_NBETerm.emb_typ = uu____510
+      FStar_TypeChecker_NBETerm.typ = uu___;
+      FStar_TypeChecker_NBETerm.emb_typ = uu___1
     }
 let (e_term : FStar_Syntax_Syntax.term FStar_TypeChecker_NBETerm.embedding) =
   e_term_aq []
@@ -209,22 +205,22 @@ let (e_aqualv :
         mkConstruct
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.Q_Meta t ->
-        let uu____541 =
-          let uu____548 =
-            let uu____553 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-            FStar_TypeChecker_NBETerm.as_arg uu____553 in
-          [uu____548] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.fv
-          [] uu____541
+          [] uu___
     | FStar_Reflection_Data.Q_Meta_attr t ->
-        let uu____563 =
-          let uu____570 =
-            let uu____575 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-            FStar_TypeChecker_NBETerm.as_arg uu____575 in
-          [uu____570] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_Q_Meta_attr.FStar_Reflection_Data.fv []
-          uu____563 in
+          uu___ in
   let unembed_aqualv cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
@@ -235,36 +231,34 @@ let (e_aqualv :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Q_Implicit
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (t1, uu____627)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (t1, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.lid
         ->
-        let uu____644 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-        FStar_Util.bind_opt uu____644
+        let uu___1 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+        FStar_Util.bind_opt uu___1
           (fun t2 ->
              FStar_Pervasives_Native.Some (FStar_Reflection_Data.Q_Meta t2))
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (t1, uu____651)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (t1, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Q_Meta_attr.FStar_Reflection_Data.lid
         ->
-        let uu____668 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-        FStar_Util.bind_opt uu____668
+        let uu___1 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+        FStar_Util.bind_opt uu___1
           (fun t2 ->
              FStar_Pervasives_Native.Some
                (FStar_Reflection_Data.Q_Meta_attr t2))
-    | uu____673 ->
-        ((let uu____675 =
-            let uu____680 =
-              let uu____681 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded aqualv: %s" uu____681 in
-            (FStar_Errors.Warning_NotEmbedded, uu____680) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____675);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded aqualv: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
-  let uu____682 =
-    mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] [] in
-  let uu____687 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv in
-  FStar_TypeChecker_NBETerm.mk_emb embed_aqualv unembed_aqualv uu____682
-    uu____687
+  let uu___ = mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] [] in
+  let uu___1 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv in
+  FStar_TypeChecker_NBETerm.mk_emb embed_aqualv unembed_aqualv uu___ uu___1
 let (e_binders :
   FStar_Syntax_Syntax.binders FStar_TypeChecker_NBETerm.embedding) =
   FStar_TypeChecker_NBETerm.e_list e_binder
@@ -278,19 +272,18 @@ let (e_fv : FStar_Syntax_Syntax.fv FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar;
-           FStar_Syntax_Syntax.ltyp = uu____719;
-           FStar_Syntax_Syntax.rng = uu____720;_},
-         uu____721)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____740 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____740
-    | uu____741 ->
-        ((let uu____743 =
-            let uu____748 =
-              let uu____749 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded fvar: %s" uu____749 in
-            (FStar_Errors.Warning_NotEmbedded, uu____748) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____743);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded fvar: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_fv unembed_fv FStar_Reflection_Data.fstar_refl_fv_fv
 let (e_comp : FStar_Syntax_Syntax.comp FStar_TypeChecker_NBETerm.embedding) =
@@ -303,19 +296,18 @@ let (e_comp : FStar_Syntax_Syntax.comp FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp;
-           FStar_Syntax_Syntax.ltyp = uu____779;
-           FStar_Syntax_Syntax.rng = uu____780;_},
-         uu____781)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____800 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____800
-    | uu____801 ->
-        ((let uu____803 =
-            let uu____808 =
-              let uu____809 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded comp: %s" uu____809 in
-            (FStar_Errors.Warning_NotEmbedded, uu____808) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____803);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded comp: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_comp unembed_comp FStar_Reflection_Data.fstar_refl_comp_fv
 let (e_env : FStar_TypeChecker_Env.env FStar_TypeChecker_NBETerm.embedding) =
@@ -328,19 +320,18 @@ let (e_env : FStar_TypeChecker_Env.env FStar_TypeChecker_NBETerm.embedding) =
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env;
-           FStar_Syntax_Syntax.ltyp = uu____839;
-           FStar_Syntax_Syntax.rng = uu____840;_},
-         uu____841)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____860 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____860
-    | uu____861 ->
-        ((let uu____863 =
-            let uu____868 =
-              let uu____869 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded env: %s" uu____869 in
-            (FStar_Errors.Warning_NotEmbedded, uu____868) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____863);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded env: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_env unembed_env FStar_Reflection_Data.fstar_refl_env_fv
 let (e_const :
@@ -357,52 +348,51 @@ let (e_const :
         mkConstruct
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.C_Int i ->
-        let uu____896 =
-          let uu____903 =
-            let uu____908 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_All.pipe_left FStar_TypeChecker_NBETerm.mk_t
                 (FStar_TypeChecker_NBETerm.Constant
                    (FStar_TypeChecker_NBETerm.Int i)) in
-            FStar_TypeChecker_NBETerm.as_arg uu____908 in
-          [uu____903] in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.fv
-          [] uu____896
+          [] uu___
     | FStar_Reflection_Data.C_String s ->
-        let uu____918 =
-          let uu____925 =
-            let uu____930 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string cb s in
-            FStar_TypeChecker_NBETerm.as_arg uu____930 in
-          [uu____925] in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.fv []
-          uu____918
+          uu___
     | FStar_Reflection_Data.C_Range r ->
-        let uu____940 =
-          let uu____947 =
-            let uu____952 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_range cb r in
-            FStar_TypeChecker_NBETerm.as_arg uu____952 in
-          [uu____947] in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
-          FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.fv []
-          uu____940
+          FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.fv [] uu___
     | FStar_Reflection_Data.C_Reify ->
         mkConstruct
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.fv [] []
     | FStar_Reflection_Data.C_Reflect ns ->
-        let uu____966 =
-          let uu____973 =
-            let uu____978 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string_list cb ns in
-            FStar_TypeChecker_NBETerm.as_arg uu____978 in
-          [uu____973] in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.fv []
-          uu____966 in
+          uu___ in
   let unembed_const cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
@@ -417,216 +407,210 @@ let (e_const :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_False
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (i, uu____1045)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (i, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.lid
         ->
-        let uu____1062 =
+        let uu___1 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
             cb i in
-        FStar_Util.bind_opt uu____1062
+        FStar_Util.bind_opt uu___1
           (fun i1 ->
              FStar_All.pipe_left
-               (fun uu____1069 -> FStar_Pervasives_Native.Some uu____1069)
+               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                (FStar_Reflection_Data.C_Int i1))
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (s, uu____1072)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (s, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.lid
         ->
-        let uu____1089 =
+        let uu___1 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb s in
-        FStar_Util.bind_opt uu____1089
+        FStar_Util.bind_opt uu___1
           (fun s1 ->
              FStar_All.pipe_left
-               (fun uu____1096 -> FStar_Pervasives_Native.Some uu____1096)
+               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                (FStar_Reflection_Data.C_String s1))
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (r, uu____1099)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (r, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.lid
         ->
-        let uu____1116 =
+        let uu___1 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_range
             cb r in
-        FStar_Util.bind_opt uu____1116
+        FStar_Util.bind_opt uu___1
           (fun r1 ->
              FStar_All.pipe_left
-               (fun uu____1123 -> FStar_Pervasives_Native.Some uu____1123)
+               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                (FStar_Reflection_Data.C_Range r1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_Reify
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (ns, uu____1139)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (ns, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.lid
         ->
-        let uu____1156 =
+        let uu___1 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string_list cb ns in
-        FStar_Util.bind_opt uu____1156
+        FStar_Util.bind_opt uu___1
           (fun ns1 ->
              FStar_All.pipe_left
-               (fun uu____1171 -> FStar_Pervasives_Native.Some uu____1171)
+               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                (FStar_Reflection_Data.C_Reflect ns1))
-    | uu____1172 ->
-        ((let uu____1174 =
-            let uu____1179 =
-              let uu____1180 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded vconst: %s" uu____1180 in
-            (FStar_Errors.Warning_NotEmbedded, uu____1179) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____1174);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded vconst: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_const unembed_const
     FStar_Reflection_Data.fstar_refl_vconst_fv
 let rec (e_pattern' :
   unit -> FStar_Reflection_Data.pattern FStar_TypeChecker_NBETerm.embedding)
   =
-  fun uu____1187 ->
+  fun uu___ ->
     let embed_pattern cb p =
       match p with
       | FStar_Reflection_Data.Pat_Constant c ->
-          let uu____1200 =
-            let uu____1207 =
-              let uu____1212 = FStar_TypeChecker_NBETerm.embed e_const cb c in
-              FStar_TypeChecker_NBETerm.as_arg uu____1212 in
-            [uu____1207] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.embed e_const cb c in
+              FStar_TypeChecker_NBETerm.as_arg uu___3 in
+            [uu___2] in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.fv
-            [] uu____1200
+            [] uu___1
       | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-          let uu____1235 =
-            let uu____1242 =
-              let uu____1247 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1247 in
-            let uu____1248 =
-              let uu____1255 =
-                let uu____1260 =
-                  let uu____1261 =
-                    let uu____1270 =
-                      let uu____1277 = e_pattern' () in
-                      FStar_TypeChecker_NBETerm.e_tuple2 uu____1277
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
+              FStar_TypeChecker_NBETerm.as_arg uu___3 in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_pattern' () in
+                      FStar_TypeChecker_NBETerm.e_tuple2 uu___8
                         FStar_TypeChecker_NBETerm.e_bool in
-                    FStar_TypeChecker_NBETerm.e_list uu____1270 in
-                  FStar_TypeChecker_NBETerm.embed uu____1261 cb ps in
-                FStar_TypeChecker_NBETerm.as_arg uu____1260 in
-              [uu____1255] in
-            uu____1242 :: uu____1248 in
+                    FStar_TypeChecker_NBETerm.e_list uu___7 in
+                  FStar_TypeChecker_NBETerm.embed uu___6 cb ps in
+                FStar_TypeChecker_NBETerm.as_arg uu___5 in
+              [uu___4] in
+            uu___2 :: uu___3 in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.fv []
-            uu____1235
+            uu___1
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1303 =
-            let uu____1310 =
-              let uu____1315 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1315 in
-            [uu____1310] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___3 in
+            [uu___2] in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.fv []
-            uu____1303
+            uu___1
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1325 =
-            let uu____1332 =
-              let uu____1337 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1337 in
-            [uu____1332] in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___3 in
+            [uu___2] in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.fv []
-            uu____1325
+            uu___1
       | FStar_Reflection_Data.Pat_Dot_Term (bv, t) ->
-          let uu____1348 =
-            let uu____1355 =
-              let uu____1360 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1360 in
-            let uu____1361 =
-              let uu____1368 =
-                let uu____1373 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-                FStar_TypeChecker_NBETerm.as_arg uu____1373 in
-              [uu____1368] in
-            uu____1355 :: uu____1361 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___3 in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+                FStar_TypeChecker_NBETerm.as_arg uu___5 in
+              [uu___4] in
+            uu___2 :: uu___3 in
           mkConstruct
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.fv
-            [] uu____1348 in
+            [] uu___1 in
     let unembed_pattern cb t =
       match t.FStar_TypeChecker_NBETerm.nbe_t with
-      | FStar_TypeChecker_NBETerm.Construct (fv, [], (c, uu____1403)::[])
-          when
+      | FStar_TypeChecker_NBETerm.Construct (fv, [], (c, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
           ->
-          let uu____1420 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
-          FStar_Util.bind_opt uu____1420
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
+          FStar_Util.bind_opt uu___2
             (fun c1 ->
                FStar_All.pipe_left
-                 (fun uu____1427 -> FStar_Pervasives_Native.Some uu____1427)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Pat_Constant c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, [], (ps, uu____1430)::(f, uu____1432)::[]) when
+          (fv, [], (ps, uu___1)::(f, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
           ->
-          let uu____1453 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
-          FStar_Util.bind_opt uu____1453
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
+          FStar_Util.bind_opt uu___3
             (fun f1 ->
-               let uu____1459 =
-                 let uu____1468 =
-                   let uu____1477 =
-                     let uu____1484 = e_pattern' () in
-                     FStar_TypeChecker_NBETerm.e_tuple2 uu____1484
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 = e_pattern' () in
+                     FStar_TypeChecker_NBETerm.e_tuple2 uu___7
                        FStar_TypeChecker_NBETerm.e_bool in
-                   FStar_TypeChecker_NBETerm.e_list uu____1477 in
-                 FStar_TypeChecker_NBETerm.unembed uu____1468 cb ps in
-               FStar_Util.bind_opt uu____1459
+                   FStar_TypeChecker_NBETerm.e_list uu___6 in
+                 FStar_TypeChecker_NBETerm.unembed uu___5 cb ps in
+               FStar_Util.bind_opt uu___4
                  (fun ps1 ->
                     FStar_All.pipe_left
-                      (fun uu____1513 ->
-                         FStar_Pervasives_Native.Some uu____1513)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-      | FStar_TypeChecker_NBETerm.Construct (fv, [], (bv, uu____1522)::[])
-          when
+      | FStar_TypeChecker_NBETerm.Construct (fv, [], (bv, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
           ->
-          let uu____1539 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
-          FStar_Util.bind_opt uu____1539
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
+          FStar_Util.bind_opt uu___2
             (fun bv1 ->
                FStar_All.pipe_left
-                 (fun uu____1546 -> FStar_Pervasives_Native.Some uu____1546)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Pat_Var bv1))
-      | FStar_TypeChecker_NBETerm.Construct (fv, [], (bv, uu____1549)::[])
-          when
+      | FStar_TypeChecker_NBETerm.Construct (fv, [], (bv, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
           ->
-          let uu____1566 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
-          FStar_Util.bind_opt uu____1566
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
+          FStar_Util.bind_opt uu___2
             (fun bv1 ->
                FStar_All.pipe_left
-                 (fun uu____1573 -> FStar_Pervasives_Native.Some uu____1573)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Pat_Wild bv1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, [], (t1, uu____1576)::(bv, uu____1578)::[]) when
+          (fv, [], (t1, uu___1)::(bv, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
           ->
-          let uu____1599 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
-          FStar_Util.bind_opt uu____1599
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
+          FStar_Util.bind_opt uu___3
             (fun bv1 ->
-               let uu____1605 =
-                 FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-               FStar_Util.bind_opt uu____1605
+               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+               FStar_Util.bind_opt uu___4
                  (fun t2 ->
                     FStar_All.pipe_left
-                      (fun uu____1612 ->
-                         FStar_Pervasives_Native.Some uu____1612)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Dot_Term (bv1, t2))))
-      | uu____1613 ->
-          ((let uu____1615 =
-              let uu____1620 =
-                let uu____1621 = FStar_TypeChecker_NBETerm.t_to_string t in
-                FStar_Util.format1 "Not an embedded pattern: %s" uu____1621 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1620) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1615);
+      | uu___1 ->
+          ((let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.t_to_string t in
+                FStar_Util.format1 "Not an embedded pattern: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___3);
            FStar_Pervasives_Native.None) in
     mk_emb' embed_pattern unembed_pattern
       FStar_Reflection_Data.fstar_refl_pattern_fv
@@ -645,8 +629,8 @@ let (e_branch_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq ->
-    let uu____1655 = e_term_aq aq in
-    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu____1655
+    let uu___ = e_term_aq aq in
+    FStar_TypeChecker_NBETerm.e_tuple2 e_pattern uu___
 let (e_argv_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
     FStar_Syntax_Syntax.syntax) Prims.list ->
@@ -654,12 +638,11 @@ let (e_argv_aq :
       FStar_TypeChecker_NBETerm.embedding)
   =
   fun aq ->
-    let uu____1685 = e_term_aq aq in
-    FStar_TypeChecker_NBETerm.e_tuple2 uu____1685 e_aqualv
+    let uu___ = e_term_aq aq in
+    FStar_TypeChecker_NBETerm.e_tuple2 uu___ e_aqualv
 let unlazy_as_t :
-  'uuuuuu1694 .
-    FStar_Syntax_Syntax.lazy_kind ->
-      FStar_TypeChecker_NBETerm.t -> 'uuuuuu1694
+  'uuuuu .
+    FStar_Syntax_Syntax.lazy_kind -> FStar_TypeChecker_NBETerm.t -> 'uuuuu
   =
   fun k ->
     fun t ->
@@ -667,11 +650,11 @@ let unlazy_as_t :
       | FStar_TypeChecker_NBETerm.Lazy
           (FStar_Util.Inl
            { FStar_Syntax_Syntax.blob = v; FStar_Syntax_Syntax.lkind = k';
-             FStar_Syntax_Syntax.ltyp = uu____1707;
-             FStar_Syntax_Syntax.rng = uu____1708;_},
-           uu____1709)
+             FStar_Syntax_Syntax.ltyp = uu___;
+             FStar_Syntax_Syntax.rng = uu___1;_},
+           uu___2)
           when FStar_Syntax_Util.eq_lazy_kind k k' -> FStar_Dyn.undyn v
-      | uu____1728 -> failwith "Not a Lazy of the expected kind (NBE)"
+      | uu___ -> failwith "Not a Lazy of the expected kind (NBE)"
 let (e_term_view_aq :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
     FStar_Syntax_Syntax.syntax) Prims.list ->
@@ -681,501 +664,476 @@ let (e_term_view_aq :
     let embed_term_view cb tv =
       match tv with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____1764 =
-            let uu____1771 =
-              let uu____1776 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1776 in
-            [uu____1771] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            [uu___1] in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.fv []
-            uu____1764
+            uu___
       | FStar_Reflection_Data.Tv_BVar bv ->
-          let uu____1786 =
-            let uu____1793 =
-              let uu____1798 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1798 in
-            [uu____1793] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            [uu___1] in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.fv []
-            uu____1786
+            uu___
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____1808 =
-            let uu____1815 =
-              let uu____1820 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____1820 in
-            [uu____1815] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            [uu___1] in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.fv []
-            uu____1808
+            uu___
       | FStar_Reflection_Data.Tv_App (hd, a) ->
-          let uu____1831 =
-            let uu____1838 =
-              let uu____1843 =
-                let uu____1844 = e_term_aq aq in
-                FStar_TypeChecker_NBETerm.embed uu____1844 cb hd in
-              FStar_TypeChecker_NBETerm.as_arg uu____1843 in
-            let uu____1847 =
-              let uu____1854 =
-                let uu____1859 =
-                  let uu____1860 = e_argv_aq aq in
-                  FStar_TypeChecker_NBETerm.embed uu____1860 cb a in
-                FStar_TypeChecker_NBETerm.as_arg uu____1859 in
-              [uu____1854] in
-            uu____1838 :: uu____1847 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = e_term_aq aq in
+                FStar_TypeChecker_NBETerm.embed uu___3 cb hd in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = e_argv_aq aq in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb a in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.fv []
-            uu____1831
+            uu___
       | FStar_Reflection_Data.Tv_Abs (b, t) ->
-          let uu____1885 =
-            let uu____1892 =
-              let uu____1897 = FStar_TypeChecker_NBETerm.embed e_binder cb b in
-              FStar_TypeChecker_NBETerm.as_arg uu____1897 in
-            let uu____1898 =
-              let uu____1905 =
-                let uu____1910 =
-                  let uu____1911 = e_term_aq aq in
-                  FStar_TypeChecker_NBETerm.embed uu____1911 cb t in
-                FStar_TypeChecker_NBETerm.as_arg uu____1910 in
-              [uu____1905] in
-            uu____1892 :: uu____1898 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_binder cb b in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = e_term_aq aq in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb t in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.fv []
-            uu____1885
+            uu___
       | FStar_Reflection_Data.Tv_Arrow (b, c) ->
-          let uu____1928 =
-            let uu____1935 =
-              let uu____1940 = FStar_TypeChecker_NBETerm.embed e_binder cb b in
-              FStar_TypeChecker_NBETerm.as_arg uu____1940 in
-            let uu____1941 =
-              let uu____1948 =
-                let uu____1953 = FStar_TypeChecker_NBETerm.embed e_comp cb c in
-                FStar_TypeChecker_NBETerm.as_arg uu____1953 in
-              [uu____1948] in
-            uu____1935 :: uu____1941 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_binder cb b in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.embed e_comp cb c in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.fv []
-            uu____1928
+            uu___
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____1967 =
-            let uu____1974 =
-              let uu____1979 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_unit cb () in
-              FStar_TypeChecker_NBETerm.as_arg uu____1979 in
-            [uu____1974] in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            [uu___1] in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.fv []
-            uu____1967
+            uu___
       | FStar_Reflection_Data.Tv_Refine (bv, t) ->
-          let uu____1990 =
-            let uu____1997 =
-              let uu____2002 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
-              FStar_TypeChecker_NBETerm.as_arg uu____2002 in
-            let uu____2003 =
-              let uu____2010 =
-                let uu____2015 =
-                  let uu____2016 = e_term_aq aq in
-                  FStar_TypeChecker_NBETerm.embed uu____2016 cb t in
-                FStar_TypeChecker_NBETerm.as_arg uu____2015 in
-              [uu____2010] in
-            uu____1997 :: uu____2003 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = e_term_aq aq in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb t in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.fv []
-            uu____1990
+            uu___
       | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2032 =
-            let uu____2039 =
-              let uu____2044 = FStar_TypeChecker_NBETerm.embed e_const cb c in
-              FStar_TypeChecker_NBETerm.as_arg uu____2044 in
-            [uu____2039] in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_const cb c in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            [uu___1] in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.fv []
-            uu____2032
+            uu___
       | FStar_Reflection_Data.Tv_Uvar (u, d) ->
-          let uu____2055 =
-            let uu____2062 =
-              let uu____2067 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_int cb u in
-              FStar_TypeChecker_NBETerm.as_arg uu____2067 in
-            let uu____2068 =
-              let uu____2075 =
-                let uu____2080 =
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
                   mk_lazy cb (u, d) FStar_Syntax_Util.t_ctx_uvar_and_sust
                     FStar_Syntax_Syntax.Lazy_uvar in
-                FStar_TypeChecker_NBETerm.as_arg uu____2080 in
-              [uu____2075] in
-            uu____2062 :: uu____2068 in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.fv []
-            uu____2055
+            uu___
       | FStar_Reflection_Data.Tv_Let (r, attrs, b, t1, t2) ->
-          let uu____2106 =
-            let uu____2113 =
-              let uu____2118 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_bool cb r in
-              FStar_TypeChecker_NBETerm.as_arg uu____2118 in
-            let uu____2119 =
-              let uu____2126 =
-                let uu____2131 =
-                  let uu____2132 = FStar_TypeChecker_NBETerm.e_list e_term in
-                  FStar_TypeChecker_NBETerm.embed uu____2132 cb attrs in
-                FStar_TypeChecker_NBETerm.as_arg uu____2131 in
-              let uu____2139 =
-                let uu____2146 =
-                  let uu____2151 = FStar_TypeChecker_NBETerm.embed e_bv cb b in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2151 in
-                let uu____2152 =
-                  let uu____2159 =
-                    let uu____2164 =
-                      let uu____2165 = e_term_aq aq in
-                      FStar_TypeChecker_NBETerm.embed uu____2165 cb t1 in
-                    FStar_TypeChecker_NBETerm.as_arg uu____2164 in
-                  let uu____2168 =
-                    let uu____2175 =
-                      let uu____2180 =
-                        let uu____2181 = e_term_aq aq in
-                        FStar_TypeChecker_NBETerm.embed uu____2181 cb t2 in
-                      FStar_TypeChecker_NBETerm.as_arg uu____2180 in
-                    [uu____2175] in
-                  uu____2159 :: uu____2168 in
-                uu____2146 :: uu____2152 in
-              uu____2126 :: uu____2139 in
-            uu____2113 :: uu____2119 in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_TypeChecker_NBETerm.e_list e_term in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb attrs in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 = FStar_TypeChecker_NBETerm.embed e_bv cb b in
+                  FStar_TypeChecker_NBETerm.as_arg uu___6 in
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 = e_term_aq aq in
+                      FStar_TypeChecker_NBETerm.embed uu___9 cb t1 in
+                    FStar_TypeChecker_NBETerm.as_arg uu___8 in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        let uu___11 = e_term_aq aq in
+                        FStar_TypeChecker_NBETerm.embed uu___11 cb t2 in
+                      FStar_TypeChecker_NBETerm.as_arg uu___10 in
+                    [uu___9] in
+                  uu___7 :: uu___8 in
+                uu___5 :: uu___6 in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.fv []
-            uu____2106
+            uu___
       | FStar_Reflection_Data.Tv_Match (t, brs) ->
-          let uu____2214 =
-            let uu____2221 =
-              let uu____2226 =
-                let uu____2227 = e_term_aq aq in
-                FStar_TypeChecker_NBETerm.embed uu____2227 cb t in
-              FStar_TypeChecker_NBETerm.as_arg uu____2226 in
-            let uu____2230 =
-              let uu____2237 =
-                let uu____2242 =
-                  let uu____2243 =
-                    let uu____2252 = e_branch_aq aq in
-                    FStar_TypeChecker_NBETerm.e_list uu____2252 in
-                  FStar_TypeChecker_NBETerm.embed uu____2243 cb brs in
-                FStar_TypeChecker_NBETerm.as_arg uu____2242 in
-              [uu____2237] in
-            uu____2221 :: uu____2230 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = e_term_aq aq in
+                FStar_TypeChecker_NBETerm.embed uu___3 cb t in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = e_branch_aq aq in
+                    FStar_TypeChecker_NBETerm.e_list uu___6 in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb brs in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              [uu___3] in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.fv []
-            uu____2214
+            uu___
       | FStar_Reflection_Data.Tv_AscribedT (e, t, tacopt) ->
-          let uu____2288 =
-            let uu____2295 =
-              let uu____2300 =
-                let uu____2301 = e_term_aq aq in
-                FStar_TypeChecker_NBETerm.embed uu____2301 cb e in
-              FStar_TypeChecker_NBETerm.as_arg uu____2300 in
-            let uu____2304 =
-              let uu____2311 =
-                let uu____2316 =
-                  let uu____2317 = e_term_aq aq in
-                  FStar_TypeChecker_NBETerm.embed uu____2317 cb t in
-                FStar_TypeChecker_NBETerm.as_arg uu____2316 in
-              let uu____2320 =
-                let uu____2327 =
-                  let uu____2332 =
-                    let uu____2333 =
-                      let uu____2338 = e_term_aq aq in
-                      FStar_TypeChecker_NBETerm.e_option uu____2338 in
-                    FStar_TypeChecker_NBETerm.embed uu____2333 cb tacopt in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2332 in
-                [uu____2327] in
-              uu____2311 :: uu____2320 in
-            uu____2295 :: uu____2304 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = e_term_aq aq in
+                FStar_TypeChecker_NBETerm.embed uu___3 cb e in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = e_term_aq aq in
+                  FStar_TypeChecker_NBETerm.embed uu___5 cb t in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_term_aq aq in
+                      FStar_TypeChecker_NBETerm.e_option uu___8 in
+                    FStar_TypeChecker_NBETerm.embed uu___7 cb tacopt in
+                  FStar_TypeChecker_NBETerm.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
-            uu____2288
+            uu___
       | FStar_Reflection_Data.Tv_AscribedC (e, c, tacopt) ->
-          let uu____2366 =
-            let uu____2373 =
-              let uu____2378 =
-                let uu____2379 = e_term_aq aq in
-                FStar_TypeChecker_NBETerm.embed uu____2379 cb e in
-              FStar_TypeChecker_NBETerm.as_arg uu____2378 in
-            let uu____2382 =
-              let uu____2389 =
-                let uu____2394 = FStar_TypeChecker_NBETerm.embed e_comp cb c in
-                FStar_TypeChecker_NBETerm.as_arg uu____2394 in
-              let uu____2395 =
-                let uu____2402 =
-                  let uu____2407 =
-                    let uu____2408 =
-                      let uu____2413 = e_term_aq aq in
-                      FStar_TypeChecker_NBETerm.e_option uu____2413 in
-                    FStar_TypeChecker_NBETerm.embed uu____2408 cb tacopt in
-                  FStar_TypeChecker_NBETerm.as_arg uu____2407 in
-                [uu____2402] in
-              uu____2389 :: uu____2395 in
-            uu____2373 :: uu____2382 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = e_term_aq aq in
+                FStar_TypeChecker_NBETerm.embed uu___3 cb e in
+              FStar_TypeChecker_NBETerm.as_arg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.embed e_comp cb c in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = e_term_aq aq in
+                      FStar_TypeChecker_NBETerm.e_option uu___8 in
+                    FStar_TypeChecker_NBETerm.embed uu___7 cb tacopt in
+                  FStar_TypeChecker_NBETerm.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           mkConstruct
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.fv []
-            uu____2366
+            uu___
       | FStar_Reflection_Data.Tv_Unknown ->
           mkConstruct
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.fv []
             [] in
     let unembed_term_view cb t =
       match t.FStar_TypeChecker_NBETerm.nbe_t with
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2454, (b, uu____2456)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (b, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
           ->
-          let uu____2475 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
-          FStar_Util.bind_opt uu____2475
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
+          FStar_Util.bind_opt uu___2
             (fun b1 ->
                FStar_All.pipe_left
-                 (fun uu____2482 -> FStar_Pervasives_Native.Some uu____2482)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Tv_Var b1))
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2484, (b, uu____2486)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (b, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
           ->
-          let uu____2505 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
-          FStar_Util.bind_opt uu____2505
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
+          FStar_Util.bind_opt uu___2
             (fun b1 ->
                FStar_All.pipe_left
-                 (fun uu____2512 -> FStar_Pervasives_Native.Some uu____2512)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Tv_BVar b1))
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2514, (f, uu____2516)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (f, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
           ->
-          let uu____2535 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
-          FStar_Util.bind_opt uu____2535
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
+          FStar_Util.bind_opt uu___2
             (fun f1 ->
                FStar_All.pipe_left
-                 (fun uu____2542 -> FStar_Pervasives_Native.Some uu____2542)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Tv_FVar f1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2544, (r, uu____2546)::(l, uu____2548)::[]) when
+          (fv, uu___, (r, uu___1)::(l, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
           ->
-          let uu____2571 = FStar_TypeChecker_NBETerm.unembed e_term cb l in
-          FStar_Util.bind_opt uu____2571
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_term cb l in
+          FStar_Util.bind_opt uu___3
             (fun l1 ->
-               let uu____2577 = FStar_TypeChecker_NBETerm.unembed e_argv cb r in
-               FStar_Util.bind_opt uu____2577
+               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_argv cb r in
+               FStar_Util.bind_opt uu___4
                  (fun r1 ->
                     FStar_All.pipe_left
-                      (fun uu____2584 ->
-                         FStar_Pervasives_Native.Some uu____2584)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_App (l1, r1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2586, (t1, uu____2588)::(b, uu____2590)::[]) when
+          (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
           ->
-          let uu____2613 = FStar_TypeChecker_NBETerm.unembed e_binder cb b in
-          FStar_Util.bind_opt uu____2613
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_binder cb b in
+          FStar_Util.bind_opt uu___3
             (fun b1 ->
-               let uu____2619 =
-                 FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-               FStar_Util.bind_opt uu____2619
+               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+               FStar_Util.bind_opt uu___4
                  (fun t2 ->
                     FStar_All.pipe_left
-                      (fun uu____2626 ->
-                         FStar_Pervasives_Native.Some uu____2626)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_Abs (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2628, (t1, uu____2630)::(b, uu____2632)::[]) when
+          (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
           ->
-          let uu____2655 = FStar_TypeChecker_NBETerm.unembed e_binder cb b in
-          FStar_Util.bind_opt uu____2655
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_binder cb b in
+          FStar_Util.bind_opt uu___3
             (fun b1 ->
-               let uu____2661 =
-                 FStar_TypeChecker_NBETerm.unembed e_comp cb t1 in
-               FStar_Util.bind_opt uu____2661
+               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_comp cb t1 in
+               FStar_Util.bind_opt uu___4
                  (fun c ->
                     FStar_All.pipe_left
-                      (fun uu____2668 ->
-                         FStar_Pervasives_Native.Some uu____2668)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_Arrow (b1, c))))
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2670, (u, uu____2672)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (u, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
           ->
-          let uu____2691 =
+          let uu___2 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_unit cb u in
-          FStar_Util.bind_opt uu____2691
+          FStar_Util.bind_opt uu___2
             (fun u1 ->
                FStar_All.pipe_left
-                 (fun uu____2698 -> FStar_Pervasives_Native.Some uu____2698)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Tv_Type ()))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2700, (t1, uu____2702)::(b, uu____2704)::[]) when
+          (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
           ->
-          let uu____2727 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
-          FStar_Util.bind_opt uu____2727
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
+          FStar_Util.bind_opt uu___3
             (fun b1 ->
-               let uu____2733 =
-                 FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-               FStar_Util.bind_opt uu____2733
+               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+               FStar_Util.bind_opt uu___4
                  (fun t2 ->
                     FStar_All.pipe_left
-                      (fun uu____2740 ->
-                         FStar_Pervasives_Native.Some uu____2740)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_Refine (b1, t2))))
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2742, (c, uu____2744)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (c, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
           ->
-          let uu____2763 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
-          FStar_Util.bind_opt uu____2763
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
+          FStar_Util.bind_opt uu___2
             (fun c1 ->
                FStar_All.pipe_left
-                 (fun uu____2770 -> FStar_Pervasives_Native.Some uu____2770)
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Tv_Const c1))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2772, (l, uu____2774)::(u, uu____2776)::[]) when
+          (fv, uu___, (l, uu___1)::(u, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
           ->
-          let uu____2799 =
+          let uu___3 =
             FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
               cb u in
-          FStar_Util.bind_opt uu____2799
+          FStar_Util.bind_opt uu___3
             (fun u1 ->
                let ctx_u_s = unlazy_as_t FStar_Syntax_Syntax.Lazy_uvar l in
                FStar_All.pipe_left
-                 (fun uu____2808 -> FStar_Pervasives_Native.Some uu____2808)
+                 (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                  (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2810,
-           (t2, uu____2812)::(t1, uu____2814)::(b, uu____2816)::(attrs,
-                                                                 uu____2818)::
-           (r, uu____2820)::[])
+          (fv, uu___,
+           (t2, uu___1)::(t1, uu___2)::(b, uu___3)::(attrs, uu___4)::
+           (r, uu___5)::[])
           when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
           ->
-          let uu____2855 =
+          let uu___6 =
             FStar_TypeChecker_NBETerm.unembed
               FStar_TypeChecker_NBETerm.e_bool cb r in
-          FStar_Util.bind_opt uu____2855
+          FStar_Util.bind_opt uu___6
             (fun r1 ->
-               let uu____2861 =
-                 let uu____2866 = FStar_TypeChecker_NBETerm.e_list e_term in
-                 FStar_TypeChecker_NBETerm.unembed uu____2866 cb attrs in
-               FStar_Util.bind_opt uu____2861
+               let uu___7 =
+                 let uu___8 = FStar_TypeChecker_NBETerm.e_list e_term in
+                 FStar_TypeChecker_NBETerm.unembed uu___8 cb attrs in
+               FStar_Util.bind_opt uu___7
                  (fun attrs1 ->
-                    let uu____2880 =
-                      FStar_TypeChecker_NBETerm.unembed e_bv cb b in
-                    FStar_Util.bind_opt uu____2880
+                    let uu___8 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
+                    FStar_Util.bind_opt uu___8
                       (fun b1 ->
-                         let uu____2886 =
+                         let uu___9 =
                            FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-                         FStar_Util.bind_opt uu____2886
+                         FStar_Util.bind_opt uu___9
                            (fun t11 ->
-                              let uu____2892 =
+                              let uu___10 =
                                 FStar_TypeChecker_NBETerm.unembed e_term cb
                                   t2 in
-                              FStar_Util.bind_opt uu____2892
+                              FStar_Util.bind_opt uu___10
                                 (fun t21 ->
                                    FStar_All.pipe_left
-                                     (fun uu____2899 ->
-                                        FStar_Pervasives_Native.Some
-                                          uu____2899)
+                                     (fun uu___11 ->
+                                        FStar_Pervasives_Native.Some uu___11)
                                      (FStar_Reflection_Data.Tv_Let
                                         (r1, attrs1, b1, t11, t21)))))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2903, (brs, uu____2905)::(t1, uu____2907)::[]) when
+          (fv, uu___, (brs, uu___1)::(t1, uu___2)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
           ->
-          let uu____2930 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-          FStar_Util.bind_opt uu____2930
+          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+          FStar_Util.bind_opt uu___3
             (fun t2 ->
-               let uu____2936 =
-                 let uu____2941 = FStar_TypeChecker_NBETerm.e_list e_branch in
-                 FStar_TypeChecker_NBETerm.unembed uu____2941 cb brs in
-               FStar_Util.bind_opt uu____2936
+               let uu___4 =
+                 let uu___5 = FStar_TypeChecker_NBETerm.e_list e_branch in
+                 FStar_TypeChecker_NBETerm.unembed uu___5 cb brs in
+               FStar_Util.bind_opt uu___4
                  (fun brs1 ->
                     FStar_All.pipe_left
-                      (fun uu____2956 ->
-                         FStar_Pervasives_Native.Some uu____2956)
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Tv_Match (t2, brs1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____2960,
-           (tacopt, uu____2962)::(t1, uu____2964)::(e, uu____2966)::[])
-          when
+          (fv, uu___, (tacopt, uu___1)::(t1, uu___2)::(e, uu___3)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
           ->
-          let uu____2993 = FStar_TypeChecker_NBETerm.unembed e_term cb e in
-          FStar_Util.bind_opt uu____2993
+          let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb e in
+          FStar_Util.bind_opt uu___4
             (fun e1 ->
-               let uu____2999 =
-                 FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-               FStar_Util.bind_opt uu____2999
+               let uu___5 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+               FStar_Util.bind_opt uu___5
                  (fun t2 ->
-                    let uu____3005 =
-                      let uu____3010 =
-                        FStar_TypeChecker_NBETerm.e_option e_term in
-                      FStar_TypeChecker_NBETerm.unembed uu____3010 cb tacopt in
-                    FStar_Util.bind_opt uu____3005
+                    let uu___6 =
+                      let uu___7 = FStar_TypeChecker_NBETerm.e_option e_term in
+                      FStar_TypeChecker_NBETerm.unembed uu___7 cb tacopt in
+                    FStar_Util.bind_opt uu___6
                       (fun tacopt1 ->
                          FStar_All.pipe_left
-                           (fun uu____3025 ->
-                              FStar_Pervasives_Native.Some uu____3025)
+                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                            (FStar_Reflection_Data.Tv_AscribedT
                               (e1, t2, tacopt1)))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____3029,
-           (tacopt, uu____3031)::(c, uu____3033)::(e, uu____3035)::[])
-          when
+          (fv, uu___, (tacopt, uu___1)::(c, uu___2)::(e, uu___3)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
           ->
-          let uu____3062 = FStar_TypeChecker_NBETerm.unembed e_term cb e in
-          FStar_Util.bind_opt uu____3062
+          let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb e in
+          FStar_Util.bind_opt uu___4
             (fun e1 ->
-               let uu____3068 = FStar_TypeChecker_NBETerm.unembed e_comp cb c in
-               FStar_Util.bind_opt uu____3068
+               let uu___5 = FStar_TypeChecker_NBETerm.unembed e_comp cb c in
+               FStar_Util.bind_opt uu___5
                  (fun c1 ->
-                    let uu____3074 =
-                      let uu____3079 =
-                        FStar_TypeChecker_NBETerm.e_option e_term in
-                      FStar_TypeChecker_NBETerm.unembed uu____3079 cb tacopt in
-                    FStar_Util.bind_opt uu____3074
+                    let uu___6 =
+                      let uu___7 = FStar_TypeChecker_NBETerm.e_option e_term in
+                      FStar_TypeChecker_NBETerm.unembed uu___7 cb tacopt in
+                    FStar_Util.bind_opt uu___6
                       (fun tacopt1 ->
                          FStar_All.pipe_left
-                           (fun uu____3094 ->
-                              FStar_Pervasives_Native.Some uu____3094)
+                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                            (FStar_Reflection_Data.Tv_AscribedC
                               (e1, c1, tacopt1)))))
-      | FStar_TypeChecker_NBETerm.Construct (fv, uu____3098, []) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
           ->
           FStar_All.pipe_left
-            (fun uu____3115 -> FStar_Pervasives_Native.Some uu____3115)
+            (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
             FStar_Reflection_Data.Tv_Unknown
-      | uu____3116 ->
-          ((let uu____3118 =
-              let uu____3123 =
-                let uu____3124 = FStar_TypeChecker_NBETerm.t_to_string t in
-                FStar_Util.format1 "Not an embedded term_view: %s" uu____3124 in
-              (FStar_Errors.Warning_NotEmbedded, uu____3123) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____3118);
+      | uu___ ->
+          ((let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+                FStar_Util.format1 "Not an embedded term_view: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
            FStar_Pervasives_Native.None) in
     mk_emb' embed_term_view unembed_term_view
       FStar_Reflection_Data.fstar_refl_term_view_fv
@@ -1185,67 +1143,63 @@ let (e_term_view :
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_TypeChecker_NBETerm.embedding) =
   let embed_bv_view cb bvv =
-    let uu____3146 =
-      let uu____3153 =
-        let uu____3158 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_string
             cb bvv.FStar_Reflection_Data.bv_ppname in
-        FStar_TypeChecker_NBETerm.as_arg uu____3158 in
-      let uu____3159 =
-        let uu____3166 =
-          let uu____3171 =
+        FStar_TypeChecker_NBETerm.as_arg uu___2 in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
             FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_int
               cb bvv.FStar_Reflection_Data.bv_index in
-          FStar_TypeChecker_NBETerm.as_arg uu____3171 in
-        let uu____3172 =
-          let uu____3179 =
-            let uu____3184 =
+          FStar_TypeChecker_NBETerm.as_arg uu___4 in
+        let uu___4 =
+          let uu___5 =
+            let uu___6 =
               FStar_TypeChecker_NBETerm.embed e_term cb
                 bvv.FStar_Reflection_Data.bv_sort in
-            FStar_TypeChecker_NBETerm.as_arg uu____3184 in
-          [uu____3179] in
-        uu____3166 :: uu____3172 in
-      uu____3153 :: uu____3159 in
+            FStar_TypeChecker_NBETerm.as_arg uu___6 in
+          [uu___5] in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     mkConstruct FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.fv []
-      uu____3146 in
+      uu___ in
   let unembed_bv_view cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____3217,
-         (s, uu____3219)::(idx, uu____3221)::(nm, uu____3223)::[])
-        when
+        (fv, uu___, (s, uu___1)::(idx, uu___2)::(nm, uu___3)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
         ->
-        let uu____3250 =
+        let uu___4 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb nm in
-        FStar_Util.bind_opt uu____3250
+        FStar_Util.bind_opt uu___4
           (fun nm1 ->
-             let uu____3256 =
+             let uu___5 =
                FStar_TypeChecker_NBETerm.unembed
                  FStar_TypeChecker_NBETerm.e_int cb idx in
-             FStar_Util.bind_opt uu____3256
+             FStar_Util.bind_opt uu___5
                (fun idx1 ->
-                  let uu____3262 =
-                    FStar_TypeChecker_NBETerm.unembed e_term cb s in
-                  FStar_Util.bind_opt uu____3262
+                  let uu___6 = FStar_TypeChecker_NBETerm.unembed e_term cb s in
+                  FStar_Util.bind_opt uu___6
                     (fun s1 ->
                        FStar_All.pipe_left
-                         (fun uu____3269 ->
-                            FStar_Pervasives_Native.Some uu____3269)
+                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                          {
                            FStar_Reflection_Data.bv_ppname = nm1;
                            FStar_Reflection_Data.bv_index = idx1;
                            FStar_Reflection_Data.bv_sort = s1
                          })))
-    | uu____3270 ->
-        ((let uu____3272 =
-            let uu____3277 =
-              let uu____3278 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded bv_view: %s" uu____3278 in
-            (FStar_Errors.Warning_NotEmbedded, uu____3277) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3272);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded bv_view: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_bv_view unembed_bv_view
     FStar_Reflection_Data.fstar_refl_bv_view_fv
@@ -1254,188 +1208,176 @@ let (e_comp_view :
   let embed_comp_view cb cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t, md) ->
-        let uu____3298 =
-          let uu____3305 =
-            let uu____3310 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-            FStar_TypeChecker_NBETerm.as_arg uu____3310 in
-          let uu____3311 =
-            let uu____3318 =
-              let uu____3323 =
-                let uu____3324 = FStar_TypeChecker_NBETerm.e_option e_term in
-                FStar_TypeChecker_NBETerm.embed uu____3324 cb md in
-              FStar_TypeChecker_NBETerm.as_arg uu____3323 in
-            [uu____3318] in
-          uu____3305 :: uu____3311 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.e_option e_term in
+                FStar_TypeChecker_NBETerm.embed uu___5 cb md in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct
-          FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.fv []
-          uu____3298
+          FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.fv [] uu___
     | FStar_Reflection_Data.C_GTotal (t, md) ->
-        let uu____3349 =
-          let uu____3356 =
-            let uu____3361 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-            FStar_TypeChecker_NBETerm.as_arg uu____3361 in
-          let uu____3362 =
-            let uu____3369 =
-              let uu____3374 =
-                let uu____3375 = FStar_TypeChecker_NBETerm.e_option e_term in
-                FStar_TypeChecker_NBETerm.embed uu____3375 cb md in
-              FStar_TypeChecker_NBETerm.as_arg uu____3374 in
-            [uu____3369] in
-          uu____3356 :: uu____3362 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.e_option e_term in
+                FStar_TypeChecker_NBETerm.embed uu___5 cb md in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct
           FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.fv []
-          uu____3349
+          uu___
     | FStar_Reflection_Data.C_Lemma (pre, post, pats) ->
-        let uu____3397 =
-          let uu____3404 =
-            let uu____3409 = FStar_TypeChecker_NBETerm.embed e_term cb pre in
-            FStar_TypeChecker_NBETerm.as_arg uu____3409 in
-          let uu____3410 =
-            let uu____3417 =
-              let uu____3422 = FStar_TypeChecker_NBETerm.embed e_term cb post in
-              FStar_TypeChecker_NBETerm.as_arg uu____3422 in
-            let uu____3423 =
-              let uu____3430 =
-                let uu____3435 =
-                  FStar_TypeChecker_NBETerm.embed e_term cb pats in
-                FStar_TypeChecker_NBETerm.as_arg uu____3435 in
-              [uu____3430] in
-            uu____3417 :: uu____3423 in
-          uu____3404 :: uu____3410 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_term cb pre in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.embed e_term cb post in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.embed e_term cb pats in
+                FStar_TypeChecker_NBETerm.as_arg uu___6 in
+              [uu___5] in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         mkConstruct
-          FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.fv []
-          uu____3397
+          FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.fv [] uu___
     | FStar_Reflection_Data.C_Eff (us, eff, res, args) ->
-        let uu____3464 =
-          let uu____3471 =
-            let uu____3476 =
-              let uu____3477 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_TypeChecker_NBETerm.e_list
                   FStar_TypeChecker_NBETerm.e_unit in
-              FStar_TypeChecker_NBETerm.embed uu____3477 cb us in
-            FStar_TypeChecker_NBETerm.as_arg uu____3476 in
-          let uu____3484 =
-            let uu____3491 =
-              let uu____3496 =
+              FStar_TypeChecker_NBETerm.embed uu___3 cb us in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_TypeChecker_NBETerm.embed
                   FStar_TypeChecker_NBETerm.e_string_list cb eff in
-              FStar_TypeChecker_NBETerm.as_arg uu____3496 in
-            let uu____3499 =
-              let uu____3506 =
-                let uu____3511 =
-                  FStar_TypeChecker_NBETerm.embed e_term cb res in
-                FStar_TypeChecker_NBETerm.as_arg uu____3511 in
-              let uu____3512 =
-                let uu____3519 =
-                  let uu____3524 =
-                    let uu____3525 = FStar_TypeChecker_NBETerm.e_list e_argv in
-                    FStar_TypeChecker_NBETerm.embed uu____3525 cb args in
-                  FStar_TypeChecker_NBETerm.as_arg uu____3524 in
-                [uu____3519] in
-              uu____3506 :: uu____3512 in
-            uu____3491 :: uu____3499 in
-          uu____3471 :: uu____3484 in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.embed e_term cb res in
+                FStar_TypeChecker_NBETerm.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 = FStar_TypeChecker_NBETerm.e_list e_argv in
+                    FStar_TypeChecker_NBETerm.embed uu___9 cb args in
+                  FStar_TypeChecker_NBETerm.as_arg uu___8 in
+                [uu___7] in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         mkConstruct FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.fv
-          [] uu____3464 in
+          [] uu___ in
   let unembed_comp_view cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____3568, (md, uu____3570)::(t1, uu____3572)::[]) when
+        (fv, uu___, (md, uu___1)::(t1, uu___2)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
         ->
-        let uu____3595 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-        FStar_Util.bind_opt uu____3595
+        let uu___3 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+        FStar_Util.bind_opt uu___3
           (fun t2 ->
-             let uu____3601 =
-               let uu____3606 = FStar_TypeChecker_NBETerm.e_option e_term in
-               FStar_TypeChecker_NBETerm.unembed uu____3606 cb md in
-             FStar_Util.bind_opt uu____3601
+             let uu___4 =
+               let uu___5 = FStar_TypeChecker_NBETerm.e_option e_term in
+               FStar_TypeChecker_NBETerm.unembed uu___5 cb md in
+             FStar_Util.bind_opt uu___4
                (fun md1 ->
                   FStar_All.pipe_left
-                    (fun uu____3621 ->
-                       FStar_Pervasives_Native.Some uu____3621)
+                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                     (FStar_Reflection_Data.C_Total (t2, md1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____3625, (md, uu____3627)::(t1, uu____3629)::[]) when
+        (fv, uu___, (md, uu___1)::(t1, uu___2)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.lid
         ->
-        let uu____3652 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-        FStar_Util.bind_opt uu____3652
+        let uu___3 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
+        FStar_Util.bind_opt uu___3
           (fun t2 ->
-             let uu____3658 =
-               let uu____3663 = FStar_TypeChecker_NBETerm.e_option e_term in
-               FStar_TypeChecker_NBETerm.unembed uu____3663 cb md in
-             FStar_Util.bind_opt uu____3658
+             let uu___4 =
+               let uu___5 = FStar_TypeChecker_NBETerm.e_option e_term in
+               FStar_TypeChecker_NBETerm.unembed uu___5 cb md in
+             FStar_Util.bind_opt uu___4
                (fun md1 ->
                   FStar_All.pipe_left
-                    (fun uu____3678 ->
-                       FStar_Pervasives_Native.Some uu____3678)
+                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                     (FStar_Reflection_Data.C_GTotal (t2, md1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____3682,
-         (post, uu____3684)::(pre, uu____3686)::(pats, uu____3688)::[])
-        when
+        (fv, uu___, (post, uu___1)::(pre, uu___2)::(pats, uu___3)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
         ->
-        let uu____3715 = FStar_TypeChecker_NBETerm.unembed e_term cb pre in
-        FStar_Util.bind_opt uu____3715
+        let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb pre in
+        FStar_Util.bind_opt uu___4
           (fun pre1 ->
-             let uu____3721 =
-               FStar_TypeChecker_NBETerm.unembed e_term cb post in
-             FStar_Util.bind_opt uu____3721
+             let uu___5 = FStar_TypeChecker_NBETerm.unembed e_term cb post in
+             FStar_Util.bind_opt uu___5
                (fun post1 ->
-                  let uu____3727 =
+                  let uu___6 =
                     FStar_TypeChecker_NBETerm.unembed e_term cb pats in
-                  FStar_Util.bind_opt uu____3727
+                  FStar_Util.bind_opt uu___6
                     (fun pats1 ->
                        FStar_All.pipe_left
-                         (fun uu____3734 ->
-                            FStar_Pervasives_Native.Some uu____3734)
+                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
                          (FStar_Reflection_Data.C_Lemma (pre1, post1, pats1)))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____3736,
-         (args, uu____3738)::(res, uu____3740)::(eff, uu____3742)::(us,
-                                                                    uu____3744)::[])
+        (fv, uu___,
+         (args, uu___1)::(res, uu___2)::(eff, uu___3)::(us, uu___4)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.lid
         ->
-        let uu____3775 =
-          let uu____3780 =
+        let uu___5 =
+          let uu___6 =
             FStar_TypeChecker_NBETerm.e_list FStar_TypeChecker_NBETerm.e_unit in
-          FStar_TypeChecker_NBETerm.unembed uu____3780 cb us in
-        FStar_Util.bind_opt uu____3775
+          FStar_TypeChecker_NBETerm.unembed uu___6 cb us in
+        FStar_Util.bind_opt uu___5
           (fun us1 ->
-             let uu____3794 =
+             let uu___6 =
                FStar_TypeChecker_NBETerm.unembed
                  FStar_TypeChecker_NBETerm.e_string_list cb eff in
-             FStar_Util.bind_opt uu____3794
+             FStar_Util.bind_opt uu___6
                (fun eff1 ->
-                  let uu____3808 =
+                  let uu___7 =
                     FStar_TypeChecker_NBETerm.unembed e_term cb res in
-                  FStar_Util.bind_opt uu____3808
+                  FStar_Util.bind_opt uu___7
                     (fun res1 ->
-                       let uu____3814 =
-                         let uu____3819 =
-                           FStar_TypeChecker_NBETerm.e_list e_argv in
-                         FStar_TypeChecker_NBETerm.unembed uu____3819 cb args in
-                       FStar_Util.bind_opt uu____3814
+                       let uu___8 =
+                         let uu___9 = FStar_TypeChecker_NBETerm.e_list e_argv in
+                         FStar_TypeChecker_NBETerm.unembed uu___9 cb args in
+                       FStar_Util.bind_opt uu___8
                          (fun args1 ->
                             FStar_All.pipe_left
-                              (fun uu____3834 ->
-                                 FStar_Pervasives_Native.Some uu____3834)
+                              (fun uu___9 ->
+                                 FStar_Pervasives_Native.Some uu___9)
                               (FStar_Reflection_Data.C_Eff
                                  (us1, eff1, res1, args1))))))
-    | uu____3839 ->
-        ((let uu____3841 =
-            let uu____3846 =
-              let uu____3847 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded comp_view: %s" uu____3847 in
-            (FStar_Errors.Warning_NotEmbedded, uu____3846) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3841);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded comp_view: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_comp_view unembed_comp_view
     FStar_Reflection_Data.fstar_refl_comp_view_fv
@@ -1447,27 +1389,27 @@ let (e_order : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
     | FStar_Order.Gt -> mkConstruct FStar_Reflection_Data.ord_Gt_fv [] [] in
   let unembed_order cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____3889, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Lt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Lt
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____3905, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Eq_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Eq
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____3921, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Reflection_Data.ord_Gt_lid ->
         FStar_Pervasives_Native.Some FStar_Order.Gt
-    | uu____3936 ->
-        ((let uu____3938 =
-            let uu____3943 =
-              let uu____3944 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded order: %s" uu____3944 in
-            (FStar_Errors.Warning_NotEmbedded, uu____3943) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3938);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded order: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
-  let uu____3945 =
+  let uu___ =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.order_lid
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-  mk_emb' embed_order unembed_order uu____3945
+  mk_emb' embed_order unembed_order uu___
 let (e_sigelt :
   FStar_Syntax_Syntax.sigelt FStar_TypeChecker_NBETerm.embedding) =
   let embed_sigelt cb se =
@@ -1479,19 +1421,18 @@ let (e_sigelt :
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt;
-           FStar_Syntax_Syntax.ltyp = uu____3975;
-           FStar_Syntax_Syntax.rng = uu____3976;_},
-         uu____3977)
+           FStar_Syntax_Syntax.ltyp = uu___;
+           FStar_Syntax_Syntax.rng = uu___1;_},
+         uu___2)
         ->
-        let uu____3996 = FStar_Dyn.undyn b in
-        FStar_Pervasives_Native.Some uu____3996
-    | uu____3997 ->
-        ((let uu____3999 =
-            let uu____4004 =
-              let uu____4005 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded sigelt: %s" uu____4005 in
-            (FStar_Errors.Warning_NotEmbedded, uu____4004) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____3999);
+        let uu___3 = FStar_Dyn.undyn b in FStar_Pervasives_Native.Some uu___3
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded sigelt: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_sigelt unembed_sigelt
     FStar_Reflection_Data.fstar_refl_sigelt_fv
@@ -1500,16 +1441,16 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
     FStar_TypeChecker_NBETerm.e_tuple2 FStar_TypeChecker_NBETerm.e_range
       FStar_TypeChecker_NBETerm.e_string in
   let embed_ident cb i =
-    let uu____4028 =
-      let uu____4033 = FStar_Ident.range_of_id i in
-      let uu____4034 = FStar_Ident.string_of_id i in (uu____4033, uu____4034) in
-    FStar_TypeChecker_NBETerm.embed repr cb uu____4028 in
+    let uu___ =
+      let uu___1 = FStar_Ident.range_of_id i in
+      let uu___2 = FStar_Ident.string_of_id i in (uu___1, uu___2) in
+    FStar_TypeChecker_NBETerm.embed repr cb uu___ in
   let unembed_ident cb t =
-    let uu____4054 = FStar_TypeChecker_NBETerm.unembed repr cb t in
-    match uu____4054 with
+    let uu___ = FStar_TypeChecker_NBETerm.unembed repr cb t in
+    match uu___ with
     | FStar_Pervasives_Native.Some (rng, s) ->
-        let uu____4073 = FStar_Ident.mk_ident (s, rng) in
-        FStar_Pervasives_Native.Some uu____4073
+        let uu___1 = FStar_Ident.mk_ident (s, rng) in
+        FStar_Pervasives_Native.Some uu___1
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
   let range_fv =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.range_lid
@@ -1518,33 +1459,31 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.string_lid
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
   let et =
-    let uu____4081 =
-      let uu____4088 =
-        FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2 in
-      let uu____4089 =
-        let uu____4092 = fv_as_emb_typ range_fv in
-        let uu____4093 =
-          let uu____4096 = fv_as_emb_typ string_fv in [uu____4096] in
-        uu____4092 :: uu____4093 in
-      (uu____4088, uu____4089) in
-    FStar_Syntax_Syntax.ET_app uu____4081 in
-  let uu____4099 =
-    let uu____4100 =
+    let uu___ =
+      let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2 in
+      let uu___2 =
+        let uu___3 = fv_as_emb_typ range_fv in
+        let uu___4 = let uu___5 = fv_as_emb_typ string_fv in [uu___5] in
+        uu___3 :: uu___4 in
+      (uu___1, uu___2) in
+    FStar_Syntax_Syntax.ET_app uu___ in
+  let uu___ =
+    let uu___1 =
       FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.lid_tuple2
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-    let uu____4101 =
-      let uu____4108 =
-        let uu____4113 = mkFV range_fv [] [] in
-        FStar_TypeChecker_NBETerm.as_arg uu____4113 in
-      let uu____4118 =
-        let uu____4125 =
-          let uu____4130 = mkFV string_fv [] [] in
-          FStar_TypeChecker_NBETerm.as_arg uu____4130 in
-        [uu____4125] in
-      uu____4108 :: uu____4118 in
-    mkFV uu____4100 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-      uu____4101 in
-  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu____4099 et
+    let uu___2 =
+      let uu___3 =
+        let uu___4 = mkFV range_fv [] [] in
+        FStar_TypeChecker_NBETerm.as_arg uu___4 in
+      let uu___4 =
+        let uu___5 =
+          let uu___6 = mkFV string_fv [] [] in
+          FStar_TypeChecker_NBETerm.as_arg uu___6 in
+        [uu___5] in
+      uu___3 :: uu___4 in
+    mkFV uu___1 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
+      uu___2 in
+  FStar_TypeChecker_NBETerm.mk_emb embed_ident unembed_ident uu___ et
 let (e_univ_name :
   FStar_Syntax_Syntax.univ_name FStar_TypeChecker_NBETerm.embedding) =
   e_ident
@@ -1564,161 +1503,152 @@ let (e_sigelt_view :
   let embed_sigelt_view cb sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r, fv, univs, ty, t) ->
-        let uu____4189 =
-          let uu____4196 =
-            let uu____4201 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_bool cb r in
-            FStar_TypeChecker_NBETerm.as_arg uu____4201 in
-          let uu____4202 =
-            let uu____4209 =
-              let uu____4214 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
-              FStar_TypeChecker_NBETerm.as_arg uu____4214 in
-            let uu____4215 =
-              let uu____4222 =
-                let uu____4227 =
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.embed e_fv cb fv in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
                   FStar_TypeChecker_NBETerm.embed e_univ_names cb univs in
-                FStar_TypeChecker_NBETerm.as_arg uu____4227 in
-              let uu____4230 =
-                let uu____4237 =
-                  let uu____4242 =
-                    FStar_TypeChecker_NBETerm.embed e_term cb ty in
-                  FStar_TypeChecker_NBETerm.as_arg uu____4242 in
-                let uu____4243 =
-                  let uu____4250 =
-                    let uu____4255 =
-                      FStar_TypeChecker_NBETerm.embed e_term cb t in
-                    FStar_TypeChecker_NBETerm.as_arg uu____4255 in
-                  [uu____4250] in
-                uu____4237 :: uu____4243 in
-              uu____4222 :: uu____4230 in
-            uu____4209 :: uu____4215 in
-          uu____4196 :: uu____4202 in
+                FStar_TypeChecker_NBETerm.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 = FStar_TypeChecker_NBETerm.embed e_term cb ty in
+                  FStar_TypeChecker_NBETerm.as_arg uu___8 in
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+                    FStar_TypeChecker_NBETerm.as_arg uu___10 in
+                  [uu___9] in
+                uu___7 :: uu___8 in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         mkConstruct FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.fv
-          [] uu____4189
+          [] uu___
     | FStar_Reflection_Data.Sg_Inductive (nm, univs, bs, t, dcs) ->
-        let uu____4297 =
-          let uu____4304 =
-            let uu____4309 =
-              FStar_TypeChecker_NBETerm.embed e_string_list cb nm in
-            FStar_TypeChecker_NBETerm.as_arg uu____4309 in
-          let uu____4312 =
-            let uu____4319 =
-              let uu____4324 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_string_list cb nm in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_TypeChecker_NBETerm.embed e_univ_names cb univs in
-              FStar_TypeChecker_NBETerm.as_arg uu____4324 in
-            let uu____4327 =
-              let uu____4334 =
-                let uu____4339 =
-                  FStar_TypeChecker_NBETerm.embed e_binders cb bs in
-                FStar_TypeChecker_NBETerm.as_arg uu____4339 in
-              let uu____4340 =
-                let uu____4347 =
-                  let uu____4352 =
-                    FStar_TypeChecker_NBETerm.embed e_term cb t in
-                  FStar_TypeChecker_NBETerm.as_arg uu____4352 in
-                let uu____4353 =
-                  let uu____4360 =
-                    let uu____4365 =
-                      let uu____4366 =
-                        FStar_TypeChecker_NBETerm.e_list e_ctor in
-                      FStar_TypeChecker_NBETerm.embed uu____4366 cb dcs in
-                    FStar_TypeChecker_NBETerm.as_arg uu____4365 in
-                  [uu____4360] in
-                uu____4347 :: uu____4353 in
-              uu____4334 :: uu____4340 in
-            uu____4319 :: uu____4327 in
-          uu____4304 :: uu____4312 in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.embed e_binders cb bs in
+                FStar_TypeChecker_NBETerm.as_arg uu___6 in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 = FStar_TypeChecker_NBETerm.embed e_term cb t in
+                  FStar_TypeChecker_NBETerm.as_arg uu___8 in
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 = FStar_TypeChecker_NBETerm.e_list e_ctor in
+                      FStar_TypeChecker_NBETerm.embed uu___11 cb dcs in
+                    FStar_TypeChecker_NBETerm.as_arg uu___10 in
+                  [uu___9] in
+                uu___7 :: uu___8 in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          uu___1 :: uu___2 in
         mkConstruct
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.fv []
-          uu____4297
+          uu___
     | FStar_Reflection_Data.Unk ->
         mkConstruct FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.fv []
           [] in
   let unembed_sigelt_view cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____4435,
-         (dcs, uu____4437)::(t1, uu____4439)::(bs, uu____4441)::(us,
-                                                                 uu____4443)::
-         (nm, uu____4445)::[])
+        (fv, uu___,
+         (dcs, uu___1)::(t1, uu___2)::(bs, uu___3)::(us, uu___4)::(nm,
+                                                                   uu___5)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
         ->
-        let uu____4480 =
-          FStar_TypeChecker_NBETerm.unembed e_string_list cb nm in
-        FStar_Util.bind_opt uu____4480
+        let uu___6 = FStar_TypeChecker_NBETerm.unembed e_string_list cb nm in
+        FStar_Util.bind_opt uu___6
           (fun nm1 ->
-             let uu____4494 =
+             let uu___7 =
                FStar_TypeChecker_NBETerm.unembed e_univ_names cb us in
-             FStar_Util.bind_opt uu____4494
+             FStar_Util.bind_opt uu___7
                (fun us1 ->
-                  let uu____4508 =
+                  let uu___8 =
                     FStar_TypeChecker_NBETerm.unembed e_binders cb bs in
-                  FStar_Util.bind_opt uu____4508
+                  FStar_Util.bind_opt uu___8
                     (fun bs1 ->
-                       let uu____4514 =
+                       let uu___9 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-                       FStar_Util.bind_opt uu____4514
+                       FStar_Util.bind_opt uu___9
                          (fun t2 ->
-                            let uu____4520 =
-                              let uu____4531 =
+                            let uu___10 =
+                              let uu___11 =
                                 FStar_TypeChecker_NBETerm.e_list e_ctor in
-                              FStar_TypeChecker_NBETerm.unembed uu____4531 cb
+                              FStar_TypeChecker_NBETerm.unembed uu___11 cb
                                 dcs in
-                            FStar_Util.bind_opt uu____4520
+                            FStar_Util.bind_opt uu___10
                               (fun dcs1 ->
                                  FStar_All.pipe_left
-                                   (fun uu____4576 ->
-                                      FStar_Pervasives_Native.Some uu____4576)
+                                   (fun uu___11 ->
+                                      FStar_Pervasives_Native.Some uu___11)
                                    (FStar_Reflection_Data.Sg_Inductive
                                       (nm1, us1, bs1, t2, dcs1)))))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____4584,
-         (t1, uu____4586)::(ty, uu____4588)::(univs, uu____4590)::(fvar,
-                                                                   uu____4592)::
-         (r, uu____4594)::[])
+        (fv, uu___,
+         (t1, uu___1)::(ty, uu___2)::(univs, uu___3)::(fvar, uu___4)::
+         (r, uu___5)::[])
         when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
         ->
-        let uu____4629 =
+        let uu___6 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_bool
             cb r in
-        FStar_Util.bind_opt uu____4629
+        FStar_Util.bind_opt uu___6
           (fun r1 ->
-             let uu____4635 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar in
-             FStar_Util.bind_opt uu____4635
+             let uu___7 = FStar_TypeChecker_NBETerm.unembed e_fv cb fvar in
+             FStar_Util.bind_opt uu___7
                (fun fvar1 ->
-                  let uu____4641 =
+                  let uu___8 =
                     FStar_TypeChecker_NBETerm.unembed e_univ_names cb univs in
-                  FStar_Util.bind_opt uu____4641
+                  FStar_Util.bind_opt uu___8
                     (fun univs1 ->
-                       let uu____4655 =
+                       let uu___9 =
                          FStar_TypeChecker_NBETerm.unembed e_term cb ty in
-                       FStar_Util.bind_opt uu____4655
+                       FStar_Util.bind_opt uu___9
                          (fun ty1 ->
-                            let uu____4661 =
+                            let uu___10 =
                               FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-                            FStar_Util.bind_opt uu____4661
+                            FStar_Util.bind_opt uu___10
                               (fun t2 ->
                                  FStar_All.pipe_left
-                                   (fun uu____4668 ->
-                                      FStar_Pervasives_Native.Some uu____4668)
+                                   (fun uu___11 ->
+                                      FStar_Pervasives_Native.Some uu___11)
                                    (FStar_Reflection_Data.Sg_Let
                                       (r1, fvar1, univs1, ty1, t2)))))))
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____4672, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-    | uu____4687 ->
-        ((let uu____4689 =
-            let uu____4694 =
-              let uu____4695 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu____4695 in
-            (FStar_Errors.Warning_NotEmbedded, uu____4694) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4689);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded sigelt_view: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_sigelt_view unembed_sigelt_view
     FStar_Reflection_Data.fstar_refl_sigelt_view_fv
@@ -1729,70 +1659,68 @@ let (e_exp : FStar_Reflection_Data.exp FStar_TypeChecker_NBETerm.embedding) =
         mkConstruct FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.fv
           [] []
     | FStar_Reflection_Data.Var i ->
-        let uu____4714 =
-          let uu____4721 =
-            let uu____4726 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.mk_t
                 (FStar_TypeChecker_NBETerm.Constant
                    (FStar_TypeChecker_NBETerm.Int i)) in
-            FStar_TypeChecker_NBETerm.as_arg uu____4726 in
-          [uu____4721] in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.fv
-          [] uu____4714
+          [] uu___
     | FStar_Reflection_Data.Mult (e1, e2) ->
-        let uu____4737 =
-          let uu____4744 =
-            let uu____4749 = embed_exp cb e1 in
-            FStar_TypeChecker_NBETerm.as_arg uu____4749 in
-          let uu____4750 =
-            let uu____4757 =
-              let uu____4762 = embed_exp cb e2 in
-              FStar_TypeChecker_NBETerm.as_arg uu____4762 in
-            [uu____4757] in
-          uu____4744 :: uu____4750 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = embed_exp cb e1 in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = embed_exp cb e2 in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.fv
-          [] uu____4737 in
+          [] uu___ in
   let rec unembed_exp cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____4791, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-    | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____4807, (i, uu____4809)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (i, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
         ->
-        let uu____4828 =
+        let uu___2 =
           FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_int
             cb i in
-        FStar_Util.bind_opt uu____4828
+        FStar_Util.bind_opt uu___2
           (fun i1 ->
              FStar_All.pipe_left
-               (fun uu____4835 -> FStar_Pervasives_Native.Some uu____4835)
+               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                (FStar_Reflection_Data.Var i1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____4837, (e2, uu____4839)::(e1, uu____4841)::[]) when
+        (fv, uu___, (e2, uu___1)::(e1, uu___2)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
         ->
-        let uu____4864 = unembed_exp cb e1 in
-        FStar_Util.bind_opt uu____4864
+        let uu___3 = unembed_exp cb e1 in
+        FStar_Util.bind_opt uu___3
           (fun e11 ->
-             let uu____4870 = unembed_exp cb e2 in
-             FStar_Util.bind_opt uu____4870
+             let uu___4 = unembed_exp cb e2 in
+             FStar_Util.bind_opt uu___4
                (fun e21 ->
                   FStar_All.pipe_left
-                    (fun uu____4877 ->
-                       FStar_Pervasives_Native.Some uu____4877)
+                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                     (FStar_Reflection_Data.Mult (e11, e21))))
-    | uu____4878 ->
-        ((let uu____4880 =
-            let uu____4885 =
-              let uu____4886 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded exp: %s" uu____4886 in
-            (FStar_Errors.Warning_NotEmbedded, uu____4885) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____4880);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded exp: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   mk_emb' embed_exp unembed_exp FStar_Reflection_Data.fstar_refl_exp_fv
 let (e_binder_view :
@@ -1806,16 +1734,15 @@ let (e_attributes :
   = FStar_TypeChecker_NBETerm.e_list e_attribute
 let (e_lid : FStar_Ident.lid FStar_TypeChecker_NBETerm.embedding) =
   let embed rng lid =
-    let uu____4908 = FStar_Ident.path_of_lid lid in
-    FStar_TypeChecker_NBETerm.embed e_string_list rng uu____4908 in
+    let uu___ = FStar_Ident.path_of_lid lid in
+    FStar_TypeChecker_NBETerm.embed e_string_list rng uu___ in
   let unembed cb t =
-    let uu____4928 = FStar_TypeChecker_NBETerm.unembed e_string_list cb t in
-    FStar_Util.map_opt uu____4928
+    let uu___ = FStar_TypeChecker_NBETerm.unembed e_string_list cb t in
+    FStar_Util.map_opt uu___
       (fun p -> FStar_Ident.lid_of_path p FStar_Range.dummyRange) in
-  let uu____4941 =
-    mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] [] in
-  let uu____4946 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv in
-  FStar_TypeChecker_NBETerm.mk_emb embed unembed uu____4941 uu____4946
+  let uu___ = mkConstruct FStar_Reflection_Data.fstar_refl_aqualv_fv [] [] in
+  let uu___1 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_aqualv_fv in
+  FStar_TypeChecker_NBETerm.mk_emb embed unembed uu___ uu___1
 let (e_qualifier :
   FStar_Reflection_Data.qualifier FStar_TypeChecker_NBETerm.embedding) =
   let embed cb q =
@@ -1886,82 +1813,82 @@ let (e_qualifier :
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.fv []
           []
     | FStar_Reflection_Data.Reflectable l ->
-        let uu____5029 =
-          let uu____5036 =
-            let uu____5041 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
-            FStar_TypeChecker_NBETerm.as_arg uu____5041 in
-          [uu____5036] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.fv
-          [] uu____5029
+          [] uu___
     | FStar_Reflection_Data.Discriminator l ->
-        let uu____5051 =
-          let uu____5058 =
-            let uu____5063 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
-            FStar_TypeChecker_NBETerm.as_arg uu____5063 in
-          [uu____5058] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.fv
-          [] uu____5051
+          [] uu___
     | FStar_Reflection_Data.Action l ->
-        let uu____5073 =
-          let uu____5080 =
-            let uu____5085 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
-            FStar_TypeChecker_NBETerm.as_arg uu____5085 in
-          [uu____5080] in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.fv []
-          uu____5073
+          uu___
     | FStar_Reflection_Data.Projector (l, i) ->
-        let uu____5096 =
-          let uu____5103 =
-            let uu____5108 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
-            FStar_TypeChecker_NBETerm.as_arg uu____5108 in
-          let uu____5109 =
-            let uu____5116 =
-              let uu____5121 = FStar_TypeChecker_NBETerm.embed e_ident cb i in
-              FStar_TypeChecker_NBETerm.as_arg uu____5121 in
-            [uu____5116] in
-          uu____5103 :: uu____5109 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_NBETerm.embed e_lid cb l in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.embed e_ident cb i in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.fv
-          [] uu____5096
+          [] uu___
     | FStar_Reflection_Data.RecordType (ids1, ids2) ->
-        let uu____5144 =
-          let uu____5151 =
-            let uu____5156 =
-              let uu____5157 = FStar_TypeChecker_NBETerm.e_list e_ident in
-              FStar_TypeChecker_NBETerm.embed uu____5157 cb ids1 in
-            FStar_TypeChecker_NBETerm.as_arg uu____5156 in
-          let uu____5164 =
-            let uu____5171 =
-              let uu____5176 =
-                let uu____5177 = FStar_TypeChecker_NBETerm.e_list e_ident in
-                FStar_TypeChecker_NBETerm.embed uu____5177 cb ids2 in
-              FStar_TypeChecker_NBETerm.as_arg uu____5176 in
-            [uu____5171] in
-          uu____5151 :: uu____5164 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.e_list e_ident in
+              FStar_TypeChecker_NBETerm.embed uu___3 cb ids1 in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.e_list e_ident in
+                FStar_TypeChecker_NBETerm.embed uu___5 cb ids2 in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.fv
-          [] uu____5144
+          [] uu___
     | FStar_Reflection_Data.RecordConstructor (ids1, ids2) ->
-        let uu____5206 =
-          let uu____5213 =
-            let uu____5218 =
-              let uu____5219 = FStar_TypeChecker_NBETerm.e_list e_ident in
-              FStar_TypeChecker_NBETerm.embed uu____5219 cb ids1 in
-            FStar_TypeChecker_NBETerm.as_arg uu____5218 in
-          let uu____5226 =
-            let uu____5233 =
-              let uu____5238 =
-                let uu____5239 = FStar_TypeChecker_NBETerm.e_list e_ident in
-                FStar_TypeChecker_NBETerm.embed uu____5239 cb ids2 in
-              FStar_TypeChecker_NBETerm.as_arg uu____5238 in
-            [uu____5233] in
-          uu____5213 :: uu____5226 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.e_list e_ident in
+              FStar_TypeChecker_NBETerm.embed uu___3 cb ids1 in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_TypeChecker_NBETerm.e_list e_ident in
+                FStar_TypeChecker_NBETerm.embed uu___5 cb ids2 in
+              FStar_TypeChecker_NBETerm.as_arg uu___4 in
+            [uu___3] in
+          uu___1 :: uu___2 in
         mkConstruct
           FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.fv
-          [] uu____5206 in
+          [] uu___ in
   let unembed cb t =
     match t.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
@@ -2038,92 +1965,90 @@ let (e_qualifier :
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
         -> FStar_Pervasives_Native.Some FStar_Reflection_Data.OnlyName
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu____5496)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
         ->
-        let uu____5513 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
-        FStar_Util.bind_opt uu____5513
+        let uu___1 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
+        FStar_Util.bind_opt uu___1
           (fun l1 ->
              FStar_Pervasives_Native.Some
                (FStar_Reflection_Data.Reflectable l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu____5520)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
         ->
-        let uu____5537 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
-        FStar_Util.bind_opt uu____5537
+        let uu___1 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
+        FStar_Util.bind_opt uu___1
           (fun l1 ->
              FStar_Pervasives_Native.Some
                (FStar_Reflection_Data.Discriminator l1))
-    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu____5544)::[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, [], (l, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
         ->
-        let uu____5561 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
-        FStar_Util.bind_opt uu____5561
+        let uu___1 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
+        FStar_Util.bind_opt uu___1
           (fun l1 ->
              FStar_Pervasives_Native.Some (FStar_Reflection_Data.Action l1))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, [], (i, uu____5568)::(l, uu____5570)::[]) when
+        (fv, [], (i, uu___)::(l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
         ->
-        let uu____5591 = FStar_TypeChecker_NBETerm.unembed e_ident cb i in
-        FStar_Util.bind_opt uu____5591
+        let uu___2 = FStar_TypeChecker_NBETerm.unembed e_ident cb i in
+        FStar_Util.bind_opt uu___2
           (fun i1 ->
-             let uu____5597 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
-             FStar_Util.bind_opt uu____5597
+             let uu___3 = FStar_TypeChecker_NBETerm.unembed e_lid cb l in
+             FStar_Util.bind_opt uu___3
                (fun l1 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.Projector (l1, i1))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, [], (ids2, uu____5604)::(ids1, uu____5606)::[]) when
+        (fv, [], (ids2, uu___)::(ids1, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
         ->
-        let uu____5627 =
-          let uu____5632 = FStar_TypeChecker_NBETerm.e_list e_ident in
-          FStar_TypeChecker_NBETerm.unembed uu____5632 cb ids1 in
-        FStar_Util.bind_opt uu____5627
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_NBETerm.e_list e_ident in
+          FStar_TypeChecker_NBETerm.unembed uu___3 cb ids1 in
+        FStar_Util.bind_opt uu___2
           (fun ids11 ->
-             let uu____5646 =
-               let uu____5651 = FStar_TypeChecker_NBETerm.e_list e_ident in
-               FStar_TypeChecker_NBETerm.unembed uu____5651 cb ids2 in
-             FStar_Util.bind_opt uu____5646
+             let uu___3 =
+               let uu___4 = FStar_TypeChecker_NBETerm.e_list e_ident in
+               FStar_TypeChecker_NBETerm.unembed uu___4 cb ids2 in
+             FStar_Util.bind_opt uu___3
                (fun ids21 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.RecordType (ids11, ids21))))
     | FStar_TypeChecker_NBETerm.Construct
-        (fv, [], (ids2, uu____5670)::(ids1, uu____5672)::[]) when
+        (fv, [], (ids2, uu___)::(ids1, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
         ->
-        let uu____5693 =
-          let uu____5698 = FStar_TypeChecker_NBETerm.e_list e_ident in
-          FStar_TypeChecker_NBETerm.unembed uu____5698 cb ids1 in
-        FStar_Util.bind_opt uu____5693
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_NBETerm.e_list e_ident in
+          FStar_TypeChecker_NBETerm.unembed uu___3 cb ids1 in
+        FStar_Util.bind_opt uu___2
           (fun ids11 ->
-             let uu____5712 =
-               let uu____5717 = FStar_TypeChecker_NBETerm.e_list e_ident in
-               FStar_TypeChecker_NBETerm.unembed uu____5717 cb ids2 in
-             FStar_Util.bind_opt uu____5712
+             let uu___3 =
+               let uu___4 = FStar_TypeChecker_NBETerm.e_list e_ident in
+               FStar_TypeChecker_NBETerm.unembed uu___4 cb ids2 in
+             FStar_Util.bind_opt uu___3
                (fun ids21 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.RecordConstructor (ids11, ids21))))
-    | uu____5734 ->
-        ((let uu____5736 =
-            let uu____5741 =
-              let uu____5742 = FStar_TypeChecker_NBETerm.t_to_string t in
-              FStar_Util.format1 "Not an embedded qualifier: %s" uu____5742 in
-            (FStar_Errors.Warning_NotEmbedded, uu____5741) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____5736);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+              FStar_Util.format1 "Not an embedded qualifier: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
-  let uu____5743 =
-    mkConstruct FStar_Reflection_Data.fstar_refl_qualifier_fv [] [] in
-  let uu____5748 =
-    fv_as_emb_typ FStar_Reflection_Data.fstar_refl_qualifier_fv in
-  FStar_TypeChecker_NBETerm.mk_emb embed unembed uu____5743 uu____5748
+  let uu___ = mkConstruct FStar_Reflection_Data.fstar_refl_qualifier_fv [] [] in
+  let uu___1 = fv_as_emb_typ FStar_Reflection_Data.fstar_refl_qualifier_fv in
+  FStar_TypeChecker_NBETerm.mk_emb embed unembed uu___ uu___1
 let (e_qualifiers :
   FStar_Reflection_Data.qualifier Prims.list
     FStar_TypeChecker_NBETerm.embedding)

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -12,17 +12,17 @@ let (norm_before_encoding :
         FStar_TypeChecker_Env.AllowUnboundUniverses;
         FStar_TypeChecker_Env.EraseUniverses;
         FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta] in
-      let uu____15 =
-        let uu____18 =
-          let uu____19 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
             FStar_TypeChecker_Env.current_module
               env.FStar_SMTEncoding_Env.tcenv in
-          FStar_Ident.string_of_lid uu____19 in
-        FStar_Pervasives_Native.Some uu____18 in
+          FStar_Ident.string_of_lid uu___2 in
+        FStar_Pervasives_Native.Some uu___1 in
       FStar_Profiling.profile
-        (fun uu____21 ->
+        (fun uu___1 ->
            FStar_TypeChecker_Normalize.normalize steps
-             env.FStar_SMTEncoding_Env.tcenv t) uu____15
+             env.FStar_SMTEncoding_Env.tcenv t) uu___
         "FStar.TypeChecker.SMTEncoding.Encode.norm_before_encoding"
 let (norm_with_steps :
   FStar_TypeChecker_Env.steps ->
@@ -32,14 +32,14 @@ let (norm_with_steps :
   fun steps ->
     fun env ->
       fun t ->
-        let uu____37 =
-          let uu____40 =
-            let uu____41 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.string_of_lid uu____41 in
-          FStar_Pervasives_Native.Some uu____40 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
         FStar_Profiling.profile
-          (fun uu____43 -> FStar_TypeChecker_Normalize.normalize steps env t)
-          uu____37 "FStar.TypeChecker.SMTEncoding.Encode.norm"
+          (fun uu___1 -> FStar_TypeChecker_Normalize.normalize steps env t)
+          uu___ "FStar.TypeChecker.SMTEncoding.Encode.norm"
 type prims_t =
   {
   mk:
@@ -61,41 +61,41 @@ let (__proj__Mkprims_t__item__is :
   fun projectee -> match projectee with | { mk; is;_} -> is
 let (prims : prims_t) =
   let module_name = "Prims" in
-  let uu____163 =
+  let uu___ =
     FStar_SMTEncoding_Env.fresh_fvar module_name "a"
       FStar_SMTEncoding_Term.Term_sort in
-  match uu____163 with
+  match uu___ with
   | (asym, a) ->
-      let uu____170 =
+      let uu___1 =
         FStar_SMTEncoding_Env.fresh_fvar module_name "x"
           FStar_SMTEncoding_Term.Term_sort in
-      (match uu____170 with
+      (match uu___1 with
        | (xsym, x) ->
-           let uu____177 =
+           let uu___2 =
              FStar_SMTEncoding_Env.fresh_fvar module_name "y"
                FStar_SMTEncoding_Term.Term_sort in
-           (match uu____177 with
+           (match uu___2 with
             | (ysym, y) ->
                 let quant vars body rng x1 =
                   let xname_decl =
-                    let uu____242 =
-                      let uu____253 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_All.pipe_right vars
                           (FStar_List.map FStar_SMTEncoding_Term.fv_sort) in
-                      (x1, uu____253, FStar_SMTEncoding_Term.Term_sort,
+                      (x1, uu___4, FStar_SMTEncoding_Term.Term_sort,
                         FStar_Pervasives_Native.None) in
-                    FStar_SMTEncoding_Term.DeclFun uu____242 in
+                    FStar_SMTEncoding_Term.DeclFun uu___3 in
                   let xtok = Prims.op_Hat x1 "@tok" in
                   let xtok_decl =
                     FStar_SMTEncoding_Term.DeclFun
                       (xtok, [], FStar_SMTEncoding_Term.Term_sort,
                         FStar_Pervasives_Native.None) in
                   let xapp =
-                    let uu____267 =
-                      let uu____274 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars in
-                      (x1, uu____274) in
-                    FStar_SMTEncoding_Util.mkApp uu____267 in
+                      (x1, uu___4) in
+                    FStar_SMTEncoding_Util.mkApp uu___3 in
                   let xtok1 = FStar_SMTEncoding_Util.mkApp (xtok, []) in
                   let xtok_app =
                     FStar_SMTEncoding_EncodeTerm.mk_Apply xtok1 vars in
@@ -105,91 +105,88 @@ let (prims : prims_t) =
                         FStar_Pervasives_Native.fst in
                     let axiom_name = Prims.op_Hat "primitive_tot_fun_" x1 in
                     let tot_fun_axiom_for_x =
-                      let uu____349 =
-                        let uu____356 =
-                          FStar_SMTEncoding_Term.mk_IsTotFun xtok1 in
-                        (uu____356, FStar_Pervasives_Native.None, axiom_name) in
-                      FStar_SMTEncoding_Util.mkAssume uu____349 in
-                    let uu____357 =
+                      let uu___3 =
+                        let uu___4 = FStar_SMTEncoding_Term.mk_IsTotFun xtok1 in
+                        (uu___4, FStar_Pervasives_Native.None, axiom_name) in
+                      FStar_SMTEncoding_Util.mkAssume uu___3 in
+                    let uu___3 =
                       FStar_List.fold_left
-                        (fun uu____405 ->
+                        (fun uu___4 ->
                            fun var ->
-                             match uu____405 with
+                             match uu___4 with
                              | (axioms, app, vars1) ->
                                  let app1 =
                                    FStar_SMTEncoding_EncodeTerm.mk_Apply app
                                      [var] in
                                  let vars2 = FStar_List.append vars1 [var] in
                                  let axiom_name1 =
-                                   let uu____509 =
-                                     let uu____510 =
-                                       let uu____511 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_All.pipe_right vars2
                                            FStar_List.length in
-                                       Prims.string_of_int uu____511 in
-                                     Prims.op_Hat "." uu____510 in
-                                   Prims.op_Hat axiom_name uu____509 in
-                                 let uu____526 =
-                                   let uu____529 =
-                                     let uu____532 =
-                                       let uu____533 =
-                                         let uu____540 =
-                                           let uu____541 =
-                                             let uu____552 =
+                                       Prims.string_of_int uu___7 in
+                                     Prims.op_Hat "." uu___6 in
+                                   Prims.op_Hat axiom_name uu___5 in
+                                 let uu___5 =
+                                   let uu___6 =
+                                     let uu___7 =
+                                       let uu___8 =
+                                         let uu___9 =
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_SMTEncoding_Term.mk_IsTotFun
                                                  app1 in
-                                             ([[app1]], vars2, uu____552) in
+                                             ([[app1]], vars2, uu___11) in
                                            FStar_SMTEncoding_Term.mkForall
-                                             rng uu____541 in
-                                         (uu____540,
+                                             rng uu___10 in
+                                         (uu___9,
                                            FStar_Pervasives_Native.None,
                                            axiom_name1) in
-                                       FStar_SMTEncoding_Util.mkAssume
-                                         uu____533 in
-                                     [uu____532] in
-                                   FStar_List.append axioms uu____529 in
-                                 (uu____526, app1, vars2))
+                                       FStar_SMTEncoding_Util.mkAssume uu___8 in
+                                     [uu___7] in
+                                   FStar_List.append axioms uu___6 in
+                                 (uu___5, app1, vars2))
                         ([tot_fun_axiom_for_x], xtok1, []) all_vars_but_one in
-                    match uu____357 with
-                    | (axioms, uu____590, uu____591) -> axioms in
-                  let uu____612 =
-                    let uu____615 =
-                      let uu____618 =
-                        let uu____621 =
-                          let uu____624 =
-                            let uu____625 =
-                              let uu____632 =
-                                let uu____633 =
-                                  let uu____644 =
+                    match uu___3 with | (axioms, uu___4, uu___5) -> axioms in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_SMTEncoding_Util.mkEq (xapp, body) in
-                                  ([[xapp]], vars, uu____644) in
-                                FStar_SMTEncoding_Term.mkForall rng uu____633 in
-                              (uu____632, FStar_Pervasives_Native.None,
+                                  ([[xapp]], vars, uu___11) in
+                                FStar_SMTEncoding_Term.mkForall rng uu___10 in
+                              (uu___9, FStar_Pervasives_Native.None,
                                 (Prims.op_Hat "primitive_" x1)) in
-                            FStar_SMTEncoding_Util.mkAssume uu____625 in
-                          [uu____624] in
-                        xtok_decl :: uu____621 in
-                      xname_decl :: uu____618 in
-                    let uu____653 =
-                      let uu____656 =
-                        let uu____659 =
-                          let uu____660 =
-                            let uu____667 =
-                              let uu____668 =
-                                let uu____679 =
+                            FStar_SMTEncoding_Util.mkAssume uu___8 in
+                          [uu___7] in
+                        xtok_decl :: uu___6 in
+                      xname_decl :: uu___5 in
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
                                   FStar_SMTEncoding_Util.mkEq
                                     (xtok_app, xapp) in
-                                ([[xtok_app]], vars, uu____679) in
-                              FStar_SMTEncoding_Term.mkForall rng uu____668 in
-                            (uu____667,
+                                ([[xtok_app]], vars, uu___11) in
+                              FStar_SMTEncoding_Term.mkForall rng uu___10 in
+                            (uu___9,
                               (FStar_Pervasives_Native.Some
                                  "Name-token correspondence"),
                               (Prims.op_Hat "token_correspondence_" x1)) in
-                          FStar_SMTEncoding_Util.mkAssume uu____660 in
-                        [uu____659] in
-                      FStar_List.append tot_fun_axioms uu____656 in
-                    FStar_List.append uu____615 uu____653 in
-                  (xtok1, (FStar_List.length vars), uu____612) in
+                          FStar_SMTEncoding_Util.mkAssume uu___8 in
+                        [uu___7] in
+                      FStar_List.append tot_fun_axioms uu___6 in
+                    FStar_List.append uu___4 uu___5 in
+                  (xtok1, (FStar_List.length vars), uu___3) in
                 let axy =
                   FStar_List.map FStar_SMTEncoding_Term.mk_fv
                     [(asym, FStar_SMTEncoding_Term.Term_sort);
@@ -202,548 +199,522 @@ let (prims : prims_t) =
                 let qx =
                   FStar_List.map FStar_SMTEncoding_Term.mk_fv
                     [(xsym, FStar_SMTEncoding_Term.Term_sort)] in
-                let prims =
-                  let uu____810 =
-                    let uu____829 =
-                      let uu____846 =
-                        let uu____847 = FStar_SMTEncoding_Util.mkEq (x, y) in
+                let prims1 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_SMTEncoding_Util.mkEq (x, y) in
                         FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                          uu____847 in
-                      quant axy uu____846 in
-                    (FStar_Parser_Const.op_Eq, uu____829) in
-                  let uu____862 =
-                    let uu____883 =
-                      let uu____902 =
-                        let uu____919 =
-                          let uu____920 =
-                            let uu____921 =
-                              FStar_SMTEncoding_Util.mkEq (x, y) in
-                            FStar_SMTEncoding_Util.mkNot uu____921 in
+                          uu___6 in
+                      quant axy uu___5 in
+                    (FStar_Parser_Const.op_Eq, uu___4) in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 = FStar_SMTEncoding_Util.mkEq (x, y) in
+                            FStar_SMTEncoding_Util.mkNot uu___9 in
                           FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                            uu____920 in
-                        quant axy uu____919 in
-                      (FStar_Parser_Const.op_notEq, uu____902) in
-                    let uu____936 =
-                      let uu____957 =
-                        let uu____976 =
-                          let uu____993 =
-                            let uu____994 =
-                              let uu____995 =
-                                let uu____1000 =
+                            uu___8 in
+                        quant axy uu___7 in
+                      (FStar_Parser_Const.op_notEq, uu___6) in
+                    let uu___6 =
+                      let uu___7 =
+                        let uu___8 =
+                          let uu___9 =
+                            let uu___10 =
+                              let uu___11 =
+                                let uu___12 =
                                   FStar_SMTEncoding_Term.unboxBool x in
-                                let uu____1001 =
+                                let uu___13 =
                                   FStar_SMTEncoding_Term.unboxBool y in
-                                (uu____1000, uu____1001) in
-                              FStar_SMTEncoding_Util.mkAnd uu____995 in
+                                (uu___12, uu___13) in
+                              FStar_SMTEncoding_Util.mkAnd uu___11 in
                             FStar_All.pipe_left
-                              FStar_SMTEncoding_Term.boxBool uu____994 in
-                          quant xy uu____993 in
-                        (FStar_Parser_Const.op_And, uu____976) in
-                      let uu____1016 =
-                        let uu____1037 =
-                          let uu____1056 =
-                            let uu____1073 =
-                              let uu____1074 =
-                                let uu____1075 =
-                                  let uu____1080 =
+                              FStar_SMTEncoding_Term.boxBool uu___10 in
+                          quant xy uu___9 in
+                        (FStar_Parser_Const.op_And, uu___8) in
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 =
+                              let uu___12 =
+                                let uu___13 =
+                                  let uu___14 =
                                     FStar_SMTEncoding_Term.unboxBool x in
-                                  let uu____1081 =
+                                  let uu___15 =
                                     FStar_SMTEncoding_Term.unboxBool y in
-                                  (uu____1080, uu____1081) in
-                                FStar_SMTEncoding_Util.mkOr uu____1075 in
+                                  (uu___14, uu___15) in
+                                FStar_SMTEncoding_Util.mkOr uu___13 in
                               FStar_All.pipe_left
-                                FStar_SMTEncoding_Term.boxBool uu____1074 in
-                            quant xy uu____1073 in
-                          (FStar_Parser_Const.op_Or, uu____1056) in
-                        let uu____1096 =
-                          let uu____1117 =
-                            let uu____1136 =
-                              let uu____1153 =
-                                let uu____1154 =
-                                  let uu____1155 =
+                                FStar_SMTEncoding_Term.boxBool uu___12 in
+                            quant xy uu___11 in
+                          (FStar_Parser_Const.op_Or, uu___10) in
+                        let uu___10 =
+                          let uu___11 =
+                            let uu___12 =
+                              let uu___13 =
+                                let uu___14 =
+                                  let uu___15 =
                                     FStar_SMTEncoding_Term.unboxBool x in
-                                  FStar_SMTEncoding_Util.mkNot uu____1155 in
+                                  FStar_SMTEncoding_Util.mkNot uu___15 in
                                 FStar_All.pipe_left
-                                  FStar_SMTEncoding_Term.boxBool uu____1154 in
-                              quant qx uu____1153 in
-                            (FStar_Parser_Const.op_Negation, uu____1136) in
-                          let uu____1170 =
-                            let uu____1191 =
-                              let uu____1210 =
-                                let uu____1227 =
-                                  let uu____1228 =
-                                    let uu____1229 =
-                                      let uu____1234 =
+                                  FStar_SMTEncoding_Term.boxBool uu___14 in
+                              quant qx uu___13 in
+                            (FStar_Parser_Const.op_Negation, uu___12) in
+                          let uu___12 =
+                            let uu___13 =
+                              let uu___14 =
+                                let uu___15 =
+                                  let uu___16 =
+                                    let uu___17 =
+                                      let uu___18 =
                                         FStar_SMTEncoding_Term.unboxInt x in
-                                      let uu____1235 =
+                                      let uu___19 =
                                         FStar_SMTEncoding_Term.unboxInt y in
-                                      (uu____1234, uu____1235) in
-                                    FStar_SMTEncoding_Util.mkLT uu____1229 in
+                                      (uu___18, uu___19) in
+                                    FStar_SMTEncoding_Util.mkLT uu___17 in
                                   FStar_All.pipe_left
-                                    FStar_SMTEncoding_Term.boxBool uu____1228 in
-                                quant xy uu____1227 in
-                              (FStar_Parser_Const.op_LT, uu____1210) in
-                            let uu____1250 =
-                              let uu____1271 =
-                                let uu____1290 =
-                                  let uu____1307 =
-                                    let uu____1308 =
-                                      let uu____1309 =
-                                        let uu____1314 =
+                                    FStar_SMTEncoding_Term.boxBool uu___16 in
+                                quant xy uu___15 in
+                              (FStar_Parser_Const.op_LT, uu___14) in
+                            let uu___14 =
+                              let uu___15 =
+                                let uu___16 =
+                                  let uu___17 =
+                                    let uu___18 =
+                                      let uu___19 =
+                                        let uu___20 =
                                           FStar_SMTEncoding_Term.unboxInt x in
-                                        let uu____1315 =
+                                        let uu___21 =
                                           FStar_SMTEncoding_Term.unboxInt y in
-                                        (uu____1314, uu____1315) in
-                                      FStar_SMTEncoding_Util.mkLTE uu____1309 in
+                                        (uu___20, uu___21) in
+                                      FStar_SMTEncoding_Util.mkLTE uu___19 in
                                     FStar_All.pipe_left
-                                      FStar_SMTEncoding_Term.boxBool
-                                      uu____1308 in
-                                  quant xy uu____1307 in
-                                (FStar_Parser_Const.op_LTE, uu____1290) in
-                              let uu____1330 =
-                                let uu____1351 =
-                                  let uu____1370 =
-                                    let uu____1387 =
-                                      let uu____1388 =
-                                        let uu____1389 =
-                                          let uu____1394 =
+                                      FStar_SMTEncoding_Term.boxBool uu___18 in
+                                  quant xy uu___17 in
+                                (FStar_Parser_Const.op_LTE, uu___16) in
+                              let uu___16 =
+                                let uu___17 =
+                                  let uu___18 =
+                                    let uu___19 =
+                                      let uu___20 =
+                                        let uu___21 =
+                                          let uu___22 =
                                             FStar_SMTEncoding_Term.unboxInt x in
-                                          let uu____1395 =
+                                          let uu___23 =
                                             FStar_SMTEncoding_Term.unboxInt y in
-                                          (uu____1394, uu____1395) in
-                                        FStar_SMTEncoding_Util.mkGT
-                                          uu____1389 in
+                                          (uu___22, uu___23) in
+                                        FStar_SMTEncoding_Util.mkGT uu___21 in
                                       FStar_All.pipe_left
                                         FStar_SMTEncoding_Term.boxBool
-                                        uu____1388 in
-                                    quant xy uu____1387 in
-                                  (FStar_Parser_Const.op_GT, uu____1370) in
-                                let uu____1410 =
-                                  let uu____1431 =
-                                    let uu____1450 =
-                                      let uu____1467 =
-                                        let uu____1468 =
-                                          let uu____1469 =
-                                            let uu____1474 =
+                                        uu___20 in
+                                    quant xy uu___19 in
+                                  (FStar_Parser_Const.op_GT, uu___18) in
+                                let uu___18 =
+                                  let uu___19 =
+                                    let uu___20 =
+                                      let uu___21 =
+                                        let uu___22 =
+                                          let uu___23 =
+                                            let uu___24 =
                                               FStar_SMTEncoding_Term.unboxInt
                                                 x in
-                                            let uu____1475 =
+                                            let uu___25 =
                                               FStar_SMTEncoding_Term.unboxInt
                                                 y in
-                                            (uu____1474, uu____1475) in
+                                            (uu___24, uu___25) in
                                           FStar_SMTEncoding_Util.mkGTE
-                                            uu____1469 in
+                                            uu___23 in
                                         FStar_All.pipe_left
                                           FStar_SMTEncoding_Term.boxBool
-                                          uu____1468 in
-                                      quant xy uu____1467 in
-                                    (FStar_Parser_Const.op_GTE, uu____1450) in
-                                  let uu____1490 =
-                                    let uu____1511 =
-                                      let uu____1530 =
-                                        let uu____1547 =
-                                          let uu____1548 =
-                                            let uu____1549 =
-                                              let uu____1554 =
+                                          uu___22 in
+                                      quant xy uu___21 in
+                                    (FStar_Parser_Const.op_GTE, uu___20) in
+                                  let uu___20 =
+                                    let uu___21 =
+                                      let uu___22 =
+                                        let uu___23 =
+                                          let uu___24 =
+                                            let uu___25 =
+                                              let uu___26 =
                                                 FStar_SMTEncoding_Term.unboxInt
                                                   x in
-                                              let uu____1555 =
+                                              let uu___27 =
                                                 FStar_SMTEncoding_Term.unboxInt
                                                   y in
-                                              (uu____1554, uu____1555) in
+                                              (uu___26, uu___27) in
                                             FStar_SMTEncoding_Util.mkSub
-                                              uu____1549 in
+                                              uu___25 in
                                           FStar_All.pipe_left
                                             FStar_SMTEncoding_Term.boxInt
-                                            uu____1548 in
-                                        quant xy uu____1547 in
+                                            uu___24 in
+                                        quant xy uu___23 in
                                       (FStar_Parser_Const.op_Subtraction,
-                                        uu____1530) in
-                                    let uu____1570 =
-                                      let uu____1591 =
-                                        let uu____1610 =
-                                          let uu____1627 =
-                                            let uu____1628 =
-                                              let uu____1629 =
+                                        uu___22) in
+                                    let uu___22 =
+                                      let uu___23 =
+                                        let uu___24 =
+                                          let uu___25 =
+                                            let uu___26 =
+                                              let uu___27 =
                                                 FStar_SMTEncoding_Term.unboxInt
                                                   x in
                                               FStar_SMTEncoding_Util.mkMinus
-                                                uu____1629 in
+                                                uu___27 in
                                             FStar_All.pipe_left
                                               FStar_SMTEncoding_Term.boxInt
-                                              uu____1628 in
-                                          quant qx uu____1627 in
+                                              uu___26 in
+                                          quant qx uu___25 in
                                         (FStar_Parser_Const.op_Minus,
-                                          uu____1610) in
-                                      let uu____1644 =
-                                        let uu____1665 =
-                                          let uu____1684 =
-                                            let uu____1701 =
-                                              let uu____1702 =
-                                                let uu____1703 =
-                                                  let uu____1708 =
+                                          uu___24) in
+                                      let uu___24 =
+                                        let uu___25 =
+                                          let uu___26 =
+                                            let uu___27 =
+                                              let uu___28 =
+                                                let uu___29 =
+                                                  let uu___30 =
                                                     FStar_SMTEncoding_Term.unboxInt
                                                       x in
-                                                  let uu____1709 =
+                                                  let uu___31 =
                                                     FStar_SMTEncoding_Term.unboxInt
                                                       y in
-                                                  (uu____1708, uu____1709) in
+                                                  (uu___30, uu___31) in
                                                 FStar_SMTEncoding_Util.mkAdd
-                                                  uu____1703 in
+                                                  uu___29 in
                                               FStar_All.pipe_left
                                                 FStar_SMTEncoding_Term.boxInt
-                                                uu____1702 in
-                                            quant xy uu____1701 in
+                                                uu___28 in
+                                            quant xy uu___27 in
                                           (FStar_Parser_Const.op_Addition,
-                                            uu____1684) in
-                                        let uu____1724 =
-                                          let uu____1745 =
-                                            let uu____1764 =
-                                              let uu____1781 =
-                                                let uu____1782 =
-                                                  let uu____1783 =
-                                                    let uu____1788 =
+                                            uu___26) in
+                                        let uu___26 =
+                                          let uu___27 =
+                                            let uu___28 =
+                                              let uu___29 =
+                                                let uu___30 =
+                                                  let uu___31 =
+                                                    let uu___32 =
                                                       FStar_SMTEncoding_Term.unboxInt
                                                         x in
-                                                    let uu____1789 =
+                                                    let uu___33 =
                                                       FStar_SMTEncoding_Term.unboxInt
                                                         y in
-                                                    (uu____1788, uu____1789) in
+                                                    (uu___32, uu___33) in
                                                   FStar_SMTEncoding_Util.mkMul
-                                                    uu____1783 in
+                                                    uu___31 in
                                                 FStar_All.pipe_left
                                                   FStar_SMTEncoding_Term.boxInt
-                                                  uu____1782 in
-                                              quant xy uu____1781 in
+                                                  uu___30 in
+                                              quant xy uu___29 in
                                             (FStar_Parser_Const.op_Multiply,
-                                              uu____1764) in
-                                          let uu____1804 =
-                                            let uu____1825 =
-                                              let uu____1844 =
-                                                let uu____1861 =
-                                                  let uu____1862 =
-                                                    let uu____1863 =
-                                                      let uu____1868 =
+                                              uu___28) in
+                                          let uu___28 =
+                                            let uu___29 =
+                                              let uu___30 =
+                                                let uu___31 =
+                                                  let uu___32 =
+                                                    let uu___33 =
+                                                      let uu___34 =
                                                         FStar_SMTEncoding_Term.unboxInt
                                                           x in
-                                                      let uu____1869 =
+                                                      let uu___35 =
                                                         FStar_SMTEncoding_Term.unboxInt
                                                           y in
-                                                      (uu____1868,
-                                                        uu____1869) in
+                                                      (uu___34, uu___35) in
                                                     FStar_SMTEncoding_Util.mkDiv
-                                                      uu____1863 in
+                                                      uu___33 in
                                                   FStar_All.pipe_left
                                                     FStar_SMTEncoding_Term.boxInt
-                                                    uu____1862 in
-                                                quant xy uu____1861 in
+                                                    uu___32 in
+                                                quant xy uu___31 in
                                               (FStar_Parser_Const.op_Division,
-                                                uu____1844) in
-                                            let uu____1884 =
-                                              let uu____1905 =
-                                                let uu____1924 =
-                                                  let uu____1941 =
-                                                    let uu____1942 =
-                                                      let uu____1943 =
-                                                        let uu____1948 =
+                                                uu___30) in
+                                            let uu___30 =
+                                              let uu___31 =
+                                                let uu___32 =
+                                                  let uu___33 =
+                                                    let uu___34 =
+                                                      let uu___35 =
+                                                        let uu___36 =
                                                           FStar_SMTEncoding_Term.unboxInt
                                                             x in
-                                                        let uu____1949 =
+                                                        let uu___37 =
                                                           FStar_SMTEncoding_Term.unboxInt
                                                             y in
-                                                        (uu____1948,
-                                                          uu____1949) in
+                                                        (uu___36, uu___37) in
                                                       FStar_SMTEncoding_Util.mkMod
-                                                        uu____1943 in
+                                                        uu___35 in
                                                     FStar_All.pipe_left
                                                       FStar_SMTEncoding_Term.boxInt
-                                                      uu____1942 in
-                                                  quant xy uu____1941 in
+                                                      uu___34 in
+                                                  quant xy uu___33 in
                                                 (FStar_Parser_Const.op_Modulus,
-                                                  uu____1924) in
-                                              let uu____1964 =
-                                                let uu____1985 =
-                                                  let uu____2004 =
-                                                    let uu____2021 =
-                                                      let uu____2022 =
-                                                        let uu____2023 =
-                                                          let uu____2028 =
+                                                  uu___32) in
+                                              let uu___32 =
+                                                let uu___33 =
+                                                  let uu___34 =
+                                                    let uu___35 =
+                                                      let uu___36 =
+                                                        let uu___37 =
+                                                          let uu___38 =
                                                             FStar_SMTEncoding_Term.unboxReal
                                                               x in
-                                                          let uu____2029 =
+                                                          let uu___39 =
                                                             FStar_SMTEncoding_Term.unboxReal
                                                               y in
-                                                          (uu____2028,
-                                                            uu____2029) in
+                                                          (uu___38, uu___39) in
                                                         FStar_SMTEncoding_Util.mkLT
-                                                          uu____2023 in
+                                                          uu___37 in
                                                       FStar_All.pipe_left
                                                         FStar_SMTEncoding_Term.boxBool
-                                                        uu____2022 in
-                                                    quant xy uu____2021 in
+                                                        uu___36 in
+                                                    quant xy uu___35 in
                                                   (FStar_Parser_Const.real_op_LT,
-                                                    uu____2004) in
-                                                let uu____2044 =
-                                                  let uu____2065 =
-                                                    let uu____2084 =
-                                                      let uu____2101 =
-                                                        let uu____2102 =
-                                                          let uu____2103 =
-                                                            let uu____2108 =
+                                                    uu___34) in
+                                                let uu___34 =
+                                                  let uu___35 =
+                                                    let uu___36 =
+                                                      let uu___37 =
+                                                        let uu___38 =
+                                                          let uu___39 =
+                                                            let uu___40 =
                                                               FStar_SMTEncoding_Term.unboxReal
                                                                 x in
-                                                            let uu____2109 =
+                                                            let uu___41 =
                                                               FStar_SMTEncoding_Term.unboxReal
                                                                 y in
-                                                            (uu____2108,
-                                                              uu____2109) in
+                                                            (uu___40,
+                                                              uu___41) in
                                                           FStar_SMTEncoding_Util.mkLTE
-                                                            uu____2103 in
+                                                            uu___39 in
                                                         FStar_All.pipe_left
                                                           FStar_SMTEncoding_Term.boxBool
-                                                          uu____2102 in
-                                                      quant xy uu____2101 in
+                                                          uu___38 in
+                                                      quant xy uu___37 in
                                                     (FStar_Parser_Const.real_op_LTE,
-                                                      uu____2084) in
-                                                  let uu____2124 =
-                                                    let uu____2145 =
-                                                      let uu____2164 =
-                                                        let uu____2181 =
-                                                          let uu____2182 =
-                                                            let uu____2183 =
-                                                              let uu____2188
-                                                                =
+                                                      uu___36) in
+                                                  let uu___36 =
+                                                    let uu___37 =
+                                                      let uu___38 =
+                                                        let uu___39 =
+                                                          let uu___40 =
+                                                            let uu___41 =
+                                                              let uu___42 =
                                                                 FStar_SMTEncoding_Term.unboxReal
                                                                   x in
-                                                              let uu____2189
-                                                                =
+                                                              let uu___43 =
                                                                 FStar_SMTEncoding_Term.unboxReal
                                                                   y in
-                                                              (uu____2188,
-                                                                uu____2189) in
+                                                              (uu___42,
+                                                                uu___43) in
                                                             FStar_SMTEncoding_Util.mkGT
-                                                              uu____2183 in
+                                                              uu___41 in
                                                           FStar_All.pipe_left
                                                             FStar_SMTEncoding_Term.boxBool
-                                                            uu____2182 in
-                                                        quant xy uu____2181 in
+                                                            uu___40 in
+                                                        quant xy uu___39 in
                                                       (FStar_Parser_Const.real_op_GT,
-                                                        uu____2164) in
-                                                    let uu____2204 =
-                                                      let uu____2225 =
-                                                        let uu____2244 =
-                                                          let uu____2261 =
-                                                            let uu____2262 =
-                                                              let uu____2263
-                                                                =
-                                                                let uu____2268
-                                                                  =
+                                                        uu___38) in
+                                                    let uu___38 =
+                                                      let uu___39 =
+                                                        let uu___40 =
+                                                          let uu___41 =
+                                                            let uu___42 =
+                                                              let uu___43 =
+                                                                let uu___44 =
                                                                   FStar_SMTEncoding_Term.unboxReal
                                                                     x in
-                                                                let uu____2269
-                                                                  =
+                                                                let uu___45 =
                                                                   FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                (uu____2268,
-                                                                  uu____2269) in
+                                                                (uu___44,
+                                                                  uu___45) in
                                                               FStar_SMTEncoding_Util.mkGTE
-                                                                uu____2263 in
+                                                                uu___43 in
                                                             FStar_All.pipe_left
                                                               FStar_SMTEncoding_Term.boxBool
-                                                              uu____2262 in
-                                                          quant xy uu____2261 in
+                                                              uu___42 in
+                                                          quant xy uu___41 in
                                                         (FStar_Parser_Const.real_op_GTE,
-                                                          uu____2244) in
-                                                      let uu____2284 =
-                                                        let uu____2305 =
-                                                          let uu____2324 =
-                                                            let uu____2341 =
-                                                              let uu____2342
-                                                                =
-                                                                let uu____2343
-                                                                  =
-                                                                  let uu____2348
+                                                          uu___40) in
+                                                      let uu___40 =
+                                                        let uu___41 =
+                                                          let uu___42 =
+                                                            let uu___43 =
+                                                              let uu___44 =
+                                                                let uu___45 =
+                                                                  let uu___46
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     x in
-                                                                  let uu____2349
+                                                                  let uu___47
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                  (uu____2348,
-                                                                    uu____2349) in
+                                                                  (uu___46,
+                                                                    uu___47) in
                                                                 FStar_SMTEncoding_Util.mkSub
-                                                                  uu____2343 in
+                                                                  uu___45 in
                                                               FStar_All.pipe_left
                                                                 FStar_SMTEncoding_Term.boxReal
-                                                                uu____2342 in
-                                                            quant xy
-                                                              uu____2341 in
+                                                                uu___44 in
+                                                            quant xy uu___43 in
                                                           (FStar_Parser_Const.real_op_Subtraction,
-                                                            uu____2324) in
-                                                        let uu____2364 =
-                                                          let uu____2385 =
-                                                            let uu____2404 =
-                                                              let uu____2421
-                                                                =
-                                                                let uu____2422
-                                                                  =
-                                                                  let uu____2423
+                                                            uu___42) in
+                                                        let uu___42 =
+                                                          let uu___43 =
+                                                            let uu___44 =
+                                                              let uu___45 =
+                                                                let uu___46 =
+                                                                  let uu___47
                                                                     =
-                                                                    let uu____2428
+                                                                    let uu___48
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     x in
-                                                                    let uu____2429
+                                                                    let uu___49
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                    (uu____2428,
-                                                                    uu____2429) in
+                                                                    (uu___48,
+                                                                    uu___49) in
                                                                   FStar_SMTEncoding_Util.mkAdd
-                                                                    uu____2423 in
+                                                                    uu___47 in
                                                                 FStar_All.pipe_left
                                                                   FStar_SMTEncoding_Term.boxReal
-                                                                  uu____2422 in
+                                                                  uu___46 in
                                                               quant xy
-                                                                uu____2421 in
+                                                                uu___45 in
                                                             (FStar_Parser_Const.real_op_Addition,
-                                                              uu____2404) in
-                                                          let uu____2444 =
-                                                            let uu____2465 =
-                                                              let uu____2484
-                                                                =
-                                                                let uu____2501
-                                                                  =
-                                                                  let uu____2502
+                                                              uu___44) in
+                                                          let uu___44 =
+                                                            let uu___45 =
+                                                              let uu___46 =
+                                                                let uu___47 =
+                                                                  let uu___48
                                                                     =
-                                                                    let uu____2503
+                                                                    let uu___49
                                                                     =
-                                                                    let uu____2508
+                                                                    let uu___50
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     x in
-                                                                    let uu____2509
+                                                                    let uu___51
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                    (uu____2508,
-                                                                    uu____2509) in
+                                                                    (uu___50,
+                                                                    uu___51) in
                                                                     FStar_SMTEncoding_Util.mkMul
-                                                                    uu____2503 in
+                                                                    uu___49 in
                                                                   FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Term.boxReal
-                                                                    uu____2502 in
+                                                                    uu___48 in
                                                                 quant xy
-                                                                  uu____2501 in
+                                                                  uu___47 in
                                                               (FStar_Parser_Const.real_op_Multiply,
-                                                                uu____2484) in
-                                                            let uu____2524 =
-                                                              let uu____2545
-                                                                =
-                                                                let uu____2564
-                                                                  =
-                                                                  let uu____2581
+                                                                uu___46) in
+                                                            let uu___46 =
+                                                              let uu___47 =
+                                                                let uu___48 =
+                                                                  let uu___49
                                                                     =
-                                                                    let uu____2582
+                                                                    let uu___50
                                                                     =
-                                                                    let uu____2583
+                                                                    let uu___51
                                                                     =
-                                                                    let uu____2588
+                                                                    let uu___52
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     x in
-                                                                    let uu____2589
+                                                                    let uu___53
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                    (uu____2588,
-                                                                    uu____2589) in
+                                                                    (uu___52,
+                                                                    uu___53) in
                                                                     FStar_SMTEncoding_Util.mkRealDiv
-                                                                    uu____2583 in
+                                                                    uu___51 in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Term.boxReal
-                                                                    uu____2582 in
+                                                                    uu___50 in
                                                                   quant xy
-                                                                    uu____2581 in
+                                                                    uu___49 in
                                                                 (FStar_Parser_Const.real_op_Division,
-                                                                  uu____2564) in
-                                                              let uu____2604
-                                                                =
-                                                                let uu____2625
-                                                                  =
-                                                                  let uu____2644
+                                                                  uu___48) in
+                                                              let uu___48 =
+                                                                let uu___49 =
+                                                                  let uu___50
                                                                     =
-                                                                    let uu____2661
+                                                                    let uu___51
                                                                     =
-                                                                    let uu____2662
+                                                                    let uu___52
                                                                     =
-                                                                    let uu____2663
+                                                                    let uu___53
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxInt
                                                                     x in
                                                                     FStar_SMTEncoding_Term.mkRealOfInt
-                                                                    uu____2663
+                                                                    uu___53
                                                                     FStar_Range.dummyRange in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Term.boxReal
-                                                                    uu____2662 in
+                                                                    uu___52 in
                                                                     quant qx
-                                                                    uu____2661 in
+                                                                    uu___51 in
                                                                   (FStar_Parser_Const.real_of_int,
-                                                                    uu____2644) in
-                                                                [uu____2625] in
-                                                              uu____2545 ::
-                                                                uu____2604 in
-                                                            uu____2465 ::
-                                                              uu____2524 in
-                                                          uu____2385 ::
-                                                            uu____2444 in
-                                                        uu____2305 ::
-                                                          uu____2364 in
-                                                      uu____2225 ::
-                                                        uu____2284 in
-                                                    uu____2145 :: uu____2204 in
-                                                  uu____2065 :: uu____2124 in
-                                                uu____1985 :: uu____2044 in
-                                              uu____1905 :: uu____1964 in
-                                            uu____1825 :: uu____1884 in
-                                          uu____1745 :: uu____1804 in
-                                        uu____1665 :: uu____1724 in
-                                      uu____1591 :: uu____1644 in
-                                    uu____1511 :: uu____1570 in
-                                  uu____1431 :: uu____1490 in
-                                uu____1351 :: uu____1410 in
-                              uu____1271 :: uu____1330 in
-                            uu____1191 :: uu____1250 in
-                          uu____1117 :: uu____1170 in
-                        uu____1037 :: uu____1096 in
-                      uu____957 :: uu____1016 in
-                    uu____883 :: uu____936 in
-                  uu____810 :: uu____862 in
+                                                                    uu___50) in
+                                                                [uu___49] in
+                                                              uu___47 ::
+                                                                uu___48 in
+                                                            uu___45 ::
+                                                              uu___46 in
+                                                          uu___43 :: uu___44 in
+                                                        uu___41 :: uu___42 in
+                                                      uu___39 :: uu___40 in
+                                                    uu___37 :: uu___38 in
+                                                  uu___35 :: uu___36 in
+                                                uu___33 :: uu___34 in
+                                              uu___31 :: uu___32 in
+                                            uu___29 :: uu___30 in
+                                          uu___27 :: uu___28 in
+                                        uu___25 :: uu___26 in
+                                      uu___23 :: uu___24 in
+                                    uu___21 :: uu___22 in
+                                  uu___19 :: uu___20 in
+                                uu___17 :: uu___18 in
+                              uu___15 :: uu___16 in
+                            uu___13 :: uu___14 in
+                          uu___11 :: uu___12 in
+                        uu___9 :: uu___10 in
+                      uu___7 :: uu___8 in
+                    uu___5 :: uu___6 in
+                  uu___3 :: uu___4 in
                 let mk l v =
-                  let uu____3147 =
-                    let uu____3158 =
-                      FStar_All.pipe_right prims
+                  let uu___3 =
+                    let uu___4 =
+                      FStar_All.pipe_right prims1
                         (FStar_List.find
-                           (fun uu____3240 ->
-                              match uu____3240 with
-                              | (l', uu____3258) ->
-                                  FStar_Ident.lid_equals l l')) in
-                    FStar_All.pipe_right uu____3158
+                           (fun uu___5 ->
+                              match uu___5 with
+                              | (l', uu___6) -> FStar_Ident.lid_equals l l')) in
+                    FStar_All.pipe_right uu___4
                       (FStar_Option.map
-                         (fun uu____3347 ->
-                            match uu____3347 with
-                            | (uu____3372, b) ->
-                                let uu____3402 = FStar_Ident.range_of_lid l in
-                                b uu____3402 v)) in
-                  FStar_All.pipe_right uu____3147 FStar_Option.get in
+                         (fun uu___5 ->
+                            match uu___5 with
+                            | (uu___6, b) ->
+                                let uu___7 = FStar_Ident.range_of_lid l in
+                                b uu___7 v)) in
+                  FStar_All.pipe_right uu___3 FStar_Option.get in
                 let is l =
-                  FStar_All.pipe_right prims
+                  FStar_All.pipe_right prims1
                     (FStar_Util.for_some
-                       (fun uu____3476 ->
-                          match uu____3476 with
-                          | (l', uu____3494) -> FStar_Ident.lid_equals l l')) in
+                       (fun uu___3 ->
+                          match uu___3 with
+                          | (l', uu___4) -> FStar_Ident.lid_equals l l')) in
                 { mk; is }))
 let (pretype_axiom :
   FStar_Range.range ->
@@ -756,61 +727,60 @@ let (pretype_axiom :
     fun env ->
       fun tapp ->
         fun vars ->
-          let uu____3559 =
+          let uu___ =
             FStar_SMTEncoding_Env.fresh_fvar
               env.FStar_SMTEncoding_Env.current_module_name "x"
               FStar_SMTEncoding_Term.Term_sort in
-          match uu____3559 with
+          match uu___ with
           | (xxsym, xx) ->
-              let uu____3566 =
+              let uu___1 =
                 FStar_SMTEncoding_Env.fresh_fvar
                   env.FStar_SMTEncoding_Env.current_module_name "f"
                   FStar_SMTEncoding_Term.Fuel_sort in
-              (match uu____3566 with
+              (match uu___1 with
                | (ffsym, ff) ->
                    let xx_has_type =
                      FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp in
                    let tapp_hash = FStar_SMTEncoding_Term.hash_of_term tapp in
                    let module_name =
                      env.FStar_SMTEncoding_Env.current_module_name in
-                   let uu____3576 =
-                     let uu____3583 =
-                       let uu____3584 =
-                         let uu____3595 =
-                           let uu____3596 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 =
                              FStar_SMTEncoding_Term.mk_fv
                                (xxsym, FStar_SMTEncoding_Term.Term_sort) in
-                           let uu____3603 =
-                             let uu____3612 =
+                           let uu___7 =
+                             let uu___8 =
                                FStar_SMTEncoding_Term.mk_fv
                                  (ffsym, FStar_SMTEncoding_Term.Fuel_sort) in
-                             uu____3612 :: vars in
-                           uu____3596 :: uu____3603 in
-                         let uu____3631 =
-                           let uu____3632 =
-                             let uu____3637 =
-                               let uu____3638 =
-                                 let uu____3643 =
+                             uu___8 :: vars in
+                           uu___6 :: uu___7 in
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_SMTEncoding_Util.mkApp
                                      ("PreType", [xx]) in
-                                 (tapp, uu____3643) in
-                               FStar_SMTEncoding_Util.mkEq uu____3638 in
-                             (xx_has_type, uu____3637) in
-                           FStar_SMTEncoding_Util.mkImp uu____3632 in
-                         ([[xx_has_type]], uu____3595, uu____3631) in
-                       FStar_SMTEncoding_Term.mkForall rng uu____3584 in
-                     let uu____3654 =
-                       let uu____3655 =
-                         let uu____3656 =
-                           let uu____3657 =
-                             FStar_Util.digest_of_string tapp_hash in
-                           Prims.op_Hat "_pretyping_" uu____3657 in
-                         Prims.op_Hat module_name uu____3656 in
+                                 (tapp, uu___10) in
+                               FStar_SMTEncoding_Util.mkEq uu___9 in
+                             (xx_has_type, uu___8) in
+                           FStar_SMTEncoding_Util.mkImp uu___7 in
+                         ([[xx_has_type]], uu___5, uu___6) in
+                       FStar_SMTEncoding_Term.mkForall rng uu___4 in
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 = FStar_Util.digest_of_string tapp_hash in
+                           Prims.op_Hat "_pretyping_" uu___7 in
+                         Prims.op_Hat module_name uu___6 in
                        FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                         uu____3655 in
-                     (uu____3583, (FStar_Pervasives_Native.Some "pretyping"),
-                       uu____3654) in
-                   FStar_SMTEncoding_Util.mkAssume uu____3576)
+                         uu___5 in
+                     (uu___3, (FStar_Pervasives_Native.Some "pretyping"),
+                       uu___4) in
+                   FStar_SMTEncoding_Util.mkAssume uu___2)
 let (primitive_type_axioms :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -824,97 +794,93 @@ let (primitive_type_axioms :
     FStar_SMTEncoding_Term.mk_fv ("y", FStar_SMTEncoding_Term.Term_sort) in
   let y = FStar_SMTEncoding_Util.mkFreeV yy in
   let mkForall_fuel env =
-    let uu____3702 =
-      let uu____3703 = FStar_TypeChecker_Env.current_module env in
-      FStar_Ident.string_of_lid uu____3703 in
-    FStar_SMTEncoding_EncodeTerm.mkForall_fuel uu____3702 in
+    let uu___ =
+      let uu___1 = FStar_TypeChecker_Env.current_module env in
+      FStar_Ident.string_of_lid uu___1 in
+    FStar_SMTEncoding_EncodeTerm.mkForall_fuel uu___ in
   let mk_unit env nm tt =
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
-    let uu____3723 =
-      let uu____3724 =
-        let uu____3731 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           FStar_SMTEncoding_Term.mk_HasType
             FStar_SMTEncoding_Term.mk_Term_unit tt in
-        (uu____3731, (FStar_Pervasives_Native.Some "unit typing"),
-          "unit_typing") in
-      FStar_SMTEncoding_Util.mkAssume uu____3724 in
-    let uu____3732 =
-      let uu____3735 =
-        let uu____3736 =
-          let uu____3743 =
-            let uu____3744 =
-              let uu____3755 =
-                let uu____3756 =
-                  let uu____3761 =
+        (uu___2, (FStar_Pervasives_Native.Some "unit typing"), "unit_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_SMTEncoding_Util.mkEq
                       (x, FStar_SMTEncoding_Term.mk_Term_unit) in
-                  (typing_pred, uu____3761) in
-                FStar_SMTEncoding_Util.mkImp uu____3756 in
-              ([[typing_pred]], [xx], uu____3755) in
-            let uu____3782 =
-              let uu____3797 = FStar_TypeChecker_Env.get_range env in
-              let uu____3798 = mkForall_fuel env in uu____3798 uu____3797 in
-            uu____3782 uu____3744 in
-          (uu____3743, (FStar_Pervasives_Native.Some "unit inversion"),
+                  (typing_pred, uu___8) in
+                FStar_SMTEncoding_Util.mkImp uu___7 in
+              ([[typing_pred]], [xx], uu___6) in
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.get_range env in
+              let uu___8 = mkForall_fuel env in uu___8 uu___7 in
+            uu___6 uu___5 in
+          (uu___4, (FStar_Pervasives_Native.Some "unit inversion"),
             "unit_inversion") in
-        FStar_SMTEncoding_Util.mkAssume uu____3736 in
-      [uu____3735] in
-    uu____3723 :: uu____3732 in
+        FStar_SMTEncoding_Util.mkAssume uu___3 in
+      [uu___2] in
+    uu___ :: uu___1 in
   let mk_bool env nm tt =
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let bb =
       FStar_SMTEncoding_Term.mk_fv ("b", FStar_SMTEncoding_Term.Bool_sort) in
     let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let uu____3837 =
-      let uu____3838 =
-        let uu____3845 =
-          let uu____3846 = FStar_TypeChecker_Env.get_range env in
-          let uu____3847 =
-            let uu____3858 =
-              let uu____3863 =
-                let uu____3866 = FStar_SMTEncoding_Term.boxBool b in
-                [uu____3866] in
-              [uu____3863] in
-            let uu____3871 =
-              let uu____3872 = FStar_SMTEncoding_Term.boxBool b in
-              FStar_SMTEncoding_Term.mk_HasType uu____3872 tt in
-            (uu____3858, [bb], uu____3871) in
-          FStar_SMTEncoding_Term.mkForall uu____3846 uu____3847 in
-        (uu____3845, (FStar_Pervasives_Native.Some "bool typing"),
-          "bool_typing") in
-      FStar_SMTEncoding_Util.mkAssume uu____3838 in
-    let uu____3889 =
-      let uu____3892 =
-        let uu____3893 =
-          let uu____3900 =
-            let uu____3901 =
-              let uu____3912 =
-                let uu____3913 =
-                  let uu____3918 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Term.boxBool b in [uu___7] in
+              [uu___6] in
+            let uu___6 =
+              let uu___7 = FStar_SMTEncoding_Term.boxBool b in
+              FStar_SMTEncoding_Term.mk_HasType uu___7 tt in
+            (uu___5, [bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "bool typing"), "bool_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
                          FStar_SMTEncoding_Term.boxBoolFun) x in
-                  (typing_pred, uu____3918) in
-                FStar_SMTEncoding_Util.mkImp uu____3913 in
-              ([[typing_pred]], [xx], uu____3912) in
-            let uu____3939 =
-              let uu____3954 = FStar_TypeChecker_Env.get_range env in
-              let uu____3955 = mkForall_fuel env in uu____3955 uu____3954 in
-            uu____3939 uu____3901 in
-          (uu____3900, (FStar_Pervasives_Native.Some "bool inversion"),
+                  (typing_pred, uu___8) in
+                FStar_SMTEncoding_Util.mkImp uu___7 in
+              ([[typing_pred]], [xx], uu___6) in
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.get_range env in
+              let uu___8 = mkForall_fuel env in uu___8 uu___7 in
+            uu___6 uu___5 in
+          (uu___4, (FStar_Pervasives_Native.Some "bool inversion"),
             "bool_inversion") in
-        FStar_SMTEncoding_Util.mkAssume uu____3893 in
-      [uu____3892] in
-    uu____3837 :: uu____3889 in
+        FStar_SMTEncoding_Util.mkAssume uu___3 in
+      [uu___2] in
+    uu___ :: uu___1 in
   let mk_int env nm tt =
     let lex_t =
-      let uu____3992 =
-        let uu____3993 =
-          let uu____3998 =
-            FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid in
-          (uu____3998, FStar_SMTEncoding_Term.Term_sort) in
-        FStar_SMTEncoding_Term.mk_fv uu____3993 in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____3992 in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid in
+          (uu___2, FStar_SMTEncoding_Term.Term_sort) in
+        FStar_SMTEncoding_Term.mk_fv uu___1 in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___ in
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt in
     let aa =
@@ -924,118 +890,115 @@ let (primitive_type_axioms :
       FStar_SMTEncoding_Term.mk_fv ("b", FStar_SMTEncoding_Term.Int_sort) in
     let b = FStar_SMTEncoding_Util.mkFreeV bb in
     let precedes_y_x =
-      let uu____4006 =
+      let uu___ =
         FStar_SMTEncoding_Util.mkApp ("Prims.precedes", [lex_t; lex_t; y; x]) in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____4006 in
-    let uu____4009 =
-      let uu____4010 =
-        let uu____4017 =
-          let uu____4018 = FStar_TypeChecker_Env.get_range env in
-          let uu____4019 =
-            let uu____4030 =
-              let uu____4035 =
-                let uu____4038 = FStar_SMTEncoding_Term.boxInt b in
-                [uu____4038] in
-              [uu____4035] in
-            let uu____4043 =
-              let uu____4044 = FStar_SMTEncoding_Term.boxInt b in
-              FStar_SMTEncoding_Term.mk_HasType uu____4044 tt in
-            (uu____4030, [bb], uu____4043) in
-          FStar_SMTEncoding_Term.mkForall uu____4018 uu____4019 in
-        (uu____4017, (FStar_Pervasives_Native.Some "int typing"),
-          "int_typing") in
-      FStar_SMTEncoding_Util.mkAssume uu____4010 in
-    let uu____4061 =
-      let uu____4064 =
-        let uu____4065 =
-          let uu____4072 =
-            let uu____4073 =
-              let uu____4084 =
-                let uu____4085 =
-                  let uu____4090 =
+      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu___ in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Term.boxInt b in [uu___7] in
+              [uu___6] in
+            let uu___6 =
+              let uu___7 = FStar_SMTEncoding_Term.boxInt b in
+              FStar_SMTEncoding_Term.mk_HasType uu___7 tt in
+            (uu___5, [bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "int typing"), "int_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
                          FStar_SMTEncoding_Term.boxIntFun) x in
-                  (typing_pred, uu____4090) in
-                FStar_SMTEncoding_Util.mkImp uu____4085 in
-              ([[typing_pred]], [xx], uu____4084) in
-            let uu____4111 =
-              let uu____4126 = FStar_TypeChecker_Env.get_range env in
-              let uu____4127 = mkForall_fuel env in uu____4127 uu____4126 in
-            uu____4111 uu____4073 in
-          (uu____4072, (FStar_Pervasives_Native.Some "int inversion"),
+                  (typing_pred, uu___8) in
+                FStar_SMTEncoding_Util.mkImp uu___7 in
+              ([[typing_pred]], [xx], uu___6) in
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.get_range env in
+              let uu___8 = mkForall_fuel env in uu___8 uu___7 in
+            uu___6 uu___5 in
+          (uu___4, (FStar_Pervasives_Native.Some "int inversion"),
             "int_inversion") in
-        FStar_SMTEncoding_Util.mkAssume uu____4065 in
-      let uu____4145 =
-        let uu____4148 =
-          let uu____4149 =
-            let uu____4156 =
-              let uu____4157 =
-                let uu____4168 =
-                  let uu____4169 =
-                    let uu____4174 =
-                      let uu____4175 =
-                        let uu____4178 =
-                          let uu____4181 =
-                            let uu____4184 =
-                              let uu____4185 =
-                                let uu____4190 =
+        FStar_SMTEncoding_Util.mkAssume uu___3 in
+      let uu___3 =
+        let uu___4 =
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 =
+                            let uu___14 =
+                              let uu___15 =
+                                let uu___16 =
                                   FStar_SMTEncoding_Term.unboxInt x in
-                                let uu____4191 =
+                                let uu___17 =
                                   FStar_SMTEncoding_Util.mkInteger'
                                     Prims.int_zero in
-                                (uu____4190, uu____4191) in
-                              FStar_SMTEncoding_Util.mkGT uu____4185 in
-                            let uu____4192 =
-                              let uu____4195 =
-                                let uu____4196 =
-                                  let uu____4201 =
+                                (uu___16, uu___17) in
+                              FStar_SMTEncoding_Util.mkGT uu___15 in
+                            let uu___15 =
+                              let uu___16 =
+                                let uu___17 =
+                                  let uu___18 =
                                     FStar_SMTEncoding_Term.unboxInt y in
-                                  let uu____4202 =
+                                  let uu___19 =
                                     FStar_SMTEncoding_Util.mkInteger'
                                       Prims.int_zero in
-                                  (uu____4201, uu____4202) in
-                                FStar_SMTEncoding_Util.mkGTE uu____4196 in
-                              let uu____4203 =
-                                let uu____4206 =
-                                  let uu____4207 =
-                                    let uu____4212 =
+                                  (uu___18, uu___19) in
+                                FStar_SMTEncoding_Util.mkGTE uu___17 in
+                              let uu___17 =
+                                let uu___18 =
+                                  let uu___19 =
+                                    let uu___20 =
                                       FStar_SMTEncoding_Term.unboxInt y in
-                                    let uu____4213 =
+                                    let uu___21 =
                                       FStar_SMTEncoding_Term.unboxInt x in
-                                    (uu____4212, uu____4213) in
-                                  FStar_SMTEncoding_Util.mkLT uu____4207 in
-                                [uu____4206] in
-                              uu____4195 :: uu____4203 in
-                            uu____4184 :: uu____4192 in
-                          typing_pred_y :: uu____4181 in
-                        typing_pred :: uu____4178 in
-                      FStar_SMTEncoding_Util.mk_and_l uu____4175 in
-                    (uu____4174, precedes_y_x) in
-                  FStar_SMTEncoding_Util.mkImp uu____4169 in
+                                    (uu___20, uu___21) in
+                                  FStar_SMTEncoding_Util.mkLT uu___19 in
+                                [uu___18] in
+                              uu___16 :: uu___17 in
+                            uu___14 :: uu___15 in
+                          typing_pred_y :: uu___13 in
+                        typing_pred :: uu___12 in
+                      FStar_SMTEncoding_Util.mk_and_l uu___11 in
+                    (uu___10, precedes_y_x) in
+                  FStar_SMTEncoding_Util.mkImp uu___9 in
                 ([[typing_pred; typing_pred_y; precedes_y_x]], [xx; yy],
-                  uu____4168) in
-              let uu____4240 =
-                let uu____4255 = FStar_TypeChecker_Env.get_range env in
-                let uu____4256 = mkForall_fuel env in uu____4256 uu____4255 in
-              uu____4240 uu____4157 in
-            (uu____4156,
+                  uu___8) in
+              let uu___8 =
+                let uu___9 = FStar_TypeChecker_Env.get_range env in
+                let uu___10 = mkForall_fuel env in uu___10 uu___9 in
+              uu___8 uu___7 in
+            (uu___6,
               (FStar_Pervasives_Native.Some
                  "well-founded ordering on nat (alt)"),
               "well-founded-ordering-on-nat") in
-          FStar_SMTEncoding_Util.mkAssume uu____4149 in
-        [uu____4148] in
-      uu____4064 :: uu____4145 in
-    uu____4009 :: uu____4061 in
+          FStar_SMTEncoding_Util.mkAssume uu___5 in
+        [uu___4] in
+      uu___2 :: uu___3 in
+    uu___ :: uu___1 in
   let mk_real env nm tt =
     let lex_t =
-      let uu____4293 =
-        let uu____4294 =
-          let uu____4299 =
-            FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid in
-          (uu____4299, FStar_SMTEncoding_Term.Term_sort) in
-        FStar_SMTEncoding_Term.mk_fv uu____4294 in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____4293 in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid in
+          (uu___2, FStar_SMTEncoding_Term.Term_sort) in
+        FStar_SMTEncoding_Term.mk_fv uu___1 in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___ in
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt in
     let aa =
@@ -1047,171 +1010,168 @@ let (primitive_type_axioms :
         ("b", (FStar_SMTEncoding_Term.Sort "Real")) in
     let b = FStar_SMTEncoding_Util.mkFreeV bb in
     let precedes_y_x =
-      let uu____4307 =
+      let uu___ =
         FStar_SMTEncoding_Util.mkApp ("Prims.precedes", [lex_t; lex_t; y; x]) in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____4307 in
-    let uu____4310 =
-      let uu____4311 =
-        let uu____4318 =
-          let uu____4319 = FStar_TypeChecker_Env.get_range env in
-          let uu____4320 =
-            let uu____4331 =
-              let uu____4336 =
-                let uu____4339 = FStar_SMTEncoding_Term.boxReal b in
-                [uu____4339] in
-              [uu____4336] in
-            let uu____4344 =
-              let uu____4345 = FStar_SMTEncoding_Term.boxReal b in
-              FStar_SMTEncoding_Term.mk_HasType uu____4345 tt in
-            (uu____4331, [bb], uu____4344) in
-          FStar_SMTEncoding_Term.mkForall uu____4319 uu____4320 in
-        (uu____4318, (FStar_Pervasives_Native.Some "real typing"),
-          "real_typing") in
-      FStar_SMTEncoding_Util.mkAssume uu____4311 in
-    let uu____4362 =
-      let uu____4365 =
-        let uu____4366 =
-          let uu____4373 =
-            let uu____4374 =
-              let uu____4385 =
-                let uu____4386 =
-                  let uu____4391 =
+      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu___ in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Term.boxReal b in [uu___7] in
+              [uu___6] in
+            let uu___6 =
+              let uu___7 = FStar_SMTEncoding_Term.boxReal b in
+              FStar_SMTEncoding_Term.mk_HasType uu___7 tt in
+            (uu___5, [bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "real typing"), "real_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
                          FStar_SMTEncoding_Term.boxRealFun) x in
-                  (typing_pred, uu____4391) in
-                FStar_SMTEncoding_Util.mkImp uu____4386 in
-              ([[typing_pred]], [xx], uu____4385) in
-            let uu____4412 =
-              let uu____4427 = FStar_TypeChecker_Env.get_range env in
-              let uu____4428 = mkForall_fuel env in uu____4428 uu____4427 in
-            uu____4412 uu____4374 in
-          (uu____4373, (FStar_Pervasives_Native.Some "real inversion"),
+                  (typing_pred, uu___8) in
+                FStar_SMTEncoding_Util.mkImp uu___7 in
+              ([[typing_pred]], [xx], uu___6) in
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.get_range env in
+              let uu___8 = mkForall_fuel env in uu___8 uu___7 in
+            uu___6 uu___5 in
+          (uu___4, (FStar_Pervasives_Native.Some "real inversion"),
             "real_inversion") in
-        FStar_SMTEncoding_Util.mkAssume uu____4366 in
-      let uu____4446 =
-        let uu____4449 =
-          let uu____4450 =
-            let uu____4457 =
-              let uu____4458 =
-                let uu____4469 =
-                  let uu____4470 =
-                    let uu____4475 =
-                      let uu____4476 =
-                        let uu____4479 =
-                          let uu____4482 =
-                            let uu____4485 =
-                              let uu____4486 =
-                                let uu____4491 =
+        FStar_SMTEncoding_Util.mkAssume uu___3 in
+      let uu___3 =
+        let uu___4 =
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 =
+                            let uu___14 =
+                              let uu___15 =
+                                let uu___16 =
                                   FStar_SMTEncoding_Term.unboxReal x in
-                                let uu____4492 =
+                                let uu___17 =
                                   FStar_SMTEncoding_Util.mkReal "0.0" in
-                                (uu____4491, uu____4492) in
-                              FStar_SMTEncoding_Util.mkGT uu____4486 in
-                            let uu____4493 =
-                              let uu____4496 =
-                                let uu____4497 =
-                                  let uu____4502 =
+                                (uu___16, uu___17) in
+                              FStar_SMTEncoding_Util.mkGT uu___15 in
+                            let uu___15 =
+                              let uu___16 =
+                                let uu___17 =
+                                  let uu___18 =
                                     FStar_SMTEncoding_Term.unboxReal y in
-                                  let uu____4503 =
+                                  let uu___19 =
                                     FStar_SMTEncoding_Util.mkReal "0.0" in
-                                  (uu____4502, uu____4503) in
-                                FStar_SMTEncoding_Util.mkGTE uu____4497 in
-                              let uu____4504 =
-                                let uu____4507 =
-                                  let uu____4508 =
-                                    let uu____4513 =
+                                  (uu___18, uu___19) in
+                                FStar_SMTEncoding_Util.mkGTE uu___17 in
+                              let uu___17 =
+                                let uu___18 =
+                                  let uu___19 =
+                                    let uu___20 =
                                       FStar_SMTEncoding_Term.unboxReal y in
-                                    let uu____4514 =
+                                    let uu___21 =
                                       FStar_SMTEncoding_Term.unboxReal x in
-                                    (uu____4513, uu____4514) in
-                                  FStar_SMTEncoding_Util.mkLT uu____4508 in
-                                [uu____4507] in
-                              uu____4496 :: uu____4504 in
-                            uu____4485 :: uu____4493 in
-                          typing_pred_y :: uu____4482 in
-                        typing_pred :: uu____4479 in
-                      FStar_SMTEncoding_Util.mk_and_l uu____4476 in
-                    (uu____4475, precedes_y_x) in
-                  FStar_SMTEncoding_Util.mkImp uu____4470 in
+                                    (uu___20, uu___21) in
+                                  FStar_SMTEncoding_Util.mkLT uu___19 in
+                                [uu___18] in
+                              uu___16 :: uu___17 in
+                            uu___14 :: uu___15 in
+                          typing_pred_y :: uu___13 in
+                        typing_pred :: uu___12 in
+                      FStar_SMTEncoding_Util.mk_and_l uu___11 in
+                    (uu___10, precedes_y_x) in
+                  FStar_SMTEncoding_Util.mkImp uu___9 in
                 ([[typing_pred; typing_pred_y; precedes_y_x]], [xx; yy],
-                  uu____4469) in
-              let uu____4541 =
-                let uu____4556 = FStar_TypeChecker_Env.get_range env in
-                let uu____4557 = mkForall_fuel env in uu____4557 uu____4556 in
-              uu____4541 uu____4458 in
-            (uu____4457,
+                  uu___8) in
+              let uu___8 =
+                let uu___9 = FStar_TypeChecker_Env.get_range env in
+                let uu___10 = mkForall_fuel env in uu___10 uu___9 in
+              uu___8 uu___7 in
+            (uu___6,
               (FStar_Pervasives_Native.Some "well-founded ordering on real"),
               "well-founded-ordering-on-real") in
-          FStar_SMTEncoding_Util.mkAssume uu____4450 in
-        [uu____4449] in
-      uu____4365 :: uu____4446 in
-    uu____4310 :: uu____4362 in
+          FStar_SMTEncoding_Util.mkAssume uu___5 in
+        [uu___4] in
+      uu___2 :: uu___3 in
+    uu___ :: uu___1 in
   let mk_str env nm tt =
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let bb =
       FStar_SMTEncoding_Term.mk_fv ("b", FStar_SMTEncoding_Term.String_sort) in
     let b = FStar_SMTEncoding_Util.mkFreeV bb in
-    let uu____4596 =
-      let uu____4597 =
-        let uu____4604 =
-          let uu____4605 = FStar_TypeChecker_Env.get_range env in
-          let uu____4606 =
-            let uu____4617 =
-              let uu____4622 =
-                let uu____4625 = FStar_SMTEncoding_Term.boxString b in
-                [uu____4625] in
-              [uu____4622] in
-            let uu____4630 =
-              let uu____4631 = FStar_SMTEncoding_Term.boxString b in
-              FStar_SMTEncoding_Term.mk_HasType uu____4631 tt in
-            (uu____4617, [bb], uu____4630) in
-          FStar_SMTEncoding_Term.mkForall uu____4605 uu____4606 in
-        (uu____4604, (FStar_Pervasives_Native.Some "string typing"),
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Term.boxString b in [uu___7] in
+              [uu___6] in
+            let uu___6 =
+              let uu___7 = FStar_SMTEncoding_Term.boxString b in
+              FStar_SMTEncoding_Term.mk_HasType uu___7 tt in
+            (uu___5, [bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "string typing"),
           "string_typing") in
-      FStar_SMTEncoding_Util.mkAssume uu____4597 in
-    let uu____4648 =
-      let uu____4651 =
-        let uu____4652 =
-          let uu____4659 =
-            let uu____4660 =
-              let uu____4671 =
-                let uu____4672 =
-                  let uu____4677 =
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
                          FStar_SMTEncoding_Term.boxStringFun) x in
-                  (typing_pred, uu____4677) in
-                FStar_SMTEncoding_Util.mkImp uu____4672 in
-              ([[typing_pred]], [xx], uu____4671) in
-            let uu____4698 =
-              let uu____4713 = FStar_TypeChecker_Env.get_range env in
-              let uu____4714 = mkForall_fuel env in uu____4714 uu____4713 in
-            uu____4698 uu____4660 in
-          (uu____4659, (FStar_Pervasives_Native.Some "string inversion"),
+                  (typing_pred, uu___8) in
+                FStar_SMTEncoding_Util.mkImp uu___7 in
+              ([[typing_pred]], [xx], uu___6) in
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.get_range env in
+              let uu___8 = mkForall_fuel env in uu___8 uu___7 in
+            uu___6 uu___5 in
+          (uu___4, (FStar_Pervasives_Native.Some "string inversion"),
             "string_inversion") in
-        FStar_SMTEncoding_Util.mkAssume uu____4652 in
-      [uu____4651] in
-    uu____4596 :: uu____4648 in
+        FStar_SMTEncoding_Util.mkAssume uu___3 in
+      [uu___2] in
+    uu___ :: uu___1 in
   let mk_true_interp env nm true_tm =
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [true_tm]) in
-    let uu____4753 =
+    let uu___ =
       FStar_SMTEncoding_Util.mkAssume
         (valid, (FStar_Pervasives_Native.Some "True interpretation"),
           "true_interp") in
-    [uu____4753] in
+    [uu___] in
   let mk_false_interp env nm false_tm =
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [false_tm]) in
-    let uu____4775 =
-      let uu____4776 =
-        let uu____4783 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           FStar_SMTEncoding_Util.mkIff
             (FStar_SMTEncoding_Util.mkFalse, valid) in
-        (uu____4783, (FStar_Pervasives_Native.Some "False interpretation"),
+        (uu___2, (FStar_Pervasives_Native.Some "False interpretation"),
           "false_interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____4776 in
-    [uu____4775] in
-  let mk_and_interp env conj uu____4801 =
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
+  let mk_and_interp env conj uu___ =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
     let bb =
@@ -1222,24 +1182,23 @@ let (primitive_type_axioms :
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_and_a_b]) in
     let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
     let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____4818 =
-      let uu____4819 =
-        let uu____4826 =
-          let uu____4827 = FStar_TypeChecker_Env.get_range env in
-          let uu____4828 =
-            let uu____4839 =
-              let uu____4840 =
-                let uu____4845 =
-                  FStar_SMTEncoding_Util.mkAnd (valid_a, valid_b) in
-                (uu____4845, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____4840 in
-            ([[l_and_a_b]], [aa; bb], uu____4839) in
-          FStar_SMTEncoding_Term.mkForall uu____4827 uu____4828 in
-        (uu____4826, (FStar_Pervasives_Native.Some "/\\ interpretation"),
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 = FStar_TypeChecker_Env.get_range env in
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStar_SMTEncoding_Util.mkAnd (valid_a, valid_b) in
+                (uu___8, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___7 in
+            ([[l_and_a_b]], [aa; bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___4 uu___5 in
+        (uu___3, (FStar_Pervasives_Native.Some "/\\ interpretation"),
           "l_and-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____4819 in
-    [uu____4818] in
-  let mk_or_interp env disj uu____4889 =
+      FStar_SMTEncoding_Util.mkAssume uu___2 in
+    [uu___1] in
+  let mk_or_interp env disj uu___ =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
     let bb =
@@ -1250,23 +1209,22 @@ let (primitive_type_axioms :
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_or_a_b]) in
     let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
     let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____4906 =
-      let uu____4907 =
-        let uu____4914 =
-          let uu____4915 = FStar_TypeChecker_Env.get_range env in
-          let uu____4916 =
-            let uu____4927 =
-              let uu____4928 =
-                let uu____4933 =
-                  FStar_SMTEncoding_Util.mkOr (valid_a, valid_b) in
-                (uu____4933, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____4928 in
-            ([[l_or_a_b]], [aa; bb], uu____4927) in
-          FStar_SMTEncoding_Term.mkForall uu____4915 uu____4916 in
-        (uu____4914, (FStar_Pervasives_Native.Some "\\/ interpretation"),
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          let uu___4 = FStar_TypeChecker_Env.get_range env in
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStar_SMTEncoding_Util.mkOr (valid_a, valid_b) in
+                (uu___8, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___7 in
+            ([[l_or_a_b]], [aa; bb], uu___6) in
+          FStar_SMTEncoding_Term.mkForall uu___4 uu___5 in
+        (uu___3, (FStar_Pervasives_Native.Some "\\/ interpretation"),
           "l_or-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____4907 in
-    [uu____4906] in
+      FStar_SMTEncoding_Util.mkAssume uu___2 in
+    [uu___1] in
   let mk_eq2_interp env eq2 tt =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
@@ -1279,22 +1237,22 @@ let (primitive_type_axioms :
     let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
     let eq2_x_y = FStar_SMTEncoding_Util.mkApp (eq2, [a; x1; y1]) in
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq2_x_y]) in
-    let uu____4990 =
-      let uu____4991 =
-        let uu____4998 =
-          let uu____4999 = FStar_TypeChecker_Env.get_range env in
-          let uu____5000 =
-            let uu____5011 =
-              let uu____5012 =
-                let uu____5017 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
-                (uu____5017, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____5012 in
-            ([[eq2_x_y]], [aa; xx1; yy1], uu____5011) in
-          FStar_SMTEncoding_Term.mkForall uu____4999 uu____5000 in
-        (uu____4998, (FStar_Pervasives_Native.Some "Eq2 interpretation"),
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
+                (uu___7, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___6 in
+            ([[eq2_x_y]], [aa; xx1; yy1], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "Eq2 interpretation"),
           "eq2-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____4991 in
-    [uu____4990] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_eq3_interp env eq3 tt =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
@@ -1310,22 +1268,22 @@ let (primitive_type_axioms :
     let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
     let eq3_x_y = FStar_SMTEncoding_Util.mkApp (eq3, [a; b; x1; y1]) in
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq3_x_y]) in
-    let uu____5082 =
-      let uu____5083 =
-        let uu____5090 =
-          let uu____5091 = FStar_TypeChecker_Env.get_range env in
-          let uu____5092 =
-            let uu____5103 =
-              let uu____5104 =
-                let uu____5109 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
-                (uu____5109, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____5104 in
-            ([[eq3_x_y]], [aa; bb; xx1; yy1], uu____5103) in
-          FStar_SMTEncoding_Term.mkForall uu____5091 uu____5092 in
-        (uu____5090, (FStar_Pervasives_Native.Some "Eq3 interpretation"),
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
+                (uu___7, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___6 in
+            ([[eq3_x_y]], [aa; bb; xx1; yy1], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "Eq3 interpretation"),
           "eq3-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____5083 in
-    [uu____5082] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_imp_interp env imp tt =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
@@ -1337,23 +1295,22 @@ let (primitive_type_axioms :
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_imp_a_b]) in
     let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
     let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____5182 =
-      let uu____5183 =
-        let uu____5190 =
-          let uu____5191 = FStar_TypeChecker_Env.get_range env in
-          let uu____5192 =
-            let uu____5203 =
-              let uu____5204 =
-                let uu____5209 =
-                  FStar_SMTEncoding_Util.mkImp (valid_a, valid_b) in
-                (uu____5209, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____5204 in
-            ([[l_imp_a_b]], [aa; bb], uu____5203) in
-          FStar_SMTEncoding_Term.mkForall uu____5191 uu____5192 in
-        (uu____5190, (FStar_Pervasives_Native.Some "==> interpretation"),
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Util.mkImp (valid_a, valid_b) in
+                (uu___7, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___6 in
+            ([[l_imp_a_b]], [aa; bb], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "==> interpretation"),
           "l_imp-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____5183 in
-    [uu____5182] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_iff_interp env iff tt =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
@@ -1365,23 +1322,22 @@ let (primitive_type_axioms :
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_iff_a_b]) in
     let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
     let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
-    let uu____5270 =
-      let uu____5271 =
-        let uu____5278 =
-          let uu____5279 = FStar_TypeChecker_Env.get_range env in
-          let uu____5280 =
-            let uu____5291 =
-              let uu____5292 =
-                let uu____5297 =
-                  FStar_SMTEncoding_Util.mkIff (valid_a, valid_b) in
-                (uu____5297, valid) in
-              FStar_SMTEncoding_Util.mkIff uu____5292 in
-            ([[l_iff_a_b]], [aa; bb], uu____5291) in
-          FStar_SMTEncoding_Term.mkForall uu____5279 uu____5280 in
-        (uu____5278, (FStar_Pervasives_Native.Some "<==> interpretation"),
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Util.mkIff (valid_a, valid_b) in
+                (uu___7, valid) in
+              FStar_SMTEncoding_Util.mkIff uu___6 in
+            ([[l_iff_a_b]], [aa; bb], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "<==> interpretation"),
           "l_iff-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____5271 in
-    [uu____5270] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_not_interp env l_not tt =
     let aa =
       FStar_SMTEncoding_Term.mk_fv ("a", FStar_SMTEncoding_Term.Term_sort) in
@@ -1389,35 +1345,33 @@ let (primitive_type_axioms :
     let l_not_a = FStar_SMTEncoding_Util.mkApp (l_not, [a]) in
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_not_a]) in
     let not_valid_a =
-      let uu____5351 = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu____5351 in
-    let uu____5354 =
-      let uu____5355 =
-        let uu____5362 =
-          let uu____5363 = FStar_TypeChecker_Env.get_range env in
-          let uu____5364 =
-            let uu____5375 =
-              FStar_SMTEncoding_Util.mkIff (not_valid_a, valid) in
-            ([[l_not_a]], [aa], uu____5375) in
-          FStar_SMTEncoding_Term.mkForall uu____5363 uu____5364 in
-        (uu____5362, (FStar_Pervasives_Native.Some "not interpretation"),
+      let uu___ = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu___ in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 = FStar_SMTEncoding_Util.mkIff (not_valid_a, valid) in
+            ([[l_not_a]], [aa], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "not interpretation"),
           "l_not-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____5355 in
-    [uu____5354] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_range_interp env range tt =
     let range_ty = FStar_SMTEncoding_Util.mkApp (range, []) in
-    let uu____5417 =
-      let uu____5418 =
-        let uu____5425 =
-          let uu____5426 = FStar_SMTEncoding_Term.mk_Range_const () in
-          FStar_SMTEncoding_Term.mk_HasTypeZ uu____5426 range_ty in
-        let uu____5427 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_SMTEncoding_Term.mk_Range_const () in
+          FStar_SMTEncoding_Term.mk_HasTypeZ uu___3 range_ty in
+        let uu___3 =
           FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
             "typing_range_const" in
-        (uu____5425, (FStar_Pervasives_Native.Some "Range_const typing"),
-          uu____5427) in
-      FStar_SMTEncoding_Util.mkAssume uu____5418 in
-    [uu____5417] in
+        (uu___2, (FStar_Pervasives_Native.Some "Range_const typing"), uu___3) in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_inversion_axiom env inversion tt =
     let tt1 =
       FStar_SMTEncoding_Term.mk_fv ("t", FStar_SMTEncoding_Term.Term_sort) in
@@ -1430,26 +1384,25 @@ let (primitive_type_axioms :
     let body =
       let hastypeZ = FStar_SMTEncoding_Term.mk_HasTypeZ x1 t in
       let hastypeS =
-        let uu____5459 = FStar_SMTEncoding_Term.n_fuel Prims.int_one in
-        FStar_SMTEncoding_Term.mk_HasTypeFuel uu____5459 x1 t in
-      let uu____5460 = FStar_TypeChecker_Env.get_range env in
-      let uu____5461 =
-        let uu____5472 = FStar_SMTEncoding_Util.mkImp (hastypeZ, hastypeS) in
-        ([[hastypeZ]], [xx1], uu____5472) in
-      FStar_SMTEncoding_Term.mkForall uu____5460 uu____5461 in
-    let uu____5493 =
-      let uu____5494 =
-        let uu____5501 =
-          let uu____5502 = FStar_TypeChecker_Env.get_range env in
-          let uu____5503 =
-            let uu____5514 = FStar_SMTEncoding_Util.mkImp (valid, body) in
-            ([[inversion_t]], [tt1], uu____5514) in
-          FStar_SMTEncoding_Term.mkForall uu____5502 uu____5503 in
-        (uu____5501,
-          (FStar_Pervasives_Native.Some "inversion interpretation"),
+        let uu___ = FStar_SMTEncoding_Term.n_fuel Prims.int_one in
+        FStar_SMTEncoding_Term.mk_HasTypeFuel uu___ x1 t in
+      let uu___ = FStar_TypeChecker_Env.get_range env in
+      let uu___1 =
+        let uu___2 = FStar_SMTEncoding_Util.mkImp (hastypeZ, hastypeS) in
+        ([[hastypeZ]], [xx1], uu___2) in
+      FStar_SMTEncoding_Term.mkForall uu___ uu___1 in
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 = FStar_SMTEncoding_Util.mkImp (valid, body) in
+            ([[inversion_t]], [tt1], uu___5) in
+          FStar_SMTEncoding_Term.mkForall uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "inversion interpretation"),
           "inversion-interp") in
-      FStar_SMTEncoding_Util.mkAssume uu____5494 in
-    [uu____5493] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let mk_with_type_axiom env with_type tt =
     let tt1 =
       FStar_SMTEncoding_Term.mk_fv ("t", FStar_SMTEncoding_Term.Term_sort) in
@@ -1458,28 +1411,26 @@ let (primitive_type_axioms :
       FStar_SMTEncoding_Term.mk_fv ("e", FStar_SMTEncoding_Term.Term_sort) in
     let e = FStar_SMTEncoding_Util.mkFreeV ee in
     let with_type_t_e = FStar_SMTEncoding_Util.mkApp (with_type, [t; e]) in
-    let uu____5560 =
-      let uu____5561 =
-        let uu____5568 =
-          let uu____5569 = FStar_TypeChecker_Env.get_range env in
-          let uu____5570 =
-            let uu____5585 =
-              let uu____5586 =
-                let uu____5591 =
-                  FStar_SMTEncoding_Util.mkEq (with_type_t_e, e) in
-                let uu____5592 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_TypeChecker_Env.get_range env in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_SMTEncoding_Util.mkEq (with_type_t_e, e) in
+                let uu___8 =
                   FStar_SMTEncoding_Term.mk_HasType with_type_t_e t in
-                (uu____5591, uu____5592) in
-              FStar_SMTEncoding_Util.mkAnd uu____5586 in
+                (uu___7, uu___8) in
+              FStar_SMTEncoding_Util.mkAnd uu___6 in
             ([[with_type_t_e]],
               (FStar_Pervasives_Native.Some Prims.int_zero), [tt1; ee],
-              uu____5585) in
-          FStar_SMTEncoding_Term.mkForall' uu____5569 uu____5570 in
-        (uu____5568,
-          (FStar_Pervasives_Native.Some "with_type primitive axiom"),
+              uu___5) in
+          FStar_SMTEncoding_Term.mkForall' uu___3 uu___4 in
+        (uu___2, (FStar_Pervasives_Native.Some "with_type primitive axiom"),
           "@with_type_primitive_axiom") in
-      FStar_SMTEncoding_Util.mkAssume uu____5561 in
-    [uu____5560] in
+      FStar_SMTEncoding_Util.mkAssume uu___1 in
+    [uu___] in
   let prims1 =
     [(FStar_Parser_Const.unit_lid, mk_unit);
     (FStar_Parser_Const.bool_lid, mk_bool);
@@ -1502,14 +1453,14 @@ let (primitive_type_axioms :
     fun t ->
       fun s ->
         fun tt ->
-          let uu____6100 =
+          let uu___ =
             FStar_Util.find_opt
-              (fun uu____6136 ->
-                 match uu____6136 with
-                 | (l, uu____6150) -> FStar_Ident.lid_equals l t) prims1 in
-          match uu____6100 with
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (l, uu___2) -> FStar_Ident.lid_equals l t) prims1 in
+          match uu___ with
           | FStar_Pervasives_Native.None -> []
-          | FStar_Pervasives_Native.Some (uu____6190, f) -> f env s tt
+          | FStar_Pervasives_Native.Some (uu___1, f) -> f env s tt
 let (encode_smt_lemma :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.fv ->
@@ -1519,28 +1470,28 @@ let (encode_smt_lemma :
     fun fv ->
       fun t ->
         let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        let uu____6247 =
+        let uu___ =
           FStar_SMTEncoding_EncodeTerm.encode_function_type_as_formula t env in
-        match uu____6247 with
+        match uu___ with
         | (form, decls) ->
-            let uu____6256 =
-              let uu____6259 =
-                let uu____6262 =
-                  let uu____6263 =
-                    let uu____6270 =
-                      let uu____6271 =
-                        let uu____6272 = FStar_Ident.string_of_lid lid in
-                        Prims.op_Hat "Lemma: " uu____6272 in
-                      FStar_Pervasives_Native.Some uu____6271 in
-                    let uu____6273 =
-                      let uu____6274 = FStar_Ident.string_of_lid lid in
-                      Prims.op_Hat "lemma_" uu____6274 in
-                    (form, uu____6270, uu____6273) in
-                  FStar_SMTEncoding_Util.mkAssume uu____6263 in
-                [uu____6262] in
-              FStar_All.pipe_right uu____6259
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 = FStar_Ident.string_of_lid lid in
+                        Prims.op_Hat "Lemma: " uu___7 in
+                      FStar_Pervasives_Native.Some uu___6 in
+                    let uu___6 =
+                      let uu___7 = FStar_Ident.string_of_lid lid in
+                      Prims.op_Hat "lemma_" uu___7 in
+                    (form, uu___5, uu___6) in
+                  FStar_SMTEncoding_Util.mkAssume uu___4 in
+                [uu___3] in
+              FStar_All.pipe_right uu___2
                 FStar_SMTEncoding_Term.mk_decls_trivial in
-            FStar_List.append decls uu____6256
+            FStar_List.append decls uu___1
 let (encode_free_var :
   Prims.bool ->
     FStar_SMTEncoding_Env.env_t ->
@@ -1558,32 +1509,31 @@ let (encode_free_var :
             fun quals ->
               let lid =
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              let uu____6326 =
-                ((let uu____6329 =
+              let uu___ =
+                ((let uu___1 =
                     (FStar_Syntax_Util.is_pure_or_ghost_function t_norm) ||
                       (FStar_SMTEncoding_Util.is_smt_reifiable_function
                          env.FStar_SMTEncoding_Env.tcenv t_norm) in
-                  FStar_All.pipe_left Prims.op_Negation uu____6329) ||
+                  FStar_All.pipe_left Prims.op_Negation uu___1) ||
                    (FStar_Syntax_Util.is_lemma t_norm))
                   || uninterpreted in
-              if uu____6326
+              if uu___
               then
                 let arg_sorts =
-                  let uu____6337 =
-                    let uu____6338 = FStar_Syntax_Subst.compress t_norm in
-                    uu____6338.FStar_Syntax_Syntax.n in
-                  match uu____6337 with
-                  | FStar_Syntax_Syntax.Tm_arrow (binders, uu____6344) ->
+                  let uu___1 =
+                    let uu___2 = FStar_Syntax_Subst.compress t_norm in
+                    uu___2.FStar_Syntax_Syntax.n in
+                  match uu___1 with
+                  | FStar_Syntax_Syntax.Tm_arrow (binders, uu___2) ->
                       FStar_All.pipe_right binders
                         (FStar_List.map
-                           (fun uu____6382 ->
-                              FStar_SMTEncoding_Term.Term_sort))
-                  | uu____6389 -> [] in
+                           (fun uu___3 -> FStar_SMTEncoding_Term.Term_sort))
+                  | uu___2 -> [] in
                 let arity = FStar_List.length arg_sorts in
-                let uu____6391 =
+                let uu___1 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env lid arity in
-                match uu____6391 with
+                match uu___1 with
                 | (vname, vtok, env1) ->
                     let d =
                       FStar_SMTEncoding_Term.DeclFun
@@ -1595,247 +1545,244 @@ let (encode_free_var :
                         (vtok, [], FStar_SMTEncoding_Term.Term_sort,
                           (FStar_Pervasives_Native.Some
                              "Uninterpreted name for impure function")) in
-                    let uu____6411 =
+                    let uu___2 =
                       FStar_All.pipe_right [d; dd]
                         FStar_SMTEncoding_Term.mk_decls_trivial in
-                    (uu____6411, env1)
+                    (uu___2, env1)
               else
-                (let uu____6415 = prims.is lid in
-                 if uu____6415
+                (let uu___2 = prims.is lid in
+                 if uu___2
                  then
                    let vname =
                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
                        lid in
-                   let uu____6421 = prims.mk lid vname in
-                   match uu____6421 with
+                   let uu___3 = prims.mk lid vname in
+                   match uu___3 with
                    | (tok, arity, definition) ->
                        let env1 =
                          FStar_SMTEncoding_Env.push_free_var env lid arity
                            vname (FStar_Pervasives_Native.Some tok) in
-                       let uu____6442 =
+                       let uu___4 =
                          FStar_All.pipe_right definition
                            FStar_SMTEncoding_Term.mk_decls_trivial in
-                       (uu____6442, env1)
+                       (uu___4, env1)
                  else
                    (let encode_non_total_function_typ =
-                      let uu____6447 = FStar_Ident.nsstr lid in
-                      uu____6447 <> "Prims" in
-                    let uu____6448 =
-                      let uu____6467 =
+                      let uu___4 = FStar_Ident.nsstr lid in uu___4 <> "Prims" in
+                    let uu___4 =
+                      let uu___5 =
                         FStar_SMTEncoding_EncodeTerm.curried_arrow_formals_comp
                           t_norm in
-                      match uu____6467 with
+                      match uu___5 with
                       | (args, comp) ->
                           let comp1 =
-                            let uu____6495 =
+                            let uu___6 =
                               FStar_SMTEncoding_Util.is_smt_reifiable_comp
                                 env.FStar_SMTEncoding_Env.tcenv comp in
-                            if uu____6495
+                            if uu___6
                             then
-                              let uu____6498 =
+                              let uu___7 =
                                 FStar_TypeChecker_Env.reify_comp
-                                  (let uu___316_6501 =
+                                  (let uu___8 =
                                      env.FStar_SMTEncoding_Env.tcenv in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___316_6501.FStar_TypeChecker_Env.solver);
+                                       (uu___8.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___316_6501.FStar_TypeChecker_Env.range);
+                                       (uu___8.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___316_6501.FStar_TypeChecker_Env.curmodule);
+                                       (uu___8.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___316_6501.FStar_TypeChecker_Env.gamma);
+                                       (uu___8.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___316_6501.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___8.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___316_6501.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___8.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___316_6501.FStar_TypeChecker_Env.modules);
+                                       (uu___8.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___316_6501.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___8.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___316_6501.FStar_TypeChecker_Env.sigtab);
+                                       (uu___8.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___316_6501.FStar_TypeChecker_Env.attrtab);
+                                       (uu___8.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___316_6501.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___8.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___316_6501.FStar_TypeChecker_Env.effects);
+                                       (uu___8.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___316_6501.FStar_TypeChecker_Env.generalize);
+                                       (uu___8.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___316_6501.FStar_TypeChecker_Env.letrecs);
+                                       (uu___8.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___316_6501.FStar_TypeChecker_Env.top_level);
+                                       (uu___8.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___316_6501.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___8.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___316_6501.FStar_TypeChecker_Env.use_eq);
+                                       (uu___8.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___316_6501.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___8.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___316_6501.FStar_TypeChecker_Env.is_iface);
+                                       (uu___8.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___316_6501.FStar_TypeChecker_Env.admit);
+                                       (uu___8.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax = true;
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___316_6501.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___8.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___316_6501.FStar_TypeChecker_Env.phase1);
+                                       (uu___8.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___316_6501.FStar_TypeChecker_Env.failhard);
+                                       (uu___8.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___316_6501.FStar_TypeChecker_Env.nosynth);
+                                       (uu___8.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___316_6501.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___8.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___316_6501.FStar_TypeChecker_Env.tc_term);
+                                       (uu___8.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___316_6501.FStar_TypeChecker_Env.type_of);
+                                       (uu___8.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___316_6501.FStar_TypeChecker_Env.universe_of);
+                                       (uu___8.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___316_6501.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___8.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___316_6501.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___316_6501.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___8.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___316_6501.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___8.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___316_6501.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___8.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___316_6501.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___8.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___316_6501.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___8.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___316_6501.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___8.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___316_6501.FStar_TypeChecker_Env.splice);
+                                       (uu___8.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___316_6501.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___8.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___316_6501.FStar_TypeChecker_Env.postprocess);
+                                       (uu___8.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___316_6501.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___8.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___316_6501.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___8.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___316_6501.FStar_TypeChecker_Env.dsenv);
+                                       (uu___8.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___316_6501.FStar_TypeChecker_Env.nbe);
+                                       (uu___8.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___316_6501.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___8.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___316_6501.FStar_TypeChecker_Env.erasable_types_tab);
+                                       (uu___8.FStar_TypeChecker_Env.erasable_types_tab);
                                      FStar_TypeChecker_Env.enable_defer_to_tac
                                        =
-                                       (uu___316_6501.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                       (uu___8.FStar_TypeChecker_Env.enable_defer_to_tac)
                                    }) comp FStar_Syntax_Syntax.U_unknown in
-                              FStar_Syntax_Syntax.mk_Total uu____6498
+                              FStar_Syntax_Syntax.mk_Total uu___7
                             else comp in
                           if encode_non_total_function_typ
                           then
-                            let uu____6521 =
+                            let uu___6 =
                               FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
                                 env.FStar_SMTEncoding_Env.tcenv comp1 in
-                            (args, uu____6521)
+                            (args, uu___6)
                           else
                             (args,
                               (FStar_Pervasives_Native.None,
                                 (FStar_Syntax_Util.comp_result comp1))) in
-                    match uu____6448 with
+                    match uu___4 with
                     | (formals, (pre_opt, res_t)) ->
                         let mk_disc_proj_axioms guard encoded_res_t vapp vars
                           =
                           FStar_All.pipe_right quals
                             (FStar_List.collect
-                               (fun uu___0_6626 ->
-                                  match uu___0_6626 with
+                               (fun uu___5 ->
+                                  match uu___5 with
                                   | FStar_Syntax_Syntax.Discriminator d ->
-                                      let uu____6630 = FStar_Util.prefix vars in
-                                      (match uu____6630 with
-                                       | (uu____6657, xxv) ->
+                                      let uu___6 = FStar_Util.prefix vars in
+                                      (match uu___6 with
+                                       | (uu___7, xxv) ->
                                            let xx =
-                                             let uu____6688 =
-                                               let uu____6689 =
-                                                 let uu____6694 =
+                                             let uu___8 =
+                                               let uu___9 =
+                                                 let uu___10 =
                                                    FStar_SMTEncoding_Term.fv_name
                                                      xxv in
-                                                 (uu____6694,
+                                                 (uu___10,
                                                    FStar_SMTEncoding_Term.Term_sort) in
                                                FStar_SMTEncoding_Term.mk_fv
-                                                 uu____6689 in
+                                                 uu___9 in
                                              FStar_All.pipe_left
                                                FStar_SMTEncoding_Util.mkFreeV
-                                               uu____6688 in
-                                           let uu____6695 =
-                                             let uu____6696 =
-                                               let uu____6703 =
-                                                 let uu____6704 =
+                                               uu___8 in
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
+                                                 let uu___11 =
                                                    FStar_Syntax_Syntax.range_of_fv
                                                      fv in
-                                                 let uu____6705 =
-                                                   let uu____6716 =
-                                                     let uu____6717 =
-                                                       let uu____6722 =
-                                                         let uu____6723 =
-                                                           let uu____6724 =
-                                                             let uu____6725 =
+                                                 let uu___12 =
+                                                   let uu___13 =
+                                                     let uu___14 =
+                                                       let uu___15 =
+                                                         let uu___16 =
+                                                           let uu___17 =
+                                                             let uu___18 =
                                                                FStar_Ident.string_of_lid
                                                                  d in
                                                              FStar_SMTEncoding_Env.escape
-                                                               uu____6725 in
+                                                               uu___18 in
                                                            FStar_SMTEncoding_Term.mk_tester
-                                                             uu____6724 xx in
+                                                             uu___17 xx in
                                                          FStar_All.pipe_left
                                                            FStar_SMTEncoding_Term.boxBool
-                                                           uu____6723 in
-                                                       (vapp, uu____6722) in
+                                                           uu___16 in
+                                                       (vapp, uu___15) in
                                                      FStar_SMTEncoding_Util.mkEq
-                                                       uu____6717 in
-                                                   ([[vapp]], vars,
-                                                     uu____6716) in
+                                                       uu___14 in
+                                                   ([[vapp]], vars, uu___13) in
                                                  FStar_SMTEncoding_Term.mkForall
-                                                   uu____6704 uu____6705 in
-                                               let uu____6734 =
-                                                 let uu____6735 =
-                                                   let uu____6736 =
+                                                   uu___11 uu___12 in
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_Ident.string_of_lid
                                                        d in
                                                    FStar_SMTEncoding_Env.escape
-                                                     uu____6736 in
+                                                     uu___13 in
                                                  Prims.op_Hat
-                                                   "disc_equation_"
-                                                   uu____6735 in
-                                               (uu____6703,
+                                                   "disc_equation_" uu___12 in
+                                               (uu___10,
                                                  (FStar_Pervasives_Native.Some
                                                     "Discriminator equation"),
-                                                 uu____6734) in
+                                                 uu___11) in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____6696 in
-                                           [uu____6695])
+                                               uu___9 in
+                                           [uu___8])
                                   | FStar_Syntax_Syntax.Projector (d, f) ->
-                                      let uu____6739 = FStar_Util.prefix vars in
-                                      (match uu____6739 with
-                                       | (uu____6766, xxv) ->
+                                      let uu___6 = FStar_Util.prefix vars in
+                                      (match uu___6 with
+                                       | (uu___7, xxv) ->
                                            let xx =
-                                             let uu____6797 =
-                                               let uu____6798 =
-                                                 let uu____6803 =
+                                             let uu___8 =
+                                               let uu___9 =
+                                                 let uu___10 =
                                                    FStar_SMTEncoding_Term.fv_name
                                                      xxv in
-                                                 (uu____6803,
+                                                 (uu___10,
                                                    FStar_SMTEncoding_Term.Term_sort) in
                                                FStar_SMTEncoding_Term.mk_fv
-                                                 uu____6798 in
+                                                 uu___9 in
                                              FStar_All.pipe_left
                                                FStar_SMTEncoding_Util.mkFreeV
-                                               uu____6797 in
+                                               uu___8 in
                                            let f1 =
                                              {
                                                FStar_Syntax_Syntax.ppname = f;
@@ -1850,52 +1797,51 @@ let (encode_free_var :
                                            let prim_app =
                                              FStar_SMTEncoding_Util.mkApp
                                                (tp_name, [xx]) in
-                                           let uu____6809 =
-                                             let uu____6810 =
-                                               let uu____6817 =
-                                                 let uu____6818 =
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
+                                                 let uu___11 =
                                                    FStar_Syntax_Syntax.range_of_fv
                                                      fv in
-                                                 let uu____6819 =
-                                                   let uu____6830 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_SMTEncoding_Util.mkEq
                                                        (vapp, prim_app) in
-                                                   ([[vapp]], vars,
-                                                     uu____6830) in
+                                                   ([[vapp]], vars, uu___13) in
                                                  FStar_SMTEncoding_Term.mkForall
-                                                   uu____6818 uu____6819 in
-                                               (uu____6817,
+                                                   uu___11 uu___12 in
+                                               (uu___10,
                                                  (FStar_Pervasives_Native.Some
                                                     "Projector equation"),
                                                  (Prims.op_Hat
                                                     "proj_equation_" tp_name)) in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____6810 in
-                                           [uu____6809])
-                                  | uu____6839 -> [])) in
-                        let uu____6840 =
+                                               uu___9 in
+                                           [uu___8])
+                                  | uu___6 -> [])) in
+                        let uu___5 =
                           FStar_SMTEncoding_EncodeTerm.encode_binders
                             FStar_Pervasives_Native.None formals env in
-                        (match uu____6840 with
-                         | (vars, guards, env', decls1, uu____6865) ->
-                             let uu____6878 =
+                        (match uu___5 with
+                         | (vars, guards, env', decls1, uu___6) ->
+                             let uu___7 =
                                match pre_opt with
                                | FStar_Pervasives_Native.None ->
-                                   let uu____6891 =
+                                   let uu___8 =
                                      FStar_SMTEncoding_Util.mk_and_l guards in
-                                   (uu____6891, decls1)
+                                   (uu___8, decls1)
                                | FStar_Pervasives_Native.Some p ->
-                                   let uu____6895 =
+                                   let uu___8 =
                                      FStar_SMTEncoding_EncodeTerm.encode_formula
                                        p env' in
-                                   (match uu____6895 with
+                                   (match uu___8 with
                                     | (g, ds) ->
-                                        let uu____6908 =
+                                        let uu___9 =
                                           FStar_SMTEncoding_Util.mk_and_l (g
                                             :: guards) in
-                                        (uu____6908,
+                                        (uu___9,
                                           (FStar_List.append decls1 ds))) in
-                             (match uu____6878 with
+                             (match uu___7 with
                               | (guard, decls11) ->
                                   let dummy_var =
                                     FStar_SMTEncoding_Term.mk_fv
@@ -1904,26 +1850,26 @@ let (encode_free_var :
                                   let dummy_tm =
                                     FStar_SMTEncoding_Term.mkFreeV dummy_var
                                       FStar_Range.dummyRange in
-                                  let should_thunk uu____6928 =
+                                  let should_thunk uu___8 =
                                     let is_type t =
-                                      let uu____6935 =
-                                        let uu____6936 =
+                                      let uu___9 =
+                                        let uu___10 =
                                           FStar_Syntax_Subst.compress t in
-                                        uu____6936.FStar_Syntax_Syntax.n in
-                                      match uu____6935 with
-                                      | FStar_Syntax_Syntax.Tm_type
-                                          uu____6939 -> true
-                                      | uu____6940 -> false in
+                                        uu___10.FStar_Syntax_Syntax.n in
+                                      match uu___9 with
+                                      | FStar_Syntax_Syntax.Tm_type uu___10
+                                          -> true
+                                      | uu___10 -> false in
                                     let is_squash t =
-                                      let uu____6947 =
+                                      let uu___9 =
                                         FStar_Syntax_Util.head_and_args t in
-                                      match uu____6947 with
-                                      | (head, uu____6965) ->
-                                          let uu____6990 =
-                                            let uu____6991 =
+                                      match uu___9 with
+                                      | (head, uu___10) ->
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_Syntax_Util.un_uinst head in
-                                            uu____6991.FStar_Syntax_Syntax.n in
-                                          (match uu____6990 with
+                                            uu___12.FStar_Syntax_Syntax.n in
+                                          (match uu___11 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv1
                                                ->
                                                FStar_Syntax_Syntax.fv_eq_lid
@@ -1932,51 +1878,51 @@ let (encode_free_var :
                                            | FStar_Syntax_Syntax.Tm_refine
                                                ({
                                                   FStar_Syntax_Syntax.ppname
-                                                    = uu____6995;
+                                                    = uu___12;
                                                   FStar_Syntax_Syntax.index =
-                                                    uu____6996;
+                                                    uu___13;
                                                   FStar_Syntax_Syntax.sort =
                                                     {
                                                       FStar_Syntax_Syntax.n =
                                                         FStar_Syntax_Syntax.Tm_fvar
                                                         fv1;
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu____6998;
+                                                        = uu___14;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu____6999;_};_},
-                                                uu____7000)
+                                                        = uu___15;_};_},
+                                                uu___16)
                                                ->
                                                FStar_Syntax_Syntax.fv_eq_lid
                                                  fv1
                                                  FStar_Parser_Const.unit_lid
-                                           | uu____7007 -> false) in
-                                    (((let uu____7010 = FStar_Ident.nsstr lid in
-                                       uu____7010 <> "Prims") &&
-                                        (let uu____7012 =
+                                           | uu___12 -> false) in
+                                    (((let uu___9 = FStar_Ident.nsstr lid in
+                                       uu___9 <> "Prims") &&
+                                        (let uu___9 =
                                            FStar_All.pipe_right quals
                                              (FStar_List.contains
                                                 FStar_Syntax_Syntax.Logic) in
-                                         Prims.op_Negation uu____7012))
+                                         Prims.op_Negation uu___9))
                                        &&
-                                       (let uu____7016 = is_squash t_norm in
-                                        Prims.op_Negation uu____7016))
+                                       (let uu___9 = is_squash t_norm in
+                                        Prims.op_Negation uu___9))
                                       &&
-                                      (let uu____7018 = is_type t_norm in
-                                       Prims.op_Negation uu____7018) in
-                                  let uu____7019 =
+                                      (let uu___9 = is_type t_norm in
+                                       Prims.op_Negation uu___9) in
+                                  let uu___8 =
                                     match vars with
                                     | [] when should_thunk () ->
                                         (true, [dummy_var])
-                                    | uu____7064 -> (false, vars) in
-                                  (match uu____7019 with
+                                    | uu___9 -> (false, vars) in
+                                  (match uu___8 with
                                    | (thunked, vars1) ->
                                        let arity = FStar_List.length formals in
-                                       let uu____7104 =
+                                       let uu___9 =
                                          FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid_maybe_thunked
                                            env lid arity thunked in
-                                       (match uu____7104 with
+                                       (match uu___9 with
                                         | (vname, vtok_opt, env1) ->
-                                            let get_vtok uu____7129 =
+                                            let get_vtok uu___10 =
                                               FStar_Option.get vtok_opt in
                                             let vtok_tm =
                                               match formals with
@@ -1988,83 +1934,81 @@ let (encode_free_var :
                                               | [] when thunked ->
                                                   FStar_SMTEncoding_Util.mkApp
                                                     (vname, [dummy_tm])
-                                              | uu____7147 ->
-                                                  let uu____7156 =
-                                                    let uu____7163 =
-                                                      get_vtok () in
-                                                    (uu____7163, []) in
+                                              | uu___10 ->
+                                                  let uu___11 =
+                                                    let uu___12 = get_vtok () in
+                                                    (uu___12, []) in
                                                   FStar_SMTEncoding_Util.mkApp
-                                                    uu____7156 in
+                                                    uu___11 in
                                             let vtok_app =
                                               FStar_SMTEncoding_EncodeTerm.mk_Apply
                                                 vtok_tm vars1 in
                                             let vapp =
-                                              let uu____7168 =
-                                                let uu____7175 =
+                                              let uu___10 =
+                                                let uu___11 =
                                                   FStar_List.map
                                                     FStar_SMTEncoding_Util.mkFreeV
                                                     vars1 in
-                                                (vname, uu____7175) in
+                                                (vname, uu___11) in
                                               FStar_SMTEncoding_Util.mkApp
-                                                uu____7168 in
-                                            let uu____7186 =
+                                                uu___10 in
+                                            let uu___10 =
                                               let vname_decl =
-                                                let uu____7194 =
-                                                  let uu____7205 =
+                                                let uu___11 =
+                                                  let uu___12 =
                                                     FStar_All.pipe_right
                                                       vars1
                                                       (FStar_List.map
                                                          FStar_SMTEncoding_Term.fv_sort) in
-                                                  (vname, uu____7205,
+                                                  (vname, uu___12,
                                                     FStar_SMTEncoding_Term.Term_sort,
                                                     FStar_Pervasives_Native.None) in
                                                 FStar_SMTEncoding_Term.DeclFun
-                                                  uu____7194 in
-                                              let uu____7214 =
+                                                  uu___11 in
+                                              let uu___11 =
                                                 let env2 =
-                                                  let uu___411_7220 = env1 in
+                                                  let uu___12 = env1 in
                                                   {
                                                     FStar_SMTEncoding_Env.bvar_bindings
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.bvar_bindings);
+                                                      (uu___12.FStar_SMTEncoding_Env.bvar_bindings);
                                                     FStar_SMTEncoding_Env.fvar_bindings
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.fvar_bindings);
+                                                      (uu___12.FStar_SMTEncoding_Env.fvar_bindings);
                                                     FStar_SMTEncoding_Env.depth
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.depth);
+                                                      (uu___12.FStar_SMTEncoding_Env.depth);
                                                     FStar_SMTEncoding_Env.tcenv
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.tcenv);
+                                                      (uu___12.FStar_SMTEncoding_Env.tcenv);
                                                     FStar_SMTEncoding_Env.warn
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.warn);
+                                                      (uu___12.FStar_SMTEncoding_Env.warn);
                                                     FStar_SMTEncoding_Env.nolabels
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.nolabels);
+                                                      (uu___12.FStar_SMTEncoding_Env.nolabels);
                                                     FStar_SMTEncoding_Env.use_zfuel_name
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                      (uu___12.FStar_SMTEncoding_Env.use_zfuel_name);
                                                     FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                       =
                                                       encode_non_total_function_typ;
                                                     FStar_SMTEncoding_Env.current_module_name
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.current_module_name);
+                                                      (uu___12.FStar_SMTEncoding_Env.current_module_name);
                                                     FStar_SMTEncoding_Env.encoding_quantifier
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                      (uu___12.FStar_SMTEncoding_Env.encoding_quantifier);
                                                     FStar_SMTEncoding_Env.global_cache
                                                       =
-                                                      (uu___411_7220.FStar_SMTEncoding_Env.global_cache)
+                                                      (uu___12.FStar_SMTEncoding_Env.global_cache)
                                                   } in
-                                                let uu____7221 =
-                                                  let uu____7222 =
+                                                let uu___12 =
+                                                  let uu___13 =
                                                     FStar_SMTEncoding_EncodeTerm.head_normal
                                                       env2 tt in
-                                                  Prims.op_Negation
-                                                    uu____7222 in
-                                                if uu____7221
+                                                  Prims.op_Negation uu___13 in
+                                                if uu___12
                                                 then
                                                   FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                     FStar_Pervasives_Native.None
@@ -2073,9 +2017,9 @@ let (encode_free_var :
                                                   FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                     FStar_Pervasives_Native.None
                                                     t_norm env2 vtok_tm in
-                                              match uu____7214 with
+                                              match uu___11 with
                                               | (tok_typing, decls2) ->
-                                                  let uu____7236 =
+                                                  let uu___12 =
                                                     match vars1 with
                                                     | [] ->
                                                         let tok_typing1 =
@@ -2086,32 +2030,30 @@ let (encode_free_var :
                                                               (Prims.op_Hat
                                                                  "function_token_typing_"
                                                                  vname)) in
-                                                        let uu____7256 =
-                                                          let uu____7259 =
+                                                        let uu___13 =
+                                                          let uu___14 =
                                                             FStar_All.pipe_right
                                                               [tok_typing1]
                                                               FStar_SMTEncoding_Term.mk_decls_trivial in
                                                           FStar_List.append
-                                                            decls2 uu____7259 in
-                                                        let uu____7266 =
-                                                          let uu____7267 =
-                                                            let uu____7270 =
+                                                            decls2 uu___14 in
+                                                        let uu___14 =
+                                                          let uu___15 =
+                                                            let uu___16 =
                                                               FStar_SMTEncoding_Util.mkApp
                                                                 (vname, []) in
                                                             FStar_All.pipe_left
-                                                              (fun uu____7275
-                                                                 ->
+                                                              (fun uu___17 ->
                                                                  FStar_Pervasives_Native.Some
-                                                                   uu____7275)
-                                                              uu____7270 in
+                                                                   uu___17)
+                                                              uu___16 in
                                                           FStar_SMTEncoding_Env.push_free_var
                                                             env1 lid arity
-                                                            vname uu____7267 in
-                                                        (uu____7256,
-                                                          uu____7266)
-                                                    | uu____7278 when thunked
-                                                        -> (decls2, env1)
-                                                    | uu____7289 ->
+                                                            vname uu___15 in
+                                                        (uu___13, uu___14)
+                                                    | uu___13 when thunked ->
+                                                        (decls2, env1)
+                                                    | uu___13 ->
                                                         let vtok =
                                                           get_vtok () in
                                                         let vtok_decl =
@@ -2121,32 +2063,31 @@ let (encode_free_var :
                                                               FStar_Pervasives_Native.None) in
                                                         let name_tok_corr_formula
                                                           pat =
-                                                          let uu____7308 =
+                                                          let uu___14 =
                                                             FStar_Syntax_Syntax.range_of_fv
                                                               fv in
-                                                          let uu____7309 =
-                                                            let uu____7320 =
+                                                          let uu___15 =
+                                                            let uu___16 =
                                                               FStar_SMTEncoding_Util.mkEq
                                                                 (vtok_app,
                                                                   vapp) in
                                                             ([[pat]], vars1,
-                                                              uu____7320) in
+                                                              uu___16) in
                                                           FStar_SMTEncoding_Term.mkForall
-                                                            uu____7308
-                                                            uu____7309 in
+                                                            uu___14 uu___15 in
                                                         let name_tok_corr =
-                                                          let uu____7330 =
-                                                            let uu____7337 =
+                                                          let uu___14 =
+                                                            let uu___15 =
                                                               name_tok_corr_formula
                                                                 vtok_app in
-                                                            (uu____7337,
+                                                            (uu___15,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Name-token correspondence"),
                                                               (Prims.op_Hat
                                                                  "token_correspondence_"
                                                                  vname)) in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____7330 in
+                                                            uu___14 in
                                                         let tok_typing1 =
                                                           let ff =
                                                             FStar_SMTEncoding_Term.mk_fv
@@ -2156,44 +2097,40 @@ let (encode_free_var :
                                                             FStar_SMTEncoding_Util.mkFreeV
                                                               ff in
                                                           let vtok_app_r =
-                                                            let uu____7342 =
-                                                              let uu____7343
-                                                                =
+                                                            let uu___14 =
+                                                              let uu___15 =
                                                                 FStar_SMTEncoding_Term.mk_fv
                                                                   (vtok,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
-                                                              [uu____7343] in
+                                                              [uu___15] in
                                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                              f uu____7342 in
+                                                              f uu___14 in
                                                           let guarded_tok_typing
                                                             =
-                                                            let uu____7363 =
+                                                            let uu___14 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv in
-                                                            let uu____7364 =
-                                                              let uu____7375
-                                                                =
-                                                                let uu____7376
-                                                                  =
-                                                                  let uu____7381
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                let uu___17 =
+                                                                  let uu___18
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_NoHoist
                                                                     f
                                                                     tok_typing in
-                                                                  let uu____7382
+                                                                  let uu___19
                                                                     =
                                                                     name_tok_corr_formula
                                                                     vapp in
-                                                                  (uu____7381,
-                                                                    uu____7382) in
+                                                                  (uu___18,
+                                                                    uu___19) in
                                                                 FStar_SMTEncoding_Util.mkAnd
-                                                                  uu____7376 in
+                                                                  uu___17 in
                                                               ([[vtok_app_r]],
                                                                 [ff],
-                                                                uu____7375) in
+                                                                uu___16) in
                                                             FStar_SMTEncoding_Term.mkForall
-                                                              uu____7363
-                                                              uu____7364 in
+                                                              uu___14 uu___15 in
                                                           FStar_SMTEncoding_Util.mkAssume
                                                             (guarded_tok_typing,
                                                               (FStar_Pervasives_Native.Some
@@ -2201,126 +2138,115 @@ let (encode_free_var :
                                                               (Prims.op_Hat
                                                                  "function_token_typing_"
                                                                  vname)) in
-                                                        let uu____7403 =
-                                                          let uu____7406 =
+                                                        let uu___14 =
+                                                          let uu___15 =
                                                             FStar_All.pipe_right
                                                               [vtok_decl;
                                                               name_tok_corr;
                                                               tok_typing1]
                                                               FStar_SMTEncoding_Term.mk_decls_trivial in
                                                           FStar_List.append
-                                                            decls2 uu____7406 in
-                                                        (uu____7403, env1) in
-                                                  (match uu____7236 with
+                                                            decls2 uu___15 in
+                                                        (uu___14, env1) in
+                                                  (match uu___12 with
                                                    | (tok_decl, env2) ->
-                                                       let uu____7427 =
-                                                         let uu____7430 =
+                                                       let uu___13 =
+                                                         let uu___14 =
                                                            FStar_All.pipe_right
                                                              [vname_decl]
                                                              FStar_SMTEncoding_Term.mk_decls_trivial in
                                                          FStar_List.append
-                                                           uu____7430
-                                                           tok_decl in
-                                                       (uu____7427, env2)) in
-                                            (match uu____7186 with
+                                                           uu___14 tok_decl in
+                                                       (uu___13, env2)) in
+                                            (match uu___10 with
                                              | (decls2, env2) ->
-                                                 let uu____7449 =
+                                                 let uu___11 =
                                                    let res_t1 =
                                                      FStar_Syntax_Subst.compress
                                                        res_t in
-                                                   let uu____7459 =
+                                                   let uu___12 =
                                                      FStar_SMTEncoding_EncodeTerm.encode_term
                                                        res_t1 env' in
-                                                   match uu____7459 with
+                                                   match uu___12 with
                                                    | (encoded_res_t, decls)
                                                        ->
-                                                       let uu____7474 =
+                                                       let uu___13 =
                                                          FStar_SMTEncoding_Term.mk_HasType
                                                            vapp encoded_res_t in
                                                        (encoded_res_t,
-                                                         uu____7474, decls) in
-                                                 (match uu____7449 with
+                                                         uu___13, decls) in
+                                                 (match uu___11 with
                                                   | (encoded_res_t, ty_pred,
                                                      decls3) ->
                                                       let typingAx =
-                                                        let uu____7489 =
-                                                          let uu____7496 =
-                                                            let uu____7497 =
+                                                        let uu___12 =
+                                                          let uu___13 =
+                                                            let uu___14 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv in
-                                                            let uu____7498 =
-                                                              let uu____7509
-                                                                =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_SMTEncoding_Util.mkImp
                                                                   (guard,
                                                                     ty_pred) in
                                                               ([[vapp]],
                                                                 vars1,
-                                                                uu____7509) in
+                                                                uu___16) in
                                                             FStar_SMTEncoding_Term.mkForall
-                                                              uu____7497
-                                                              uu____7498 in
-                                                          (uu____7496,
+                                                              uu___14 uu___15 in
+                                                          (uu___13,
                                                             (FStar_Pervasives_Native.Some
                                                                "free var typing"),
                                                             (Prims.op_Hat
                                                                "typing_"
                                                                vname)) in
                                                         FStar_SMTEncoding_Util.mkAssume
-                                                          uu____7489 in
+                                                          uu___12 in
                                                       let freshness =
-                                                        let uu____7521 =
+                                                        let uu___12 =
                                                           FStar_All.pipe_right
                                                             quals
                                                             (FStar_List.contains
                                                                FStar_Syntax_Syntax.New) in
-                                                        if uu____7521
+                                                        if uu___12
                                                         then
-                                                          let uu____7526 =
-                                                            let uu____7527 =
+                                                          let uu___13 =
+                                                            let uu___14 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv in
-                                                            let uu____7528 =
-                                                              let uu____7539
-                                                                =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_All.pipe_right
                                                                   vars1
                                                                   (FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_sort) in
-                                                              let uu____7546
-                                                                =
+                                                              let uu___17 =
                                                                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                                   () in
                                                               (vname,
-                                                                uu____7539,
+                                                                uu___16,
                                                                 FStar_SMTEncoding_Term.Term_sort,
-                                                                uu____7546) in
+                                                                uu___17) in
                                                             FStar_SMTEncoding_Term.fresh_constructor
-                                                              uu____7527
-                                                              uu____7528 in
-                                                          let uu____7549 =
-                                                            let uu____7552 =
-                                                              let uu____7553
-                                                                =
+                                                              uu___14 uu___15 in
+                                                          let uu___14 =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_Syntax_Syntax.range_of_fv
                                                                   fv in
                                                               pretype_axiom
-                                                                uu____7553
-                                                                env2 vapp
-                                                                vars1 in
-                                                            [uu____7552] in
-                                                          uu____7526 ::
-                                                            uu____7549
+                                                                uu___16 env2
+                                                                vapp vars1 in
+                                                            [uu___15] in
+                                                          uu___13 :: uu___14
                                                         else [] in
                                                       let g =
-                                                        let uu____7558 =
-                                                          let uu____7561 =
-                                                            let uu____7564 =
-                                                              let uu____7567
-                                                                =
-                                                                let uu____7570
-                                                                  =
-                                                                  let uu____7573
+                                                        let uu___12 =
+                                                          let uu___13 =
+                                                            let uu___14 =
+                                                              let uu___15 =
+                                                                let uu___16 =
+                                                                  let uu___17
                                                                     =
                                                                     mk_disc_proj_axioms
                                                                     guard
@@ -2328,20 +2254,19 @@ let (encode_free_var :
                                                                     vapp
                                                                     vars1 in
                                                                   typingAx ::
-                                                                    uu____7573 in
+                                                                    uu___17 in
                                                                 FStar_List.append
                                                                   freshness
-                                                                  uu____7570 in
+                                                                  uu___16 in
                                                               FStar_All.pipe_right
-                                                                uu____7567
+                                                                uu___15
                                                                 FStar_SMTEncoding_Term.mk_decls_trivial in
                                                             FStar_List.append
-                                                              decls3
-                                                              uu____7564 in
+                                                              decls3 uu___14 in
                                                           FStar_List.append
-                                                            decls2 uu____7561 in
+                                                            decls2 uu___13 in
                                                         FStar_List.append
-                                                          decls11 uu____7558 in
+                                                          decls11 uu___12 in
                                                       (g, env2)))))))))
 let (declare_top_level_let :
   FStar_SMTEncoding_Env.env_t ->
@@ -2356,13 +2281,13 @@ let (declare_top_level_let :
     fun x ->
       fun t ->
         fun t_norm ->
-          let uu____7612 =
+          let uu___ =
             FStar_SMTEncoding_Env.lookup_fvar_binding env
               (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          match uu____7612 with
+          match uu___ with
           | FStar_Pervasives_Native.None ->
-              let uu____7623 = encode_free_var false env x t t_norm [] in
-              (match uu____7623 with
+              let uu___1 = encode_free_var false env x t t_norm [] in
+              (match uu___1 with
                | (decls, env1) ->
                    let fvb =
                      FStar_SMTEncoding_Env.lookup_lid env1
@@ -2383,16 +2308,16 @@ let (encode_top_level_val :
         fun t ->
           fun quals ->
             let tt = norm_before_encoding env t in
-            let uu____7682 = encode_free_var uninterpreted env lid t tt quals in
-            match uu____7682 with
+            let uu___ = encode_free_var uninterpreted env lid t tt quals in
+            match uu___ with
             | (decls, env1) ->
-                let uu____7693 = FStar_Syntax_Util.is_smt_lemma t in
-                if uu____7693
+                let uu___1 = FStar_Syntax_Util.is_smt_lemma t in
+                if uu___1
                 then
-                  let uu____7698 =
-                    let uu____7699 = encode_smt_lemma env1 lid tt in
-                    FStar_List.append decls uu____7699 in
-                  (uu____7698, env1)
+                  let uu___2 =
+                    let uu___3 = encode_smt_lemma env1 lid tt in
+                    FStar_List.append decls uu___3 in
+                  (uu___2, env1)
                 else (decls, env1)
 let (encode_top_level_vals :
   FStar_SMTEncoding_Env.env_t ->
@@ -2406,16 +2331,16 @@ let (encode_top_level_vals :
       fun quals ->
         FStar_All.pipe_right bindings
           (FStar_List.fold_left
-             (fun uu____7753 ->
+             (fun uu___ ->
                 fun lb ->
-                  match uu____7753 with
+                  match uu___ with
                   | (decls, env1) ->
-                      let uu____7773 =
-                        let uu____7778 =
+                      let uu___1 =
+                        let uu___2 =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                        encode_top_level_val false env1 uu____7778
+                        encode_top_level_val false env1 uu___2
                           lb.FStar_Syntax_Syntax.lbtyp quals in
-                      (match uu____7773 with
+                      (match uu___1 with
                        | (decls', env2) ->
                            ((FStar_List.append decls decls'), env2)))
              ([], env))
@@ -2423,51 +2348,47 @@ let (is_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let fstar_tactics_tactic_lid =
       FStar_Parser_Const.p2l ["FStar"; "Tactics"; "tactic"] in
-    let uu____7797 = FStar_Syntax_Util.head_and_args t in
-    match uu____7797 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (hd, args) ->
-        let uu____7840 =
-          let uu____7841 = FStar_Syntax_Util.un_uinst hd in
-          uu____7841.FStar_Syntax_Syntax.n in
-        (match uu____7840 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Util.un_uinst hd in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_tactic_lid ->
              true
-         | FStar_Syntax_Syntax.Tm_arrow (uu____7845, c) ->
+         | FStar_Syntax_Syntax.Tm_arrow (uu___2, c) ->
              let effect_name = FStar_Syntax_Util.comp_effect_name c in
-             let uu____7868 = FStar_Ident.string_of_lid effect_name in
-             FStar_Util.starts_with "FStar.Tactics" uu____7868
-         | uu____7869 -> false)
+             let uu___3 = FStar_Ident.string_of_lid effect_name in
+             FStar_Util.starts_with "FStar.Tactics" uu___3
+         | uu___2 -> false)
 exception Let_rec_unencodeable 
 let (uu___is_Let_rec_unencodeable : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Let_rec_unencodeable -> true | uu____7875 -> false
+    match projectee with | Let_rec_unencodeable -> true | uu___ -> false
 let (copy_env : FStar_SMTEncoding_Env.env_t -> FStar_SMTEncoding_Env.env_t) =
   fun en ->
-    let uu___495_7881 = en in
-    let uu____7882 =
-      FStar_Util.smap_copy en.FStar_SMTEncoding_Env.global_cache in
+    let uu___ = en in
+    let uu___1 = FStar_Util.smap_copy en.FStar_SMTEncoding_Env.global_cache in
     {
       FStar_SMTEncoding_Env.bvar_bindings =
-        (uu___495_7881.FStar_SMTEncoding_Env.bvar_bindings);
+        (uu___.FStar_SMTEncoding_Env.bvar_bindings);
       FStar_SMTEncoding_Env.fvar_bindings =
-        (uu___495_7881.FStar_SMTEncoding_Env.fvar_bindings);
-      FStar_SMTEncoding_Env.depth =
-        (uu___495_7881.FStar_SMTEncoding_Env.depth);
-      FStar_SMTEncoding_Env.tcenv =
-        (uu___495_7881.FStar_SMTEncoding_Env.tcenv);
-      FStar_SMTEncoding_Env.warn = (uu___495_7881.FStar_SMTEncoding_Env.warn);
-      FStar_SMTEncoding_Env.nolabels =
-        (uu___495_7881.FStar_SMTEncoding_Env.nolabels);
+        (uu___.FStar_SMTEncoding_Env.fvar_bindings);
+      FStar_SMTEncoding_Env.depth = (uu___.FStar_SMTEncoding_Env.depth);
+      FStar_SMTEncoding_Env.tcenv = (uu___.FStar_SMTEncoding_Env.tcenv);
+      FStar_SMTEncoding_Env.warn = (uu___.FStar_SMTEncoding_Env.warn);
+      FStar_SMTEncoding_Env.nolabels = (uu___.FStar_SMTEncoding_Env.nolabels);
       FStar_SMTEncoding_Env.use_zfuel_name =
-        (uu___495_7881.FStar_SMTEncoding_Env.use_zfuel_name);
+        (uu___.FStar_SMTEncoding_Env.use_zfuel_name);
       FStar_SMTEncoding_Env.encode_non_total_function_typ =
-        (uu___495_7881.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+        (uu___.FStar_SMTEncoding_Env.encode_non_total_function_typ);
       FStar_SMTEncoding_Env.current_module_name =
-        (uu___495_7881.FStar_SMTEncoding_Env.current_module_name);
+        (uu___.FStar_SMTEncoding_Env.current_module_name);
       FStar_SMTEncoding_Env.encoding_quantifier =
-        (uu___495_7881.FStar_SMTEncoding_Env.encoding_quantifier);
-      FStar_SMTEncoding_Env.global_cache = uu____7882
+        (uu___.FStar_SMTEncoding_Env.encoding_quantifier);
+      FStar_SMTEncoding_Env.global_cache = uu___1
     }
 let (encode_top_level_let :
   FStar_SMTEncoding_Env.env_t ->
@@ -2476,182 +2397,179 @@ let (encode_top_level_let :
         (FStar_SMTEncoding_Term.decls_t * FStar_SMTEncoding_Env.env_t))
   =
   fun env ->
-    fun uu____7910 ->
+    fun uu___ ->
       fun quals ->
-        match uu____7910 with
+        match uu___ with
         | (is_rec, bindings) ->
             let eta_expand binders formals body t =
               let nbinders = FStar_List.length binders in
-              let uu____8010 = FStar_Util.first_N nbinders formals in
-              match uu____8010 with
+              let uu___1 = FStar_Util.first_N nbinders formals in
+              match uu___1 with
               | (formals1, extra_formals) ->
                   let subst =
                     FStar_List.map2
-                      (fun uu____8105 ->
-                         fun uu____8106 ->
-                           match (uu____8105, uu____8106) with
-                           | ((formal, uu____8132), (binder, uu____8134)) ->
-                               let uu____8155 =
-                                 let uu____8162 =
+                      (fun uu___2 ->
+                         fun uu___3 ->
+                           match (uu___2, uu___3) with
+                           | ((formal, uu___4), (binder, uu___5)) ->
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.bv_to_name binder in
-                                 (formal, uu____8162) in
-                               FStar_Syntax_Syntax.NT uu____8155) formals1
+                                 (formal, uu___7) in
+                               FStar_Syntax_Syntax.NT uu___6) formals1
                       binders in
                   let extra_formals1 =
-                    let uu____8176 =
+                    let uu___2 =
                       FStar_All.pipe_right extra_formals
                         (FStar_List.map
-                           (fun uu____8217 ->
-                              match uu____8217 with
+                           (fun uu___3 ->
+                              match uu___3 with
                               | (x, i) ->
-                                  let uu____8236 =
-                                    let uu___521_8237 = x in
-                                    let uu____8238 =
+                                  let uu___4 =
+                                    let uu___5 = x in
+                                    let uu___6 =
                                       FStar_Syntax_Subst.subst subst
                                         x.FStar_Syntax_Syntax.sort in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___521_8237.FStar_Syntax_Syntax.ppname);
+                                        (uu___5.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___521_8237.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = uu____8238
+                                        (uu___5.FStar_Syntax_Syntax.index);
+                                      FStar_Syntax_Syntax.sort = uu___6
                                     } in
-                                  (uu____8236, i))) in
-                    FStar_All.pipe_right uu____8176
+                                  (uu___4, i))) in
+                    FStar_All.pipe_right uu___2
                       FStar_Syntax_Util.name_binders in
                   let body1 =
-                    let uu____8260 = FStar_Syntax_Subst.compress body in
-                    let uu____8261 =
-                      let uu____8262 =
+                    let uu___2 = FStar_Syntax_Subst.compress body in
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Util.args_of_binders extra_formals1 in
-                      FStar_All.pipe_left FStar_Pervasives_Native.snd
-                        uu____8262 in
-                    FStar_Syntax_Syntax.extend_app_n uu____8260 uu____8261
+                      FStar_All.pipe_left FStar_Pervasives_Native.snd uu___4 in
+                    FStar_Syntax_Syntax.extend_app_n uu___2 uu___3
                       body.FStar_Syntax_Syntax.pos in
                   ((FStar_List.append binders extra_formals1), body1) in
             let destruct_bound_function t e =
               let tcenv =
-                let uu___528_8309 = env.FStar_SMTEncoding_Env.tcenv in
+                let uu___1 = env.FStar_SMTEncoding_Env.tcenv in
                 {
                   FStar_TypeChecker_Env.solver =
-                    (uu___528_8309.FStar_TypeChecker_Env.solver);
+                    (uu___1.FStar_TypeChecker_Env.solver);
                   FStar_TypeChecker_Env.range =
-                    (uu___528_8309.FStar_TypeChecker_Env.range);
+                    (uu___1.FStar_TypeChecker_Env.range);
                   FStar_TypeChecker_Env.curmodule =
-                    (uu___528_8309.FStar_TypeChecker_Env.curmodule);
+                    (uu___1.FStar_TypeChecker_Env.curmodule);
                   FStar_TypeChecker_Env.gamma =
-                    (uu___528_8309.FStar_TypeChecker_Env.gamma);
+                    (uu___1.FStar_TypeChecker_Env.gamma);
                   FStar_TypeChecker_Env.gamma_sig =
-                    (uu___528_8309.FStar_TypeChecker_Env.gamma_sig);
+                    (uu___1.FStar_TypeChecker_Env.gamma_sig);
                   FStar_TypeChecker_Env.gamma_cache =
-                    (uu___528_8309.FStar_TypeChecker_Env.gamma_cache);
+                    (uu___1.FStar_TypeChecker_Env.gamma_cache);
                   FStar_TypeChecker_Env.modules =
-                    (uu___528_8309.FStar_TypeChecker_Env.modules);
+                    (uu___1.FStar_TypeChecker_Env.modules);
                   FStar_TypeChecker_Env.expected_typ =
-                    (uu___528_8309.FStar_TypeChecker_Env.expected_typ);
+                    (uu___1.FStar_TypeChecker_Env.expected_typ);
                   FStar_TypeChecker_Env.sigtab =
-                    (uu___528_8309.FStar_TypeChecker_Env.sigtab);
+                    (uu___1.FStar_TypeChecker_Env.sigtab);
                   FStar_TypeChecker_Env.attrtab =
-                    (uu___528_8309.FStar_TypeChecker_Env.attrtab);
+                    (uu___1.FStar_TypeChecker_Env.attrtab);
                   FStar_TypeChecker_Env.instantiate_imp =
-                    (uu___528_8309.FStar_TypeChecker_Env.instantiate_imp);
+                    (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                   FStar_TypeChecker_Env.effects =
-                    (uu___528_8309.FStar_TypeChecker_Env.effects);
+                    (uu___1.FStar_TypeChecker_Env.effects);
                   FStar_TypeChecker_Env.generalize =
-                    (uu___528_8309.FStar_TypeChecker_Env.generalize);
+                    (uu___1.FStar_TypeChecker_Env.generalize);
                   FStar_TypeChecker_Env.letrecs =
-                    (uu___528_8309.FStar_TypeChecker_Env.letrecs);
+                    (uu___1.FStar_TypeChecker_Env.letrecs);
                   FStar_TypeChecker_Env.top_level =
-                    (uu___528_8309.FStar_TypeChecker_Env.top_level);
+                    (uu___1.FStar_TypeChecker_Env.top_level);
                   FStar_TypeChecker_Env.check_uvars =
-                    (uu___528_8309.FStar_TypeChecker_Env.check_uvars);
+                    (uu___1.FStar_TypeChecker_Env.check_uvars);
                   FStar_TypeChecker_Env.use_eq =
-                    (uu___528_8309.FStar_TypeChecker_Env.use_eq);
+                    (uu___1.FStar_TypeChecker_Env.use_eq);
                   FStar_TypeChecker_Env.use_eq_strict =
-                    (uu___528_8309.FStar_TypeChecker_Env.use_eq_strict);
+                    (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                   FStar_TypeChecker_Env.is_iface =
-                    (uu___528_8309.FStar_TypeChecker_Env.is_iface);
+                    (uu___1.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
-                    (uu___528_8309.FStar_TypeChecker_Env.admit);
+                    (uu___1.FStar_TypeChecker_Env.admit);
                   FStar_TypeChecker_Env.lax = true;
                   FStar_TypeChecker_Env.lax_universes =
-                    (uu___528_8309.FStar_TypeChecker_Env.lax_universes);
+                    (uu___1.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
-                    (uu___528_8309.FStar_TypeChecker_Env.phase1);
+                    (uu___1.FStar_TypeChecker_Env.phase1);
                   FStar_TypeChecker_Env.failhard =
-                    (uu___528_8309.FStar_TypeChecker_Env.failhard);
+                    (uu___1.FStar_TypeChecker_Env.failhard);
                   FStar_TypeChecker_Env.nosynth =
-                    (uu___528_8309.FStar_TypeChecker_Env.nosynth);
+                    (uu___1.FStar_TypeChecker_Env.nosynth);
                   FStar_TypeChecker_Env.uvar_subtyping =
-                    (uu___528_8309.FStar_TypeChecker_Env.uvar_subtyping);
+                    (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.tc_term =
-                    (uu___528_8309.FStar_TypeChecker_Env.tc_term);
+                    (uu___1.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.type_of =
-                    (uu___528_8309.FStar_TypeChecker_Env.type_of);
+                    (uu___1.FStar_TypeChecker_Env.type_of);
                   FStar_TypeChecker_Env.universe_of =
-                    (uu___528_8309.FStar_TypeChecker_Env.universe_of);
+                    (uu___1.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.check_type_of =
-                    (uu___528_8309.FStar_TypeChecker_Env.check_type_of);
+                    (uu___1.FStar_TypeChecker_Env.check_type_of);
                   FStar_TypeChecker_Env.use_bv_sorts =
-                    (uu___528_8309.FStar_TypeChecker_Env.use_bv_sorts);
+                    (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                    (uu___528_8309.FStar_TypeChecker_Env.qtbl_name_and_index);
+                    (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                   FStar_TypeChecker_Env.normalized_eff_names =
-                    (uu___528_8309.FStar_TypeChecker_Env.normalized_eff_names);
+                    (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                   FStar_TypeChecker_Env.fv_delta_depths =
-                    (uu___528_8309.FStar_TypeChecker_Env.fv_delta_depths);
+                    (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                   FStar_TypeChecker_Env.proof_ns =
-                    (uu___528_8309.FStar_TypeChecker_Env.proof_ns);
+                    (uu___1.FStar_TypeChecker_Env.proof_ns);
                   FStar_TypeChecker_Env.synth_hook =
-                    (uu___528_8309.FStar_TypeChecker_Env.synth_hook);
+                    (uu___1.FStar_TypeChecker_Env.synth_hook);
                   FStar_TypeChecker_Env.try_solve_implicits_hook =
-                    (uu___528_8309.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                    (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                   FStar_TypeChecker_Env.splice =
-                    (uu___528_8309.FStar_TypeChecker_Env.splice);
+                    (uu___1.FStar_TypeChecker_Env.splice);
                   FStar_TypeChecker_Env.mpreprocess =
-                    (uu___528_8309.FStar_TypeChecker_Env.mpreprocess);
+                    (uu___1.FStar_TypeChecker_Env.mpreprocess);
                   FStar_TypeChecker_Env.postprocess =
-                    (uu___528_8309.FStar_TypeChecker_Env.postprocess);
+                    (uu___1.FStar_TypeChecker_Env.postprocess);
                   FStar_TypeChecker_Env.identifier_info =
-                    (uu___528_8309.FStar_TypeChecker_Env.identifier_info);
+                    (uu___1.FStar_TypeChecker_Env.identifier_info);
                   FStar_TypeChecker_Env.tc_hooks =
-                    (uu___528_8309.FStar_TypeChecker_Env.tc_hooks);
+                    (uu___1.FStar_TypeChecker_Env.tc_hooks);
                   FStar_TypeChecker_Env.dsenv =
-                    (uu___528_8309.FStar_TypeChecker_Env.dsenv);
+                    (uu___1.FStar_TypeChecker_Env.dsenv);
                   FStar_TypeChecker_Env.nbe =
-                    (uu___528_8309.FStar_TypeChecker_Env.nbe);
+                    (uu___1.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___528_8309.FStar_TypeChecker_Env.strict_args_tab);
+                    (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                   FStar_TypeChecker_Env.erasable_types_tab =
-                    (uu___528_8309.FStar_TypeChecker_Env.erasable_types_tab);
+                    (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                    (uu___528_8309.FStar_TypeChecker_Env.enable_defer_to_tac)
+                    (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                 } in
               let subst_comp formals actuals comp =
                 let subst =
                   FStar_List.map2
-                    (fun uu____8380 ->
-                       fun uu____8381 ->
-                         match (uu____8380, uu____8381) with
-                         | ((x, uu____8407), (b, uu____8409)) ->
-                             let uu____8430 =
-                               let uu____8437 =
-                                 FStar_Syntax_Syntax.bv_to_name b in
-                               (x, uu____8437) in
-                             FStar_Syntax_Syntax.NT uu____8430) formals
-                    actuals in
+                    (fun uu___1 ->
+                       fun uu___2 ->
+                         match (uu___1, uu___2) with
+                         | ((x, uu___3), (b, uu___4)) ->
+                             let uu___5 =
+                               let uu___6 = FStar_Syntax_Syntax.bv_to_name b in
+                               (x, uu___6) in
+                             FStar_Syntax_Syntax.NT uu___5) formals actuals in
                 FStar_Syntax_Subst.subst_comp subst comp in
               let rec arrow_formals_comp_norm norm t1 =
                 let t2 =
-                  let uu____8460 = FStar_Syntax_Subst.compress t1 in
-                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____8460 in
+                  let uu___1 = FStar_Syntax_Subst.compress t1 in
+                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu___1 in
                 match t2.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_arrow (formals, comp) ->
                     FStar_Syntax_Subst.open_comp formals comp
-                | FStar_Syntax_Syntax.Tm_refine uu____8489 ->
-                    let uu____8496 = FStar_Syntax_Util.unrefine t2 in
-                    arrow_formals_comp_norm norm uu____8496
-                | uu____8497 when Prims.op_Negation norm ->
+                | FStar_Syntax_Syntax.Tm_refine uu___1 ->
+                    let uu___2 = FStar_Syntax_Util.unrefine t2 in
+                    arrow_formals_comp_norm norm uu___2
+                | uu___1 when Prims.op_Negation norm ->
                     let t_norm =
                       norm_with_steps
                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -2664,102 +2582,100 @@ let (encode_top_level_let :
                           FStar_Syntax_Syntax.delta_constant;
                         FStar_TypeChecker_Env.EraseUniverses] tcenv t2 in
                     arrow_formals_comp_norm true t_norm
-                | uu____8499 ->
-                    let uu____8500 = FStar_Syntax_Syntax.mk_Total t2 in
-                    ([], uu____8500) in
+                | uu___1 ->
+                    let uu___2 = FStar_Syntax_Syntax.mk_Total t2 in
+                    ([], uu___2) in
               let aux t1 e1 =
-                let uu____8542 = FStar_Syntax_Util.abs_formals e1 in
-                match uu____8542 with
+                let uu___1 = FStar_Syntax_Util.abs_formals e1 in
+                match uu___1 with
                 | (binders, body, lopt) ->
-                    let uu____8574 =
+                    let uu___2 =
                       match binders with
                       | [] -> arrow_formals_comp_norm true t1
-                      | uu____8589 -> arrow_formals_comp_norm false t1 in
-                    (match uu____8574 with
+                      | uu___3 -> arrow_formals_comp_norm false t1 in
+                    (match uu___2 with
                      | (formals, comp) ->
                          let nformals = FStar_List.length formals in
                          let nbinders = FStar_List.length binders in
-                         let uu____8622 =
+                         let uu___3 =
                            if nformals < nbinders
                            then
-                             let uu____8655 =
-                               FStar_Util.first_N nformals binders in
-                             match uu____8655 with
+                             let uu___4 = FStar_Util.first_N nformals binders in
+                             match uu___4 with
                              | (bs0, rest) ->
                                  let body1 =
                                    FStar_Syntax_Util.abs rest body lopt in
-                                 let uu____8735 = subst_comp formals bs0 comp in
-                                 (bs0, body1, uu____8735)
+                                 let uu___5 = subst_comp formals bs0 comp in
+                                 (bs0, body1, uu___5)
                            else
                              if nformals > nbinders
                              then
-                               (let uu____8763 =
+                               (let uu___5 =
                                   eta_expand binders formals body
                                     (FStar_Syntax_Util.comp_result comp) in
-                                match uu____8763 with
+                                match uu___5 with
                                 | (binders1, body1) ->
-                                    let uu____8810 =
+                                    let uu___6 =
                                       subst_comp formals binders1 comp in
-                                    (binders1, body1, uu____8810))
+                                    (binders1, body1, uu___6))
                              else
-                               (let uu____8822 =
-                                  subst_comp formals binders comp in
-                                (binders, body, uu____8822)) in
-                         (match uu____8622 with
+                               (let uu___6 = subst_comp formals binders comp in
+                                (binders, body, uu___6)) in
+                         (match uu___3 with
                           | (binders1, body1, comp1) ->
                               (binders1, body1, comp1))) in
-              let uu____8882 = aux t e in
-              match uu____8882 with
+              let uu___1 = aux t e in
+              match uu___1 with
               | (binders, body, comp) ->
-                  let uu____8928 =
-                    let uu____8939 =
+                  let uu___2 =
+                    let uu___3 =
                       FStar_SMTEncoding_Util.is_smt_reifiable_comp tcenv comp in
-                    if uu____8939
+                    if uu___3
                     then
                       let comp1 =
                         FStar_TypeChecker_Env.reify_comp tcenv comp
                           FStar_Syntax_Syntax.U_unknown in
                       let body1 =
                         FStar_TypeChecker_Util.reify_body tcenv [] body in
-                      let uu____8952 = aux comp1 body1 in
-                      match uu____8952 with
+                      let uu___4 = aux comp1 body1 in
+                      match uu___4 with
                       | (more_binders, body2, comp2) ->
                           ((FStar_List.append binders more_binders), body2,
                             comp2)
                     else (binders, body, comp) in
-                  (match uu____8928 with
+                  (match uu___2 with
                    | (binders1, body1, comp1) ->
-                       let uu____9034 =
+                       let uu___3 =
                          FStar_Syntax_Util.ascribe body1
                            ((FStar_Util.Inl
                                (FStar_Syntax_Util.comp_result comp1)),
                              FStar_Pervasives_Native.None) in
-                       (binders1, uu____9034, comp1)) in
+                       (binders1, uu___3, comp1)) in
             (try
-               (fun uu___598_9061 ->
+               (fun uu___1 ->
                   match () with
                   | () ->
-                      let uu____9068 =
+                      let uu___2 =
                         FStar_All.pipe_right bindings
                           (FStar_Util.for_all
                              (fun lb ->
                                 (FStar_Syntax_Util.is_lemma
                                    lb.FStar_Syntax_Syntax.lbtyp)
                                   || (is_tactic lb.FStar_Syntax_Syntax.lbtyp))) in
-                      if uu____9068
+                      if uu___2
                       then encode_top_level_vals env bindings quals
                       else
-                        (let uu____9080 =
+                        (let uu___4 =
                            FStar_All.pipe_right bindings
                              (FStar_List.fold_left
-                                (fun uu____9143 ->
+                                (fun uu___5 ->
                                    fun lb ->
-                                     match uu____9143 with
+                                     match uu___5 with
                                      | (toks, typs, decls, env1) ->
-                                         ((let uu____9198 =
+                                         ((let uu___7 =
                                              FStar_Syntax_Util.is_lemma
                                                lb.FStar_Syntax_Syntax.lbtyp in
-                                           if uu____9198
+                                           if uu___7
                                            then
                                              FStar_Exn.raise
                                                Let_rec_unencodeable
@@ -2767,20 +2683,20 @@ let (encode_top_level_let :
                                           (let t_norm =
                                              norm_before_encoding env1
                                                lb.FStar_Syntax_Syntax.lbtyp in
-                                           let uu____9201 =
-                                             let uu____9210 =
+                                           let uu___7 =
+                                             let uu___8 =
                                                FStar_Util.right
                                                  lb.FStar_Syntax_Syntax.lbname in
                                              declare_top_level_let env1
-                                               uu____9210
+                                               uu___8
                                                lb.FStar_Syntax_Syntax.lbtyp
                                                t_norm in
-                                           match uu____9201 with
+                                           match uu___7 with
                                            | (tok, decl, env2) ->
                                                ((tok :: toks), (t_norm ::
                                                  typs), (decl :: decls),
                                                  env2)))) ([], [], [], env)) in
-                         match uu____9080 with
+                         match uu___4 with
                          | (toks, typs, decls, env1) ->
                              let toks_fvbs = FStar_List.rev toks in
                              let decls1 =
@@ -2793,99 +2709,97 @@ let (encode_top_level_let :
                                match (bindings1, typs2, toks1) with
                                | ({ FStar_Syntax_Syntax.lbname = lbn;
                                     FStar_Syntax_Syntax.lbunivs = uvs;
-                                    FStar_Syntax_Syntax.lbtyp = uu____9351;
-                                    FStar_Syntax_Syntax.lbeff = uu____9352;
+                                    FStar_Syntax_Syntax.lbtyp = uu___5;
+                                    FStar_Syntax_Syntax.lbeff = uu___6;
                                     FStar_Syntax_Syntax.lbdef = e;
-                                    FStar_Syntax_Syntax.lbattrs = uu____9354;
-                                    FStar_Syntax_Syntax.lbpos = uu____9355;_}::[],
+                                    FStar_Syntax_Syntax.lbattrs = uu___7;
+                                    FStar_Syntax_Syntax.lbpos = uu___8;_}::[],
                                   t_norm::[], fvb::[]) ->
                                    let flid =
                                      fvb.FStar_SMTEncoding_Env.fvar_lid in
-                                   let uu____9379 =
-                                     let uu____9386 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_TypeChecker_Env.open_universes_in
                                          env2.FStar_SMTEncoding_Env.tcenv uvs
                                          [e; t_norm] in
-                                     match uu____9386 with
-                                     | (tcenv', uu____9402, e_t) ->
-                                         let uu____9408 =
+                                     match uu___10 with
+                                     | (tcenv', uu___11, e_t) ->
+                                         let uu___12 =
                                            match e_t with
                                            | e1::t_norm1::[] -> (e1, t_norm1)
-                                           | uu____9419 ->
-                                               failwith "Impossible" in
-                                         (match uu____9408 with
+                                           | uu___13 -> failwith "Impossible" in
+                                         (match uu___12 with
                                           | (e1, t_norm1) ->
-                                              ((let uu___661_9435 = env2 in
+                                              ((let uu___13 = env2 in
                                                 {
                                                   FStar_SMTEncoding_Env.bvar_bindings
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.bvar_bindings);
+                                                    (uu___13.FStar_SMTEncoding_Env.bvar_bindings);
                                                   FStar_SMTEncoding_Env.fvar_bindings
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.fvar_bindings);
+                                                    (uu___13.FStar_SMTEncoding_Env.fvar_bindings);
                                                   FStar_SMTEncoding_Env.depth
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.depth);
+                                                    (uu___13.FStar_SMTEncoding_Env.depth);
                                                   FStar_SMTEncoding_Env.tcenv
                                                     = tcenv';
                                                   FStar_SMTEncoding_Env.warn
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.warn);
+                                                    (uu___13.FStar_SMTEncoding_Env.warn);
                                                   FStar_SMTEncoding_Env.nolabels
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.nolabels);
+                                                    (uu___13.FStar_SMTEncoding_Env.nolabels);
                                                   FStar_SMTEncoding_Env.use_zfuel_name
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                    (uu___13.FStar_SMTEncoding_Env.use_zfuel_name);
                                                   FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                    (uu___13.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                   FStar_SMTEncoding_Env.current_module_name
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.current_module_name);
+                                                    (uu___13.FStar_SMTEncoding_Env.current_module_name);
                                                   FStar_SMTEncoding_Env.encoding_quantifier
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                    (uu___13.FStar_SMTEncoding_Env.encoding_quantifier);
                                                   FStar_SMTEncoding_Env.global_cache
                                                     =
-                                                    (uu___661_9435.FStar_SMTEncoding_Env.global_cache)
+                                                    (uu___13.FStar_SMTEncoding_Env.global_cache)
                                                 }), e1, t_norm1)) in
-                                   (match uu____9379 with
+                                   (match uu___9 with
                                     | (env', e1, t_norm1) ->
-                                        let uu____9445 =
+                                        let uu___10 =
                                           destruct_bound_function t_norm1 e1 in
-                                        (match uu____9445 with
+                                        (match uu___10 with
                                          | (binders, body, t_body_comp) ->
                                              let t_body =
                                                FStar_Syntax_Util.comp_result
                                                  t_body_comp in
-                                             ((let uu____9465 =
+                                             ((let uu___12 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env2.FStar_SMTEncoding_Env.tcenv)
                                                    (FStar_Options.Other
                                                       "SMTEncoding") in
-                                               if uu____9465
+                                               if uu___12
                                                then
-                                                 let uu____9466 =
+                                                 let uu___13 =
                                                    FStar_Syntax_Print.binders_to_string
                                                      ", " binders in
-                                                 let uu____9467 =
+                                                 let uu___14 =
                                                    FStar_Syntax_Print.term_to_string
                                                      body in
                                                  FStar_Util.print2
                                                    "Encoding let : binders=[%s], body=%s\n"
-                                                   uu____9466 uu____9467
+                                                   uu___13 uu___14
                                                else ());
-                                              (let uu____9469 =
+                                              (let uu___12 =
                                                  FStar_SMTEncoding_EncodeTerm.encode_binders
                                                    FStar_Pervasives_Native.None
                                                    binders env' in
-                                               match uu____9469 with
+                                               match uu___12 with
                                                | (vars, _guards, env'1,
-                                                  binder_decls, uu____9496)
-                                                   ->
-                                                   let uu____9509 =
+                                                  binder_decls, uu___13) ->
+                                                   let uu___14 =
                                                      if
                                                        fvb.FStar_SMTEncoding_Env.fvb_thunked
                                                          && (vars = [])
@@ -2899,38 +2813,37 @@ let (encode_top_level_let :
                                                            dummy_var
                                                            FStar_Range.dummyRange in
                                                        let app =
-                                                         let uu____9523 =
+                                                         let uu___15 =
                                                            FStar_Syntax_Util.range_of_lbname
                                                              lbn in
                                                          FStar_SMTEncoding_Term.mkApp
                                                            ((fvb.FStar_SMTEncoding_Env.smt_id),
                                                              [dummy_tm])
-                                                           uu____9523 in
+                                                           uu___15 in
                                                        ([dummy_var], app)
                                                      else
-                                                       (let uu____9539 =
-                                                          let uu____9540 =
+                                                       (let uu___16 =
+                                                          let uu___17 =
                                                             FStar_Syntax_Util.range_of_lbname
                                                               lbn in
-                                                          let uu____9541 =
+                                                          let uu___18 =
                                                             FStar_List.map
                                                               FStar_SMTEncoding_Util.mkFreeV
                                                               vars in
                                                           FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
-                                                            uu____9540 fvb
-                                                            uu____9541 in
-                                                        (vars, uu____9539)) in
-                                                   (match uu____9509 with
+                                                            uu___17 fvb
+                                                            uu___18 in
+                                                        (vars, uu___16)) in
+                                                   (match uu___14 with
                                                     | (vars1, app) ->
-                                                        let uu____9552 =
+                                                        let uu___15 =
                                                           let is_logical =
-                                                            let uu____9564 =
-                                                              let uu____9565
-                                                                =
+                                                            let uu___16 =
+                                                              let uu___17 =
                                                                 FStar_Syntax_Subst.compress
                                                                   t_body in
-                                                              uu____9565.FStar_Syntax_Syntax.n in
-                                                            match uu____9564
+                                                              uu___17.FStar_Syntax_Syntax.n in
+                                                            match uu___16
                                                             with
                                                             | FStar_Syntax_Syntax.Tm_fvar
                                                                 fv when
@@ -2938,33 +2851,32 @@ let (encode_top_level_let :
                                                                   fv
                                                                   FStar_Parser_Const.logical_lid
                                                                 -> true
-                                                            | uu____9569 ->
+                                                            | uu___17 ->
                                                                 false in
                                                           let is_prims =
-                                                            let uu____9571 =
-                                                              let uu____9572
-                                                                =
+                                                            let uu___16 =
+                                                              let uu___17 =
                                                                 FStar_All.pipe_right
                                                                   lbn
                                                                   FStar_Util.right in
                                                               FStar_All.pipe_right
-                                                                uu____9572
+                                                                uu___17
                                                                 FStar_Syntax_Syntax.lid_of_fv in
                                                             FStar_All.pipe_right
-                                                              uu____9571
+                                                              uu___16
                                                               (fun lid ->
-                                                                 let uu____9580
+                                                                 let uu___17
                                                                    =
-                                                                   let uu____9581
+                                                                   let uu___18
                                                                     =
                                                                     FStar_Ident.ns_of_lid
                                                                     lid in
                                                                    FStar_Ident.lid_of_ids
-                                                                    uu____9581 in
+                                                                    uu___18 in
                                                                  FStar_Ident.lid_equals
-                                                                   uu____9580
+                                                                   uu___17
                                                                    FStar_Parser_Const.prims_lid) in
-                                                          let uu____9582 =
+                                                          let uu___16 =
                                                             (Prims.op_Negation
                                                                is_prims)
                                                               &&
@@ -2974,79 +2886,76 @@ let (encode_top_level_let :
                                                                     FStar_Syntax_Syntax.Logic))
                                                                  ||
                                                                  is_logical) in
-                                                          if uu____9582
+                                                          if uu___16
                                                           then
-                                                            let uu____9595 =
+                                                            let uu___17 =
                                                               FStar_SMTEncoding_Term.mk_Valid
                                                                 app in
-                                                            let uu____9596 =
+                                                            let uu___18 =
                                                               FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                 body env'1 in
-                                                            (app, uu____9595,
-                                                              uu____9596)
+                                                            (app, uu___17,
+                                                              uu___18)
                                                           else
-                                                            (let uu____9606 =
+                                                            (let uu___18 =
                                                                FStar_SMTEncoding_EncodeTerm.encode_term
                                                                  body env'1 in
                                                              (app, app,
-                                                               uu____9606)) in
-                                                        (match uu____9552
-                                                         with
+                                                               uu___18)) in
+                                                        (match uu___15 with
                                                          | (pat, app1,
                                                             (body1, decls2))
                                                              ->
                                                              let eqn =
-                                                               let uu____9630
-                                                                 =
-                                                                 let uu____9637
+                                                               let uu___16 =
+                                                                 let uu___17
                                                                    =
-                                                                   let uu____9638
+                                                                   let uu___18
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                   let uu____9639
+                                                                   let uu___19
                                                                     =
-                                                                    let uu____9650
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app1,
                                                                     body1) in
                                                                     ([[pat]],
                                                                     vars1,
-                                                                    uu____9650) in
+                                                                    uu___20) in
                                                                    FStar_SMTEncoding_Term.mkForall
-                                                                    uu____9638
-                                                                    uu____9639 in
-                                                                 let uu____9659
+                                                                    uu___18
+                                                                    uu___19 in
+                                                                 let uu___18
                                                                    =
-                                                                   let uu____9660
+                                                                   let uu___19
                                                                     =
-                                                                    let uu____9661
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     flid in
                                                                     FStar_Util.format1
                                                                     "Equation for %s"
-                                                                    uu____9661 in
+                                                                    uu___20 in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____9660 in
-                                                                 (uu____9637,
-                                                                   uu____9659,
+                                                                    uu___19 in
+                                                                 (uu___17,
+                                                                   uu___18,
                                                                    (Prims.op_Hat
                                                                     "equation_"
                                                                     fvb.FStar_SMTEncoding_Env.smt_id)) in
                                                                FStar_SMTEncoding_Util.mkAssume
-                                                                 uu____9630 in
-                                                             let uu____9662 =
-                                                               let uu____9665
-                                                                 =
-                                                                 let uu____9668
+                                                                 uu___16 in
+                                                             let uu___16 =
+                                                               let uu___17 =
+                                                                 let uu___18
                                                                    =
-                                                                   let uu____9671
+                                                                   let uu___19
                                                                     =
-                                                                    let uu____9674
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____9677
+                                                                    let uu___21
                                                                     =
                                                                     primitive_type_axioms
                                                                     env2.FStar_SMTEncoding_Env.tcenv
@@ -3054,172 +2963,164 @@ let (encode_top_level_let :
                                                                     fvb.FStar_SMTEncoding_Env.smt_id
                                                                     app1 in
                                                                     eqn ::
-                                                                    uu____9677 in
+                                                                    uu___21 in
                                                                     FStar_All.pipe_right
-                                                                    uu____9674
+                                                                    uu___20
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial in
                                                                    FStar_List.append
                                                                     decls2
-                                                                    uu____9671 in
+                                                                    uu___19 in
                                                                  FStar_List.append
                                                                    binder_decls
-                                                                   uu____9668 in
+                                                                   uu___18 in
                                                                FStar_List.append
                                                                  decls1
-                                                                 uu____9665 in
-                                                             (uu____9662,
-                                                               env2)))))))
-                               | uu____9686 -> failwith "Impossible" in
+                                                                 uu___17 in
+                                                             (uu___16, env2)))))))
+                               | uu___5 -> failwith "Impossible" in
                              let encode_rec_lbdefs bindings1 typs2 toks1 env2
                                =
                                let fuel =
-                                 let uu____9745 =
-                                   let uu____9750 =
+                                 let uu___5 =
+                                   let uu___6 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                                        env2.FStar_SMTEncoding_Env.current_module_name
                                        "fuel" in
-                                   (uu____9750,
-                                     FStar_SMTEncoding_Term.Fuel_sort) in
-                                 FStar_SMTEncoding_Term.mk_fv uu____9745 in
+                                   (uu___6, FStar_SMTEncoding_Term.Fuel_sort) in
+                                 FStar_SMTEncoding_Term.mk_fv uu___5 in
                                let fuel_tm =
                                  FStar_SMTEncoding_Util.mkFreeV fuel in
                                let env0 = env2 in
-                               let uu____9753 =
+                               let uu___5 =
                                  FStar_All.pipe_right toks1
                                    (FStar_List.fold_left
-                                      (fun uu____9800 ->
+                                      (fun uu___6 ->
                                          fun fvb ->
-                                           match uu____9800 with
+                                           match uu___6 with
                                            | (gtoks, env3) ->
                                                let flid =
                                                  fvb.FStar_SMTEncoding_Env.fvar_lid in
                                                let g =
-                                                 let uu____9846 =
+                                                 let uu___7 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid "fuel_instrumented" in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____9846 in
+                                                   uu___7 in
                                                let gtok =
-                                                 let uu____9848 =
+                                                 let uu___7 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid
                                                      "fuel_instrumented_token" in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____9848 in
+                                                   uu___7 in
                                                let env4 =
-                                                 let uu____9850 =
-                                                   let uu____9853 =
+                                                 let uu___7 =
+                                                   let uu___8 =
                                                      FStar_SMTEncoding_Util.mkApp
                                                        (g, [fuel_tm]) in
                                                    FStar_All.pipe_left
-                                                     (fun uu____9858 ->
+                                                     (fun uu___9 ->
                                                         FStar_Pervasives_Native.Some
-                                                          uu____9858)
-                                                     uu____9853 in
+                                                          uu___9) uu___8 in
                                                  FStar_SMTEncoding_Env.push_free_var
                                                    env3 flid
                                                    fvb.FStar_SMTEncoding_Env.smt_arity
-                                                   gtok uu____9850 in
+                                                   gtok uu___7 in
                                                (((fvb, g, gtok) :: gtoks),
                                                  env4)) ([], env2)) in
-                               match uu____9753 with
+                               match uu___5 with
                                | (gtoks, env3) ->
                                    let gtoks1 = FStar_List.rev gtoks in
-                                   let encode_one_binding env01 uu____9958
-                                     t_norm uu____9960 =
-                                     match (uu____9958, uu____9960) with
+                                   let encode_one_binding env01 uu___6 t_norm
+                                     uu___7 =
+                                     match (uu___6, uu___7) with
                                      | ((fvb, g, gtok),
                                         { FStar_Syntax_Syntax.lbname = lbn;
                                           FStar_Syntax_Syntax.lbunivs = uvs;
-                                          FStar_Syntax_Syntax.lbtyp =
-                                            uu____9986;
-                                          FStar_Syntax_Syntax.lbeff =
-                                            uu____9987;
+                                          FStar_Syntax_Syntax.lbtyp = uu___8;
+                                          FStar_Syntax_Syntax.lbeff = uu___9;
                                           FStar_Syntax_Syntax.lbdef = e;
                                           FStar_Syntax_Syntax.lbattrs =
-                                            uu____9989;
-                                          FStar_Syntax_Syntax.lbpos =
-                                            uu____9990;_})
+                                            uu___10;
+                                          FStar_Syntax_Syntax.lbpos = uu___11;_})
                                          ->
-                                         let uu____10011 =
-                                           let uu____10018 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_TypeChecker_Env.open_universes_in
                                                env3.FStar_SMTEncoding_Env.tcenv
                                                uvs [e; t_norm] in
-                                           match uu____10018 with
-                                           | (tcenv', uu____10034, e_t) ->
-                                               let uu____10040 =
+                                           match uu___13 with
+                                           | (tcenv', uu___14, e_t) ->
+                                               let uu___15 =
                                                  match e_t with
                                                  | e1::t_norm1::[] ->
                                                      (e1, t_norm1)
-                                                 | uu____10051 ->
+                                                 | uu___16 ->
                                                      failwith "Impossible" in
-                                               (match uu____10040 with
+                                               (match uu___15 with
                                                 | (e1, t_norm1) ->
-                                                    ((let uu___748_10067 =
-                                                        env3 in
+                                                    ((let uu___16 = env3 in
                                                       {
                                                         FStar_SMTEncoding_Env.bvar_bindings
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.bvar_bindings);
+                                                          (uu___16.FStar_SMTEncoding_Env.bvar_bindings);
                                                         FStar_SMTEncoding_Env.fvar_bindings
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.fvar_bindings);
+                                                          (uu___16.FStar_SMTEncoding_Env.fvar_bindings);
                                                         FStar_SMTEncoding_Env.depth
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.depth);
+                                                          (uu___16.FStar_SMTEncoding_Env.depth);
                                                         FStar_SMTEncoding_Env.tcenv
                                                           = tcenv';
                                                         FStar_SMTEncoding_Env.warn
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.warn);
+                                                          (uu___16.FStar_SMTEncoding_Env.warn);
                                                         FStar_SMTEncoding_Env.nolabels
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.nolabels);
+                                                          (uu___16.FStar_SMTEncoding_Env.nolabels);
                                                         FStar_SMTEncoding_Env.use_zfuel_name
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                          (uu___16.FStar_SMTEncoding_Env.use_zfuel_name);
                                                         FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                          (uu___16.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                         FStar_SMTEncoding_Env.current_module_name
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.current_module_name);
+                                                          (uu___16.FStar_SMTEncoding_Env.current_module_name);
                                                         FStar_SMTEncoding_Env.encoding_quantifier
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                          (uu___16.FStar_SMTEncoding_Env.encoding_quantifier);
                                                         FStar_SMTEncoding_Env.global_cache
                                                           =
-                                                          (uu___748_10067.FStar_SMTEncoding_Env.global_cache)
+                                                          (uu___16.FStar_SMTEncoding_Env.global_cache)
                                                       }), e1, t_norm1)) in
-                                         (match uu____10011 with
+                                         (match uu___12 with
                                           | (env', e1, t_norm1) ->
-                                              ((let uu____10080 =
+                                              ((let uu___14 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env01.FStar_SMTEncoding_Env.tcenv)
                                                     (FStar_Options.Other
                                                        "SMTEncoding") in
-                                                if uu____10080
+                                                if uu___14
                                                 then
-                                                  let uu____10081 =
+                                                  let uu___15 =
                                                     FStar_Syntax_Print.lbname_to_string
                                                       lbn in
-                                                  let uu____10082 =
+                                                  let uu___16 =
                                                     FStar_Syntax_Print.term_to_string
                                                       t_norm1 in
-                                                  let uu____10083 =
+                                                  let uu___17 =
                                                     FStar_Syntax_Print.term_to_string
                                                       e1 in
                                                   FStar_Util.print3
                                                     "Encoding let rec %s : %s = %s\n"
-                                                    uu____10081 uu____10082
-                                                    uu____10083
+                                                    uu___15 uu___16 uu___17
                                                 else ());
-                                               (let uu____10085 =
+                                               (let uu___14 =
                                                   destruct_bound_function
                                                     t_norm1 e1 in
-                                                match uu____10085 with
+                                                match uu___14 with
                                                 | (binders, body, tres_comp)
                                                     ->
                                                     let curry =
@@ -3227,86 +3128,80 @@ let (encode_top_level_let :
                                                         <>
                                                         (FStar_List.length
                                                            binders) in
-                                                    let uu____10110 =
+                                                    let uu___15 =
                                                       FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
                                                         env3.FStar_SMTEncoding_Env.tcenv
                                                         tres_comp in
-                                                    (match uu____10110 with
+                                                    (match uu___15 with
                                                      | (pre_opt, tres) ->
-                                                         ((let uu____10132 =
+                                                         ((let uu___17 =
                                                              FStar_All.pipe_left
                                                                (FStar_TypeChecker_Env.debug
                                                                   env01.FStar_SMTEncoding_Env.tcenv)
                                                                (FStar_Options.Other
                                                                   "SMTEncodingReify") in
-                                                           if uu____10132
+                                                           if uu___17
                                                            then
-                                                             let uu____10133
-                                                               =
+                                                             let uu___18 =
                                                                FStar_Syntax_Print.lbname_to_string
                                                                  lbn in
-                                                             let uu____10134
-                                                               =
+                                                             let uu___19 =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", " binders in
-                                                             let uu____10135
-                                                               =
+                                                             let uu___20 =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body in
-                                                             let uu____10136
-                                                               =
+                                                             let uu___21 =
                                                                FStar_Syntax_Print.comp_to_string
                                                                  tres_comp in
                                                              FStar_Util.print4
                                                                "Encoding let rec %s: \n\tbinders=[%s], \n\tbody=%s, \n\ttres=%s\n"
-                                                               uu____10133
-                                                               uu____10134
-                                                               uu____10135
-                                                               uu____10136
+                                                               uu___18
+                                                               uu___19
+                                                               uu___20
+                                                               uu___21
                                                            else ());
-                                                          (let uu____10138 =
+                                                          (let uu___17 =
                                                              FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                FStar_Pervasives_Native.None
                                                                binders env' in
-                                                           match uu____10138
-                                                           with
+                                                           match uu___17 with
                                                            | (vars, guards,
                                                               env'1,
                                                               binder_decls,
-                                                              uu____10167) ->
-                                                               let uu____10180
-                                                                 =
+                                                              uu___18) ->
+                                                               let uu___19 =
                                                                  match pre_opt
                                                                  with
                                                                  | FStar_Pervasives_Native.None
                                                                     ->
-                                                                    let uu____10193
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     guards in
-                                                                    (uu____10193,
+                                                                    (uu___20,
                                                                     [])
                                                                  | FStar_Pervasives_Native.Some
                                                                     pre ->
-                                                                    let uu____10197
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                     pre env'1 in
-                                                                    (match uu____10197
+                                                                    (match uu___20
                                                                     with
                                                                     | 
                                                                     (guard,
                                                                     decls0)
                                                                     ->
-                                                                    let uu____10210
+                                                                    let uu___21
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     guards
                                                                     [guard]) in
-                                                                    (uu____10210,
+                                                                    (uu___21,
                                                                     decls0)) in
-                                                               (match uu____10180
+                                                               (match uu___19
                                                                 with
                                                                 | (guard,
                                                                    guard_decls)
@@ -3318,34 +3213,34 @@ let (encode_top_level_let :
                                                                     guard_decls in
                                                                     let decl_g
                                                                     =
-                                                                    let uu____10231
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____10242
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____10245
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10248
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____10251
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Util.first_N
                                                                     fvb.FStar_SMTEncoding_Env.smt_arity
                                                                     vars in
                                                                     FStar_Pervasives_Native.fst
-                                                                    uu____10251 in
+                                                                    uu___24 in
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_sort
-                                                                    uu____10248 in
+                                                                    uu___23 in
                                                                     FStar_SMTEncoding_Term.Fuel_sort
                                                                     ::
-                                                                    uu____10245 in
+                                                                    uu___22 in
                                                                     (g,
-                                                                    uu____10242,
+                                                                    uu___21,
                                                                     FStar_SMTEncoding_Term.Term_sort,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel-instrumented function name")) in
                                                                     FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____10231 in
+                                                                    uu___20 in
                                                                     let env02
                                                                     =
                                                                     FStar_SMTEncoding_Env.push_zfuel_name
@@ -3369,14 +3264,14 @@ let (encode_top_level_let :
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
                                                                     let app =
-                                                                    let uu____10275
+                                                                    let uu___20
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     vars in
                                                                     FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
                                                                     rng fvb
-                                                                    uu____10275 in
+                                                                    uu___20 in
                                                                     let mk_g_app
                                                                     args =
                                                                     FStar_SMTEncoding_EncodeTerm.maybe_curry_app
@@ -3390,38 +3285,38 @@ let (encode_top_level_let :
                                                                     args in
                                                                     let gsapp
                                                                     =
-                                                                    let uu____10289
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____10292
+                                                                    let uu___21
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("SFuel",
                                                                     [fuel_tm]) in
-                                                                    uu____10292
+                                                                    uu___21
                                                                     ::
                                                                     vars_tm in
                                                                     mk_g_app
-                                                                    uu____10289 in
+                                                                    uu___20 in
                                                                     let gmax
                                                                     =
-                                                                    let uu____10296
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____10299
+                                                                    let uu___21
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("MaxFuel",
                                                                     []) in
-                                                                    uu____10299
+                                                                    uu___21
                                                                     ::
                                                                     vars_tm in
                                                                     mk_g_app
-                                                                    uu____10296 in
-                                                                    let uu____10302
+                                                                    uu___20 in
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term
                                                                     body
                                                                     env'1 in
-                                                                    (match uu____10302
+                                                                    (match uu___20
                                                                     with
                                                                     | 
                                                                     (body_tm,
@@ -3429,140 +3324,140 @@ let (encode_top_level_let :
                                                                     ->
                                                                     let eqn_g
                                                                     =
-                                                                    let uu____10318
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____10325
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10326
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                    let uu____10327
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10342
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____10343
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____10348
+                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (gsapp,
                                                                     body_tm) in
                                                                     (guard,
-                                                                    uu____10348) in
+                                                                    uu___27) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____10343 in
+                                                                    uu___26 in
                                                                     ([
                                                                     [gsapp]],
                                                                     (FStar_Pervasives_Native.Some
                                                                     Prims.int_zero),
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____10342) in
+                                                                    uu___25) in
                                                                     FStar_SMTEncoding_Term.mkForall'
-                                                                    uu____10326
-                                                                    uu____10327 in
-                                                                    let uu____10359
+                                                                    uu___23
+                                                                    uu___24 in
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____10360
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10361
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     fvb.FStar_SMTEncoding_Env.fvar_lid in
                                                                     FStar_Util.format1
                                                                     "Equation for fuel-instrumented recursive function: %s"
-                                                                    uu____10361 in
+                                                                    uu___25 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____10360 in
-                                                                    (uu____10325,
-                                                                    uu____10359,
+                                                                    uu___24 in
+                                                                    (uu___22,
+                                                                    uu___23,
                                                                     (Prims.op_Hat
                                                                     "equation_with_fuel_"
                                                                     g)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____10318 in
+                                                                    uu___21 in
                                                                     let eqn_f
                                                                     =
-                                                                    let uu____10363
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____10370
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10371
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                    let uu____10372
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10383
+                                                                    let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     gmax) in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____10383) in
+                                                                    uu___25) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10371
-                                                                    uu____10372 in
-                                                                    (uu____10370,
+                                                                    uu___23
+                                                                    uu___24 in
+                                                                    (uu___22,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Correspondence of recursive function to instrumented version"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_correspondence_"
                                                                     g)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____10363 in
+                                                                    uu___21 in
                                                                     let eqn_g'
                                                                     =
-                                                                    let uu____10393
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____10400
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10401
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                    let uu____10402
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10413
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____10414
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____10419
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10420
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____10423
+                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Term.n_fuel
                                                                     Prims.int_zero in
-                                                                    uu____10423
+                                                                    uu___29
                                                                     ::
                                                                     vars_tm in
                                                                     mk_g_app
-                                                                    uu____10420 in
+                                                                    uu___28 in
                                                                     (gsapp,
-                                                                    uu____10419) in
+                                                                    uu___27) in
                                                                     FStar_SMTEncoding_Util.mkEq
-                                                                    uu____10414 in
+                                                                    uu___26 in
                                                                     ([
                                                                     [gsapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____10413) in
+                                                                    uu___25) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10401
-                                                                    uu____10402 in
-                                                                    (uu____10400,
+                                                                    uu___23
+                                                                    uu___24 in
+                                                                    (uu___22,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel irrelevance"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_irrelevance_"
                                                                     g)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____10393 in
-                                                                    let uu____10432
+                                                                    uu___21 in
+                                                                    let uu___21
                                                                     =
                                                                     let gapp
                                                                     =
@@ -3574,32 +3469,32 @@ let (encode_top_level_let :
                                                                     =
                                                                     let tok_app
                                                                     =
-                                                                    let uu____10444
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10445
+                                                                    let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____10445 in
+                                                                    uu___23 in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu____10444
+                                                                    uu___22
                                                                     (fuel ::
                                                                     vars) in
                                                                     let tot_fun_axioms
                                                                     =
                                                                     let head
                                                                     =
-                                                                    let uu____10448
+                                                                    let uu___22
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____10448 in
+                                                                    uu___22 in
                                                                     let vars1
                                                                     = fuel ::
                                                                     vars in
@@ -3607,11 +3502,11 @@ let (encode_top_level_let :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____10456
+                                                                    uu___22
                                                                     ->
                                                                     FStar_SMTEncoding_Util.mkTrue)
                                                                     vars1 in
-                                                                    let uu____10457
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_comp
                                                                     tres_comp in
@@ -3619,22 +3514,22 @@ let (encode_top_level_let :
                                                                     rng head
                                                                     vars1
                                                                     guards1
-                                                                    uu____10457 in
-                                                                    let uu____10458
+                                                                    uu___22 in
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10465
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____10466
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10471
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____10472
+                                                                    let uu___26
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                    let uu____10473
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10484
+                                                                    let uu___28
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (tok_app,
@@ -3643,51 +3538,51 @@ let (encode_top_level_let :
                                                                     [tok_app]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____10484) in
+                                                                    uu___28) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10472
-                                                                    uu____10473 in
-                                                                    (uu____10471,
+                                                                    uu___26
+                                                                    uu___27 in
+                                                                    (uu___25,
                                                                     tot_fun_axioms) in
                                                                     FStar_SMTEncoding_Util.mkAnd
-                                                                    uu____10466 in
-                                                                    (uu____10465,
+                                                                    uu___24 in
+                                                                    (uu___23,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel token correspondence"),
                                                                     (Prims.op_Hat
                                                                     "fuel_token_correspondence_"
                                                                     gtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____10458 in
-                                                                    let uu____10493
+                                                                    uu___22 in
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10502
+                                                                    let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     tres
                                                                     env'1
                                                                     gapp in
-                                                                    match uu____10502
+                                                                    match uu___23
                                                                     with
                                                                     | 
                                                                     (g_typing,
                                                                     d3) ->
-                                                                    let uu____10517
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10520
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____10521
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____10528
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10529
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn in
-                                                                    let uu____10530
+                                                                    let uu___29
                                                                     =
-                                                                    let uu____10541
+                                                                    let uu___30
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard,
@@ -3695,22 +3590,22 @@ let (encode_top_level_let :
                                                                     ([[gapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____10541) in
+                                                                    uu___30) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10529
-                                                                    uu____10530 in
-                                                                    (uu____10528,
+                                                                    uu___28
+                                                                    uu___29 in
+                                                                    (uu___27,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Typing correspondence of token to term"),
                                                                     (Prims.op_Hat
                                                                     "token_correspondence_"
                                                                     g)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____10521 in
-                                                                    [uu____10520] in
+                                                                    uu___26 in
+                                                                    [uu___25] in
                                                                     (d3,
-                                                                    uu____10517) in
-                                                                    match uu____10493
+                                                                    uu___24) in
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     (aux_decls,
@@ -3720,19 +3615,19 @@ let (encode_top_level_let :
                                                                     (FStar_List.append
                                                                     typing_corr
                                                                     [tok_corr])) in
-                                                                    (match uu____10432
+                                                                    (match uu___21
                                                                     with
                                                                     | 
                                                                     (aux_decls,
                                                                     g_typing)
                                                                     ->
-                                                                    let uu____10594
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____10597
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____10600
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____10603
+                                                                    let uu___25
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     [decl_g;
@@ -3740,14 +3635,14 @@ let (encode_top_level_let :
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial in
                                                                     FStar_List.append
                                                                     aux_decls
-                                                                    uu____10603 in
+                                                                    uu___25 in
                                                                     FStar_List.append
                                                                     decls2
-                                                                    uu____10600 in
+                                                                    uu___24 in
                                                                     FStar_List.append
                                                                     binder_decls1
-                                                                    uu____10597 in
-                                                                    let uu____10610
+                                                                    uu___23 in
+                                                                    let uu___23
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     (FStar_List.append
@@ -3756,50 +3651,48 @@ let (encode_top_level_let :
                                                                     eqn_f]
                                                                     g_typing)
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                                                                    (uu____10594,
-                                                                    uu____10610,
+                                                                    (uu___22,
+                                                                    uu___23,
                                                                     env02)))))))))) in
-                                   let uu____10615 =
-                                     let uu____10628 =
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_List.zip3 gtoks1 typs2 bindings1 in
                                      FStar_List.fold_left
-                                       (fun uu____10685 ->
-                                          fun uu____10686 ->
-                                            match (uu____10685, uu____10686)
-                                            with
+                                       (fun uu___8 ->
+                                          fun uu___9 ->
+                                            match (uu___8, uu___9) with
                                             | ((decls2, eqns, env01),
                                                (gtok, ty, lb)) ->
-                                                let uu____10801 =
+                                                let uu___10 =
                                                   encode_one_binding env01
                                                     gtok ty lb in
-                                                (match uu____10801 with
+                                                (match uu___10 with
                                                  | (decls', eqns', env02) ->
                                                      ((decls' :: decls2),
                                                        (FStar_List.append
                                                           eqns' eqns), env02)))
-                                       ([decls1], [], env0) uu____10628 in
-                                   (match uu____10615 with
+                                       ([decls1], [], env0) uu___7 in
+                                   (match uu___6 with
                                     | (decls2, eqns, env01) ->
-                                        let uu____10868 =
-                                          let isDeclFun uu___1_10884 =
-                                            match uu___1_10884 with
+                                        let uu___7 =
+                                          let isDeclFun uu___8 =
+                                            match uu___8 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____10885 -> true
-                                            | uu____10896 -> false in
-                                          let uu____10897 =
+                                                uu___9 -> true
+                                            | uu___9 -> false in
+                                          let uu___8 =
                                             FStar_All.pipe_right decls2
                                               FStar_List.flatten in
-                                          FStar_All.pipe_right uu____10897
+                                          FStar_All.pipe_right uu___8
                                             (fun decls3 ->
-                                               let uu____10927 =
+                                               let uu___9 =
                                                  FStar_List.fold_left
-                                                   (fun uu____10958 ->
+                                                   (fun uu___10 ->
                                                       fun elt ->
-                                                        match uu____10958
-                                                        with
+                                                        match uu___10 with
                                                         | (prefix_decls,
                                                            elts, rest) ->
-                                                            let uu____10999 =
+                                                            let uu___11 =
                                                               (FStar_All.pipe_right
                                                                  elt.FStar_SMTEncoding_Term.key
                                                                  FStar_Util.is_some)
@@ -3807,7 +3700,7 @@ let (encode_top_level_let :
                                                                 (FStar_List.existsb
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls) in
-                                                            if uu____10999
+                                                            if uu___11
                                                             then
                                                               (prefix_decls,
                                                                 (FStar_List.append
@@ -3815,12 +3708,11 @@ let (encode_top_level_let :
                                                                    [elt]),
                                                                 rest)
                                                             else
-                                                              (let uu____11021
-                                                                 =
+                                                              (let uu___13 =
                                                                  FStar_List.partition
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls in
-                                                               match uu____11021
+                                                               match uu___13
                                                                with
                                                                | (elt_decl_funs,
                                                                   elt_rest)
@@ -3832,51 +3724,51 @@ let (encode_top_level_let :
                                                                     (FStar_List.append
                                                                     rest
                                                                     [(
-                                                                    let uu___846_11059
+                                                                    let uu___14
                                                                     = elt in
                                                                     {
                                                                     FStar_SMTEncoding_Term.sym_name
                                                                     =
-                                                                    (uu___846_11059.FStar_SMTEncoding_Term.sym_name);
+                                                                    (uu___14.FStar_SMTEncoding_Term.sym_name);
                                                                     FStar_SMTEncoding_Term.key
                                                                     =
-                                                                    (uu___846_11059.FStar_SMTEncoding_Term.key);
+                                                                    (uu___14.FStar_SMTEncoding_Term.key);
                                                                     FStar_SMTEncoding_Term.decls
                                                                     =
                                                                     elt_rest;
                                                                     FStar_SMTEncoding_Term.a_names
                                                                     =
-                                                                    (uu___846_11059.FStar_SMTEncoding_Term.a_names)
+                                                                    (uu___14.FStar_SMTEncoding_Term.a_names)
                                                                     })]))))
                                                    ([], [], []) decls3 in
-                                               match uu____10927 with
+                                               match uu___9 with
                                                | (prefix_decls, elts, rest)
                                                    ->
-                                                   let uu____11091 =
+                                                   let uu___10 =
                                                      FStar_All.pipe_right
                                                        prefix_decls
                                                        FStar_SMTEncoding_Term.mk_decls_trivial in
-                                                   (uu____11091, elts, rest)) in
-                                        (match uu____10868 with
+                                                   (uu___10, elts, rest)) in
+                                        (match uu___7 with
                                          | (prefix_decls, elts, rest) ->
                                              let eqns1 = FStar_List.rev eqns in
                                              ((FStar_List.append prefix_decls
                                                  (FStar_List.append elts
                                                     (FStar_List.append rest
                                                        eqns1))), env01))) in
-                             let uu____11120 =
+                             let uu___5 =
                                (FStar_All.pipe_right quals
                                   (FStar_Util.for_some
-                                     (fun uu___2_11124 ->
-                                        match uu___2_11124 with
+                                     (fun uu___6 ->
+                                        match uu___6 with
                                         | FStar_Syntax_Syntax.HasMaskedEffect
                                             -> true
-                                        | uu____11125 -> false)))
+                                        | uu___7 -> false)))
                                  ||
                                  (FStar_All.pipe_right typs1
                                     (FStar_Util.for_some
                                        (fun t ->
-                                          let uu____11131 =
+                                          let uu___6 =
                                             (FStar_Syntax_Util.is_pure_or_ghost_function
                                                t)
                                               ||
@@ -3884,12 +3776,12 @@ let (encode_top_level_let :
                                                  env1.FStar_SMTEncoding_Env.tcenv
                                                  t) in
                                           FStar_All.pipe_left
-                                            Prims.op_Negation uu____11131))) in
-                             if uu____11120
+                                            Prims.op_Negation uu___6))) in
+                             if uu___5
                              then (decls1, env_decls)
                              else
                                (try
-                                  (fun uu___863_11148 ->
+                                  (fun uu___7 ->
                                      match () with
                                      | () ->
                                          if Prims.op_Negation is_rec
@@ -3906,52 +3798,50 @@ let (encode_top_level_let :
                                       (FStar_List.length names) >
                                         Prims.int_one in
                                     let r =
-                                      let uu____11187 = FStar_List.hd names in
-                                      FStar_All.pipe_right uu____11187
+                                      let uu___8 = FStar_List.hd names in
+                                      FStar_All.pipe_right uu___8
                                         FStar_Pervasives_Native.snd in
-                                    ((let uu____11201 =
-                                        let uu____11210 =
-                                          let uu____11217 =
-                                            let uu____11218 =
-                                              let uu____11219 =
+                                    ((let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              let uu___13 =
                                                 FStar_List.map
                                                   FStar_Pervasives_Native.fst
                                                   names in
-                                              FStar_All.pipe_right
-                                                uu____11219
+                                              FStar_All.pipe_right uu___13
                                                 (FStar_String.concat ",") in
                                             FStar_Util.format3
                                               "Definitions of inner let-rec%s %s and %s enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types"
                                               (if plural then "s" else "")
-                                              uu____11218
+                                              uu___12
                                               (if plural
                                                then "their"
                                                else "its") in
                                           (FStar_Errors.Warning_DefinitionNotTranslated,
-                                            uu____11217, r) in
-                                        [uu____11210] in
+                                            uu___11, r) in
+                                        [uu___10] in
                                       FStar_TypeChecker_Err.add_errors
                                         env1.FStar_SMTEncoding_Env.tcenv
-                                        uu____11201);
+                                        uu___9);
                                      (decls1, env_decls))))) ()
              with
              | Let_rec_unencodeable ->
                  let msg =
-                   let uu____11256 =
+                   let uu___2 =
                      FStar_All.pipe_right bindings
                        (FStar_List.map
                           (fun lb ->
                              FStar_Syntax_Print.lbname_to_string
                                lb.FStar_Syntax_Syntax.lbname)) in
-                   FStar_All.pipe_right uu____11256
-                     (FStar_String.concat " and ") in
+                   FStar_All.pipe_right uu___2 (FStar_String.concat " and ") in
                  let decl =
                    FStar_SMTEncoding_Term.Caption
                      (Prims.op_Hat "let rec unencodeable: Skipping: " msg) in
-                 let uu____11268 =
+                 let uu___2 =
                    FStar_All.pipe_right [decl]
                      FStar_SMTEncoding_Term.mk_decls_trivial in
-                 (uu____11268, env))
+                 (uu___2, env))
 let rec (encode_sigelt :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -3960,53 +3850,53 @@ let rec (encode_sigelt :
   fun env ->
     fun se ->
       let nm =
-        let uu____11322 = FStar_Syntax_Util.lid_of_sigelt se in
-        match uu____11322 with
+        let uu___ = FStar_Syntax_Util.lid_of_sigelt se in
+        match uu___ with
         | FStar_Pervasives_Native.None -> ""
         | FStar_Pervasives_Native.Some l -> FStar_Ident.string_of_lid l in
-      let uu____11326 = encode_sigelt' env se in
-      match uu____11326 with
+      let uu___ = encode_sigelt' env se in
+      match uu___ with
       | (g, env1) ->
           let g1 =
             match g with
             | [] ->
-                ((let uu____11339 =
+                ((let uu___2 =
                     FStar_All.pipe_left
                       (FStar_TypeChecker_Env.debug
                          env1.FStar_SMTEncoding_Env.tcenv)
                       (FStar_Options.Other "SMTEncoding") in
-                  if uu____11339
+                  if uu___2
                   then FStar_Util.print1 "Skipped encoding of %s\n" nm
                   else ());
-                 (let uu____11341 =
-                    let uu____11344 =
-                      let uu____11345 = FStar_Util.format1 "<Skipped %s/>" nm in
-                      FStar_SMTEncoding_Term.Caption uu____11345 in
-                    [uu____11344] in
-                  FStar_All.pipe_right uu____11341
+                 (let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Util.format1 "<Skipped %s/>" nm in
+                      FStar_SMTEncoding_Term.Caption uu___4 in
+                    [uu___3] in
+                  FStar_All.pipe_right uu___2
                     FStar_SMTEncoding_Term.mk_decls_trivial))
-            | uu____11348 ->
-                let uu____11349 =
-                  let uu____11352 =
-                    let uu____11355 =
-                      let uu____11356 =
+            | uu___1 ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
                         FStar_Util.format1 "<Start encoding %s>" nm in
-                      FStar_SMTEncoding_Term.Caption uu____11356 in
-                    [uu____11355] in
-                  FStar_All.pipe_right uu____11352
+                      FStar_SMTEncoding_Term.Caption uu___5 in
+                    [uu___4] in
+                  FStar_All.pipe_right uu___3
                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                let uu____11361 =
-                  let uu____11364 =
-                    let uu____11367 =
-                      let uu____11370 =
-                        let uu____11371 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 =
                           FStar_Util.format1 "</end encoding %s>" nm in
-                        FStar_SMTEncoding_Term.Caption uu____11371 in
-                      [uu____11370] in
-                    FStar_All.pipe_right uu____11367
+                        FStar_SMTEncoding_Term.Caption uu___7 in
+                      [uu___6] in
+                    FStar_All.pipe_right uu___5
                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                  FStar_List.append g uu____11364 in
-                FStar_List.append uu____11349 uu____11361 in
+                  FStar_List.append g uu___4 in
+                FStar_List.append uu___2 uu___3 in
           (g1, env1)
 and (encode_sigelt' :
   FStar_SMTEncoding_Env.env_t ->
@@ -4015,55 +3905,55 @@ and (encode_sigelt' :
   =
   fun env ->
     fun se ->
-      (let uu____11383 =
+      (let uu___1 =
          FStar_All.pipe_left
            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
            (FStar_Options.Other "SMTEncoding") in
-       if uu____11383
+       if uu___1
        then
-         let uu____11384 = FStar_Syntax_Print.sigelt_to_string se in
-         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu____11384
+         let uu___2 = FStar_Syntax_Print.sigelt_to_string se in
+         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu___2
        else ());
       (let is_opaque_to_smt t =
-         let uu____11392 =
-           let uu____11393 = FStar_Syntax_Subst.compress t in
-           uu____11393.FStar_Syntax_Syntax.n in
-         match uu____11392 with
+         let uu___1 =
+           let uu___2 = FStar_Syntax_Subst.compress t in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s, uu____11397)) -> s = "opaque_to_smt"
-         | uu____11398 -> false in
+             (s, uu___2)) -> s = "opaque_to_smt"
+         | uu___2 -> false in
        let is_uninterpreted_by_smt t =
-         let uu____11405 =
-           let uu____11406 = FStar_Syntax_Subst.compress t in
-           uu____11406.FStar_Syntax_Syntax.n in
-         match uu____11405 with
+         let uu___1 =
+           let uu___2 = FStar_Syntax_Subst.compress t in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s, uu____11410)) -> s = "uninterpreted_by_smt"
-         | uu____11411 -> false in
+             (s, uu___2)) -> s = "uninterpreted_by_smt"
+         | uu___2 -> false in
        match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_splice uu____11416 ->
+       | FStar_Syntax_Syntax.Sig_splice uu___1 ->
            failwith "impossible -- splice should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_fail uu____11427 ->
+       | FStar_Syntax_Syntax.Sig_fail uu___1 ->
            failwith
              "impossible -- Sig_fail should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_pragma uu____11442 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____11443 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____11456 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____11457 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____11468 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_pragma uu___1 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu___1 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_sub_effect uu___1 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___1 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___1 -> ([], env)
        | FStar_Syntax_Syntax.Sig_new_effect ed ->
-           let uu____11478 =
-             let uu____11479 =
+           let uu___1 =
+             let uu___2 =
                FStar_SMTEncoding_Util.is_smt_reifiable_effect
                  env.FStar_SMTEncoding_Env.tcenv ed.FStar_Syntax_Syntax.mname in
-             Prims.op_Negation uu____11479 in
-           if uu____11478
+             Prims.op_Negation uu___2 in
+           if uu___1
            then ([], env)
            else
              (let close_effect_params tm =
                 match ed.FStar_Syntax_Syntax.binders with
                 | [] -> tm
-                | uu____11505 ->
+                | uu___3 ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_abs
                          ((ed.FStar_Syntax_Syntax.binders), tm,
@@ -4075,156 +3965,152 @@ and (encode_sigelt' :
                       tm.FStar_Syntax_Syntax.pos in
               let encode_action env1 a =
                 let action_defn =
-                  let uu____11538 =
+                  let uu___3 =
                     close_effect_params a.FStar_Syntax_Syntax.action_defn in
-                  norm_before_encoding env1 uu____11538 in
-                let uu____11539 =
+                  norm_before_encoding env1 uu___3 in
+                let uu___3 =
                   FStar_Syntax_Util.arrow_formals_comp
                     a.FStar_Syntax_Syntax.action_typ in
-                match uu____11539 with
-                | (formals, uu____11551) ->
+                match uu___3 with
+                | (formals, uu___4) ->
                     let arity = FStar_List.length formals in
-                    let uu____11559 =
+                    let uu___5 =
                       FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                         env1 a.FStar_Syntax_Syntax.action_name arity in
-                    (match uu____11559 with
+                    (match uu___5 with
                      | (aname, atok, env2) ->
-                         let uu____11575 =
+                         let uu___6 =
                            FStar_SMTEncoding_EncodeTerm.encode_term
                              action_defn env2 in
-                         (match uu____11575 with
+                         (match uu___6 with
                           | (tm, decls) ->
                               let a_decls =
-                                let uu____11591 =
-                                  let uu____11592 =
-                                    let uu____11603 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
                                       FStar_All.pipe_right formals
                                         (FStar_List.map
-                                           (fun uu____11623 ->
+                                           (fun uu___10 ->
                                               FStar_SMTEncoding_Term.Term_sort)) in
-                                    (aname, uu____11603,
+                                    (aname, uu___9,
                                       FStar_SMTEncoding_Term.Term_sort,
                                       (FStar_Pervasives_Native.Some "Action")) in
-                                  FStar_SMTEncoding_Term.DeclFun uu____11592 in
-                                [uu____11591;
+                                  FStar_SMTEncoding_Term.DeclFun uu___8 in
+                                [uu___7;
                                 FStar_SMTEncoding_Term.DeclFun
                                   (atok, [],
                                     FStar_SMTEncoding_Term.Term_sort,
                                     (FStar_Pervasives_Native.Some
                                        "Action token"))] in
-                              let uu____11634 =
-                                let aux uu____11680 uu____11681 =
-                                  match (uu____11680, uu____11681) with
-                                  | ((bv, uu____11725),
-                                     (env3, acc_sorts, acc)) ->
-                                      let uu____11757 =
+                              let uu___7 =
+                                let aux uu___8 uu___9 =
+                                  match (uu___8, uu___9) with
+                                  | ((bv, uu___10), (env3, acc_sorts, acc))
+                                      ->
+                                      let uu___11 =
                                         FStar_SMTEncoding_Env.gen_term_var
                                           env3 bv in
-                                      (match uu____11757 with
+                                      (match uu___11 with
                                        | (xxsym, xx, env4) ->
-                                           let uu____11777 =
-                                             let uu____11780 =
+                                           let uu___12 =
+                                             let uu___13 =
                                                FStar_SMTEncoding_Term.mk_fv
                                                  (xxsym,
                                                    FStar_SMTEncoding_Term.Term_sort) in
-                                             uu____11780 :: acc_sorts in
-                                           (env4, uu____11777, (xx :: acc))) in
+                                             uu___13 :: acc_sorts in
+                                           (env4, uu___12, (xx :: acc))) in
                                 FStar_List.fold_right aux formals
                                   (env2, [], []) in
-                              (match uu____11634 with
-                               | (uu____11811, xs_sorts, xs) ->
+                              (match uu___7 with
+                               | (uu___8, xs_sorts, xs) ->
                                    let app =
                                      FStar_SMTEncoding_Util.mkApp (aname, xs) in
                                    let a_eq =
-                                     let uu____11826 =
-                                       let uu____11833 =
-                                         let uu____11834 =
+                                     let uu___9 =
+                                       let uu___10 =
+                                         let uu___11 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name in
-                                         let uu____11835 =
-                                           let uu____11846 =
-                                             let uu____11847 =
-                                               let uu____11852 =
+                                         let uu___12 =
+                                           let uu___13 =
+                                             let uu___14 =
+                                               let uu___15 =
                                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                                    tm xs_sorts in
-                                               (app, uu____11852) in
+                                               (app, uu___15) in
                                              FStar_SMTEncoding_Util.mkEq
-                                               uu____11847 in
-                                           ([[app]], xs_sorts, uu____11846) in
+                                               uu___14 in
+                                           ([[app]], xs_sorts, uu___13) in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____11834 uu____11835 in
-                                       (uu____11833,
+                                           uu___11 uu___12 in
+                                       (uu___10,
                                          (FStar_Pervasives_Native.Some
                                             "Action equality"),
                                          (Prims.op_Hat aname "_equality")) in
-                                     FStar_SMTEncoding_Util.mkAssume
-                                       uu____11826 in
+                                     FStar_SMTEncoding_Util.mkAssume uu___9 in
                                    let tok_correspondence =
                                      let tok_term =
-                                       let uu____11863 =
+                                       let uu___9 =
                                          FStar_SMTEncoding_Term.mk_fv
                                            (atok,
                                              FStar_SMTEncoding_Term.Term_sort) in
                                        FStar_All.pipe_left
                                          FStar_SMTEncoding_Util.mkFreeV
-                                         uu____11863 in
+                                         uu___9 in
                                      let tok_app =
                                        FStar_SMTEncoding_EncodeTerm.mk_Apply
                                          tok_term xs_sorts in
-                                     let uu____11865 =
-                                       let uu____11872 =
-                                         let uu____11873 =
+                                     let uu___9 =
+                                       let uu___10 =
+                                         let uu___11 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name in
-                                         let uu____11874 =
-                                           let uu____11885 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (tok_app, app) in
-                                           ([[tok_app]], xs_sorts,
-                                             uu____11885) in
+                                           ([[tok_app]], xs_sorts, uu___13) in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____11873 uu____11874 in
-                                       (uu____11872,
+                                           uu___11 uu___12 in
+                                       (uu___10,
                                          (FStar_Pervasives_Native.Some
                                             "Action token correspondence"),
                                          (Prims.op_Hat aname
                                             "_token_correspondence")) in
-                                     FStar_SMTEncoding_Util.mkAssume
-                                       uu____11865 in
-                                   let uu____11894 =
-                                     let uu____11897 =
+                                     FStar_SMTEncoding_Util.mkAssume uu___9 in
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_All.pipe_right
                                          (FStar_List.append a_decls
                                             [a_eq; tok_correspondence])
                                          FStar_SMTEncoding_Term.mk_decls_trivial in
-                                     FStar_List.append decls uu____11897 in
-                                   (env2, uu____11894)))) in
-              let uu____11906 =
+                                     FStar_List.append decls uu___10 in
+                                   (env2, uu___9)))) in
+              let uu___3 =
                 FStar_Util.fold_map encode_action env
                   ed.FStar_Syntax_Syntax.actions in
-              match uu____11906 with
+              match uu___3 with
               | (env1, decls2) -> ((FStar_List.flatten decls2), env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____11932, uu____11933)
-           when FStar_Ident.lid_equals lid FStar_Parser_Const.precedes_lid ->
-           let uu____11934 =
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___1, uu___2) when
+           FStar_Ident.lid_equals lid FStar_Parser_Const.precedes_lid ->
+           let uu___3 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env lid
                (Prims.of_int (4)) in
-           (match uu____11934 with | (tname, ttok, env1) -> ([], env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____11949, t) ->
+           (match uu___3 with | (tname, ttok, env1) -> ([], env1))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___1, t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals in
            let will_encode_definition =
-             let uu____11955 =
+             let uu___2 =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___3_11959 ->
-                       match uu___3_11959 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | FStar_Syntax_Syntax.Assumption -> true
-                       | FStar_Syntax_Syntax.Projector uu____11960 -> true
-                       | FStar_Syntax_Syntax.Discriminator uu____11965 ->
-                           true
+                       | FStar_Syntax_Syntax.Projector uu___4 -> true
+                       | FStar_Syntax_Syntax.Discriminator uu___4 -> true
                        | FStar_Syntax_Syntax.Irreducible -> true
-                       | uu____11966 -> false)) in
-             Prims.op_Negation uu____11955 in
+                       | uu___4 -> false)) in
+             Prims.op_Negation uu___2 in
            if will_encode_definition
            then ([], env)
            else
@@ -4232,89 +4118,87 @@ and (encode_sigelt' :
                 FStar_Syntax_Syntax.lid_as_fv lid
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
-              let uu____11973 =
-                let uu____11978 =
+              let uu___3 =
+                let uu___4 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigattrs
                     (FStar_Util.for_some is_uninterpreted_by_smt) in
-                encode_top_level_val uu____11978 env fv t quals in
-              match uu____11973 with
+                encode_top_level_val uu___4 env fv t quals in
+              match uu___3 with
               | (decls, env1) ->
                   let tname = FStar_Ident.string_of_lid lid in
                   let tsym =
-                    let uu____11989 =
+                    let uu___4 =
                       FStar_SMTEncoding_Env.try_lookup_free_var env1 lid in
-                    FStar_Option.get uu____11989 in
-                  let uu____11992 =
-                    let uu____11993 =
-                      let uu____11996 =
+                    FStar_Option.get uu___4 in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 =
                         primitive_type_axioms
                           env1.FStar_SMTEncoding_Env.tcenv lid tname tsym in
-                      FStar_All.pipe_right uu____11996
+                      FStar_All.pipe_right uu___6
                         FStar_SMTEncoding_Term.mk_decls_trivial in
-                    FStar_List.append decls uu____11993 in
-                  (uu____11992, env1))
+                    FStar_List.append decls uu___5 in
+                  (uu___4, env1))
        | FStar_Syntax_Syntax.Sig_assume (l, us, f) ->
-           let uu____12006 = FStar_Syntax_Subst.open_univ_vars us f in
-           (match uu____12006 with
+           let uu___1 = FStar_Syntax_Subst.open_univ_vars us f in
+           (match uu___1 with
             | (uvs, f1) ->
                 let env1 =
-                  let uu___1010_12018 = env in
-                  let uu____12019 =
+                  let uu___2 = env in
+                  let uu___3 =
                     FStar_TypeChecker_Env.push_univ_vars
                       env.FStar_SMTEncoding_Env.tcenv uvs in
                   {
                     FStar_SMTEncoding_Env.bvar_bindings =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.bvar_bindings);
+                      (uu___2.FStar_SMTEncoding_Env.bvar_bindings);
                     FStar_SMTEncoding_Env.fvar_bindings =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.fvar_bindings);
+                      (uu___2.FStar_SMTEncoding_Env.fvar_bindings);
                     FStar_SMTEncoding_Env.depth =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.depth);
-                    FStar_SMTEncoding_Env.tcenv = uu____12019;
+                      (uu___2.FStar_SMTEncoding_Env.depth);
+                    FStar_SMTEncoding_Env.tcenv = uu___3;
                     FStar_SMTEncoding_Env.warn =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.warn);
+                      (uu___2.FStar_SMTEncoding_Env.warn);
                     FStar_SMTEncoding_Env.nolabels =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.nolabels);
+                      (uu___2.FStar_SMTEncoding_Env.nolabels);
                     FStar_SMTEncoding_Env.use_zfuel_name =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.use_zfuel_name);
+                      (uu___2.FStar_SMTEncoding_Env.use_zfuel_name);
                     FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                      (uu___2.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                     FStar_SMTEncoding_Env.current_module_name =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.current_module_name);
+                      (uu___2.FStar_SMTEncoding_Env.current_module_name);
                     FStar_SMTEncoding_Env.encoding_quantifier =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.encoding_quantifier);
+                      (uu___2.FStar_SMTEncoding_Env.encoding_quantifier);
                     FStar_SMTEncoding_Env.global_cache =
-                      (uu___1010_12018.FStar_SMTEncoding_Env.global_cache)
+                      (uu___2.FStar_SMTEncoding_Env.global_cache)
                   } in
                 let f2 = norm_before_encoding env1 f1 in
-                let uu____12021 =
+                let uu___2 =
                   FStar_SMTEncoding_EncodeTerm.encode_formula f2 env1 in
-                (match uu____12021 with
+                (match uu___2 with
                  | (f3, decls) ->
                      let g =
-                       let uu____12035 =
-                         let uu____12038 =
-                           let uu____12039 =
-                             let uu____12046 =
-                               let uu____12047 =
-                                 let uu____12048 =
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 =
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Print.lid_to_string l in
-                                 FStar_Util.format1 "Assumption: %s"
-                                   uu____12048 in
-                               FStar_Pervasives_Native.Some uu____12047 in
-                             let uu____12049 =
-                               let uu____12050 =
-                                 let uu____12051 =
-                                   FStar_Ident.string_of_lid l in
-                                 Prims.op_Hat "assumption_" uu____12051 in
+                                 FStar_Util.format1 "Assumption: %s" uu___8 in
+                               FStar_Pervasives_Native.Some uu___7 in
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = FStar_Ident.string_of_lid l in
+                                 Prims.op_Hat "assumption_" uu___9 in
                                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                 uu____12050 in
-                             (f3, uu____12046, uu____12049) in
-                           FStar_SMTEncoding_Util.mkAssume uu____12039 in
-                         [uu____12038] in
-                       FStar_All.pipe_right uu____12035
+                                 uu___8 in
+                             (f3, uu___6, uu___7) in
+                           FStar_SMTEncoding_Util.mkAssume uu___5 in
+                         [uu___4] in
+                       FStar_All.pipe_right uu___3
                          FStar_SMTEncoding_Term.mk_decls_trivial in
                      ((FStar_List.append decls g), env1)))
-       | FStar_Syntax_Syntax.Sig_let (lbs, uu____12057) when
+       | FStar_Syntax_Syntax.Sig_let (lbs, uu___1) when
            (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_List.contains FStar_Syntax_Syntax.Irreducible))
              ||
@@ -4322,64 +4206,64 @@ and (encode_sigelt' :
                 (FStar_Util.for_some is_opaque_to_smt))
            ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs in
-           let uu____12069 =
+           let uu___2 =
              FStar_Util.fold_map
                (fun env1 ->
                   fun lb ->
                     let lid =
-                      let uu____12091 =
-                        let uu____12094 =
+                      let uu___3 =
+                        let uu___4 =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                        uu____12094.FStar_Syntax_Syntax.fv_name in
-                      uu____12091.FStar_Syntax_Syntax.v in
-                    let uu____12095 =
-                      let uu____12096 =
+                        uu___4.FStar_Syntax_Syntax.fv_name in
+                      uu___3.FStar_Syntax_Syntax.v in
+                    let uu___3 =
+                      let uu___4 =
                         FStar_TypeChecker_Env.try_lookup_val_decl
                           env1.FStar_SMTEncoding_Env.tcenv lid in
-                      FStar_All.pipe_left FStar_Option.isNone uu____12096 in
-                    if uu____12095
+                      FStar_All.pipe_left FStar_Option.isNone uu___4 in
+                    if uu___3
                     then
                       let val_decl =
-                        let uu___1027_12126 = se in
+                        let uu___4 = se in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_declare_typ
                                (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                  (lb.FStar_Syntax_Syntax.lbtyp)));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1027_12126.FStar_Syntax_Syntax.sigrng);
+                            (uu___4.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Irreducible ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1027_12126.FStar_Syntax_Syntax.sigmeta);
+                            (uu___4.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1027_12126.FStar_Syntax_Syntax.sigattrs);
+                            (uu___4.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___1027_12126.FStar_Syntax_Syntax.sigopts)
+                            (uu___4.FStar_Syntax_Syntax.sigopts)
                         } in
-                      let uu____12127 = encode_sigelt' env1 val_decl in
-                      match uu____12127 with | (decls, env2) -> (env2, decls)
+                      let uu___4 = encode_sigelt' env1 val_decl in
+                      match uu___4 with | (decls, env2) -> (env2, decls)
                     else (env1, [])) env (FStar_Pervasives_Native.snd lbs) in
-           (match uu____12069 with
+           (match uu___2 with
             | (env1, decls) -> ((FStar_List.flatten decls), env1))
        | FStar_Syntax_Syntax.Sig_let
-           ((uu____12161,
+           ((uu___1,
              { FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t;
-               FStar_Syntax_Syntax.lbunivs = uu____12163;
-               FStar_Syntax_Syntax.lbtyp = uu____12164;
-               FStar_Syntax_Syntax.lbeff = uu____12165;
-               FStar_Syntax_Syntax.lbdef = uu____12166;
-               FStar_Syntax_Syntax.lbattrs = uu____12167;
-               FStar_Syntax_Syntax.lbpos = uu____12168;_}::[]),
-            uu____12169)
+               FStar_Syntax_Syntax.lbunivs = uu___2;
+               FStar_Syntax_Syntax.lbtyp = uu___3;
+               FStar_Syntax_Syntax.lbeff = uu___4;
+               FStar_Syntax_Syntax.lbdef = uu___5;
+               FStar_Syntax_Syntax.lbattrs = uu___6;
+               FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
+            uu___8)
            when FStar_Syntax_Syntax.fv_eq_lid b2t FStar_Parser_Const.b2t_lid
            ->
-           let uu____12186 =
+           let uu___9 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env
                (b2t.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                Prims.int_one in
-           (match uu____12186 with
+           (match uu___9 with
             | (tname, ttok, env1) ->
                 let xx =
                   FStar_SMTEncoding_Term.mk_fv
@@ -4389,122 +4273,118 @@ and (encode_sigelt' :
                 let valid_b2t_x =
                   FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x]) in
                 let decls =
-                  let uu____12211 =
-                    let uu____12214 =
-                      let uu____12215 =
-                        let uu____12222 =
-                          let uu____12223 =
-                            FStar_Syntax_Syntax.range_of_fv b2t in
-                          let uu____12224 =
-                            let uu____12235 =
-                              let uu____12236 =
-                                let uu____12241 =
+                  let uu___10 =
+                    let uu___11 =
+                      let uu___12 =
+                        let uu___13 =
+                          let uu___14 = FStar_Syntax_Syntax.range_of_fv b2t in
+                          let uu___15 =
+                            let uu___16 =
+                              let uu___17 =
+                                let uu___18 =
                                   FStar_SMTEncoding_Util.mkApp
                                     ((FStar_Pervasives_Native.snd
                                         FStar_SMTEncoding_Term.boxBoolFun),
                                       [x]) in
-                                (valid_b2t_x, uu____12241) in
-                              FStar_SMTEncoding_Util.mkEq uu____12236 in
-                            ([[b2t_x]], [xx], uu____12235) in
-                          FStar_SMTEncoding_Term.mkForall uu____12223
-                            uu____12224 in
-                        (uu____12222,
-                          (FStar_Pervasives_Native.Some "b2t def"),
+                                (valid_b2t_x, uu___18) in
+                              FStar_SMTEncoding_Util.mkEq uu___17 in
+                            ([[b2t_x]], [xx], uu___16) in
+                          FStar_SMTEncoding_Term.mkForall uu___14 uu___15 in
+                        (uu___13, (FStar_Pervasives_Native.Some "b2t def"),
                           "b2t_def") in
-                      FStar_SMTEncoding_Util.mkAssume uu____12215 in
-                    [uu____12214] in
+                      FStar_SMTEncoding_Util.mkAssume uu___12 in
+                    [uu___11] in
                   (FStar_SMTEncoding_Term.DeclFun
                      (tname, [FStar_SMTEncoding_Term.Term_sort],
                        FStar_SMTEncoding_Term.Term_sort,
                        FStar_Pervasives_Native.None))
-                    :: uu____12211 in
-                let uu____12266 =
+                    :: uu___10 in
+                let uu___10 =
                   FStar_All.pipe_right decls
                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                (uu____12266, env1))
-       | FStar_Syntax_Syntax.Sig_let (uu____12269, uu____12270) when
+                (uu___10, env1))
+       | FStar_Syntax_Syntax.Sig_let (uu___1, uu___2) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___4_12279 ->
-                   match uu___4_12279 with
-                   | FStar_Syntax_Syntax.Discriminator uu____12280 -> true
-                   | uu____12281 -> false))
+                (fun uu___3 ->
+                   match uu___3 with
+                   | FStar_Syntax_Syntax.Discriminator uu___4 -> true
+                   | uu___4 -> false))
            ->
-           ((let uu____12283 =
+           ((let uu___4 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding") in
-             if uu____12283
+             if uu___4
              then
-               let uu____12284 = FStar_Syntax_Print.sigelt_to_string_short se in
-               FStar_Util.print1 "Not encoding discriminator '%s'\n"
-                 uu____12284
+               let uu___5 = FStar_Syntax_Print.sigelt_to_string_short se in
+               FStar_Util.print1 "Not encoding discriminator '%s'\n" uu___5
              else ());
             ([], env))
-       | FStar_Syntax_Syntax.Sig_let (uu____12286, lids) when
+       | FStar_Syntax_Syntax.Sig_let (uu___1, lids) when
            (FStar_All.pipe_right lids
               (FStar_Util.for_some
                  (fun l ->
-                    let uu____12297 =
-                      let uu____12298 =
-                        let uu____12299 = FStar_Ident.ns_of_lid l in
-                        FStar_List.hd uu____12299 in
-                      FStar_Ident.string_of_id uu____12298 in
-                    uu____12297 = "Prims")))
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = FStar_Ident.ns_of_lid l in
+                        FStar_List.hd uu___4 in
+                      FStar_Ident.string_of_id uu___3 in
+                    uu___2 = "Prims")))
              &&
              (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some
-                   (fun uu___5_12305 ->
-                      match uu___5_12305 with
+                   (fun uu___2 ->
+                      match uu___2 with
                       | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                           -> true
-                      | uu____12306 -> false)))
+                      | uu___3 -> false)))
            ->
-           ((let uu____12308 =
+           ((let uu___3 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding") in
-             if uu____12308
+             if uu___3
              then
-               let uu____12309 = FStar_Syntax_Print.sigelt_to_string_short se in
+               let uu___4 = FStar_Syntax_Print.sigelt_to_string_short se in
                FStar_Util.print1 "Not encoding unfold let from Prims '%s'\n"
-                 uu____12309
+                 uu___4
              else ());
             ([], env))
-       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____12312) when
+       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___1) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___6_12323 ->
-                   match uu___6_12323 with
-                   | FStar_Syntax_Syntax.Projector uu____12324 -> true
-                   | uu____12329 -> false))
+                (fun uu___2 ->
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Projector uu___3 -> true
+                   | uu___3 -> false))
            ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
            let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-           let uu____12332 = FStar_SMTEncoding_Env.try_lookup_free_var env l in
-           (match uu____12332 with
-            | FStar_Pervasives_Native.Some uu____12339 -> ([], env)
+           let uu___2 = FStar_SMTEncoding_Env.try_lookup_free_var env l in
+           (match uu___2 with
+            | FStar_Pervasives_Native.Some uu___3 -> ([], env)
             | FStar_Pervasives_Native.None ->
                 let se1 =
-                  let uu___1096_12341 = se in
-                  let uu____12342 = FStar_Ident.range_of_lid l in
+                  let uu___3 = se in
+                  let uu___4 = FStar_Ident.range_of_lid l in
                   {
                     FStar_Syntax_Syntax.sigel =
                       (FStar_Syntax_Syntax.Sig_declare_typ
                          (l, (lb.FStar_Syntax_Syntax.lbunivs),
                            (lb.FStar_Syntax_Syntax.lbtyp)));
-                    FStar_Syntax_Syntax.sigrng = uu____12342;
+                    FStar_Syntax_Syntax.sigrng = uu___4;
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___1096_12341.FStar_Syntax_Syntax.sigquals);
+                      (uu___3.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1096_12341.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1096_12341.FStar_Syntax_Syntax.sigattrs);
+                      (uu___3.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___1096_12341.FStar_Syntax_Syntax.sigopts)
+                      (uu___3.FStar_Syntax_Syntax.sigopts)
                   } in
                 encode_sigelt env se1)
-       | FStar_Syntax_Syntax.Sig_let ((is_rec, bindings), uu____12345) ->
+       | FStar_Syntax_Syntax.Sig_let ((is_rec, bindings), uu___1) ->
            let bindings1 =
              FStar_List.map
                (fun lb ->
@@ -4512,396 +4392,386 @@ and (encode_sigelt' :
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbdef in
                   let typ =
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbtyp in
-                  let uu___1108_12364 = lb in
+                  let uu___2 = lb in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___1108_12364.FStar_Syntax_Syntax.lbname);
+                      (uu___2.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___1108_12364.FStar_Syntax_Syntax.lbunivs);
+                      (uu___2.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp = typ;
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___1108_12364.FStar_Syntax_Syntax.lbeff);
+                      (uu___2.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = def;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___1108_12364.FStar_Syntax_Syntax.lbattrs);
+                      (uu___2.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___1108_12364.FStar_Syntax_Syntax.lbpos)
+                      (uu___2.FStar_Syntax_Syntax.lbpos)
                   }) bindings in
            encode_top_level_let env (is_rec, bindings1)
              se.FStar_Syntax_Syntax.sigquals
-       | FStar_Syntax_Syntax.Sig_bundle (ses, uu____12368) ->
-           let uu____12377 = encode_sigelts env ses in
-           (match uu____12377 with
+       | FStar_Syntax_Syntax.Sig_bundle (ses, uu___1) ->
+           let uu___2 = encode_sigelts env ses in
+           (match uu___2 with
             | (g, env1) ->
-                let uu____12388 =
+                let uu___3 =
                   FStar_List.fold_left
-                    (fun uu____12412 ->
+                    (fun uu___4 ->
                        fun elt ->
-                         match uu____12412 with
+                         match uu___4 with
                          | (g', inversions) ->
-                             let uu____12440 =
+                             let uu___5 =
                                FStar_All.pipe_right
                                  elt.FStar_SMTEncoding_Term.decls
                                  (FStar_List.partition
-                                    (fun uu___7_12463 ->
-                                       match uu___7_12463 with
+                                    (fun uu___6 ->
+                                       match uu___6 with
                                        | FStar_SMTEncoding_Term.Assume
                                            {
                                              FStar_SMTEncoding_Term.assumption_term
-                                               = uu____12464;
+                                               = uu___7;
                                              FStar_SMTEncoding_Term.assumption_caption
                                                = FStar_Pervasives_Native.Some
                                                "inversion axiom";
                                              FStar_SMTEncoding_Term.assumption_name
-                                               = uu____12465;
+                                               = uu___8;
                                              FStar_SMTEncoding_Term.assumption_fact_ids
-                                               = uu____12466;_}
+                                               = uu___9;_}
                                            -> false
-                                       | uu____12469 -> true)) in
-                             (match uu____12440 with
+                                       | uu___7 -> true)) in
+                             (match uu___5 with
                               | (elt_g', elt_inversions) ->
                                   ((FStar_List.append g'
-                                      [(let uu___1134_12493 = elt in
+                                      [(let uu___6 = elt in
                                         {
                                           FStar_SMTEncoding_Term.sym_name =
-                                            (uu___1134_12493.FStar_SMTEncoding_Term.sym_name);
+                                            (uu___6.FStar_SMTEncoding_Term.sym_name);
                                           FStar_SMTEncoding_Term.key =
-                                            (uu___1134_12493.FStar_SMTEncoding_Term.key);
+                                            (uu___6.FStar_SMTEncoding_Term.key);
                                           FStar_SMTEncoding_Term.decls =
                                             elt_g';
                                           FStar_SMTEncoding_Term.a_names =
-                                            (uu___1134_12493.FStar_SMTEncoding_Term.a_names)
+                                            (uu___6.FStar_SMTEncoding_Term.a_names)
                                         })]),
                                     (FStar_List.append inversions
                                        elt_inversions)))) ([], []) g in
-                (match uu____12388 with
+                (match uu___3 with
                  | (g', inversions) ->
-                     let uu____12512 =
+                     let uu___4 =
                        FStar_List.fold_left
-                         (fun uu____12543 ->
+                         (fun uu___5 ->
                             fun elt ->
-                              match uu____12543 with
+                              match uu___5 with
                               | (decls, elts, rest) ->
-                                  let uu____12584 =
+                                  let uu___6 =
                                     (FStar_All.pipe_right
                                        elt.FStar_SMTEncoding_Term.key
                                        FStar_Util.is_some)
                                       &&
                                       (FStar_List.existsb
-                                         (fun uu___8_12589 ->
-                                            match uu___8_12589 with
+                                         (fun uu___7 ->
+                                            match uu___7 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____12590 -> true
-                                            | uu____12601 -> false)
+                                                uu___8 -> true
+                                            | uu___8 -> false)
                                          elt.FStar_SMTEncoding_Term.decls) in
-                                  if uu____12584
+                                  if uu___6
                                   then
                                     (decls, (FStar_List.append elts [elt]),
                                       rest)
                                   else
-                                    (let uu____12621 =
+                                    (let uu___8 =
                                        FStar_All.pipe_right
                                          elt.FStar_SMTEncoding_Term.decls
                                          (FStar_List.partition
-                                            (fun uu___9_12642 ->
-                                               match uu___9_12642 with
+                                            (fun uu___9 ->
+                                               match uu___9 with
                                                | FStar_SMTEncoding_Term.DeclFun
-                                                   uu____12643 -> true
-                                               | uu____12654 -> false)) in
-                                     match uu____12621 with
+                                                   uu___10 -> true
+                                               | uu___10 -> false)) in
+                                     match uu___8 with
                                      | (elt_decls, elt_rest) ->
                                          ((FStar_List.append decls elt_decls),
                                            elts,
                                            (FStar_List.append rest
-                                              [(let uu___1156_12684 = elt in
+                                              [(let uu___9 = elt in
                                                 {
                                                   FStar_SMTEncoding_Term.sym_name
                                                     =
-                                                    (uu___1156_12684.FStar_SMTEncoding_Term.sym_name);
+                                                    (uu___9.FStar_SMTEncoding_Term.sym_name);
                                                   FStar_SMTEncoding_Term.key
                                                     =
-                                                    (uu___1156_12684.FStar_SMTEncoding_Term.key);
+                                                    (uu___9.FStar_SMTEncoding_Term.key);
                                                   FStar_SMTEncoding_Term.decls
                                                     = elt_rest;
                                                   FStar_SMTEncoding_Term.a_names
                                                     =
-                                                    (uu___1156_12684.FStar_SMTEncoding_Term.a_names)
+                                                    (uu___9.FStar_SMTEncoding_Term.a_names)
                                                 })])))) ([], [], []) g' in
-                     (match uu____12512 with
+                     (match uu___4 with
                       | (decls, elts, rest) ->
-                          let uu____12710 =
-                            let uu____12711 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_All.pipe_right decls
                                 FStar_SMTEncoding_Term.mk_decls_trivial in
-                            let uu____12718 =
-                              let uu____12721 =
-                                let uu____12724 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
                                   FStar_All.pipe_right inversions
                                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                                FStar_List.append rest uu____12724 in
-                              FStar_List.append elts uu____12721 in
-                            FStar_List.append uu____12711 uu____12718 in
-                          (uu____12710, env1))))
+                                FStar_List.append rest uu___9 in
+                              FStar_List.append elts uu___8 in
+                            FStar_List.append uu___6 uu___7 in
+                          (uu___5, env1))))
        | FStar_Syntax_Syntax.Sig_inductive_typ
-           (t, universe_names, tps, k, uu____12735, datas) ->
+           (t, universe_names, tps, k, uu___1, datas) ->
            let tcenv = env.FStar_SMTEncoding_Env.tcenv in
            let is_injective =
-             let uu____12747 =
-               FStar_Syntax_Subst.univ_var_opening universe_names in
-             match uu____12747 with
+             let uu___2 = FStar_Syntax_Subst.univ_var_opening universe_names in
+             match uu___2 with
              | (usubst, uvs) ->
-                 let uu____12766 =
-                   let uu____12773 =
+                 let uu___3 =
+                   let uu___4 =
                      FStar_TypeChecker_Env.push_univ_vars tcenv uvs in
-                   let uu____12774 =
-                     FStar_Syntax_Subst.subst_binders usubst tps in
-                   let uu____12775 =
-                     let uu____12776 =
+                   let uu___5 = FStar_Syntax_Subst.subst_binders usubst tps in
+                   let uu___6 =
+                     let uu___7 =
                        FStar_Syntax_Subst.shift_subst (FStar_List.length tps)
                          usubst in
-                     FStar_Syntax_Subst.subst uu____12776 k in
-                   (uu____12773, uu____12774, uu____12775) in
-                 (match uu____12766 with
+                     FStar_Syntax_Subst.subst uu___7 k in
+                   (uu___4, uu___5, uu___6) in
+                 (match uu___3 with
                   | (env1, tps1, k1) ->
-                      let uu____12788 = FStar_Syntax_Subst.open_term tps1 k1 in
-                      (match uu____12788 with
+                      let uu___4 = FStar_Syntax_Subst.open_term tps1 k1 in
+                      (match uu___4 with
                        | (tps2, k2) ->
-                           let uu____12795 =
-                             FStar_Syntax_Util.arrow_formals k2 in
-                           (match uu____12795 with
-                            | (uu____12802, k3) ->
-                                let uu____12808 =
+                           let uu___5 = FStar_Syntax_Util.arrow_formals k2 in
+                           (match uu___5 with
+                            | (uu___6, k3) ->
+                                let uu___7 =
                                   FStar_TypeChecker_TcTerm.tc_binders env1
                                     tps2 in
-                                (match uu____12808 with
-                                 | (tps3, env_tps, uu____12819, us) ->
+                                (match uu___7 with
+                                 | (tps3, env_tps, uu___8, us) ->
                                      let u_k =
-                                       let uu____12822 =
-                                         let uu____12823 =
+                                       let uu___9 =
+                                         let uu___10 =
                                            FStar_Syntax_Syntax.fvar t
                                              (FStar_Syntax_Syntax.Delta_constant_at_level
                                                 Prims.int_zero)
                                              FStar_Pervasives_Native.None in
-                                         let uu____12824 =
-                                           let uu____12825 =
+                                         let uu___11 =
+                                           let uu___12 =
                                              FStar_Syntax_Util.args_of_binders
                                                tps3 in
                                            FStar_Pervasives_Native.snd
-                                             uu____12825 in
-                                         let uu____12830 =
+                                             uu___12 in
+                                         let uu___12 =
                                            FStar_Ident.range_of_lid t in
                                          FStar_Syntax_Syntax.mk_Tm_app
-                                           uu____12823 uu____12824
-                                           uu____12830 in
+                                           uu___10 uu___11 uu___12 in
                                        FStar_TypeChecker_TcTerm.level_of_type
-                                         env_tps uu____12822 k3 in
+                                         env_tps uu___9 k3 in
                                      let rec universe_leq u v =
                                        match (u, v) with
-                                       | (FStar_Syntax_Syntax.U_zero,
-                                          uu____12842) -> true
+                                       | (FStar_Syntax_Syntax.U_zero, uu___9)
+                                           -> true
                                        | (FStar_Syntax_Syntax.U_succ u0,
                                           FStar_Syntax_Syntax.U_succ v0) ->
                                            universe_leq u0 v0
                                        | (FStar_Syntax_Syntax.U_name u0,
                                           FStar_Syntax_Syntax.U_name v0) ->
                                            FStar_Ident.ident_equals u0 v0
-                                       | (FStar_Syntax_Syntax.U_name
-                                          uu____12847,
+                                       | (FStar_Syntax_Syntax.U_name uu___9,
                                           FStar_Syntax_Syntax.U_succ v0) ->
                                            universe_leq u v0
                                        | (FStar_Syntax_Syntax.U_max us1,
-                                          uu____12850) ->
+                                          uu___9) ->
                                            FStar_All.pipe_right us1
                                              (FStar_Util.for_all
                                                 (fun u1 -> universe_leq u1 v))
-                                       | (uu____12857,
-                                          FStar_Syntax_Syntax.U_max vs) ->
+                                       | (uu___9, FStar_Syntax_Syntax.U_max
+                                          vs) ->
                                            FStar_All.pipe_right vs
                                              (FStar_Util.for_some
                                                 (universe_leq u))
                                        | (FStar_Syntax_Syntax.U_unknown,
-                                          uu____12863) ->
-                                           let uu____12864 =
-                                             let uu____12865 =
+                                          uu___9) ->
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_Ident.string_of_lid t in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____12865 in
-                                           failwith uu____12864
-                                       | (uu____12866,
+                                               uu___11 in
+                                           failwith uu___10
+                                       | (uu___9,
                                           FStar_Syntax_Syntax.U_unknown) ->
-                                           let uu____12867 =
-                                             let uu____12868 =
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_Ident.string_of_lid t in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____12868 in
-                                           failwith uu____12867
-                                       | (FStar_Syntax_Syntax.U_unif
-                                          uu____12869, uu____12870) ->
-                                           let uu____12881 =
-                                             let uu____12882 =
+                                               uu___11 in
+                                           failwith uu___10
+                                       | (FStar_Syntax_Syntax.U_unif uu___9,
+                                          uu___10) ->
+                                           let uu___11 =
+                                             let uu___12 =
                                                FStar_Ident.string_of_lid t in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____12882 in
-                                           failwith uu____12881
-                                       | (uu____12883,
-                                          FStar_Syntax_Syntax.U_unif
-                                          uu____12884) ->
-                                           let uu____12895 =
-                                             let uu____12896 =
+                                               uu___12 in
+                                           failwith uu___11
+                                       | (uu___9, FStar_Syntax_Syntax.U_unif
+                                          uu___10) ->
+                                           let uu___11 =
+                                             let uu___12 =
                                                FStar_Ident.string_of_lid t in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____12896 in
-                                           failwith uu____12895
-                                       | uu____12897 -> false in
+                                               uu___12 in
+                                           failwith uu___11
+                                       | uu___9 -> false in
                                      let u_leq_u_k u =
-                                       let uu____12908 =
+                                       let uu___9 =
                                          FStar_TypeChecker_Normalize.normalize_universe
                                            env_tps u in
-                                       universe_leq uu____12908 u_k in
+                                       universe_leq uu___9 u_k in
                                      let tp_ok tp u_tp =
                                        let t_tp =
                                          (FStar_Pervasives_Native.fst tp).FStar_Syntax_Syntax.sort in
-                                       let uu____12925 = u_leq_u_k u_tp in
-                                       if uu____12925
+                                       let uu___9 = u_leq_u_k u_tp in
+                                       if uu___9
                                        then true
                                        else
-                                         (let uu____12927 =
+                                         (let uu___11 =
                                             FStar_Syntax_Util.arrow_formals
                                               t_tp in
-                                          match uu____12927 with
-                                          | (formals, uu____12935) ->
-                                              let uu____12940 =
+                                          match uu___11 with
+                                          | (formals, uu___12) ->
+                                              let uu___13 =
                                                 FStar_TypeChecker_TcTerm.tc_binders
                                                   env_tps formals in
-                                              (match uu____12940 with
-                                               | (uu____12949, uu____12950,
-                                                  uu____12951, u_formals) ->
+                                              (match uu___13 with
+                                               | (uu___14, uu___15, uu___16,
+                                                  u_formals) ->
                                                    FStar_Util.for_all
                                                      (fun u_formal ->
                                                         u_leq_u_k u_formal)
                                                      u_formals)) in
                                      FStar_List.forall2 tp_ok tps3 us)))) in
-           ((let uu____12962 =
+           ((let uu___3 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding") in
-             if uu____12962
+             if uu___3
              then
-               let uu____12963 = FStar_Ident.string_of_lid t in
+               let uu___4 = FStar_Ident.string_of_lid t in
                FStar_Util.print2 "%s injectivity for %s\n"
-                 (if is_injective then "YES" else "NO") uu____12963
+                 (if is_injective then "YES" else "NO") uu___4
              else ());
             (let quals = se.FStar_Syntax_Syntax.sigquals in
              let is_logical =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___10_12973 ->
-                       match uu___10_12973 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | FStar_Syntax_Syntax.Logic -> true
                        | FStar_Syntax_Syntax.Assumption -> true
-                       | uu____12974 -> false)) in
+                       | uu___4 -> false)) in
              let constructor_or_logic_type_decl c =
                if is_logical
                then
-                 let uu____12985 = c in
-                 match uu____12985 with
-                 | (name, args, uu____12990, uu____12991, uu____12992) ->
-                     let uu____12997 =
-                       let uu____12998 =
-                         let uu____13009 =
+                 let uu___3 = c in
+                 match uu___3 with
+                 | (name, args, uu___4, uu___5, uu___6) ->
+                     let uu___7 =
+                       let uu___8 =
+                         let uu___9 =
                            FStar_All.pipe_right args
                              (FStar_List.map
-                                (fun uu____13032 ->
-                                   match uu____13032 with
-                                   | (uu____13039, sort, uu____13041) -> sort)) in
-                         (name, uu____13009,
-                           FStar_SMTEncoding_Term.Term_sort,
+                                (fun uu___10 ->
+                                   match uu___10 with
+                                   | (uu___11, sort, uu___12) -> sort)) in
+                         (name, uu___9, FStar_SMTEncoding_Term.Term_sort,
                            FStar_Pervasives_Native.None) in
-                       FStar_SMTEncoding_Term.DeclFun uu____12998 in
-                     [uu____12997]
+                       FStar_SMTEncoding_Term.DeclFun uu___8 in
+                     [uu___7]
                else
-                 (let uu____13045 = FStar_Ident.range_of_lid t in
-                  FStar_SMTEncoding_Term.constructor_to_decl uu____13045 c) in
+                 (let uu___4 = FStar_Ident.range_of_lid t in
+                  FStar_SMTEncoding_Term.constructor_to_decl uu___4 c) in
              let inversion_axioms tapp vars =
-               let uu____13063 =
+               let uu___3 =
                  FStar_All.pipe_right datas
                    (FStar_Util.for_some
                       (fun l ->
-                         let uu____13069 =
+                         let uu___4 =
                            FStar_TypeChecker_Env.try_lookup_lid
                              env.FStar_SMTEncoding_Env.tcenv l in
-                         FStar_All.pipe_right uu____13069 FStar_Option.isNone)) in
-               if uu____13063
+                         FStar_All.pipe_right uu___4 FStar_Option.isNone)) in
+               if uu___3
                then []
                else
-                 (let uu____13101 =
+                 (let uu___5 =
                     FStar_SMTEncoding_Env.fresh_fvar
                       env.FStar_SMTEncoding_Env.current_module_name "x"
                       FStar_SMTEncoding_Term.Term_sort in
-                  match uu____13101 with
+                  match uu___5 with
                   | (xxsym, xx) ->
-                      let uu____13110 =
+                      let uu___6 =
                         FStar_All.pipe_right datas
                           (FStar_List.fold_left
-                             (fun uu____13149 ->
+                             (fun uu___7 ->
                                 fun l ->
-                                  match uu____13149 with
+                                  match uu___7 with
                                   | (out, decls) ->
-                                      let uu____13169 =
+                                      let uu___8 =
                                         FStar_TypeChecker_Env.lookup_datacon
                                           env.FStar_SMTEncoding_Env.tcenv l in
-                                      (match uu____13169 with
-                                       | (uu____13180, data_t) ->
-                                           let uu____13182 =
+                                      (match uu___8 with
+                                       | (uu___9, data_t) ->
+                                           let uu___10 =
                                              FStar_Syntax_Util.arrow_formals
                                                data_t in
-                                           (match uu____13182 with
+                                           (match uu___10 with
                                             | (args, res) ->
                                                 let indices =
-                                                  let uu____13202 =
-                                                    let uu____13203 =
+                                                  let uu___11 =
+                                                    let uu___12 =
                                                       FStar_Syntax_Subst.compress
                                                         res in
-                                                    uu____13203.FStar_Syntax_Syntax.n in
-                                                  match uu____13202 with
+                                                    uu___12.FStar_Syntax_Syntax.n in
+                                                  match uu___11 with
                                                   | FStar_Syntax_Syntax.Tm_app
-                                                      (uu____13206, indices)
-                                                      -> indices
-                                                  | uu____13232 -> [] in
+                                                      (uu___12, indices1) ->
+                                                      indices1
+                                                  | uu___12 -> [] in
                                                 let env1 =
                                                   FStar_All.pipe_right args
                                                     (FStar_List.fold_left
-                                                       (fun env1 ->
-                                                          fun uu____13262 ->
-                                                            match uu____13262
+                                                       (fun env2 ->
+                                                          fun uu___11 ->
+                                                            match uu___11
                                                             with
-                                                            | (x,
-                                                               uu____13270)
-                                                                ->
-                                                                let uu____13275
-                                                                  =
-                                                                  let uu____13276
+                                                            | (x, uu___12) ->
+                                                                let uu___13 =
+                                                                  let uu___14
                                                                     =
-                                                                    let uu____13283
+                                                                    let uu___15
                                                                     =
                                                                     FStar_SMTEncoding_Env.mk_term_projector_name
                                                                     l x in
-                                                                    (uu____13283,
+                                                                    (uu___15,
                                                                     [xx]) in
                                                                   FStar_SMTEncoding_Util.mkApp
-                                                                    uu____13276 in
+                                                                    uu___14 in
                                                                 FStar_SMTEncoding_Env.push_term_var
-                                                                  env1 x
-                                                                  uu____13275)
+                                                                  env2 x
+                                                                  uu___13)
                                                        env) in
-                                                let uu____13286 =
+                                                let uu___11 =
                                                   FStar_SMTEncoding_EncodeTerm.encode_args
                                                     indices env1 in
-                                                (match uu____13286 with
+                                                (match uu___11 with
                                                  | (indices1, decls') ->
                                                      (if
                                                         (FStar_List.length
@@ -4918,50 +4788,47 @@ and (encode_sigelt' :
                                                            FStar_List.map2
                                                              (fun v ->
                                                                 fun a ->
-                                                                  let uu____13317
+                                                                  let uu___13
                                                                     =
-                                                                    let uu____13322
+                                                                    let uu___14
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
-                                                                    (uu____13322,
+                                                                    (uu___14,
                                                                     a) in
                                                                   FStar_SMTEncoding_Util.mkEq
-                                                                    uu____13317)
+                                                                    uu___13)
                                                              vars indices1
                                                          else [] in
-                                                       let uu____13324 =
-                                                         let uu____13325 =
-                                                           let uu____13330 =
-                                                             let uu____13331
-                                                               =
-                                                               let uu____13336
-                                                                 =
+                                                       let uu___13 =
+                                                         let uu___14 =
+                                                           let uu___15 =
+                                                             let uu___16 =
+                                                               let uu___17 =
                                                                  FStar_SMTEncoding_Env.mk_data_tester
                                                                    env1 l xx in
-                                                               let uu____13337
-                                                                 =
+                                                               let uu___18 =
                                                                  FStar_All.pipe_right
                                                                    eqs
                                                                    FStar_SMTEncoding_Util.mk_and_l in
-                                                               (uu____13336,
-                                                                 uu____13337) in
+                                                               (uu___17,
+                                                                 uu___18) in
                                                              FStar_SMTEncoding_Util.mkAnd
-                                                               uu____13331 in
-                                                           (out, uu____13330) in
+                                                               uu___16 in
+                                                           (out, uu___15) in
                                                          FStar_SMTEncoding_Util.mkOr
-                                                           uu____13325 in
-                                                       (uu____13324,
+                                                           uu___14 in
+                                                       (uu___13,
                                                          (FStar_List.append
                                                             decls decls'))))))))
                              (FStar_SMTEncoding_Util.mkFalse, [])) in
-                      (match uu____13110 with
+                      (match uu___6 with
                        | (data_ax, decls) ->
-                           let uu____13352 =
+                           let uu___7 =
                              FStar_SMTEncoding_Env.fresh_fvar
                                env.FStar_SMTEncoding_Env.current_module_name
                                "f" FStar_SMTEncoding_Term.Fuel_sort in
-                           (match uu____13352 with
+                           (match uu___7 with
                             | (ffsym, ff) ->
                                 let fuel_guarded_inversion =
                                   let xx_has_type_sfuel =
@@ -4969,133 +4836,131 @@ and (encode_sigelt' :
                                       (FStar_List.length datas) >
                                         Prims.int_one
                                     then
-                                      let uu____13363 =
+                                      let uu___8 =
                                         FStar_SMTEncoding_Util.mkApp
                                           ("SFuel", [ff]) in
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
-                                        uu____13363 xx tapp
+                                        uu___8 xx tapp
                                     else
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
                                         ff xx tapp in
-                                  let uu____13367 =
-                                    let uu____13374 =
-                                      let uu____13375 =
+                                  let uu___8 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_Ident.range_of_lid t in
-                                      let uu____13376 =
-                                        let uu____13387 =
-                                          let uu____13388 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          let uu___13 =
                                             FStar_SMTEncoding_Term.mk_fv
                                               (ffsym,
                                                 FStar_SMTEncoding_Term.Fuel_sort) in
-                                          let uu____13389 =
-                                            let uu____13392 =
+                                          let uu___14 =
+                                            let uu___15 =
                                               FStar_SMTEncoding_Term.mk_fv
                                                 (xxsym,
                                                   FStar_SMTEncoding_Term.Term_sort) in
-                                            uu____13392 :: vars in
+                                            uu___15 :: vars in
                                           FStar_SMTEncoding_Env.add_fuel
-                                            uu____13388 uu____13389 in
-                                        let uu____13393 =
+                                            uu___13 uu___14 in
+                                        let uu___13 =
                                           FStar_SMTEncoding_Util.mkImp
                                             (xx_has_type_sfuel, data_ax) in
-                                        ([[xx_has_type_sfuel]], uu____13387,
-                                          uu____13393) in
-                                      FStar_SMTEncoding_Term.mkForall
-                                        uu____13375 uu____13376 in
-                                    let uu____13402 =
-                                      let uu____13403 =
-                                        let uu____13404 =
+                                        ([[xx_has_type_sfuel]], uu___12,
+                                          uu___13) in
+                                      FStar_SMTEncoding_Term.mkForall uu___10
+                                        uu___11 in
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
                                           FStar_Ident.string_of_lid t in
                                         Prims.op_Hat
-                                          "fuel_guarded_inversion_"
-                                          uu____13404 in
+                                          "fuel_guarded_inversion_" uu___12 in
                                       FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                        uu____13403 in
-                                    (uu____13374,
+                                        uu___11 in
+                                    (uu___9,
                                       (FStar_Pervasives_Native.Some
-                                         "inversion axiom"), uu____13402) in
-                                  FStar_SMTEncoding_Util.mkAssume uu____13367 in
-                                let uu____13405 =
+                                         "inversion axiom"), uu___10) in
+                                  FStar_SMTEncoding_Util.mkAssume uu___8 in
+                                let uu___8 =
                                   FStar_All.pipe_right
                                     [fuel_guarded_inversion]
                                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                                FStar_List.append decls uu____13405))) in
-             let uu____13412 =
+                                FStar_List.append decls uu___8))) in
+             let uu___3 =
                let k1 =
                  match tps with
                  | [] -> k
-                 | uu____13426 ->
-                     let uu____13427 =
-                       let uu____13428 =
-                         let uu____13443 = FStar_Syntax_Syntax.mk_Total k in
-                         (tps, uu____13443) in
-                       FStar_Syntax_Syntax.Tm_arrow uu____13428 in
-                     FStar_Syntax_Syntax.mk uu____13427
-                       k.FStar_Syntax_Syntax.pos in
+                 | uu___4 ->
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 = FStar_Syntax_Syntax.mk_Total k in
+                         (tps, uu___7) in
+                       FStar_Syntax_Syntax.Tm_arrow uu___6 in
+                     FStar_Syntax_Syntax.mk uu___5 k.FStar_Syntax_Syntax.pos in
                let k2 = norm_before_encoding env k1 in
                FStar_Syntax_Util.arrow_formals k2 in
-             match uu____13412 with
+             match uu___3 with
              | (formals, res) ->
-                 let uu____13467 =
+                 let uu___4 =
                    FStar_SMTEncoding_EncodeTerm.encode_binders
                      FStar_Pervasives_Native.None formals env in
-                 (match uu____13467 with
-                  | (vars, guards, env', binder_decls, uu____13492) ->
+                 (match uu___4 with
+                  | (vars, guards, env', binder_decls, uu___5) ->
                       let arity = FStar_List.length vars in
-                      let uu____13506 =
+                      let uu___6 =
                         FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                           env t arity in
-                      (match uu____13506 with
+                      (match uu___6 with
                        | (tname, ttok, env1) ->
                            let ttok_tm =
                              FStar_SMTEncoding_Util.mkApp (ttok, []) in
                            let guard = FStar_SMTEncoding_Util.mk_and_l guards in
                            let tapp =
-                             let uu____13525 =
-                               let uu____13532 =
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_List.map
                                    FStar_SMTEncoding_Util.mkFreeV vars in
-                               (tname, uu____13532) in
-                             FStar_SMTEncoding_Util.mkApp uu____13525 in
-                           let uu____13537 =
+                               (tname, uu___8) in
+                             FStar_SMTEncoding_Util.mkApp uu___7 in
+                           let uu___7 =
                              let tname_decl =
-                               let uu____13547 =
-                                 let uu____13548 =
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_All.pipe_right vars
                                      (FStar_List.map
                                         (fun fv ->
-                                           let uu____13565 =
-                                             let uu____13566 =
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_SMTEncoding_Term.fv_name
                                                  fv in
-                                             Prims.op_Hat tname uu____13566 in
-                                           let uu____13567 =
+                                             Prims.op_Hat tname uu___11 in
+                                           let uu___11 =
                                              FStar_SMTEncoding_Term.fv_sort
                                                fv in
-                                           (uu____13565, uu____13567, false))) in
-                                 let uu____13568 =
+                                           (uu___10, uu___11, false))) in
+                                 let uu___10 =
                                    FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                      () in
-                                 (tname, uu____13548,
-                                   FStar_SMTEncoding_Term.Term_sort,
-                                   uu____13568, false) in
-                               constructor_or_logic_type_decl uu____13547 in
-                             let uu____13571 =
+                                 (tname, uu___9,
+                                   FStar_SMTEncoding_Term.Term_sort, uu___10,
+                                   false) in
+                               constructor_or_logic_type_decl uu___8 in
+                             let uu___8 =
                                match vars with
                                | [] ->
-                                   let uu____13584 =
-                                     let uu____13585 =
-                                       let uu____13588 =
+                                   let uu___9 =
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_SMTEncoding_Util.mkApp
                                            (tname, []) in
                                        FStar_All.pipe_left
-                                         (fun uu____13593 ->
+                                         (fun uu___12 ->
                                             FStar_Pervasives_Native.Some
-                                              uu____13593) uu____13588 in
+                                              uu___12) uu___11 in
                                      FStar_SMTEncoding_Env.push_free_var env1
-                                       t arity tname uu____13585 in
-                                   ([], uu____13584)
-                               | uu____13596 ->
+                                       t arity tname uu___10 in
+                                   ([], uu___9)
+                               | uu___9 ->
                                    let ttok_decl =
                                      FStar_SMTEncoding_Term.DeclFun
                                        (ttok, [],
@@ -5103,176 +4968,172 @@ and (encode_sigelt' :
                                          (FStar_Pervasives_Native.Some
                                             "token")) in
                                    let ttok_fresh =
-                                     let uu____13603 =
+                                     let uu___10 =
                                        FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                          () in
                                      FStar_SMTEncoding_Term.fresh_token
                                        (ttok,
                                          FStar_SMTEncoding_Term.Term_sort)
-                                       uu____13603 in
+                                       uu___10 in
                                    let ttok_app =
                                      FStar_SMTEncoding_EncodeTerm.mk_Apply
                                        ttok_tm vars in
                                    let pats = [[ttok_app]; [tapp]] in
                                    let name_tok_corr =
-                                     let uu____13617 =
-                                       let uu____13624 =
-                                         let uu____13625 =
+                                     let uu___10 =
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_Ident.range_of_lid t in
-                                         let uu____13626 =
-                                           let uu____13641 =
+                                         let uu___13 =
+                                           let uu___14 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (ttok_app, tapp) in
                                            (pats,
                                              FStar_Pervasives_Native.None,
-                                             vars, uu____13641) in
+                                             vars, uu___14) in
                                          FStar_SMTEncoding_Term.mkForall'
-                                           uu____13625 uu____13626 in
-                                       (uu____13624,
+                                           uu___12 uu___13 in
+                                       (uu___11,
                                          (FStar_Pervasives_Native.Some
                                             "name-token correspondence"),
                                          (Prims.op_Hat
                                             "token_correspondence_" ttok)) in
-                                     FStar_SMTEncoding_Util.mkAssume
-                                       uu____13617 in
+                                     FStar_SMTEncoding_Util.mkAssume uu___10 in
                                    ([ttok_decl; ttok_fresh; name_tok_corr],
                                      env1) in
-                             match uu____13571 with
+                             match uu___8 with
                              | (tok_decls, env2) ->
-                                 let uu____13662 =
+                                 let uu___9 =
                                    FStar_Ident.lid_equals t
                                      FStar_Parser_Const.lex_t_lid in
-                                 if uu____13662
+                                 if uu___9
                                  then (tok_decls, env2)
                                  else
                                    ((FStar_List.append tname_decl tok_decls),
                                      env2) in
-                           (match uu____13537 with
+                           (match uu___7 with
                             | (decls, env2) ->
                                 let kindingAx =
-                                  let uu____13687 =
+                                  let uu___8 =
                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                       FStar_Pervasives_Native.None res env'
                                       tapp in
-                                  match uu____13687 with
+                                  match uu___8 with
                                   | (k1, decls1) ->
                                       let karr =
                                         if
                                           (FStar_List.length formals) >
                                             Prims.int_zero
                                         then
-                                          let uu____13707 =
-                                            let uu____13708 =
-                                              let uu____13715 =
-                                                let uu____13716 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
+                                                let uu___12 =
                                                   FStar_SMTEncoding_Term.mk_PreType
                                                     ttok_tm in
                                                 FStar_SMTEncoding_Term.mk_tester
-                                                  "Tm_arrow" uu____13716 in
-                                              (uu____13715,
+                                                  "Tm_arrow" uu___12 in
+                                              (uu___11,
                                                 (FStar_Pervasives_Native.Some
                                                    "kinding"),
                                                 (Prims.op_Hat "pre_kinding_"
                                                    ttok)) in
                                             FStar_SMTEncoding_Util.mkAssume
-                                              uu____13708 in
-                                          [uu____13707]
+                                              uu___10 in
+                                          [uu___9]
                                         else [] in
                                       let rng = FStar_Ident.range_of_lid t in
                                       let tot_fun_axioms =
-                                        let uu____13720 =
+                                        let uu___9 =
                                           FStar_List.map
-                                            (fun uu____13724 ->
+                                            (fun uu___10 ->
                                                FStar_SMTEncoding_Util.mkTrue)
                                             vars in
                                         FStar_SMTEncoding_EncodeTerm.isTotFun_axioms
-                                          rng ttok_tm vars uu____13720 true in
-                                      let uu____13725 =
-                                        let uu____13728 =
-                                          let uu____13731 =
-                                            let uu____13734 =
-                                              let uu____13735 =
-                                                let uu____13742 =
-                                                  let uu____13743 =
-                                                    let uu____13748 =
-                                                      let uu____13749 =
-                                                        let uu____13760 =
+                                          rng ttok_tm vars uu___9 true in
+                                      let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              let uu___13 =
+                                                let uu___14 =
+                                                  let uu___15 =
+                                                    let uu___16 =
+                                                      let uu___17 =
+                                                        let uu___18 =
                                                           FStar_SMTEncoding_Util.mkImp
                                                             (guard, k1) in
                                                         ([[tapp]], vars,
-                                                          uu____13760) in
+                                                          uu___18) in
                                                       FStar_SMTEncoding_Term.mkForall
-                                                        rng uu____13749 in
-                                                    (tot_fun_axioms,
-                                                      uu____13748) in
+                                                        rng uu___17 in
+                                                    (tot_fun_axioms, uu___16) in
                                                   FStar_SMTEncoding_Util.mkAnd
-                                                    uu____13743 in
-                                                (uu____13742,
+                                                    uu___15 in
+                                                (uu___14,
                                                   FStar_Pervasives_Native.None,
                                                   (Prims.op_Hat "kinding_"
                                                      ttok)) in
                                               FStar_SMTEncoding_Util.mkAssume
-                                                uu____13735 in
-                                            [uu____13734] in
-                                          FStar_List.append karr uu____13731 in
-                                        FStar_All.pipe_right uu____13728
+                                                uu___13 in
+                                            [uu___12] in
+                                          FStar_List.append karr uu___11 in
+                                        FStar_All.pipe_right uu___10
                                           FStar_SMTEncoding_Term.mk_decls_trivial in
-                                      FStar_List.append decls1 uu____13725 in
+                                      FStar_List.append decls1 uu___9 in
                                 let aux =
-                                  let uu____13776 =
-                                    let uu____13779 =
-                                      inversion_axioms tapp vars in
-                                    let uu____13782 =
-                                      let uu____13785 =
-                                        let uu____13788 =
-                                          let uu____13789 =
+                                  let uu___8 =
+                                    let uu___9 = inversion_axioms tapp vars in
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          let uu___13 =
                                             FStar_Ident.range_of_lid t in
-                                          pretype_axiom uu____13789 env2 tapp
+                                          pretype_axiom uu___13 env2 tapp
                                             vars in
-                                        [uu____13788] in
-                                      FStar_All.pipe_right uu____13785
+                                        [uu___12] in
+                                      FStar_All.pipe_right uu___11
                                         FStar_SMTEncoding_Term.mk_decls_trivial in
-                                    FStar_List.append uu____13779 uu____13782 in
-                                  FStar_List.append kindingAx uu____13776 in
+                                    FStar_List.append uu___9 uu___10 in
+                                  FStar_List.append kindingAx uu___8 in
                                 let g =
-                                  let uu____13797 =
+                                  let uu___8 =
                                     FStar_All.pipe_right decls
                                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                                  FStar_List.append uu____13797
+                                  FStar_List.append uu___8
                                     (FStar_List.append binder_decls aux) in
                                 (g, env2))))))
        | FStar_Syntax_Syntax.Sig_datacon
-           (d, uu____13805, uu____13806, uu____13807, uu____13808,
-            uu____13809)
-           when FStar_Ident.lid_equals d FStar_Parser_Const.lexcons_lid ->
+           (d, uu___1, uu___2, uu___3, uu___4, uu___5) when
+           FStar_Ident.lid_equals d FStar_Parser_Const.lexcons_lid ->
            ([], env)
        | FStar_Syntax_Syntax.Sig_datacon
-           (d, uu____13815, t, uu____13817, n_tps, uu____13819) ->
+           (d, uu___1, t, uu___2, n_tps, uu___3) ->
            let quals = se.FStar_Syntax_Syntax.sigquals in
            let t1 = norm_before_encoding env t in
-           let uu____13828 = FStar_Syntax_Util.arrow_formals t1 in
-           (match uu____13828 with
+           let uu___4 = FStar_Syntax_Util.arrow_formals t1 in
+           (match uu___4 with
             | (formals, t_res) ->
                 let arity = FStar_List.length formals in
-                let uu____13852 =
+                let uu___5 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env d arity in
-                (match uu____13852 with
+                (match uu___5 with
                  | (ddconstrsym, ddtok, env1) ->
                      let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, []) in
-                     let uu____13869 =
+                     let uu___6 =
                        FStar_SMTEncoding_Env.fresh_fvar
                          env1.FStar_SMTEncoding_Env.current_module_name "f"
                          FStar_SMTEncoding_Term.Fuel_sort in
-                     (match uu____13869 with
+                     (match uu___6 with
                       | (fuel_var, fuel_tm) ->
                           let s_fuel_tm =
                             FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm]) in
-                          let uu____13883 =
+                          let uu___7 =
                             FStar_SMTEncoding_EncodeTerm.encode_binders
                               (FStar_Pervasives_Native.Some fuel_tm) formals
                               env1 in
-                          (match uu____13883 with
+                          (match uu___7 with
                            | (vars, guards, env', binder_decls, names) ->
                                let fields =
                                  FStar_All.pipe_right names
@@ -5280,26 +5141,25 @@ and (encode_sigelt' :
                                       (fun n ->
                                          fun x ->
                                            let projectible = true in
-                                           let uu____13953 =
+                                           let uu___8 =
                                              FStar_SMTEncoding_Env.mk_term_projector_name
                                                d x in
-                                           (uu____13953,
+                                           (uu___8,
                                              FStar_SMTEncoding_Term.Term_sort,
                                              projectible))) in
                                let datacons =
-                                 let uu____13957 =
-                                   let uu____13958 =
+                                 let uu___8 =
+                                   let uu___9 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                        () in
                                    (ddconstrsym, fields,
                                      FStar_SMTEncoding_Term.Term_sort,
-                                     uu____13958, true) in
-                                 let uu____13961 =
-                                   let uu____13968 =
-                                     FStar_Ident.range_of_lid d in
+                                     uu___9, true) in
+                                 let uu___9 =
+                                   let uu___10 = FStar_Ident.range_of_lid d in
                                    FStar_SMTEncoding_Term.constructor_to_decl
-                                     uu____13968 in
-                                 FStar_All.pipe_right uu____13957 uu____13961 in
+                                     uu___10 in
+                                 FStar_All.pipe_right uu___8 uu___9 in
                                let app =
                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                    ddtok_tm vars in
@@ -5311,15 +5171,15 @@ and (encode_sigelt' :
                                let dapp =
                                  FStar_SMTEncoding_Util.mkApp
                                    (ddconstrsym, xvars) in
-                               let uu____13979 =
+                               let uu___8 =
                                  FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                    FStar_Pervasives_Native.None t1 env1
                                    ddtok_tm in
-                               (match uu____13979 with
+                               (match uu___8 with
                                 | (tok_typing, decls3) ->
                                     let tok_typing1 =
                                       match fields with
-                                      | uu____13991::uu____13992 ->
+                                      | uu___9::uu___10 ->
                                           let ff =
                                             FStar_SMTEncoding_Term.mk_fv
                                               ("ty",
@@ -5330,33 +5190,33 @@ and (encode_sigelt' :
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
                                               ddtok_tm [ff] in
                                           let vtok_app_r =
-                                            let uu____14029 =
-                                              let uu____14030 =
+                                            let uu___11 =
+                                              let uu___12 =
                                                 FStar_SMTEncoding_Term.mk_fv
                                                   (ddtok,
                                                     FStar_SMTEncoding_Term.Term_sort) in
-                                              [uu____14030] in
+                                              [uu___12] in
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                              f uu____14029 in
-                                          let uu____14049 =
+                                              f uu___11 in
+                                          let uu___11 =
                                             FStar_Ident.range_of_lid d in
-                                          let uu____14050 =
-                                            let uu____14061 =
+                                          let uu___12 =
+                                            let uu___13 =
                                               FStar_SMTEncoding_Term.mk_NoHoist
                                                 f tok_typing in
                                             ([[vtok_app_l]; [vtok_app_r]],
-                                              [ff], uu____14061) in
+                                              [ff], uu___13) in
                                           FStar_SMTEncoding_Term.mkForall
-                                            uu____14049 uu____14050
-                                      | uu____14084 -> tok_typing in
-                                    let uu____14093 =
+                                            uu___11 uu___12
+                                      | uu___9 -> tok_typing in
+                                    let uu___9 =
                                       FStar_SMTEncoding_EncodeTerm.encode_binders
                                         (FStar_Pervasives_Native.Some fuel_tm)
                                         formals env1 in
-                                    (match uu____14093 with
+                                    (match uu___9 with
                                      | (vars', guards', env'', decls_formals,
-                                        uu____14118) ->
-                                         let uu____14131 =
+                                        uu___10) ->
+                                         let uu___11 =
                                            let xvars1 =
                                              FStar_List.map
                                                FStar_SMTEncoding_Util.mkFreeV
@@ -5367,7 +5227,7 @@ and (encode_sigelt' :
                                            FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                              (FStar_Pervasives_Native.Some
                                                 fuel_tm) t_res env'' dapp1 in
-                                         (match uu____14131 with
+                                         (match uu___11 with
                                           | (ty_pred', decls_pred) ->
                                               let guard' =
                                                 FStar_SMTEncoding_Util.mk_and_l
@@ -5375,28 +5235,28 @@ and (encode_sigelt' :
                                               let proxy_fresh =
                                                 match formals with
                                                 | [] -> []
-                                                | uu____14160 ->
-                                                    let uu____14161 =
-                                                      let uu____14162 =
+                                                | uu___12 ->
+                                                    let uu___13 =
+                                                      let uu___14 =
                                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                           () in
                                                       FStar_SMTEncoding_Term.fresh_token
                                                         (ddtok,
                                                           FStar_SMTEncoding_Term.Term_sort)
-                                                        uu____14162 in
-                                                    [uu____14161] in
-                                              let encode_elim uu____14176 =
-                                                let uu____14177 =
+                                                        uu___14 in
+                                                    [uu___13] in
+                                              let encode_elim uu___12 =
+                                                let uu___13 =
                                                   FStar_Syntax_Util.head_and_args
                                                     t_res in
-                                                match uu____14177 with
+                                                match uu___13 with
                                                 | (head, args) ->
-                                                    let uu____14228 =
-                                                      let uu____14229 =
+                                                    let uu___14 =
+                                                      let uu___15 =
                                                         FStar_Syntax_Subst.compress
                                                           head in
-                                                      uu____14229.FStar_Syntax_Syntax.n in
-                                                    (match uu____14228 with
+                                                      uu___15.FStar_Syntax_Syntax.n in
+                                                    (match uu___14 with
                                                      | FStar_Syntax_Syntax.Tm_uinst
                                                          ({
                                                             FStar_Syntax_Syntax.n
@@ -5404,21 +5264,20 @@ and (encode_sigelt' :
                                                               FStar_Syntax_Syntax.Tm_fvar
                                                               fv;
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____14241;
+                                                              = uu___15;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____14242;_},
-                                                          uu____14243)
+                                                              = uu___16;_},
+                                                          uu___17)
                                                          ->
                                                          let encoded_head_fvb
                                                            =
                                                            FStar_SMTEncoding_Env.lookup_free_var_name
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name in
-                                                         let uu____14249 =
+                                                         let uu___18 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env' in
-                                                         (match uu____14249
-                                                          with
+                                                         (match uu___18 with
                                                           | (encoded_args,
                                                              arg_decls) ->
                                                               let guards_for_parameter
@@ -5429,25 +5288,25 @@ and (encode_sigelt' :
                                                                     arg.FStar_SMTEncoding_Term.tm
                                                                   with
                                                                   | FStar_SMTEncoding_Term.FreeV
-                                                                    fv1 ->
-                                                                    fv1
-                                                                  | uu____14306
+                                                                    fv2 ->
+                                                                    fv2
+                                                                  | uu___19
                                                                     ->
-                                                                    let uu____14307
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____14312
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____14313
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____14313 in
+                                                                    uu___22 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____14312) in
+                                                                    uu___21) in
                                                                     FStar_Errors.raise_error
-                                                                    uu____14307
+                                                                    uu___20
                                                                     orig_arg.FStar_Syntax_Syntax.pos in
                                                                 let guards1 =
                                                                   FStar_All.pipe_right
@@ -5455,43 +5314,41 @@ and (encode_sigelt' :
                                                                     (
                                                                     FStar_List.collect
                                                                     (fun g ->
-                                                                    let uu____14331
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____14332
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____14332 in
+                                                                    uu___20 in
                                                                     if
-                                                                    uu____14331
+                                                                    uu___19
                                                                     then
-                                                                    let uu____14349
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
-                                                                    [uu____14349]
+                                                                    [uu___20]
                                                                     else [])) in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1 in
-                                                              let uu____14351
-                                                                =
-                                                                let uu____14364
-                                                                  =
+                                                              let uu___19 =
+                                                                let uu___20 =
                                                                   FStar_List.zip
                                                                     args
                                                                     encoded_args in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____14420
+                                                                    uu___21
                                                                     ->
                                                                     fun
-                                                                    uu____14421
+                                                                    uu___22
                                                                     ->
                                                                     match 
-                                                                    (uu____14420,
-                                                                    uu____14421)
+                                                                    (uu___21,
+                                                                    uu___22)
                                                                     with
                                                                     | 
                                                                     ((env2,
@@ -5500,20 +5357,20 @@ and (encode_sigelt' :
                                                                     i),
                                                                     (orig_arg,
                                                                     arg)) ->
-                                                                    let uu____14526
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____14533
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____14533 in
-                                                                    (match uu____14526
+                                                                    uu___24 in
+                                                                    (match uu___23
                                                                     with
                                                                     | 
-                                                                    (uu____14546,
+                                                                    (uu___24,
                                                                     xv, env3)
                                                                     ->
                                                                     let eqns
@@ -5521,21 +5378,21 @@ and (encode_sigelt' :
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____14554
+                                                                    let uu___25
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv in
-                                                                    uu____14554
+                                                                    uu___25
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____14558
+                                                                    (let uu___26
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv) in
-                                                                    uu____14558
+                                                                    uu___26
                                                                     ::
                                                                     eqns_or_guards) in
                                                                     (env3,
@@ -5547,14 +5404,13 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____14364 in
-                                                              (match uu____14351
+                                                                  uu___20 in
+                                                              (match uu___19
                                                                with
-                                                               | (uu____14575,
+                                                               | (uu___20,
                                                                   arg_vars,
                                                                   elim_eqns_or_guards,
-                                                                  uu____14578)
-                                                                   ->
+                                                                  uu___21) ->
                                                                    let arg_vars1
                                                                     =
                                                                     FStar_List.rev
@@ -5587,79 +5443,79 @@ and (encode_sigelt' :
                                                                     arg_vars1 in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____14602
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____14609
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____14610
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____14611
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____14622
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____14623
+                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____14623
+                                                                    uu___27
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
-                                                                    let uu____14624
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____14625
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____14630
+                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
                                                                     guards) in
                                                                     (ty_pred,
-                                                                    uu____14630) in
+                                                                    uu___29) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____14625 in
+                                                                    uu___28 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____14622,
-                                                                    uu____14624) in
+                                                                    uu___26,
+                                                                    uu___27) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____14610
-                                                                    uu____14611 in
-                                                                    (uu____14609,
+                                                                    uu___24
+                                                                    uu___25 in
+                                                                    (uu___23,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
                                                                     "data_elim_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____14602 in
+                                                                    uu___22 in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____14641
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____14642
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____14647
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid in
-                                                                    (uu____14647,
+                                                                    (uu___24,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____14642 in
+                                                                    uu___23 in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____14641 in
+                                                                    uu___22 in
                                                                     let prec
                                                                     =
-                                                                    let uu____14651
+                                                                    let uu___22
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -5670,70 +5526,70 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____14671
+                                                                    (let uu___24
                                                                     =
-                                                                    let uu____14672
+                                                                    let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____14672
+                                                                    uu___25
                                                                     dapp1 in
-                                                                    [uu____14671]))) in
+                                                                    [uu___24]))) in
                                                                     FStar_All.pipe_right
-                                                                    uu____14651
+                                                                    uu___22
                                                                     FStar_List.flatten in
-                                                                    let uu____14679
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____14686
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____14687
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____14688
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____14699
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____14700
+                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____14700
+                                                                    uu___27
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
-                                                                    let uu____14701
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____14702
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____14707
+                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec in
                                                                     (ty_pred,
-                                                                    uu____14707) in
+                                                                    uu___29) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____14702 in
+                                                                    uu___28 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____14699,
-                                                                    uu____14701) in
+                                                                    uu___26,
+                                                                    uu___27) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____14687
-                                                                    uu____14688 in
-                                                                    (uu____14686,
+                                                                    uu___24
+                                                                    uu___25 in
+                                                                    (uu___23,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
                                                                     "subterm_ordering_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____14679 in
+                                                                    uu___22 in
                                                                    (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
@@ -5744,11 +5600,10 @@ and (encode_sigelt' :
                                                            FStar_SMTEncoding_Env.lookup_free_var_name
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name in
-                                                         let uu____14722 =
+                                                         let uu___15 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env' in
-                                                         (match uu____14722
-                                                          with
+                                                         (match uu___15 with
                                                           | (encoded_args,
                                                              arg_decls) ->
                                                               let guards_for_parameter
@@ -5759,25 +5614,25 @@ and (encode_sigelt' :
                                                                     arg.FStar_SMTEncoding_Term.tm
                                                                   with
                                                                   | FStar_SMTEncoding_Term.FreeV
-                                                                    fv1 ->
-                                                                    fv1
-                                                                  | uu____14779
+                                                                    fv2 ->
+                                                                    fv2
+                                                                  | uu___16
                                                                     ->
-                                                                    let uu____14780
+                                                                    let uu___17
                                                                     =
-                                                                    let uu____14785
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____14786
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____14786 in
+                                                                    uu___19 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____14785) in
+                                                                    uu___18) in
                                                                     FStar_Errors.raise_error
-                                                                    uu____14780
+                                                                    uu___17
                                                                     orig_arg.FStar_Syntax_Syntax.pos in
                                                                 let guards1 =
                                                                   FStar_All.pipe_right
@@ -5785,43 +5640,41 @@ and (encode_sigelt' :
                                                                     (
                                                                     FStar_List.collect
                                                                     (fun g ->
-                                                                    let uu____14804
+                                                                    let uu___16
                                                                     =
-                                                                    let uu____14805
+                                                                    let uu___17
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____14805 in
+                                                                    uu___17 in
                                                                     if
-                                                                    uu____14804
+                                                                    uu___16
                                                                     then
-                                                                    let uu____14822
+                                                                    let uu___17
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
-                                                                    [uu____14822]
+                                                                    [uu___17]
                                                                     else [])) in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1 in
-                                                              let uu____14824
-                                                                =
-                                                                let uu____14837
-                                                                  =
+                                                              let uu___16 =
+                                                                let uu___17 =
                                                                   FStar_List.zip
                                                                     args
                                                                     encoded_args in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____14893
+                                                                    uu___18
                                                                     ->
                                                                     fun
-                                                                    uu____14894
+                                                                    uu___19
                                                                     ->
                                                                     match 
-                                                                    (uu____14893,
-                                                                    uu____14894)
+                                                                    (uu___18,
+                                                                    uu___19)
                                                                     with
                                                                     | 
                                                                     ((env2,
@@ -5830,20 +5683,20 @@ and (encode_sigelt' :
                                                                     i),
                                                                     (orig_arg,
                                                                     arg)) ->
-                                                                    let uu____14999
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____15006
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____15006 in
-                                                                    (match uu____14999
+                                                                    uu___21 in
+                                                                    (match uu___20
                                                                     with
                                                                     | 
-                                                                    (uu____15019,
+                                                                    (uu___21,
                                                                     xv, env3)
                                                                     ->
                                                                     let eqns
@@ -5851,21 +5704,21 @@ and (encode_sigelt' :
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____15027
+                                                                    let uu___22
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv in
-                                                                    uu____15027
+                                                                    uu___22
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____15031
+                                                                    (let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv) in
-                                                                    uu____15031
+                                                                    uu___23
                                                                     ::
                                                                     eqns_or_guards) in
                                                                     (env3,
@@ -5877,14 +5730,13 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____14837 in
-                                                              (match uu____14824
+                                                                  uu___17 in
+                                                              (match uu___16
                                                                with
-                                                               | (uu____15048,
+                                                               | (uu___17,
                                                                   arg_vars,
                                                                   elim_eqns_or_guards,
-                                                                  uu____15051)
-                                                                   ->
+                                                                  uu___18) ->
                                                                    let arg_vars1
                                                                     =
                                                                     FStar_List.rev
@@ -5917,79 +5769,79 @@ and (encode_sigelt' :
                                                                     arg_vars1 in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____15075
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____15082
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____15083
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____15084
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____15095
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____15096
+                                                                    let uu___24
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____15096
+                                                                    uu___24
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
-                                                                    let uu____15097
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____15098
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____15103
+                                                                    let uu___26
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
                                                                     guards) in
                                                                     (ty_pred,
-                                                                    uu____15103) in
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____15098 in
+                                                                    uu___25 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____15095,
-                                                                    uu____15097) in
+                                                                    uu___23,
+                                                                    uu___24) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____15083
-                                                                    uu____15084 in
-                                                                    (uu____15082,
+                                                                    uu___21
+                                                                    uu___22 in
+                                                                    (uu___20,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
                                                                     "data_elim_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____15075 in
+                                                                    uu___19 in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____15114
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____15115
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____15120
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid in
-                                                                    (uu____15120,
+                                                                    (uu___21,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____15115 in
+                                                                    uu___20 in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____15114 in
+                                                                    uu___19 in
                                                                     let prec
                                                                     =
-                                                                    let uu____15124
+                                                                    let uu___19
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -6000,148 +5852,140 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____15144
+                                                                    (let uu___21
                                                                     =
-                                                                    let uu____15145
+                                                                    let uu___22
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____15145
+                                                                    uu___22
                                                                     dapp1 in
-                                                                    [uu____15144]))) in
+                                                                    [uu___21]))) in
                                                                     FStar_All.pipe_right
-                                                                    uu____15124
+                                                                    uu___19
                                                                     FStar_List.flatten in
-                                                                    let uu____15152
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____15159
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____15160
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____15161
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____15172
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____15173
+                                                                    let uu___24
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____15173
+                                                                    uu___24
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
-                                                                    let uu____15174
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____15175
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____15180
+                                                                    let uu___26
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec in
                                                                     (ty_pred,
-                                                                    uu____15180) in
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____15175 in
+                                                                    uu___25 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____15172,
-                                                                    uu____15174) in
+                                                                    uu___23,
+                                                                    uu___24) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____15160
-                                                                    uu____15161 in
-                                                                    (uu____15159,
+                                                                    uu___21
+                                                                    uu___22 in
+                                                                    (uu___20,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
                                                                     "subterm_ordering_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____15152 in
+                                                                    uu___19 in
                                                                    (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
-                                                     | uu____15193 ->
-                                                         ((let uu____15195 =
-                                                             let uu____15200
-                                                               =
-                                                               let uu____15201
-                                                                 =
+                                                     | uu___15 ->
+                                                         ((let uu___17 =
+                                                             let uu___18 =
+                                                               let uu___19 =
                                                                  FStar_Syntax_Print.lid_to_string
                                                                    d in
-                                                               let uu____15202
-                                                                 =
+                                                               let uu___20 =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    head in
                                                                FStar_Util.format2
                                                                  "Constructor %s builds an unexpected type %s\n"
-                                                                 uu____15201
-                                                                 uu____15202 in
+                                                                 uu___19
+                                                                 uu___20 in
                                                              (FStar_Errors.Warning_ConstructorBuildsUnexpectedType,
-                                                               uu____15200) in
+                                                               uu___18) in
                                                            FStar_Errors.log_issue
                                                              se.FStar_Syntax_Syntax.sigrng
-                                                             uu____15195);
+                                                             uu___17);
                                                           ([], []))) in
-                                              let uu____15207 =
-                                                encode_elim () in
-                                              (match uu____15207 with
+                                              let uu___12 = encode_elim () in
+                                              (match uu___12 with
                                                | (decls2, elim) ->
                                                    let g =
-                                                     let uu____15233 =
-                                                       let uu____15236 =
-                                                         let uu____15239 =
-                                                           let uu____15242 =
-                                                             let uu____15245
-                                                               =
-                                                               let uu____15248
-                                                                 =
-                                                                 let uu____15251
+                                                     let uu___13 =
+                                                       let uu___14 =
+                                                         let uu___15 =
+                                                           let uu___16 =
+                                                             let uu___17 =
+                                                               let uu___18 =
+                                                                 let uu___19
                                                                    =
-                                                                   let uu____15252
+                                                                   let uu___20
                                                                     =
-                                                                    let uu____15263
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____15264
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____15265
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Print.lid_to_string
                                                                     d in
                                                                     FStar_Util.format1
                                                                     "data constructor proxy: %s"
-                                                                    uu____15265 in
+                                                                    uu___23 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____15264 in
+                                                                    uu___22 in
                                                                     (ddtok,
                                                                     [],
                                                                     FStar_SMTEncoding_Term.Term_sort,
-                                                                    uu____15263) in
+                                                                    uu___21) in
                                                                    FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____15252 in
-                                                                 [uu____15251] in
+                                                                    uu___20 in
+                                                                 [uu___19] in
                                                                FStar_List.append
-                                                                 uu____15248
+                                                                 uu___18
                                                                  proxy_fresh in
                                                              FStar_All.pipe_right
-                                                               uu____15245
+                                                               uu___17
                                                                FStar_SMTEncoding_Term.mk_decls_trivial in
-                                                           let uu____15272 =
-                                                             let uu____15275
-                                                               =
-                                                               let uu____15278
-                                                                 =
-                                                                 let uu____15281
+                                                           let uu___17 =
+                                                             let uu___18 =
+                                                               let uu___19 =
+                                                                 let uu___20
                                                                    =
-                                                                   let uu____15284
+                                                                   let uu___21
                                                                     =
-                                                                    let uu____15287
+                                                                    let uu___22
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     (tok_typing1,
@@ -6150,120 +5994,118 @@ and (encode_sigelt' :
                                                                     (Prims.op_Hat
                                                                     "typing_tok_"
                                                                     ddtok)) in
-                                                                    let uu____15288
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____15291
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____15292
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____15299
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____15300
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____15301
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____15312
+                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     dapp) in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____15312) in
+                                                                    uu___29) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____15300
-                                                                    uu____15301 in
-                                                                    (uu____15299,
+                                                                    uu___27
+                                                                    uu___28 in
+                                                                    (uu___26,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "equality for proxy"),
                                                                     (Prims.op_Hat
                                                                     "equality_tok_"
                                                                     ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____15292 in
-                                                                    let uu____15321
+                                                                    uu___25 in
+                                                                    let uu___25
                                                                     =
-                                                                    let uu____15324
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____15325
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____15332
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____15333
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu____15334
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____15345
+                                                                    let uu___31
                                                                     =
-                                                                    let uu____15346
+                                                                    let uu___32
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____15346
+                                                                    uu___32
                                                                     vars' in
-                                                                    let uu____15347
+                                                                    let uu___32
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard',
                                                                     ty_pred') in
                                                                     ([
                                                                     [ty_pred']],
-                                                                    uu____15345,
-                                                                    uu____15347) in
+                                                                    uu___31,
+                                                                    uu___32) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____15333
-                                                                    uu____15334 in
-                                                                    (uu____15332,
+                                                                    uu___29
+                                                                    uu___30 in
+                                                                    (uu___28,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing intro"),
                                                                     (Prims.op_Hat
                                                                     "data_typing_intro_"
                                                                     ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____15325 in
-                                                                    [uu____15324] in
-                                                                    uu____15291
+                                                                    uu___27 in
+                                                                    [uu___26] in
+                                                                    uu___24
                                                                     ::
-                                                                    uu____15321 in
-                                                                    uu____15287
+                                                                    uu___25 in
+                                                                    uu___22
                                                                     ::
-                                                                    uu____15288 in
+                                                                    uu___23 in
                                                                    FStar_List.append
-                                                                    uu____15284
+                                                                    uu___21
                                                                     elim in
                                                                  FStar_All.pipe_right
-                                                                   uu____15281
+                                                                   uu___20
                                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
                                                                FStar_List.append
                                                                  decls_pred
-                                                                 uu____15278 in
+                                                                 uu___19 in
                                                              FStar_List.append
                                                                decls_formals
-                                                               uu____15275 in
+                                                               uu___18 in
                                                            FStar_List.append
-                                                             uu____15242
-                                                             uu____15272 in
+                                                             uu___16 uu___17 in
                                                          FStar_List.append
-                                                           decls3 uu____15239 in
+                                                           decls3 uu___15 in
                                                        FStar_List.append
-                                                         decls2 uu____15236 in
+                                                         decls2 uu___14 in
                                                      FStar_List.append
-                                                       binder_decls
-                                                       uu____15233 in
-                                                   let uu____15360 =
-                                                     let uu____15361 =
+                                                       binder_decls uu___13 in
+                                                   let uu___13 =
+                                                     let uu___14 =
                                                        FStar_All.pipe_right
                                                          datacons
                                                          FStar_SMTEncoding_Term.mk_decls_trivial in
                                                      FStar_List.append
-                                                       uu____15361 g in
-                                                   (uu____15360, env1))))))))))
+                                                       uu___14 g in
+                                                   (uu___13, env1))))))))))
 and (encode_sigelts :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -6273,12 +6115,12 @@ and (encode_sigelts :
     fun ses ->
       FStar_All.pipe_right ses
         (FStar_List.fold_left
-           (fun uu____15395 ->
+           (fun uu___ ->
               fun se ->
-                match uu____15395 with
+                match uu___ with
                 | (g, env1) ->
-                    let uu____15415 = encode_sigelt env1 se in
-                    (match uu____15415 with
+                    let uu___1 = encode_sigelt env1 se in
+                    (match uu___1 with
                      | (g', env2) -> ((FStar_List.append g g'), env2)))
            ([], env))
 let (encode_env_bindings :
@@ -6288,65 +6130,64 @@ let (encode_env_bindings :
   =
   fun env ->
     fun bindings ->
-      let encode_binding b uu____15480 =
-        match uu____15480 with
+      let encode_binding b uu___ =
+        match uu___ with
         | (i, decls, env1) ->
             (match b with
-             | FStar_Syntax_Syntax.Binding_univ uu____15512 ->
+             | FStar_Syntax_Syntax.Binding_univ uu___1 ->
                  ((i + Prims.int_one), decls, env1)
              | FStar_Syntax_Syntax.Binding_var x ->
                  let t1 =
                    norm_before_encoding env1 x.FStar_Syntax_Syntax.sort in
-                 ((let uu____15518 =
+                 ((let uu___2 =
                      FStar_All.pipe_left
                        (FStar_TypeChecker_Env.debug
                           env1.FStar_SMTEncoding_Env.tcenv)
                        (FStar_Options.Other "SMTEncoding") in
-                   if uu____15518
+                   if uu___2
                    then
-                     let uu____15519 = FStar_Syntax_Print.bv_to_string x in
-                     let uu____15520 =
+                     let uu___3 = FStar_Syntax_Print.bv_to_string x in
+                     let uu___4 =
                        FStar_Syntax_Print.term_to_string
                          x.FStar_Syntax_Syntax.sort in
-                     let uu____15521 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print3 "Normalized %s : %s to %s\n"
-                       uu____15519 uu____15520 uu____15521
+                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print3 "Normalized %s : %s to %s\n" uu___3
+                       uu___4 uu___5
                    else ());
-                  (let uu____15523 =
+                  (let uu___2 =
                      FStar_SMTEncoding_EncodeTerm.encode_term t1 env1 in
-                   match uu____15523 with
+                   match uu___2 with
                    | (t, decls') ->
                        let t_hash = FStar_SMTEncoding_Term.hash_of_term t in
-                       let uu____15539 =
-                         let uu____15546 =
-                           let uu____15547 =
-                             let uu____15548 =
-                               FStar_Util.digest_of_string t_hash in
-                             Prims.op_Hat uu____15548
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 =
+                             let uu___6 = FStar_Util.digest_of_string t_hash in
+                             Prims.op_Hat uu___6
                                (Prims.op_Hat "_" (Prims.string_of_int i)) in
-                           Prims.op_Hat "x_" uu____15547 in
+                           Prims.op_Hat "x_" uu___5 in
                          FStar_SMTEncoding_Env.new_term_constant_from_string
-                           env1 x uu____15546 in
-                       (match uu____15539 with
+                           env1 x uu___4 in
+                       (match uu___3 with
                         | (xxsym, xx, env') ->
                             let t2 =
                               FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                 FStar_Pervasives_Native.None xx t in
                             let caption =
-                              let uu____15562 = FStar_Options.log_queries () in
-                              if uu____15562
+                              let uu___4 = FStar_Options.log_queries () in
+                              if uu___4
                               then
-                                let uu____15563 =
-                                  let uu____15564 =
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Syntax_Print.bv_to_string x in
-                                  let uu____15565 =
+                                  let uu___7 =
                                     FStar_Syntax_Print.term_to_string
                                       x.FStar_Syntax_Syntax.sort in
-                                  let uu____15566 =
+                                  let uu___8 =
                                     FStar_Syntax_Print.term_to_string t1 in
-                                  FStar_Util.format3 "%s : %s (%s)"
-                                    uu____15564 uu____15565 uu____15566 in
-                                FStar_Pervasives_Native.Some uu____15563
+                                  FStar_Util.format3 "%s : %s (%s)" uu___6
+                                    uu___7 uu___8 in
+                                FStar_Pervasives_Native.Some uu___5
                               else FStar_Pervasives_Native.None in
                             let ax =
                               let a_name = Prims.op_Hat "binder_" xxsym in
@@ -6354,36 +6195,36 @@ let (encode_env_bindings :
                                 (t2, (FStar_Pervasives_Native.Some a_name),
                                   a_name) in
                             let g =
-                              let uu____15573 =
+                              let uu___4 =
                                 FStar_All.pipe_right
                                   [FStar_SMTEncoding_Term.DeclFun
                                      (xxsym, [],
                                        FStar_SMTEncoding_Term.Term_sort,
                                        caption)]
                                   FStar_SMTEncoding_Term.mk_decls_trivial in
-                              let uu____15582 =
-                                let uu____15585 =
+                              let uu___5 =
+                                let uu___6 =
                                   FStar_All.pipe_right [ax]
                                     FStar_SMTEncoding_Term.mk_decls_trivial in
-                                FStar_List.append decls' uu____15585 in
-                              FStar_List.append uu____15573 uu____15582 in
+                                FStar_List.append decls' uu___6 in
+                              FStar_List.append uu___4 uu___5 in
                             ((i + Prims.int_one),
                               (FStar_List.append decls g), env'))))
-             | FStar_Syntax_Syntax.Binding_lid (x, (uu____15595, t)) ->
+             | FStar_Syntax_Syntax.Binding_lid (x, (uu___1, t)) ->
                  let t_norm = norm_before_encoding env1 t in
                  let fv =
                    FStar_Syntax_Syntax.lid_as_fv x
                      FStar_Syntax_Syntax.delta_constant
                      FStar_Pervasives_Native.None in
-                 let uu____15609 = encode_free_var false env1 fv t t_norm [] in
-                 (match uu____15609 with
+                 let uu___2 = encode_free_var false env1 fv t t_norm [] in
+                 (match uu___2 with
                   | (g, env') ->
                       ((i + Prims.int_one), (FStar_List.append decls g),
                         env'))) in
-      let uu____15626 =
+      let uu___ =
         FStar_List.fold_right encode_binding bindings
           (Prims.int_zero, [], env) in
-      match uu____15626 with | (uu____15649, decls, env1) -> (decls, env1)
+      match uu___ with | (uu___1, decls, env1) -> (decls, env1)
 let (encode_labels :
   FStar_SMTEncoding_Term.error_label Prims.list ->
     (FStar_SMTEncoding_Term.decl Prims.list * FStar_SMTEncoding_Term.decl
@@ -6393,116 +6234,114 @@ let (encode_labels :
     let prefix =
       FStar_All.pipe_right labs
         (FStar_List.map
-           (fun uu____15697 ->
-              match uu____15697 with
-              | (l, uu____15705, uu____15706) ->
-                  let uu____15707 =
-                    let uu____15718 = FStar_SMTEncoding_Term.fv_name l in
-                    (uu____15718, [], FStar_SMTEncoding_Term.Bool_sort,
+           (fun uu___ ->
+              match uu___ with
+              | (l, uu___1, uu___2) ->
+                  let uu___3 =
+                    let uu___4 = FStar_SMTEncoding_Term.fv_name l in
+                    (uu___4, [], FStar_SMTEncoding_Term.Bool_sort,
                       FStar_Pervasives_Native.None) in
-                  FStar_SMTEncoding_Term.DeclFun uu____15707)) in
+                  FStar_SMTEncoding_Term.DeclFun uu___3)) in
     let suffix =
       FStar_All.pipe_right labs
         (FStar_List.collect
-           (fun uu____15746 ->
-              match uu____15746 with
-              | (l, uu____15756, uu____15757) ->
-                  let uu____15758 =
-                    let uu____15759 = FStar_SMTEncoding_Term.fv_name l in
+           (fun uu___ ->
+              match uu___ with
+              | (l, uu___1, uu___2) ->
+                  let uu___3 =
+                    let uu___4 = FStar_SMTEncoding_Term.fv_name l in
                     FStar_All.pipe_left
-                      (fun uu____15760 ->
-                         FStar_SMTEncoding_Term.Echo uu____15760) uu____15759 in
-                  let uu____15761 =
-                    let uu____15764 =
-                      let uu____15765 = FStar_SMTEncoding_Util.mkFreeV l in
-                      FStar_SMTEncoding_Term.Eval uu____15765 in
-                    [uu____15764] in
-                  uu____15758 :: uu____15761)) in
+                      (fun uu___5 -> FStar_SMTEncoding_Term.Echo uu___5)
+                      uu___4 in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = FStar_SMTEncoding_Util.mkFreeV l in
+                      FStar_SMTEncoding_Term.Eval uu___6 in
+                    [uu___5] in
+                  uu___3 :: uu___4)) in
     (prefix, suffix)
 let (last_env : FStar_SMTEncoding_Env.env_t Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (init_env : FStar_TypeChecker_Env.env -> unit) =
   fun tcenv ->
-    let uu____15781 =
-      let uu____15784 =
-        let uu____15785 = FStar_Util.psmap_empty () in
-        let uu____15800 =
-          let uu____15809 = FStar_Util.psmap_empty () in (uu____15809, []) in
-        let uu____15816 =
-          let uu____15817 = FStar_TypeChecker_Env.current_module tcenv in
-          FStar_All.pipe_right uu____15817 FStar_Ident.string_of_lid in
-        let uu____15818 = FStar_Util.smap_create (Prims.of_int (100)) in
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Util.psmap_empty () in
+        let uu___3 = let uu___4 = FStar_Util.psmap_empty () in (uu___4, []) in
+        let uu___4 =
+          let uu___5 = FStar_TypeChecker_Env.current_module tcenv in
+          FStar_All.pipe_right uu___5 FStar_Ident.string_of_lid in
+        let uu___5 = FStar_Util.smap_create (Prims.of_int (100)) in
         {
-          FStar_SMTEncoding_Env.bvar_bindings = uu____15785;
-          FStar_SMTEncoding_Env.fvar_bindings = uu____15800;
+          FStar_SMTEncoding_Env.bvar_bindings = uu___2;
+          FStar_SMTEncoding_Env.fvar_bindings = uu___3;
           FStar_SMTEncoding_Env.depth = Prims.int_zero;
           FStar_SMTEncoding_Env.tcenv = tcenv;
           FStar_SMTEncoding_Env.warn = true;
           FStar_SMTEncoding_Env.nolabels = false;
           FStar_SMTEncoding_Env.use_zfuel_name = false;
           FStar_SMTEncoding_Env.encode_non_total_function_typ = true;
-          FStar_SMTEncoding_Env.current_module_name = uu____15816;
+          FStar_SMTEncoding_Env.current_module_name = uu___4;
           FStar_SMTEncoding_Env.encoding_quantifier = false;
-          FStar_SMTEncoding_Env.global_cache = uu____15818
+          FStar_SMTEncoding_Env.global_cache = uu___5
         } in
-      [uu____15784] in
-    FStar_ST.op_Colon_Equals last_env uu____15781
+      [uu___1] in
+    FStar_ST.op_Colon_Equals last_env uu___
 let (get_env :
   FStar_Ident.lident ->
     FStar_TypeChecker_Env.env -> FStar_SMTEncoding_Env.env_t)
   =
   fun cmn ->
     fun tcenv ->
-      let uu____15841 = FStar_ST.op_Bang last_env in
-      match uu____15841 with
+      let uu___ = FStar_ST.op_Bang last_env in
+      match uu___ with
       | [] -> failwith "No env; call init first!"
-      | e::uu____15855 ->
-          let uu___1580_15858 = e in
-          let uu____15859 = FStar_Ident.string_of_lid cmn in
+      | e::uu___1 ->
+          let uu___2 = e in
+          let uu___3 = FStar_Ident.string_of_lid cmn in
           {
             FStar_SMTEncoding_Env.bvar_bindings =
-              (uu___1580_15858.FStar_SMTEncoding_Env.bvar_bindings);
+              (uu___2.FStar_SMTEncoding_Env.bvar_bindings);
             FStar_SMTEncoding_Env.fvar_bindings =
-              (uu___1580_15858.FStar_SMTEncoding_Env.fvar_bindings);
+              (uu___2.FStar_SMTEncoding_Env.fvar_bindings);
             FStar_SMTEncoding_Env.depth =
-              (uu___1580_15858.FStar_SMTEncoding_Env.depth);
+              (uu___2.FStar_SMTEncoding_Env.depth);
             FStar_SMTEncoding_Env.tcenv = tcenv;
-            FStar_SMTEncoding_Env.warn =
-              (uu___1580_15858.FStar_SMTEncoding_Env.warn);
+            FStar_SMTEncoding_Env.warn = (uu___2.FStar_SMTEncoding_Env.warn);
             FStar_SMTEncoding_Env.nolabels =
-              (uu___1580_15858.FStar_SMTEncoding_Env.nolabels);
+              (uu___2.FStar_SMTEncoding_Env.nolabels);
             FStar_SMTEncoding_Env.use_zfuel_name =
-              (uu___1580_15858.FStar_SMTEncoding_Env.use_zfuel_name);
+              (uu___2.FStar_SMTEncoding_Env.use_zfuel_name);
             FStar_SMTEncoding_Env.encode_non_total_function_typ =
-              (uu___1580_15858.FStar_SMTEncoding_Env.encode_non_total_function_typ);
-            FStar_SMTEncoding_Env.current_module_name = uu____15859;
+              (uu___2.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            FStar_SMTEncoding_Env.current_module_name = uu___3;
             FStar_SMTEncoding_Env.encoding_quantifier =
-              (uu___1580_15858.FStar_SMTEncoding_Env.encoding_quantifier);
+              (uu___2.FStar_SMTEncoding_Env.encoding_quantifier);
             FStar_SMTEncoding_Env.global_cache =
-              (uu___1580_15858.FStar_SMTEncoding_Env.global_cache)
+              (uu___2.FStar_SMTEncoding_Env.global_cache)
           }
 let (set_env : FStar_SMTEncoding_Env.env_t -> unit) =
   fun env ->
-    let uu____15865 = FStar_ST.op_Bang last_env in
-    match uu____15865 with
+    let uu___ = FStar_ST.op_Bang last_env in
+    match uu___ with
     | [] -> failwith "Empty env stack"
-    | uu____15878::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
+    | uu___1::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
 let (push_env : unit -> unit) =
-  fun uu____15896 ->
-    let uu____15897 = FStar_ST.op_Bang last_env in
-    match uu____15897 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang last_env in
+    match uu___1 with
     | [] -> failwith "Empty env stack"
     | hd::tl ->
         let top = copy_env hd in
         FStar_ST.op_Colon_Equals last_env (top :: hd :: tl)
 let (pop_env : unit -> unit) =
-  fun uu____15929 ->
-    let uu____15930 = FStar_ST.op_Bang last_env in
-    match uu____15930 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang last_env in
+    match uu___1 with
     | [] -> failwith "Popping an empty stack"
-    | uu____15943::tl -> FStar_ST.op_Colon_Equals last_env tl
+    | uu___2::tl -> FStar_ST.op_Colon_Equals last_env tl
 let (snapshot_env : unit -> (Prims.int * unit)) =
-  fun uu____15965 -> FStar_Common.snapshot push_env last_env ()
+  fun uu___ -> FStar_Common.snapshot push_env last_env ()
 let (rollback_env : Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth -> FStar_Common.rollback pop_env last_env depth
 let (init : FStar_TypeChecker_Env.env -> unit) =
@@ -6514,16 +6353,16 @@ let (snapshot :
   Prims.string -> (FStar_TypeChecker_Env.solver_depth_t * unit)) =
   fun msg ->
     FStar_Util.atomically
-      (fun uu____16008 ->
-         let uu____16009 = snapshot_env () in
-         match uu____16009 with
+      (fun uu___ ->
+         let uu___1 = snapshot_env () in
+         match uu___1 with
          | (env_depth, ()) ->
-             let uu____16025 =
+             let uu___2 =
                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.snapshot () in
-             (match uu____16025 with
+             (match uu___2 with
               | (varops_depth, ()) ->
-                  let uu____16041 = FStar_SMTEncoding_Z3.snapshot msg in
-                  (match uu____16041 with
+                  let uu___3 = FStar_SMTEncoding_Z3.snapshot msg in
+                  (match uu___3 with
                    | (z3_depth, ()) ->
                        ((env_depth, varops_depth, z3_depth), ()))))
 let (rollback :
@@ -6534,8 +6373,8 @@ let (rollback :
   fun msg ->
     fun depth ->
       FStar_Util.atomically
-        (fun uu____16084 ->
-           let uu____16085 =
+        (fun uu___ ->
+           let uu___1 =
              match depth with
              | FStar_Pervasives_Native.Some (s1, s2, s3) ->
                  ((FStar_Pervasives_Native.Some s1),
@@ -6544,14 +6383,13 @@ let (rollback :
              | FStar_Pervasives_Native.None ->
                  (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None,
                    FStar_Pervasives_Native.None) in
-           match uu____16085 with
+           match uu___1 with
            | (env_depth, varops_depth, z3_depth) ->
                (rollback_env env_depth;
                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.rollback
                   varops_depth;
                 FStar_SMTEncoding_Z3.rollback msg z3_depth))
-let (push : Prims.string -> unit) =
-  fun msg -> let uu____16147 = snapshot msg in ()
+let (push : Prims.string -> unit) = fun msg -> let uu___ = snapshot msg in ()
 let (pop : Prims.string -> unit) =
   fun msg -> rollback msg FStar_Pervasives_Native.None
 let (open_fact_db_tags :
@@ -6566,19 +6404,19 @@ let (place_decl_in_fact_dbs :
     fun fact_db_ids ->
       fun d ->
         match (fact_db_ids, d) with
-        | (uu____16188::uu____16189, FStar_SMTEncoding_Term.Assume a) ->
+        | (uu___::uu___1, FStar_SMTEncoding_Term.Assume a) ->
             FStar_SMTEncoding_Term.Assume
-              (let uu___1641_16197 = a in
+              (let uu___2 = a in
                {
                  FStar_SMTEncoding_Term.assumption_term =
-                   (uu___1641_16197.FStar_SMTEncoding_Term.assumption_term);
+                   (uu___2.FStar_SMTEncoding_Term.assumption_term);
                  FStar_SMTEncoding_Term.assumption_caption =
-                   (uu___1641_16197.FStar_SMTEncoding_Term.assumption_caption);
+                   (uu___2.FStar_SMTEncoding_Term.assumption_caption);
                  FStar_SMTEncoding_Term.assumption_name =
-                   (uu___1641_16197.FStar_SMTEncoding_Term.assumption_name);
+                   (uu___2.FStar_SMTEncoding_Term.assumption_name);
                  FStar_SMTEncoding_Term.assumption_fact_ids = fact_db_ids
                })
-        | uu____16198 -> d
+        | uu___ -> d
 let (place_decl_elt_in_fact_dbs :
   FStar_SMTEncoding_Env.env_t ->
     FStar_SMTEncoding_Term.fact_db_id Prims.list ->
@@ -6587,18 +6425,17 @@ let (place_decl_elt_in_fact_dbs :
   fun env ->
     fun fact_db_ids ->
       fun elt ->
-        let uu___1647_16224 = elt in
-        let uu____16225 =
+        let uu___ = elt in
+        let uu___1 =
           FStar_All.pipe_right elt.FStar_SMTEncoding_Term.decls
             (FStar_List.map (place_decl_in_fact_dbs env fact_db_ids)) in
         {
           FStar_SMTEncoding_Term.sym_name =
-            (uu___1647_16224.FStar_SMTEncoding_Term.sym_name);
-          FStar_SMTEncoding_Term.key =
-            (uu___1647_16224.FStar_SMTEncoding_Term.key);
-          FStar_SMTEncoding_Term.decls = uu____16225;
+            (uu___.FStar_SMTEncoding_Term.sym_name);
+          FStar_SMTEncoding_Term.key = (uu___.FStar_SMTEncoding_Term.key);
+          FStar_SMTEncoding_Term.decls = uu___1;
           FStar_SMTEncoding_Term.a_names =
-            (uu___1647_16224.FStar_SMTEncoding_Term.a_names)
+            (uu___.FStar_SMTEncoding_Term.a_names)
         }
 let (fact_dbs_for_lid :
   FStar_SMTEncoding_Env.env_t ->
@@ -6606,14 +6443,14 @@ let (fact_dbs_for_lid :
   =
   fun env ->
     fun lid ->
-      let uu____16244 =
-        let uu____16247 =
-          let uu____16248 =
-            let uu____16249 = FStar_Ident.ns_of_lid lid in
-            FStar_Ident.lid_of_ids uu____16249 in
-          FStar_SMTEncoding_Term.Namespace uu____16248 in
-        let uu____16250 = open_fact_db_tags env in uu____16247 :: uu____16250 in
-      (FStar_SMTEncoding_Term.Name lid) :: uu____16244
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Ident.ns_of_lid lid in
+            FStar_Ident.lid_of_ids uu___3 in
+          FStar_SMTEncoding_Term.Namespace uu___2 in
+        let uu___2 = open_fact_db_tags env in uu___1 :: uu___2 in
+      (FStar_SMTEncoding_Term.Name lid) :: uu___
 let (encode_top_level_facts :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -6625,8 +6462,8 @@ let (encode_top_level_facts :
       let fact_db_ids =
         FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
           (FStar_List.collect (fact_dbs_for_lid env)) in
-      let uu____16276 = encode_sigelt env se in
-      match uu____16276 with
+      let uu___ = encode_sigelt env se in
+      match uu___ with
       | (g, env1) ->
           let g1 =
             FStar_All.pipe_right g
@@ -6645,68 +6482,66 @@ let (recover_caching_and_update_env :
                 elt.FStar_SMTEncoding_Term.key = FStar_Pervasives_Native.None
               then [elt]
               else
-                (let uu____16317 =
-                   let uu____16320 =
+                (let uu___1 =
+                   let uu___2 =
                      FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                        FStar_Util.must in
                    FStar_Util.smap_try_find
-                     env.FStar_SMTEncoding_Env.global_cache uu____16320 in
-                 match uu____16317 with
+                     env.FStar_SMTEncoding_Env.global_cache uu___2 in
+                 match uu___1 with
                  | FStar_Pervasives_Native.Some cache_elt ->
                      FStar_All.pipe_right
                        [FStar_SMTEncoding_Term.RetainAssumptions
                           (cache_elt.FStar_SMTEncoding_Term.a_names)]
                        FStar_SMTEncoding_Term.mk_decls_trivial
                  | FStar_Pervasives_Native.None ->
-                     ((let uu____16331 =
+                     ((let uu___3 =
                          FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                            FStar_Util.must in
                        FStar_Util.smap_add
-                         env.FStar_SMTEncoding_Env.global_cache uu____16331
-                         elt);
+                         env.FStar_SMTEncoding_Env.global_cache uu___3 elt);
                       [elt]))))
 let (encode_sig :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun tcenv ->
     fun se ->
       let caption decls =
-        let uu____16356 = FStar_Options.log_queries () in
-        if uu____16356
+        let uu___ = FStar_Options.log_queries () in
+        if uu___
         then
-          let uu____16359 =
-            let uu____16360 =
-              let uu____16361 =
-                let uu____16362 =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
                   FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                     (FStar_List.map FStar_Syntax_Print.lid_to_string) in
-                FStar_All.pipe_right uu____16362 (FStar_String.concat ", ") in
-              Prims.op_Hat "encoding sigelt " uu____16361 in
-            FStar_SMTEncoding_Term.Caption uu____16360 in
-          uu____16359 :: decls
+                FStar_All.pipe_right uu___4 (FStar_String.concat ", ") in
+              Prims.op_Hat "encoding sigelt " uu___3 in
+            FStar_SMTEncoding_Term.Caption uu___2 in
+          uu___1 :: decls
         else decls in
-      (let uu____16373 =
-         FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
-       if uu____16373
+      (let uu___1 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
+       if uu___1
        then
-         let uu____16374 = FStar_Syntax_Print.sigelt_to_string se in
-         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____16374
+         let uu___2 = FStar_Syntax_Print.sigelt_to_string se in
+         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu___2
        else ());
       (let env =
-         let uu____16377 = FStar_TypeChecker_Env.current_module tcenv in
-         get_env uu____16377 tcenv in
-       let uu____16378 = encode_top_level_facts env se in
-       match uu____16378 with
+         let uu___1 = FStar_TypeChecker_Env.current_module tcenv in
+         get_env uu___1 tcenv in
+       let uu___1 = encode_top_level_facts env se in
+       match uu___1 with
        | (decls, env1) ->
            (set_env env1;
-            (let uu____16392 =
-               let uu____16395 =
-                 let uu____16398 =
+            (let uu___3 =
+               let uu___4 =
+                 let uu___5 =
                    FStar_All.pipe_right decls
                      (recover_caching_and_update_env env1) in
-                 FStar_All.pipe_right uu____16398
+                 FStar_All.pipe_right uu___5
                    FStar_SMTEncoding_Term.decls_list_of in
-               caption uu____16395 in
-             FStar_SMTEncoding_Z3.giveZ3 uu____16392)))
+               caption uu___4 in
+             FStar_SMTEncoding_Z3.giveZ3 uu___3)))
 let (give_decls_to_z3_and_set_env :
   FStar_SMTEncoding_Env.env_t ->
     Prims.string -> FStar_SMTEncoding_Term.decls_t -> unit)
@@ -6715,8 +6550,8 @@ let (give_decls_to_z3_and_set_env :
     fun name ->
       fun decls ->
         let caption decls1 =
-          let uu____16428 = FStar_Options.log_queries () in
-          if uu____16428
+          let uu___ = FStar_Options.log_queries () in
+          if uu___
           then
             let msg = Prims.op_Hat "Externals for " name in
             [FStar_SMTEncoding_Term.Module
@@ -6726,38 +6561,37 @@ let (give_decls_to_z3_and_set_env :
                     [FStar_SMTEncoding_Term.Caption (Prims.op_Hat "End " msg)]))]
           else [FStar_SMTEncoding_Term.Module (name, decls1)] in
         set_env
-          (let uu___1685_16440 = env in
+          (let uu___1 = env in
            {
              FStar_SMTEncoding_Env.bvar_bindings =
-               (uu___1685_16440.FStar_SMTEncoding_Env.bvar_bindings);
+               (uu___1.FStar_SMTEncoding_Env.bvar_bindings);
              FStar_SMTEncoding_Env.fvar_bindings =
-               (uu___1685_16440.FStar_SMTEncoding_Env.fvar_bindings);
+               (uu___1.FStar_SMTEncoding_Env.fvar_bindings);
              FStar_SMTEncoding_Env.depth =
-               (uu___1685_16440.FStar_SMTEncoding_Env.depth);
+               (uu___1.FStar_SMTEncoding_Env.depth);
              FStar_SMTEncoding_Env.tcenv =
-               (uu___1685_16440.FStar_SMTEncoding_Env.tcenv);
+               (uu___1.FStar_SMTEncoding_Env.tcenv);
              FStar_SMTEncoding_Env.warn = true;
              FStar_SMTEncoding_Env.nolabels =
-               (uu___1685_16440.FStar_SMTEncoding_Env.nolabels);
+               (uu___1.FStar_SMTEncoding_Env.nolabels);
              FStar_SMTEncoding_Env.use_zfuel_name =
-               (uu___1685_16440.FStar_SMTEncoding_Env.use_zfuel_name);
+               (uu___1.FStar_SMTEncoding_Env.use_zfuel_name);
              FStar_SMTEncoding_Env.encode_non_total_function_typ =
-               (uu___1685_16440.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+               (uu___1.FStar_SMTEncoding_Env.encode_non_total_function_typ);
              FStar_SMTEncoding_Env.current_module_name =
-               (uu___1685_16440.FStar_SMTEncoding_Env.current_module_name);
+               (uu___1.FStar_SMTEncoding_Env.current_module_name);
              FStar_SMTEncoding_Env.encoding_quantifier =
-               (uu___1685_16440.FStar_SMTEncoding_Env.encoding_quantifier);
+               (uu___1.FStar_SMTEncoding_Env.encoding_quantifier);
              FStar_SMTEncoding_Env.global_cache =
-               (uu___1685_16440.FStar_SMTEncoding_Env.global_cache)
+               (uu___1.FStar_SMTEncoding_Env.global_cache)
            });
         (let z3_decls =
-           let uu____16444 =
-             let uu____16447 =
+           let uu___1 =
+             let uu___2 =
                FStar_All.pipe_right decls
                  (recover_caching_and_update_env env) in
-             FStar_All.pipe_right uu____16447
-               FStar_SMTEncoding_Term.decls_list_of in
-           caption uu____16444 in
+             FStar_All.pipe_right uu___2 FStar_SMTEncoding_Term.decls_list_of in
+           caption uu___1 in
          FStar_SMTEncoding_Z3.giveZ3 z3_decls)
 let (encode_modul :
   FStar_TypeChecker_Env.env ->
@@ -6767,92 +6601,90 @@ let (encode_modul :
   =
   fun tcenv ->
     fun modul ->
-      let uu____16466 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
-      if uu____16466
+      let uu___ = (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
+      if uu___
       then ([], [])
       else
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____16496 ->
+          (fun uu___2 ->
              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.reset_fresh
                ();
              (let name =
-                let uu____16499 =
+                let uu___4 =
                   FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
                 FStar_Util.format2 "%s %s"
                   (if modul.FStar_Syntax_Syntax.is_interface
                    then "interface"
-                   else "module") uu____16499 in
-              (let uu____16502 =
+                   else "module") uu___4 in
+              (let uu___5 =
                  FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
-               if uu____16502
+               if uu___5
                then
-                 let uu____16503 =
+                 let uu___6 =
                    FStar_All.pipe_right
                      (FStar_List.length
                         modul.FStar_Syntax_Syntax.declarations)
                      Prims.string_of_int in
                  FStar_Util.print2
                    "+++++++++++Encoding externals for %s ... %s declarations\n"
-                   name uu____16503
+                   name uu___6
                else ());
               (let env =
-                 let uu____16506 =
-                   get_env modul.FStar_Syntax_Syntax.name tcenv in
-                 FStar_All.pipe_right uu____16506
+                 let uu___5 = get_env modul.FStar_Syntax_Syntax.name tcenv in
+                 FStar_All.pipe_right uu___5
                    FStar_SMTEncoding_Env.reset_current_module_fvbs in
                let encode_signature env1 ses =
                  FStar_All.pipe_right ses
                    (FStar_List.fold_left
-                      (fun uu____16545 ->
+                      (fun uu___5 ->
                          fun se ->
-                           match uu____16545 with
+                           match uu___5 with
                            | (g, env2) ->
-                               let uu____16565 =
-                                 encode_top_level_facts env2 se in
-                               (match uu____16565 with
+                               let uu___6 = encode_top_level_facts env2 se in
+                               (match uu___6 with
                                 | (g', env3) ->
                                     ((FStar_List.append g g'), env3)))
                       ([], env1)) in
-               let uu____16588 =
+               let uu___5 =
                  encode_signature
-                   (let uu___1709_16597 = env in
+                   (let uu___6 = env in
                     {
                       FStar_SMTEncoding_Env.bvar_bindings =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.bvar_bindings);
+                        (uu___6.FStar_SMTEncoding_Env.bvar_bindings);
                       FStar_SMTEncoding_Env.fvar_bindings =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.fvar_bindings);
+                        (uu___6.FStar_SMTEncoding_Env.fvar_bindings);
                       FStar_SMTEncoding_Env.depth =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.depth);
+                        (uu___6.FStar_SMTEncoding_Env.depth);
                       FStar_SMTEncoding_Env.tcenv =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.tcenv);
+                        (uu___6.FStar_SMTEncoding_Env.tcenv);
                       FStar_SMTEncoding_Env.warn = false;
                       FStar_SMTEncoding_Env.nolabels =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.nolabels);
+                        (uu___6.FStar_SMTEncoding_Env.nolabels);
                       FStar_SMTEncoding_Env.use_zfuel_name =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.use_zfuel_name);
+                        (uu___6.FStar_SMTEncoding_Env.use_zfuel_name);
                       FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                        (uu___6.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                       FStar_SMTEncoding_Env.current_module_name =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.current_module_name);
+                        (uu___6.FStar_SMTEncoding_Env.current_module_name);
                       FStar_SMTEncoding_Env.encoding_quantifier =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.encoding_quantifier);
+                        (uu___6.FStar_SMTEncoding_Env.encoding_quantifier);
                       FStar_SMTEncoding_Env.global_cache =
-                        (uu___1709_16597.FStar_SMTEncoding_Env.global_cache)
+                        (uu___6.FStar_SMTEncoding_Env.global_cache)
                     }) modul.FStar_Syntax_Syntax.declarations in
-               match uu____16588 with
+               match uu___5 with
                | (decls, env1) ->
                    (give_decls_to_z3_and_set_env env1 name decls;
-                    (let uu____16614 =
+                    (let uu___8 =
                        FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
-                     if uu____16614
+                     if uu___8
                      then
                        FStar_Util.print1 "Done encoding externals for %s\n"
                          name
                      else ());
-                    (let uu____16616 =
+                    (let uu___8 =
                        FStar_All.pipe_right env1
                          FStar_SMTEncoding_Env.get_current_module_fvbs in
-                     (decls, uu____16616))))))
+                     (decls, uu___8))))))
 let (encode_modul_from_cache :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
@@ -6861,49 +6693,47 @@ let (encode_modul_from_cache :
   =
   fun tcenv ->
     fun tcmod ->
-      fun uu____16645 ->
-        match uu____16645 with
+      fun uu___ ->
+        match uu___ with
         | (decls, fvbs) ->
-            let uu____16658 =
-              (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
-            if uu____16658
+            let uu___1 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
+            if uu___1
             then ()
             else
               (let name =
-                 let uu____16661 =
+                 let uu___3 =
                    FStar_Ident.string_of_lid tcmod.FStar_Syntax_Syntax.name in
                  FStar_Util.format2 "%s %s"
                    (if tcmod.FStar_Syntax_Syntax.is_interface
                     then "interface"
-                    else "module") uu____16661 in
-               (let uu____16664 =
+                    else "module") uu___3 in
+               (let uu___4 =
                   FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
-                if uu____16664
+                if uu___4
                 then
-                  let uu____16665 =
+                  let uu___5 =
                     FStar_All.pipe_right (FStar_List.length decls)
                       Prims.string_of_int in
                   FStar_Util.print2
                     "+++++++++++Encoding externals from cache for %s ... %s decls\n"
-                    name uu____16665
+                    name uu___5
                 else ());
                (let env =
-                  let uu____16668 =
-                    get_env tcmod.FStar_Syntax_Syntax.name tcenv in
-                  FStar_All.pipe_right uu____16668
+                  let uu___4 = get_env tcmod.FStar_Syntax_Syntax.name tcenv in
+                  FStar_All.pipe_right uu___4
                     FStar_SMTEncoding_Env.reset_current_module_fvbs in
                 let env1 =
-                  let uu____16670 = FStar_All.pipe_right fvbs FStar_List.rev in
-                  FStar_All.pipe_right uu____16670
+                  let uu___4 = FStar_All.pipe_right fvbs FStar_List.rev in
+                  FStar_All.pipe_right uu___4
                     (FStar_List.fold_left
-                       (fun env1 ->
+                       (fun env2 ->
                           fun fvb ->
                             FStar_SMTEncoding_Env.add_fvar_binding_to_env fvb
-                              env1) env) in
+                              env2) env) in
                 give_decls_to_z3_and_set_env env1 name decls;
-                (let uu____16684 =
+                (let uu___5 =
                    FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
-                 if uu____16684
+                 if uu___5
                  then
                    FStar_Util.print1
                      "Done encoding externals from cache for %s\n" name
@@ -6920,34 +6750,34 @@ let (encode_query :
   fun use_env_msg ->
     fun tcenv ->
       fun q ->
-        (let uu____16739 =
-           let uu____16740 = FStar_TypeChecker_Env.current_module tcenv in
-           FStar_Ident.string_of_lid uu____16740 in
+        (let uu___1 =
+           let uu___2 = FStar_TypeChecker_Env.current_module tcenv in
+           FStar_Ident.string_of_lid uu___2 in
          FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name
-           uu____16739);
+           uu___1);
         (let env =
-           let uu____16742 = FStar_TypeChecker_Env.current_module tcenv in
-           get_env uu____16742 tcenv in
-         let uu____16743 =
+           let uu___1 = FStar_TypeChecker_Env.current_module tcenv in
+           get_env uu___1 tcenv in
+         let uu___1 =
            let rec aux bindings =
              match bindings with
              | (FStar_Syntax_Syntax.Binding_var x)::rest ->
-                 let uu____16780 = aux rest in
-                 (match uu____16780 with
+                 let uu___2 = aux rest in
+                 (match uu___2 with
                   | (out, rest1) ->
                       let t =
-                        let uu____16808 =
+                        let uu___3 =
                           FStar_Syntax_Util.destruct_typ_as_formula
                             x.FStar_Syntax_Syntax.sort in
-                        match uu____16808 with
-                        | FStar_Pervasives_Native.Some uu____16811 ->
-                            let uu____16812 =
+                        match uu___3 with
+                        | FStar_Pervasives_Native.Some uu___4 ->
+                            let uu___5 =
                               FStar_Syntax_Syntax.new_bv
                                 FStar_Pervasives_Native.None
                                 FStar_Syntax_Syntax.t_unit in
-                            FStar_Syntax_Util.refine uu____16812
+                            FStar_Syntax_Util.refine uu___5
                               x.FStar_Syntax_Syntax.sort
-                        | uu____16813 -> x.FStar_Syntax_Syntax.sort in
+                        | uu___4 -> x.FStar_Syntax_Syntax.sort in
                       let t1 =
                         norm_with_steps
                           [FStar_TypeChecker_Env.Eager_unfolding;
@@ -6956,33 +6786,33 @@ let (encode_query :
                           FStar_TypeChecker_Env.Primops;
                           FStar_TypeChecker_Env.EraseUniverses]
                           env.FStar_SMTEncoding_Env.tcenv t in
-                      let uu____16817 =
-                        let uu____16820 =
+                      let uu___3 =
+                        let uu___4 =
                           FStar_Syntax_Syntax.mk_binder
-                            (let uu___1752_16823 = x in
+                            (let uu___5 = x in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1752_16823.FStar_Syntax_Syntax.ppname);
+                                 (uu___5.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1752_16823.FStar_Syntax_Syntax.index);
+                                 (uu___5.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = t1
                              }) in
-                        uu____16820 :: out in
-                      (uu____16817, rest1))
-             | uu____16828 -> ([], bindings) in
-           let uu____16835 = aux tcenv.FStar_TypeChecker_Env.gamma in
-           match uu____16835 with
+                        uu___4 :: out in
+                      (uu___3, rest1))
+             | uu___2 -> ([], bindings) in
+           let uu___2 = aux tcenv.FStar_TypeChecker_Env.gamma in
+           match uu___2 with
            | (closing, bindings) ->
-               let uu____16860 =
+               let uu___3 =
                  FStar_Syntax_Util.close_forall_no_univs
                    (FStar_List.rev closing) q in
-               (uu____16860, bindings) in
-         match uu____16743 with
+               (uu___3, bindings) in
+         match uu___1 with
          | (q1, bindings) ->
-             let uu____16883 = encode_env_bindings env bindings in
-             (match uu____16883 with
+             let uu___2 = encode_env_bindings env bindings in
+             (match uu___2 with
               | (env_decls, env1) ->
-                  ((let uu____16905 =
+                  ((let uu___4 =
                       ((FStar_TypeChecker_Env.debug tcenv
                           FStar_Options.Medium)
                          ||
@@ -6993,79 +6823,72 @@ let (encode_query :
                         (FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug tcenv)
                            (FStar_Options.Other "SMTQuery")) in
-                    if uu____16905
+                    if uu___4
                     then
-                      let uu____16906 = FStar_Syntax_Print.term_to_string q1 in
+                      let uu___5 = FStar_Syntax_Print.term_to_string q1 in
                       FStar_Util.print1 "Encoding query formula {: %s\n"
-                        uu____16906
+                        uu___5
                     else ());
-                   (let uu____16908 =
+                   (let uu___4 =
                       FStar_Util.record_time
-                        (fun uu____16922 ->
+                        (fun uu___5 ->
                            FStar_SMTEncoding_EncodeTerm.encode_formula q1
                              env1) in
-                    match uu____16908 with
+                    match uu___4 with
                     | ((phi, qdecls), ms) ->
-                        let uu____16944 =
-                          let uu____16949 =
-                            FStar_TypeChecker_Env.get_range tcenv in
+                        let uu___5 =
+                          let uu___6 = FStar_TypeChecker_Env.get_range tcenv in
                           FStar_SMTEncoding_ErrorReporting.label_goals
-                            use_env_msg uu____16949 phi in
-                        (match uu____16944 with
+                            use_env_msg uu___6 phi in
+                        (match uu___5 with
                          | (labels, phi1) ->
-                             let uu____16966 = encode_labels labels in
-                             (match uu____16966 with
+                             let uu___6 = encode_labels labels in
+                             (match uu___6 with
                               | (label_prefix, label_suffix) ->
                                   let caption =
-                                    let uu____17002 =
-                                      FStar_Options.log_queries () in
-                                    if uu____17002
+                                    let uu___7 = FStar_Options.log_queries () in
+                                    if uu___7
                                     then
-                                      let uu____17005 =
-                                        let uu____17006 =
-                                          let uu____17007 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             FStar_Syntax_Print.term_to_string
                                               q1 in
                                           Prims.op_Hat
                                             "Encoding query formula : "
-                                            uu____17007 in
-                                        FStar_SMTEncoding_Term.Caption
-                                          uu____17006 in
-                                      [uu____17005]
+                                            uu___10 in
+                                        FStar_SMTEncoding_Term.Caption uu___9 in
+                                      [uu___8]
                                     else [] in
                                   let query_prelude =
-                                    let uu____17012 =
-                                      let uu____17013 =
-                                        let uu____17014 =
-                                          let uu____17017 =
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             FStar_All.pipe_right label_prefix
                                               FStar_SMTEncoding_Term.mk_decls_trivial in
-                                          let uu____17024 =
-                                            let uu____17027 =
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_All.pipe_right caption
                                                 FStar_SMTEncoding_Term.mk_decls_trivial in
-                                            FStar_List.append qdecls
-                                              uu____17027 in
-                                          FStar_List.append uu____17017
-                                            uu____17024 in
-                                        FStar_List.append env_decls
-                                          uu____17014 in
-                                      FStar_All.pipe_right uu____17013
+                                            FStar_List.append qdecls uu___12 in
+                                          FStar_List.append uu___10 uu___11 in
+                                        FStar_List.append env_decls uu___9 in
+                                      FStar_All.pipe_right uu___8
                                         (recover_caching_and_update_env env1) in
-                                    FStar_All.pipe_right uu____17012
+                                    FStar_All.pipe_right uu___7
                                       FStar_SMTEncoding_Term.decls_list_of in
                                   let qry =
-                                    let uu____17037 =
-                                      let uu____17044 =
+                                    let uu___7 =
+                                      let uu___8 =
                                         FStar_SMTEncoding_Util.mkNot phi1 in
-                                      let uu____17045 =
+                                      let uu___9 =
                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
                                           "@query" in
-                                      (uu____17044,
+                                      (uu___8,
                                         (FStar_Pervasives_Native.Some "query"),
-                                        uu____17045) in
-                                    FStar_SMTEncoding_Util.mkAssume
-                                      uu____17037 in
+                                        uu___9) in
+                                    FStar_SMTEncoding_Util.mkAssume uu___7 in
                                   let suffix =
                                     FStar_List.append
                                       [FStar_SMTEncoding_Term.Echo "<labels>"]
@@ -7073,7 +6896,7 @@ let (encode_query :
                                          [FStar_SMTEncoding_Term.Echo
                                             "</labels>";
                                          FStar_SMTEncoding_Term.Echo "Done!"]) in
-                                  ((let uu____17050 =
+                                  ((let uu___8 =
                                       ((FStar_TypeChecker_Env.debug tcenv
                                           FStar_Options.Medium)
                                          ||
@@ -7086,12 +6909,12 @@ let (encode_query :
                                         (FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "SMTQuery")) in
-                                    if uu____17050
+                                    if uu___8
                                     then
                                       FStar_Util.print_string
                                         "} Done encoding\n"
                                     else ());
-                                   (let uu____17053 =
+                                   (let uu___9 =
                                       (((FStar_TypeChecker_Env.debug tcenv
                                            FStar_Options.Medium)
                                           ||
@@ -7109,7 +6932,7 @@ let (encode_query :
                                         (FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "Time")) in
-                                    if uu____17053
+                                    if uu___9
                                     then
                                       FStar_Util.print1
                                         "Encoding took %sms\n"

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -1,9 +1,9 @@
 open Prims
 let mkForall_fuel' :
-  'uuuuuu14 .
+  'uuuuu .
     Prims.string ->
       FStar_Range.range ->
-        'uuuuuu14 ->
+        'uuuuu ->
           (FStar_SMTEncoding_Term.pat Prims.list Prims.list *
             FStar_SMTEncoding_Term.fvs * FStar_SMTEncoding_Term.term) ->
             FStar_SMTEncoding_Term.term
@@ -11,19 +11,19 @@ let mkForall_fuel' :
   fun mname ->
     fun r ->
       fun n ->
-        fun uu____44 ->
-          match uu____44 with
+        fun uu___ ->
+          match uu___ with
           | (pats, vars, body) ->
-              let fallback uu____71 =
+              let fallback uu___1 =
                 FStar_SMTEncoding_Term.mkForall r (pats, vars, body) in
-              let uu____76 = FStar_Options.unthrottle_inductives () in
-              if uu____76
+              let uu___1 = FStar_Options.unthrottle_inductives () in
+              if uu___1
               then fallback ()
               else
-                (let uu____78 =
+                (let uu___3 =
                    FStar_SMTEncoding_Env.fresh_fvar mname "f"
                      FStar_SMTEncoding_Term.Fuel_sort in
-                 match uu____78 with
+                 match uu___3 with
                  | (fsym, fterm) ->
                      let add_fuel tms =
                        FStar_All.pipe_right tms
@@ -36,7 +36,7 @@ let mkForall_fuel' :
                                    ->
                                    FStar_SMTEncoding_Util.mkApp
                                      ("HasTypeFuel", (fterm :: args))
-                               | uu____111 -> p)) in
+                               | uu___4 -> p)) in
                      let pats1 = FStar_List.map add_fuel pats in
                      let body1 =
                        match body.FStar_SMTEncoding_Term.tm with
@@ -46,18 +46,18 @@ let mkForall_fuel' :
                              match guard.FStar_SMTEncoding_Term.tm with
                              | FStar_SMTEncoding_Term.App
                                  (FStar_SMTEncoding_Term.And, guards) ->
-                                 let uu____132 = add_fuel guards in
-                                 FStar_SMTEncoding_Util.mk_and_l uu____132
-                             | uu____135 ->
-                                 let uu____136 = add_fuel [guard] in
-                                 FStar_All.pipe_right uu____136 FStar_List.hd in
+                                 let uu___4 = add_fuel guards in
+                                 FStar_SMTEncoding_Util.mk_and_l uu___4
+                             | uu___4 ->
+                                 let uu___5 = add_fuel [guard] in
+                                 FStar_All.pipe_right uu___5 FStar_List.hd in
                            FStar_SMTEncoding_Util.mkImp (guard1, body')
-                       | uu____141 -> body in
+                       | uu___4 -> body in
                      let vars1 =
-                       let uu____151 =
+                       let uu___4 =
                          FStar_SMTEncoding_Term.mk_fv
                            (fsym, FStar_SMTEncoding_Term.Fuel_sort) in
-                       uu____151 :: vars in
+                       uu___4 :: vars in
                      FStar_SMTEncoding_Term.mkForall r (pats1, vars1, body1))
 let (mkForall_fuel :
   Prims.string ->
@@ -72,42 +72,42 @@ let (head_normal :
     fun t ->
       let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_arrow uu____202 -> true
-      | FStar_Syntax_Syntax.Tm_refine uu____217 -> true
-      | FStar_Syntax_Syntax.Tm_bvar uu____224 -> true
-      | FStar_Syntax_Syntax.Tm_uvar uu____225 -> true
-      | FStar_Syntax_Syntax.Tm_abs uu____238 -> true
-      | FStar_Syntax_Syntax.Tm_constant uu____257 -> true
+      | FStar_Syntax_Syntax.Tm_arrow uu___ -> true
+      | FStar_Syntax_Syntax.Tm_refine uu___ -> true
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> true
+      | FStar_Syntax_Syntax.Tm_uvar uu___ -> true
+      | FStar_Syntax_Syntax.Tm_abs uu___ -> true
+      | FStar_Syntax_Syntax.Tm_constant uu___ -> true
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____259 =
+          let uu___ =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_All.pipe_right uu____259 FStar_Option.isNone
+          FStar_All.pipe_right uu___ FStar_Option.isNone
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____277;
-             FStar_Syntax_Syntax.vars = uu____278;_},
-           uu____279)
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
+           uu___2)
           ->
-          let uu____304 =
+          let uu___3 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_All.pipe_right uu____304 FStar_Option.isNone
-      | uu____321 -> false
+          FStar_All.pipe_right uu___3 FStar_Option.isNone
+      | uu___ -> false
 let (head_redex :
   FStar_SMTEncoding_Env.env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env ->
     fun t ->
-      let uu____332 =
-        let uu____333 = FStar_Syntax_Util.un_uinst t in
-        uu____333.FStar_Syntax_Syntax.n in
-      match uu____332 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.un_uinst t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_abs
-          (uu____336, uu____337, FStar_Pervasives_Native.Some rc) ->
+          (uu___1, uu___2, FStar_Pervasives_Native.Some rc) ->
           ((FStar_Ident.lid_equals rc.FStar_Syntax_Syntax.residual_effect
               FStar_Parser_Const.effect_Tot_lid)
              ||
@@ -115,18 +115,18 @@ let (head_redex :
                 FStar_Parser_Const.effect_GTot_lid))
             ||
             (FStar_List.existsb
-               (fun uu___0_362 ->
-                  match uu___0_362 with
+               (fun uu___3 ->
+                  match uu___3 with
                   | FStar_Syntax_Syntax.TOTAL -> true
-                  | uu____363 -> false) rc.FStar_Syntax_Syntax.residual_flags)
+                  | uu___4 -> false) rc.FStar_Syntax_Syntax.residual_flags)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____365 =
+          let uu___1 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_All.pipe_right uu____365 FStar_Option.isSome
-      | uu____382 -> false
+          FStar_All.pipe_right uu___1 FStar_Option.isSome
+      | uu___1 -> false
 let (norm_with_steps :
   FStar_TypeChecker_Env.steps ->
     FStar_TypeChecker_Env.env ->
@@ -135,15 +135,14 @@ let (norm_with_steps :
   fun steps ->
     fun env ->
       fun t ->
-        let uu____398 =
-          let uu____401 =
-            let uu____402 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.string_of_lid uu____402 in
-          FStar_Pervasives_Native.Some uu____401 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
         FStar_Profiling.profile
-          (fun uu____404 -> FStar_TypeChecker_Normalize.normalize steps env t)
-          uu____398
-          "FStar.TypeChecker.SMTEncoding.EncodeTerm.norm_with_steps"
+          (fun uu___1 -> FStar_TypeChecker_Normalize.normalize steps env t)
+          uu___ "FStar.TypeChecker.SMTEncoding.EncodeTerm.norm_with_steps"
 let (normalize_refinement :
   FStar_TypeChecker_Env.steps ->
     FStar_TypeChecker_Env.env ->
@@ -152,15 +151,15 @@ let (normalize_refinement :
   fun steps ->
     fun env ->
       fun t ->
-        let uu____420 =
-          let uu____423 =
-            let uu____424 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.string_of_lid uu____424 in
-          FStar_Pervasives_Native.Some uu____423 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
         FStar_Profiling.profile
-          (fun uu____426 ->
+          (fun uu___1 ->
              FStar_TypeChecker_Normalize.normalize_refinement steps env t)
-          uu____420
+          uu___
           "FStar.TypeChecker.SMTEncoding.EncodeTerm.normalize_refinement"
 let (whnf :
   FStar_SMTEncoding_Env.env_t ->
@@ -168,8 +167,8 @@ let (whnf :
   =
   fun env ->
     fun t ->
-      let uu____437 = head_normal env t in
-      if uu____437
+      let uu___ = head_normal env t in
+      if uu___
       then t
       else
         norm_with_steps
@@ -200,21 +199,20 @@ let (maybe_whnf :
   fun env ->
     fun t ->
       let t' = whnf env t in
-      let uu____462 = FStar_Syntax_Util.head_and_args t' in
-      match uu____462 with
-      | (head', uu____482) ->
-          let uu____507 = head_redex env head' in
-          if uu____507
+      let uu___ = FStar_Syntax_Util.head_and_args t' in
+      match uu___ with
+      | (head', uu___1) ->
+          let uu___2 = head_redex env head' in
+          if uu___2
           then FStar_Pervasives_Native.None
           else FStar_Pervasives_Native.Some t'
 let (trivial_post : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____516 =
-      let uu____517 = FStar_Syntax_Syntax.null_binder t in [uu____517] in
-    let uu____536 =
+    let uu___ = let uu___1 = FStar_Syntax_Syntax.null_binder t in [uu___1] in
+    let uu___1 =
       FStar_Syntax_Syntax.fvar FStar_Parser_Const.true_lid
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-    FStar_Syntax_Util.abs uu____516 uu____536 FStar_Pervasives_Native.None
+    FStar_Syntax_Util.abs uu___ uu___1 FStar_Pervasives_Native.None
 let (mk_Apply :
   FStar_SMTEncoding_Term.term ->
     FStar_SMTEncoding_Term.fvs -> FStar_SMTEncoding_Term.term)
@@ -225,14 +223,14 @@ let (mk_Apply :
         (FStar_List.fold_left
            (fun out ->
               fun var ->
-                let uu____557 = FStar_SMTEncoding_Term.fv_sort var in
-                match uu____557 with
+                let uu___ = FStar_SMTEncoding_Term.fv_sort var in
+                match uu___ with
                 | FStar_SMTEncoding_Term.Fuel_sort ->
-                    let uu____558 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Term.mk_ApplyTF out uu____558
+                    let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
+                    FStar_SMTEncoding_Term.mk_ApplyTF out uu___1
                 | s ->
-                    let uu____560 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Util.mk_ApplyTT out uu____560) e)
+                    let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
+                    FStar_SMTEncoding_Util.mk_ApplyTT out uu___1) e)
 let (mk_Apply_args :
   FStar_SMTEncoding_Term.term ->
     FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term)
@@ -247,15 +245,15 @@ let raise_arity_mismatch :
     fun arity ->
       fun n_args ->
         fun rng ->
-          let uu____608 =
-            let uu____613 =
-              let uu____614 = FStar_Util.string_of_int arity in
-              let uu____615 = FStar_Util.string_of_int n_args in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Util.string_of_int arity in
+              let uu___3 = FStar_Util.string_of_int n_args in
               FStar_Util.format3
                 "Head symbol %s expects at least %s arguments; got only %s"
-                head uu____614 uu____615 in
-            (FStar_Errors.Fatal_SMTEncodingArityMismatch, uu____613) in
-          FStar_Errors.raise_error uu____608 rng
+                head uu___2 uu___3 in
+            (FStar_Errors.Fatal_SMTEncodingArityMismatch, uu___1) in
+          FStar_Errors.raise_error uu___ rng
 let (isTotFun_axioms :
   FStar_Range.range ->
     FStar_SMTEncoding_Term.term ->
@@ -271,31 +269,29 @@ let (isTotFun_axioms :
             let maybe_mkForall pat vars1 body =
               match vars1 with
               | [] -> body
-              | uu____691 ->
+              | uu___ ->
                   FStar_SMTEncoding_Term.mkForall pos (pat, vars1, body) in
             let rec is_tot_fun_axioms ctx ctx_guard head1 vars1 guards1 =
               match (vars1, guards1) with
               | ([], []) -> FStar_SMTEncoding_Util.mkTrue
-              | (uu____792::[], uu____793) ->
+              | (uu___::[], uu___1) ->
                   if is_pure
                   then
-                    let uu____824 =
-                      let uu____825 =
-                        let uu____830 =
-                          FStar_SMTEncoding_Term.mk_IsTotFun head1 in
-                        (ctx_guard, uu____830) in
-                      FStar_SMTEncoding_Util.mkImp uu____825 in
-                    maybe_mkForall [[head1]] ctx uu____824
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = FStar_SMTEncoding_Term.mk_IsTotFun head1 in
+                        (ctx_guard, uu___4) in
+                      FStar_SMTEncoding_Util.mkImp uu___3 in
+                    maybe_mkForall [[head1]] ctx uu___2
                   else FStar_SMTEncoding_Util.mkTrue
               | (x::vars2, g_x::guards2) ->
                   let is_tot_fun_head =
-                    let uu____873 =
-                      let uu____874 =
-                        let uu____879 =
-                          FStar_SMTEncoding_Term.mk_IsTotFun head1 in
-                        (ctx_guard, uu____879) in
-                      FStar_SMTEncoding_Util.mkImp uu____874 in
-                    maybe_mkForall [[head1]] ctx uu____873 in
+                    let uu___ =
+                      let uu___1 =
+                        let uu___2 = FStar_SMTEncoding_Term.mk_IsTotFun head1 in
+                        (ctx_guard, uu___2) in
+                      FStar_SMTEncoding_Util.mkImp uu___1 in
+                    maybe_mkForall [[head1]] ctx uu___ in
                   let app = mk_Apply head1 [x] in
                   let ctx1 = FStar_List.append ctx [x] in
                   let ctx_guard1 =
@@ -303,7 +299,7 @@ let (isTotFun_axioms :
                   let rest =
                     is_tot_fun_axioms ctx1 ctx_guard1 app vars2 guards2 in
                   FStar_SMTEncoding_Util.mkAnd (is_tot_fun_head, rest)
-              | uu____926 -> failwith "impossible: isTotFun_axioms" in
+              | uu___ -> failwith "impossible: isTotFun_axioms" in
             is_tot_fun_axioms [] FStar_SMTEncoding_Util.mkTrue head vars
               guards
 let (maybe_curry_app :
@@ -326,15 +322,15 @@ let (maybe_curry_app :
               else
                 if n_args > arity
                 then
-                  (let uu____985 = FStar_Util.first_N arity args in
-                   match uu____985 with
+                  (let uu___1 = FStar_Util.first_N arity args in
+                   match uu___1 with
                    | (args1, rest) ->
                        let head2 =
                          FStar_SMTEncoding_Util.mkApp' (head1, args1) in
                        mk_Apply_args head2 rest)
                 else
-                  (let uu____1008 = FStar_SMTEncoding_Term.op_to_string head1 in
-                   raise_arity_mismatch uu____1008 arity n_args rng)
+                  (let uu___2 = FStar_SMTEncoding_Term.op_to_string head1 in
+                   raise_arity_mismatch uu___2 arity n_args rng)
 let (maybe_curry_fvb :
   FStar_Range.range ->
     FStar_SMTEncoding_Env.fvar_binding ->
@@ -345,19 +341,19 @@ let (maybe_curry_fvb :
       fun args ->
         if fvb.FStar_SMTEncoding_Env.fvb_thunked
         then
-          let uu____1028 = FStar_SMTEncoding_Env.force_thunk fvb in
-          mk_Apply_args uu____1028 args
+          let uu___ = FStar_SMTEncoding_Env.force_thunk fvb in
+          mk_Apply_args uu___ args
         else
           maybe_curry_app rng
             (FStar_Util.Inl
                (FStar_SMTEncoding_Term.Var (fvb.FStar_SMTEncoding_Env.smt_id)))
             fvb.FStar_SMTEncoding_Env.smt_arity args
 let (is_app : FStar_SMTEncoding_Term.op -> Prims.bool) =
-  fun uu___1_1034 ->
-    match uu___1_1034 with
+  fun uu___ ->
+    match uu___ with
     | FStar_SMTEncoding_Term.Var "ApplyTT" -> true
     | FStar_SMTEncoding_Term.Var "ApplyTF" -> true
-    | uu____1035 -> false
+    | uu___1 -> false
 let (is_an_eta_expansion :
   FStar_SMTEncoding_Env.env_t ->
     FStar_SMTEncoding_Term.fv Prims.list ->
@@ -373,13 +369,13 @@ let (is_an_eta_expansion :
              (app,
               f::{
                    FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV y;
-                   FStar_SMTEncoding_Term.freevars = uu____1081;
-                   FStar_SMTEncoding_Term.rng = uu____1082;_}::[]),
+                   FStar_SMTEncoding_Term.freevars = uu___;
+                   FStar_SMTEncoding_Term.rng = uu___1;_}::[]),
              x::xs1) when (is_app app) && (FStar_SMTEncoding_Term.fv_eq x y)
               -> check_partial_applications f xs1
           | (FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Var f, args),
-             uu____1109) ->
-              let uu____1118 =
+             uu___) ->
+              let uu___1 =
                 ((FStar_List.length args) = (FStar_List.length xs)) &&
                   (FStar_List.forall2
                      (fun a ->
@@ -387,49 +383,49 @@ let (is_an_eta_expansion :
                           match a.FStar_SMTEncoding_Term.tm with
                           | FStar_SMTEncoding_Term.FreeV fv ->
                               FStar_SMTEncoding_Term.fv_eq fv v
-                          | uu____1131 -> false) args (FStar_List.rev xs)) in
-              if uu____1118
+                          | uu___2 -> false) args (FStar_List.rev xs)) in
+              if uu___1
               then
                 let n = FStar_SMTEncoding_Env.tok_of_name env f in
-                ((let uu____1138 =
+                ((let uu___3 =
                     FStar_All.pipe_left
                       (FStar_TypeChecker_Env.debug
                          env.FStar_SMTEncoding_Env.tcenv)
                       (FStar_Options.Other "PartialApp") in
-                  if uu____1138
+                  if uu___3
                   then
-                    let uu____1139 = FStar_SMTEncoding_Term.print_smt_term t in
-                    let uu____1140 =
+                    let uu___4 = FStar_SMTEncoding_Term.print_smt_term t in
+                    let uu___5 =
                       match n with
                       | FStar_Pervasives_Native.None -> "None"
                       | FStar_Pervasives_Native.Some x ->
                           FStar_SMTEncoding_Term.print_smt_term x in
                     FStar_Util.print2
-                      "is_eta_expansion %s  ... tok_of_name = %s\n"
-                      uu____1139 uu____1140
+                      "is_eta_expansion %s  ... tok_of_name = %s\n" uu___4
+                      uu___5
                   else ());
                  n)
               else FStar_Pervasives_Native.None
-          | (uu____1144, []) ->
+          | (uu___, []) ->
               let fvs = FStar_SMTEncoding_Term.free_variables t in
-              let uu____1148 =
+              let uu___1 =
                 FStar_All.pipe_right fvs
                   (FStar_List.for_all
                      (fun fv ->
-                        let uu____1154 =
+                        let uu___2 =
                           FStar_Util.for_some
                             (FStar_SMTEncoding_Term.fv_eq fv) vars in
-                        Prims.op_Negation uu____1154)) in
-              if uu____1148
+                        Prims.op_Negation uu___2)) in
+              if uu___1
               then FStar_Pervasives_Native.Some t
               else FStar_Pervasives_Native.None
-          | uu____1158 -> FStar_Pervasives_Native.None in
+          | uu___ -> FStar_Pervasives_Native.None in
         check_partial_applications body (FStar_List.rev vars)
 let check_pattern_vars :
-  'uuuuuu1175 'uuuuuu1176 .
+  'uuuuu 'uuuuu1 .
     FStar_SMTEncoding_Env.env_t ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu1175) Prims.list ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1176) Prims.list -> unit
+      (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuu1) Prims.list -> unit
   =
   fun env ->
     fun vars ->
@@ -437,9 +433,9 @@ let check_pattern_vars :
         let pats1 =
           FStar_All.pipe_right pats
             (FStar_List.map
-               (fun uu____1234 ->
-                  match uu____1234 with
-                  | (x, uu____1240) ->
+               (fun uu___ ->
+                  match uu___ with
+                  | (x, uu___1) ->
                       norm_with_steps
                         [FStar_TypeChecker_Env.Beta;
                         FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -449,23 +445,23 @@ let check_pattern_vars :
         | [] -> ()
         | hd::tl ->
             let pat_vars =
-              let uu____1248 = FStar_Syntax_Free.names hd in
+              let uu___ = FStar_Syntax_Free.names hd in
               FStar_List.fold_left
                 (fun out ->
                    fun x ->
-                     let uu____1260 = FStar_Syntax_Free.names x in
-                     FStar_Util.set_union out uu____1260) uu____1248 tl in
-            let uu____1263 =
+                     let uu___1 = FStar_Syntax_Free.names x in
+                     FStar_Util.set_union out uu___1) uu___ tl in
+            let uu___ =
               FStar_All.pipe_right vars
                 (FStar_Util.find_opt
-                   (fun uu____1290 ->
-                      match uu____1290 with
-                      | (b, uu____1296) ->
-                          let uu____1297 = FStar_Util.set_mem b pat_vars in
-                          Prims.op_Negation uu____1297)) in
-            (match uu____1263 with
+                   (fun uu___1 ->
+                      match uu___1 with
+                      | (b, uu___2) ->
+                          let uu___3 = FStar_Util.set_mem b pat_vars in
+                          Prims.op_Negation uu___3)) in
+            (match uu___ with
              | FStar_Pervasives_Native.None -> ()
-             | FStar_Pervasives_Native.Some (x, uu____1303) ->
+             | FStar_Pervasives_Native.Some (x, uu___1) ->
                  let pos =
                    FStar_List.fold_left
                      (fun out ->
@@ -473,14 +469,14 @@ let check_pattern_vars :
                           FStar_Range.union_ranges out
                             t.FStar_Syntax_Syntax.pos)
                      hd.FStar_Syntax_Syntax.pos tl in
-                 let uu____1317 =
-                   let uu____1322 =
-                     let uu____1323 = FStar_Syntax_Print.bv_to_string x in
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Print.bv_to_string x in
                      FStar_Util.format1
                        "SMT pattern misses at least one bound variable: %s"
-                       uu____1323 in
-                   (FStar_Errors.Warning_SMTPatternIllFormed, uu____1322) in
-                 FStar_Errors.log_issue pos uu____1317)
+                       uu___4 in
+                   (FStar_Errors.Warning_SMTPatternIllFormed, uu___3) in
+                 FStar_Errors.log_issue pos uu___2)
 type label = (FStar_SMTEncoding_Term.fv * Prims.string * FStar_Range.range)
 type labels = label Prims.list
 type pattern =
@@ -529,21 +525,20 @@ let (as_function_typ :
       let rec aux norm1 t =
         let t1 = FStar_Syntax_Subst.compress t in
         match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_arrow uu____1598 -> t1
-        | FStar_Syntax_Syntax.Tm_refine uu____1613 ->
-            let uu____1620 = FStar_Syntax_Util.unrefine t1 in
-            aux true uu____1620
-        | uu____1621 ->
+        | FStar_Syntax_Syntax.Tm_arrow uu___ -> t1
+        | FStar_Syntax_Syntax.Tm_refine uu___ ->
+            let uu___1 = FStar_Syntax_Util.unrefine t1 in aux true uu___1
+        | uu___ ->
             if norm1
-            then let uu____1622 = whnf env t1 in aux false uu____1622
+            then let uu___1 = whnf env t1 in aux false uu___1
             else
-              (let uu____1624 =
-                 let uu____1625 =
+              (let uu___2 =
+                 let uu___3 =
                    FStar_Range.string_of_range t0.FStar_Syntax_Syntax.pos in
-                 let uu____1626 = FStar_Syntax_Print.term_to_string t0 in
+                 let uu___4 = FStar_Syntax_Print.term_to_string t0 in
                  FStar_Util.format2 "(%s) Expected a function typ; got %s"
-                   uu____1625 uu____1626 in
-               failwith uu____1624) in
+                   uu___3 uu___4 in
+               failwith uu___2) in
       aux true t0
 let rec (curried_arrow_formals_comp :
   FStar_Syntax_Syntax.term ->
@@ -554,27 +549,25 @@ let rec (curried_arrow_formals_comp :
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
         FStar_Syntax_Subst.open_comp bs c
-    | FStar_Syntax_Syntax.Tm_refine (bv, uu____1664) ->
-        let uu____1669 =
-          curried_arrow_formals_comp bv.FStar_Syntax_Syntax.sort in
-        (match uu____1669 with
+    | FStar_Syntax_Syntax.Tm_refine (bv, uu___) ->
+        let uu___1 = curried_arrow_formals_comp bv.FStar_Syntax_Syntax.sort in
+        (match uu___1 with
          | (args, res) ->
              (match args with
               | [] ->
-                  let uu____1690 = FStar_Syntax_Syntax.mk_Total k1 in
-                  ([], uu____1690)
-              | uu____1697 -> (args, res)))
-    | uu____1698 ->
-        let uu____1699 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____1699)
+                  let uu___2 = FStar_Syntax_Syntax.mk_Total k1 in
+                  ([], uu___2)
+              | uu___2 -> (args, res)))
+    | uu___ -> let uu___1 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu___1)
 let is_arithmetic_primitive :
-  'uuuuuu1712 .
+  'uuuuu .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      'uuuuuu1712 Prims.list -> Prims.bool
+      'uuuuu Prims.list -> Prims.bool
   =
   fun head ->
     fun args ->
       match ((head.FStar_Syntax_Syntax.n), args) with
-      | (FStar_Syntax_Syntax.Tm_fvar fv, uu____1734::uu____1735::[]) ->
+      | (FStar_Syntax_Syntax.Tm_fvar fv, uu___::uu___1::[]) ->
           ((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.op_Addition)
                        ||
@@ -613,32 +606,32 @@ let is_arithmetic_primitive :
             ||
             (FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.real_op_Division)
-      | (FStar_Syntax_Syntax.Tm_fvar fv, uu____1739::[]) ->
+      | (FStar_Syntax_Syntax.Tm_fvar fv, uu___::[]) ->
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.op_Minus
-      | uu____1742 -> false
+      | uu___ -> false
 let (isInteger : FStar_Syntax_Syntax.term' -> Prims.bool) =
   fun tm ->
     match tm with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
         (n, FStar_Pervasives_Native.None)) -> true
-    | uu____1765 -> false
+    | uu___ -> false
 let (getInteger : FStar_Syntax_Syntax.term' -> Prims.int) =
   fun tm ->
     match tm with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
         (n, FStar_Pervasives_Native.None)) -> FStar_Util.int_of_string n
-    | uu____1782 -> failwith "Expected an Integer term"
+    | uu___ -> failwith "Expected an Integer term"
 let is_BitVector_primitive :
-  'uuuuuu1789 .
+  'uuuuu .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax * 'uuuuuu1789)
+      (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax * 'uuuuu)
         Prims.list -> Prims.bool
   =
   fun head ->
     fun args ->
       match ((head.FStar_Syntax_Syntax.n), args) with
-      | (FStar_Syntax_Syntax.Tm_fvar fv,
-         (sz_arg, uu____1830)::uu____1831::uu____1832::[]) ->
+      | (FStar_Syntax_Syntax.Tm_fvar fv, (sz_arg, uu___)::uu___1::uu___2::[])
+          ->
           (((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.bv_and_lid)
                       ||
@@ -671,14 +664,13 @@ let is_BitVector_primitive :
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.bv_mul_lid))
             && (isInteger sz_arg.FStar_Syntax_Syntax.n)
-      | (FStar_Syntax_Syntax.Tm_fvar fv,
-         (sz_arg, uu____1883)::uu____1884::[]) ->
+      | (FStar_Syntax_Syntax.Tm_fvar fv, (sz_arg, uu___)::uu___1::[]) ->
           ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nat_to_bv_lid)
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv
                 FStar_Parser_Const.bv_to_nat_lid))
             && (isInteger sz_arg.FStar_Syntax_Syntax.n)
-      | uu____1921 -> false
+      | uu___ -> false
 let rec (encode_const :
   FStar_Const.sconst ->
     FStar_SMTEncoding_Env.env_t ->
@@ -689,56 +681,56 @@ let rec (encode_const :
       match c with
       | FStar_Const.Const_unit -> (FStar_SMTEncoding_Term.mk_Term_unit, [])
       | FStar_Const.Const_bool (true) ->
-          let uu____2242 =
+          let uu___ =
             FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue in
-          (uu____2242, [])
+          (uu___, [])
       | FStar_Const.Const_bool (false) ->
-          let uu____2243 =
+          let uu___ =
             FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkFalse in
-          (uu____2243, [])
+          (uu___, [])
       | FStar_Const.Const_char c1 ->
-          let uu____2245 =
-            let uu____2246 =
-              let uu____2253 =
-                let uu____2256 =
-                  let uu____2257 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
                     FStar_SMTEncoding_Util.mkInteger'
                       (FStar_Util.int_of_char c1) in
-                  FStar_SMTEncoding_Term.boxInt uu____2257 in
-                [uu____2256] in
-              ("FStar.Char.__char_of_int", uu____2253) in
-            FStar_SMTEncoding_Util.mkApp uu____2246 in
-          (uu____2245, [])
+                  FStar_SMTEncoding_Term.boxInt uu___4 in
+                [uu___3] in
+              ("FStar.Char.__char_of_int", uu___2) in
+            FStar_SMTEncoding_Util.mkApp uu___1 in
+          (uu___, [])
       | FStar_Const.Const_int (i, FStar_Pervasives_Native.None) ->
-          let uu____2271 =
-            let uu____2272 = FStar_SMTEncoding_Util.mkInteger i in
-            FStar_SMTEncoding_Term.boxInt uu____2272 in
-          (uu____2271, [])
+          let uu___ =
+            let uu___1 = FStar_SMTEncoding_Util.mkInteger i in
+            FStar_SMTEncoding_Term.boxInt uu___1 in
+          (uu___, [])
       | FStar_Const.Const_int (repr, FStar_Pervasives_Native.Some sw) ->
           let syntax_term =
             FStar_ToSyntax_ToSyntax.desugar_machine_integer
               (env.FStar_SMTEncoding_Env.tcenv).FStar_TypeChecker_Env.dsenv
               repr sw FStar_Range.dummyRange in
           encode_term syntax_term env
-      | FStar_Const.Const_string (s, uu____2291) ->
-          let uu____2292 =
-            let uu____2293 = FStar_SMTEncoding_Util.mk_String_const s in
-            FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____2293 in
-          (uu____2292, [])
-      | FStar_Const.Const_range uu____2294 ->
-          let uu____2295 = FStar_SMTEncoding_Term.mk_Range_const () in
-          (uu____2295, [])
+      | FStar_Const.Const_string (s, uu___) ->
+          let uu___1 =
+            let uu___2 = FStar_SMTEncoding_Util.mk_String_const s in
+            FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu___2 in
+          (uu___1, [])
+      | FStar_Const.Const_range uu___ ->
+          let uu___1 = FStar_SMTEncoding_Term.mk_Range_const () in
+          (uu___1, [])
       | FStar_Const.Const_effect -> (FStar_SMTEncoding_Term.mk_Term_type, [])
       | FStar_Const.Const_real r ->
-          let uu____2297 =
-            let uu____2298 = FStar_SMTEncoding_Util.mkReal r in
-            FStar_SMTEncoding_Term.boxReal uu____2298 in
-          (uu____2297, [])
+          let uu___ =
+            let uu___1 = FStar_SMTEncoding_Util.mkReal r in
+            FStar_SMTEncoding_Term.boxReal uu___1 in
+          (uu___, [])
       | c1 ->
-          let uu____2300 =
-            let uu____2301 = FStar_Syntax_Print.const_to_string c1 in
-            FStar_Util.format1 "Unhandled constant: %s" uu____2301 in
-          failwith uu____2300
+          let uu___ =
+            let uu___1 = FStar_Syntax_Print.const_to_string c1 in
+            FStar_Util.format1 "Unhandled constant: %s" uu___1 in
+          failwith uu___
 and (encode_binders :
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.binders ->
@@ -750,44 +742,44 @@ and (encode_binders :
   fun fuel_opt ->
     fun bs ->
       fun env ->
-        (let uu____2328 =
+        (let uu___1 =
            FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
              FStar_Options.Medium in
-         if uu____2328
+         if uu___1
          then
-           let uu____2329 = FStar_Syntax_Print.binders_to_string ", " bs in
-           FStar_Util.print1 "Encoding binders %s\n" uu____2329
+           let uu___2 = FStar_Syntax_Print.binders_to_string ", " bs in
+           FStar_Util.print1 "Encoding binders %s\n" uu___2
          else ());
-        (let uu____2331 =
+        (let uu___1 =
            FStar_All.pipe_right bs
              (FStar_List.fold_left
-                (fun uu____2413 ->
+                (fun uu___2 ->
                    fun b ->
-                     match uu____2413 with
+                     match uu___2 with
                      | (vars, guards, env1, decls, names) ->
-                         let uu____2478 =
+                         let uu___3 =
                            let x = FStar_Pervasives_Native.fst b in
-                           let uu____2494 =
+                           let uu___4 =
                              FStar_SMTEncoding_Env.gen_term_var env1 x in
-                           match uu____2494 with
+                           match uu___4 with
                            | (xxsym, xx, env') ->
-                               let uu____2516 =
-                                 let uu____2521 =
+                               let uu___5 =
+                                 let uu___6 =
                                    norm env1 x.FStar_Syntax_Syntax.sort in
-                                 encode_term_pred fuel_opt uu____2521 env1 xx in
-                               (match uu____2516 with
+                                 encode_term_pred fuel_opt uu___6 env1 xx in
+                               (match uu___5 with
                                 | (guard_x_t, decls') ->
-                                    let uu____2536 =
+                                    let uu___6 =
                                       FStar_SMTEncoding_Term.mk_fv
                                         (xxsym,
                                           FStar_SMTEncoding_Term.Term_sort) in
-                                    (uu____2536, guard_x_t, env', decls', x)) in
-                         (match uu____2478 with
+                                    (uu___6, guard_x_t, env', decls', x)) in
+                         (match uu___3 with
                           | (v, g, env2, decls', n) ->
                               ((v :: vars), (g :: guards), env2,
                                 (FStar_List.append decls decls'), (n ::
                                 names)))) ([], [], env, [], [])) in
-         match uu____2331 with
+         match uu___1 with
          | (vars, guards, env1, decls, names) ->
              ((FStar_List.rev vars), (FStar_List.rev guards), env1, decls,
                (FStar_List.rev names)))
@@ -802,12 +794,12 @@ and (encode_term_pred :
     fun t ->
       fun env ->
         fun e ->
-          let uu____2635 = encode_term t env in
-          match uu____2635 with
+          let uu___ = encode_term t env in
+          match uu___ with
           | (t1, decls) ->
-              let uu____2646 =
+              let uu___1 =
                 FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1 in
-              (uu____2646, decls)
+              (uu___1, decls)
 and (encode_term_pred' :
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.typ ->
@@ -819,17 +811,16 @@ and (encode_term_pred' :
     fun t ->
       fun env ->
         fun e ->
-          let uu____2657 = encode_term t env in
-          match uu____2657 with
+          let uu___ = encode_term t env in
+          match uu___ with
           | (t1, decls) ->
               (match fuel_opt with
                | FStar_Pervasives_Native.None ->
-                   let uu____2672 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1 in
-                   (uu____2672, decls)
+                   let uu___1 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1 in
+                   (uu___1, decls)
                | FStar_Pervasives_Native.Some f ->
-                   let uu____2674 =
-                     FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1 in
-                   (uu____2674, decls))
+                   let uu___1 = FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1 in
+                   (uu___1, decls))
 and (encode_arith_term :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -839,58 +830,54 @@ and (encode_arith_term :
   fun env ->
     fun head ->
       fun args_e ->
-        let uu____2680 = encode_args args_e env in
-        match uu____2680 with
+        let uu___ = encode_args args_e env in
+        match uu___ with
         | (arg_tms, decls) ->
             let head_fv =
               match head.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-              | uu____2699 -> failwith "Impossible" in
+              | uu___1 -> failwith "Impossible" in
             let unary unbox arg_tms1 =
-              let uu____2720 = FStar_List.hd arg_tms1 in unbox uu____2720 in
+              let uu___1 = FStar_List.hd arg_tms1 in unbox uu___1 in
             let binary unbox arg_tms1 =
-              let uu____2745 =
-                let uu____2746 = FStar_List.hd arg_tms1 in unbox uu____2746 in
-              let uu____2747 =
-                let uu____2748 =
-                  let uu____2749 = FStar_List.tl arg_tms1 in
-                  FStar_List.hd uu____2749 in
-                unbox uu____2748 in
-              (uu____2745, uu____2747) in
-            let mk_default uu____2757 =
-              let uu____2758 =
+              let uu___1 =
+                let uu___2 = FStar_List.hd arg_tms1 in unbox uu___2 in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_List.tl arg_tms1 in FStar_List.hd uu___4 in
+                unbox uu___3 in
+              (uu___1, uu___2) in
+            let mk_default uu___1 =
+              let uu___2 =
                 FStar_SMTEncoding_Env.lookup_free_var_sym env
                   head_fv.FStar_Syntax_Syntax.fv_name in
-              match uu____2758 with
+              match uu___2 with
               | (fname, fuel_args, arity) ->
                   let args = FStar_List.append fuel_args arg_tms in
                   maybe_curry_app head.FStar_Syntax_Syntax.pos fname arity
                     args in
             let mk_l box op mk_args ts =
-              let uu____2844 = FStar_Options.smtencoding_l_arith_native () in
-              if uu____2844
+              let uu___1 = FStar_Options.smtencoding_l_arith_native () in
+              if uu___1
               then
-                let uu____2845 = let uu____2846 = mk_args ts in op uu____2846 in
-                FStar_All.pipe_right uu____2845 box
+                let uu___2 = let uu___3 = mk_args ts in op uu___3 in
+                FStar_All.pipe_right uu___2 box
               else mk_default () in
             let mk_nl box unbox nm op ts =
-              let uu____2901 = FStar_Options.smtencoding_nl_arith_wrapped () in
-              if uu____2901
+              let uu___1 = FStar_Options.smtencoding_nl_arith_wrapped () in
+              if uu___1
               then
-                let uu____2902 = binary unbox ts in
-                match uu____2902 with
+                let uu___2 = binary unbox ts in
+                match uu___2 with
                 | (t1, t2) ->
-                    let uu____2909 =
-                      FStar_SMTEncoding_Util.mkApp (nm, [t1; t2]) in
-                    FStar_All.pipe_right uu____2909 box
+                    let uu___3 = FStar_SMTEncoding_Util.mkApp (nm, [t1; t2]) in
+                    FStar_All.pipe_right uu___3 box
               else
-                (let uu____2913 =
-                   FStar_Options.smtencoding_nl_arith_native () in
-                 if uu____2913
+                (let uu___3 = FStar_Options.smtencoding_nl_arith_native () in
+                 if uu___3
                  then
-                   let uu____2914 =
-                     let uu____2915 = binary unbox ts in op uu____2915 in
-                   FStar_All.pipe_right uu____2914 box
+                   let uu___4 = let uu___5 = binary unbox ts in op uu___5 in
+                   FStar_All.pipe_right uu___4 box
                  else mk_default ()) in
             let add box unbox =
               mk_l box FStar_SMTEncoding_Util.mkAdd (binary unbox) in
@@ -952,17 +939,16 @@ and (encode_arith_term :
                 (mk_l FStar_SMTEncoding_Term.boxBool
                    FStar_SMTEncoding_Util.mkGTE
                    (binary FStar_SMTEncoding_Term.unboxReal)))] in
-            let uu____3340 =
-              let uu____3350 =
+            let uu___1 =
+              let uu___2 =
                 FStar_List.tryFind
-                  (fun uu____3374 ->
-                     match uu____3374 with
-                     | (l, uu____3384) ->
-                         FStar_Syntax_Syntax.fv_eq_lid head_fv l) ops in
-              FStar_All.pipe_right uu____3350 FStar_Util.must in
-            (match uu____3340 with
-             | (uu____3428, op) ->
-                 let uu____3440 = op arg_tms in (uu____3440, decls))
+                  (fun uu___3 ->
+                     match uu___3 with
+                     | (l, uu___4) -> FStar_Syntax_Syntax.fv_eq_lid head_fv l)
+                  ops in
+              FStar_All.pipe_right uu___2 FStar_Util.must in
+            (match uu___1 with
+             | (uu___2, op) -> let uu___3 = op arg_tms in (uu___3, decls))
 and (encode_BitVector_term :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -975,83 +961,82 @@ and (encode_BitVector_term :
   fun env ->
     fun head ->
       fun args_e ->
-        let uu____3456 = FStar_List.hd args_e in
-        match uu____3456 with
-        | (tm_sz, uu____3472) ->
-            let uu____3481 = uu____3456 in
+        let uu___ = FStar_List.hd args_e in
+        match uu___ with
+        | (tm_sz, uu___1) ->
+            let uu___2 = uu___ in
             let sz = getInteger tm_sz.FStar_Syntax_Syntax.n in
             let sz_key =
               FStar_Util.format1 "BitVector_%s" (Prims.string_of_int sz) in
             let sz_decls =
               let t_decls = FStar_SMTEncoding_Term.mkBvConstructor sz in
               FStar_SMTEncoding_Term.mk_decls "" sz_key t_decls [] in
-            let uu____3488 =
+            let uu___3 =
               match ((head.FStar_Syntax_Syntax.n), args_e) with
               | (FStar_Syntax_Syntax.Tm_fvar fv,
-                 uu____3512::(sz_arg, uu____3514)::uu____3515::[]) when
+                 uu___4::(sz_arg, uu___5)::uu___6::[]) when
                   (FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.bv_uext_lid)
                     && (isInteger sz_arg.FStar_Syntax_Syntax.n)
                   ->
-                  let uu____3582 =
-                    let uu____3583 = FStar_List.tail args_e in
-                    FStar_List.tail uu____3583 in
-                  let uu____3610 =
-                    let uu____3613 = getInteger sz_arg.FStar_Syntax_Syntax.n in
-                    FStar_Pervasives_Native.Some uu____3613 in
-                  (uu____3582, uu____3610)
+                  let uu___7 =
+                    let uu___8 = FStar_List.tail args_e in
+                    FStar_List.tail uu___8 in
+                  let uu___8 =
+                    let uu___9 = getInteger sz_arg.FStar_Syntax_Syntax.n in
+                    FStar_Pervasives_Native.Some uu___9 in
+                  (uu___7, uu___8)
               | (FStar_Syntax_Syntax.Tm_fvar fv,
-                 uu____3617::(sz_arg, uu____3619)::uu____3620::[]) when
+                 uu___4::(sz_arg, uu___5)::uu___6::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.bv_uext_lid
                   ->
-                  let uu____3687 =
-                    let uu____3688 = FStar_Syntax_Print.term_to_string sz_arg in
+                  let uu___7 =
+                    let uu___8 = FStar_Syntax_Print.term_to_string sz_arg in
                     FStar_Util.format1
-                      "Not a constant bitvector extend size: %s" uu____3688 in
-                  failwith uu____3687
-              | uu____3695 ->
-                  let uu____3710 = FStar_List.tail args_e in
-                  (uu____3710, FStar_Pervasives_Native.None) in
-            (match uu____3488 with
+                      "Not a constant bitvector extend size: %s" uu___8 in
+                  failwith uu___7
+              | uu___4 ->
+                  let uu___5 = FStar_List.tail args_e in
+                  (uu___5, FStar_Pervasives_Native.None) in
+            (match uu___3 with
              | (arg_tms, ext_sz) ->
-                 let uu____3733 = encode_args arg_tms env in
-                 (match uu____3733 with
+                 let uu___4 = encode_args arg_tms env in
+                 (match uu___4 with
                   | (arg_tms1, decls) ->
                       let head_fv =
                         match head.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                        | uu____3754 -> failwith "Impossible" in
+                        | uu___5 -> failwith "Impossible" in
                       let unary arg_tms2 =
-                        let uu____3765 = FStar_List.hd arg_tms2 in
-                        FStar_SMTEncoding_Term.unboxBitVec sz uu____3765 in
+                        let uu___5 = FStar_List.hd arg_tms2 in
+                        FStar_SMTEncoding_Term.unboxBitVec sz uu___5 in
                       let unary_arith arg_tms2 =
-                        let uu____3776 = FStar_List.hd arg_tms2 in
-                        FStar_SMTEncoding_Term.unboxInt uu____3776 in
+                        let uu___5 = FStar_List.hd arg_tms2 in
+                        FStar_SMTEncoding_Term.unboxInt uu___5 in
                       let binary arg_tms2 =
-                        let uu____3791 =
-                          let uu____3792 = FStar_List.hd arg_tms2 in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____3792 in
-                        let uu____3793 =
-                          let uu____3794 =
-                            let uu____3795 = FStar_List.tl arg_tms2 in
-                            FStar_List.hd uu____3795 in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____3794 in
-                        (uu____3791, uu____3793) in
+                        let uu___5 =
+                          let uu___6 = FStar_List.hd arg_tms2 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu___6 in
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 = FStar_List.tl arg_tms2 in
+                            FStar_List.hd uu___8 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu___7 in
+                        (uu___5, uu___6) in
                       let binary_arith arg_tms2 =
-                        let uu____3812 =
-                          let uu____3813 = FStar_List.hd arg_tms2 in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____3813 in
-                        let uu____3814 =
-                          let uu____3815 =
-                            let uu____3816 = FStar_List.tl arg_tms2 in
-                            FStar_List.hd uu____3816 in
-                          FStar_SMTEncoding_Term.unboxInt uu____3815 in
-                        (uu____3812, uu____3814) in
+                        let uu___5 =
+                          let uu___6 = FStar_List.hd arg_tms2 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu___6 in
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 = FStar_List.tl arg_tms2 in
+                            FStar_List.hd uu___8 in
+                          FStar_SMTEncoding_Term.unboxInt uu___7 in
+                        (uu___5, uu___6) in
                       let mk_bv op mk_args resBox ts =
-                        let uu____3874 =
-                          let uu____3875 = mk_args ts in op uu____3875 in
-                        FStar_All.pipe_right uu____3874 resBox in
+                        let uu___5 = let uu___6 = mk_args ts in op uu___6 in
+                        FStar_All.pipe_right uu___5 resBox in
                       let bv_and =
                         mk_bv FStar_SMTEncoding_Util.mkBvAnd binary
                           (FStar_SMTEncoding_Term.boxBitVec sz) in
@@ -1086,23 +1071,23 @@ and (encode_BitVector_term :
                         mk_bv FStar_SMTEncoding_Util.mkBvUlt binary
                           FStar_SMTEncoding_Term.boxBool in
                       let bv_uext arg_tms2 =
-                        let uu____4007 =
-                          let uu____4012 =
+                        let uu___5 =
+                          let uu___6 =
                             match ext_sz with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None ->
                                 failwith "impossible" in
-                          FStar_SMTEncoding_Util.mkBvUext uu____4012 in
-                        let uu____4014 =
-                          let uu____4019 =
-                            let uu____4020 =
+                          FStar_SMTEncoding_Util.mkBvUext uu___6 in
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
                               match ext_sz with
                               | FStar_Pervasives_Native.Some x -> x
                               | FStar_Pervasives_Native.None ->
                                   failwith "impossible" in
-                            sz + uu____4020 in
-                          FStar_SMTEncoding_Term.boxBitVec uu____4019 in
-                        mk_bv uu____4007 unary uu____4014 arg_tms2 in
+                            sz + uu___8 in
+                          FStar_SMTEncoding_Term.boxBitVec uu___7 in
+                        mk_bv uu___5 unary uu___6 arg_tms2 in
                       let to_int =
                         mk_bv FStar_SMTEncoding_Util.mkBvToNat unary
                           FStar_SMTEncoding_Term.boxInt in
@@ -1124,19 +1109,19 @@ and (encode_BitVector_term :
                         (FStar_Parser_Const.bv_uext_lid, bv_uext);
                         (FStar_Parser_Const.bv_to_nat_lid, to_int);
                         (FStar_Parser_Const.nat_to_bv_lid, bv_to)] in
-                      let uu____4253 =
-                        let uu____4263 =
+                      let uu___5 =
+                        let uu___6 =
                           FStar_List.tryFind
-                            (fun uu____4287 ->
-                               match uu____4287 with
-                               | (l, uu____4297) ->
+                            (fun uu___7 ->
+                               match uu___7 with
+                               | (l, uu___8) ->
                                    FStar_Syntax_Syntax.fv_eq_lid head_fv l)
                             ops in
-                        FStar_All.pipe_right uu____4263 FStar_Util.must in
-                      (match uu____4253 with
-                       | (uu____4343, op) ->
-                           let uu____4355 = op arg_tms1 in
-                           (uu____4355, (FStar_List.append sz_decls decls)))))
+                        FStar_All.pipe_right uu___6 FStar_Util.must in
+                      (match uu___5 with
+                       | (uu___6, op) ->
+                           let uu___7 = op arg_tms1 in
+                           (uu___7, (FStar_List.append sz_decls decls)))))
 and (encode_deeply_embedded_quantifier :
   FStar_Syntax_Syntax.term ->
     FStar_SMTEncoding_Env.env_t ->
@@ -1145,32 +1130,29 @@ and (encode_deeply_embedded_quantifier :
   fun t ->
     fun env ->
       let env1 =
-        let uu___601_4365 = env in
+        let uu___ = env in
         {
           FStar_SMTEncoding_Env.bvar_bindings =
-            (uu___601_4365.FStar_SMTEncoding_Env.bvar_bindings);
+            (uu___.FStar_SMTEncoding_Env.bvar_bindings);
           FStar_SMTEncoding_Env.fvar_bindings =
-            (uu___601_4365.FStar_SMTEncoding_Env.fvar_bindings);
-          FStar_SMTEncoding_Env.depth =
-            (uu___601_4365.FStar_SMTEncoding_Env.depth);
-          FStar_SMTEncoding_Env.tcenv =
-            (uu___601_4365.FStar_SMTEncoding_Env.tcenv);
-          FStar_SMTEncoding_Env.warn =
-            (uu___601_4365.FStar_SMTEncoding_Env.warn);
+            (uu___.FStar_SMTEncoding_Env.fvar_bindings);
+          FStar_SMTEncoding_Env.depth = (uu___.FStar_SMTEncoding_Env.depth);
+          FStar_SMTEncoding_Env.tcenv = (uu___.FStar_SMTEncoding_Env.tcenv);
+          FStar_SMTEncoding_Env.warn = (uu___.FStar_SMTEncoding_Env.warn);
           FStar_SMTEncoding_Env.nolabels =
-            (uu___601_4365.FStar_SMTEncoding_Env.nolabels);
+            (uu___.FStar_SMTEncoding_Env.nolabels);
           FStar_SMTEncoding_Env.use_zfuel_name =
-            (uu___601_4365.FStar_SMTEncoding_Env.use_zfuel_name);
+            (uu___.FStar_SMTEncoding_Env.use_zfuel_name);
           FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (uu___601_4365.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            (uu___.FStar_SMTEncoding_Env.encode_non_total_function_typ);
           FStar_SMTEncoding_Env.current_module_name =
-            (uu___601_4365.FStar_SMTEncoding_Env.current_module_name);
+            (uu___.FStar_SMTEncoding_Env.current_module_name);
           FStar_SMTEncoding_Env.encoding_quantifier = true;
           FStar_SMTEncoding_Env.global_cache =
-            (uu___601_4365.FStar_SMTEncoding_Env.global_cache)
+            (uu___.FStar_SMTEncoding_Env.global_cache)
         } in
-      let uu____4366 = encode_term t env1 in
-      match uu____4366 with
+      let uu___ = encode_term t env1 in
+      match uu___ with
       | (tm, decls) ->
           let vars = FStar_SMTEncoding_Term.free_variables tm in
           let valid_tm = FStar_SMTEncoding_Term.mk_Valid tm in
@@ -1180,69 +1162,65 @@ and (encode_deeply_embedded_quantifier :
           let tkey_hash = FStar_SMTEncoding_Term.hash_of_term key in
           (match tm.FStar_SMTEncoding_Term.tm with
            | FStar_SMTEncoding_Term.App
-               (uu____4391,
+               (uu___1,
                 {
                   FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV
-                    uu____4392;
-                  FStar_SMTEncoding_Term.freevars = uu____4393;
-                  FStar_SMTEncoding_Term.rng = uu____4394;_}::{
-                                                                FStar_SMTEncoding_Term.tm
-                                                                  =
-                                                                  FStar_SMTEncoding_Term.FreeV
-                                                                  uu____4395;
-                                                                FStar_SMTEncoding_Term.freevars
-                                                                  =
-                                                                  uu____4396;
-                                                                FStar_SMTEncoding_Term.rng
-                                                                  =
-                                                                  uu____4397;_}::[])
+                    uu___2;
+                  FStar_SMTEncoding_Term.freevars = uu___3;
+                  FStar_SMTEncoding_Term.rng = uu___4;_}::{
+                                                            FStar_SMTEncoding_Term.tm
+                                                              =
+                                                              FStar_SMTEncoding_Term.FreeV
+                                                              uu___5;
+                                                            FStar_SMTEncoding_Term.freevars
+                                                              = uu___6;
+                                                            FStar_SMTEncoding_Term.rng
+                                                              = uu___7;_}::[])
                ->
                (FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
                   (FStar_Errors.Warning_QuantifierWithoutPattern,
                     "Not encoding deeply embedded, unguarded quantifier to SMT");
                 (tm, decls))
-           | uu____4433 ->
-               let uu____4434 = encode_formula t env1 in
-               (match uu____4434 with
+           | uu___1 ->
+               let uu___2 = encode_formula t env1 in
+               (match uu___2 with
                 | (phi, decls') ->
                     let interp =
                       match vars with
                       | [] ->
-                          let uu____4452 =
-                            let uu____4457 =
-                              FStar_SMTEncoding_Term.mk_Valid tm in
-                            (uu____4457, phi) in
-                          FStar_SMTEncoding_Util.mkIff uu____4452
-                      | uu____4458 ->
-                          let uu____4459 =
-                            let uu____4470 =
-                              let uu____4471 =
-                                let uu____4476 =
+                          let uu___3 =
+                            let uu___4 = FStar_SMTEncoding_Term.mk_Valid tm in
+                            (uu___4, phi) in
+                          FStar_SMTEncoding_Util.mkIff uu___3
+                      | uu___3 ->
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_SMTEncoding_Term.mk_Valid tm in
-                                (uu____4476, phi) in
-                              FStar_SMTEncoding_Util.mkIff uu____4471 in
-                            ([[valid_tm]], vars, uu____4470) in
+                                (uu___7, phi) in
+                              FStar_SMTEncoding_Util.mkIff uu___6 in
+                            ([[valid_tm]], vars, uu___5) in
                           FStar_SMTEncoding_Term.mkForall
-                            t.FStar_Syntax_Syntax.pos uu____4459 in
+                            t.FStar_Syntax_Syntax.pos uu___4 in
                     let ax =
-                      let uu____4486 =
-                        let uu____4493 =
-                          let uu____4494 =
-                            FStar_Util.digest_of_string tkey_hash in
-                          Prims.op_Hat "l_quant_interp_" uu____4494 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Util.digest_of_string tkey_hash in
+                          Prims.op_Hat "l_quant_interp_" uu___5 in
                         (interp,
                           (FStar_Pervasives_Native.Some
                              "Interpretation of deeply embedded quantifier"),
-                          uu____4493) in
-                      FStar_SMTEncoding_Util.mkAssume uu____4486 in
-                    let uu____4495 =
-                      let uu____4496 =
-                        let uu____4499 =
+                          uu___4) in
+                      FStar_SMTEncoding_Util.mkAssume uu___3 in
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_SMTEncoding_Term.mk_decls "" tkey_hash 
                             [ax] (FStar_List.append decls decls') in
-                        FStar_List.append decls' uu____4499 in
-                      FStar_List.append decls uu____4496 in
-                    (tm, uu____4495)))
+                        FStar_List.append decls' uu___5 in
+                      FStar_List.append decls uu___4 in
+                    (tm, uu___3)))
 and (encode_term :
   FStar_Syntax_Syntax.typ ->
     FStar_SMTEncoding_Env.env_t ->
@@ -1252,125 +1230,120 @@ and (encode_term :
     fun env ->
       let t1 = FStar_Syntax_Subst.compress t in
       let t0 = t1 in
-      (let uu____4511 =
+      (let uu___1 =
          FStar_All.pipe_left
            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
            (FStar_Options.Other "SMTEncoding") in
-       if uu____4511
+       if uu___1
        then
-         let uu____4512 = FStar_Syntax_Print.tag_of_term t1 in
-         let uu____4513 = FStar_Syntax_Print.term_to_string t1 in
-         FStar_Util.print2 "(%s)   %s\n" uu____4512 uu____4513
+         let uu___2 = FStar_Syntax_Print.tag_of_term t1 in
+         let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+         FStar_Util.print2 "(%s)   %s\n" uu___2 uu___3
        else ());
       (match t1.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____4519 ->
-           let uu____4534 =
-             let uu____4535 =
+       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
+           let uu___2 =
+             let uu___3 =
                FStar_All.pipe_left FStar_Range.string_of_range
                  t1.FStar_Syntax_Syntax.pos in
-             let uu____4536 = FStar_Syntax_Print.tag_of_term t1 in
-             let uu____4537 = FStar_Syntax_Print.term_to_string t1 in
-             FStar_Util.format3 "(%s) Impossible: %s\n%s\n" uu____4535
-               uu____4536 uu____4537 in
-           failwith uu____4534
+             let uu___4 = FStar_Syntax_Print.tag_of_term t1 in
+             let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+             FStar_Util.format3 "(%s) Impossible: %s\n%s\n" uu___3 uu___4
+               uu___5 in
+           failwith uu___2
        | FStar_Syntax_Syntax.Tm_unknown ->
-           let uu____4542 =
-             let uu____4543 =
+           let uu___1 =
+             let uu___2 =
                FStar_All.pipe_left FStar_Range.string_of_range
                  t1.FStar_Syntax_Syntax.pos in
-             let uu____4544 = FStar_Syntax_Print.tag_of_term t1 in
-             let uu____4545 = FStar_Syntax_Print.term_to_string t1 in
-             FStar_Util.format3 "(%s) Impossible: %s\n%s\n" uu____4543
-               uu____4544 uu____4545 in
-           failwith uu____4542
+             let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
+             let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+             FStar_Util.format3 "(%s) Impossible: %s\n%s\n" uu___2 uu___3
+               uu___4 in
+           failwith uu___1
        | FStar_Syntax_Syntax.Tm_lazy i ->
            let e = FStar_Syntax_Util.unfold_lazy i in
-           ((let uu____4553 =
+           ((let uu___2 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding") in
-             if uu____4553
+             if uu___2
              then
-               let uu____4554 = FStar_Syntax_Print.term_to_string t1 in
-               let uu____4555 = FStar_Syntax_Print.term_to_string e in
-               FStar_Util.print2 ">> Unfolded (%s) ~> (%s)\n" uu____4554
-                 uu____4555
+               let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+               let uu___4 = FStar_Syntax_Print.term_to_string e in
+               FStar_Util.print2 ">> Unfolded (%s) ~> (%s)\n" uu___3 uu___4
              else ());
             encode_term e env)
        | FStar_Syntax_Syntax.Tm_bvar x ->
-           let uu____4558 =
-             let uu____4559 = FStar_Syntax_Print.bv_to_string x in
-             FStar_Util.format1 "Impossible: locally nameless; got %s"
-               uu____4559 in
-           failwith uu____4558
-       | FStar_Syntax_Syntax.Tm_ascribed (t2, (k, uu____4566), uu____4567) ->
-           let uu____4616 =
+           let uu___1 =
+             let uu___2 = FStar_Syntax_Print.bv_to_string x in
+             FStar_Util.format1 "Impossible: locally nameless; got %s" uu___2 in
+           failwith uu___1
+       | FStar_Syntax_Syntax.Tm_ascribed (t2, (k, uu___1), uu___2) ->
+           let uu___3 =
              match k with
              | FStar_Util.Inl t3 -> FStar_Syntax_Util.is_unit t3
-             | uu____4624 -> false in
-           if uu____4616
+             | uu___4 -> false in
+           if uu___3
            then (FStar_SMTEncoding_Term.mk_Term_unit, [])
            else encode_term t2 env
-       | FStar_Syntax_Syntax.Tm_quoted (qt, uu____4639) ->
+       | FStar_Syntax_Syntax.Tm_quoted (qt, uu___1) ->
            let tv =
-             let uu____4645 =
-               let uu____4652 = FStar_Reflection_Basic.inspect_ln qt in
+             let uu___2 =
+               let uu___3 = FStar_Reflection_Basic.inspect_ln qt in
                FStar_Syntax_Embeddings.embed
-                 FStar_Reflection_Embeddings.e_term_view uu____4652 in
-             uu____4645 t1.FStar_Syntax_Syntax.pos
-               FStar_Pervasives_Native.None
+                 FStar_Reflection_Embeddings.e_term_view uu___3 in
+             uu___2 t1.FStar_Syntax_Syntax.pos FStar_Pervasives_Native.None
                FStar_Syntax_Embeddings.id_norm_cb in
-           ((let uu____4656 =
+           ((let uu___3 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding") in
-             if uu____4656
+             if uu___3
              then
-               let uu____4657 = FStar_Syntax_Print.term_to_string t0 in
-               let uu____4658 = FStar_Syntax_Print.term_to_string tv in
-               FStar_Util.print2 ">> Inspected (%s) ~> (%s)\n" uu____4657
-                 uu____4658
+               let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+               let uu___5 = FStar_Syntax_Print.term_to_string tv in
+               FStar_Util.print2 ">> Inspected (%s) ~> (%s)\n" uu___4 uu___5
              else ());
             (let t2 =
-               let uu____4663 =
-                 let uu____4674 = FStar_Syntax_Syntax.as_arg tv in
-                 [uu____4674] in
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Syntax.as_arg tv in [uu___4] in
                FStar_Syntax_Util.mk_app
                  (FStar_Reflection_Data.refl_constant_term
-                    FStar_Reflection_Data.fstar_refl_pack_ln) uu____4663 in
+                    FStar_Reflection_Data.fstar_refl_pack_ln) uu___3 in
              encode_term t2 env))
        | FStar_Syntax_Syntax.Tm_meta
-           (t2, FStar_Syntax_Syntax.Meta_pattern uu____4700) ->
+           (t2, FStar_Syntax_Syntax.Meta_pattern uu___1) ->
            encode_term t2
-             (let uu___674_4726 = env in
+             (let uu___2 = env in
               {
                 FStar_SMTEncoding_Env.bvar_bindings =
-                  (uu___674_4726.FStar_SMTEncoding_Env.bvar_bindings);
+                  (uu___2.FStar_SMTEncoding_Env.bvar_bindings);
                 FStar_SMTEncoding_Env.fvar_bindings =
-                  (uu___674_4726.FStar_SMTEncoding_Env.fvar_bindings);
+                  (uu___2.FStar_SMTEncoding_Env.fvar_bindings);
                 FStar_SMTEncoding_Env.depth =
-                  (uu___674_4726.FStar_SMTEncoding_Env.depth);
+                  (uu___2.FStar_SMTEncoding_Env.depth);
                 FStar_SMTEncoding_Env.tcenv =
-                  (uu___674_4726.FStar_SMTEncoding_Env.tcenv);
+                  (uu___2.FStar_SMTEncoding_Env.tcenv);
                 FStar_SMTEncoding_Env.warn =
-                  (uu___674_4726.FStar_SMTEncoding_Env.warn);
+                  (uu___2.FStar_SMTEncoding_Env.warn);
                 FStar_SMTEncoding_Env.nolabels =
-                  (uu___674_4726.FStar_SMTEncoding_Env.nolabels);
+                  (uu___2.FStar_SMTEncoding_Env.nolabels);
                 FStar_SMTEncoding_Env.use_zfuel_name =
-                  (uu___674_4726.FStar_SMTEncoding_Env.use_zfuel_name);
+                  (uu___2.FStar_SMTEncoding_Env.use_zfuel_name);
                 FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                  (uu___674_4726.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                  (uu___2.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                 FStar_SMTEncoding_Env.current_module_name =
-                  (uu___674_4726.FStar_SMTEncoding_Env.current_module_name);
+                  (uu___2.FStar_SMTEncoding_Env.current_module_name);
                 FStar_SMTEncoding_Env.encoding_quantifier = false;
                 FStar_SMTEncoding_Env.global_cache =
-                  (uu___674_4726.FStar_SMTEncoding_Env.global_cache)
+                  (uu___2.FStar_SMTEncoding_Env.global_cache)
               })
-       | FStar_Syntax_Syntax.Tm_meta (t2, uu____4728) -> encode_term t2 env
+       | FStar_Syntax_Syntax.Tm_meta (t2, uu___1) -> encode_term t2 env
        | FStar_Syntax_Syntax.Tm_name x ->
            let t2 = FStar_SMTEncoding_Env.lookup_term_var env x in (t2, [])
        | FStar_Syntax_Syntax.Tm_fvar v ->
-           let encode_freev uu____4745 =
+           let encode_freev uu___1 =
              let fvb =
                FStar_SMTEncoding_Env.lookup_free_var_name env
                  v.FStar_Syntax_Syntax.fv_name in
@@ -1378,45 +1351,45 @@ and (encode_term :
                FStar_SMTEncoding_Env.lookup_free_var env
                  v.FStar_Syntax_Syntax.fv_name in
              let tkey_hash = FStar_SMTEncoding_Term.hash_of_term tok in
-             let uu____4749 =
+             let uu___2 =
                if fvb.FStar_SMTEncoding_Env.smt_arity > Prims.int_zero
                then
                  match tok.FStar_SMTEncoding_Term.tm with
-                 | FStar_SMTEncoding_Term.FreeV uu____4768 ->
+                 | FStar_SMTEncoding_Term.FreeV uu___3 ->
                      let sym_name =
-                       let uu____4776 = FStar_Util.digest_of_string tkey_hash in
-                       Prims.op_Hat "@kick_partial_app_" uu____4776 in
-                     let uu____4777 =
-                       let uu____4780 =
-                         let uu____4781 =
-                           let uu____4788 =
+                       let uu___4 = FStar_Util.digest_of_string tkey_hash in
+                       Prims.op_Hat "@kick_partial_app_" uu___4 in
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_SMTEncoding_Term.kick_partial_app tok in
-                           (uu____4788,
+                           (uu___7,
                              (FStar_Pervasives_Native.Some "kick_partial_app"),
                              sym_name) in
-                         FStar_SMTEncoding_Util.mkAssume uu____4781 in
-                       [uu____4780] in
-                     (uu____4777, sym_name)
-                 | FStar_SMTEncoding_Term.App (uu____4791, []) ->
+                         FStar_SMTEncoding_Util.mkAssume uu___6 in
+                       [uu___5] in
+                     (uu___4, sym_name)
+                 | FStar_SMTEncoding_Term.App (uu___3, []) ->
                      let sym_name =
-                       let uu____4795 = FStar_Util.digest_of_string tkey_hash in
-                       Prims.op_Hat "@kick_partial_app_" uu____4795 in
-                     let uu____4796 =
-                       let uu____4799 =
-                         let uu____4800 =
-                           let uu____4807 =
+                       let uu___4 = FStar_Util.digest_of_string tkey_hash in
+                       Prims.op_Hat "@kick_partial_app_" uu___4 in
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_SMTEncoding_Term.kick_partial_app tok in
-                           (uu____4807,
+                           (uu___7,
                              (FStar_Pervasives_Native.Some "kick_partial_app"),
                              sym_name) in
-                         FStar_SMTEncoding_Util.mkAssume uu____4800 in
-                       [uu____4799] in
-                     (uu____4796, sym_name)
-                 | uu____4810 -> ([], "")
+                         FStar_SMTEncoding_Util.mkAssume uu___6 in
+                       [uu___5] in
+                     (uu___4, sym_name)
+                 | uu___3 -> ([], "")
                else ([], "") in
-             match uu____4749 with
+             match uu___2 with
              | (aux_decls, sym_name) ->
-                 let uu____4826 =
+                 let uu___3 =
                    if aux_decls = []
                    then
                      FStar_All.pipe_right []
@@ -1424,184 +1397,181 @@ and (encode_term :
                    else
                      FStar_SMTEncoding_Term.mk_decls sym_name tkey_hash
                        aux_decls [] in
-                 (tok, uu____4826) in
-           let uu____4832 = head_redex env t1 in
-           if uu____4832
+                 (tok, uu___3) in
+           let uu___1 = head_redex env t1 in
+           if uu___1
            then
-             let uu____4837 = maybe_whnf env t1 in
-             (match uu____4837 with
+             let uu___2 = maybe_whnf env t1 in
+             (match uu___2 with
               | FStar_Pervasives_Native.None -> encode_freev ()
               | FStar_Pervasives_Native.Some t2 -> encode_term t2 env)
            else encode_freev ()
-       | FStar_Syntax_Syntax.Tm_type uu____4846 ->
+       | FStar_Syntax_Syntax.Tm_type uu___1 ->
            (FStar_SMTEncoding_Term.mk_Term_type, [])
-       | FStar_Syntax_Syntax.Tm_uinst (t2, uu____4848) -> encode_term t2 env
+       | FStar_Syntax_Syntax.Tm_uinst (t2, uu___1) -> encode_term t2 env
        | FStar_Syntax_Syntax.Tm_constant c -> encode_const c env
        | FStar_Syntax_Syntax.Tm_arrow (binders, c) ->
            let module_name = env.FStar_SMTEncoding_Env.current_module_name in
-           let uu____4877 = FStar_Syntax_Subst.open_comp binders c in
-           (match uu____4877 with
+           let uu___1 = FStar_Syntax_Subst.open_comp binders c in
+           (match uu___1 with
             | (binders1, res) ->
-                let uu____4888 =
+                let uu___2 =
                   (env.FStar_SMTEncoding_Env.encode_non_total_function_typ &&
                      (FStar_Syntax_Util.is_pure_or_ghost_comp res))
                     || (FStar_Syntax_Util.is_tot_or_gtot_comp res) in
-                if uu____4888
+                if uu___2
                 then
-                  let uu____4893 =
+                  let uu___3 =
                     encode_binders FStar_Pervasives_Native.None binders1 env in
-                  (match uu____4893 with
-                   | (vars, guards_l, env', decls, uu____4918) ->
+                  (match uu___3 with
+                   | (vars, guards_l, env', decls, uu___4) ->
                        let fsym =
-                         let uu____4932 =
-                           let uu____4937 =
+                         let uu___5 =
+                           let uu___6 =
                              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                                module_name "f" in
-                           (uu____4937, FStar_SMTEncoding_Term.Term_sort) in
-                         FStar_SMTEncoding_Term.mk_fv uu____4932 in
+                           (uu___6, FStar_SMTEncoding_Term.Term_sort) in
+                         FStar_SMTEncoding_Term.mk_fv uu___5 in
                        let f = FStar_SMTEncoding_Util.mkFreeV fsym in
                        let app = mk_Apply f vars in
-                       let uu____4940 =
+                       let uu___5 =
                          FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
-                           (let uu___733_4949 =
-                              env.FStar_SMTEncoding_Env.tcenv in
+                           (let uu___6 = env.FStar_SMTEncoding_Env.tcenv in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___733_4949.FStar_TypeChecker_Env.solver);
+                                (uu___6.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___733_4949.FStar_TypeChecker_Env.range);
+                                (uu___6.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___733_4949.FStar_TypeChecker_Env.curmodule);
+                                (uu___6.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___733_4949.FStar_TypeChecker_Env.gamma);
+                                (uu___6.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___733_4949.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___6.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___733_4949.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___6.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___733_4949.FStar_TypeChecker_Env.modules);
+                                (uu___6.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___733_4949.FStar_TypeChecker_Env.expected_typ);
+                                (uu___6.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___733_4949.FStar_TypeChecker_Env.sigtab);
+                                (uu___6.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___733_4949.FStar_TypeChecker_Env.attrtab);
+                                (uu___6.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___733_4949.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___733_4949.FStar_TypeChecker_Env.effects);
+                                (uu___6.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___733_4949.FStar_TypeChecker_Env.generalize);
+                                (uu___6.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___733_4949.FStar_TypeChecker_Env.letrecs);
+                                (uu___6.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___733_4949.FStar_TypeChecker_Env.top_level);
+                                (uu___6.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___733_4949.FStar_TypeChecker_Env.check_uvars);
+                                (uu___6.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___733_4949.FStar_TypeChecker_Env.use_eq);
+                                (uu___6.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___733_4949.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___733_4949.FStar_TypeChecker_Env.is_iface);
+                                (uu___6.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___733_4949.FStar_TypeChecker_Env.admit);
+                                (uu___6.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___733_4949.FStar_TypeChecker_Env.lax_universes);
+                                (uu___6.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___733_4949.FStar_TypeChecker_Env.phase1);
+                                (uu___6.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___733_4949.FStar_TypeChecker_Env.failhard);
+                                (uu___6.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___733_4949.FStar_TypeChecker_Env.nosynth);
+                                (uu___6.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___733_4949.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___733_4949.FStar_TypeChecker_Env.tc_term);
+                                (uu___6.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___733_4949.FStar_TypeChecker_Env.type_of);
+                                (uu___6.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___733_4949.FStar_TypeChecker_Env.universe_of);
+                                (uu___6.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___733_4949.FStar_TypeChecker_Env.check_type_of);
+                                (uu___6.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___733_4949.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___733_4949.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___733_4949.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___733_4949.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___733_4949.FStar_TypeChecker_Env.proof_ns);
+                                (uu___6.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___733_4949.FStar_TypeChecker_Env.synth_hook);
+                                (uu___6.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___733_4949.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___733_4949.FStar_TypeChecker_Env.splice);
+                                (uu___6.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___733_4949.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___6.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___733_4949.FStar_TypeChecker_Env.postprocess);
+                                (uu___6.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___733_4949.FStar_TypeChecker_Env.identifier_info);
+                                (uu___6.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___733_4949.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___6.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___733_4949.FStar_TypeChecker_Env.dsenv);
+                                (uu___6.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___733_4949.FStar_TypeChecker_Env.nbe);
+                                (uu___6.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___733_4949.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___733_4949.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___733_4949.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) res in
-                       (match uu____4940 with
+                       (match uu___5 with
                         | (pre_opt, res_t) ->
-                            let uu____4960 =
+                            let uu___6 =
                               encode_term_pred FStar_Pervasives_Native.None
                                 res_t env' app in
-                            (match uu____4960 with
+                            (match uu___6 with
                              | (res_pred, decls') ->
-                                 let uu____4971 =
+                                 let uu___7 =
                                    match pre_opt with
                                    | FStar_Pervasives_Native.None ->
-                                       let uu____4984 =
+                                       let uu___8 =
                                          FStar_SMTEncoding_Util.mk_and_l
                                            guards_l in
-                                       (uu____4984, [])
+                                       (uu___8, [])
                                    | FStar_Pervasives_Native.Some pre ->
-                                       let uu____4988 =
-                                         encode_formula pre env' in
-                                       (match uu____4988 with
+                                       let uu___8 = encode_formula pre env' in
+                                       (match uu___8 with
                                         | (guard, decls0) ->
-                                            let uu____5001 =
+                                            let uu___9 =
                                               FStar_SMTEncoding_Util.mk_and_l
                                                 (guard :: guards_l) in
-                                            (uu____5001, decls0)) in
-                                 (match uu____4971 with
+                                            (uu___9, decls0)) in
+                                 (match uu___7 with
                                   | (guards, guard_decls) ->
                                       let is_pure =
-                                        let uu____5015 =
+                                        let uu___8 =
                                           FStar_All.pipe_right res
                                             (FStar_TypeChecker_Normalize.ghost_to_pure
                                                env.FStar_SMTEncoding_Env.tcenv) in
-                                        FStar_All.pipe_right uu____5015
+                                        FStar_All.pipe_right uu___8
                                           FStar_Syntax_Util.is_pure_comp in
                                       let t_interp =
-                                        let uu____5023 =
-                                          let uu____5034 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_SMTEncoding_Util.mkImp
                                               (guards, res_pred) in
-                                          ([[app]], vars, uu____5034) in
+                                          ([[app]], vars, uu___9) in
                                         FStar_SMTEncoding_Term.mkForall
-                                          t1.FStar_Syntax_Syntax.pos
-                                          uu____5023 in
+                                          t1.FStar_Syntax_Syntax.pos uu___8 in
                                       let t_interp1 =
                                         let tot_fun_axioms =
                                           isTotFun_axioms
@@ -1610,19 +1580,19 @@ and (encode_term :
                                         FStar_SMTEncoding_Util.mkAnd
                                           (t_interp, tot_fun_axioms) in
                                       let cvars =
-                                        let uu____5054 =
+                                        let uu___8 =
                                           FStar_SMTEncoding_Term.free_variables
                                             t_interp1 in
-                                        FStar_All.pipe_right uu____5054
+                                        FStar_All.pipe_right uu___8
                                           (FStar_List.filter
                                              (fun x ->
-                                                let uu____5071 =
+                                                let uu___9 =
                                                   FStar_SMTEncoding_Term.fv_name
                                                     x in
-                                                let uu____5072 =
+                                                let uu___10 =
                                                   FStar_SMTEncoding_Term.fv_name
                                                     fsym in
-                                                uu____5071 <> uu____5072)) in
+                                                uu___9 <> uu___10)) in
                                       let tkey =
                                         FStar_SMTEncoding_Term.mkForall
                                           t1.FStar_Syntax_Syntax.pos
@@ -1632,33 +1602,32 @@ and (encode_term :
                                         then "Tm_arrow_"
                                         else "Tm_ghost_arrow_" in
                                       let tkey_hash =
-                                        let uu____5089 =
+                                        let uu___8 =
                                           FStar_SMTEncoding_Term.hash_of_term
                                             tkey in
-                                        Prims.op_Hat prefix uu____5089 in
+                                        Prims.op_Hat prefix uu___8 in
                                       let tsym =
-                                        let uu____5091 =
+                                        let uu___8 =
                                           FStar_Util.digest_of_string
                                             tkey_hash in
-                                        Prims.op_Hat prefix uu____5091 in
+                                        Prims.op_Hat prefix uu___8 in
                                       let cvar_sorts =
                                         FStar_List.map
                                           FStar_SMTEncoding_Term.fv_sort
                                           cvars in
                                       let caption =
-                                        let uu____5102 =
+                                        let uu___8 =
                                           FStar_Options.log_queries () in
-                                        if uu____5102
+                                        if uu___8
                                         then
-                                          let uu____5103 =
-                                            let uu____5104 =
+                                          let uu___9 =
+                                            let uu___10 =
                                               FStar_TypeChecker_Normalize.term_to_string
                                                 env.FStar_SMTEncoding_Env.tcenv
                                                 t0 in
-                                            FStar_Util.replace_char
-                                              uu____5104 10 32 in
-                                          FStar_Pervasives_Native.Some
-                                            uu____5103
+                                            FStar_Util.replace_char uu___10
+                                              10 32 in
+                                          FStar_Pervasives_Native.Some uu___9
                                         else FStar_Pervasives_Native.None in
                                       let tdecl =
                                         FStar_SMTEncoding_Term.DeclFun
@@ -1666,31 +1635,30 @@ and (encode_term :
                                             FStar_SMTEncoding_Term.Term_sort,
                                             caption) in
                                       let t2 =
-                                        let uu____5110 =
-                                          let uu____5117 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_List.map
                                               FStar_SMTEncoding_Util.mkFreeV
                                               cvars in
-                                          (tsym, uu____5117) in
-                                        FStar_SMTEncoding_Util.mkApp
-                                          uu____5110 in
+                                          (tsym, uu___9) in
+                                        FStar_SMTEncoding_Util.mkApp uu___8 in
                                       let t_has_kind =
                                         FStar_SMTEncoding_Term.mk_HasType t2
                                           FStar_SMTEncoding_Term.mk_Term_type in
                                       let k_assumption =
                                         let a_name =
                                           Prims.op_Hat "kinding_" tsym in
-                                        let uu____5131 =
-                                          let uu____5138 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_SMTEncoding_Term.mkForall
                                               t0.FStar_Syntax_Syntax.pos
                                               ([[t_has_kind]], cvars,
                                                 t_has_kind) in
-                                          (uu____5138,
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                a_name), a_name) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5131 in
+                                          uu___8 in
                                       let f_has_t =
                                         FStar_SMTEncoding_Term.mk_HasType f
                                           t2 in
@@ -1700,127 +1668,127 @@ and (encode_term :
                                       let pre_typing =
                                         let a_name =
                                           Prims.op_Hat "pre_typing_" tsym in
-                                        let uu____5151 =
-                                          let uu____5158 =
-                                            let uu____5159 =
-                                              let uu____5170 =
-                                                let uu____5171 =
-                                                  let uu____5176 =
-                                                    let uu____5177 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
+                                                let uu___12 =
+                                                  let uu___13 =
+                                                    let uu___14 =
                                                       FStar_SMTEncoding_Term.mk_PreType
                                                         f in
                                                     FStar_SMTEncoding_Term.mk_tester
-                                                      "Tm_arrow" uu____5177 in
-                                                  (f_has_t, uu____5176) in
+                                                      "Tm_arrow" uu___14 in
+                                                  (f_has_t, uu___13) in
                                                 FStar_SMTEncoding_Util.mkImp
-                                                  uu____5171 in
+                                                  uu___12 in
                                               ([[f_has_t]], (fsym :: cvars),
-                                                uu____5170) in
-                                            let uu____5192 =
+                                                uu___11) in
+                                            let uu___11 =
                                               mkForall_fuel module_name
                                                 t0.FStar_Syntax_Syntax.pos in
-                                            uu____5192 uu____5159 in
-                                          (uu____5158,
+                                            uu___11 uu___10 in
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                "pre-typing for functions"),
                                             (Prims.op_Hat module_name
                                                (Prims.op_Hat "_" a_name))) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5151 in
+                                          uu___8 in
                                       let t_interp2 =
                                         let a_name =
                                           Prims.op_Hat "interpretation_" tsym in
-                                        let uu____5209 =
-                                          let uu____5216 =
-                                            let uu____5217 =
-                                              let uu____5228 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Util.mkIff
                                                   (f_has_t_z, t_interp1) in
                                               ([[f_has_t_z]], (fsym ::
-                                                cvars), uu____5228) in
+                                                cvars), uu___11) in
                                             FStar_SMTEncoding_Term.mkForall
                                               t0.FStar_Syntax_Syntax.pos
-                                              uu____5217 in
-                                          (uu____5216,
+                                              uu___10 in
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                a_name),
                                             (Prims.op_Hat module_name
                                                (Prims.op_Hat "_" a_name))) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5209 in
+                                          uu___8 in
                                       let t_decls =
                                         [tdecl;
                                         k_assumption;
                                         pre_typing;
                                         t_interp2] in
-                                      let uu____5246 =
-                                        let uu____5247 =
-                                          let uu____5250 =
-                                            let uu____5253 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_SMTEncoding_Term.mk_decls
                                                 tsym tkey_hash t_decls
                                                 (FStar_List.append decls
                                                    (FStar_List.append decls'
                                                       guard_decls)) in
                                             FStar_List.append guard_decls
-                                              uu____5253 in
-                                          FStar_List.append decls' uu____5250 in
-                                        FStar_List.append decls uu____5247 in
-                                      (t2, uu____5246)))))
+                                              uu___11 in
+                                          FStar_List.append decls' uu___10 in
+                                        FStar_List.append decls uu___9 in
+                                      (t2, uu___8)))))
                 else
                   (let tkey_hash =
-                     let uu____5258 =
+                     let uu___4 =
                        encode_binders FStar_Pervasives_Native.None binders1
                          env in
-                     match uu____5258 with
-                     | (vars, guards_l, env_bs, uu____5278, uu____5279) ->
+                     match uu___4 with
+                     | (vars, guards_l, env_bs, uu___5, uu___6) ->
                          let c1 =
-                           let uu____5295 =
+                           let uu___7 =
                              FStar_TypeChecker_Env.unfold_effect_abbrev
                                env.FStar_SMTEncoding_Env.tcenv res in
-                           FStar_All.pipe_right uu____5295
+                           FStar_All.pipe_right uu___7
                              FStar_Syntax_Syntax.mk_Comp in
-                         let uu____5298 =
-                           let uu____5303 =
+                         let uu___7 =
+                           let uu___8 =
                              FStar_All.pipe_right c1
                                FStar_Syntax_Util.comp_result in
-                           encode_term uu____5303 env_bs in
-                         (match uu____5298 with
-                          | (ct, uu____5307) ->
-                              let uu____5308 =
-                                let uu____5315 =
+                           encode_term uu___8 env_bs in
+                         (match uu___7 with
+                          | (ct, uu___8) ->
+                              let uu___9 =
+                                let uu___10 =
                                   FStar_All.pipe_right c1
                                     FStar_Syntax_Util.comp_effect_args in
-                                encode_args uu____5315 env_bs in
-                              (match uu____5308 with
-                               | (effect_args, uu____5317) ->
+                                encode_args uu___10 env_bs in
+                              (match uu___9 with
+                               | (effect_args, uu___10) ->
                                    let tkey =
-                                     let uu____5323 =
-                                       let uu____5334 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_SMTEncoding_Util.mk_and_l
                                            (FStar_List.append guards_l
                                               (FStar_List.append [ct]
                                                  effect_args)) in
-                                       ([], vars, uu____5334) in
+                                       ([], vars, uu___12) in
                                      FStar_SMTEncoding_Term.mkForall
-                                       t1.FStar_Syntax_Syntax.pos uu____5323 in
-                                   let tkey_hash =
-                                     let uu____5342 =
-                                       let uu____5343 =
+                                       t1.FStar_Syntax_Syntax.pos uu___11 in
+                                   let tkey_hash1 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_SMTEncoding_Term.hash_of_term
                                            tkey in
-                                       let uu____5344 =
-                                         let uu____5345 =
-                                           let uu____5346 =
+                                       let uu___13 =
+                                         let uu___14 =
+                                           let uu___15 =
                                              FStar_All.pipe_right c1
                                                FStar_Syntax_Util.comp_effect_name in
-                                           FStar_All.pipe_right uu____5346
+                                           FStar_All.pipe_right uu___15
                                              FStar_Ident.string_of_lid in
-                                         Prims.op_Hat "@Effect=" uu____5345 in
-                                       Prims.op_Hat uu____5343 uu____5344 in
+                                         Prims.op_Hat "@Effect=" uu___14 in
+                                       Prims.op_Hat uu___12 uu___13 in
                                      Prims.op_Hat "Non_total_Tm_arrow"
-                                       uu____5342 in
-                                   FStar_Util.digest_of_string tkey_hash)) in
+                                       uu___11 in
+                                   FStar_Util.digest_of_string tkey_hash1)) in
                    let tsym = Prims.op_Hat "Non_total_Tm_arrow_" tkey_hash in
                    let tdecl =
                      FStar_SMTEncoding_Term.DeclFun
@@ -1830,14 +1798,14 @@ and (encode_term :
                    let t_kinding =
                      let a_name =
                        Prims.op_Hat "non_total_function_typing_" tsym in
-                     let uu____5358 =
-                       let uu____5365 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_SMTEncoding_Term.mk_HasType t2
                            FStar_SMTEncoding_Term.mk_Term_type in
-                       (uu____5365,
+                       (uu___5,
                          (FStar_Pervasives_Native.Some
                             "Typing for non-total arrows"), a_name) in
-                     FStar_SMTEncoding_Util.mkAssume uu____5358 in
+                     FStar_SMTEncoding_Util.mkAssume uu___4 in
                    let fsym =
                      FStar_SMTEncoding_Term.mk_fv
                        ("f", FStar_SMTEncoding_Term.Term_sort) in
@@ -1845,70 +1813,69 @@ and (encode_term :
                    let f_has_t = FStar_SMTEncoding_Term.mk_HasType f t2 in
                    let t_interp =
                      let a_name = Prims.op_Hat "pre_typing_" tsym in
-                     let uu____5371 =
-                       let uu____5378 =
-                         let uu____5379 =
-                           let uu____5390 =
-                             let uu____5391 =
-                               let uu____5396 =
-                                 let uu____5397 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_SMTEncoding_Term.mk_PreType f in
                                  FStar_SMTEncoding_Term.mk_tester "Tm_arrow"
-                                   uu____5397 in
-                               (f_has_t, uu____5396) in
-                             FStar_SMTEncoding_Util.mkImp uu____5391 in
-                           ([[f_has_t]], [fsym], uu____5390) in
-                         let uu____5418 =
+                                   uu___10 in
+                               (f_has_t, uu___9) in
+                             FStar_SMTEncoding_Util.mkImp uu___8 in
+                           ([[f_has_t]], [fsym], uu___7) in
+                         let uu___7 =
                            mkForall_fuel module_name
                              t0.FStar_Syntax_Syntax.pos in
-                         uu____5418 uu____5379 in
-                       (uu____5378, (FStar_Pervasives_Native.Some a_name),
+                         uu___7 uu___6 in
+                       (uu___5, (FStar_Pervasives_Native.Some a_name),
                          a_name) in
-                     FStar_SMTEncoding_Util.mkAssume uu____5371 in
-                   let uu____5433 =
+                     FStar_SMTEncoding_Util.mkAssume uu___4 in
+                   let uu___4 =
                      FStar_SMTEncoding_Term.mk_decls tsym tkey_hash
                        [tdecl; t_kinding; t_interp] [] in
-                   (t2, uu____5433)))
-       | FStar_Syntax_Syntax.Tm_refine uu____5434 ->
-           let uu____5441 =
+                   (t2, uu___4)))
+       | FStar_Syntax_Syntax.Tm_refine uu___1 ->
+           let uu___2 =
              let steps =
                [FStar_TypeChecker_Env.Weak;
                FStar_TypeChecker_Env.HNF;
                FStar_TypeChecker_Env.EraseUniverses] in
-             let uu____5451 =
+             let uu___3 =
                normalize_refinement steps env.FStar_SMTEncoding_Env.tcenv t0 in
-             match uu____5451 with
+             match uu___3 with
              | {
                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine (x, f);
-                 FStar_Syntax_Syntax.pos = uu____5460;
-                 FStar_Syntax_Syntax.vars = uu____5461;_} ->
-                 let uu____5468 =
+                 FStar_Syntax_Syntax.pos = uu___4;
+                 FStar_Syntax_Syntax.vars = uu___5;_} ->
+                 let uu___6 =
                    FStar_Syntax_Subst.open_term
                      [(x, FStar_Pervasives_Native.None)] f in
-                 (match uu____5468 with
+                 (match uu___6 with
                   | (b, f1) ->
-                      let uu____5495 =
-                        let uu____5496 = FStar_List.hd b in
-                        FStar_Pervasives_Native.fst uu____5496 in
-                      (uu____5495, f1))
-             | uu____5513 -> failwith "impossible" in
-           (match uu____5441 with
+                      let uu___7 =
+                        let uu___8 = FStar_List.hd b in
+                        FStar_Pervasives_Native.fst uu___8 in
+                      (uu___7, f1))
+             | uu___4 -> failwith "impossible" in
+           (match uu___2 with
             | (x, f) ->
-                let uu____5530 = encode_term x.FStar_Syntax_Syntax.sort env in
-                (match uu____5530 with
+                let uu___3 = encode_term x.FStar_Syntax_Syntax.sort env in
+                (match uu___3 with
                  | (base_t, decls) ->
-                     let uu____5541 =
-                       FStar_SMTEncoding_Env.gen_term_var env x in
-                     (match uu____5541 with
+                     let uu___4 = FStar_SMTEncoding_Env.gen_term_var env x in
+                     (match uu___4 with
                       | (x1, xtm, env') ->
-                          let uu____5555 = encode_formula f env' in
-                          (match uu____5555 with
+                          let uu___5 = encode_formula f env' in
+                          (match uu___5 with
                            | (refinement, decls') ->
-                               let uu____5566 =
+                               let uu___6 =
                                  FStar_SMTEncoding_Env.fresh_fvar
                                    env.FStar_SMTEncoding_Env.current_module_name
                                    "f" FStar_SMTEncoding_Term.Fuel_sort in
-                               (match uu____5566 with
+                               (match uu___6 with
                                 | (fsym, fterm) ->
                                     let tm_has_type_with_fuel =
                                       FStar_SMTEncoding_Term.mk_HasTypeWithFuel
@@ -1918,30 +1885,28 @@ and (encode_term :
                                       FStar_SMTEncoding_Util.mkAnd
                                         (tm_has_type_with_fuel, refinement) in
                                     let cvars =
-                                      let uu____5588 =
-                                        let uu____5597 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_SMTEncoding_Term.free_variables
                                             refinement in
-                                        let uu____5606 =
+                                        let uu___9 =
                                           FStar_SMTEncoding_Term.free_variables
                                             tm_has_type_with_fuel in
-                                        FStar_List.append uu____5597
-                                          uu____5606 in
+                                        FStar_List.append uu___8 uu___9 in
                                       FStar_Util.remove_dups
-                                        FStar_SMTEncoding_Term.fv_eq
-                                        uu____5588 in
+                                        FStar_SMTEncoding_Term.fv_eq uu___7 in
                                     let cvars1 =
                                       FStar_All.pipe_right cvars
                                         (FStar_List.filter
                                            (fun y ->
-                                              (let uu____5650 =
+                                              (let uu___7 =
                                                  FStar_SMTEncoding_Term.fv_name
                                                    y in
-                                               uu____5650 <> x1) &&
-                                                (let uu____5652 =
+                                               uu___7 <> x1) &&
+                                                (let uu___7 =
                                                    FStar_SMTEncoding_Term.fv_name
                                                      y in
-                                                 uu____5652 <> fsym))) in
+                                                 uu___7 <> fsym))) in
                                     let xfv =
                                       FStar_SMTEncoding_Term.mk_fv
                                         (x1,
@@ -1958,26 +1923,26 @@ and (encode_term :
                                     let tkey_hash =
                                       FStar_SMTEncoding_Term.hash_of_term
                                         tkey in
-                                    ((let uu____5676 =
+                                    ((let uu___8 =
                                         FStar_TypeChecker_Env.debug
                                           env.FStar_SMTEncoding_Env.tcenv
                                           (FStar_Options.Other "SMTEncoding") in
-                                      if uu____5676
+                                      if uu___8
                                       then
-                                        let uu____5677 =
+                                        let uu___9 =
                                           FStar_Syntax_Print.term_to_string f in
-                                        let uu____5678 =
+                                        let uu___10 =
                                           FStar_Util.digest_of_string
                                             tkey_hash in
                                         FStar_Util.print3
                                           "Encoding Tm_refine %s with tkey_hash %s and digest %s\n"
-                                          uu____5677 tkey_hash uu____5678
+                                          uu___9 tkey_hash uu___10
                                       else ());
                                      (let tsym =
-                                        let uu____5681 =
+                                        let uu___8 =
                                           FStar_Util.digest_of_string
                                             tkey_hash in
-                                        Prims.op_Hat "Tm_refine_" uu____5681 in
+                                        Prims.op_Hat "Tm_refine_" uu___8 in
                                       let cvar_sorts =
                                         FStar_List.map
                                           FStar_SMTEncoding_Term.fv_sort
@@ -1988,14 +1953,13 @@ and (encode_term :
                                             FStar_SMTEncoding_Term.Term_sort,
                                             FStar_Pervasives_Native.None) in
                                       let t2 =
-                                        let uu____5695 =
-                                          let uu____5702 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_List.map
                                               FStar_SMTEncoding_Util.mkFreeV
                                               cvars1 in
-                                          (tsym, uu____5702) in
-                                        FStar_SMTEncoding_Util.mkApp
-                                          uu____5695 in
+                                          (tsym, uu___9) in
+                                        FStar_SMTEncoding_Util.mkApp uu___8 in
                                       let x_has_base_t =
                                         FStar_SMTEncoding_Term.mk_HasType xtm
                                           base_t in
@@ -2012,128 +1976,128 @@ and (encode_term :
                                       let t_haseq_ref =
                                         FStar_SMTEncoding_Term.mk_haseq t2 in
                                       let t_haseq =
-                                        let uu____5719 =
-                                          let uu____5726 =
-                                            let uu____5727 =
-                                              let uu____5738 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Util.mkIff
                                                   (t_haseq_ref, t_haseq_base) in
                                               ([[t_haseq_ref]], cvars1,
-                                                uu____5738) in
+                                                uu___11) in
                                             FStar_SMTEncoding_Term.mkForall
                                               t0.FStar_Syntax_Syntax.pos
-                                              uu____5727 in
-                                          (uu____5726,
+                                              uu___10 in
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                (Prims.op_Hat "haseq for "
                                                   tsym)),
                                             (Prims.op_Hat "haseq" tsym)) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5719 in
+                                          uu___8 in
                                       let t_kinding =
-                                        let uu____5748 =
-                                          let uu____5755 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_SMTEncoding_Term.mkForall
                                               t0.FStar_Syntax_Syntax.pos
                                               ([[t_has_kind]], cvars1,
                                                 t_has_kind) in
-                                          (uu____5755,
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                "refinement kinding"),
                                             (Prims.op_Hat
                                                "refinement_kinding_" tsym)) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5748 in
+                                          uu___8 in
                                       let t_interp =
-                                        let uu____5765 =
-                                          let uu____5772 =
-                                            let uu____5773 =
-                                              let uu____5784 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Util.mkIff
                                                   (x_has_t, encoding) in
                                               ([[x_has_t]], (ffv :: xfv ::
-                                                cvars1), uu____5784) in
+                                                cvars1), uu___11) in
                                             FStar_SMTEncoding_Term.mkForall
                                               t0.FStar_Syntax_Syntax.pos
-                                              uu____5773 in
-                                          (uu____5772,
+                                              uu___10 in
+                                          (uu___9,
                                             (FStar_Pervasives_Native.Some
                                                "refinement_interpretation"),
                                             (Prims.op_Hat
                                                "refinement_interpretation_"
                                                tsym)) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____5765 in
+                                          uu___8 in
                                       let t_decls =
                                         [tdecl; t_kinding; t_interp; t_haseq] in
-                                      let uu____5808 =
-                                        let uu____5809 =
-                                          let uu____5812 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             FStar_SMTEncoding_Term.mk_decls
                                               tsym tkey_hash t_decls
                                               (FStar_List.append decls decls') in
-                                          FStar_List.append decls' uu____5812 in
-                                        FStar_List.append decls uu____5809 in
-                                      (t2, uu____5808))))))))
-       | FStar_Syntax_Syntax.Tm_uvar (uv, uu____5816) ->
+                                          FStar_List.append decls' uu___10 in
+                                        FStar_List.append decls uu___9 in
+                                      (t2, uu___8))))))))
+       | FStar_Syntax_Syntax.Tm_uvar (uv, uu___1) ->
            let ttm =
-             let uu____5834 =
+             let uu___2 =
                FStar_Syntax_Unionfind.uvar_id
                  uv.FStar_Syntax_Syntax.ctx_uvar_head in
-             FStar_SMTEncoding_Util.mk_Term_uvar uu____5834 in
-           let uu____5835 =
+             FStar_SMTEncoding_Util.mk_Term_uvar uu___2 in
+           let uu___2 =
              encode_term_pred FStar_Pervasives_Native.None
                uv.FStar_Syntax_Syntax.ctx_uvar_typ env ttm in
-           (match uu____5835 with
+           (match uu___2 with
             | (t_has_k, decls) ->
                 let d =
-                  let uu____5847 =
-                    let uu____5854 =
-                      let uu____5855 =
-                        let uu____5856 =
-                          let uu____5857 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
                             FStar_Syntax_Unionfind.uvar_id
                               uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                          FStar_Util.string_of_int uu____5857 in
-                        FStar_Util.format1 "uvar_typing_%s" uu____5856 in
+                          FStar_Util.string_of_int uu___7 in
+                        FStar_Util.format1 "uvar_typing_%s" uu___6 in
                       FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                        uu____5855 in
+                        uu___5 in
                     (t_has_k, (FStar_Pervasives_Native.Some "Uvar typing"),
-                      uu____5854) in
-                  FStar_SMTEncoding_Util.mkAssume uu____5847 in
-                let uu____5858 =
-                  let uu____5859 =
+                      uu___4) in
+                  FStar_SMTEncoding_Util.mkAssume uu___3 in
+                let uu___3 =
+                  let uu___4 =
                     FStar_All.pipe_right [d]
                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                  FStar_List.append decls uu____5859 in
-                (ttm, uu____5858))
-       | FStar_Syntax_Syntax.Tm_app uu____5866 ->
-           let uu____5883 = FStar_Syntax_Util.head_and_args t0 in
-           (match uu____5883 with
+                  FStar_List.append decls uu___4 in
+                (ttm, uu___3))
+       | FStar_Syntax_Syntax.Tm_app uu___1 ->
+           let uu___2 = FStar_Syntax_Util.head_and_args t0 in
+           (match uu___2 with
             | (head, args_e) ->
-                let uu____5930 =
-                  let uu____5947 = head_redex env head in
-                  if uu____5947
+                let uu___3 =
+                  let uu___4 = head_redex env head in
+                  if uu___4
                   then
-                    let uu____5964 = maybe_whnf env t0 in
-                    match uu____5964 with
+                    let uu___5 = maybe_whnf env t0 in
+                    match uu___5 with
                     | FStar_Pervasives_Native.None -> (head, args_e)
                     | FStar_Pervasives_Native.Some t2 ->
                         FStar_Syntax_Util.head_and_args t2
                   else (head, args_e) in
-                (match uu____5930 with
+                (match uu___3 with
                  | (head1, args_e1) ->
-                     let uu____6039 =
-                       let uu____6054 =
-                         let uu____6055 = FStar_Syntax_Subst.compress head1 in
-                         uu____6055.FStar_Syntax_Syntax.n in
-                       (uu____6054, args_e1) in
-                     (match uu____6039 with
-                      | uu____6072 when is_arithmetic_primitive head1 args_e1
-                          -> encode_arith_term env head1 args_e1
-                      | uu____6095 when is_BitVector_primitive head1 args_e1
-                          -> encode_BitVector_term env head1 args_e1
-                      | (FStar_Syntax_Syntax.Tm_fvar fv, uu____6113) when
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 = FStar_Syntax_Subst.compress head1 in
+                         uu___6.FStar_Syntax_Syntax.n in
+                       (uu___5, args_e1) in
+                     (match uu___4 with
+                      | uu___5 when is_arithmetic_primitive head1 args_e1 ->
+                          encode_arith_term env head1 args_e1
+                      | uu___5 when is_BitVector_primitive head1 args_e1 ->
+                          encode_BitVector_term env head1 args_e1
+                      | (FStar_Syntax_Syntax.Tm_fvar fv, uu___5) when
                           (Prims.op_Negation
                              env.FStar_SMTEncoding_Env.encoding_quantifier)
                             &&
@@ -2147,10 +2111,10 @@ and (encode_term :
                          ({
                             FStar_Syntax_Syntax.n =
                               FStar_Syntax_Syntax.Tm_fvar fv;
-                            FStar_Syntax_Syntax.pos = uu____6135;
-                            FStar_Syntax_Syntax.vars = uu____6136;_},
-                          uu____6137),
-                         uu____6138) when
+                            FStar_Syntax_Syntax.pos = uu___5;
+                            FStar_Syntax_Syntax.vars = uu___6;_},
+                          uu___7),
+                         uu___8) when
                           (Prims.op_Negation
                              env.FStar_SMTEncoding_Env.encoding_quantifier)
                             &&
@@ -2164,228 +2128,222 @@ and (encode_term :
                          ({
                             FStar_Syntax_Syntax.n =
                               FStar_Syntax_Syntax.Tm_fvar fv;
-                            FStar_Syntax_Syntax.pos = uu____6164;
-                            FStar_Syntax_Syntax.vars = uu____6165;_},
-                          uu____6166),
-                         (v0, uu____6168)::(v1, uu____6170)::(v2, uu____6172)::[])
-                          when
+                            FStar_Syntax_Syntax.pos = uu___5;
+                            FStar_Syntax_Syntax.vars = uu___6;_},
+                          uu___7),
+                         (v0, uu___8)::(v1, uu___9)::(v2, uu___10)::[]) when
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           ->
-                          let uu____6243 = encode_term v0 env in
-                          (match uu____6243 with
+                          let uu___11 = encode_term v0 env in
+                          (match uu___11 with
                            | (v01, decls0) ->
-                               let uu____6254 = encode_term v1 env in
-                               (match uu____6254 with
+                               let uu___12 = encode_term v1 env in
+                               (match uu___12 with
                                 | (v11, decls1) ->
-                                    let uu____6265 = encode_term v2 env in
-                                    (match uu____6265 with
+                                    let uu___13 = encode_term v2 env in
+                                    (match uu___13 with
                                      | (v21, decls2) ->
-                                         let uu____6276 =
+                                         let uu___14 =
                                            FStar_SMTEncoding_Util.mk_LexCons
                                              v01 v11 v21 in
-                                         (uu____6276,
+                                         (uu___14,
                                            (FStar_List.append decls0
                                               (FStar_List.append decls1
                                                  decls2))))))
                       | (FStar_Syntax_Syntax.Tm_fvar fv,
-                         (v0, uu____6279)::(v1, uu____6281)::(v2, uu____6283)::[])
-                          when
+                         (v0, uu___5)::(v1, uu___6)::(v2, uu___7)::[]) when
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           ->
-                          let uu____6350 = encode_term v0 env in
-                          (match uu____6350 with
+                          let uu___8 = encode_term v0 env in
+                          (match uu___8 with
                            | (v01, decls0) ->
-                               let uu____6361 = encode_term v1 env in
-                               (match uu____6361 with
+                               let uu___9 = encode_term v1 env in
+                               (match uu___9 with
                                 | (v11, decls1) ->
-                                    let uu____6372 = encode_term v2 env in
-                                    (match uu____6372 with
+                                    let uu___10 = encode_term v2 env in
+                                    (match uu___10 with
                                      | (v21, decls2) ->
-                                         let uu____6383 =
+                                         let uu___11 =
                                            FStar_SMTEncoding_Util.mk_LexCons
                                              v01 v11 v21 in
-                                         (uu____6383,
+                                         (uu___11,
                                            (FStar_List.append decls0
                                               (FStar_List.append decls1
                                                  decls2))))))
                       | (FStar_Syntax_Syntax.Tm_constant
-                         (FStar_Const.Const_range_of), (arg, uu____6385)::[])
-                          ->
+                         (FStar_Const.Const_range_of), (arg, uu___5)::[]) ->
                           encode_const
                             (FStar_Const.Const_range
                                (arg.FStar_Syntax_Syntax.pos)) env
                       | (FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_set_range_of),
-                         (arg, uu____6421)::(rng, uu____6423)::[]) ->
+                         (arg, uu___5)::(rng, uu___6)::[]) ->
                           encode_term arg env
                       | (FStar_Syntax_Syntax.Tm_constant
-                         (FStar_Const.Const_reify), uu____6474) ->
+                         (FStar_Const.Const_reify), uu___5) ->
                           let e0 =
-                            let uu____6496 = FStar_List.hd args_e1 in
+                            let uu___6 = FStar_List.hd args_e1 in
                             FStar_TypeChecker_Util.reify_body_with_arg
-                              env.FStar_SMTEncoding_Env.tcenv [] head1
-                              uu____6496 in
-                          ((let uu____6506 =
+                              env.FStar_SMTEncoding_Env.tcenv [] head1 uu___6 in
+                          ((let uu___7 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug
                                    env.FStar_SMTEncoding_Env.tcenv)
                                 (FStar_Options.Other "SMTEncodingReify") in
-                            if uu____6506
+                            if uu___7
                             then
-                              let uu____6507 =
+                              let uu___8 =
                                 FStar_Syntax_Print.term_to_string e0 in
                               FStar_Util.print1
-                                "Result of normalization %s\n" uu____6507
+                                "Result of normalization %s\n" uu___8
                             else ());
                            (let e =
-                              let uu____6510 =
+                              let uu___7 =
                                 FStar_TypeChecker_Util.remove_reify e0 in
-                              let uu____6511 = FStar_List.tl args_e1 in
-                              FStar_Syntax_Syntax.mk_Tm_app uu____6510
-                                uu____6511 t0.FStar_Syntax_Syntax.pos in
+                              let uu___8 = FStar_List.tl args_e1 in
+                              FStar_Syntax_Syntax.mk_Tm_app uu___7 uu___8
+                                t0.FStar_Syntax_Syntax.pos in
                             encode_term e env))
                       | (FStar_Syntax_Syntax.Tm_constant
-                         (FStar_Const.Const_reflect uu____6520),
-                         (arg, uu____6522)::[]) -> encode_term arg env
-                      | uu____6557 ->
-                          let uu____6572 = encode_args args_e1 env in
-                          (match uu____6572 with
+                         (FStar_Const.Const_reflect uu___5),
+                         (arg, uu___6)::[]) -> encode_term arg env
+                      | uu___5 ->
+                          let uu___6 = encode_args args_e1 env in
+                          (match uu___6 with
                            | (args, decls) ->
                                let encode_partial_app ht_opt =
-                                 let uu____6641 = encode_term head1 env in
-                                 match uu____6641 with
+                                 let uu___7 = encode_term head1 env in
+                                 match uu___7 with
                                  | (smt_head, decls') ->
                                      let app_tm = mk_Apply_args smt_head args in
                                      (match ht_opt with
-                                      | uu____6661 when
+                                      | uu___8 when
                                           Prims.int_one = Prims.int_one ->
                                           (app_tm,
                                             (FStar_List.append decls decls'))
                                       | FStar_Pervasives_Native.Some
                                           (head_type, formals, c) ->
-                                          ((let uu____6730 =
+                                          ((let uu___9 =
                                               FStar_TypeChecker_Env.debug
                                                 env.FStar_SMTEncoding_Env.tcenv
                                                 (FStar_Options.Other
                                                    "PartialApp") in
-                                            if uu____6730
+                                            if uu___9
                                             then
-                                              let uu____6731 =
+                                              let uu___10 =
                                                 FStar_Syntax_Print.term_to_string
                                                   head1 in
-                                              let uu____6732 =
+                                              let uu___11 =
                                                 FStar_Syntax_Print.term_to_string
                                                   head_type in
-                                              let uu____6733 =
+                                              let uu___12 =
                                                 FStar_Syntax_Print.binders_to_string
                                                   ", " formals in
-                                              let uu____6734 =
+                                              let uu___13 =
                                                 FStar_Syntax_Print.comp_to_string
                                                   c in
-                                              let uu____6735 =
+                                              let uu___14 =
                                                 FStar_Syntax_Print.args_to_string
                                                   args_e1 in
                                               FStar_Util.print5
                                                 "Encoding partial application:\n\thead=%s\n\thead_type=%s\n\tformals=%s\n\tcomp=%s\n\tactual args=%s\n"
-                                                uu____6731 uu____6732
-                                                uu____6733 uu____6734
-                                                uu____6735
+                                                uu___10 uu___11 uu___12
+                                                uu___13 uu___14
                                             else ());
-                                           (let uu____6737 =
+                                           (let uu___9 =
                                               FStar_Util.first_N
                                                 (FStar_List.length args_e1)
                                                 formals in
-                                            match uu____6737 with
+                                            match uu___9 with
                                             | (formals1, rest) ->
                                                 let subst =
                                                   FStar_List.map2
-                                                    (fun uu____6835 ->
-                                                       fun uu____6836 ->
-                                                         match (uu____6835,
-                                                                 uu____6836)
+                                                    (fun uu___10 ->
+                                                       fun uu___11 ->
+                                                         match (uu___10,
+                                                                 uu___11)
                                                          with
-                                                         | ((bv, uu____6866),
-                                                            (a, uu____6868))
-                                                             ->
+                                                         | ((bv, uu___12),
+                                                            (a, uu___13)) ->
                                                              FStar_Syntax_Syntax.NT
                                                                (bv, a))
                                                     formals1 args_e1 in
                                                 let ty =
-                                                  let uu____6900 =
+                                                  let uu___10 =
                                                     FStar_Syntax_Util.arrow
                                                       rest c in
                                                   FStar_All.pipe_right
-                                                    uu____6900
+                                                    uu___10
                                                     (FStar_Syntax_Subst.subst
                                                        subst) in
-                                                ((let uu____6904 =
+                                                ((let uu___11 =
                                                     FStar_TypeChecker_Env.debug
                                                       env.FStar_SMTEncoding_Env.tcenv
                                                       (FStar_Options.Other
                                                          "PartialApp") in
-                                                  if uu____6904
+                                                  if uu___11
                                                   then
-                                                    let uu____6905 =
+                                                    let uu___12 =
                                                       FStar_Syntax_Print.term_to_string
                                                         ty in
                                                     FStar_Util.print1
                                                       "Encoding partial application, after subst:\n\tty=%s\n"
-                                                      uu____6905
+                                                      uu___12
                                                   else ());
-                                                 (let uu____6907 =
-                                                    let uu____6920 =
+                                                 (let uu___11 =
+                                                    let uu___12 =
                                                       FStar_List.fold_left2
-                                                        (fun uu____6955 ->
-                                                           fun uu____6956 ->
+                                                        (fun uu___13 ->
+                                                           fun uu___14 ->
                                                              fun e ->
                                                                match 
-                                                                 (uu____6955,
-                                                                   uu____6956)
+                                                                 (uu___13,
+                                                                   uu___14)
                                                                with
                                                                | ((t_hyps,
                                                                    decls1),
                                                                   (bv,
-                                                                   uu____6997))
+                                                                   uu___15))
                                                                    ->
                                                                    let t2 =
                                                                     FStar_Syntax_Subst.subst
                                                                     subst
                                                                     bv.FStar_Syntax_Syntax.sort in
-                                                                   let uu____7025
+                                                                   let uu___16
                                                                     =
                                                                     encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     t2 env e in
-                                                                   (match uu____7025
+                                                                   (match uu___16
                                                                     with
                                                                     | 
                                                                     (t_hyp,
                                                                     decls'1)
                                                                     ->
                                                                     ((
-                                                                    let uu____7041
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_Env.debug
                                                                     env.FStar_SMTEncoding_Env.tcenv
                                                                     (FStar_Options.Other
                                                                     "PartialApp") in
                                                                     if
-                                                                    uu____7041
+                                                                    uu___18
                                                                     then
-                                                                    let uu____7042
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2 in
-                                                                    let uu____7043
+                                                                    let uu___20
                                                                     =
                                                                     FStar_SMTEncoding_Term.print_smt_term
                                                                     t_hyp in
                                                                     FStar_Util.print2
                                                                     "Encoded typing hypothesis for %s ... got %s\n"
-                                                                    uu____7042
-                                                                    uu____7043
+                                                                    uu___19
+                                                                    uu___20
                                                                     else ());
                                                                     ((t_hyp
                                                                     ::
@@ -2395,22 +2353,21 @@ and (encode_term :
                                                                     decls'1)))))
                                                         ([], []) formals1
                                                         args in
-                                                    match uu____6920 with
+                                                    match uu___12 with
                                                     | (t_hyps, decls1) ->
-                                                        let uu____7075 =
+                                                        let uu___13 =
                                                           match smt_head.FStar_SMTEncoding_Term.tm
                                                           with
                                                           | FStar_SMTEncoding_Term.FreeV
-                                                              uu____7084 ->
+                                                              uu___14 ->
                                                               encode_term_pred
                                                                 FStar_Pervasives_Native.None
                                                                 head_type env
                                                                 smt_head
-                                                          | uu____7091 ->
+                                                          | uu___14 ->
                                                               (FStar_SMTEncoding_Util.mkTrue,
                                                                 []) in
-                                                        (match uu____7075
-                                                         with
+                                                        (match uu___13 with
                                                          | (t_head_hyp,
                                                             decls'1) ->
                                                              let hyp =
@@ -2418,12 +2375,12 @@ and (encode_term :
                                                                  (t_head_hyp
                                                                  :: t_hyps)
                                                                  FStar_Range.dummyRange in
-                                                             let uu____7107 =
+                                                             let uu___14 =
                                                                encode_term_pred
                                                                  FStar_Pervasives_Native.None
                                                                  ty env
                                                                  app_tm in
-                                                             (match uu____7107
+                                                             (match uu___14
                                                               with
                                                               | (has_type_conclusion,
                                                                  decls'') ->
@@ -2439,54 +2396,54 @@ and (encode_term :
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     app_tm in
-                                                                  let uu____7129
+                                                                  let uu___15
                                                                     =
-                                                                    let uu____7136
+                                                                    let uu___16
                                                                     =
                                                                     FStar_SMTEncoding_Term.fvs_subset_of
                                                                     cvars
                                                                     app_tm_vars in
                                                                     if
-                                                                    uu____7136
+                                                                    uu___16
                                                                     then
                                                                     ([app_tm],
                                                                     app_tm_vars)
                                                                     else
-                                                                    (let uu____7146
+                                                                    (let uu___18
                                                                     =
-                                                                    let uu____7147
+                                                                    let uu___19
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     has_type_conclusion in
                                                                     FStar_SMTEncoding_Term.fvs_subset_of
                                                                     cvars
-                                                                    uu____7147 in
+                                                                    uu___19 in
                                                                     if
-                                                                    uu____7146
+                                                                    uu___18
                                                                     then
                                                                     ([has_type_conclusion],
                                                                     cvars)
                                                                     else
                                                                     ((
-                                                                    let uu____7158
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____7163
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____7164
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t0 in
                                                                     FStar_Util.format1
                                                                     "No SMT pattern for partial application %s"
-                                                                    uu____7164 in
+                                                                    uu___23 in
                                                                     (FStar_Errors.Warning_SMTPatternIllFormed,
-                                                                    uu____7163) in
+                                                                    uu___22) in
                                                                     FStar_Errors.log_issue
                                                                     t0.FStar_Syntax_Syntax.pos
-                                                                    uu____7158);
+                                                                    uu___21);
                                                                     ([],
                                                                     cvars))) in
-                                                                  (match uu____7129
+                                                                  (match uu___15
                                                                    with
                                                                    | 
                                                                    (pattern1,
@@ -2499,57 +2456,54 @@ and (encode_term :
                                                                     (FStar_List.append
                                                                     decls'1
                                                                     decls'')))))) in
-                                                  match uu____6907 with
+                                                  match uu___11 with
                                                   | (vars, pattern1,
                                                      has_type, decls'') ->
-                                                      ((let uu____7208 =
+                                                      ((let uu___13 =
                                                           FStar_TypeChecker_Env.debug
                                                             env.FStar_SMTEncoding_Env.tcenv
                                                             (FStar_Options.Other
                                                                "PartialApp") in
-                                                        if uu____7208
+                                                        if uu___13
                                                         then
-                                                          let uu____7209 =
+                                                          let uu___14 =
                                                             FStar_SMTEncoding_Term.print_smt_term
                                                               has_type in
                                                           FStar_Util.print1
                                                             "Encoding partial application, after SMT encoded predicate:\n\t=%s\n"
-                                                            uu____7209
+                                                            uu___14
                                                         else ());
                                                        (let tkey_hash =
                                                           FStar_SMTEncoding_Term.hash_of_term
                                                             app_tm in
                                                         let e_typing =
-                                                          let uu____7213 =
-                                                            let uu____7220 =
+                                                          let uu___13 =
+                                                            let uu___14 =
                                                               FStar_SMTEncoding_Term.mkForall
                                                                 t0.FStar_Syntax_Syntax.pos
                                                                 ([pattern1],
                                                                   vars,
                                                                   has_type) in
-                                                            let uu____7229 =
-                                                              let uu____7230
-                                                                =
-                                                                let uu____7231
-                                                                  =
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                let uu___17 =
                                                                   FStar_SMTEncoding_Term.hash_of_term
                                                                     app_tm in
                                                                 FStar_Util.digest_of_string
-                                                                  uu____7231 in
+                                                                  uu___17 in
                                                               Prims.op_Hat
                                                                 "partial_app_typing_"
-                                                                uu____7230 in
-                                                            (uu____7220,
+                                                                uu___16 in
+                                                            (uu___14,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Partial app typing"),
-                                                              uu____7229) in
+                                                              uu___15) in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____7213 in
-                                                        let uu____7232 =
-                                                          let uu____7235 =
-                                                            let uu____7238 =
-                                                              let uu____7241
-                                                                =
+                                                            uu___13 in
+                                                        let uu___13 =
+                                                          let uu___14 =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_SMTEncoding_Term.mk_decls
                                                                   ""
                                                                   tkey_hash
@@ -2561,20 +2515,19 @@ and (encode_term :
                                                                     decls'')) in
                                                               FStar_List.append
                                                                 decls''
-                                                                uu____7241 in
+                                                                uu___16 in
                                                             FStar_List.append
-                                                              decls'
-                                                              uu____7238 in
+                                                              decls' uu___15 in
                                                           FStar_List.append
-                                                            decls uu____7235 in
-                                                        (app_tm, uu____7232)))))))
+                                                            decls uu___14 in
+                                                        (app_tm, uu___13)))))))
                                       | FStar_Pervasives_Native.None ->
                                           failwith "impossible") in
                                let encode_full_app fv =
-                                 let uu____7284 =
+                                 let uu___7 =
                                    FStar_SMTEncoding_Env.lookup_free_var_sym
                                      env fv in
-                                 match uu____7284 with
+                                 match uu___7 with
                                  | (fname, fuel_args, arity) ->
                                      let tm =
                                        maybe_curry_app
@@ -2589,9 +2542,9 @@ and (encode_term :
                                      ({
                                         FStar_Syntax_Syntax.n =
                                           FStar_Syntax_Syntax.Tm_name x;
-                                        FStar_Syntax_Syntax.pos = uu____7324;
-                                        FStar_Syntax_Syntax.vars = uu____7325;_},
-                                      uu____7326)
+                                        FStar_Syntax_Syntax.pos = uu___7;
+                                        FStar_Syntax_Syntax.vars = uu___8;_},
+                                      uu___9)
                                      ->
                                      FStar_Pervasives_Native.Some
                                        (x.FStar_Syntax_Syntax.sort)
@@ -2602,54 +2555,52 @@ and (encode_term :
                                      ({
                                         FStar_Syntax_Syntax.n =
                                           FStar_Syntax_Syntax.Tm_fvar fv;
-                                        FStar_Syntax_Syntax.pos = uu____7333;
-                                        FStar_Syntax_Syntax.vars = uu____7334;_},
-                                      uu____7335)
+                                        FStar_Syntax_Syntax.pos = uu___7;
+                                        FStar_Syntax_Syntax.vars = uu___8;_},
+                                      uu___9)
                                      ->
-                                     let uu____7340 =
-                                       let uu____7341 =
-                                         let uu____7346 =
+                                     let uu___10 =
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_TypeChecker_Env.lookup_lid
                                              env.FStar_SMTEncoding_Env.tcenv
                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                         FStar_All.pipe_right uu____7346
+                                         FStar_All.pipe_right uu___12
                                            FStar_Pervasives_Native.fst in
-                                       FStar_All.pipe_right uu____7341
+                                       FStar_All.pipe_right uu___11
                                          FStar_Pervasives_Native.snd in
-                                     FStar_Pervasives_Native.Some uu____7340
+                                     FStar_Pervasives_Native.Some uu___10
                                  | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                     let uu____7376 =
-                                       let uu____7377 =
-                                         let uu____7382 =
+                                     let uu___7 =
+                                       let uu___8 =
+                                         let uu___9 =
                                            FStar_TypeChecker_Env.lookup_lid
                                              env.FStar_SMTEncoding_Env.tcenv
                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                         FStar_All.pipe_right uu____7382
+                                         FStar_All.pipe_right uu___9
                                            FStar_Pervasives_Native.fst in
-                                       FStar_All.pipe_right uu____7377
+                                       FStar_All.pipe_right uu___8
                                          FStar_Pervasives_Native.snd in
-                                     FStar_Pervasives_Native.Some uu____7376
+                                     FStar_Pervasives_Native.Some uu___7
                                  | FStar_Syntax_Syntax.Tm_ascribed
-                                     (uu____7411,
-                                      (FStar_Util.Inl t2, uu____7413),
-                                      uu____7414)
+                                     (uu___7, (FStar_Util.Inl t2, uu___8),
+                                      uu___9)
                                      -> FStar_Pervasives_Native.Some t2
                                  | FStar_Syntax_Syntax.Tm_ascribed
-                                     (uu____7461,
-                                      (FStar_Util.Inr c, uu____7463),
-                                      uu____7464)
+                                     (uu___7, (FStar_Util.Inr c, uu___8),
+                                      uu___9)
                                      ->
                                      FStar_Pervasives_Native.Some
                                        (FStar_Syntax_Util.comp_result c)
-                                 | uu____7511 -> FStar_Pervasives_Native.None in
+                                 | uu___7 -> FStar_Pervasives_Native.None in
                                (match head_type with
                                 | FStar_Pervasives_Native.None ->
                                     encode_partial_app
                                       FStar_Pervasives_Native.None
                                 | FStar_Pervasives_Native.Some head_type1 ->
-                                    let uu____7535 =
+                                    let uu___7 =
                                       let head_type2 =
-                                        let uu____7557 =
+                                        let uu___8 =
                                           normalize_refinement
                                             [FStar_TypeChecker_Env.Weak;
                                             FStar_TypeChecker_Env.HNF;
@@ -2657,18 +2608,17 @@ and (encode_term :
                                             env.FStar_SMTEncoding_Env.tcenv
                                             head_type1 in
                                         FStar_All.pipe_left
-                                          FStar_Syntax_Util.unrefine
-                                          uu____7557 in
-                                      let uu____7560 =
+                                          FStar_Syntax_Util.unrefine uu___8 in
+                                      let uu___8 =
                                         curried_arrow_formals_comp head_type2 in
-                                      match uu____7560 with
+                                      match uu___8 with
                                       | (formals, c) ->
                                           if
                                             (FStar_List.length formals) <
                                               (FStar_List.length args)
                                           then
                                             let head_type3 =
-                                              let uu____7610 =
+                                              let uu___9 =
                                                 normalize_refinement
                                                   [FStar_TypeChecker_Env.Weak;
                                                   FStar_TypeChecker_Env.HNF;
@@ -2679,36 +2629,35 @@ and (encode_term :
                                                   head_type2 in
                                               FStar_All.pipe_left
                                                 FStar_Syntax_Util.unrefine
-                                                uu____7610 in
-                                            let uu____7611 =
+                                                uu___9 in
+                                            let uu___9 =
                                               curried_arrow_formals_comp
                                                 head_type3 in
-                                            (match uu____7611 with
+                                            (match uu___9 with
                                              | (formals1, c1) ->
                                                  (head_type3, formals1, c1))
                                           else (head_type2, formals, c) in
-                                    (match uu____7535 with
+                                    (match uu___7 with
                                      | (head_type2, formals, c) ->
-                                         ((let uu____7693 =
+                                         ((let uu___9 =
                                              FStar_TypeChecker_Env.debug
                                                env.FStar_SMTEncoding_Env.tcenv
                                                (FStar_Options.Other
                                                   "PartialApp") in
-                                           if uu____7693
+                                           if uu___9
                                            then
-                                             let uu____7694 =
+                                             let uu___10 =
                                                FStar_Syntax_Print.term_to_string
                                                  head_type2 in
-                                             let uu____7695 =
+                                             let uu___11 =
                                                FStar_Syntax_Print.binders_to_string
                                                  ", " formals in
-                                             let uu____7696 =
+                                             let uu___12 =
                                                FStar_Syntax_Print.args_to_string
                                                  args_e1 in
                                              FStar_Util.print3
                                                "Encoding partial application, head_type = %s, formals = %s, args = %s\n"
-                                               uu____7694 uu____7695
-                                               uu____7696
+                                               uu___10 uu___11 uu___12
                                            else ());
                                           (match head2.FStar_Syntax_Syntax.n
                                            with
@@ -2718,10 +2667,10 @@ and (encode_term :
                                                     FStar_Syntax_Syntax.Tm_fvar
                                                     fv;
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____7703;
+                                                    uu___9;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____7704;_},
-                                                uu____7705)
+                                                    uu___10;_},
+                                                uu___11)
                                                when
                                                (FStar_List.length formals) =
                                                  (FStar_List.length args)
@@ -2735,7 +2684,7 @@ and (encode_term :
                                                ->
                                                encode_full_app
                                                  fv.FStar_Syntax_Syntax.fv_name
-                                           | uu____7723 ->
+                                           | uu___9 ->
                                                if
                                                  (FStar_List.length formals)
                                                    > (FStar_List.length args)
@@ -2748,10 +2697,10 @@ and (encode_term :
                                                  encode_partial_app
                                                    FStar_Pervasives_Native.None))))))))
        | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
-           let uu____7810 = FStar_Syntax_Subst.open_term' bs body in
-           (match uu____7810 with
+           let uu___1 = FStar_Syntax_Subst.open_term' bs body in
+           (match uu___1 with
             | (bs1, body1, opening) ->
-                let fallback uu____7833 =
+                let fallback uu___2 =
                   let f =
                     FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                       env.FStar_SMTEncoding_Env.current_module_name "Tm_abs" in
@@ -2760,150 +2709,146 @@ and (encode_term :
                       (f, [], FStar_SMTEncoding_Term.Term_sort,
                         (FStar_Pervasives_Native.Some
                            "Imprecise function encoding")) in
-                  let uu____7838 =
-                    let uu____7839 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_SMTEncoding_Term.mk_fv
                         (f, FStar_SMTEncoding_Term.Term_sort) in
-                    FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV
-                      uu____7839 in
-                  let uu____7840 =
+                    FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___4 in
+                  let uu___4 =
                     FStar_All.pipe_right [decl]
                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                  (uu____7838, uu____7840) in
+                  (uu___3, uu___4) in
                 let is_impure rc =
-                  let uu____7849 =
+                  let uu___2 =
                     FStar_TypeChecker_Util.is_pure_or_ghost_effect
                       env.FStar_SMTEncoding_Env.tcenv
                       rc.FStar_Syntax_Syntax.residual_effect in
-                  FStar_All.pipe_right uu____7849 Prims.op_Negation in
+                  FStar_All.pipe_right uu___2 Prims.op_Negation in
                 let codomain_eff rc =
                   let res_typ =
                     match rc.FStar_Syntax_Syntax.residual_typ with
                     | FStar_Pervasives_Native.None ->
-                        let uu____7861 =
-                          let uu____7874 =
+                        let uu___2 =
+                          let uu___3 =
                             FStar_TypeChecker_Env.get_range
                               env.FStar_SMTEncoding_Env.tcenv in
                           FStar_TypeChecker_Util.new_implicit_var
-                            "SMTEncoding codomain" uu____7874
+                            "SMTEncoding codomain" uu___3
                             env.FStar_SMTEncoding_Env.tcenv
                             FStar_Syntax_Util.ktype0 in
-                        (match uu____7861 with
-                         | (t2, uu____7876, uu____7877) -> t2)
+                        (match uu___2 with | (t2, uu___3, uu___4) -> t2)
                     | FStar_Pervasives_Native.Some t2 -> t2 in
-                  let uu____7895 =
+                  let uu___2 =
                     FStar_Ident.lid_equals
                       rc.FStar_Syntax_Syntax.residual_effect
                       FStar_Parser_Const.effect_Tot_lid in
-                  if uu____7895
+                  if uu___2
                   then
-                    let uu____7898 = FStar_Syntax_Syntax.mk_Total res_typ in
-                    FStar_Pervasives_Native.Some uu____7898
+                    let uu___3 = FStar_Syntax_Syntax.mk_Total res_typ in
+                    FStar_Pervasives_Native.Some uu___3
                   else
-                    (let uu____7900 =
+                    (let uu___4 =
                        FStar_Ident.lid_equals
                          rc.FStar_Syntax_Syntax.residual_effect
                          FStar_Parser_Const.effect_GTot_lid in
-                     if uu____7900
+                     if uu___4
                      then
-                       let uu____7903 = FStar_Syntax_Syntax.mk_GTotal res_typ in
-                       FStar_Pervasives_Native.Some uu____7903
+                       let uu___5 = FStar_Syntax_Syntax.mk_GTotal res_typ in
+                       FStar_Pervasives_Native.Some uu___5
                      else FStar_Pervasives_Native.None) in
                 (match lopt with
                  | FStar_Pervasives_Native.None ->
-                     ((let uu____7910 =
-                         let uu____7915 =
-                           let uu____7916 =
-                             FStar_Syntax_Print.term_to_string t0 in
+                     ((let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Syntax_Print.term_to_string t0 in
                            FStar_Util.format1
                              "Losing precision when encoding a function literal: %s\n(Unnannotated abstraction in the compiler ?)"
-                             uu____7916 in
+                             uu___5 in
                          (FStar_Errors.Warning_FunctionLiteralPrecisionLoss,
-                           uu____7915) in
+                           uu___4) in
                        FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                         uu____7910);
+                         uu___3);
                       fallback ())
                  | FStar_Pervasives_Native.Some rc ->
-                     let uu____7918 =
+                     let uu___2 =
                        (is_impure rc) &&
-                         (let uu____7920 =
+                         (let uu___3 =
                             FStar_SMTEncoding_Util.is_smt_reifiable_rc
                               env.FStar_SMTEncoding_Env.tcenv rc in
-                          Prims.op_Negation uu____7920) in
-                     if uu____7918
+                          Prims.op_Negation uu___3) in
+                     if uu___2
                      then fallback ()
                      else
-                       (let uu____7926 =
+                       (let uu___4 =
                           encode_binders FStar_Pervasives_Native.None bs1 env in
-                        match uu____7926 with
-                        | (vars, guards, envbody, decls, uu____7951) ->
+                        match uu___4 with
+                        | (vars, guards, envbody, decls, uu___5) ->
                             let body2 =
-                              let uu____7965 =
+                              let uu___6 =
                                 FStar_SMTEncoding_Util.is_smt_reifiable_rc
                                   env.FStar_SMTEncoding_Env.tcenv rc in
-                              if uu____7965
+                              if uu___6
                               then
                                 FStar_TypeChecker_Util.reify_body
                                   env.FStar_SMTEncoding_Env.tcenv [] body1
                               else body1 in
-                            let uu____7967 = encode_term body2 envbody in
-                            (match uu____7967 with
+                            let uu___6 = encode_term body2 envbody in
+                            (match uu___6 with
                              | (body3, decls') ->
                                  let is_pure =
                                    FStar_Syntax_Util.is_pure_effect
                                      rc.FStar_Syntax_Syntax.residual_effect in
-                                 let uu____7979 =
-                                   let uu____7988 = codomain_eff rc in
-                                   match uu____7988 with
+                                 let uu___7 =
+                                   let uu___8 = codomain_eff rc in
+                                   match uu___8 with
                                    | FStar_Pervasives_Native.None ->
                                        (FStar_Pervasives_Native.None, [])
                                    | FStar_Pervasives_Native.Some c ->
                                        let tfun =
                                          FStar_Syntax_Util.arrow bs1 c in
-                                       let uu____8007 = encode_term tfun env in
-                                       (match uu____8007 with
+                                       let uu___9 = encode_term tfun env in
+                                       (match uu___9 with
                                         | (t2, decls1) ->
                                             ((FStar_Pervasives_Native.Some t2),
                                               decls1)) in
-                                 (match uu____7979 with
+                                 (match uu___7 with
                                   | (arrow_t_opt, decls'') ->
                                       let key_body =
-                                        let uu____8041 =
-                                          let uu____8052 =
-                                            let uu____8053 =
-                                              let uu____8058 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Util.mk_and_l
                                                   guards in
-                                              (uu____8058, body3) in
+                                              (uu___11, body3) in
                                             FStar_SMTEncoding_Util.mkImp
-                                              uu____8053 in
-                                          ([], vars, uu____8052) in
+                                              uu___10 in
+                                          ([], vars, uu___9) in
                                         FStar_SMTEncoding_Term.mkForall
-                                          t0.FStar_Syntax_Syntax.pos
-                                          uu____8041 in
+                                          t0.FStar_Syntax_Syntax.pos uu___8 in
                                       let cvars =
                                         FStar_SMTEncoding_Term.free_variables
                                           key_body in
-                                      let uu____8066 =
+                                      let uu___8 =
                                         match arrow_t_opt with
                                         | FStar_Pervasives_Native.None ->
                                             (cvars, key_body)
                                         | FStar_Pervasives_Native.Some t2 ->
-                                            let uu____8082 =
-                                              let uu____8085 =
-                                                let uu____8094 =
+                                            let uu___9 =
+                                              let uu___10 =
+                                                let uu___11 =
                                                   FStar_SMTEncoding_Term.free_variables
                                                     t2 in
-                                                FStar_List.append uu____8094
+                                                FStar_List.append uu___11
                                                   cvars in
                                               FStar_Util.remove_dups
                                                 FStar_SMTEncoding_Term.fv_eq
-                                                uu____8085 in
-                                            let uu____8115 =
+                                                uu___10 in
+                                            let uu___10 =
                                               FStar_SMTEncoding_Util.mkAnd
                                                 (key_body, t2) in
-                                            (uu____8082, uu____8115) in
-                                      (match uu____8066 with
+                                            (uu___9, uu___10) in
+                                      (match uu___8 with
                                        | (cvars1, key_body1) ->
                                            let tkey =
                                              FStar_SMTEncoding_Term.mkForall
@@ -2912,49 +2857,48 @@ and (encode_term :
                                            let tkey_hash =
                                              FStar_SMTEncoding_Term.hash_of_term
                                                tkey in
-                                           ((let uu____8137 =
+                                           ((let uu___10 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env.FStar_SMTEncoding_Env.tcenv)
                                                  (FStar_Options.Other
                                                     "PartialApp") in
-                                             if uu____8137
+                                             if uu___10
                                              then
-                                               let uu____8138 =
-                                                 let uu____8139 =
+                                               let uu___11 =
+                                                 let uu___12 =
                                                    FStar_List.map
                                                      FStar_SMTEncoding_Term.fv_name
                                                      vars in
-                                                 FStar_All.pipe_right
-                                                   uu____8139
+                                                 FStar_All.pipe_right uu___12
                                                    (FStar_String.concat ", ") in
-                                               let uu____8144 =
+                                               let uu___12 =
                                                  FStar_SMTEncoding_Term.print_smt_term
                                                    body3 in
                                                FStar_Util.print2
                                                  "Checking eta expansion of\n\tvars={%s}\n\tbody=%s\n"
-                                                 uu____8138 uu____8144
+                                                 uu___11 uu___12
                                              else ());
-                                            (let uu____8146 =
+                                            (let uu___10 =
                                                is_an_eta_expansion env vars
                                                  body3 in
-                                             match uu____8146 with
+                                             match uu___10 with
                                              | FStar_Pervasives_Native.Some
                                                  t2 ->
-                                                 ((let uu____8155 =
+                                                 ((let uu___12 =
                                                      FStar_All.pipe_left
                                                        (FStar_TypeChecker_Env.debug
                                                           env.FStar_SMTEncoding_Env.tcenv)
                                                        (FStar_Options.Other
                                                           "PartialApp") in
-                                                   if uu____8155
+                                                   if uu___12
                                                    then
-                                                     let uu____8156 =
+                                                     let uu___13 =
                                                        FStar_SMTEncoding_Term.print_smt_term
                                                          t2 in
                                                      FStar_Util.print1
                                                        "Yes, is an eta expansion of\n\tcore=%s\n"
-                                                       uu____8156
+                                                       uu___13
                                                    else ());
                                                   (let decls1 =
                                                      FStar_List.append decls
@@ -2968,25 +2912,25 @@ and (encode_term :
                                                      FStar_SMTEncoding_Term.fv_sort
                                                      cvars1 in
                                                  let fsym =
-                                                   let uu____8165 =
+                                                   let uu___11 =
                                                      FStar_Util.digest_of_string
                                                        tkey_hash in
                                                    Prims.op_Hat "Tm_abs_"
-                                                     uu____8165 in
+                                                     uu___11 in
                                                  let fdecl =
                                                    FStar_SMTEncoding_Term.DeclFun
                                                      (fsym, cvar_sorts,
                                                        FStar_SMTEncoding_Term.Term_sort,
                                                        FStar_Pervasives_Native.None) in
                                                  let f =
-                                                   let uu____8170 =
-                                                     let uu____8177 =
+                                                   let uu___11 =
+                                                     let uu___12 =
                                                        FStar_List.map
                                                          FStar_SMTEncoding_Util.mkFreeV
                                                          cvars1 in
-                                                     (fsym, uu____8177) in
+                                                     (fsym, uu___12) in
                                                    FStar_SMTEncoding_Util.mkApp
-                                                     uu____8170 in
+                                                     uu___11 in
                                                  let app = mk_Apply f vars in
                                                  let typing_f =
                                                    match arrow_t_opt with
@@ -2994,22 +2938,21 @@ and (encode_term :
                                                        ->
                                                        let tot_fun_ax =
                                                          let ax =
-                                                           let uu____8190 =
+                                                           let uu___11 =
                                                              FStar_All.pipe_right
                                                                vars
                                                                (FStar_List.map
                                                                   (fun
-                                                                    uu____8198
+                                                                    uu___12
                                                                     ->
                                                                     FStar_SMTEncoding_Util.mkTrue)) in
                                                            isTotFun_axioms
                                                              t0.FStar_Syntax_Syntax.pos
-                                                             f vars
-                                                             uu____8190
+                                                             f vars uu___11
                                                              is_pure in
                                                          match cvars1 with
                                                          | [] -> ax
-                                                         | uu____8199 ->
+                                                         | uu___11 ->
                                                              FStar_SMTEncoding_Term.mkForall
                                                                t0.FStar_Syntax_Syntax.pos
                                                                ([[f]],
@@ -3017,13 +2960,13 @@ and (encode_term :
                                                        let a_name =
                                                          Prims.op_Hat
                                                            "tot_fun_" fsym in
-                                                       let uu____8211 =
+                                                       let uu___11 =
                                                          FStar_SMTEncoding_Util.mkAssume
                                                            (tot_fun_ax,
                                                              (FStar_Pervasives_Native.Some
                                                                 a_name),
                                                              a_name) in
-                                                       [uu____8211]
+                                                       [uu___11]
                                                    | FStar_Pervasives_Native.Some
                                                        t2 ->
                                                        let f_has_t =
@@ -3033,50 +2976,50 @@ and (encode_term :
                                                        let a_name =
                                                          Prims.op_Hat
                                                            "typing_" fsym in
-                                                       let uu____8215 =
-                                                         let uu____8216 =
-                                                           let uu____8223 =
+                                                       let uu___11 =
+                                                         let uu___12 =
+                                                           let uu___13 =
                                                              FStar_SMTEncoding_Term.mkForall
                                                                t0.FStar_Syntax_Syntax.pos
                                                                ([[f]],
                                                                  cvars1,
                                                                  f_has_t) in
-                                                           (uu____8223,
+                                                           (uu___13,
                                                              (FStar_Pervasives_Native.Some
                                                                 a_name),
                                                              a_name) in
                                                          FStar_SMTEncoding_Util.mkAssume
-                                                           uu____8216 in
-                                                       [uu____8215] in
+                                                           uu___12 in
+                                                       [uu___11] in
                                                  let interp_f =
                                                    let a_name =
                                                      Prims.op_Hat
                                                        "interpretation_" fsym in
-                                                   let uu____8234 =
-                                                     let uu____8241 =
-                                                       let uu____8242 =
-                                                         let uu____8253 =
+                                                   let uu___11 =
+                                                     let uu___12 =
+                                                       let uu___13 =
+                                                         let uu___14 =
                                                            FStar_SMTEncoding_Util.mkEq
                                                              (app, body3) in
                                                          ([[app]],
                                                            (FStar_List.append
                                                               vars cvars1),
-                                                           uu____8253) in
+                                                           uu___14) in
                                                        FStar_SMTEncoding_Term.mkForall
                                                          t0.FStar_Syntax_Syntax.pos
-                                                         uu____8242 in
-                                                     (uu____8241,
+                                                         uu___13 in
+                                                     (uu___12,
                                                        (FStar_Pervasives_Native.Some
                                                           a_name), a_name) in
                                                    FStar_SMTEncoding_Util.mkAssume
-                                                     uu____8234 in
+                                                     uu___11 in
                                                  let f_decls =
                                                    FStar_List.append (fdecl
                                                      :: typing_f) [interp_f] in
-                                                 let uu____8265 =
-                                                   let uu____8266 =
-                                                     let uu____8269 =
-                                                       let uu____8272 =
+                                                 let uu___11 =
+                                                   let uu___12 =
+                                                     let uu___13 =
+                                                       let uu___14 =
                                                          FStar_SMTEncoding_Term.mk_decls
                                                            fsym tkey_hash
                                                            f_decls
@@ -3086,57 +3029,56 @@ and (encode_term :
                                                                  decls'
                                                                  decls'')) in
                                                        FStar_List.append
-                                                         decls'' uu____8272 in
+                                                         decls'' uu___14 in
                                                      FStar_List.append decls'
-                                                       uu____8269 in
+                                                       uu___13 in
                                                    FStar_List.append decls
-                                                     uu____8266 in
-                                                 (f, uu____8265)))))))))
+                                                     uu___12 in
+                                                 (f, uu___11)))))))))
        | FStar_Syntax_Syntax.Tm_let
-           ((uu____8275,
-             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8276;
-               FStar_Syntax_Syntax.lbunivs = uu____8277;
-               FStar_Syntax_Syntax.lbtyp = uu____8278;
-               FStar_Syntax_Syntax.lbeff = uu____8279;
-               FStar_Syntax_Syntax.lbdef = uu____8280;
-               FStar_Syntax_Syntax.lbattrs = uu____8281;
-               FStar_Syntax_Syntax.lbpos = uu____8282;_}::uu____8283),
-            uu____8284)
+           ((uu___1,
+             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu___2;
+               FStar_Syntax_Syntax.lbunivs = uu___3;
+               FStar_Syntax_Syntax.lbtyp = uu___4;
+               FStar_Syntax_Syntax.lbeff = uu___5;
+               FStar_Syntax_Syntax.lbdef = uu___6;
+               FStar_Syntax_Syntax.lbattrs = uu___7;
+               FStar_Syntax_Syntax.lbpos = uu___8;_}::uu___9),
+            uu___10)
            -> failwith "Impossible: already handled by encoding of Sig_let"
        | FStar_Syntax_Syntax.Tm_let
            ((false,
              { FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-               FStar_Syntax_Syntax.lbunivs = uu____8314;
+               FStar_Syntax_Syntax.lbunivs = uu___1;
                FStar_Syntax_Syntax.lbtyp = t11;
-               FStar_Syntax_Syntax.lbeff = uu____8316;
+               FStar_Syntax_Syntax.lbeff = uu___2;
                FStar_Syntax_Syntax.lbdef = e1;
-               FStar_Syntax_Syntax.lbattrs = uu____8318;
-               FStar_Syntax_Syntax.lbpos = uu____8319;_}::[]),
+               FStar_Syntax_Syntax.lbattrs = uu___3;
+               FStar_Syntax_Syntax.lbpos = uu___4;_}::[]),
             e2)
            -> encode_let x t11 e1 e2 env encode_term
-       | FStar_Syntax_Syntax.Tm_let
-           ((false, uu____8343::uu____8344), uu____8345) ->
+       | FStar_Syntax_Syntax.Tm_let ((false, uu___1::uu___2), uu___3) ->
            failwith "Impossible: non-recursive let with multiple bindings"
-       | FStar_Syntax_Syntax.Tm_let ((uu____8364, lbs), uu____8366) ->
+       | FStar_Syntax_Syntax.Tm_let ((uu___1, lbs), uu___2) ->
            let names =
              FStar_All.pipe_right lbs
                (FStar_List.map
                   (fun lb ->
-                     let uu____8413 = lb in
-                     match uu____8413 with
+                     let uu___3 = lb in
+                     match uu___3 with
                      | { FStar_Syntax_Syntax.lbname = lbname;
-                         FStar_Syntax_Syntax.lbunivs = uu____8419;
-                         FStar_Syntax_Syntax.lbtyp = uu____8420;
-                         FStar_Syntax_Syntax.lbeff = uu____8421;
-                         FStar_Syntax_Syntax.lbdef = uu____8422;
-                         FStar_Syntax_Syntax.lbattrs = uu____8423;
-                         FStar_Syntax_Syntax.lbpos = uu____8424;_} ->
+                         FStar_Syntax_Syntax.lbunivs = uu___4;
+                         FStar_Syntax_Syntax.lbtyp = uu___5;
+                         FStar_Syntax_Syntax.lbeff = uu___6;
+                         FStar_Syntax_Syntax.lbdef = uu___7;
+                         FStar_Syntax_Syntax.lbattrs = uu___8;
+                         FStar_Syntax_Syntax.lbpos = uu___9;_} ->
                          let x = FStar_Util.left lbname in
-                         let uu____8440 =
+                         let uu___10 =
                            FStar_Ident.string_of_id
                              x.FStar_Syntax_Syntax.ppname in
-                         let uu____8441 = FStar_Syntax_Syntax.range_of_bv x in
-                         (uu____8440, uu____8441))) in
+                         let uu___11 = FStar_Syntax_Syntax.range_of_bv x in
+                         (uu___10, uu___11))) in
            FStar_Exn.raise (FStar_SMTEncoding_Env.Inner_let_rec names)
        | FStar_Syntax_Syntax.Tm_match (e, pats) ->
            encode_match e pats FStar_SMTEncoding_Term.mk_Term_unit env
@@ -3160,25 +3102,25 @@ and (encode_let :
         fun e2 ->
           fun env ->
             fun encode_body ->
-              let uu____8498 =
-                let uu____8503 =
+              let uu___ =
+                let uu___1 =
                   FStar_Syntax_Util.ascribe e1
                     ((FStar_Util.Inl t1), FStar_Pervasives_Native.None) in
-                encode_term uu____8503 env in
-              match uu____8498 with
+                encode_term uu___1 env in
+              match uu___ with
               | (ee1, decls1) ->
-                  let uu____8528 =
+                  let uu___1 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] e2 in
-                  (match uu____8528 with
+                  (match uu___1 with
                    | (xs, e21) ->
-                       let uu____8553 = FStar_List.hd xs in
-                       (match uu____8553 with
-                        | (x1, uu____8571) ->
+                       let uu___2 = FStar_List.hd xs in
+                       (match uu___2 with
+                        | (x1, uu___3) ->
                             let env' =
                               FStar_SMTEncoding_Env.push_term_var env x1 ee1 in
-                            let uu____8577 = encode_body e21 env' in
-                            (match uu____8577 with
+                            let uu___4 = encode_body e21 env' in
+                            (match uu___4 with
                              | (ee2, decls2) ->
                                  (ee2, (FStar_List.append decls1 decls2)))))
 and (encode_match :
@@ -3196,28 +3138,27 @@ and (encode_match :
       fun default_case ->
         fun env ->
           fun encode_br ->
-            let uu____8607 =
-              let uu____8614 =
-                let uu____8615 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
                   FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
                     FStar_Range.dummyRange in
-                FStar_Syntax_Syntax.null_bv uu____8615 in
-              FStar_SMTEncoding_Env.gen_term_var env uu____8614 in
-            match uu____8607 with
+                FStar_Syntax_Syntax.null_bv uu___2 in
+              FStar_SMTEncoding_Env.gen_term_var env uu___1 in
+            match uu___ with
             | (scrsym, scr', env1) ->
-                let uu____8623 = encode_term e env1 in
-                (match uu____8623 with
+                let uu___1 = encode_term e env1 in
+                (match uu___1 with
                  | (scr, decls) ->
-                     let uu____8634 =
-                       let encode_branch b uu____8663 =
-                         match uu____8663 with
+                     let uu___2 =
+                       let encode_branch b uu___3 =
+                         match uu___3 with
                          | (else_case, decls1) ->
-                             let uu____8682 =
-                               FStar_Syntax_Subst.open_branch b in
-                             (match uu____8682 with
+                             let uu___4 = FStar_Syntax_Subst.open_branch b in
+                             (match uu___4 with
                               | (p, w, br) ->
-                                  let uu____8708 = encode_pat env1 p in
-                                  (match uu____8708 with
+                                  let uu___5 = encode_pat env1 p in
+                                  (match uu___5 with
                                    | (env0, pattern1) ->
                                        let guard = pattern1.guard scr' in
                                        let projections =
@@ -3225,122 +3166,120 @@ and (encode_match :
                                        let env2 =
                                          FStar_All.pipe_right projections
                                            (FStar_List.fold_left
-                                              (fun env2 ->
-                                                 fun uu____8745 ->
-                                                   match uu____8745 with
+                                              (fun env3 ->
+                                                 fun uu___6 ->
+                                                   match uu___6 with
                                                    | (x, t) ->
                                                        FStar_SMTEncoding_Env.push_term_var
-                                                         env2 x t) env1) in
-                                       let uu____8752 =
+                                                         env3 x t) env1) in
+                                       let uu___6 =
                                          match w with
                                          | FStar_Pervasives_Native.None ->
                                              (guard, [])
                                          | FStar_Pervasives_Native.Some w1 ->
-                                             let uu____8774 =
-                                               encode_term w1 env2 in
-                                             (match uu____8774 with
+                                             let uu___7 = encode_term w1 env2 in
+                                             (match uu___7 with
                                               | (w2, decls2) ->
-                                                  let uu____8787 =
-                                                    let uu____8788 =
-                                                      let uu____8793 =
-                                                        let uu____8794 =
-                                                          let uu____8799 =
+                                                  let uu___8 =
+                                                    let uu___9 =
+                                                      let uu___10 =
+                                                        let uu___11 =
+                                                          let uu___12 =
                                                             FStar_SMTEncoding_Term.boxBool
                                                               FStar_SMTEncoding_Util.mkTrue in
-                                                          (w2, uu____8799) in
+                                                          (w2, uu___12) in
                                                         FStar_SMTEncoding_Util.mkEq
-                                                          uu____8794 in
-                                                      (guard, uu____8793) in
+                                                          uu___11 in
+                                                      (guard, uu___10) in
                                                     FStar_SMTEncoding_Util.mkAnd
-                                                      uu____8788 in
-                                                  (uu____8787, decls2)) in
-                                       (match uu____8752 with
+                                                      uu___9 in
+                                                  (uu___8, decls2)) in
+                                       (match uu___6 with
                                         | (guard1, decls2) ->
-                                            let uu____8814 =
-                                              encode_br br env2 in
-                                            (match uu____8814 with
+                                            let uu___7 = encode_br br env2 in
+                                            (match uu___7 with
                                              | (br1, decls3) ->
-                                                 let uu____8827 =
+                                                 let uu___8 =
                                                    FStar_SMTEncoding_Util.mkITE
                                                      (guard1, br1, else_case) in
-                                                 (uu____8827,
+                                                 (uu___8,
                                                    (FStar_List.append decls1
                                                       (FStar_List.append
                                                          decls2 decls3))))))) in
                        FStar_List.fold_right encode_branch pats
                          (default_case, decls) in
-                     (match uu____8634 with
+                     (match uu___2 with
                       | (match_tm, decls1) ->
-                          let uu____8848 =
-                            let uu____8849 =
-                              let uu____8860 =
-                                let uu____8867 =
-                                  let uu____8872 =
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
+                                  let uu___7 =
                                     FStar_SMTEncoding_Term.mk_fv
                                       (scrsym,
                                         FStar_SMTEncoding_Term.Term_sort) in
-                                  (uu____8872, scr) in
-                                [uu____8867] in
-                              (uu____8860, match_tm) in
-                            FStar_SMTEncoding_Term.mkLet' uu____8849
+                                  (uu___7, scr) in
+                                [uu___6] in
+                              (uu___5, match_tm) in
+                            FStar_SMTEncoding_Term.mkLet' uu___4
                               FStar_Range.dummyRange in
-                          (uu____8848, decls1)))
+                          (uu___3, decls1)))
 and (encode_pat :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.pat -> (FStar_SMTEncoding_Env.env_t * pattern))
   =
   fun env ->
     fun pat ->
-      (let uu____8894 =
+      (let uu___1 =
          FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
            FStar_Options.Medium in
-       if uu____8894
+       if uu___1
        then
-         let uu____8895 = FStar_Syntax_Print.pat_to_string pat in
-         FStar_Util.print1 "Encoding pattern %s\n" uu____8895
+         let uu___2 = FStar_Syntax_Print.pat_to_string pat in
+         FStar_Util.print1 "Encoding pattern %s\n" uu___2
        else ());
-      (let uu____8897 = FStar_TypeChecker_Util.decorated_pattern_as_term pat in
-       match uu____8897 with
+      (let uu___1 = FStar_TypeChecker_Util.decorated_pattern_as_term pat in
+       match uu___1 with
        | (vars, pat_term) ->
-           let uu____8914 =
+           let uu___2 =
              FStar_All.pipe_right vars
                (FStar_List.fold_left
-                  (fun uu____8956 ->
+                  (fun uu___3 ->
                      fun v ->
-                       match uu____8956 with
+                       match uu___3 with
                        | (env1, vars1) ->
-                           let uu____8992 =
+                           let uu___4 =
                              FStar_SMTEncoding_Env.gen_term_var env1 v in
-                           (match uu____8992 with
-                            | (xx, uu____9010, env2) ->
-                                let uu____9012 =
-                                  let uu____9019 =
-                                    let uu____9024 =
+                           (match uu___4 with
+                            | (xx, uu___5, env2) ->
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
                                       FStar_SMTEncoding_Term.mk_fv
                                         (xx,
                                           FStar_SMTEncoding_Term.Term_sort) in
-                                    (v, uu____9024) in
-                                  uu____9019 :: vars1 in
-                                (env2, uu____9012))) (env, [])) in
-           (match uu____8914 with
+                                    (v, uu___8) in
+                                  uu___7 :: vars1 in
+                                (env2, uu___6))) (env, [])) in
+           (match uu___2 with
             | (env1, vars1) ->
                 let rec mk_guard pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_var uu____9078 ->
+                  | FStar_Syntax_Syntax.Pat_var uu___3 ->
                       FStar_SMTEncoding_Util.mkTrue
-                  | FStar_Syntax_Syntax.Pat_wild uu____9079 ->
+                  | FStar_Syntax_Syntax.Pat_wild uu___3 ->
                       FStar_SMTEncoding_Util.mkTrue
-                  | FStar_Syntax_Syntax.Pat_dot_term uu____9080 ->
+                  | FStar_Syntax_Syntax.Pat_dot_term uu___3 ->
                       FStar_SMTEncoding_Util.mkTrue
                   | FStar_Syntax_Syntax.Pat_constant c ->
-                      let uu____9088 = encode_const c env1 in
-                      (match uu____9088 with
+                      let uu___3 = encode_const c env1 in
+                      (match uu___3 with
                        | (tm, decls) ->
                            ((match decls with
-                             | uu____9096::uu____9097 ->
+                             | uu___5::uu___6 ->
                                  failwith
                                    "Unexpected encoding of constant pattern"
-                             | uu____9100 -> ());
+                             | uu___5 -> ());
                             FStar_SMTEncoding_Util.mkEq (scrutinee, tm)))
                   | FStar_Syntax_Syntax.Pat_cons (f, args) ->
                       let is_f =
@@ -3348,13 +3287,13 @@ and (encode_pat :
                           FStar_TypeChecker_Env.typ_of_datacon
                             env1.FStar_SMTEncoding_Env.tcenv
                             (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                        let uu____9121 =
+                        let uu___3 =
                           FStar_TypeChecker_Env.datacons_of_typ
                             env1.FStar_SMTEncoding_Env.tcenv tc_name in
-                        match uu____9121 with
-                        | (uu____9128, uu____9129::[]) ->
+                        match uu___3 with
+                        | (uu___4, uu___5::[]) ->
                             FStar_SMTEncoding_Util.mkTrue
-                        | uu____9132 ->
+                        | uu___4 ->
                             FStar_SMTEncoding_Env.mk_data_tester env1
                               (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               scrutinee in
@@ -3362,46 +3301,46 @@ and (encode_pat :
                         FStar_All.pipe_right args
                           (FStar_List.mapi
                              (fun i ->
-                                fun uu____9165 ->
-                                  match uu____9165 with
-                                  | (arg, uu____9173) ->
+                                fun uu___3 ->
+                                  match uu___3 with
+                                  | (arg, uu___4) ->
                                       let proj =
                                         FStar_SMTEncoding_Env.primitive_projector_by_pos
                                           env1.FStar_SMTEncoding_Env.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                           i in
-                                      let uu____9179 =
+                                      let uu___5 =
                                         FStar_SMTEncoding_Util.mkApp
                                           (proj, [scrutinee]) in
-                                      mk_guard arg uu____9179)) in
+                                      mk_guard arg uu___5)) in
                       FStar_SMTEncoding_Util.mk_and_l (is_f ::
                         sub_term_guards) in
                 let rec mk_projections pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_dot_term (x, uu____9210) ->
+                  | FStar_Syntax_Syntax.Pat_dot_term (x, uu___3) ->
                       [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_var x -> [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_wild x -> [(x, scrutinee)]
-                  | FStar_Syntax_Syntax.Pat_constant uu____9241 -> []
+                  | FStar_Syntax_Syntax.Pat_constant uu___3 -> []
                   | FStar_Syntax_Syntax.Pat_cons (f, args) ->
-                      let uu____9264 =
+                      let uu___3 =
                         FStar_All.pipe_right args
                           (FStar_List.mapi
                              (fun i ->
-                                fun uu____9308 ->
-                                  match uu____9308 with
-                                  | (arg, uu____9322) ->
+                                fun uu___4 ->
+                                  match uu___4 with
+                                  | (arg, uu___5) ->
                                       let proj =
                                         FStar_SMTEncoding_Env.primitive_projector_by_pos
                                           env1.FStar_SMTEncoding_Env.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                           i in
-                                      let uu____9328 =
+                                      let uu___6 =
                                         FStar_SMTEncoding_Util.mkApp
                                           (proj, [scrutinee]) in
-                                      mk_projections arg uu____9328)) in
-                      FStar_All.pipe_right uu____9264 FStar_List.flatten in
-                let pat_term1 uu____9358 = encode_term pat_term env1 in
+                                      mk_projections arg uu___6)) in
+                      FStar_All.pipe_right uu___3 FStar_List.flatten in
+                let pat_term1 uu___3 = encode_term pat_term env1 in
                 let pattern1 =
                   {
                     pat_vars = vars1;
@@ -3418,19 +3357,19 @@ and (encode_args :
   =
   fun l ->
     fun env ->
-      let uu____9368 =
+      let uu___ =
         FStar_All.pipe_right l
           (FStar_List.fold_left
-             (fun uu____9416 ->
-                fun uu____9417 ->
-                  match (uu____9416, uu____9417) with
-                  | ((tms, decls), (t, uu____9457)) ->
-                      let uu____9484 = encode_term t env in
-                      (match uu____9484 with
+             (fun uu___1 ->
+                fun uu___2 ->
+                  match (uu___1, uu___2) with
+                  | ((tms, decls), (t, uu___3)) ->
+                      let uu___4 = encode_term t env in
+                      (match uu___4 with
                        | (t1, decls') ->
                            ((t1 :: tms), (FStar_List.append decls decls'))))
              ([], [])) in
-      match uu____9368 with | (l1, decls) -> ((FStar_List.rev l1), decls)
+      match uu___ with | (l1, decls) -> ((FStar_List.rev l1), decls)
 and (encode_function_type_as_formula :
   FStar_Syntax_Syntax.typ ->
     FStar_SMTEncoding_Env.env_t ->
@@ -3439,32 +3378,29 @@ and (encode_function_type_as_formula :
   fun t ->
     fun env ->
       let universe_of_binders binders =
-        FStar_List.map (fun uu____9562 -> FStar_Syntax_Syntax.U_zero) binders in
+        FStar_List.map (fun uu___ -> FStar_Syntax_Syntax.U_zero) binders in
       let quant = FStar_Syntax_Util.smt_lemma_as_forall t universe_of_binders in
       let env1 =
-        let uu___1425_9571 = env in
+        let uu___ = env in
         {
           FStar_SMTEncoding_Env.bvar_bindings =
-            (uu___1425_9571.FStar_SMTEncoding_Env.bvar_bindings);
+            (uu___.FStar_SMTEncoding_Env.bvar_bindings);
           FStar_SMTEncoding_Env.fvar_bindings =
-            (uu___1425_9571.FStar_SMTEncoding_Env.fvar_bindings);
-          FStar_SMTEncoding_Env.depth =
-            (uu___1425_9571.FStar_SMTEncoding_Env.depth);
-          FStar_SMTEncoding_Env.tcenv =
-            (uu___1425_9571.FStar_SMTEncoding_Env.tcenv);
-          FStar_SMTEncoding_Env.warn =
-            (uu___1425_9571.FStar_SMTEncoding_Env.warn);
+            (uu___.FStar_SMTEncoding_Env.fvar_bindings);
+          FStar_SMTEncoding_Env.depth = (uu___.FStar_SMTEncoding_Env.depth);
+          FStar_SMTEncoding_Env.tcenv = (uu___.FStar_SMTEncoding_Env.tcenv);
+          FStar_SMTEncoding_Env.warn = (uu___.FStar_SMTEncoding_Env.warn);
           FStar_SMTEncoding_Env.nolabels =
-            (uu___1425_9571.FStar_SMTEncoding_Env.nolabels);
+            (uu___.FStar_SMTEncoding_Env.nolabels);
           FStar_SMTEncoding_Env.use_zfuel_name = true;
           FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (uu___1425_9571.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            (uu___.FStar_SMTEncoding_Env.encode_non_total_function_typ);
           FStar_SMTEncoding_Env.current_module_name =
-            (uu___1425_9571.FStar_SMTEncoding_Env.current_module_name);
+            (uu___.FStar_SMTEncoding_Env.current_module_name);
           FStar_SMTEncoding_Env.encoding_quantifier =
-            (uu___1425_9571.FStar_SMTEncoding_Env.encoding_quantifier);
+            (uu___.FStar_SMTEncoding_Env.encoding_quantifier);
           FStar_SMTEncoding_Env.global_cache =
-            (uu___1425_9571.FStar_SMTEncoding_Env.global_cache)
+            (uu___.FStar_SMTEncoding_Env.global_cache)
         } in
       encode_formula quant env1
 and (encode_smt_patterns :
@@ -3476,94 +3412,90 @@ and (encode_smt_patterns :
   fun pats_l ->
     fun env ->
       let env1 =
-        let uu___1430_9587 = env in
+        let uu___ = env in
         {
           FStar_SMTEncoding_Env.bvar_bindings =
-            (uu___1430_9587.FStar_SMTEncoding_Env.bvar_bindings);
+            (uu___.FStar_SMTEncoding_Env.bvar_bindings);
           FStar_SMTEncoding_Env.fvar_bindings =
-            (uu___1430_9587.FStar_SMTEncoding_Env.fvar_bindings);
-          FStar_SMTEncoding_Env.depth =
-            (uu___1430_9587.FStar_SMTEncoding_Env.depth);
-          FStar_SMTEncoding_Env.tcenv =
-            (uu___1430_9587.FStar_SMTEncoding_Env.tcenv);
-          FStar_SMTEncoding_Env.warn =
-            (uu___1430_9587.FStar_SMTEncoding_Env.warn);
+            (uu___.FStar_SMTEncoding_Env.fvar_bindings);
+          FStar_SMTEncoding_Env.depth = (uu___.FStar_SMTEncoding_Env.depth);
+          FStar_SMTEncoding_Env.tcenv = (uu___.FStar_SMTEncoding_Env.tcenv);
+          FStar_SMTEncoding_Env.warn = (uu___.FStar_SMTEncoding_Env.warn);
           FStar_SMTEncoding_Env.nolabels =
-            (uu___1430_9587.FStar_SMTEncoding_Env.nolabels);
+            (uu___.FStar_SMTEncoding_Env.nolabels);
           FStar_SMTEncoding_Env.use_zfuel_name = true;
           FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (uu___1430_9587.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            (uu___.FStar_SMTEncoding_Env.encode_non_total_function_typ);
           FStar_SMTEncoding_Env.current_module_name =
-            (uu___1430_9587.FStar_SMTEncoding_Env.current_module_name);
+            (uu___.FStar_SMTEncoding_Env.current_module_name);
           FStar_SMTEncoding_Env.encoding_quantifier =
-            (uu___1430_9587.FStar_SMTEncoding_Env.encoding_quantifier);
+            (uu___.FStar_SMTEncoding_Env.encoding_quantifier);
           FStar_SMTEncoding_Env.global_cache =
-            (uu___1430_9587.FStar_SMTEncoding_Env.global_cache)
+            (uu___.FStar_SMTEncoding_Env.global_cache)
         } in
       let encode_smt_pattern t =
-        let uu____9602 = FStar_Syntax_Util.head_and_args t in
-        match uu____9602 with
+        let uu___ = FStar_Syntax_Util.head_and_args t in
+        match uu___ with
         | (head, args) ->
             let head1 = FStar_Syntax_Util.un_uinst head in
             (match ((head1.FStar_Syntax_Syntax.n), args) with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                uu____9665::(x, uu____9667)::(t1, uu____9669)::[]) when
+                uu___1::(x, uu___2)::(t1, uu___3)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.has_type_lid
                  ->
-                 let uu____9736 = encode_term x env1 in
-                 (match uu____9736 with
+                 let uu___4 = encode_term x env1 in
+                 (match uu___4 with
                   | (x1, decls) ->
-                      let uu____9747 = encode_term t1 env1 in
-                      (match uu____9747 with
+                      let uu___5 = encode_term t1 env1 in
+                      (match uu___5 with
                        | (t2, decls') ->
-                           let uu____9758 =
+                           let uu___6 =
                              FStar_SMTEncoding_Term.mk_HasType x1 t2 in
-                           (uu____9758, (FStar_List.append decls decls'))))
-             | uu____9759 -> encode_term t env1) in
+                           (uu___6, (FStar_List.append decls decls'))))
+             | uu___1 -> encode_term t env1) in
       FStar_List.fold_right
         (fun pats ->
-           fun uu____9802 ->
-             match uu____9802 with
+           fun uu___ ->
+             match uu___ with
              | (pats_l1, decls) ->
-                 let uu____9847 =
+                 let uu___1 =
                    FStar_List.fold_right
-                     (fun uu____9882 ->
-                        fun uu____9883 ->
-                          match (uu____9882, uu____9883) with
-                          | ((p, uu____9925), (pats1, decls1)) ->
-                              let uu____9960 = encode_smt_pattern p in
-                              (match uu____9960 with
+                     (fun uu___2 ->
+                        fun uu___3 ->
+                          match (uu___2, uu___3) with
+                          | ((p, uu___4), (pats1, decls1)) ->
+                              let uu___5 = encode_smt_pattern p in
+                              (match uu___5 with
                                | (t, d) ->
-                                   let uu____9975 =
+                                   let uu___6 =
                                      FStar_SMTEncoding_Term.check_pattern_ok
                                        t in
-                                   (match uu____9975 with
+                                   (match uu___6 with
                                     | FStar_Pervasives_Native.None ->
                                         ((t :: pats1),
                                           (FStar_List.append d decls1))
                                     | FStar_Pervasives_Native.Some
                                         illegal_subterm ->
-                                        ((let uu____9992 =
-                                            let uu____9997 =
-                                              let uu____9998 =
+                                        ((let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
                                                 FStar_Syntax_Print.term_to_string
                                                   p in
-                                              let uu____9999 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Term.print_smt_term
                                                   illegal_subterm in
                                               FStar_Util.format2
                                                 "Pattern %s contains illegal sub-term (%s); dropping it"
-                                                uu____9998 uu____9999 in
+                                                uu___10 uu___11 in
                                             (FStar_Errors.Warning_SMTPatternIllFormed,
-                                              uu____9997) in
+                                              uu___9) in
                                           FStar_Errors.log_issue
-                                            p.FStar_Syntax_Syntax.pos
-                                            uu____9992);
+                                            p.FStar_Syntax_Syntax.pos uu___8);
                                          (pats1,
                                            (FStar_List.append d decls1))))))
                      pats ([], decls) in
-                 (match uu____9847 with
+                 (match uu___1 with
                   | (pats1, decls1) -> ((pats1 :: pats_l1), decls1))) pats_l
         ([], [])
 and (encode_formula :
@@ -3574,193 +3506,187 @@ and (encode_formula :
   fun phi ->
     fun env ->
       let debug phi1 =
-        let uu____10056 =
+        let uu___ =
           FStar_All.pipe_left
             (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
             (FStar_Options.Other "SMTEncoding") in
-        if uu____10056
+        if uu___
         then
-          let uu____10057 = FStar_Syntax_Print.tag_of_term phi1 in
-          let uu____10058 = FStar_Syntax_Print.term_to_string phi1 in
-          FStar_Util.print2 "Formula (%s)  %s\n" uu____10057 uu____10058
+          let uu___1 = FStar_Syntax_Print.tag_of_term phi1 in
+          let uu___2 = FStar_Syntax_Print.term_to_string phi1 in
+          FStar_Util.print2 "Formula (%s)  %s\n" uu___1 uu___2
         else () in
       let enc f r l =
-        let uu____10097 =
+        let uu___ =
           FStar_Util.fold_map
             (fun decls ->
                fun x ->
-                 let uu____10129 =
-                   encode_term (FStar_Pervasives_Native.fst x) env in
-                 match uu____10129 with
+                 let uu___1 = encode_term (FStar_Pervasives_Native.fst x) env in
+                 match uu___1 with
                  | (t, decls') -> ((FStar_List.append decls decls'), t)) [] l in
-        match uu____10097 with
+        match uu___ with
         | (decls, args) ->
-            let uu____10160 =
-              let uu___1494_10161 = f args in
+            let uu___1 =
+              let uu___2 = f args in
               {
                 FStar_SMTEncoding_Term.tm =
-                  (uu___1494_10161.FStar_SMTEncoding_Term.tm);
+                  (uu___2.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
-                  (uu___1494_10161.FStar_SMTEncoding_Term.freevars);
+                  (uu___2.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
               } in
-            (uu____10160, decls) in
-      let const_op f r uu____10196 =
-        let uu____10209 = f r in (uu____10209, []) in
+            (uu___1, decls) in
+      let const_op f r uu___ = let uu___1 = f r in (uu___1, []) in
       let un_op f l =
-        let uu____10232 = FStar_List.hd l in
-        FStar_All.pipe_left f uu____10232 in
-      let bin_op f uu___2_10252 =
-        match uu___2_10252 with
+        let uu___ = FStar_List.hd l in FStar_All.pipe_left f uu___ in
+      let bin_op f uu___ =
+        match uu___ with
         | t1::t2::[] -> f (t1, t2)
-        | uu____10263 -> failwith "Impossible" in
+        | uu___1 -> failwith "Impossible" in
       let enc_prop_c f r l =
-        let uu____10303 =
+        let uu___ =
           FStar_Util.fold_map
             (fun decls ->
-               fun uu____10328 ->
-                 match uu____10328 with
-                 | (t, uu____10344) ->
-                     let uu____10349 = encode_formula t env in
-                     (match uu____10349 with
+               fun uu___1 ->
+                 match uu___1 with
+                 | (t, uu___2) ->
+                     let uu___3 = encode_formula t env in
+                     (match uu___3 with
                       | (phi1, decls') ->
                           ((FStar_List.append decls decls'), phi1))) [] l in
-        match uu____10303 with
+        match uu___ with
         | (decls, phis) ->
-            let uu____10378 =
-              let uu___1524_10379 = f phis in
+            let uu___1 =
+              let uu___2 = f phis in
               {
                 FStar_SMTEncoding_Term.tm =
-                  (uu___1524_10379.FStar_SMTEncoding_Term.tm);
+                  (uu___2.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
-                  (uu___1524_10379.FStar_SMTEncoding_Term.freevars);
+                  (uu___2.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
               } in
-            (uu____10378, decls) in
+            (uu___1, decls) in
       let eq_op r args =
         let rf =
           FStar_List.filter
-            (fun uu____10442 ->
-               match uu____10442 with
+            (fun uu___ ->
+               match uu___ with
                | (a, q) ->
                    (match q with
                     | FStar_Pervasives_Native.Some
-                        (FStar_Syntax_Syntax.Implicit uu____10461) -> false
-                    | uu____10462 -> true)) args in
+                        (FStar_Syntax_Syntax.Implicit uu___1) -> false
+                    | uu___1 -> true)) args in
         if (FStar_List.length rf) <> (Prims.of_int (2))
         then
-          let uu____10477 =
+          let uu___ =
             FStar_Util.format1
               "eq_op: got %s non-implicit arguments instead of 2?"
               (Prims.string_of_int (FStar_List.length rf)) in
-          failwith uu____10477
+          failwith uu___
         else
-          (let uu____10491 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
-           uu____10491 r rf) in
+          (let uu___1 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
+           uu___1 r rf) in
       let eq3_op r args =
         let n = FStar_List.length args in
         if n = (Prims.of_int (4))
         then
-          let uu____10556 =
+          let uu___ =
             enc
               (fun terms ->
                  match terms with
                  | t0::t1::v0::v1::[] ->
-                     let uu____10588 =
-                       let uu____10593 = FStar_SMTEncoding_Util.mkEq (t0, t1) in
-                       let uu____10594 = FStar_SMTEncoding_Util.mkEq (v0, v1) in
-                       (uu____10593, uu____10594) in
-                     FStar_SMTEncoding_Util.mkAnd uu____10588
-                 | uu____10595 -> failwith "Impossible") in
-          uu____10556 r args
+                     let uu___1 =
+                       let uu___2 = FStar_SMTEncoding_Util.mkEq (t0, t1) in
+                       let uu___3 = FStar_SMTEncoding_Util.mkEq (v0, v1) in
+                       (uu___2, uu___3) in
+                     FStar_SMTEncoding_Util.mkAnd uu___1
+                 | uu___1 -> failwith "Impossible") in
+          uu___ r args
         else
-          (let uu____10599 =
+          (let uu___1 =
              FStar_Util.format1
                "eq3_op: got %s non-implicit arguments instead of 4?"
                (Prims.string_of_int n) in
-           failwith uu____10599) in
+           failwith uu___1) in
       let h_equals_op r args =
         let n = FStar_List.length args in
         if n = (Prims.of_int (4))
         then
-          let uu____10656 =
+          let uu___ =
             enc
               (fun terms ->
                  match terms with
                  | t0::v0::t1::v1::[] ->
-                     let uu____10688 =
-                       let uu____10693 = FStar_SMTEncoding_Util.mkEq (t0, t1) in
-                       let uu____10694 = FStar_SMTEncoding_Util.mkEq (v0, v1) in
-                       (uu____10693, uu____10694) in
-                     FStar_SMTEncoding_Util.mkAnd uu____10688
-                 | uu____10695 -> failwith "Impossible") in
-          uu____10656 r args
+                     let uu___1 =
+                       let uu___2 = FStar_SMTEncoding_Util.mkEq (t0, t1) in
+                       let uu___3 = FStar_SMTEncoding_Util.mkEq (v0, v1) in
+                       (uu___2, uu___3) in
+                     FStar_SMTEncoding_Util.mkAnd uu___1
+                 | uu___1 -> failwith "Impossible") in
+          uu___ r args
         else
-          (let uu____10699 =
+          (let uu___1 =
              FStar_Util.format1
                "eq3_op: got %s non-implicit arguments instead of 4?"
                (Prims.string_of_int n) in
-           failwith uu____10699) in
-      let mk_imp r uu___3_10726 =
-        match uu___3_10726 with
-        | (lhs, uu____10732)::(rhs, uu____10734)::[] ->
-            let uu____10775 = encode_formula rhs env in
-            (match uu____10775 with
+           failwith uu___1) in
+      let mk_imp r uu___ =
+        match uu___ with
+        | (lhs, uu___1)::(rhs, uu___2)::[] ->
+            let uu___3 = encode_formula rhs env in
+            (match uu___3 with
              | (l1, decls1) ->
                  (match l1.FStar_SMTEncoding_Term.tm with
                   | FStar_SMTEncoding_Term.App
-                      (FStar_SMTEncoding_Term.TrueOp, uu____10790) ->
-                      (l1, decls1)
-                  | uu____10795 ->
-                      let uu____10796 = encode_formula lhs env in
-                      (match uu____10796 with
+                      (FStar_SMTEncoding_Term.TrueOp, uu___4) -> (l1, decls1)
+                  | uu___4 ->
+                      let uu___5 = encode_formula lhs env in
+                      (match uu___5 with
                        | (l2, decls2) ->
-                           let uu____10807 =
+                           let uu___6 =
                              FStar_SMTEncoding_Term.mkImp (l2, l1) r in
-                           (uu____10807, (FStar_List.append decls1 decls2)))))
-        | uu____10808 -> failwith "impossible" in
-      let mk_ite r uu___4_10835 =
-        match uu___4_10835 with
-        | (guard, uu____10841)::(_then, uu____10843)::(_else, uu____10845)::[]
-            ->
-            let uu____10902 = encode_formula guard env in
-            (match uu____10902 with
+                           (uu___6, (FStar_List.append decls1 decls2)))))
+        | uu___1 -> failwith "impossible" in
+      let mk_ite r uu___ =
+        match uu___ with
+        | (guard, uu___1)::(_then, uu___2)::(_else, uu___3)::[] ->
+            let uu___4 = encode_formula guard env in
+            (match uu___4 with
              | (g, decls1) ->
-                 let uu____10913 = encode_formula _then env in
-                 (match uu____10913 with
+                 let uu___5 = encode_formula _then env in
+                 (match uu___5 with
                   | (t, decls2) ->
-                      let uu____10924 = encode_formula _else env in
-                      (match uu____10924 with
+                      let uu___6 = encode_formula _else env in
+                      (match uu___6 with
                        | (e, decls3) ->
                            let res = FStar_SMTEncoding_Term.mkITE (g, t, e) r in
                            (res,
                              (FStar_List.append decls1
                                 (FStar_List.append decls2 decls3))))))
-        | uu____10936 -> failwith "impossible" in
+        | uu___1 -> failwith "impossible" in
       let unboxInt_l f l =
-        let uu____10965 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l in
-        f uu____10965 in
+        let uu___ = FStar_List.map FStar_SMTEncoding_Term.unboxInt l in
+        f uu___ in
       let connectives =
-        let uu____10995 =
-          let uu____11020 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd) in
-          (FStar_Parser_Const.and_lid, uu____11020) in
-        let uu____11063 =
-          let uu____11090 =
-            let uu____11115 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr) in
-            (FStar_Parser_Const.or_lid, uu____11115) in
-          let uu____11158 =
-            let uu____11185 =
-              let uu____11212 =
-                let uu____11237 =
-                  enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff) in
-                (FStar_Parser_Const.iff_lid, uu____11237) in
-              let uu____11280 =
-                let uu____11307 =
-                  let uu____11334 =
-                    let uu____11359 =
+        let uu___ =
+          let uu___1 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd) in
+          (FStar_Parser_Const.and_lid, uu___1) in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr) in
+            (FStar_Parser_Const.or_lid, uu___3) in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff) in
+                (FStar_Parser_Const.iff_lid, uu___6) in
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 =
                       enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot) in
-                    (FStar_Parser_Const.not_lid, uu____11359) in
-                  [uu____11334;
+                    (FStar_Parser_Const.not_lid, uu___9) in
+                  [uu___8;
                   (FStar_Parser_Const.eq2_lid, eq_op);
                   (FStar_Parser_Const.c_eq2_lid, eq_op);
                   (FStar_Parser_Const.eq3_lid, eq3_op);
@@ -3769,79 +3695,78 @@ and (encode_formula :
                     (const_op FStar_SMTEncoding_Term.mkTrue));
                   (FStar_Parser_Const.false_lid,
                     (const_op FStar_SMTEncoding_Term.mkFalse))] in
-                (FStar_Parser_Const.ite_lid, mk_ite) :: uu____11307 in
-              uu____11212 :: uu____11280 in
-            (FStar_Parser_Const.imp_lid, mk_imp) :: uu____11185 in
-          uu____11090 :: uu____11158 in
-        uu____10995 :: uu____11063 in
+                (FStar_Parser_Const.ite_lid, mk_ite) :: uu___7 in
+              uu___5 :: uu___6 in
+            (FStar_Parser_Const.imp_lid, mk_imp) :: uu___4 in
+          uu___2 :: uu___3 in
+        uu___ :: uu___1 in
       let rec fallback phi1 =
         match phi1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_meta
             (phi', FStar_Syntax_Syntax.Meta_labeled (msg, r, b)) ->
-            let uu____11900 = encode_formula phi' env in
-            (match uu____11900 with
+            let uu___ = encode_formula phi' env in
+            (match uu___ with
              | (phi2, decls) ->
-                 let uu____11911 =
+                 let uu___1 =
                    FStar_SMTEncoding_Term.mk
                      (FStar_SMTEncoding_Term.Labeled (phi2, msg, r)) r in
-                 (uu____11911, decls))
-        | FStar_Syntax_Syntax.Tm_meta uu____11912 ->
-            let uu____11919 = FStar_Syntax_Util.unmeta phi1 in
-            encode_formula uu____11919 env
+                 (uu___1, decls))
+        | FStar_Syntax_Syntax.Tm_meta uu___ ->
+            let uu___1 = FStar_Syntax_Util.unmeta phi1 in
+            encode_formula uu___1 env
         | FStar_Syntax_Syntax.Tm_match (e, pats) ->
-            let uu____11958 =
+            let uu___ =
               encode_match e pats FStar_SMTEncoding_Util.mkFalse env
                 encode_formula in
-            (match uu____11958 with | (t, decls) -> (t, decls))
+            (match uu___ with | (t, decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_let
             ((false,
               { FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-                FStar_Syntax_Syntax.lbunivs = uu____11970;
+                FStar_Syntax_Syntax.lbunivs = uu___;
                 FStar_Syntax_Syntax.lbtyp = t1;
-                FStar_Syntax_Syntax.lbeff = uu____11972;
+                FStar_Syntax_Syntax.lbeff = uu___1;
                 FStar_Syntax_Syntax.lbdef = e1;
-                FStar_Syntax_Syntax.lbattrs = uu____11974;
-                FStar_Syntax_Syntax.lbpos = uu____11975;_}::[]),
+                FStar_Syntax_Syntax.lbattrs = uu___2;
+                FStar_Syntax_Syntax.lbpos = uu___3;_}::[]),
              e2)
             ->
-            let uu____11999 = encode_let x t1 e1 e2 env encode_formula in
-            (match uu____11999 with | (t, decls) -> (t, decls))
+            let uu___4 = encode_let x t1 e1 e2 env encode_formula in
+            (match uu___4 with | (t, decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_app (head, args) ->
             let head1 = FStar_Syntax_Util.un_uinst head in
             (match ((head1.FStar_Syntax_Syntax.n), args) with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                uu____12052::(x, uu____12054)::(t, uu____12056)::[]) when
+                uu___::(x, uu___1)::(t, uu___2)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.has_type_lid
                  ->
-                 let uu____12123 = encode_term x env in
-                 (match uu____12123 with
+                 let uu___3 = encode_term x env in
+                 (match uu___3 with
                   | (x1, decls) ->
-                      let uu____12134 = encode_term t env in
-                      (match uu____12134 with
+                      let uu___4 = encode_term t env in
+                      (match uu___4 with
                        | (t1, decls') ->
-                           let uu____12145 =
+                           let uu___5 =
                              FStar_SMTEncoding_Term.mk_HasType x1 t1 in
-                           (uu____12145, (FStar_List.append decls decls'))))
+                           (uu___5, (FStar_List.append decls decls'))))
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (r, uu____12148)::(msg, uu____12150)::(phi2, uu____12152)::[])
-                 when
+                (r, uu___)::(msg, uu___1)::(phi2, uu___2)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.labeled_lid
                  ->
-                 let uu____12219 =
-                   let uu____12228 =
-                     let uu____12231 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
                        FStar_Syntax_Embeddings.unembed
                          FStar_Syntax_Embeddings.e_range r in
-                     uu____12231 false FStar_Syntax_Embeddings.id_norm_cb in
-                   let uu____12238 =
-                     let uu____12241 =
+                     uu___5 false FStar_Syntax_Embeddings.id_norm_cb in
+                   let uu___5 =
+                     let uu___6 =
                        FStar_Syntax_Embeddings.unembed
                          FStar_Syntax_Embeddings.e_string msg in
-                     uu____12241 false FStar_Syntax_Embeddings.id_norm_cb in
-                   (uu____12228, uu____12238) in
-                 (match uu____12219 with
+                     uu___6 false FStar_Syntax_Embeddings.id_norm_cb in
+                   (uu___4, uu___5) in
+                 (match uu___3 with
                   | (FStar_Pervasives_Native.Some r1,
                      FStar_Pervasives_Native.Some s) ->
                       let phi3 =
@@ -3861,85 +3786,85 @@ and (encode_formula :
                                   (s, (phi2.FStar_Syntax_Syntax.pos), false))))
                           phi2.FStar_Syntax_Syntax.pos in
                       fallback phi3
-                  | uu____12277 -> fallback phi2)
-             | (FStar_Syntax_Syntax.Tm_fvar fv, (t, uu____12288)::[]) when
+                  | uu___4 -> fallback phi2)
+             | (FStar_Syntax_Syntax.Tm_fvar fv, (t, uu___)::[]) when
                  (FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.squash_lid)
                    ||
                    (FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.auto_squash_lid)
                  -> encode_formula t env
-             | uu____12323 ->
-                 let encode_valid uu____12347 =
-                   let uu____12348 = encode_term phi1 env in
-                   match uu____12348 with
+             | uu___ ->
+                 let encode_valid uu___1 =
+                   let uu___2 = encode_term phi1 env in
+                   match uu___2 with
                    | (tt, decls) ->
                        let tt1 =
-                         let uu____12360 =
-                           let uu____12361 =
+                         let uu___3 =
+                           let uu___4 =
                              FStar_Range.use_range
                                tt.FStar_SMTEncoding_Term.rng in
-                           let uu____12362 =
+                           let uu___5 =
                              FStar_Range.use_range
                                phi1.FStar_Syntax_Syntax.pos in
-                           FStar_Range.rng_included uu____12361 uu____12362 in
-                         if uu____12360
+                           FStar_Range.rng_included uu___4 uu___5 in
+                         if uu___3
                          then tt
                          else
-                           (let uu___1713_12364 = tt in
+                           (let uu___5 = tt in
                             {
                               FStar_SMTEncoding_Term.tm =
-                                (uu___1713_12364.FStar_SMTEncoding_Term.tm);
+                                (uu___5.FStar_SMTEncoding_Term.tm);
                               FStar_SMTEncoding_Term.freevars =
-                                (uu___1713_12364.FStar_SMTEncoding_Term.freevars);
+                                (uu___5.FStar_SMTEncoding_Term.freevars);
                               FStar_SMTEncoding_Term.rng =
                                 (phi1.FStar_Syntax_Syntax.pos)
                             }) in
-                       let uu____12365 = FStar_SMTEncoding_Term.mk_Valid tt1 in
-                       (uu____12365, decls) in
-                 let uu____12366 = head_redex env head1 in
-                 if uu____12366
+                       let uu___3 = FStar_SMTEncoding_Term.mk_Valid tt1 in
+                       (uu___3, decls) in
+                 let uu___1 = head_redex env head1 in
+                 if uu___1
                  then
-                   let uu____12371 = maybe_whnf env head1 in
-                   (match uu____12371 with
+                   let uu___2 = maybe_whnf env head1 in
+                   (match uu___2 with
                     | FStar_Pervasives_Native.None -> encode_valid ()
                     | FStar_Pervasives_Native.Some phi2 ->
                         encode_formula phi2 env)
                  else encode_valid ())
-        | uu____12380 ->
-            let uu____12381 = encode_term phi1 env in
-            (match uu____12381 with
+        | uu___ ->
+            let uu___1 = encode_term phi1 env in
+            (match uu___1 with
              | (tt, decls) ->
                  let tt1 =
-                   let uu____12393 =
-                     let uu____12394 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Range.use_range tt.FStar_SMTEncoding_Term.rng in
-                     let uu____12395 =
+                     let uu___4 =
                        FStar_Range.use_range phi1.FStar_Syntax_Syntax.pos in
-                     FStar_Range.rng_included uu____12394 uu____12395 in
-                   if uu____12393
+                     FStar_Range.rng_included uu___3 uu___4 in
+                   if uu___2
                    then tt
                    else
-                     (let uu___1725_12397 = tt in
+                     (let uu___4 = tt in
                       {
                         FStar_SMTEncoding_Term.tm =
-                          (uu___1725_12397.FStar_SMTEncoding_Term.tm);
+                          (uu___4.FStar_SMTEncoding_Term.tm);
                         FStar_SMTEncoding_Term.freevars =
-                          (uu___1725_12397.FStar_SMTEncoding_Term.freevars);
+                          (uu___4.FStar_SMTEncoding_Term.freevars);
                         FStar_SMTEncoding_Term.rng =
                           (phi1.FStar_Syntax_Syntax.pos)
                       }) in
-                 let uu____12398 = FStar_SMTEncoding_Term.mk_Valid tt1 in
-                 (uu____12398, decls)) in
+                 let uu___2 = FStar_SMTEncoding_Term.mk_Valid tt1 in
+                 (uu___2, decls)) in
       let encode_q_body env1 bs ps body =
-        let uu____12442 = encode_binders FStar_Pervasives_Native.None bs env1 in
-        match uu____12442 with
-        | (vars, guards, env2, decls, uu____12481) ->
-            let uu____12494 = encode_smt_patterns ps env2 in
-            (match uu____12494 with
+        let uu___ = encode_binders FStar_Pervasives_Native.None bs env1 in
+        match uu___ with
+        | (vars, guards, env2, decls, uu___1) ->
+            let uu___2 = encode_smt_patterns ps env2 in
+            (match uu___2 with
              | (pats, decls') ->
-                 let uu____12531 = encode_formula body env2 in
-                 (match uu____12531 with
+                 let uu___3 = encode_formula body env2 in
+                 (match uu___3 with
                   | (body1, decls'') ->
                       let guards1 =
                         match pats with
@@ -3947,63 +3872,60 @@ and (encode_formula :
                              FStar_SMTEncoding_Term.tm =
                                FStar_SMTEncoding_Term.App
                                (FStar_SMTEncoding_Term.Var gf, p::[]);
-                             FStar_SMTEncoding_Term.freevars = uu____12563;
-                             FStar_SMTEncoding_Term.rng = uu____12564;_}::[])::[]
+                             FStar_SMTEncoding_Term.freevars = uu___4;
+                             FStar_SMTEncoding_Term.rng = uu___5;_}::[])::[]
                             when
-                            let uu____12581 =
+                            let uu___6 =
                               FStar_Ident.string_of_lid
                                 FStar_Parser_Const.guard_free in
-                            uu____12581 = gf -> []
-                        | uu____12582 -> guards in
-                      let uu____12587 =
-                        FStar_SMTEncoding_Util.mk_and_l guards1 in
-                      (vars, pats, uu____12587, body1,
+                            uu___6 = gf -> []
+                        | uu___4 -> guards in
+                      let uu___4 = FStar_SMTEncoding_Util.mk_and_l guards1 in
+                      (vars, pats, uu___4, body1,
                         (FStar_List.append decls
                            (FStar_List.append decls' decls''))))) in
       debug phi;
       (let phi1 = FStar_Syntax_Util.unascribe phi in
-       let uu____12598 = FStar_Syntax_Util.destruct_typ_as_formula phi1 in
-       match uu____12598 with
+       let uu___1 = FStar_Syntax_Util.destruct_typ_as_formula phi1 in
+       match uu___1 with
        | FStar_Pervasives_Native.None -> fallback phi1
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn (op, arms))
            ->
-           let uu____12607 =
+           let uu___2 =
              FStar_All.pipe_right connectives
                (FStar_List.tryFind
-                  (fun uu____12713 ->
-                     match uu____12713 with
-                     | (l, uu____12737) -> FStar_Ident.lid_equals op l)) in
-           (match uu____12607 with
+                  (fun uu___3 ->
+                     match uu___3 with
+                     | (l, uu___4) -> FStar_Ident.lid_equals op l)) in
+           (match uu___2 with
             | FStar_Pervasives_Native.None -> fallback phi1
-            | FStar_Pervasives_Native.Some (uu____12806, f) ->
+            | FStar_Pervasives_Native.Some (uu___3, f) ->
                 f phi1.FStar_Syntax_Syntax.pos arms)
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
            (vars, pats, body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars env vars));
-            (let uu____12898 = encode_q_body env vars pats body in
-             match uu____12898 with
+            (let uu___3 = encode_q_body env vars pats body in
+             match uu___3 with
              | (vars1, pats1, guard, body1, decls) ->
                  let tm =
-                   let uu____12943 =
-                     let uu____12954 =
-                       FStar_SMTEncoding_Util.mkImp (guard, body1) in
-                     (pats1, vars1, uu____12954) in
+                   let uu___4 =
+                     let uu___5 = FStar_SMTEncoding_Util.mkImp (guard, body1) in
+                     (pats1, vars1, uu___5) in
                    FStar_SMTEncoding_Term.mkForall
-                     phi1.FStar_Syntax_Syntax.pos uu____12943 in
+                     phi1.FStar_Syntax_Syntax.pos uu___4 in
                  (tm, decls)))
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QEx
            (vars, pats, body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars env vars));
-            (let uu____12985 = encode_q_body env vars pats body in
-             match uu____12985 with
+            (let uu___3 = encode_q_body env vars pats body in
+             match uu___3 with
              | (vars1, pats1, guard, body1, decls) ->
-                 let uu____13029 =
-                   let uu____13030 =
-                     let uu____13041 =
-                       FStar_SMTEncoding_Util.mkAnd (guard, body1) in
-                     (pats1, vars1, uu____13041) in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_SMTEncoding_Util.mkAnd (guard, body1) in
+                     (pats1, vars1, uu___6) in
                    FStar_SMTEncoding_Term.mkExists
-                     phi1.FStar_Syntax_Syntax.pos uu____13030 in
-                 (uu____13029, decls))))
+                     phi1.FStar_Syntax_Syntax.pos uu___5 in
+                 (uu___4, decls))))

--- a/src/ocaml-output/FStar_SMTEncoding_Env.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Env.ml
@@ -2,43 +2,41 @@ open Prims
 exception Inner_let_rec of (Prims.string * FStar_Range.range) Prims.list 
 let (uu___is_Inner_let_rec : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Inner_let_rec uu____42 -> true | uu____49 -> false
+    match projectee with | Inner_let_rec uu___ -> true | uu___ -> false
 let (__proj__Inner_let_rec__item__uu___ :
   Prims.exn -> (Prims.string * FStar_Range.range) Prims.list) =
-  fun projectee -> match projectee with | Inner_let_rec uu____67 -> uu____67
-let add_fuel :
-  'uuuuuu80 . 'uuuuuu80 -> 'uuuuuu80 Prims.list -> 'uuuuuu80 Prims.list =
+  fun projectee -> match projectee with | Inner_let_rec uu___ -> uu___
+let add_fuel : 'uuuuu . 'uuuuu -> 'uuuuu Prims.list -> 'uuuuu Prims.list =
   fun x ->
     fun tl ->
-      let uu____97 = FStar_Options.unthrottle_inductives () in
-      if uu____97 then tl else x :: tl
+      let uu___ = FStar_Options.unthrottle_inductives () in
+      if uu___ then tl else x :: tl
 let withenv :
-  'uuuuuu111 'uuuuuu112 'uuuuuu113 .
-    'uuuuuu111 ->
-      ('uuuuuu112 * 'uuuuuu113) -> ('uuuuuu112 * 'uuuuuu113 * 'uuuuuu111)
-  = fun c -> fun uu____133 -> match uu____133 with | (a, b) -> (a, b, c)
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    'uuuuu -> ('uuuuu1 * 'uuuuu2) -> ('uuuuu1 * 'uuuuu2 * 'uuuuu)
+  = fun c -> fun uu___ -> match uu___ with | (a, b) -> (a, b, c)
 let vargs :
-  'uuuuuu148 'uuuuuu149 'uuuuuu150 .
-    (('uuuuuu148, 'uuuuuu149) FStar_Util.either * 'uuuuuu150) Prims.list ->
-      (('uuuuuu148, 'uuuuuu149) FStar_Util.either * 'uuuuuu150) Prims.list
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    (('uuuuu, 'uuuuu1) FStar_Util.either * 'uuuuu2) Prims.list ->
+      (('uuuuu, 'uuuuu1) FStar_Util.either * 'uuuuu2) Prims.list
   =
   fun args ->
     FStar_List.filter
-      (fun uu___0_197 ->
-         match uu___0_197 with
-         | (FStar_Util.Inl uu____206, uu____207) -> false
-         | uu____212 -> true) args
+      (fun uu___ ->
+         match uu___ with
+         | (FStar_Util.Inl uu___1, uu___2) -> false
+         | uu___1 -> true) args
 let (escape : Prims.string -> Prims.string) =
   fun s -> FStar_Util.replace_char s 39 95
 let (mk_term_projector_name :
   FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> Prims.string) =
   fun lid ->
     fun a ->
-      let uu____236 =
-        let uu____237 = FStar_Ident.string_of_lid lid in
-        let uu____238 = FStar_Ident.string_of_id a.FStar_Syntax_Syntax.ppname in
-        FStar_Util.format2 "%s_%s" uu____237 uu____238 in
-      FStar_All.pipe_left escape uu____236
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_lid lid in
+        let uu___2 = FStar_Ident.string_of_id a.FStar_Syntax_Syntax.ppname in
+        FStar_Util.format2 "%s_%s" uu___1 uu___2 in
+      FStar_All.pipe_left escape uu___
 let (primitive_projector_by_pos :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident -> Prims.int -> Prims.string)
@@ -46,24 +44,24 @@ let (primitive_projector_by_pos :
   fun env ->
     fun lid ->
       fun i ->
-        let fail uu____259 =
-          let uu____260 =
-            let uu____261 = FStar_Ident.string_of_lid lid in
+        let fail uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_lid lid in
             FStar_Util.format2
               "Projector %s on data constructor %s not found"
-              (Prims.string_of_int i) uu____261 in
-          failwith uu____260 in
-        let uu____262 = FStar_TypeChecker_Env.lookup_datacon env lid in
-        match uu____262 with
-        | (uu____267, t) ->
-            let uu____269 =
-              let uu____270 = FStar_Syntax_Subst.compress t in
-              uu____270.FStar_Syntax_Syntax.n in
-            (match uu____269 with
+              (Prims.string_of_int i) uu___2 in
+          failwith uu___1 in
+        let uu___ = FStar_TypeChecker_Env.lookup_datacon env lid in
+        match uu___ with
+        | (uu___1, t) ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.compress t in
+              uu___3.FStar_Syntax_Syntax.n in
+            (match uu___2 with
              | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                 let uu____295 = FStar_Syntax_Subst.open_comp bs c in
-                 (match uu____295 with
-                  | (binders, uu____301) ->
+                 let uu___3 = FStar_Syntax_Subst.open_comp bs c in
+                 (match uu___3 with
+                  | (binders, uu___4) ->
                       if
                         (i < Prims.int_zero) ||
                           (i >= (FStar_List.length binders))
@@ -72,54 +70,53 @@ let (primitive_projector_by_pos :
                         (let b = FStar_List.nth binders i in
                          mk_term_projector_name lid
                            (FStar_Pervasives_Native.fst b)))
-             | uu____324 -> fail ())
+             | uu___3 -> fail ())
 let (mk_term_projector_name_by_pos :
   FStar_Ident.lident -> Prims.int -> Prims.string) =
   fun lid ->
     fun i ->
-      let uu____335 =
-        let uu____336 = FStar_Ident.string_of_lid lid in
-        FStar_Util.format2 "%s_%s" uu____336 (Prims.string_of_int i) in
-      FStar_All.pipe_left escape uu____335
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_lid lid in
+        FStar_Util.format2 "%s_%s" uu___1 (Prims.string_of_int i) in
+      FStar_All.pipe_left escape uu___
 let (mk_term_projector :
   FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term)
   =
   fun lid ->
     fun a ->
-      let uu____347 =
-        let uu____348 =
-          let uu____353 = mk_term_projector_name lid a in
-          (uu____353,
+      let uu___ =
+        let uu___1 =
+          let uu___2 = mk_term_projector_name lid a in
+          (uu___2,
             (FStar_SMTEncoding_Term.Arrow
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort))) in
-        FStar_SMTEncoding_Term.mk_fv uu____348 in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____347
+        FStar_SMTEncoding_Term.mk_fv uu___1 in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___
 let (mk_term_projector_by_pos :
   FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term) =
   fun lid ->
     fun i ->
-      let uu____364 =
-        let uu____365 =
-          let uu____370 = mk_term_projector_name_by_pos lid i in
-          (uu____370,
+      let uu___ =
+        let uu___1 =
+          let uu___2 = mk_term_projector_name_by_pos lid i in
+          (uu___2,
             (FStar_SMTEncoding_Term.Arrow
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort))) in
-        FStar_SMTEncoding_Term.mk_fv uu____365 in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____364
+        FStar_SMTEncoding_Term.mk_fv uu___1 in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___
 let mk_data_tester :
-  'uuuuuu379 .
-    'uuuuuu379 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_Ident.lident ->
         FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
   =
   fun env ->
     fun l ->
       fun x ->
-        let uu____395 =
-          let uu____396 = FStar_Ident.string_of_lid l in escape uu____396 in
-        FStar_SMTEncoding_Term.mk_tester uu____395 x
+        let uu___ = let uu___1 = FStar_Ident.string_of_lid l in escape uu___1 in
+        FStar_SMTEncoding_Term.mk_tester uu___ x
 type varops_t =
   {
   push: unit -> unit ;
@@ -191,54 +188,53 @@ let (__proj__Mkvarops_t__item__mk_unique :
 let (varops : varops_t) =
   let initial_ctr = (Prims.of_int (100)) in
   let ctr = FStar_Util.mk_ref initial_ctr in
-  let new_scope uu____1190 = FStar_Util.smap_create (Prims.of_int (100)) in
+  let new_scope uu___ = FStar_Util.smap_create (Prims.of_int (100)) in
   let scopes =
-    let uu____1200 = let uu____1205 = new_scope () in [uu____1205] in
-    FStar_Util.mk_ref uu____1200 in
+    let uu___ = let uu___1 = new_scope () in [uu___1] in
+    FStar_Util.mk_ref uu___ in
   let mk_unique y =
     let y1 = escape y in
     let y2 =
-      let uu____1224 =
-        let uu____1227 = FStar_ST.op_Bang scopes in
-        FStar_Util.find_map uu____1227
+      let uu___ =
+        let uu___1 = FStar_ST.op_Bang scopes in
+        FStar_Util.find_map uu___1
           (fun names -> FStar_Util.smap_try_find names y1) in
-      match uu____1224 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> y1
-      | FStar_Pervasives_Native.Some uu____1252 ->
+      | FStar_Pervasives_Native.Some uu___1 ->
           (FStar_Util.incr ctr;
-           (let uu____1254 =
-              let uu____1255 =
-                let uu____1256 = FStar_ST.op_Bang ctr in
-                Prims.string_of_int uu____1256 in
-              Prims.op_Hat "__" uu____1255 in
-            Prims.op_Hat y1 uu____1254)) in
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_ST.op_Bang ctr in
+                Prims.string_of_int uu___5 in
+              Prims.op_Hat "__" uu___4 in
+            Prims.op_Hat y1 uu___3)) in
     let top_scope =
-      let uu____1266 = FStar_ST.op_Bang scopes in FStar_List.hd uu____1266 in
+      let uu___ = FStar_ST.op_Bang scopes in FStar_List.hd uu___ in
     FStar_Util.smap_add top_scope y2 true; y2 in
   let new_var pp rn =
-    let uu____1299 =
-      let uu____1300 = FStar_Ident.string_of_id pp in
-      Prims.op_Hat uu____1300 (Prims.op_Hat "__" (Prims.string_of_int rn)) in
-    FStar_All.pipe_left mk_unique uu____1299 in
+    let uu___ =
+      let uu___1 = FStar_Ident.string_of_id pp in
+      Prims.op_Hat uu___1 (Prims.op_Hat "__" (Prims.string_of_int rn)) in
+    FStar_All.pipe_left mk_unique uu___ in
   let new_fvar lid =
-    let uu____1307 = FStar_Ident.string_of_lid lid in mk_unique uu____1307 in
-  let next_id uu____1313 = FStar_Util.incr ctr; FStar_ST.op_Bang ctr in
+    let uu___ = FStar_Ident.string_of_lid lid in mk_unique uu___ in
+  let next_id uu___ = FStar_Util.incr ctr; FStar_ST.op_Bang ctr in
   let fresh mname pfx =
-    let uu____1332 =
-      let uu____1333 = next_id () in
-      FStar_All.pipe_left Prims.string_of_int uu____1333 in
-    FStar_Util.format3 "%s_%s_%s" pfx mname uu____1332 in
-  let reset_fresh uu____1339 = FStar_ST.op_Colon_Equals ctr initial_ctr in
-  let push uu____1351 =
-    let uu____1352 =
-      let uu____1357 = new_scope () in
-      let uu____1360 = FStar_ST.op_Bang scopes in uu____1357 :: uu____1360 in
-    FStar_ST.op_Colon_Equals scopes uu____1352 in
-  let pop uu____1400 =
-    let uu____1401 =
-      let uu____1406 = FStar_ST.op_Bang scopes in FStar_List.tl uu____1406 in
-    FStar_ST.op_Colon_Equals scopes uu____1401 in
-  let snapshot uu____1450 = FStar_Common.snapshot push scopes () in
+    let uu___ =
+      let uu___1 = next_id () in
+      FStar_All.pipe_left Prims.string_of_int uu___1 in
+    FStar_Util.format3 "%s_%s_%s" pfx mname uu___ in
+  let reset_fresh uu___ = FStar_ST.op_Colon_Equals ctr initial_ctr in
+  let push uu___ =
+    let uu___1 =
+      let uu___2 = new_scope () in
+      let uu___3 = FStar_ST.op_Bang scopes in uu___2 :: uu___3 in
+    FStar_ST.op_Colon_Equals scopes uu___1 in
+  let pop uu___ =
+    let uu___1 = let uu___2 = FStar_ST.op_Bang scopes in FStar_List.tl uu___2 in
+    FStar_ST.op_Colon_Equals scopes uu___1 in
+  let snapshot uu___ = FStar_Common.snapshot push scopes () in
   let rollback depth = FStar_Common.rollback pop scopes depth in
   {
     push;
@@ -299,18 +295,18 @@ let (__proj__Mkfvar_binding__item__fvb_thunked : fvar_binding -> Prims.bool)
         fvb_thunked;_} -> fvb_thunked
 let (fvb_to_string : fvar_binding -> Prims.string) =
   fun fvb ->
-    let term_opt_to_string uu___1_1609 =
-      match uu___1_1609 with
+    let term_opt_to_string uu___ =
+      match uu___ with
       | FStar_Pervasives_Native.None -> "None"
       | FStar_Pervasives_Native.Some s ->
           FStar_SMTEncoding_Term.print_smt_term s in
-    let uu____1613 = FStar_Ident.string_of_lid fvb.fvar_lid in
-    let uu____1614 = term_opt_to_string fvb.smt_token in
-    let uu____1615 = term_opt_to_string fvb.smt_fuel_partial_app in
-    let uu____1616 = FStar_Util.string_of_bool fvb.fvb_thunked in
+    let uu___ = FStar_Ident.string_of_lid fvb.fvar_lid in
+    let uu___1 = term_opt_to_string fvb.smt_token in
+    let uu___2 = term_opt_to_string fvb.smt_fuel_partial_app in
+    let uu___3 = FStar_Util.string_of_bool fvb.fvb_thunked in
     FStar_Util.format5
       "{ lid = %s;\n  smt_id = %s;\n  smt_token = %s;\n smt_fuel_partial_app = %s;\n fvb_thunked = %s }"
-      uu____1613 fvb.smt_id uu____1614 uu____1615 uu____1616
+      uu___ fvb.smt_id uu___1 uu___2 uu___3
 let (check_valid_fvb : fvar_binding -> unit) =
   fun fvb ->
     if
@@ -318,35 +314,33 @@ let (check_valid_fvb : fvar_binding -> unit) =
          (FStar_Option.isSome fvb.smt_fuel_partial_app))
         && fvb.fvb_thunked
     then
-      (let uu____1623 =
-         let uu____1624 = FStar_Ident.string_of_lid fvb.fvar_lid in
-         FStar_Util.format1 "Unexpected thunked SMT symbol: %s" uu____1624 in
-       failwith uu____1623)
+      (let uu___1 =
+         let uu___2 = FStar_Ident.string_of_lid fvb.fvar_lid in
+         FStar_Util.format1 "Unexpected thunked SMT symbol: %s" uu___2 in
+       failwith uu___1)
     else
       if fvb.fvb_thunked && (fvb.smt_arity <> Prims.int_zero)
       then
-        (let uu____1626 =
-           let uu____1627 = FStar_Ident.string_of_lid fvb.fvar_lid in
+        (let uu___2 =
+           let uu___3 = FStar_Ident.string_of_lid fvb.fvar_lid in
            FStar_Util.format1 "Unexpected arity of thunked SMT symbol: %s"
-             uu____1627 in
-         failwith uu____1626)
+             uu___3 in
+         failwith uu___2)
       else ();
     (match fvb.smt_token with
      | FStar_Pervasives_Native.Some
-         {
-           FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV
-             uu____1629;
-           FStar_SMTEncoding_Term.freevars = uu____1630;
-           FStar_SMTEncoding_Term.rng = uu____1631;_}
+         { FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.FreeV uu___1;
+           FStar_SMTEncoding_Term.freevars = uu___2;
+           FStar_SMTEncoding_Term.rng = uu___3;_}
          ->
-         let uu____1648 =
-           let uu____1649 = fvb_to_string fvb in
-           FStar_Util.format1 "bad fvb\n%s" uu____1649 in
-         failwith uu____1648
-     | uu____1650 -> ())
+         let uu___4 =
+           let uu___5 = fvb_to_string fvb in
+           FStar_Util.format1 "bad fvb\n%s" uu___5 in
+         failwith uu___4
+     | uu___1 -> ())
 let binder_of_eithervar :
-  'uuuuuu1659 'uuuuuu1660 .
-    'uuuuuu1659 -> ('uuuuuu1659 * 'uuuuuu1660 FStar_Pervasives_Native.option)
+  'uuuuu 'uuuuu1 .
+    'uuuuu -> ('uuuuu * 'uuuuu1 FStar_Pervasives_Native.option)
   = fun v -> (v, FStar_Pervasives_Native.None)
 type env_t =
   {
@@ -446,24 +440,23 @@ let (print_env : env_t -> Prims.string) =
              fun acc ->
                FStar_Util.pimap_fold pi
                  (fun _i ->
-                    fun uu____2200 ->
+                    fun uu___ ->
                       fun acc1 ->
-                        match uu____2200 with
+                        match uu___ with
                         | (x, _term) ->
-                            let uu____2212 =
-                              FStar_Syntax_Print.bv_to_string x in
-                            uu____2212 :: acc1) acc) [] in
+                            let uu___1 = FStar_Syntax_Print.bv_to_string x in
+                            uu___1 :: acc1) acc) [] in
     let allvars =
-      let uu____2216 =
+      let uu___ =
         FStar_All.pipe_right e.fvar_bindings FStar_Pervasives_Native.fst in
-      FStar_Util.psmap_fold uu____2216
+      FStar_Util.psmap_fold uu___
         (fun _k -> fun fvb -> fun acc -> (fvb.fvar_lid) :: acc) [] in
     let last_fvar =
       match FStar_List.rev allvars with
       | [] -> ""
-      | l::uu____2245 ->
-          let uu____2248 = FStar_Syntax_Print.lid_to_string l in
-          Prims.op_Hat "...," uu____2248 in
+      | l::uu___ ->
+          let uu___1 = FStar_Syntax_Print.lid_to_string l in
+          Prims.op_Hat "...," uu___1 in
     FStar_String.concat ", " (last_fvar :: bvars)
 let (lookup_bvar_binding :
   env_t ->
@@ -473,11 +466,10 @@ let (lookup_bvar_binding :
   =
   fun env ->
     fun bv ->
-      let uu____2265 =
-        let uu____2274 =
-          FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
-        FStar_Util.psmap_try_find env.bvar_bindings uu____2274 in
-      match uu____2265 with
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+        FStar_Util.psmap_try_find env.bvar_bindings uu___1 in
+      match uu___ with
       | FStar_Pervasives_Native.Some bvs ->
           FStar_Util.pimap_try_find bvs bv.FStar_Syntax_Syntax.index
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -486,29 +478,27 @@ let (lookup_fvar_binding :
   =
   fun env ->
     fun lid ->
-      let uu____2326 =
+      let uu___ =
         FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst in
-      let uu____2343 = FStar_Ident.string_of_lid lid in
-      FStar_Util.psmap_try_find uu____2326 uu____2343
+      let uu___1 = FStar_Ident.string_of_lid lid in
+      FStar_Util.psmap_try_find uu___ uu___1
 let add_bvar_binding :
-  'uuuuuu2350 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu2350) ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu2350) FStar_Util.pimap
-        FStar_Util.psmap ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu2350) FStar_Util.pimap
-          FStar_Util.psmap
+  'uuuuu .
+    (FStar_Syntax_Syntax.bv * 'uuuuu) ->
+      (FStar_Syntax_Syntax.bv * 'uuuuu) FStar_Util.pimap FStar_Util.psmap ->
+        (FStar_Syntax_Syntax.bv * 'uuuuu) FStar_Util.pimap FStar_Util.psmap
   =
   fun bvb ->
     fun bvbs ->
-      let uu____2393 =
+      let uu___ =
         FStar_Ident.string_of_id
           (FStar_Pervasives_Native.fst bvb).FStar_Syntax_Syntax.ppname in
-      FStar_Util.psmap_modify bvbs uu____2393
+      FStar_Util.psmap_modify bvbs uu___
         (fun pimap_opt ->
-           let uu____2411 =
-             let uu____2418 = FStar_Util.pimap_empty () in
-             FStar_Util.dflt uu____2418 pimap_opt in
-           FStar_Util.pimap_add uu____2411
+           let uu___1 =
+             let uu___2 = FStar_Util.pimap_empty () in
+             FStar_Util.dflt uu___2 pimap_opt in
+           FStar_Util.pimap_add uu___1
              (FStar_Pervasives_Native.fst bvb).FStar_Syntax_Syntax.index bvb)
 let (add_fvar_binding :
   fvar_binding ->
@@ -516,13 +506,13 @@ let (add_fvar_binding :
       (fvar_binding FStar_Util.psmap * fvar_binding Prims.list))
   =
   fun fvb ->
-    fun uu____2464 ->
-      match uu____2464 with
+    fun uu___ ->
+      match uu___ with
       | (fvb_map, fvb_list) ->
-          let uu____2491 =
-            let uu____2494 = FStar_Ident.string_of_lid fvb.fvar_lid in
-            FStar_Util.psmap_add fvb_map uu____2494 fvb in
-          (uu____2491, (fvb :: fvb_list))
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_lid fvb.fvar_lid in
+            FStar_Util.psmap_add fvb_map uu___2 fvb in
+          (uu___1, (fvb :: fvb_list))
 let (fresh_fvar :
   Prims.string ->
     Prims.string ->
@@ -533,10 +523,10 @@ let (fresh_fvar :
     fun x ->
       fun s ->
         let xsym = varops.fresh mname x in
-        let uu____2519 =
-          let uu____2520 = FStar_SMTEncoding_Term.mk_fv (xsym, s) in
-          FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____2520 in
-        (xsym, uu____2519)
+        let uu___ =
+          let uu___1 = FStar_SMTEncoding_Term.mk_fv (xsym, s) in
+          FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___1 in
+        (xsym, uu___)
 let (gen_term_var :
   env_t ->
     FStar_Syntax_Syntax.bv ->
@@ -546,28 +536,28 @@ let (gen_term_var :
     fun x ->
       let ysym = Prims.op_Hat "@x" (Prims.string_of_int env.depth) in
       let y =
-        let uu____2539 =
+        let uu___ =
           FStar_SMTEncoding_Term.mk_fv
             (ysym, FStar_SMTEncoding_Term.Term_sort) in
-        FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu____2539 in
-      let uu____2540 =
-        let uu___224_2541 = env in
-        let uu____2542 = add_bvar_binding (x, y) env.bvar_bindings in
+        FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV uu___ in
+      let uu___ =
+        let uu___1 = env in
+        let uu___2 = add_bvar_binding (x, y) env.bvar_bindings in
         {
-          bvar_bindings = uu____2542;
-          fvar_bindings = (uu___224_2541.fvar_bindings);
+          bvar_bindings = uu___2;
+          fvar_bindings = (uu___1.fvar_bindings);
           depth = (env.depth + Prims.int_one);
-          tcenv = (uu___224_2541.tcenv);
-          warn = (uu___224_2541.warn);
-          nolabels = (uu___224_2541.nolabels);
-          use_zfuel_name = (uu___224_2541.use_zfuel_name);
+          tcenv = (uu___1.tcenv);
+          warn = (uu___1.warn);
+          nolabels = (uu___1.nolabels);
+          use_zfuel_name = (uu___1.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___224_2541.encode_non_total_function_typ);
-          current_module_name = (uu___224_2541.current_module_name);
-          encoding_quantifier = (uu___224_2541.encoding_quantifier);
-          global_cache = (uu___224_2541.global_cache)
+            (uu___1.encode_non_total_function_typ);
+          current_module_name = (uu___1.current_module_name);
+          encoding_quantifier = (uu___1.encoding_quantifier);
+          global_cache = (uu___1.global_cache)
         } in
-      (ysym, y, uu____2540)
+      (ysym, y, uu___)
 let (new_term_constant :
   env_t ->
     FStar_Syntax_Syntax.bv ->
@@ -579,24 +569,24 @@ let (new_term_constant :
         varops.new_var x.FStar_Syntax_Syntax.ppname
           x.FStar_Syntax_Syntax.index in
       let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
-      let uu____2571 =
-        let uu___230_2572 = env in
-        let uu____2573 = add_bvar_binding (x, y) env.bvar_bindings in
+      let uu___ =
+        let uu___1 = env in
+        let uu___2 = add_bvar_binding (x, y) env.bvar_bindings in
         {
-          bvar_bindings = uu____2573;
-          fvar_bindings = (uu___230_2572.fvar_bindings);
-          depth = (uu___230_2572.depth);
-          tcenv = (uu___230_2572.tcenv);
-          warn = (uu___230_2572.warn);
-          nolabels = (uu___230_2572.nolabels);
-          use_zfuel_name = (uu___230_2572.use_zfuel_name);
+          bvar_bindings = uu___2;
+          fvar_bindings = (uu___1.fvar_bindings);
+          depth = (uu___1.depth);
+          tcenv = (uu___1.tcenv);
+          warn = (uu___1.warn);
+          nolabels = (uu___1.nolabels);
+          use_zfuel_name = (uu___1.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___230_2572.encode_non_total_function_typ);
-          current_module_name = (uu___230_2572.current_module_name);
-          encoding_quantifier = (uu___230_2572.encoding_quantifier);
-          global_cache = (uu___230_2572.global_cache)
+            (uu___1.encode_non_total_function_typ);
+          current_module_name = (uu___1.current_module_name);
+          encoding_quantifier = (uu___1.encoding_quantifier);
+          global_cache = (uu___1.global_cache)
         } in
-      (ysym, y, uu____2571)
+      (ysym, y, uu___)
 let (new_term_constant_from_string :
   env_t ->
     FStar_Syntax_Syntax.bv ->
@@ -607,62 +597,62 @@ let (new_term_constant_from_string :
       fun str ->
         let ysym = varops.mk_unique str in
         let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
-        let uu____2607 =
-          let uu___237_2608 = env in
-          let uu____2609 = add_bvar_binding (x, y) env.bvar_bindings in
+        let uu___ =
+          let uu___1 = env in
+          let uu___2 = add_bvar_binding (x, y) env.bvar_bindings in
           {
-            bvar_bindings = uu____2609;
-            fvar_bindings = (uu___237_2608.fvar_bindings);
-            depth = (uu___237_2608.depth);
-            tcenv = (uu___237_2608.tcenv);
-            warn = (uu___237_2608.warn);
-            nolabels = (uu___237_2608.nolabels);
-            use_zfuel_name = (uu___237_2608.use_zfuel_name);
+            bvar_bindings = uu___2;
+            fvar_bindings = (uu___1.fvar_bindings);
+            depth = (uu___1.depth);
+            tcenv = (uu___1.tcenv);
+            warn = (uu___1.warn);
+            nolabels = (uu___1.nolabels);
+            use_zfuel_name = (uu___1.use_zfuel_name);
             encode_non_total_function_typ =
-              (uu___237_2608.encode_non_total_function_typ);
-            current_module_name = (uu___237_2608.current_module_name);
-            encoding_quantifier = (uu___237_2608.encoding_quantifier);
-            global_cache = (uu___237_2608.global_cache)
+              (uu___1.encode_non_total_function_typ);
+            current_module_name = (uu___1.current_module_name);
+            encoding_quantifier = (uu___1.encoding_quantifier);
+            global_cache = (uu___1.global_cache)
           } in
-        (ysym, y, uu____2607)
+        (ysym, y, uu___)
 let (push_term_var :
   env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term -> env_t) =
   fun env ->
     fun x ->
       fun t ->
-        let uu___242_2633 = env in
-        let uu____2634 = add_bvar_binding (x, t) env.bvar_bindings in
+        let uu___ = env in
+        let uu___1 = add_bvar_binding (x, t) env.bvar_bindings in
         {
-          bvar_bindings = uu____2634;
-          fvar_bindings = (uu___242_2633.fvar_bindings);
-          depth = (uu___242_2633.depth);
-          tcenv = (uu___242_2633.tcenv);
-          warn = (uu___242_2633.warn);
-          nolabels = (uu___242_2633.nolabels);
-          use_zfuel_name = (uu___242_2633.use_zfuel_name);
+          bvar_bindings = uu___1;
+          fvar_bindings = (uu___.fvar_bindings);
+          depth = (uu___.depth);
+          tcenv = (uu___.tcenv);
+          warn = (uu___.warn);
+          nolabels = (uu___.nolabels);
+          use_zfuel_name = (uu___.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___242_2633.encode_non_total_function_typ);
-          current_module_name = (uu___242_2633.current_module_name);
-          encoding_quantifier = (uu___242_2633.encoding_quantifier);
-          global_cache = (uu___242_2633.global_cache)
+            (uu___.encode_non_total_function_typ);
+          current_module_name = (uu___.current_module_name);
+          encoding_quantifier = (uu___.encoding_quantifier);
+          global_cache = (uu___.global_cache)
         }
 let (lookup_term_var :
   env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term) =
   fun env ->
     fun a ->
-      let uu____2653 = lookup_bvar_binding env a in
-      match uu____2653 with
+      let uu___ = lookup_bvar_binding env a in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____2664 = lookup_bvar_binding env a in
-          (match uu____2664 with
+          let uu___1 = lookup_bvar_binding env a in
+          (match uu___1 with
            | FStar_Pervasives_Native.None ->
-               let uu____2675 =
-                 let uu____2676 = FStar_Syntax_Print.bv_to_string a in
-                 let uu____2677 = print_env env in
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Print.bv_to_string a in
+                 let uu___4 = print_env env in
                  FStar_Util.format2
                    "Bound term variable not found  %s in environment: %s"
-                   uu____2676 uu____2677 in
-               failwith uu____2675
+                   uu___3 uu___4 in
+               failwith uu___2
            | FStar_Pervasives_Native.Some (b, t) -> t)
       | FStar_Pervasives_Native.Some (b, t) -> t
 let (mk_fvb :
@@ -702,7 +692,7 @@ let (new_term_constant_and_tok_from_lid_aux :
       fun arity ->
         fun thunked ->
           let fname = varops.new_fvar x in
-          let uu____2759 =
+          let uu___ =
             if thunked
             then (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
             else
@@ -710,29 +700,29 @@ let (new_term_constant_and_tok_from_lid_aux :
                let ftok = FStar_SMTEncoding_Util.mkApp (ftok_name, []) in
                ((FStar_Pervasives_Native.Some ftok_name),
                  (FStar_Pervasives_Native.Some ftok))) in
-          match uu____2759 with
+          match uu___ with
           | (ftok_name, ftok) ->
               let fvb =
                 mk_fvb x fname arity ftok FStar_Pervasives_Native.None
                   thunked in
-              let uu____2808 =
-                let uu___276_2809 = env in
-                let uu____2810 = add_fvar_binding fvb env.fvar_bindings in
+              let uu___1 =
+                let uu___2 = env in
+                let uu___3 = add_fvar_binding fvb env.fvar_bindings in
                 {
-                  bvar_bindings = (uu___276_2809.bvar_bindings);
-                  fvar_bindings = uu____2810;
-                  depth = (uu___276_2809.depth);
-                  tcenv = (uu___276_2809.tcenv);
-                  warn = (uu___276_2809.warn);
-                  nolabels = (uu___276_2809.nolabels);
-                  use_zfuel_name = (uu___276_2809.use_zfuel_name);
+                  bvar_bindings = (uu___2.bvar_bindings);
+                  fvar_bindings = uu___3;
+                  depth = (uu___2.depth);
+                  tcenv = (uu___2.tcenv);
+                  warn = (uu___2.warn);
+                  nolabels = (uu___2.nolabels);
+                  use_zfuel_name = (uu___2.use_zfuel_name);
                   encode_non_total_function_typ =
-                    (uu___276_2809.encode_non_total_function_typ);
-                  current_module_name = (uu___276_2809.current_module_name);
-                  encoding_quantifier = (uu___276_2809.encoding_quantifier);
-                  global_cache = (uu___276_2809.global_cache)
+                    (uu___2.encode_non_total_function_typ);
+                  current_module_name = (uu___2.current_module_name);
+                  encoding_quantifier = (uu___2.encoding_quantifier);
+                  global_cache = (uu___2.global_cache)
                 } in
-              (fname, ftok_name, uu____2808)
+              (fname, ftok_name, uu___1)
 let (new_term_constant_and_tok_from_lid :
   env_t ->
     FStar_Ident.lident -> Prims.int -> (Prims.string * Prims.string * env_t))
@@ -740,12 +730,11 @@ let (new_term_constant_and_tok_from_lid :
   fun env ->
     fun x ->
       fun arity ->
-        let uu____2842 =
-          new_term_constant_and_tok_from_lid_aux env x arity false in
-        match uu____2842 with
+        let uu___ = new_term_constant_and_tok_from_lid_aux env x arity false in
+        match uu___ with
         | (fname, ftok_name_opt, env1) ->
-            let uu____2864 = FStar_Option.get ftok_name_opt in
-            (fname, uu____2864, env1)
+            let uu___1 = FStar_Option.get ftok_name_opt in
+            (fname, uu___1, env1)
 let (new_term_constant_and_tok_from_lid_maybe_thunked :
   env_t ->
     FStar_Ident.lident ->
@@ -761,13 +750,13 @@ let (new_term_constant_and_tok_from_lid_maybe_thunked :
 let (lookup_lid : env_t -> FStar_Ident.lident -> fvar_binding) =
   fun env ->
     fun a ->
-      let uu____2903 = lookup_fvar_binding env a in
-      match uu____2903 with
+      let uu___ = lookup_fvar_binding env a in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____2906 =
-            let uu____2907 = FStar_Syntax_Print.lid_to_string a in
-            FStar_Util.format1 "Name not found: %s" uu____2907 in
-          failwith uu____2906
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.lid_to_string a in
+            FStar_Util.format1 "Name not found: %s" uu___2 in
+          failwith uu___1
       | FStar_Pervasives_Native.Some s -> (check_valid_fvb s; s)
 let (push_free_var_maybe_thunked :
   env_t ->
@@ -786,21 +775,21 @@ let (push_free_var_maybe_thunked :
               let fvb =
                 mk_fvb x fname arity ftok FStar_Pervasives_Native.None
                   thunked in
-              let uu___302_2945 = env in
-              let uu____2946 = add_fvar_binding fvb env.fvar_bindings in
+              let uu___ = env in
+              let uu___1 = add_fvar_binding fvb env.fvar_bindings in
               {
-                bvar_bindings = (uu___302_2945.bvar_bindings);
-                fvar_bindings = uu____2946;
-                depth = (uu___302_2945.depth);
-                tcenv = (uu___302_2945.tcenv);
-                warn = (uu___302_2945.warn);
-                nolabels = (uu___302_2945.nolabels);
-                use_zfuel_name = (uu___302_2945.use_zfuel_name);
+                bvar_bindings = (uu___.bvar_bindings);
+                fvar_bindings = uu___1;
+                depth = (uu___.depth);
+                tcenv = (uu___.tcenv);
+                warn = (uu___.warn);
+                nolabels = (uu___.nolabels);
+                use_zfuel_name = (uu___.use_zfuel_name);
                 encode_non_total_function_typ =
-                  (uu___302_2945.encode_non_total_function_typ);
-                current_module_name = (uu___302_2945.current_module_name);
-                encoding_quantifier = (uu___302_2945.encoding_quantifier);
-                global_cache = (uu___302_2945.global_cache)
+                  (uu___.encode_non_total_function_typ);
+                current_module_name = (uu___.current_module_name);
+                encoding_quantifier = (uu___.encoding_quantifier);
+                global_cache = (uu___.global_cache)
               }
 let (push_free_var :
   env_t ->
@@ -836,30 +825,30 @@ let (push_zfuel_name : env_t -> FStar_Ident.lident -> Prims.string -> env_t)
       fun f ->
         let fvb = lookup_lid env x in
         let t3 =
-          let uu____3030 =
-            let uu____3037 =
-              let uu____3040 = FStar_SMTEncoding_Util.mkApp ("ZFuel", []) in
-              [uu____3040] in
-            (f, uu____3037) in
-          FStar_SMTEncoding_Util.mkApp uu____3030 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_SMTEncoding_Util.mkApp ("ZFuel", []) in
+              [uu___2] in
+            (f, uu___1) in
+          FStar_SMTEncoding_Util.mkApp uu___ in
         let fvb1 =
           mk_fvb x fvb.smt_id fvb.smt_arity fvb.smt_token
             (FStar_Pervasives_Native.Some t3) false in
-        let uu___320_3046 = env in
-        let uu____3047 = add_fvar_binding fvb1 env.fvar_bindings in
+        let uu___ = env in
+        let uu___1 = add_fvar_binding fvb1 env.fvar_bindings in
         {
-          bvar_bindings = (uu___320_3046.bvar_bindings);
-          fvar_bindings = uu____3047;
-          depth = (uu___320_3046.depth);
-          tcenv = (uu___320_3046.tcenv);
-          warn = (uu___320_3046.warn);
-          nolabels = (uu___320_3046.nolabels);
-          use_zfuel_name = (uu___320_3046.use_zfuel_name);
+          bvar_bindings = (uu___.bvar_bindings);
+          fvar_bindings = uu___1;
+          depth = (uu___.depth);
+          tcenv = (uu___.tcenv);
+          warn = (uu___.warn);
+          nolabels = (uu___.nolabels);
+          use_zfuel_name = (uu___.use_zfuel_name);
           encode_non_total_function_typ =
-            (uu___320_3046.encode_non_total_function_typ);
-          current_module_name = (uu___320_3046.current_module_name);
-          encoding_quantifier = (uu___320_3046.encoding_quantifier);
-          global_cache = (uu___320_3046.global_cache)
+            (uu___.encode_non_total_function_typ);
+          current_module_name = (uu___.current_module_name);
+          encoding_quantifier = (uu___.encoding_quantifier);
+          global_cache = (uu___.global_cache)
         }
 let (force_thunk : fvar_binding -> FStar_SMTEncoding_Term.term) =
   fun fvb ->
@@ -877,60 +866,57 @@ let (try_lookup_free_var :
   =
   fun env ->
     fun l ->
-      let uu____3075 = lookup_fvar_binding env l in
-      match uu____3075 with
+      let uu___ = lookup_fvar_binding env l in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some fvb ->
-          ((let uu____3082 =
+          ((let uu___2 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
                 (FStar_Options.Other "PartialApp") in
-            if uu____3082
+            if uu___2
             then
-              let uu____3083 = FStar_Ident.string_of_lid l in
-              let uu____3084 = fvb_to_string fvb in
-              FStar_Util.print2 "Looked up %s found\n%s\n" uu____3083
-                uu____3084
+              let uu___3 = FStar_Ident.string_of_lid l in
+              let uu___4 = fvb_to_string fvb in
+              FStar_Util.print2 "Looked up %s found\n%s\n" uu___3 uu___4
             else ());
            if fvb.fvb_thunked
            then
-             (let uu____3088 = force_thunk fvb in
-              FStar_Pervasives_Native.Some uu____3088)
+             (let uu___2 = force_thunk fvb in
+              FStar_Pervasives_Native.Some uu___2)
            else
              (match fvb.smt_fuel_partial_app with
               | FStar_Pervasives_Native.Some f when env.use_zfuel_name ->
                   FStar_Pervasives_Native.Some f
-              | uu____3093 ->
+              | uu___3 ->
                   (match fvb.smt_token with
                    | FStar_Pervasives_Native.Some t ->
                        (match t.FStar_SMTEncoding_Term.tm with
-                        | FStar_SMTEncoding_Term.App (uu____3101, fuel::[])
-                            ->
-                            let uu____3105 =
-                              let uu____3106 =
-                                let uu____3107 =
+                        | FStar_SMTEncoding_Term.App (uu___4, fuel::[]) ->
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_SMTEncoding_Term.fv_of_term fuel in
-                                FStar_All.pipe_right uu____3107
+                                FStar_All.pipe_right uu___7
                                   FStar_SMTEncoding_Term.fv_name in
-                              FStar_Util.starts_with uu____3106 "fuel" in
-                            if uu____3105
+                              FStar_Util.starts_with uu___6 "fuel" in
+                            if uu___5
                             then
-                              let uu____3110 =
-                                let uu____3111 =
-                                  let uu____3112 =
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
                                     FStar_SMTEncoding_Term.mk_fv
                                       ((fvb.smt_id),
                                         FStar_SMTEncoding_Term.Term_sort) in
                                   FStar_All.pipe_left
-                                    FStar_SMTEncoding_Util.mkFreeV uu____3112 in
-                                FStar_SMTEncoding_Term.mk_ApplyTF uu____3111
-                                  fuel in
+                                    FStar_SMTEncoding_Util.mkFreeV uu___8 in
+                                FStar_SMTEncoding_Term.mk_ApplyTF uu___7 fuel in
                               FStar_All.pipe_left
-                                (fun uu____3115 ->
-                                   FStar_Pervasives_Native.Some uu____3115)
-                                uu____3110
+                                (fun uu___7 ->
+                                   FStar_Pervasives_Native.Some uu___7)
+                                uu___6
                             else FStar_Pervasives_Native.Some t
-                        | uu____3117 -> FStar_Pervasives_Native.Some t)
-                   | uu____3118 -> FStar_Pervasives_Native.None)))
+                        | uu___4 -> FStar_Pervasives_Native.Some t)
+                   | uu___4 -> FStar_Pervasives_Native.None)))
 let (lookup_free_var :
   env_t ->
     FStar_Ident.lid FStar_Syntax_Syntax.withinfo_t ->
@@ -938,15 +924,15 @@ let (lookup_free_var :
   =
   fun env ->
     fun a ->
-      let uu____3135 = try_lookup_free_var env a.FStar_Syntax_Syntax.v in
-      match uu____3135 with
+      let uu___ = try_lookup_free_var env a.FStar_Syntax_Syntax.v in
+      match uu___ with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None ->
-          let uu____3139 =
-            let uu____3140 =
+          let uu___1 =
+            let uu___2 =
               FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v in
-            FStar_Util.format1 "Name not found: %s" uu____3140 in
-          failwith uu____3139
+            FStar_Util.format1 "Name not found: %s" uu___2 in
+          failwith uu___1
 let (lookup_free_var_name :
   env_t -> FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> fvar_binding)
   = fun env -> fun a -> lookup_lid env a.FStar_Syntax_Syntax.v
@@ -963,17 +949,16 @@ let (lookup_free_var_sym :
       match fvb.smt_fuel_partial_app with
       | FStar_Pervasives_Native.Some
           { FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App (g, zf);
-            FStar_SMTEncoding_Term.freevars = uu____3196;
-            FStar_SMTEncoding_Term.rng = uu____3197;_}
+            FStar_SMTEncoding_Term.freevars = uu___;
+            FStar_SMTEncoding_Term.rng = uu___1;_}
           when env.use_zfuel_name ->
           ((FStar_Util.Inl g), zf, (fvb.smt_arity + Prims.int_one))
-      | uu____3218 ->
+      | uu___ ->
           (match fvb.smt_token with
            | FStar_Pervasives_Native.None when fvb.fvb_thunked ->
-               let uu____3233 =
-                 let uu____3238 = force_thunk fvb in
-                 FStar_Util.Inr uu____3238 in
-               (uu____3233, [], (fvb.smt_arity))
+               let uu___1 =
+                 let uu___2 = force_thunk fvb in FStar_Util.Inr uu___2 in
+               (uu___1, [], (fvb.smt_arity))
            | FStar_Pervasives_Native.None ->
                ((FStar_Util.Inl (FStar_SMTEncoding_Term.Var (fvb.smt_id))),
                  [], (fvb.smt_arity))
@@ -982,7 +967,7 @@ let (lookup_free_var_sym :
                 | FStar_SMTEncoding_Term.App (g, fuel::[]) ->
                     ((FStar_Util.Inl g), [fuel],
                       (fvb.smt_arity + Prims.int_one))
-                | uu____3274 ->
+                | uu___1 ->
                     ((FStar_Util.Inl
                         (FStar_SMTEncoding_Term.Var (fvb.smt_id))), [],
                       (fvb.smt_arity))))
@@ -993,62 +978,61 @@ let (tok_of_name :
   =
   fun env ->
     fun nm ->
-      let uu____3293 =
-        let uu____3296 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst in
-        FStar_Util.psmap_find_map uu____3296
-          (fun uu____3316 ->
+        FStar_Util.psmap_find_map uu___1
+          (fun uu___2 ->
              fun fvb ->
                check_valid_fvb fvb;
                if fvb.smt_id = nm
                then fvb.smt_token
                else FStar_Pervasives_Native.None) in
-      match uu____3293 with
+      match uu___ with
       | FStar_Pervasives_Native.Some b -> FStar_Pervasives_Native.Some b
       | FStar_Pervasives_Native.None ->
           FStar_Util.psmap_find_map env.bvar_bindings
-            (fun uu____3333 ->
+            (fun uu___1 ->
                fun pi ->
                  FStar_Util.pimap_fold pi
-                   (fun uu____3352 ->
+                   (fun uu___2 ->
                       fun y ->
                         fun res ->
                           match (res, y) with
-                          | (FStar_Pervasives_Native.Some uu____3369,
-                             uu____3370) -> res
+                          | (FStar_Pervasives_Native.Some uu___3, uu___4) ->
+                              res
                           | (FStar_Pervasives_Native.None,
-                             (uu____3381,
+                             (uu___3,
                               {
                                 FStar_SMTEncoding_Term.tm =
                                   FStar_SMTEncoding_Term.App
                                   (FStar_SMTEncoding_Term.Var sym, []);
-                                FStar_SMTEncoding_Term.freevars = uu____3383;
-                                FStar_SMTEncoding_Term.rng = uu____3384;_}))
+                                FStar_SMTEncoding_Term.freevars = uu___4;
+                                FStar_SMTEncoding_Term.rng = uu___5;_}))
                               when sym = nm ->
                               FStar_Pervasives_Native.Some
                                 (FStar_Pervasives_Native.snd y)
-                          | uu____3403 -> FStar_Pervasives_Native.None)
+                          | uu___3 -> FStar_Pervasives_Native.None)
                    FStar_Pervasives_Native.None)
 let (reset_current_module_fvbs : env_t -> env_t) =
   fun env ->
-    let uu___407_3419 = env in
-    let uu____3420 =
-      let uu____3429 =
+    let uu___ = env in
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right env.fvar_bindings FStar_Pervasives_Native.fst in
-      (uu____3429, []) in
+      (uu___2, []) in
     {
-      bvar_bindings = (uu___407_3419.bvar_bindings);
-      fvar_bindings = uu____3420;
-      depth = (uu___407_3419.depth);
-      tcenv = (uu___407_3419.tcenv);
-      warn = (uu___407_3419.warn);
-      nolabels = (uu___407_3419.nolabels);
-      use_zfuel_name = (uu___407_3419.use_zfuel_name);
-      encode_non_total_function_typ =
-        (uu___407_3419.encode_non_total_function_typ);
-      current_module_name = (uu___407_3419.current_module_name);
-      encoding_quantifier = (uu___407_3419.encoding_quantifier);
-      global_cache = (uu___407_3419.global_cache)
+      bvar_bindings = (uu___.bvar_bindings);
+      fvar_bindings = uu___1;
+      depth = (uu___.depth);
+      tcenv = (uu___.tcenv);
+      warn = (uu___.warn);
+      nolabels = (uu___.nolabels);
+      use_zfuel_name = (uu___.use_zfuel_name);
+      encode_non_total_function_typ = (uu___.encode_non_total_function_typ);
+      current_module_name = (uu___.current_module_name);
+      encoding_quantifier = (uu___.encoding_quantifier);
+      global_cache = (uu___.global_cache)
     }
 let (get_current_module_fvbs : env_t -> fvar_binding Prims.list) =
   fun env ->
@@ -1056,19 +1040,18 @@ let (get_current_module_fvbs : env_t -> fvar_binding Prims.list) =
 let (add_fvar_binding_to_env : fvar_binding -> env_t -> env_t) =
   fun fvb ->
     fun env ->
-      let uu___412_3481 = env in
-      let uu____3482 = add_fvar_binding fvb env.fvar_bindings in
+      let uu___ = env in
+      let uu___1 = add_fvar_binding fvb env.fvar_bindings in
       {
-        bvar_bindings = (uu___412_3481.bvar_bindings);
-        fvar_bindings = uu____3482;
-        depth = (uu___412_3481.depth);
-        tcenv = (uu___412_3481.tcenv);
-        warn = (uu___412_3481.warn);
-        nolabels = (uu___412_3481.nolabels);
-        use_zfuel_name = (uu___412_3481.use_zfuel_name);
-        encode_non_total_function_typ =
-          (uu___412_3481.encode_non_total_function_typ);
-        current_module_name = (uu___412_3481.current_module_name);
-        encoding_quantifier = (uu___412_3481.encoding_quantifier);
-        global_cache = (uu___412_3481.global_cache)
+        bvar_bindings = (uu___.bvar_bindings);
+        fvar_bindings = uu___1;
+        depth = (uu___.depth);
+        tcenv = (uu___.tcenv);
+        warn = (uu___.warn);
+        nolabels = (uu___.nolabels);
+        use_zfuel_name = (uu___.use_zfuel_name);
+        encode_non_total_function_typ = (uu___.encode_non_total_function_typ);
+        current_module_name = (uu___.current_module_name);
+        encoding_quantifier = (uu___.encoding_quantifier);
+        global_cache = (uu___.global_cache)
       }

--- a/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
@@ -3,11 +3,10 @@ exception Not_a_wp_implication of Prims.string
 let (uu___is_Not_a_wp_implication : Prims.exn -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | Not_a_wp_implication uu____9 -> true
-    | uu____10 -> false
+    | Not_a_wp_implication uu___ -> true
+    | uu___ -> false
 let (__proj__Not_a_wp_implication__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee ->
-    match projectee with | Not_a_wp_implication uu____16 -> uu____16
+  fun projectee -> match projectee with | Not_a_wp_implication uu___ -> uu___
 type label = FStar_SMTEncoding_Term.error_label
 type labels = FStar_SMTEncoding_Term.error_labels
 let (sort_labels :
@@ -17,23 +16,22 @@ let (sort_labels :
   =
   fun l ->
     FStar_List.sortWith
-      (fun uu____66 ->
-         fun uu____67 ->
-           match (uu____66, uu____67) with
-           | (((uu____108, uu____109, r1), uu____111),
-              ((uu____112, uu____113, r2), uu____115)) ->
-               FStar_Range.compare r1 r2) l
+      (fun uu___ ->
+         fun uu___1 ->
+           match (uu___, uu___1) with
+           | (((uu___2, uu___3, r1), uu___4), ((uu___5, uu___6, r2), uu___7))
+               -> FStar_Range.compare r1 r2) l
 let (remove_dups :
   labels ->
     (FStar_SMTEncoding_Term.fv * Prims.string * FStar_Range.range) Prims.list)
   =
   fun l ->
     FStar_Util.remove_dups
-      (fun uu____175 ->
-         fun uu____176 ->
-           match (uu____175, uu____176) with
-           | ((uu____201, m1, r1), (uu____204, m2, r2)) ->
-               (r1 = r2) && (m1 = m2)) l
+      (fun uu___ ->
+         fun uu___1 ->
+           match (uu___, uu___1) with
+           | ((uu___2, m1, r1), (uu___3, m2, r2)) -> (r1 = r2) && (m1 = m2))
+      l
 type msg = (Prims.string * FStar_Range.range)
 type ranges =
   (Prims.string FStar_Pervasives_Native.option * FStar_Range.range)
@@ -49,10 +47,10 @@ let (fresh_label :
       fun t ->
         let l =
           FStar_Util.incr ctr;
-          (let uu____255 =
-             let uu____256 = FStar_ST.op_Bang ctr in
-             FStar_Util.string_of_int uu____256 in
-           FStar_Util.format1 "label_%s" uu____255) in
+          (let uu___1 =
+             let uu___2 = FStar_ST.op_Bang ctr in
+             FStar_Util.string_of_int uu___2 in
+           FStar_Util.format1 "label_%s" uu___1) in
         let lvar =
           FStar_SMTEncoding_Term.mk_fv (l, FStar_SMTEncoding_Term.Bool_sort) in
         let label1 = (lvar, message, range) in
@@ -68,22 +66,21 @@ let (label_goals :
       fun q ->
         let rec is_a_post_condition post_name_opt tm =
           match (post_name_opt, (tm.FStar_SMTEncoding_Term.tm)) with
-          | (FStar_Pervasives_Native.None, uu____322) -> false
+          | (FStar_Pervasives_Native.None, uu___) -> false
           | (FStar_Pervasives_Native.Some nm, FStar_SMTEncoding_Term.FreeV
              fv) ->
-              let uu____335 = FStar_SMTEncoding_Term.fv_name fv in
-              nm = uu____335
-          | (uu____336, FStar_SMTEncoding_Term.App
+              let uu___ = FStar_SMTEncoding_Term.fv_name fv in nm = uu___
+          | (uu___, FStar_SMTEncoding_Term.App
              (FStar_SMTEncoding_Term.Var "Valid", tm1::[])) ->
               is_a_post_condition post_name_opt tm1
-          | (uu____344, FStar_SMTEncoding_Term.App
-             (FStar_SMTEncoding_Term.Var "ApplyTT", tm1::uu____346)) ->
+          | (uu___, FStar_SMTEncoding_Term.App
+             (FStar_SMTEncoding_Term.Var "ApplyTT", tm1::uu___1)) ->
               is_a_post_condition post_name_opt tm1
-          | uu____355 -> false in
+          | uu___ -> false in
         let conjuncts t =
           match t.FStar_SMTEncoding_Term.tm with
           | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And, cs) -> cs
-          | uu____377 -> [t] in
+          | uu___ -> [t] in
         let is_guard_free tm =
           match tm.FStar_SMTEncoding_Term.tm with
           | FStar_SMTEncoding_Term.Quant
@@ -91,25 +88,25 @@ let (label_goals :
                ({
                   FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
                     (FStar_SMTEncoding_Term.Var "Prims.guard_free", p::[]);
-                  FStar_SMTEncoding_Term.freevars = uu____385;
-                  FStar_SMTEncoding_Term.rng = uu____386;_}::[])::[],
-               iopt, uu____388,
+                  FStar_SMTEncoding_Term.freevars = uu___;
+                  FStar_SMTEncoding_Term.rng = uu___1;_}::[])::[],
+               iopt, uu___2,
                {
                  FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
                    (FStar_SMTEncoding_Term.Imp, l::r1::[]);
-                 FStar_SMTEncoding_Term.freevars = uu____391;
-                 FStar_SMTEncoding_Term.rng = uu____392;_})
+                 FStar_SMTEncoding_Term.freevars = uu___3;
+                 FStar_SMTEncoding_Term.rng = uu___4;_})
               -> true
-          | uu____433 -> false in
+          | uu___ -> false in
         let is_a_named_continuation lhs =
           FStar_All.pipe_right (conjuncts lhs)
             (FStar_Util.for_some is_guard_free) in
-        let uu____442 =
+        let uu___ =
           match use_env_msg with
           | FStar_Pervasives_Native.None -> (false, "")
           | FStar_Pervasives_Native.Some f ->
-              let uu____461 = f () in (true, uu____461) in
-        match uu____442 with
+              let uu___1 = f () in (true, uu___1) in
+        match uu___ with
         | (flag, msg_prefix) ->
             let fresh_label1 msg1 ropt rng t =
               let msg2 =
@@ -122,30 +119,29 @@ let (label_goals :
                 match ropt with
                 | FStar_Pervasives_Native.None -> rng
                 | FStar_Pervasives_Native.Some r1 ->
-                    let uu____501 =
-                      let uu____502 = FStar_Range.use_range rng in
-                      let uu____503 = FStar_Range.use_range r1 in
-                      FStar_Range.rng_included uu____502 uu____503 in
-                    if uu____501
+                    let uu___1 =
+                      let uu___2 = FStar_Range.use_range rng in
+                      let uu___3 = FStar_Range.use_range r1 in
+                      FStar_Range.rng_included uu___2 uu___3 in
+                    if uu___1
                     then rng
                     else
-                      (let uu____505 = FStar_Range.def_range rng in
-                       FStar_Range.set_def_range r1 uu____505) in
+                      (let uu___3 = FStar_Range.def_range rng in
+                       FStar_Range.set_def_range r1 uu___3) in
               fresh_label msg2 rng1 t in
             let rec aux default_msg ropt post_name_opt labels1 q1 =
               match q1.FStar_SMTEncoding_Term.tm with
-              | FStar_SMTEncoding_Term.BoundV uu____556 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.Integer uu____559 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.String uu____562 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.Real uu____565 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.LblPos uu____568 ->
-                  failwith "Impossible"
+              | FStar_SMTEncoding_Term.BoundV uu___1 -> (labels1, q1)
+              | FStar_SMTEncoding_Term.Integer uu___1 -> (labels1, q1)
+              | FStar_SMTEncoding_Term.String uu___1 -> (labels1, q1)
+              | FStar_SMTEncoding_Term.Real uu___1 -> (labels1, q1)
+              | FStar_SMTEncoding_Term.LblPos uu___1 -> failwith "Impossible"
               | FStar_SMTEncoding_Term.Labeled
-                  (arg, "could not prove post-condition", uu____580) ->
+                  (arg, "could not prove post-condition", uu___1) ->
                   let fallback msg1 =
                     aux default_msg ropt post_name_opt labels1 arg in
                   (try
-                     (fun uu___144_622 ->
+                     (fun uu___2 ->
                         match () with
                         | () ->
                             (match arg.FStar_SMTEncoding_Term.tm with
@@ -157,59 +153,58 @@ let (label_goals :
                                       FStar_SMTEncoding_Term.App
                                       (FStar_SMTEncoding_Term.Imp,
                                        lhs::rhs::[]);
-                                    FStar_SMTEncoding_Term.freevars =
-                                      uu____641;
+                                    FStar_SMTEncoding_Term.freevars = uu___3;
                                     FStar_SMTEncoding_Term.rng = rng;_})
                                  ->
                                  let post_name =
-                                   let uu____672 =
-                                     let uu____673 = FStar_Ident.next_id () in
+                                   let uu___4 =
+                                     let uu___5 = FStar_Ident.next_id () in
                                      FStar_All.pipe_left
-                                       FStar_Util.string_of_int uu____673 in
-                                   Prims.op_Hat "^^post_condition_" uu____672 in
+                                       FStar_Util.string_of_int uu___5 in
+                                   Prims.op_Hat "^^post_condition_" uu___4 in
                                  let names =
-                                   let uu____677 =
+                                   let uu___4 =
                                      FStar_SMTEncoding_Term.mk_fv
                                        (post_name, post) in
-                                   let uu____678 =
+                                   let uu___5 =
                                      FStar_List.map
                                        (fun s ->
-                                          let uu____684 =
-                                            let uu____689 =
-                                              let uu____690 =
-                                                let uu____691 =
+                                          let uu___6 =
+                                            let uu___7 =
+                                              let uu___8 =
+                                                let uu___9 =
                                                   FStar_Ident.next_id () in
                                                 FStar_All.pipe_left
                                                   FStar_Util.string_of_int
-                                                  uu____691 in
-                                              Prims.op_Hat "^^" uu____690 in
-                                            (uu____689, s) in
-                                          FStar_SMTEncoding_Term.mk_fv
-                                            uu____684) sorts in
-                                   uu____677 :: uu____678 in
+                                                  uu___9 in
+                                              Prims.op_Hat "^^" uu___8 in
+                                            (uu___7, s) in
+                                          FStar_SMTEncoding_Term.mk_fv uu___6)
+                                       sorts in
+                                   uu___4 :: uu___5 in
                                  let instantiation =
                                    FStar_List.map
                                      FStar_SMTEncoding_Util.mkFreeV names in
-                                 let uu____695 =
-                                   let uu____700 =
+                                 let uu___4 =
+                                   let uu___5 =
                                      FStar_SMTEncoding_Term.inst
                                        instantiation lhs in
-                                   let uu____701 =
+                                   let uu___6 =
                                      FStar_SMTEncoding_Term.inst
                                        instantiation rhs in
-                                   (uu____700, uu____701) in
-                                 (match uu____695 with
+                                   (uu___5, uu___6) in
+                                 (match uu___4 with
                                   | (lhs1, rhs1) ->
-                                      let uu____710 =
+                                      let uu___5 =
                                         match lhs1.FStar_SMTEncoding_Term.tm
                                         with
                                         | FStar_SMTEncoding_Term.App
                                             (FStar_SMTEncoding_Term.And,
                                              clauses_lhs)
                                             ->
-                                            let uu____728 =
+                                            let uu___6 =
                                               FStar_Util.prefix clauses_lhs in
-                                            (match uu____728 with
+                                            (match uu___6 with
                                              | (req, ens) ->
                                                  (match ens.FStar_SMTEncoding_Term.tm
                                                   with
@@ -224,17 +219,17 @@ let (label_goals :
                                                            (FStar_SMTEncoding_Term.Imp,
                                                             ensures_conjuncts::post1::[]);
                                                          FStar_SMTEncoding_Term.freevars
-                                                           = uu____758;
+                                                           = uu___7;
                                                          FStar_SMTEncoding_Term.rng
                                                            = rng_ens;_})
                                                       ->
-                                                      let uu____788 =
+                                                      let uu___8 =
                                                         is_a_post_condition
                                                           (FStar_Pervasives_Native.Some
                                                              post_name) post1 in
-                                                      if uu____788
+                                                      if uu___8
                                                       then
-                                                        let uu____795 =
+                                                        let uu___9 =
                                                           aux
                                                             "could not prove post-condition"
                                                             FStar_Pervasives_Native.None
@@ -242,7 +237,7 @@ let (label_goals :
                                                                post_name)
                                                             labels1
                                                             ensures_conjuncts in
-                                                        (match uu____795 with
+                                                        (match uu___9 with
                                                          | (labels2,
                                                             ensures_conjuncts1)
                                                              ->
@@ -253,14 +248,13 @@ let (label_goals :
                                                                    [[post1]]
                                                                | []::[] ->
                                                                    [[post1]]
-                                                               | uu____837 ->
+                                                               | uu___10 ->
                                                                    pats_ens in
                                                              let ens1 =
-                                                               let uu____843
-                                                                 =
-                                                                 let uu____844
+                                                               let uu___10 =
+                                                                 let uu___11
                                                                    =
-                                                                   let uu____863
+                                                                   let uu___12
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk
                                                                     (FStar_SMTEncoding_Term.App
@@ -272,11 +266,11 @@ let (label_goals :
                                                                     pats_ens1,
                                                                     iopt_ens,
                                                                     sorts_ens,
-                                                                    uu____863) in
+                                                                    uu___12) in
                                                                  FStar_SMTEncoding_Term.Quant
-                                                                   uu____844 in
+                                                                   uu___11 in
                                                                FStar_SMTEncoding_Term.mk
-                                                                 uu____843
+                                                                 uu___10
                                                                  ens.FStar_SMTEncoding_Term.rng in
                                                              let lhs2 =
                                                                FStar_SMTEncoding_Term.mk
@@ -286,100 +280,98 @@ let (label_goals :
                                                                     req
                                                                     [ens1])))
                                                                  lhs1.FStar_SMTEncoding_Term.rng in
-                                                             let uu____877 =
+                                                             let uu___10 =
                                                                FStar_SMTEncoding_Term.abstr
                                                                  names lhs2 in
                                                              (labels2,
-                                                               uu____877))
+                                                               uu___10))
                                                       else
-                                                        (let uu____881 =
-                                                           let uu____882 =
-                                                             let uu____883 =
-                                                               let uu____884
-                                                                 =
-                                                                 let uu____885
+                                                        (let uu___10 =
+                                                           let uu___11 =
+                                                             let uu___12 =
+                                                               let uu___13 =
+                                                                 let uu___14
                                                                    =
                                                                    FStar_SMTEncoding_Term.print_smt_term
                                                                     post1 in
                                                                  Prims.op_Hat
                                                                    "  ... "
-                                                                   uu____885 in
+                                                                   uu___14 in
                                                                Prims.op_Hat
                                                                  post_name
-                                                                 uu____884 in
+                                                                 uu___13 in
                                                              Prims.op_Hat
                                                                "Ensures clause doesn't match post name:  "
-                                                               uu____883 in
+                                                               uu___12 in
                                                            Not_a_wp_implication
-                                                             uu____882 in
+                                                             uu___11 in
                                                          FStar_Exn.raise
-                                                           uu____881)
-                                                  | uu____892 ->
-                                                      let uu____893 =
-                                                        let uu____894 =
-                                                          let uu____895 =
-                                                            let uu____896 =
-                                                              let uu____897 =
+                                                           uu___10)
+                                                  | uu___7 ->
+                                                      let uu___8 =
+                                                        let uu___9 =
+                                                          let uu___10 =
+                                                            let uu___11 =
+                                                              let uu___12 =
                                                                 FStar_SMTEncoding_Term.print_smt_term
                                                                   ens in
                                                               Prims.op_Hat
                                                                 "  ... "
-                                                                uu____897 in
+                                                                uu___12 in
                                                             Prims.op_Hat
                                                               post_name
-                                                              uu____896 in
+                                                              uu___11 in
                                                           Prims.op_Hat
                                                             "Ensures clause doesn't have the expected shape for post-condition "
-                                                            uu____895 in
+                                                            uu___10 in
                                                         Not_a_wp_implication
-                                                          uu____894 in
-                                                      FStar_Exn.raise
-                                                        uu____893))
-                                        | uu____904 ->
-                                            let uu____905 =
-                                              let uu____906 =
-                                                let uu____907 =
+                                                          uu___9 in
+                                                      FStar_Exn.raise uu___8))
+                                        | uu___6 ->
+                                            let uu___7 =
+                                              let uu___8 =
+                                                let uu___9 =
                                                   FStar_SMTEncoding_Term.print_smt_term
                                                     lhs1 in
                                                 Prims.op_Hat
                                                   "LHS not a conjunct: "
-                                                  uu____907 in
-                                              Not_a_wp_implication uu____906 in
-                                            FStar_Exn.raise uu____905 in
-                                      (match uu____710 with
+                                                  uu___9 in
+                                              Not_a_wp_implication uu___8 in
+                                            FStar_Exn.raise uu___7 in
+                                      (match uu___5 with
                                        | (labels2, lhs2) ->
-                                           let uu____926 =
-                                             let uu____933 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                aux default_msg
                                                  FStar_Pervasives_Native.None
                                                  (FStar_Pervasives_Native.Some
                                                     post_name) labels2 rhs1 in
-                                             match uu____933 with
+                                             match uu___7 with
                                              | (labels3, rhs2) ->
-                                                 let uu____952 =
+                                                 let uu___8 =
                                                    FStar_SMTEncoding_Term.abstr
                                                      names rhs2 in
-                                                 (labels3, uu____952) in
-                                           (match uu____926 with
+                                                 (labels3, uu___8) in
+                                           (match uu___6 with
                                             | (labels3, rhs2) ->
                                                 let body =
                                                   FStar_SMTEncoding_Term.mkImp
                                                     (lhs2, rhs2) rng in
-                                                let uu____968 =
+                                                let uu___7 =
                                                   FStar_SMTEncoding_Term.mk
                                                     (FStar_SMTEncoding_Term.Quant
                                                        (FStar_SMTEncoding_Term.Forall,
                                                          pats, iopt, (post ::
                                                          sorts), body))
                                                     q1.FStar_SMTEncoding_Term.rng in
-                                                (labels3, uu____968))))
-                             | uu____979 ->
-                                 let uu____980 =
-                                   let uu____981 =
+                                                (labels3, uu___7))))
+                             | uu___3 ->
+                                 let uu___4 =
+                                   let uu___5 =
                                      FStar_SMTEncoding_Term.print_smt_term
                                        arg in
-                                   Prims.op_Hat "arg not a quant: " uu____981 in
-                                 fallback uu____980)) ()
+                                   Prims.op_Hat "arg not a quant: " uu___5 in
+                                 fallback uu___4)) ()
                    with | Not_a_wp_implication msg1 -> fallback msg1)
               | FStar_SMTEncoding_Term.Labeled (arg, reason, r1) ->
                   aux reason (FStar_Pervasives_Native.Some r1) post_name_opt
@@ -390,49 +382,48 @@ let (label_goals :
                    {
                      FStar_SMTEncoding_Term.tm = FStar_SMTEncoding_Term.App
                        (FStar_SMTEncoding_Term.Imp, lhs::rhs::[]);
-                     FStar_SMTEncoding_Term.freevars = uu____998;
+                     FStar_SMTEncoding_Term.freevars = uu___1;
                      FStar_SMTEncoding_Term.rng = rng;_})
                   when is_a_named_continuation lhs ->
-                  let uu____1024 = FStar_Util.prefix sorts in
-                  (match uu____1024 with
+                  let uu___2 = FStar_Util.prefix sorts in
+                  (match uu___2 with
                    | (sorts', post) ->
                        let new_post_name =
-                         let uu____1044 =
-                           let uu____1045 = FStar_Ident.next_id () in
+                         let uu___3 =
+                           let uu___4 = FStar_Ident.next_id () in
                            FStar_All.pipe_left FStar_Util.string_of_int
-                             uu____1045 in
-                         Prims.op_Hat "^^post_condition_" uu____1044 in
+                             uu___4 in
+                         Prims.op_Hat "^^post_condition_" uu___3 in
                        let names =
-                         let uu____1049 =
+                         let uu___3 =
                            FStar_List.map
                              (fun s ->
-                                let uu____1055 =
-                                  let uu____1060 =
-                                    let uu____1061 =
-                                      let uu____1062 = FStar_Ident.next_id () in
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 = FStar_Ident.next_id () in
                                       FStar_All.pipe_left
-                                        FStar_Util.string_of_int uu____1062 in
-                                    Prims.op_Hat "^^" uu____1061 in
-                                  (uu____1060, s) in
-                                FStar_SMTEncoding_Term.mk_fv uu____1055)
-                             sorts' in
-                         let uu____1063 =
-                           let uu____1066 =
+                                        FStar_Util.string_of_int uu___7 in
+                                    Prims.op_Hat "^^" uu___6 in
+                                  (uu___5, s) in
+                                FStar_SMTEncoding_Term.mk_fv uu___4) sorts' in
+                         let uu___4 =
+                           let uu___5 =
                              FStar_SMTEncoding_Term.mk_fv
                                (new_post_name, post) in
-                           [uu____1066] in
-                         FStar_List.append uu____1049 uu____1063 in
+                           [uu___5] in
+                         FStar_List.append uu___3 uu___4 in
                        let instantiation =
                          FStar_List.map FStar_SMTEncoding_Util.mkFreeV names in
-                       let uu____1070 =
-                         let uu____1075 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_SMTEncoding_Term.inst instantiation lhs in
-                         let uu____1076 =
+                         let uu___5 =
                            FStar_SMTEncoding_Term.inst instantiation rhs in
-                         (uu____1075, uu____1076) in
-                       (match uu____1070 with
+                         (uu___4, uu___5) in
+                       (match uu___3 with
                         | (lhs1, rhs1) ->
-                            let uu____1085 =
+                            let uu___4 =
                               FStar_Util.fold_map
                                 (fun labels2 ->
                                    fun tm ->
@@ -445,9 +436,9 @@ let (label_goals :
                                                (FStar_SMTEncoding_Term.Var
                                                 "Prims.guard_free", p::[]);
                                              FStar_SMTEncoding_Term.freevars
-                                               = uu____1123;
+                                               = uu___5;
                                              FStar_SMTEncoding_Term.rng =
-                                               uu____1124;_}::[])::[],
+                                               uu___6;_}::[])::[],
                                           iopt, sorts1,
                                           {
                                             FStar_SMTEncoding_Term.tm =
@@ -455,26 +446,26 @@ let (label_goals :
                                               (FStar_SMTEncoding_Term.Imp,
                                                l0::r1::[]);
                                             FStar_SMTEncoding_Term.freevars =
-                                              uu____1129;
+                                              uu___7;
                                             FStar_SMTEncoding_Term.rng =
-                                              uu____1130;_})
+                                              uu___8;_})
                                          ->
-                                         let uu____1171 =
+                                         let uu___9 =
                                            is_a_post_condition
                                              (FStar_Pervasives_Native.Some
                                                 new_post_name) r1 in
-                                         if uu____1171
+                                         if uu___9
                                          then
-                                           let uu____1178 =
+                                           let uu___10 =
                                              aux default_msg
                                                FStar_Pervasives_Native.None
                                                post_name_opt labels2 l0 in
-                                           (match uu____1178 with
+                                           (match uu___10 with
                                             | (labels3, l) ->
-                                                let uu____1197 =
-                                                  let uu____1198 =
-                                                    let uu____1199 =
-                                                      let uu____1218 =
+                                                let uu___11 =
+                                                  let uu___12 =
+                                                    let uu___13 =
+                                                      let uu___14 =
                                                         FStar_SMTEncoding_Util.norng
                                                           FStar_SMTEncoding_Term.mk
                                                           (FStar_SMTEncoding_Term.App
@@ -484,36 +475,36 @@ let (label_goals :
                                                         [[p]],
                                                         (FStar_Pervasives_Native.Some
                                                            Prims.int_zero),
-                                                        sorts1, uu____1218) in
+                                                        sorts1, uu___14) in
                                                     FStar_SMTEncoding_Term.Quant
-                                                      uu____1199 in
+                                                      uu___13 in
                                                   FStar_SMTEncoding_Term.mk
-                                                    uu____1198
+                                                    uu___12
                                                     q1.FStar_SMTEncoding_Term.rng in
-                                                (labels3, uu____1197))
+                                                (labels3, uu___11))
                                          else (labels2, tm)
-                                     | uu____1238 -> (labels2, tm)) labels1
+                                     | uu___5 -> (labels2, tm)) labels1
                                 (conjuncts lhs1) in
-                            (match uu____1085 with
+                            (match uu___4 with
                              | (labels2, lhs_conjs) ->
-                                 let uu____1257 =
+                                 let uu___5 =
                                    aux default_msg
                                      FStar_Pervasives_Native.None
                                      (FStar_Pervasives_Native.Some
                                         new_post_name) labels2 rhs1 in
-                                 (match uu____1257 with
+                                 (match uu___5 with
                                   | (labels3, rhs2) ->
                                       let body =
-                                        let uu____1277 =
-                                          let uu____1278 =
-                                            let uu____1283 =
+                                        let uu___6 =
+                                          let uu___7 =
+                                            let uu___8 =
                                               FStar_SMTEncoding_Term.mk_and_l
                                                 lhs_conjs
                                                 lhs1.FStar_SMTEncoding_Term.rng in
-                                            (uu____1283, rhs2) in
-                                          FStar_SMTEncoding_Term.mkImp
-                                            uu____1278 rng in
-                                        FStar_All.pipe_right uu____1277
+                                            (uu___8, rhs2) in
+                                          FStar_SMTEncoding_Term.mkImp uu___7
+                                            rng in
+                                        FStar_All.pipe_right uu___6
                                           (FStar_SMTEncoding_Term.abstr names) in
                                       let q2 =
                                         FStar_SMTEncoding_Term.mk
@@ -526,227 +517,210 @@ let (label_goals :
                                       (labels3, q2)))))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Imp, lhs::rhs::[]) ->
-                  let uu____1301 =
-                    aux default_msg ropt post_name_opt labels1 rhs in
-                  (match uu____1301 with
+                  let uu___1 = aux default_msg ropt post_name_opt labels1 rhs in
+                  (match uu___1 with
                    | (labels2, rhs1) ->
-                       let uu____1320 =
-                         FStar_SMTEncoding_Util.mkImp (lhs, rhs1) in
-                       (labels2, uu____1320))
+                       let uu___2 = FStar_SMTEncoding_Util.mkImp (lhs, rhs1) in
+                       (labels2, uu___2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.And, conjuncts1) ->
-                  let uu____1328 =
+                  let uu___1 =
                     FStar_Util.fold_map (aux default_msg ropt post_name_opt)
                       labels1 conjuncts1 in
-                  (match uu____1328 with
+                  (match uu___1 with
                    | (labels2, conjuncts2) ->
-                       let uu____1355 =
+                       let uu___2 =
                          FStar_SMTEncoding_Term.mk_and_l conjuncts2
                            q1.FStar_SMTEncoding_Term.rng in
-                       (labels2, uu____1355))
+                       (labels2, uu___2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.ITE, hd::q11::q2::[]) ->
-                  let uu____1363 =
-                    aux default_msg ropt post_name_opt labels1 q11 in
-                  (match uu____1363 with
+                  let uu___1 = aux default_msg ropt post_name_opt labels1 q11 in
+                  (match uu___1 with
                    | (labels2, q12) ->
-                       let uu____1382 =
+                       let uu___2 =
                          aux default_msg ropt post_name_opt labels2 q2 in
-                       (match uu____1382 with
+                       (match uu___2 with
                         | (labels3, q21) ->
-                            let uu____1401 =
+                            let uu___3 =
                               FStar_SMTEncoding_Term.mkITE (hd, q12, q21)
                                 q1.FStar_SMTEncoding_Term.rng in
-                            (labels3, uu____1401)))
+                            (labels3, uu___3)))
               | FStar_SMTEncoding_Term.Quant
-                  (FStar_SMTEncoding_Term.Exists, uu____1404, uu____1405,
-                   uu____1406, uu____1407)
+                  (FStar_SMTEncoding_Term.Exists, uu___1, uu___2, uu___3,
+                   uu___4)
                   ->
-                  let uu____1424 =
+                  let uu___5 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1424 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___5 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Iff, uu____1439) ->
-                  let uu____1444 =
+                  (FStar_SMTEncoding_Term.Iff, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1444 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Or, uu____1459) ->
-                  let uu____1464 =
+                  (FStar_SMTEncoding_Term.Or, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1464 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Var uu____1479, uu____1480) when
+                  (FStar_SMTEncoding_Term.Var uu___1, uu___2) when
                   is_a_post_condition post_name_opt q1 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.FreeV uu____1487 ->
-                  let uu____1494 =
+              | FStar_SMTEncoding_Term.FreeV uu___1 ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1494 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.TrueOp, uu____1509) ->
-                  let uu____1514 =
+                  (FStar_SMTEncoding_Term.TrueOp, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1514 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.FalseOp, uu____1529) ->
-                  let uu____1534 =
+                  (FStar_SMTEncoding_Term.FalseOp, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1534 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Not, uu____1549) ->
-                  let uu____1554 =
+                  (FStar_SMTEncoding_Term.Not, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1554 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Eq, uu____1569) ->
-                  let uu____1574 =
+                  (FStar_SMTEncoding_Term.Eq, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1574 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.LT, uu____1589) ->
-                  let uu____1594 =
+                  (FStar_SMTEncoding_Term.LT, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1594 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.LTE, uu____1609) ->
-                  let uu____1614 =
+                  (FStar_SMTEncoding_Term.LTE, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1614 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.GT, uu____1629) ->
-                  let uu____1634 =
+                  (FStar_SMTEncoding_Term.GT, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1634 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.GTE, uu____1649) ->
-                  let uu____1654 =
+                  (FStar_SMTEncoding_Term.GTE, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1654 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvUlt, uu____1669) ->
-                  let uu____1674 =
+                  (FStar_SMTEncoding_Term.BvUlt, uu___1) ->
+                  let uu___2 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1674 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___2 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Var uu____1689, uu____1690) ->
-                  let uu____1695 =
+                  (FStar_SMTEncoding_Term.Var uu___1, uu___2) ->
+                  let uu___3 =
                     fresh_label1 default_msg ropt
                       q1.FStar_SMTEncoding_Term.rng q1 in
-                  (match uu____1695 with
-                   | (lab, q2) -> ((lab :: labels1), q2))
+                  (match uu___3 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.RealDiv, uu____1710) ->
+                  (FStar_SMTEncoding_Term.RealDiv, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Add, uu____1721) ->
+                  (FStar_SMTEncoding_Term.Add, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Sub, uu____1732) ->
+                  (FStar_SMTEncoding_Term.Sub, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Div, uu____1743) ->
+                  (FStar_SMTEncoding_Term.Div, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Mul, uu____1754) ->
+                  (FStar_SMTEncoding_Term.Mul, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Minus, uu____1765) ->
+                  (FStar_SMTEncoding_Term.Minus, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Mod, uu____1776) ->
+                  (FStar_SMTEncoding_Term.Mod, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvAnd, uu____1787) ->
+                  (FStar_SMTEncoding_Term.BvAnd, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvXor, uu____1798) ->
+                  (FStar_SMTEncoding_Term.BvXor, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvOr, uu____1809) ->
+                  (FStar_SMTEncoding_Term.BvOr, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvAdd, uu____1820) ->
+                  (FStar_SMTEncoding_Term.BvAdd, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvSub, uu____1831) ->
+                  (FStar_SMTEncoding_Term.BvSub, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvShl, uu____1842) ->
+                  (FStar_SMTEncoding_Term.BvShl, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvShr, uu____1853) ->
+                  (FStar_SMTEncoding_Term.BvShr, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvUdiv, uu____1864) ->
+                  (FStar_SMTEncoding_Term.BvUdiv, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvMod, uu____1875) ->
+                  (FStar_SMTEncoding_Term.BvMod, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvMul, uu____1886) ->
+                  (FStar_SMTEncoding_Term.BvMul, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvUext uu____1897, uu____1898) ->
+                  (FStar_SMTEncoding_Term.BvUext uu___1, uu___2) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.BvToNat, uu____1909) ->
+                  (FStar_SMTEncoding_Term.BvToNat, uu___1) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.NatToBv uu____1920, uu____1921) ->
+                  (FStar_SMTEncoding_Term.NatToBv uu___1, uu___2) ->
                   failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.ITE, uu____1932) ->
+                  (FStar_SMTEncoding_Term.ITE, uu___1) ->
                   failwith "Impossible: arity mismatch"
               | FStar_SMTEncoding_Term.App
-                  (FStar_SMTEncoding_Term.Imp, uu____1943) ->
+                  (FStar_SMTEncoding_Term.Imp, uu___1) ->
                   failwith "Impossible: arity mismatch"
               | FStar_SMTEncoding_Term.Quant
                   (FStar_SMTEncoding_Term.Forall, pats, iopt, sorts, body) ->
-                  let uu____1974 =
+                  let uu___1 =
                     aux default_msg ropt post_name_opt labels1 body in
-                  (match uu____1974 with
+                  (match uu___1 with
                    | (labels2, body1) ->
-                       let uu____1993 =
+                       let uu___2 =
                          FStar_SMTEncoding_Term.mk
                            (FStar_SMTEncoding_Term.Quant
                               (FStar_SMTEncoding_Term.Forall, pats, iopt,
                                 sorts, body1)) q1.FStar_SMTEncoding_Term.rng in
-                       (labels2, uu____1993))
+                       (labels2, uu___2))
               | FStar_SMTEncoding_Term.Let (es, body) ->
-                  let uu____2010 =
+                  let uu___1 =
                     aux default_msg ropt post_name_opt labels1 body in
-                  (match uu____2010 with
+                  (match uu___1 with
                    | (labels2, body1) ->
-                       let uu____2029 =
+                       let uu___2 =
                          FStar_SMTEncoding_Term.mkLet (es, body1)
                            q1.FStar_SMTEncoding_Term.rng in
-                       (labels2, uu____2029)) in
+                       (labels2, uu___2)) in
             aux "assertion failed" FStar_Pervasives_Native.None
               FStar_Pervasives_Native.None [] q
 let (detail_errors :
@@ -761,28 +735,28 @@ let (detail_errors :
     fun env ->
       fun all_labels ->
         fun askZ3 ->
-          let print_banner uu____2068 =
+          let print_banner uu___ =
             let msg1 =
-              let uu____2070 =
-                let uu____2071 = FStar_TypeChecker_Env.get_range env in
-                FStar_Range.string_of_range uu____2071 in
-              let uu____2072 = FStar_Util.string_of_int (Prims.of_int (5)) in
-              let uu____2073 =
+              let uu___1 =
+                let uu___2 = FStar_TypeChecker_Env.get_range env in
+                FStar_Range.string_of_range uu___2 in
+              let uu___2 = FStar_Util.string_of_int (Prims.of_int (5)) in
+              let uu___3 =
                 FStar_Util.string_of_int (FStar_List.length all_labels) in
               FStar_Util.format4
                 "Detailed %s report follows for %s\nTaking %s seconds per proof obligation (%s proofs in total)\n"
-                (if hint_replay then "hint replay" else "error") uu____2070
-                uu____2072 uu____2073 in
+                (if hint_replay then "hint replay" else "error") uu___1
+                uu___2 uu___3 in
             FStar_Util.print_error msg1 in
-          let print_result uu____2090 =
-            match uu____2090 with
-            | ((uu____2101, msg1, r), success) ->
+          let print_result uu___ =
+            match uu___ with
+            | ((uu___1, msg1, r), success) ->
                 if success
                 then
-                  let uu____2111 = FStar_Range.string_of_range r in
+                  let uu___2 = FStar_Range.string_of_range r in
                   FStar_Util.print1
                     "OK: proof obligation at %s was proven in isolation\n"
-                    uu____2111
+                    uu___2
                 else
                   if hint_replay
                   then
@@ -791,37 +765,34 @@ let (detail_errors :
                         (Prims.op_Hat
                            "Hint failed to replay this sub-proof: " msg1))
                   else
-                    (let uu____2114 =
-                       let uu____2119 =
-                         let uu____2120 = FStar_Range.string_of_range r in
+                    (let uu___4 =
+                       let uu___5 =
+                         let uu___6 = FStar_Range.string_of_range r in
                          FStar_Util.format2
-                           "XX: proof obligation at %s failed\n\t%s\n"
-                           uu____2120 msg1 in
-                       (FStar_Errors.Error_ProofObligationFailed, uu____2119) in
-                     FStar_Errors.log_issue r uu____2114) in
+                           "XX: proof obligation at %s failed\n\t%s\n" uu___6
+                           msg1 in
+                       (FStar_Errors.Error_ProofObligationFailed, uu___5) in
+                     FStar_Errors.log_issue r uu___4) in
           let elim labs =
             FStar_All.pipe_right labs
               (FStar_List.map
-                 (fun uu____2166 ->
-                    match uu____2166 with
-                    | (l, uu____2174, uu____2175) ->
+                 (fun uu___ ->
+                    match uu___ with
+                    | (l, uu___1, uu___2) ->
                         let a =
-                          let uu____2177 =
-                            let uu____2178 =
-                              let uu____2183 =
-                                FStar_SMTEncoding_Util.mkFreeV l in
-                              (uu____2183, FStar_SMTEncoding_Util.mkTrue) in
-                            FStar_SMTEncoding_Util.mkEq uu____2178 in
-                          let uu____2184 =
-                            let uu____2185 = FStar_SMTEncoding_Term.fv_name l in
-                            Prims.op_Hat "@disable_label_" uu____2185 in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 = FStar_SMTEncoding_Util.mkFreeV l in
+                              (uu___5, FStar_SMTEncoding_Util.mkTrue) in
+                            FStar_SMTEncoding_Util.mkEq uu___4 in
+                          let uu___4 =
+                            let uu___5 = FStar_SMTEncoding_Term.fv_name l in
+                            Prims.op_Hat "@disable_label_" uu___5 in
                           {
-                            FStar_SMTEncoding_Term.assumption_term =
-                              uu____2177;
+                            FStar_SMTEncoding_Term.assumption_term = uu___3;
                             FStar_SMTEncoding_Term.assumption_caption =
                               (FStar_Pervasives_Native.Some "Disabling label");
-                            FStar_SMTEncoding_Term.assumption_name =
-                              uu____2184;
+                            FStar_SMTEncoding_Term.assumption_name = uu___4;
                             FStar_SMTEncoding_Term.assumption_fact_ids = []
                           } in
                         FStar_SMTEncoding_Term.Assume a)) in
@@ -830,34 +801,32 @@ let (detail_errors :
             (match active with
              | [] ->
                  let results =
-                   let uu____2246 =
+                   let uu___1 =
                      FStar_List.map (fun x -> (x, true)) eliminated in
-                   let uu____2259 =
-                     FStar_List.map (fun x -> (x, false)) errors in
-                   FStar_List.append uu____2246 uu____2259 in
+                   let uu___2 = FStar_List.map (fun x -> (x, false)) errors in
+                   FStar_List.append uu___1 uu___2 in
                  sort_labels results
              | hd::tl ->
-                 ((let uu____2281 =
+                 ((let uu___2 =
                      FStar_Util.string_of_int (FStar_List.length active) in
-                   FStar_Util.print1 "%s, " uu____2281);
+                   FStar_Util.print1 "%s, " uu___2);
                   (let decls =
                      FStar_All.pipe_left elim
                        (FStar_List.append eliminated
                           (FStar_List.append errors tl)) in
                    let result = askZ3 decls in
                    match result.FStar_SMTEncoding_Z3.z3result_status with
-                   | FStar_SMTEncoding_Z3.UNSAT uu____2308 ->
+                   | FStar_SMTEncoding_Z3.UNSAT uu___2 ->
                        linear_check (hd :: eliminated) errors tl
-                   | uu____2309 -> linear_check eliminated (hd :: errors) tl))) in
+                   | uu___2 -> linear_check eliminated (hd :: errors) tl))) in
           print_banner ();
           FStar_Options.set_option "z3rlimit"
             (FStar_Options.Int (Prims.of_int (5)));
           (let res = linear_check [] [] all_labels in
            FStar_Util.print_string "\n";
            FStar_All.pipe_right res (FStar_List.iter print_result);
-           (let uu____2349 =
-              FStar_Util.for_all FStar_Pervasives_Native.snd res in
-            if uu____2349
+           (let uu___4 = FStar_Util.for_all FStar_Pervasives_Native.snd res in
+            if uu___4
             then
               FStar_Util.print_string
                 "Failed: the heuristic of trying each proof in isolation failed to identify a precise error\n"

--- a/src/ocaml-output/FStar_SMTEncoding_Solver.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Solver.ml
@@ -3,37 +3,37 @@ type z3_replay_result =
   (FStar_SMTEncoding_Z3.unsat_core, FStar_SMTEncoding_Term.error_labels)
     FStar_Util.either
 let z3_result_as_replay_result :
-  'uuuuuu35 'uuuuuu36 'uuuuuu37 .
-    ('uuuuuu35, ('uuuuuu36 * 'uuuuuu37)) FStar_Util.either ->
-      ('uuuuuu35, 'uuuuuu36) FStar_Util.either
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    ('uuuuu, ('uuuuu1 * 'uuuuu2)) FStar_Util.either ->
+      ('uuuuu, 'uuuuu1) FStar_Util.either
   =
-  fun uu___0_54 ->
-    match uu___0_54 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.Inl l -> FStar_Util.Inl l
-    | FStar_Util.Inr (r, uu____69) -> FStar_Util.Inr r
+    | FStar_Util.Inr (r, uu___1) -> FStar_Util.Inr r
 let (recorded_hints :
   FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref) =
   FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (replaying_hints :
   FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref) =
   FStar_Util.mk_ref FStar_Pervasives_Native.None
-let initialize_hints_db : 'uuuuuu92 . Prims.string -> 'uuuuuu92 -> unit =
+let initialize_hints_db : 'uuuuu . Prims.string -> 'uuuuu -> unit =
   fun src_filename ->
     fun format_filename ->
-      (let uu____104 = FStar_Options.record_hints () in
-       if uu____104
+      (let uu___1 = FStar_Options.record_hints () in
+       if uu___1
        then
          FStar_ST.op_Colon_Equals recorded_hints
            (FStar_Pervasives_Native.Some [])
        else ());
       (let norm_src_filename = FStar_Util.normalize_file_path src_filename in
        let val_filename = FStar_Options.hint_file_for_src norm_src_filename in
-       let uu____120 = FStar_Util.read_hints val_filename in
-       match uu____120 with
+       let uu___1 = FStar_Util.read_hints val_filename in
+       match uu___1 with
        | FStar_Util.HintsOK hints ->
            let expected_digest = FStar_Util.digest_of_file norm_src_filename in
-           ((let uu____124 = FStar_Options.hint_info () in
-             if uu____124
+           ((let uu___3 = FStar_Options.hint_info () in
+             if uu___3
              then
                FStar_Util.print3 "(%s) digest is %s from %s.\n"
                  norm_src_filename
@@ -44,40 +44,40 @@ let initialize_hints_db : 'uuuuuu92 . Prims.string -> 'uuuuuu92 -> unit =
             FStar_ST.op_Colon_Equals replaying_hints
               (FStar_Pervasives_Native.Some (hints.FStar_Util.hints)))
        | FStar_Util.MalformedJson ->
-           let uu____138 = FStar_Options.use_hints () in
-           if uu____138
+           let uu___3 = FStar_Options.use_hints () in
+           if uu___3
            then
-             let uu____139 =
-               let uu____144 =
+             let uu___4 =
+               let uu___5 =
                  FStar_Util.format1
                    "Malformed JSON hints file: %s; ran without hints\n"
                    val_filename in
-               (FStar_Errors.Warning_CouldNotReadHints, uu____144) in
-             FStar_Errors.log_issue FStar_Range.dummyRange uu____139
+               (FStar_Errors.Warning_CouldNotReadHints, uu___5) in
+             FStar_Errors.log_issue FStar_Range.dummyRange uu___4
            else ()
        | FStar_Util.UnableToOpen ->
-           let uu____147 = FStar_Options.use_hints () in
-           if uu____147
+           let uu___3 = FStar_Options.use_hints () in
+           if uu___3
            then
-             let uu____148 =
-               let uu____153 =
+             let uu___4 =
+               let uu___5 =
                  FStar_Util.format1
                    "Unable to open hints file: %s; ran without hints\n"
                    val_filename in
-               (FStar_Errors.Warning_CouldNotReadHints, uu____153) in
-             FStar_Errors.log_issue FStar_Range.dummyRange uu____148
+               (FStar_Errors.Warning_CouldNotReadHints, uu___5) in
+             FStar_Errors.log_issue FStar_Range.dummyRange uu___4
            else ())
 let (finalize_hints_db : Prims.string -> unit) =
   fun src_filename ->
-    (let uu____161 = FStar_Options.record_hints () in
-     if uu____161
+    (let uu___1 = FStar_Options.record_hints () in
+     if uu___1
      then
        let hints =
-         let uu____163 = FStar_ST.op_Bang recorded_hints in
-         FStar_Option.get uu____163 in
+         let uu___2 = FStar_ST.op_Bang recorded_hints in
+         FStar_Option.get uu___2 in
        let hints_db =
-         let uu____177 = FStar_Util.digest_of_file src_filename in
-         { FStar_Util.module_digest = uu____177; FStar_Util.hints = hints } in
+         let uu___2 = FStar_Util.digest_of_file src_filename in
+         { FStar_Util.module_digest = uu___2; FStar_Util.hints = hints } in
        let norm_src_filename = FStar_Util.normalize_file_path src_filename in
        let val_filename = FStar_Options.hint_file_for_src norm_src_filename in
        FStar_Util.write_hints val_filename hints_db
@@ -99,26 +99,26 @@ let (filter_using_facts_from :
       let matches_fact_ids include_assumption_names a =
         match a.FStar_SMTEncoding_Term.assumption_fact_ids with
         | [] -> true
-        | uu____258 ->
+        | uu___ ->
             (FStar_All.pipe_right
                a.FStar_SMTEncoding_Term.assumption_fact_ids
                (FStar_Util.for_some
-                  (fun uu___1_265 ->
-                     match uu___1_265 with
+                  (fun uu___1 ->
+                     match uu___1 with
                      | FStar_SMTEncoding_Term.Name lid ->
                          FStar_TypeChecker_Env.should_enc_lid e lid
-                     | uu____267 -> false)))
+                     | uu___2 -> false)))
               ||
-              (let uu____269 =
+              (let uu___1 =
                  FStar_Util.smap_try_find include_assumption_names
                    a.FStar_SMTEncoding_Term.assumption_name in
-               FStar_Option.isSome uu____269) in
+               FStar_Option.isSome uu___1) in
       let theory_rev = FStar_List.rev theory in
       let pruned_theory =
         let include_assumption_names =
           FStar_Util.smap_create (Prims.of_int (10000)) in
-        let keep_decl uu___2_286 =
-          match uu___2_286 with
+        let keep_decl uu___ =
+          match uu___ with
           | FStar_SMTEncoding_Term.Assume a ->
               matches_fact_ids include_assumption_names a
           | FStar_SMTEncoding_Term.RetainAssumptions names ->
@@ -127,23 +127,23 @@ let (filter_using_facts_from :
                     FStar_Util.smap_add include_assumption_names x true)
                  names;
                true)
-          | FStar_SMTEncoding_Term.Module uu____294 ->
+          | FStar_SMTEncoding_Term.Module uu___1 ->
               failwith
                 "Solver.fs::keep_decl should never have been called with a Module decl"
-          | uu____301 -> true in
+          | uu___1 -> true in
         FStar_List.fold_left
           (fun out ->
              fun d ->
                match d with
                | FStar_SMTEncoding_Term.Module (name, decls) ->
-                   let uu____321 =
+                   let uu___ =
                      FStar_All.pipe_right decls (FStar_List.filter keep_decl) in
-                   FStar_All.pipe_right uu____321
+                   FStar_All.pipe_right uu___
                      (fun decls1 ->
                         (FStar_SMTEncoding_Term.Module (name, decls1)) :: out)
-               | uu____338 ->
-                   let uu____339 = keep_decl d in
-                   if uu____339 then d :: out else out) [] theory_rev in
+               | uu___ ->
+                   let uu___1 = keep_decl d in
+                   if uu___1 then d :: out else out) [] theory_rev in
       pruned_theory
 let rec (filter_assertions_with_stats :
   FStar_TypeChecker_Env.env ->
@@ -157,25 +157,25 @@ let rec (filter_assertions_with_stats :
       fun theory ->
         match core with
         | FStar_Pervasives_Native.None ->
-            let uu____384 = filter_using_facts_from e theory in
-            (uu____384, false, Prims.int_zero, Prims.int_zero)
+            let uu___ = filter_using_facts_from e theory in
+            (uu___, false, Prims.int_zero, Prims.int_zero)
         | FStar_Pervasives_Native.Some core1 ->
             let theory_rev = FStar_List.rev theory in
-            let uu____397 =
-              let uu____406 =
-                let uu____415 =
-                  let uu____418 =
-                    let uu____419 =
-                      let uu____420 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
                         FStar_All.pipe_right core1 (FStar_String.concat ", ") in
-                      Prims.op_Hat "UNSAT CORE: " uu____420 in
-                    FStar_SMTEncoding_Term.Caption uu____419 in
-                  [uu____418] in
-                (uu____415, Prims.int_zero, Prims.int_zero) in
+                      Prims.op_Hat "UNSAT CORE: " uu___5 in
+                    FStar_SMTEncoding_Term.Caption uu___4 in
+                  [uu___3] in
+                (uu___2, Prims.int_zero, Prims.int_zero) in
               FStar_List.fold_left
-                (fun uu____439 ->
+                (fun uu___2 ->
                    fun d ->
-                     match uu____439 with
+                     match uu___2 with
                      | (theory1, n_retained, n_pruned) ->
                          (match d with
                           | FStar_SMTEncoding_Term.Assume a ->
@@ -196,21 +196,20 @@ let rec (filter_assertions_with_stats :
                                   (theory1, n_retained,
                                     (n_pruned + Prims.int_one))
                           | FStar_SMTEncoding_Term.Module (name, decls) ->
-                              let uu____503 =
+                              let uu___3 =
                                 FStar_All.pipe_right decls
                                   (filter_assertions_with_stats e
                                      (FStar_Pervasives_Native.Some core1)) in
-                              FStar_All.pipe_right uu____503
-                                (fun uu____551 ->
-                                   match uu____551 with
-                                   | (decls1, uu____571, r, p) ->
+                              FStar_All.pipe_right uu___3
+                                (fun uu___4 ->
+                                   match uu___4 with
+                                   | (decls1, uu___5, r, p) ->
                                        (((FStar_SMTEncoding_Term.Module
                                             (name, decls1)) :: theory1),
                                          (n_retained + r), (n_pruned + p)))
-                          | uu____582 ->
-                              ((d :: theory1), n_retained, n_pruned)))
-                uu____406 theory_rev in
-            (match uu____397 with
+                          | uu___3 -> ((d :: theory1), n_retained, n_pruned)))
+                uu___1 theory_rev in
+            (match uu___ with
              | (theory', n_retained, n_pruned) ->
                  (theory', true, n_retained, n_pruned))
 let (filter_assertions :
@@ -222,17 +221,14 @@ let (filter_assertions :
   fun e ->
     fun core ->
       fun theory ->
-        let uu____629 = filter_assertions_with_stats e core theory in
-        match uu____629 with
-        | (theory1, b, uu____648, uu____649) -> (theory1, b)
+        let uu___ = filter_assertions_with_stats e core theory in
+        match uu___ with | (theory1, b, uu___1, uu___2) -> (theory1, b)
 let (filter_facts_without_core :
   FStar_TypeChecker_Env.env ->
     FStar_SMTEncoding_Term.decl Prims.list ->
       (FStar_SMTEncoding_Term.decl Prims.list * Prims.bool))
   =
-  fun e ->
-    fun x ->
-      let uu____676 = filter_using_facts_from e x in (uu____676, false)
+  fun e -> fun x -> let uu___ = filter_using_facts_from e x in (uu___, false)
 type errors =
   {
   error_reason: Prims.string ;
@@ -272,22 +268,22 @@ let (__proj__Mkerrors__item__error_messages :
         -> error_messages
 let (error_to_short_string : errors -> Prims.string) =
   fun err ->
-    let uu____857 = FStar_Util.string_of_int err.error_fuel in
-    let uu____858 = FStar_Util.string_of_int err.error_ifuel in
-    FStar_Util.format4 "%s (fuel=%s; ifuel=%s%s)" err.error_reason uu____857
-      uu____858
+    let uu___ = FStar_Util.string_of_int err.error_fuel in
+    let uu___1 = FStar_Util.string_of_int err.error_ifuel in
+    FStar_Util.format4 "%s (fuel=%s; ifuel=%s%s)" err.error_reason uu___
+      uu___1
       (if FStar_Option.isSome err.error_hint then "; with hint" else "")
 let (error_to_is_timeout : errors -> Prims.string Prims.list) =
   fun err ->
     if FStar_Util.ends_with err.error_reason "canceled"
     then
-      let uu____871 =
-        let uu____872 = FStar_Util.string_of_int err.error_fuel in
-        let uu____873 = FStar_Util.string_of_int err.error_ifuel in
+      let uu___ =
+        let uu___1 = FStar_Util.string_of_int err.error_fuel in
+        let uu___2 = FStar_Util.string_of_int err.error_ifuel in
         FStar_Util.format4 "timeout (fuel=%s; ifuel=%s; %s)" err.error_reason
-          uu____872 uu____873
+          uu___1 uu___2
           (if FStar_Option.isSome err.error_hint then "with hint" else "") in
-      [uu____871]
+      [uu___]
     else []
 type query_settings =
   {
@@ -405,67 +401,63 @@ let (with_fuel_and_diagnostics :
       let n = settings.query_fuel in
       let i = settings.query_ifuel in
       let rlimit = settings.query_rlimit in
-      let uu____1292 =
-        let uu____1295 =
-          let uu____1296 =
-            let uu____1297 = FStar_Util.string_of_int n in
-            let uu____1298 = FStar_Util.string_of_int i in
-            FStar_Util.format2 "<fuel='%s' ifuel='%s'>" uu____1297 uu____1298 in
-          FStar_SMTEncoding_Term.Caption uu____1296 in
-        let uu____1299 =
-          let uu____1302 =
-            let uu____1303 =
-              let uu____1310 =
-                let uu____1311 =
-                  let uu____1316 =
-                    FStar_SMTEncoding_Util.mkApp ("MaxFuel", []) in
-                  let uu____1319 = FStar_SMTEncoding_Term.n_fuel n in
-                  (uu____1316, uu____1319) in
-                FStar_SMTEncoding_Util.mkEq uu____1311 in
-              (uu____1310, FStar_Pervasives_Native.None,
-                "@MaxFuel_assumption") in
-            FStar_SMTEncoding_Util.mkAssume uu____1303 in
-          let uu____1320 =
-            let uu____1323 =
-              let uu____1324 =
-                let uu____1331 =
-                  let uu____1332 =
-                    let uu____1337 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Util.string_of_int n in
+            let uu___4 = FStar_Util.string_of_int i in
+            FStar_Util.format2 "<fuel='%s' ifuel='%s'>" uu___3 uu___4 in
+          FStar_SMTEncoding_Term.Caption uu___2 in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = FStar_SMTEncoding_Util.mkApp ("MaxFuel", []) in
+                  let uu___8 = FStar_SMTEncoding_Term.n_fuel n in
+                  (uu___7, uu___8) in
+                FStar_SMTEncoding_Util.mkEq uu___6 in
+              (uu___5, FStar_Pervasives_Native.None, "@MaxFuel_assumption") in
+            FStar_SMTEncoding_Util.mkAssume uu___4 in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 =
                       FStar_SMTEncoding_Util.mkApp ("MaxIFuel", []) in
-                    let uu____1340 = FStar_SMTEncoding_Term.n_fuel i in
-                    (uu____1337, uu____1340) in
-                  FStar_SMTEncoding_Util.mkEq uu____1332 in
-                (uu____1331, FStar_Pervasives_Native.None,
+                    let uu___10 = FStar_SMTEncoding_Term.n_fuel i in
+                    (uu___9, uu___10) in
+                  FStar_SMTEncoding_Util.mkEq uu___8 in
+                (uu___7, FStar_Pervasives_Native.None,
                   "@MaxIFuel_assumption") in
-              FStar_SMTEncoding_Util.mkAssume uu____1324 in
-            [uu____1323; settings.query_decl] in
-          uu____1302 :: uu____1320 in
-        uu____1295 :: uu____1299 in
-      let uu____1341 =
-        let uu____1344 =
-          let uu____1347 =
-            let uu____1350 =
-              let uu____1351 =
-                let uu____1356 = FStar_Util.string_of_int rlimit in
-                ("rlimit", uu____1356) in
-              FStar_SMTEncoding_Term.SetOption uu____1351 in
-            [uu____1350;
+              FStar_SMTEncoding_Util.mkAssume uu___6 in
+            [uu___5; settings.query_decl] in
+          uu___3 :: uu___4 in
+        uu___1 :: uu___2 in
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_Util.string_of_int rlimit in
+                ("rlimit", uu___6) in
+              FStar_SMTEncoding_Term.SetOption uu___5 in
+            [uu___4;
             FStar_SMTEncoding_Term.CheckSat;
             FStar_SMTEncoding_Term.SetOption ("rlimit", "0");
             FStar_SMTEncoding_Term.GetReasonUnknown;
             FStar_SMTEncoding_Term.GetUnsatCore] in
-          let uu____1357 =
-            let uu____1360 =
-              let uu____1363 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
                 (FStar_Options.print_z3_statistics ()) ||
                   (FStar_Options.query_stats ()) in
-              if uu____1363
-              then [FStar_SMTEncoding_Term.GetStatistics]
-              else [] in
-            FStar_List.append uu____1360 settings.query_suffix in
-          FStar_List.append uu____1347 uu____1357 in
-        FStar_List.append label_assumptions uu____1344 in
-      FStar_List.append uu____1292 uu____1341
+              if uu___6 then [FStar_SMTEncoding_Term.GetStatistics] else [] in
+            FStar_List.append uu___5 settings.query_suffix in
+          FStar_List.append uu___3 uu___4 in
+        FStar_List.append label_assumptions uu___2 in
+      FStar_List.append uu___ uu___1
 let (used_hint : query_settings -> Prims.bool) =
   fun s -> FStar_Option.isSome s.query_hint
 let (get_hint_for :
@@ -473,18 +465,18 @@ let (get_hint_for :
   =
   fun qname ->
     fun qindex ->
-      let uu____1386 = FStar_ST.op_Bang replaying_hints in
-      match uu____1386 with
+      let uu___ = FStar_ST.op_Bang replaying_hints in
+      match uu___ with
       | FStar_Pervasives_Native.Some hints ->
           FStar_Util.find_map hints
-            (fun uu___3_1406 ->
-               match uu___3_1406 with
+            (fun uu___1 ->
+               match uu___1 with
                | FStar_Pervasives_Native.Some hint when
                    (hint.FStar_Util.hint_name = qname) &&
                      (hint.FStar_Util.hint_index = qindex)
                    -> FStar_Pervasives_Native.Some hint
-               | uu____1412 -> FStar_Pervasives_Native.None)
-      | uu____1415 -> FStar_Pervasives_Native.None
+               | uu___2 -> FStar_Pervasives_Native.None)
+      | uu___1 -> FStar_Pervasives_Native.None
 let (query_errors :
   query_settings ->
     FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option)
@@ -492,19 +484,19 @@ let (query_errors :
   fun settings ->
     fun z3result ->
       match z3result.FStar_SMTEncoding_Z3.z3result_status with
-      | FStar_SMTEncoding_Z3.UNSAT uu____1432 -> FStar_Pervasives_Native.None
-      | uu____1433 ->
-          let uu____1434 =
+      | FStar_SMTEncoding_Z3.UNSAT uu___ -> FStar_Pervasives_Native.None
+      | uu___ ->
+          let uu___1 =
             FStar_SMTEncoding_Z3.status_string_and_errors
               z3result.FStar_SMTEncoding_Z3.z3result_status in
-          (match uu____1434 with
+          (match uu___1 with
            | (msg, error_labels) ->
                let err =
-                 let uu____1444 =
+                 let uu___2 =
                    FStar_List.map
-                     (fun uu____1469 ->
-                        match uu____1469 with
-                        | (uu____1482, x, y) ->
+                     (fun uu___3 ->
+                        match uu___3 with
+                        | (uu___4, x, y) ->
                             (FStar_Errors.Error_Z3SolverError, x, y))
                      error_labels in
                  {
@@ -512,26 +504,26 @@ let (query_errors :
                    error_fuel = (settings.query_fuel);
                    error_ifuel = (settings.query_ifuel);
                    error_hint = (settings.query_hint);
-                   error_messages = uu____1444
+                   error_messages = uu___2
                  } in
                FStar_Pervasives_Native.Some err)
 let (detail_hint_replay :
   query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
   fun settings ->
     fun z3result ->
-      let uu____1495 =
+      let uu___ =
         (used_hint settings) && (FStar_Options.detail_hint_replay ()) in
-      if uu____1495
+      if uu___
       then
         match z3result.FStar_SMTEncoding_Z3.z3result_status with
-        | FStar_SMTEncoding_Z3.UNSAT uu____1496 -> ()
+        | FStar_SMTEncoding_Z3.UNSAT uu___1 -> ()
         | _failed ->
             let ask_z3 label_assumptions =
-              let uu____1508 =
+              let uu___1 =
                 with_fuel_and_diagnostics settings label_assumptions in
               FStar_SMTEncoding_Z3.ask settings.query_range
                 (filter_assertions settings.query_env settings.query_hint)
-                settings.query_hash settings.query_all_labels uu____1508
+                settings.query_hash settings.query_all_labels uu___1
                 FStar_Pervasives_Native.None false in
             FStar_SMTEncoding_ErrorReporting.detail_errors true
               settings.query_env settings.query_all_labels ask_z3
@@ -542,7 +534,7 @@ let (find_localized_errors :
     FStar_All.pipe_right errs
       (FStar_List.tryFind
          (fun err ->
-            match err.error_messages with | [] -> false | uu____1535 -> true))
+            match err.error_messages with | [] -> false | uu___ -> true))
 let (errors_to_report : query_settings -> FStar_Errors.error Prims.list) =
   fun settings ->
     let format_smt_error msg =
@@ -551,24 +543,23 @@ let (errors_to_report : query_settings -> FStar_Errors.error Prims.list) =
         msg in
     let basic_errors =
       let smt_error =
-        let uu____1567 = FStar_Options.query_stats () in
-        if uu____1567
+        let uu___ = FStar_Options.query_stats () in
+        if uu___
         then
-          let uu____1572 =
-            let uu____1573 =
-              let uu____1574 =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_All.pipe_right settings.query_errors
                   (FStar_List.map error_to_short_string) in
-              FStar_All.pipe_right uu____1574 (FStar_String.concat ";\n\t") in
-            FStar_All.pipe_right uu____1573 format_smt_error in
-          FStar_All.pipe_right uu____1572
-            (fun uu____1587 -> FStar_Util.Inr uu____1587)
+              FStar_All.pipe_right uu___3 (FStar_String.concat ";\n\t") in
+            FStar_All.pipe_right uu___2 format_smt_error in
+          FStar_All.pipe_right uu___1 (fun uu___2 -> FStar_Util.Inr uu___2)
         else
-          (let uu____1589 =
+          (let uu___2 =
              FStar_List.fold_left
-               (fun uu____1608 ->
+               (fun uu___3 ->
                   fun err ->
-                    match uu____1608 with
+                    match uu___3 with
                     | (ic, cc, uc) ->
                         let err1 =
                           FStar_Util.substring_from err.error_reason
@@ -584,28 +575,26 @@ let (errors_to_report : query_settings -> FStar_Errors.error Prims.list) =
                           else (ic, cc, (uc + Prims.int_one)))
                (Prims.int_zero, Prims.int_zero, Prims.int_zero)
                settings.query_errors in
-           match uu____1589 with
+           match uu___2 with
            | (incomplete_count, canceled_count, unknown_count) ->
                FStar_All.pipe_right
                  (match (incomplete_count, canceled_count, unknown_count)
                   with
-                  | (uu____1652, uu____1653, uu____1654) when
-                      ((uu____1653 = Prims.int_zero) &&
-                         (uu____1654 = Prims.int_zero))
+                  | (uu___3, uu___4, uu___5) when
+                      ((uu___4 = Prims.int_zero) && (uu___5 = Prims.int_zero))
                         && (incomplete_count > Prims.int_zero)
                       ->
                       "The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel"
-                  | (uu____1656, uu____1655, uu____1657) when
-                      ((uu____1656 = Prims.int_zero) &&
-                         (uu____1657 = Prims.int_zero))
+                  | (uu___3, uu___4, uu___5) when
+                      ((uu___3 = Prims.int_zero) && (uu___5 = Prims.int_zero))
                         && (canceled_count > Prims.int_zero)
                       ->
                       "The SMT query timed out, you might want to increase the rlimit"
-                  | (uu____1658, uu____1659, uu____1660) ->
+                  | (uu___3, uu___4, uu___5) ->
                       "Try with --query_stats to get more details")
-                 (fun uu____1661 -> FStar_Util.Inl uu____1661)) in
-      let uu____1662 = find_localized_errors settings.query_errors in
-      match uu____1662 with
+                 (fun uu___3 -> FStar_Util.Inl uu___3)) in
+      let uu___ = find_localized_errors settings.query_errors in
+      match uu___ with
       | FStar_Pervasives_Native.Some err ->
           FStar_TypeChecker_Err.errors_smt_detail settings.query_env
             err.error_messages smt_error
@@ -613,34 +602,34 @@ let (errors_to_report : query_settings -> FStar_Errors.error Prims.list) =
           FStar_TypeChecker_Err.errors_smt_detail settings.query_env
             [(FStar_Errors.Error_UnknownFatal_AssertionFailure,
                "Unknown assertion failed", (settings.query_range))] smt_error in
-    (let uu____1681 = FStar_Options.detail_errors () in
-     if uu____1681
+    (let uu___ = FStar_Options.detail_errors () in
+     if uu___
      then
        let initial_fuel =
-         let uu___252_1683 = settings in
-         let uu____1684 = FStar_Options.initial_fuel () in
-         let uu____1685 = FStar_Options.initial_ifuel () in
+         let uu___1 = settings in
+         let uu___2 = FStar_Options.initial_fuel () in
+         let uu___3 = FStar_Options.initial_ifuel () in
          {
-           query_env = (uu___252_1683.query_env);
-           query_decl = (uu___252_1683.query_decl);
-           query_name = (uu___252_1683.query_name);
-           query_index = (uu___252_1683.query_index);
-           query_range = (uu___252_1683.query_range);
-           query_fuel = uu____1684;
-           query_ifuel = uu____1685;
-           query_rlimit = (uu___252_1683.query_rlimit);
+           query_env = (uu___1.query_env);
+           query_decl = (uu___1.query_decl);
+           query_name = (uu___1.query_name);
+           query_index = (uu___1.query_index);
+           query_range = (uu___1.query_range);
+           query_fuel = uu___2;
+           query_ifuel = uu___3;
+           query_rlimit = (uu___1.query_rlimit);
            query_hint = FStar_Pervasives_Native.None;
-           query_errors = (uu___252_1683.query_errors);
-           query_all_labels = (uu___252_1683.query_all_labels);
-           query_suffix = (uu___252_1683.query_suffix);
-           query_hash = (uu___252_1683.query_hash)
+           query_errors = (uu___1.query_errors);
+           query_all_labels = (uu___1.query_all_labels);
+           query_suffix = (uu___1.query_suffix);
+           query_hash = (uu___1.query_hash)
          } in
        let ask_z3 label_assumptions =
-         let uu____1698 =
+         let uu___1 =
            with_fuel_and_diagnostics initial_fuel label_assumptions in
          FStar_SMTEncoding_Z3.ask settings.query_range
            (filter_facts_without_core settings.query_env) settings.query_hash
-           settings.query_all_labels uu____1698 FStar_Pervasives_Native.None
+           settings.query_all_labels uu___1 FStar_Pervasives_Native.None
            false in
        FStar_SMTEncoding_ErrorReporting.detail_errors false
          settings.query_env settings.query_all_labels ask_z3
@@ -648,31 +637,31 @@ let (errors_to_report : query_settings -> FStar_Errors.error Prims.list) =
     basic_errors
 let (report_errors : query_settings -> unit) =
   fun qry_settings ->
-    let uu____1707 = errors_to_report qry_settings in
-    FStar_Errors.add_errors uu____1707
+    let uu___ = errors_to_report qry_settings in
+    FStar_Errors.add_errors uu___
 let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
   fun settings ->
     fun z3result ->
       let process_unsat_core core =
-        let accumulator uu____1749 =
+        let accumulator uu___ =
           let r = FStar_Util.mk_ref [] in
-          let uu____1757 =
+          let uu___1 =
             let module_names = FStar_Util.mk_ref [] in
             ((fun m ->
                 let ms = FStar_ST.op_Bang module_names in
                 if FStar_List.contains m ms
                 then ()
                 else FStar_ST.op_Colon_Equals module_names (m :: ms)),
-              (fun uu____1814 ->
-                 let uu____1815 = FStar_ST.op_Bang module_names in
-                 FStar_All.pipe_right uu____1815
+              (fun uu___2 ->
+                 let uu___3 = FStar_ST.op_Bang module_names in
+                 FStar_All.pipe_right uu___3
                    (FStar_Util.sort_with FStar_String.compare))) in
-          match uu____1757 with | (add, get) -> (add, get) in
-        let uu____1870 = accumulator () in
-        match uu____1870 with
+          match uu___1 with | (add, get) -> (add, get) in
+        let uu___ = accumulator () in
+        match uu___ with
         | (add_module_name, get_module_names) ->
-            let uu____1901 = accumulator () in
-            (match uu____1901 with
+            let uu___1 = accumulator () in
+            (match uu___1 with
              | (add_discarded_name, get_discarded_names) ->
                  let parse_axiom_name s =
                    let chars = FStar_String.list_of_string s in
@@ -702,9 +691,9 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                              (fun sfx ->
                                 if FStar_Util.contains s2 sfx
                                 then
-                                  let uu____1974 =
+                                  let uu___2 =
                                     FStar_List.hd (FStar_Util.split s2 sfx) in
-                                  FStar_Pervasives_Native.Some uu____1974
+                                  FStar_Pervasives_Native.Some uu___2
                                 else FStar_Pervasives_Native.None) in
                          match sopt with
                          | FStar_Pervasives_Native.None ->
@@ -714,84 +703,84 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                        let components1 =
                          match components with
                          | [] -> []
-                         | uu____1990 ->
-                             let uu____1993 = FStar_Util.prefix components in
-                             (match uu____1993 with
+                         | uu___2 ->
+                             let uu___3 = FStar_Util.prefix components in
+                             (match uu___3 with
                               | (module_name, last) ->
-                                  let components1 =
-                                    let uu____2011 = exclude_suffix last in
-                                    FStar_List.append module_name uu____2011 in
-                                  ((match components1 with
+                                  let components2 =
+                                    let uu___4 = exclude_suffix last in
+                                    FStar_List.append module_name uu___4 in
+                                  ((match components2 with
                                     | [] -> ()
-                                    | uu____2015::[] -> ()
-                                    | uu____2016 ->
+                                    | uu___5::[] -> ()
+                                    | uu___5 ->
                                         add_module_name
                                           (FStar_String.concat "."
                                              module_name));
-                                   components1)) in
+                                   components2)) in
                        if components1 = []
                        then (add_discarded_name s; [])
                        else
-                         (let uu____2025 =
+                         (let uu___3 =
                             FStar_All.pipe_right components1
                               (FStar_String.concat ".") in
-                          [uu____2025]) in
+                          [uu___3]) in
                  (match core with
                   | FStar_Pervasives_Native.None ->
                       FStar_Util.print_string "no unsat core\n"
                   | FStar_Pervasives_Native.Some core1 ->
                       let core2 = FStar_List.collect parse_axiom_name core1 in
-                      ((let uu____2039 =
-                          let uu____2040 = get_module_names () in
-                          FStar_All.pipe_right uu____2040
+                      ((let uu___3 =
+                          let uu___4 = get_module_names () in
+                          FStar_All.pipe_right uu___4
                             (FStar_String.concat "\nZ3 Proof Stats:\t") in
                         FStar_Util.print1
                           "Z3 Proof Stats: Modules relevant to this proof:\nZ3 Proof Stats:\t%s\n"
-                          uu____2039);
+                          uu___3);
                        FStar_Util.print1
                          "Z3 Proof Stats (Detail 1): Specifically:\nZ3 Proof Stats (Detail 1):\t%s\n"
                          (FStar_String.concat
                             "\nZ3 Proof Stats (Detail 1):\t" core2);
-                       (let uu____2046 =
-                          let uu____2047 = get_discarded_names () in
-                          FStar_All.pipe_right uu____2047
+                       (let uu___4 =
+                          let uu___5 = get_discarded_names () in
+                          FStar_All.pipe_right uu___5
                             (FStar_String.concat ", ") in
                         FStar_Util.print1
                           "Z3 Proof Stats (Detail 2): Note, this report ignored the following names in the context: %s\n"
-                          uu____2046)))) in
-      let uu____2052 =
+                          uu___4)))) in
+      let uu___ =
         (FStar_Options.hint_info ()) || (FStar_Options.query_stats ()) in
-      if uu____2052
+      if uu___
       then
-        let uu____2053 =
+        let uu___1 =
           FStar_SMTEncoding_Z3.status_string_and_errors
             z3result.FStar_SMTEncoding_Z3.z3result_status in
-        match uu____2053 with
+        match uu___1 with
         | (status_string, errs) ->
             let at_log_file =
               match z3result.FStar_SMTEncoding_Z3.z3result_log_file with
               | FStar_Pervasives_Native.None -> ""
               | FStar_Pervasives_Native.Some s -> Prims.op_Hat "@" s in
-            let uu____2062 =
+            let uu___2 =
               match z3result.FStar_SMTEncoding_Z3.z3result_status with
               | FStar_SMTEncoding_Z3.UNSAT core -> ("succeeded", core)
-              | uu____2072 ->
+              | uu___3 ->
                   ((Prims.op_Hat "failed {reason-unknown="
                       (Prims.op_Hat status_string "}")),
                     FStar_Pervasives_Native.None) in
-            (match uu____2062 with
+            (match uu___2 with
              | (tag, core) ->
                  let range =
-                   let uu____2078 =
-                     let uu____2079 =
+                   let uu___3 =
+                     let uu___4 =
                        FStar_Range.string_of_range settings.query_range in
-                     Prims.op_Hat uu____2079 (Prims.op_Hat at_log_file ")") in
-                   Prims.op_Hat "(" uu____2078 in
+                     Prims.op_Hat uu___4 (Prims.op_Hat at_log_file ")") in
+                   Prims.op_Hat "(" uu___3 in
                  let used_hint_tag =
                    if used_hint settings then " (with hint)" else "" in
                  let stats =
-                   let uu____2083 = FStar_Options.query_stats () in
-                   if uu____2083
+                   let uu___3 = FStar_Options.query_stats () in
+                   if uu___3
                    then
                      let f k v a =
                        Prims.op_Hat a
@@ -801,53 +790,53 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                        FStar_Util.smap_fold
                          z3result.FStar_SMTEncoding_Z3.z3result_statistics f
                          "statistics={" in
-                     let uu____2101 =
+                     let uu___4 =
                        FStar_Util.substring str Prims.int_zero
                          ((FStar_String.length str) - Prims.int_one) in
-                     Prims.op_Hat uu____2101 "}"
+                     Prims.op_Hat uu___4 "}"
                    else "" in
-                 ((let uu____2104 =
-                     let uu____2107 =
-                       let uu____2110 =
-                         let uu____2113 =
+                 ((let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_Util.string_of_int settings.query_index in
-                         let uu____2114 =
-                           let uu____2117 =
-                             let uu____2120 =
-                               let uu____2123 =
+                         let uu___8 =
+                           let uu___9 =
+                             let uu___10 =
+                               let uu___11 =
                                  FStar_Util.string_of_int
                                    z3result.FStar_SMTEncoding_Z3.z3result_time in
-                               let uu____2124 =
-                                 let uu____2127 =
+                               let uu___12 =
+                                 let uu___13 =
                                    FStar_Util.string_of_int
                                      settings.query_fuel in
-                                 let uu____2128 =
-                                   let uu____2131 =
+                                 let uu___14 =
+                                   let uu___15 =
                                      FStar_Util.string_of_int
                                        settings.query_ifuel in
-                                   let uu____2132 =
-                                     let uu____2135 =
+                                   let uu___16 =
+                                     let uu___17 =
                                        FStar_Util.string_of_int
                                          settings.query_rlimit in
-                                     [uu____2135; stats] in
-                                   uu____2131 :: uu____2132 in
-                                 uu____2127 :: uu____2128 in
-                               uu____2123 :: uu____2124 in
-                             used_hint_tag :: uu____2120 in
-                           tag :: uu____2117 in
-                         uu____2113 :: uu____2114 in
-                       (settings.query_name) :: uu____2110 in
-                     range :: uu____2107 in
+                                     [uu___17; stats] in
+                                   uu___15 :: uu___16 in
+                                 uu___13 :: uu___14 in
+                               uu___11 :: uu___12 in
+                             used_hint_tag :: uu___10 in
+                           tag :: uu___9 in
+                         uu___7 :: uu___8 in
+                       (settings.query_name) :: uu___6 in
+                     range :: uu___5 in
                    FStar_Util.print
                      "%s\tQuery-stats (%s, %s)\t%s%s in %s milliseconds with fuel %s and ifuel %s and rlimit %s %s\n"
-                     uu____2104);
-                  (let uu____2137 = FStar_Options.print_z3_statistics () in
-                   if uu____2137 then process_unsat_core core else ());
+                     uu___4);
+                  (let uu___5 = FStar_Options.print_z3_statistics () in
+                   if uu___5 then process_unsat_core core else ());
                   FStar_All.pipe_right errs
                     (FStar_List.iter
-                       (fun uu____2158 ->
-                          match uu____2158 with
-                          | (uu____2165, msg, range1) ->
+                       (fun uu___5 ->
+                          match uu___5 with
+                          | (uu___6, msg, range1) ->
                               let tag1 =
                                 if used_hint settings
                                 then "(Hint-replay failed): "
@@ -858,20 +847,20 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
       else ()
 let (store_hint : FStar_Util.hint -> unit) =
   fun hint ->
-    let uu____2176 = FStar_ST.op_Bang recorded_hints in
-    match uu____2176 with
+    let uu___ = FStar_ST.op_Bang recorded_hints in
+    match uu___ with
     | FStar_Pervasives_Native.Some l ->
         FStar_ST.op_Colon_Equals recorded_hints
           (FStar_Pervasives_Native.Some
              (FStar_List.append l [FStar_Pervasives_Native.Some hint]))
-    | uu____2206 -> ()
+    | uu___1 -> ()
 let (record_hint : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
   fun settings ->
     fun z3result ->
-      let uu____2220 =
-        let uu____2221 = FStar_Options.record_hints () in
-        Prims.op_Negation uu____2221 in
-      if uu____2220
+      let uu___ =
+        let uu___1 = FStar_Options.record_hints () in
+        Prims.op_Negation uu___1 in
+      if uu___
       then ()
       else
         (let mk_hint core =
@@ -886,20 +875,20 @@ let (record_hint : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                (match z3result.FStar_SMTEncoding_Z3.z3result_status with
                 | FStar_SMTEncoding_Z3.UNSAT core1 ->
                     z3result.FStar_SMTEncoding_Z3.z3result_query_hash
-                | uu____2241 -> FStar_Pervasives_Native.None)
+                | uu___2 -> FStar_Pervasives_Native.None)
            } in
          match z3result.FStar_SMTEncoding_Z3.z3result_status with
          | FStar_SMTEncoding_Z3.UNSAT (FStar_Pervasives_Native.None) ->
-             let uu____2244 =
-               let uu____2245 =
+             let uu___2 =
+               let uu___3 =
                  get_hint_for settings.query_name settings.query_index in
-               FStar_Option.get uu____2245 in
-             store_hint uu____2244
+               FStar_Option.get uu___3 in
+             store_hint uu___2
          | FStar_SMTEncoding_Z3.UNSAT unsat_core ->
              if used_hint settings
              then store_hint (mk_hint settings.query_hint)
              else store_hint (mk_hint unsat_core)
-         | uu____2250 -> ())
+         | uu___2 -> ())
 let (process_result :
   query_settings ->
     FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option)
@@ -927,21 +916,21 @@ let (fold_queries :
           | [] -> FStar_Util.Inl acc
           | q::qs2 ->
               let res = ask q in
-              let uu____2359 = f q res in
-              (match uu____2359 with
+              let uu___ = f q res in
+              (match uu___ with
                | FStar_Pervasives_Native.None -> FStar_Util.Inr q
                | FStar_Pervasives_Native.Some errs -> aux (errs :: acc) qs2) in
         aux [] qs
 let (full_query_id : query_settings -> Prims.string) =
   fun settings ->
-    let uu____2376 =
-      let uu____2377 =
-        let uu____2378 =
-          let uu____2379 = FStar_Util.string_of_int settings.query_index in
-          Prims.op_Hat uu____2379 ")" in
-        Prims.op_Hat ", " uu____2378 in
-      Prims.op_Hat settings.query_name uu____2377 in
-    Prims.op_Hat "(" uu____2376
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Util.string_of_int settings.query_index in
+          Prims.op_Hat uu___3 ")" in
+        Prims.op_Hat ", " uu___2 in
+      Prims.op_Hat settings.query_name uu___1 in
+    Prims.op_Hat "(" uu___
 let collect : 'a . 'a Prims.list -> ('a * Prims.int) Prims.list =
   fun l ->
     let acc = [] in
@@ -951,7 +940,7 @@ let collect : 'a . 'a Prims.list -> ('a * Prims.int) Prims.list =
       | (h, n)::t ->
           if h = x
           then (h, (n + Prims.int_one)) :: t
-          else (let uu____2482 = add_one t x in (h, n) :: uu____2482) in
+          else (let uu___1 = add_one t x in (h, n) :: uu___1) in
     FStar_List.fold_left add_one acc l
 let (ask_and_report_errors :
   FStar_TypeChecker_Env.env ->
@@ -966,35 +955,34 @@ let (ask_and_report_errors :
         fun query ->
           fun suffix ->
             FStar_SMTEncoding_Z3.giveZ3 prefix;
-            (let uu____2533 =
-               let uu____2540 =
+            (let uu___1 =
+               let uu___2 =
                  match env.FStar_TypeChecker_Env.qtbl_name_and_index with
-                 | (uu____2549, FStar_Pervasives_Native.None) ->
+                 | (uu___3, FStar_Pervasives_Native.None) ->
                      failwith "No query name set!"
-                 | (uu____2568, FStar_Pervasives_Native.Some (q, n)) ->
-                     let uu____2585 = FStar_Ident.string_of_lid q in
-                     (uu____2585, n) in
-               match uu____2540 with
+                 | (uu___3, FStar_Pervasives_Native.Some (q, n)) ->
+                     let uu___4 = FStar_Ident.string_of_lid q in (uu___4, n) in
+               match uu___2 with
                | (qname, index) ->
                    let rlimit =
-                     let uu____2595 = FStar_Options.z3_rlimit_factor () in
-                     let uu____2596 =
-                       let uu____2597 = FStar_Options.z3_rlimit () in
-                       uu____2597 * (Prims.parse_int "544656") in
-                     uu____2595 * uu____2596 in
+                     let uu___3 = FStar_Options.z3_rlimit_factor () in
+                     let uu___4 =
+                       let uu___5 = FStar_Options.z3_rlimit () in
+                       uu___5 * (Prims.parse_int "544656") in
+                     uu___3 * uu___4 in
                    let next_hint = get_hint_for qname index in
                    let default_settings =
-                     let uu____2602 = FStar_TypeChecker_Env.get_range env in
-                     let uu____2603 = FStar_Options.initial_fuel () in
-                     let uu____2604 = FStar_Options.initial_ifuel () in
+                     let uu___3 = FStar_TypeChecker_Env.get_range env in
+                     let uu___4 = FStar_Options.initial_fuel () in
+                     let uu___5 = FStar_Options.initial_ifuel () in
                      {
                        query_env = env;
                        query_decl = query;
                        query_name = qname;
                        query_index = index;
-                       query_range = uu____2602;
-                       query_fuel = uu____2603;
-                       query_ifuel = uu____2604;
+                       query_range = uu___3;
+                       query_fuel = uu___4;
+                       query_ifuel = uu___5;
                        query_rlimit = rlimit;
                        query_hint = FStar_Pervasives_Native.None;
                        query_errors = [];
@@ -1005,168 +993,167 @@ let (ask_and_report_errors :
                           | FStar_Pervasives_Native.None ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some
-                              { FStar_Util.hint_name = uu____2609;
-                                FStar_Util.hint_index = uu____2610;
-                                FStar_Util.fuel = uu____2611;
-                                FStar_Util.ifuel = uu____2612;
-                                FStar_Util.unsat_core = uu____2613;
-                                FStar_Util.query_elapsed_time = uu____2614;
+                              { FStar_Util.hint_name = uu___6;
+                                FStar_Util.hint_index = uu___7;
+                                FStar_Util.fuel = uu___8;
+                                FStar_Util.ifuel = uu___9;
+                                FStar_Util.unsat_core = uu___10;
+                                FStar_Util.query_elapsed_time = uu___11;
                                 FStar_Util.hash = h;_}
                               -> h)
                      } in
                    (default_settings, next_hint) in
-             match uu____2533 with
+             match uu___1 with
              | (default_settings, next_hint) ->
                  let use_hints_setting =
-                   let uu____2633 =
+                   let uu___2 =
                      (FStar_Options.use_hints ()) &&
                        (FStar_All.pipe_right next_hint FStar_Util.is_some) in
-                   if uu____2633
+                   if uu___2
                    then
-                     let uu____2638 =
+                     let uu___3 =
                        FStar_All.pipe_right next_hint FStar_Util.must in
-                     match uu____2638 with
-                     | { FStar_Util.hint_name = uu____2643;
-                         FStar_Util.hint_index = uu____2644;
-                         FStar_Util.fuel = i; FStar_Util.ifuel = j;
+                     match uu___3 with
+                     | { FStar_Util.hint_name = uu___4;
+                         FStar_Util.hint_index = uu___5; FStar_Util.fuel = i;
+                         FStar_Util.ifuel = j;
                          FStar_Util.unsat_core = FStar_Pervasives_Native.Some
                            core;
-                         FStar_Util.query_elapsed_time = uu____2648;
+                         FStar_Util.query_elapsed_time = uu___6;
                          FStar_Util.hash = h;_} ->
-                         [(let uu___452_2657 = default_settings in
+                         [(let uu___7 = default_settings in
                            {
-                             query_env = (uu___452_2657.query_env);
-                             query_decl = (uu___452_2657.query_decl);
-                             query_name = (uu___452_2657.query_name);
-                             query_index = (uu___452_2657.query_index);
-                             query_range = (uu___452_2657.query_range);
+                             query_env = (uu___7.query_env);
+                             query_decl = (uu___7.query_decl);
+                             query_name = (uu___7.query_name);
+                             query_index = (uu___7.query_index);
+                             query_range = (uu___7.query_range);
                              query_fuel = i;
                              query_ifuel = j;
-                             query_rlimit = (uu___452_2657.query_rlimit);
+                             query_rlimit = (uu___7.query_rlimit);
                              query_hint = (FStar_Pervasives_Native.Some core);
-                             query_errors = (uu___452_2657.query_errors);
-                             query_all_labels =
-                               (uu___452_2657.query_all_labels);
-                             query_suffix = (uu___452_2657.query_suffix);
-                             query_hash = (uu___452_2657.query_hash)
+                             query_errors = (uu___7.query_errors);
+                             query_all_labels = (uu___7.query_all_labels);
+                             query_suffix = (uu___7.query_suffix);
+                             query_hash = (uu___7.query_hash)
                            })]
                    else [] in
                  let initial_fuel_max_ifuel =
-                   let uu____2664 =
-                     let uu____2665 = FStar_Options.max_ifuel () in
-                     let uu____2666 = FStar_Options.initial_ifuel () in
-                     uu____2665 > uu____2666 in
-                   if uu____2664
+                   let uu___2 =
+                     let uu___3 = FStar_Options.max_ifuel () in
+                     let uu___4 = FStar_Options.initial_ifuel () in
+                     uu___3 > uu___4 in
+                   if uu___2
                    then
-                     let uu____2669 =
-                       let uu___456_2670 = default_settings in
-                       let uu____2671 = FStar_Options.max_ifuel () in
+                     let uu___3 =
+                       let uu___4 = default_settings in
+                       let uu___5 = FStar_Options.max_ifuel () in
                        {
-                         query_env = (uu___456_2670.query_env);
-                         query_decl = (uu___456_2670.query_decl);
-                         query_name = (uu___456_2670.query_name);
-                         query_index = (uu___456_2670.query_index);
-                         query_range = (uu___456_2670.query_range);
-                         query_fuel = (uu___456_2670.query_fuel);
-                         query_ifuel = uu____2671;
-                         query_rlimit = (uu___456_2670.query_rlimit);
-                         query_hint = (uu___456_2670.query_hint);
-                         query_errors = (uu___456_2670.query_errors);
-                         query_all_labels = (uu___456_2670.query_all_labels);
-                         query_suffix = (uu___456_2670.query_suffix);
-                         query_hash = (uu___456_2670.query_hash)
+                         query_env = (uu___4.query_env);
+                         query_decl = (uu___4.query_decl);
+                         query_name = (uu___4.query_name);
+                         query_index = (uu___4.query_index);
+                         query_range = (uu___4.query_range);
+                         query_fuel = (uu___4.query_fuel);
+                         query_ifuel = uu___5;
+                         query_rlimit = (uu___4.query_rlimit);
+                         query_hint = (uu___4.query_hint);
+                         query_errors = (uu___4.query_errors);
+                         query_all_labels = (uu___4.query_all_labels);
+                         query_suffix = (uu___4.query_suffix);
+                         query_hash = (uu___4.query_hash)
                        } in
-                     [uu____2669]
+                     [uu___3]
                    else [] in
                  let half_max_fuel_max_ifuel =
-                   let uu____2676 =
-                     let uu____2677 =
-                       let uu____2678 = FStar_Options.max_fuel () in
-                       uu____2678 / (Prims.of_int (2)) in
-                     let uu____2679 = FStar_Options.initial_fuel () in
-                     uu____2677 > uu____2679 in
-                   if uu____2676
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = FStar_Options.max_fuel () in
+                       uu___4 / (Prims.of_int (2)) in
+                     let uu___4 = FStar_Options.initial_fuel () in
+                     uu___3 > uu___4 in
+                   if uu___2
                    then
-                     let uu____2682 =
-                       let uu___460_2683 = default_settings in
-                       let uu____2684 =
-                         let uu____2685 = FStar_Options.max_fuel () in
-                         uu____2685 / (Prims.of_int (2)) in
-                       let uu____2686 = FStar_Options.max_ifuel () in
+                     let uu___3 =
+                       let uu___4 = default_settings in
+                       let uu___5 =
+                         let uu___6 = FStar_Options.max_fuel () in
+                         uu___6 / (Prims.of_int (2)) in
+                       let uu___6 = FStar_Options.max_ifuel () in
                        {
-                         query_env = (uu___460_2683.query_env);
-                         query_decl = (uu___460_2683.query_decl);
-                         query_name = (uu___460_2683.query_name);
-                         query_index = (uu___460_2683.query_index);
-                         query_range = (uu___460_2683.query_range);
-                         query_fuel = uu____2684;
-                         query_ifuel = uu____2686;
-                         query_rlimit = (uu___460_2683.query_rlimit);
-                         query_hint = (uu___460_2683.query_hint);
-                         query_errors = (uu___460_2683.query_errors);
-                         query_all_labels = (uu___460_2683.query_all_labels);
-                         query_suffix = (uu___460_2683.query_suffix);
-                         query_hash = (uu___460_2683.query_hash)
+                         query_env = (uu___4.query_env);
+                         query_decl = (uu___4.query_decl);
+                         query_name = (uu___4.query_name);
+                         query_index = (uu___4.query_index);
+                         query_range = (uu___4.query_range);
+                         query_fuel = uu___5;
+                         query_ifuel = uu___6;
+                         query_rlimit = (uu___4.query_rlimit);
+                         query_hint = (uu___4.query_hint);
+                         query_errors = (uu___4.query_errors);
+                         query_all_labels = (uu___4.query_all_labels);
+                         query_suffix = (uu___4.query_suffix);
+                         query_hash = (uu___4.query_hash)
                        } in
-                     [uu____2682]
+                     [uu___3]
                    else [] in
                  let max_fuel_max_ifuel =
-                   let uu____2691 =
-                     (let uu____2696 = FStar_Options.max_fuel () in
-                      let uu____2697 = FStar_Options.initial_fuel () in
-                      uu____2696 > uu____2697) &&
-                       (let uu____2700 = FStar_Options.max_ifuel () in
-                        let uu____2701 = FStar_Options.initial_ifuel () in
-                        uu____2700 >= uu____2701) in
-                   if uu____2691
+                   let uu___2 =
+                     (let uu___3 = FStar_Options.max_fuel () in
+                      let uu___4 = FStar_Options.initial_fuel () in
+                      uu___3 > uu___4) &&
+                       (let uu___3 = FStar_Options.max_ifuel () in
+                        let uu___4 = FStar_Options.initial_ifuel () in
+                        uu___3 >= uu___4) in
+                   if uu___2
                    then
-                     let uu____2704 =
-                       let uu___464_2705 = default_settings in
-                       let uu____2706 = FStar_Options.max_fuel () in
-                       let uu____2707 = FStar_Options.max_ifuel () in
+                     let uu___3 =
+                       let uu___4 = default_settings in
+                       let uu___5 = FStar_Options.max_fuel () in
+                       let uu___6 = FStar_Options.max_ifuel () in
                        {
-                         query_env = (uu___464_2705.query_env);
-                         query_decl = (uu___464_2705.query_decl);
-                         query_name = (uu___464_2705.query_name);
-                         query_index = (uu___464_2705.query_index);
-                         query_range = (uu___464_2705.query_range);
-                         query_fuel = uu____2706;
-                         query_ifuel = uu____2707;
-                         query_rlimit = (uu___464_2705.query_rlimit);
-                         query_hint = (uu___464_2705.query_hint);
-                         query_errors = (uu___464_2705.query_errors);
-                         query_all_labels = (uu___464_2705.query_all_labels);
-                         query_suffix = (uu___464_2705.query_suffix);
-                         query_hash = (uu___464_2705.query_hash)
+                         query_env = (uu___4.query_env);
+                         query_decl = (uu___4.query_decl);
+                         query_name = (uu___4.query_name);
+                         query_index = (uu___4.query_index);
+                         query_range = (uu___4.query_range);
+                         query_fuel = uu___5;
+                         query_ifuel = uu___6;
+                         query_rlimit = (uu___4.query_rlimit);
+                         query_hint = (uu___4.query_hint);
+                         query_errors = (uu___4.query_errors);
+                         query_all_labels = (uu___4.query_all_labels);
+                         query_suffix = (uu___4.query_suffix);
+                         query_hash = (uu___4.query_hash)
                        } in
-                     [uu____2704]
+                     [uu___3]
                    else [] in
                  let min_fuel =
-                   let uu____2712 =
-                     let uu____2713 = FStar_Options.min_fuel () in
-                     let uu____2714 = FStar_Options.initial_fuel () in
-                     uu____2713 < uu____2714 in
-                   if uu____2712
+                   let uu___2 =
+                     let uu___3 = FStar_Options.min_fuel () in
+                     let uu___4 = FStar_Options.initial_fuel () in
+                     uu___3 < uu___4 in
+                   if uu___2
                    then
-                     let uu____2717 =
-                       let uu___468_2718 = default_settings in
-                       let uu____2719 = FStar_Options.min_fuel () in
+                     let uu___3 =
+                       let uu___4 = default_settings in
+                       let uu___5 = FStar_Options.min_fuel () in
                        {
-                         query_env = (uu___468_2718.query_env);
-                         query_decl = (uu___468_2718.query_decl);
-                         query_name = (uu___468_2718.query_name);
-                         query_index = (uu___468_2718.query_index);
-                         query_range = (uu___468_2718.query_range);
-                         query_fuel = uu____2719;
+                         query_env = (uu___4.query_env);
+                         query_decl = (uu___4.query_decl);
+                         query_name = (uu___4.query_name);
+                         query_index = (uu___4.query_index);
+                         query_range = (uu___4.query_range);
+                         query_fuel = uu___5;
                          query_ifuel = Prims.int_one;
-                         query_rlimit = (uu___468_2718.query_rlimit);
-                         query_hint = (uu___468_2718.query_hint);
-                         query_errors = (uu___468_2718.query_errors);
-                         query_all_labels = (uu___468_2718.query_all_labels);
-                         query_suffix = (uu___468_2718.query_suffix);
-                         query_hash = (uu___468_2718.query_hash)
+                         query_rlimit = (uu___4.query_rlimit);
+                         query_hint = (uu___4.query_hint);
+                         query_errors = (uu___4.query_errors);
+                         query_all_labels = (uu___4.query_all_labels);
+                         query_suffix = (uu___4.query_suffix);
+                         query_hash = (uu___4.query_hash)
                        } in
-                     [uu____2717]
+                     [uu___3]
                    else [] in
                  let all_configs =
                    FStar_List.append use_hints_setting
@@ -1175,18 +1162,16 @@ let (ask_and_report_errors :
                            (FStar_List.append half_max_fuel_max_ifuel
                               max_fuel_max_ifuel))) in
                  let check_one_config config =
-                   (let uu____2731 = FStar_Options.z3_refresh () in
-                    if uu____2731
-                    then FStar_SMTEncoding_Z3.refresh ()
-                    else ());
-                   (let uu____2733 = with_fuel_and_diagnostics config [] in
-                    let uu____2736 =
-                      let uu____2739 = FStar_SMTEncoding_Z3.mk_fresh_scope () in
-                      FStar_Pervasives_Native.Some uu____2739 in
+                   (let uu___3 = FStar_Options.z3_refresh () in
+                    if uu___3 then FStar_SMTEncoding_Z3.refresh () else ());
+                   (let uu___3 = with_fuel_and_diagnostics config [] in
+                    let uu___4 =
+                      let uu___5 = FStar_SMTEncoding_Z3.mk_fresh_scope () in
+                      FStar_Pervasives_Native.Some uu___5 in
                     FStar_SMTEncoding_Z3.ask config.query_range
                       (filter_assertions config.query_env config.query_hint)
-                      config.query_hash config.query_all_labels uu____2733
-                      uu____2736 (used_hint config)) in
+                      config.query_hash config.query_all_labels uu___3 uu___4
+                      (used_hint config)) in
                  let check_all_configs configs =
                    fold_queries configs check_one_config process_result in
                  let quake_and_check_all_configs configs =
@@ -1196,8 +1181,8 @@ let (ask_and_report_errors :
                    let name = full_query_id default_settings in
                    let quaking =
                      (hi > Prims.int_one) &&
-                       (let uu____2778 = FStar_Options.retry () in
-                        Prims.op_Negation uu____2778) in
+                       (let uu___2 = FStar_Options.retry () in
+                        Prims.op_Negation uu___2) in
                    let quaking_or_retrying = hi > Prims.int_one in
                    let hi1 = if hi < Prims.int_one then Prims.int_one else hi in
                    let lo1 =
@@ -1205,11 +1190,11 @@ let (ask_and_report_errors :
                      then Prims.int_one
                      else if lo > hi1 then hi1 else lo in
                    let run_one seed1 =
-                     let uu____2797 = FStar_Options.z3_refresh () in
-                     if uu____2797
+                     let uu___2 = FStar_Options.z3_refresh () in
+                     if uu___2
                      then
                        FStar_Options.with_saved_options
-                         (fun uu____2812 ->
+                         (fun uu___3 ->
                             FStar_Options.set_option "z3seed"
                               (FStar_Options.Int seed1);
                             check_all_configs configs)
@@ -1218,15 +1203,15 @@ let (ask_and_report_errors :
                      if lo2 > hi2
                      then acc
                      else
-                       (let uu____2858 = f acc lo2 in
-                        fold_nat' f uu____2858 (lo2 + Prims.int_one) hi2) in
+                       (let uu___3 = f acc lo2 in
+                        fold_nat' f uu___3 (lo2 + Prims.int_one) hi2) in
                    let best_fuel =
                      FStar_Util.mk_ref FStar_Pervasives_Native.None in
                    let best_ifuel =
                      FStar_Util.mk_ref FStar_Pervasives_Native.None in
                    let maybe_improve r n =
-                     let uu____2916 = FStar_ST.op_Bang r in
-                     match uu____2916 with
+                     let uu___2 = FStar_ST.op_Bang r in
+                     match uu___2 with
                      | FStar_Pervasives_Native.None ->
                          FStar_ST.op_Colon_Equals r
                            (FStar_Pervasives_Native.Some n)
@@ -1236,52 +1221,50 @@ let (ask_and_report_errors :
                            FStar_ST.op_Colon_Equals r
                              (FStar_Pervasives_Native.Some n)
                          else () in
-                   let uu____2951 =
+                   let uu___2 =
                      fold_nat'
-                       (fun uu____2986 ->
+                       (fun uu___3 ->
                           fun n ->
-                            match uu____2986 with
+                            match uu___3 with
                             | (nsucc, nfail, rs) ->
-                                let uu____3035 =
-                                  (let uu____3038 =
-                                     FStar_Options.quake_keep () in
-                                   Prims.op_Negation uu____3038) &&
+                                let uu___4 =
+                                  (let uu___5 = FStar_Options.quake_keep () in
+                                   Prims.op_Negation uu___5) &&
                                     ((nsucc >= lo1) || (nfail > (hi1 - lo1))) in
-                                if uu____3035
+                                if uu___4
                                 then (nsucc, nfail, rs)
                                 else
-                                  ((let uu____3063 =
+                                  ((let uu___7 =
                                       (quaking_or_retrying &&
                                          ((FStar_Options.interactive ()) ||
                                             (FStar_Options.debug_any ())))
                                         && (n > Prims.int_zero) in
-                                    if uu____3063
+                                    if uu___7
                                     then
-                                      let uu____3064 =
+                                      let uu___8 =
                                         if quaking
                                         then
-                                          let uu____3065 =
+                                          let uu___9 =
                                             FStar_Util.string_of_int nsucc in
                                           FStar_Util.format1
-                                            "succeeded %s times and "
-                                            uu____3065
+                                            "succeeded %s times and " uu___9
                                         else "" in
-                                      let uu____3067 =
+                                      let uu___9 =
                                         if quaking
                                         then FStar_Util.string_of_int nfail
                                         else
-                                          (let uu____3069 =
+                                          (let uu___11 =
                                              FStar_Util.string_of_int nfail in
-                                           Prims.op_Hat uu____3069 " times") in
-                                      let uu____3070 =
+                                           Prims.op_Hat uu___11 " times") in
+                                      let uu___10 =
                                         FStar_Util.string_of_int (hi1 - n) in
                                       FStar_Util.print5
                                         "%s: so far query %s %sfailed %s (%s runs remain)\n"
                                         (if quaking then "Quake" else "Retry")
-                                        name uu____3064 uu____3067 uu____3070
+                                        name uu___8 uu___9 uu___10
                                     else ());
                                    (let r = run_one (seed + n) in
-                                    let uu____3080 =
+                                    let uu___7 =
                                       match r with
                                       | FStar_Util.Inr cfg ->
                                           (maybe_improve best_fuel
@@ -1289,38 +1272,37 @@ let (ask_and_report_errors :
                                            maybe_improve best_ifuel
                                              cfg.query_ifuel;
                                            ((nsucc + Prims.int_one), nfail))
-                                      | uu____3094 ->
+                                      | uu___8 ->
                                           (nsucc, (nfail + Prims.int_one)) in
-                                    match uu____3080 with
+                                    match uu___7 with
                                     | (nsucc1, nfail1) ->
                                         (nsucc1, nfail1, (r :: rs)))))
                        (Prims.int_zero, Prims.int_zero, []) Prims.int_zero
                        (hi1 - Prims.int_one) in
-                   match uu____2951 with
+                   match uu___2 with
                    | (nsuccess, nfailures, rs) ->
                        let total_ran = nsuccess + nfailures in
                        (if quaking
                         then
                           (let fuel_msg =
-                             let uu____3167 =
-                               let uu____3176 = FStar_ST.op_Bang best_fuel in
-                               let uu____3189 = FStar_ST.op_Bang best_ifuel in
-                               (uu____3176, uu____3189) in
-                             match uu____3167 with
+                             let uu___4 =
+                               let uu___5 = FStar_ST.op_Bang best_fuel in
+                               let uu___6 = FStar_ST.op_Bang best_ifuel in
+                               (uu___5, uu___6) in
+                             match uu___4 with
                              | (FStar_Pervasives_Native.Some f,
                                 FStar_Pervasives_Native.Some i) ->
-                                 let uu____3212 = FStar_Util.string_of_int f in
-                                 let uu____3213 = FStar_Util.string_of_int i in
+                                 let uu___5 = FStar_Util.string_of_int f in
+                                 let uu___6 = FStar_Util.string_of_int i in
                                  FStar_Util.format2
-                                   " (best fuel=%s, best ifuel=%s)"
-                                   uu____3212 uu____3213
-                             | (uu____3214, uu____3215) -> "" in
-                           let uu____3224 = FStar_Util.string_of_int nsuccess in
-                           let uu____3225 =
-                             FStar_Util.string_of_int total_ran in
+                                   " (best fuel=%s, best ifuel=%s)" uu___5
+                                   uu___6
+                             | (uu___5, uu___6) -> "" in
+                           let uu___4 = FStar_Util.string_of_int nsuccess in
+                           let uu___5 = FStar_Util.string_of_int total_ran in
                            FStar_Util.print5
                              "Quake: query %s succeeded %s/%s times%s%s\n"
-                             name uu____3224 uu____3225
+                             name uu___4 uu___5
                              (if total_ran < hi1
                               then " (early finish)"
                               else "") fuel_msg)
@@ -1329,143 +1311,133 @@ let (ask_and_report_errors :
                         then
                           (let all_errs =
                              FStar_List.concatMap
-                               (fun uu___4_3243 ->
-                                  match uu___4_3243 with
-                                  | FStar_Util.Inr uu____3254 -> []
+                               (fun uu___4 ->
+                                  match uu___4 with
+                                  | FStar_Util.Inr uu___5 -> []
                                   | FStar_Util.Inl es -> [es]) rs in
-                           let uu____3268 =
+                           let uu___4 =
                              quaking_or_retrying &&
-                               (let uu____3270 = FStar_Options.query_stats () in
-                                Prims.op_Negation uu____3270) in
-                           if uu____3268
+                               (let uu___5 = FStar_Options.query_stats () in
+                                Prims.op_Negation uu___5) in
+                           if uu___4
                            then
                              let errors_to_report1 errs =
                                errors_to_report
-                                 (let uu___559_3285 = default_settings in
+                                 (let uu___5 = default_settings in
                                   {
-                                    query_env = (uu___559_3285.query_env);
-                                    query_decl = (uu___559_3285.query_decl);
-                                    query_name = (uu___559_3285.query_name);
-                                    query_index = (uu___559_3285.query_index);
-                                    query_range = (uu___559_3285.query_range);
-                                    query_fuel = (uu___559_3285.query_fuel);
-                                    query_ifuel = (uu___559_3285.query_ifuel);
-                                    query_rlimit =
-                                      (uu___559_3285.query_rlimit);
-                                    query_hint = (uu___559_3285.query_hint);
+                                    query_env = (uu___5.query_env);
+                                    query_decl = (uu___5.query_decl);
+                                    query_name = (uu___5.query_name);
+                                    query_index = (uu___5.query_index);
+                                    query_range = (uu___5.query_range);
+                                    query_fuel = (uu___5.query_fuel);
+                                    query_ifuel = (uu___5.query_ifuel);
+                                    query_rlimit = (uu___5.query_rlimit);
+                                    query_hint = (uu___5.query_hint);
                                     query_errors = errs;
                                     query_all_labels =
-                                      (uu___559_3285.query_all_labels);
-                                    query_suffix =
-                                      (uu___559_3285.query_suffix);
-                                    query_hash = (uu___559_3285.query_hash)
+                                      (uu___5.query_all_labels);
+                                    query_suffix = (uu___5.query_suffix);
+                                    query_hash = (uu___5.query_hash)
                                   }) in
                              let errs =
                                FStar_List.map errors_to_report1 all_errs in
                              let errs1 =
-                               let uu____3308 =
+                               let uu___5 =
                                  FStar_All.pipe_right errs FStar_List.flatten in
-                               FStar_All.pipe_right uu____3308 collect in
+                               FStar_All.pipe_right uu___5 collect in
                              let errs2 =
                                FStar_All.pipe_right errs1
                                  (FStar_List.map
-                                    (fun uu____3382 ->
-                                       match uu____3382 with
+                                    (fun uu___5 ->
+                                       match uu___5 with
                                        | ((e, m, r), n) ->
                                            if n > Prims.int_one
                                            then
-                                             let uu____3415 =
-                                               let uu____3416 =
-                                                 let uu____3417 =
+                                             let uu___6 =
+                                               let uu___7 =
+                                                 let uu___8 =
                                                    FStar_Util.string_of_int n in
                                                  FStar_Util.format1
-                                                   " (%s times)" uu____3417 in
-                                               Prims.op_Hat m uu____3416 in
-                                             (e, uu____3415, r)
+                                                   " (%s times)" uu___8 in
+                                               Prims.op_Hat m uu___7 in
+                                             (e, uu___6, r)
                                            else (e, m, r))) in
                              (FStar_Errors.add_errors errs2;
                               (let rng =
                                  match FStar_Pervasives_Native.snd
                                          env.FStar_TypeChecker_Env.qtbl_name_and_index
                                  with
-                                 | FStar_Pervasives_Native.Some
-                                     (l, uu____3430) ->
-                                     FStar_Ident.range_of_lid l
-                                 | uu____3435 -> FStar_Range.dummyRange in
+                                 | FStar_Pervasives_Native.Some (l, uu___6)
+                                     -> FStar_Ident.range_of_lid l
+                                 | uu___6 -> FStar_Range.dummyRange in
                                if quaking
                                then
-                                 let uu____3442 =
-                                   let uu____3451 =
-                                     let uu____3458 =
-                                       let uu____3459 =
+                                 let uu___6 =
+                                   let uu___7 =
+                                     let uu___8 =
+                                       let uu___9 =
                                          FStar_Util.string_of_int nsuccess in
-                                       let uu____3460 =
+                                       let uu___10 =
                                          FStar_Util.string_of_int total_ran in
-                                       let uu____3461 =
+                                       let uu___11 =
                                          FStar_Util.string_of_int lo1 in
-                                       let uu____3462 =
+                                       let uu___12 =
                                          FStar_Util.string_of_int hi1 in
                                        FStar_Util.format6
                                          "Query %s failed the quake test, %s out of %s attempts succeded, but the threshold was %s out of %s%s"
-                                         name uu____3459 uu____3460
-                                         uu____3461 uu____3462
+                                         name uu___9 uu___10 uu___11 uu___12
                                          (if total_ran < hi1
                                           then " (early abort)"
                                           else "") in
-                                     (FStar_Errors.Error_QuakeFailed,
-                                       uu____3458, rng) in
-                                   [uu____3451] in
-                                 FStar_TypeChecker_Err.add_errors env
-                                   uu____3442
+                                     (FStar_Errors.Error_QuakeFailed, uu___8,
+                                       rng) in
+                                   [uu___7] in
+                                 FStar_TypeChecker_Err.add_errors env uu___6
                                else ()))
                            else
                              (let report errs =
                                 report_errors
-                                  (let uu___582_3490 = default_settings in
+                                  (let uu___6 = default_settings in
                                    {
-                                     query_env = (uu___582_3490.query_env);
-                                     query_decl = (uu___582_3490.query_decl);
-                                     query_name = (uu___582_3490.query_name);
-                                     query_index =
-                                       (uu___582_3490.query_index);
-                                     query_range =
-                                       (uu___582_3490.query_range);
-                                     query_fuel = (uu___582_3490.query_fuel);
-                                     query_ifuel =
-                                       (uu___582_3490.query_ifuel);
-                                     query_rlimit =
-                                       (uu___582_3490.query_rlimit);
-                                     query_hint = (uu___582_3490.query_hint);
+                                     query_env = (uu___6.query_env);
+                                     query_decl = (uu___6.query_decl);
+                                     query_name = (uu___6.query_name);
+                                     query_index = (uu___6.query_index);
+                                     query_range = (uu___6.query_range);
+                                     query_fuel = (uu___6.query_fuel);
+                                     query_ifuel = (uu___6.query_ifuel);
+                                     query_rlimit = (uu___6.query_rlimit);
+                                     query_hint = (uu___6.query_hint);
                                      query_errors = errs;
                                      query_all_labels =
-                                       (uu___582_3490.query_all_labels);
-                                     query_suffix =
-                                       (uu___582_3490.query_suffix);
-                                     query_hash = (uu___582_3490.query_hash)
+                                       (uu___6.query_all_labels);
+                                     query_suffix = (uu___6.query_suffix);
+                                     query_hash = (uu___6.query_hash)
                                    }) in
                               FStar_List.iter report all_errs))
                         else ()) in
                  let skip =
                    (FStar_Options.admit_smt_queries ()) ||
-                     (let uu____3498 = FStar_Options.admit_except () in
-                      match uu____3498 with
+                     (let uu___2 = FStar_Options.admit_except () in
+                      match uu___2 with
                       | FStar_Pervasives_Native.Some id ->
                           if FStar_Util.starts_with id "("
                           then
-                            let uu____3502 = full_query_id default_settings in
-                            uu____3502 <> id
+                            let uu___3 = full_query_id default_settings in
+                            uu___3 <> id
                           else default_settings.query_name <> id
                       | FStar_Pervasives_Native.None -> false) in
                  if skip
                  then
-                   let uu____3504 =
+                   let uu___2 =
                      (FStar_Options.record_hints ()) &&
                        (FStar_All.pipe_right next_hint FStar_Util.is_some) in
-                   (if uu____3504
+                   (if uu___2
                     then
-                      let uu____3507 =
+                      let uu___3 =
                         FStar_All.pipe_right next_hint FStar_Util.must in
-                      FStar_All.pipe_right uu____3507 store_hint
+                      FStar_All.pipe_right uu___3 store_hint
                     else ())
                  else quake_and_check_all_configs all_configs)
 type solver_cfg =
@@ -1501,30 +1473,30 @@ let (_last_cfg : solver_cfg FStar_Pervasives_Native.option FStar_ST.ref) =
   FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (get_cfg : FStar_TypeChecker_Env.env -> solver_cfg) =
   fun env ->
-    let uu____3678 = FStar_Options.z3_seed () in
-    let uu____3679 = FStar_Options.z3_cliopt () in
-    let uu____3682 = FStar_Options.smtencoding_valid_intro () in
-    let uu____3683 = FStar_Options.smtencoding_valid_elim () in
+    let uu___ = FStar_Options.z3_seed () in
+    let uu___1 = FStar_Options.z3_cliopt () in
+    let uu___2 = FStar_Options.smtencoding_valid_intro () in
+    let uu___3 = FStar_Options.smtencoding_valid_elim () in
     {
-      seed = uu____3678;
-      cliopt = uu____3679;
+      seed = uu___;
+      cliopt = uu___1;
       facts = (env.FStar_TypeChecker_Env.proof_ns);
-      valid_intro = uu____3682;
-      valid_elim = uu____3683
+      valid_intro = uu___2;
+      valid_elim = uu___3
     }
 let (save_cfg : FStar_TypeChecker_Env.env -> unit) =
   fun env ->
-    let uu____3689 =
-      let uu____3692 = get_cfg env in FStar_Pervasives_Native.Some uu____3692 in
-    FStar_ST.op_Colon_Equals _last_cfg uu____3689
+    let uu___ =
+      let uu___1 = get_cfg env in FStar_Pervasives_Native.Some uu___1 in
+    FStar_ST.op_Colon_Equals _last_cfg uu___
 let (should_refresh : FStar_TypeChecker_Env.env -> Prims.bool) =
   fun env ->
-    let uu____3708 = FStar_ST.op_Bang _last_cfg in
-    match uu____3708 with
+    let uu___ = FStar_ST.op_Bang _last_cfg in
+    match uu___ with
     | FStar_Pervasives_Native.None -> (save_cfg env; false)
     | FStar_Pervasives_Native.Some cfg ->
-        let uu____3723 = let uu____3724 = get_cfg env in cfg = uu____3724 in
-        Prims.op_Negation uu____3723
+        let uu___1 = let uu___2 = get_cfg env in cfg = uu___2 in
+        Prims.op_Negation uu___1
 let (do_solve :
   (unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> unit)
@@ -1532,30 +1504,30 @@ let (do_solve :
   fun use_env_msg ->
     fun tcenv ->
       fun q ->
-        (let uu____3750 = should_refresh tcenv in
-         if uu____3750
+        (let uu___1 = should_refresh tcenv in
+         if uu___1
          then (save_cfg tcenv; FStar_SMTEncoding_Z3.refresh ())
          else ());
-        (let uu____3754 =
-           let uu____3755 =
-             let uu____3756 = FStar_TypeChecker_Env.get_range tcenv in
-             FStar_All.pipe_left FStar_Range.string_of_range uu____3756 in
-           FStar_Util.format1 "Starting query at %s" uu____3755 in
-         FStar_SMTEncoding_Encode.push uu____3754);
-        (let pop uu____3762 =
-           let uu____3763 =
-             let uu____3764 =
-               let uu____3765 = FStar_TypeChecker_Env.get_range tcenv in
-               FStar_All.pipe_left FStar_Range.string_of_range uu____3765 in
-             FStar_Util.format1 "Ending query at %s" uu____3764 in
-           FStar_SMTEncoding_Encode.pop uu____3763 in
+        (let uu___2 =
+           let uu___3 =
+             let uu___4 = FStar_TypeChecker_Env.get_range tcenv in
+             FStar_All.pipe_left FStar_Range.string_of_range uu___4 in
+           FStar_Util.format1 "Starting query at %s" uu___3 in
+         FStar_SMTEncoding_Encode.push uu___2);
+        (let pop uu___2 =
+           let uu___3 =
+             let uu___4 =
+               let uu___5 = FStar_TypeChecker_Env.get_range tcenv in
+               FStar_All.pipe_left FStar_Range.string_of_range uu___5 in
+             FStar_Util.format1 "Ending query at %s" uu___4 in
+           FStar_SMTEncoding_Encode.pop uu___3 in
          try
-           (fun uu___623_3779 ->
+           (fun uu___2 ->
               match () with
               | () ->
-                  let uu____3780 =
+                  let uu___3 =
                     FStar_SMTEncoding_Encode.encode_query use_env_msg tcenv q in
-                  (match uu____3780 with
+                  (match uu___3 with
                    | (prefix, labels, qry, suffix) ->
                        let tcenv1 =
                          FStar_TypeChecker_Env.incr_query_index tcenv in
@@ -1566,42 +1538,39 @@ let (do_solve :
                                 {
                                   FStar_SMTEncoding_Term.tm =
                                     FStar_SMTEncoding_Term.App
-                                    (FStar_SMTEncoding_Term.FalseOp,
-                                     uu____3812);
-                                  FStar_SMTEncoding_Term.freevars =
-                                    uu____3813;
-                                  FStar_SMTEncoding_Term.rng = uu____3814;_};
+                                    (FStar_SMTEncoding_Term.FalseOp, uu___4);
+                                  FStar_SMTEncoding_Term.freevars = uu___5;
+                                  FStar_SMTEncoding_Term.rng = uu___6;_};
                               FStar_SMTEncoding_Term.assumption_caption =
-                                uu____3815;
-                              FStar_SMTEncoding_Term.assumption_name =
-                                uu____3816;
+                                uu___7;
+                              FStar_SMTEncoding_Term.assumption_name = uu___8;
                               FStar_SMTEncoding_Term.assumption_fact_ids =
-                                uu____3817;_}
+                                uu___9;_}
                             -> pop ()
-                        | uu____3834 when tcenv1.FStar_TypeChecker_Env.admit
-                            -> pop ()
-                        | FStar_SMTEncoding_Term.Assume uu____3835 ->
+                        | uu___4 when tcenv1.FStar_TypeChecker_Env.admit ->
+                            pop ()
+                        | FStar_SMTEncoding_Term.Assume uu___4 ->
                             (ask_and_report_errors tcenv1 labels prefix qry
                                suffix;
                              pop ())
-                        | uu____3837 -> failwith "Impossible"))) ()
+                        | uu___4 -> failwith "Impossible"))) ()
          with
          | FStar_SMTEncoding_Env.Inner_let_rec names ->
              (pop ();
-              (let uu____3851 =
-                 let uu____3860 =
-                   let uu____3867 =
-                     let uu____3868 =
-                       let uu____3869 =
+              (let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 =
+                       let uu___8 =
                          FStar_List.map FStar_Pervasives_Native.fst names in
-                       FStar_String.concat "," uu____3869 in
+                       FStar_String.concat "," uu___8 in
                      FStar_Util.format1
                        "Could not encode the query since F* does not support precise smtencoding of inner let-recs yet (in this case %s)"
-                       uu____3868 in
+                       uu___7 in
                    (FStar_Errors.Error_NonTopRecFunctionNotFullyEncoded,
-                     uu____3867, (tcenv.FStar_TypeChecker_Env.range)) in
-                 [uu____3860] in
-               FStar_TypeChecker_Err.add_errors tcenv uu____3851)))
+                     uu___6, (tcenv.FStar_TypeChecker_Env.range)) in
+                 [uu___5] in
+               FStar_TypeChecker_Err.add_errors tcenv uu___4)))
 let (solve :
   (unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> unit)
@@ -1609,28 +1578,28 @@ let (solve :
   fun use_env_msg ->
     fun tcenv ->
       fun q ->
-        let uu____3912 = FStar_Options.no_smt () in
-        if uu____3912
+        let uu___ = FStar_Options.no_smt () in
+        if uu___
         then
-          let uu____3913 =
-            let uu____3922 =
-              let uu____3929 =
-                let uu____3930 = FStar_Syntax_Print.term_to_string q in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string q in
                 FStar_Util.format1
                   "Q = %s\nA query could not be solved internally, and --no_smt was given"
-                  uu____3930 in
-              (FStar_Errors.Error_NoSMTButNeeded, uu____3929,
+                  uu___4 in
+              (FStar_Errors.Error_NoSMTButNeeded, uu___3,
                 (tcenv.FStar_TypeChecker_Env.range)) in
-            [uu____3922] in
-          FStar_TypeChecker_Err.add_errors tcenv uu____3913
+            [uu___2] in
+          FStar_TypeChecker_Err.add_errors tcenv uu___1
         else
-          (let uu____3944 =
-             let uu____3947 =
-               let uu____3948 = FStar_TypeChecker_Env.current_module tcenv in
-               FStar_Ident.string_of_lid uu____3948 in
-             FStar_Pervasives_Native.Some uu____3947 in
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_TypeChecker_Env.current_module tcenv in
+               FStar_Ident.string_of_lid uu___4 in
+             FStar_Pervasives_Native.Some uu___3 in
            FStar_Profiling.profile
-             (fun uu____3950 -> do_solve use_env_msg tcenv q) uu____3944
+             (fun uu___3 -> do_solve use_env_msg tcenv q) uu___2
              "FStar.TypeChecker.SMTEncoding.solve_top_level")
 let (solver : FStar_TypeChecker_Env.solver_t) =
   {
@@ -1644,32 +1613,28 @@ let (solver : FStar_TypeChecker_Env.solver_t) =
     FStar_TypeChecker_Env.preprocess =
       (fun e ->
          fun g ->
-           let uu____3962 =
-             let uu____3969 = FStar_Options.peek () in (e, g, uu____3969) in
-           [uu____3962]);
+           let uu___ = let uu___1 = FStar_Options.peek () in (e, g, uu___1) in
+           [uu___]);
     FStar_TypeChecker_Env.solve = solve;
     FStar_TypeChecker_Env.finish = FStar_SMTEncoding_Z3.finish;
     FStar_TypeChecker_Env.refresh = FStar_SMTEncoding_Z3.refresh
   }
 let (dummy : FStar_TypeChecker_Env.solver_t) =
   {
-    FStar_TypeChecker_Env.init = (fun uu____3984 -> ());
-    FStar_TypeChecker_Env.push = (fun uu____3986 -> ());
-    FStar_TypeChecker_Env.pop = (fun uu____3988 -> ());
+    FStar_TypeChecker_Env.init = (fun uu___ -> ());
+    FStar_TypeChecker_Env.push = (fun uu___ -> ());
+    FStar_TypeChecker_Env.pop = (fun uu___ -> ());
     FStar_TypeChecker_Env.snapshot =
-      (fun uu____3990 ->
-         ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    FStar_TypeChecker_Env.rollback = (fun uu____3999 -> fun uu____4000 -> ());
-    FStar_TypeChecker_Env.encode_sig =
-      (fun uu____4011 -> fun uu____4012 -> ());
+      (fun uu___ -> ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
+    FStar_TypeChecker_Env.rollback = (fun uu___ -> fun uu___1 -> ());
+    FStar_TypeChecker_Env.encode_sig = (fun uu___ -> fun uu___1 -> ());
     FStar_TypeChecker_Env.preprocess =
       (fun e ->
          fun g ->
-           let uu____4018 =
-             let uu____4025 = FStar_Options.peek () in (e, g, uu____4025) in
-           [uu____4018]);
+           let uu___ = let uu___1 = FStar_Options.peek () in (e, g, uu___1) in
+           [uu___]);
     FStar_TypeChecker_Env.solve =
-      (fun uu____4041 -> fun uu____4042 -> fun uu____4043 -> ());
-    FStar_TypeChecker_Env.finish = (fun uu____4049 -> ());
-    FStar_TypeChecker_Env.refresh = (fun uu____4051 -> ())
+      (fun uu___ -> fun uu___1 -> fun uu___2 -> ());
+    FStar_TypeChecker_Env.finish = (fun uu___ -> ());
+    FStar_TypeChecker_Env.refresh = (fun uu___ -> ())
   }

--- a/src/ocaml-output/FStar_SMTEncoding_Term.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Term.ml
@@ -12,38 +12,31 @@ type sort =
   | Arrow of (sort * sort) 
   | Sort of Prims.string 
 let (uu___is_Bool_sort : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Bool_sort -> true | uu____49 -> false
+  fun projectee -> match projectee with | Bool_sort -> true | uu___ -> false
 let (uu___is_Int_sort : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Int_sort -> true | uu____55 -> false
+  fun projectee -> match projectee with | Int_sort -> true | uu___ -> false
 let (uu___is_String_sort : sort -> Prims.bool) =
   fun projectee ->
-    match projectee with | String_sort -> true | uu____61 -> false
+    match projectee with | String_sort -> true | uu___ -> false
 let (uu___is_Term_sort : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Term_sort -> true | uu____67 -> false
+  fun projectee -> match projectee with | Term_sort -> true | uu___ -> false
 let (uu___is_Fuel_sort : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Fuel_sort -> true | uu____73 -> false
+  fun projectee -> match projectee with | Fuel_sort -> true | uu___ -> false
 let (uu___is_BitVec_sort : sort -> Prims.bool) =
   fun projectee ->
-    match projectee with | BitVec_sort _0 -> true | uu____80 -> false
+    match projectee with | BitVec_sort _0 -> true | uu___ -> false
 let (__proj__BitVec_sort__item___0 : sort -> Prims.int) =
   fun projectee -> match projectee with | BitVec_sort _0 -> _0
 let (uu___is_Array : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Array _0 -> true | uu____97 -> false
+  fun projectee -> match projectee with | Array _0 -> true | uu___ -> false
 let (__proj__Array__item___0 : sort -> (sort * sort)) =
   fun projectee -> match projectee with | Array _0 -> _0
 let (uu___is_Arrow : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Arrow _0 -> true | uu____126 -> false
+  fun projectee -> match projectee with | Arrow _0 -> true | uu___ -> false
 let (__proj__Arrow__item___0 : sort -> (sort * sort)) =
   fun projectee -> match projectee with | Arrow _0 -> _0
 let (uu___is_Sort : sort -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Sort _0 -> true | uu____151 -> false
+  fun projectee -> match projectee with | Sort _0 -> true | uu___ -> false
 let (__proj__Sort__item___0 : sort -> Prims.string) =
   fun projectee -> match projectee with | Sort _0 -> _0
 let rec (strSort : sort -> Prims.string) =
@@ -55,16 +48,16 @@ let rec (strSort : sort -> Prims.string) =
     | String_sort -> "FString"
     | Fuel_sort -> "Fuel"
     | BitVec_sort n ->
-        let uu____164 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "(_ BitVec %s)" uu____164
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "(_ BitVec %s)" uu___
     | Array (s1, s2) ->
-        let uu____167 = strSort s1 in
-        let uu____168 = strSort s2 in
-        FStar_Util.format2 "(Array %s %s)" uu____167 uu____168
+        let uu___ = strSort s1 in
+        let uu___1 = strSort s2 in
+        FStar_Util.format2 "(Array %s %s)" uu___ uu___1
     | Arrow (s1, s2) ->
-        let uu____171 = strSort s1 in
-        let uu____172 = strSort s2 in
-        FStar_Util.format2 "(%s -> %s)" uu____171 uu____172
+        let uu___ = strSort s1 in
+        let uu___1 = strSort s2 in
+        FStar_Util.format2 "(%s -> %s)" uu___ uu___1
     | Sort s -> s
 type op =
   | TrueOp 
@@ -103,93 +96,88 @@ type op =
   | ITE 
   | Var of Prims.string 
 let (uu___is_TrueOp : op -> Prims.bool) =
-  fun projectee -> match projectee with | TrueOp -> true | uu____194 -> false
+  fun projectee -> match projectee with | TrueOp -> true | uu___ -> false
 let (uu___is_FalseOp : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FalseOp -> true | uu____200 -> false
+  fun projectee -> match projectee with | FalseOp -> true | uu___ -> false
 let (uu___is_Not : op -> Prims.bool) =
-  fun projectee -> match projectee with | Not -> true | uu____206 -> false
+  fun projectee -> match projectee with | Not -> true | uu___ -> false
 let (uu___is_And : op -> Prims.bool) =
-  fun projectee -> match projectee with | And -> true | uu____212 -> false
+  fun projectee -> match projectee with | And -> true | uu___ -> false
 let (uu___is_Or : op -> Prims.bool) =
-  fun projectee -> match projectee with | Or -> true | uu____218 -> false
+  fun projectee -> match projectee with | Or -> true | uu___ -> false
 let (uu___is_Imp : op -> Prims.bool) =
-  fun projectee -> match projectee with | Imp -> true | uu____224 -> false
+  fun projectee -> match projectee with | Imp -> true | uu___ -> false
 let (uu___is_Iff : op -> Prims.bool) =
-  fun projectee -> match projectee with | Iff -> true | uu____230 -> false
+  fun projectee -> match projectee with | Iff -> true | uu___ -> false
 let (uu___is_Eq : op -> Prims.bool) =
-  fun projectee -> match projectee with | Eq -> true | uu____236 -> false
+  fun projectee -> match projectee with | Eq -> true | uu___ -> false
 let (uu___is_LT : op -> Prims.bool) =
-  fun projectee -> match projectee with | LT -> true | uu____242 -> false
+  fun projectee -> match projectee with | LT -> true | uu___ -> false
 let (uu___is_LTE : op -> Prims.bool) =
-  fun projectee -> match projectee with | LTE -> true | uu____248 -> false
+  fun projectee -> match projectee with | LTE -> true | uu___ -> false
 let (uu___is_GT : op -> Prims.bool) =
-  fun projectee -> match projectee with | GT -> true | uu____254 -> false
+  fun projectee -> match projectee with | GT -> true | uu___ -> false
 let (uu___is_GTE : op -> Prims.bool) =
-  fun projectee -> match projectee with | GTE -> true | uu____260 -> false
+  fun projectee -> match projectee with | GTE -> true | uu___ -> false
 let (uu___is_Add : op -> Prims.bool) =
-  fun projectee -> match projectee with | Add -> true | uu____266 -> false
+  fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_Sub : op -> Prims.bool) =
-  fun projectee -> match projectee with | Sub -> true | uu____272 -> false
+  fun projectee -> match projectee with | Sub -> true | uu___ -> false
 let (uu___is_Div : op -> Prims.bool) =
-  fun projectee -> match projectee with | Div -> true | uu____278 -> false
+  fun projectee -> match projectee with | Div -> true | uu___ -> false
 let (uu___is_RealDiv : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | RealDiv -> true | uu____284 -> false
+  fun projectee -> match projectee with | RealDiv -> true | uu___ -> false
 let (uu___is_Mul : op -> Prims.bool) =
-  fun projectee -> match projectee with | Mul -> true | uu____290 -> false
+  fun projectee -> match projectee with | Mul -> true | uu___ -> false
 let (uu___is_Minus : op -> Prims.bool) =
-  fun projectee -> match projectee with | Minus -> true | uu____296 -> false
+  fun projectee -> match projectee with | Minus -> true | uu___ -> false
 let (uu___is_Mod : op -> Prims.bool) =
-  fun projectee -> match projectee with | Mod -> true | uu____302 -> false
+  fun projectee -> match projectee with | Mod -> true | uu___ -> false
 let (uu___is_BvAnd : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvAnd -> true | uu____308 -> false
+  fun projectee -> match projectee with | BvAnd -> true | uu___ -> false
 let (uu___is_BvXor : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvXor -> true | uu____314 -> false
+  fun projectee -> match projectee with | BvXor -> true | uu___ -> false
 let (uu___is_BvOr : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvOr -> true | uu____320 -> false
+  fun projectee -> match projectee with | BvOr -> true | uu___ -> false
 let (uu___is_BvAdd : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvAdd -> true | uu____326 -> false
+  fun projectee -> match projectee with | BvAdd -> true | uu___ -> false
 let (uu___is_BvSub : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvSub -> true | uu____332 -> false
+  fun projectee -> match projectee with | BvSub -> true | uu___ -> false
 let (uu___is_BvShl : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvShl -> true | uu____338 -> false
+  fun projectee -> match projectee with | BvShl -> true | uu___ -> false
 let (uu___is_BvShr : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvShr -> true | uu____344 -> false
+  fun projectee -> match projectee with | BvShr -> true | uu___ -> false
 let (uu___is_BvUdiv : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvUdiv -> true | uu____350 -> false
+  fun projectee -> match projectee with | BvUdiv -> true | uu___ -> false
 let (uu___is_BvMod : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvMod -> true | uu____356 -> false
+  fun projectee -> match projectee with | BvMod -> true | uu___ -> false
 let (uu___is_BvMul : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvMul -> true | uu____362 -> false
+  fun projectee -> match projectee with | BvMul -> true | uu___ -> false
 let (uu___is_BvUlt : op -> Prims.bool) =
-  fun projectee -> match projectee with | BvUlt -> true | uu____368 -> false
+  fun projectee -> match projectee with | BvUlt -> true | uu___ -> false
 let (uu___is_BvUext : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BvUext _0 -> true | uu____375 -> false
+  fun projectee -> match projectee with | BvUext _0 -> true | uu___ -> false
 let (__proj__BvUext__item___0 : op -> Prims.int) =
   fun projectee -> match projectee with | BvUext _0 -> _0
 let (uu___is_NatToBv : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NatToBv _0 -> true | uu____388 -> false
+  fun projectee -> match projectee with | NatToBv _0 -> true | uu___ -> false
 let (__proj__NatToBv__item___0 : op -> Prims.int) =
   fun projectee -> match projectee with | NatToBv _0 -> _0
 let (uu___is_BvToNat : op -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BvToNat -> true | uu____400 -> false
+  fun projectee -> match projectee with | BvToNat -> true | uu___ -> false
 let (uu___is_ITE : op -> Prims.bool) =
-  fun projectee -> match projectee with | ITE -> true | uu____406 -> false
+  fun projectee -> match projectee with | ITE -> true | uu___ -> false
 let (uu___is_Var : op -> Prims.bool) =
-  fun projectee -> match projectee with | Var _0 -> true | uu____413 -> false
+  fun projectee -> match projectee with | Var _0 -> true | uu___ -> false
 let (__proj__Var__item___0 : op -> Prims.string) =
   fun projectee -> match projectee with | Var _0 -> _0
 type qop =
   | Forall 
   | Exists 
 let (uu___is_Forall : qop -> Prims.bool) =
-  fun projectee -> match projectee with | Forall -> true | uu____425 -> false
+  fun projectee -> match projectee with | Forall -> true | uu___ -> false
 let (uu___is_Exists : qop -> Prims.bool) =
-  fun projectee -> match projectee with | Exists -> true | uu____431 -> false
+  fun projectee -> match projectee with | Exists -> true | uu___ -> false
 type term' =
   | Integer of Prims.string 
   | String of Prims.string 
@@ -209,55 +197,47 @@ and term =
     (Prims.string * sort * Prims.bool) Prims.list FStar_Syntax_Syntax.memo ;
   rng: FStar_Range.range }
 let (uu___is_Integer : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Integer _0 -> true | uu____561 -> false
+  fun projectee -> match projectee with | Integer _0 -> true | uu___ -> false
 let (__proj__Integer__item___0 : term' -> Prims.string) =
   fun projectee -> match projectee with | Integer _0 -> _0
 let (uu___is_String : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | String _0 -> true | uu____574 -> false
+  fun projectee -> match projectee with | String _0 -> true | uu___ -> false
 let (__proj__String__item___0 : term' -> Prims.string) =
   fun projectee -> match projectee with | String _0 -> _0
 let (uu___is_Real : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Real _0 -> true | uu____587 -> false
+  fun projectee -> match projectee with | Real _0 -> true | uu___ -> false
 let (__proj__Real__item___0 : term' -> Prims.string) =
   fun projectee -> match projectee with | Real _0 -> _0
 let (uu___is_BoundV : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BoundV _0 -> true | uu____600 -> false
+  fun projectee -> match projectee with | BoundV _0 -> true | uu___ -> false
 let (__proj__BoundV__item___0 : term' -> Prims.int) =
   fun projectee -> match projectee with | BoundV _0 -> _0
 let (uu___is_FreeV : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FreeV _0 -> true | uu____619 -> false
+  fun projectee -> match projectee with | FreeV _0 -> true | uu___ -> false
 let (__proj__FreeV__item___0 : term' -> (Prims.string * sort * Prims.bool)) =
   fun projectee -> match projectee with | FreeV _0 -> _0
 let (uu___is_App : term' -> Prims.bool) =
-  fun projectee -> match projectee with | App _0 -> true | uu____656 -> false
+  fun projectee -> match projectee with | App _0 -> true | uu___ -> false
 let (__proj__App__item___0 : term' -> (op * term Prims.list)) =
   fun projectee -> match projectee with | App _0 -> _0
 let (uu___is_Quant : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Quant _0 -> true | uu____705 -> false
+  fun projectee -> match projectee with | Quant _0 -> true | uu___ -> false
 let (__proj__Quant__item___0 :
   term' ->
     (qop * term Prims.list Prims.list * Prims.int
       FStar_Pervasives_Native.option * sort Prims.list * term))
   = fun projectee -> match projectee with | Quant _0 -> _0
 let (uu___is_Let : term' -> Prims.bool) =
-  fun projectee -> match projectee with | Let _0 -> true | uu____778 -> false
+  fun projectee -> match projectee with | Let _0 -> true | uu___ -> false
 let (__proj__Let__item___0 : term' -> (term Prims.list * term)) =
   fun projectee -> match projectee with | Let _0 -> _0
 let (uu___is_Labeled : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Labeled _0 -> true | uu____815 -> false
+  fun projectee -> match projectee with | Labeled _0 -> true | uu___ -> false
 let (__proj__Labeled__item___0 :
   term' -> (term * Prims.string * FStar_Range.range)) =
   fun projectee -> match projectee with | Labeled _0 -> _0
 let (uu___is_LblPos : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LblPos _0 -> true | uu____850 -> false
+  fun projectee -> match projectee with | LblPos _0 -> true | uu___ -> false
 let (__proj__LblPos__item___0 : term' -> (term * Prims.string)) =
   fun projectee -> match projectee with | LblPos _0 -> _0
 let (__proj__Mkterm__item__tm : term -> term') =
@@ -284,18 +264,16 @@ type fact_db_id =
   | Namespace of FStar_Ident.lid 
   | Tag of Prims.string 
 let (uu___is_Name : fact_db_id -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Name _0 -> true | uu____1006 -> false
+  fun projectee -> match projectee with | Name _0 -> true | uu___ -> false
 let (__proj__Name__item___0 : fact_db_id -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Name _0 -> _0
 let (uu___is_Namespace : fact_db_id -> Prims.bool) =
   fun projectee ->
-    match projectee with | Namespace _0 -> true | uu____1019 -> false
+    match projectee with | Namespace _0 -> true | uu___ -> false
 let (__proj__Namespace__item___0 : fact_db_id -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Namespace _0 -> _0
 let (uu___is_Tag : fact_db_id -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tag _0 -> true | uu____1032 -> false
+  fun projectee -> match projectee with | Tag _0 -> true | uu___ -> false
 let (__proj__Tag__item___0 : fact_db_id -> Prims.string) =
   fun projectee -> match projectee with | Tag _0 -> _0
 type assumption =
@@ -345,71 +323,63 @@ type decl =
   | GetStatistics 
   | GetReasonUnknown 
 let (uu___is_DefPrelude : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | DefPrelude -> true | uu____1193 -> false
+  fun projectee -> match projectee with | DefPrelude -> true | uu___ -> false
 let (uu___is_DeclFun : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | DeclFun _0 -> true | uu____1210 -> false
+  fun projectee -> match projectee with | DeclFun _0 -> true | uu___ -> false
 let (__proj__DeclFun__item___0 :
   decl -> (Prims.string * sort Prims.list * sort * caption)) =
   fun projectee -> match projectee with | DeclFun _0 -> _0
 let (uu___is_DefineFun : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | DefineFun _0 -> true | uu____1265 -> false
+    match projectee with | DefineFun _0 -> true | uu___ -> false
 let (__proj__DefineFun__item___0 :
   decl -> (Prims.string * sort Prims.list * sort * term * caption)) =
   fun projectee -> match projectee with | DefineFun _0 -> _0
 let (uu___is_Assume : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assume _0 -> true | uu____1314 -> false
+  fun projectee -> match projectee with | Assume _0 -> true | uu___ -> false
 let (__proj__Assume__item___0 : decl -> assumption) =
   fun projectee -> match projectee with | Assume _0 -> _0
 let (uu___is_Caption : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Caption _0 -> true | uu____1327 -> false
+  fun projectee -> match projectee with | Caption _0 -> true | uu___ -> false
 let (__proj__Caption__item___0 : decl -> Prims.string) =
   fun projectee -> match projectee with | Caption _0 -> _0
 let (uu___is_Module : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Module _0 -> true | uu____1346 -> false
+  fun projectee -> match projectee with | Module _0 -> true | uu___ -> false
 let (__proj__Module__item___0 : decl -> (Prims.string * decl Prims.list)) =
   fun projectee -> match projectee with | Module _0 -> _0
 let (uu___is_Eval : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Eval _0 -> true | uu____1377 -> false
+  fun projectee -> match projectee with | Eval _0 -> true | uu___ -> false
 let (__proj__Eval__item___0 : decl -> term) =
   fun projectee -> match projectee with | Eval _0 -> _0
 let (uu___is_Echo : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Echo _0 -> true | uu____1390 -> false
+  fun projectee -> match projectee with | Echo _0 -> true | uu___ -> false
 let (__proj__Echo__item___0 : decl -> Prims.string) =
   fun projectee -> match projectee with | Echo _0 -> _0
 let (uu___is_RetainAssumptions : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | RetainAssumptions _0 -> true | uu____1405 -> false
+    match projectee with | RetainAssumptions _0 -> true | uu___ -> false
 let (__proj__RetainAssumptions__item___0 : decl -> Prims.string Prims.list) =
   fun projectee -> match projectee with | RetainAssumptions _0 -> _0
 let (uu___is_Push : decl -> Prims.bool) =
-  fun projectee -> match projectee with | Push -> true | uu____1423 -> false
+  fun projectee -> match projectee with | Push -> true | uu___ -> false
 let (uu___is_Pop : decl -> Prims.bool) =
-  fun projectee -> match projectee with | Pop -> true | uu____1429 -> false
+  fun projectee -> match projectee with | Pop -> true | uu___ -> false
 let (uu___is_CheckSat : decl -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CheckSat -> true | uu____1435 -> false
+  fun projectee -> match projectee with | CheckSat -> true | uu___ -> false
 let (uu___is_GetUnsatCore : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | GetUnsatCore -> true | uu____1441 -> false
+    match projectee with | GetUnsatCore -> true | uu___ -> false
 let (uu___is_SetOption : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | SetOption _0 -> true | uu____1452 -> false
+    match projectee with | SetOption _0 -> true | uu___ -> false
 let (__proj__SetOption__item___0 : decl -> (Prims.string * Prims.string)) =
   fun projectee -> match projectee with | SetOption _0 -> _0
 let (uu___is_GetStatistics : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | GetStatistics -> true | uu____1476 -> false
+    match projectee with | GetStatistics -> true | uu___ -> false
 let (uu___is_GetReasonUnknown : decl -> Prims.bool) =
   fun projectee ->
-    match projectee with | GetReasonUnknown -> true | uu____1482 -> false
+    match projectee with | GetReasonUnknown -> true | uu___ -> false
 type decls_elt =
   {
   sym_name: Prims.string FStar_Pervasives_Native.option ;
@@ -440,8 +410,8 @@ let (mk_decls :
     fun key ->
       fun decls ->
         fun aux_decls ->
-          let uu____1625 =
-            let uu____1626 =
+          let uu___ =
+            let uu___1 =
               let sm = FStar_Util.smap_create (Prims.of_int (20)) in
               FStar_List.iter
                 (fun elt ->
@@ -451,113 +421,104 @@ let (mk_decls :
                 (fun d ->
                    match d with
                    | Assume a -> FStar_Util.smap_add sm a.assumption_name "0"
-                   | uu____1642 -> ()) decls;
+                   | uu___4 -> ()) decls;
               FStar_Util.smap_keys sm in
             {
               sym_name = (FStar_Pervasives_Native.Some name);
               key = (FStar_Pervasives_Native.Some key);
               decls;
-              a_names = uu____1626
+              a_names = uu___1
             } in
-          [uu____1625]
+          [uu___]
 let (mk_decls_trivial : decl Prims.list -> decls_t) =
   fun decls ->
-    let uu____1652 =
-      let uu____1653 =
+    let uu___ =
+      let uu___1 =
         FStar_List.collect
-          (fun uu___0_1658 ->
-             match uu___0_1658 with
+          (fun uu___2 ->
+             match uu___2 with
              | Assume a -> [a.assumption_name]
-             | uu____1662 -> []) decls in
+             | uu___3 -> []) decls in
       {
         sym_name = FStar_Pervasives_Native.None;
         key = FStar_Pervasives_Native.None;
         decls;
-        a_names = uu____1653
+        a_names = uu___1
       } in
-    [uu____1652]
+    [uu___]
 let (decls_list_of : decls_t -> decl Prims.list) =
   fun l -> FStar_All.pipe_right l (FStar_List.collect (fun elt -> elt.decls))
 type error_label = (fv * Prims.string * FStar_Range.range)
 type error_labels = error_label Prims.list
 let (mk_fv : (Prims.string * sort) -> fv) =
-  fun uu____1692 -> match uu____1692 with | (x, y) -> (x, y, false)
+  fun uu___ -> match uu___ with | (x, y) -> (x, y, false)
 let (fv_name : fv -> Prims.string) =
-  fun x ->
-    let uu____1704 = x in
-    match uu____1704 with | (nm, uu____1706, uu____1707) -> nm
+  fun x -> let uu___ = x in match uu___ with | (nm, uu___1, uu___2) -> nm
 let (fv_sort : fv -> sort) =
   fun x ->
-    let uu____1713 = x in
-    match uu____1713 with | (uu____1714, sort1, uu____1716) -> sort1
+    let uu___ = x in match uu___ with | (uu___1, sort1, uu___2) -> sort1
 let (fv_force : fv -> Prims.bool) =
   fun x ->
-    let uu____1722 = x in
-    match uu____1722 with | (uu____1723, uu____1724, force) -> force
+    let uu___ = x in match uu___ with | (uu___1, uu___2, force) -> force
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun x ->
     fun y ->
-      let uu____1736 = fv_name x in
-      let uu____1737 = fv_name y in uu____1736 = uu____1737
+      let uu___ = fv_name x in let uu___1 = fv_name y in uu___ = uu___1
 let (fvs_subset_of : fvs -> fvs -> Prims.bool) =
   fun x ->
     fun y ->
       let cmp_fv x1 y1 =
-        let uu____1759 = fv_name x1 in
-        let uu____1760 = fv_name y1 in
-        FStar_Util.compare uu____1759 uu____1760 in
-      let uu____1761 = FStar_Util.as_set x cmp_fv in
-      let uu____1776 = FStar_Util.as_set y cmp_fv in
-      FStar_Util.set_is_subset_of uu____1761 uu____1776
+        let uu___ = fv_name x1 in
+        let uu___1 = fv_name y1 in FStar_Util.compare uu___ uu___1 in
+      let uu___ = FStar_Util.as_set x cmp_fv in
+      let uu___1 = FStar_Util.as_set y cmp_fv in
+      FStar_Util.set_is_subset_of uu___ uu___1
 let (freevar_eq : term -> term -> Prims.bool) =
   fun x ->
     fun y ->
       match ((x.tm), (y.tm)) with
       | (FreeV x1, FreeV y1) -> fv_eq x1 y1
-      | uu____1821 -> false
+      | uu___ -> false
 let (freevar_sort : term -> sort) =
-  fun uu___1_1830 ->
-    match uu___1_1830 with
-    | { tm = FreeV x; freevars = uu____1832; rng = uu____1833;_} -> fv_sort x
-    | uu____1850 -> failwith "impossible"
+  fun uu___ ->
+    match uu___ with
+    | { tm = FreeV x; freevars = uu___1; rng = uu___2;_} -> fv_sort x
+    | uu___1 -> failwith "impossible"
 let (fv_of_term : term -> fv) =
-  fun uu___2_1855 ->
-    match uu___2_1855 with
-    | { tm = FreeV fv1; freevars = uu____1857; rng = uu____1858;_} -> fv1
-    | uu____1875 -> failwith "impossible"
+  fun uu___ ->
+    match uu___ with
+    | { tm = FreeV fv1; freevars = uu___1; rng = uu___2;_} -> fv1
+    | uu___1 -> failwith "impossible"
 let rec (freevars : term -> (Prims.string * sort * Prims.bool) Prims.list) =
   fun t ->
     match t.tm with
-    | Integer uu____1897 -> []
-    | String uu____1904 -> []
-    | Real uu____1911 -> []
-    | BoundV uu____1918 -> []
+    | Integer uu___ -> []
+    | String uu___ -> []
+    | Real uu___ -> []
+    | BoundV uu___ -> []
     | FreeV fv1 when fv_force fv1 -> []
     | FreeV fv1 -> [fv1]
-    | App (uu____1957, tms) -> FStar_List.collect freevars tms
-    | Quant (uu____1969, uu____1970, uu____1971, uu____1972, t1) ->
-        freevars t1
-    | Labeled (t1, uu____1991, uu____1992) -> freevars t1
-    | LblPos (t1, uu____1994) -> freevars t1
+    | App (uu___, tms) -> FStar_List.collect freevars tms
+    | Quant (uu___, uu___1, uu___2, uu___3, t1) -> freevars t1
+    | Labeled (t1, uu___, uu___1) -> freevars t1
+    | LblPos (t1, uu___) -> freevars t1
     | Let (es, body) -> FStar_List.collect freevars (body :: es)
 let (free_variables : term -> fvs) =
   fun t ->
-    let uu____2012 = FStar_ST.op_Bang t.freevars in
-    match uu____2012 with
+    let uu___ = FStar_ST.op_Bang t.freevars in
+    match uu___ with
     | FStar_Pervasives_Native.Some b -> b
     | FStar_Pervasives_Native.None ->
         let fvs1 =
-          let uu____2083 = freevars t in
-          FStar_Util.remove_dups fv_eq uu____2083 in
+          let uu___1 = freevars t in FStar_Util.remove_dups fv_eq uu___1 in
         (FStar_ST.op_Colon_Equals t.freevars
            (FStar_Pervasives_Native.Some fvs1);
          fvs1)
 let (qop_to_string : qop -> Prims.string) =
-  fun uu___3_2137 ->
-    match uu___3_2137 with | Forall -> "forall" | Exists -> "exists"
+  fun uu___ -> match uu___ with | Forall -> "forall" | Exists -> "exists"
 let (op_to_string : op -> Prims.string) =
-  fun uu___4_2142 ->
-    match uu___4_2142 with
+  fun uu___ ->
+    match uu___ with
     | TrueOp -> "true"
     | FalseOp -> "false"
     | Not -> "not"
@@ -591,20 +552,20 @@ let (op_to_string : op -> Prims.string) =
     | BvUlt -> "bvult"
     | BvToNat -> "bv2int"
     | BvUext n ->
-        let uu____2144 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "(_ zero_extend %s)" uu____2144
+        let uu___1 = FStar_Util.string_of_int n in
+        FStar_Util.format1 "(_ zero_extend %s)" uu___1
     | NatToBv n ->
-        let uu____2146 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "(_ int2bv %s)" uu____2146
+        let uu___1 = FStar_Util.string_of_int n in
+        FStar_Util.format1 "(_ int2bv %s)" uu___1
     | Var s -> s
 let (weightToSmt : Prims.int FStar_Pervasives_Native.option -> Prims.string)
   =
-  fun uu___5_2154 ->
-    match uu___5_2154 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> ""
     | FStar_Pervasives_Native.Some i ->
-        let uu____2158 = FStar_Util.string_of_int i in
-        FStar_Util.format1 ":weight %s\n" uu____2158
+        let uu___1 = FStar_Util.string_of_int i in
+        FStar_Util.format1 ":weight %s\n" uu___1
 let rec (hash_of_term' : term' -> Prims.string) =
   fun t ->
     match t with
@@ -612,84 +573,81 @@ let rec (hash_of_term' : term' -> Prims.string) =
     | String s -> s
     | Real r -> r
     | BoundV i ->
-        let uu____2172 = FStar_Util.string_of_int i in
-        Prims.op_Hat "@" uu____2172
+        let uu___ = FStar_Util.string_of_int i in Prims.op_Hat "@" uu___
     | FreeV x ->
-        let uu____2180 = fv_name x in
-        let uu____2181 =
-          let uu____2182 = let uu____2183 = fv_sort x in strSort uu____2183 in
-          Prims.op_Hat ":" uu____2182 in
-        Prims.op_Hat uu____2180 uu____2181
+        let uu___ = fv_name x in
+        let uu___1 =
+          let uu___2 = let uu___3 = fv_sort x in strSort uu___3 in
+          Prims.op_Hat ":" uu___2 in
+        Prims.op_Hat uu___ uu___1
     | App (op1, tms) ->
-        let uu____2190 =
-          let uu____2191 = op_to_string op1 in
-          let uu____2192 =
-            let uu____2193 =
-              let uu____2194 = FStar_List.map hash_of_term tms in
-              FStar_All.pipe_right uu____2194 (FStar_String.concat " ") in
-            Prims.op_Hat uu____2193 ")" in
-          Prims.op_Hat uu____2191 uu____2192 in
-        Prims.op_Hat "(" uu____2190
+        let uu___ =
+          let uu___1 = op_to_string op1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_List.map hash_of_term tms in
+              FStar_All.pipe_right uu___4 (FStar_String.concat " ") in
+            Prims.op_Hat uu___3 ")" in
+          Prims.op_Hat uu___1 uu___2 in
+        Prims.op_Hat "(" uu___
     | Labeled (t1, r1, r2) ->
-        let uu____2202 = hash_of_term t1 in
-        let uu____2203 =
-          let uu____2204 = FStar_Range.string_of_range r2 in
-          Prims.op_Hat r1 uu____2204 in
-        Prims.op_Hat uu____2202 uu____2203
+        let uu___ = hash_of_term t1 in
+        let uu___1 =
+          let uu___2 = FStar_Range.string_of_range r2 in
+          Prims.op_Hat r1 uu___2 in
+        Prims.op_Hat uu___ uu___1
     | LblPos (t1, r) ->
-        let uu____2207 =
-          let uu____2208 = hash_of_term t1 in
-          Prims.op_Hat uu____2208
-            (Prims.op_Hat " :lblpos " (Prims.op_Hat r ")")) in
-        Prims.op_Hat "(! " uu____2207
+        let uu___ =
+          let uu___1 = hash_of_term t1 in
+          Prims.op_Hat uu___1 (Prims.op_Hat " :lblpos " (Prims.op_Hat r ")")) in
+        Prims.op_Hat "(! " uu___
     | Quant (qop1, pats, wopt, sorts, body) ->
-        let uu____2230 =
-          let uu____2231 =
-            let uu____2232 =
-              let uu____2233 =
-                let uu____2234 = FStar_List.map strSort sorts in
-                FStar_All.pipe_right uu____2234 (FStar_String.concat " ") in
-              let uu____2239 =
-                let uu____2240 =
-                  let uu____2241 = hash_of_term body in
-                  let uu____2242 =
-                    let uu____2243 =
-                      let uu____2244 = weightToSmt wopt in
-                      let uu____2245 =
-                        let uu____2246 =
-                          let uu____2247 =
-                            let uu____2248 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_List.map strSort sorts in
+                FStar_All.pipe_right uu___4 (FStar_String.concat " ") in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 = hash_of_term body in
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 = weightToSmt wopt in
+                      let uu___10 =
+                        let uu___11 =
+                          let uu___12 =
+                            let uu___13 =
                               FStar_All.pipe_right pats
                                 (FStar_List.map
                                    (fun pats1 ->
-                                      let uu____2264 =
+                                      let uu___14 =
                                         FStar_List.map hash_of_term pats1 in
-                                      FStar_All.pipe_right uu____2264
+                                      FStar_All.pipe_right uu___14
                                         (FStar_String.concat " "))) in
-                            FStar_All.pipe_right uu____2248
+                            FStar_All.pipe_right uu___13
                               (FStar_String.concat "; ") in
-                          Prims.op_Hat uu____2247 "))" in
-                        Prims.op_Hat " " uu____2246 in
-                      Prims.op_Hat uu____2244 uu____2245 in
-                    Prims.op_Hat " " uu____2243 in
-                  Prims.op_Hat uu____2241 uu____2242 in
-                Prims.op_Hat ")(! " uu____2240 in
-              Prims.op_Hat uu____2233 uu____2239 in
-            Prims.op_Hat " (" uu____2232 in
-          Prims.op_Hat (qop_to_string qop1) uu____2231 in
-        Prims.op_Hat "(" uu____2230
+                          Prims.op_Hat uu___12 "))" in
+                        Prims.op_Hat " " uu___11 in
+                      Prims.op_Hat uu___9 uu___10 in
+                    Prims.op_Hat " " uu___8 in
+                  Prims.op_Hat uu___6 uu___7 in
+                Prims.op_Hat ")(! " uu___5 in
+              Prims.op_Hat uu___3 uu___4 in
+            Prims.op_Hat " (" uu___2 in
+          Prims.op_Hat (qop_to_string qop1) uu___1 in
+        Prims.op_Hat "(" uu___
     | Let (es, body) ->
-        let uu____2277 =
-          let uu____2278 =
-            let uu____2279 = FStar_List.map hash_of_term es in
-            FStar_All.pipe_right uu____2279 (FStar_String.concat " ") in
-          let uu____2284 =
-            let uu____2285 =
-              let uu____2286 = hash_of_term body in
-              Prims.op_Hat uu____2286 ")" in
-            Prims.op_Hat ") " uu____2285 in
-          Prims.op_Hat uu____2278 uu____2284 in
-        Prims.op_Hat "(let (" uu____2277
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_List.map hash_of_term es in
+            FStar_All.pipe_right uu___2 (FStar_String.concat " ") in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = hash_of_term body in Prims.op_Hat uu___4 ")" in
+            Prims.op_Hat ") " uu___3 in
+          Prims.op_Hat uu___1 uu___2 in
+        Prims.op_Hat "(let (" uu___
 and (hash_of_term : term -> Prims.string) = fun tm -> hash_of_term' tm.tm
 let (mkBoxFunctions : Prims.string -> (Prims.string * Prims.string)) =
   fun s -> (s, (Prims.op_Hat s "_proj_0"))
@@ -699,40 +657,37 @@ let (boxStringFun : (Prims.string * Prims.string)) =
   mkBoxFunctions "BoxString"
 let (boxBitVecFun : Prims.int -> (Prims.string * Prims.string)) =
   fun sz ->
-    let uu____2318 =
-      let uu____2319 = FStar_Util.string_of_int sz in
-      Prims.op_Hat "BoxBitVec" uu____2319 in
-    mkBoxFunctions uu____2318
+    let uu___ =
+      let uu___1 = FStar_Util.string_of_int sz in
+      Prims.op_Hat "BoxBitVec" uu___1 in
+    mkBoxFunctions uu___
 let (boxRealFun : (Prims.string * Prims.string)) = mkBoxFunctions "BoxReal"
 let (isInjective : Prims.string -> Prims.bool) =
   fun s ->
     if (FStar_String.length s) >= (Prims.of_int (3))
     then
-      (let uu____2331 =
-         FStar_String.substring s Prims.int_zero (Prims.of_int (3)) in
-       uu____2331 = "Box") &&
-        (let uu____2333 =
-           let uu____2334 = FStar_String.list_of_string s in
-           FStar_List.existsML (fun c -> c = 46) uu____2334 in
-         Prims.op_Negation uu____2333)
+      (let uu___ = FStar_String.substring s Prims.int_zero (Prims.of_int (3)) in
+       uu___ = "Box") &&
+        (let uu___ =
+           let uu___1 = FStar_String.list_of_string s in
+           FStar_List.existsML (fun c -> c = 46) uu___1 in
+         Prims.op_Negation uu___)
     else false
 let (mk : term' -> FStar_Range.range -> term) =
   fun t ->
     fun r ->
-      let uu____2350 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-      { tm = t; freevars = uu____2350; rng = r }
+      let uu___ = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+      { tm = t; freevars = uu___; rng = r }
 let (mkTrue : FStar_Range.range -> term) = fun r -> mk (App (TrueOp, [])) r
 let (mkFalse : FStar_Range.range -> term) = fun r -> mk (App (FalseOp, [])) r
 let (mkInteger : Prims.string -> FStar_Range.range -> term) =
   fun i ->
     fun r ->
-      let uu____2403 =
-        let uu____2404 = FStar_Util.ensure_decimal i in Integer uu____2404 in
-      mk uu____2403 r
+      let uu___ = let uu___1 = FStar_Util.ensure_decimal i in Integer uu___1 in
+      mk uu___ r
 let (mkInteger' : Prims.int -> FStar_Range.range -> term) =
   fun i ->
-    fun r ->
-      let uu____2415 = FStar_Util.string_of_int i in mkInteger uu____2415 r
+    fun r -> let uu___ = FStar_Util.string_of_int i in mkInteger uu___ r
 let (mkReal : Prims.string -> FStar_Range.range -> term) =
   fun i -> fun r -> mk (Real i) r
 let (mkBoundV : Prims.int -> FStar_Range.range -> term) =
@@ -742,67 +697,66 @@ let (mkFreeV : fv -> FStar_Range.range -> term) =
 let (mkApp' : (op * term Prims.list) -> FStar_Range.range -> term) =
   fun f -> fun r -> mk (App f) r
 let (mkApp : (Prims.string * term Prims.list) -> FStar_Range.range -> term) =
-  fun uu____2482 ->
-    fun r -> match uu____2482 with | (s, args) -> mk (App ((Var s), args)) r
+  fun uu___ ->
+    fun r -> match uu___ with | (s, args) -> mk (App ((Var s), args)) r
 let (mkNot : term -> FStar_Range.range -> term) =
   fun t ->
     fun r ->
       match t.tm with
-      | App (TrueOp, uu____2508) -> mkFalse r
-      | App (FalseOp, uu____2513) -> mkTrue r
-      | uu____2518 -> mkApp' (Not, [t]) r
+      | App (TrueOp, uu___) -> mkFalse r
+      | App (FalseOp, uu___) -> mkTrue r
+      | uu___ -> mkApp' (Not, [t]) r
 let (mkAnd : (term * term) -> FStar_Range.range -> term) =
-  fun uu____2533 ->
+  fun uu___ ->
     fun r ->
-      match uu____2533 with
+      match uu___ with
       | (t1, t2) ->
           (match ((t1.tm), (t2.tm)) with
-           | (App (TrueOp, uu____2541), uu____2542) -> t2
-           | (uu____2547, App (TrueOp, uu____2548)) -> t1
-           | (App (FalseOp, uu____2553), uu____2554) -> mkFalse r
-           | (uu____2559, App (FalseOp, uu____2560)) -> mkFalse r
+           | (App (TrueOp, uu___1), uu___2) -> t2
+           | (uu___1, App (TrueOp, uu___2)) -> t1
+           | (App (FalseOp, uu___1), uu___2) -> mkFalse r
+           | (uu___1, App (FalseOp, uu___2)) -> mkFalse r
            | (App (And, ts1), App (And, ts2)) ->
                mkApp' (And, (FStar_List.append ts1 ts2)) r
-           | (uu____2577, App (And, ts2)) -> mkApp' (And, (t1 :: ts2)) r
-           | (App (And, ts1), uu____2586) ->
+           | (uu___1, App (And, ts2)) -> mkApp' (And, (t1 :: ts2)) r
+           | (App (And, ts1), uu___1) ->
                mkApp' (And, (FStar_List.append ts1 [t2])) r
-           | uu____2593 -> mkApp' (And, [t1; t2]) r)
+           | uu___1 -> mkApp' (And, [t1; t2]) r)
 let (mkOr : (term * term) -> FStar_Range.range -> term) =
-  fun uu____2612 ->
+  fun uu___ ->
     fun r ->
-      match uu____2612 with
+      match uu___ with
       | (t1, t2) ->
           (match ((t1.tm), (t2.tm)) with
-           | (App (TrueOp, uu____2620), uu____2621) -> mkTrue r
-           | (uu____2626, App (TrueOp, uu____2627)) -> mkTrue r
-           | (App (FalseOp, uu____2632), uu____2633) -> t2
-           | (uu____2638, App (FalseOp, uu____2639)) -> t1
+           | (App (TrueOp, uu___1), uu___2) -> mkTrue r
+           | (uu___1, App (TrueOp, uu___2)) -> mkTrue r
+           | (App (FalseOp, uu___1), uu___2) -> t2
+           | (uu___1, App (FalseOp, uu___2)) -> t1
            | (App (Or, ts1), App (Or, ts2)) ->
                mkApp' (Or, (FStar_List.append ts1 ts2)) r
-           | (uu____2656, App (Or, ts2)) -> mkApp' (Or, (t1 :: ts2)) r
-           | (App (Or, ts1), uu____2665) ->
+           | (uu___1, App (Or, ts2)) -> mkApp' (Or, (t1 :: ts2)) r
+           | (App (Or, ts1), uu___1) ->
                mkApp' (Or, (FStar_List.append ts1 [t2])) r
-           | uu____2672 -> mkApp' (Or, [t1; t2]) r)
+           | uu___1 -> mkApp' (Or, [t1; t2]) r)
 let (mkImp : (term * term) -> FStar_Range.range -> term) =
-  fun uu____2691 ->
+  fun uu___ ->
     fun r ->
-      match uu____2691 with
+      match uu___ with
       | (t1, t2) ->
           (match ((t1.tm), (t2.tm)) with
-           | (uu____2699, App (TrueOp, uu____2700)) -> mkTrue r
-           | (App (FalseOp, uu____2705), uu____2706) -> mkTrue r
-           | (App (TrueOp, uu____2711), uu____2712) -> t2
-           | (uu____2717, App (Imp, t1'::t2'::[])) ->
-               let uu____2722 =
-                 let uu____2729 =
-                   let uu____2732 = mkAnd (t1, t1') r in [uu____2732; t2'] in
-                 (Imp, uu____2729) in
-               mkApp' uu____2722 r
-           | uu____2735 -> mkApp' (Imp, [t1; t2]) r)
+           | (uu___1, App (TrueOp, uu___2)) -> mkTrue r
+           | (App (FalseOp, uu___1), uu___2) -> mkTrue r
+           | (App (TrueOp, uu___1), uu___2) -> t2
+           | (uu___1, App (Imp, t1'::t2'::[])) ->
+               let uu___2 =
+                 let uu___3 = let uu___4 = mkAnd (t1, t1') r in [uu___4; t2'] in
+                 (Imp, uu___3) in
+               mkApp' uu___2 r
+           | uu___1 -> mkApp' (Imp, [t1; t2]) r)
 let (mk_bin_op : op -> (term * term) -> FStar_Range.range -> term) =
   fun op1 ->
-    fun uu____2759 ->
-      fun r -> match uu____2759 with | (t1, t2) -> mkApp' (op1, [t1; t2]) r
+    fun uu___ ->
+      fun r -> match uu___ with | (t1, t2) -> mkApp' (op1, [t1; t2]) r
 let (mkMinus : term -> FStar_Range.range -> term) =
   fun t -> fun r -> mkApp' (Minus, [t]) r
 let (mkNatToBv : Prims.int -> term -> FStar_Range.range -> term) =
@@ -818,80 +772,75 @@ let (mkBvAdd : (term * term) -> FStar_Range.range -> term) = mk_bin_op BvAdd
 let (mkBvSub : (term * term) -> FStar_Range.range -> term) = mk_bin_op BvSub
 let (mkBvShl : Prims.int -> (term * term) -> FStar_Range.range -> term) =
   fun sz ->
-    fun uu____2904 ->
+    fun uu___ ->
       fun r ->
-        match uu____2904 with
+        match uu___ with
         | (t1, t2) ->
-            let uu____2912 =
-              let uu____2919 =
-                let uu____2922 =
-                  let uu____2925 = mkNatToBv sz t2 r in [uu____2925] in
-                t1 :: uu____2922 in
-              (BvShl, uu____2919) in
-            mkApp' uu____2912 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = mkNatToBv sz t2 r in [uu___4] in t1
+                  :: uu___3 in
+              (BvShl, uu___2) in
+            mkApp' uu___1 r
 let (mkBvShr : Prims.int -> (term * term) -> FStar_Range.range -> term) =
   fun sz ->
-    fun uu____2945 ->
+    fun uu___ ->
       fun r ->
-        match uu____2945 with
+        match uu___ with
         | (t1, t2) ->
-            let uu____2953 =
-              let uu____2960 =
-                let uu____2963 =
-                  let uu____2966 = mkNatToBv sz t2 r in [uu____2966] in
-                t1 :: uu____2963 in
-              (BvShr, uu____2960) in
-            mkApp' uu____2953 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = mkNatToBv sz t2 r in [uu___4] in t1
+                  :: uu___3 in
+              (BvShr, uu___2) in
+            mkApp' uu___1 r
 let (mkBvUdiv : Prims.int -> (term * term) -> FStar_Range.range -> term) =
   fun sz ->
-    fun uu____2986 ->
+    fun uu___ ->
       fun r ->
-        match uu____2986 with
+        match uu___ with
         | (t1, t2) ->
-            let uu____2994 =
-              let uu____3001 =
-                let uu____3004 =
-                  let uu____3007 = mkNatToBv sz t2 r in [uu____3007] in
-                t1 :: uu____3004 in
-              (BvUdiv, uu____3001) in
-            mkApp' uu____2994 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = mkNatToBv sz t2 r in [uu___4] in t1
+                  :: uu___3 in
+              (BvUdiv, uu___2) in
+            mkApp' uu___1 r
 let (mkBvMod : Prims.int -> (term * term) -> FStar_Range.range -> term) =
   fun sz ->
-    fun uu____3027 ->
+    fun uu___ ->
       fun r ->
-        match uu____3027 with
+        match uu___ with
         | (t1, t2) ->
-            let uu____3035 =
-              let uu____3042 =
-                let uu____3045 =
-                  let uu____3048 = mkNatToBv sz t2 r in [uu____3048] in
-                t1 :: uu____3045 in
-              (BvMod, uu____3042) in
-            mkApp' uu____3035 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = mkNatToBv sz t2 r in [uu___4] in t1
+                  :: uu___3 in
+              (BvMod, uu___2) in
+            mkApp' uu___1 r
 let (mkBvMul : Prims.int -> (term * term) -> FStar_Range.range -> term) =
   fun sz ->
-    fun uu____3068 ->
+    fun uu___ ->
       fun r ->
-        match uu____3068 with
+        match uu___ with
         | (t1, t2) ->
-            let uu____3076 =
-              let uu____3083 =
-                let uu____3086 =
-                  let uu____3089 = mkNatToBv sz t2 r in [uu____3089] in
-                t1 :: uu____3086 in
-              (BvMul, uu____3083) in
-            mkApp' uu____3076 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = mkNatToBv sz t2 r in [uu___4] in t1
+                  :: uu___3 in
+              (BvMul, uu___2) in
+            mkApp' uu___1 r
 let (mkBvUlt : (term * term) -> FStar_Range.range -> term) = mk_bin_op BvUlt
 let (mkIff : (term * term) -> FStar_Range.range -> term) = mk_bin_op Iff
 let (mkEq : (term * term) -> FStar_Range.range -> term) =
-  fun uu____3128 ->
+  fun uu___ ->
     fun r ->
-      match uu____3128 with
+      match uu___ with
       | (t1, t2) ->
           (match ((t1.tm), (t2.tm)) with
            | (App (Var f1, s1::[]), App (Var f2, s2::[])) when
                (f1 = f2) && (isInjective f1) -> mk_bin_op Eq (s1, s2) r
-           | uu____3144 -> mk_bin_op Eq (t1, t2) r)
+           | uu___1 -> mk_bin_op Eq (t1, t2) r)
 let (mkLT : (term * term) -> FStar_Range.range -> term) = mk_bin_op LT
 let (mkLTE : (term * term) -> FStar_Range.range -> term) = mk_bin_op LTE
 let (mkGT : (term * term) -> FStar_Range.range -> term) = mk_bin_op GT
@@ -906,23 +855,21 @@ let (mkMod : (term * term) -> FStar_Range.range -> term) = mk_bin_op Mod
 let (mkRealOfInt : term -> FStar_Range.range -> term) =
   fun t -> fun r -> mkApp ("to_real", [t]) r
 let (mkITE : (term * term * term) -> FStar_Range.range -> term) =
-  fun uu____3295 ->
+  fun uu___ ->
     fun r ->
-      match uu____3295 with
+      match uu___ with
       | (t1, t2, t3) ->
           (match t1.tm with
-           | App (TrueOp, uu____3306) -> t2
-           | App (FalseOp, uu____3311) -> t3
-           | uu____3316 ->
+           | App (TrueOp, uu___1) -> t2
+           | App (FalseOp, uu___1) -> t3
+           | uu___1 ->
                (match ((t2.tm), (t3.tm)) with
-                | (App (TrueOp, uu____3317), App (TrueOp, uu____3318)) ->
-                    mkTrue r
-                | (App (TrueOp, uu____3327), uu____3328) ->
-                    let uu____3333 =
-                      let uu____3338 = mkNot t1 t1.rng in (uu____3338, t3) in
-                    mkImp uu____3333 r
-                | (uu____3339, App (TrueOp, uu____3340)) -> mkImp (t1, t2) r
-                | (uu____3345, uu____3346) -> mkApp' (ITE, [t1; t2; t3]) r))
+                | (App (TrueOp, uu___2), App (TrueOp, uu___3)) -> mkTrue r
+                | (App (TrueOp, uu___2), uu___3) ->
+                    let uu___4 = let uu___5 = mkNot t1 t1.rng in (uu___5, t3) in
+                    mkImp uu___4 r
+                | (uu___2, App (TrueOp, uu___3)) -> mkImp (t1, t2) r
+                | (uu___2, uu___3) -> mkApp' (ITE, [t1; t2; t3]) r))
 let (mkCases : term Prims.list -> FStar_Range.range -> term) =
   fun t ->
     fun r ->
@@ -934,16 +881,16 @@ let (check_pattern_ok : term -> term FStar_Pervasives_Native.option) =
   fun t ->
     let rec aux t1 =
       match t1.tm with
-      | Integer uu____3399 -> FStar_Pervasives_Native.None
-      | String uu____3400 -> FStar_Pervasives_Native.None
-      | Real uu____3401 -> FStar_Pervasives_Native.None
-      | BoundV uu____3402 -> FStar_Pervasives_Native.None
-      | FreeV uu____3403 -> FStar_Pervasives_Native.None
+      | Integer uu___ -> FStar_Pervasives_Native.None
+      | String uu___ -> FStar_Pervasives_Native.None
+      | Real uu___ -> FStar_Pervasives_Native.None
+      | BoundV uu___ -> FStar_Pervasives_Native.None
+      | FreeV uu___ -> FStar_Pervasives_Native.None
       | Let (tms, tm) -> aux_l (tm :: tms)
       | App (head, terms) ->
           let head_ok =
             match head with
-            | Var uu____3423 -> true
+            | Var uu___ -> true
             | TrueOp -> true
             | FalseOp -> true
             | Not -> false
@@ -974,22 +921,22 @@ let (check_pattern_ok : term -> term FStar_Pervasives_Native.option) =
             | BvMod -> false
             | BvMul -> false
             | BvUlt -> false
-            | BvUext uu____3424 -> false
-            | NatToBv uu____3425 -> false
+            | BvUext uu___ -> false
+            | NatToBv uu___ -> false
             | BvToNat -> false
             | ITE -> false in
           if Prims.op_Negation head_ok
           then FStar_Pervasives_Native.Some t1
           else aux_l terms
-      | Labeled (t2, uu____3430, uu____3431) -> aux t2
-      | Quant uu____3432 -> FStar_Pervasives_Native.Some t1
-      | LblPos uu____3451 -> FStar_Pervasives_Native.Some t1
+      | Labeled (t2, uu___, uu___1) -> aux t2
+      | Quant uu___ -> FStar_Pervasives_Native.Some t1
+      | LblPos uu___ -> FStar_Pervasives_Native.Some t1
     and aux_l ts =
       match ts with
       | [] -> FStar_Pervasives_Native.None
       | t1::ts1 ->
-          let uu____3465 = aux t1 in
-          (match uu____3465 with
+          let uu___ = aux t1 in
+          (match uu___ with
            | FStar_Pervasives_Native.Some t2 ->
                FStar_Pervasives_Native.Some t2
            | FStar_Pervasives_Native.None -> aux_l ts1) in
@@ -1001,45 +948,43 @@ let rec (print_smt_term : term -> Prims.string) =
     | String s -> FStar_Util.format1 "(String %s)" s
     | Real r -> FStar_Util.format1 "(Real %s)" r
     | BoundV n ->
-        let uu____3494 = FStar_Util.string_of_int n in
-        FStar_Util.format1 "(BoundV %s)" uu____3494
+        let uu___ = FStar_Util.string_of_int n in
+        FStar_Util.format1 "(BoundV %s)" uu___
     | FreeV fv1 ->
-        let uu____3502 = fv_name fv1 in
-        FStar_Util.format1 "(FreeV %s)" uu____3502
+        let uu___ = fv_name fv1 in FStar_Util.format1 "(FreeV %s)" uu___
     | App (op1, l) ->
-        let uu____3509 = op_to_string op1 in
-        let uu____3510 = print_smt_term_list l in
-        FStar_Util.format2 "(%s %s)" uu____3509 uu____3510
+        let uu___ = op_to_string op1 in
+        let uu___1 = print_smt_term_list l in
+        FStar_Util.format2 "(%s %s)" uu___ uu___1
     | Labeled (t1, r1, r2) ->
-        let uu____3514 = print_smt_term t1 in
-        FStar_Util.format2 "(Labeled '%s' %s)" r1 uu____3514
+        let uu___ = print_smt_term t1 in
+        FStar_Util.format2 "(Labeled '%s' %s)" r1 uu___
     | LblPos (t1, s) ->
-        let uu____3517 = print_smt_term t1 in
-        FStar_Util.format2 "(LblPos %s %s)" s uu____3517
-    | Quant (qop1, l, uu____3520, uu____3521, t1) ->
-        let uu____3539 = print_smt_term_list_list l in
-        let uu____3540 = print_smt_term t1 in
-        FStar_Util.format3 "(%s %s %s)" (qop_to_string qop1) uu____3539
-          uu____3540
+        let uu___ = print_smt_term t1 in
+        FStar_Util.format2 "(LblPos %s %s)" s uu___
+    | Quant (qop1, l, uu___, uu___1, t1) ->
+        let uu___2 = print_smt_term_list_list l in
+        let uu___3 = print_smt_term t1 in
+        FStar_Util.format3 "(%s %s %s)" (qop_to_string qop1) uu___2 uu___3
     | Let (es, body) ->
-        let uu____3547 = print_smt_term_list es in
-        let uu____3548 = print_smt_term body in
-        FStar_Util.format2 "(let %s %s)" uu____3547 uu____3548
+        let uu___ = print_smt_term_list es in
+        let uu___1 = print_smt_term body in
+        FStar_Util.format2 "(let %s %s)" uu___ uu___1
 and (print_smt_term_list : term Prims.list -> Prims.string) =
   fun l ->
-    let uu____3552 = FStar_List.map print_smt_term l in
-    FStar_All.pipe_right uu____3552 (FStar_String.concat " ")
+    let uu___ = FStar_List.map print_smt_term l in
+    FStar_All.pipe_right uu___ (FStar_String.concat " ")
 and (print_smt_term_list_list : term Prims.list Prims.list -> Prims.string) =
   fun l ->
     FStar_List.fold_left
       (fun s ->
          fun l1 ->
-           let uu____3571 =
-             let uu____3572 =
-               let uu____3573 = print_smt_term_list l1 in
-               Prims.op_Hat uu____3573 " ] " in
-             Prims.op_Hat "; [ " uu____3572 in
-           Prims.op_Hat s uu____3571) "" l
+           let uu___ =
+             let uu___1 =
+               let uu___2 = print_smt_term_list l1 in
+               Prims.op_Hat uu___2 " ] " in
+             Prims.op_Hat "; [ " uu___1 in
+           Prims.op_Hat s uu___) "" l
 let (mkQuant :
   FStar_Range.range ->
     Prims.bool ->
@@ -1048,45 +993,44 @@ let (mkQuant :
   =
   fun r ->
     fun check_pats ->
-      fun uu____3606 ->
-        match uu____3606 with
+      fun uu___ ->
+        match uu___ with
         | (qop1, pats, wopt, vars, body) ->
             let all_pats_ok pats1 =
               if Prims.op_Negation check_pats
               then pats1
               else
-                (let uu____3669 =
+                (let uu___2 =
                    FStar_Util.find_map pats1
                      (fun x -> FStar_Util.find_map x check_pattern_ok) in
-                 match uu____3669 with
+                 match uu___2 with
                  | FStar_Pervasives_Native.None -> pats1
                  | FStar_Pervasives_Native.Some p ->
-                     ((let uu____3684 =
-                         let uu____3689 =
-                           let uu____3690 = print_smt_term p in
+                     ((let uu___4 =
+                         let uu___5 =
+                           let uu___6 = print_smt_term p in
                            FStar_Util.format1
                              "Pattern (%s) contains illegal symbols; dropping it"
-                             uu____3690 in
-                         (FStar_Errors.Warning_SMTPatternIllFormed,
-                           uu____3689) in
-                       FStar_Errors.log_issue r uu____3684);
+                             uu___6 in
+                         (FStar_Errors.Warning_SMTPatternIllFormed, uu___5) in
+                       FStar_Errors.log_issue r uu___4);
                       [])) in
             if (FStar_List.length vars) = Prims.int_zero
             then body
             else
               (match body.tm with
-               | App (TrueOp, uu____3694) -> body
-               | uu____3699 ->
-                   let uu____3700 =
-                     let uu____3701 =
-                       let uu____3720 = all_pats_ok pats in
-                       (qop1, uu____3720, wopt, vars, body) in
-                     Quant uu____3701 in
-                   mk uu____3700 r)
+               | App (TrueOp, uu___2) -> body
+               | uu___2 ->
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = all_pats_ok pats in
+                       (qop1, uu___5, wopt, vars, body) in
+                     Quant uu___4 in
+                   mk uu___3 r)
 let (mkLet : (term Prims.list * term) -> FStar_Range.range -> term) =
-  fun uu____3747 ->
+  fun uu___ ->
     fun r ->
-      match uu____3747 with
+      match uu___ with
       | (es, body) ->
           if (FStar_List.length es) = Prims.int_zero
           then body
@@ -1096,70 +1040,66 @@ let (abstr : fv Prims.list -> term -> term) =
     fun t ->
       let nvars = FStar_List.length fvs1 in
       let index_of fv1 =
-        let uu____3787 = FStar_Util.try_find_index (fv_eq fv1) fvs1 in
-        match uu____3787 with
+        let uu___ = FStar_Util.try_find_index (fv_eq fv1) fvs1 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some i ->
             FStar_Pervasives_Native.Some (nvars - (i + Prims.int_one)) in
       let rec aux ix t1 =
-        let uu____3804 = FStar_ST.op_Bang t1.freevars in
-        match uu____3804 with
+        let uu___ = FStar_ST.op_Bang t1.freevars in
+        match uu___ with
         | FStar_Pervasives_Native.Some [] -> t1
-        | uu____3855 ->
+        | uu___1 ->
             (match t1.tm with
-             | Integer uu____3866 -> t1
-             | String uu____3867 -> t1
-             | Real uu____3868 -> t1
-             | BoundV uu____3869 -> t1
+             | Integer uu___2 -> t1
+             | String uu___2 -> t1
+             | Real uu___2 -> t1
+             | BoundV uu___2 -> t1
              | FreeV x ->
-                 let uu____3877 = index_of x in
-                 (match uu____3877 with
+                 let uu___2 = index_of x in
+                 (match uu___2 with
                   | FStar_Pervasives_Native.None -> t1
                   | FStar_Pervasives_Native.Some i ->
                       mkBoundV (i + ix) t1.rng)
              | App (op1, tms) ->
-                 let uu____3887 =
-                   let uu____3894 = FStar_List.map (aux ix) tms in
-                   (op1, uu____3894) in
-                 mkApp' uu____3887 t1.rng
+                 let uu___2 =
+                   let uu___3 = FStar_List.map (aux ix) tms in (op1, uu___3) in
+                 mkApp' uu___2 t1.rng
              | Labeled (t2, r1, r2) ->
-                 let uu____3902 =
-                   let uu____3903 =
-                     let uu____3910 = aux ix t2 in (uu____3910, r1, r2) in
-                   Labeled uu____3903 in
-                 mk uu____3902 t2.rng
+                 let uu___2 =
+                   let uu___3 = let uu___4 = aux ix t2 in (uu___4, r1, r2) in
+                   Labeled uu___3 in
+                 mk uu___2 t2.rng
              | LblPos (t2, r) ->
-                 let uu____3913 =
-                   let uu____3914 =
-                     let uu____3919 = aux ix t2 in (uu____3919, r) in
-                   LblPos uu____3914 in
-                 mk uu____3913 t2.rng
+                 let uu___2 =
+                   let uu___3 = let uu___4 = aux ix t2 in (uu___4, r) in
+                   LblPos uu___3 in
+                 mk uu___2 t2.rng
              | Quant (qop1, pats, wopt, vars, body) ->
                  let n = FStar_List.length vars in
-                 let uu____3942 =
-                   let uu____3961 =
+                 let uu___2 =
+                   let uu___3 =
                      FStar_All.pipe_right pats
                        (FStar_List.map (FStar_List.map (aux (ix + n)))) in
-                   let uu____3978 = aux (ix + n) body in
-                   (qop1, uu____3961, wopt, vars, uu____3978) in
-                 mkQuant t1.rng false uu____3942
+                   let uu___4 = aux (ix + n) body in
+                   (qop1, uu___3, wopt, vars, uu___4) in
+                 mkQuant t1.rng false uu___2
              | Let (es, body) ->
-                 let uu____3993 =
+                 let uu___2 =
                    FStar_List.fold_left
-                     (fun uu____4011 ->
+                     (fun uu___3 ->
                         fun e ->
-                          match uu____4011 with
+                          match uu___3 with
                           | (ix1, l) ->
-                              let uu____4031 =
-                                let uu____4034 = aux ix1 e in uu____4034 :: l in
-                              ((ix1 + Prims.int_one), uu____4031)) (ix, [])
-                     es in
-                 (match uu____3993 with
+                              let uu___4 =
+                                let uu___5 = aux ix1 e in uu___5 :: l in
+                              ((ix1 + Prims.int_one), uu___4)) (ix, []) es in
+                 (match uu___2 with
                   | (ix1, es_rev) ->
-                      let uu____4045 =
-                        let uu____4052 = aux ix1 body in
-                        ((FStar_List.rev es_rev), uu____4052) in
-                      mkLet uu____4045 t1.rng)) in
+                      let uu___3 =
+                        let uu___4 = aux ix1 body in
+                        ((FStar_List.rev es_rev), uu___4) in
+                      mkLet uu___3 t1.rng)) in
       aux Prims.int_zero t
 let (inst : term Prims.list -> term -> term) =
   fun tms ->
@@ -1168,84 +1108,79 @@ let (inst : term Prims.list -> term -> term) =
       let n = FStar_List.length tms1 in
       let rec aux shift t1 =
         match t1.tm with
-        | Integer uu____4084 -> t1
-        | String uu____4085 -> t1
-        | Real uu____4086 -> t1
-        | FreeV uu____4087 -> t1
+        | Integer uu___ -> t1
+        | String uu___ -> t1
+        | Real uu___ -> t1
+        | FreeV uu___ -> t1
         | BoundV i ->
             if (Prims.int_zero <= (i - shift)) && ((i - shift) < n)
             then FStar_List.nth tms1 (i - shift)
             else t1
         | App (op1, tms2) ->
-            let uu____4102 =
-              let uu____4109 = FStar_List.map (aux shift) tms2 in
-              (op1, uu____4109) in
-            mkApp' uu____4102 t1.rng
+            let uu___ =
+              let uu___1 = FStar_List.map (aux shift) tms2 in (op1, uu___1) in
+            mkApp' uu___ t1.rng
         | Labeled (t2, r1, r2) ->
-            let uu____4117 =
-              let uu____4118 =
-                let uu____4125 = aux shift t2 in (uu____4125, r1, r2) in
-              Labeled uu____4118 in
-            mk uu____4117 t2.rng
+            let uu___ =
+              let uu___1 = let uu___2 = aux shift t2 in (uu___2, r1, r2) in
+              Labeled uu___1 in
+            mk uu___ t2.rng
         | LblPos (t2, r) ->
-            let uu____4128 =
-              let uu____4129 =
-                let uu____4134 = aux shift t2 in (uu____4134, r) in
-              LblPos uu____4129 in
-            mk uu____4128 t2.rng
+            let uu___ =
+              let uu___1 = let uu___2 = aux shift t2 in (uu___2, r) in
+              LblPos uu___1 in
+            mk uu___ t2.rng
         | Quant (qop1, pats, wopt, vars, body) ->
             let m = FStar_List.length vars in
             let shift1 = shift + m in
-            let uu____4158 =
-              let uu____4177 =
+            let uu___ =
+              let uu___1 =
                 FStar_All.pipe_right pats
                   (FStar_List.map (FStar_List.map (aux shift1))) in
-              let uu____4194 = aux shift1 body in
-              (qop1, uu____4177, wopt, vars, uu____4194) in
-            mkQuant t1.rng false uu____4158
+              let uu___2 = aux shift1 body in
+              (qop1, uu___1, wopt, vars, uu___2) in
+            mkQuant t1.rng false uu___
         | Let (es, body) ->
-            let uu____4209 =
+            let uu___ =
               FStar_List.fold_left
-                (fun uu____4227 ->
+                (fun uu___1 ->
                    fun e ->
-                     match uu____4227 with
+                     match uu___1 with
                      | (ix, es1) ->
-                         let uu____4247 =
-                           let uu____4250 = aux shift e in uu____4250 :: es1 in
-                         ((shift + Prims.int_one), uu____4247)) (shift, [])
-                es in
-            (match uu____4209 with
+                         let uu___2 =
+                           let uu___3 = aux shift e in uu___3 :: es1 in
+                         ((shift + Prims.int_one), uu___2)) (shift, []) es in
+            (match uu___ with
              | (shift1, es_rev) ->
-                 let uu____4261 =
-                   let uu____4268 = aux shift1 body in
-                   ((FStar_List.rev es_rev), uu____4268) in
-                 mkLet uu____4261 t1.rng) in
+                 let uu___1 =
+                   let uu___2 = aux shift1 body in
+                   ((FStar_List.rev es_rev), uu___2) in
+                 mkLet uu___1 t1.rng) in
       aux Prims.int_zero t
 let (subst : term -> fv -> term -> term) =
-  fun t ->
-    fun fv1 -> fun s -> let uu____4286 = abstr [fv1] t in inst [s] uu____4286
+  fun t -> fun fv1 -> fun s -> let uu___ = abstr [fv1] t in inst [s] uu___
 let (mkQuant' :
   FStar_Range.range ->
     (qop * term Prims.list Prims.list * Prims.int
       FStar_Pervasives_Native.option * fv Prims.list * term) -> term)
   =
   fun r ->
-    fun uu____4314 ->
-      match uu____4314 with
+    fun uu___ ->
+      match uu___ with
       | (qop1, pats, wopt, vars, body) ->
-          let uu____4354 =
-            let uu____4373 =
+          let uu___1 =
+            let uu___2 =
               FStar_All.pipe_right pats
                 (FStar_List.map (FStar_List.map (abstr vars))) in
-            let uu____4390 = FStar_List.map fv_sort vars in
-            let uu____4393 = abstr vars body in
-            (qop1, uu____4373, wopt, uu____4390, uu____4393) in
-          mkQuant r true uu____4354
+            let uu___3 = FStar_List.map fv_sort vars in
+            let uu___4 = abstr vars body in
+            (qop1, uu___2, wopt, uu___3, uu___4) in
+          mkQuant r true uu___1
 let (mkForall :
   FStar_Range.range -> (pat Prims.list Prims.list * fvs * term) -> term) =
   fun r ->
-    fun uu____4421 ->
-      match uu____4421 with
+    fun uu___ ->
+      match uu___ with
       | (pats, vars, body) ->
           mkQuant' r (Forall, pats, FStar_Pervasives_Native.None, vars, body)
 let (mkForall'' :
@@ -1254,8 +1189,8 @@ let (mkForall'' :
       sort Prims.list * term) -> term)
   =
   fun r ->
-    fun uu____4476 ->
-      match uu____4476 with
+    fun uu___ ->
+      match uu___ with
       | (pats, wopt, sorts, body) ->
           mkQuant r true (Forall, pats, wopt, sorts, body)
 let (mkForall' :
@@ -1264,69 +1199,65 @@ let (mkForall' :
       fvs * term) -> term)
   =
   fun r ->
-    fun uu____4544 ->
-      match uu____4544 with
+    fun uu___ ->
+      match uu___ with
       | (pats, wopt, vars, body) ->
           mkQuant' r (Forall, pats, wopt, vars, body)
 let (mkExists :
   FStar_Range.range -> (pat Prims.list Prims.list * fvs * term) -> term) =
   fun r ->
-    fun uu____4602 ->
-      match uu____4602 with
+    fun uu___ ->
+      match uu___ with
       | (pats, vars, body) ->
           mkQuant' r (Exists, pats, FStar_Pervasives_Native.None, vars, body)
 let (mkLet' : ((fv * term) Prims.list * term) -> FStar_Range.range -> term) =
-  fun uu____4650 ->
+  fun uu___ ->
     fun r ->
-      match uu____4650 with
+      match uu___ with
       | (bindings, body) ->
-          let uu____4676 = FStar_List.split bindings in
-          (match uu____4676 with
+          let uu___1 = FStar_List.split bindings in
+          (match uu___1 with
            | (vars, es) ->
-               let uu____4695 =
-                 let uu____4702 = abstr vars body in (es, uu____4702) in
-               mkLet uu____4695 r)
+               let uu___2 = let uu___3 = abstr vars body in (es, uu___3) in
+               mkLet uu___2 r)
 let (norng : FStar_Range.range) = FStar_Range.dummyRange
 let (mkDefineFun :
   (Prims.string * fv Prims.list * sort * term * caption) -> decl) =
-  fun uu____4721 ->
-    match uu____4721 with
+  fun uu___ ->
+    match uu___ with
     | (nm, vars, s, tm, c) ->
-        let uu____4743 =
-          let uu____4756 = FStar_List.map fv_sort vars in
-          let uu____4759 = abstr vars tm in
-          (nm, uu____4756, s, uu____4759, c) in
-        DefineFun uu____4743
+        let uu___1 =
+          let uu___2 = FStar_List.map fv_sort vars in
+          let uu___3 = abstr vars tm in (nm, uu___2, s, uu___3, c) in
+        DefineFun uu___1
 let (constr_id_of_sort : sort -> Prims.string) =
   fun sort1 ->
-    let uu____4767 = strSort sort1 in
-    FStar_Util.format1 "%s_constr_id" uu____4767
+    let uu___ = strSort sort1 in FStar_Util.format1 "%s_constr_id" uu___
 let (fresh_token : (Prims.string * sort) -> Prims.int -> decl) =
-  fun uu____4780 ->
+  fun uu___ ->
     fun id ->
-      match uu____4780 with
+      match uu___ with
       | (tok_name, sort1) ->
           let a_name = Prims.op_Hat "fresh_token_" tok_name in
           let a =
-            let uu____4790 =
-              let uu____4791 =
-                let uu____4796 = mkInteger' id norng in
-                let uu____4797 =
-                  let uu____4798 =
-                    let uu____4805 = constr_id_of_sort sort1 in
-                    let uu____4806 =
-                      let uu____4809 = mkApp (tok_name, []) norng in
-                      [uu____4809] in
-                    (uu____4805, uu____4806) in
-                  mkApp uu____4798 norng in
-                (uu____4796, uu____4797) in
-              mkEq uu____4791 norng in
-            let uu____4814 = escape a_name in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = mkInteger' id norng in
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = constr_id_of_sort sort1 in
+                    let uu___7 =
+                      let uu___8 = mkApp (tok_name, []) norng in [uu___8] in
+                    (uu___6, uu___7) in
+                  mkApp uu___5 norng in
+                (uu___3, uu___4) in
+              mkEq uu___2 norng in
+            let uu___2 = escape a_name in
             {
-              assumption_term = uu____4790;
+              assumption_term = uu___1;
               assumption_caption =
                 (FStar_Pervasives_Native.Some "fresh token");
-              assumption_name = uu____4814;
+              assumption_name = uu___2;
               assumption_fact_ids = []
             } in
           Assume a
@@ -1335,8 +1266,8 @@ let (fresh_constructor :
     (Prims.string * sort Prims.list * sort * Prims.int) -> decl)
   =
   fun rng ->
-    fun uu____4834 ->
-      match uu____4834 with
+    fun uu___ ->
+      match uu___ with
       | (name, arg_sorts, sort1, id) ->
           let id1 = FStar_Util.string_of_int id in
           let bvars =
@@ -1344,38 +1275,36 @@ let (fresh_constructor :
               (FStar_List.mapi
                  (fun i ->
                     fun s ->
-                      let uu____4866 =
-                        let uu____4867 =
-                          let uu____4872 =
-                            let uu____4873 = FStar_Util.string_of_int i in
-                            Prims.op_Hat "x_" uu____4873 in
-                          (uu____4872, s) in
-                        mk_fv uu____4867 in
-                      mkFreeV uu____4866 norng)) in
+                      let uu___1 =
+                        let uu___2 =
+                          let uu___3 =
+                            let uu___4 = FStar_Util.string_of_int i in
+                            Prims.op_Hat "x_" uu___4 in
+                          (uu___3, s) in
+                        mk_fv uu___2 in
+                      mkFreeV uu___1 norng)) in
           let bvar_names = FStar_List.map fv_of_term bvars in
           let capp = mkApp (name, bvars) norng in
           let cid_app =
-            let uu____4893 =
-              let uu____4900 = constr_id_of_sort sort1 in
-              (uu____4900, [capp]) in
-            mkApp uu____4893 norng in
+            let uu___1 =
+              let uu___2 = constr_id_of_sort sort1 in (uu___2, [capp]) in
+            mkApp uu___1 norng in
           let a_name = Prims.op_Hat "constructor_distinct_" name in
           let a =
-            let uu____4905 =
-              let uu____4906 =
-                let uu____4917 =
-                  let uu____4918 =
-                    let uu____4923 = mkInteger id1 norng in
-                    (uu____4923, cid_app) in
-                  mkEq uu____4918 norng in
-                ([[capp]], bvar_names, uu____4917) in
-              mkForall rng uu____4906 in
-            let uu____4932 = escape a_name in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = mkInteger id1 norng in (uu___5, cid_app) in
+                  mkEq uu___4 norng in
+                ([[capp]], bvar_names, uu___3) in
+              mkForall rng uu___2 in
+            let uu___2 = escape a_name in
             {
-              assumption_term = uu____4905;
+              assumption_term = uu___1;
               assumption_caption =
                 (FStar_Pervasives_Native.Some "Constructor distinct");
-              assumption_name = uu____4932;
+              assumption_name = uu___2;
               assumption_fact_ids = []
             } in
           Assume a
@@ -1384,36 +1313,35 @@ let (injective_constructor :
     (Prims.string * constructor_field Prims.list * sort) -> decl Prims.list)
   =
   fun rng ->
-    fun uu____4952 ->
-      match uu____4952 with
+    fun uu___ ->
+      match uu___ with
       | (name, fields, sort1) ->
           let n_bvars = FStar_List.length fields in
           let bvar_name i =
-            let uu____4979 = FStar_Util.string_of_int i in
-            Prims.op_Hat "x_" uu____4979 in
+            let uu___1 = FStar_Util.string_of_int i in
+            Prims.op_Hat "x_" uu___1 in
           let bvar_index i = n_bvars - (i + Prims.int_one) in
           let bvar i s =
-            let uu____5000 =
-              let uu____5001 =
-                let uu____5006 = bvar_name i in (uu____5006, s) in
-              mk_fv uu____5001 in
-            FStar_All.pipe_left mkFreeV uu____5000 in
+            let uu___1 =
+              let uu___2 = let uu___3 = bvar_name i in (uu___3, s) in
+              mk_fv uu___2 in
+            FStar_All.pipe_left mkFreeV uu___1 in
           let bvars =
             FStar_All.pipe_right fields
               (FStar_List.mapi
                  (fun i ->
-                    fun uu____5036 ->
-                      match uu____5036 with
-                      | (uu____5043, s, uu____5045) ->
-                          let uu____5046 = bvar i s in uu____5046 norng)) in
+                    fun uu___1 ->
+                      match uu___1 with
+                      | (uu___2, s, uu___3) ->
+                          let uu___4 = bvar i s in uu___4 norng)) in
           let bvar_names = FStar_List.map fv_of_term bvars in
           let capp = mkApp (name, bvars) norng in
-          let uu____5069 =
+          let uu___1 =
             FStar_All.pipe_right fields
               (FStar_List.mapi
                  (fun i ->
-                    fun uu____5103 ->
-                      match uu____5103 with
+                    fun uu___2 ->
+                      match uu___2 with
                       | (name1, s, projectible) ->
                           let cproj_app = mkApp (name1, [capp]) norng in
                           let proj_name =
@@ -1423,44 +1351,42 @@ let (injective_constructor :
                           if projectible
                           then
                             let a =
-                              let uu____5124 =
-                                let uu____5125 =
-                                  let uu____5136 =
-                                    let uu____5137 =
-                                      let uu____5142 =
-                                        let uu____5143 = bvar i s in
-                                        uu____5143 norng in
-                                      (cproj_app, uu____5142) in
-                                    mkEq uu____5137 norng in
-                                  ([[capp]], bvar_names, uu____5136) in
-                                mkForall rng uu____5125 in
-                              let uu____5156 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 =
+                                        let uu___8 = bvar i s in uu___8 norng in
+                                      (cproj_app, uu___7) in
+                                    mkEq uu___6 norng in
+                                  ([[capp]], bvar_names, uu___5) in
+                                mkForall rng uu___4 in
+                              let uu___4 =
                                 escape
                                   (Prims.op_Hat "projection_inverse_" name1) in
                               {
-                                assumption_term = uu____5124;
+                                assumption_term = uu___3;
                                 assumption_caption =
                                   (FStar_Pervasives_Native.Some
                                      "Projection inverse");
-                                assumption_name = uu____5156;
+                                assumption_name = uu___4;
                                 assumption_fact_ids = []
                               } in
                             [proj_name; Assume a]
                           else [proj_name])) in
-          FStar_All.pipe_right uu____5069 FStar_List.flatten
+          FStar_All.pipe_right uu___1 FStar_List.flatten
 let (constructor_to_decl :
   FStar_Range.range -> constructor_t -> decl Prims.list) =
   fun rng ->
-    fun uu____5175 ->
-      match uu____5175 with
+    fun uu___ ->
+      match uu___ with
       | (name, fields, sort1, id, injective) ->
           let injective1 = injective || true in
           let field_sorts =
             FStar_All.pipe_right fields
               (FStar_List.map
-                 (fun uu____5211 ->
-                    match uu____5211 with
-                    | (uu____5218, sort2, uu____5220) -> sort2)) in
+                 (fun uu___1 ->
+                    match uu___1 with | (uu___2, sort2, uu___3) -> sort2)) in
           let cdecl =
             DeclFun
               (name, field_sorts, sort1,
@@ -1471,54 +1397,52 @@ let (constructor_to_decl :
             let xfv = mk_fv ("x", sort1) in
             let xx = mkFreeV xfv norng in
             let disc_eq =
-              let uu____5232 =
-                let uu____5237 =
-                  let uu____5238 =
-                    let uu____5245 = constr_id_of_sort sort1 in
-                    (uu____5245, [xx]) in
-                  mkApp uu____5238 norng in
-                let uu____5248 =
-                  let uu____5249 = FStar_Util.string_of_int id in
-                  mkInteger uu____5249 norng in
-                (uu____5237, uu____5248) in
-              mkEq uu____5232 norng in
-            let uu____5250 =
-              let uu____5267 =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = constr_id_of_sort sort1 in (uu___4, [xx]) in
+                  mkApp uu___3 norng in
+                let uu___3 =
+                  let uu___4 = FStar_Util.string_of_int id in
+                  mkInteger uu___4 norng in
+                (uu___2, uu___3) in
+              mkEq uu___1 norng in
+            let uu___1 =
+              let uu___2 =
                 FStar_All.pipe_right fields
                   (FStar_List.mapi
                      (fun i ->
-                        fun uu____5323 ->
-                          match uu____5323 with
+                        fun uu___3 ->
+                          match uu___3 with
                           | (proj, s, projectible) ->
                               if projectible
                               then
-                                let uu____5345 = mkApp (proj, [xx]) norng in
-                                (uu____5345, [])
+                                let uu___4 = mkApp (proj, [xx]) norng in
+                                (uu___4, [])
                               else
                                 (let fi =
-                                   let uu____5352 =
-                                     let uu____5357 =
-                                       let uu____5358 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_Util.string_of_int i in
-                                       Prims.op_Hat "f_" uu____5358 in
-                                     (uu____5357, s) in
-                                   mk_fv uu____5352 in
-                                 let uu____5359 = mkFreeV fi norng in
-                                 (uu____5359, [fi])))) in
-              FStar_All.pipe_right uu____5267 FStar_List.split in
-            match uu____5250 with
+                                       Prims.op_Hat "f_" uu___7 in
+                                     (uu___6, s) in
+                                   mk_fv uu___5 in
+                                 let uu___5 = mkFreeV fi norng in
+                                 (uu___5, [fi])))) in
+              FStar_All.pipe_right uu___2 FStar_List.split in
+            match uu___1 with
             | (proj_terms, ex_vars) ->
                 let ex_vars1 = FStar_List.flatten ex_vars in
                 let disc_inv_body =
-                  let uu____5442 =
-                    let uu____5447 = mkApp (name, proj_terms) norng in
-                    (xx, uu____5447) in
-                  mkEq uu____5442 norng in
+                  let uu___2 =
+                    let uu___3 = mkApp (name, proj_terms) norng in
+                    (xx, uu___3) in
+                  mkEq uu___2 norng in
                 let disc_inv_body1 =
                   match ex_vars1 with
                   | [] -> disc_inv_body
-                  | uu____5457 ->
-                      mkExists norng ([], ex_vars1, disc_inv_body) in
+                  | uu___2 -> mkExists norng ([], ex_vars1, disc_inv_body) in
                 let disc_ax = mkAnd (disc_eq, disc_inv_body1) norng in
                 let def =
                   mkDefineFun
@@ -1530,21 +1454,19 @@ let (constructor_to_decl :
             if injective1
             then injective_constructor rng (name, fields, sort1)
             else [] in
-          let uu____5484 =
-            let uu____5487 =
-              let uu____5488 =
-                FStar_Util.format1 "<start constructor %s>" name in
-              Caption uu____5488 in
-            uu____5487 :: cdecl :: cid :: projs in
-          let uu____5489 =
-            let uu____5492 =
-              let uu____5495 =
-                let uu____5496 =
-                  FStar_Util.format1 "</end constructor %s>" name in
-                Caption uu____5496 in
-              [uu____5495] in
-            FStar_List.append [disc] uu____5492 in
-          FStar_List.append uu____5484 uu____5489
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Util.format1 "<start constructor %s>" name in
+              Caption uu___3 in
+            uu___2 :: cdecl :: cid :: projs in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Util.format1 "</end constructor %s>" name in
+                Caption uu___5 in
+              [uu___4] in
+            FStar_List.append [disc] uu___3 in
+          FStar_List.append uu___1 uu___2
 let (name_binders_inner :
   Prims.string FStar_Pervasives_Native.option ->
     fv Prims.list ->
@@ -1556,42 +1478,39 @@ let (name_binders_inner :
     fun outer_names ->
       fun start ->
         fun sorts ->
-          let uu____5539 =
+          let uu___ =
             FStar_All.pipe_right sorts
               (FStar_List.fold_left
-                 (fun uu____5582 ->
+                 (fun uu___1 ->
                     fun s ->
-                      match uu____5582 with
+                      match uu___1 with
                       | (names, binders1, n) ->
                           let prefix =
-                            match s with
-                            | Term_sort -> "@x"
-                            | uu____5616 -> "@u" in
+                            match s with | Term_sort -> "@x" | uu___2 -> "@u" in
                           let prefix1 =
                             match prefix_opt with
                             | FStar_Pervasives_Native.None -> prefix
                             | FStar_Pervasives_Native.Some p ->
                                 Prims.op_Hat p prefix in
                           let nm =
-                            let uu____5620 = FStar_Util.string_of_int n in
-                            Prims.op_Hat prefix1 uu____5620 in
+                            let uu___2 = FStar_Util.string_of_int n in
+                            Prims.op_Hat prefix1 uu___2 in
                           let names1 =
-                            let uu____5624 = mk_fv (nm, s) in uu____5624 ::
-                              names in
+                            let uu___2 = mk_fv (nm, s) in uu___2 :: names in
                           let b =
-                            let uu____5626 = strSort s in
-                            FStar_Util.format2 "(%s %s)" nm uu____5626 in
+                            let uu___2 = strSort s in
+                            FStar_Util.format2 "(%s %s)" nm uu___2 in
                           (names1, (b :: binders1), (n + Prims.int_one)))
                  (outer_names, [], start)) in
-          match uu____5539 with
+          match uu___ with
           | (names, binders1, n) -> (names, (FStar_List.rev binders1), n)
 let (name_macro_binders :
   sort Prims.list -> (fv Prims.list * Prims.string Prims.list)) =
   fun sorts ->
-    let uu____5677 =
+    let uu___ =
       name_binders_inner (FStar_Pervasives_Native.Some "__") []
         Prims.int_zero sorts in
-    match uu____5677 with
+    match uu___ with
     | (names, binders1, n) -> ((FStar_List.rev names), binders1)
 let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
   let string_id_counter = FStar_Util.mk_ref Prims.int_zero in
@@ -1607,8 +1526,8 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
             if n = Prims.int_zero
             then enclosing_name
             else
-              (let uu____5750 = FStar_Util.string_of_int n in
-               FStar_Util.format2 "%s.%s" enclosing_name uu____5750) in
+              (let uu___2 = FStar_Util.string_of_int n in
+               FStar_Util.format2 "%s.%s" enclosing_name uu___2) in
         let remove_guard_free pats =
           FStar_All.pipe_right pats
             (FStar_List.map
@@ -1619,11 +1538,11 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                           match tm.tm with
                           | App
                               (Var "Prims.guard_free",
-                               { tm = BoundV uu____5794;
-                                 freevars = uu____5795; rng = uu____5796;_}::[])
+                               { tm = BoundV uu___; freevars = uu___1;
+                                 rng = uu___2;_}::[])
                               -> tm
                           | App (Var "Prims.guard_free", p::[]) -> p
-                          | uu____5812 -> tm)))) in
+                          | uu___ -> tm)))) in
         let rec aux' depth n names t1 =
           let aux1 = aux (depth + Prims.int_one) in
           match t1.tm with
@@ -1635,36 +1554,35 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                | FStar_Pervasives_Native.Some id -> id
                | FStar_Pervasives_Native.None ->
                    let id =
-                     let uu____5880 = FStar_ST.op_Bang string_id_counter in
-                     FStar_All.pipe_right uu____5880 FStar_Util.string_of_int in
+                     let uu___ = FStar_ST.op_Bang string_id_counter in
+                     FStar_All.pipe_right uu___ FStar_Util.string_of_int in
                    (FStar_Util.incr string_id_counter;
                     FStar_Util.smap_add string_cache s id;
                     id))
           | BoundV i ->
-              let uu____5890 = FStar_List.nth names i in
-              FStar_All.pipe_right uu____5890 fv_name
+              let uu___ = FStar_List.nth names i in
+              FStar_All.pipe_right uu___ fv_name
           | FreeV x when fv_force x ->
-              let uu____5898 =
-                let uu____5899 = fv_name x in
-                Prims.op_Hat uu____5899 " Dummy_value)" in
-              Prims.op_Hat "(" uu____5898
+              let uu___ =
+                let uu___1 = fv_name x in Prims.op_Hat uu___1 " Dummy_value)" in
+              Prims.op_Hat "(" uu___
           | FreeV x -> fv_name x
           | App (op1, []) -> op_to_string op1
           | App (op1, tms) ->
-              let uu____5916 = op_to_string op1 in
-              let uu____5917 =
-                let uu____5918 = FStar_List.map (aux1 n names) tms in
-                FStar_All.pipe_right uu____5918 (FStar_String.concat "\n") in
-              FStar_Util.format2 "(%s %s)" uu____5916 uu____5917
-          | Labeled (t2, uu____5924, uu____5925) -> aux1 n names t2
+              let uu___ = op_to_string op1 in
+              let uu___1 =
+                let uu___2 = FStar_List.map (aux1 n names) tms in
+                FStar_All.pipe_right uu___2 (FStar_String.concat "\n") in
+              FStar_Util.format2 "(%s %s)" uu___ uu___1
+          | Labeled (t2, uu___, uu___1) -> aux1 n names t2
           | LblPos (t2, s) ->
-              let uu____5928 = aux1 n names t2 in
-              FStar_Util.format2 "(! %s :lblpos %s)" uu____5928 s
+              let uu___ = aux1 n names t2 in
+              FStar_Util.format2 "(! %s :lblpos %s)" uu___ s
           | Quant (qop1, pats, wopt, sorts, body) ->
               let qid = next_qid () in
-              let uu____5951 =
+              let uu___ =
                 name_binders_inner FStar_Pervasives_Native.None names n sorts in
-              (match uu____5951 with
+              (match uu___ with
                | (names1, binders1, n1) ->
                    let binders2 =
                      FStar_All.pipe_right binders1 (FStar_String.concat " ") in
@@ -1673,82 +1591,81 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                      match pats1 with
                      | []::[] -> ";;no pats"
                      | [] -> ";;no pats"
-                     | uu____5988 ->
-                         let uu____5993 =
+                     | uu___1 ->
+                         let uu___2 =
                            FStar_All.pipe_right pats1
                              (FStar_List.map
                                 (fun pats2 ->
-                                   let uu____6009 =
-                                     let uu____6010 =
+                                   let uu___3 =
+                                     let uu___4 =
                                        FStar_List.map
                                          (fun p ->
-                                            let uu____6016 = aux1 n1 names1 p in
-                                            FStar_Util.format1 "%s"
-                                              uu____6016) pats2 in
-                                     FStar_String.concat " " uu____6010 in
+                                            let uu___5 = aux1 n1 names1 p in
+                                            FStar_Util.format1 "%s" uu___5)
+                                         pats2 in
+                                     FStar_String.concat " " uu___4 in
                                    FStar_Util.format1 "\n:pattern (%s)"
-                                     uu____6009)) in
-                         FStar_All.pipe_right uu____5993
+                                     uu___3)) in
+                         FStar_All.pipe_right uu___2
                            (FStar_String.concat "\n") in
-                   let uu____6019 =
-                     let uu____6022 =
-                       let uu____6025 =
-                         let uu____6028 = aux1 n1 names1 body in
-                         let uu____6029 =
-                           let uu____6032 = weightToSmt wopt in
-                           [uu____6032; pats_str; qid] in
-                         uu____6028 :: uu____6029 in
-                       binders2 :: uu____6025 in
-                     (qop_to_string qop1) :: uu____6022 in
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = aux1 n1 names1 body in
+                         let uu___5 =
+                           let uu___6 = weightToSmt wopt in
+                           [uu___6; pats_str; qid] in
+                         uu___4 :: uu___5 in
+                       binders2 :: uu___3 in
+                     (qop_to_string qop1) :: uu___2 in
                    FStar_Util.format "(%s (%s)\n (! %s\n %s\n%s\n:qid %s))"
-                     uu____6019)
+                     uu___1)
           | Let (es, body) ->
-              let uu____6039 =
+              let uu___ =
                 FStar_List.fold_left
-                  (fun uu____6068 ->
+                  (fun uu___1 ->
                      fun e ->
-                       match uu____6068 with
+                       match uu___1 with
                        | (names0, binders1, n0) ->
                            let nm =
-                             let uu____6102 = FStar_Util.string_of_int n0 in
-                             Prims.op_Hat "@lb" uu____6102 in
+                             let uu___2 = FStar_Util.string_of_int n0 in
+                             Prims.op_Hat "@lb" uu___2 in
                            let names01 =
-                             let uu____6106 = mk_fv (nm, Term_sort) in
-                             uu____6106 :: names0 in
+                             let uu___2 = mk_fv (nm, Term_sort) in uu___2 ::
+                               names0 in
                            let b =
-                             let uu____6108 = aux1 n names e in
-                             FStar_Util.format2 "(%s %s)" nm uu____6108 in
+                             let uu___2 = aux1 n names e in
+                             FStar_Util.format2 "(%s %s)" nm uu___2 in
                            (names01, (b :: binders1), (n0 + Prims.int_one)))
                   (names, [], n) es in
-              (match uu____6039 with
+              (match uu___ with
                | (names1, binders1, n1) ->
-                   let uu____6128 = aux1 n1 names1 body in
+                   let uu___1 = aux1 n1 names1 body in
                    FStar_Util.format2 "(let (%s)\n%s)"
-                     (FStar_String.concat " " binders1) uu____6128)
+                     (FStar_String.concat " " binders1) uu___1)
         and aux depth n names t1 =
           let s = aux' depth n names t1 in
           if print_ranges && (t1.rng <> norng)
           then
-            let uu____6136 = FStar_Range.string_of_range t1.rng in
-            let uu____6137 = FStar_Range.string_of_use_range t1.rng in
-            FStar_Util.format3 "\n;; def=%s; use=%s\n%s\n" uu____6136
-              uu____6137 s
+            let uu___ = FStar_Range.string_of_range t1.rng in
+            let uu___1 = FStar_Range.string_of_use_range t1.rng in
+            FStar_Util.format3 "\n;; def=%s; use=%s\n%s\n" uu___ uu___1 s
           else s in
         aux Prims.int_zero Prims.int_zero [] t
 let (caption_to_string :
   Prims.bool -> Prims.string FStar_Pervasives_Native.option -> Prims.string)
   =
   fun print_captions ->
-    fun uu___6_6150 ->
-      match uu___6_6150 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.Some c when print_captions ->
           let c1 =
-            let uu____6155 =
+            let uu___1 =
               FStar_All.pipe_right (FStar_String.split [10] c)
                 (FStar_List.map FStar_Util.trim_string) in
-            FStar_All.pipe_right uu____6155 (FStar_String.concat " ") in
+            FStar_All.pipe_right uu___1 (FStar_String.concat " ") in
           Prims.op_Hat ";;;;;;;;;;;;;;;;" (Prims.op_Hat c1 "\n")
-      | uu____6164 -> ""
+      | uu___1 -> ""
 let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
   fun print_captions ->
     fun z3options ->
@@ -1757,85 +1674,81 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
         | DefPrelude -> mkPrelude z3options
         | Module (s, decls) ->
             let res =
-              let uu____6201 =
+              let uu___ =
                 FStar_List.map (declToSmt' print_captions z3options) decls in
-              FStar_All.pipe_right uu____6201 (FStar_String.concat "\n") in
-            let uu____6206 = FStar_Options.keep_query_captions () in
-            if uu____6206
+              FStar_All.pipe_right uu___ (FStar_String.concat "\n") in
+            let uu___ = FStar_Options.keep_query_captions () in
+            if uu___
             then
-              let uu____6207 =
-                FStar_Util.string_of_int (FStar_List.length decls) in
-              let uu____6208 =
-                FStar_Util.string_of_int (FStar_String.length res) in
+              let uu___1 = FStar_Util.string_of_int (FStar_List.length decls) in
+              let uu___2 = FStar_Util.string_of_int (FStar_String.length res) in
               FStar_Util.format5
                 "\n;;; Start %s\n%s\n;;; End %s (%s decls; total size %s)" s
-                res s uu____6207 uu____6208
+                res s uu___1 uu___2
             else res
         | Caption c ->
             if print_captions
             then
-              let uu____6211 =
-                let uu____6212 =
+              let uu___ =
+                let uu___1 =
                   FStar_All.pipe_right (FStar_Util.splitlines c)
                     (FStar_List.map
                        (fun s -> Prims.op_Hat "; " (Prims.op_Hat s "\n"))) in
-                FStar_All.pipe_right uu____6212 (FStar_String.concat "") in
-              Prims.op_Hat "\n" uu____6211
+                FStar_All.pipe_right uu___1 (FStar_String.concat "") in
+              Prims.op_Hat "\n" uu___
             else ""
         | DeclFun (f, argsorts, retsort, c) ->
             let l = FStar_List.map strSort argsorts in
-            let uu____6235 = caption_to_string print_captions c in
-            let uu____6236 = strSort retsort in
-            FStar_Util.format4 "%s(declare-fun %s (%s) %s)" uu____6235 f
-              (FStar_String.concat " " l) uu____6236
+            let uu___ = caption_to_string print_captions c in
+            let uu___1 = strSort retsort in
+            FStar_Util.format4 "%s(declare-fun %s (%s) %s)" uu___ f
+              (FStar_String.concat " " l) uu___1
         | DefineFun (f, arg_sorts, retsort, body, c) ->
-            let uu____6246 = name_macro_binders arg_sorts in
-            (match uu____6246 with
+            let uu___ = name_macro_binders arg_sorts in
+            (match uu___ with
              | (names, binders1) ->
                  let body1 =
-                   let uu____6266 =
+                   let uu___1 =
                      FStar_List.map (fun x -> mkFreeV x norng) names in
-                   inst uu____6266 body in
-                 let uu____6271 = caption_to_string print_captions c in
-                 let uu____6272 = strSort retsort in
-                 let uu____6273 =
-                   let uu____6274 = escape f in
-                   termToSmt print_captions uu____6274 body1 in
-                 FStar_Util.format5 "%s(define-fun %s (%s) %s\n %s)"
-                   uu____6271 f (FStar_String.concat " " binders1) uu____6272
-                   uu____6273)
+                   inst uu___1 body in
+                 let uu___1 = caption_to_string print_captions c in
+                 let uu___2 = strSort retsort in
+                 let uu___3 =
+                   let uu___4 = escape f in
+                   termToSmt print_captions uu___4 body1 in
+                 FStar_Util.format5 "%s(define-fun %s (%s) %s\n %s)" uu___1 f
+                   (FStar_String.concat " " binders1) uu___2 uu___3)
         | Assume a ->
             let fact_ids_to_string ids =
               FStar_All.pipe_right ids
                 (FStar_List.map
-                   (fun uu___7_6295 ->
-                      match uu___7_6295 with
+                   (fun uu___ ->
+                      match uu___ with
                       | Name n ->
-                          let uu____6297 = FStar_Ident.string_of_lid n in
-                          Prims.op_Hat "Name " uu____6297
+                          let uu___1 = FStar_Ident.string_of_lid n in
+                          Prims.op_Hat "Name " uu___1
                       | Namespace ns ->
-                          let uu____6299 = FStar_Ident.string_of_lid ns in
-                          Prims.op_Hat "Namespace " uu____6299
+                          let uu___1 = FStar_Ident.string_of_lid ns in
+                          Prims.op_Hat "Namespace " uu___1
                       | Tag t -> Prims.op_Hat "Tag " t)) in
             let fids =
               if print_captions
               then
-                let uu____6302 =
-                  let uu____6303 = fact_ids_to_string a.assumption_fact_ids in
-                  FStar_String.concat "; " uu____6303 in
-                FStar_Util.format1 ";;; Fact-ids: %s\n" uu____6302
+                let uu___ =
+                  let uu___1 = fact_ids_to_string a.assumption_fact_ids in
+                  FStar_String.concat "; " uu___1 in
+                FStar_Util.format1 ";;; Fact-ids: %s\n" uu___
               else "" in
             let n = a.assumption_name in
-            let uu____6308 =
-              caption_to_string print_captions a.assumption_caption in
-            let uu____6309 = termToSmt print_captions n a.assumption_term in
-            FStar_Util.format4 "%s%s(assert (! %s\n:named %s))" uu____6308
-              fids uu____6309 n
+            let uu___ = caption_to_string print_captions a.assumption_caption in
+            let uu___1 = termToSmt print_captions n a.assumption_term in
+            FStar_Util.format4 "%s%s(assert (! %s\n:named %s))" uu___ fids
+              uu___1 n
         | Eval t ->
-            let uu____6311 = termToSmt print_captions "eval" t in
-            FStar_Util.format1 "(eval %s)" uu____6311
+            let uu___ = termToSmt print_captions "eval" t in
+            FStar_Util.format1 "(eval %s)" uu___
         | Echo s -> FStar_Util.format1 "(echo \"%s\")" s
-        | RetainAssumptions uu____6313 -> ""
+        | RetainAssumptions uu___ -> ""
         | CheckSat ->
             "(echo \"<result>\")\n(check-sat)\n(echo \"</result>\")"
         | GetUnsatCore ->
@@ -1850,8 +1763,8 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
 and (declToSmt : Prims.string -> decl -> Prims.string) =
   fun z3options ->
     fun decl1 ->
-      let uu____6320 = FStar_Options.keep_query_captions () in
-      declToSmt' uu____6320 z3options decl1
+      let uu___ = FStar_Options.keep_query_captions () in
+      declToSmt' uu___ z3options decl1
 and (mkPrelude : Prims.string -> Prims.string) =
   fun z3options ->
     let basic =
@@ -1882,76 +1795,73 @@ and (mkPrelude : Prims.string -> Prims.string) =
         ("LexCons_2", Term_sort, true)], Term_sort, (Prims.of_int (11)),
         true)] in
     let bcons =
-      let uu____6343 =
-        let uu____6346 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right constrs
             (FStar_List.collect (constructor_to_decl norng)) in
-        FStar_All.pipe_right uu____6346
-          (FStar_List.map (declToSmt z3options)) in
-      FStar_All.pipe_right uu____6343 (FStar_String.concat "\n") in
+        FStar_All.pipe_right uu___1 (FStar_List.map (declToSmt z3options)) in
+      FStar_All.pipe_right uu___ (FStar_String.concat "\n") in
     let lex_ordering =
       "\n(define-fun is-Prims.LexCons ((t Term)) Bool \n(is-LexCons t))\n(declare-fun Prims.lex_t () Term)\n(assert (forall ((t1 Term) (t2 Term) (x1 Term) (x2 Term) (y1 Term) (y2 Term))\n(iff (Valid (Prims.precedes Prims.lex_t Prims.lex_t (LexCons t1 x1 x2) (LexCons t2 y1 y2)))\n(or (Valid (Prims.precedes t1 t2 x1 y1))\n(and (= x1 y1)\n(Valid (Prims.precedes Prims.lex_t Prims.lex_t x2 y2)))))))\n(assert (forall ((t1 Term) (t2 Term) (e1 Term) (e2 Term))\n(! (iff (Valid (Prims.precedes t1 t2 e1 e2))\n(Valid (Prims.precedes Prims.lex_t Prims.lex_t e1 e2)))\n:pattern (Prims.precedes t1 t2 e1 e2))))\n(assert (forall ((t1 Term) (t2 Term))\n(! (iff (Valid (Prims.precedes Prims.lex_t Prims.lex_t t1 t2)) \n(< (Rank t1) (Rank t2)))\n:pattern ((Prims.precedes Prims.lex_t Prims.lex_t t1 t2)))))\n" in
     let valid_intro =
       "(assert (forall ((e Term) (t Term))\n(! (implies (HasType e t)\n(Valid t))\n:pattern ((HasType e t)\n(Valid t))\n:qid __prelude_valid_intro)))\n" in
     let valid_elim =
       "(assert (forall ((t Term))\n(! (implies (Valid t)\n(exists ((e Term)) (HasType e t)))\n:pattern ((Valid t))\n:qid __prelude_valid_elim)))\n" in
-    let uu____6362 =
-      let uu____6363 =
-        let uu____6364 =
-          let uu____6365 =
-            let uu____6366 = FStar_Options.smtencoding_valid_intro () in
-            if uu____6366 then valid_intro else "" in
-          let uu____6368 =
-            let uu____6369 = FStar_Options.smtencoding_valid_elim () in
-            if uu____6369 then valid_elim else "" in
-          Prims.op_Hat uu____6365 uu____6368 in
-        Prims.op_Hat lex_ordering uu____6364 in
-      Prims.op_Hat bcons uu____6363 in
-    Prims.op_Hat basic uu____6362
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Options.smtencoding_valid_intro () in
+            if uu___4 then valid_intro else "" in
+          let uu___4 =
+            let uu___5 = FStar_Options.smtencoding_valid_elim () in
+            if uu___5 then valid_elim else "" in
+          Prims.op_Hat uu___3 uu___4 in
+        Prims.op_Hat lex_ordering uu___2 in
+      Prims.op_Hat bcons uu___1 in
+    Prims.op_Hat basic uu___
 let (declsToSmt : Prims.string -> decl Prims.list -> Prims.string) =
   fun z3options ->
     fun decls ->
-      let uu____6385 = FStar_List.map (declToSmt z3options) decls in
-      FStar_All.pipe_right uu____6385 (FStar_String.concat "\n")
+      let uu___ = FStar_List.map (declToSmt z3options) decls in
+      FStar_All.pipe_right uu___ (FStar_String.concat "\n")
 let (declToSmt_no_caps : Prims.string -> decl -> Prims.string) =
   fun z3options -> fun decl1 -> declToSmt' false z3options decl1
 let (mkBvConstructor : Prims.int -> decl Prims.list) =
   fun sz ->
-    let uu____6407 =
-      let uu____6408 =
-        let uu____6409 = boxBitVecFun sz in
-        FStar_Pervasives_Native.fst uu____6409 in
-      let uu____6414 =
-        let uu____6417 =
-          let uu____6418 =
-            let uu____6419 = boxBitVecFun sz in
-            FStar_Pervasives_Native.snd uu____6419 in
-          (uu____6418, (BitVec_sort sz), true) in
-        [uu____6417] in
-      (uu____6408, uu____6414, Term_sort, ((Prims.of_int (12)) + sz), true) in
-    FStar_All.pipe_right uu____6407 (constructor_to_decl norng)
+    let uu___ =
+      let uu___1 =
+        let uu___2 = boxBitVecFun sz in FStar_Pervasives_Native.fst uu___2 in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = boxBitVecFun sz in
+            FStar_Pervasives_Native.snd uu___5 in
+          (uu___4, (BitVec_sort sz), true) in
+        [uu___3] in
+      (uu___1, uu___2, Term_sort, ((Prims.of_int (12)) + sz), true) in
+    FStar_All.pipe_right uu___ (constructor_to_decl norng)
 let (__range_c : Prims.int FStar_ST.ref) = FStar_Util.mk_ref Prims.int_zero
 let (mk_Range_const : unit -> term) =
-  fun uu____6434 ->
+  fun uu___ ->
     let i = FStar_ST.op_Bang __range_c in
-    (let uu____6443 =
-       let uu____6444 = FStar_ST.op_Bang __range_c in
-       uu____6444 + Prims.int_one in
-     FStar_ST.op_Colon_Equals __range_c uu____6443);
-    (let uu____6457 =
-       let uu____6464 = let uu____6467 = mkInteger' i norng in [uu____6467] in
-       ("Range_const", uu____6464) in
-     mkApp uu____6457 norng)
+    (let uu___2 =
+       let uu___3 = FStar_ST.op_Bang __range_c in uu___3 + Prims.int_one in
+     FStar_ST.op_Colon_Equals __range_c uu___2);
+    (let uu___2 =
+       let uu___3 = let uu___4 = mkInteger' i norng in [uu___4] in
+       ("Range_const", uu___3) in
+     mkApp uu___2 norng)
 let (mk_Term_type : term) = mkApp ("Tm_type", []) norng
 let (mk_Term_app : term -> term -> FStar_Range.range -> term) =
   fun t1 -> fun t2 -> fun r -> mkApp ("Tm_app", [t1; t2]) r
 let (mk_Term_uvar : Prims.int -> FStar_Range.range -> term) =
   fun i ->
     fun r ->
-      let uu____6499 =
-        let uu____6506 = let uu____6509 = mkInteger' i norng in [uu____6509] in
-        ("Tm_uvar", uu____6506) in
-      mkApp uu____6499 r
+      let uu___ =
+        let uu___1 = let uu___2 = mkInteger' i norng in [uu___2] in
+        ("Tm_uvar", uu___1) in
+      mkApp uu___ r
 let (mk_Term_unit : term) = mkApp ("Tm_unit", []) norng
 let (elim_box : Prims.bool -> Prims.string -> Prims.string -> term -> term) =
   fun cond ->
@@ -1960,13 +1870,13 @@ let (elim_box : Prims.bool -> Prims.string -> Prims.string -> term -> term) =
         fun t ->
           match t.tm with
           | App (Var v', t1::[]) when (v = v') && cond -> t1
-          | uu____6538 -> mkApp (u, [t]) t.rng
+          | uu___ -> mkApp (u, [t]) t.rng
 let (maybe_elim_box : Prims.string -> Prims.string -> term -> term) =
   fun u ->
     fun v ->
       fun t ->
-        let uu____6556 = FStar_Options.smtencoding_elim_box () in
-        elim_box uu____6556 u v t
+        let uu___ = FStar_Options.smtencoding_elim_box () in
+        elim_box uu___ u v t
 let (boxInt : term -> term) =
   fun t ->
     maybe_elim_box (FStar_Pervasives_Native.fst boxIntFun)
@@ -2002,23 +1912,19 @@ let (unboxReal : term -> term) =
 let (boxBitVec : Prims.int -> term -> term) =
   fun sz ->
     fun t ->
-      let uu____6607 =
-        let uu____6608 = boxBitVecFun sz in
-        FStar_Pervasives_Native.fst uu____6608 in
-      let uu____6613 =
-        let uu____6614 = boxBitVecFun sz in
-        FStar_Pervasives_Native.snd uu____6614 in
-      elim_box true uu____6607 uu____6613 t
+      let uu___ =
+        let uu___1 = boxBitVecFun sz in FStar_Pervasives_Native.fst uu___1 in
+      let uu___1 =
+        let uu___2 = boxBitVecFun sz in FStar_Pervasives_Native.snd uu___2 in
+      elim_box true uu___ uu___1 t
 let (unboxBitVec : Prims.int -> term -> term) =
   fun sz ->
     fun t ->
-      let uu____6629 =
-        let uu____6630 = boxBitVecFun sz in
-        FStar_Pervasives_Native.snd uu____6630 in
-      let uu____6635 =
-        let uu____6636 = boxBitVecFun sz in
-        FStar_Pervasives_Native.fst uu____6636 in
-      elim_box true uu____6629 uu____6635 t
+      let uu___ =
+        let uu___1 = boxBitVecFun sz in FStar_Pervasives_Native.snd uu___1 in
+      let uu___1 =
+        let uu___2 = boxBitVecFun sz in FStar_Pervasives_Native.fst uu___2 in
+      elim_box true uu___ uu___1 t
 let (boxTerm : sort -> term -> term) =
   fun sort1 ->
     fun t ->
@@ -2028,7 +1934,7 @@ let (boxTerm : sort -> term -> term) =
       | String_sort -> boxString t
       | BitVec_sort sz -> boxBitVec sz t
       | Sort "Real" -> boxReal t
-      | uu____6652 -> FStar_Exn.raise FStar_Util.Impos
+      | uu___ -> FStar_Exn.raise FStar_Util.Impos
 let (unboxTerm : sort -> term -> term) =
   fun sort1 ->
     fun t ->
@@ -2038,130 +1944,122 @@ let (unboxTerm : sort -> term -> term) =
       | String_sort -> unboxString t
       | BitVec_sort sz -> unboxBitVec sz t
       | Sort "Real" -> unboxReal t
-      | uu____6664 -> FStar_Exn.raise FStar_Util.Impos
+      | uu___ -> FStar_Exn.raise FStar_Util.Impos
 let (getBoxedInteger : term -> Prims.int FStar_Pervasives_Native.option) =
   fun t ->
     match t.tm with
     | App (Var s, t2::[]) when s = (FStar_Pervasives_Native.fst boxIntFun) ->
         (match t2.tm with
          | Integer n ->
-             let uu____6681 = FStar_Util.int_of_string n in
-             FStar_Pervasives_Native.Some uu____6681
-         | uu____6682 -> FStar_Pervasives_Native.None)
-    | uu____6683 -> FStar_Pervasives_Native.None
+             let uu___ = FStar_Util.int_of_string n in
+             FStar_Pervasives_Native.Some uu___
+         | uu___ -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (mk_PreType : term -> term) = fun t -> mkApp ("PreType", [t]) t.rng
 let (mk_Valid : term -> term) =
   fun t ->
     match t.tm with
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_Equality", uu____6696::t1::t2::[]);
-           freevars = uu____6699; rng = uu____6700;_}::[])
+         { tm = App (Var "Prims.op_Equality", uu___::t1::t2::[]);
+           freevars = uu___1; rng = uu___2;_}::[])
         -> mkEq (t1, t2) t.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_disEquality", uu____6715::t1::t2::[]);
-           freevars = uu____6718; rng = uu____6719;_}::[])
-        -> let uu____6734 = mkEq (t1, t2) norng in mkNot uu____6734 t.rng
+         { tm = App (Var "Prims.op_disEquality", uu___::t1::t2::[]);
+           freevars = uu___1; rng = uu___2;_}::[])
+        -> let uu___3 = mkEq (t1, t2) norng in mkNot uu___3 t.rng
     | App
         (Var "Prims.b2t",
          { tm = App (Var "Prims.op_LessThanOrEqual", t1::t2::[]);
-           freevars = uu____6737; rng = uu____6738;_}::[])
+           freevars = uu___; rng = uu___1;_}::[])
         ->
-        let uu____6753 =
-          let uu____6758 = unboxInt t1 in
-          let uu____6759 = unboxInt t2 in (uu____6758, uu____6759) in
-        mkLTE uu____6753 t.rng
+        let uu___2 =
+          let uu___3 = unboxInt t1 in
+          let uu___4 = unboxInt t2 in (uu___3, uu___4) in
+        mkLTE uu___2 t.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_LessThan", t1::t2::[]);
-           freevars = uu____6762; rng = uu____6763;_}::[])
+         { tm = App (Var "Prims.op_LessThan", t1::t2::[]); freevars = uu___;
+           rng = uu___1;_}::[])
         ->
-        let uu____6778 =
-          let uu____6783 = unboxInt t1 in
-          let uu____6784 = unboxInt t2 in (uu____6783, uu____6784) in
-        mkLT uu____6778 t.rng
+        let uu___2 =
+          let uu___3 = unboxInt t1 in
+          let uu___4 = unboxInt t2 in (uu___3, uu___4) in
+        mkLT uu___2 t.rng
     | App
         (Var "Prims.b2t",
          { tm = App (Var "Prims.op_GreaterThanOrEqual", t1::t2::[]);
-           freevars = uu____6787; rng = uu____6788;_}::[])
+           freevars = uu___; rng = uu___1;_}::[])
         ->
-        let uu____6803 =
-          let uu____6808 = unboxInt t1 in
-          let uu____6809 = unboxInt t2 in (uu____6808, uu____6809) in
-        mkGTE uu____6803 t.rng
+        let uu___2 =
+          let uu___3 = unboxInt t1 in
+          let uu___4 = unboxInt t2 in (uu___3, uu___4) in
+        mkGTE uu___2 t.rng
     | App
         (Var "Prims.b2t",
          { tm = App (Var "Prims.op_GreaterThan", t1::t2::[]);
-           freevars = uu____6812; rng = uu____6813;_}::[])
+           freevars = uu___; rng = uu___1;_}::[])
         ->
-        let uu____6828 =
-          let uu____6833 = unboxInt t1 in
-          let uu____6834 = unboxInt t2 in (uu____6833, uu____6834) in
-        mkGT uu____6828 t.rng
+        let uu___2 =
+          let uu___3 = unboxInt t1 in
+          let uu___4 = unboxInt t2 in (uu___3, uu___4) in
+        mkGT uu___2 t.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_AmpAmp", t1::t2::[]);
-           freevars = uu____6837; rng = uu____6838;_}::[])
+         { tm = App (Var "Prims.op_AmpAmp", t1::t2::[]); freevars = uu___;
+           rng = uu___1;_}::[])
         ->
-        let uu____6853 =
-          let uu____6858 = unboxBool t1 in
-          let uu____6859 = unboxBool t2 in (uu____6858, uu____6859) in
-        mkAnd uu____6853 t.rng
+        let uu___2 =
+          let uu___3 = unboxBool t1 in
+          let uu___4 = unboxBool t2 in (uu___3, uu___4) in
+        mkAnd uu___2 t.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_BarBar", t1::t2::[]);
-           freevars = uu____6862; rng = uu____6863;_}::[])
+         { tm = App (Var "Prims.op_BarBar", t1::t2::[]); freevars = uu___;
+           rng = uu___1;_}::[])
         ->
-        let uu____6878 =
-          let uu____6883 = unboxBool t1 in
-          let uu____6884 = unboxBool t2 in (uu____6883, uu____6884) in
-        mkOr uu____6878 t.rng
+        let uu___2 =
+          let uu___3 = unboxBool t1 in
+          let uu___4 = unboxBool t2 in (uu___3, uu___4) in
+        mkOr uu___2 t.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "Prims.op_Negation", t1::[]); freevars = uu____6886;
-           rng = uu____6887;_}::[])
-        -> let uu____6902 = unboxBool t1 in mkNot uu____6902 t1.rng
+         { tm = App (Var "Prims.op_Negation", t1::[]); freevars = uu___;
+           rng = uu___1;_}::[])
+        -> let uu___2 = unboxBool t1 in mkNot uu___2 t1.rng
     | App
         (Var "Prims.b2t",
-         { tm = App (Var "FStar.BV.bvult", t0::t1::t2::[]);
-           freevars = uu____6906; rng = uu____6907;_}::[])
-        when
-        let uu____6922 = getBoxedInteger t0 in FStar_Util.is_some uu____6922
-        ->
+         { tm = App (Var "FStar.BV.bvult", t0::t1::t2::[]); freevars = uu___;
+           rng = uu___1;_}::[])
+        when let uu___2 = getBoxedInteger t0 in FStar_Util.is_some uu___2 ->
         let sz =
-          let uu____6926 = getBoxedInteger t0 in
-          match uu____6926 with
-          | FStar_Pervasives_Native.Some sz -> sz
-          | uu____6930 -> failwith "impossible" in
-        let uu____6933 =
-          let uu____6938 = unboxBitVec sz t1 in
-          let uu____6939 = unboxBitVec sz t2 in (uu____6938, uu____6939) in
-        mkBvUlt uu____6933 t.rng
+          let uu___2 = getBoxedInteger t0 in
+          match uu___2 with
+          | FStar_Pervasives_Native.Some sz1 -> sz1
+          | uu___3 -> failwith "impossible" in
+        let uu___2 =
+          let uu___3 = unboxBitVec sz t1 in
+          let uu___4 = unboxBitVec sz t2 in (uu___3, uu___4) in
+        mkBvUlt uu___2 t.rng
     | App
         (Var "Prims.equals",
-         uu____6940::{ tm = App (Var "FStar.BV.bvult", t0::t1::t2::[]);
-                       freevars = uu____6944; rng = uu____6945;_}::uu____6946::[])
-        when
-        let uu____6961 = getBoxedInteger t0 in FStar_Util.is_some uu____6961
-        ->
+         uu___::{ tm = App (Var "FStar.BV.bvult", t0::t1::t2::[]);
+                  freevars = uu___1; rng = uu___2;_}::uu___3::[])
+        when let uu___4 = getBoxedInteger t0 in FStar_Util.is_some uu___4 ->
         let sz =
-          let uu____6965 = getBoxedInteger t0 in
-          match uu____6965 with
-          | FStar_Pervasives_Native.Some sz -> sz
-          | uu____6969 -> failwith "impossible" in
-        let uu____6972 =
-          let uu____6977 = unboxBitVec sz t1 in
-          let uu____6978 = unboxBitVec sz t2 in (uu____6977, uu____6978) in
-        mkBvUlt uu____6972 t.rng
+          let uu___4 = getBoxedInteger t0 in
+          match uu___4 with
+          | FStar_Pervasives_Native.Some sz1 -> sz1
+          | uu___5 -> failwith "impossible" in
+        let uu___4 =
+          let uu___5 = unboxBitVec sz t1 in
+          let uu___6 = unboxBitVec sz t2 in (uu___5, uu___6) in
+        mkBvUlt uu___4 t.rng
     | App (Var "Prims.b2t", t1::[]) ->
-        let uu___1422_6982 = unboxBool t1 in
-        {
-          tm = (uu___1422_6982.tm);
-          freevars = (uu___1422_6982.freevars);
-          rng = (t.rng)
-        }
-    | uu____6983 -> mkApp ("Valid", [t]) t.rng
+        let uu___ = unboxBool t1 in
+        { tm = (uu___.tm); freevars = (uu___.freevars); rng = (t.rng) }
+    | uu___ -> mkApp ("Valid", [t]) t.rng
 let (mk_HasType : term -> term -> term) =
   fun v -> fun t -> mkApp ("HasType", [v; t]) t.rng
 let (mk_HasTypeZ : term -> term -> term) =
@@ -2172,8 +2070,8 @@ let (mk_HasTypeFuel : term -> term -> term -> term) =
   fun f ->
     fun v ->
       fun t ->
-        let uu____7039 = FStar_Options.unthrottle_inductives () in
-        if uu____7039
+        let uu___ = FStar_Options.unthrottle_inductives () in
+        if uu___
         then mk_HasType v t
         else mkApp ("HasTypeFuel", [f; v; t]) t.rng
 let (mk_HasTypeWithFuel :
@@ -2198,17 +2096,17 @@ let (mk_ApplyTT : term -> term -> FStar_Range.range -> term) =
   fun t -> fun t' -> fun r -> mkApp ("ApplyTT", [t; t']) r
 let (kick_partial_app : term -> term) =
   fun t ->
-    let uu____7145 =
-      let uu____7146 = mkApp ("__uu__PartialApp", []) t.rng in
-      mk_ApplyTT uu____7146 t t.rng in
-    FStar_All.pipe_right uu____7145 mk_Valid
+    let uu___ =
+      let uu___1 = mkApp ("__uu__PartialApp", []) t.rng in
+      mk_ApplyTT uu___1 t t.rng in
+    FStar_All.pipe_right uu___ mk_Valid
 let (mk_String_const : Prims.string -> FStar_Range.range -> term) =
   fun s ->
     fun r ->
-      let uu____7159 =
-        let uu____7166 = let uu____7169 = mk (String s) r in [uu____7169] in
-        ("FString_const", uu____7166) in
-      mkApp uu____7159 r
+      let uu___ =
+        let uu___1 = let uu___2 = mk (String s) r in [uu___2] in
+        ("FString_const", uu___1) in
+      mkApp uu___ r
 let (mk_Precedes : term -> term -> term -> term -> FStar_Range.range -> term)
   =
   fun x1 ->
@@ -2216,8 +2114,8 @@ let (mk_Precedes : term -> term -> term -> term -> FStar_Range.range -> term)
       fun x3 ->
         fun x4 ->
           fun r ->
-            let uu____7197 = mkApp ("Prims.precedes", [x1; x2; x3; x4]) r in
-            FStar_All.pipe_right uu____7197 mk_Valid
+            let uu___ = mkApp ("Prims.precedes", [x1; x2; x3; x4]) r in
+            FStar_All.pipe_right uu___ mk_Valid
 let (mk_LexCons : term -> term -> term -> FStar_Range.range -> term) =
   fun x1 -> fun x2 -> fun x3 -> fun r -> mkApp ("LexCons", [x1; x2; x3]) r
 let rec (n_fuel : Prims.int -> term) =
@@ -2225,11 +2123,10 @@ let rec (n_fuel : Prims.int -> term) =
     if n = Prims.int_zero
     then mkApp ("ZFuel", []) norng
     else
-      (let uu____7230 =
-         let uu____7237 =
-           let uu____7240 = n_fuel (n - Prims.int_one) in [uu____7240] in
-         ("SFuel", uu____7237) in
-       mkApp uu____7230 norng)
+      (let uu___1 =
+         let uu___2 = let uu___3 = n_fuel (n - Prims.int_one) in [uu___3] in
+         ("SFuel", uu___2) in
+       mkApp uu___1 norng)
 let (fuel_2 : term) = n_fuel (Prims.of_int (2))
 let (fuel_100 : term) = n_fuel (Prims.of_int (100))
 let (mk_and_opt :
@@ -2243,8 +2140,8 @@ let (mk_and_opt :
         match (p1, p2) with
         | (FStar_Pervasives_Native.Some p11, FStar_Pervasives_Native.Some
            p21) ->
-            let uu____7280 = mkAnd (p11, p21) r in
-            FStar_Pervasives_Native.Some uu____7280
+            let uu___ = mkAnd (p11, p21) r in
+            FStar_Pervasives_Native.Some uu___
         | (FStar_Pervasives_Native.Some p, FStar_Pervasives_Native.None) ->
             FStar_Pervasives_Native.Some p
         | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some p) ->
@@ -2262,16 +2159,13 @@ let (mk_and_opt_l :
 let (mk_and_l : term Prims.list -> FStar_Range.range -> term) =
   fun l ->
     fun r ->
-      let uu____7341 = mkTrue r in
-      FStar_List.fold_right (fun p1 -> fun p2 -> mkAnd (p1, p2) r) l
-        uu____7341
+      let uu___ = mkTrue r in
+      FStar_List.fold_right (fun p1 -> fun p2 -> mkAnd (p1, p2) r) l uu___
 let (mk_or_l : term Prims.list -> FStar_Range.range -> term) =
   fun l ->
     fun r ->
-      let uu____7360 = mkFalse r in
-      FStar_List.fold_right (fun p1 -> fun p2 -> mkOr (p1, p2) r) l
-        uu____7360
+      let uu___ = mkFalse r in
+      FStar_List.fold_right (fun p1 -> fun p2 -> mkOr (p1, p2) r) l uu___
 let (mk_haseq : term -> term) =
-  fun t ->
-    let uu____7370 = mkApp ("Prims.hasEq", [t]) t.rng in mk_Valid uu____7370
+  fun t -> let uu___ = mkApp ("Prims.hasEq", [t]) t.rng in mk_Valid uu___
 let (dummy_sort : sort) = Sort "Dummy_sort"

--- a/src/ocaml-output/FStar_SMTEncoding_Util.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Util.ml
@@ -3,21 +3,21 @@ let (mkAssume :
   (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.caption *
     Prims.string) -> FStar_SMTEncoding_Term.decl)
   =
-  fun uu____10 ->
-    match uu____10 with
+  fun uu___ ->
+    match uu___ with
     | (tm, cap, nm) ->
-        let uu____20 =
-          let uu____21 = FStar_SMTEncoding_Term.escape nm in
+        let uu___1 =
+          let uu___2 = FStar_SMTEncoding_Term.escape nm in
           {
             FStar_SMTEncoding_Term.assumption_term = tm;
             FStar_SMTEncoding_Term.assumption_caption = cap;
-            FStar_SMTEncoding_Term.assumption_name = uu____21;
+            FStar_SMTEncoding_Term.assumption_name = uu___2;
             FStar_SMTEncoding_Term.assumption_fact_ids = []
           } in
-        FStar_SMTEncoding_Term.Assume uu____20
+        FStar_SMTEncoding_Term.Assume uu___1
 let norng :
-  'uuuuuu30 'uuuuuu31 .
-    ('uuuuuu30 -> FStar_Range.range -> 'uuuuuu31) -> 'uuuuuu30 -> 'uuuuuu31
+  'uuuuu 'uuuuu1 .
+    ('uuuuu -> FStar_Range.range -> 'uuuuu1) -> 'uuuuu -> 'uuuuu1
   = fun f -> fun x -> f x FStar_Range.dummyRange
 let (mkTrue : FStar_SMTEncoding_Term.term) =
   FStar_SMTEncoding_Term.mkTrue FStar_Range.dummyRange
@@ -170,22 +170,19 @@ let (mkCases :
   FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term) =
   norng FStar_SMTEncoding_Term.mkCases
 let norng2 :
-  'uuuuuu514 'uuuuuu515 'uuuuuu516 .
-    ('uuuuuu514 -> 'uuuuuu515 -> FStar_Range.range -> 'uuuuuu516) ->
-      'uuuuuu514 -> 'uuuuuu515 -> 'uuuuuu516
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    ('uuuuu -> 'uuuuu1 -> FStar_Range.range -> 'uuuuu2) ->
+      'uuuuu -> 'uuuuu1 -> 'uuuuu2
   = fun f -> fun x -> fun y -> f x y FStar_Range.dummyRange
 let norng3 :
-  'uuuuuu563 'uuuuuu564 'uuuuuu565 'uuuuuu566 .
-    ('uuuuuu563 ->
-       'uuuuuu564 -> 'uuuuuu565 -> FStar_Range.range -> 'uuuuuu566)
-      -> 'uuuuuu563 -> 'uuuuuu564 -> 'uuuuuu565 -> 'uuuuuu566
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 .
+    ('uuuuu -> 'uuuuu1 -> 'uuuuu2 -> FStar_Range.range -> 'uuuuu3) ->
+      'uuuuu -> 'uuuuu1 -> 'uuuuu2 -> 'uuuuu3
   = fun f -> fun x -> fun y -> fun z -> f x y z FStar_Range.dummyRange
 let norng4 :
-  'uuuuuu627 'uuuuuu628 'uuuuuu629 'uuuuuu630 'uuuuuu631 .
-    ('uuuuuu627 ->
-       'uuuuuu628 ->
-         'uuuuuu629 -> 'uuuuuu630 -> FStar_Range.range -> 'uuuuuu631)
-      -> 'uuuuuu627 -> 'uuuuuu628 -> 'uuuuuu629 -> 'uuuuuu630 -> 'uuuuuu631
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 'uuuuu4 .
+    ('uuuuu -> 'uuuuu1 -> 'uuuuu2 -> 'uuuuu3 -> FStar_Range.range -> 'uuuuu4)
+      -> 'uuuuu -> 'uuuuu1 -> 'uuuuu2 -> 'uuuuu3 -> 'uuuuu4
   =
   fun f ->
     fun x -> fun y -> fun z -> fun w -> f x y z w FStar_Range.dummyRange
@@ -224,12 +221,12 @@ let (is_smt_reifiable_effect :
     fun l ->
       let l1 = FStar_TypeChecker_Env.norm_eff_name en l in
       (FStar_TypeChecker_Env.is_reifiable_effect en l1) &&
-        (let uu____762 =
-           let uu____763 =
+        (let uu___ =
+           let uu___1 =
              FStar_All.pipe_right l1
                (FStar_TypeChecker_Env.get_effect_decl en) in
-           FStar_All.pipe_right uu____763 FStar_Syntax_Util.is_layered in
-         Prims.op_Negation uu____762)
+           FStar_All.pipe_right uu___1 FStar_Syntax_Util.is_layered in
+         Prims.op_Negation uu___)
 let (is_smt_reifiable_comp :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
   fun en ->
@@ -237,7 +234,7 @@ let (is_smt_reifiable_comp :
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_smt_reifiable_effect en ct.FStar_Syntax_Syntax.effect_name
-      | uu____775 -> false
+      | uu___ -> false
 let (is_smt_reifiable_rc :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.residual_comp -> Prims.bool)
@@ -249,10 +246,10 @@ let (is_smt_reifiable_function :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun en ->
     fun t ->
-      let uu____796 =
-        let uu____797 = FStar_Syntax_Subst.compress t in
-        uu____797.FStar_Syntax_Syntax.n in
-      match uu____796 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____800, c) ->
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
           is_smt_reifiable_comp en c
-      | uu____822 -> false
+      | uu___1 -> false

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -7,16 +7,16 @@ let (parse_z3_version_lines :
   Prims.string -> Prims.string FStar_Pervasives_Native.option) =
   fun out ->
     match FStar_Util.splitlines out with
-    | version::uu____29 ->
+    | version::uu___ ->
         if FStar_Util.starts_with version _z3version_expected
         then
-          ((let uu____35 = FStar_Options.debug_any () in
-            if uu____35
+          ((let uu___2 = FStar_Options.debug_any () in
+            if uu___2
             then
-              let uu____36 =
+              let uu___3 =
                 FStar_Util.format1
                   "Successfully found expected Z3 version %s\n" version in
-              FStar_Util.print_string uu____36
+              FStar_Util.print_string uu___3
             else ());
            FStar_Pervasives_Native.None)
         else
@@ -24,44 +24,44 @@ let (parse_z3_version_lines :
              FStar_Util.format2 "Expected Z3 version \"%s\", got \"%s\""
                _z3version_expected out in
            FStar_Pervasives_Native.Some msg)
-    | uu____40 -> FStar_Pervasives_Native.Some "No Z3 version string found"
+    | uu___ -> FStar_Pervasives_Native.Some "No Z3 version string found"
 let (z3version_warning_message :
   unit ->
     (FStar_Errors.raw_error * Prims.string) FStar_Pervasives_Native.option)
   =
-  fun uu____53 ->
+  fun uu___ ->
     let run_proc_result =
       try
-        (fun uu___15_61 ->
+        (fun uu___1 ->
            match () with
            | () ->
-               let uu____64 =
-                 let uu____65 = FStar_Options.z3_exe () in
-                 FStar_Util.run_process "z3_version" uu____65 ["-version"]
+               let uu___2 =
+                 let uu___3 = FStar_Options.z3_exe () in
+                 FStar_Util.run_process "z3_version" uu___3 ["-version"]
                    FStar_Pervasives_Native.None in
-               FStar_Pervasives_Native.Some uu____64) ()
-      with | uu___14_67 -> FStar_Pervasives_Native.None in
+               FStar_Pervasives_Native.Some uu___2) ()
+      with | uu___1 -> FStar_Pervasives_Native.None in
     match run_proc_result with
     | FStar_Pervasives_Native.None ->
         FStar_Pervasives_Native.Some
           (FStar_Errors.Error_Z3InvocationError, "Could not run Z3")
     | FStar_Pervasives_Native.Some out ->
-        let uu____81 = parse_z3_version_lines out in
-        (match uu____81 with
+        let uu___1 = parse_z3_version_lines out in
+        (match uu___1 with
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some msg ->
              FStar_Pervasives_Native.Some
                (FStar_Errors.Warning_Z3InvocationWarning, msg))
 let (check_z3version : unit -> unit) =
-  fun uu____103 ->
-    let uu____104 =
-      let uu____105 = FStar_ST.op_Bang _z3version_checked in
-      Prims.op_Negation uu____105 in
-    if uu____104
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang _z3version_checked in
+      Prims.op_Negation uu___2 in
+    if uu___1
     then
       (FStar_ST.op_Colon_Equals _z3version_checked true;
-       (let uu____119 = z3version_warning_message () in
-        match uu____119 with
+       (let uu___3 = z3version_warning_message () in
+        match uu___3 with
         | FStar_Pervasives_Native.None -> ()
         | FStar_Pervasives_Native.Some (e, msg) ->
             let msg1 =
@@ -82,74 +82,71 @@ type z3status =
   FStar_Pervasives_Native.option) 
   | KILLED 
 let (uu___is_UNSAT : z3status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UNSAT _0 -> true | uu____186 -> false
+  fun projectee -> match projectee with | UNSAT _0 -> true | uu___ -> false
 let (__proj__UNSAT__item___0 : z3status -> unsat_core) =
   fun projectee -> match projectee with | UNSAT _0 -> _0
 let (uu___is_SAT : z3status -> Prims.bool) =
-  fun projectee -> match projectee with | SAT _0 -> true | uu____205 -> false
+  fun projectee -> match projectee with | SAT _0 -> true | uu___ -> false
 let (__proj__SAT__item___0 :
   z3status ->
     (FStar_SMTEncoding_Term.error_labels * Prims.string
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | SAT _0 -> _0
 let (uu___is_UNKNOWN : z3status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UNKNOWN _0 -> true | uu____242 -> false
+  fun projectee -> match projectee with | UNKNOWN _0 -> true | uu___ -> false
 let (__proj__UNKNOWN__item___0 :
   z3status ->
     (FStar_SMTEncoding_Term.error_labels * Prims.string
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | UNKNOWN _0 -> _0
 let (uu___is_TIMEOUT : z3status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TIMEOUT _0 -> true | uu____279 -> false
+  fun projectee -> match projectee with | TIMEOUT _0 -> true | uu___ -> false
 let (__proj__TIMEOUT__item___0 :
   z3status ->
     (FStar_SMTEncoding_Term.error_labels * Prims.string
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | TIMEOUT _0 -> _0
 let (uu___is_KILLED : z3status -> Prims.bool) =
-  fun projectee -> match projectee with | KILLED -> true | uu____309 -> false
+  fun projectee -> match projectee with | KILLED -> true | uu___ -> false
 type z3statistics = Prims.string FStar_Util.smap
 let (status_tag : z3status -> Prims.string) =
-  fun uu___0_316 ->
-    match uu___0_316 with
-    | SAT uu____317 -> "sat"
-    | UNSAT uu____324 -> "unsat"
-    | UNKNOWN uu____325 -> "unknown"
-    | TIMEOUT uu____332 -> "timeout"
+  fun uu___ ->
+    match uu___ with
+    | SAT uu___1 -> "sat"
+    | UNSAT uu___1 -> "unsat"
+    | UNKNOWN uu___1 -> "unknown"
+    | TIMEOUT uu___1 -> "timeout"
     | KILLED -> "killed"
 let (status_string_and_errors :
   z3status -> (Prims.string * FStar_SMTEncoding_Term.error_labels)) =
   fun s ->
     match s with
     | KILLED -> ((status_tag s), [])
-    | UNSAT uu____352 -> ((status_tag s), [])
+    | UNSAT uu___ -> ((status_tag s), [])
     | SAT (errs, msg) ->
-        let uu____359 =
+        let uu___ =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.op_Hat " because " msg1) in
-        (uu____359, errs)
+        (uu___, errs)
     | UNKNOWN (errs, msg) ->
-        let uu____367 =
+        let uu___ =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.op_Hat " because " msg1) in
-        (uu____367, errs)
+        (uu___, errs)
     | TIMEOUT (errs, msg) ->
-        let uu____375 =
+        let uu___ =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.op_Hat " because " msg1) in
-        (uu____375, errs)
+        (uu___, errs)
 type query_log =
   {
   get_module_name: unit -> Prims.string ;
@@ -188,35 +185,34 @@ let (query_logging : query_log) =
   let set_module_name n =
     FStar_ST.op_Colon_Equals current_module_name
       (FStar_Pervasives_Native.Some n) in
-  let get_module_name uu____629 =
-    let uu____630 = FStar_ST.op_Bang current_module_name in
-    match uu____630 with
+  let get_module_name uu___ =
+    let uu___1 = FStar_ST.op_Bang current_module_name in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> failwith "Module name not set"
     | FStar_Pervasives_Native.Some n -> n in
-  let next_file_name uu____649 =
+  let next_file_name uu___ =
     let n = get_module_name () in
     let file_name =
-      let uu____652 =
-        let uu____659 = FStar_ST.op_Bang used_file_names in
+      let uu___1 =
+        let uu___2 = FStar_ST.op_Bang used_file_names in
         FStar_List.tryFind
-          (fun uu____691 -> match uu____691 with | (m, uu____697) -> n = m)
-          uu____659 in
-      match uu____652 with
+          (fun uu___3 -> match uu___3 with | (m, uu___4) -> n = m) uu___2 in
+      match uu___1 with
       | FStar_Pervasives_Native.None ->
-          ((let uu____703 =
-              let uu____710 = FStar_ST.op_Bang used_file_names in
-              (n, Prims.int_zero) :: uu____710 in
-            FStar_ST.op_Colon_Equals used_file_names uu____703);
+          ((let uu___3 =
+              let uu___4 = FStar_ST.op_Bang used_file_names in
+              (n, Prims.int_zero) :: uu___4 in
+            FStar_ST.op_Colon_Equals used_file_names uu___3);
            n)
-      | FStar_Pervasives_Native.Some (uu____757, k) ->
-          ((let uu____764 =
-              let uu____771 = FStar_ST.op_Bang used_file_names in
-              (n, (k + Prims.int_one)) :: uu____771 in
-            FStar_ST.op_Colon_Equals used_file_names uu____764);
-           (let uu____818 = FStar_Util.string_of_int (k + Prims.int_one) in
-            FStar_Util.format2 "%s-%s" n uu____818)) in
+      | FStar_Pervasives_Native.Some (uu___2, k) ->
+          ((let uu___4 =
+              let uu___5 = FStar_ST.op_Bang used_file_names in
+              (n, (k + Prims.int_one)) :: uu___5 in
+            FStar_ST.op_Colon_Equals used_file_names uu___4);
+           (let uu___4 = FStar_Util.string_of_int (k + Prims.int_one) in
+            FStar_Util.format2 "%s-%s" n uu___4)) in
     FStar_Util.format1 "queries-%s.smt2" file_name in
-  let new_log_file uu____828 =
+  let new_log_file uu___ =
     let file_name = next_file_name () in
     FStar_ST.op_Colon_Equals current_file_name
       (FStar_Pervasives_Native.Some file_name);
@@ -224,49 +220,49 @@ let (query_logging : query_log) =
      FStar_ST.op_Colon_Equals log_file_opt
        (FStar_Pervasives_Native.Some (fh, file_name));
      (fh, file_name)) in
-  let get_log_file uu____874 =
-    let uu____875 = FStar_ST.op_Bang log_file_opt in
-    match uu____875 with
+  let get_log_file uu___ =
+    let uu___1 = FStar_ST.op_Bang log_file_opt in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> new_log_file ()
     | FStar_Pervasives_Native.Some fh -> fh in
   let append_to_log str =
-    let uu____923 = get_log_file () in
-    match uu____923 with | (f, nm) -> (FStar_Util.append_to_file f str; nm) in
+    let uu___ = get_log_file () in
+    match uu___ with | (f, nm) -> (FStar_Util.append_to_file f str; nm) in
   let write_to_new_log str =
     let file_name = next_file_name () in
     FStar_Util.write_file file_name str; file_name in
   let write_to_log fresh str =
     if fresh then write_to_new_log str else append_to_log str in
-  let close_log uu____956 =
-    let uu____957 = FStar_ST.op_Bang log_file_opt in
-    match uu____957 with
+  let close_log uu___ =
+    let uu___1 = FStar_ST.op_Bang log_file_opt in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> ()
-    | FStar_Pervasives_Native.Some (fh, uu____987) ->
+    | FStar_Pervasives_Native.Some (fh, uu___2) ->
         (FStar_Util.close_file fh;
          FStar_ST.op_Colon_Equals log_file_opt FStar_Pervasives_Native.None) in
-  let log_file_name uu____1020 =
-    let uu____1021 = FStar_ST.op_Bang current_file_name in
-    match uu____1021 with
+  let log_file_name uu___ =
+    let uu___1 = FStar_ST.op_Bang current_file_name in
+    match uu___1 with
     | FStar_Pervasives_Native.None -> failwith "no log file"
     | FStar_Pervasives_Native.Some n -> n in
   { get_module_name; set_module_name; write_to_log; close_log }
 let (z3_cmd_and_args : unit -> (Prims.string * Prims.string Prims.list)) =
-  fun uu____1045 ->
+  fun uu___ ->
     let cmd = FStar_Options.z3_exe () in
     let cmd_args =
-      let uu____1050 =
-        let uu____1053 =
-          let uu____1056 =
-            let uu____1059 =
-              let uu____1060 =
-                let uu____1061 = FStar_Options.z3_seed () in
-                FStar_Util.string_of_int uu____1061 in
-              FStar_Util.format1 "smt.random_seed=%s" uu____1060 in
-            [uu____1059] in
-          "-in" :: uu____1056 in
-        "-smt2" :: uu____1053 in
-      let uu____1062 = FStar_Options.z3_cliopt () in
-      FStar_List.append uu____1050 uu____1062 in
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_Options.z3_seed () in
+                FStar_Util.string_of_int uu___6 in
+              FStar_Util.format1 "smt.random_seed=%s" uu___5 in
+            [uu___4] in
+          "-in" :: uu___3 in
+        "-smt2" :: uu___2 in
+      let uu___2 = FStar_Options.z3_cliopt () in
+      FStar_List.append uu___1 uu___2 in
     (cmd, cmd_args)
 let (new_z3proc :
   Prims.string -> (Prims.string * Prims.string Prims.list) -> FStar_Util.proc)
@@ -280,13 +276,13 @@ let (new_z3proc_with_id :
   (Prims.string * Prims.string Prims.list) -> FStar_Util.proc) =
   let ctr = FStar_Util.mk_ref (~- Prims.int_one) in
   fun cmd_and_args ->
-    let uu____1116 =
-      let uu____1117 =
+    let uu___ =
+      let uu___1 =
         FStar_Util.incr ctr;
-        (let uu____1119 = FStar_ST.op_Bang ctr in
-         FStar_All.pipe_right uu____1119 FStar_Util.string_of_int) in
-      FStar_Util.format1 "bg-%s" uu____1117 in
-    new_z3proc uu____1116 cmd_and_args
+        (let uu___3 = FStar_ST.op_Bang ctr in
+         FStar_All.pipe_right uu___3 FStar_Util.string_of_int) in
+      FStar_Util.format1 "bg-%s" uu___1 in
+    new_z3proc uu___ cmd_and_args
 type bgproc =
   {
   ask: Prims.string -> Prims.string ;
@@ -315,60 +311,59 @@ let (bg_z3_proc : bgproc FStar_ST.ref) =
     FStar_Util.mk_ref (FStar_Pervasives_Native.Some ("", [""])) in
   let the_z3proc_ask_count = FStar_Util.mk_ref Prims.int_zero in
   let make_new_z3_proc cmd_and_args =
-    (let uu____1307 =
-       let uu____1310 = new_z3proc_with_id cmd_and_args in
-       FStar_Pervasives_Native.Some uu____1310 in
-     FStar_ST.op_Colon_Equals the_z3proc uu____1307);
+    (let uu___1 =
+       let uu___2 = new_z3proc_with_id cmd_and_args in
+       FStar_Pervasives_Native.Some uu___2 in
+     FStar_ST.op_Colon_Equals the_z3proc uu___1);
     FStar_ST.op_Colon_Equals the_z3proc_params
       (FStar_Pervasives_Native.Some cmd_and_args);
     FStar_ST.op_Colon_Equals the_z3proc_ask_count Prims.int_zero in
-  let z3proc uu____1361 =
-    (let uu____1363 =
-       let uu____1364 = FStar_ST.op_Bang the_z3proc in
-       uu____1364 = FStar_Pervasives_Native.None in
-     if uu____1363
-     then let uu____1379 = z3_cmd_and_args () in make_new_z3_proc uu____1379
+  let z3proc uu___ =
+    (let uu___2 =
+       let uu___3 = FStar_ST.op_Bang the_z3proc in
+       uu___3 = FStar_Pervasives_Native.None in
+     if uu___2
+     then let uu___3 = z3_cmd_and_args () in make_new_z3_proc uu___3
      else ());
-    (let uu____1387 = FStar_ST.op_Bang the_z3proc in
-     FStar_Util.must uu____1387) in
+    (let uu___2 = FStar_ST.op_Bang the_z3proc in FStar_Util.must uu___2) in
   let ask input =
     FStar_Util.incr the_z3proc_ask_count;
-    (let kill_handler uu____1412 = "\nkilled\n" in
-     let uu____1413 = z3proc () in
-     FStar_Util.ask_process uu____1413 input kill_handler) in
-  let refresh uu____1419 =
+    (let kill_handler uu___1 = "\nkilled\n" in
+     let uu___1 = z3proc () in
+     FStar_Util.ask_process uu___1 input kill_handler) in
+  let refresh uu___ =
     let next_params = z3_cmd_and_args () in
     let old_params =
-      let uu____1434 = FStar_ST.op_Bang the_z3proc_params in
-      FStar_Util.must uu____1434 in
-    (let uu____1472 =
+      let uu___1 = FStar_ST.op_Bang the_z3proc_params in
+      FStar_Util.must uu___1 in
+    (let uu___2 =
        ((FStar_Options.log_queries ()) ||
-          (let uu____1474 = FStar_ST.op_Bang the_z3proc_ask_count in
-           uu____1474 > Prims.int_zero))
+          (let uu___3 = FStar_ST.op_Bang the_z3proc_ask_count in
+           uu___3 > Prims.int_zero))
          || (Prims.op_Negation (old_params = next_params)) in
-     if uu____1472
+     if uu___2
      then
-       ((let uu____1488 =
+       ((let uu___4 =
            (FStar_Options.query_stats ()) &&
-             (let uu____1490 =
-                let uu____1491 = FStar_ST.op_Bang the_z3proc in
-                uu____1491 = FStar_Pervasives_Native.None in
-              Prims.op_Negation uu____1490) in
-         if uu____1488
+             (let uu___5 =
+                let uu___6 = FStar_ST.op_Bang the_z3proc in
+                uu___6 = FStar_Pervasives_Native.None in
+              Prims.op_Negation uu___5) in
+         if uu___4
          then
-           let uu____1506 =
-             let uu____1507 = FStar_ST.op_Bang the_z3proc_ask_count in
-             FStar_Util.string_of_int uu____1507 in
+           let uu___5 =
+             let uu___6 = FStar_ST.op_Bang the_z3proc_ask_count in
+             FStar_Util.string_of_int uu___6 in
            FStar_Util.print3
              "Refreshing the z3proc (ask_count=%s old=[%s] new=[%s]) \n"
-             uu____1506 (cmd_and_args_to_string old_params)
+             uu___5 (cmd_and_args_to_string old_params)
              (cmd_and_args_to_string next_params)
          else ());
-        (let uu____1516 = z3proc () in FStar_Util.kill_process uu____1516);
+        (let uu___5 = z3proc () in FStar_Util.kill_process uu___5);
         make_new_z3_proc next_params)
      else ());
     query_logging.close_log () in
-  let restart uu____1523 =
+  let restart uu___ =
     query_logging.close_log ();
     (let next_params = z3_cmd_and_args () in make_new_z3_proc next_params) in
   let x = [] in
@@ -430,21 +425,21 @@ let (smt_output_sections :
               if tag = l
               then FStar_Pervasives_Native.Some ([], lines2)
               else
-                (let uu____1775 = until tag lines2 in
-                 FStar_Util.map_opt uu____1775
-                   (fun uu____1805 ->
-                      match uu____1805 with
+                (let uu___1 = until tag lines2 in
+                 FStar_Util.map_opt uu___1
+                   (fun uu___2 ->
+                      match uu___2 with
                       | (until_tag, rest) -> ((l :: until_tag), rest))) in
         let start_tag tag = Prims.op_Hat "<" (Prims.op_Hat tag ">") in
         let end_tag tag = Prims.op_Hat "</" (Prims.op_Hat tag ">") in
         let find_section tag lines1 =
-          let uu____1883 = until (start_tag tag) lines1 in
-          match uu____1883 with
+          let uu___ = until (start_tag tag) lines1 in
+          match uu___ with
           | FStar_Pervasives_Native.None ->
               (FStar_Pervasives_Native.None, lines1)
           | FStar_Pervasives_Native.Some (prefix, suffix) ->
-              let uu____1938 = until (end_tag tag) suffix in
-              (match uu____1938 with
+              let uu___1 = until (end_tag tag) suffix in
+              (match uu___1 with
                | FStar_Pervasives_Native.None ->
                    failwith
                      (Prims.op_Hat "Parse error: "
@@ -452,32 +447,32 @@ let (smt_output_sections :
                | FStar_Pervasives_Native.Some (section, suffix1) ->
                    ((FStar_Pervasives_Native.Some section),
                      (FStar_List.append prefix suffix1))) in
-        let uu____2003 = find_section "result" lines in
-        match uu____2003 with
+        let uu___ = find_section "result" lines in
+        match uu___ with
         | (result_opt, lines1) ->
             let result = FStar_Util.must result_opt in
-            let uu____2033 = find_section "reason-unknown" lines1 in
-            (match uu____2033 with
+            let uu___1 = find_section "reason-unknown" lines1 in
+            (match uu___1 with
              | (reason_unknown, lines2) ->
-                 let uu____2058 = find_section "unsat-core" lines2 in
-                 (match uu____2058 with
+                 let uu___2 = find_section "unsat-core" lines2 in
+                 (match uu___2 with
                   | (unsat_core1, lines3) ->
-                      let uu____2083 = find_section "statistics" lines3 in
-                      (match uu____2083 with
+                      let uu___3 = find_section "statistics" lines3 in
+                      (match uu___3 with
                        | (statistics, lines4) ->
-                           let uu____2108 = find_section "labels" lines4 in
-                           (match uu____2108 with
+                           let uu___4 = find_section "labels" lines4 in
+                           (match uu___4 with
                             | (labels, lines5) ->
                                 let remaining =
-                                  let uu____2136 = until "Done!" lines5 in
-                                  match uu____2136 with
+                                  let uu___5 = until "Done!" lines5 in
+                                  match uu___5 with
                                   | FStar_Pervasives_Native.None -> lines5
                                   | FStar_Pervasives_Native.Some
                                       (prefix, suffix) ->
                                       FStar_List.append prefix suffix in
                                 ((match remaining with
                                   | [] -> ()
-                                  | uu____2176 ->
+                                  | uu___6 ->
                                       let msg =
                                         FStar_Util.format2
                                           "%sUnexpected output from Z3: %s\n"
@@ -490,9 +485,9 @@ let (smt_output_sections :
                                       FStar_Errors.log_issue r
                                         (FStar_Errors.Warning_UnexpectedZ3Output,
                                           msg));
-                                 (let uu____2181 = FStar_Util.must result_opt in
+                                 (let uu___6 = FStar_Util.must result_opt in
                                   {
-                                    smt_result = uu____2181;
+                                    smt_result = uu___6;
                                     smt_reason_unknown = reason_unknown;
                                     smt_unsat_core = unsat_core1;
                                     smt_statistics = statistics;
@@ -528,10 +523,10 @@ let (doZ3Exe :
                     if FStar_Util.starts_with s2 "error"
                     then FStar_Pervasives_Native.None
                     else
-                      (let uu____2248 =
+                      (let uu___1 =
                          FStar_All.pipe_right (FStar_Util.split s2 " ")
                            (FStar_Util.sort_with FStar_String.compare) in
-                       FStar_Pervasives_Native.Some uu____2248) in
+                       FStar_Pervasives_Native.Some uu___1) in
               let labels =
                 match smt_output1.smt_labels with
                 | FStar_Pervasives_Native.None -> []
@@ -540,33 +535,32 @@ let (doZ3Exe :
                       match lines2 with
                       | lname::"false"::rest when
                           FStar_Util.starts_with lname "label_" ->
-                          let uu____2277 = lblnegs rest in lname ::
-                            uu____2277
-                      | lname::uu____2281::rest when
+                          let uu___ = lblnegs rest in lname :: uu___
+                      | lname::uu___::rest when
                           FStar_Util.starts_with lname "label_" ->
                           lblnegs rest
-                      | uu____2285 -> [] in
+                      | uu___ -> [] in
                     let lblnegs1 = lblnegs lines1 in
                     FStar_All.pipe_right lblnegs1
                       (FStar_List.collect
                          (fun l ->
-                            let uu____2302 =
+                            let uu___ =
                               FStar_All.pipe_right label_messages
                                 (FStar_List.tryFind
-                                   (fun uu____2338 ->
-                                      match uu____2338 with
-                                      | (m, uu____2346, uu____2347) ->
-                                          let uu____2348 =
+                                   (fun uu___1 ->
+                                      match uu___1 with
+                                      | (m, uu___2, uu___3) ->
+                                          let uu___4 =
                                             FStar_SMTEncoding_Term.fv_name m in
-                                          uu____2348 = l)) in
-                            match uu____2302 with
+                                          uu___4 = l)) in
+                            match uu___ with
                             | FStar_Pervasives_Native.None -> []
                             | FStar_Pervasives_Native.Some (lbl, msg, r1) ->
                                 [(lbl, msg, r1)])) in
               let statistics =
-                let statistics = FStar_Util.smap_create Prims.int_zero in
+                let statistics1 = FStar_Util.smap_create Prims.int_zero in
                 match smt_output1.smt_statistics with
-                | FStar_Pervasives_Native.None -> statistics
+                | FStar_Pervasives_Native.None -> statistics1
                 | FStar_Pervasives_Native.Some lines1 ->
                     let parse_line line =
                       let pline =
@@ -584,7 +578,7 @@ let (doZ3Exe :
                               FStar_Util.substring ltok Prims.int_zero
                                 ((FStar_String.length ltok) - Prims.int_one)
                             else ltok in
-                          FStar_Util.smap_add statistics key value
+                          FStar_Util.smap_add statistics1 key value
                       | ""::entry::[] ->
                           let tokens = FStar_Util.split entry " " in
                           let key = FStar_List.hd tokens in
@@ -597,9 +591,9 @@ let (doZ3Exe :
                               FStar_Util.substring ltok Prims.int_zero
                                 ((FStar_String.length ltok) - Prims.int_one)
                             else ltok in
-                          FStar_Util.smap_add statistics key value
-                      | uu____2418 -> () in
-                    (FStar_List.iter parse_line lines1; statistics) in
+                          FStar_Util.smap_add statistics1 key value
+                      | uu___ -> () in
+                    (FStar_List.iter parse_line lines1; statistics1) in
               let reason_unknown =
                 FStar_Util.map_opt smt_output1.smt_reason_unknown
                   (fun x ->
@@ -615,13 +609,13 @@ let (doZ3Exe :
                        res
                      else ru) in
               let status =
-                (let uu____2436 = FStar_Options.debug_any () in
-                 if uu____2436
+                (let uu___1 = FStar_Options.debug_any () in
+                 if uu___1
                  then
-                   let uu____2437 =
+                   let uu___2 =
                      FStar_Util.format1 "Z3 says: %s\n"
                        (FStar_String.concat "\n" smt_output1.smt_result) in
-                   FStar_All.pipe_left FStar_Util.print_string uu____2437
+                   FStar_All.pipe_left FStar_Util.print_string uu___2
                  else ());
                 (match smt_output1.smt_result with
                  | "unsat"::[] -> UNSAT unsat_core1
@@ -629,28 +623,26 @@ let (doZ3Exe :
                  | "unknown"::[] -> UNKNOWN (labels, reason_unknown)
                  | "timeout"::[] -> TIMEOUT (labels, reason_unknown)
                  | "killed"::[] ->
-                     ((let uu____2446 = FStar_ST.op_Bang bg_z3_proc in
-                       uu____2446.restart ());
+                     ((let uu___2 = FStar_ST.op_Bang bg_z3_proc in
+                       uu___2.restart ());
                       KILLED)
-                 | uu____2453 ->
-                     let uu____2454 =
+                 | uu___1 ->
+                     let uu___2 =
                        FStar_Util.format1
                          "Unexpected output from Z3: got output result: %s\n"
                          (FStar_String.concat "\n" smt_output1.smt_result) in
-                     failwith uu____2454) in
+                     failwith uu___2) in
               (status, statistics) in
             let stdout =
               if fresh
               then
                 let proc =
-                  let uu____2457 = z3_cmd_and_args () in
-                  new_z3proc_with_id uu____2457 in
-                let kill_handler uu____2469 = "\nkilled\n" in
+                  let uu___ = z3_cmd_and_args () in new_z3proc_with_id uu___ in
+                let kill_handler uu___ = "\nkilled\n" in
                 let out = FStar_Util.ask_process proc input kill_handler in
                 (FStar_Util.kill_process proc; out)
               else
-                (let uu____2473 = FStar_ST.op_Bang bg_z3_proc in
-                 uu____2473.ask input) in
+                (let uu___1 = FStar_ST.op_Bang bg_z3_proc in uu___1.ask input) in
             parse (FStar_Util.trim_string stdout)
 let (z3_options : Prims.string FStar_ST.ref) =
   FStar_Util.mk_ref
@@ -692,125 +684,120 @@ let (__proj__Mkz3result__item__z3result_log_file :
     match projectee with
     | { z3result_status; z3result_time; z3result_statistics;
         z3result_query_hash; z3result_log_file;_} -> z3result_log_file
-let (init : unit -> unit) = fun uu____2604 -> ()
-let (finish : unit -> unit) = fun uu____2609 -> ()
+let (init : unit -> unit) = fun uu___ -> ()
+let (finish : unit -> unit) = fun uu___ -> ()
 type scope_t = FStar_SMTEncoding_Term.decl Prims.list Prims.list
 let (fresh_scope : scope_t FStar_ST.ref) = FStar_Util.mk_ref [[]]
 let (mk_fresh_scope : unit -> scope_t) =
-  fun uu____2624 -> FStar_ST.op_Bang fresh_scope
+  fun uu___ -> FStar_ST.op_Bang fresh_scope
 let (flatten_fresh_scope : unit -> FStar_SMTEncoding_Term.decl Prims.list) =
-  fun uu____2637 ->
-    let uu____2638 =
-      let uu____2643 = FStar_ST.op_Bang fresh_scope in
-      FStar_List.rev uu____2643 in
-    FStar_List.flatten uu____2638
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang fresh_scope in FStar_List.rev uu___2 in
+    FStar_List.flatten uu___1
 let (bg_scope : FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (push : Prims.string -> unit) =
   fun msg ->
     FStar_Util.atomically
-      (fun uu____2670 ->
-         (let uu____2672 =
-            let uu____2673 = FStar_ST.op_Bang fresh_scope in
+      (fun uu___ ->
+         (let uu___2 =
+            let uu___3 = FStar_ST.op_Bang fresh_scope in
             [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Push]
-              :: uu____2673 in
-          FStar_ST.op_Colon_Equals fresh_scope uu____2672);
-         (let uu____2692 =
-            let uu____2695 = FStar_ST.op_Bang bg_scope in
-            FStar_List.append uu____2695
+              :: uu___3 in
+          FStar_ST.op_Colon_Equals fresh_scope uu___2);
+         (let uu___2 =
+            let uu___3 = FStar_ST.op_Bang bg_scope in
+            FStar_List.append uu___3
               [FStar_SMTEncoding_Term.Push;
               FStar_SMTEncoding_Term.Caption msg] in
-          FStar_ST.op_Colon_Equals bg_scope uu____2692))
+          FStar_ST.op_Colon_Equals bg_scope uu___2))
 let (pop : Prims.string -> unit) =
   fun msg ->
     FStar_Util.atomically
-      (fun uu____2726 ->
-         (let uu____2728 =
-            let uu____2729 = FStar_ST.op_Bang fresh_scope in
-            FStar_List.tl uu____2729 in
-          FStar_ST.op_Colon_Equals fresh_scope uu____2728);
-         (let uu____2748 =
-            let uu____2751 = FStar_ST.op_Bang bg_scope in
-            FStar_List.append uu____2751
+      (fun uu___ ->
+         (let uu___2 =
+            let uu___3 = FStar_ST.op_Bang fresh_scope in FStar_List.tl uu___3 in
+          FStar_ST.op_Colon_Equals fresh_scope uu___2);
+         (let uu___2 =
+            let uu___3 = FStar_ST.op_Bang bg_scope in
+            FStar_List.append uu___3
               [FStar_SMTEncoding_Term.Caption msg;
               FStar_SMTEncoding_Term.Pop] in
-          FStar_ST.op_Colon_Equals bg_scope uu____2748))
+          FStar_ST.op_Colon_Equals bg_scope uu___2))
 let (snapshot : Prims.string -> (Prims.int * unit)) =
   fun msg -> FStar_Common.snapshot push fresh_scope msg
 let (rollback :
   Prims.string -> Prims.int FStar_Pervasives_Native.option -> unit) =
   fun msg ->
     fun depth ->
-      FStar_Common.rollback (fun uu____2802 -> pop msg) fresh_scope depth
+      FStar_Common.rollback (fun uu___ -> pop msg) fresh_scope depth
 let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun decls ->
     FStar_All.pipe_right decls
       (FStar_List.iter
-         (fun uu___1_2816 ->
-            match uu___1_2816 with
+         (fun uu___1 ->
+            match uu___1 with
             | FStar_SMTEncoding_Term.Push -> failwith "Unexpected push/pop"
             | FStar_SMTEncoding_Term.Pop -> failwith "Unexpected push/pop"
-            | uu____2817 -> ()));
-    (let uu____2819 = FStar_ST.op_Bang fresh_scope in
-     match uu____2819 with
+            | uu___2 -> ()));
+    (let uu___2 = FStar_ST.op_Bang fresh_scope in
+     match uu___2 with
      | hd::tl ->
          FStar_ST.op_Colon_Equals fresh_scope ((FStar_List.append hd decls)
            :: tl)
-     | uu____2844 -> failwith "Impossible");
-    (let uu____2845 =
-       let uu____2848 = FStar_ST.op_Bang bg_scope in
-       FStar_List.append uu____2848 decls in
-     FStar_ST.op_Colon_Equals bg_scope uu____2845)
+     | uu___3 -> failwith "Impossible");
+    (let uu___2 =
+       let uu___3 = FStar_ST.op_Bang bg_scope in
+       FStar_List.append uu___3 decls in
+     FStar_ST.op_Colon_Equals bg_scope uu___2)
 let (refresh : unit -> unit) =
-  fun uu____2875 ->
-    (let uu____2877 = FStar_ST.op_Bang bg_z3_proc in uu____2877.refresh ());
-    (let uu____2884 = flatten_fresh_scope () in
-     FStar_ST.op_Colon_Equals bg_scope uu____2884)
+  fun uu___ ->
+    (let uu___2 = FStar_ST.op_Bang bg_z3_proc in uu___2.refresh ());
+    (let uu___2 = flatten_fresh_scope () in
+     FStar_ST.op_Colon_Equals bg_scope uu___2)
 let (context_profile : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun theory ->
-    let uu____2906 =
+    let uu___ =
       FStar_List.fold_left
-        (fun uu____2935 ->
+        (fun uu___1 ->
            fun d ->
-             match uu____2935 with
+             match uu___1 with
              | (out, _total) ->
                  (match d with
                   | FStar_SMTEncoding_Term.Module (name, decls) ->
                       let decls1 =
                         FStar_List.filter
-                          (fun uu___2_2992 ->
-                             match uu___2_2992 with
-                             | FStar_SMTEncoding_Term.Assume uu____2993 ->
-                                 true
-                             | uu____2994 -> false) decls in
+                          (fun uu___2 ->
+                             match uu___2 with
+                             | FStar_SMTEncoding_Term.Assume uu___3 -> true
+                             | uu___3 -> false) decls in
                       let n = FStar_List.length decls1 in
                       (((name, n) :: out), (n + _total))
-                  | uu____3006 -> (out, _total))) ([], Prims.int_zero) theory in
-    match uu____2906 with
+                  | uu___2 -> (out, _total))) ([], Prims.int_zero) theory in
+    match uu___ with
     | (modules, total_decls) ->
         let modules1 =
           FStar_List.sortWith
-            (fun uu____3054 ->
-               fun uu____3055 ->
-                 match (uu____3054, uu____3055) with
-                 | ((uu____3072, n), (uu____3074, m)) -> m - n) modules in
+            (fun uu___1 ->
+               fun uu___2 ->
+                 match (uu___1, uu___2) with
+                 | ((uu___3, n), (uu___4, m)) -> m - n) modules in
         (if modules1 <> []
          then
-           (let uu____3095 = FStar_Util.string_of_int total_decls in
+           (let uu___2 = FStar_Util.string_of_int total_decls in
             FStar_Util.print1
-              "Z3 Proof Stats: context_profile with %s assertions\n"
-              uu____3095)
+              "Z3 Proof Stats: context_profile with %s assertions\n" uu___2)
          else ();
          FStar_List.iter
-           (fun uu____3105 ->
-              match uu____3105 with
+           (fun uu___2 ->
+              match uu___2 with
               | (m, n) ->
                   if n <> Prims.int_zero
                   then
-                    let uu____3112 = FStar_Util.string_of_int n in
+                    let uu___3 = FStar_Util.string_of_int n in
                     FStar_Util.print2
-                      "Z3 Proof Stats: %s produced %s SMT decls\n" m
-                      uu____3112
+                      "Z3 Proof Stats: %s produced %s SMT decls\n" m uu___3
                   else ()) modules1)
 let (mk_input :
   Prims.bool ->
@@ -821,25 +808,25 @@ let (mk_input :
   fun fresh ->
     fun theory ->
       let options = FStar_ST.op_Bang z3_options in
-      (let uu____3146 = FStar_Options.print_z3_statistics () in
-       if uu____3146 then context_profile theory else ());
-      (let uu____3148 =
-         let uu____3155 =
+      (let uu___1 = FStar_Options.print_z3_statistics () in
+       if uu___1 then context_profile theory else ());
+      (let uu___1 =
+         let uu___2 =
            (FStar_Options.record_hints ()) ||
              ((FStar_Options.use_hints ()) &&
                 (FStar_Options.use_hint_hashes ())) in
-         if uu____3155
+         if uu___2
          then
-           let uu____3162 =
-             let uu____3173 =
+           let uu___3 =
+             let uu___4 =
                FStar_All.pipe_right theory
                  (FStar_Util.prefix_until
-                    (fun uu___3_3201 ->
-                       match uu___3_3201 with
+                    (fun uu___5 ->
+                       match uu___5 with
                        | FStar_SMTEncoding_Term.CheckSat -> true
-                       | uu____3202 -> false)) in
-             FStar_All.pipe_right uu____3173 FStar_Option.get in
-           match uu____3162 with
+                       | uu___6 -> false)) in
+             FStar_All.pipe_right uu___4 FStar_Option.get in
+           match uu___3 with
            | (prefix, check_sat, suffix) ->
                let pp =
                  FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) in
@@ -849,34 +836,34 @@ let (mk_input :
                let ps = FStar_String.concat "\n" ps_lines in
                let ss = FStar_String.concat "\n" ss_lines in
                let hs =
-                 let uu____3273 = FStar_Options.keep_query_captions () in
-                 if uu____3273
+                 let uu___4 = FStar_Options.keep_query_captions () in
+                 if uu___4
                  then
-                   let uu____3274 =
+                   let uu___5 =
                      FStar_All.pipe_right prefix
                        (FStar_List.map
                           (FStar_SMTEncoding_Term.declToSmt_no_caps options)) in
-                   FStar_All.pipe_right uu____3274 (FStar_String.concat "\n")
+                   FStar_All.pipe_right uu___5 (FStar_String.concat "\n")
                  else ps in
-               let uu____3284 =
-                 let uu____3287 = FStar_Util.digest_of_string hs in
-                 FStar_Pervasives_Native.Some uu____3287 in
-               ((Prims.op_Hat ps (Prims.op_Hat "\n" ss)), uu____3284)
+               let uu___4 =
+                 let uu___5 = FStar_Util.digest_of_string hs in
+                 FStar_Pervasives_Native.Some uu___5 in
+               ((Prims.op_Hat ps (Prims.op_Hat "\n" ss)), uu___4)
          else
-           (let uu____3291 =
-              let uu____3292 =
+           (let uu___4 =
+              let uu___5 =
                 FStar_List.map (FStar_SMTEncoding_Term.declToSmt options)
                   theory in
-              FStar_All.pipe_right uu____3292 (FStar_String.concat "\n") in
-            (uu____3291, FStar_Pervasives_Native.None)) in
-       match uu____3148 with
+              FStar_All.pipe_right uu___5 (FStar_String.concat "\n") in
+            (uu___4, FStar_Pervasives_Native.None)) in
+       match uu___1 with
        | (r, hash) ->
            let log_file_name =
-             let uu____3318 = FStar_Options.log_queries () in
-             if uu____3318
+             let uu___2 = FStar_Options.log_queries () in
+             if uu___2
              then
-               let uu____3321 = query_logging.write_to_log fresh r in
-               FStar_Pervasives_Native.Some uu____3321
+               let uu___3 = query_logging.write_to_log fresh r in
+               FStar_Pervasives_Native.Some uu___3
              else FStar_Pervasives_Native.None in
            (r, hash, log_file_name))
 let (cache_hit :
@@ -888,9 +875,9 @@ let (cache_hit :
   fun log_file ->
     fun cache ->
       fun qhash ->
-        let uu____3358 =
+        let uu___ =
           (FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ()) in
-        if uu____3358
+        if uu___
         then
           match qhash with
           | FStar_Pervasives_Native.Some x when qhash = cache ->
@@ -905,7 +892,7 @@ let (cache_hit :
                     z3result_log_file = log_file
                   } in
                 FStar_Pervasives_Native.Some result))
-          | uu____3371 -> FStar_Pervasives_Native.None
+          | uu___1 -> FStar_Pervasives_Native.None
         else FStar_Pervasives_Native.None
 let (z3_job :
   Prims.string FStar_Pervasives_Native.option ->
@@ -921,26 +908,24 @@ let (z3_job :
         fun label_messages ->
           fun input ->
             fun qhash ->
-              fun uu____3413 ->
-                let uu____3418 =
-                  let uu____3427 =
-                    let uu____3430 = query_logging.get_module_name () in
-                    FStar_Pervasives_Native.Some uu____3430 in
+              fun uu___ ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = query_logging.get_module_name () in
+                    FStar_Pervasives_Native.Some uu___3 in
                   FStar_Profiling.profile
-                    (fun uu____3440 ->
+                    (fun uu___3 ->
                        try
-                         (fun uu___487_3450 ->
+                         (fun uu___4 ->
                             match () with
                             | () ->
                                 FStar_Util.record_time
-                                  (fun uu____3464 ->
+                                  (fun uu___5 ->
                                      doZ3Exe log_file r fresh input
                                        label_messages)) ()
-                       with
-                       | uu___486_3467 ->
-                           (refresh (); FStar_Exn.raise uu___486_3467))
-                    uu____3427 "FStar.SMTEncoding.Z3 (aggregate query time)" in
-                match uu____3418 with
+                       with | uu___4 -> (refresh (); FStar_Exn.raise uu___4))
+                    uu___2 "FStar.SMTEncoding.Z3 (aggregate query time)" in
+                match uu___1 with
                 | ((status, statistics), elapsed_time) ->
                     {
                       z3result_status = status;
@@ -970,26 +955,25 @@ let (ask :
                   if fresh
                   then flatten_fresh_scope ()
                   else
-                    (let theory = FStar_ST.op_Bang bg_scope in
-                     FStar_ST.op_Colon_Equals bg_scope []; theory) in
+                    (let theory1 = FStar_ST.op_Bang bg_scope in
+                     FStar_ST.op_Colon_Equals bg_scope []; theory1) in
                 let theory1 =
                   FStar_List.append theory
                     (FStar_List.append [FStar_SMTEncoding_Term.Push]
                        (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
-                let uu____3593 = filter_theory theory1 in
-                match uu____3593 with
+                let uu___ = filter_theory theory1 in
+                match uu___ with
                 | (theory2, _used_unsat_core) ->
-                    let uu____3606 = mk_input fresh theory2 in
-                    (match uu____3606 with
+                    let uu___1 = mk_input fresh theory2 in
+                    (match uu___1 with
                      | (input, qhash, log_file_name) ->
-                         let just_ask uu____3633 =
+                         let just_ask uu___2 =
                            z3_job log_file_name r fresh label_messages input
                              qhash () in
                          if fresh
                          then
-                           let uu____3634 =
-                             cache_hit log_file_name cache qhash in
-                           (match uu____3634 with
+                           let uu___2 = cache_hit log_file_name cache qhash in
+                           (match uu___2 with
                             | FStar_Pervasives_Native.Some z3r -> z3r
                             | FStar_Pervasives_Native.None -> just_ask ())
                          else just_ask ())

--- a/src/ocaml-output/FStar_Syntax_DsEnv.ml
+++ b/src/ocaml-output/FStar_Syntax_DsEnv.ml
@@ -11,10 +11,10 @@ type open_kind =
   | Open_namespace 
 let (uu___is_Open_module : open_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Open_module -> true | uu____55 -> false
+    match projectee with | Open_module -> true | uu___ -> false
 let (uu___is_Open_namespace : open_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Open_namespace -> true | uu____61 -> false
+    match projectee with | Open_namespace -> true | uu___ -> false
 type open_module_or_namespace = (FStar_Ident.lident * open_kind)
 type record_or_dc =
   {
@@ -67,35 +67,35 @@ type scope_mod =
   | Record_or_dc of record_or_dc 
 let (uu___is_Local_binding : scope_mod -> Prims.bool) =
   fun projectee ->
-    match projectee with | Local_binding _0 -> true | uu____256 -> false
+    match projectee with | Local_binding _0 -> true | uu___ -> false
 let (__proj__Local_binding__item___0 : scope_mod -> local_binding) =
   fun projectee -> match projectee with | Local_binding _0 -> _0
 let (uu___is_Rec_binding : scope_mod -> Prims.bool) =
   fun projectee ->
-    match projectee with | Rec_binding _0 -> true | uu____269 -> false
+    match projectee with | Rec_binding _0 -> true | uu___ -> false
 let (__proj__Rec_binding__item___0 : scope_mod -> rec_binding) =
   fun projectee -> match projectee with | Rec_binding _0 -> _0
 let (uu___is_Module_abbrev : scope_mod -> Prims.bool) =
   fun projectee ->
-    match projectee with | Module_abbrev _0 -> true | uu____282 -> false
+    match projectee with | Module_abbrev _0 -> true | uu___ -> false
 let (__proj__Module_abbrev__item___0 : scope_mod -> module_abbrev) =
   fun projectee -> match projectee with | Module_abbrev _0 -> _0
 let (uu___is_Open_module_or_namespace : scope_mod -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Open_module_or_namespace _0 -> true
-    | uu____295 -> false
+    | uu___ -> false
 let (__proj__Open_module_or_namespace__item___0 :
   scope_mod -> open_module_or_namespace) =
   fun projectee -> match projectee with | Open_module_or_namespace _0 -> _0
 let (uu___is_Top_level_def : scope_mod -> Prims.bool) =
   fun projectee ->
-    match projectee with | Top_level_def _0 -> true | uu____308 -> false
+    match projectee with | Top_level_def _0 -> true | uu___ -> false
 let (__proj__Top_level_def__item___0 : scope_mod -> FStar_Ident.ident) =
   fun projectee -> match projectee with | Top_level_def _0 -> _0
 let (uu___is_Record_or_dc : scope_mod -> Prims.bool) =
   fun projectee ->
-    match projectee with | Record_or_dc _0 -> true | uu____321 -> false
+    match projectee with | Record_or_dc _0 -> true | uu___ -> false
 let (__proj__Record_or_dc__item___0 : scope_mod -> record_or_dc) =
   fun projectee -> match projectee with | Record_or_dc _0 -> _0
 type string_set = Prims.string FStar_Util.set
@@ -104,10 +104,10 @@ type exported_id_kind =
   | Exported_id_field 
 let (uu___is_Exported_id_term_type : exported_id_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Exported_id_term_type -> true | uu____335 -> false
+    match projectee with | Exported_id_term_type -> true | uu___ -> false
 let (uu___is_Exported_id_field : exported_id_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Exported_id_field -> true | uu____341 -> false
+    match projectee with | Exported_id_field -> true | uu___ -> false
 type exported_id_set = exported_id_kind -> string_set FStar_ST.ref
 type env =
   {
@@ -276,10 +276,10 @@ let (__proj__Mkdsenv_hooks__item__ds_push_module_abbrev_hook :
 type 'a withenv = env -> ('a * env)
 let (default_ds_hooks : dsenv_hooks) =
   {
-    ds_push_open_hook = (fun uu____1694 -> fun uu____1695 -> ());
-    ds_push_include_hook = (fun uu____1698 -> fun uu____1699 -> ());
+    ds_push_open_hook = (fun uu___ -> fun uu___1 -> ());
+    ds_push_include_hook = (fun uu___ -> fun uu___1 -> ());
     ds_push_module_abbrev_hook =
-      (fun uu____1703 -> fun uu____1704 -> fun uu____1705 -> ())
+      (fun uu___ -> fun uu___1 -> fun uu___2 -> ())
   }
 type foundname =
   | Term_name of (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.attribute
@@ -287,84 +287,84 @@ type foundname =
   | Eff_name of (FStar_Syntax_Syntax.sigelt * FStar_Ident.lident) 
 let (uu___is_Term_name : foundname -> Prims.bool) =
   fun projectee ->
-    match projectee with | Term_name _0 -> true | uu____1738 -> false
+    match projectee with | Term_name _0 -> true | uu___ -> false
 let (__proj__Term_name__item___0 :
   foundname ->
     (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.attribute Prims.list))
   = fun projectee -> match projectee with | Term_name _0 -> _0
 let (uu___is_Eff_name : foundname -> Prims.bool) =
   fun projectee ->
-    match projectee with | Eff_name _0 -> true | uu____1773 -> false
+    match projectee with | Eff_name _0 -> true | uu___ -> false
 let (__proj__Eff_name__item___0 :
   foundname -> (FStar_Syntax_Syntax.sigelt * FStar_Ident.lident)) =
   fun projectee -> match projectee with | Eff_name _0 -> _0
 let (set_iface : env -> Prims.bool -> env) =
   fun env1 ->
     fun b ->
-      let uu___125_1802 = env1 in
+      let uu___ = env1 in
       {
-        curmodule = (uu___125_1802.curmodule);
-        curmonad = (uu___125_1802.curmonad);
-        modules = (uu___125_1802.modules);
-        scope_mods = (uu___125_1802.scope_mods);
-        exported_ids = (uu___125_1802.exported_ids);
-        trans_exported_ids = (uu___125_1802.trans_exported_ids);
-        includes = (uu___125_1802.includes);
-        sigaccum = (uu___125_1802.sigaccum);
-        sigmap = (uu___125_1802.sigmap);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
         iface = b;
-        admitted_iface = (uu___125_1802.admitted_iface);
-        expect_typ = (uu___125_1802.expect_typ);
-        remaining_iface_decls = (uu___125_1802.remaining_iface_decls);
-        syntax_only = (uu___125_1802.syntax_only);
-        ds_hooks = (uu___125_1802.ds_hooks);
-        dep_graph = (uu___125_1802.dep_graph)
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (iface : env -> Prims.bool) = fun e -> e.iface
 let (set_admitted_iface : env -> Prims.bool -> env) =
   fun e ->
     fun b ->
-      let uu___130_1818 = e in
+      let uu___ = e in
       {
-        curmodule = (uu___130_1818.curmodule);
-        curmonad = (uu___130_1818.curmonad);
-        modules = (uu___130_1818.modules);
-        scope_mods = (uu___130_1818.scope_mods);
-        exported_ids = (uu___130_1818.exported_ids);
-        trans_exported_ids = (uu___130_1818.trans_exported_ids);
-        includes = (uu___130_1818.includes);
-        sigaccum = (uu___130_1818.sigaccum);
-        sigmap = (uu___130_1818.sigmap);
-        iface = (uu___130_1818.iface);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
         admitted_iface = b;
-        expect_typ = (uu___130_1818.expect_typ);
-        remaining_iface_decls = (uu___130_1818.remaining_iface_decls);
-        syntax_only = (uu___130_1818.syntax_only);
-        ds_hooks = (uu___130_1818.ds_hooks);
-        dep_graph = (uu___130_1818.dep_graph)
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (admitted_iface : env -> Prims.bool) = fun e -> e.admitted_iface
 let (set_expect_typ : env -> Prims.bool -> env) =
   fun e ->
     fun b ->
-      let uu___135_1834 = e in
+      let uu___ = e in
       {
-        curmodule = (uu___135_1834.curmodule);
-        curmonad = (uu___135_1834.curmonad);
-        modules = (uu___135_1834.modules);
-        scope_mods = (uu___135_1834.scope_mods);
-        exported_ids = (uu___135_1834.exported_ids);
-        trans_exported_ids = (uu___135_1834.trans_exported_ids);
-        includes = (uu___135_1834.includes);
-        sigaccum = (uu___135_1834.sigaccum);
-        sigmap = (uu___135_1834.sigmap);
-        iface = (uu___135_1834.iface);
-        admitted_iface = (uu___135_1834.admitted_iface);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
         expect_typ = b;
-        remaining_iface_decls = (uu___135_1834.remaining_iface_decls);
-        syntax_only = (uu___135_1834.syntax_only);
-        ds_hooks = (uu___135_1834.ds_hooks);
-        dep_graph = (uu___135_1834.dep_graph)
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (expect_typ : env -> Prims.bool) = fun e -> e.expect_typ
 let (all_exported_id_kinds : exported_id_kind Prims.list) =
@@ -374,47 +374,47 @@ let (transitive_exported_ids :
   fun env1 ->
     fun lid ->
       let module_name = FStar_Ident.string_of_lid lid in
-      let uu____1855 =
+      let uu___ =
         FStar_Util.smap_try_find env1.trans_exported_ids module_name in
-      match uu____1855 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> []
       | FStar_Pervasives_Native.Some exported_id_set1 ->
-          let uu____1866 =
-            let uu____1869 = exported_id_set1 Exported_id_term_type in
-            FStar_ST.op_Bang uu____1869 in
-          FStar_All.pipe_right uu____1866 FStar_Util.set_elements
+          let uu___1 =
+            let uu___2 = exported_id_set1 Exported_id_term_type in
+            FStar_ST.op_Bang uu___2 in
+          FStar_All.pipe_right uu___1 FStar_Util.set_elements
 let (open_modules :
   env -> (FStar_Ident.lident * FStar_Syntax_Syntax.modul) Prims.list) =
   fun e -> e.modules
 let (open_modules_and_namespaces : env -> FStar_Ident.lident Prims.list) =
   fun env1 ->
     FStar_List.filter_map
-      (fun uu___0_1913 ->
-         match uu___0_1913 with
+      (fun uu___ ->
+         match uu___ with
          | Open_module_or_namespace (lid, _info) ->
              FStar_Pervasives_Native.Some lid
-         | uu____1918 -> FStar_Pervasives_Native.None) env1.scope_mods
+         | uu___1 -> FStar_Pervasives_Native.None) env1.scope_mods
 let (set_current_module : env -> FStar_Ident.lident -> env) =
   fun e ->
     fun l ->
-      let uu___154_1929 = e in
+      let uu___ = e in
       {
         curmodule = (FStar_Pervasives_Native.Some l);
-        curmonad = (uu___154_1929.curmonad);
-        modules = (uu___154_1929.modules);
-        scope_mods = (uu___154_1929.scope_mods);
-        exported_ids = (uu___154_1929.exported_ids);
-        trans_exported_ids = (uu___154_1929.trans_exported_ids);
-        includes = (uu___154_1929.includes);
-        sigaccum = (uu___154_1929.sigaccum);
-        sigmap = (uu___154_1929.sigmap);
-        iface = (uu___154_1929.iface);
-        admitted_iface = (uu___154_1929.admitted_iface);
-        expect_typ = (uu___154_1929.expect_typ);
-        remaining_iface_decls = (uu___154_1929.remaining_iface_decls);
-        syntax_only = (uu___154_1929.syntax_only);
-        ds_hooks = (uu___154_1929.ds_hooks);
-        dep_graph = (uu___154_1929.dep_graph)
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (current_module : env -> FStar_Ident.lident) =
   fun env1 ->
@@ -428,47 +428,45 @@ let (iface_decls :
   =
   fun env1 ->
     fun l ->
-      let uu____1950 =
+      let uu___ =
         FStar_All.pipe_right env1.remaining_iface_decls
           (FStar_List.tryFind
-             (fun uu____1984 ->
-                match uu____1984 with
-                | (m, uu____1992) -> FStar_Ident.lid_equals l m)) in
-      match uu____1950 with
+             (fun uu___1 ->
+                match uu___1 with | (m, uu___2) -> FStar_Ident.lid_equals l m)) in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some (uu____2009, decls) ->
+      | FStar_Pervasives_Native.Some (uu___1, decls) ->
           FStar_Pervasives_Native.Some decls
 let (set_iface_decls :
   env -> FStar_Ident.lident -> FStar_Parser_AST.decl Prims.list -> env) =
   fun env1 ->
     fun l ->
       fun ds ->
-        let uu____2042 =
+        let uu___ =
           FStar_List.partition
-            (fun uu____2072 ->
-               match uu____2072 with
-               | (m, uu____2080) -> FStar_Ident.lid_equals l m)
+            (fun uu___1 ->
+               match uu___1 with | (m, uu___2) -> FStar_Ident.lid_equals l m)
             env1.remaining_iface_decls in
-        match uu____2042 with
-        | (uu____2085, rest) ->
-            let uu___179_2119 = env1 in
+        match uu___ with
+        | (uu___1, rest) ->
+            let uu___2 = env1 in
             {
-              curmodule = (uu___179_2119.curmodule);
-              curmonad = (uu___179_2119.curmonad);
-              modules = (uu___179_2119.modules);
-              scope_mods = (uu___179_2119.scope_mods);
-              exported_ids = (uu___179_2119.exported_ids);
-              trans_exported_ids = (uu___179_2119.trans_exported_ids);
-              includes = (uu___179_2119.includes);
-              sigaccum = (uu___179_2119.sigaccum);
-              sigmap = (uu___179_2119.sigmap);
-              iface = (uu___179_2119.iface);
-              admitted_iface = (uu___179_2119.admitted_iface);
-              expect_typ = (uu___179_2119.expect_typ);
+              curmodule = (uu___2.curmodule);
+              curmonad = (uu___2.curmonad);
+              modules = (uu___2.modules);
+              scope_mods = (uu___2.scope_mods);
+              exported_ids = (uu___2.exported_ids);
+              trans_exported_ids = (uu___2.trans_exported_ids);
+              includes = (uu___2.includes);
+              sigaccum = (uu___2.sigaccum);
+              sigmap = (uu___2.sigmap);
+              iface = (uu___2.iface);
+              admitted_iface = (uu___2.admitted_iface);
+              expect_typ = (uu___2.expect_typ);
               remaining_iface_decls = ((l, ds) :: rest);
-              syntax_only = (uu___179_2119.syntax_only);
-              ds_hooks = (uu___179_2119.ds_hooks);
-              dep_graph = (uu___179_2119.dep_graph)
+              syntax_only = (uu___2.syntax_only);
+              ds_hooks = (uu___2.ds_hooks);
+              dep_graph = (uu___2.dep_graph)
             }
 let (qual : FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident) =
   FStar_Ident.qual_id
@@ -477,75 +475,74 @@ let (qualify : env -> FStar_Ident.ident -> FStar_Ident.lident) =
     fun id ->
       match env1.curmonad with
       | FStar_Pervasives_Native.None ->
-          let uu____2146 = current_module env1 in qual uu____2146 id
+          let uu___ = current_module env1 in qual uu___ id
       | FStar_Pervasives_Native.Some monad ->
-          let uu____2148 =
-            let uu____2149 = current_module env1 in qual uu____2149 monad in
-          FStar_Syntax_Util.mk_field_projector_name_from_ident uu____2148 id
+          let uu___ = let uu___1 = current_module env1 in qual uu___1 monad in
+          FStar_Syntax_Util.mk_field_projector_name_from_ident uu___ id
 let (syntax_only : env -> Prims.bool) = fun env1 -> env1.syntax_only
 let (set_syntax_only : env -> Prims.bool -> env) =
   fun env1 ->
     fun b ->
-      let uu___189_2165 = env1 in
+      let uu___ = env1 in
       {
-        curmodule = (uu___189_2165.curmodule);
-        curmonad = (uu___189_2165.curmonad);
-        modules = (uu___189_2165.modules);
-        scope_mods = (uu___189_2165.scope_mods);
-        exported_ids = (uu___189_2165.exported_ids);
-        trans_exported_ids = (uu___189_2165.trans_exported_ids);
-        includes = (uu___189_2165.includes);
-        sigaccum = (uu___189_2165.sigaccum);
-        sigmap = (uu___189_2165.sigmap);
-        iface = (uu___189_2165.iface);
-        admitted_iface = (uu___189_2165.admitted_iface);
-        expect_typ = (uu___189_2165.expect_typ);
-        remaining_iface_decls = (uu___189_2165.remaining_iface_decls);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
         syntax_only = b;
-        ds_hooks = (uu___189_2165.ds_hooks);
-        dep_graph = (uu___189_2165.dep_graph)
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (ds_hooks : env -> dsenv_hooks) = fun env1 -> env1.ds_hooks
 let (set_ds_hooks : env -> dsenv_hooks -> env) =
   fun env1 ->
     fun hooks ->
-      let uu___194_2181 = env1 in
+      let uu___ = env1 in
       {
-        curmodule = (uu___194_2181.curmodule);
-        curmonad = (uu___194_2181.curmonad);
-        modules = (uu___194_2181.modules);
-        scope_mods = (uu___194_2181.scope_mods);
-        exported_ids = (uu___194_2181.exported_ids);
-        trans_exported_ids = (uu___194_2181.trans_exported_ids);
-        includes = (uu___194_2181.includes);
-        sigaccum = (uu___194_2181.sigaccum);
-        sigmap = (uu___194_2181.sigmap);
-        iface = (uu___194_2181.iface);
-        admitted_iface = (uu___194_2181.admitted_iface);
-        expect_typ = (uu___194_2181.expect_typ);
-        remaining_iface_decls = (uu___194_2181.remaining_iface_decls);
-        syntax_only = (uu___194_2181.syntax_only);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
         ds_hooks = hooks;
-        dep_graph = (uu___194_2181.dep_graph)
+        dep_graph = (uu___.dep_graph)
       }
-let new_sigmap : 'uuuuuu2186 . unit -> 'uuuuuu2186 FStar_Util.smap =
-  fun uu____2193 -> FStar_Util.smap_create (Prims.of_int (100))
+let new_sigmap : 'uuuuu . unit -> 'uuuuu FStar_Util.smap =
+  fun uu___ -> FStar_Util.smap_create (Prims.of_int (100))
 let (empty_env : FStar_Parser_Dep.deps -> env) =
   fun deps ->
-    let uu____2199 = new_sigmap () in
-    let uu____2204 = new_sigmap () in
-    let uu____2209 = new_sigmap () in
-    let uu____2220 = new_sigmap () in
+    let uu___ = new_sigmap () in
+    let uu___1 = new_sigmap () in
+    let uu___2 = new_sigmap () in
+    let uu___3 = new_sigmap () in
     {
       curmodule = FStar_Pervasives_Native.None;
       curmonad = FStar_Pervasives_Native.None;
       modules = [];
       scope_mods = [];
-      exported_ids = uu____2199;
-      trans_exported_ids = uu____2204;
-      includes = uu____2209;
+      exported_ids = uu___;
+      trans_exported_ids = uu___1;
+      includes = uu___2;
       sigaccum = [];
-      sigmap = uu____2220;
+      sigmap = uu___3;
       iface = false;
       admitted_iface = false;
       expect_typ = false;
@@ -558,23 +555,23 @@ let (dep_graph : env -> FStar_Parser_Dep.deps) = fun env1 -> env1.dep_graph
 let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
   fun env1 ->
     fun ds ->
-      let uu___201_2256 = env1 in
+      let uu___ = env1 in
       {
-        curmodule = (uu___201_2256.curmodule);
-        curmonad = (uu___201_2256.curmonad);
-        modules = (uu___201_2256.modules);
-        scope_mods = (uu___201_2256.scope_mods);
-        exported_ids = (uu___201_2256.exported_ids);
-        trans_exported_ids = (uu___201_2256.trans_exported_ids);
-        includes = (uu___201_2256.includes);
-        sigaccum = (uu___201_2256.sigaccum);
-        sigmap = (uu___201_2256.sigmap);
-        iface = (uu___201_2256.iface);
-        admitted_iface = (uu___201_2256.admitted_iface);
-        expect_typ = (uu___201_2256.expect_typ);
-        remaining_iface_decls = (uu___201_2256.remaining_iface_decls);
-        syntax_only = (uu___201_2256.syntax_only);
-        ds_hooks = (uu___201_2256.ds_hooks);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
+        scope_mods = (uu___.scope_mods);
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
         dep_graph = ds
       }
 let (sigmap :
@@ -583,28 +580,26 @@ let (sigmap :
 let (has_all_in_scope : env -> Prims.bool) =
   fun env1 ->
     FStar_List.existsb
-      (fun uu____2280 ->
-         match uu____2280 with
-         | (m, uu____2286) ->
-             FStar_Ident.lid_equals m FStar_Parser_Const.all_lid)
+      (fun uu___ ->
+         match uu___ with
+         | (m, uu___1) -> FStar_Ident.lid_equals m FStar_Parser_Const.all_lid)
       env1.modules
 let (set_bv_range :
   FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.bv) =
   fun bv ->
     fun r ->
       let id = FStar_Ident.set_id_range r bv.FStar_Syntax_Syntax.ppname in
-      let uu___211_2298 = bv in
+      let uu___ = bv in
       {
         FStar_Syntax_Syntax.ppname = id;
-        FStar_Syntax_Syntax.index = (uu___211_2298.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = (uu___211_2298.FStar_Syntax_Syntax.sort)
+        FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = (uu___.FStar_Syntax_Syntax.sort)
       }
 let (bv_to_name :
   FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.term) =
   fun bv ->
     fun r ->
-      let uu____2309 = set_bv_range bv r in
-      FStar_Syntax_Syntax.bv_to_name uu____2309
+      let uu___ = set_bv_range bv r in FStar_Syntax_Syntax.bv_to_name uu___
 let (unmangleMap :
   (Prims.string * Prims.string * FStar_Syntax_Syntax.delta_depth *
     FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option) Prims.list)
@@ -619,82 +614,79 @@ let (unmangleOpName :
   =
   fun id ->
     FStar_Util.find_map unmangleMap
-      (fun uu____2382 ->
-         match uu____2382 with
+      (fun uu___ ->
+         match uu___ with
          | (x, y, dd, dq) ->
-             let uu____2403 =
-               let uu____2404 = FStar_Ident.string_of_id id in uu____2404 = x in
-             if uu____2403
+             let uu___1 =
+               let uu___2 = FStar_Ident.string_of_id id in uu___2 = x in
+             if uu___1
              then
-               let uu____2407 =
-                 let uu____2408 =
-                   let uu____2409 = FStar_Ident.range_of_id id in
-                   FStar_Ident.lid_of_path ["Prims"; y] uu____2409 in
-                 FStar_Syntax_Syntax.fvar uu____2408 dd dq in
-               FStar_Pervasives_Native.Some uu____2407
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Ident.range_of_id id in
+                   FStar_Ident.lid_of_path ["Prims"; y] uu___4 in
+                 FStar_Syntax_Syntax.fvar uu___3 dd dq in
+               FStar_Pervasives_Native.Some uu___2
              else FStar_Pervasives_Native.None)
 type 'a cont_t =
   | Cont_ok of 'a 
   | Cont_fail 
   | Cont_ignore 
 let uu___is_Cont_ok : 'a . 'a cont_t -> Prims.bool =
-  fun projectee ->
-    match projectee with | Cont_ok _0 -> true | uu____2441 -> false
+  fun projectee -> match projectee with | Cont_ok _0 -> true | uu___ -> false
 let __proj__Cont_ok__item___0 : 'a . 'a cont_t -> 'a =
   fun projectee -> match projectee with | Cont_ok _0 -> _0
 let uu___is_Cont_fail : 'a . 'a cont_t -> Prims.bool =
-  fun projectee ->
-    match projectee with | Cont_fail -> true | uu____2473 -> false
+  fun projectee -> match projectee with | Cont_fail -> true | uu___ -> false
 let uu___is_Cont_ignore : 'a . 'a cont_t -> Prims.bool =
   fun projectee ->
-    match projectee with | Cont_ignore -> true | uu____2490 -> false
+    match projectee with | Cont_ignore -> true | uu___ -> false
 let option_of_cont :
   'a .
     (unit -> 'a FStar_Pervasives_Native.option) ->
       'a cont_t -> 'a FStar_Pervasives_Native.option
   =
   fun k_ignore ->
-    fun uu___1_2518 ->
-      match uu___1_2518 with
+    fun uu___ ->
+      match uu___ with
       | Cont_ok a1 -> FStar_Pervasives_Native.Some a1
       | Cont_fail -> FStar_Pervasives_Native.None
       | Cont_ignore -> k_ignore ()
 let find_in_record :
-  'uuuuuu2536 .
+  'uuuuu .
     FStar_Ident.ident Prims.list ->
       FStar_Ident.ident ->
-        record_or_dc ->
-          (record_or_dc -> 'uuuuuu2536 cont_t) -> 'uuuuuu2536 cont_t
+        record_or_dc -> (record_or_dc -> 'uuuuu cont_t) -> 'uuuuu cont_t
   =
   fun ns ->
     fun id ->
       fun record ->
         fun cont ->
           let typename' =
-            let uu____2573 =
-              let uu____2574 =
-                let uu____2577 = FStar_Ident.ident_of_lid record.typename in
-                [uu____2577] in
-              FStar_List.append ns uu____2574 in
-            FStar_Ident.lid_of_ids uu____2573 in
-          let uu____2578 = FStar_Ident.lid_equals typename' record.typename in
-          if uu____2578
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Ident.ident_of_lid record.typename in
+                [uu___2] in
+              FStar_List.append ns uu___1 in
+            FStar_Ident.lid_of_ids uu___ in
+          let uu___ = FStar_Ident.lid_equals typename' record.typename in
+          if uu___
           then
             let fname =
-              let uu____2582 =
-                let uu____2583 = FStar_Ident.ns_of_lid record.typename in
-                FStar_List.append uu____2583 [id] in
-              FStar_Ident.lid_of_ids uu____2582 in
+              let uu___1 =
+                let uu___2 = FStar_Ident.ns_of_lid record.typename in
+                FStar_List.append uu___2 [id] in
+              FStar_Ident.lid_of_ids uu___1 in
             let find =
               FStar_Util.find_map record.fields
-                (fun uu____2597 ->
-                   match uu____2597 with
-                   | (f, uu____2605) ->
-                       let uu____2606 =
-                         let uu____2607 = FStar_Ident.string_of_id id in
-                         let uu____2608 = FStar_Ident.string_of_id f in
-                         uu____2607 = uu____2608 in
-                       if uu____2606
+                (fun uu___1 ->
+                   match uu___1 with
+                   | (f, uu___2) ->
+                       let uu___3 =
+                         let uu___4 = FStar_Ident.string_of_id id in
+                         let uu___5 = FStar_Ident.string_of_id f in
+                         uu___4 = uu___5 in
+                       if uu___3
                        then FStar_Pervasives_Native.Some record
                        else FStar_Pervasives_Native.None) in
             match find with
@@ -714,8 +706,8 @@ let (get_trans_exported_id_set :
         FStar_Pervasives_Native.option)
   = fun e -> fun mname -> FStar_Util.smap_try_find e.trans_exported_ids mname
 let (string_of_exported_id_kind : exported_id_kind -> Prims.string) =
-  fun uu___2_2670 ->
-    match uu___2_2670 with
+  fun uu___ ->
+    match uu___ with
     | Exported_id_field -> "field"
     | Exported_id_term_type -> "term/type"
 let find_in_module_with_includes :
@@ -732,40 +724,38 @@ let find_in_module_with_includes :
           fun ns ->
             fun id ->
               let idstr = FStar_Ident.string_of_id id in
-              let rec aux uu___3_2741 =
-                match uu___3_2741 with
+              let rec aux uu___ =
+                match uu___ with
                 | [] -> find_in_module_default
                 | modul::q ->
                     let mname = FStar_Ident.string_of_lid modul in
                     let not_shadowed =
-                      let uu____2752 = get_exported_id_set env1 mname in
-                      match uu____2752 with
+                      let uu___1 = get_exported_id_set env1 mname in
+                      match uu___1 with
                       | FStar_Pervasives_Native.None -> true
                       | FStar_Pervasives_Native.Some mex ->
                           let mexports =
-                            let uu____2777 = mex eikind in
-                            FStar_ST.op_Bang uu____2777 in
+                            let uu___2 = mex eikind in
+                            FStar_ST.op_Bang uu___2 in
                           FStar_Util.set_mem idstr mexports in
                     let mincludes =
-                      let uu____2799 =
+                      let uu___1 =
                         FStar_Util.smap_try_find env1.includes mname in
-                      match uu____2799 with
+                      match uu___1 with
                       | FStar_Pervasives_Native.None -> []
                       | FStar_Pervasives_Native.Some minc ->
                           FStar_ST.op_Bang minc in
                     let look_into =
                       if not_shadowed
                       then
-                        let uu____2840 = qual modul id in
-                        find_in_module uu____2840
+                        let uu___1 = qual modul id in find_in_module uu___1
                       else Cont_ignore in
                     (match look_into with
                      | Cont_ignore -> aux (FStar_List.append mincludes q)
-                     | uu____2844 -> look_into) in
+                     | uu___1 -> look_into) in
               aux [ns]
 let (is_exported_id_field : exported_id_kind -> Prims.bool) =
-  fun uu___4_2851 ->
-    match uu___4_2851 with | Exported_id_field -> true | uu____2852 -> false
+  fun uu___ -> match uu___ with | Exported_id_field -> true | uu___1 -> false
 let try_lookup_id'' :
   'a .
     env ->
@@ -786,89 +776,83 @@ let try_lookup_id'' :
             fun k_record ->
               fun find_in_module ->
                 fun lookup_default_id ->
-                  let check_local_binding_id uu___5_2973 =
-                    match uu___5_2973 with
-                    | (id', uu____2975, uu____2976) ->
-                        let uu____2977 = FStar_Ident.string_of_id id' in
-                        let uu____2978 = FStar_Ident.string_of_id id in
-                        uu____2977 = uu____2978 in
-                  let check_rec_binding_id uu___6_2984 =
-                    match uu___6_2984 with
-                    | (id', uu____2986, uu____2987, uu____2988) ->
-                        let uu____2989 = FStar_Ident.string_of_id id' in
-                        let uu____2990 = FStar_Ident.string_of_id id in
-                        uu____2989 = uu____2990 in
+                  let check_local_binding_id uu___ =
+                    match uu___ with
+                    | (id', uu___1, uu___2) ->
+                        let uu___3 = FStar_Ident.string_of_id id' in
+                        let uu___4 = FStar_Ident.string_of_id id in
+                        uu___3 = uu___4 in
+                  let check_rec_binding_id uu___ =
+                    match uu___ with
+                    | (id', uu___1, uu___2, uu___3) ->
+                        let uu___4 = FStar_Ident.string_of_id id' in
+                        let uu___5 = FStar_Ident.string_of_id id in
+                        uu___4 = uu___5 in
                   let curmod_ns =
-                    let uu____2992 = current_module env1 in
-                    FStar_Ident.ids_of_lid uu____2992 in
-                  let proc uu___7_3000 =
-                    match uu___7_3000 with
+                    let uu___ = current_module env1 in
+                    FStar_Ident.ids_of_lid uu___ in
+                  let proc uu___ =
+                    match uu___ with
                     | Local_binding l when check_local_binding_id l ->
-                        let uu____3004 = l in
-                        (match uu____3004 with
-                         | (uu____3007, uu____3008, used_marker1) ->
+                        let uu___1 = l in
+                        (match uu___1 with
+                         | (uu___2, uu___3, used_marker1) ->
                              (FStar_ST.op_Colon_Equals used_marker1 true;
                               k_local_binding l))
                     | Rec_binding r when check_rec_binding_id r ->
-                        let uu____3018 = r in
-                        (match uu____3018 with
-                         | (uu____3021, uu____3022, uu____3023, used_marker1)
-                             ->
+                        let uu___1 = r in
+                        (match uu___1 with
+                         | (uu___2, uu___3, uu___4, used_marker1) ->
                              (FStar_ST.op_Colon_Equals used_marker1 true;
                               k_rec_binding r))
                     | Open_module_or_namespace (ns, Open_module) ->
                         find_in_module_with_includes eikind find_in_module
                           Cont_ignore env1 ns id
                     | Top_level_def id' when
-                        let uu____3034 = FStar_Ident.string_of_id id' in
-                        let uu____3035 = FStar_Ident.string_of_id id in
-                        uu____3034 = uu____3035 ->
-                        lookup_default_id Cont_ignore id
+                        let uu___1 = FStar_Ident.string_of_id id' in
+                        let uu___2 = FStar_Ident.string_of_id id in
+                        uu___1 = uu___2 -> lookup_default_id Cont_ignore id
                     | Record_or_dc r when is_exported_id_field eikind ->
-                        let uu____3037 = FStar_Ident.lid_of_ids curmod_ns in
+                        let uu___1 = FStar_Ident.lid_of_ids curmod_ns in
                         find_in_module_with_includes Exported_id_field
                           (fun lid ->
                              let id1 = FStar_Ident.ident_of_lid lid in
-                             let uu____3043 = FStar_Ident.ns_of_lid lid in
-                             find_in_record uu____3043 id1 r k_record)
-                          Cont_ignore env1 uu____3037 id
-                    | uu____3046 -> Cont_ignore in
-                  let rec aux uu___8_3056 =
-                    match uu___8_3056 with
+                             let uu___2 = FStar_Ident.ns_of_lid lid in
+                             find_in_record uu___2 id1 r k_record)
+                          Cont_ignore env1 uu___1 id
+                    | uu___1 -> Cont_ignore in
+                  let rec aux uu___ =
+                    match uu___ with
                     | a1::q ->
-                        let uu____3065 = proc a1 in
-                        option_of_cont (fun uu____3069 -> aux q) uu____3065
+                        let uu___1 = proc a1 in
+                        option_of_cont (fun uu___2 -> aux q) uu___1
                     | [] ->
-                        let uu____3070 = lookup_default_id Cont_fail id in
+                        let uu___1 = lookup_default_id Cont_fail id in
                         option_of_cont
-                          (fun uu____3074 -> FStar_Pervasives_Native.None)
-                          uu____3070 in
+                          (fun uu___2 -> FStar_Pervasives_Native.None) uu___1 in
                   aux env1.scope_mods
 let found_local_binding :
-  'uuuuuu3083 'uuuuuu3084 .
+  'uuuuu 'uuuuu1 .
     FStar_Range.range ->
-      ('uuuuuu3083 * FStar_Syntax_Syntax.bv * 'uuuuuu3084) ->
-        FStar_Syntax_Syntax.term
+      ('uuuuu * FStar_Syntax_Syntax.bv * 'uuuuu1) -> FStar_Syntax_Syntax.term
   =
-  fun r ->
-    fun uu____3100 ->
-      match uu____3100 with | (id', x, uu____3109) -> bv_to_name x r
+  fun r -> fun uu___ -> match uu___ with | (id', x, uu___1) -> bv_to_name x r
 let find_in_module :
-  'uuuuuu3120 .
+  'uuuuu .
     env ->
       FStar_Ident.lident ->
         (FStar_Ident.lident ->
-           (FStar_Syntax_Syntax.sigelt * Prims.bool) -> 'uuuuuu3120)
-          -> 'uuuuuu3120 -> 'uuuuuu3120
+           (FStar_Syntax_Syntax.sigelt * Prims.bool) -> 'uuuuu)
+          -> 'uuuuu -> 'uuuuu
   =
   fun env1 ->
     fun lid ->
       fun k_global_def ->
         fun k_not_found ->
-          let uu____3159 =
-            let uu____3166 = FStar_Ident.string_of_lid lid in
-            FStar_Util.smap_try_find (sigmap env1) uu____3166 in
-          match uu____3159 with
+          let uu___ =
+            let uu___1 = FStar_Ident.string_of_lid lid in
+            FStar_Util.smap_try_find (sigmap env1) uu___1 in
+          match uu___ with
           | FStar_Pervasives_Native.Some sb -> k_global_def lid sb
           | FStar_Pervasives_Native.None -> k_not_found
 let (try_lookup_id :
@@ -878,21 +862,20 @@ let (try_lookup_id :
   =
   fun env1 ->
     fun id ->
-      let uu____3198 = unmangleOpName id in
-      match uu____3198 with
+      let uu___ = unmangleOpName id in
+      match uu___ with
       | FStar_Pervasives_Native.Some f -> FStar_Pervasives_Native.Some f
-      | uu____3204 ->
+      | uu___1 ->
           try_lookup_id'' env1 id Exported_id_term_type
             (fun r ->
-               let uu____3210 =
-                 let uu____3211 = FStar_Ident.range_of_id id in
-                 found_local_binding uu____3211 r in
-               Cont_ok uu____3210) (fun uu____3213 -> Cont_fail)
-            (fun uu____3215 -> Cont_ignore)
+               let uu___2 =
+                 let uu___3 = FStar_Ident.range_of_id id in
+                 found_local_binding uu___3 r in
+               Cont_ok uu___2) (fun uu___2 -> Cont_fail)
+            (fun uu___2 -> Cont_ignore)
             (fun i ->
-               find_in_module env1 i
-                 (fun uu____3222 -> fun uu____3223 -> Cont_fail) Cont_ignore)
-            (fun uu____3230 -> fun uu____3231 -> Cont_fail)
+               find_in_module env1 i (fun uu___2 -> fun uu___3 -> Cont_fail)
+                 Cont_ignore) (fun uu___2 -> fun uu___3 -> Cont_fail)
 let lookup_default_id :
   'a .
     env ->
@@ -907,23 +890,22 @@ let lookup_default_id :
         fun k_not_found ->
           let find_in_monad =
             match env1.curmonad with
-            | FStar_Pervasives_Native.Some uu____3302 ->
+            | FStar_Pervasives_Native.Some uu___ ->
                 let lid = qualify env1 id in
-                let uu____3304 =
-                  let uu____3311 = FStar_Ident.string_of_lid lid in
-                  FStar_Util.smap_try_find (sigmap env1) uu____3311 in
-                (match uu____3304 with
+                let uu___1 =
+                  let uu___2 = FStar_Ident.string_of_lid lid in
+                  FStar_Util.smap_try_find (sigmap env1) uu___2 in
+                (match uu___1 with
                  | FStar_Pervasives_Native.Some r ->
-                     let uu____3329 = k_global_def lid r in
-                     FStar_Pervasives_Native.Some uu____3329
+                     let uu___2 = k_global_def lid r in
+                     FStar_Pervasives_Native.Some uu___2
                  | FStar_Pervasives_Native.None ->
                      FStar_Pervasives_Native.None)
             | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
           match find_in_monad with
           | FStar_Pervasives_Native.Some v -> v
           | FStar_Pervasives_Native.None ->
-              let lid =
-                let uu____3352 = current_module env1 in qual uu____3352 id in
+              let lid = let uu___ = current_module env1 in qual uu___ id in
               find_in_module env1 lid k_global_def k_not_found
 let (lid_is_curmod : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
@@ -948,48 +930,45 @@ let (resolve_module_name :
     fun lid ->
       fun honor_ns ->
         let nslen =
-          let uu____3406 = FStar_Ident.ns_of_lid lid in
-          FStar_List.length uu____3406 in
-        let rec aux uu___9_3418 =
-          match uu___9_3418 with
+          let uu___ = FStar_Ident.ns_of_lid lid in FStar_List.length uu___ in
+        let rec aux uu___ =
+          match uu___ with
           | [] ->
-              let uu____3423 = module_is_defined env1 lid in
-              if uu____3423
+              let uu___1 = module_is_defined env1 lid in
+              if uu___1
               then FStar_Pervasives_Native.Some lid
               else FStar_Pervasives_Native.None
           | (Open_module_or_namespace (ns, Open_namespace))::q when honor_ns
               ->
               let new_lid =
-                let uu____3432 =
-                  let uu____3433 = FStar_Ident.path_of_lid ns in
-                  let uu____3436 = FStar_Ident.path_of_lid lid in
-                  FStar_List.append uu____3433 uu____3436 in
-                let uu____3439 = FStar_Ident.range_of_lid lid in
-                FStar_Ident.lid_of_path uu____3432 uu____3439 in
-              let uu____3440 = module_is_defined env1 new_lid in
-              if uu____3440
-              then FStar_Pervasives_Native.Some new_lid
-              else aux q
-          | (Module_abbrev (name, modul))::uu____3446 when
+                let uu___1 =
+                  let uu___2 = FStar_Ident.path_of_lid ns in
+                  let uu___3 = FStar_Ident.path_of_lid lid in
+                  FStar_List.append uu___2 uu___3 in
+                let uu___2 = FStar_Ident.range_of_lid lid in
+                FStar_Ident.lid_of_path uu___1 uu___2 in
+              let uu___1 = module_is_defined env1 new_lid in
+              if uu___1 then FStar_Pervasives_Native.Some new_lid else aux q
+          | (Module_abbrev (name, modul))::uu___1 when
               (nslen = Prims.int_zero) &&
-                (let uu____3451 = FStar_Ident.string_of_id name in
-                 let uu____3452 =
-                   let uu____3453 = FStar_Ident.ident_of_lid lid in
-                   FStar_Ident.string_of_id uu____3453 in
-                 uu____3451 = uu____3452)
+                (let uu___2 = FStar_Ident.string_of_id name in
+                 let uu___3 =
+                   let uu___4 = FStar_Ident.ident_of_lid lid in
+                   FStar_Ident.string_of_id uu___4 in
+                 uu___2 = uu___3)
               -> FStar_Pervasives_Native.Some modul
-          | uu____3454::q -> aux q in
+          | uu___1::q -> aux q in
         aux env1.scope_mods
 let (is_open : env -> FStar_Ident.lident -> open_kind -> Prims.bool) =
   fun env1 ->
     fun lid ->
       fun open_kind1 ->
         FStar_List.existsb
-          (fun uu___10_3476 ->
-             match uu___10_3476 with
+          (fun uu___ ->
+             match uu___ with
              | Open_module_or_namespace (ns, k) ->
                  (k = open_kind1) && (FStar_Ident.lid_equals lid ns)
-             | uu____3479 -> false) env1.scope_mods
+             | uu___1 -> false) env1.scope_mods
 let (namespace_is_open : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 -> fun lid -> is_open env1 lid Open_namespace
 let (module_is_open : env -> FStar_Ident.lident -> Prims.bool) =
@@ -1013,31 +992,31 @@ let (shorten_module_path :
             (match revns with
              | [] -> FStar_Pervasives_Native.None
              | ns_last_id::rev_ns_prefix ->
-                 let uu____3598 = aux rev_ns_prefix ns_last_id in
-                 FStar_All.pipe_right uu____3598
+                 let uu___1 = aux rev_ns_prefix ns_last_id in
+                 FStar_All.pipe_right uu___1
                    (FStar_Util.map_option
-                      (fun uu____3648 ->
-                         match uu____3648 with
+                      (fun uu___2 ->
+                         match uu___2 with
                          | (stripped_ids, rev_kept_ids) ->
                              (stripped_ids, (id :: rev_kept_ids))))) in
         let do_shorten env2 ids1 =
           match FStar_List.rev ids1 with
           | [] -> ([], [])
           | ns_last_id::ns_rev_prefix ->
-              let uu____3718 = aux ns_rev_prefix ns_last_id in
-              (match uu____3718 with
+              let uu___ = aux ns_rev_prefix ns_last_id in
+              (match uu___ with
                | FStar_Pervasives_Native.None -> ([], ids1)
                | FStar_Pervasives_Native.Some (stripped_ids, rev_kept_ids) ->
                    (stripped_ids, (FStar_List.rev rev_kept_ids))) in
         if is_full_path && ((FStar_List.length ids) > Prims.int_zero)
         then
-          let uu____3779 =
-            let uu____3782 = FStar_Ident.lid_of_ids ids in
-            resolve_module_name env1 uu____3782 true in
-          match uu____3779 with
+          let uu___ =
+            let uu___1 = FStar_Ident.lid_of_ids ids in
+            resolve_module_name env1 uu___1 true in
+          match uu___ with
           | FStar_Pervasives_Native.Some m when module_is_open env1 m ->
               (ids, [])
-          | uu____3796 -> do_shorten env1 ids
+          | uu___1 -> do_shorten env1 ids
         else do_shorten env1 ids
 let resolve_in_open_namespaces'' :
   'a .
@@ -1059,37 +1038,37 @@ let resolve_in_open_namespaces'' :
             fun k_record ->
               fun f_module ->
                 fun l_default ->
-                  let uu____3915 = FStar_Ident.ns_of_lid lid in
-                  match uu____3915 with
-                  | uu____3918::uu____3919 ->
-                      let uu____3922 =
-                        let uu____3925 =
-                          let uu____3926 =
-                            let uu____3927 = FStar_Ident.ns_of_lid lid in
-                            FStar_Ident.lid_of_ids uu____3927 in
-                          let uu____3928 = FStar_Ident.range_of_lid lid in
-                          FStar_Ident.set_lid_range uu____3926 uu____3928 in
-                        resolve_module_name env1 uu____3925 true in
-                      (match uu____3922 with
+                  let uu___ = FStar_Ident.ns_of_lid lid in
+                  match uu___ with
+                  | uu___1::uu___2 ->
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Ident.ns_of_lid lid in
+                            FStar_Ident.lid_of_ids uu___6 in
+                          let uu___6 = FStar_Ident.range_of_lid lid in
+                          FStar_Ident.set_lid_range uu___5 uu___6 in
+                        resolve_module_name env1 uu___4 true in
+                      (match uu___3 with
                        | FStar_Pervasives_Native.None ->
                            FStar_Pervasives_Native.None
                        | FStar_Pervasives_Native.Some modul ->
-                           let uu____3932 =
-                             let uu____3935 = FStar_Ident.ident_of_lid lid in
+                           let uu___4 =
+                             let uu___5 = FStar_Ident.ident_of_lid lid in
                              find_in_module_with_includes eikind f_module
-                               Cont_fail env1 modul uu____3935 in
+                               Cont_fail env1 modul uu___5 in
                            option_of_cont
-                             (fun uu____3937 -> FStar_Pervasives_Native.None)
-                             uu____3932)
+                             (fun uu___5 -> FStar_Pervasives_Native.None)
+                             uu___4)
                   | [] ->
-                      let uu____3938 = FStar_Ident.ident_of_lid lid in
-                      try_lookup_id'' env1 uu____3938 eikind k_local_binding
+                      let uu___1 = FStar_Ident.ident_of_lid lid in
+                      try_lookup_id'' env1 uu___1 eikind k_local_binding
                         k_rec_binding k_record f_module l_default
 let cont_of_option :
   'a . 'a cont_t -> 'a FStar_Pervasives_Native.option -> 'a cont_t =
   fun k_none ->
-    fun uu___11_3961 ->
-      match uu___11_3961 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.Some v -> Cont_ok v
       | FStar_Pervasives_Native.None -> k_none
 let resolve_in_open_namespaces' :
@@ -1109,20 +1088,19 @@ let resolve_in_open_namespaces' :
         fun k_rec_binding ->
           fun k_global_def ->
             let k_global_def' k lid1 def =
-              let uu____4077 = k_global_def lid1 def in
-              cont_of_option k uu____4077 in
+              let uu___ = k_global_def lid1 def in cont_of_option k uu___ in
             let f_module lid' =
               let k = Cont_ignore in
               find_in_module env1 lid' (k_global_def' k) k in
             let l_default k i = lookup_default_id env1 i (k_global_def' k) k in
             resolve_in_open_namespaces'' env1 lid Exported_id_term_type
               (fun l ->
-                 let uu____4113 = k_local_binding l in
-                 cont_of_option Cont_fail uu____4113)
+                 let uu___ = k_local_binding l in
+                 cont_of_option Cont_fail uu___)
               (fun r ->
-                 let uu____4119 = k_rec_binding r in
-                 cont_of_option Cont_fail uu____4119)
-              (fun uu____4123 -> Cont_ignore) f_module l_default
+                 let uu___ = k_rec_binding r in
+                 cont_of_option Cont_fail uu___) (fun uu___ -> Cont_ignore)
+              f_module l_default
 let (fv_qual_of_se :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option)
@@ -1130,52 +1108,50 @@ let (fv_qual_of_se :
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
-        (uu____4133, uu____4134, uu____4135, l, uu____4137, uu____4138) ->
+        (uu___, uu___1, uu___2, l, uu___3, uu___4) ->
         let qopt =
           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
-            (fun uu___12_4149 ->
-               match uu___12_4149 with
-               | FStar_Syntax_Syntax.RecordConstructor (uu____4152, fs) ->
+            (fun uu___5 ->
+               match uu___5 with
+               | FStar_Syntax_Syntax.RecordConstructor (uu___6, fs) ->
                    FStar_Pervasives_Native.Some
                      (FStar_Syntax_Syntax.Record_ctor (l, fs))
-               | uu____4164 -> FStar_Pervasives_Native.None) in
+               | uu___6 -> FStar_Pervasives_Native.None) in
         (match qopt with
          | FStar_Pervasives_Native.None ->
              FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
          | x -> x)
-    | FStar_Syntax_Syntax.Sig_declare_typ
-        (uu____4170, uu____4171, uu____4172) -> FStar_Pervasives_Native.None
-    | uu____4173 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Sig_declare_typ (uu___, uu___1, uu___2) ->
+        FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (lb_fv :
   FStar_Syntax_Syntax.letbinding Prims.list ->
     FStar_Ident.lident -> FStar_Syntax_Syntax.fv)
   =
   fun lbs ->
     fun lid ->
-      let uu____4188 =
+      let uu___ =
         FStar_Util.find_map lbs
           (fun lb ->
              let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-             let uu____4196 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
-             if uu____4196
+             let uu___1 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
+             if uu___1
              then FStar_Pervasives_Native.Some fv
              else FStar_Pervasives_Native.None) in
-      FStar_All.pipe_right uu____4188 FStar_Util.must
+      FStar_All.pipe_right uu___ FStar_Util.must
 let (ns_of_lid_equals :
   FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool) =
   fun lid ->
     fun ns ->
-      (let uu____4216 =
-         let uu____4217 = FStar_Ident.ns_of_lid lid in
-         FStar_List.length uu____4217 in
-       let uu____4220 =
-         let uu____4221 = FStar_Ident.ids_of_lid ns in
-         FStar_List.length uu____4221 in
-       uu____4216 = uu____4220) &&
-        (let uu____4225 =
-           let uu____4226 = FStar_Ident.ns_of_lid lid in
-           FStar_Ident.lid_of_ids uu____4226 in
-         FStar_Ident.lid_equals uu____4225 ns)
+      (let uu___ =
+         let uu___1 = FStar_Ident.ns_of_lid lid in FStar_List.length uu___1 in
+       let uu___1 =
+         let uu___2 = FStar_Ident.ids_of_lid ns in FStar_List.length uu___2 in
+       uu___ = uu___1) &&
+        (let uu___ =
+           let uu___1 = FStar_Ident.ns_of_lid lid in
+           FStar_Ident.lid_of_ids uu___1 in
+         FStar_Ident.lid_equals uu___ ns)
 let (delta_depth_of_declaration :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -1184,35 +1160,35 @@ let (delta_depth_of_declaration :
   fun lid ->
     fun quals ->
       let dd =
-        let uu____4242 =
+        let uu___ =
           (FStar_Syntax_Util.is_primop_lid lid) ||
             (FStar_All.pipe_right quals
                (FStar_Util.for_some
-                  (fun uu___13_4247 ->
-                     match uu___13_4247 with
-                     | FStar_Syntax_Syntax.Projector uu____4248 -> true
-                     | FStar_Syntax_Syntax.Discriminator uu____4253 -> true
-                     | uu____4254 -> false))) in
-        if uu____4242
+                  (fun uu___1 ->
+                     match uu___1 with
+                     | FStar_Syntax_Syntax.Projector uu___2 -> true
+                     | FStar_Syntax_Syntax.Discriminator uu___2 -> true
+                     | uu___2 -> false))) in
+        if uu___
         then FStar_Syntax_Syntax.delta_equational
         else FStar_Syntax_Syntax.delta_constant in
-      let uu____4256 =
+      let uu___ =
         (FStar_All.pipe_right quals
            (FStar_Util.for_some
-              (fun uu___14_4260 ->
-                 match uu___14_4260 with
+              (fun uu___1 ->
+                 match uu___1 with
                  | FStar_Syntax_Syntax.Assumption -> true
-                 | uu____4261 -> false)))
+                 | uu___2 -> false)))
           &&
-          (let uu____4263 =
+          (let uu___1 =
              FStar_All.pipe_right quals
                (FStar_Util.for_some
-                  (fun uu___15_4267 ->
-                     match uu___15_4267 with
+                  (fun uu___2 ->
+                     match uu___2 with
                      | FStar_Syntax_Syntax.New -> true
-                     | uu____4268 -> false)) in
-           Prims.op_Negation uu____4263) in
-      if uu____4256 then FStar_Syntax_Syntax.Delta_abstract dd else dd
+                     | uu___3 -> false)) in
+           Prims.op_Negation uu___1) in
+      if uu___ then FStar_Syntax_Syntax.Delta_abstract dd else dd
 let (try_lookup_name :
   Prims.bool ->
     Prims.bool ->
@@ -1223,69 +1199,68 @@ let (try_lookup_name :
       fun env1 ->
         fun lid ->
           let occurrence_range = FStar_Ident.range_of_lid lid in
-          let k_global_def source_lid uu___18_4311 =
-            match uu___18_4311 with
-            | (uu____4318, true) when exclude_interf ->
+          let k_global_def source_lid uu___ =
+            match uu___ with
+            | (uu___1, true) when exclude_interf ->
                 FStar_Pervasives_Native.None
-            | (se, uu____4320) ->
+            | (se, uu___1) ->
                 (match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_inductive_typ uu____4323 ->
-                     let uu____4340 =
-                       let uu____4341 =
-                         let uu____4348 =
+                 | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Syntax_Syntax.fvar source_lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None in
-                         (uu____4348, (se.FStar_Syntax_Syntax.sigattrs)) in
-                       Term_name uu____4341 in
-                     FStar_Pervasives_Native.Some uu____4340
-                 | FStar_Syntax_Syntax.Sig_datacon uu____4351 ->
-                     let uu____4366 =
-                       let uu____4367 =
-                         let uu____4374 =
-                           let uu____4375 = fv_qual_of_se se in
+                         (uu___5, (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu___4 in
+                     FStar_Pervasives_Native.Some uu___3
+                 | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 = fv_qual_of_se se in
                            FStar_Syntax_Syntax.fvar source_lid
-                             FStar_Syntax_Syntax.delta_constant uu____4375 in
-                         (uu____4374, (se.FStar_Syntax_Syntax.sigattrs)) in
-                       Term_name uu____4367 in
-                     FStar_Pervasives_Native.Some uu____4366
-                 | FStar_Syntax_Syntax.Sig_let
-                     ((uu____4380, lbs), uu____4382) ->
+                             FStar_Syntax_Syntax.delta_constant uu___6 in
+                         (uu___5, (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu___4 in
+                     FStar_Pervasives_Native.Some uu___3
+                 | FStar_Syntax_Syntax.Sig_let ((uu___2, lbs), uu___3) ->
                      let fv = lb_fv lbs source_lid in
-                     let uu____4392 =
-                       let uu____4393 =
-                         let uu____4400 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_Syntax_Syntax.fvar source_lid
                              fv.FStar_Syntax_Syntax.fv_delta
                              fv.FStar_Syntax_Syntax.fv_qual in
-                         (uu____4400, (se.FStar_Syntax_Syntax.sigattrs)) in
-                       Term_name uu____4393 in
-                     FStar_Pervasives_Native.Some uu____4392
-                 | FStar_Syntax_Syntax.Sig_declare_typ
-                     (lid1, uu____4404, uu____4405) ->
+                         (uu___6, (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu___5 in
+                     FStar_Pervasives_Native.Some uu___4
+                 | FStar_Syntax_Syntax.Sig_declare_typ (lid1, uu___2, uu___3)
+                     ->
                      let quals = se.FStar_Syntax_Syntax.sigquals in
-                     let uu____4409 =
+                     let uu___4 =
                        any_val ||
                          (FStar_All.pipe_right quals
                             (FStar_Util.for_some
-                               (fun uu___16_4413 ->
-                                  match uu___16_4413 with
+                               (fun uu___5 ->
+                                  match uu___5 with
                                   | FStar_Syntax_Syntax.Assumption -> true
-                                  | uu____4414 -> false))) in
-                     if uu____4409
+                                  | uu___6 -> false))) in
+                     if uu___4
                      then
                        let lid2 =
-                         let uu____4418 = FStar_Ident.range_of_lid source_lid in
-                         FStar_Ident.set_lid_range lid1 uu____4418 in
+                         let uu___5 = FStar_Ident.range_of_lid source_lid in
+                         FStar_Ident.set_lid_range lid1 uu___5 in
                        let dd = delta_depth_of_declaration lid2 quals in
-                       let uu____4420 =
+                       let uu___5 =
                          FStar_Util.find_map quals
-                           (fun uu___17_4425 ->
-                              match uu___17_4425 with
+                           (fun uu___6 ->
+                              match uu___6 with
                               | FStar_Syntax_Syntax.Reflectable refl_monad ->
                                   FStar_Pervasives_Native.Some refl_monad
-                              | uu____4429 -> FStar_Pervasives_Native.None) in
-                       (match uu____4420 with
+                              | uu___7 -> FStar_Pervasives_Native.None) in
+                       (match uu___5 with
                         | FStar_Pervasives_Native.Some refl_monad ->
                             let refl_const =
                               FStar_Syntax_Syntax.mk
@@ -1296,73 +1271,71 @@ let (try_lookup_name :
                               (Term_name
                                  (refl_const,
                                    (se.FStar_Syntax_Syntax.sigattrs)))
-                        | uu____4438 ->
-                            let uu____4441 =
-                              let uu____4442 =
-                                let uu____4449 =
-                                  let uu____4450 = fv_qual_of_se se in
-                                  FStar_Syntax_Syntax.fvar lid2 dd uu____4450 in
-                                (uu____4449,
-                                  (se.FStar_Syntax_Syntax.sigattrs)) in
-                              Term_name uu____4442 in
-                            FStar_Pervasives_Native.Some uu____4441)
+                        | uu___6 ->
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 = fv_qual_of_se se in
+                                  FStar_Syntax_Syntax.fvar lid2 dd uu___10 in
+                                (uu___9, (se.FStar_Syntax_Syntax.sigattrs)) in
+                              Term_name uu___8 in
+                            FStar_Pervasives_Native.Some uu___7)
                      else FStar_Pervasives_Native.None
                  | FStar_Syntax_Syntax.Sig_new_effect ne ->
-                     let uu____4457 =
-                       let uu____4458 =
-                         let uu____4463 =
-                           let uu____4464 =
-                             FStar_Ident.range_of_lid source_lid in
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Ident.range_of_lid source_lid in
                            FStar_Ident.set_lid_range
-                             ne.FStar_Syntax_Syntax.mname uu____4464 in
-                         (se, uu____4463) in
-                       Eff_name uu____4458 in
-                     FStar_Pervasives_Native.Some uu____4457
-                 | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4465 ->
+                             ne.FStar_Syntax_Syntax.mname uu___5 in
+                         (se, uu___4) in
+                       Eff_name uu___3 in
+                     FStar_Pervasives_Native.Some uu___2
+                 | FStar_Syntax_Syntax.Sig_effect_abbrev uu___2 ->
                      FStar_Pervasives_Native.Some (Eff_name (se, source_lid))
                  | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
-                     let uu____4484 =
-                       let uu____4485 =
-                         let uu____4492 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_Syntax_Syntax.fvar source_lid
                              (FStar_Syntax_Syntax.Delta_constant_at_level
                                 Prims.int_one) FStar_Pervasives_Native.None in
-                         (uu____4492, []) in
-                       Term_name uu____4485 in
-                     FStar_Pervasives_Native.Some uu____4484
-                 | uu____4495 -> FStar_Pervasives_Native.None) in
+                         (uu___4, []) in
+                       Term_name uu___3 in
+                     FStar_Pervasives_Native.Some uu___2
+                 | uu___2 -> FStar_Pervasives_Native.None) in
           let k_local_binding r =
             let t =
-              let uu____4517 = FStar_Ident.range_of_lid lid in
-              found_local_binding uu____4517 r in
+              let uu___ = FStar_Ident.range_of_lid lid in
+              found_local_binding uu___ r in
             FStar_Pervasives_Native.Some (Term_name (t, [])) in
-          let k_rec_binding uu____4547 =
-            match uu____4547 with
+          let k_rec_binding uu___ =
+            match uu___ with
             | (id, l, dd, used_marker1) ->
                 (FStar_ST.op_Colon_Equals used_marker1 true;
-                 (let uu____4605 =
-                    let uu____4606 =
-                      let uu____4613 =
-                        let uu____4614 =
-                          let uu____4615 = FStar_Ident.range_of_lid lid in
-                          FStar_Ident.set_lid_range l uu____4615 in
-                        FStar_Syntax_Syntax.fvar uu____4614 dd
+                 (let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = FStar_Ident.range_of_lid lid in
+                          FStar_Ident.set_lid_range l uu___6 in
+                        FStar_Syntax_Syntax.fvar uu___5 dd
                           FStar_Pervasives_Native.None in
-                      (uu____4613, []) in
-                    Term_name uu____4606 in
-                  FStar_Pervasives_Native.Some uu____4605)) in
+                      (uu___4, []) in
+                    Term_name uu___3 in
+                  FStar_Pervasives_Native.Some uu___2)) in
           let found_unmangled =
-            let uu____4621 = FStar_Ident.ns_of_lid lid in
-            match uu____4621 with
+            let uu___ = FStar_Ident.ns_of_lid lid in
+            match uu___ with
             | [] ->
-                let uu____4624 =
-                  let uu____4627 = FStar_Ident.ident_of_lid lid in
-                  unmangleOpName uu____4627 in
-                (match uu____4624 with
+                let uu___1 =
+                  let uu___2 = FStar_Ident.ident_of_lid lid in
+                  unmangleOpName uu___2 in
+                (match uu___1 with
                  | FStar_Pervasives_Native.Some t ->
                      FStar_Pervasives_Native.Some (Term_name (t, []))
-                 | uu____4633 -> FStar_Pervasives_Native.None)
-            | uu____4636 -> FStar_Pervasives_Native.None in
+                 | uu___2 -> FStar_Pervasives_Native.None)
+            | uu___1 -> FStar_Pervasives_Native.None in
           match found_unmangled with
           | FStar_Pervasives_Native.None ->
               resolve_in_open_namespaces' env1 lid k_local_binding
@@ -1378,23 +1351,23 @@ let (try_lookup_effect_name' :
   fun exclude_interf ->
     fun env1 ->
       fun lid ->
-        let uu____4669 = try_lookup_name true exclude_interf env1 lid in
-        match uu____4669 with
+        let uu___ = try_lookup_name true exclude_interf env1 lid in
+        match uu___ with
         | FStar_Pervasives_Native.Some (Eff_name (o, l)) ->
             FStar_Pervasives_Native.Some (o, l)
-        | uu____4684 -> FStar_Pervasives_Native.None
+        | uu___1 -> FStar_Pervasives_Native.None
 let (try_lookup_effect_name :
   env ->
     FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
   =
   fun env1 ->
     fun l ->
-      let uu____4703 =
+      let uu___ =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l in
-      match uu____4703 with
+      match uu___ with
       | FStar_Pervasives_Native.Some (o, l1) ->
           FStar_Pervasives_Native.Some l1
-      | uu____4718 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (try_lookup_effect_name_and_attributes :
   env ->
     FStar_Ident.lident ->
@@ -1403,18 +1376,18 @@ let (try_lookup_effect_name_and_attributes :
   =
   fun env1 ->
     fun l ->
-      let uu____4743 =
+      let uu___ =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l in
-      match uu____4743 with
+      match uu___ with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
                ne;
-             FStar_Syntax_Syntax.sigrng = uu____4759;
-             FStar_Syntax_Syntax.sigquals = uu____4760;
-             FStar_Syntax_Syntax.sigmeta = uu____4761;
-             FStar_Syntax_Syntax.sigattrs = uu____4762;
-             FStar_Syntax_Syntax.sigopts = uu____4763;_},
+             FStar_Syntax_Syntax.sigrng = uu___1;
+             FStar_Syntax_Syntax.sigquals = uu___2;
+             FStar_Syntax_Syntax.sigmeta = uu___3;
+             FStar_Syntax_Syntax.sigattrs = uu___4;
+             FStar_Syntax_Syntax.sigopts = uu___5;_},
            l1)
           ->
           FStar_Pervasives_Native.Some
@@ -1423,15 +1396,15 @@ let (try_lookup_effect_name_and_attributes :
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (uu____4783, uu____4784, uu____4785, uu____4786, cattributes);
-             FStar_Syntax_Syntax.sigrng = uu____4788;
-             FStar_Syntax_Syntax.sigquals = uu____4789;
-             FStar_Syntax_Syntax.sigmeta = uu____4790;
-             FStar_Syntax_Syntax.sigattrs = uu____4791;
-             FStar_Syntax_Syntax.sigopts = uu____4792;_},
+               (uu___1, uu___2, uu___3, uu___4, cattributes);
+             FStar_Syntax_Syntax.sigrng = uu___5;
+             FStar_Syntax_Syntax.sigquals = uu___6;
+             FStar_Syntax_Syntax.sigmeta = uu___7;
+             FStar_Syntax_Syntax.sigattrs = uu___8;
+             FStar_Syntax_Syntax.sigopts = uu___9;_},
            l1)
           -> FStar_Pervasives_Native.Some (l1, cattributes)
-      | uu____4816 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (try_lookup_effect_defn :
   env ->
     FStar_Ident.lident ->
@@ -1439,72 +1412,72 @@ let (try_lookup_effect_defn :
   =
   fun env1 ->
     fun l ->
-      let uu____4841 =
+      let uu___ =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l in
-      match uu____4841 with
+      match uu___ with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
                ne;
-             FStar_Syntax_Syntax.sigrng = uu____4851;
-             FStar_Syntax_Syntax.sigquals = uu____4852;
-             FStar_Syntax_Syntax.sigmeta = uu____4853;
-             FStar_Syntax_Syntax.sigattrs = uu____4854;
-             FStar_Syntax_Syntax.sigopts = uu____4855;_},
-           uu____4856)
+             FStar_Syntax_Syntax.sigrng = uu___1;
+             FStar_Syntax_Syntax.sigquals = uu___2;
+             FStar_Syntax_Syntax.sigmeta = uu___3;
+             FStar_Syntax_Syntax.sigattrs = uu___4;
+             FStar_Syntax_Syntax.sigopts = uu___5;_},
+           uu___6)
           -> FStar_Pervasives_Native.Some ne
-      | uu____4867 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (is_effect_name : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
-      let uu____4884 = try_lookup_effect_name env1 lid in
-      match uu____4884 with
+      let uu___ = try_lookup_effect_name env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.None -> false
-      | FStar_Pervasives_Native.Some uu____4887 -> true
+      | FStar_Pervasives_Native.Some uu___1 -> true
 let (try_lookup_root_effect_name :
   env ->
     FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
   =
   fun env1 ->
     fun l ->
-      let uu____4900 =
+      let uu___ =
         try_lookup_effect_name' (Prims.op_Negation env1.iface) env1 l in
-      match uu____4900 with
+      match uu___ with
       | FStar_Pervasives_Native.Some
           ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_effect_abbrev
-               (l', uu____4910, uu____4911, uu____4912, uu____4913);
-             FStar_Syntax_Syntax.sigrng = uu____4914;
-             FStar_Syntax_Syntax.sigquals = uu____4915;
-             FStar_Syntax_Syntax.sigmeta = uu____4916;
-             FStar_Syntax_Syntax.sigattrs = uu____4917;
-             FStar_Syntax_Syntax.sigopts = uu____4918;_},
-           uu____4919)
+               (l', uu___1, uu___2, uu___3, uu___4);
+             FStar_Syntax_Syntax.sigrng = uu___5;
+             FStar_Syntax_Syntax.sigquals = uu___6;
+             FStar_Syntax_Syntax.sigmeta = uu___7;
+             FStar_Syntax_Syntax.sigattrs = uu___8;
+             FStar_Syntax_Syntax.sigopts = uu___9;_},
+           uu___10)
           ->
           let rec aux new_name =
-            let uu____4942 =
-              let uu____4949 = FStar_Ident.string_of_lid new_name in
-              FStar_Util.smap_try_find (sigmap env1) uu____4949 in
-            match uu____4942 with
+            let uu___11 =
+              let uu___12 = FStar_Ident.string_of_lid new_name in
+              FStar_Util.smap_try_find (sigmap env1) uu___12 in
+            match uu___11 with
             | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-            | FStar_Pervasives_Native.Some (s, uu____4961) ->
+            | FStar_Pervasives_Native.Some (s, uu___12) ->
                 (match s.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_new_effect ne ->
-                     let uu____4969 =
-                       let uu____4970 = FStar_Ident.range_of_lid l in
+                     let uu___13 =
+                       let uu___14 = FStar_Ident.range_of_lid l in
                        FStar_Ident.set_lid_range ne.FStar_Syntax_Syntax.mname
-                         uu____4970 in
-                     FStar_Pervasives_Native.Some uu____4969
+                         uu___14 in
+                     FStar_Pervasives_Native.Some uu___13
                  | FStar_Syntax_Syntax.Sig_effect_abbrev
-                     (uu____4971, uu____4972, uu____4973, cmp, uu____4975) ->
+                     (uu___13, uu___14, uu___15, cmp, uu___16) ->
                      let l'' = FStar_Syntax_Util.comp_effect_name cmp in
                      aux l''
-                 | uu____4981 -> FStar_Pervasives_Native.None) in
+                 | uu___13 -> FStar_Pervasives_Native.None) in
           aux l'
-      | FStar_Pervasives_Native.Some (uu____4982, l') ->
+      | FStar_Pervasives_Native.Some (uu___1, l') ->
           FStar_Pervasives_Native.Some l'
-      | uu____4988 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (lookup_letbinding_quals_and_attrs :
   env ->
     FStar_Ident.lident ->
@@ -1513,25 +1486,25 @@ let (lookup_letbinding_quals_and_attrs :
   =
   fun env1 ->
     fun lid ->
-      let k_global_def lid1 uu___19_5037 =
-        match uu___19_5037 with
+      let k_global_def lid1 uu___ =
+        match uu___ with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____5052, uu____5053, uu____5054);
-             FStar_Syntax_Syntax.sigrng = uu____5055;
+               (uu___1, uu___2, uu___3);
+             FStar_Syntax_Syntax.sigrng = uu___4;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____5057;
+             FStar_Syntax_Syntax.sigmeta = uu___5;
              FStar_Syntax_Syntax.sigattrs = attrs;
-             FStar_Syntax_Syntax.sigopts = uu____5059;_},
-           uu____5060) -> FStar_Pervasives_Native.Some (quals, attrs)
-        | uu____5079 -> FStar_Pervasives_Native.None in
-      let uu____5092 =
+             FStar_Syntax_Syntax.sigopts = uu___6;_},
+           uu___7) -> FStar_Pervasives_Native.Some (quals, attrs)
+        | uu___1 -> FStar_Pervasives_Native.None in
+      let uu___ =
         resolve_in_open_namespaces' env1 lid
-          (fun uu____5112 -> FStar_Pervasives_Native.None)
-          (fun uu____5122 -> FStar_Pervasives_Native.None) k_global_def in
-      match uu____5092 with
+          (fun uu___1 -> FStar_Pervasives_Native.None)
+          (fun uu___1 -> FStar_Pervasives_Native.None) k_global_def in
+      match uu___ with
       | FStar_Pervasives_Native.Some qa -> qa
-      | uu____5156 -> ([], [])
+      | uu___1 -> ([], [])
 let (try_lookup_module :
   env ->
     FStar_Ident.path ->
@@ -1539,15 +1512,15 @@ let (try_lookup_module :
   =
   fun env1 ->
     fun path ->
-      let uu____5183 =
+      let uu___ =
         FStar_List.tryFind
-          (fun uu____5198 ->
-             match uu____5198 with
+          (fun uu___1 ->
+             match uu___1 with
              | (mlid, modul) ->
-                 let uu____5205 = FStar_Ident.path_of_lid mlid in
-                 uu____5205 = path) env1.modules in
-      match uu____5183 with
-      | FStar_Pervasives_Native.Some (uu____5208, modul) ->
+                 let uu___2 = FStar_Ident.path_of_lid mlid in uu___2 = path)
+          env1.modules in
+      match uu___ with
+      | FStar_Pervasives_Native.Some (uu___1, modul) ->
           FStar_Pervasives_Native.Some modul
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let (try_lookup_let :
@@ -1557,26 +1530,26 @@ let (try_lookup_let :
   =
   fun env1 ->
     fun lid ->
-      let k_global_def lid1 uu___20_5246 =
-        match uu___20_5246 with
+      let k_global_def lid1 uu___ =
+        match uu___ with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               ((uu____5253, lbs), uu____5255);
-             FStar_Syntax_Syntax.sigrng = uu____5256;
-             FStar_Syntax_Syntax.sigquals = uu____5257;
-             FStar_Syntax_Syntax.sigmeta = uu____5258;
-             FStar_Syntax_Syntax.sigattrs = uu____5259;
-             FStar_Syntax_Syntax.sigopts = uu____5260;_},
-           uu____5261) ->
+               ((uu___1, lbs), uu___2);
+             FStar_Syntax_Syntax.sigrng = uu___3;
+             FStar_Syntax_Syntax.sigquals = uu___4;
+             FStar_Syntax_Syntax.sigmeta = uu___5;
+             FStar_Syntax_Syntax.sigattrs = uu___6;
+             FStar_Syntax_Syntax.sigopts = uu___7;_},
+           uu___8) ->
             let fv = lb_fv lbs lid1 in
-            let uu____5277 =
+            let uu___9 =
               FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
                 fv.FStar_Syntax_Syntax.fv_qual in
-            FStar_Pervasives_Native.Some uu____5277
-        | uu____5278 -> FStar_Pervasives_Native.None in
+            FStar_Pervasives_Native.Some uu___9
+        | uu___1 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____5284 -> FStar_Pervasives_Native.None)
-        (fun uu____5286 -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
 let (try_lookup_definition :
   env ->
     FStar_Ident.lident ->
@@ -1584,17 +1557,17 @@ let (try_lookup_definition :
   =
   fun env1 ->
     fun lid ->
-      let k_global_def lid1 uu___21_5317 =
-        match uu___21_5317 with
+      let k_global_def lid1 uu___ =
+        match uu___ with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-               (lbs, uu____5327);
-             FStar_Syntax_Syntax.sigrng = uu____5328;
-             FStar_Syntax_Syntax.sigquals = uu____5329;
-             FStar_Syntax_Syntax.sigmeta = uu____5330;
-             FStar_Syntax_Syntax.sigattrs = uu____5331;
-             FStar_Syntax_Syntax.sigopts = uu____5332;_},
-           uu____5333) ->
+               (lbs, uu___1);
+             FStar_Syntax_Syntax.sigrng = uu___2;
+             FStar_Syntax_Syntax.sigquals = uu___3;
+             FStar_Syntax_Syntax.sigmeta = uu___4;
+             FStar_Syntax_Syntax.sigattrs = uu___5;
+             FStar_Syntax_Syntax.sigopts = uu___6;_},
+           uu___7) ->
             FStar_Util.find_map (FStar_Pervasives_Native.snd lbs)
               (fun lb ->
                  match lb.FStar_Syntax_Syntax.lbname with
@@ -1602,11 +1575,11 @@ let (try_lookup_definition :
                      FStar_Syntax_Syntax.fv_eq_lid fv lid1 ->
                      FStar_Pervasives_Native.Some
                        (lb.FStar_Syntax_Syntax.lbdef)
-                 | uu____5358 -> FStar_Pervasives_Native.None)
-        | uu____5365 -> FStar_Pervasives_Native.None in
+                 | uu___8 -> FStar_Pervasives_Native.None)
+        | uu___1 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____5375 -> FStar_Pervasives_Native.None)
-        (fun uu____5379 -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
 let (empty_include_smap :
   FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap) = new_sigmap ()
 let (empty_exported_id_smap : exported_id_set FStar_Util.smap) =
@@ -1623,11 +1596,11 @@ let (try_lookup_lid' :
     fun exclude_interface ->
       fun env1 ->
         fun lid ->
-          let uu____5432 = try_lookup_name any_val exclude_interface env1 lid in
-          match uu____5432 with
+          let uu___ = try_lookup_name any_val exclude_interface env1 lid in
+          match uu___ with
           | FStar_Pervasives_Native.Some (Term_name (e, attrs)) ->
               FStar_Pervasives_Native.Some (e, attrs)
-          | uu____5457 -> FStar_Pervasives_Native.None
+          | uu___1 -> FStar_Pervasives_Native.None
 let (drop_attributes :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.attribute Prims.list)
     FStar_Pervasives_Native.option ->
@@ -1635,7 +1608,7 @@ let (drop_attributes :
   =
   fun x ->
     match x with
-    | FStar_Pervasives_Native.Some (t, uu____5494) ->
+    | FStar_Pervasives_Native.Some (t, uu___) ->
         FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let (try_lookup_lid_with_attributes :
@@ -1651,53 +1624,52 @@ let (try_lookup_lid :
   =
   fun env1 ->
     fun l ->
-      let uu____5549 = try_lookup_lid_with_attributes env1 l in
-      FStar_All.pipe_right uu____5549 drop_attributes
+      let uu___ = try_lookup_lid_with_attributes env1 l in
+      FStar_All.pipe_right uu___ drop_attributes
 let (resolve_to_fully_qualified_name :
   env ->
     FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
   =
   fun env1 ->
     fun l ->
-      let uu____5580 = try_lookup_lid env1 l in
-      match uu____5580 with
+      let uu___ = try_lookup_lid env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some e ->
-          let uu____5586 =
-            let uu____5587 = FStar_Syntax_Subst.compress e in
-            uu____5587.FStar_Syntax_Syntax.n in
-          (match uu____5586 with
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Subst.compress e in
+            uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                FStar_Pervasives_Native.Some
                  ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-           | uu____5593 -> FStar_Pervasives_Native.None)
+           | uu___2 -> FStar_Pervasives_Native.None)
 let (shorten_lid' : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1 ->
     fun lid ->
-      let uu____5604 =
-        let uu____5613 = FStar_Ident.ns_of_lid lid in
-        shorten_module_path env1 uu____5613 true in
-      match uu____5604 with
-      | (uu____5616, short) ->
-          let uu____5626 = FStar_Ident.ident_of_lid lid in
-          FStar_Ident.lid_of_ns_and_id short uu____5626
+      let uu___ =
+        let uu___1 = FStar_Ident.ns_of_lid lid in
+        shorten_module_path env1 uu___1 true in
+      match uu___ with
+      | (uu___1, short) ->
+          let uu___2 = FStar_Ident.ident_of_lid lid in
+          FStar_Ident.lid_of_ns_and_id short uu___2
 let (shorten_lid : env -> FStar_Ident.lid -> FStar_Ident.lid) =
   fun env1 ->
     fun lid ->
       match env1.curmodule with
       | FStar_Pervasives_Native.None -> shorten_lid' env1 lid
-      | uu____5637 ->
+      | uu___ ->
           let lid_without_ns =
-            let uu____5641 = FStar_Ident.ident_of_lid lid in
-            FStar_Ident.lid_of_ns_and_id [] uu____5641 in
-          let uu____5642 =
-            resolve_to_fully_qualified_name env1 lid_without_ns in
-          (match uu____5642 with
+            let uu___1 = FStar_Ident.ident_of_lid lid in
+            FStar_Ident.lid_of_ns_and_id [] uu___1 in
+          let uu___1 = resolve_to_fully_qualified_name env1 lid_without_ns in
+          (match uu___1 with
            | FStar_Pervasives_Native.Some lid' when
-               let uu____5646 = FStar_Ident.string_of_lid lid' in
-               let uu____5647 = FStar_Ident.string_of_lid lid in
-               uu____5646 = uu____5647 -> lid_without_ns
-           | uu____5648 -> shorten_lid' env1 lid)
+               let uu___2 = FStar_Ident.string_of_lid lid' in
+               let uu___3 = FStar_Ident.string_of_lid lid in uu___2 = uu___3
+               -> lid_without_ns
+           | uu___2 -> shorten_lid' env1 lid)
 let (try_lookup_lid_with_attributes_no_resolve :
   env ->
     FStar_Ident.lident ->
@@ -1707,24 +1679,24 @@ let (try_lookup_lid_with_attributes_no_resolve :
   fun env1 ->
     fun l ->
       let env' =
-        let uu___863_5678 = env1 in
+        let uu___ = env1 in
         {
-          curmodule = (uu___863_5678.curmodule);
-          curmonad = (uu___863_5678.curmonad);
-          modules = (uu___863_5678.modules);
+          curmodule = (uu___.curmodule);
+          curmonad = (uu___.curmonad);
+          modules = (uu___.modules);
           scope_mods = [];
           exported_ids = empty_exported_id_smap;
-          trans_exported_ids = (uu___863_5678.trans_exported_ids);
+          trans_exported_ids = (uu___.trans_exported_ids);
           includes = empty_include_smap;
-          sigaccum = (uu___863_5678.sigaccum);
-          sigmap = (uu___863_5678.sigmap);
-          iface = (uu___863_5678.iface);
-          admitted_iface = (uu___863_5678.admitted_iface);
-          expect_typ = (uu___863_5678.expect_typ);
-          remaining_iface_decls = (uu___863_5678.remaining_iface_decls);
-          syntax_only = (uu___863_5678.syntax_only);
-          ds_hooks = (uu___863_5678.ds_hooks);
-          dep_graph = (uu___863_5678.dep_graph)
+          sigaccum = (uu___.sigaccum);
+          sigmap = (uu___.sigmap);
+          iface = (uu___.iface);
+          admitted_iface = (uu___.admitted_iface);
+          expect_typ = (uu___.expect_typ);
+          remaining_iface_decls = (uu___.remaining_iface_decls);
+          syntax_only = (uu___.syntax_only);
+          ds_hooks = (uu___.ds_hooks);
+          dep_graph = (uu___.dep_graph)
         } in
       try_lookup_lid_with_attributes env' l
 let (try_lookup_lid_no_resolve :
@@ -1734,8 +1706,8 @@ let (try_lookup_lid_no_resolve :
   =
   fun env1 ->
     fun l ->
-      let uu____5693 = try_lookup_lid_with_attributes_no_resolve env1 l in
-      FStar_All.pipe_right uu____5693 drop_attributes
+      let uu___ = try_lookup_lid_with_attributes_no_resolve env1 l in
+      FStar_All.pipe_right uu___ drop_attributes
 let (try_lookup_datacon :
   env ->
     FStar_Ident.lident ->
@@ -1747,60 +1719,59 @@ let (try_lookup_datacon :
         match se with
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____5747, uu____5748, uu____5749);
-             FStar_Syntax_Syntax.sigrng = uu____5750;
+               (uu___, uu___1, uu___2);
+             FStar_Syntax_Syntax.sigrng = uu___3;
              FStar_Syntax_Syntax.sigquals = quals;
-             FStar_Syntax_Syntax.sigmeta = uu____5752;
-             FStar_Syntax_Syntax.sigattrs = uu____5753;
-             FStar_Syntax_Syntax.sigopts = uu____5754;_},
-           uu____5755) ->
-            let uu____5762 =
+             FStar_Syntax_Syntax.sigmeta = uu___4;
+             FStar_Syntax_Syntax.sigattrs = uu___5;
+             FStar_Syntax_Syntax.sigopts = uu___6;_},
+           uu___7) ->
+            let uu___8 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___22_5766 ->
-                      match uu___22_5766 with
+                   (fun uu___9 ->
+                      match uu___9 with
                       | FStar_Syntax_Syntax.Assumption -> true
-                      | uu____5767 -> false)) in
-            if uu____5762
+                      | uu___10 -> false)) in
+            if uu___8
             then
-              let uu____5770 =
+              let uu___9 =
                 FStar_Syntax_Syntax.lid_as_fv lid1
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
-              FStar_Pervasives_Native.Some uu____5770
+              FStar_Pervasives_Native.Some uu___9
             else FStar_Pervasives_Native.None
         | ({
-             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_splice
-               uu____5772;
-             FStar_Syntax_Syntax.sigrng = uu____5773;
-             FStar_Syntax_Syntax.sigquals = uu____5774;
-             FStar_Syntax_Syntax.sigmeta = uu____5775;
-             FStar_Syntax_Syntax.sigattrs = uu____5776;
-             FStar_Syntax_Syntax.sigopts = uu____5777;_},
-           uu____5778) ->
+             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_splice uu___;
+             FStar_Syntax_Syntax.sigrng = uu___1;
+             FStar_Syntax_Syntax.sigquals = uu___2;
+             FStar_Syntax_Syntax.sigmeta = uu___3;
+             FStar_Syntax_Syntax.sigattrs = uu___4;
+             FStar_Syntax_Syntax.sigopts = uu___5;_},
+           uu___6) ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se) in
-            let uu____5794 =
+            let uu___7 =
               FStar_Syntax_Syntax.lid_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1 in
-            FStar_Pervasives_Native.Some uu____5794
+            FStar_Pervasives_Native.Some uu___7
         | ({
              FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-               uu____5795;
-             FStar_Syntax_Syntax.sigrng = uu____5796;
-             FStar_Syntax_Syntax.sigquals = uu____5797;
-             FStar_Syntax_Syntax.sigmeta = uu____5798;
-             FStar_Syntax_Syntax.sigattrs = uu____5799;
-             FStar_Syntax_Syntax.sigopts = uu____5800;_},
-           uu____5801) ->
+               uu___;
+             FStar_Syntax_Syntax.sigrng = uu___1;
+             FStar_Syntax_Syntax.sigquals = uu___2;
+             FStar_Syntax_Syntax.sigmeta = uu___3;
+             FStar_Syntax_Syntax.sigattrs = uu___4;
+             FStar_Syntax_Syntax.sigopts = uu___5;_},
+           uu___6) ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se) in
-            let uu____5825 =
+            let uu___7 =
               FStar_Syntax_Syntax.lid_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1 in
-            FStar_Pervasives_Native.Some uu____5825
-        | uu____5826 -> FStar_Pervasives_Native.None in
+            FStar_Pervasives_Native.Some uu___7
+        | uu___ -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____5832 -> FStar_Pervasives_Native.None)
-        (fun uu____5834 -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
 let (find_all_datacons :
   env ->
     FStar_Ident.lident ->
@@ -1808,23 +1779,22 @@ let (find_all_datacons :
   =
   fun env1 ->
     fun lid ->
-      let k_global_def lid1 uu___23_5867 =
-        match uu___23_5867 with
+      let k_global_def lid1 uu___ =
+        match uu___ with
         | ({
              FStar_Syntax_Syntax.sigel =
                FStar_Syntax_Syntax.Sig_inductive_typ
-               (uu____5876, uu____5877, uu____5878, uu____5879, datas,
-                uu____5881);
-             FStar_Syntax_Syntax.sigrng = uu____5882;
-             FStar_Syntax_Syntax.sigquals = uu____5883;
-             FStar_Syntax_Syntax.sigmeta = uu____5884;
-             FStar_Syntax_Syntax.sigattrs = uu____5885;
-             FStar_Syntax_Syntax.sigopts = uu____5886;_},
-           uu____5887) -> FStar_Pervasives_Native.Some datas
-        | uu____5904 -> FStar_Pervasives_Native.None in
+               (uu___1, uu___2, uu___3, uu___4, datas, uu___5);
+             FStar_Syntax_Syntax.sigrng = uu___6;
+             FStar_Syntax_Syntax.sigquals = uu___7;
+             FStar_Syntax_Syntax.sigmeta = uu___8;
+             FStar_Syntax_Syntax.sigattrs = uu___9;
+             FStar_Syntax_Syntax.sigopts = uu___10;_},
+           uu___11) -> FStar_Pervasives_Native.Some datas
+        | uu___1 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env1 lid
-        (fun uu____5914 -> FStar_Pervasives_Native.None)
-        (fun uu____5918 -> FStar_Pervasives_Native.None) k_global_def
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
 let (record_cache_aux_with_filter :
   ((((unit -> unit) * (unit -> unit)) * (((unit -> (Prims.int * unit)) *
     (Prims.int FStar_Pervasives_Native.option -> unit)) *
@@ -1832,42 +1802,36 @@ let (record_cache_aux_with_filter :
     (unit -> unit)))
   =
   let record_cache = FStar_Util.mk_ref [[]] in
-  let push uu____5994 =
-    let uu____5995 =
-      let uu____6000 =
-        let uu____6003 = FStar_ST.op_Bang record_cache in
-        FStar_List.hd uu____6003 in
-      let uu____6024 = FStar_ST.op_Bang record_cache in uu____6000 ::
-        uu____6024 in
-    FStar_ST.op_Colon_Equals record_cache uu____5995 in
-  let pop uu____6064 =
-    let uu____6065 =
-      let uu____6070 = FStar_ST.op_Bang record_cache in
-      FStar_List.tl uu____6070 in
-    FStar_ST.op_Colon_Equals record_cache uu____6065 in
-  let snapshot uu____6114 = FStar_Common.snapshot push record_cache () in
+  let push uu___ =
+    let uu___1 =
+      let uu___2 =
+        let uu___3 = FStar_ST.op_Bang record_cache in FStar_List.hd uu___3 in
+      let uu___3 = FStar_ST.op_Bang record_cache in uu___2 :: uu___3 in
+    FStar_ST.op_Colon_Equals record_cache uu___1 in
+  let pop uu___ =
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang record_cache in FStar_List.tl uu___2 in
+    FStar_ST.op_Colon_Equals record_cache uu___1 in
+  let snapshot uu___ = FStar_Common.snapshot push record_cache () in
   let rollback depth = FStar_Common.rollback pop record_cache depth in
-  let peek uu____6136 =
-    let uu____6137 = FStar_ST.op_Bang record_cache in
-    FStar_List.hd uu____6137 in
+  let peek uu___ =
+    let uu___1 = FStar_ST.op_Bang record_cache in FStar_List.hd uu___1 in
   let insert r =
-    let uu____6164 =
-      let uu____6169 = let uu____6172 = peek () in r :: uu____6172 in
-      let uu____6175 =
-        let uu____6180 = FStar_ST.op_Bang record_cache in
-        FStar_List.tl uu____6180 in
-      uu____6169 :: uu____6175 in
-    FStar_ST.op_Colon_Equals record_cache uu____6164 in
-  let filter uu____6222 =
+    let uu___ =
+      let uu___1 = let uu___2 = peek () in r :: uu___2 in
+      let uu___2 =
+        let uu___3 = FStar_ST.op_Bang record_cache in FStar_List.tl uu___3 in
+      uu___1 :: uu___2 in
+    FStar_ST.op_Colon_Equals record_cache uu___ in
+  let filter uu___ =
     let rc = peek () in
     let filtered =
       FStar_List.filter (fun r -> Prims.op_Negation r.is_private) rc in
-    let uu____6231 =
-      let uu____6236 =
-        let uu____6241 = FStar_ST.op_Bang record_cache in
-        FStar_List.tl uu____6241 in
-      filtered :: uu____6236 in
-    FStar_ST.op_Colon_Equals record_cache uu____6231 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 = FStar_ST.op_Bang record_cache in FStar_List.tl uu___3 in
+      filtered :: uu___2 in
+    FStar_ST.op_Colon_Equals record_cache uu___1 in
   let aux = ((push, pop), ((snapshot, rollback), (peek, insert))) in
   (aux, filter)
 let (record_cache_aux :
@@ -1906,100 +1870,96 @@ let (extract_record :
     fun new_globs ->
       fun se ->
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_bundle (sigs, uu____7090) ->
+        | FStar_Syntax_Syntax.Sig_bundle (sigs, uu___) ->
             let is_record =
               FStar_Util.for_some
-                (fun uu___24_7108 ->
-                   match uu___24_7108 with
-                   | FStar_Syntax_Syntax.RecordType uu____7109 -> true
-                   | FStar_Syntax_Syntax.RecordConstructor uu____7118 -> true
-                   | uu____7127 -> false) in
+                (fun uu___1 ->
+                   match uu___1 with
+                   | FStar_Syntax_Syntax.RecordType uu___2 -> true
+                   | FStar_Syntax_Syntax.RecordConstructor uu___2 -> true
+                   | uu___2 -> false) in
             let find_dc dc =
               FStar_All.pipe_right sigs
                 (FStar_Util.find_opt
-                   (fun uu___25_7152 ->
-                      match uu___25_7152 with
+                   (fun uu___1 ->
+                      match uu___1 with
                       | {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_datacon
-                            (lid, uu____7154, uu____7155, uu____7156,
-                             uu____7157, uu____7158);
-                          FStar_Syntax_Syntax.sigrng = uu____7159;
-                          FStar_Syntax_Syntax.sigquals = uu____7160;
-                          FStar_Syntax_Syntax.sigmeta = uu____7161;
-                          FStar_Syntax_Syntax.sigattrs = uu____7162;
-                          FStar_Syntax_Syntax.sigopts = uu____7163;_} ->
+                            (lid, uu___2, uu___3, uu___4, uu___5, uu___6);
+                          FStar_Syntax_Syntax.sigrng = uu___7;
+                          FStar_Syntax_Syntax.sigquals = uu___8;
+                          FStar_Syntax_Syntax.sigmeta = uu___9;
+                          FStar_Syntax_Syntax.sigattrs = uu___10;
+                          FStar_Syntax_Syntax.sigopts = uu___11;_} ->
                           FStar_Ident.lid_equals dc lid
-                      | uu____7174 -> false)) in
+                      | uu___2 -> false)) in
             FStar_All.pipe_right sigs
               (FStar_List.iter
-                 (fun uu___26_7214 ->
-                    match uu___26_7214 with
+                 (fun uu___1 ->
+                    match uu___1 with
                     | {
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_inductive_typ
-                          (typename, univs, parms, uu____7218, uu____7219,
-                           dc::[]);
-                        FStar_Syntax_Syntax.sigrng = uu____7221;
+                          (typename, univs, parms, uu___2, uu___3, dc::[]);
+                        FStar_Syntax_Syntax.sigrng = uu___4;
                         FStar_Syntax_Syntax.sigquals = typename_quals;
-                        FStar_Syntax_Syntax.sigmeta = uu____7223;
-                        FStar_Syntax_Syntax.sigattrs = uu____7224;
-                        FStar_Syntax_Syntax.sigopts = uu____7225;_} ->
-                        let uu____7238 =
-                          let uu____7239 = find_dc dc in
-                          FStar_All.pipe_left FStar_Util.must uu____7239 in
-                        (match uu____7238 with
+                        FStar_Syntax_Syntax.sigmeta = uu___5;
+                        FStar_Syntax_Syntax.sigattrs = uu___6;
+                        FStar_Syntax_Syntax.sigopts = uu___7;_} ->
+                        let uu___8 =
+                          let uu___9 = find_dc dc in
+                          FStar_All.pipe_left FStar_Util.must uu___9 in
+                        (match uu___8 with
                          | {
                              FStar_Syntax_Syntax.sigel =
                                FStar_Syntax_Syntax.Sig_datacon
-                               (constrname, uu____7245, t, uu____7247, n,
-                                uu____7249);
-                             FStar_Syntax_Syntax.sigrng = uu____7250;
-                             FStar_Syntax_Syntax.sigquals = uu____7251;
-                             FStar_Syntax_Syntax.sigmeta = uu____7252;
-                             FStar_Syntax_Syntax.sigattrs = uu____7253;
-                             FStar_Syntax_Syntax.sigopts = uu____7254;_} ->
-                             let uu____7265 =
-                               FStar_Syntax_Util.arrow_formals t in
-                             (match uu____7265 with
-                              | (all_formals, uu____7273) ->
-                                  let uu____7278 =
+                               (constrname, uu___9, t, uu___10, n, uu___11);
+                             FStar_Syntax_Syntax.sigrng = uu___12;
+                             FStar_Syntax_Syntax.sigquals = uu___13;
+                             FStar_Syntax_Syntax.sigmeta = uu___14;
+                             FStar_Syntax_Syntax.sigattrs = uu___15;
+                             FStar_Syntax_Syntax.sigopts = uu___16;_} ->
+                             let uu___17 = FStar_Syntax_Util.arrow_formals t in
+                             (match uu___17 with
+                              | (all_formals, uu___18) ->
+                                  let uu___19 =
                                     FStar_Util.first_N n all_formals in
-                                  (match uu____7278 with
+                                  (match uu___19 with
                                    | (_params, formals) ->
                                        let is_rec = is_record typename_quals in
                                        let formals' =
                                          FStar_All.pipe_right formals
                                            (FStar_List.collect
-                                              (fun uu____7371 ->
-                                                 match uu____7371 with
+                                              (fun uu___20 ->
+                                                 match uu___20 with
                                                  | (x, q) ->
-                                                     let uu____7384 =
+                                                     let uu___21 =
                                                        (FStar_Syntax_Syntax.is_null_bv
                                                           x)
                                                          ||
                                                          (is_rec &&
                                                             (FStar_Syntax_Syntax.is_implicit
                                                                q)) in
-                                                     if uu____7384
+                                                     if uu___21
                                                      then []
                                                      else [(x, q)])) in
                                        let fields' =
                                          FStar_All.pipe_right formals'
                                            (FStar_List.map
-                                              (fun uu____7436 ->
-                                                 match uu____7436 with
+                                              (fun uu___20 ->
+                                                 match uu___20 with
                                                  | (x, q) ->
                                                      ((x.FStar_Syntax_Syntax.ppname),
                                                        (x.FStar_Syntax_Syntax.sort)))) in
                                        let fields = fields' in
                                        let record =
-                                         let uu____7459 =
+                                         let uu___20 =
                                            FStar_Ident.ident_of_lid
                                              constrname in
                                          {
                                            typename;
-                                           constrname = uu____7459;
+                                           constrname = uu___20;
                                            parms;
                                            fields;
                                            is_private =
@@ -2008,81 +1968,77 @@ let (extract_record :
                                                 typename_quals);
                                            is_record = is_rec
                                          } in
-                                       ((let uu____7461 =
-                                           let uu____7464 =
+                                       ((let uu___21 =
+                                           let uu___22 =
                                              FStar_ST.op_Bang new_globs in
-                                           (Record_or_dc record) ::
-                                             uu____7464 in
+                                           (Record_or_dc record) :: uu___22 in
                                          FStar_ST.op_Colon_Equals new_globs
-                                           uu____7461);
+                                           uu___21);
                                         (match () with
                                          | () ->
-                                             ((let add_field uu____7497 =
-                                                 match uu____7497 with
-                                                 | (id, uu____7503) ->
+                                             ((let add_field uu___22 =
+                                                 match uu___22 with
+                                                 | (id, uu___23) ->
                                                      let modul =
-                                                       let uu____7505 =
-                                                         let uu____7506 =
+                                                       let uu___24 =
+                                                         let uu___25 =
                                                            FStar_Ident.ns_of_lid
                                                              constrname in
                                                          FStar_Ident.lid_of_ids
-                                                           uu____7506 in
+                                                           uu___25 in
                                                        FStar_Ident.string_of_lid
-                                                         uu____7505 in
-                                                     let uu____7507 =
+                                                         uu___24 in
+                                                     let uu___24 =
                                                        get_exported_id_set e
                                                          modul in
-                                                     (match uu____7507 with
+                                                     (match uu___24 with
                                                       | FStar_Pervasives_Native.Some
                                                           my_ex ->
                                                           let my_exported_ids
                                                             =
                                                             my_ex
                                                               Exported_id_field in
-                                                          ((let uu____7530 =
-                                                              let uu____7531
-                                                                =
+                                                          ((let uu___26 =
+                                                              let uu___27 =
                                                                 FStar_Ident.string_of_id
                                                                   id in
-                                                              let uu____7532
-                                                                =
+                                                              let uu___28 =
                                                                 FStar_ST.op_Bang
                                                                   my_exported_ids in
                                                               FStar_Util.set_add
-                                                                uu____7531
-                                                                uu____7532 in
+                                                                uu___27
+                                                                uu___28 in
                                                             FStar_ST.op_Colon_Equals
                                                               my_exported_ids
-                                                              uu____7530);
+                                                              uu___26);
                                                            (match () with
                                                             | () ->
                                                                 let projname
                                                                   =
-                                                                  let uu____7548
+                                                                  let uu___26
                                                                     =
-                                                                    let uu____7549
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Util.mk_field_projector_name_from_ident
                                                                     constrname
                                                                     id in
                                                                     FStar_All.pipe_right
-                                                                    uu____7549
+                                                                    uu___27
                                                                     FStar_Ident.ident_of_lid in
                                                                   FStar_All.pipe_right
-                                                                    uu____7548
+                                                                    uu___26
                                                                     FStar_Ident.string_of_id in
-                                                                let uu____7551
-                                                                  =
-                                                                  let uu____7552
+                                                                let uu___27 =
+                                                                  let uu___28
                                                                     =
                                                                     FStar_ST.op_Bang
                                                                     my_exported_ids in
                                                                   FStar_Util.set_add
                                                                     projname
-                                                                    uu____7552 in
+                                                                    uu___28 in
                                                                 FStar_ST.op_Colon_Equals
                                                                   my_exported_ids
-                                                                  uu____7551))
+                                                                  uu___27))
                                                       | FStar_Pervasives_Native.None
                                                           -> ()) in
                                                FStar_List.iter add_field
@@ -2090,64 +2046,59 @@ let (extract_record :
                                               (match () with
                                                | () ->
                                                    insert_record_cache record))))))
-                         | uu____7576 -> ())
-                    | uu____7577 -> ()))
-        | uu____7578 -> ()
+                         | uu___9 -> ())
+                    | uu___2 -> ()))
+        | uu___ -> ()
 let (try_lookup_record_or_dc_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env1 ->
     fun fieldname ->
       let find_in_cache fieldname1 =
-        let uu____7599 =
-          let uu____7606 = FStar_Ident.ns_of_lid fieldname1 in
-          let uu____7609 = FStar_Ident.ident_of_lid fieldname1 in
-          (uu____7606, uu____7609) in
-        match uu____7599 with
+        let uu___ =
+          let uu___1 = FStar_Ident.ns_of_lid fieldname1 in
+          let uu___2 = FStar_Ident.ident_of_lid fieldname1 in
+          (uu___1, uu___2) in
+        match uu___ with
         | (ns, id) ->
-            let uu____7620 = peek_record_cache () in
-            FStar_Util.find_map uu____7620
+            let uu___1 = peek_record_cache () in
+            FStar_Util.find_map uu___1
               (fun record ->
-                 let uu____7626 =
+                 let uu___2 =
                    find_in_record ns id record (fun r -> Cont_ok r) in
-                 option_of_cont
-                   (fun uu____7632 -> FStar_Pervasives_Native.None)
-                   uu____7626) in
+                 option_of_cont (fun uu___3 -> FStar_Pervasives_Native.None)
+                   uu___2) in
       resolve_in_open_namespaces'' env1 fieldname Exported_id_field
-        (fun uu____7634 -> Cont_ignore) (fun uu____7636 -> Cont_ignore)
+        (fun uu___ -> Cont_ignore) (fun uu___ -> Cont_ignore)
         (fun r -> Cont_ok r)
         (fun fn ->
-           let uu____7642 = find_in_cache fn in
-           cont_of_option Cont_ignore uu____7642)
-        (fun k -> fun uu____7648 -> k)
+           let uu___ = find_in_cache fn in cont_of_option Cont_ignore uu___)
+        (fun k -> fun uu___ -> k)
 let (try_lookup_record_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
   fun env1 ->
     fun fieldname ->
-      let uu____7663 = try_lookup_record_or_dc_by_field_name env1 fieldname in
-      match uu____7663 with
+      let uu___ = try_lookup_record_or_dc_by_field_name env1 fieldname in
+      match uu___ with
       | FStar_Pervasives_Native.Some r when r.is_record ->
           FStar_Pervasives_Native.Some r
-      | uu____7669 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (belongs_to_record :
   env -> FStar_Ident.lident -> record_or_dc -> Prims.bool) =
   fun env1 ->
     fun lid ->
       fun record ->
-        let uu____7687 = try_lookup_record_by_field_name env1 lid in
-        match uu____7687 with
+        let uu___ = try_lookup_record_by_field_name env1 lid in
+        match uu___ with
         | FStar_Pervasives_Native.Some record' when
-            let uu____7691 = FStar_Ident.nsstr record.typename in
-            let uu____7692 = FStar_Ident.nsstr record'.typename in
-            uu____7691 = uu____7692 ->
-            let uu____7693 =
-              let uu____7696 = FStar_Ident.ns_of_lid record.typename in
-              let uu____7699 = FStar_Ident.ident_of_lid lid in
-              find_in_record uu____7696 uu____7699 record
-                (fun uu____7701 -> Cont_ok ()) in
-            (match uu____7693 with
-             | Cont_ok uu____7702 -> true
-             | uu____7703 -> false)
-        | uu____7706 -> false
+            let uu___1 = FStar_Ident.nsstr record.typename in
+            let uu___2 = FStar_Ident.nsstr record'.typename in
+            uu___1 = uu___2 ->
+            let uu___1 =
+              let uu___2 = FStar_Ident.ns_of_lid record.typename in
+              let uu___3 = FStar_Ident.ident_of_lid lid in
+              find_in_record uu___2 uu___3 record (fun uu___4 -> Cont_ok ()) in
+            (match uu___1 with | Cont_ok uu___2 -> true | uu___2 -> false)
+        | uu___1 -> false
 let (try_lookup_dc_by_field_name :
   env ->
     FStar_Ident.lident ->
@@ -2155,32 +2106,32 @@ let (try_lookup_dc_by_field_name :
   =
   fun env1 ->
     fun fieldname ->
-      let uu____7725 = try_lookup_record_or_dc_by_field_name env1 fieldname in
-      match uu____7725 with
+      let uu___ = try_lookup_record_or_dc_by_field_name env1 fieldname in
+      match uu___ with
       | FStar_Pervasives_Native.Some r ->
-          let uu____7735 =
-            let uu____7740 =
-              let uu____7741 =
-                let uu____7742 =
-                  let uu____7743 = FStar_Ident.ns_of_lid r.typename in
-                  FStar_List.append uu____7743 [r.constrname] in
-                FStar_Ident.lid_of_ids uu____7742 in
-              let uu____7746 = FStar_Ident.range_of_lid fieldname in
-              FStar_Ident.set_lid_range uu____7741 uu____7746 in
-            (uu____7740, (r.is_record)) in
-          FStar_Pervasives_Native.Some uu____7735
-      | uu____7751 -> FStar_Pervasives_Native.None
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Ident.ns_of_lid r.typename in
+                  FStar_List.append uu___5 [r.constrname] in
+                FStar_Ident.lid_of_ids uu___4 in
+              let uu___4 = FStar_Ident.range_of_lid fieldname in
+              FStar_Ident.set_lid_range uu___3 uu___4 in
+            (uu___2, (r.is_record)) in
+          FStar_Pervasives_Native.Some uu___1
+      | uu___1 -> FStar_Pervasives_Native.None
 let (string_set_ref_new : unit -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____7766 ->
-    let uu____7767 = FStar_Util.new_set FStar_Util.compare in
-    FStar_Util.mk_ref uu____7767
+  fun uu___ ->
+    let uu___1 = FStar_Util.new_set FStar_Util.compare in
+    FStar_Util.mk_ref uu___1
 let (exported_id_set_new :
   unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref) =
-  fun uu____7783 ->
+  fun uu___ ->
     let term_type_set = string_set_ref_new () in
     let field_set = string_set_ref_new () in
-    fun uu___27_7794 ->
-      match uu___27_7794 with
+    fun uu___1 ->
+      match uu___1 with
       | Exported_id_term_type -> term_type_set
       | Exported_id_field -> field_set
 let (unique :
@@ -2189,58 +2140,54 @@ let (unique :
     fun exclude_interface ->
       fun env1 ->
         fun lid ->
-          let filter_scope_mods uu___28_7824 =
-            match uu___28_7824 with
-            | Rec_binding uu____7825 -> true
-            | uu____7826 -> false in
+          let filter_scope_mods uu___ =
+            match uu___ with | Rec_binding uu___1 -> true | uu___1 -> false in
           let this_env =
-            let uu___1106_7828 = env1 in
-            let uu____7829 =
-              FStar_List.filter filter_scope_mods env1.scope_mods in
+            let uu___ = env1 in
+            let uu___1 = FStar_List.filter filter_scope_mods env1.scope_mods in
             {
-              curmodule = (uu___1106_7828.curmodule);
-              curmonad = (uu___1106_7828.curmonad);
-              modules = (uu___1106_7828.modules);
-              scope_mods = uu____7829;
+              curmodule = (uu___.curmodule);
+              curmonad = (uu___.curmonad);
+              modules = (uu___.modules);
+              scope_mods = uu___1;
               exported_ids = empty_exported_id_smap;
-              trans_exported_ids = (uu___1106_7828.trans_exported_ids);
+              trans_exported_ids = (uu___.trans_exported_ids);
               includes = empty_include_smap;
-              sigaccum = (uu___1106_7828.sigaccum);
-              sigmap = (uu___1106_7828.sigmap);
-              iface = (uu___1106_7828.iface);
-              admitted_iface = (uu___1106_7828.admitted_iface);
-              expect_typ = (uu___1106_7828.expect_typ);
-              remaining_iface_decls = (uu___1106_7828.remaining_iface_decls);
-              syntax_only = (uu___1106_7828.syntax_only);
-              ds_hooks = (uu___1106_7828.ds_hooks);
-              dep_graph = (uu___1106_7828.dep_graph)
+              sigaccum = (uu___.sigaccum);
+              sigmap = (uu___.sigmap);
+              iface = (uu___.iface);
+              admitted_iface = (uu___.admitted_iface);
+              expect_typ = (uu___.expect_typ);
+              remaining_iface_decls = (uu___.remaining_iface_decls);
+              syntax_only = (uu___.syntax_only);
+              ds_hooks = (uu___.ds_hooks);
+              dep_graph = (uu___.dep_graph)
             } in
-          let uu____7832 =
-            try_lookup_lid' any_val exclude_interface this_env lid in
-          match uu____7832 with
+          let uu___ = try_lookup_lid' any_val exclude_interface this_env lid in
+          match uu___ with
           | FStar_Pervasives_Native.None -> true
-          | FStar_Pervasives_Native.Some uu____7847 -> false
+          | FStar_Pervasives_Native.Some uu___1 -> false
 let (push_scope_mod : env -> scope_mod -> env) =
   fun env1 ->
     fun scope_mod1 ->
-      let uu___1114_7870 = env1 in
+      let uu___ = env1 in
       {
-        curmodule = (uu___1114_7870.curmodule);
-        curmonad = (uu___1114_7870.curmonad);
-        modules = (uu___1114_7870.modules);
+        curmodule = (uu___.curmodule);
+        curmonad = (uu___.curmonad);
+        modules = (uu___.modules);
         scope_mods = (scope_mod1 :: (env1.scope_mods));
-        exported_ids = (uu___1114_7870.exported_ids);
-        trans_exported_ids = (uu___1114_7870.trans_exported_ids);
-        includes = (uu___1114_7870.includes);
-        sigaccum = (uu___1114_7870.sigaccum);
-        sigmap = (uu___1114_7870.sigmap);
-        iface = (uu___1114_7870.iface);
-        admitted_iface = (uu___1114_7870.admitted_iface);
-        expect_typ = (uu___1114_7870.expect_typ);
-        remaining_iface_decls = (uu___1114_7870.remaining_iface_decls);
-        syntax_only = (uu___1114_7870.syntax_only);
-        ds_hooks = (uu___1114_7870.ds_hooks);
-        dep_graph = (uu___1114_7870.dep_graph)
+        exported_ids = (uu___.exported_ids);
+        trans_exported_ids = (uu___.trans_exported_ids);
+        includes = (uu___.includes);
+        sigaccum = (uu___.sigaccum);
+        sigmap = (uu___.sigmap);
+        iface = (uu___.iface);
+        admitted_iface = (uu___.admitted_iface);
+        expect_typ = (uu___.expect_typ);
+        remaining_iface_decls = (uu___.remaining_iface_decls);
+        syntax_only = (uu___.syntax_only);
+        ds_hooks = (uu___.ds_hooks);
+        dep_graph = (uu___.dep_graph)
       }
 let (push_bv' :
   env -> FStar_Ident.ident -> (env * FStar_Syntax_Syntax.bv * used_marker)) =
@@ -2248,15 +2195,13 @@ let (push_bv' :
     fun x ->
       let r = FStar_Ident.range_of_id x in
       let bv =
-        let uu____7889 = FStar_Ident.string_of_id x in
-        FStar_Syntax_Syntax.gen_bv uu____7889
-          (FStar_Pervasives_Native.Some r)
-          (let uu___1119_7891 = FStar_Syntax_Syntax.tun in
+        let uu___ = FStar_Ident.string_of_id x in
+        FStar_Syntax_Syntax.gen_bv uu___ (FStar_Pervasives_Native.Some r)
+          (let uu___1 = FStar_Syntax_Syntax.tun in
            {
-             FStar_Syntax_Syntax.n = (uu___1119_7891.FStar_Syntax_Syntax.n);
+             FStar_Syntax_Syntax.n = (uu___1.FStar_Syntax_Syntax.n);
              FStar_Syntax_Syntax.pos = r;
-             FStar_Syntax_Syntax.vars =
-               (uu___1119_7891.FStar_Syntax_Syntax.vars)
+             FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
            }) in
       let used_marker1 = FStar_Util.mk_ref false in
       ((push_scope_mod env1 (Local_binding (x, bv, used_marker1))), bv,
@@ -2264,8 +2209,8 @@ let (push_bv' :
 let (push_bv : env -> FStar_Ident.ident -> (env * FStar_Syntax_Syntax.bv)) =
   fun env1 ->
     fun x ->
-      let uu____7909 = push_bv' env1 x in
-      match uu____7909 with | (env2, bv, uu____7922) -> (env2, bv)
+      let uu___ = push_bv' env1 x in
+      match uu___ with | (env2, bv, uu___1) -> (env2, bv)
 let (push_top_level_rec_binding :
   env ->
     FStar_Ident.ident ->
@@ -2275,171 +2220,167 @@ let (push_top_level_rec_binding :
     fun x ->
       fun dd ->
         let l = qualify env0 x in
-        let uu____7951 =
+        let uu___ =
           (unique false true env0 l) || (FStar_Options.interactive ()) in
-        if uu____7951
+        if uu___
         then
           let used_marker1 = FStar_Util.mk_ref false in
           ((push_scope_mod env0 (Rec_binding (x, l, dd, used_marker1))),
             used_marker1)
         else
-          (let uu____7964 =
-             let uu____7969 =
-               let uu____7970 = FStar_Ident.string_of_lid l in
-               Prims.op_Hat "Duplicate top-level names " uu____7970 in
-             (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____7969) in
-           let uu____7971 = FStar_Ident.range_of_lid l in
-           FStar_Errors.raise_error uu____7964 uu____7971)
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Ident.string_of_lid l in
+               Prims.op_Hat "Duplicate top-level names " uu___4 in
+             (FStar_Errors.Fatal_DuplicateTopLevelNames, uu___3) in
+           let uu___3 = FStar_Ident.range_of_lid l in
+           FStar_Errors.raise_error uu___2 uu___3)
 let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun fail_on_dup ->
     fun env1 ->
       fun s ->
         let err l =
           let sopt =
-            let uu____8006 = FStar_Ident.string_of_lid l in
-            FStar_Util.smap_try_find (sigmap env1) uu____8006 in
+            let uu___ = FStar_Ident.string_of_lid l in
+            FStar_Util.smap_try_find (sigmap env1) uu___ in
           let r =
             match sopt with
-            | FStar_Pervasives_Native.Some (se, uu____8013) ->
-                let uu____8018 =
+            | FStar_Pervasives_Native.Some (se, uu___) ->
+                let uu___1 =
                   FStar_Util.find_opt (FStar_Ident.lid_equals l)
                     (FStar_Syntax_Util.lids_of_sigelt se) in
-                (match uu____8018 with
+                (match uu___1 with
                  | FStar_Pervasives_Native.Some l1 ->
-                     let uu____8022 = FStar_Ident.range_of_lid l1 in
-                     FStar_All.pipe_left FStar_Range.string_of_range
-                       uu____8022
+                     let uu___2 = FStar_Ident.range_of_lid l1 in
+                     FStar_All.pipe_left FStar_Range.string_of_range uu___2
                  | FStar_Pervasives_Native.None -> "<unknown>")
             | FStar_Pervasives_Native.None -> "<unknown>" in
-          let uu____8027 =
-            let uu____8032 =
-              let uu____8033 = FStar_Ident.string_of_lid l in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Ident.string_of_lid l in
               FStar_Util.format2
                 "Duplicate top-level names [%s]; previously declared at %s"
-                uu____8033 r in
-            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____8032) in
-          let uu____8034 = FStar_Ident.range_of_lid l in
-          FStar_Errors.raise_error uu____8027 uu____8034 in
+                uu___2 r in
+            (FStar_Errors.Fatal_DuplicateTopLevelNames, uu___1) in
+          let uu___1 = FStar_Ident.range_of_lid l in
+          FStar_Errors.raise_error uu___ uu___1 in
         let globals = FStar_Util.mk_ref env1.scope_mods in
         let env2 =
-          let uu____8043 =
+          let uu___ =
             match s.FStar_Syntax_Syntax.sigel with
-            | FStar_Syntax_Syntax.Sig_let uu____8052 -> (false, true)
-            | FStar_Syntax_Syntax.Sig_bundle uu____8059 -> (false, true)
-            | uu____8068 -> (false, false) in
-          match uu____8043 with
+            | FStar_Syntax_Syntax.Sig_let uu___1 -> (false, true)
+            | FStar_Syntax_Syntax.Sig_bundle uu___1 -> (false, true)
+            | uu___1 -> (false, false) in
+          match uu___ with
           | (any_val, exclude_interface) ->
               let lids = FStar_Syntax_Util.lids_of_sigelt s in
-              let uu____8074 =
+              let uu___1 =
                 FStar_Util.find_map lids
                   (fun l ->
-                     let uu____8080 =
-                       let uu____8081 =
-                         unique any_val exclude_interface env1 l in
-                       Prims.op_Negation uu____8081 in
-                     if uu____8080
+                     let uu___2 =
+                       let uu___3 = unique any_val exclude_interface env1 l in
+                       Prims.op_Negation uu___3 in
+                     if uu___2
                      then FStar_Pervasives_Native.Some l
                      else FStar_Pervasives_Native.None) in
-              (match uu____8074 with
+              (match uu___1 with
                | FStar_Pervasives_Native.Some l when fail_on_dup -> err l
-               | uu____8086 ->
+               | uu___2 ->
                    (extract_record env1 globals s;
-                    (let uu___1166_8090 = env1 in
+                    (let uu___4 = env1 in
                      {
-                       curmodule = (uu___1166_8090.curmodule);
-                       curmonad = (uu___1166_8090.curmonad);
-                       modules = (uu___1166_8090.modules);
-                       scope_mods = (uu___1166_8090.scope_mods);
-                       exported_ids = (uu___1166_8090.exported_ids);
-                       trans_exported_ids =
-                         (uu___1166_8090.trans_exported_ids);
-                       includes = (uu___1166_8090.includes);
+                       curmodule = (uu___4.curmodule);
+                       curmonad = (uu___4.curmonad);
+                       modules = (uu___4.modules);
+                       scope_mods = (uu___4.scope_mods);
+                       exported_ids = (uu___4.exported_ids);
+                       trans_exported_ids = (uu___4.trans_exported_ids);
+                       includes = (uu___4.includes);
                        sigaccum = (s :: (env1.sigaccum));
-                       sigmap = (uu___1166_8090.sigmap);
-                       iface = (uu___1166_8090.iface);
-                       admitted_iface = (uu___1166_8090.admitted_iface);
-                       expect_typ = (uu___1166_8090.expect_typ);
-                       remaining_iface_decls =
-                         (uu___1166_8090.remaining_iface_decls);
-                       syntax_only = (uu___1166_8090.syntax_only);
-                       ds_hooks = (uu___1166_8090.ds_hooks);
-                       dep_graph = (uu___1166_8090.dep_graph)
+                       sigmap = (uu___4.sigmap);
+                       iface = (uu___4.iface);
+                       admitted_iface = (uu___4.admitted_iface);
+                       expect_typ = (uu___4.expect_typ);
+                       remaining_iface_decls = (uu___4.remaining_iface_decls);
+                       syntax_only = (uu___4.syntax_only);
+                       ds_hooks = (uu___4.ds_hooks);
+                       dep_graph = (uu___4.dep_graph)
                      }))) in
         let env3 =
-          let uu___1169_8092 = env2 in
-          let uu____8093 = FStar_ST.op_Bang globals in
+          let uu___ = env2 in
+          let uu___1 = FStar_ST.op_Bang globals in
           {
-            curmodule = (uu___1169_8092.curmodule);
-            curmonad = (uu___1169_8092.curmonad);
-            modules = (uu___1169_8092.modules);
-            scope_mods = uu____8093;
-            exported_ids = (uu___1169_8092.exported_ids);
-            trans_exported_ids = (uu___1169_8092.trans_exported_ids);
-            includes = (uu___1169_8092.includes);
-            sigaccum = (uu___1169_8092.sigaccum);
-            sigmap = (uu___1169_8092.sigmap);
-            iface = (uu___1169_8092.iface);
-            admitted_iface = (uu___1169_8092.admitted_iface);
-            expect_typ = (uu___1169_8092.expect_typ);
-            remaining_iface_decls = (uu___1169_8092.remaining_iface_decls);
-            syntax_only = (uu___1169_8092.syntax_only);
-            ds_hooks = (uu___1169_8092.ds_hooks);
-            dep_graph = (uu___1169_8092.dep_graph)
+            curmodule = (uu___.curmodule);
+            curmonad = (uu___.curmonad);
+            modules = (uu___.modules);
+            scope_mods = uu___1;
+            exported_ids = (uu___.exported_ids);
+            trans_exported_ids = (uu___.trans_exported_ids);
+            includes = (uu___.includes);
+            sigaccum = (uu___.sigaccum);
+            sigmap = (uu___.sigmap);
+            iface = (uu___.iface);
+            admitted_iface = (uu___.admitted_iface);
+            expect_typ = (uu___.expect_typ);
+            remaining_iface_decls = (uu___.remaining_iface_decls);
+            syntax_only = (uu___.syntax_only);
+            ds_hooks = (uu___.ds_hooks);
+            dep_graph = (uu___.dep_graph)
           } in
-        let uu____8106 =
+        let uu___ =
           match s.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses, uu____8132) ->
-              let uu____8141 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses, uu___1) ->
+              let uu___2 =
                 FStar_List.map
                   (fun se -> ((FStar_Syntax_Util.lids_of_sigelt se), se)) ses in
-              (env3, uu____8141)
-          | uu____8168 -> (env3, [((FStar_Syntax_Util.lids_of_sigelt s), s)]) in
-        match uu____8106 with
+              (env3, uu___2)
+          | uu___1 -> (env3, [((FStar_Syntax_Util.lids_of_sigelt s), s)]) in
+        match uu___ with
         | (env4, lss) ->
             (FStar_All.pipe_right lss
                (FStar_List.iter
-                  (fun uu____8227 ->
-                     match uu____8227 with
+                  (fun uu___2 ->
+                     match uu___2 with
                      | (lids, se) ->
                          FStar_All.pipe_right lids
                            (FStar_List.iter
                               (fun lid ->
-                                 (let uu____8250 =
-                                    let uu____8253 =
-                                      let uu____8254 =
+                                 (let uu___4 =
+                                    let uu___5 =
+                                      let uu___6 =
                                         FStar_Ident.ident_of_lid lid in
-                                      Top_level_def uu____8254 in
-                                    let uu____8255 = FStar_ST.op_Bang globals in
-                                    uu____8253 :: uu____8255 in
-                                  FStar_ST.op_Colon_Equals globals uu____8250);
+                                      Top_level_def uu___6 in
+                                    let uu___6 = FStar_ST.op_Bang globals in
+                                    uu___5 :: uu___6 in
+                                  FStar_ST.op_Colon_Equals globals uu___4);
                                  (match () with
                                   | () ->
                                       let modul =
-                                        let uu____8279 =
-                                          let uu____8280 =
+                                        let uu___4 =
+                                          let uu___5 =
                                             FStar_Ident.ns_of_lid lid in
-                                          FStar_Ident.lid_of_ids uu____8280 in
-                                        FStar_Ident.string_of_lid uu____8279 in
-                                      ((let uu____8282 =
+                                          FStar_Ident.lid_of_ids uu___5 in
+                                        FStar_Ident.string_of_lid uu___4 in
+                                      ((let uu___5 =
                                           get_exported_id_set env4 modul in
-                                        match uu____8282 with
+                                        match uu___5 with
                                         | FStar_Pervasives_Native.Some f ->
                                             let my_exported_ids =
                                               f Exported_id_term_type in
-                                            let uu____8304 =
-                                              let uu____8305 =
-                                                let uu____8306 =
+                                            let uu___6 =
+                                              let uu___7 =
+                                                let uu___8 =
                                                   FStar_Ident.ident_of_lid
                                                     lid in
                                                 FStar_Ident.string_of_id
-                                                  uu____8306 in
-                                              let uu____8307 =
+                                                  uu___8 in
+                                              let uu___8 =
                                                 FStar_ST.op_Bang
                                                   my_exported_ids in
-                                              FStar_Util.set_add uu____8305
-                                                uu____8307 in
+                                              FStar_Util.set_add uu___7
+                                                uu___8 in
                                             FStar_ST.op_Colon_Equals
-                                              my_exported_ids uu____8304
+                                              my_exported_ids uu___6
                                         | FStar_Pervasives_Native.None -> ());
                                        (match () with
                                         | () ->
@@ -2447,35 +2388,34 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
                                               env4.iface &&
                                                 (Prims.op_Negation
                                                    env4.admitted_iface) in
-                                            let uu____8328 =
+                                            let uu___5 =
                                               FStar_Ident.string_of_lid lid in
                                             FStar_Util.smap_add (sigmap env4)
-                                              uu____8328
+                                              uu___5
                                               (se,
                                                 (env4.iface &&
                                                    (Prims.op_Negation
                                                       env4.admitted_iface))))))))));
              (let env5 =
-                let uu___1194_8334 = env4 in
-                let uu____8335 = FStar_ST.op_Bang globals in
+                let uu___2 = env4 in
+                let uu___3 = FStar_ST.op_Bang globals in
                 {
-                  curmodule = (uu___1194_8334.curmodule);
-                  curmonad = (uu___1194_8334.curmonad);
-                  modules = (uu___1194_8334.modules);
-                  scope_mods = uu____8335;
-                  exported_ids = (uu___1194_8334.exported_ids);
-                  trans_exported_ids = (uu___1194_8334.trans_exported_ids);
-                  includes = (uu___1194_8334.includes);
-                  sigaccum = (uu___1194_8334.sigaccum);
-                  sigmap = (uu___1194_8334.sigmap);
-                  iface = (uu___1194_8334.iface);
-                  admitted_iface = (uu___1194_8334.admitted_iface);
-                  expect_typ = (uu___1194_8334.expect_typ);
-                  remaining_iface_decls =
-                    (uu___1194_8334.remaining_iface_decls);
-                  syntax_only = (uu___1194_8334.syntax_only);
-                  ds_hooks = (uu___1194_8334.ds_hooks);
-                  dep_graph = (uu___1194_8334.dep_graph)
+                  curmodule = (uu___2.curmodule);
+                  curmonad = (uu___2.curmonad);
+                  modules = (uu___2.modules);
+                  scope_mods = uu___3;
+                  exported_ids = (uu___2.exported_ids);
+                  trans_exported_ids = (uu___2.trans_exported_ids);
+                  includes = (uu___2.includes);
+                  sigaccum = (uu___2.sigaccum);
+                  sigmap = (uu___2.sigmap);
+                  iface = (uu___2.iface);
+                  admitted_iface = (uu___2.admitted_iface);
+                  expect_typ = (uu___2.expect_typ);
+                  remaining_iface_decls = (uu___2.remaining_iface_decls);
+                  syntax_only = (uu___2.syntax_only);
+                  ds_hooks = (uu___2.ds_hooks);
+                  dep_graph = (uu___2.dep_graph)
                 } in
               env5))
 let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
@@ -2485,37 +2425,36 @@ let (push_sigelt_force : env -> FStar_Syntax_Syntax.sigelt -> env) =
 let (push_namespace : env -> FStar_Ident.lident -> env) =
   fun env1 ->
     fun ns ->
-      let uu____8378 =
-        let uu____8383 = resolve_module_name env1 ns false in
-        match uu____8383 with
+      let uu___ =
+        let uu___1 = resolve_module_name env1 ns false in
+        match uu___1 with
         | FStar_Pervasives_Native.None ->
             let modules = env1.modules in
-            let uu____8397 =
+            let uu___2 =
               FStar_All.pipe_right modules
                 (FStar_Util.for_some
-                   (fun uu____8413 ->
-                      match uu____8413 with
-                      | (m, uu____8419) ->
-                          let uu____8420 =
-                            let uu____8421 = FStar_Ident.string_of_lid m in
-                            Prims.op_Hat uu____8421 "." in
-                          let uu____8422 =
-                            let uu____8423 = FStar_Ident.string_of_lid ns in
-                            Prims.op_Hat uu____8423 "." in
-                          FStar_Util.starts_with uu____8420 uu____8422)) in
-            if uu____8397
+                   (fun uu___3 ->
+                      match uu___3 with
+                      | (m, uu___4) ->
+                          let uu___5 =
+                            let uu___6 = FStar_Ident.string_of_lid m in
+                            Prims.op_Hat uu___6 "." in
+                          let uu___6 =
+                            let uu___7 = FStar_Ident.string_of_lid ns in
+                            Prims.op_Hat uu___7 "." in
+                          FStar_Util.starts_with uu___5 uu___6)) in
+            if uu___2
             then (ns, Open_namespace)
             else
-              (let uu____8429 =
-                 let uu____8434 =
-                   let uu____8435 = FStar_Ident.string_of_lid ns in
-                   FStar_Util.format1 "Namespace %s cannot be found"
-                     uu____8435 in
-                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____8434) in
-               let uu____8436 = FStar_Ident.range_of_lid ns in
-               FStar_Errors.raise_error uu____8429 uu____8436)
+              (let uu___4 =
+                 let uu___5 =
+                   let uu___6 = FStar_Ident.string_of_lid ns in
+                   FStar_Util.format1 "Namespace %s cannot be found" uu___6 in
+                 (FStar_Errors.Fatal_NameSpaceNotFound, uu___5) in
+               let uu___5 = FStar_Ident.range_of_lid ns in
+               FStar_Errors.raise_error uu___4 uu___5)
         | FStar_Pervasives_Native.Some ns' -> (ns', Open_module) in
-      match uu____8378 with
+      match uu___ with
       | (ns', kd) ->
           ((env1.ds_hooks).ds_push_open_hook env1 (ns', kd);
            push_scope_mod env1 (Open_module_or_namespace (ns', kd)))
@@ -2523,98 +2462,92 @@ let (push_include : env -> FStar_Ident.lident -> env) =
   fun env1 ->
     fun ns ->
       let ns0 = ns in
-      let uu____8456 = resolve_module_name env1 ns false in
-      match uu____8456 with
+      let uu___ = resolve_module_name env1 ns false in
+      match uu___ with
       | FStar_Pervasives_Native.Some ns1 ->
           ((env1.ds_hooks).ds_push_include_hook env1 ns1;
            (let env2 =
               push_scope_mod env1
                 (Open_module_or_namespace (ns1, Open_module)) in
             let curmod =
-              let uu____8463 = current_module env2 in
-              FStar_Ident.string_of_lid uu____8463 in
-            (let uu____8465 = FStar_Util.smap_try_find env2.includes curmod in
-             match uu____8465 with
+              let uu___2 = current_module env2 in
+              FStar_Ident.string_of_lid uu___2 in
+            (let uu___3 = FStar_Util.smap_try_find env2.includes curmod in
+             match uu___3 with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some incl ->
-                 let uu____8489 =
-                   let uu____8492 = FStar_ST.op_Bang incl in ns1 ::
-                     uu____8492 in
-                 FStar_ST.op_Colon_Equals incl uu____8489);
+                 let uu___4 =
+                   let uu___5 = FStar_ST.op_Bang incl in ns1 :: uu___5 in
+                 FStar_ST.op_Colon_Equals incl uu___4);
             (match () with
              | () ->
-                 let uu____8515 =
-                   let uu____8523 = FStar_Ident.string_of_lid ns1 in
-                   get_trans_exported_id_set env2 uu____8523 in
-                 (match uu____8515 with
+                 let uu___3 =
+                   let uu___4 = FStar_Ident.string_of_lid ns1 in
+                   get_trans_exported_id_set env2 uu___4 in
+                 (match uu___3 with
                   | FStar_Pervasives_Native.Some ns_trans_exports ->
-                      ((let uu____8536 =
-                          let uu____8579 = get_exported_id_set env2 curmod in
-                          let uu____8599 =
-                            get_trans_exported_id_set env2 curmod in
-                          (uu____8579, uu____8599) in
-                        match uu____8536 with
+                      ((let uu___5 =
+                          let uu___6 = get_exported_id_set env2 curmod in
+                          let uu___7 = get_trans_exported_id_set env2 curmod in
+                          (uu___6, uu___7) in
+                        match uu___5 with
                         | (FStar_Pervasives_Native.Some cur_exports,
                            FStar_Pervasives_Native.Some cur_trans_exports) ->
                             let update_exports k =
                               let ns_ex =
-                                let uu____8772 = ns_trans_exports k in
-                                FStar_ST.op_Bang uu____8772 in
+                                let uu___6 = ns_trans_exports k in
+                                FStar_ST.op_Bang uu___6 in
                               let ex = cur_exports k in
-                              (let uu____8807 =
-                                 let uu____8810 = FStar_ST.op_Bang ex in
-                                 FStar_Util.set_difference uu____8810 ns_ex in
-                               FStar_ST.op_Colon_Equals ex uu____8807);
+                              (let uu___7 =
+                                 let uu___8 = FStar_ST.op_Bang ex in
+                                 FStar_Util.set_difference uu___8 ns_ex in
+                               FStar_ST.op_Colon_Equals ex uu___7);
                               (match () with
                                | () ->
                                    let trans_ex = cur_trans_exports k in
-                                   let uu____8845 =
-                                     let uu____8848 =
-                                       FStar_ST.op_Bang trans_ex in
-                                     FStar_Util.set_union uu____8848 ns_ex in
-                                   FStar_ST.op_Colon_Equals trans_ex
-                                     uu____8845) in
+                                   let uu___8 =
+                                     let uu___9 = FStar_ST.op_Bang trans_ex in
+                                     FStar_Util.set_union uu___9 ns_ex in
+                                   FStar_ST.op_Colon_Equals trans_ex uu___8) in
                             FStar_List.iter update_exports
                               all_exported_id_kinds
-                        | uu____8867 -> ());
+                        | uu___6 -> ());
                        (match () with | () -> env2))
                   | FStar_Pervasives_Native.None ->
-                      let uu____8915 =
-                        let uu____8920 =
-                          let uu____8921 = FStar_Ident.string_of_lid ns1 in
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = FStar_Ident.string_of_lid ns1 in
                           FStar_Util.format1
-                            "include: Module %s was not prepared" uu____8921 in
-                        (FStar_Errors.Fatal_IncludeModuleNotPrepared,
-                          uu____8920) in
-                      let uu____8922 = FStar_Ident.range_of_lid ns1 in
-                      FStar_Errors.raise_error uu____8915 uu____8922))))
-      | uu____8923 ->
-          let uu____8926 =
-            let uu____8931 =
-              let uu____8932 = FStar_Ident.string_of_lid ns in
-              FStar_Util.format1 "include: Module %s cannot be found"
-                uu____8932 in
-            (FStar_Errors.Fatal_ModuleNotFound, uu____8931) in
-          let uu____8933 = FStar_Ident.range_of_lid ns in
-          FStar_Errors.raise_error uu____8926 uu____8933
+                            "include: Module %s was not prepared" uu___6 in
+                        (FStar_Errors.Fatal_IncludeModuleNotPrepared, uu___5) in
+                      let uu___5 = FStar_Ident.range_of_lid ns1 in
+                      FStar_Errors.raise_error uu___4 uu___5))))
+      | uu___1 ->
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Ident.string_of_lid ns in
+              FStar_Util.format1 "include: Module %s cannot be found" uu___4 in
+            (FStar_Errors.Fatal_ModuleNotFound, uu___3) in
+          let uu___3 = FStar_Ident.range_of_lid ns in
+          FStar_Errors.raise_error uu___2 uu___3
 let (push_module_abbrev :
   env -> FStar_Ident.ident -> FStar_Ident.lident -> env) =
   fun env1 ->
     fun x ->
       fun l ->
-        let uu____8949 = module_is_defined env1 l in
-        if uu____8949
+        let uu___ = module_is_defined env1 l in
+        if uu___
         then
           ((env1.ds_hooks).ds_push_module_abbrev_hook env1 x l;
            push_scope_mod env1 (Module_abbrev (x, l)))
         else
-          (let uu____8952 =
-             let uu____8957 =
-               let uu____8958 = FStar_Ident.string_of_lid l in
-               FStar_Util.format1 "Module %s cannot be found" uu____8958 in
-             (FStar_Errors.Fatal_ModuleNotFound, uu____8957) in
-           let uu____8959 = FStar_Ident.range_of_lid l in
-           FStar_Errors.raise_error uu____8952 uu____8959)
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Ident.string_of_lid l in
+               FStar_Util.format1 "Module %s cannot be found" uu___4 in
+             (FStar_Errors.Fatal_ModuleNotFound, uu___3) in
+           let uu___3 = FStar_Ident.range_of_lid l in
+           FStar_Errors.raise_error uu___2 uu___3)
 let (check_admits :
   env -> FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul) =
   fun env1 ->
@@ -2626,111 +2559,109 @@ let (check_admits :
                 fun se ->
                   match se.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_declare_typ (l, u, t) when
-                      let uu____9001 =
+                      let uu___ =
                         FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption) in
-                      Prims.op_Negation uu____9001 ->
-                      let uu____9004 =
-                        let uu____9011 = FStar_Ident.string_of_lid l in
-                        FStar_Util.smap_try_find (sigmap env1) uu____9011 in
-                      (match uu____9004 with
+                      Prims.op_Negation uu___ ->
+                      let uu___ =
+                        let uu___1 = FStar_Ident.string_of_lid l in
+                        FStar_Util.smap_try_find (sigmap env1) uu___1 in
+                      (match uu___ with
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_let uu____9018;
-                              FStar_Syntax_Syntax.sigrng = uu____9019;
-                              FStar_Syntax_Syntax.sigquals = uu____9020;
-                              FStar_Syntax_Syntax.sigmeta = uu____9021;
-                              FStar_Syntax_Syntax.sigattrs = uu____9022;
-                              FStar_Syntax_Syntax.sigopts = uu____9023;_},
-                            uu____9024)
+                                FStar_Syntax_Syntax.Sig_let uu___1;
+                              FStar_Syntax_Syntax.sigrng = uu___2;
+                              FStar_Syntax_Syntax.sigquals = uu___3;
+                              FStar_Syntax_Syntax.sigmeta = uu___4;
+                              FStar_Syntax_Syntax.sigattrs = uu___5;
+                              FStar_Syntax_Syntax.sigopts = uu___6;_},
+                            uu___7)
                            -> lids
                        | FStar_Pervasives_Native.Some
                            ({
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_inductive_typ
-                                uu____9041;
-                              FStar_Syntax_Syntax.sigrng = uu____9042;
-                              FStar_Syntax_Syntax.sigquals = uu____9043;
-                              FStar_Syntax_Syntax.sigmeta = uu____9044;
-                              FStar_Syntax_Syntax.sigattrs = uu____9045;
-                              FStar_Syntax_Syntax.sigopts = uu____9046;_},
-                            uu____9047)
+                                FStar_Syntax_Syntax.Sig_inductive_typ uu___1;
+                              FStar_Syntax_Syntax.sigrng = uu___2;
+                              FStar_Syntax_Syntax.sigquals = uu___3;
+                              FStar_Syntax_Syntax.sigmeta = uu___4;
+                              FStar_Syntax_Syntax.sigattrs = uu___5;
+                              FStar_Syntax_Syntax.sigopts = uu___6;_},
+                            uu___7)
                            -> lids
-                       | uu____9074 ->
-                           ((let uu____9082 =
-                               let uu____9083 = FStar_Options.interactive () in
-                               Prims.op_Negation uu____9083 in
-                             if uu____9082
+                       | uu___1 ->
+                           ((let uu___3 =
+                               let uu___4 = FStar_Options.interactive () in
+                               Prims.op_Negation uu___4 in
+                             if uu___3
                              then
-                               let uu____9084 = FStar_Ident.range_of_lid l in
-                               let uu____9085 =
-                                 let uu____9090 =
-                                   let uu____9091 =
-                                     FStar_Ident.string_of_lid l in
+                               let uu___4 = FStar_Ident.range_of_lid l in
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 = FStar_Ident.string_of_lid l in
                                    FStar_Util.format1
                                      "Admitting %s without a definition"
-                                     uu____9091 in
+                                     uu___7 in
                                  (FStar_Errors.Warning_AdmitWithoutDefinition,
-                                   uu____9090) in
-                               FStar_Errors.log_issue uu____9084 uu____9085
+                                   uu___6) in
+                               FStar_Errors.log_issue uu___4 uu___5
                              else ());
                             (let quals = FStar_Syntax_Syntax.Assumption ::
                                (se.FStar_Syntax_Syntax.sigquals) in
-                             (let uu____9097 = FStar_Ident.string_of_lid l in
-                              FStar_Util.smap_add (sigmap env1) uu____9097
-                                ((let uu___1285_9103 = se in
+                             (let uu___4 = FStar_Ident.string_of_lid l in
+                              FStar_Util.smap_add (sigmap env1) uu___4
+                                ((let uu___5 = se in
                                   {
                                     FStar_Syntax_Syntax.sigel =
-                                      (uu___1285_9103.FStar_Syntax_Syntax.sigel);
+                                      (uu___5.FStar_Syntax_Syntax.sigel);
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___1285_9103.FStar_Syntax_Syntax.sigrng);
+                                      (uu___5.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals = quals;
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___1285_9103.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___5.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___1285_9103.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___5.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___1285_9103.FStar_Syntax_Syntax.sigopts)
+                                      (uu___5.FStar_Syntax_Syntax.sigopts)
                                   }), false));
                              l
                              ::
                              lids)))
-                  | uu____9104 -> lids) []) in
-      let uu___1290_9105 = m in
-      let uu____9106 =
+                  | uu___ -> lids) []) in
+      let uu___ = m in
+      let uu___1 =
         FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
           (FStar_List.map
              (fun s ->
                 match s.FStar_Syntax_Syntax.sigel with
-                | FStar_Syntax_Syntax.Sig_declare_typ
-                    (lid, uu____9116, uu____9117) when
+                | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___2, uu___3)
+                    when
                     FStar_List.existsb
                       (fun l -> FStar_Ident.lid_equals l lid)
                       admitted_sig_lids
                     ->
-                    let uu___1299_9120 = s in
+                    let uu___4 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1299_9120.FStar_Syntax_Syntax.sigel);
+                        (uu___4.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1299_9120.FStar_Syntax_Syntax.sigrng);
+                        (uu___4.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
                         (FStar_Syntax_Syntax.Assumption ::
                         (s.FStar_Syntax_Syntax.sigquals));
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1299_9120.FStar_Syntax_Syntax.sigmeta);
+                        (uu___4.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1299_9120.FStar_Syntax_Syntax.sigattrs);
+                        (uu___4.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1299_9120.FStar_Syntax_Syntax.sigopts)
+                        (uu___4.FStar_Syntax_Syntax.sigopts)
                     }
-                | uu____9121 -> s)) in
+                | uu___2 -> s)) in
       {
-        FStar_Syntax_Syntax.name = (uu___1290_9105.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____9106;
+        FStar_Syntax_Syntax.name = (uu___.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu___1;
         FStar_Syntax_Syntax.is_interface =
-          (uu___1290_9105.FStar_Syntax_Syntax.is_interface)
+          (uu___.FStar_Syntax_Syntax.is_interface)
       }
 let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
   fun env1 ->
@@ -2740,7 +2671,7 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
            (fun se ->
               let quals = se.FStar_Syntax_Syntax.sigquals in
               match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_bundle (ses, uu____9144) ->
+              | FStar_Syntax_Syntax.Sig_bundle (ses, uu___1) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
                     FStar_All.pipe_right ses
@@ -2748,180 +2679,170 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                          (fun se1 ->
                             match se1.FStar_Syntax_Syntax.sigel with
                             | FStar_Syntax_Syntax.Sig_datacon
-                                (lid, uu____9165, uu____9166, uu____9167,
-                                 uu____9168, uu____9169)
+                                (lid, uu___2, uu___3, uu___4, uu___5, uu___6)
                                 ->
-                                let uu____9174 =
-                                  FStar_Ident.string_of_lid lid in
-                                FStar_Util.smap_remove (sigmap env1)
-                                  uu____9174
+                                let uu___7 = FStar_Ident.string_of_lid lid in
+                                FStar_Util.smap_remove (sigmap env1) uu___7
                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (lid, univ_names, binders, typ, uu____9183,
-                                 uu____9184)
+                                (lid, univ_names, binders, typ, uu___2,
+                                 uu___3)
                                 ->
-                                ((let uu____9194 =
-                                    FStar_Ident.string_of_lid lid in
-                                  FStar_Util.smap_remove (sigmap env1)
-                                    uu____9194);
+                                ((let uu___5 = FStar_Ident.string_of_lid lid in
+                                  FStar_Util.smap_remove (sigmap env1) uu___5);
                                  if
                                    Prims.op_Negation
                                      (FStar_List.contains
                                         FStar_Syntax_Syntax.Private quals)
                                  then
                                    (let sigel =
-                                      let uu____9200 =
-                                        let uu____9207 =
-                                          let uu____9208 =
-                                            let uu____9209 =
-                                              let uu____9224 =
+                                      let uu___5 =
+                                        let uu___6 =
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
                                                 FStar_Syntax_Syntax.mk_Total
                                                   typ in
-                                              (binders, uu____9224) in
+                                              (binders, uu___9) in
                                             FStar_Syntax_Syntax.Tm_arrow
-                                              uu____9209 in
-                                          let uu____9237 =
+                                              uu___8 in
+                                          let uu___8 =
                                             FStar_Ident.range_of_lid lid in
-                                          FStar_Syntax_Syntax.mk uu____9208
-                                            uu____9237 in
-                                        (lid, univ_names, uu____9207) in
+                                          FStar_Syntax_Syntax.mk uu___7
+                                            uu___8 in
+                                        (lid, univ_names, uu___6) in
                                       FStar_Syntax_Syntax.Sig_declare_typ
-                                        uu____9200 in
+                                        uu___5 in
                                     let se2 =
-                                      let uu___1331_9239 = se1 in
+                                      let uu___5 = se1 in
                                       {
                                         FStar_Syntax_Syntax.sigel = sigel;
                                         FStar_Syntax_Syntax.sigrng =
-                                          (uu___1331_9239.FStar_Syntax_Syntax.sigrng);
+                                          (uu___5.FStar_Syntax_Syntax.sigrng);
                                         FStar_Syntax_Syntax.sigquals =
                                           (FStar_Syntax_Syntax.Assumption ::
                                           quals);
                                         FStar_Syntax_Syntax.sigmeta =
-                                          (uu___1331_9239.FStar_Syntax_Syntax.sigmeta);
+                                          (uu___5.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
-                                          (uu___1331_9239.FStar_Syntax_Syntax.sigattrs);
+                                          (uu___5.FStar_Syntax_Syntax.sigattrs);
                                         FStar_Syntax_Syntax.sigopts =
-                                          (uu___1331_9239.FStar_Syntax_Syntax.sigopts)
+                                          (uu___5.FStar_Syntax_Syntax.sigopts)
                                       } in
-                                    let uu____9240 =
+                                    let uu___5 =
                                       FStar_Ident.string_of_lid lid in
-                                    FStar_Util.smap_add (sigmap env1)
-                                      uu____9240 (se2, false))
+                                    FStar_Util.smap_add (sigmap env1) uu___5
+                                      (se2, false))
                                  else ())
-                            | uu____9246 -> ()))
+                            | uu___2 -> ()))
                   else ()
-              | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid, uu____9249, uu____9250) ->
+              | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___1, uu___2) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
-                    let uu____9251 = FStar_Ident.string_of_lid lid in
-                    FStar_Util.smap_remove (sigmap env1) uu____9251
+                    let uu___3 = FStar_Ident.string_of_lid lid in
+                    FStar_Util.smap_remove (sigmap env1) uu___3
                   else ()
-              | FStar_Syntax_Syntax.Sig_let ((uu____9257, lbs), uu____9259)
-                  ->
+              | FStar_Syntax_Syntax.Sig_let ((uu___1, lbs), uu___2) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
                     FStar_All.pipe_right lbs
                       (FStar_List.iter
                          (fun lb ->
-                            let uu____9273 =
-                              let uu____9274 =
-                                let uu____9275 =
-                                  let uu____9278 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Util.right
                                       lb.FStar_Syntax_Syntax.lbname in
-                                  uu____9278.FStar_Syntax_Syntax.fv_name in
-                                uu____9275.FStar_Syntax_Syntax.v in
-                              FStar_Ident.string_of_lid uu____9274 in
-                            FStar_Util.smap_remove (sigmap env1) uu____9273))
+                                  uu___6.FStar_Syntax_Syntax.fv_name in
+                                uu___5.FStar_Syntax_Syntax.v in
+                              FStar_Ident.string_of_lid uu___4 in
+                            FStar_Util.smap_remove (sigmap env1) uu___3))
                   else ()
-              | uu____9284 -> ()));
+              | uu___1 -> ()));
       (let curmod =
-         let uu____9286 = current_module env1 in
-         FStar_Ident.string_of_lid uu____9286 in
-       (let uu____9288 =
-          let uu____9331 = get_exported_id_set env1 curmod in
-          let uu____9351 = get_trans_exported_id_set env1 curmod in
-          (uu____9331, uu____9351) in
-        match uu____9288 with
+         let uu___1 = current_module env1 in FStar_Ident.string_of_lid uu___1 in
+       (let uu___2 =
+          let uu___3 = get_exported_id_set env1 curmod in
+          let uu___4 = get_trans_exported_id_set env1 curmod in
+          (uu___3, uu___4) in
+        match uu___2 with
         | (FStar_Pervasives_Native.Some cur_ex, FStar_Pervasives_Native.Some
            cur_trans_ex) ->
             let update_exports eikind =
               let cur_ex_set =
-                let uu____9526 = cur_ex eikind in FStar_ST.op_Bang uu____9526 in
+                let uu___3 = cur_ex eikind in FStar_ST.op_Bang uu___3 in
               let cur_trans_ex_set_ref = cur_trans_ex eikind in
-              let uu____9564 =
-                let uu____9567 = FStar_ST.op_Bang cur_trans_ex_set_ref in
-                FStar_Util.set_union cur_ex_set uu____9567 in
-              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____9564 in
+              let uu___3 =
+                let uu___4 = FStar_ST.op_Bang cur_trans_ex_set_ref in
+                FStar_Util.set_union cur_ex_set uu___4 in
+              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu___3 in
             FStar_List.iter update_exports all_exported_id_kinds
-        | uu____9586 -> ());
+        | uu___3 -> ());
        (match () with
         | () ->
             (filter_record_cache ();
              (match () with
               | () ->
-                  let uu___1364_9630 = env1 in
+                  let uu___3 = env1 in
                   {
                     curmodule = FStar_Pervasives_Native.None;
-                    curmonad = (uu___1364_9630.curmonad);
+                    curmonad = (uu___3.curmonad);
                     modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
                       (env1.modules));
                     scope_mods = [];
-                    exported_ids = (uu___1364_9630.exported_ids);
-                    trans_exported_ids = (uu___1364_9630.trans_exported_ids);
-                    includes = (uu___1364_9630.includes);
+                    exported_ids = (uu___3.exported_ids);
+                    trans_exported_ids = (uu___3.trans_exported_ids);
+                    includes = (uu___3.includes);
                     sigaccum = [];
-                    sigmap = (uu___1364_9630.sigmap);
-                    iface = (uu___1364_9630.iface);
-                    admitted_iface = (uu___1364_9630.admitted_iface);
-                    expect_typ = (uu___1364_9630.expect_typ);
-                    remaining_iface_decls =
-                      (uu___1364_9630.remaining_iface_decls);
-                    syntax_only = (uu___1364_9630.syntax_only);
-                    ds_hooks = (uu___1364_9630.ds_hooks);
-                    dep_graph = (uu___1364_9630.dep_graph)
+                    sigmap = (uu___3.sigmap);
+                    iface = (uu___3.iface);
+                    admitted_iface = (uu___3.admitted_iface);
+                    expect_typ = (uu___3.expect_typ);
+                    remaining_iface_decls = (uu___3.remaining_iface_decls);
+                    syntax_only = (uu___3.syntax_only);
+                    ds_hooks = (uu___3.ds_hooks);
+                    dep_graph = (uu___3.dep_graph)
                   }))))
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref []
 let (push : env -> env) =
   fun env1 ->
     FStar_Util.atomically
-      (fun uu____9654 ->
+      (fun uu___ ->
          push_record_cache ();
-         (let uu____9657 =
-            let uu____9660 = FStar_ST.op_Bang stack in env1 :: uu____9660 in
-          FStar_ST.op_Colon_Equals stack uu____9657);
-         (let uu___1370_9683 = env1 in
-          let uu____9684 = FStar_Util.smap_copy env1.exported_ids in
-          let uu____9689 = FStar_Util.smap_copy env1.trans_exported_ids in
-          let uu____9694 = FStar_Util.smap_copy env1.includes in
-          let uu____9705 = FStar_Util.smap_copy env1.sigmap in
+         (let uu___3 = let uu___4 = FStar_ST.op_Bang stack in env1 :: uu___4 in
+          FStar_ST.op_Colon_Equals stack uu___3);
+         (let uu___3 = env1 in
+          let uu___4 = FStar_Util.smap_copy env1.exported_ids in
+          let uu___5 = FStar_Util.smap_copy env1.trans_exported_ids in
+          let uu___6 = FStar_Util.smap_copy env1.includes in
+          let uu___7 = FStar_Util.smap_copy env1.sigmap in
           {
-            curmodule = (uu___1370_9683.curmodule);
-            curmonad = (uu___1370_9683.curmonad);
-            modules = (uu___1370_9683.modules);
-            scope_mods = (uu___1370_9683.scope_mods);
-            exported_ids = uu____9684;
-            trans_exported_ids = uu____9689;
-            includes = uu____9694;
-            sigaccum = (uu___1370_9683.sigaccum);
-            sigmap = uu____9705;
-            iface = (uu___1370_9683.iface);
-            admitted_iface = (uu___1370_9683.admitted_iface);
-            expect_typ = (uu___1370_9683.expect_typ);
-            remaining_iface_decls = (uu___1370_9683.remaining_iface_decls);
-            syntax_only = (uu___1370_9683.syntax_only);
-            ds_hooks = (uu___1370_9683.ds_hooks);
-            dep_graph = (uu___1370_9683.dep_graph)
+            curmodule = (uu___3.curmodule);
+            curmonad = (uu___3.curmonad);
+            modules = (uu___3.modules);
+            scope_mods = (uu___3.scope_mods);
+            exported_ids = uu___4;
+            trans_exported_ids = uu___5;
+            includes = uu___6;
+            sigaccum = (uu___3.sigaccum);
+            sigmap = uu___7;
+            iface = (uu___3.iface);
+            admitted_iface = (uu___3.admitted_iface);
+            expect_typ = (uu___3.expect_typ);
+            remaining_iface_decls = (uu___3.remaining_iface_decls);
+            syntax_only = (uu___3.syntax_only);
+            ds_hooks = (uu___3.ds_hooks);
+            dep_graph = (uu___3.dep_graph)
           }))
 let (pop : unit -> env) =
-  fun uu____9720 ->
+  fun uu___ ->
     FStar_Util.atomically
-      (fun uu____9727 ->
-         let uu____9728 = FStar_ST.op_Bang stack in
-         match uu____9728 with
+      (fun uu___1 ->
+         let uu___2 = FStar_ST.op_Bang stack in
+         match uu___2 with
          | env1::tl ->
              (pop_record_cache (); FStar_ST.op_Colon_Equals stack tl; env1)
-         | uu____9757 -> failwith "Impossible: Too many pops")
+         | uu___3 -> failwith "Impossible: Too many pops")
 let (snapshot : env -> (Prims.int * env)) =
   fun env1 -> FStar_Common.snapshot push stack env1
 let (rollback : Prims.int FStar_Pervasives_Native.option -> env) =
@@ -2931,11 +2852,10 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
     fun env1 ->
       let sigelt_in_m se =
         match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____9795 ->
-            let uu____9798 = FStar_Ident.nsstr l in
-            let uu____9799 = FStar_Ident.string_of_lid m in
-            uu____9798 = uu____9799
-        | uu____9800 -> false in
+        | l::uu___ ->
+            let uu___1 = FStar_Ident.nsstr l in
+            let uu___2 = FStar_Ident.string_of_lid m in uu___1 = uu___2
+        | uu___ -> false in
       let sm = sigmap env1 in
       let env2 = pop () in
       let keys = FStar_Util.smap_keys sm in
@@ -2943,33 +2863,33 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
       FStar_All.pipe_right keys
         (FStar_List.iter
            (fun k ->
-              let uu____9834 = FStar_Util.smap_try_find sm' k in
-              match uu____9834 with
+              let uu___1 = FStar_Util.smap_try_find sm' k in
+              match uu___1 with
               | FStar_Pervasives_Native.Some (se, true) when sigelt_in_m se
                   ->
                   (FStar_Util.smap_remove sm' k;
                    (let se1 =
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_declare_typ (l, u, t) ->
-                          let uu___1405_9859 = se in
+                          let uu___3 = se in
                           {
                             FStar_Syntax_Syntax.sigel =
-                              (uu___1405_9859.FStar_Syntax_Syntax.sigel);
+                              (uu___3.FStar_Syntax_Syntax.sigel);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___1405_9859.FStar_Syntax_Syntax.sigrng);
+                              (uu___3.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
                               (FStar_Syntax_Syntax.Assumption ::
                               (se.FStar_Syntax_Syntax.sigquals));
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___1405_9859.FStar_Syntax_Syntax.sigmeta);
+                              (uu___3.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___1405_9859.FStar_Syntax_Syntax.sigattrs);
+                              (uu___3.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___1405_9859.FStar_Syntax_Syntax.sigopts)
+                              (uu___3.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____9860 -> se in
+                      | uu___3 -> se in
                     FStar_Util.smap_add sm' k (se1, false)))
-              | uu____9865 -> ()));
+              | uu___2 -> ()));
       env2
 let (finish_module_or_interface :
   env -> FStar_Syntax_Syntax.modul -> (env * FStar_Syntax_Syntax.modul)) =
@@ -2979,7 +2899,7 @@ let (finish_module_or_interface :
         if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
         then check_admits env1 modul
         else modul in
-      let uu____9888 = finish env1 modul1 in (uu____9888, modul1)
+      let uu___ = finish env1 modul1 in (uu___, modul1)
 type exported_ids =
   {
   exported_id_terms: Prims.string Prims.list ;
@@ -2997,14 +2917,12 @@ let (__proj__Mkexported_ids__item__exported_id_fields :
 let (as_exported_ids : exported_id_set -> exported_ids) =
   fun e ->
     let terms =
-      let uu____9943 =
-        let uu____9946 = e Exported_id_term_type in
-        FStar_ST.op_Bang uu____9946 in
-      FStar_Util.set_elements uu____9943 in
+      let uu___ =
+        let uu___1 = e Exported_id_term_type in FStar_ST.op_Bang uu___1 in
+      FStar_Util.set_elements uu___ in
     let fields =
-      let uu____9968 =
-        let uu____9971 = e Exported_id_field in FStar_ST.op_Bang uu____9971 in
-      FStar_Util.set_elements uu____9968 in
+      let uu___ = let uu___1 = e Exported_id_field in FStar_ST.op_Bang uu___1 in
+      FStar_Util.set_elements uu___ in
     { exported_id_terms = terms; exported_id_fields = fields }
 let (as_exported_id_set :
   exported_ids FStar_Pervasives_Native.option ->
@@ -3015,15 +2933,15 @@ let (as_exported_id_set :
     | FStar_Pervasives_Native.None -> exported_id_set_new ()
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
-          let uu____10019 =
+          let uu___ =
             FStar_Util.as_set e1.exported_id_terms FStar_Util.compare in
-          FStar_Util.mk_ref uu____10019 in
+          FStar_Util.mk_ref uu___ in
         let fields =
-          let uu____10029 =
+          let uu___ =
             FStar_Util.as_set e1.exported_id_fields FStar_Util.compare in
-          FStar_Util.mk_ref uu____10029 in
-        (fun uu___29_10034 ->
-           match uu___29_10034 with
+          FStar_Util.mk_ref uu___ in
+        (fun uu___ ->
+           match uu___ with
            | Exported_id_term_type -> terms
            | Exported_id_field -> fields)
 type module_inclusion_info =
@@ -3058,12 +2976,12 @@ let (default_mii : module_inclusion_info) =
     mii_includes = FStar_Pervasives_Native.None
   }
 let as_includes :
-  'uuuuuu10132 .
-    'uuuuuu10132 Prims.list FStar_Pervasives_Native.option ->
-      'uuuuuu10132 Prims.list FStar_ST.ref
+  'uuuuu .
+    'uuuuu Prims.list FStar_Pervasives_Native.option ->
+      'uuuuu Prims.list FStar_ST.ref
   =
-  fun uu___30_10145 ->
-    match uu___30_10145 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> FStar_Util.mk_ref []
     | FStar_Pervasives_Native.Some l -> FStar_Util.mk_ref l
 let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
@@ -3071,17 +2989,17 @@ let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
     fun l ->
       let mname = FStar_Ident.string_of_lid l in
       let as_ids_opt m =
-        let uu____10186 = FStar_Util.smap_try_find m mname in
-        FStar_Util.map_opt uu____10186 as_exported_ids in
-      let uu____10192 = as_ids_opt env1.exported_ids in
-      let uu____10195 = as_ids_opt env1.trans_exported_ids in
-      let uu____10198 =
-        let uu____10203 = FStar_Util.smap_try_find env1.includes mname in
-        FStar_Util.map_opt uu____10203 (fun r -> FStar_ST.op_Bang r) in
+        let uu___ = FStar_Util.smap_try_find m mname in
+        FStar_Util.map_opt uu___ as_exported_ids in
+      let uu___ = as_ids_opt env1.exported_ids in
+      let uu___1 = as_ids_opt env1.trans_exported_ids in
+      let uu___2 =
+        let uu___3 = FStar_Util.smap_try_find env1.includes mname in
+        FStar_Util.map_opt uu___3 (fun r -> FStar_ST.op_Bang r) in
       {
-        mii_exported_ids = uu____10192;
-        mii_trans_exported_ids = uu____10195;
-        mii_includes = uu____10198
+        mii_exported_ids = uu___;
+        mii_trans_exported_ids = uu___1;
+        mii_includes = uu___2
       }
 let (prepare_module_or_interface :
   Prims.bool ->
@@ -3096,156 +3014,150 @@ let (prepare_module_or_interface :
           fun mii ->
             let prep env2 =
               let filename =
-                let uu____10272 = FStar_Ident.string_of_lid mname in
-                FStar_Util.strcat uu____10272 ".fst" in
+                let uu___ = FStar_Ident.string_of_lid mname in
+                FStar_Util.strcat uu___ ".fst" in
               let auto_open =
                 FStar_Parser_Dep.hard_coded_dependencies filename in
               let auto_open1 =
-                let convert_kind uu___31_10292 =
-                  match uu___31_10292 with
+                let convert_kind uu___ =
+                  match uu___ with
                   | FStar_Parser_Dep.Open_namespace -> Open_namespace
                   | FStar_Parser_Dep.Open_module -> Open_module in
                 FStar_List.map
-                  (fun uu____10304 ->
-                     match uu____10304 with
+                  (fun uu___ ->
+                     match uu___ with
                      | (lid, kind) -> (lid, (convert_kind kind))) auto_open in
               let namespace_of_module =
-                let uu____10322 =
-                  let uu____10323 =
-                    let uu____10324 = FStar_Ident.ns_of_lid mname in
-                    FStar_List.length uu____10324 in
-                  uu____10323 > Prims.int_zero in
-                if uu____10322
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 = FStar_Ident.ns_of_lid mname in
+                    FStar_List.length uu___2 in
+                  uu___1 > Prims.int_zero in
+                if uu___
                 then
-                  let uu____10333 =
-                    let uu____10338 =
-                      let uu____10339 = FStar_Ident.ns_of_lid mname in
-                      FStar_Ident.lid_of_ids uu____10339 in
-                    (uu____10338, Open_namespace) in
-                  [uu____10333]
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = FStar_Ident.ns_of_lid mname in
+                      FStar_Ident.lid_of_ids uu___3 in
+                    (uu___2, Open_namespace) in
+                  [uu___1]
                 else [] in
               let auto_open2 =
                 FStar_List.append namespace_of_module
                   (FStar_List.rev auto_open1) in
-              (let uu____10369 = FStar_Ident.string_of_lid mname in
-               let uu____10370 = as_exported_id_set mii.mii_exported_ids in
-               FStar_Util.smap_add env2.exported_ids uu____10369 uu____10370);
+              (let uu___1 = FStar_Ident.string_of_lid mname in
+               let uu___2 = as_exported_id_set mii.mii_exported_ids in
+               FStar_Util.smap_add env2.exported_ids uu___1 uu___2);
               (match () with
                | () ->
-                   ((let uu____10375 = FStar_Ident.string_of_lid mname in
-                     let uu____10376 =
+                   ((let uu___2 = FStar_Ident.string_of_lid mname in
+                     let uu___3 =
                        as_exported_id_set mii.mii_trans_exported_ids in
-                     FStar_Util.smap_add env2.trans_exported_ids uu____10375
-                       uu____10376);
+                     FStar_Util.smap_add env2.trans_exported_ids uu___2
+                       uu___3);
                     (match () with
                      | () ->
-                         ((let uu____10381 = FStar_Ident.string_of_lid mname in
-                           let uu____10382 = as_includes mii.mii_includes in
-                           FStar_Util.smap_add env2.includes uu____10381
-                             uu____10382);
+                         ((let uu___3 = FStar_Ident.string_of_lid mname in
+                           let uu___4 = as_includes mii.mii_includes in
+                           FStar_Util.smap_add env2.includes uu___3 uu___4);
                           (match () with
                            | () ->
                                let env' =
-                                 let uu___1475_10392 = env2 in
-                                 let uu____10393 =
+                                 let uu___3 = env2 in
+                                 let uu___4 =
                                    FStar_List.map
                                      (fun x -> Open_module_or_namespace x)
                                      auto_open2 in
                                  {
                                    curmodule =
                                      (FStar_Pervasives_Native.Some mname);
-                                   curmonad = (uu___1475_10392.curmonad);
-                                   modules = (uu___1475_10392.modules);
-                                   scope_mods = uu____10393;
-                                   exported_ids =
-                                     (uu___1475_10392.exported_ids);
+                                   curmonad = (uu___3.curmonad);
+                                   modules = (uu___3.modules);
+                                   scope_mods = uu___4;
+                                   exported_ids = (uu___3.exported_ids);
                                    trans_exported_ids =
-                                     (uu___1475_10392.trans_exported_ids);
-                                   includes = (uu___1475_10392.includes);
-                                   sigaccum = (uu___1475_10392.sigaccum);
+                                     (uu___3.trans_exported_ids);
+                                   includes = (uu___3.includes);
+                                   sigaccum = (uu___3.sigaccum);
                                    sigmap = (env2.sigmap);
                                    iface = intf;
                                    admitted_iface = admitted;
-                                   expect_typ = (uu___1475_10392.expect_typ);
+                                   expect_typ = (uu___3.expect_typ);
                                    remaining_iface_decls =
-                                     (uu___1475_10392.remaining_iface_decls);
-                                   syntax_only =
-                                     (uu___1475_10392.syntax_only);
-                                   ds_hooks = (uu___1475_10392.ds_hooks);
-                                   dep_graph = (uu___1475_10392.dep_graph)
+                                     (uu___3.remaining_iface_decls);
+                                   syntax_only = (uu___3.syntax_only);
+                                   ds_hooks = (uu___3.ds_hooks);
+                                   dep_graph = (uu___3.dep_graph)
                                  } in
                                (FStar_List.iter
                                   (fun op ->
                                      (env2.ds_hooks).ds_push_open_hook env'
                                        op) (FStar_List.rev auto_open2);
                                 env')))))) in
-            let uu____10405 =
+            let uu___ =
               FStar_All.pipe_right env1.modules
                 (FStar_Util.find_opt
-                   (fun uu____10431 ->
-                      match uu____10431 with
-                      | (l, uu____10437) -> FStar_Ident.lid_equals l mname)) in
-            match uu____10405 with
+                   (fun uu___1 ->
+                      match uu___1 with
+                      | (l, uu___2) -> FStar_Ident.lid_equals l mname)) in
+            match uu___ with
             | FStar_Pervasives_Native.None ->
-                let uu____10446 = prep env1 in (uu____10446, false)
-            | FStar_Pervasives_Native.Some (uu____10447, m) ->
-                ((let uu____10454 =
-                    (let uu____10457 = FStar_Options.interactive () in
-                     Prims.op_Negation uu____10457) &&
+                let uu___1 = prep env1 in (uu___1, false)
+            | FStar_Pervasives_Native.Some (uu___1, m) ->
+                ((let uu___3 =
+                    (let uu___4 = FStar_Options.interactive () in
+                     Prims.op_Negation uu___4) &&
                       ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
                          || intf) in
-                  if uu____10454
+                  if uu___3
                   then
-                    let uu____10458 =
-                      let uu____10463 =
-                        let uu____10464 = FStar_Ident.string_of_lid mname in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Ident.string_of_lid mname in
                         FStar_Util.format1
-                          "Duplicate module or interface name: %s"
-                          uu____10464 in
-                      (FStar_Errors.Fatal_DuplicateModuleOrInterface,
-                        uu____10463) in
-                    let uu____10465 = FStar_Ident.range_of_lid mname in
-                    FStar_Errors.raise_error uu____10458 uu____10465
+                          "Duplicate module or interface name: %s" uu___6 in
+                      (FStar_Errors.Fatal_DuplicateModuleOrInterface, uu___5) in
+                    let uu___5 = FStar_Ident.range_of_lid mname in
+                    FStar_Errors.raise_error uu___4 uu___5
                   else ());
-                 (let uu____10467 =
-                    let uu____10468 = push env1 in prep uu____10468 in
-                  (uu____10467, true)))
+                 (let uu___3 = let uu___4 = push env1 in prep uu___4 in
+                  (uu___3, true)))
 let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
   fun env1 ->
     fun mname ->
       match env1.curmonad with
       | FStar_Pervasives_Native.Some mname' ->
-          let uu____10480 =
-            let uu____10485 =
-              let uu____10486 =
-                let uu____10487 = FStar_Ident.string_of_id mname in
-                let uu____10488 =
-                  let uu____10489 = FStar_Ident.string_of_id mname' in
-                  Prims.op_Hat ", but already in monad scope " uu____10489 in
-                Prims.op_Hat uu____10487 uu____10488 in
-              Prims.op_Hat "Trying to define monad " uu____10486 in
-            (FStar_Errors.Fatal_MonadAlreadyDefined, uu____10485) in
-          let uu____10490 = FStar_Ident.range_of_id mname in
-          FStar_Errors.raise_error uu____10480 uu____10490
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Ident.string_of_id mname in
+                let uu___4 =
+                  let uu___5 = FStar_Ident.string_of_id mname' in
+                  Prims.op_Hat ", but already in monad scope " uu___5 in
+                Prims.op_Hat uu___3 uu___4 in
+              Prims.op_Hat "Trying to define monad " uu___2 in
+            (FStar_Errors.Fatal_MonadAlreadyDefined, uu___1) in
+          let uu___1 = FStar_Ident.range_of_id mname in
+          FStar_Errors.raise_error uu___ uu___1
       | FStar_Pervasives_Native.None ->
-          let uu___1496_10491 = env1 in
+          let uu___ = env1 in
           {
-            curmodule = (uu___1496_10491.curmodule);
+            curmodule = (uu___.curmodule);
             curmonad = (FStar_Pervasives_Native.Some mname);
-            modules = (uu___1496_10491.modules);
-            scope_mods = (uu___1496_10491.scope_mods);
-            exported_ids = (uu___1496_10491.exported_ids);
-            trans_exported_ids = (uu___1496_10491.trans_exported_ids);
-            includes = (uu___1496_10491.includes);
-            sigaccum = (uu___1496_10491.sigaccum);
-            sigmap = (uu___1496_10491.sigmap);
-            iface = (uu___1496_10491.iface);
-            admitted_iface = (uu___1496_10491.admitted_iface);
-            expect_typ = (uu___1496_10491.expect_typ);
-            remaining_iface_decls = (uu___1496_10491.remaining_iface_decls);
-            syntax_only = (uu___1496_10491.syntax_only);
-            ds_hooks = (uu___1496_10491.ds_hooks);
-            dep_graph = (uu___1496_10491.dep_graph)
+            modules = (uu___.modules);
+            scope_mods = (uu___.scope_mods);
+            exported_ids = (uu___.exported_ids);
+            trans_exported_ids = (uu___.trans_exported_ids);
+            includes = (uu___.includes);
+            sigaccum = (uu___.sigaccum);
+            sigmap = (uu___.sigmap);
+            iface = (uu___.iface);
+            admitted_iface = (uu___.admitted_iface);
+            expect_typ = (uu___.expect_typ);
+            remaining_iface_decls = (uu___.remaining_iface_decls);
+            syntax_only = (uu___.syntax_only);
+            ds_hooks = (uu___.ds_hooks);
+            dep_graph = (uu___.dep_graph)
           }
 let fail_or :
   'a .
@@ -3256,69 +3168,68 @@ let fail_or :
   fun env1 ->
     fun lookup ->
       fun lid ->
-        let uu____10525 = lookup lid in
-        match uu____10525 with
+        let uu___ = lookup lid in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
             let opened_modules =
               FStar_List.map
-                (fun uu____10538 ->
-                   match uu____10538 with
-                   | (lid1, uu____10544) -> FStar_Ident.string_of_lid lid1)
+                (fun uu___1 ->
+                   match uu___1 with
+                   | (lid1, uu___2) -> FStar_Ident.string_of_lid lid1)
                 env1.modules in
             let msg =
-              let uu____10546 = FStar_Ident.string_of_lid lid in
-              FStar_Util.format1 "Identifier not found: [%s]" uu____10546 in
+              let uu___1 = FStar_Ident.string_of_lid lid in
+              FStar_Util.format1 "Identifier not found: [%s]" uu___1 in
             let msg1 =
-              let uu____10548 =
-                let uu____10549 =
-                  let uu____10550 = FStar_Ident.ns_of_lid lid in
-                  FStar_List.length uu____10550 in
-                uu____10549 = Prims.int_zero in
-              if uu____10548
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Ident.ns_of_lid lid in
+                  FStar_List.length uu___3 in
+                uu___2 = Prims.int_zero in
+              if uu___1
               then msg
               else
                 (let modul =
-                   let uu____10555 =
-                     let uu____10556 = FStar_Ident.ns_of_lid lid in
-                     FStar_Ident.lid_of_ids uu____10556 in
-                   let uu____10557 = FStar_Ident.range_of_lid lid in
-                   FStar_Ident.set_lid_range uu____10555 uu____10557 in
-                 let uu____10558 = resolve_module_name env1 modul true in
-                 match uu____10558 with
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.ns_of_lid lid in
+                     FStar_Ident.lid_of_ids uu___4 in
+                   let uu___4 = FStar_Ident.range_of_lid lid in
+                   FStar_Ident.set_lid_range uu___3 uu___4 in
+                 let uu___3 = resolve_module_name env1 modul true in
+                 match uu___3 with
                  | FStar_Pervasives_Native.None ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules in
-                     let uu____10562 = FStar_Ident.string_of_lid modul in
+                     let uu___4 = FStar_Ident.string_of_lid modul in
                      FStar_Util.format3
                        "%s\nModule %s does not belong to the list of modules in scope, namely %s"
-                       msg uu____10562 opened_modules1
+                       msg uu___4 opened_modules1
                  | FStar_Pervasives_Native.Some modul' when
                      Prims.op_Negation
                        (FStar_List.existsb
                           (fun m ->
-                             let uu____10567 =
-                               FStar_Ident.string_of_lid modul' in
-                             m = uu____10567) opened_modules)
+                             let uu___4 = FStar_Ident.string_of_lid modul' in
+                             m = uu___4) opened_modules)
                      ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules in
-                     let uu____10569 = FStar_Ident.string_of_lid modul in
-                     let uu____10570 = FStar_Ident.string_of_lid modul' in
+                     let uu___4 = FStar_Ident.string_of_lid modul in
+                     let uu___5 = FStar_Ident.string_of_lid modul' in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s"
-                       msg uu____10569 uu____10570 opened_modules1
+                       msg uu___4 uu___5 opened_modules1
                  | FStar_Pervasives_Native.Some modul' ->
-                     let uu____10572 = FStar_Ident.string_of_lid modul in
-                     let uu____10573 = FStar_Ident.string_of_lid modul' in
-                     let uu____10574 =
-                       let uu____10575 = FStar_Ident.ident_of_lid lid in
-                       FStar_Ident.string_of_id uu____10575 in
+                     let uu___4 = FStar_Ident.string_of_lid modul in
+                     let uu___5 = FStar_Ident.string_of_lid modul' in
+                     let uu___6 =
+                       let uu___7 = FStar_Ident.ident_of_lid lid in
+                       FStar_Ident.string_of_id uu___7 in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, definition %s not found"
-                       msg uu____10572 uu____10573 uu____10574) in
-            let uu____10576 = FStar_Ident.range_of_lid lid in
+                       msg uu___4 uu___5 uu___6) in
+            let uu___1 = FStar_Ident.range_of_lid lid in
             FStar_Errors.raise_error
-              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____10576
+              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu___1
         | FStar_Pervasives_Native.Some r -> r
 let fail_or2 :
   'a .
@@ -3327,16 +3238,16 @@ let fail_or2 :
   =
   fun lookup ->
     fun id ->
-      let uu____10604 = lookup id in
-      match uu____10604 with
+      let uu___ = lookup id in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____10607 =
-            let uu____10612 =
-              let uu____10613 =
-                let uu____10614 = FStar_Ident.string_of_id id in
-                Prims.op_Hat uu____10614 "]" in
-              Prims.op_Hat "Identifier not found [" uu____10613 in
-            (FStar_Errors.Fatal_IdentifierNotFound, uu____10612) in
-          let uu____10615 = FStar_Ident.range_of_id id in
-          FStar_Errors.raise_error uu____10607 uu____10615
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Ident.string_of_id id in
+                Prims.op_Hat uu___4 "]" in
+              Prims.op_Hat "Identifier not found [" uu___3 in
+            (FStar_Errors.Fatal_IdentifierNotFound, uu___2) in
+          let uu___2 = FStar_Ident.range_of_id id in
+          FStar_Errors.raise_error uu___1 uu___2
       | FStar_Pervasives_Native.Some r -> r

--- a/src/ocaml-output/FStar_Syntax_Embeddings.ml
+++ b/src/ocaml-output/FStar_Syntax_Embeddings.ml
@@ -3,22 +3,22 @@ type norm_cb =
   (FStar_Ident.lid, FStar_Syntax_Syntax.term) FStar_Util.either ->
     FStar_Syntax_Syntax.term
 let (id_norm_cb : norm_cb) =
-  fun uu___0_16 ->
-    match uu___0_16 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.Inr x -> x
     | FStar_Util.Inl l ->
-        let uu____23 =
+        let uu___1 =
           FStar_Syntax_Syntax.lid_as_fv l
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None in
-        FStar_Syntax_Syntax.fv_to_tm uu____23
+        FStar_Syntax_Syntax.fv_to_tm uu___1
 exception Embedding_failure 
 let (uu___is_Embedding_failure : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Embedding_failure -> true | uu____29 -> false
+    match projectee with | Embedding_failure -> true | uu___ -> false
 exception Unembedding_failure 
 let (uu___is_Unembedding_failure : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | Unembedding_failure -> true | uu____35 -> false
+    match projectee with | Unembedding_failure -> true | uu___ -> false
 type shadow_term =
   FStar_Syntax_Syntax.term FStar_Thunk.t FStar_Pervasives_Native.option
 let (map_shadow :
@@ -63,23 +63,23 @@ let __proj__Mkembedding__item__emb_typ :
 let emb_typ_of : 'a . 'a embedding -> FStar_Syntax_Syntax.emb_typ =
   fun e -> e.emb_typ
 let unknown_printer :
-  'uuuuuu396 . FStar_Syntax_Syntax.term -> 'uuuuuu396 -> Prims.string =
+  'uuuuu . FStar_Syntax_Syntax.term -> 'uuuuu -> Prims.string =
   fun typ ->
-    fun uu____406 ->
-      let uu____407 = FStar_Syntax_Print.term_to_string typ in
-      FStar_Util.format1 "unknown %s" uu____407
+    fun uu___ ->
+      let uu___1 = FStar_Syntax_Print.term_to_string typ in
+      FStar_Util.format1 "unknown %s" uu___1
 let (term_as_fv : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.fv) =
   fun t ->
-    let uu____413 =
-      let uu____414 = FStar_Syntax_Subst.compress t in
-      uu____414.FStar_Syntax_Syntax.n in
-    match uu____413 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-    | uu____418 ->
-        let uu____419 =
-          let uu____420 = FStar_Syntax_Print.term_to_string t in
-          FStar_Util.format1 "Embeddings not defined for type %s" uu____420 in
-        failwith uu____419
+    | uu___1 ->
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Print.term_to_string t in
+          FStar_Util.format1 "Embeddings not defined for type %s" uu___3 in
+        failwith uu___2
 let mk_emb :
   'a .
     'a raw_embedder ->
@@ -89,14 +89,14 @@ let mk_emb :
     fun un ->
       fun fv ->
         let typ = FStar_Syntax_Syntax.fv_to_tm fv in
-        let uu____460 =
-          let uu____461 =
-            let uu____468 =
-              let uu____469 = FStar_Syntax_Syntax.lid_of_fv fv in
-              FStar_All.pipe_right uu____469 FStar_Ident.string_of_lid in
-            (uu____468, []) in
-          FStar_Syntax_Syntax.ET_app uu____461 in
-        { em; un; typ; print = (unknown_printer typ); emb_typ = uu____460 }
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.lid_of_fv fv in
+              FStar_All.pipe_right uu___3 FStar_Ident.string_of_lid in
+            (uu___2, []) in
+          FStar_Syntax_Syntax.ET_app uu___1 in
+        { em; un; typ; print = (unknown_printer typ); emb_typ = uu___ }
 let mk_emb_full :
   'a .
     'a raw_embedder ->
@@ -117,26 +117,24 @@ let warn_unembed :
     'a embedding ->
       FStar_Syntax_Syntax.term ->
         norm_cb -> 'a FStar_Pervasives_Native.option
-  =
-  fun e -> fun t -> fun n -> let uu____610 = unembed e t in uu____610 true n
+  = fun e -> fun t -> fun n -> let uu___ = unembed e t in uu___ true n
 let try_unembed :
   'a .
     'a embedding ->
       FStar_Syntax_Syntax.term ->
         norm_cb -> 'a FStar_Pervasives_Native.option
-  =
-  fun e -> fun t -> fun n -> let uu____649 = unembed e t in uu____649 false n
+  = fun e -> fun t -> fun n -> let uu___ = unembed e t in uu___ false n
 let type_of : 'a . 'a embedding -> FStar_Syntax_Syntax.typ = fun e -> e.typ
 let set_type : 'a . FStar_Syntax_Syntax.typ -> 'a embedding -> 'a embedding =
   fun ty ->
     fun e ->
-      let uu___77_693 = e in
+      let uu___ = e in
       {
-        em = (uu___77_693.em);
-        un = (uu___77_693.un);
+        em = (uu___.em);
+        un = (uu___.un);
         typ = ty;
-        print = (uu___77_693.print);
-        emb_typ = (uu___77_693.emb_typ)
+        print = (uu___.print);
+        emb_typ = (uu___.emb_typ)
       }
 let embed_as :
   'a 'b .
@@ -150,20 +148,19 @@ let embed_as :
     fun ab ->
       fun ba ->
         fun o ->
-          let uu____750 =
+          let uu___ =
             match o with
             | FStar_Pervasives_Native.Some t -> t
-            | uu____752 -> type_of ea in
-          mk_emb_full (fun x -> let uu____758 = ba x in embed ea uu____758)
+            | uu___1 -> type_of ea in
+          mk_emb_full (fun x -> let uu___1 = ba x in embed ea uu___1)
             (fun t ->
                fun w ->
                  fun cb ->
-                   let uu____767 =
-                     let uu____770 = unembed ea t in uu____770 w cb in
-                   FStar_Util.map_opt uu____767 ab) uu____750
+                   let uu___1 = let uu___2 = unembed ea t in uu___2 w cb in
+                   FStar_Util.map_opt uu___1 ab) uu___
             (fun x ->
-               let uu____780 = let uu____781 = ba x in ea.print uu____781 in
-               FStar_Util.format1 "(embed_as>> %s)\n" uu____780) ea.emb_typ
+               let uu___1 = let uu___2 = ba x in ea.print uu___2 in
+               FStar_Util.format1 "(embed_as>> %s)\n" uu___1) ea.emb_typ
 let lazy_embed :
   'a .
     'a printer ->
@@ -179,18 +176,18 @@ let lazy_embed :
         fun ta ->
           fun x ->
             fun f ->
-              (let uu____839 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-               if uu____839
+              (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+               if uu___1
                then
-                 let uu____846 = FStar_Syntax_Print.term_to_string ta in
-                 let uu____847 = FStar_Syntax_Print.emb_typ_to_string et in
-                 let uu____848 = pa x in
+                 let uu___2 = FStar_Syntax_Print.term_to_string ta in
+                 let uu___3 = FStar_Syntax_Print.emb_typ_to_string et in
+                 let uu___4 = pa x in
                  FStar_Util.print3
-                   "Embedding a %s\n\temb_typ=%s\n\tvalue is %s\n" uu____846
-                   uu____847 uu____848
+                   "Embedding a %s\n\temb_typ=%s\n\tvalue is %s\n" uu___2
+                   uu___3 uu___4
                else ());
-              (let uu____850 = FStar_ST.op_Bang FStar_Options.eager_embedding in
-               if uu____850
+              (let uu___1 = FStar_ST.op_Bang FStar_Options.eager_embedding in
+               if uu___1
                then f ()
                else
                  (let thunk = FStar_Thunk.mk f in
@@ -217,83 +214,78 @@ let lazy_unembed :
                 { FStar_Syntax_Syntax.blob = b;
                   FStar_Syntax_Syntax.lkind =
                     FStar_Syntax_Syntax.Lazy_embedding (et', t);
-                  FStar_Syntax_Syntax.ltyp = uu____930;
-                  FStar_Syntax_Syntax.rng = uu____931;_}
+                  FStar_Syntax_Syntax.ltyp = uu___;
+                  FStar_Syntax_Syntax.rng = uu___1;_}
                 ->
-                let uu____942 =
+                let uu___2 =
                   (et <> et') ||
                     (FStar_ST.op_Bang FStar_Options.eager_embedding) in
-                if uu____942
+                if uu___2
                 then
-                  let res =
-                    let uu____954 = FStar_Thunk.force t in f uu____954 in
-                  ((let uu____958 =
+                  let res = let uu___3 = FStar_Thunk.force t in f uu___3 in
+                  ((let uu___4 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding in
-                    if uu____958
+                    if uu___4
                     then
-                      let uu____965 = FStar_Syntax_Print.emb_typ_to_string et in
-                      let uu____966 =
-                        FStar_Syntax_Print.emb_typ_to_string et' in
-                      let uu____967 =
+                      let uu___5 = FStar_Syntax_Print.emb_typ_to_string et in
+                      let uu___6 = FStar_Syntax_Print.emb_typ_to_string et' in
+                      let uu___7 =
                         match res with
                         | FStar_Pervasives_Native.None -> "None"
                         | FStar_Pervasives_Native.Some x2 ->
-                            let uu____969 = pa x2 in
-                            Prims.op_Hat "Some " uu____969 in
+                            let uu___8 = pa x2 in Prims.op_Hat "Some " uu___8 in
                       FStar_Util.print3
                         "Unembed cancellation failed\n\t%s <> %s\nvalue is %s\n"
-                        uu____965 uu____966 uu____967
+                        uu___5 uu___6 uu___7
                     else ());
                    res)
                 else
                   (let a1 = FStar_Dyn.undyn b in
-                   (let uu____974 =
+                   (let uu___5 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding in
-                    if uu____974
+                    if uu___5
                     then
-                      let uu____981 = FStar_Syntax_Print.emb_typ_to_string et in
-                      let uu____982 = pa a1 in
+                      let uu___6 = FStar_Syntax_Print.emb_typ_to_string et in
+                      let uu___7 = pa a1 in
                       FStar_Util.print2
-                        "Unembed cancelled for %s\n\tvalue is %s\n" uu____981
-                        uu____982
+                        "Unembed cancelled for %s\n\tvalue is %s\n" uu___6
+                        uu___7
                     else ());
                    FStar_Pervasives_Native.Some a1)
-            | uu____984 ->
+            | uu___ ->
                 let aopt = f x1 in
-                ((let uu____989 =
-                    FStar_ST.op_Bang FStar_Options.debug_embedding in
-                  if uu____989
+                ((let uu___2 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+                  if uu___2
                   then
-                    let uu____996 = FStar_Syntax_Print.emb_typ_to_string et in
-                    let uu____997 = FStar_Syntax_Print.term_to_string x1 in
-                    let uu____998 =
+                    let uu___3 = FStar_Syntax_Print.emb_typ_to_string et in
+                    let uu___4 = FStar_Syntax_Print.term_to_string x1 in
+                    let uu___5 =
                       match aopt with
                       | FStar_Pervasives_Native.None -> "None"
                       | FStar_Pervasives_Native.Some a1 ->
-                          let uu____1000 = pa a1 in
-                          Prims.op_Hat "Some " uu____1000 in
+                          let uu___6 = pa a1 in Prims.op_Hat "Some " uu___6 in
                     FStar_Util.print3
                       "Unembedding:\n\temb_typ=%s\n\tterm is %s\n\tvalue is %s\n"
-                      uu____996 uu____997 uu____998
+                      uu___3 uu___4 uu___5
                   else ());
                  aopt)
 let (mk_any_emb :
   FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term embedding) =
   fun typ ->
     let em t _r _topt _norm =
-      (let uu____1033 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-       if uu____1033
+      (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+       if uu___1
        then
-         let uu____1040 = unknown_printer typ t in
-         FStar_Util.print1 "Embedding abstract: %s\n" uu____1040
+         let uu___2 = unknown_printer typ t in
+         FStar_Util.print1 "Embedding abstract: %s\n" uu___2
        else ());
       t in
     let un t _w _n =
-      (let uu____1063 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-       if uu____1063
+      (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+       if uu___1
        then
-         let uu____1070 = unknown_printer typ t in
-         FStar_Util.print1 "Unembedding abstract: %s\n" uu____1070
+         let uu___2 = unknown_printer typ t in
+         FStar_Util.print1 "Unembedding abstract: %s\n" uu___2
        else ());
       FStar_Pervasives_Native.Some t in
     mk_emb_full em un typ (unknown_printer typ)
@@ -301,163 +293,162 @@ let (mk_any_emb :
 let (e_any : FStar_Syntax_Syntax.term embedding) =
   let em t _r _topt _norm = t in
   let un t _w _n = FStar_Pervasives_Native.Some t in
-  let uu____1117 =
-    let uu____1118 =
-      let uu____1125 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.term_lid
           FStar_Ident.string_of_lid in
-      (uu____1125, []) in
-    FStar_Syntax_Syntax.ET_app uu____1118 in
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
   mk_emb_full em un FStar_Syntax_Syntax.t_term
-    FStar_Syntax_Print.term_to_string uu____1117
+    FStar_Syntax_Print.term_to_string uu___
 let (e_unit : unit embedding) =
   let em u rng _topt _norm =
-    let uu___167_1153 = FStar_Syntax_Util.exp_unit in
+    let uu___ = FStar_Syntax_Util.exp_unit in
     {
-      FStar_Syntax_Syntax.n = (uu___167_1153.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___167_1153.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unascribe t0 in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit) ->
         FStar_Pervasives_Native.Some ()
-    | uu____1179 ->
+    | uu___ ->
         (if w
          then
-           (let uu____1181 =
-              let uu____1186 =
-                let uu____1187 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded unit: %s" uu____1187 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1186) in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1181)
+           (let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded unit: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
          else ();
          FStar_Pervasives_Native.None) in
-  let uu____1189 =
-    let uu____1190 =
-      let uu____1197 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.unit_lid
           FStar_Ident.string_of_lid in
-      (uu____1197, []) in
-    FStar_Syntax_Syntax.ET_app uu____1190 in
-  mk_emb_full em un FStar_Syntax_Syntax.t_unit (fun uu____1201 -> "()")
-    uu____1189
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
+  mk_emb_full em un FStar_Syntax_Syntax.t_unit (fun uu___1 -> "()") uu___
 let (e_bool : Prims.bool embedding) =
   let em b rng _topt _norm =
     let t =
       if b
       then FStar_Syntax_Util.exp_true_bool
       else FStar_Syntax_Util.exp_false_bool in
-    let uu___187_1233 = t in
+    let uu___ = t in
     {
-      FStar_Syntax_Syntax.n = (uu___187_1233.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___187_1233.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0 in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool b) ->
         FStar_Pervasives_Native.Some b
-    | uu____1262 ->
+    | uu___ ->
         (if w
          then
-           (let uu____1264 =
-              let uu____1269 =
-                let uu____1270 = FStar_Syntax_Print.term_to_string t0 in
-                FStar_Util.format1 "Not an embedded bool: %s" uu____1270 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1269) in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1264)
+           (let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+                FStar_Util.format1 "Not an embedded bool: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
          else ();
          FStar_Pervasives_Native.None) in
-  let uu____1272 =
-    let uu____1273 =
-      let uu____1280 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.bool_lid
           FStar_Ident.string_of_lid in
-      (uu____1280, []) in
-    FStar_Syntax_Syntax.ET_app uu____1273 in
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
   mk_emb_full em un FStar_Syntax_Syntax.t_bool FStar_Util.string_of_bool
-    uu____1272
+    uu___
 let (e_char : FStar_Char.char embedding) =
   let em c rng _topt _norm =
     let t = FStar_Syntax_Util.exp_char c in
-    let uu___206_1309 = t in
+    let uu___ = t in
     {
-      FStar_Syntax_Syntax.n = (uu___206_1309.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___206_1309.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     } in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0 in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c) ->
         FStar_Pervasives_Native.Some c
-    | uu____1336 ->
+    | uu___ ->
         (if w
          then
-           (let uu____1338 =
-              let uu____1343 =
-                let uu____1344 = FStar_Syntax_Print.term_to_string t0 in
-                FStar_Util.format1 "Not an embedded char: %s" uu____1344 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1343) in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1338)
+           (let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+                FStar_Util.format1 "Not an embedded char: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
          else ();
          FStar_Pervasives_Native.None) in
-  let uu____1346 =
-    let uu____1347 =
-      let uu____1354 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.char_lid
           FStar_Ident.string_of_lid in
-      (uu____1354, []) in
-    FStar_Syntax_Syntax.ET_app uu____1347 in
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
   mk_emb_full em un FStar_Syntax_Syntax.t_char FStar_Util.string_of_char
-    uu____1346
+    uu___
 let (e_int : FStar_BigInt.t embedding) =
   let t_int = FStar_Syntax_Util.fvar_const FStar_Parser_Const.int_lid in
   let emb_t_int =
-    let uu____1361 =
-      let uu____1368 =
+    let uu___ =
+      let uu___1 =
         FStar_All.pipe_right FStar_Parser_Const.int_lid
           FStar_Ident.string_of_lid in
-      (uu____1368, []) in
-    FStar_Syntax_Syntax.ET_app uu____1361 in
+      (uu___1, []) in
+    FStar_Syntax_Syntax.ET_app uu___ in
   let em i rng _topt _norm =
     lazy_embed FStar_BigInt.string_of_big_int emb_t_int rng t_int i
-      (fun uu____1396 ->
-         let uu____1397 = FStar_BigInt.string_of_big_int i in
-         FStar_Syntax_Util.exp_int uu____1397) in
+      (fun uu___ ->
+         let uu___1 = FStar_BigInt.string_of_big_int i in
+         FStar_Syntax_Util.exp_int uu___1) in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0 in
     lazy_unembed FStar_BigInt.string_of_big_int emb_t_int t t_int
       (fun t1 ->
          match t1.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
-             (s, uu____1429)) ->
-             let uu____1442 = FStar_BigInt.big_int_of_string s in
-             FStar_Pervasives_Native.Some uu____1442
-         | uu____1443 ->
+         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (s, uu___))
+             ->
+             let uu___1 = FStar_BigInt.big_int_of_string s in
+             FStar_Pervasives_Native.Some uu___1
+         | uu___ ->
              (if w
               then
-                (let uu____1445 =
-                   let uu____1450 =
-                     let uu____1451 = FStar_Syntax_Print.term_to_string t0 in
-                     FStar_Util.format1 "Not an embedded int: %s" uu____1451 in
-                   (FStar_Errors.Warning_NotEmbedded, uu____1450) in
-                 FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1445)
+                (let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+                     FStar_Util.format1 "Not an embedded int: %s" uu___4 in
+                   (FStar_Errors.Warning_NotEmbedded, uu___3) in
+                 FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
               else ();
               FStar_Pervasives_Native.None)) in
   mk_emb_full em un FStar_Syntax_Syntax.t_int FStar_BigInt.string_of_big_int
     emb_t_int
 let (e_string : Prims.string embedding) =
   let emb_t_string =
-    let uu____1456 =
-      let uu____1463 =
+    let uu___ =
+      let uu___1 =
         FStar_All.pipe_right FStar_Parser_Const.string_lid
           FStar_Ident.string_of_lid in
-      (uu____1463, []) in
-    FStar_Syntax_Syntax.ET_app uu____1456 in
+      (uu___1, []) in
+    FStar_Syntax_Syntax.ET_app uu___ in
   let em s rng _topt _norm =
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (s, rng)))
@@ -465,17 +456,17 @@ let (e_string : Prims.string embedding) =
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0 in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-        (s, uu____1515)) -> FStar_Pervasives_Native.Some s
-    | uu____1516 ->
+    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (s, uu___))
+        -> FStar_Pervasives_Native.Some s
+    | uu___ ->
         (if w
          then
-           (let uu____1518 =
-              let uu____1523 =
-                let uu____1524 = FStar_Syntax_Print.term_to_string t0 in
-                FStar_Util.format1 "Not an embedded string: %s" uu____1524 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1523) in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1518)
+           (let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+                FStar_Util.format1 "Not an embedded string: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb_full em un FStar_Syntax_Syntax.t_string
@@ -485,40 +476,37 @@ let e_option :
   fun ea ->
     let t_option_a =
       let t_opt = FStar_Syntax_Util.fvar_const FStar_Parser_Const.option_lid in
-      let uu____1548 =
-        let uu____1549 = FStar_Syntax_Syntax.as_arg ea.typ in [uu____1549] in
-      FStar_Syntax_Syntax.mk_Tm_app t_opt uu____1548 FStar_Range.dummyRange in
+      let uu___ = let uu___1 = FStar_Syntax_Syntax.as_arg ea.typ in [uu___1] in
+      FStar_Syntax_Syntax.mk_Tm_app t_opt uu___ FStar_Range.dummyRange in
     let emb_t_option_a =
-      let uu____1575 =
-        let uu____1582 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right FStar_Parser_Const.option_lid
             FStar_Ident.string_of_lid in
-        (uu____1582, [ea.emb_typ]) in
-      FStar_Syntax_Syntax.ET_app uu____1575 in
-    let printer1 uu___1_1592 =
-      match uu___1_1592 with
+        (uu___1, [ea.emb_typ]) in
+      FStar_Syntax_Syntax.ET_app uu___ in
+    let printer1 uu___ =
+      match uu___ with
       | FStar_Pervasives_Native.None -> "None"
       | FStar_Pervasives_Native.Some x ->
-          let uu____1596 =
-            let uu____1597 = ea.print x in Prims.op_Hat uu____1597 ")" in
-          Prims.op_Hat "(Some " uu____1596 in
+          let uu___1 = let uu___2 = ea.print x in Prims.op_Hat uu___2 ")" in
+          Prims.op_Hat "(Some " uu___1 in
     let em o rng topt norm =
       lazy_embed printer1 emb_t_option_a rng t_option_a o
-        (fun uu____1630 ->
+        (fun uu___ ->
            match o with
            | FStar_Pervasives_Native.None ->
-               let uu____1631 =
-                 let uu____1632 =
+               let uu___1 =
+                 let uu___2 =
                    FStar_Syntax_Syntax.tdataconstr
                      FStar_Parser_Const.none_lid in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____1632
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                    [FStar_Syntax_Syntax.U_zero] in
-               let uu____1633 =
-                 let uu____1634 =
-                   let uu____1643 = type_of ea in
-                   FStar_Syntax_Syntax.iarg uu____1643 in
-                 [uu____1634] in
-               FStar_Syntax_Syntax.mk_Tm_app uu____1631 uu____1633 rng
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = type_of ea in FStar_Syntax_Syntax.iarg uu___4 in
+                 [uu___3] in
+               FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng
            | FStar_Pervasives_Native.Some a1 ->
                let shadow_a =
                  map_shadow topt
@@ -528,234 +516,218 @@ let e_option :
                         FStar_Syntax_Util.mk_field_projector_name_from_ident
                           FStar_Parser_Const.some_lid v in
                       let some_v_tm =
-                        let uu____1672 =
+                        let uu___1 =
                           FStar_Syntax_Syntax.lid_as_fv some_v
                             FStar_Syntax_Syntax.delta_equational
                             FStar_Pervasives_Native.None in
-                        FStar_Syntax_Syntax.fv_to_tm uu____1672 in
-                      let uu____1673 =
+                        FStar_Syntax_Syntax.fv_to_tm uu___1 in
+                      let uu___1 =
                         FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
                           [FStar_Syntax_Syntax.U_zero] in
-                      let uu____1674 =
-                        let uu____1675 =
-                          let uu____1684 = type_of ea in
-                          FStar_Syntax_Syntax.iarg uu____1684 in
-                        let uu____1685 =
-                          let uu____1696 = FStar_Syntax_Syntax.as_arg t in
-                          [uu____1696] in
-                        uu____1675 :: uu____1685 in
-                      FStar_Syntax_Syntax.mk_Tm_app uu____1673 uu____1674 rng) in
-               let uu____1729 =
-                 let uu____1730 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = type_of ea in
+                          FStar_Syntax_Syntax.iarg uu___4 in
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.as_arg t in
+                          [uu___5] in
+                        uu___3 :: uu___4 in
+                      FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng) in
+               let uu___1 =
+                 let uu___2 =
                    FStar_Syntax_Syntax.tdataconstr
                      FStar_Parser_Const.some_lid in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____1730
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                    [FStar_Syntax_Syntax.U_zero] in
-               let uu____1731 =
-                 let uu____1732 =
-                   let uu____1741 = type_of ea in
-                   FStar_Syntax_Syntax.iarg uu____1741 in
-                 let uu____1742 =
-                   let uu____1753 =
-                     let uu____1762 =
-                       let uu____1763 = embed ea a1 in
-                       uu____1763 rng shadow_a norm in
-                     FStar_Syntax_Syntax.as_arg uu____1762 in
-                   [uu____1753] in
-                 uu____1732 :: uu____1742 in
-               FStar_Syntax_Syntax.mk_Tm_app uu____1729 uu____1731 rng) in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = type_of ea in FStar_Syntax_Syntax.iarg uu___4 in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = embed ea a1 in uu___7 rng shadow_a norm in
+                     FStar_Syntax_Syntax.as_arg uu___6 in
+                   [uu___5] in
+                 uu___3 :: uu___4 in
+               FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng) in
     let un t0 w norm =
       let t = FStar_Syntax_Util.unmeta_safe t0 in
       lazy_unembed printer1 emb_t_option_a t t_option_a
         (fun t1 ->
-           let uu____1831 = FStar_Syntax_Util.head_and_args' t1 in
-           match uu____1831 with
+           let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+           match uu___ with
            | (hd, args) ->
-               let uu____1872 =
-                 let uu____1887 =
-                   let uu____1888 = FStar_Syntax_Util.un_uinst hd in
-                   uu____1888.FStar_Syntax_Syntax.n in
-                 (uu____1887, args) in
-               (match uu____1872 with
-                | (FStar_Syntax_Syntax.Tm_fvar fv, uu____1906) when
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (uu___2, args) in
+               (match uu___1 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.none_lid
                     ->
                     FStar_Pervasives_Native.Some FStar_Pervasives_Native.None
-                | (FStar_Syntax_Syntax.Tm_fvar fv,
-                   uu____1930::(a1, uu____1932)::[]) when
+                | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(a1, uu___3)::[])
+                    when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.some_lid
                     ->
-                    let uu____1983 =
-                      let uu____1986 = unembed ea a1 in uu____1986 w norm in
-                    FStar_Util.bind_opt uu____1983
+                    let uu___4 = let uu___5 = unembed ea a1 in uu___5 w norm in
+                    FStar_Util.bind_opt uu___4
                       (fun a2 ->
                          FStar_Pervasives_Native.Some
                            (FStar_Pervasives_Native.Some a2))
-                | uu____1999 ->
+                | uu___2 ->
                     (if w
                      then
-                       (let uu____2015 =
-                          let uu____2020 =
-                            let uu____2021 =
-                              FStar_Syntax_Print.term_to_string t0 in
+                       (let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Print.term_to_string t0 in
                             FStar_Util.format1 "Not an embedded option: %s"
-                              uu____2021 in
-                          (FStar_Errors.Warning_NotEmbedded, uu____2020) in
+                              uu___6 in
+                          (FStar_Errors.Warning_NotEmbedded, uu___5) in
                         FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                          uu____2015)
+                          uu___4)
                      else ();
                      FStar_Pervasives_Native.None))) in
-    let uu____2025 =
-      let uu____2026 = type_of ea in
-      FStar_Syntax_Syntax.t_option_of uu____2026 in
-    mk_emb_full em un uu____2025 printer1 emb_t_option_a
+    let uu___ =
+      let uu___1 = type_of ea in FStar_Syntax_Syntax.t_option_of uu___1 in
+    mk_emb_full em un uu___ printer1 emb_t_option_a
 let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
   fun ea ->
     fun eb ->
       let t_pair_a_b =
         let t_tup2 =
           FStar_Syntax_Util.fvar_const FStar_Parser_Const.lid_tuple2 in
-        let uu____2065 =
-          let uu____2066 = FStar_Syntax_Syntax.as_arg ea.typ in
-          let uu____2075 =
-            let uu____2086 = FStar_Syntax_Syntax.as_arg eb.typ in
-            [uu____2086] in
-          uu____2066 :: uu____2075 in
-        FStar_Syntax_Syntax.mk_Tm_app t_tup2 uu____2065
-          FStar_Range.dummyRange in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Syntax.as_arg ea.typ in
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Syntax.as_arg eb.typ in [uu___3] in
+          uu___1 :: uu___2 in
+        FStar_Syntax_Syntax.mk_Tm_app t_tup2 uu___ FStar_Range.dummyRange in
       let emb_t_pair_a_b =
-        let uu____2120 =
-          let uu____2127 =
+        let uu___ =
+          let uu___1 =
             FStar_All.pipe_right FStar_Parser_Const.lid_tuple2
               FStar_Ident.string_of_lid in
-          (uu____2127, [ea.emb_typ; eb.emb_typ]) in
-        FStar_Syntax_Syntax.ET_app uu____2120 in
-      let printer1 uu____2139 =
-        match uu____2139 with
+          (uu___1, [ea.emb_typ; eb.emb_typ]) in
+        FStar_Syntax_Syntax.ET_app uu___ in
+      let printer1 uu___ =
+        match uu___ with
         | (x, y) ->
-            let uu____2146 = ea.print x in
-            let uu____2147 = eb.print y in
-            FStar_Util.format2 "(%s, %s)" uu____2146 uu____2147 in
+            let uu___1 = ea.print x in
+            let uu___2 = eb.print y in
+            FStar_Util.format2 "(%s, %s)" uu___1 uu___2 in
       let em x rng topt norm =
         lazy_embed printer1 emb_t_pair_a_b rng t_pair_a_b x
-          (fun uu____2189 ->
+          (fun uu___ ->
              let proj i ab =
                let proj_1 =
-                 let uu____2202 =
+                 let uu___1 =
                    FStar_Parser_Const.mk_tuple_data_lid (Prims.of_int (2))
                      rng in
-                 let uu____2203 =
+                 let uu___2 =
                    FStar_Syntax_Syntax.null_bv FStar_Syntax_Syntax.tun in
-                 FStar_Syntax_Util.mk_field_projector_name uu____2202
-                   uu____2203 i in
+                 FStar_Syntax_Util.mk_field_projector_name uu___1 uu___2 i in
                let proj_1_tm =
-                 let uu____2205 =
+                 let uu___1 =
                    FStar_Syntax_Syntax.lid_as_fv proj_1
                      FStar_Syntax_Syntax.delta_equational
                      FStar_Pervasives_Native.None in
-                 FStar_Syntax_Syntax.fv_to_tm uu____2205 in
-               let uu____2206 =
+                 FStar_Syntax_Syntax.fv_to_tm uu___1 in
+               let uu___1 =
                  FStar_Syntax_Syntax.mk_Tm_uinst proj_1_tm
                    [FStar_Syntax_Syntax.U_zero] in
-               let uu____2207 =
-                 let uu____2208 =
-                   let uu____2217 = type_of ea in
-                   FStar_Syntax_Syntax.iarg uu____2217 in
-                 let uu____2218 =
-                   let uu____2229 =
-                     let uu____2238 = type_of eb in
-                     FStar_Syntax_Syntax.iarg uu____2238 in
-                   let uu____2239 =
-                     let uu____2250 = FStar_Syntax_Syntax.as_arg ab in
-                     [uu____2250] in
-                   uu____2229 :: uu____2239 in
-                 uu____2208 :: uu____2218 in
-               FStar_Syntax_Syntax.mk_Tm_app uu____2206 uu____2207 rng in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = type_of ea in FStar_Syntax_Syntax.iarg uu___4 in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 = type_of eb in
+                     FStar_Syntax_Syntax.iarg uu___6 in
+                   let uu___6 =
+                     let uu___7 = FStar_Syntax_Syntax.as_arg ab in [uu___7] in
+                   uu___5 :: uu___6 in
+                 uu___3 :: uu___4 in
+               FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng in
              let shadow_a = map_shadow topt (proj Prims.int_one) in
              let shadow_b = map_shadow topt (proj (Prims.of_int (2))) in
-             let uu____2293 =
-               let uu____2294 =
+             let uu___1 =
+               let uu___2 =
                  FStar_Syntax_Syntax.tdataconstr
                    FStar_Parser_Const.lid_Mktuple2 in
-               FStar_Syntax_Syntax.mk_Tm_uinst uu____2294
+               FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] in
-             let uu____2295 =
-               let uu____2296 =
-                 let uu____2305 = type_of ea in
-                 FStar_Syntax_Syntax.iarg uu____2305 in
-               let uu____2306 =
-                 let uu____2317 =
-                   let uu____2326 = type_of eb in
-                   FStar_Syntax_Syntax.iarg uu____2326 in
-                 let uu____2327 =
-                   let uu____2338 =
-                     let uu____2347 =
-                       let uu____2348 =
-                         embed ea (FStar_Pervasives_Native.fst x) in
-                       uu____2348 rng shadow_a norm in
-                     FStar_Syntax_Syntax.as_arg uu____2347 in
-                   let uu____2355 =
-                     let uu____2366 =
-                       let uu____2375 =
-                         let uu____2376 =
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = type_of ea in FStar_Syntax_Syntax.iarg uu___4 in
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 = type_of eb in FStar_Syntax_Syntax.iarg uu___6 in
+                 let uu___6 =
+                   let uu___7 =
+                     let uu___8 =
+                       let uu___9 = embed ea (FStar_Pervasives_Native.fst x) in
+                       uu___9 rng shadow_a norm in
+                     FStar_Syntax_Syntax.as_arg uu___8 in
+                   let uu___8 =
+                     let uu___9 =
+                       let uu___10 =
+                         let uu___11 =
                            embed eb (FStar_Pervasives_Native.snd x) in
-                         uu____2376 rng shadow_b norm in
-                       FStar_Syntax_Syntax.as_arg uu____2375 in
-                     [uu____2366] in
-                   uu____2338 :: uu____2355 in
-                 uu____2317 :: uu____2327 in
-               uu____2296 :: uu____2306 in
-             FStar_Syntax_Syntax.mk_Tm_app uu____2293 uu____2295 rng) in
+                         uu___11 rng shadow_b norm in
+                       FStar_Syntax_Syntax.as_arg uu___10 in
+                     [uu___9] in
+                   uu___7 :: uu___8 in
+                 uu___5 :: uu___6 in
+               uu___3 :: uu___4 in
+             FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng) in
       let un t0 w norm =
         let t = FStar_Syntax_Util.unmeta_safe t0 in
         lazy_unembed printer1 emb_t_pair_a_b t t_pair_a_b
           (fun t1 ->
-             let uu____2472 = FStar_Syntax_Util.head_and_args' t1 in
-             match uu____2472 with
+             let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+             match uu___ with
              | (hd, args) ->
-                 let uu____2515 =
-                   let uu____2528 =
-                     let uu____2529 = FStar_Syntax_Util.un_uinst hd in
-                     uu____2529.FStar_Syntax_Syntax.n in
-                   (uu____2528, args) in
-                 (match uu____2515 with
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   (uu___2, args) in
+                 (match uu___1 with
                   | (FStar_Syntax_Syntax.Tm_fvar fv,
-                     uu____2547::uu____2548::(a1, uu____2550)::(b1,
-                                                                uu____2552)::[])
-                      when
+                     uu___2::uu___3::(a1, uu___4)::(b1, uu___5)::[]) when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.lid_Mktuple2
                       ->
-                      let uu____2611 =
-                        let uu____2614 = unembed ea a1 in uu____2614 w norm in
-                      FStar_Util.bind_opt uu____2611
+                      let uu___6 =
+                        let uu___7 = unembed ea a1 in uu___7 w norm in
+                      FStar_Util.bind_opt uu___6
                         (fun a2 ->
-                           let uu____2628 =
-                             let uu____2631 = unembed eb b1 in
-                             uu____2631 w norm in
-                           FStar_Util.bind_opt uu____2628
+                           let uu___7 =
+                             let uu___8 = unembed eb b1 in uu___8 w norm in
+                           FStar_Util.bind_opt uu___7
                              (fun b2 -> FStar_Pervasives_Native.Some (a2, b2)))
-                  | uu____2648 ->
+                  | uu___2 ->
                       (if w
                        then
-                         (let uu____2662 =
-                            let uu____2667 =
-                              let uu____2668 =
+                         (let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string t0 in
                               FStar_Util.format1 "Not an embedded pair: %s"
-                                uu____2668 in
-                            (FStar_Errors.Warning_NotEmbedded, uu____2667) in
+                                uu___6 in
+                            (FStar_Errors.Warning_NotEmbedded, uu___5) in
                           FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                            uu____2662)
+                            uu___4)
                        else ();
                        FStar_Pervasives_Native.None))) in
-      let uu____2674 =
-        let uu____2675 = type_of ea in
-        let uu____2676 = type_of eb in
-        FStar_Syntax_Syntax.t_tuple2_of uu____2675 uu____2676 in
-      mk_emb_full em un uu____2674 printer1 emb_t_pair_a_b
+      let uu___ =
+        let uu___1 = type_of ea in
+        let uu___2 = type_of eb in
+        FStar_Syntax_Syntax.t_tuple2_of uu___1 uu___2 in
+      mk_emb_full em un uu___ printer1 emb_t_pair_a_b
 let e_either :
   'a 'b .
     'a embedding -> 'b embedding -> ('a, 'b) FStar_Util.either embedding
@@ -765,34 +737,30 @@ let e_either :
       let t_sum_a_b =
         let t_either =
           FStar_Syntax_Util.fvar_const FStar_Parser_Const.either_lid in
-        let uu____2717 =
-          let uu____2718 = FStar_Syntax_Syntax.as_arg ea.typ in
-          let uu____2727 =
-            let uu____2738 = FStar_Syntax_Syntax.as_arg eb.typ in
-            [uu____2738] in
-          uu____2718 :: uu____2727 in
-        FStar_Syntax_Syntax.mk_Tm_app t_either uu____2717
-          FStar_Range.dummyRange in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Syntax.as_arg ea.typ in
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Syntax.as_arg eb.typ in [uu___3] in
+          uu___1 :: uu___2 in
+        FStar_Syntax_Syntax.mk_Tm_app t_either uu___ FStar_Range.dummyRange in
       let emb_t_sum_a_b =
-        let uu____2772 =
-          let uu____2779 =
+        let uu___ =
+          let uu___1 =
             FStar_All.pipe_right FStar_Parser_Const.either_lid
               FStar_Ident.string_of_lid in
-          (uu____2779, [ea.emb_typ; eb.emb_typ]) in
-        FStar_Syntax_Syntax.ET_app uu____2772 in
+          (uu___1, [ea.emb_typ; eb.emb_typ]) in
+        FStar_Syntax_Syntax.ET_app uu___ in
       let printer1 s =
         match s with
         | FStar_Util.Inl a1 ->
-            let uu____2797 = ea.print a1 in
-            FStar_Util.format1 "Inl %s" uu____2797
+            let uu___ = ea.print a1 in FStar_Util.format1 "Inl %s" uu___
         | FStar_Util.Inr b1 ->
-            let uu____2799 = eb.print b1 in
-            FStar_Util.format1 "Inr %s" uu____2799 in
+            let uu___ = eb.print b1 in FStar_Util.format1 "Inr %s" uu___ in
       let em s rng topt norm =
         lazy_embed printer1 emb_t_sum_a_b rng t_sum_a_b s
           (match s with
            | FStar_Util.Inl a1 ->
-               (fun uu____2844 ->
+               (fun uu___ ->
                   let shadow_a =
                     map_shadow topt
                       (fun t ->
@@ -801,56 +769,55 @@ let e_either :
                            FStar_Syntax_Util.mk_field_projector_name_from_ident
                              FStar_Parser_Const.inl_lid v in
                          let some_v_tm =
-                           let uu____2856 =
+                           let uu___1 =
                              FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None in
-                           FStar_Syntax_Syntax.fv_to_tm uu____2856 in
-                         let uu____2857 =
+                           FStar_Syntax_Syntax.fv_to_tm uu___1 in
+                         let uu___1 =
                            FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
                              [FStar_Syntax_Syntax.U_zero] in
-                         let uu____2858 =
-                           let uu____2859 =
-                             let uu____2868 = type_of ea in
-                             FStar_Syntax_Syntax.iarg uu____2868 in
-                           let uu____2869 =
-                             let uu____2880 =
-                               let uu____2889 = type_of eb in
-                               FStar_Syntax_Syntax.iarg uu____2889 in
-                             let uu____2890 =
-                               let uu____2901 = FStar_Syntax_Syntax.as_arg t in
-                               [uu____2901] in
-                             uu____2880 :: uu____2890 in
-                           uu____2859 :: uu____2869 in
-                         FStar_Syntax_Syntax.mk_Tm_app uu____2857 uu____2858
-                           rng) in
-                  let uu____2942 =
-                    let uu____2943 =
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = type_of ea in
+                             FStar_Syntax_Syntax.iarg uu___4 in
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 = type_of eb in
+                               FStar_Syntax_Syntax.iarg uu___6 in
+                             let uu___6 =
+                               let uu___7 = FStar_Syntax_Syntax.as_arg t in
+                               [uu___7] in
+                             uu___5 :: uu___6 in
+                           uu___3 :: uu___4 in
+                         FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng) in
+                  let uu___1 =
+                    let uu___2 =
                       FStar_Syntax_Syntax.tdataconstr
                         FStar_Parser_Const.inl_lid in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____2943
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                       [FStar_Syntax_Syntax.U_zero;
                       FStar_Syntax_Syntax.U_zero] in
-                  let uu____2944 =
-                    let uu____2945 =
-                      let uu____2954 = type_of ea in
-                      FStar_Syntax_Syntax.iarg uu____2954 in
-                    let uu____2955 =
-                      let uu____2966 =
-                        let uu____2975 = type_of eb in
-                        FStar_Syntax_Syntax.iarg uu____2975 in
-                      let uu____2976 =
-                        let uu____2987 =
-                          let uu____2996 =
-                            let uu____2997 = embed ea a1 in
-                            uu____2997 rng shadow_a norm in
-                          FStar_Syntax_Syntax.as_arg uu____2996 in
-                        [uu____2987] in
-                      uu____2966 :: uu____2976 in
-                    uu____2945 :: uu____2955 in
-                  FStar_Syntax_Syntax.mk_Tm_app uu____2942 uu____2944 rng)
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = type_of ea in
+                      FStar_Syntax_Syntax.iarg uu___4 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = type_of eb in
+                        FStar_Syntax_Syntax.iarg uu___6 in
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 = embed ea a1 in
+                            uu___9 rng shadow_a norm in
+                          FStar_Syntax_Syntax.as_arg uu___8 in
+                        [uu___7] in
+                      uu___5 :: uu___6 in
+                    uu___3 :: uu___4 in
+                  FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng)
            | FStar_Util.Inr b1 ->
-               (fun uu____3037 ->
+               (fun uu___ ->
                   let shadow_b =
                     map_shadow topt
                       (fun t ->
@@ -859,219 +826,213 @@ let e_either :
                            FStar_Syntax_Util.mk_field_projector_name_from_ident
                              FStar_Parser_Const.inr_lid v in
                          let some_v_tm =
-                           let uu____3049 =
+                           let uu___1 =
                              FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None in
-                           FStar_Syntax_Syntax.fv_to_tm uu____3049 in
-                         let uu____3050 =
+                           FStar_Syntax_Syntax.fv_to_tm uu___1 in
+                         let uu___1 =
                            FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
                              [FStar_Syntax_Syntax.U_zero] in
-                         let uu____3051 =
-                           let uu____3052 =
-                             let uu____3061 = type_of ea in
-                             FStar_Syntax_Syntax.iarg uu____3061 in
-                           let uu____3062 =
-                             let uu____3073 =
-                               let uu____3082 = type_of eb in
-                               FStar_Syntax_Syntax.iarg uu____3082 in
-                             let uu____3083 =
-                               let uu____3094 = FStar_Syntax_Syntax.as_arg t in
-                               [uu____3094] in
-                             uu____3073 :: uu____3083 in
-                           uu____3052 :: uu____3062 in
-                         FStar_Syntax_Syntax.mk_Tm_app uu____3050 uu____3051
-                           rng) in
-                  let uu____3135 =
-                    let uu____3136 =
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = type_of ea in
+                             FStar_Syntax_Syntax.iarg uu___4 in
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 = type_of eb in
+                               FStar_Syntax_Syntax.iarg uu___6 in
+                             let uu___6 =
+                               let uu___7 = FStar_Syntax_Syntax.as_arg t in
+                               [uu___7] in
+                             uu___5 :: uu___6 in
+                           uu___3 :: uu___4 in
+                         FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng) in
+                  let uu___1 =
+                    let uu___2 =
                       FStar_Syntax_Syntax.tdataconstr
                         FStar_Parser_Const.inr_lid in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____3136
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                       [FStar_Syntax_Syntax.U_zero;
                       FStar_Syntax_Syntax.U_zero] in
-                  let uu____3137 =
-                    let uu____3138 =
-                      let uu____3147 = type_of ea in
-                      FStar_Syntax_Syntax.iarg uu____3147 in
-                    let uu____3148 =
-                      let uu____3159 =
-                        let uu____3168 = type_of eb in
-                        FStar_Syntax_Syntax.iarg uu____3168 in
-                      let uu____3169 =
-                        let uu____3180 =
-                          let uu____3189 =
-                            let uu____3190 = embed eb b1 in
-                            uu____3190 rng shadow_b norm in
-                          FStar_Syntax_Syntax.as_arg uu____3189 in
-                        [uu____3180] in
-                      uu____3159 :: uu____3169 in
-                    uu____3138 :: uu____3148 in
-                  FStar_Syntax_Syntax.mk_Tm_app uu____3135 uu____3137 rng)) in
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = type_of ea in
+                      FStar_Syntax_Syntax.iarg uu___4 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = type_of eb in
+                        FStar_Syntax_Syntax.iarg uu___6 in
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 = embed eb b1 in
+                            uu___9 rng shadow_b norm in
+                          FStar_Syntax_Syntax.as_arg uu___8 in
+                        [uu___7] in
+                      uu___5 :: uu___6 in
+                    uu___3 :: uu___4 in
+                  FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng)) in
       let un t0 w norm =
         let t = FStar_Syntax_Util.unmeta_safe t0 in
         lazy_unembed printer1 emb_t_sum_a_b t t_sum_a_b
           (fun t1 ->
-             let uu____3276 = FStar_Syntax_Util.head_and_args' t1 in
-             match uu____3276 with
+             let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+             match uu___ with
              | (hd, args) ->
-                 let uu____3319 =
-                   let uu____3334 =
-                     let uu____3335 = FStar_Syntax_Util.un_uinst hd in
-                     uu____3335.FStar_Syntax_Syntax.n in
-                   (uu____3334, args) in
-                 (match uu____3319 with
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   (uu___2, args) in
+                 (match uu___1 with
                   | (FStar_Syntax_Syntax.Tm_fvar fv,
-                     uu____3355::uu____3356::(a1, uu____3358)::[]) when
+                     uu___2::uu___3::(a1, uu___4)::[]) when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.inl_lid
                       ->
-                      let uu____3425 =
-                        let uu____3428 = unembed ea a1 in uu____3428 w norm in
-                      FStar_Util.bind_opt uu____3425
+                      let uu___5 =
+                        let uu___6 = unembed ea a1 in uu___6 w norm in
+                      FStar_Util.bind_opt uu___5
                         (fun a2 ->
                            FStar_Pervasives_Native.Some (FStar_Util.Inl a2))
                   | (FStar_Syntax_Syntax.Tm_fvar fv,
-                     uu____3446::uu____3447::(b1, uu____3449)::[]) when
+                     uu___2::uu___3::(b1, uu___4)::[]) when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.inr_lid
                       ->
-                      let uu____3516 =
-                        let uu____3519 = unembed eb b1 in uu____3519 w norm in
-                      FStar_Util.bind_opt uu____3516
+                      let uu___5 =
+                        let uu___6 = unembed eb b1 in uu___6 w norm in
+                      FStar_Util.bind_opt uu___5
                         (fun b2 ->
                            FStar_Pervasives_Native.Some (FStar_Util.Inr b2))
-                  | uu____3536 ->
+                  | uu___2 ->
                       (if w
                        then
-                         (let uu____3552 =
-                            let uu____3557 =
-                              let uu____3558 =
+                         (let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string t0 in
                               FStar_Util.format1 "Not an embedded sum: %s"
-                                uu____3558 in
-                            (FStar_Errors.Warning_NotEmbedded, uu____3557) in
+                                uu___6 in
+                            (FStar_Errors.Warning_NotEmbedded, uu___5) in
                           FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                            uu____3552)
+                            uu___4)
                        else ();
                        FStar_Pervasives_Native.None))) in
-      let uu____3564 =
-        let uu____3565 = type_of ea in
-        let uu____3566 = type_of eb in
-        FStar_Syntax_Syntax.t_either_of uu____3565 uu____3566 in
-      mk_emb_full em un uu____3564 printer1 emb_t_sum_a_b
+      let uu___ =
+        let uu___1 = type_of ea in
+        let uu___2 = type_of eb in
+        FStar_Syntax_Syntax.t_either_of uu___1 uu___2 in
+      mk_emb_full em un uu___ printer1 emb_t_sum_a_b
 let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
   fun ea ->
     let t_list_a =
       let t_list = FStar_Syntax_Util.fvar_const FStar_Parser_Const.list_lid in
-      let uu____3591 =
-        let uu____3592 = FStar_Syntax_Syntax.as_arg ea.typ in [uu____3592] in
-      FStar_Syntax_Syntax.mk_Tm_app t_list uu____3591 FStar_Range.dummyRange in
+      let uu___ = let uu___1 = FStar_Syntax_Syntax.as_arg ea.typ in [uu___1] in
+      FStar_Syntax_Syntax.mk_Tm_app t_list uu___ FStar_Range.dummyRange in
     let emb_t_list_a =
-      let uu____3618 =
-        let uu____3625 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right FStar_Parser_Const.list_lid
             FStar_Ident.string_of_lid in
-        (uu____3625, [ea.emb_typ]) in
-      FStar_Syntax_Syntax.ET_app uu____3618 in
+        (uu___1, [ea.emb_typ]) in
+      FStar_Syntax_Syntax.ET_app uu___ in
     let printer1 l =
-      let uu____3638 =
-        let uu____3639 =
-          let uu____3640 = FStar_List.map ea.print l in
-          FStar_All.pipe_right uu____3640 (FStar_String.concat "; ") in
-        Prims.op_Hat uu____3639 "]" in
-      Prims.op_Hat "[" uu____3638 in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_List.map ea.print l in
+          FStar_All.pipe_right uu___2 (FStar_String.concat "; ") in
+        Prims.op_Hat uu___1 "]" in
+      Prims.op_Hat "[" uu___ in
     let rec em l rng shadow_l norm =
       lazy_embed printer1 emb_t_list_a rng t_list_a l
-        (fun uu____3677 ->
-           let t =
-             let uu____3679 = type_of ea in
-             FStar_Syntax_Syntax.iarg uu____3679 in
+        (fun uu___ ->
+           let t = let uu___1 = type_of ea in FStar_Syntax_Syntax.iarg uu___1 in
            match l with
            | [] ->
-               let uu____3680 =
-                 let uu____3681 =
+               let uu___1 =
+                 let uu___2 =
                    FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.nil_lid in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____3681
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu___2
                    [FStar_Syntax_Syntax.U_zero] in
-               FStar_Syntax_Syntax.mk_Tm_app uu____3680 [t] rng
+               FStar_Syntax_Syntax.mk_Tm_app uu___1 [t] rng
            | hd::tl ->
                let cons =
-                 let uu____3703 =
+                 let uu___1 =
                    FStar_Syntax_Syntax.tdataconstr
                      FStar_Parser_Const.cons_lid in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____3703
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu___1
                    [FStar_Syntax_Syntax.U_zero] in
                let proj f cons_tm =
                  let fid = FStar_Ident.mk_ident (f, rng) in
-                 let proj =
+                 let proj1 =
                    FStar_Syntax_Util.mk_field_projector_name_from_ident
                      FStar_Parser_Const.cons_lid fid in
                  let proj_tm =
-                   let uu____3718 =
-                     FStar_Syntax_Syntax.lid_as_fv proj
+                   let uu___1 =
+                     FStar_Syntax_Syntax.lid_as_fv proj1
                        FStar_Syntax_Syntax.delta_equational
                        FStar_Pervasives_Native.None in
-                   FStar_Syntax_Syntax.fv_to_tm uu____3718 in
-                 let uu____3719 =
+                   FStar_Syntax_Syntax.fv_to_tm uu___1 in
+                 let uu___1 =
                    FStar_Syntax_Syntax.mk_Tm_uinst proj_tm
                      [FStar_Syntax_Syntax.U_zero] in
-                 let uu____3720 =
-                   let uu____3721 =
-                     let uu____3730 = type_of ea in
-                     FStar_Syntax_Syntax.iarg uu____3730 in
-                   let uu____3731 =
-                     let uu____3742 = FStar_Syntax_Syntax.as_arg cons_tm in
-                     [uu____3742] in
-                   uu____3721 :: uu____3731 in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____3719 uu____3720 rng in
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = type_of ea in
+                     FStar_Syntax_Syntax.iarg uu___4 in
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Syntax.as_arg cons_tm in
+                     [uu___5] in
+                   uu___3 :: uu___4 in
+                 FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 rng in
                let shadow_hd = map_shadow shadow_l (proj "hd") in
                let shadow_tl = map_shadow shadow_l (proj "tl") in
-               let uu____3777 =
-                 let uu____3778 =
-                   let uu____3789 =
-                     let uu____3798 =
-                       let uu____3799 = embed ea hd in
-                       uu____3799 rng shadow_hd norm in
-                     FStar_Syntax_Syntax.as_arg uu____3798 in
-                   let uu____3806 =
-                     let uu____3817 =
-                       let uu____3826 = em tl rng shadow_tl norm in
-                       FStar_Syntax_Syntax.as_arg uu____3826 in
-                     [uu____3817] in
-                   uu____3789 :: uu____3806 in
-                 t :: uu____3778 in
-               FStar_Syntax_Syntax.mk_Tm_app cons uu____3777 rng) in
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = embed ea hd in uu___5 rng shadow_hd norm in
+                     FStar_Syntax_Syntax.as_arg uu___4 in
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = em tl rng shadow_tl norm in
+                       FStar_Syntax_Syntax.as_arg uu___6 in
+                     [uu___5] in
+                   uu___3 :: uu___4 in
+                 t :: uu___2 in
+               FStar_Syntax_Syntax.mk_Tm_app cons uu___1 rng) in
     let rec un t0 w norm =
       let t = FStar_Syntax_Util.unmeta_safe t0 in
       lazy_unembed printer1 emb_t_list_a t t_list_a
         (fun t1 ->
-           let uu____3896 = FStar_Syntax_Util.head_and_args' t1 in
-           match uu____3896 with
+           let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+           match uu___ with
            | (hd, args) ->
-               let uu____3937 =
-                 let uu____3950 =
-                   let uu____3951 = FStar_Syntax_Util.un_uinst hd in
-                   uu____3951.FStar_Syntax_Syntax.n in
-                 (uu____3950, args) in
-               (match uu____3937 with
-                | (FStar_Syntax_Syntax.Tm_fvar fv, uu____3967) when
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (uu___2, args) in
+               (match uu___1 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.nil_lid
                     -> FStar_Pervasives_Native.Some []
                 | (FStar_Syntax_Syntax.Tm_fvar fv,
-                   (uu____3987, FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Implicit uu____3988))::(hd1,
-                                                                 FStar_Pervasives_Native.None)::
+                   (uu___2, FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.Implicit uu___3))::(hd1,
+                                                             FStar_Pervasives_Native.None)::
                    (tl, FStar_Pervasives_Native.None)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.cons_lid
                     ->
-                    let uu____4029 =
-                      let uu____4032 = unembed ea hd1 in uu____4032 w norm in
-                    FStar_Util.bind_opt uu____4029
+                    let uu___4 = let uu___5 = unembed ea hd1 in uu___5 w norm in
+                    FStar_Util.bind_opt uu___4
                       (fun hd2 ->
-                         let uu____4044 = un tl w norm in
-                         FStar_Util.bind_opt uu____4044
+                         let uu___5 = un tl w norm in
+                         FStar_Util.bind_opt uu___5
                            (fun tl1 ->
                               FStar_Pervasives_Native.Some (hd2 :: tl1)))
                 | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -1081,31 +1042,29 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.cons_lid
                     ->
-                    let uu____4092 =
-                      let uu____4095 = unembed ea hd1 in uu____4095 w norm in
-                    FStar_Util.bind_opt uu____4092
+                    let uu___2 = let uu___3 = unembed ea hd1 in uu___3 w norm in
+                    FStar_Util.bind_opt uu___2
                       (fun hd2 ->
-                         let uu____4107 = un tl w norm in
-                         FStar_Util.bind_opt uu____4107
+                         let uu___3 = un tl w norm in
+                         FStar_Util.bind_opt uu___3
                            (fun tl1 ->
                               FStar_Pervasives_Native.Some (hd2 :: tl1)))
-                | uu____4122 ->
+                | uu___2 ->
                     (if w
                      then
-                       (let uu____4136 =
-                          let uu____4141 =
-                            let uu____4142 =
-                              FStar_Syntax_Print.term_to_string t0 in
+                       (let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Print.term_to_string t0 in
                             FStar_Util.format1 "Not an embedded list: %s"
-                              uu____4142 in
-                          (FStar_Errors.Warning_NotEmbedded, uu____4141) in
+                              uu___6 in
+                          (FStar_Errors.Warning_NotEmbedded, uu___5) in
                         FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                          uu____4136)
+                          uu___4)
                      else ();
                      FStar_Pervasives_Native.None))) in
-    let uu____4146 =
-      let uu____4147 = type_of ea in FStar_Syntax_Syntax.t_list_of uu____4147 in
-    mk_emb_full em un uu____4146 printer1 emb_t_list_a
+    let uu___ =
+      let uu___1 = type_of ea in FStar_Syntax_Syntax.t_list_of uu___1 in
+    mk_emb_full em un uu___ printer1 emb_t_list_a
 let (e_string_list : Prims.string Prims.list embedding) = e_list e_string
 type norm_step =
   | Simpl 
@@ -1122,42 +1081,40 @@ type norm_step =
   | UnfoldAttr of Prims.string Prims.list 
   | NBE 
 let (uu___is_Simpl : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Simpl -> true | uu____4180 -> false
+  fun projectee -> match projectee with | Simpl -> true | uu___ -> false
 let (uu___is_Weak : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Weak -> true | uu____4186 -> false
+  fun projectee -> match projectee with | Weak -> true | uu___ -> false
 let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | HNF -> true | uu____4192 -> false
+  fun projectee -> match projectee with | HNF -> true | uu___ -> false
 let (uu___is_Primops : norm_step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Primops -> true | uu____4198 -> false
+  fun projectee -> match projectee with | Primops -> true | uu___ -> false
 let (uu___is_Delta : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Delta -> true | uu____4204 -> false
+  fun projectee -> match projectee with | Delta -> true | uu___ -> false
 let (uu___is_Zeta : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Zeta -> true | uu____4210 -> false
+  fun projectee -> match projectee with | Zeta -> true | uu___ -> false
 let (uu___is_ZetaFull : norm_step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ZetaFull -> true | uu____4216 -> false
+  fun projectee -> match projectee with | ZetaFull -> true | uu___ -> false
 let (uu___is_Iota : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Iota -> true | uu____4222 -> false
+  fun projectee -> match projectee with | Iota -> true | uu___ -> false
 let (uu___is_Reify : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | Reify -> true | uu____4228 -> false
+  fun projectee -> match projectee with | Reify -> true | uu___ -> false
 let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldOnly _0 -> true | uu____4237 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu___ -> false
 let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldOnly _0 -> _0
 let (uu___is_UnfoldFully : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldFully _0 -> true | uu____4258 -> false
+    match projectee with | UnfoldFully _0 -> true | uu___ -> false
 let (__proj__UnfoldFully__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldFully _0 -> _0
 let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldAttr _0 -> true | uu____4279 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu___ -> false
 let (__proj__UnfoldAttr__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee -> match projectee with | UnfoldAttr _0 -> _0
 let (uu___is_NBE : norm_step -> Prims.bool) =
-  fun projectee -> match projectee with | NBE -> true | uu____4297 -> false
+  fun projectee -> match projectee with | NBE -> true | uu___ -> false
 let (steps_Simpl : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tconst FStar_Parser_Const.steps_simpl
 let (steps_Weak : FStar_Syntax_Syntax.term) =
@@ -1186,20 +1143,19 @@ let (steps_NBE : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tconst FStar_Parser_Const.steps_nbe
 let (e_norm_step : norm_step embedding) =
   let t_norm_step =
-    let uu____4301 =
-      FStar_Ident.lid_of_str "FStar.Syntax.Embeddings.norm_step" in
-    FStar_Syntax_Util.fvar_const uu____4301 in
+    let uu___ = FStar_Ident.lid_of_str "FStar.Syntax.Embeddings.norm_step" in
+    FStar_Syntax_Util.fvar_const uu___ in
   let emb_t_norm_step =
-    let uu____4303 =
-      let uu____4310 =
+    let uu___ =
+      let uu___1 =
         FStar_All.pipe_right FStar_Parser_Const.norm_step_lid
           FStar_Ident.string_of_lid in
-      (uu____4310, []) in
-    FStar_Syntax_Syntax.ET_app uu____4303 in
-  let printer1 uu____4318 = "norm_step" in
+      (uu___1, []) in
+    FStar_Syntax_Syntax.ET_app uu___ in
+  let printer1 uu___ = "norm_step" in
   let em n rng _topt norm =
     lazy_embed printer1 emb_t_norm_step rng t_norm_step n
-      (fun uu____4343 ->
+      (fun uu___ ->
          match n with
          | Simpl -> steps_Simpl
          | Weak -> steps_Weak
@@ -1212,48 +1168,48 @@ let (e_norm_step : norm_step embedding) =
          | NBE -> steps_NBE
          | Reify -> steps_Reify
          | UnfoldOnly l ->
-             let uu____4347 =
-               let uu____4348 =
-                 let uu____4357 =
-                   let uu____4358 =
-                     let uu____4365 = e_list e_string in embed uu____4365 l in
-                   uu____4358 rng FStar_Pervasives_Native.None norm in
-                 FStar_Syntax_Syntax.as_arg uu____4357 in
-               [uu____4348] in
-             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu____4347 rng
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = e_list e_string in embed uu___5 l in
+                   uu___4 rng FStar_Pervasives_Native.None norm in
+                 FStar_Syntax_Syntax.as_arg uu___3 in
+               [uu___2] in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu___1 rng
          | UnfoldFully l ->
-             let uu____4393 =
-               let uu____4394 =
-                 let uu____4403 =
-                   let uu____4404 =
-                     let uu____4411 = e_list e_string in embed uu____4411 l in
-                   uu____4404 rng FStar_Pervasives_Native.None norm in
-                 FStar_Syntax_Syntax.as_arg uu____4403 in
-               [uu____4394] in
-             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldFully uu____4393 rng
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = e_list e_string in embed uu___5 l in
+                   uu___4 rng FStar_Pervasives_Native.None norm in
+                 FStar_Syntax_Syntax.as_arg uu___3 in
+               [uu___2] in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldFully uu___1 rng
          | UnfoldAttr l ->
-             let uu____4439 =
-               let uu____4440 =
-                 let uu____4449 =
-                   let uu____4450 =
-                     let uu____4457 = e_list e_string in embed uu____4457 l in
-                   uu____4450 rng FStar_Pervasives_Native.None norm in
-                 FStar_Syntax_Syntax.as_arg uu____4449 in
-               [uu____4440] in
-             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu____4439 rng) in
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = e_list e_string in embed uu___5 l in
+                   uu___4 rng FStar_Pervasives_Native.None norm in
+                 FStar_Syntax_Syntax.as_arg uu___3 in
+               [uu___2] in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu___1 rng) in
   let un t0 w norm =
     let t = FStar_Syntax_Util.unmeta_safe t0 in
     lazy_unembed printer1 emb_t_norm_step t t_norm_step
       (fun t1 ->
-         let uu____4512 = FStar_Syntax_Util.head_and_args t1 in
-         match uu____4512 with
+         let uu___ = FStar_Syntax_Util.head_and_args t1 in
+         match uu___ with
          | (hd, args) ->
-             let uu____4557 =
-               let uu____4572 =
-                 let uu____4573 = FStar_Syntax_Util.un_uinst hd in
-                 uu____4573.FStar_Syntax_Syntax.n in
-               (uu____4572, args) in
-             (match uu____4557 with
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (uu___2, args) in
+             (match uu___1 with
               | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_simpl
@@ -1294,63 +1250,56 @@ let (e_norm_step : norm_step embedding) =
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_reify
                   -> FStar_Pervasives_Native.Some Reify
-              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____4780)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldonly
                   ->
-                  let uu____4815 =
-                    let uu____4820 =
-                      let uu____4829 = e_list e_string in
-                      unembed uu____4829 l in
-                    uu____4820 w norm in
-                  FStar_Util.bind_opt uu____4815
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = e_list e_string in unembed uu___5 l in
+                    uu___4 w norm in
+                  FStar_Util.bind_opt uu___3
                     (fun ss ->
                        FStar_All.pipe_left
-                         (fun uu____4844 ->
-                            FStar_Pervasives_Native.Some uu____4844)
+                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                          (UnfoldOnly ss))
-              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____4847)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldfully
                   ->
-                  let uu____4882 =
-                    let uu____4887 =
-                      let uu____4896 = e_list e_string in
-                      unembed uu____4896 l in
-                    uu____4887 w norm in
-                  FStar_Util.bind_opt uu____4882
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = e_list e_string in unembed uu___5 l in
+                    uu___4 w norm in
+                  FStar_Util.bind_opt uu___3
                     (fun ss ->
                        FStar_All.pipe_left
-                         (fun uu____4911 ->
-                            FStar_Pervasives_Native.Some uu____4911)
+                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                          (UnfoldFully ss))
-              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu____4914)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldattr
                   ->
-                  let uu____4949 =
-                    let uu____4954 =
-                      let uu____4963 = e_list e_string in
-                      unembed uu____4963 l in
-                    uu____4954 w norm in
-                  FStar_Util.bind_opt uu____4949
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = e_list e_string in unembed uu___5 l in
+                    uu___4 w norm in
+                  FStar_Util.bind_opt uu___3
                     (fun ss ->
                        FStar_All.pipe_left
-                         (fun uu____4978 ->
-                            FStar_Pervasives_Native.Some uu____4978)
+                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
                          (UnfoldAttr ss))
-              | uu____4979 ->
+              | uu___2 ->
                   (if w
                    then
-                     (let uu____4995 =
-                        let uu____5000 =
-                          let uu____5001 =
-                            FStar_Syntax_Print.term_to_string t0 in
+                     (let uu___4 =
+                        let uu___5 =
+                          let uu___6 = FStar_Syntax_Print.term_to_string t0 in
                           FStar_Util.format1 "Not an embedded norm_step: %s"
-                            uu____5001 in
-                        (FStar_Errors.Warning_NotEmbedded, uu____5000) in
+                            uu___6 in
+                        (FStar_Errors.Warning_NotEmbedded, uu___5) in
                       FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                        uu____4995)
+                        uu___4)
                    else ();
                    FStar_Pervasives_Native.None))) in
   mk_emb_full em un FStar_Syntax_Syntax.t_norm_step printer1 emb_t_norm_step
@@ -1363,26 +1312,26 @@ let (e_range : FStar_Range.range embedding) =
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r) ->
         FStar_Pervasives_Native.Some r
-    | uu____5054 ->
+    | uu___ ->
         (if w
          then
-           (let uu____5056 =
-              let uu____5061 =
-                let uu____5062 = FStar_Syntax_Print.term_to_string t0 in
-                FStar_Util.format1 "Not an embedded range: %s" uu____5062 in
-              (FStar_Errors.Warning_NotEmbedded, uu____5061) in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____5056)
+           (let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Print.term_to_string t0 in
+                FStar_Util.format1 "Not an embedded range: %s" uu___4 in
+              (FStar_Errors.Warning_NotEmbedded, uu___3) in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___2)
          else ();
          FStar_Pervasives_Native.None) in
-  let uu____5064 =
-    let uu____5065 =
-      let uu____5072 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.range_lid
           FStar_Ident.string_of_lid in
-      (uu____5072, []) in
-    FStar_Syntax_Syntax.ET_app uu____5065 in
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
   mk_emb_full em un FStar_Syntax_Syntax.t_range FStar_Range.string_of_range
-    uu____5064
+    uu___
 let or_else : 'a . 'a FStar_Pervasives_Native.option -> (unit -> 'a) -> 'a =
   fun f ->
     fun g ->
@@ -1393,84 +1342,79 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
   fun ea ->
     fun eb ->
       let t_arrow =
-        let uu____5138 =
-          let uu____5139 =
-            let uu____5154 =
-              let uu____5163 =
-                let uu____5170 = FStar_Syntax_Syntax.null_bv ea.typ in
-                (uu____5170, FStar_Pervasives_Native.None) in
-              [uu____5163] in
-            let uu____5185 = FStar_Syntax_Syntax.mk_Total eb.typ in
-            (uu____5154, uu____5185) in
-          FStar_Syntax_Syntax.Tm_arrow uu____5139 in
-        FStar_Syntax_Syntax.mk uu____5138 FStar_Range.dummyRange in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Syntax.null_bv ea.typ in
+                (uu___4, FStar_Pervasives_Native.None) in
+              [uu___3] in
+            let uu___3 = FStar_Syntax_Syntax.mk_Total eb.typ in
+            (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_arrow uu___1 in
+        FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange in
       let emb_t_arr_a_b =
         FStar_Syntax_Syntax.ET_fun ((ea.emb_typ), (eb.emb_typ)) in
       let printer1 f = "<fun>" in
       let em f rng shadow_f norm =
-        lazy_embed (fun uu____5253 -> "<fun>") emb_t_arr_a_b rng t_arrow f
-          (fun uu____5258 ->
-             let uu____5259 = force_shadow shadow_f in
-             match uu____5259 with
+        lazy_embed (fun uu___ -> "<fun>") emb_t_arr_a_b rng t_arrow f
+          (fun uu___ ->
+             let uu___1 = force_shadow shadow_f in
+             match uu___1 with
              | FStar_Pervasives_Native.None ->
                  FStar_Exn.raise Embedding_failure
              | FStar_Pervasives_Native.Some repr_f ->
-                 ((let uu____5264 =
+                 ((let uu___3 =
                      FStar_ST.op_Bang FStar_Options.debug_embedding in
-                   if uu____5264
+                   if uu___3
                    then
-                     let uu____5271 =
-                       FStar_Syntax_Print.term_to_string repr_f in
-                     let uu____5272 = FStar_Util.stack_dump () in
+                     let uu___4 = FStar_Syntax_Print.term_to_string repr_f in
+                     let uu___5 = FStar_Util.stack_dump () in
                      FStar_Util.print2
                        "e_arrow forced back to term using shadow %s; repr=%s\n"
-                       uu____5271 uu____5272
+                       uu___4 uu___5
                    else ());
                   (let res = norm (FStar_Util.Inr repr_f) in
-                   (let uu____5276 =
+                   (let uu___4 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding in
-                    if uu____5276
+                    if uu___4
                     then
-                      let uu____5283 =
-                        FStar_Syntax_Print.term_to_string repr_f in
-                      let uu____5284 = FStar_Syntax_Print.term_to_string res in
-                      let uu____5285 = FStar_Util.stack_dump () in
+                      let uu___5 = FStar_Syntax_Print.term_to_string repr_f in
+                      let uu___6 = FStar_Syntax_Print.term_to_string res in
+                      let uu___7 = FStar_Util.stack_dump () in
                       FStar_Util.print3
                         "e_arrow forced back to term using shadow %s; repr=%s\n\t%s\n"
-                        uu____5283 uu____5284 uu____5285
+                        uu___5 uu___6 uu___7
                     else ());
                    res))) in
       let un f w norm =
         lazy_unembed printer1 emb_t_arr_a_b f t_arrow
           (fun f1 ->
              let f_wrapped a1 =
-               (let uu____5339 =
-                  FStar_ST.op_Bang FStar_Options.debug_embedding in
-                if uu____5339
+               (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+                if uu___1
                 then
-                  let uu____5346 = FStar_Syntax_Print.term_to_string f1 in
-                  let uu____5347 = FStar_Util.stack_dump () in
+                  let uu___2 = FStar_Syntax_Print.term_to_string f1 in
+                  let uu___3 = FStar_Util.stack_dump () in
                   FStar_Util.print2
-                    "Calling back into normalizer for %s\n%s\n" uu____5346
-                    uu____5347
+                    "Calling back into normalizer for %s\n%s\n" uu___2 uu___3
                 else ());
                (let a_tm =
-                  let uu____5350 = embed ea a1 in
-                  uu____5350 f1.FStar_Syntax_Syntax.pos
+                  let uu___1 = embed ea a1 in
+                  uu___1 f1.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None norm in
                 let b_tm =
-                  let uu____5360 =
-                    let uu____5365 =
-                      let uu____5366 =
-                        let uu____5367 = FStar_Syntax_Syntax.as_arg a_tm in
-                        [uu____5367] in
-                      FStar_Syntax_Syntax.mk_Tm_app f1 uu____5366
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.as_arg a_tm in
+                        [uu___4] in
+                      FStar_Syntax_Syntax.mk_Tm_app f1 uu___3
                         f1.FStar_Syntax_Syntax.pos in
-                    FStar_Util.Inr uu____5365 in
-                  norm uu____5360 in
-                let uu____5392 =
-                  let uu____5395 = unembed eb b_tm in uu____5395 w norm in
-                match uu____5392 with
+                    FStar_Util.Inr uu___2 in
+                  norm uu___1 in
+                let uu___1 = let uu___2 = unembed eb b_tm in uu___2 w norm in
+                match uu___1 with
                 | FStar_Pervasives_Native.None ->
                     FStar_Exn.raise Unembedding_failure
                 | FStar_Pervasives_Native.Some b1 -> b1) in
@@ -1495,32 +1439,29 @@ let arrow_as_prim_step_1 :
             fun norm ->
               let rng = FStar_Ident.range_of_lid fv_lid in
               let f_wrapped args =
-                let uu____5486 = FStar_List.splitAt n_tvars args in
-                match uu____5486 with
+                let uu___ = FStar_List.splitAt n_tvars args in
+                match uu___ with
                 | (_tvar_args, rest_args) ->
-                    let uu____5563 = FStar_List.hd rest_args in
-                    (match uu____5563 with
-                     | (x, uu____5583) ->
+                    let uu___1 = FStar_List.hd rest_args in
+                    (match uu___1 with
+                     | (x, uu___2) ->
                          let shadow_app =
-                           let uu____5597 =
+                           let uu___3 =
                              FStar_Thunk.mk
-                               (fun uu____5602 ->
-                                  let uu____5603 =
-                                    norm (FStar_Util.Inl fv_lid) in
-                                  FStar_Syntax_Syntax.mk_Tm_app uu____5603
-                                    args rng) in
-                           FStar_Pervasives_Native.Some uu____5597 in
-                         let uu____5606 =
-                           let uu____5609 =
-                             let uu____5612 = unembed ea x in
-                             uu____5612 true norm in
-                           FStar_Util.map_opt uu____5609
+                               (fun uu___4 ->
+                                  let uu___5 = norm (FStar_Util.Inl fv_lid) in
+                                  FStar_Syntax_Syntax.mk_Tm_app uu___5 args
+                                    rng) in
+                           FStar_Pervasives_Native.Some uu___3 in
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 = unembed ea x in uu___5 true norm in
+                           FStar_Util.map_opt uu___4
                              (fun x1 ->
-                                let uu____5622 =
-                                  let uu____5629 = f x1 in
-                                  embed eb uu____5629 in
-                                uu____5622 rng shadow_app norm) in
-                         (match uu____5606 with
+                                let uu___5 =
+                                  let uu___6 = f x1 in embed eb uu___6 in
+                                uu___5 rng shadow_app norm) in
+                         (match uu___3 with
                           | FStar_Pervasives_Native.Some x1 ->
                               FStar_Pervasives_Native.Some x1
                           | FStar_Pervasives_Native.None ->
@@ -1547,45 +1488,45 @@ let arrow_as_prim_step_2 :
               fun norm ->
                 let rng = FStar_Ident.range_of_lid fv_lid in
                 let f_wrapped args =
-                  let uu____5729 = FStar_List.splitAt n_tvars args in
-                  match uu____5729 with
+                  let uu___ = FStar_List.splitAt n_tvars args in
+                  match uu___ with
                   | (_tvar_args, rest_args) ->
-                      let uu____5792 = FStar_List.hd rest_args in
-                      (match uu____5792 with
-                       | (x, uu____5808) ->
-                           let uu____5813 =
-                             let uu____5820 = FStar_List.tl rest_args in
-                             FStar_List.hd uu____5820 in
-                           (match uu____5813 with
-                            | (y, uu____5844) ->
+                      let uu___1 = FStar_List.hd rest_args in
+                      (match uu___1 with
+                       | (x, uu___2) ->
+                           let uu___3 =
+                             let uu___4 = FStar_List.tl rest_args in
+                             FStar_List.hd uu___4 in
+                           (match uu___3 with
+                            | (y, uu___4) ->
                                 let shadow_app =
-                                  let uu____5854 =
+                                  let uu___5 =
                                     FStar_Thunk.mk
-                                      (fun uu____5859 ->
-                                         let uu____5860 =
+                                      (fun uu___6 ->
+                                         let uu___7 =
                                            norm (FStar_Util.Inl fv_lid) in
-                                         FStar_Syntax_Syntax.mk_Tm_app
-                                           uu____5860 args rng) in
-                                  FStar_Pervasives_Native.Some uu____5854 in
-                                let uu____5863 =
-                                  let uu____5866 =
-                                    let uu____5869 = unembed ea x in
-                                    uu____5869 true norm in
-                                  FStar_Util.bind_opt uu____5866
+                                         FStar_Syntax_Syntax.mk_Tm_app uu___7
+                                           args rng) in
+                                  FStar_Pervasives_Native.Some uu___5 in
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 = unembed ea x in
+                                    uu___7 true norm in
+                                  FStar_Util.bind_opt uu___6
                                     (fun x1 ->
-                                       let uu____5879 =
-                                         let uu____5882 = unembed eb y in
-                                         uu____5882 true norm in
-                                       FStar_Util.bind_opt uu____5879
+                                       let uu___7 =
+                                         let uu___8 = unembed eb y in
+                                         uu___8 true norm in
+                                       FStar_Util.bind_opt uu___7
                                          (fun y1 ->
-                                            let uu____5892 =
-                                              let uu____5893 =
-                                                let uu____5900 = f x1 y1 in
-                                                embed ec uu____5900 in
-                                              uu____5893 rng shadow_app norm in
+                                            let uu___8 =
+                                              let uu___9 =
+                                                let uu___10 = f x1 y1 in
+                                                embed ec uu___10 in
+                                              uu___9 rng shadow_app norm in
                                             FStar_Pervasives_Native.Some
-                                              uu____5892)) in
-                                (match uu____5863 with
+                                              uu___8)) in
+                                (match uu___5 with
                                  | FStar_Pervasives_Native.Some x1 ->
                                      FStar_Pervasives_Native.Some x1
                                  | FStar_Pervasives_Native.None ->
@@ -1614,65 +1555,62 @@ let arrow_as_prim_step_3 :
                 fun norm ->
                   let rng = FStar_Ident.range_of_lid fv_lid in
                   let f_wrapped args =
-                    let uu____6019 = FStar_List.splitAt n_tvars args in
-                    match uu____6019 with
+                    let uu___ = FStar_List.splitAt n_tvars args in
+                    match uu___ with
                     | (_tvar_args, rest_args) ->
-                        let uu____6082 = FStar_List.hd rest_args in
-                        (match uu____6082 with
-                         | (x, uu____6098) ->
-                             let uu____6103 =
-                               let uu____6110 = FStar_List.tl rest_args in
-                               FStar_List.hd uu____6110 in
-                             (match uu____6103 with
-                              | (y, uu____6134) ->
-                                  let uu____6139 =
-                                    let uu____6146 =
-                                      let uu____6155 =
-                                        FStar_List.tl rest_args in
-                                      FStar_List.tl uu____6155 in
-                                    FStar_List.hd uu____6146 in
-                                  (match uu____6139 with
-                                   | (z, uu____6185) ->
+                        let uu___1 = FStar_List.hd rest_args in
+                        (match uu___1 with
+                         | (x, uu___2) ->
+                             let uu___3 =
+                               let uu___4 = FStar_List.tl rest_args in
+                               FStar_List.hd uu___4 in
+                             (match uu___3 with
+                              | (y, uu___4) ->
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 = FStar_List.tl rest_args in
+                                      FStar_List.tl uu___7 in
+                                    FStar_List.hd uu___6 in
+                                  (match uu___5 with
+                                   | (z, uu___6) ->
                                        let shadow_app =
-                                         let uu____6195 =
+                                         let uu___7 =
                                            FStar_Thunk.mk
-                                             (fun uu____6200 ->
-                                                let uu____6201 =
+                                             (fun uu___8 ->
+                                                let uu___9 =
                                                   norm
                                                     (FStar_Util.Inl fv_lid) in
                                                 FStar_Syntax_Syntax.mk_Tm_app
-                                                  uu____6201 args rng) in
-                                         FStar_Pervasives_Native.Some
-                                           uu____6195 in
-                                       let uu____6204 =
-                                         let uu____6207 =
-                                           let uu____6210 = unembed ea x in
-                                           uu____6210 true norm in
-                                         FStar_Util.bind_opt uu____6207
+                                                  uu___9 args rng) in
+                                         FStar_Pervasives_Native.Some uu___7 in
+                                       let uu___7 =
+                                         let uu___8 =
+                                           let uu___9 = unembed ea x in
+                                           uu___9 true norm in
+                                         FStar_Util.bind_opt uu___8
                                            (fun x1 ->
-                                              let uu____6220 =
-                                                let uu____6223 = unembed eb y in
-                                                uu____6223 true norm in
-                                              FStar_Util.bind_opt uu____6220
+                                              let uu___9 =
+                                                let uu___10 = unembed eb y in
+                                                uu___10 true norm in
+                                              FStar_Util.bind_opt uu___9
                                                 (fun y1 ->
-                                                   let uu____6233 =
-                                                     let uu____6236 =
+                                                   let uu___10 =
+                                                     let uu___11 =
                                                        unembed ec z in
-                                                     uu____6236 true norm in
+                                                     uu___11 true norm in
                                                    FStar_Util.bind_opt
-                                                     uu____6233
+                                                     uu___10
                                                      (fun z1 ->
-                                                        let uu____6246 =
-                                                          let uu____6247 =
-                                                            let uu____6254 =
+                                                        let uu___11 =
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               f x1 y1 z1 in
-                                                            embed ed
-                                                              uu____6254 in
-                                                          uu____6247 rng
+                                                            embed ed uu___13 in
+                                                          uu___12 rng
                                                             shadow_app norm in
                                                         FStar_Pervasives_Native.Some
-                                                          uu____6246))) in
-                                       (match uu____6204 with
+                                                          uu___11))) in
+                                       (match uu___7 with
                                         | FStar_Pervasives_Native.Some x1 ->
                                             FStar_Pervasives_Native.Some x1
                                         | FStar_Pervasives_Native.None ->
@@ -1681,9 +1619,9 @@ let arrow_as_prim_step_3 :
 let debug_wrap : 'a . Prims.string -> (unit -> 'a) -> 'a =
   fun s ->
     fun f ->
-      (let uu____6281 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-       if uu____6281 then FStar_Util.print1 "++++starting %s\n" s else ());
+      (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+       if uu___1 then FStar_Util.print1 "++++starting %s\n" s else ());
       (let res = f () in
-       (let uu____6291 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-        if uu____6291 then FStar_Util.print1 "------ending %s\n" s else ());
+       (let uu___2 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+        if uu___2 then FStar_Util.print1 "------ending %s\n" s else ());
        res)

--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -3,81 +3,81 @@ type free_vars_and_fvars =
   (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set)
 let (no_free_vars :
   (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set)) =
-  let uu____12 = FStar_Syntax_Syntax.new_fv_set () in
+  let uu___ = FStar_Syntax_Syntax.new_fv_set () in
   ({
      FStar_Syntax_Syntax.free_names = [];
      FStar_Syntax_Syntax.free_uvars = [];
      FStar_Syntax_Syntax.free_univs = [];
      FStar_Syntax_Syntax.free_univ_names = []
-   }, uu____12)
+   }, uu___)
 let (singleton_fvar :
   FStar_Syntax_Syntax.fv ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set))
   =
   fun fv ->
-    let uu____28 =
-      let uu____31 = FStar_Syntax_Syntax.new_fv_set () in
+    let uu___ =
+      let uu___1 = FStar_Syntax_Syntax.new_fv_set () in
       FStar_Util.set_add
-        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v uu____31 in
-    ((FStar_Pervasives_Native.fst no_free_vars), uu____28)
+        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v uu___1 in
+    ((FStar_Pervasives_Native.fst no_free_vars), uu___)
 let (singleton_bv :
   FStar_Syntax_Syntax.bv ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set))
   =
   fun x ->
-    ((let uu___2_52 = FStar_Pervasives_Native.fst no_free_vars in
+    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names = [x];
         FStar_Syntax_Syntax.free_uvars =
-          (uu___2_52.FStar_Syntax_Syntax.free_uvars);
+          (uu___.FStar_Syntax_Syntax.free_uvars);
         FStar_Syntax_Syntax.free_univs =
-          (uu___2_52.FStar_Syntax_Syntax.free_univs);
+          (uu___.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___2_52.FStar_Syntax_Syntax.free_univ_names)
+          (uu___.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_uv :
   FStar_Syntax_Syntax.ctx_uvar ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set))
   =
   fun x ->
-    ((let uu___5_71 = FStar_Pervasives_Native.fst no_free_vars in
+    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___5_71.FStar_Syntax_Syntax.free_names);
+          (uu___.FStar_Syntax_Syntax.free_names);
         FStar_Syntax_Syntax.free_uvars = [x];
         FStar_Syntax_Syntax.free_univs =
-          (uu___5_71.FStar_Syntax_Syntax.free_univs);
+          (uu___.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___5_71.FStar_Syntax_Syntax.free_univ_names)
+          (uu___.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_univ :
   FStar_Syntax_Syntax.universe_uvar ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set))
   =
   fun x ->
-    ((let uu___8_90 = FStar_Pervasives_Native.fst no_free_vars in
+    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___8_90.FStar_Syntax_Syntax.free_names);
+          (uu___.FStar_Syntax_Syntax.free_names);
         FStar_Syntax_Syntax.free_uvars =
-          (uu___8_90.FStar_Syntax_Syntax.free_uvars);
+          (uu___.FStar_Syntax_Syntax.free_uvars);
         FStar_Syntax_Syntax.free_univs = [x];
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___8_90.FStar_Syntax_Syntax.free_univ_names)
+          (uu___.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_univ_name :
   FStar_Syntax_Syntax.univ_name ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident FStar_Util.set))
   =
   fun x ->
-    ((let uu___11_109 = FStar_Pervasives_Native.fst no_free_vars in
+    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___11_109.FStar_Syntax_Syntax.free_names);
+          (uu___.FStar_Syntax_Syntax.free_names);
         FStar_Syntax_Syntax.free_uvars =
-          (uu___11_109.FStar_Syntax_Syntax.free_uvars);
+          (uu___.FStar_Syntax_Syntax.free_uvars);
         FStar_Syntax_Syntax.free_univs =
-          (uu___11_109.FStar_Syntax_Syntax.free_univs);
+          (uu___.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names = [x]
       }), (FStar_Pervasives_Native.snd no_free_vars))
 let (union :
@@ -87,7 +87,7 @@ let (union :
   =
   fun f1 ->
     fun f2 ->
-      let uu____130 =
+      let uu___ =
         FStar_Util.set_union (FStar_Pervasives_Native.snd f1)
           (FStar_Pervasives_Native.snd f2) in
       ({
@@ -107,20 +107,19 @@ let (union :
            (FStar_List.append
               (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univ_names
               (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univ_names)
-       }, uu____130)
+       }, uu___)
 let rec (free_univs : FStar_Syntax_Syntax.universe -> free_vars_and_fvars) =
   fun u ->
-    let uu____160 = FStar_Syntax_Subst.compress_univ u in
-    match uu____160 with
+    let uu___ = FStar_Syntax_Subst.compress_univ u in
+    match uu___ with
     | FStar_Syntax_Syntax.U_zero -> no_free_vars
-    | FStar_Syntax_Syntax.U_bvar uu____161 -> no_free_vars
+    | FStar_Syntax_Syntax.U_bvar uu___1 -> no_free_vars
     | FStar_Syntax_Syntax.U_unknown -> no_free_vars
     | FStar_Syntax_Syntax.U_name uname -> singleton_univ_name uname
     | FStar_Syntax_Syntax.U_succ u1 -> free_univs u1
     | FStar_Syntax_Syntax.U_max us ->
         FStar_List.fold_left
-          (fun out ->
-             fun x -> let uu____172 = free_univs x in union out uu____172)
+          (fun out -> fun x -> let uu___1 = free_univs x in union out uu___1)
           no_free_vars us
     | FStar_Syntax_Syntax.U_unif u1 -> singleton_univ u1
 let rec (free_names_and_uvs' :
@@ -132,50 +131,49 @@ let rec (free_names_and_uvs' :
           FStar_All.pipe_right bs
             (FStar_List.fold_left
                (fun n ->
-                  fun uu____294 ->
-                    match uu____294 with
-                    | (x, uu____302) ->
-                        let uu____307 =
+                  fun uu___ ->
+                    match uu___ with
+                    | (x, uu___1) ->
+                        let uu___2 =
                           free_names_and_uvars x.FStar_Syntax_Syntax.sort
                             use_cache in
-                        union n uu____307) no_free_vars) in
+                        union n uu___2) no_free_vars) in
         union from_binders from_body in
       let t = FStar_Syntax_Subst.compress tm in
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____309 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x -> singleton_bv x
-      | FStar_Syntax_Syntax.Tm_uvar (uv, uu____326) -> singleton_uv uv
+      | FStar_Syntax_Syntax.Tm_uvar (uv, uu___) -> singleton_uv uv
       | FStar_Syntax_Syntax.Tm_type u -> free_univs u
-      | FStar_Syntax_Syntax.Tm_bvar uu____344 -> no_free_vars
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> no_free_vars
       | FStar_Syntax_Syntax.Tm_fvar fv -> singleton_fvar fv
-      | FStar_Syntax_Syntax.Tm_constant uu____346 -> no_free_vars
-      | FStar_Syntax_Syntax.Tm_lazy uu____347 -> no_free_vars
+      | FStar_Syntax_Syntax.Tm_constant uu___ -> no_free_vars
+      | FStar_Syntax_Syntax.Tm_lazy uu___ -> no_free_vars
       | FStar_Syntax_Syntax.Tm_unknown -> no_free_vars
       | FStar_Syntax_Syntax.Tm_uinst (t1, us) ->
           let f = free_names_and_uvars t1 use_cache in
           FStar_List.fold_left
-            (fun out ->
-               fun u -> let uu____360 = free_univs u in union out uu____360)
+            (fun out -> fun u -> let uu___ = free_univs u in union out uu___)
             f us
-      | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu____363) ->
-          let uu____388 = free_names_and_uvars t1 use_cache in
-          aux_binders bs uu____388
+      | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu___) ->
+          let uu___1 = free_names_and_uvars t1 use_cache in
+          aux_binders bs uu___1
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____411 = free_names_and_uvars_comp c use_cache in
-          aux_binders bs uu____411
+          let uu___ = free_names_and_uvars_comp c use_cache in
+          aux_binders bs uu___
       | FStar_Syntax_Syntax.Tm_refine (bv, t1) ->
-          let uu____418 = free_names_and_uvars t1 use_cache in
-          aux_binders [(bv, FStar_Pervasives_Native.None)] uu____418
+          let uu___ = free_names_and_uvars t1 use_cache in
+          aux_binders [(bv, FStar_Pervasives_Native.None)] uu___
       | FStar_Syntax_Syntax.Tm_app (t1, args) ->
-          let uu____459 = free_names_and_uvars t1 use_cache in
-          free_names_and_uvars_args args uu____459 use_cache
+          let uu___ = free_names_and_uvars t1 use_cache in
+          free_names_and_uvars_args args uu___ use_cache
       | FStar_Syntax_Syntax.Tm_match (t1, pats) ->
-          let uu____504 =
-            let uu____523 = free_names_and_uvars t1 use_cache in
+          let uu___ =
+            let uu___1 = free_names_and_uvars t1 use_cache in
             FStar_List.fold_left
               (fun n ->
-                 fun uu____546 ->
-                   match uu____546 with
+                 fun uu___2 ->
+                   match uu___2 with
                    | (p, wopt, t2) ->
                        let n1 =
                          match wopt with
@@ -184,19 +182,18 @@ let rec (free_names_and_uvs' :
                              free_names_and_uvars w use_cache in
                        let n2 = free_names_and_uvars t2 use_cache in
                        let n3 =
-                         let uu____584 = FStar_Syntax_Syntax.pat_bvs p in
-                         FStar_All.pipe_right uu____584
+                         let uu___3 = FStar_Syntax_Syntax.pat_bvs p in
+                         FStar_All.pipe_right uu___3
                            (FStar_List.fold_left
-                              (fun n3 ->
+                              (fun n4 ->
                                  fun x ->
-                                   let uu____594 =
+                                   let uu___4 =
                                      free_names_and_uvars
                                        x.FStar_Syntax_Syntax.sort use_cache in
-                                   union n3 uu____594) n) in
-                       let uu____595 = union n1 n2 in union n3 uu____595)
-              uu____523 in
-          FStar_All.pipe_right pats uu____504
-      | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____612) ->
+                                   union n4 uu___4) n) in
+                       let uu___3 = union n1 n2 in union n3 uu___3) uu___1 in
+          FStar_All.pipe_right pats uu___
+      | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu___) ->
           let u1 = free_names_and_uvars t1 use_cache in
           let u2 =
             match FStar_Pervasives_Native.fst asc with
@@ -205,25 +202,25 @@ let rec (free_names_and_uvs' :
           (match FStar_Pervasives_Native.snd asc with
            | FStar_Pervasives_Native.None -> union u1 u2
            | FStar_Pervasives_Native.Some tac ->
-               let uu____700 = union u1 u2 in
-               let uu____701 = free_names_and_uvars tac use_cache in
-               union uu____700 uu____701)
+               let uu___1 = union u1 u2 in
+               let uu___2 = free_names_and_uvars tac use_cache in
+               union uu___1 uu___2)
       | FStar_Syntax_Syntax.Tm_let (lbs, t1) ->
-          let uu____720 =
-            let uu____727 = free_names_and_uvars t1 use_cache in
+          let uu___ =
+            let uu___1 = free_names_and_uvars t1 use_cache in
             FStar_List.fold_left
               (fun n ->
                  fun lb ->
-                   let uu____733 =
-                     let uu____734 =
+                   let uu___2 =
+                     let uu___3 =
                        free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp
                          use_cache in
-                     let uu____735 =
+                     let uu___4 =
                        free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef
                          use_cache in
-                     union uu____734 uu____735 in
-                   union n uu____733) uu____727 in
-          FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs) uu____720
+                     union uu___3 uu___4 in
+                   union n uu___2) uu___1 in
+          FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs) uu___
       | FStar_Syntax_Syntax.Tm_quoted (tm1, qi) ->
           (match qi.FStar_Syntax_Syntax.qkind with
            | FStar_Syntax_Syntax.Quote_static -> no_free_vars
@@ -232,21 +229,20 @@ let rec (free_names_and_uvs' :
       | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
           let u1 = free_names_and_uvars t1 use_cache in
           (match m with
-           | FStar_Syntax_Syntax.Meta_pattern (uu____753, args) ->
+           | FStar_Syntax_Syntax.Meta_pattern (uu___, args) ->
                FStar_List.fold_right
                  (fun a ->
                     fun acc -> free_names_and_uvars_args a acc use_cache)
                  args u1
-           | FStar_Syntax_Syntax.Meta_monadic (uu____823, t') ->
-               let uu____829 = free_names_and_uvars t' use_cache in
-               union u1 uu____829
-           | FStar_Syntax_Syntax.Meta_monadic_lift (uu____830, uu____831, t')
-               ->
-               let uu____837 = free_names_and_uvars t' use_cache in
-               union u1 uu____837
-           | FStar_Syntax_Syntax.Meta_labeled uu____838 -> u1
-           | FStar_Syntax_Syntax.Meta_desugared uu____845 -> u1
-           | FStar_Syntax_Syntax.Meta_named uu____846 -> u1)
+           | FStar_Syntax_Syntax.Meta_monadic (uu___, t') ->
+               let uu___1 = free_names_and_uvars t' use_cache in
+               union u1 uu___1
+           | FStar_Syntax_Syntax.Meta_monadic_lift (uu___, uu___1, t') ->
+               let uu___2 = free_names_and_uvars t' use_cache in
+               union u1 uu___2
+           | FStar_Syntax_Syntax.Meta_labeled uu___ -> u1
+           | FStar_Syntax_Syntax.Meta_desugared uu___ -> u1
+           | FStar_Syntax_Syntax.Meta_named uu___ -> u1)
 and (free_names_and_uvars :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     Prims.bool -> free_vars_and_fvars)
@@ -254,13 +250,13 @@ and (free_names_and_uvars :
   fun t ->
     fun use_cache ->
       let t1 = FStar_Syntax_Subst.compress t in
-      let uu____852 = FStar_ST.op_Bang t1.FStar_Syntax_Syntax.vars in
-      match uu____852 with
+      let uu___ = FStar_ST.op_Bang t1.FStar_Syntax_Syntax.vars in
+      match uu___ with
       | FStar_Pervasives_Native.Some n when
-          let uu____866 = should_invalidate_cache n use_cache in
-          Prims.op_Negation uu____866 ->
-          let uu____867 = FStar_Syntax_Syntax.new_fv_set () in (n, uu____867)
-      | uu____872 ->
+          let uu___1 = should_invalidate_cache n use_cache in
+          Prims.op_Negation uu___1 ->
+          let uu___1 = FStar_Syntax_Syntax.new_fv_set () in (n, uu___1)
+      | uu___1 ->
           (FStar_ST.op_Colon_Equals t1.FStar_Syntax_Syntax.vars
              FStar_Pervasives_Native.None;
            (let n = free_names_and_uvs' t1 use_cache in
@@ -281,30 +277,29 @@ and (free_names_and_uvars_args :
         FStar_All.pipe_right args
           (FStar_List.fold_left
              (fun n ->
-                fun uu____949 ->
-                  match uu____949 with
-                  | (x, uu____959) ->
-                      let uu____968 = free_names_and_uvars x use_cache in
-                      union n uu____968) acc)
+                fun uu___ ->
+                  match uu___ with
+                  | (x, uu___1) ->
+                      let uu___2 = free_names_and_uvars x use_cache in
+                      union n uu___2) acc)
 and (free_names_and_uvars_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     Prims.bool -> free_vars_and_fvars)
   =
   fun c ->
     fun use_cache ->
-      let uu____973 = FStar_ST.op_Bang c.FStar_Syntax_Syntax.vars in
-      match uu____973 with
+      let uu___ = FStar_ST.op_Bang c.FStar_Syntax_Syntax.vars in
+      match uu___ with
       | FStar_Pervasives_Native.Some n ->
-          let uu____987 = should_invalidate_cache n use_cache in
-          if uu____987
+          let uu___1 = should_invalidate_cache n use_cache in
+          if uu___1
           then
             (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
                FStar_Pervasives_Native.None;
              free_names_and_uvars_comp c use_cache)
           else
-            (let uu____1000 = FStar_Syntax_Syntax.new_fv_set () in
-             (n, uu____1000))
-      | uu____1005 ->
+            (let uu___3 = FStar_Syntax_Syntax.new_fv_set () in (n, uu___3))
+      | uu___1 ->
           let n =
             match c.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.GTotal (t, FStar_Pervasives_Native.None) ->
@@ -313,25 +308,24 @@ and (free_names_and_uvars_comp :
                 free_names_and_uvars t use_cache
             | FStar_Syntax_Syntax.GTotal (t, FStar_Pervasives_Native.Some u)
                 ->
-                let uu____1043 = free_univs u in
-                let uu____1044 = free_names_and_uvars t use_cache in
-                union uu____1043 uu____1044
+                let uu___2 = free_univs u in
+                let uu___3 = free_names_and_uvars t use_cache in
+                union uu___2 uu___3
             | FStar_Syntax_Syntax.Total (t, FStar_Pervasives_Native.Some u)
                 ->
-                let uu____1053 = free_univs u in
-                let uu____1054 = free_names_and_uvars t use_cache in
-                union uu____1053 uu____1054
+                let uu___2 = free_univs u in
+                let uu___3 = free_names_and_uvars t use_cache in
+                union uu___2 uu___3
             | FStar_Syntax_Syntax.Comp ct ->
                 let us =
-                  let uu____1063 =
+                  let uu___2 =
                     free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ
                       use_cache in
                   free_names_and_uvars_args
-                    ct.FStar_Syntax_Syntax.effect_args uu____1063 use_cache in
+                    ct.FStar_Syntax_Syntax.effect_args uu___2 use_cache in
                 FStar_List.fold_left
                   (fun us1 ->
-                     fun u ->
-                       let uu____1075 = free_univs u in union us1 uu____1075)
+                     fun u -> let uu___2 = free_univs u in union us1 uu___2)
                   us ct.FStar_Syntax_Syntax.comp_univs in
           (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
              (FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst n));
@@ -344,19 +338,19 @@ and (should_invalidate_cache :
         ((FStar_All.pipe_right n.FStar_Syntax_Syntax.free_uvars
             (FStar_Util.for_some
                (fun u ->
-                  let uu____1097 =
+                  let uu___ =
                     FStar_Syntax_Unionfind.find
                       u.FStar_Syntax_Syntax.ctx_uvar_head in
-                  match uu____1097 with
-                  | FStar_Pervasives_Native.Some uu____1100 -> true
-                  | uu____1101 -> false)))
+                  match uu___ with
+                  | FStar_Pervasives_Native.Some uu___1 -> true
+                  | uu___1 -> false)))
            ||
            (FStar_All.pipe_right n.FStar_Syntax_Syntax.free_univs
               (FStar_Util.for_some
                  (fun u ->
-                    let uu____1110 = FStar_Syntax_Unionfind.univ_find u in
-                    match uu____1110 with
-                    | FStar_Pervasives_Native.Some uu____1113 -> true
+                    let uu___ = FStar_Syntax_Unionfind.univ_find u in
+                    match uu___ with
+                    | FStar_Pervasives_Native.Some uu___1 -> true
                     | FStar_Pervasives_Native.None -> false))))
 let (free_names_and_uvars_binders :
   FStar_Syntax_Syntax.binders ->
@@ -368,105 +362,104 @@ let (free_names_and_uvars_binders :
         FStar_All.pipe_right bs
           (FStar_List.fold_left
              (fun n ->
-                fun uu____1149 ->
-                  match uu____1149 with
-                  | (x, uu____1157) ->
-                      let uu____1162 =
+                fun uu___ ->
+                  match uu___ with
+                  | (x, uu___1) ->
+                      let uu___2 =
                         free_names_and_uvars x.FStar_Syntax_Syntax.sort
                           use_cache in
-                      union n uu____1162) acc)
+                      union n uu___2) acc)
 let (compare_uv :
   FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.ctx_uvar -> Prims.int)
   =
   fun uv1 ->
     fun uv2 ->
-      let uu____1173 =
+      let uu___ =
         FStar_Syntax_Unionfind.uvar_id uv1.FStar_Syntax_Syntax.ctx_uvar_head in
-      let uu____1174 =
+      let uu___1 =
         FStar_Syntax_Unionfind.uvar_id uv2.FStar_Syntax_Syntax.ctx_uvar_head in
-      uu____1173 - uu____1174
+      uu___ - uu___1
 let (new_uv_set : unit -> FStar_Syntax_Syntax.uvars) =
-  fun uu____1179 -> FStar_Util.new_set compare_uv
+  fun uu___ -> FStar_Util.new_set compare_uv
 let (compare_universe_uvar :
   FStar_Syntax_Syntax.universe_uvar ->
     FStar_Syntax_Syntax.universe_uvar -> Prims.int)
   =
   fun x ->
     fun y ->
-      let uu____1190 = FStar_Syntax_Unionfind.univ_uvar_id x in
-      let uu____1191 = FStar_Syntax_Unionfind.univ_uvar_id y in
-      uu____1190 - uu____1191
+      let uu___ = FStar_Syntax_Unionfind.univ_uvar_id x in
+      let uu___1 = FStar_Syntax_Unionfind.univ_uvar_id y in uu___ - uu___1
 let (new_universe_uvar_set :
   unit -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
-  fun uu____1198 -> FStar_Util.new_set compare_universe_uvar
+  fun uu___ -> FStar_Util.new_set compare_universe_uvar
 let (empty : FStar_Syntax_Syntax.bv FStar_Util.set) =
   FStar_Util.new_set FStar_Syntax_Syntax.order_bv
 let (names :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun t ->
-    let uu____1210 =
-      let uu____1213 =
-        let uu____1214 = free_names_and_uvars t true in
-        FStar_Pervasives_Native.fst uu____1214 in
-      uu____1213.FStar_Syntax_Syntax.free_names in
-    FStar_Util.as_set uu____1210 FStar_Syntax_Syntax.order_bv
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_names in
+    FStar_Util.as_set uu___ FStar_Syntax_Syntax.order_bv
 let (uvars :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar FStar_Util.set) =
   fun t ->
-    let uu____1230 =
-      let uu____1233 =
-        let uu____1234 = free_names_and_uvars t true in
-        FStar_Pervasives_Native.fst uu____1234 in
-      uu____1233.FStar_Syntax_Syntax.free_uvars in
-    FStar_Util.as_set uu____1230 compare_uv
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_uvars in
+    FStar_Util.as_set uu___ compare_uv
 let (univs :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.universe_uvar FStar_Util.set)
   =
   fun t ->
-    let uu____1250 =
-      let uu____1253 =
-        let uu____1254 = free_names_and_uvars t true in
-        FStar_Pervasives_Native.fst uu____1254 in
-      uu____1253.FStar_Syntax_Syntax.free_univs in
-    FStar_Util.as_set uu____1250 compare_universe_uvar
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_univs in
+    FStar_Util.as_set uu___ compare_universe_uvar
 let (univnames :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
   fun t ->
-    let uu____1270 =
-      let uu____1273 =
-        let uu____1274 = free_names_and_uvars t true in
-        FStar_Pervasives_Native.fst uu____1274 in
-      uu____1273.FStar_Syntax_Syntax.free_univ_names in
-    FStar_Util.as_set uu____1270 FStar_Syntax_Syntax.order_univ_name
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_univ_names in
+    FStar_Util.as_set uu___ FStar_Syntax_Syntax.order_univ_name
 let (univnames_comp :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
   fun c ->
-    let uu____1290 =
-      let uu____1293 =
-        let uu____1294 = free_names_and_uvars_comp c true in
-        FStar_Pervasives_Native.fst uu____1294 in
-      uu____1293.FStar_Syntax_Syntax.free_univ_names in
-    FStar_Util.as_set uu____1290 FStar_Syntax_Syntax.order_univ_name
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars_comp c true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_univ_names in
+    FStar_Util.as_set uu___ FStar_Syntax_Syntax.order_univ_name
 let (fvars : FStar_Syntax_Syntax.term -> FStar_Ident.lident FStar_Util.set) =
   fun t ->
-    let uu____1310 = free_names_and_uvars t false in
-    FStar_Pervasives_Native.snd uu____1310
+    let uu___ = free_names_and_uvars t false in
+    FStar_Pervasives_Native.snd uu___
 let (names_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun bs ->
-    let uu____1326 =
-      let uu____1329 =
-        let uu____1330 = free_names_and_uvars_binders bs no_free_vars true in
-        FStar_Pervasives_Native.fst uu____1330 in
-      uu____1329.FStar_Syntax_Syntax.free_names in
-    FStar_Util.as_set uu____1326 FStar_Syntax_Syntax.order_bv
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars_binders bs no_free_vars true in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_names in
+    FStar_Util.as_set uu___ FStar_Syntax_Syntax.order_bv
 let (uvars_uncached :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar FStar_Util.set) =
   fun t ->
-    let uu____1346 =
-      let uu____1349 =
-        let uu____1350 = free_names_and_uvars t false in
-        FStar_Pervasives_Native.fst uu____1350 in
-      uu____1349.FStar_Syntax_Syntax.free_uvars in
-    FStar_Util.as_set uu____1346 compare_uv
+    let uu___ =
+      let uu___1 =
+        let uu___2 = free_names_and_uvars t false in
+        FStar_Pervasives_Native.fst uu___2 in
+      uu___1.FStar_Syntax_Syntax.free_uvars in
+    FStar_Util.as_set uu___ compare_uv

--- a/src/ocaml-output/FStar_Syntax_InstFV.ml
+++ b/src/ocaml-output/FStar_Syntax_InstFV.ml
@@ -1,9 +1,9 @@
 open Prims
 type inst_t = (FStar_Ident.lident * FStar_Syntax_Syntax.universes) Prims.list
 let mk :
-  'uuuuuu14 'uuuuuu15 .
-    'uuuuuu14 FStar_Syntax_Syntax.syntax ->
-      'uuuuuu15 -> 'uuuuuu15 FStar_Syntax_Syntax.syntax
+  'uuuuu 'uuuuu1 .
+    'uuuuu FStar_Syntax_Syntax.syntax ->
+      'uuuuu1 -> 'uuuuu1 FStar_Syntax_Syntax.syntax
   = fun t -> fun s -> FStar_Syntax_Syntax.mk s t.FStar_Syntax_Syntax.pos
 let rec (inst :
   (FStar_Syntax_Syntax.term ->
@@ -15,147 +15,142 @@ let rec (inst :
       let t1 = FStar_Syntax_Subst.compress t in
       let mk1 = mk t1 in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____144 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_name uu____159 -> t1
-      | FStar_Syntax_Syntax.Tm_uvar uu____160 -> t1
-      | FStar_Syntax_Syntax.Tm_uvar uu____173 -> t1
-      | FStar_Syntax_Syntax.Tm_type uu____186 -> t1
-      | FStar_Syntax_Syntax.Tm_bvar uu____187 -> t1
-      | FStar_Syntax_Syntax.Tm_constant uu____188 -> t1
-      | FStar_Syntax_Syntax.Tm_quoted uu____189 -> t1
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_name uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_uvar uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_uvar uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_type uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_constant uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_quoted uu___ -> t1
       | FStar_Syntax_Syntax.Tm_unknown -> t1
-      | FStar_Syntax_Syntax.Tm_uinst uu____196 -> t1
-      | FStar_Syntax_Syntax.Tm_lazy uu____203 -> t1
+      | FStar_Syntax_Syntax.Tm_uinst uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_lazy uu___ -> t1
       | FStar_Syntax_Syntax.Tm_fvar fv -> s t1 fv
       | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
           let bs1 = inst_binders s bs in
           let body1 = inst s body in
-          let uu____234 =
-            let uu____235 =
-              let uu____254 = inst_lcomp_opt s lopt in
-              (bs1, body1, uu____254) in
-            FStar_Syntax_Syntax.Tm_abs uu____235 in
-          mk1 uu____234
+          let uu___ =
+            let uu___1 =
+              let uu___2 = inst_lcomp_opt s lopt in (bs1, body1, uu___2) in
+            FStar_Syntax_Syntax.Tm_abs uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
           let bs1 = inst_binders s bs in
           let c1 = inst_comp s c in
           mk1 (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
       | FStar_Syntax_Syntax.Tm_refine (bv, t2) ->
           let bv1 =
-            let uu___47_312 = bv in
-            let uu____313 = inst s bv.FStar_Syntax_Syntax.sort in
+            let uu___ = bv in
+            let uu___1 = inst s bv.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___47_312.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___47_312.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____313
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let t3 = inst s t2 in mk1 (FStar_Syntax_Syntax.Tm_refine (bv1, t3))
       | FStar_Syntax_Syntax.Tm_app (t2, args) ->
-          let uu____345 =
-            let uu____346 =
-              let uu____363 = inst s t2 in
-              let uu____366 = inst_args s args in (uu____363, uu____366) in
-            FStar_Syntax_Syntax.Tm_app uu____346 in
-          mk1 uu____345
+          let uu___ =
+            let uu___1 =
+              let uu___2 = inst s t2 in
+              let uu___3 = inst_args s args in (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_app uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_match (t2, pats) ->
           let pats1 =
             FStar_All.pipe_right pats
               (FStar_List.map
-                 (fun uu____498 ->
-                    match uu____498 with
+                 (fun uu___ ->
+                    match uu___ with
                     | (p, wopt, t3) ->
                         let wopt1 =
                           match wopt with
                           | FStar_Pervasives_Native.None ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some w ->
-                              let uu____536 = inst s w in
-                              FStar_Pervasives_Native.Some uu____536 in
+                              let uu___1 = inst s w in
+                              FStar_Pervasives_Native.Some uu___1 in
                         let t4 = inst s t3 in (p, wopt1, t4))) in
-          let uu____542 =
-            let uu____543 = let uu____566 = inst s t2 in (uu____566, pats1) in
-            FStar_Syntax_Syntax.Tm_match uu____543 in
-          mk1 uu____542
+          let uu___ =
+            let uu___1 = let uu___2 = inst s t2 in (uu___2, pats1) in
+            FStar_Syntax_Syntax.Tm_match uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_ascribed (t11, asc, f) ->
-          let inst_asc uu____659 =
-            match uu____659 with
+          let inst_asc uu___ =
+            match uu___ with
             | (annot, topt) ->
                 let topt1 = FStar_Util.map_opt topt (inst s) in
                 let annot1 =
                   match annot with
                   | FStar_Util.Inl t2 ->
-                      let uu____721 = inst s t2 in FStar_Util.Inl uu____721
+                      let uu___1 = inst s t2 in FStar_Util.Inl uu___1
                   | FStar_Util.Inr c ->
-                      let uu____729 = inst_comp s c in
-                      FStar_Util.Inr uu____729 in
+                      let uu___1 = inst_comp s c in FStar_Util.Inr uu___1 in
                 (annot1, topt1) in
-          let uu____742 =
-            let uu____743 =
-              let uu____770 = inst s t11 in
-              let uu____773 = inst_asc asc in (uu____770, uu____773, f) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____743 in
-          mk1 uu____742
+          let uu___ =
+            let uu___1 =
+              let uu___2 = inst s t11 in
+              let uu___3 = inst_asc asc in (uu___2, uu___3, f) in
+            FStar_Syntax_Syntax.Tm_ascribed uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_let (lbs, t2) ->
           let lbs1 =
-            let uu____835 =
+            let uu___ =
               FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                 (FStar_List.map
                    (fun lb ->
-                      let uu___89_849 = lb in
-                      let uu____850 = inst s lb.FStar_Syntax_Syntax.lbtyp in
-                      let uu____853 = inst s lb.FStar_Syntax_Syntax.lbdef in
+                      let uu___1 = lb in
+                      let uu___2 = inst s lb.FStar_Syntax_Syntax.lbtyp in
+                      let uu___3 = inst s lb.FStar_Syntax_Syntax.lbdef in
                       {
                         FStar_Syntax_Syntax.lbname =
-                          (uu___89_849.FStar_Syntax_Syntax.lbname);
+                          (uu___1.FStar_Syntax_Syntax.lbname);
                         FStar_Syntax_Syntax.lbunivs =
-                          (uu___89_849.FStar_Syntax_Syntax.lbunivs);
-                        FStar_Syntax_Syntax.lbtyp = uu____850;
+                          (uu___1.FStar_Syntax_Syntax.lbunivs);
+                        FStar_Syntax_Syntax.lbtyp = uu___2;
                         FStar_Syntax_Syntax.lbeff =
-                          (uu___89_849.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu____853;
+                          (uu___1.FStar_Syntax_Syntax.lbeff);
+                        FStar_Syntax_Syntax.lbdef = uu___3;
                         FStar_Syntax_Syntax.lbattrs =
-                          (uu___89_849.FStar_Syntax_Syntax.lbattrs);
+                          (uu___1.FStar_Syntax_Syntax.lbattrs);
                         FStar_Syntax_Syntax.lbpos =
-                          (uu___89_849.FStar_Syntax_Syntax.lbpos)
+                          (uu___1.FStar_Syntax_Syntax.lbpos)
                       })) in
-            ((FStar_Pervasives_Native.fst lbs), uu____835) in
-          let uu____860 =
-            let uu____861 = let uu____874 = inst s t2 in (lbs1, uu____874) in
-            FStar_Syntax_Syntax.Tm_let uu____861 in
-          mk1 uu____860
+            ((FStar_Pervasives_Native.fst lbs), uu___) in
+          let uu___ =
+            let uu___1 = let uu___2 = inst s t2 in (lbs1, uu___2) in
+            FStar_Syntax_Syntax.Tm_let uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_meta
           (t2, FStar_Syntax_Syntax.Meta_pattern (bvs, args)) ->
-          let uu____924 =
-            let uu____925 =
-              let uu____932 = inst s t2 in
-              let uu____935 =
-                let uu____936 =
-                  let uu____957 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = inst s t2 in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
                     FStar_All.pipe_right args (FStar_List.map (inst_args s)) in
-                  (bvs, uu____957) in
-                FStar_Syntax_Syntax.Meta_pattern uu____936 in
-              (uu____932, uu____935) in
-            FStar_Syntax_Syntax.Tm_meta uu____925 in
-          mk1 uu____924
+                  (bvs, uu___5) in
+                FStar_Syntax_Syntax.Meta_pattern uu___4 in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_meta
           (t2, FStar_Syntax_Syntax.Meta_monadic (m, t')) ->
-          let uu____1043 =
-            let uu____1044 =
-              let uu____1051 = inst s t2 in
-              let uu____1054 =
-                let uu____1055 =
-                  let uu____1062 = inst s t' in (m, uu____1062) in
-                FStar_Syntax_Syntax.Meta_monadic uu____1055 in
-              (uu____1051, uu____1054) in
-            FStar_Syntax_Syntax.Tm_meta uu____1044 in
-          mk1 uu____1043
+          let uu___ =
+            let uu___1 =
+              let uu___2 = inst s t2 in
+              let uu___3 =
+                let uu___4 = let uu___5 = inst s t' in (m, uu___5) in
+                FStar_Syntax_Syntax.Meta_monadic uu___4 in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk1 uu___
       | FStar_Syntax_Syntax.Tm_meta (t2, tag) ->
-          let uu____1075 =
-            let uu____1076 = let uu____1083 = inst s t2 in (uu____1083, tag) in
-            FStar_Syntax_Syntax.Tm_meta uu____1076 in
-          mk1 uu____1075
+          let uu___ =
+            let uu___1 = let uu___2 = inst s t2 in (uu___2, tag) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk1 uu___
 and (inst_binders :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
@@ -165,20 +160,20 @@ and (inst_binders :
     fun bs ->
       FStar_All.pipe_right bs
         (FStar_List.map
-           (fun uu____1118 ->
-              match uu____1118 with
+           (fun uu___ ->
+              match uu___ with
               | (x, imp) ->
-                  let uu____1137 =
-                    let uu___115_1138 = x in
-                    let uu____1139 = inst s x.FStar_Syntax_Syntax.sort in
+                  let uu___1 =
+                    let uu___2 = x in
+                    let uu___3 = inst s x.FStar_Syntax_Syntax.sort in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___115_1138.FStar_Syntax_Syntax.ppname);
+                        (uu___2.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___115_1138.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu____1139
+                        (uu___2.FStar_Syntax_Syntax.index);
+                      FStar_Syntax_Syntax.sort = uu___3
                     } in
-                  (uu____1137, imp)))
+                  (uu___1, imp)))
 and (inst_args :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
@@ -194,9 +189,9 @@ and (inst_args :
     fun args ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____1194 ->
-              match uu____1194 with
-              | (a, imp) -> let uu____1213 = inst s a in (uu____1213, imp)))
+           (fun uu___ ->
+              match uu___ with
+              | (a, imp) -> let uu___1 = inst s a in (uu___1, imp)))
 and (inst_comp :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
@@ -208,33 +203,31 @@ and (inst_comp :
     fun c ->
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Total (t, uopt) ->
-          let uu____1236 = inst s t in
-          FStar_Syntax_Syntax.mk_Total' uu____1236 uopt
+          let uu___ = inst s t in FStar_Syntax_Syntax.mk_Total' uu___ uopt
       | FStar_Syntax_Syntax.GTotal (t, uopt) ->
-          let uu____1247 = inst s t in
-          FStar_Syntax_Syntax.mk_GTotal' uu____1247 uopt
+          let uu___ = inst s t in FStar_Syntax_Syntax.mk_GTotal' uu___ uopt
       | FStar_Syntax_Syntax.Comp ct ->
           let ct1 =
-            let uu___134_1250 = ct in
-            let uu____1251 = inst s ct.FStar_Syntax_Syntax.result_typ in
-            let uu____1254 = inst_args s ct.FStar_Syntax_Syntax.effect_args in
-            let uu____1265 =
+            let uu___ = ct in
+            let uu___1 = inst s ct.FStar_Syntax_Syntax.result_typ in
+            let uu___2 = inst_args s ct.FStar_Syntax_Syntax.effect_args in
+            let uu___3 =
               FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                 (FStar_List.map
-                   (fun uu___0_1275 ->
-                      match uu___0_1275 with
+                   (fun uu___4 ->
+                      match uu___4 with
                       | FStar_Syntax_Syntax.DECREASES t ->
-                          let uu____1279 = inst s t in
-                          FStar_Syntax_Syntax.DECREASES uu____1279
+                          let uu___5 = inst s t in
+                          FStar_Syntax_Syntax.DECREASES uu___5
                       | f -> f)) in
             {
               FStar_Syntax_Syntax.comp_univs =
-                (uu___134_1250.FStar_Syntax_Syntax.comp_univs);
+                (uu___.FStar_Syntax_Syntax.comp_univs);
               FStar_Syntax_Syntax.effect_name =
-                (uu___134_1250.FStar_Syntax_Syntax.effect_name);
-              FStar_Syntax_Syntax.result_typ = uu____1251;
-              FStar_Syntax_Syntax.effect_args = uu____1254;
-              FStar_Syntax_Syntax.flags = uu____1265
+                (uu___.FStar_Syntax_Syntax.effect_name);
+              FStar_Syntax_Syntax.result_typ = uu___1;
+              FStar_Syntax_Syntax.effect_args = uu___2;
+              FStar_Syntax_Syntax.flags = uu___3
             } in
           FStar_Syntax_Syntax.mk_Comp ct1
 and (inst_lcomp_opt :
@@ -249,36 +242,36 @@ and (inst_lcomp_opt :
       match l with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
-          let uu____1294 =
-            let uu___146_1295 = rc in
-            let uu____1296 =
+          let uu___ =
+            let uu___1 = rc in
+            let uu___2 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ (inst s) in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___146_1295.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____1296;
+                (uu___1.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu___2;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___146_1295.FStar_Syntax_Syntax.residual_flags)
+                (uu___1.FStar_Syntax_Syntax.residual_flags)
             } in
-          FStar_Pervasives_Native.Some uu____1294
+          FStar_Pervasives_Native.Some uu___
 let (instantiate :
   inst_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun i ->
     fun t ->
       match i with
       | [] -> t
-      | uu____1319 ->
+      | uu___ ->
           let inst_fv t1 fv =
-            let uu____1331 =
+            let uu___1 =
               FStar_Util.find_opt
-                (fun uu____1345 ->
-                   match uu____1345 with
-                   | (x, uu____1351) ->
+                (fun uu___2 ->
+                   match uu___2 with
+                   | (x, uu___3) ->
                        FStar_Ident.lid_equals x
                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                 i in
-            match uu____1331 with
+            match uu___1 with
             | FStar_Pervasives_Native.None -> t1
-            | FStar_Pervasives_Native.Some (uu____1356, us) ->
+            | FStar_Pervasives_Native.Some (uu___2, us) ->
                 mk t1 (FStar_Syntax_Syntax.Tm_uinst (t1, us)) in
           inst inst_fv t

--- a/src/ocaml-output/FStar_Syntax_MutRecTy.ml
+++ b/src/ocaml-output/FStar_Syntax_MutRecTy.ml
@@ -22,20 +22,19 @@ let (disentangle_abbrevs_from_bundle :
                     | FStar_Syntax_Syntax.Sig_let
                         ((false,
                           {
-                            FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                              uu____68;
-                            FStar_Syntax_Syntax.lbunivs = uu____69;
-                            FStar_Syntax_Syntax.lbtyp = uu____70;
-                            FStar_Syntax_Syntax.lbeff = uu____71;
-                            FStar_Syntax_Syntax.lbdef = uu____72;
-                            FStar_Syntax_Syntax.lbattrs = uu____73;
-                            FStar_Syntax_Syntax.lbpos = uu____74;_}::[]),
-                         uu____75)
+                            FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu___;
+                            FStar_Syntax_Syntax.lbunivs = uu___1;
+                            FStar_Syntax_Syntax.lbtyp = uu___2;
+                            FStar_Syntax_Syntax.lbeff = uu___3;
+                            FStar_Syntax_Syntax.lbdef = uu___4;
+                            FStar_Syntax_Syntax.lbattrs = uu___5;
+                            FStar_Syntax_Syntax.lbpos = uu___6;_}::[]),
+                         uu___7)
                         -> [x]
-                    | FStar_Syntax_Syntax.Sig_let (uu____92, uu____93) ->
+                    | FStar_Syntax_Syntax.Sig_let (uu___, uu___1) ->
                         failwith
                           "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
-                    | uu____100 -> [])) in
+                    | uu___ -> [])) in
           match type_abbrev_sigelts with
           | [] ->
               ({
@@ -48,27 +47,27 @@ let (disentangle_abbrevs_from_bundle :
                  FStar_Syntax_Syntax.sigattrs = sigattrs;
                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }, [])
-          | uu____113 ->
+          | uu___ ->
               let type_abbrevs =
                 FStar_All.pipe_right type_abbrev_sigelts
                   (FStar_List.map
                      (fun x ->
                         match x.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_let
-                            ((uu____134,
+                            ((uu___1,
                               {
                                 FStar_Syntax_Syntax.lbname = FStar_Util.Inr
                                   fv;
-                                FStar_Syntax_Syntax.lbunivs = uu____136;
-                                FStar_Syntax_Syntax.lbtyp = uu____137;
-                                FStar_Syntax_Syntax.lbeff = uu____138;
-                                FStar_Syntax_Syntax.lbdef = uu____139;
-                                FStar_Syntax_Syntax.lbattrs = uu____140;
-                                FStar_Syntax_Syntax.lbpos = uu____141;_}::[]),
-                             uu____142)
+                                FStar_Syntax_Syntax.lbunivs = uu___2;
+                                FStar_Syntax_Syntax.lbtyp = uu___3;
+                                FStar_Syntax_Syntax.lbeff = uu___4;
+                                FStar_Syntax_Syntax.lbdef = uu___5;
+                                FStar_Syntax_Syntax.lbattrs = uu___6;
+                                FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
+                             uu___8)
                             ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____159 ->
+                        | uu___1 ->
                             failwith
                               "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")) in
               let unfolded_type_abbrevs =
@@ -76,129 +75,127 @@ let (disentangle_abbrevs_from_bundle :
                 let in_progress = FStar_Util.mk_ref [] in
                 let not_unfolded_yet = FStar_Util.mk_ref type_abbrev_sigelts in
                 let remove_not_unfolded lid =
-                  let uu____190 =
-                    let uu____193 = FStar_ST.op_Bang not_unfolded_yet in
-                    FStar_All.pipe_right uu____193
+                  let uu___1 =
+                    let uu___2 = FStar_ST.op_Bang not_unfolded_yet in
+                    FStar_All.pipe_right uu___2
                       (FStar_List.filter
                          (fun x ->
                             match x.FStar_Syntax_Syntax.sigel with
                             | FStar_Syntax_Syntax.Sig_let
-                                ((uu____222,
+                                ((uu___3,
                                   {
                                     FStar_Syntax_Syntax.lbname =
                                       FStar_Util.Inr fv;
-                                    FStar_Syntax_Syntax.lbunivs = uu____224;
-                                    FStar_Syntax_Syntax.lbtyp = uu____225;
-                                    FStar_Syntax_Syntax.lbeff = uu____226;
-                                    FStar_Syntax_Syntax.lbdef = uu____227;
-                                    FStar_Syntax_Syntax.lbattrs = uu____228;
-                                    FStar_Syntax_Syntax.lbpos = uu____229;_}::[]),
-                                 uu____230)
+                                    FStar_Syntax_Syntax.lbunivs = uu___4;
+                                    FStar_Syntax_Syntax.lbtyp = uu___5;
+                                    FStar_Syntax_Syntax.lbeff = uu___6;
+                                    FStar_Syntax_Syntax.lbdef = uu___7;
+                                    FStar_Syntax_Syntax.lbattrs = uu___8;
+                                    FStar_Syntax_Syntax.lbpos = uu___9;_}::[]),
+                                 uu___10)
                                 ->
-                                let uu____247 =
+                                let uu___11 =
                                   FStar_Ident.lid_equals lid
                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                Prims.op_Negation uu____247
-                            | uu____248 -> true)) in
-                  FStar_ST.op_Colon_Equals not_unfolded_yet uu____190 in
+                                Prims.op_Negation uu___11
+                            | uu___3 -> true)) in
+                  FStar_ST.op_Colon_Equals not_unfolded_yet uu___1 in
                 let rec unfold_abbrev_fv t fv =
                   let replacee x =
                     match x.FStar_Syntax_Syntax.sigel with
                     | FStar_Syntax_Syntax.Sig_let
-                        ((uu____285,
+                        ((uu___1,
                           { FStar_Syntax_Syntax.lbname = FStar_Util.Inr fv';
-                            FStar_Syntax_Syntax.lbunivs = uu____287;
-                            FStar_Syntax_Syntax.lbtyp = uu____288;
-                            FStar_Syntax_Syntax.lbeff = uu____289;
-                            FStar_Syntax_Syntax.lbdef = uu____290;
-                            FStar_Syntax_Syntax.lbattrs = uu____291;
-                            FStar_Syntax_Syntax.lbpos = uu____292;_}::[]),
-                         uu____293)
+                            FStar_Syntax_Syntax.lbunivs = uu___2;
+                            FStar_Syntax_Syntax.lbtyp = uu___3;
+                            FStar_Syntax_Syntax.lbeff = uu___4;
+                            FStar_Syntax_Syntax.lbdef = uu___5;
+                            FStar_Syntax_Syntax.lbattrs = uu___6;
+                            FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
+                         uu___8)
                         when
                         FStar_Ident.lid_equals
                           (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                         -> FStar_Pervasives_Native.Some x
-                    | uu____310 -> FStar_Pervasives_Native.None in
+                    | uu___1 -> FStar_Pervasives_Native.None in
                   let replacee_term x =
                     match replacee x with
                     | FStar_Pervasives_Native.Some
                         {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_let
-                            ((uu____325,
-                              { FStar_Syntax_Syntax.lbname = uu____326;
-                                FStar_Syntax_Syntax.lbunivs = uu____327;
-                                FStar_Syntax_Syntax.lbtyp = uu____328;
-                                FStar_Syntax_Syntax.lbeff = uu____329;
+                            ((uu___1,
+                              { FStar_Syntax_Syntax.lbname = uu___2;
+                                FStar_Syntax_Syntax.lbunivs = uu___3;
+                                FStar_Syntax_Syntax.lbtyp = uu___4;
+                                FStar_Syntax_Syntax.lbeff = uu___5;
                                 FStar_Syntax_Syntax.lbdef = tm;
-                                FStar_Syntax_Syntax.lbattrs = uu____331;
-                                FStar_Syntax_Syntax.lbpos = uu____332;_}::[]),
-                             uu____333);
-                          FStar_Syntax_Syntax.sigrng = uu____334;
-                          FStar_Syntax_Syntax.sigquals = uu____335;
-                          FStar_Syntax_Syntax.sigmeta = uu____336;
-                          FStar_Syntax_Syntax.sigattrs = uu____337;
-                          FStar_Syntax_Syntax.sigopts = uu____338;_}
+                                FStar_Syntax_Syntax.lbattrs = uu___6;
+                                FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
+                             uu___8);
+                          FStar_Syntax_Syntax.sigrng = uu___9;
+                          FStar_Syntax_Syntax.sigquals = uu___10;
+                          FStar_Syntax_Syntax.sigmeta = uu___11;
+                          FStar_Syntax_Syntax.sigattrs = uu___12;
+                          FStar_Syntax_Syntax.sigopts = uu___13;_}
                         -> FStar_Pervasives_Native.Some tm
-                    | uu____367 -> FStar_Pervasives_Native.None in
-                  let uu____372 =
-                    let uu____377 =
-                      FStar_ST.op_Bang rev_unfolded_type_abbrevs in
-                    FStar_Util.find_map uu____377 replacee_term in
-                  match uu____372 with
+                    | uu___1 -> FStar_Pervasives_Native.None in
+                  let uu___1 =
+                    let uu___2 = FStar_ST.op_Bang rev_unfolded_type_abbrevs in
+                    FStar_Util.find_map uu___2 replacee_term in
+                  match uu___1 with
                   | FStar_Pervasives_Native.Some x -> x
                   | FStar_Pervasives_Native.None ->
-                      let uu____399 =
+                      let uu___2 =
                         FStar_Util.find_map type_abbrev_sigelts replacee in
-                      (match uu____399 with
+                      (match uu___2 with
                        | FStar_Pervasives_Native.Some se ->
-                           let uu____403 =
-                             let uu____404 = FStar_ST.op_Bang in_progress in
+                           let uu___3 =
+                             let uu___4 = FStar_ST.op_Bang in_progress in
                              FStar_List.existsb
                                (fun x ->
                                   FStar_Ident.lid_equals x
                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                               uu____404 in
-                           if uu____403
+                               uu___4 in
+                           if uu___3
                            then
                              let msg =
-                               let uu____420 =
+                               let uu___4 =
                                  FStar_Ident.string_of_lid
                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                FStar_Util.format1
                                  "Cycle on %s in mutually recursive type abbreviations"
-                                 uu____420 in
-                             let uu____421 =
+                                 uu___4 in
+                             let uu___4 =
                                FStar_Ident.range_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_CycleInRecTypeAbbreviation,
-                                 msg) uu____421
+                                 msg) uu___4
                            else unfold_abbrev se
-                       | uu____423 -> t)
+                       | uu___3 -> t)
                 and unfold_abbrev x =
                   match x.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____428)
-                      ->
+                  | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___1) ->
                       let quals1 =
                         FStar_All.pipe_right x.FStar_Syntax_Syntax.sigquals
                           (FStar_List.filter
-                             (fun uu___0_443 ->
-                                match uu___0_443 with
+                             (fun uu___2 ->
+                                match uu___2 with
                                 | FStar_Syntax_Syntax.Noeq -> false
-                                | uu____444 -> true)) in
+                                | uu___3 -> true)) in
                       let lid =
                         match lb.FStar_Syntax_Syntax.lbname with
                         | FStar_Util.Inr fv ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu____447 ->
+                        | uu___2 ->
                             failwith
                               "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible" in
-                      ((let uu____453 =
-                          let uu____456 = FStar_ST.op_Bang in_progress in lid
-                            :: uu____456 in
-                        FStar_ST.op_Colon_Equals in_progress uu____453);
+                      ((let uu___3 =
+                          let uu___4 = FStar_ST.op_Bang in_progress in lid ::
+                            uu___4 in
+                        FStar_ST.op_Colon_Equals in_progress uu___3);
                        (match () with
                         | () ->
                             (remove_not_unfolded lid;
@@ -211,100 +208,99 @@ let (disentangle_abbrevs_from_bundle :
                                     FStar_Syntax_InstFV.inst unfold_abbrev_fv
                                       lb.FStar_Syntax_Syntax.lbdef in
                                   let lb' =
-                                    let uu___146_483 = lb in
+                                    let uu___4 = lb in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___146_483.FStar_Syntax_Syntax.lbname);
+                                        (uu___4.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___146_483.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___4.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp = ty';
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___146_483.FStar_Syntax_Syntax.lbeff);
+                                        (uu___4.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = tm';
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___146_483.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___4.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___146_483.FStar_Syntax_Syntax.lbpos)
+                                        (uu___4.FStar_Syntax_Syntax.lbpos)
                                     } in
                                   let sigelt' =
                                     FStar_Syntax_Syntax.Sig_let
                                       ((false, [lb']), [lid]) in
-                                  ((let uu____490 =
-                                      let uu____493 =
+                                  ((let uu___5 =
+                                      let uu___6 =
                                         FStar_ST.op_Bang
                                           rev_unfolded_type_abbrevs in
-                                      (let uu___150_507 = x in
+                                      (let uu___7 = x in
                                        {
                                          FStar_Syntax_Syntax.sigel = sigelt';
                                          FStar_Syntax_Syntax.sigrng =
-                                           (uu___150_507.FStar_Syntax_Syntax.sigrng);
+                                           (uu___7.FStar_Syntax_Syntax.sigrng);
                                          FStar_Syntax_Syntax.sigquals =
                                            quals1;
                                          FStar_Syntax_Syntax.sigmeta =
-                                           (uu___150_507.FStar_Syntax_Syntax.sigmeta);
+                                           (uu___7.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
-                                           (uu___150_507.FStar_Syntax_Syntax.sigattrs);
+                                           (uu___7.FStar_Syntax_Syntax.sigattrs);
                                          FStar_Syntax_Syntax.sigopts =
-                                           (uu___150_507.FStar_Syntax_Syntax.sigopts)
-                                       }) :: uu____493 in
+                                           (uu___7.FStar_Syntax_Syntax.sigopts)
+                                       }) :: uu___6 in
                                     FStar_ST.op_Colon_Equals
-                                      rev_unfolded_type_abbrevs uu____490);
+                                      rev_unfolded_type_abbrevs uu___5);
                                    (match () with
                                     | () ->
-                                        ((let uu____519 =
-                                            let uu____522 =
+                                        ((let uu___6 =
+                                            let uu___7 =
                                               FStar_ST.op_Bang in_progress in
-                                            FStar_List.tl uu____522 in
+                                            FStar_List.tl uu___7 in
                                           FStar_ST.op_Colon_Equals
-                                            in_progress uu____519);
+                                            in_progress uu___6);
                                          (match () with | () -> tm'))))))))
-                  | uu____545 ->
+                  | uu___1 ->
                       failwith
                         "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible" in
-                let rec aux uu____553 =
-                  let uu____554 = FStar_ST.op_Bang not_unfolded_yet in
-                  match uu____554 with
-                  | x::uu____570 -> let _unused = unfold_abbrev x in aux ()
-                  | uu____574 ->
-                      let uu____577 =
-                        FStar_ST.op_Bang rev_unfolded_type_abbrevs in
-                      FStar_List.rev uu____577 in
+                let rec aux uu___1 =
+                  let uu___2 = FStar_ST.op_Bang not_unfolded_yet in
+                  match uu___2 with
+                  | x::uu___3 -> let _unused = unfold_abbrev x in aux ()
+                  | uu___3 ->
+                      let uu___4 = FStar_ST.op_Bang rev_unfolded_type_abbrevs in
+                      FStar_List.rev uu___4 in
                 aux () in
               let filter_out_type_abbrevs l =
                 FStar_List.filter
                   (fun lid ->
                      FStar_List.for_all
                        (fun lid' ->
-                          let uu____607 = FStar_Ident.lid_equals lid lid' in
-                          Prims.op_Negation uu____607) type_abbrevs) l in
+                          let uu___1 = FStar_Ident.lid_equals lid lid' in
+                          Prims.op_Negation uu___1) type_abbrevs) l in
               let inductives_with_abbrevs_unfolded =
                 let find_in_unfolded fv =
                   FStar_Util.find_map unfolded_type_abbrevs
                     (fun x ->
                        match x.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_let
-                           ((uu____638,
+                           ((uu___1,
                              {
                                FStar_Syntax_Syntax.lbname = FStar_Util.Inr
                                  fv';
-                               FStar_Syntax_Syntax.lbunivs = uu____640;
-                               FStar_Syntax_Syntax.lbtyp = uu____641;
-                               FStar_Syntax_Syntax.lbeff = uu____642;
+                               FStar_Syntax_Syntax.lbunivs = uu___2;
+                               FStar_Syntax_Syntax.lbtyp = uu___3;
+                               FStar_Syntax_Syntax.lbeff = uu___4;
                                FStar_Syntax_Syntax.lbdef = tm;
-                               FStar_Syntax_Syntax.lbattrs = uu____644;
-                               FStar_Syntax_Syntax.lbpos = uu____645;_}::[]),
-                            uu____646)
+                               FStar_Syntax_Syntax.lbattrs = uu___5;
+                               FStar_Syntax_Syntax.lbpos = uu___6;_}::[]),
+                            uu___7)
                            when
                            FStar_Ident.lid_equals
                              (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                            -> FStar_Pervasives_Native.Some tm
-                       | uu____665 -> FStar_Pervasives_Native.None) in
+                       | uu___1 -> FStar_Pervasives_Native.None) in
                 let unfold_fv t fv =
-                  let uu____679 = find_in_unfolded fv in
-                  match uu____679 with
+                  let uu___1 = find_in_unfolded fv in
+                  match uu___1 with
                   | FStar_Pervasives_Native.Some t' -> t'
-                  | uu____689 -> t in
+                  | uu___2 -> t in
                 let unfold_in_sig x =
                   match x.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_inductive_typ
@@ -313,44 +309,44 @@ let (disentangle_abbrevs_from_bundle :
                         FStar_Syntax_InstFV.inst_binders unfold_fv bnd in
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
                       let mut' = filter_out_type_abbrevs mut in
-                      [(let uu___205_724 = x in
+                      [(let uu___1 = x in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_inductive_typ
                                (lid, univs, bnd', ty', mut', dc));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___205_724.FStar_Syntax_Syntax.sigrng);
+                            (uu___1.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___205_724.FStar_Syntax_Syntax.sigquals);
+                            (uu___1.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___205_724.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___205_724.FStar_Syntax_Syntax.sigattrs);
+                            (uu___1.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___205_724.FStar_Syntax_Syntax.sigopts)
+                            (uu___1.FStar_Syntax_Syntax.sigopts)
                         })]
                   | FStar_Syntax_Syntax.Sig_datacon
                       (lid, univs, ty, res, npars, mut) ->
                       let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
                       let mut' = filter_out_type_abbrevs mut in
-                      [(let uu___217_744 = x in
+                      [(let uu___1 = x in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_datacon
                                (lid, univs, ty', res, npars, mut'));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___217_744.FStar_Syntax_Syntax.sigrng);
+                            (uu___1.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (uu___217_744.FStar_Syntax_Syntax.sigquals);
+                            (uu___1.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___217_744.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___217_744.FStar_Syntax_Syntax.sigattrs);
+                            (uu___1.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___217_744.FStar_Syntax_Syntax.sigopts)
+                            (uu___1.FStar_Syntax_Syntax.sigopts)
                         })]
-                  | FStar_Syntax_Syntax.Sig_let (uu____747, uu____748) -> []
-                  | uu____753 ->
+                  | FStar_Syntax_Syntax.Sig_let (uu___1, uu___2) -> []
+                  | uu___1 ->
                       failwith
                         "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible" in
                 FStar_List.collect unfold_in_sig sigelts in

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -1,50 +1,50 @@
 open Prims
 let rec (delta_depth_to_string :
   FStar_Syntax_Syntax.delta_depth -> Prims.string) =
-  fun uu___0_4 ->
-    match uu___0_4 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Delta_constant_at_level i ->
-        let uu____6 = FStar_Util.string_of_int i in
-        Prims.op_Hat "Delta_constant_at_level " uu____6
+        let uu___1 = FStar_Util.string_of_int i in
+        Prims.op_Hat "Delta_constant_at_level " uu___1
     | FStar_Syntax_Syntax.Delta_equational_at_level i ->
-        let uu____8 = FStar_Util.string_of_int i in
-        Prims.op_Hat "Delta_equational_at_level " uu____8
+        let uu___1 = FStar_Util.string_of_int i in
+        Prims.op_Hat "Delta_equational_at_level " uu___1
     | FStar_Syntax_Syntax.Delta_abstract d ->
-        let uu____10 =
-          let uu____11 = delta_depth_to_string d in Prims.op_Hat uu____11 ")" in
-        Prims.op_Hat "Delta_abstract (" uu____10
+        let uu___1 =
+          let uu___2 = delta_depth_to_string d in Prims.op_Hat uu___2 ")" in
+        Prims.op_Hat "Delta_abstract (" uu___1
 let (sli : FStar_Ident.lident -> Prims.string) =
   fun l ->
-    let uu____17 = FStar_Options.print_real_names () in
-    if uu____17
+    let uu___ = FStar_Options.print_real_names () in
+    if uu___
     then FStar_Ident.string_of_lid l
     else
-      (let uu____19 = FStar_Ident.ident_of_lid l in
-       FStar_Ident.string_of_id uu____19)
+      (let uu___2 = FStar_Ident.ident_of_lid l in
+       FStar_Ident.string_of_id uu___2)
 let (lid_to_string : FStar_Ident.lid -> Prims.string) = fun l -> sli l
 let (fv_to_string : FStar_Syntax_Syntax.fv -> Prims.string) =
   fun fv ->
     lid_to_string (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
 let (bv_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv ->
-    let uu____35 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
-    let uu____36 =
-      let uu____37 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
-      Prims.op_Hat "#" uu____37 in
-    Prims.op_Hat uu____35 uu____36
+    let uu___ = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+    let uu___1 =
+      let uu___2 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
+      Prims.op_Hat "#" uu___2 in
+    Prims.op_Hat uu___ uu___1
 let (nm_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv ->
-    let uu____43 = FStar_Options.print_real_names () in
-    if uu____43
+    let uu___ = FStar_Options.print_real_names () in
+    if uu___
     then bv_to_string bv
     else FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname
 let (db_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
   fun bv ->
-    let uu____50 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
-    let uu____51 =
-      let uu____52 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
-      Prims.op_Hat "@" uu____52 in
-    Prims.op_Hat uu____50 uu____51
+    let uu___ = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+    let uu___1 =
+      let uu___2 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
+      Prims.op_Hat "@" uu___2 in
+    Prims.op_Hat uu___ uu___1
 let (infix_prim_ops : (FStar_Ident.lident * Prims.string) Prims.list) =
   [(FStar_Parser_Const.op_Addition, "+");
   (FStar_Parser_Const.op_Subtraction, "-");
@@ -81,7 +81,7 @@ let (is_prim_op :
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_All.pipe_right ps
             (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
-      | uu____190 -> false
+      | uu___ -> false
 let (get_lid :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
   =
@@ -89,7 +89,7 @@ let (get_lid :
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____201 -> failwith "get_lid"
+    | uu___ -> failwith "get_lid"
 let (is_infix_prim_op : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
     is_prim_op
@@ -114,63 +114,60 @@ let (is_lex_cons : exp -> Prims.bool) =
 let (is_lex_top : exp -> Prims.bool) =
   fun f -> is_prim_op [FStar_Parser_Const.lextop_lid] f
 let is_inr :
-  'uuuuuu273 'uuuuuu274 .
-    ('uuuuuu273, 'uuuuuu274) FStar_Util.either -> Prims.bool
-  =
-  fun uu___1_283 ->
-    match uu___1_283 with
-    | FStar_Util.Inl uu____288 -> false
-    | FStar_Util.Inr uu____289 -> true
+  'uuuuu 'uuuuu1 . ('uuuuu, 'uuuuu1) FStar_Util.either -> Prims.bool =
+  fun uu___ ->
+    match uu___ with
+    | FStar_Util.Inl uu___1 -> false
+    | FStar_Util.Inr uu___1 -> true
 let filter_imp :
-  'uuuuuu294 .
-    ('uuuuuu294 * FStar_Syntax_Syntax.arg_qualifier
+  'uuuuu .
+    ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
       FStar_Pervasives_Native.option) Prims.list ->
-      ('uuuuuu294 * FStar_Syntax_Syntax.arg_qualifier
+      ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
         FStar_Pervasives_Native.option) Prims.list
   =
   fun a ->
     FStar_All.pipe_right a
       (FStar_List.filter
-         (fun uu___2_349 ->
-            match uu___2_349 with
-            | (uu____356, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta
+         (fun uu___ ->
+            match uu___ with
+            | (uu___1, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t))) when
                 FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t
                 -> true
-            | (uu____362, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Implicit uu____363)) -> false
-            | (uu____366, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta uu____367)) -> false
-            | uu____370 -> true))
+            | (uu___1, FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Implicit uu___2)) -> false
+            | (uu___1, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
+               uu___2)) -> false
+            | uu___1 -> true))
 let rec (reconstruct_lex :
   exp -> exp Prims.list FStar_Pervasives_Native.option) =
   fun e ->
-    let uu____386 =
-      let uu____387 = FStar_Syntax_Subst.compress e in
-      uu____387.FStar_Syntax_Syntax.n in
-    match uu____386 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress e in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_app (f, args) ->
         let args1 = filter_imp args in
         let exps = FStar_List.map FStar_Pervasives_Native.fst args1 in
-        let uu____448 =
+        let uu___1 =
           (is_lex_cons f) && ((FStar_List.length exps) = (Prims.of_int (2))) in
-        if uu____448
+        if uu___1
         then
-          let uu____453 =
-            let uu____458 = FStar_List.nth exps Prims.int_one in
-            reconstruct_lex uu____458 in
-          (match uu____453 with
+          let uu___2 =
+            let uu___3 = FStar_List.nth exps Prims.int_one in
+            reconstruct_lex uu___3 in
+          (match uu___2 with
            | FStar_Pervasives_Native.Some xs ->
-               let uu____468 =
-                 let uu____471 = FStar_List.nth exps Prims.int_zero in
-                 uu____471 :: xs in
-               FStar_Pervasives_Native.Some uu____468
+               let uu___3 =
+                 let uu___4 = FStar_List.nth exps Prims.int_zero in uu___4 ::
+                   xs in
+               FStar_Pervasives_Native.Some uu___3
            | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
         else FStar_Pervasives_Native.None
-    | uu____481 ->
-        let uu____482 = is_lex_top e in
-        if uu____482
+    | uu___1 ->
+        let uu___2 = is_lex_top e in
+        if uu___2
         then FStar_Pervasives_Native.Some []
         else FStar_Pervasives_Native.None
 let rec find : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a =
@@ -178,73 +175,73 @@ let rec find : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a =
     fun l ->
       match l with
       | [] -> failwith "blah"
-      | hd::tl -> let uu____523 = f hd in if uu____523 then hd else find f tl
+      | hd::tl -> let uu___ = f hd in if uu___ then hd else find f tl
 let (find_lid :
   FStar_Ident.lident ->
     (FStar_Ident.lident * Prims.string) Prims.list -> Prims.string)
   =
   fun x ->
     fun xs ->
-      let uu____547 =
+      let uu___ =
         find
           (fun p -> FStar_Ident.lid_equals x (FStar_Pervasives_Native.fst p))
           xs in
-      FStar_Pervasives_Native.snd uu____547
+      FStar_Pervasives_Native.snd uu___
 let (infix_prim_op_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e -> let uu____571 = get_lid e in find_lid uu____571 infix_prim_ops
+  fun e -> let uu___ = get_lid e in find_lid uu___ infix_prim_ops
 let (unary_prim_op_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e -> let uu____581 = get_lid e in find_lid uu____581 unary_prim_ops
+  fun e -> let uu___ = get_lid e in find_lid uu___ unary_prim_ops
 let (quant_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun t -> let uu____591 = get_lid t in find_lid uu____591 quants
+  fun t -> let uu___ = get_lid t in find_lid uu___ quants
 let (const_to_string : FStar_Const.sconst -> Prims.string) =
   fun x -> FStar_Parser_Const.const_to_string x
 let (lbname_to_string : FStar_Syntax_Syntax.lbname -> Prims.string) =
-  fun uu___3_601 ->
-    match uu___3_601 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.Inl l -> bv_to_string l
     | FStar_Util.Inr l ->
         lid_to_string (l.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
 let (uvar_to_string : FStar_Syntax_Syntax.uvar -> Prims.string) =
   fun u ->
-    let uu____609 = FStar_Options.hide_uvar_nums () in
-    if uu____609
+    let uu___ = FStar_Options.hide_uvar_nums () in
+    if uu___
     then "?"
     else
-      (let uu____611 =
-         let uu____612 = FStar_Syntax_Unionfind.uvar_id u in
-         FStar_All.pipe_right uu____612 FStar_Util.string_of_int in
-       Prims.op_Hat "?" uu____611)
+      (let uu___2 =
+         let uu___3 = FStar_Syntax_Unionfind.uvar_id u in
+         FStar_All.pipe_right uu___3 FStar_Util.string_of_int in
+       Prims.op_Hat "?" uu___2)
 let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
   fun v ->
-    let uu____618 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major in
-    let uu____619 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor in
-    FStar_Util.format2 "%s.%s" uu____618 uu____619
+    let uu___ = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major in
+    let uu___1 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor in
+    FStar_Util.format2 "%s.%s" uu___ uu___1
 let (univ_uvar_to_string :
   (FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
     FStar_Unionfind.p_uvar * FStar_Syntax_Syntax.version * FStar_Range.range)
     -> Prims.string)
   =
   fun u ->
-    let uu____645 = FStar_Options.hide_uvar_nums () in
-    if uu____645
+    let uu___ = FStar_Options.hide_uvar_nums () in
+    if uu___
     then "?"
     else
-      (let uu____647 =
-         let uu____648 =
-           let uu____649 = FStar_Syntax_Unionfind.univ_uvar_id u in
-           FStar_All.pipe_right uu____649 FStar_Util.string_of_int in
-         let uu____650 =
-           let uu____651 =
+      (let uu___2 =
+         let uu___3 =
+           let uu___4 = FStar_Syntax_Unionfind.univ_uvar_id u in
+           FStar_All.pipe_right uu___4 FStar_Util.string_of_int in
+         let uu___4 =
+           let uu___5 =
              FStar_All.pipe_right u
-               (fun uu____666 ->
-                  match uu____666 with
-                  | (uu____677, u1, uu____679) -> version_to_string u1) in
-           Prims.op_Hat ":" uu____651 in
-         Prims.op_Hat uu____648 uu____650 in
-       Prims.op_Hat "?" uu____647)
+               (fun uu___6 ->
+                  match uu___6 with
+                  | (uu___7, u1, uu___8) -> version_to_string u1) in
+           Prims.op_Hat ":" uu___5 in
+         Prims.op_Hat uu___3 uu___4 in
+       Prims.op_Hat "?" uu___2)
 let rec (int_of_univ :
   Prims.int ->
     FStar_Syntax_Syntax.universe ->
@@ -253,50 +250,48 @@ let rec (int_of_univ :
   =
   fun n ->
     fun u ->
-      let uu____704 = FStar_Syntax_Subst.compress_univ u in
-      match uu____704 with
+      let uu___ = FStar_Syntax_Subst.compress_univ u in
+      match uu___ with
       | FStar_Syntax_Syntax.U_zero -> (n, FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.U_succ u1 -> int_of_univ (n + Prims.int_one) u1
-      | uu____714 -> (n, (FStar_Pervasives_Native.Some u))
+      | uu___1 -> (n, (FStar_Pervasives_Native.Some u))
 let rec (univ_to_string : FStar_Syntax_Syntax.universe -> Prims.string) =
   fun u ->
-    let uu____722 = FStar_Syntax_Subst.compress_univ u in
-    match uu____722 with
+    let uu___ = FStar_Syntax_Subst.compress_univ u in
+    match uu___ with
     | FStar_Syntax_Syntax.U_unif u1 ->
-        let uu____734 = univ_uvar_to_string u1 in
-        Prims.op_Hat "U_unif " uu____734
+        let uu___1 = univ_uvar_to_string u1 in Prims.op_Hat "U_unif " uu___1
     | FStar_Syntax_Syntax.U_name x ->
-        let uu____736 = FStar_Ident.string_of_id x in
-        Prims.op_Hat "U_name " uu____736
+        let uu___1 = FStar_Ident.string_of_id x in
+        Prims.op_Hat "U_name " uu___1
     | FStar_Syntax_Syntax.U_bvar x ->
-        let uu____738 = FStar_Util.string_of_int x in
-        Prims.op_Hat "@" uu____738
+        let uu___1 = FStar_Util.string_of_int x in Prims.op_Hat "@" uu___1
     | FStar_Syntax_Syntax.U_zero -> "0"
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____740 = int_of_univ Prims.int_one u1 in
-        (match uu____740 with
+        let uu___1 = int_of_univ Prims.int_one u1 in
+        (match uu___1 with
          | (n, FStar_Pervasives_Native.None) -> FStar_Util.string_of_int n
          | (n, FStar_Pervasives_Native.Some u2) ->
-             let uu____754 = univ_to_string u2 in
-             let uu____755 = FStar_Util.string_of_int n in
-             FStar_Util.format2 "(%s + %s)" uu____754 uu____755)
+             let uu___2 = univ_to_string u2 in
+             let uu___3 = FStar_Util.string_of_int n in
+             FStar_Util.format2 "(%s + %s)" uu___2 uu___3)
     | FStar_Syntax_Syntax.U_max us ->
-        let uu____759 =
-          let uu____760 = FStar_List.map univ_to_string us in
-          FStar_All.pipe_right uu____760 (FStar_String.concat ", ") in
-        FStar_Util.format1 "(max %s)" uu____759
+        let uu___1 =
+          let uu___2 = FStar_List.map univ_to_string us in
+          FStar_All.pipe_right uu___2 (FStar_String.concat ", ") in
+        FStar_Util.format1 "(max %s)" uu___1
     | FStar_Syntax_Syntax.U_unknown -> "unknown"
 let (univs_to_string : FStar_Syntax_Syntax.universes -> Prims.string) =
   fun us ->
-    let uu____770 = FStar_List.map univ_to_string us in
-    FStar_All.pipe_right uu____770 (FStar_String.concat ", ")
+    let uu___ = FStar_List.map univ_to_string us in
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let (univ_names_to_string : FStar_Syntax_Syntax.univ_names -> Prims.string) =
   fun us ->
-    let uu____780 = FStar_List.map (fun x -> FStar_Ident.string_of_id x) us in
-    FStar_All.pipe_right uu____780 (FStar_String.concat ", ")
+    let uu___ = FStar_List.map (fun x -> FStar_Ident.string_of_id x) us in
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
-  fun uu___4_791 ->
-    match uu___4_791 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Assumption -> "assume"
     | FStar_Syntax_Syntax.New -> "new"
     | FStar_Syntax_Syntax.Private -> "private"
@@ -310,106 +305,102 @@ let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
     | FStar_Syntax_Syntax.Logic -> "logic"
     | FStar_Syntax_Syntax.TotalEffect -> "total"
     | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____793 = lid_to_string l in
-        FStar_Util.format1 "(Discriminator %s)" uu____793
+        let uu___1 = lid_to_string l in
+        FStar_Util.format1 "(Discriminator %s)" uu___1
     | FStar_Syntax_Syntax.Projector (l, x) ->
-        let uu____796 = lid_to_string l in
-        let uu____797 = FStar_Ident.string_of_id x in
-        FStar_Util.format2 "(Projector %s %s)" uu____796 uu____797
+        let uu___1 = lid_to_string l in
+        let uu___2 = FStar_Ident.string_of_id x in
+        FStar_Util.format2 "(Projector %s %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.RecordType (ns, fns) ->
-        let uu____808 =
-          let uu____809 = FStar_Ident.path_of_ns ns in
-          FStar_Ident.text_of_path uu____809 in
-        let uu____810 =
-          let uu____811 =
+        let uu___1 =
+          let uu___2 = FStar_Ident.path_of_ns ns in
+          FStar_Ident.text_of_path uu___2 in
+        let uu___2 =
+          let uu___3 =
             FStar_All.pipe_right fns
               (FStar_List.map FStar_Ident.string_of_id) in
-          FStar_All.pipe_right uu____811 (FStar_String.concat ", ") in
-        FStar_Util.format2 "(RecordType %s %s)" uu____808 uu____810
+          FStar_All.pipe_right uu___3 (FStar_String.concat ", ") in
+        FStar_Util.format2 "(RecordType %s %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.RecordConstructor (ns, fns) ->
-        let uu____830 =
-          let uu____831 = FStar_Ident.path_of_ns ns in
-          FStar_Ident.text_of_path uu____831 in
-        let uu____832 =
-          let uu____833 =
+        let uu___1 =
+          let uu___2 = FStar_Ident.path_of_ns ns in
+          FStar_Ident.text_of_path uu___2 in
+        let uu___2 =
+          let uu___3 =
             FStar_All.pipe_right fns
               (FStar_List.map FStar_Ident.string_of_id) in
-          FStar_All.pipe_right uu____833 (FStar_String.concat ", ") in
-        FStar_Util.format2 "(RecordConstructor %s %s)" uu____830 uu____832
+          FStar_All.pipe_right uu___3 (FStar_String.concat ", ") in
+        FStar_Util.format2 "(RecordConstructor %s %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.Action eff_lid ->
-        let uu____843 = lid_to_string eff_lid in
-        FStar_Util.format1 "(Action %s)" uu____843
+        let uu___1 = lid_to_string eff_lid in
+        FStar_Util.format1 "(Action %s)" uu___1
     | FStar_Syntax_Syntax.ExceptionConstructor -> "ExceptionConstructor"
     | FStar_Syntax_Syntax.HasMaskedEffect -> "HasMaskedEffect"
     | FStar_Syntax_Syntax.Effect -> "Effect"
     | FStar_Syntax_Syntax.Reifiable -> "reify"
     | FStar_Syntax_Syntax.Reflectable l ->
-        let uu____845 = FStar_Ident.string_of_lid l in
-        FStar_Util.format1 "(reflect %s)" uu____845
+        let uu___1 = FStar_Ident.string_of_lid l in
+        FStar_Util.format1 "(reflect %s)" uu___1
     | FStar_Syntax_Syntax.OnlyName -> "OnlyName"
 let (quals_to_string :
   FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
   fun quals ->
     match quals with
     | [] -> ""
-    | uu____855 ->
-        let uu____858 =
+    | uu___ ->
+        let uu___1 =
           FStar_All.pipe_right quals (FStar_List.map qual_to_string) in
-        FStar_All.pipe_right uu____858 (FStar_String.concat " ")
+        FStar_All.pipe_right uu___1 (FStar_String.concat " ")
 let (quals_to_string' :
   FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
   fun quals ->
     match quals with
     | [] -> ""
-    | uu____876 ->
-        let uu____879 = quals_to_string quals in Prims.op_Hat uu____879 " "
+    | uu___ -> let uu___1 = quals_to_string quals in Prims.op_Hat uu___1 " "
 let (paren : Prims.string -> Prims.string) =
   fun s -> Prims.op_Hat "(" (Prims.op_Hat s ")")
 let rec (tag_of_term : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_bvar x ->
-        let uu____1029 = db_to_string x in
-        Prims.op_Hat "Tm_bvar: " uu____1029
+        let uu___ = db_to_string x in Prims.op_Hat "Tm_bvar: " uu___
     | FStar_Syntax_Syntax.Tm_name x ->
-        let uu____1031 = nm_to_string x in
-        Prims.op_Hat "Tm_name: " uu____1031
+        let uu___ = nm_to_string x in Prims.op_Hat "Tm_name: " uu___
     | FStar_Syntax_Syntax.Tm_fvar x ->
-        let uu____1033 =
+        let uu___ =
           lid_to_string (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        Prims.op_Hat "Tm_fvar: " uu____1033
-    | FStar_Syntax_Syntax.Tm_uinst uu____1034 -> "Tm_uinst"
-    | FStar_Syntax_Syntax.Tm_constant uu____1041 -> "Tm_constant"
-    | FStar_Syntax_Syntax.Tm_type uu____1042 -> "Tm_type"
+        Prims.op_Hat "Tm_fvar: " uu___
+    | FStar_Syntax_Syntax.Tm_uinst uu___ -> "Tm_uinst"
+    | FStar_Syntax_Syntax.Tm_constant uu___ -> "Tm_constant"
+    | FStar_Syntax_Syntax.Tm_type uu___ -> "Tm_type"
     | FStar_Syntax_Syntax.Tm_quoted
-        (uu____1043,
+        (uu___,
          { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static;
-           FStar_Syntax_Syntax.antiquotes = uu____1044;_})
+           FStar_Syntax_Syntax.antiquotes = uu___1;_})
         -> "Tm_quoted (static)"
     | FStar_Syntax_Syntax.Tm_quoted
-        (uu____1057,
+        (uu___,
          { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
-           FStar_Syntax_Syntax.antiquotes = uu____1058;_})
+           FStar_Syntax_Syntax.antiquotes = uu___1;_})
         -> "Tm_quoted (dynamic)"
-    | FStar_Syntax_Syntax.Tm_abs uu____1071 -> "Tm_abs"
-    | FStar_Syntax_Syntax.Tm_arrow uu____1090 -> "Tm_arrow"
-    | FStar_Syntax_Syntax.Tm_refine uu____1105 -> "Tm_refine"
-    | FStar_Syntax_Syntax.Tm_app uu____1112 -> "Tm_app"
-    | FStar_Syntax_Syntax.Tm_match uu____1129 -> "Tm_match"
-    | FStar_Syntax_Syntax.Tm_ascribed uu____1152 -> "Tm_ascribed"
-    | FStar_Syntax_Syntax.Tm_let uu____1179 -> "Tm_let"
-    | FStar_Syntax_Syntax.Tm_uvar uu____1192 -> "Tm_uvar"
-    | FStar_Syntax_Syntax.Tm_delayed uu____1205 -> "Tm_delayed"
-    | FStar_Syntax_Syntax.Tm_meta (uu____1220, m) ->
-        let uu____1226 = metadata_to_string m in
-        Prims.op_Hat "Tm_meta:" uu____1226
+    | FStar_Syntax_Syntax.Tm_abs uu___ -> "Tm_abs"
+    | FStar_Syntax_Syntax.Tm_arrow uu___ -> "Tm_arrow"
+    | FStar_Syntax_Syntax.Tm_refine uu___ -> "Tm_refine"
+    | FStar_Syntax_Syntax.Tm_app uu___ -> "Tm_app"
+    | FStar_Syntax_Syntax.Tm_match uu___ -> "Tm_match"
+    | FStar_Syntax_Syntax.Tm_ascribed uu___ -> "Tm_ascribed"
+    | FStar_Syntax_Syntax.Tm_let uu___ -> "Tm_let"
+    | FStar_Syntax_Syntax.Tm_uvar uu___ -> "Tm_uvar"
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> "Tm_delayed"
+    | FStar_Syntax_Syntax.Tm_meta (uu___, m) ->
+        let uu___1 = metadata_to_string m in Prims.op_Hat "Tm_meta:" uu___1
     | FStar_Syntax_Syntax.Tm_unknown -> "Tm_unknown"
-    | FStar_Syntax_Syntax.Tm_lazy uu____1227 -> "Tm_lazy"
+    | FStar_Syntax_Syntax.Tm_lazy uu___ -> "Tm_lazy"
 and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun x ->
-    let uu____1229 =
-      let uu____1230 = FStar_Options.ugly () in Prims.op_Negation uu____1230 in
-    if uu____1229
+    let uu___ =
+      let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+    if uu___
     then
       let e = FStar_Syntax_Resugar.resugar_term x in
       let d = FStar_Parser_ToDocument.term_to_document e in
@@ -418,247 +409,240 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
     else
       (let x1 = FStar_Syntax_Subst.compress x in
        let x2 =
-         let uu____1238 = FStar_Options.print_implicits () in
-         if uu____1238 then x1 else FStar_Syntax_Util.unmeta x1 in
+         let uu___2 = FStar_Options.print_implicits () in
+         if uu___2 then x1 else FStar_Syntax_Util.unmeta x1 in
        match x2.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____1242 -> failwith "impossible"
-       | FStar_Syntax_Syntax.Tm_app (uu____1257, []) ->
-           failwith "Empty args!"
+       | FStar_Syntax_Syntax.Tm_delayed uu___2 -> failwith "impossible"
+       | FStar_Syntax_Syntax.Tm_app (uu___2, []) -> failwith "Empty args!"
        | FStar_Syntax_Syntax.Tm_lazy
            { FStar_Syntax_Syntax.blob = b;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               (uu____1281, thunk);
-             FStar_Syntax_Syntax.ltyp = uu____1283;
-             FStar_Syntax_Syntax.rng = uu____1284;_}
+               (uu___2, thunk);
+             FStar_Syntax_Syntax.ltyp = uu___3;
+             FStar_Syntax_Syntax.rng = uu___4;_}
            ->
-           let uu____1295 =
-             let uu____1296 =
-               let uu____1297 = FStar_Thunk.force thunk in
-               term_to_string uu____1297 in
-             Prims.op_Hat uu____1296 "]" in
-           Prims.op_Hat "[LAZYEMB:" uu____1295
+           let uu___5 =
+             let uu___6 =
+               let uu___7 = FStar_Thunk.force thunk in term_to_string uu___7 in
+             Prims.op_Hat uu___6 "]" in
+           Prims.op_Hat "[LAZYEMB:" uu___5
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____1301 =
-             let uu____1302 =
-               let uu____1303 =
-                 let uu____1304 =
-                   let uu____1313 =
+           let uu___2 =
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
                      FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
-                   FStar_Util.must uu____1313 in
-                 uu____1304 i.FStar_Syntax_Syntax.lkind i in
-               term_to_string uu____1303 in
-             Prims.op_Hat uu____1302 "]" in
-           Prims.op_Hat "[lazy:" uu____1301
+                   FStar_Util.must uu___6 in
+                 uu___5 i.FStar_Syntax_Syntax.lkind i in
+               term_to_string uu___4 in
+             Prims.op_Hat uu___3 "]" in
+           Prims.op_Hat "[lazy:" uu___2
        | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
            (match qi.FStar_Syntax_Syntax.qkind with
             | FStar_Syntax_Syntax.Quote_static ->
-                let print_aq uu____1365 =
-                  match uu____1365 with
+                let print_aq uu___2 =
+                  match uu___2 with
                   | (bv, t) ->
-                      let uu____1372 = bv_to_string bv in
-                      let uu____1373 = term_to_string t in
-                      FStar_Util.format2 "%s -> %s" uu____1372 uu____1373 in
-                let uu____1374 = term_to_string tm in
-                let uu____1375 =
+                      let uu___3 = bv_to_string bv in
+                      let uu___4 = term_to_string t in
+                      FStar_Util.format2 "%s -> %s" uu___3 uu___4 in
+                let uu___2 = term_to_string tm in
+                let uu___3 =
                   FStar_Common.string_of_list print_aq
                     qi.FStar_Syntax_Syntax.antiquotes in
-                FStar_Util.format2 "`(%s)%s" uu____1374 uu____1375
+                FStar_Util.format2 "`(%s)%s" uu___2 uu___3
             | FStar_Syntax_Syntax.Quote_dynamic ->
-                let uu____1382 = term_to_string tm in
-                FStar_Util.format1 "quote (%s)" uu____1382)
+                let uu___2 = term_to_string tm in
+                FStar_Util.format1 "quote (%s)" uu___2)
        | FStar_Syntax_Syntax.Tm_meta
-           (t, FStar_Syntax_Syntax.Meta_pattern (uu____1384, ps)) ->
+           (t, FStar_Syntax_Syntax.Meta_pattern (uu___2, ps)) ->
            let pats =
-             let uu____1423 =
+             let uu___3 =
                FStar_All.pipe_right ps
                  (FStar_List.map
                     (fun args ->
-                       let uu____1457 =
+                       let uu___4 =
                          FStar_All.pipe_right args
                            (FStar_List.map
-                              (fun uu____1479 ->
-                                 match uu____1479 with
-                                 | (t1, uu____1487) -> term_to_string t1)) in
-                       FStar_All.pipe_right uu____1457
-                         (FStar_String.concat "; "))) in
-             FStar_All.pipe_right uu____1423 (FStar_String.concat "\\/") in
-           let uu____1496 = term_to_string t in
-           FStar_Util.format2 "{:pattern %s} %s" pats uu____1496
+                              (fun uu___5 ->
+                                 match uu___5 with
+                                 | (t1, uu___6) -> term_to_string t1)) in
+                       FStar_All.pipe_right uu___4 (FStar_String.concat "; "))) in
+             FStar_All.pipe_right uu___3 (FStar_String.concat "\\/") in
+           let uu___3 = term_to_string t in
+           FStar_Util.format2 "{:pattern %s} %s" pats uu___3
        | FStar_Syntax_Syntax.Tm_meta
            (t, FStar_Syntax_Syntax.Meta_monadic (m, t')) ->
-           let uu____1508 = tag_of_term t in
-           let uu____1509 = sli m in
-           let uu____1510 = term_to_string t' in
-           let uu____1511 = term_to_string t in
-           FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____1508 uu____1509
-             uu____1510 uu____1511
+           let uu___2 = tag_of_term t in
+           let uu___3 = sli m in
+           let uu___4 = term_to_string t' in
+           let uu___5 = term_to_string t in
+           FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu___2 uu___3 uu___4
+             uu___5
        | FStar_Syntax_Syntax.Tm_meta
            (t, FStar_Syntax_Syntax.Meta_monadic_lift (m0, m1, t')) ->
-           let uu____1524 = tag_of_term t in
-           let uu____1525 = term_to_string t' in
-           let uu____1526 = sli m0 in
-           let uu____1527 = sli m1 in
-           let uu____1528 = term_to_string t in
-           FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____1524
-             uu____1525 uu____1526 uu____1527 uu____1528
+           let uu___2 = tag_of_term t in
+           let uu___3 = term_to_string t' in
+           let uu___4 = sli m0 in
+           let uu___5 = sli m1 in
+           let uu___6 = term_to_string t in
+           FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu___2
+             uu___3 uu___4 uu___5 uu___6
        | FStar_Syntax_Syntax.Tm_meta
            (t, FStar_Syntax_Syntax.Meta_labeled (l, r, b)) ->
-           let uu____1537 = FStar_Range.string_of_range r in
-           let uu____1538 = term_to_string t in
-           FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____1537
-             uu____1538
+           let uu___2 = FStar_Range.string_of_range r in
+           let uu___3 = term_to_string t in
+           FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_meta (t, FStar_Syntax_Syntax.Meta_named l) ->
-           let uu____1545 = lid_to_string l in
-           let uu____1546 =
-             FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
-           let uu____1547 = term_to_string t in
-           FStar_Util.format3 "Meta_named(%s, %s){%s}" uu____1545 uu____1546
-             uu____1547
+           let uu___2 = lid_to_string l in
+           let uu___3 = FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
+           let uu___4 = term_to_string t in
+           FStar_Util.format3 "Meta_named(%s, %s){%s}" uu___2 uu___3 uu___4
        | FStar_Syntax_Syntax.Tm_meta
-           (t, FStar_Syntax_Syntax.Meta_desugared uu____1549) ->
-           let uu____1554 = term_to_string t in
-           FStar_Util.format1 "Meta_desugared{%s}" uu____1554
+           (t, FStar_Syntax_Syntax.Meta_desugared uu___2) ->
+           let uu___3 = term_to_string t in
+           FStar_Util.format1 "Meta_desugared{%s}" uu___3
        | FStar_Syntax_Syntax.Tm_bvar x3 ->
-           let uu____1556 = db_to_string x3 in
-           let uu____1557 =
-             let uu____1558 =
-               let uu____1559 = tag_of_term x3.FStar_Syntax_Syntax.sort in
-               Prims.op_Hat uu____1559 ")" in
-             Prims.op_Hat ":(" uu____1558 in
-           Prims.op_Hat uu____1556 uu____1557
+           let uu___2 = db_to_string x3 in
+           let uu___3 =
+             let uu___4 =
+               let uu___5 = tag_of_term x3.FStar_Syntax_Syntax.sort in
+               Prims.op_Hat uu___5 ")" in
+             Prims.op_Hat ":(" uu___4 in
+           Prims.op_Hat uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_name x3 -> nm_to_string x3
        | FStar_Syntax_Syntax.Tm_fvar f -> fv_to_string f
-       | FStar_Syntax_Syntax.Tm_uvar (u, ([], uu____1563)) ->
-           let uu____1578 =
+       | FStar_Syntax_Syntax.Tm_uvar (u, ([], uu___2)) ->
+           let uu___3 =
              (FStar_Options.print_bound_var_types ()) &&
                (FStar_Options.print_effect_args ()) in
-           if uu____1578
+           if uu___3
            then ctx_uvar_to_string_aux true u
            else
-             (let uu____1580 =
-                let uu____1581 =
+             (let uu___5 =
+                let uu___6 =
                   FStar_Syntax_Unionfind.uvar_id
                     u.FStar_Syntax_Syntax.ctx_uvar_head in
-                FStar_All.pipe_left FStar_Util.string_of_int uu____1581 in
-              Prims.op_Hat "?" uu____1580)
+                FStar_All.pipe_left FStar_Util.string_of_int uu___6 in
+              Prims.op_Hat "?" uu___5)
        | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-           let uu____1600 =
+           let uu___2 =
              (FStar_Options.print_bound_var_types ()) &&
                (FStar_Options.print_effect_args ()) in
-           if uu____1600
+           if uu___2
            then
-             let uu____1601 = ctx_uvar_to_string_aux true u in
-             let uu____1602 =
-               let uu____1603 =
+             let uu___3 = ctx_uvar_to_string_aux true u in
+             let uu___4 =
+               let uu___5 =
                  FStar_List.map subst_to_string
                    (FStar_Pervasives_Native.fst s) in
-               FStar_All.pipe_right uu____1603 (FStar_String.concat "; ") in
-             FStar_Util.format2 "(%s @ %s)" uu____1601 uu____1602
+               FStar_All.pipe_right uu___5 (FStar_String.concat "; ") in
+             FStar_Util.format2 "(%s @ %s)" uu___3 uu___4
            else
-             (let uu____1615 =
-                let uu____1616 =
+             (let uu___4 =
+                let uu___5 =
                   FStar_Syntax_Unionfind.uvar_id
                     u.FStar_Syntax_Syntax.ctx_uvar_head in
-                FStar_All.pipe_left FStar_Util.string_of_int uu____1616 in
-              Prims.op_Hat "?" uu____1615)
+                FStar_All.pipe_left FStar_Util.string_of_int uu___5 in
+              Prims.op_Hat "?" uu___4)
        | FStar_Syntax_Syntax.Tm_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Tm_type u ->
-           let uu____1619 = FStar_Options.print_universes () in
-           if uu____1619
+           let uu___2 = FStar_Options.print_universes () in
+           if uu___2
            then
-             let uu____1620 = univ_to_string u in
-             FStar_Util.format1 "Type u#(%s)" uu____1620
+             let uu___3 = univ_to_string u in
+             FStar_Util.format1 "Type u#(%s)" uu___3
            else "Type"
        | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-           let uu____1644 = binders_to_string " -> " bs in
-           let uu____1645 = comp_to_string c in
-           FStar_Util.format2 "(%s -> %s)" uu____1644 uu____1645
+           let uu___2 = binders_to_string " -> " bs in
+           let uu___3 = comp_to_string c in
+           FStar_Util.format2 "(%s -> %s)" uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_abs (bs, t2, lc) ->
            (match lc with
             | FStar_Pervasives_Native.Some rc when
                 FStar_Options.print_implicits () ->
-                let uu____1674 = binders_to_string " " bs in
-                let uu____1675 = term_to_string t2 in
-                let uu____1676 =
+                let uu___2 = binders_to_string " " bs in
+                let uu___3 = term_to_string t2 in
+                let uu___4 =
                   FStar_Ident.string_of_lid
                     rc.FStar_Syntax_Syntax.residual_effect in
-                let uu____1677 =
+                let uu___5 =
                   if FStar_Option.isNone rc.FStar_Syntax_Syntax.residual_typ
                   then "None"
                   else
-                    (let uu____1681 =
+                    (let uu___7 =
                        FStar_Option.get rc.FStar_Syntax_Syntax.residual_typ in
-                     term_to_string uu____1681) in
+                     term_to_string uu___7) in
                 FStar_Util.format4 "(fun %s -> (%s $$ (residual) %s %s))"
-                  uu____1674 uu____1675 uu____1676 uu____1677
-            | uu____1684 ->
-                let uu____1687 = binders_to_string " " bs in
-                let uu____1688 = term_to_string t2 in
-                FStar_Util.format2 "(fun %s -> %s)" uu____1687 uu____1688)
+                  uu___2 uu___3 uu___4 uu___5
+            | uu___2 ->
+                let uu___3 = binders_to_string " " bs in
+                let uu___4 = term_to_string t2 in
+                FStar_Util.format2 "(fun %s -> %s)" uu___3 uu___4)
        | FStar_Syntax_Syntax.Tm_refine (xt, f) ->
-           let uu____1695 = bv_to_string xt in
-           let uu____1696 =
+           let uu___2 = bv_to_string xt in
+           let uu___3 =
              FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string in
-           let uu____1697 = FStar_All.pipe_right f formula_to_string in
-           FStar_Util.format3 "(%s:%s{%s})" uu____1695 uu____1696 uu____1697
+           let uu___4 = FStar_All.pipe_right f formula_to_string in
+           FStar_Util.format3 "(%s:%s{%s})" uu___2 uu___3 uu___4
        | FStar_Syntax_Syntax.Tm_app (t, args) ->
-           let uu____1726 = term_to_string t in
-           let uu____1727 = args_to_string args in
-           FStar_Util.format2 "(%s %s)" uu____1726 uu____1727
+           let uu___2 = term_to_string t in
+           let uu___3 = args_to_string args in
+           FStar_Util.format2 "(%s %s)" uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_let (lbs, e) ->
-           let uu____1746 = lbs_to_string [] lbs in
-           let uu____1747 = term_to_string e in
-           FStar_Util.format2 "%s\nin\n%s" uu____1746 uu____1747
+           let uu___2 = lbs_to_string [] lbs in
+           let uu___3 = term_to_string e in
+           FStar_Util.format2 "%s\nin\n%s" uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_ascribed (e, (annot, topt), eff_name) ->
            let annot1 =
              match annot with
              | FStar_Util.Inl t ->
-                 let uu____1808 =
-                   let uu____1809 =
+                 let uu___2 =
+                   let uu___3 =
                      FStar_Util.map_opt eff_name FStar_Ident.string_of_lid in
-                   FStar_All.pipe_right uu____1809
-                     (FStar_Util.dflt "default") in
-                 let uu____1814 = term_to_string t in
-                 FStar_Util.format2 "[%s] %s" uu____1808 uu____1814
+                   FStar_All.pipe_right uu___3 (FStar_Util.dflt "default") in
+                 let uu___3 = term_to_string t in
+                 FStar_Util.format2 "[%s] %s" uu___2 uu___3
              | FStar_Util.Inr c -> comp_to_string c in
            let topt1 =
              match topt with
              | FStar_Pervasives_Native.None -> ""
              | FStar_Pervasives_Native.Some t ->
-                 let uu____1830 = term_to_string t in
-                 FStar_Util.format1 "by %s" uu____1830 in
-           let uu____1831 = term_to_string e in
-           FStar_Util.format3 "(%s <ascribed: %s %s)" uu____1831 annot1 topt1
+                 let uu___2 = term_to_string t in
+                 FStar_Util.format1 "by %s" uu___2 in
+           let uu___2 = term_to_string e in
+           FStar_Util.format3 "(%s <ascribed: %s %s)" uu___2 annot1 topt1
        | FStar_Syntax_Syntax.Tm_match (head, branches) ->
-           let uu____1870 = term_to_string head in
-           let uu____1871 =
-             let uu____1872 =
+           let uu___2 = term_to_string head in
+           let uu___3 =
+             let uu___4 =
                FStar_All.pipe_right branches
                  (FStar_List.map branch_to_string) in
-             FStar_Util.concat_l "\n\t|" uu____1872 in
-           FStar_Util.format2 "(match %s with\n\t| %s)" uu____1870 uu____1871
+             FStar_Util.concat_l "\n\t|" uu___4 in
+           FStar_Util.format2 "(match %s with\n\t| %s)" uu___2 uu___3
        | FStar_Syntax_Syntax.Tm_uinst (t, us) ->
-           let uu____1885 = FStar_Options.print_universes () in
-           if uu____1885
+           let uu___2 = FStar_Options.print_universes () in
+           if uu___2
            then
-             let uu____1886 = term_to_string t in
-             let uu____1887 = univs_to_string us in
-             FStar_Util.format2 "%s<%s>" uu____1886 uu____1887
+             let uu___3 = term_to_string t in
+             let uu___4 = univs_to_string us in
+             FStar_Util.format2 "%s<%s>" uu___3 uu___4
            else term_to_string t
        | FStar_Syntax_Syntax.Tm_unknown -> "_")
 and (branch_to_string : FStar_Syntax_Syntax.branch -> Prims.string) =
-  fun uu____1889 ->
-    match uu____1889 with
+  fun uu___ ->
+    match uu___ with
     | (p, wopt, e) ->
-        let uu____1909 = FStar_All.pipe_right p pat_to_string in
-        let uu____1910 =
+        let uu___1 = FStar_All.pipe_right p pat_to_string in
+        let uu___2 =
           match wopt with
           | FStar_Pervasives_Native.None -> ""
           | FStar_Pervasives_Native.Some w ->
-              let uu____1918 = FStar_All.pipe_right w term_to_string in
-              FStar_Util.format1 "when %s" uu____1918 in
-        let uu____1919 = FStar_All.pipe_right e term_to_string in
-        FStar_Util.format3 "%s %s -> %s" uu____1909 uu____1910 uu____1919
+              let uu___3 = FStar_All.pipe_right w term_to_string in
+              FStar_Util.format1 "when %s" uu___3 in
+        let uu___3 = FStar_All.pipe_right e term_to_string in
+        FStar_Util.format3 "%s %s -> %s" uu___1 uu___2 uu___3
 and (ctx_uvar_to_string_aux :
   Prims.bool -> FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
   fun print_reason ->
@@ -669,105 +653,101 @@ and (ctx_uvar_to_string_aux :
           FStar_Util.format1 "(* %s *)\n"
             ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_reason
         else
-          (let uu____1924 =
-             let uu____1925 =
+          (let uu___1 =
+             let uu___2 =
                FStar_Range.start_of_range
                  ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_range in
-             FStar_Range.string_of_pos uu____1925 in
-           let uu____1926 =
-             let uu____1927 =
+             FStar_Range.string_of_pos uu___2 in
+           let uu___2 =
+             let uu___3 =
                FStar_Range.end_of_range
                  ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_range in
-             FStar_Range.string_of_pos uu____1927 in
-           FStar_Util.format2 "(%s-%s) " uu____1924 uu____1926) in
-      let uu____1928 =
+             FStar_Range.string_of_pos uu___3 in
+           FStar_Util.format2 "(%s-%s) " uu___1 uu___2) in
+      let uu___ =
         binders_to_string ", " ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders in
-      let uu____1929 =
-        uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-      let uu____1930 =
-        term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-      FStar_Util.format4 "%s(%s |- %s : %s)" reason_string uu____1928
-        uu____1929 uu____1930
+      let uu___1 = uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
+      let uu___2 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
+      FStar_Util.format4 "%s(%s |- %s : %s)" reason_string uu___ uu___1
+        uu___2
 and (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
-  fun uu___5_1931 ->
-    match uu___5_1931 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.DB (i, x) ->
-        let uu____1934 = FStar_Util.string_of_int i in
-        let uu____1935 = bv_to_string x in
-        FStar_Util.format2 "DB (%s, %s)" uu____1934 uu____1935
+        let uu___1 = FStar_Util.string_of_int i in
+        let uu___2 = bv_to_string x in
+        FStar_Util.format2 "DB (%s, %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.NM (x, i) ->
-        let uu____1938 = bv_to_string x in
-        let uu____1939 = FStar_Util.string_of_int i in
-        FStar_Util.format2 "NM (%s, %s)" uu____1938 uu____1939
+        let uu___1 = bv_to_string x in
+        let uu___2 = FStar_Util.string_of_int i in
+        FStar_Util.format2 "NM (%s, %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.NT (x, t) ->
-        let uu____1946 = bv_to_string x in
-        let uu____1947 = term_to_string t in
-        FStar_Util.format2 "NT (%s, %s)" uu____1946 uu____1947
+        let uu___1 = bv_to_string x in
+        let uu___2 = term_to_string t in
+        FStar_Util.format2 "NT (%s, %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.UN (i, u) ->
-        let uu____1950 = FStar_Util.string_of_int i in
-        let uu____1951 = univ_to_string u in
-        FStar_Util.format2 "UN (%s, %s)" uu____1950 uu____1951
+        let uu___1 = FStar_Util.string_of_int i in
+        let uu___2 = univ_to_string u in
+        FStar_Util.format2 "UN (%s, %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.UD (u, i) ->
-        let uu____1954 = FStar_Ident.string_of_id u in
-        let uu____1955 = FStar_Util.string_of_int i in
-        FStar_Util.format2 "UD (%s, %s)" uu____1954 uu____1955
+        let uu___1 = FStar_Ident.string_of_id u in
+        let uu___2 = FStar_Util.string_of_int i in
+        FStar_Util.format2 "UD (%s, %s)" uu___1 uu___2
 and (subst_to_string : FStar_Syntax_Syntax.subst_t -> Prims.string) =
   fun s ->
-    let uu____1957 =
-      FStar_All.pipe_right s (FStar_List.map subst_elt_to_string) in
-    FStar_All.pipe_right uu____1957 (FStar_String.concat "; ")
+    let uu___ = FStar_All.pipe_right s (FStar_List.map subst_elt_to_string) in
+    FStar_All.pipe_right uu___ (FStar_String.concat "; ")
 and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
   fun x ->
-    let uu____1967 =
-      let uu____1968 = FStar_Options.ugly () in Prims.op_Negation uu____1968 in
-    if uu____1967
+    let uu___ =
+      let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+    if uu___
     then
       let e =
-        let uu____1970 = FStar_Syntax_Syntax.new_bv_set () in
-        FStar_Syntax_Resugar.resugar_pat x uu____1970 in
+        let uu___1 = FStar_Syntax_Syntax.new_bv_set () in
+        FStar_Syntax_Resugar.resugar_pat x uu___1 in
       let d = FStar_Parser_ToDocument.pat_to_document e in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.of_int (100)) d
     else
       (match x.FStar_Syntax_Syntax.v with
        | FStar_Syntax_Syntax.Pat_cons (l, pats) ->
-           let uu____1993 = fv_to_string l in
-           let uu____1994 =
-             let uu____1995 =
+           let uu___2 = fv_to_string l in
+           let uu___3 =
+             let uu___4 =
                FStar_List.map
-                 (fun uu____2006 ->
-                    match uu____2006 with
+                 (fun uu___5 ->
+                    match uu___5 with
                     | (x1, b) ->
                         let p = pat_to_string x1 in
                         if b then Prims.op_Hat "#" p else p) pats in
-             FStar_All.pipe_right uu____1995 (FStar_String.concat " ") in
-           FStar_Util.format2 "(%s %s)" uu____1993 uu____1994
-       | FStar_Syntax_Syntax.Pat_dot_term (x1, uu____2018) ->
-           let uu____2023 = FStar_Options.print_bound_var_types () in
-           if uu____2023
+             FStar_All.pipe_right uu___4 (FStar_String.concat " ") in
+           FStar_Util.format2 "(%s %s)" uu___2 uu___3
+       | FStar_Syntax_Syntax.Pat_dot_term (x1, uu___2) ->
+           let uu___3 = FStar_Options.print_bound_var_types () in
+           if uu___3
            then
-             let uu____2024 = bv_to_string x1 in
-             let uu____2025 = term_to_string x1.FStar_Syntax_Syntax.sort in
-             FStar_Util.format2 ".%s:%s" uu____2024 uu____2025
+             let uu___4 = bv_to_string x1 in
+             let uu___5 = term_to_string x1.FStar_Syntax_Syntax.sort in
+             FStar_Util.format2 ".%s:%s" uu___4 uu___5
            else
-             (let uu____2027 = bv_to_string x1 in
-              FStar_Util.format1 ".%s" uu____2027)
+             (let uu___5 = bv_to_string x1 in FStar_Util.format1 ".%s" uu___5)
        | FStar_Syntax_Syntax.Pat_var x1 ->
-           let uu____2029 = FStar_Options.print_bound_var_types () in
-           if uu____2029
+           let uu___2 = FStar_Options.print_bound_var_types () in
+           if uu___2
            then
-             let uu____2030 = bv_to_string x1 in
-             let uu____2031 = term_to_string x1.FStar_Syntax_Syntax.sort in
-             FStar_Util.format2 "%s:%s" uu____2030 uu____2031
+             let uu___3 = bv_to_string x1 in
+             let uu___4 = term_to_string x1.FStar_Syntax_Syntax.sort in
+             FStar_Util.format2 "%s:%s" uu___3 uu___4
            else bv_to_string x1
        | FStar_Syntax_Syntax.Pat_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Pat_wild x1 ->
-           let uu____2035 = FStar_Options.print_bound_var_types () in
-           if uu____2035
+           let uu___2 = FStar_Options.print_bound_var_types () in
+           if uu___2
            then
-             let uu____2036 = bv_to_string x1 in
-             let uu____2037 = term_to_string x1.FStar_Syntax_Syntax.sort in
-             FStar_Util.format2 "_wild_%s:%s" uu____2036 uu____2037
+             let uu___3 = bv_to_string x1 in
+             let uu___4 = term_to_string x1.FStar_Syntax_Syntax.sort in
+             FStar_Util.format2 "_wild_%s:%s" uu___3 uu___4
            else bv_to_string x1)
 and (lbs_to_string :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -775,57 +755,53 @@ and (lbs_to_string :
   =
   fun quals ->
     fun lbs ->
-      let uu____2043 = quals_to_string' quals in
-      let uu____2044 =
-        let uu____2045 =
+      let uu___ = quals_to_string' quals in
+      let uu___1 =
+        let uu___2 =
           FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
             (FStar_List.map
                (fun lb ->
-                  let uu____2061 =
-                    attrs_to_string lb.FStar_Syntax_Syntax.lbattrs in
-                  let uu____2062 =
-                    lbname_to_string lb.FStar_Syntax_Syntax.lbname in
-                  let uu____2063 =
-                    let uu____2064 = FStar_Options.print_universes () in
-                    if uu____2064
+                  let uu___3 = attrs_to_string lb.FStar_Syntax_Syntax.lbattrs in
+                  let uu___4 = lbname_to_string lb.FStar_Syntax_Syntax.lbname in
+                  let uu___5 =
+                    let uu___6 = FStar_Options.print_universes () in
+                    if uu___6
                     then
-                      let uu____2065 =
-                        let uu____2066 =
+                      let uu___7 =
+                        let uu___8 =
                           univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs in
-                        Prims.op_Hat uu____2066 ">" in
-                      Prims.op_Hat "<" uu____2065
+                        Prims.op_Hat uu___8 ">" in
+                      Prims.op_Hat "<" uu___7
                     else "" in
-                  let uu____2068 =
-                    term_to_string lb.FStar_Syntax_Syntax.lbtyp in
-                  let uu____2069 =
+                  let uu___6 = term_to_string lb.FStar_Syntax_Syntax.lbtyp in
+                  let uu___7 =
                     FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbdef
                       term_to_string in
-                  FStar_Util.format5 "%s%s %s : %s = %s" uu____2061
-                    uu____2062 uu____2063 uu____2068 uu____2069)) in
-        FStar_Util.concat_l "\n and " uu____2045 in
-      FStar_Util.format3 "%slet %s %s" uu____2043
-        (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu____2044
+                  FStar_Util.format5 "%s%s %s : %s = %s" uu___3 uu___4 uu___5
+                    uu___6 uu___7)) in
+        FStar_Util.concat_l "\n and " uu___2 in
+      FStar_Util.format3 "%slet %s %s" uu___
+        (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu___1
 and (attrs_to_string :
   FStar_Syntax_Syntax.attribute Prims.list -> Prims.string) =
-  fun uu___6_2073 ->
-    match uu___6_2073 with
+  fun uu___ ->
+    match uu___ with
     | [] -> ""
     | tms ->
-        let uu____2079 =
-          let uu____2080 =
+        let uu___1 =
+          let uu___2 =
             FStar_List.map
-              (fun t -> let uu____2086 = term_to_string t in paren uu____2086)
-              tms in
-          FStar_All.pipe_right uu____2080 (FStar_String.concat "; ") in
-        FStar_Util.format1 "[@ %s]" uu____2079
+              (fun t -> let uu___3 = term_to_string t in paren uu___3) tms in
+          FStar_All.pipe_right uu___2 (FStar_String.concat "; ") in
+        FStar_Util.format1 "[@ %s]" uu___1
 and (aqual_to_string' :
   Prims.string ->
     FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
       Prims.string)
   =
   fun s ->
-    fun uu___7_2090 ->
-      match uu___7_2090 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (false))
           -> Prims.op_Hat "#" s
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (true)) ->
@@ -838,16 +814,16 @@ and (aqual_to_string' :
           Prims.op_Hat "[|" (Prims.op_Hat s "|]")
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-          let uu____2099 =
-            let uu____2100 = term_to_string t in
-            Prims.op_Hat uu____2100 (Prims.op_Hat "]" s) in
-          Prims.op_Hat "#[" uu____2099
+          let uu___1 =
+            let uu___2 = term_to_string t in
+            Prims.op_Hat uu___2 (Prims.op_Hat "]" s) in
+          Prims.op_Hat "#[" uu___1
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-          let uu____2104 =
-            let uu____2105 = term_to_string t in
-            Prims.op_Hat uu____2105 (Prims.op_Hat "]" s) in
-          Prims.op_Hat "#[@@" uu____2104
+          let uu___1 =
+            let uu___2 = term_to_string t in
+            Prims.op_Hat uu___2 (Prims.op_Hat "]" s) in
+          Prims.op_Hat "#[@@" uu___1
       | FStar_Pervasives_Native.None -> s
 and (imp_to_string :
   Prims.string ->
@@ -861,46 +837,43 @@ and (binder_to_string' :
   =
   fun is_arrow ->
     fun b ->
-      let uu____2118 =
-        let uu____2119 = FStar_Options.ugly () in
-        Prims.op_Negation uu____2119 in
-      if uu____2118
+      let uu___ =
+        let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+      if uu___
       then
-        let uu____2120 =
+        let uu___1 =
           FStar_Syntax_Resugar.resugar_binder b FStar_Range.dummyRange in
-        match uu____2120 with
+        match uu___1 with
         | FStar_Pervasives_Native.None -> ""
         | FStar_Pervasives_Native.Some e ->
             let d = FStar_Parser_ToDocument.binder_to_document e in
             FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
               (Prims.of_int (100)) d
       else
-        (let uu____2126 = b in
-         match uu____2126 with
+        (let uu___2 = b in
+         match uu___2 with
          | (a, imp) ->
-             let uu____2139 = FStar_Syntax_Syntax.is_null_binder b in
-             if uu____2139
+             let uu___3 = FStar_Syntax_Syntax.is_null_binder b in
+             if uu___3
              then
-               let uu____2140 = term_to_string a.FStar_Syntax_Syntax.sort in
-               Prims.op_Hat "_:" uu____2140
+               let uu___4 = term_to_string a.FStar_Syntax_Syntax.sort in
+               Prims.op_Hat "_:" uu___4
              else
-               (let uu____2142 =
+               (let uu___5 =
                   (Prims.op_Negation is_arrow) &&
-                    (let uu____2144 = FStar_Options.print_bound_var_types () in
-                     Prims.op_Negation uu____2144) in
-                if uu____2142
-                then
-                  let uu____2145 = nm_to_string a in
-                  imp_to_string uu____2145 imp
+                    (let uu___6 = FStar_Options.print_bound_var_types () in
+                     Prims.op_Negation uu___6) in
+                if uu___5
+                then let uu___6 = nm_to_string a in imp_to_string uu___6 imp
                 else
-                  (let uu____2147 =
-                     let uu____2148 = nm_to_string a in
-                     let uu____2149 =
-                       let uu____2150 =
+                  (let uu___7 =
+                     let uu___8 = nm_to_string a in
+                     let uu___9 =
+                       let uu___10 =
                          term_to_string a.FStar_Syntax_Syntax.sort in
-                       Prims.op_Hat ":" uu____2150 in
-                     Prims.op_Hat uu____2148 uu____2149 in
-                   imp_to_string uu____2147 imp)))
+                       Prims.op_Hat ":" uu___10 in
+                     Prims.op_Hat uu___8 uu___9 in
+                   imp_to_string uu___7 imp)))
 and (binder_to_string : FStar_Syntax_Syntax.binder -> Prims.string) =
   fun b -> binder_to_string' false b
 and (arrow_binder_to_string :
@@ -912,38 +885,36 @@ and (binders_to_string :
   fun sep ->
     fun bs ->
       let bs1 =
-        let uu____2164 = FStar_Options.print_implicits () in
-        if uu____2164 then bs else filter_imp bs in
+        let uu___ = FStar_Options.print_implicits () in
+        if uu___ then bs else filter_imp bs in
       if sep = " -> "
       then
-        let uu____2168 =
+        let uu___ =
           FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string) in
-        FStar_All.pipe_right uu____2168 (FStar_String.concat sep)
+        FStar_All.pipe_right uu___ (FStar_String.concat sep)
       else
-        (let uu____2190 =
+        (let uu___1 =
            FStar_All.pipe_right bs1 (FStar_List.map binder_to_string) in
-         FStar_All.pipe_right uu____2190 (FStar_String.concat sep))
+         FStar_All.pipe_right uu___1 (FStar_String.concat sep))
 and (arg_to_string :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) -> Prims.string)
   =
-  fun uu___8_2199 ->
-    match uu___8_2199 with
-    | (a, imp) ->
-        let uu____2212 = term_to_string a in imp_to_string uu____2212 imp
+  fun uu___ ->
+    match uu___ with
+    | (a, imp) -> let uu___1 = term_to_string a in imp_to_string uu___1 imp
 and (args_to_string : FStar_Syntax_Syntax.args -> Prims.string) =
   fun args ->
     let args1 =
-      let uu____2223 = FStar_Options.print_implicits () in
-      if uu____2223 then args else filter_imp args in
-    let uu____2235 =
-      FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
-    FStar_All.pipe_right uu____2235 (FStar_String.concat " ")
+      let uu___ = FStar_Options.print_implicits () in
+      if uu___ then args else filter_imp args in
+    let uu___ = FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
+    FStar_All.pipe_right uu___ (FStar_String.concat " ")
 and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
   fun c ->
-    let uu____2257 =
-      let uu____2258 = FStar_Options.ugly () in Prims.op_Negation uu____2258 in
-    if uu____2257
+    let uu___ =
+      let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+    if uu___
     then
       let e = FStar_Syntax_Resugar.resugar_comp c in
       let d = FStar_Parser_ToDocument.term_to_document e in
@@ -952,128 +923,126 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
     else
       (match c.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Total (t, uopt) ->
-           let uu____2272 =
-             let uu____2273 = FStar_Syntax_Subst.compress t in
-             uu____2273.FStar_Syntax_Syntax.n in
-           (match uu____2272 with
-            | FStar_Syntax_Syntax.Tm_type uu____2276 when
-                let uu____2277 =
+           let uu___2 =
+             let uu___3 = FStar_Syntax_Subst.compress t in
+             uu___3.FStar_Syntax_Syntax.n in
+           (match uu___2 with
+            | FStar_Syntax_Syntax.Tm_type uu___3 when
+                let uu___4 =
                   (FStar_Options.print_implicits ()) ||
                     (FStar_Options.print_universes ()) in
-                Prims.op_Negation uu____2277 -> term_to_string t
-            | uu____2278 ->
+                Prims.op_Negation uu___4 -> term_to_string t
+            | uu___3 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____2280 = univ_to_string u in
-                     let uu____2281 = term_to_string t in
-                     FStar_Util.format2 "Tot<%s> %s" uu____2280 uu____2281
-                 | uu____2282 ->
-                     let uu____2285 = term_to_string t in
-                     FStar_Util.format1 "Tot %s" uu____2285))
+                     let uu___4 = univ_to_string u in
+                     let uu___5 = term_to_string t in
+                     FStar_Util.format2 "Tot<%s> %s" uu___4 uu___5
+                 | uu___4 ->
+                     let uu___5 = term_to_string t in
+                     FStar_Util.format1 "Tot %s" uu___5))
        | FStar_Syntax_Syntax.GTotal (t, uopt) ->
-           let uu____2296 =
-             let uu____2297 = FStar_Syntax_Subst.compress t in
-             uu____2297.FStar_Syntax_Syntax.n in
-           (match uu____2296 with
-            | FStar_Syntax_Syntax.Tm_type uu____2300 when
-                let uu____2301 =
+           let uu___2 =
+             let uu___3 = FStar_Syntax_Subst.compress t in
+             uu___3.FStar_Syntax_Syntax.n in
+           (match uu___2 with
+            | FStar_Syntax_Syntax.Tm_type uu___3 when
+                let uu___4 =
                   (FStar_Options.print_implicits ()) ||
                     (FStar_Options.print_universes ()) in
-                Prims.op_Negation uu____2301 -> term_to_string t
-            | uu____2302 ->
+                Prims.op_Negation uu___4 -> term_to_string t
+            | uu___3 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____2304 = univ_to_string u in
-                     let uu____2305 = term_to_string t in
-                     FStar_Util.format2 "GTot<%s> %s" uu____2304 uu____2305
-                 | uu____2306 ->
-                     let uu____2309 = term_to_string t in
-                     FStar_Util.format1 "GTot %s" uu____2309))
+                     let uu___4 = univ_to_string u in
+                     let uu___5 = term_to_string t in
+                     FStar_Util.format2 "GTot<%s> %s" uu___4 uu___5
+                 | uu___4 ->
+                     let uu___5 = term_to_string t in
+                     FStar_Util.format1 "GTot %s" uu___5))
        | FStar_Syntax_Syntax.Comp c1 ->
            let basic =
-             let uu____2312 = FStar_Options.print_effect_args () in
-             if uu____2312
+             let uu___2 = FStar_Options.print_effect_args () in
+             if uu___2
              then
-               let uu____2313 = sli c1.FStar_Syntax_Syntax.effect_name in
-               let uu____2314 =
-                 let uu____2315 =
+               let uu___3 = sli c1.FStar_Syntax_Syntax.effect_name in
+               let uu___4 =
+                 let uu___5 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.comp_univs
                      (FStar_List.map univ_to_string) in
-                 FStar_All.pipe_right uu____2315 (FStar_String.concat ", ") in
-               let uu____2324 =
-                 term_to_string c1.FStar_Syntax_Syntax.result_typ in
-               let uu____2325 =
-                 let uu____2326 =
+                 FStar_All.pipe_right uu___5 (FStar_String.concat ", ") in
+               let uu___5 = term_to_string c1.FStar_Syntax_Syntax.result_typ in
+               let uu___6 =
+                 let uu___7 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
                      (FStar_List.map arg_to_string) in
-                 FStar_All.pipe_right uu____2326 (FStar_String.concat ", ") in
-               let uu____2347 = cflags_to_string c1.FStar_Syntax_Syntax.flags in
-               FStar_Util.format5 "%s<%s> (%s) %s (attributes %s)" uu____2313
-                 uu____2314 uu____2324 uu____2325 uu____2347
+                 FStar_All.pipe_right uu___7 (FStar_String.concat ", ") in
+               let uu___7 = cflags_to_string c1.FStar_Syntax_Syntax.flags in
+               FStar_Util.format5 "%s<%s> (%s) %s (attributes %s)" uu___3
+                 uu___4 uu___5 uu___6 uu___7
              else
-               (let uu____2349 =
+               (let uu___4 =
                   (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                      (FStar_Util.for_some
-                        (fun uu___9_2353 ->
-                           match uu___9_2353 with
+                        (fun uu___5 ->
+                           match uu___5 with
                            | FStar_Syntax_Syntax.TOTAL -> true
-                           | uu____2354 -> false)))
+                           | uu___6 -> false)))
                     &&
-                    (let uu____2356 = FStar_Options.print_effect_args () in
-                     Prims.op_Negation uu____2356) in
-                if uu____2349
+                    (let uu___5 = FStar_Options.print_effect_args () in
+                     Prims.op_Negation uu___5) in
+                if uu___4
                 then
-                  let uu____2357 =
+                  let uu___5 =
                     term_to_string c1.FStar_Syntax_Syntax.result_typ in
-                  FStar_Util.format1 "Tot %s" uu____2357
+                  FStar_Util.format1 "Tot %s" uu___5
                 else
-                  (let uu____2359 =
-                     ((let uu____2362 = FStar_Options.print_effect_args () in
-                       Prims.op_Negation uu____2362) &&
-                        (let uu____2364 = FStar_Options.print_implicits () in
-                         Prims.op_Negation uu____2364))
+                  (let uu___6 =
+                     ((let uu___7 = FStar_Options.print_effect_args () in
+                       Prims.op_Negation uu___7) &&
+                        (let uu___7 = FStar_Options.print_implicits () in
+                         Prims.op_Negation uu___7))
                        &&
                        (FStar_Ident.lid_equals
                           c1.FStar_Syntax_Syntax.effect_name
                           FStar_Parser_Const.effect_ML_lid) in
-                   if uu____2359
+                   if uu___6
                    then term_to_string c1.FStar_Syntax_Syntax.result_typ
                    else
-                     (let uu____2366 =
-                        (let uu____2369 = FStar_Options.print_effect_args () in
-                         Prims.op_Negation uu____2369) &&
+                     (let uu___8 =
+                        (let uu___9 = FStar_Options.print_effect_args () in
+                         Prims.op_Negation uu___9) &&
                           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                              (FStar_Util.for_some
-                                (fun uu___10_2373 ->
-                                   match uu___10_2373 with
+                                (fun uu___9 ->
+                                   match uu___9 with
                                    | FStar_Syntax_Syntax.MLEFFECT -> true
-                                   | uu____2374 -> false))) in
-                      if uu____2366
+                                   | uu___10 -> false))) in
+                      if uu___8
                       then
-                        let uu____2375 =
+                        let uu___9 =
                           term_to_string c1.FStar_Syntax_Syntax.result_typ in
-                        FStar_Util.format1 "ALL %s" uu____2375
+                        FStar_Util.format1 "ALL %s" uu___9
                       else
-                        (let uu____2377 =
-                           sli c1.FStar_Syntax_Syntax.effect_name in
-                         let uu____2378 =
+                        (let uu___10 = sli c1.FStar_Syntax_Syntax.effect_name in
+                         let uu___11 =
                            term_to_string c1.FStar_Syntax_Syntax.result_typ in
-                         FStar_Util.format2 "%s (%s)" uu____2377 uu____2378)))) in
+                         FStar_Util.format2 "%s (%s)" uu___10 uu___11)))) in
            let dec =
-             let uu____2380 =
+             let uu___2 =
                FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                  (FStar_List.collect
-                    (fun uu___11_2390 ->
-                       match uu___11_2390 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | FStar_Syntax_Syntax.DECREASES e ->
-                           let uu____2396 =
-                             let uu____2397 = term_to_string e in
-                             FStar_Util.format1 " (decreases %s)" uu____2397 in
-                           [uu____2396]
-                       | uu____2398 -> [])) in
-             FStar_All.pipe_right uu____2380 (FStar_String.concat " ") in
+                           let uu___4 =
+                             let uu___5 = term_to_string e in
+                             FStar_Util.format1 " (decreases %s)" uu___5 in
+                           [uu___4]
+                       | uu___4 -> [])) in
+             FStar_All.pipe_right uu___2 (FStar_String.concat " ") in
            FStar_Util.format2 "%s%s" basic dec)
 and (cflag_to_string : FStar_Syntax_Syntax.cflag -> Prims.string) =
   fun c ->
@@ -1087,56 +1056,54 @@ and (cflag_to_string : FStar_Syntax_Syntax.cflag -> Prims.string) =
     | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> "should_not_inline"
     | FStar_Syntax_Syntax.LEMMA -> "lemma"
     | FStar_Syntax_Syntax.CPS -> "cps"
-    | FStar_Syntax_Syntax.DECREASES uu____2402 -> ""
+    | FStar_Syntax_Syntax.DECREASES uu___ -> ""
 and (cflags_to_string : FStar_Syntax_Syntax.cflag Prims.list -> Prims.string)
   = fun fs -> FStar_Common.string_of_list cflag_to_string fs
 and (formula_to_string :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
   fun phi -> term_to_string phi
 and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
-  fun uu___12_2411 ->
-    match uu___12_2411 with
-    | FStar_Syntax_Syntax.Meta_pattern (uu____2412, ps) ->
+  fun uu___ ->
+    match uu___ with
+    | FStar_Syntax_Syntax.Meta_pattern (uu___1, ps) ->
         let pats =
-          let uu____2447 =
+          let uu___2 =
             FStar_All.pipe_right ps
               (FStar_List.map
                  (fun args ->
-                    let uu____2481 =
+                    let uu___3 =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____2503 ->
-                              match uu____2503 with
-                              | (t, uu____2511) -> term_to_string t)) in
-                    FStar_All.pipe_right uu____2481
-                      (FStar_String.concat "; "))) in
-          FStar_All.pipe_right uu____2447 (FStar_String.concat "\\/") in
+                           (fun uu___4 ->
+                              match uu___4 with
+                              | (t, uu___5) -> term_to_string t)) in
+                    FStar_All.pipe_right uu___3 (FStar_String.concat "; "))) in
+          FStar_All.pipe_right uu___2 (FStar_String.concat "\\/") in
         FStar_Util.format1 "{Meta_pattern %s}" pats
     | FStar_Syntax_Syntax.Meta_named lid ->
-        let uu____2521 = sli lid in
-        FStar_Util.format1 "{Meta_named %s}" uu____2521
-    | FStar_Syntax_Syntax.Meta_labeled (l, r, uu____2524) ->
-        let uu____2525 = FStar_Range.string_of_range r in
-        FStar_Util.format2 "{Meta_labeled (%s, %s)}" l uu____2525
+        let uu___1 = sli lid in FStar_Util.format1 "{Meta_named %s}" uu___1
+    | FStar_Syntax_Syntax.Meta_labeled (l, r, uu___1) ->
+        let uu___2 = FStar_Range.string_of_range r in
+        FStar_Util.format2 "{Meta_labeled (%s, %s)}" l uu___2
     | FStar_Syntax_Syntax.Meta_desugared msi -> "{Meta_desugared}"
     | FStar_Syntax_Syntax.Meta_monadic (m, t) ->
-        let uu____2533 = sli m in
-        let uu____2534 = term_to_string t in
-        FStar_Util.format2 "{Meta_monadic(%s @ %s)}" uu____2533 uu____2534
+        let uu___1 = sli m in
+        let uu___2 = term_to_string t in
+        FStar_Util.format2 "{Meta_monadic(%s @ %s)}" uu___1 uu___2
     | FStar_Syntax_Syntax.Meta_monadic_lift (m, m', t) ->
-        let uu____2542 = sli m in
-        let uu____2543 = sli m' in
-        let uu____2544 = term_to_string t in
-        FStar_Util.format3 "{Meta_monadic_lift(%s -> %s @ %s)}" uu____2542
-          uu____2543 uu____2544
+        let uu___1 = sli m in
+        let uu___2 = sli m' in
+        let uu___3 = term_to_string t in
+        FStar_Util.format3 "{Meta_monadic_lift(%s -> %s @ %s)}" uu___1 uu___2
+          uu___3
 let (aqual_to_string : FStar_Syntax_Syntax.aqual -> Prims.string) =
   fun aq -> aqual_to_string' "" aq
 let (comp_to_string' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.comp -> Prims.string) =
   fun env ->
     fun c ->
-      let uu____2560 = FStar_Options.ugly () in
-      if uu____2560
+      let uu___ = FStar_Options.ugly () in
+      if uu___
       then comp_to_string c
       else
         (let e = FStar_Syntax_Resugar.resugar_comp' env c in
@@ -1147,8 +1114,8 @@ let (term_to_string' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.term -> Prims.string) =
   fun env ->
     fun x ->
-      let uu____2574 = FStar_Options.ugly () in
-      if uu____2574
+      let uu___ = FStar_Options.ugly () in
+      if uu___
       then term_to_string x
       else
         (let e = FStar_Syntax_Resugar.resugar_term' env x in
@@ -1159,146 +1126,139 @@ let (binder_to_json :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.binder -> FStar_Util.json) =
   fun env ->
     fun b ->
-      let uu____2588 = b in
-      match uu____2588 with
+      let uu___ = b in
+      match uu___ with
       | (a, imp) ->
           let n =
-            let uu____2596 = FStar_Syntax_Syntax.is_null_binder b in
-            if uu____2596
+            let uu___1 = FStar_Syntax_Syntax.is_null_binder b in
+            if uu___1
             then FStar_Util.JsonNull
             else
-              (let uu____2598 =
-                 let uu____2599 = nm_to_string a in
-                 imp_to_string uu____2599 imp in
-               FStar_Util.JsonStr uu____2598) in
+              (let uu___3 =
+                 let uu___4 = nm_to_string a in imp_to_string uu___4 imp in
+               FStar_Util.JsonStr uu___3) in
           let t =
-            let uu____2601 = term_to_string' env a.FStar_Syntax_Syntax.sort in
-            FStar_Util.JsonStr uu____2601 in
+            let uu___1 = term_to_string' env a.FStar_Syntax_Syntax.sort in
+            FStar_Util.JsonStr uu___1 in
           FStar_Util.JsonAssoc [("name", n); ("type", t)]
 let (binders_to_json :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.binders -> FStar_Util.json) =
   fun env ->
     fun bs ->
-      let uu____2624 = FStar_List.map (binder_to_json env) bs in
-      FStar_Util.JsonList uu____2624
+      let uu___ = FStar_List.map (binder_to_json env) bs in
+      FStar_Util.JsonList uu___
 let (enclose_universes : Prims.string -> Prims.string) =
   fun s ->
-    let uu____2638 = FStar_Options.print_universes () in
-    if uu____2638 then Prims.op_Hat "<" (Prims.op_Hat s ">") else ""
+    let uu___ = FStar_Options.print_universes () in
+    if uu___ then Prims.op_Hat "<" (Prims.op_Hat s ">") else ""
 let (tscheme_to_string : FStar_Syntax_Syntax.tscheme -> Prims.string) =
   fun s ->
-    let uu____2645 =
-      let uu____2646 = FStar_Options.ugly () in Prims.op_Negation uu____2646 in
-    if uu____2645
+    let uu___ =
+      let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+    if uu___
     then
       let d = FStar_Syntax_Resugar.resugar_tscheme s in
       let d1 = FStar_Parser_ToDocument.decl_to_document d in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.of_int (100)) d1
     else
-      (let uu____2650 = s in
-       match uu____2650 with
+      (let uu___2 = s in
+       match uu___2 with
        | (us, t) ->
-           let uu____2661 =
-             let uu____2662 = univ_names_to_string us in
-             FStar_All.pipe_left enclose_universes uu____2662 in
-           let uu____2663 = term_to_string t in
-           FStar_Util.format2 "%s%s" uu____2661 uu____2663)
+           let uu___3 =
+             let uu___4 = univ_names_to_string us in
+             FStar_All.pipe_left enclose_universes uu___4 in
+           let uu___4 = term_to_string t in
+           FStar_Util.format2 "%s%s" uu___3 uu___4)
 let (action_to_string : FStar_Syntax_Syntax.action -> Prims.string) =
   fun a ->
-    let uu____2669 = sli a.FStar_Syntax_Syntax.action_name in
-    let uu____2670 =
-      binders_to_string " " a.FStar_Syntax_Syntax.action_params in
-    let uu____2671 =
-      let uu____2672 =
-        univ_names_to_string a.FStar_Syntax_Syntax.action_univs in
-      FStar_All.pipe_left enclose_universes uu____2672 in
-    let uu____2673 = term_to_string a.FStar_Syntax_Syntax.action_typ in
-    let uu____2674 = term_to_string a.FStar_Syntax_Syntax.action_defn in
-    FStar_Util.format5 "%s%s %s : %s = %s" uu____2669 uu____2670 uu____2671
-      uu____2673 uu____2674
+    let uu___ = sli a.FStar_Syntax_Syntax.action_name in
+    let uu___1 = binders_to_string " " a.FStar_Syntax_Syntax.action_params in
+    let uu___2 =
+      let uu___3 = univ_names_to_string a.FStar_Syntax_Syntax.action_univs in
+      FStar_All.pipe_left enclose_universes uu___3 in
+    let uu___3 = term_to_string a.FStar_Syntax_Syntax.action_typ in
+    let uu___4 = term_to_string a.FStar_Syntax_Syntax.action_defn in
+    FStar_Util.format5 "%s%s %s : %s = %s" uu___ uu___1 uu___2 uu___3 uu___4
 let (wp_eff_combinators_to_string :
   FStar_Syntax_Syntax.wp_eff_combinators -> Prims.string) =
   fun combs ->
-    let tscheme_opt_to_string uu___13_2687 =
-      match uu___13_2687 with
+    let tscheme_opt_to_string uu___ =
+      match uu___ with
       | FStar_Pervasives_Native.Some ts -> tscheme_to_string ts
       | FStar_Pervasives_Native.None -> "None" in
-    let uu____2691 =
-      let uu____2694 = tscheme_to_string combs.FStar_Syntax_Syntax.ret_wp in
-      let uu____2695 =
-        let uu____2698 = tscheme_to_string combs.FStar_Syntax_Syntax.bind_wp in
-        let uu____2699 =
-          let uu____2702 =
-            tscheme_to_string combs.FStar_Syntax_Syntax.stronger in
-          let uu____2703 =
-            let uu____2706 =
+    let uu___ =
+      let uu___1 = tscheme_to_string combs.FStar_Syntax_Syntax.ret_wp in
+      let uu___2 =
+        let uu___3 = tscheme_to_string combs.FStar_Syntax_Syntax.bind_wp in
+        let uu___4 =
+          let uu___5 = tscheme_to_string combs.FStar_Syntax_Syntax.stronger in
+          let uu___6 =
+            let uu___7 =
               tscheme_to_string combs.FStar_Syntax_Syntax.if_then_else in
-            let uu____2707 =
-              let uu____2710 =
-                tscheme_to_string combs.FStar_Syntax_Syntax.ite_wp in
-              let uu____2711 =
-                let uu____2714 =
+            let uu___8 =
+              let uu___9 = tscheme_to_string combs.FStar_Syntax_Syntax.ite_wp in
+              let uu___10 =
+                let uu___11 =
                   tscheme_to_string combs.FStar_Syntax_Syntax.close_wp in
-                let uu____2715 =
-                  let uu____2718 =
+                let uu___12 =
+                  let uu___13 =
                     tscheme_to_string combs.FStar_Syntax_Syntax.trivial in
-                  let uu____2719 =
-                    let uu____2722 =
+                  let uu___14 =
+                    let uu___15 =
                       tscheme_opt_to_string combs.FStar_Syntax_Syntax.repr in
-                    let uu____2723 =
-                      let uu____2726 =
+                    let uu___16 =
+                      let uu___17 =
                         tscheme_opt_to_string
                           combs.FStar_Syntax_Syntax.return_repr in
-                      let uu____2727 =
-                        let uu____2730 =
+                      let uu___18 =
+                        let uu___19 =
                           tscheme_opt_to_string
                             combs.FStar_Syntax_Syntax.bind_repr in
-                        [uu____2730] in
-                      uu____2726 :: uu____2727 in
-                    uu____2722 :: uu____2723 in
-                  uu____2718 :: uu____2719 in
-                uu____2714 :: uu____2715 in
-              uu____2710 :: uu____2711 in
-            uu____2706 :: uu____2707 in
-          uu____2702 :: uu____2703 in
-        uu____2698 :: uu____2699 in
-      uu____2694 :: uu____2695 in
+                        [uu___19] in
+                      uu___17 :: uu___18 in
+                    uu___15 :: uu___16 in
+                  uu___13 :: uu___14 in
+                uu___11 :: uu___12 in
+              uu___9 :: uu___10 in
+            uu___7 :: uu___8 in
+          uu___5 :: uu___6 in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     FStar_Util.format
       "{\nret_wp       = %s\n; bind_wp      = %s\n; stronger     = %s\n; if_then_else = %s\n; ite_wp       = %s\n; close_wp     = %s\n; trivial      = %s\n; repr         = %s\n; return_repr  = %s\n; bind_repr    = %s\n}\n"
-      uu____2691
+      uu___
 let (layered_eff_combinators_to_string :
   FStar_Syntax_Syntax.layered_eff_combinators -> Prims.string) =
   fun combs ->
-    let to_str uu____2745 =
-      match uu____2745 with
+    let to_str uu___ =
+      match uu___ with
       | (ts_t, ts_ty) ->
-          let uu____2752 = tscheme_to_string ts_t in
-          let uu____2753 = tscheme_to_string ts_ty in
-          FStar_Util.format2 "(%s) : (%s)" uu____2752 uu____2753 in
-    let uu____2754 =
-      let uu____2757 = to_str combs.FStar_Syntax_Syntax.l_repr in
-      let uu____2758 =
-        let uu____2761 = to_str combs.FStar_Syntax_Syntax.l_return in
-        let uu____2762 =
-          let uu____2765 = to_str combs.FStar_Syntax_Syntax.l_bind in
-          let uu____2766 =
-            let uu____2769 = to_str combs.FStar_Syntax_Syntax.l_subcomp in
-            let uu____2770 =
-              let uu____2773 =
-                to_str combs.FStar_Syntax_Syntax.l_if_then_else in
-              [uu____2773] in
-            uu____2769 :: uu____2770 in
-          uu____2765 :: uu____2766 in
-        uu____2761 :: uu____2762 in
-      uu____2757 :: uu____2758 in
+          let uu___1 = tscheme_to_string ts_t in
+          let uu___2 = tscheme_to_string ts_ty in
+          FStar_Util.format2 "(%s) : (%s)" uu___1 uu___2 in
+    let uu___ =
+      let uu___1 = to_str combs.FStar_Syntax_Syntax.l_repr in
+      let uu___2 =
+        let uu___3 = to_str combs.FStar_Syntax_Syntax.l_return in
+        let uu___4 =
+          let uu___5 = to_str combs.FStar_Syntax_Syntax.l_bind in
+          let uu___6 =
+            let uu___7 = to_str combs.FStar_Syntax_Syntax.l_subcomp in
+            let uu___8 =
+              let uu___9 = to_str combs.FStar_Syntax_Syntax.l_if_then_else in
+              [uu___9] in
+            uu___7 :: uu___8 in
+          uu___5 :: uu___6 in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     FStar_Util.format
       "{\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  }\n"
-      uu____2754
+      uu___
 let (eff_combinators_to_string :
   FStar_Syntax_Syntax.eff_combinators -> Prims.string) =
-  fun uu___14_2778 ->
-    match uu___14_2778 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         wp_eff_combinators_to_string combs
     | FStar_Syntax_Syntax.DM4F_eff combs ->
@@ -1315,10 +1275,9 @@ let (eff_decl_to_string' :
     fun r ->
       fun q ->
         fun ed ->
-          let uu____2806 =
-            let uu____2807 = FStar_Options.ugly () in
-            Prims.op_Negation uu____2807 in
-          if uu____2806
+          let uu___ =
+            let uu___1 = FStar_Options.ugly () in Prims.op_Negation uu___1 in
+          if uu___
           then
             let d = FStar_Syntax_Resugar.resugar_eff_decl r q ed in
             let d1 = FStar_Parser_ToDocument.decl_to_document d in
@@ -1326,48 +1285,47 @@ let (eff_decl_to_string' :
               (Prims.of_int (100)) d1
           else
             (let actions_to_string actions =
-               let uu____2821 =
+               let uu___2 =
                  FStar_All.pipe_right actions
                    (FStar_List.map action_to_string) in
-               FStar_All.pipe_right uu____2821 (FStar_String.concat ",\n\t") in
+               FStar_All.pipe_right uu___2 (FStar_String.concat ",\n\t") in
              let eff_name =
-               let uu____2831 = FStar_Syntax_Util.is_layered ed in
-               if uu____2831 then "layered_effect" else "new_effect" in
-             let uu____2833 =
-               let uu____2836 =
-                 let uu____2839 =
-                   let uu____2842 =
-                     lid_to_string ed.FStar_Syntax_Syntax.mname in
-                   let uu____2843 =
-                     let uu____2846 =
-                       let uu____2847 =
+               let uu___2 = FStar_Syntax_Util.is_layered ed in
+               if uu___2 then "layered_effect" else "new_effect" in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = lid_to_string ed.FStar_Syntax_Syntax.mname in
+                   let uu___6 =
+                     let uu___7 =
+                       let uu___8 =
                          univ_names_to_string ed.FStar_Syntax_Syntax.univs in
-                       FStar_All.pipe_left enclose_universes uu____2847 in
-                     let uu____2848 =
-                       let uu____2851 =
+                       FStar_All.pipe_left enclose_universes uu___8 in
+                     let uu___8 =
+                       let uu___9 =
                          binders_to_string " " ed.FStar_Syntax_Syntax.binders in
-                       let uu____2852 =
-                         let uu____2855 =
+                       let uu___10 =
+                         let uu___11 =
                            tscheme_to_string ed.FStar_Syntax_Syntax.signature in
-                         let uu____2856 =
-                           let uu____2859 =
+                         let uu___12 =
+                           let uu___13 =
                              eff_combinators_to_string
                                ed.FStar_Syntax_Syntax.combinators in
-                           let uu____2860 =
-                             let uu____2863 =
+                           let uu___14 =
+                             let uu___15 =
                                actions_to_string
                                  ed.FStar_Syntax_Syntax.actions in
-                             [uu____2863] in
-                           uu____2859 :: uu____2860 in
-                         uu____2855 :: uu____2856 in
-                       uu____2851 :: uu____2852 in
-                     uu____2846 :: uu____2848 in
-                   uu____2842 :: uu____2843 in
-                 (if for_free then "_for_free " else "") :: uu____2839 in
-               eff_name :: uu____2836 in
+                             [uu___15] in
+                           uu___13 :: uu___14 in
+                         uu___11 :: uu___12 in
+                       uu___9 :: uu___10 in
+                     uu___7 :: uu___8 in
+                   uu___5 :: uu___6 in
+                 (if for_free then "_for_free " else "") :: uu___4 in
+               eff_name :: uu___3 in
              FStar_Util.format
                "%s%s { %s%s %s : %s \n  %s\nand effect_actions\n\t%s\n}\n"
-               uu____2833)
+               uu___2)
 let (eff_decl_to_string :
   Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string) =
   fun for_free ->
@@ -1377,15 +1335,15 @@ let (sub_eff_to_string : FStar_Syntax_Syntax.sub_eff -> Prims.string) =
     let tsopt_to_string ts_opt =
       if FStar_Util.is_some ts_opt
       then
-        let uu____2890 = FStar_All.pipe_right ts_opt FStar_Util.must in
-        FStar_All.pipe_right uu____2890 tscheme_to_string
+        let uu___ = FStar_All.pipe_right ts_opt FStar_Util.must in
+        FStar_All.pipe_right uu___ tscheme_to_string
       else "<None>" in
-    let uu____2894 = lid_to_string se.FStar_Syntax_Syntax.source in
-    let uu____2895 = lid_to_string se.FStar_Syntax_Syntax.target in
-    let uu____2896 = tsopt_to_string se.FStar_Syntax_Syntax.lift in
-    let uu____2897 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp in
+    let uu___ = lid_to_string se.FStar_Syntax_Syntax.source in
+    let uu___1 = lid_to_string se.FStar_Syntax_Syntax.target in
+    let uu___2 = tsopt_to_string se.FStar_Syntax_Syntax.lift in
+    let uu___3 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp in
     FStar_Util.format4 "sub_effect %s ~> %s : lift = %s ;; lift_wp = %s"
-      uu____2894 uu____2895 uu____2896 uu____2897
+      uu___ uu___1 uu___2 uu___3
 let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x ->
     let basic =
@@ -1409,201 +1367,197 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
       | FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.PopOptions) ->
           "#pop-options"
       | FStar_Syntax_Syntax.Sig_inductive_typ
-          (lid, univs, tps, k, uu____2911, uu____2912) ->
+          (lid, univs, tps, k, uu___, uu___1) ->
           let quals_str = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
           let binders_str = binders_to_string " " tps in
           let term_str = term_to_string k in
-          let uu____2924 = FStar_Options.print_universes () in
-          if uu____2924
+          let uu___2 = FStar_Options.print_universes () in
+          if uu___2
           then
-            let uu____2925 = FStar_Ident.string_of_lid lid in
-            let uu____2926 = univ_names_to_string univs in
-            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str uu____2925
-              uu____2926 binders_str term_str
+            let uu___3 = FStar_Ident.string_of_lid lid in
+            let uu___4 = univ_names_to_string univs in
+            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str uu___3
+              uu___4 binders_str term_str
           else
-            (let uu____2928 = FStar_Ident.string_of_lid lid in
-             FStar_Util.format4 "%stype %s %s : %s" quals_str uu____2928
+            (let uu___4 = FStar_Ident.string_of_lid lid in
+             FStar_Util.format4 "%stype %s %s : %s" quals_str uu___4
                binders_str term_str)
       | FStar_Syntax_Syntax.Sig_datacon
-          (lid, univs, t, uu____2932, uu____2933, uu____2934) ->
-          let uu____2939 = FStar_Options.print_universes () in
-          if uu____2939
+          (lid, univs, t, uu___, uu___1, uu___2) ->
+          let uu___3 = FStar_Options.print_universes () in
+          if uu___3
           then
-            let uu____2940 = univ_names_to_string univs in
-            let uu____2941 = FStar_Ident.string_of_lid lid in
-            let uu____2942 = term_to_string t in
-            FStar_Util.format3 "datacon<%s> %s : %s" uu____2940 uu____2941
-              uu____2942
+            let uu___4 = univ_names_to_string univs in
+            let uu___5 = FStar_Ident.string_of_lid lid in
+            let uu___6 = term_to_string t in
+            FStar_Util.format3 "datacon<%s> %s : %s" uu___4 uu___5 uu___6
           else
-            (let uu____2944 = FStar_Ident.string_of_lid lid in
-             let uu____2945 = term_to_string t in
-             FStar_Util.format2 "datacon %s : %s" uu____2944 uu____2945)
+            (let uu___5 = FStar_Ident.string_of_lid lid in
+             let uu___6 = term_to_string t in
+             FStar_Util.format2 "datacon %s : %s" uu___5 uu___6)
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) ->
-          let uu____2949 = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
-          let uu____2950 = FStar_Ident.string_of_lid lid in
-          let uu____2951 =
-            let uu____2952 = FStar_Options.print_universes () in
-            if uu____2952
+          let uu___ = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
+          let uu___1 = FStar_Ident.string_of_lid lid in
+          let uu___2 =
+            let uu___3 = FStar_Options.print_universes () in
+            if uu___3
             then
-              let uu____2953 = univ_names_to_string univs in
-              FStar_Util.format1 "<%s>" uu____2953
+              let uu___4 = univ_names_to_string univs in
+              FStar_Util.format1 "<%s>" uu___4
             else "" in
-          let uu____2955 = term_to_string t in
-          FStar_Util.format4 "%sval %s %s : %s" uu____2949 uu____2950
-            uu____2951 uu____2955
+          let uu___3 = term_to_string t in
+          FStar_Util.format4 "%sval %s %s : %s" uu___ uu___1 uu___2 uu___3
       | FStar_Syntax_Syntax.Sig_assume (lid, us, f) ->
-          let uu____2959 = FStar_Options.print_universes () in
-          if uu____2959
+          let uu___ = FStar_Options.print_universes () in
+          if uu___
           then
-            let uu____2960 = FStar_Ident.string_of_lid lid in
-            let uu____2961 = univ_names_to_string us in
-            let uu____2962 = term_to_string f in
-            FStar_Util.format3 "val %s<%s> : %s" uu____2960 uu____2961
-              uu____2962
+            let uu___1 = FStar_Ident.string_of_lid lid in
+            let uu___2 = univ_names_to_string us in
+            let uu___3 = term_to_string f in
+            FStar_Util.format3 "val %s<%s> : %s" uu___1 uu___2 uu___3
           else
-            (let uu____2964 = FStar_Ident.string_of_lid lid in
-             let uu____2965 = term_to_string f in
-             FStar_Util.format2 "val %s : %s" uu____2964 uu____2965)
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu____2967) ->
+            (let uu___2 = FStar_Ident.string_of_lid lid in
+             let uu___3 = term_to_string f in
+             FStar_Util.format2 "val %s : %s" uu___2 uu___3)
+      | FStar_Syntax_Syntax.Sig_let (lbs, uu___) ->
           lbs_to_string x.FStar_Syntax_Syntax.sigquals lbs
-      | FStar_Syntax_Syntax.Sig_bundle (ses, uu____2973) ->
-          let uu____2982 =
-            let uu____2983 = FStar_List.map sigelt_to_string ses in
-            FStar_All.pipe_right uu____2983 (FStar_String.concat "\n") in
-          Prims.op_Hat "(* Sig_bundle *)" uu____2982
+      | FStar_Syntax_Syntax.Sig_bundle (ses, uu___) ->
+          let uu___1 =
+            let uu___2 = FStar_List.map sigelt_to_string ses in
+            FStar_All.pipe_right uu___2 (FStar_String.concat "\n") in
+          Prims.op_Hat "(* Sig_bundle *)" uu___1
       | FStar_Syntax_Syntax.Sig_fail (errs, lax, ses) ->
-          let uu____2999 = FStar_Util.string_of_bool lax in
-          let uu____3000 =
+          let uu___ = FStar_Util.string_of_bool lax in
+          let uu___1 =
             FStar_Common.string_of_list FStar_Util.string_of_int errs in
-          let uu____3001 =
-            let uu____3002 = FStar_List.map sigelt_to_string ses in
-            FStar_All.pipe_right uu____3002 (FStar_String.concat "\n") in
+          let uu___2 =
+            let uu___3 = FStar_List.map sigelt_to_string ses in
+            FStar_All.pipe_right uu___3 (FStar_String.concat "\n") in
           FStar_Util.format3 "(* Sig_fail %s %s *)\n%s\n(* / Sig_fail*)\n"
-            uu____2999 uu____3000 uu____3001
+            uu___ uu___1 uu___2
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3008 = FStar_Syntax_Util.is_dm4f ed in
-          eff_decl_to_string' uu____3008 x.FStar_Syntax_Syntax.sigrng
+          let uu___ = FStar_Syntax_Util.is_dm4f ed in
+          eff_decl_to_string' uu___ x.FStar_Syntax_Syntax.sigrng
             x.FStar_Syntax_Syntax.sigquals ed
       | FStar_Syntax_Syntax.Sig_sub_effect se -> sub_eff_to_string se
       | FStar_Syntax_Syntax.Sig_effect_abbrev (l, univs, tps, c, flags) ->
-          let uu____3019 = FStar_Options.print_universes () in
-          if uu____3019
+          let uu___ = FStar_Options.print_universes () in
+          if uu___
           then
-            let uu____3020 =
-              let uu____3025 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (tps, c))
                   FStar_Range.dummyRange in
-              FStar_Syntax_Subst.open_univ_vars univs uu____3025 in
-            (match uu____3020 with
+              FStar_Syntax_Subst.open_univ_vars univs uu___2 in
+            (match uu___1 with
              | (univs1, t) ->
-                 let uu____3038 =
-                   let uu____3043 =
-                     let uu____3044 = FStar_Syntax_Subst.compress t in
-                     uu____3044.FStar_Syntax_Syntax.n in
-                   match uu____3043 with
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Subst.compress t in
+                     uu___4.FStar_Syntax_Syntax.n in
+                   match uu___3 with
                    | FStar_Syntax_Syntax.Tm_arrow (bs, c1) -> (bs, c1)
-                   | uu____3073 -> failwith "impossible" in
-                 (match uu____3038 with
+                   | uu___4 -> failwith "impossible" in
+                 (match uu___2 with
                   | (tps1, c1) ->
-                      let uu____3080 = sli l in
-                      let uu____3081 = univ_names_to_string univs1 in
-                      let uu____3082 = binders_to_string " " tps1 in
-                      let uu____3083 = comp_to_string c1 in
-                      FStar_Util.format4 "effect %s<%s> %s = %s" uu____3080
-                        uu____3081 uu____3082 uu____3083))
+                      let uu___3 = sli l in
+                      let uu___4 = univ_names_to_string univs1 in
+                      let uu___5 = binders_to_string " " tps1 in
+                      let uu___6 = comp_to_string c1 in
+                      FStar_Util.format4 "effect %s<%s> %s = %s" uu___3
+                        uu___4 uu___5 uu___6))
           else
-            (let uu____3085 = sli l in
-             let uu____3086 = binders_to_string " " tps in
-             let uu____3087 = comp_to_string c in
-             FStar_Util.format3 "effect %s %s = %s" uu____3085 uu____3086
-               uu____3087)
+            (let uu___2 = sli l in
+             let uu___3 = binders_to_string " " tps in
+             let uu___4 = comp_to_string c in
+             FStar_Util.format3 "effect %s %s = %s" uu___2 uu___3 uu___4)
       | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
-          let uu____3094 =
-            let uu____3095 = FStar_List.map FStar_Ident.string_of_lid lids in
-            FStar_All.pipe_left (FStar_String.concat "; ") uu____3095 in
-          let uu____3100 = term_to_string t in
-          FStar_Util.format2 "splice[%s] (%s)" uu____3094 uu____3100
+          let uu___ =
+            let uu___1 = FStar_List.map FStar_Ident.string_of_lid lids in
+            FStar_All.pipe_left (FStar_String.concat "; ") uu___1 in
+          let uu___1 = term_to_string t in
+          FStar_Util.format2 "splice[%s] (%s)" uu___ uu___1
       | FStar_Syntax_Syntax.Sig_polymonadic_bind (m, n, p, t, ty) ->
-          let uu____3106 = FStar_Ident.string_of_lid m in
-          let uu____3107 = FStar_Ident.string_of_lid n in
-          let uu____3108 = FStar_Ident.string_of_lid p in
-          let uu____3109 = tscheme_to_string t in
-          let uu____3110 = tscheme_to_string ty in
+          let uu___ = FStar_Ident.string_of_lid m in
+          let uu___1 = FStar_Ident.string_of_lid n in
+          let uu___2 = FStar_Ident.string_of_lid p in
+          let uu___3 = tscheme_to_string t in
+          let uu___4 = tscheme_to_string ty in
           FStar_Util.format5 "polymonadic_bind (%s, %s) |> %s = (%s, %s)"
-            uu____3106 uu____3107 uu____3108 uu____3109 uu____3110
+            uu___ uu___1 uu___2 uu___3 uu___4
       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp (m, n, t, ty) ->
-          let uu____3115 = FStar_Ident.string_of_lid m in
-          let uu____3116 = FStar_Ident.string_of_lid n in
-          let uu____3117 = tscheme_to_string t in
-          let uu____3118 = tscheme_to_string ty in
-          FStar_Util.format4 "polymonadic_subcomp %s <: %s = (%s, %s)"
-            uu____3115 uu____3116 uu____3117 uu____3118 in
+          let uu___ = FStar_Ident.string_of_lid m in
+          let uu___1 = FStar_Ident.string_of_lid n in
+          let uu___2 = tscheme_to_string t in
+          let uu___3 = tscheme_to_string ty in
+          FStar_Util.format4 "polymonadic_subcomp %s <: %s = (%s, %s)" uu___
+            uu___1 uu___2 uu___3 in
     match x.FStar_Syntax_Syntax.sigattrs with
     | [] -> Prims.op_Hat "[@ ]" (Prims.op_Hat "\n" basic)
-    | uu____3119 ->
-        let uu____3122 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs in
-        Prims.op_Hat uu____3122 (Prims.op_Hat "\n" basic)
+    | uu___ ->
+        let uu___1 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs in
+        Prims.op_Hat uu___1 (Prims.op_Hat "\n" basic)
 let (format_error : FStar_Range.range -> Prims.string -> Prims.string) =
   fun r ->
     fun msg ->
-      let uu____3133 = FStar_Range.string_of_range r in
-      FStar_Util.format2 "%s: %s\n" uu____3133 msg
+      let uu___ = FStar_Range.string_of_range r in
+      FStar_Util.format2 "%s: %s\n" uu___ msg
 let (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x ->
     match x.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_let
-        ((uu____3139,
+        ((uu___,
           { FStar_Syntax_Syntax.lbname = lb;
-            FStar_Syntax_Syntax.lbunivs = uu____3141;
+            FStar_Syntax_Syntax.lbunivs = uu___1;
             FStar_Syntax_Syntax.lbtyp = t;
-            FStar_Syntax_Syntax.lbeff = uu____3143;
-            FStar_Syntax_Syntax.lbdef = uu____3144;
-            FStar_Syntax_Syntax.lbattrs = uu____3145;
-            FStar_Syntax_Syntax.lbpos = uu____3146;_}::[]),
-         uu____3147)
+            FStar_Syntax_Syntax.lbeff = uu___2;
+            FStar_Syntax_Syntax.lbdef = uu___3;
+            FStar_Syntax_Syntax.lbattrs = uu___4;
+            FStar_Syntax_Syntax.lbpos = uu___5;_}::[]),
+         uu___6)
         ->
-        let uu____3168 = lbname_to_string lb in
-        let uu____3169 = term_to_string t in
-        FStar_Util.format2 "let %s : %s" uu____3168 uu____3169
-    | uu____3170 ->
-        let uu____3171 =
+        let uu___7 = lbname_to_string lb in
+        let uu___8 = term_to_string t in
+        FStar_Util.format2 "let %s : %s" uu___7 uu___8
+    | uu___ ->
+        let uu___1 =
           FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x)
             (FStar_List.map (fun l -> FStar_Ident.string_of_lid l)) in
-        FStar_All.pipe_right uu____3171 (FStar_String.concat ", ")
+        FStar_All.pipe_right uu___1 (FStar_String.concat ", ")
 let (tag_of_sigelt : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_inductive_typ uu____3187 -> "Sig_inductive_typ"
-    | FStar_Syntax_Syntax.Sig_bundle uu____3204 -> "Sig_bundle"
-    | FStar_Syntax_Syntax.Sig_datacon uu____3213 -> "Sig_datacon"
-    | FStar_Syntax_Syntax.Sig_declare_typ uu____3228 -> "Sig_declare_typ"
-    | FStar_Syntax_Syntax.Sig_let uu____3235 -> "Sig_let"
-    | FStar_Syntax_Syntax.Sig_assume uu____3242 -> "Sig_assume"
-    | FStar_Syntax_Syntax.Sig_new_effect uu____3249 -> "Sig_new_effect"
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____3250 -> "Sig_sub_effect"
-    | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3251 -> "Sig_effect_abbrev"
-    | FStar_Syntax_Syntax.Sig_pragma uu____3264 -> "Sig_pragma"
-    | FStar_Syntax_Syntax.Sig_splice uu____3265 -> "Sig_splice"
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3272 ->
+    | FStar_Syntax_Syntax.Sig_inductive_typ uu___ -> "Sig_inductive_typ"
+    | FStar_Syntax_Syntax.Sig_bundle uu___ -> "Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_datacon uu___ -> "Sig_datacon"
+    | FStar_Syntax_Syntax.Sig_declare_typ uu___ -> "Sig_declare_typ"
+    | FStar_Syntax_Syntax.Sig_let uu___ -> "Sig_let"
+    | FStar_Syntax_Syntax.Sig_assume uu___ -> "Sig_assume"
+    | FStar_Syntax_Syntax.Sig_new_effect uu___ -> "Sig_new_effect"
+    | FStar_Syntax_Syntax.Sig_sub_effect uu___ -> "Sig_sub_effect"
+    | FStar_Syntax_Syntax.Sig_effect_abbrev uu___ -> "Sig_effect_abbrev"
+    | FStar_Syntax_Syntax.Sig_pragma uu___ -> "Sig_pragma"
+    | FStar_Syntax_Syntax.Sig_splice uu___ -> "Sig_splice"
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___ ->
         "Sig_polymonadic_bind"
-    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____3283 ->
+    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___ ->
         "Sig_polymonadic_subcomp"
-    | FStar_Syntax_Syntax.Sig_fail uu____3292 -> "Sig_fail"
+    | FStar_Syntax_Syntax.Sig_fail uu___ -> "Sig_fail"
 let (modul_to_string : FStar_Syntax_Syntax.modul -> Prims.string) =
   fun m ->
-    let uu____3308 = sli m.FStar_Syntax_Syntax.name in
-    let uu____3309 =
-      let uu____3310 =
+    let uu___ = sli m.FStar_Syntax_Syntax.name in
+    let uu___1 =
+      let uu___2 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations in
-      FStar_All.pipe_right uu____3310 (FStar_String.concat "\n") in
-    let uu____3315 =
-      let uu____3316 =
+      FStar_All.pipe_right uu___2 (FStar_String.concat "\n") in
+    let uu___2 =
+      let uu___3 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations in
-      FStar_All.pipe_right uu____3316 (FStar_String.concat "\n") in
+      FStar_All.pipe_right uu___3 (FStar_String.concat "\n") in
     FStar_Util.format3
-      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu____3308
-      uu____3309 uu____3315
+      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu___ uu___1
+      uu___2
 let list_to_string :
   'a . ('a -> Prims.string) -> 'a Prims.list -> Prims.string =
   fun f ->
@@ -1613,13 +1567,12 @@ let list_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "[";
-           (let uu____3354 = f x in
-            FStar_Util.string_builder_append strb uu____3354);
+           (let uu___2 = f x in FStar_Util.string_builder_append strb uu___2);
            FStar_List.iter
              (fun x1 ->
                 FStar_Util.string_builder_append strb "; ";
-                (let uu____3361 = f x1 in
-                 FStar_Util.string_builder_append strb uu____3361)) xs;
+                (let uu___4 = f x1 in
+                 FStar_Util.string_builder_append strb uu___4)) xs;
            FStar_Util.string_builder_append strb "]";
            FStar_Util.string_of_string_builder strb)
 let set_to_string :
@@ -1632,47 +1585,45 @@ let set_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "{";
-           (let uu____3399 = f x in
-            FStar_Util.string_builder_append strb uu____3399);
+           (let uu___2 = f x in FStar_Util.string_builder_append strb uu___2);
            FStar_List.iter
              (fun x1 ->
                 FStar_Util.string_builder_append strb ", ";
-                (let uu____3406 = f x1 in
-                 FStar_Util.string_builder_append strb uu____3406)) xs;
+                (let uu___4 = f x1 in
+                 FStar_Util.string_builder_append strb uu___4)) xs;
            FStar_Util.string_builder_append strb "}";
            FStar_Util.string_of_string_builder strb)
 let (bvs_to_string :
   Prims.string -> FStar_Syntax_Syntax.bv Prims.list -> Prims.string) =
   fun sep ->
     fun bvs ->
-      let uu____3422 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
-      binders_to_string sep uu____3422
+      let uu___ = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
+      binders_to_string sep uu___
 let (ctx_uvar_to_string : FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
   fun ctx_uvar -> ctx_uvar_to_string_aux true ctx_uvar
 let (ctx_uvar_to_string_no_reason :
   FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
   fun ctx_uvar -> ctx_uvar_to_string_aux false ctx_uvar
 let rec (emb_typ_to_string : FStar_Syntax_Syntax.emb_typ -> Prims.string) =
-  fun uu___15_3443 ->
-    match uu___15_3443 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.ET_abstract -> "abstract"
     | FStar_Syntax_Syntax.ET_app (h, []) -> h
     | FStar_Syntax_Syntax.ET_app (h, args) ->
-        let uu____3453 =
-          let uu____3454 =
-            let uu____3455 =
-              let uu____3456 =
-                let uu____3457 = FStar_List.map emb_typ_to_string args in
-                FStar_All.pipe_right uu____3457 (FStar_String.concat " ") in
-              Prims.op_Hat uu____3456 ")" in
-            Prims.op_Hat " " uu____3455 in
-          Prims.op_Hat h uu____3454 in
-        Prims.op_Hat "(" uu____3453
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_List.map emb_typ_to_string args in
+                FStar_All.pipe_right uu___5 (FStar_String.concat " ") in
+              Prims.op_Hat uu___4 ")" in
+            Prims.op_Hat " " uu___3 in
+          Prims.op_Hat h uu___2 in
+        Prims.op_Hat "(" uu___1
     | FStar_Syntax_Syntax.ET_fun (a, b) ->
-        let uu____3464 =
-          let uu____3465 = emb_typ_to_string a in
-          let uu____3466 =
-            let uu____3467 = emb_typ_to_string b in
-            Prims.op_Hat ") -> " uu____3467 in
-          Prims.op_Hat uu____3465 uu____3466 in
-        Prims.op_Hat "(" uu____3464
+        let uu___1 =
+          let uu___2 = emb_typ_to_string a in
+          let uu___3 =
+            let uu___4 = emb_typ_to_string b in Prims.op_Hat ") -> " uu___4 in
+          Prims.op_Hat uu___2 uu___3 in
+        Prims.op_Hat "(" uu___1

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -5,69 +5,67 @@ let (doc_to_string : FStar_Pprint.document -> Prims.string) =
       (Prims.of_int (100)) doc
 let (parser_term_to_string : FStar_Parser_AST.term -> Prims.string) =
   fun t ->
-    let uu____10 = FStar_Parser_ToDocument.term_to_document t in
-    doc_to_string uu____10
+    let uu___ = FStar_Parser_ToDocument.term_to_document t in
+    doc_to_string uu___
 let (parser_pat_to_string : FStar_Parser_AST.pattern -> Prims.string) =
   fun t ->
-    let uu____16 = FStar_Parser_ToDocument.pat_to_document t in
-    doc_to_string uu____16
+    let uu___ = FStar_Parser_ToDocument.pat_to_document t in
+    doc_to_string uu___
 let (tts : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t -> FStar_Syntax_Util.tts t
 let map_opt :
-  'uuuuuu30 'uuuuuu31 .
+  'uuuuu 'uuuuu1 .
     unit ->
-      ('uuuuuu30 -> 'uuuuuu31 FStar_Pervasives_Native.option) ->
-        'uuuuuu30 Prims.list -> 'uuuuuu31 Prims.list
-  = fun uu____48 -> FStar_List.filter_map
+      ('uuuuu -> 'uuuuu1 FStar_Pervasives_Native.option) ->
+        'uuuuu Prims.list -> 'uuuuu1 Prims.list
+  = fun uu___ -> FStar_List.filter_map
 let (bv_as_unique_ident : FStar_Syntax_Syntax.bv -> FStar_Ident.ident) =
   fun x ->
     let unique_name =
-      let uu____55 =
-        (let uu____58 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
-         FStar_Util.starts_with FStar_Ident.reserved_prefix uu____58) ||
+      let uu___ =
+        (let uu___1 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
+         FStar_Util.starts_with FStar_Ident.reserved_prefix uu___1) ||
           (FStar_Options.print_real_names ()) in
-      if uu____55
+      if uu___
       then
-        let uu____59 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
-        let uu____60 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
-        Prims.op_Hat uu____59 uu____60
+        let uu___1 = FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
+        let uu___2 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
+        Prims.op_Hat uu___1 uu___2
       else FStar_Ident.string_of_id x.FStar_Syntax_Syntax.ppname in
-    let uu____62 =
-      let uu____67 = FStar_Ident.range_of_id x.FStar_Syntax_Syntax.ppname in
-      (unique_name, uu____67) in
-    FStar_Ident.mk_ident uu____62
+    let uu___ =
+      let uu___1 = FStar_Ident.range_of_id x.FStar_Syntax_Syntax.ppname in
+      (unique_name, uu___1) in
+    FStar_Ident.mk_ident uu___
 let filter_imp :
-  'uuuuuu72 .
-    ('uuuuuu72 * FStar_Syntax_Syntax.arg_qualifier
+  'uuuuu .
+    ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
       FStar_Pervasives_Native.option) Prims.list ->
-      ('uuuuuu72 * FStar_Syntax_Syntax.arg_qualifier
+      ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
         FStar_Pervasives_Native.option) Prims.list
   =
   fun a ->
     FStar_All.pipe_right a
       (FStar_List.filter
-         (fun uu___0_127 ->
-            match uu___0_127 with
-            | (uu____134, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta
+         (fun uu___ ->
+            match uu___ with
+            | (uu___1, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t))) when
                 FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t
                 -> true
-            | (uu____140, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Implicit uu____141)) -> false
-            | (uu____144, FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Meta uu____145)) -> false
-            | uu____148 -> true))
+            | (uu___1, FStar_Pervasives_Native.Some
+               (FStar_Syntax_Syntax.Implicit uu___2)) -> false
+            | (uu___1, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
+               uu___2)) -> false
+            | uu___1 -> true))
 let filter_pattern_imp :
-  'uuuuuu159 .
-    ('uuuuuu159 * Prims.bool) Prims.list ->
-      ('uuuuuu159 * Prims.bool) Prims.list
+  'uuuuu .
+    ('uuuuu * Prims.bool) Prims.list -> ('uuuuu * Prims.bool) Prims.list
   =
   fun xs ->
     FStar_List.filter
-      (fun uu____190 ->
-         match uu____190 with
-         | (uu____195, is_implicit) -> Prims.op_Negation is_implicit) xs
+      (fun uu___ ->
+         match uu___ with
+         | (uu___1, is_implicit) -> Prims.op_Negation is_implicit) xs
 let (label : Prims.string -> FStar_Parser_AST.term -> FStar_Parser_AST.term)
   =
   fun s ->
@@ -87,15 +85,14 @@ let rec (universe_to_int :
       match u with
       | FStar_Syntax_Syntax.U_succ u1 ->
           universe_to_int (n + Prims.int_one) u1
-      | uu____227 -> (n, u)
+      | uu___ -> (n, u)
 let (universe_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
   fun univs ->
-    let uu____237 = FStar_Options.print_universes () in
-    if uu____237
+    let uu___ = FStar_Options.print_universes () in
+    if uu___
     then
-      let uu____238 =
-        FStar_List.map (fun x -> FStar_Ident.string_of_id x) univs in
-      FStar_All.pipe_right uu____238 (FStar_String.concat ", ")
+      let uu___1 = FStar_List.map (fun x -> FStar_Ident.string_of_id x) univs in
+      FStar_All.pipe_right uu___1 (FStar_String.concat ", ")
     else ""
 let rec (resugar_universe :
   FStar_Syntax_Syntax.universe -> FStar_Range.range -> FStar_Parser_AST.term)
@@ -108,65 +105,65 @@ let rec (resugar_universe :
           mk
             (FStar_Parser_AST.Const
                (FStar_Const.Const_int ("0", FStar_Pervasives_Native.None))) r
-      | FStar_Syntax_Syntax.U_succ uu____277 ->
-          let uu____278 = universe_to_int Prims.int_zero u in
-          (match uu____278 with
+      | FStar_Syntax_Syntax.U_succ uu___ ->
+          let uu___1 = universe_to_int Prims.int_zero u in
+          (match uu___1 with
            | (n, u1) ->
                (match u1 with
                 | FStar_Syntax_Syntax.U_zero ->
-                    let uu____285 =
-                      let uu____286 =
-                        let uu____287 =
-                          let uu____298 = FStar_Util.string_of_int n in
-                          (uu____298, FStar_Pervasives_Native.None) in
-                        FStar_Const.Const_int uu____287 in
-                      FStar_Parser_AST.Const uu____286 in
-                    mk uu____285 r
-                | uu____309 ->
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Util.string_of_int n in
+                          (uu___5, FStar_Pervasives_Native.None) in
+                        FStar_Const.Const_int uu___4 in
+                      FStar_Parser_AST.Const uu___3 in
+                    mk uu___2 r
+                | uu___2 ->
                     let e1 =
-                      let uu____311 =
-                        let uu____312 =
-                          let uu____313 =
-                            let uu____324 = FStar_Util.string_of_int n in
-                            (uu____324, FStar_Pervasives_Native.None) in
-                          FStar_Const.Const_int uu____313 in
-                        FStar_Parser_AST.Const uu____312 in
-                      mk uu____311 r in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Util.string_of_int n in
+                            (uu___6, FStar_Pervasives_Native.None) in
+                          FStar_Const.Const_int uu___5 in
+                        FStar_Parser_AST.Const uu___4 in
+                      mk uu___3 r in
                     let e2 = resugar_universe u1 r in
-                    let uu____336 =
-                      let uu____337 =
-                        let uu____344 = FStar_Ident.id_of_text "+" in
-                        (uu____344, [e1; e2]) in
-                      FStar_Parser_AST.Op uu____337 in
-                    mk uu____336 r))
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 = FStar_Ident.id_of_text "+" in
+                        (uu___5, [e1; e2]) in
+                      FStar_Parser_AST.Op uu___4 in
+                    mk uu___3 r))
       | FStar_Syntax_Syntax.U_max l ->
           (match l with
            | [] -> failwith "Impossible: U_max without arguments"
-           | uu____350 ->
+           | uu___ ->
                let t =
-                 let uu____354 =
-                   let uu____355 = FStar_Ident.lid_of_path ["max"] r in
-                   FStar_Parser_AST.Var uu____355 in
-                 mk uu____354 r in
+                 let uu___1 =
+                   let uu___2 = FStar_Ident.lid_of_path ["max"] r in
+                   FStar_Parser_AST.Var uu___2 in
+                 mk uu___1 r in
                FStar_List.fold_left
                  (fun acc ->
                     fun x ->
-                      let uu____361 =
-                        let uu____362 =
-                          let uu____369 = resugar_universe x r in
-                          (acc, uu____369, FStar_Parser_AST.Nothing) in
-                        FStar_Parser_AST.App uu____362 in
-                      mk uu____361 r) t l)
+                      let uu___1 =
+                        let uu___2 =
+                          let uu___3 = resugar_universe x r in
+                          (acc, uu___3, FStar_Parser_AST.Nothing) in
+                        FStar_Parser_AST.App uu___2 in
+                      mk uu___1 r) t l)
       | FStar_Syntax_Syntax.U_name u1 -> mk (FStar_Parser_AST.Uvar u1) r
-      | FStar_Syntax_Syntax.U_unif uu____371 -> mk FStar_Parser_AST.Wild r
+      | FStar_Syntax_Syntax.U_unif uu___ -> mk FStar_Parser_AST.Wild r
       | FStar_Syntax_Syntax.U_bvar x ->
           let id =
-            let uu____384 =
-              let uu____389 =
-                let uu____390 = FStar_Util.string_of_int x in
-                FStar_Util.strcat "uu__univ_bvar_" uu____390 in
-              (uu____389, r) in
-            FStar_Ident.mk_ident uu____384 in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Util.string_of_int x in
+                FStar_Util.strcat "uu__univ_bvar_" uu___2 in
+              (uu___1, r) in
+            FStar_Ident.mk_ident uu___ in
           mk (FStar_Parser_AST.Uvar id) r
       | FStar_Syntax_Syntax.U_unknown -> mk FStar_Parser_AST.Wild r
 let (resugar_universe' :
@@ -180,8 +177,8 @@ let (string_to_op :
       FStar_Pervasives_Native.option)
   =
   fun s ->
-    let name_of_op uu___1_432 =
-      match uu___1_432 with
+    let name_of_op uu___ =
+      match uu___ with
       | "Amp" ->
           FStar_Pervasives_Native.Some ("&", FStar_Pervasives_Native.None)
       | "At" ->
@@ -225,7 +222,7 @@ let (string_to_op :
           FStar_Pervasives_Native.Some ("$", FStar_Pervasives_Native.None)
       | "Dot" ->
           FStar_Pervasives_Native.Some (".", FStar_Pervasives_Native.None)
-      | uu____609 -> FStar_Pervasives_Native.None in
+      | uu___1 -> FStar_Pervasives_Native.None in
     match s with
     | "op_String_Assignment" ->
         FStar_Pervasives_Native.Some (".[]<-", FStar_Pervasives_Native.None)
@@ -245,18 +242,18 @@ let (string_to_op :
         FStar_Pervasives_Native.Some (".[||]", FStar_Pervasives_Native.None)
     | "op_Lens_Access" ->
         FStar_Pervasives_Native.Some (".(||)", FStar_Pervasives_Native.None)
-    | uu____688 ->
+    | uu___ ->
         if FStar_Util.starts_with s "op_"
         then
           let s1 =
-            let uu____700 =
+            let uu___1 =
               FStar_Util.substring_from s (FStar_String.length "op_") in
-            FStar_Util.split uu____700 "_" in
+            FStar_Util.split uu___1 "_" in
           (match s1 with
            | op::[] -> name_of_op op
-           | uu____710 ->
+           | uu___1 ->
                let maybeop =
-                 let uu____716 = FStar_List.map name_of_op s1 in
+                 let uu___2 = FStar_List.map name_of_op s1 in
                  FStar_List.fold_left
                    (fun acc ->
                       fun x ->
@@ -265,13 +262,12 @@ let (string_to_op :
                             FStar_Pervasives_Native.None
                         | FStar_Pervasives_Native.Some acc1 ->
                             (match x with
-                             | FStar_Pervasives_Native.Some (op, uu____765)
-                                 ->
+                             | FStar_Pervasives_Native.Some (op, uu___3) ->
                                  FStar_Pervasives_Native.Some
                                    (Prims.op_Hat acc1 op)
                              | FStar_Pervasives_Native.None ->
                                  FStar_Pervasives_Native.None))
-                   (FStar_Pervasives_Native.Some "") uu____716 in
+                   (FStar_Pervasives_Native.Some "") uu___2 in
                FStar_Util.map_opt maybeop
                  (fun o -> (o, FStar_Pervasives_Native.None)))
         else FStar_Pervasives_Native.None
@@ -316,140 +312,138 @@ let rec (resugar_term_as_op :
       (FStar_Parser_Const.salloc_lid, "alloc");
       (FStar_Parser_Const.calc_finish_lid, "calc_finish")] in
     let fallback fv =
-      let uu____975 =
+      let uu___ =
         FStar_All.pipe_right infix_prim_ops
           (FStar_Util.find_opt
              (fun d ->
                 FStar_Syntax_Syntax.fv_eq_lid fv
                   (FStar_Pervasives_Native.fst d))) in
-      match uu____975 with
+      match uu___ with
       | FStar_Pervasives_Native.Some op ->
           FStar_Pervasives_Native.Some
             ((FStar_Pervasives_Native.snd op), FStar_Pervasives_Native.None)
-      | uu____1029 ->
+      | uu___1 ->
           let length =
-            let uu____1037 =
+            let uu___2 =
               FStar_Ident.nsstr
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            FStar_String.length uu____1037 in
+            FStar_String.length uu___2 in
           let str =
             if length = Prims.int_zero
             then
               FStar_Ident.string_of_lid
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             else
-              (let uu____1040 =
+              (let uu___3 =
                  FStar_Ident.string_of_lid
                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-               FStar_Util.substring_from uu____1040 (length + Prims.int_one)) in
-          let uu____1041 =
+               FStar_Util.substring_from uu___3 (length + Prims.int_one)) in
+          let uu___2 =
             (FStar_Util.starts_with str "dtuple") &&
-              (let uu____1043 =
-                 let uu____1046 =
+              (let uu___3 =
+                 let uu___4 =
                    FStar_Util.substring_from str (Prims.of_int (6)) in
-                 FStar_Util.safe_int_of_string uu____1046 in
-               FStar_Option.isSome uu____1043) in
-          if uu____1041
+                 FStar_Util.safe_int_of_string uu___4 in
+               FStar_Option.isSome uu___3) in
+          if uu___2
           then
-            let uu____1055 =
-              let uu____1062 =
-                let uu____1065 =
-                  FStar_Util.substring_from str (Prims.of_int (6)) in
-                FStar_Util.safe_int_of_string uu____1065 in
-              ("dtuple", uu____1062) in
-            FStar_Pervasives_Native.Some uu____1055
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Util.substring_from str (Prims.of_int (6)) in
+                FStar_Util.safe_int_of_string uu___5 in
+              ("dtuple", uu___4) in
+            FStar_Pervasives_Native.Some uu___3
           else
-            (let uu____1075 =
+            (let uu___4 =
                (FStar_Util.starts_with str "tuple") &&
-                 (let uu____1077 =
-                    let uu____1080 =
+                 (let uu___5 =
+                    let uu___6 =
                       FStar_Util.substring_from str (Prims.of_int (5)) in
-                    FStar_Util.safe_int_of_string uu____1080 in
-                  FStar_Option.isSome uu____1077) in
-             if uu____1075
+                    FStar_Util.safe_int_of_string uu___6 in
+                  FStar_Option.isSome uu___5) in
+             if uu___4
              then
-               let uu____1089 =
-                 let uu____1096 =
-                   let uu____1099 =
+               let uu___5 =
+                 let uu___6 =
+                   let uu___7 =
                      FStar_Util.substring_from str (Prims.of_int (5)) in
-                   FStar_Util.safe_int_of_string uu____1099 in
-                 ("tuple", uu____1096) in
-               FStar_Pervasives_Native.Some uu____1089
+                   FStar_Util.safe_int_of_string uu___7 in
+                 ("tuple", uu___6) in
+               FStar_Pervasives_Native.Some uu___5
              else
                if FStar_Util.starts_with str "try_with"
                then
                  FStar_Pervasives_Native.Some
                    ("try_with", FStar_Pervasives_Native.None)
                else
-                 (let uu____1126 =
+                 (let uu___7 =
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.sread_lid in
-                  if uu____1126
+                  if uu___7
                   then
-                    let uu____1135 =
-                      let uu____1142 =
+                    let uu___8 =
+                      let uu___9 =
                         FStar_Ident.string_of_lid
                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                      (uu____1142, FStar_Pervasives_Native.None) in
-                    FStar_Pervasives_Native.Some uu____1135
+                      (uu___9, FStar_Pervasives_Native.None) in
+                    FStar_Pervasives_Native.Some uu___8
                   else FStar_Pervasives_Native.None)) in
-    let uu____1158 =
-      let uu____1159 = FStar_Syntax_Subst.compress t in
-      uu____1159.FStar_Syntax_Syntax.n in
-    match uu____1158 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         let length =
-          let uu____1170 =
+          let uu___1 =
             FStar_Ident.nsstr
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_String.length uu____1170 in
+          FStar_String.length uu___1 in
         let s =
           if length = Prims.int_zero
           then
             FStar_Ident.string_of_lid
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
           else
-            (let uu____1173 =
+            (let uu___2 =
                FStar_Ident.string_of_lid
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             FStar_Util.substring_from uu____1173 (length + Prims.int_one)) in
-        let uu____1174 = string_to_op s in
-        (match uu____1174 with
+             FStar_Util.substring_from uu___2 (length + Prims.int_one)) in
+        let uu___1 = string_to_op s in
+        (match uu___1 with
          | FStar_Pervasives_Native.Some t1 -> FStar_Pervasives_Native.Some t1
-         | uu____1206 -> fallback fv)
+         | uu___2 -> fallback fv)
     | FStar_Syntax_Syntax.Tm_uinst (e, us) -> resugar_term_as_op e
-    | uu____1221 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_true_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
   fun p ->
     match p.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true)) ->
         true
-    | uu____1231 -> false
+    | uu___ -> false
 let (is_wild_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
   fun p ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____1237 -> true
-    | uu____1238 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu___ -> true
+    | uu___ -> false
 let (is_tuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
     (FStar_Parser_Const.is_tuple_data_lid' lid) ||
       (FStar_Parser_Const.is_dtuple_data_lid' lid)
 let (may_shorten : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
-    let uu____1249 = FStar_Ident.string_of_lid lid in
-    match uu____1249 with
+    let uu___ = FStar_Ident.string_of_lid lid in
+    match uu___ with
     | "Prims.Nil" -> false
     | "Prims.Cons" -> false
-    | uu____1250 ->
-        let uu____1251 = is_tuple_constructor_lid lid in
-        Prims.op_Negation uu____1251
+    | uu___1 ->
+        let uu___2 = is_tuple_constructor_lid lid in Prims.op_Negation uu___2
 let (maybe_shorten_fv :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lident) =
   fun env ->
     fun fv ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu____1263 = may_shorten lid in
-      if uu____1263 then FStar_Syntax_DsEnv.shorten_lid env lid else lid
+      let uu___ = may_shorten lid in
+      if uu___ then FStar_Syntax_DsEnv.shorten_lid env lid else lid
 let rec (resugar_term' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.term -> FStar_Parser_AST.term)
   =
@@ -459,52 +453,50 @@ let rec (resugar_term' :
         FStar_Parser_AST.mk_term a t.FStar_Syntax_Syntax.pos
           FStar_Parser_AST.Un in
       let name a r =
-        let uu____1412 = FStar_Ident.lid_of_path [a] r in
-        FStar_Parser_AST.Name uu____1412 in
-      let uu____1413 =
-        let uu____1414 = FStar_Syntax_Subst.compress t in
-        uu____1414.FStar_Syntax_Syntax.n in
-      match uu____1413 with
-      | FStar_Syntax_Syntax.Tm_delayed uu____1417 ->
+        let uu___ = FStar_Ident.lid_of_path [a] r in
+        FStar_Parser_AST.Name uu___ in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
           failwith "Tm_delayed is impossible after compress"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____1433 = FStar_Syntax_Util.unfold_lazy i in
-          resugar_term' env uu____1433
+          let uu___1 = FStar_Syntax_Util.unfold_lazy i in
+          resugar_term' env uu___1
       | FStar_Syntax_Syntax.Tm_bvar x ->
           let l =
-            let uu____1436 =
-              let uu____1437 = bv_as_unique_ident x in [uu____1437] in
-            FStar_Ident.lid_of_ids uu____1436 in
+            let uu___1 = let uu___2 = bv_as_unique_ident x in [uu___2] in
+            FStar_Ident.lid_of_ids uu___1 in
           mk (FStar_Parser_AST.Var l)
       | FStar_Syntax_Syntax.Tm_name x ->
           let l =
-            let uu____1440 =
-              let uu____1441 = bv_as_unique_ident x in [uu____1441] in
-            FStar_Ident.lid_of_ids uu____1440 in
+            let uu___1 = let uu___2 = bv_as_unique_ident x in [uu___2] in
+            FStar_Ident.lid_of_ids uu___1 in
           mk (FStar_Parser_AST.Var l)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let a = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           let length =
-            let uu____1445 =
+            let uu___1 =
               FStar_Ident.nsstr
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            FStar_String.length uu____1445 in
+            FStar_String.length uu___1 in
           let s =
             if length = Prims.int_zero
             then FStar_Ident.string_of_lid a
             else
-              (let uu____1448 = FStar_Ident.string_of_lid a in
-               FStar_Util.substring_from uu____1448 (length + Prims.int_one)) in
+              (let uu___2 = FStar_Ident.string_of_lid a in
+               FStar_Util.substring_from uu___2 (length + Prims.int_one)) in
           let is_prefix = Prims.op_Hat FStar_Ident.reserved_prefix "is_" in
           if FStar_Util.starts_with s is_prefix
           then
             let rest =
               FStar_Util.substring_from s (FStar_String.length is_prefix) in
-            let uu____1451 =
-              let uu____1452 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Ident.lid_of_path [rest] t.FStar_Syntax_Syntax.pos in
-              FStar_Parser_AST.Discrim uu____1452 in
-            mk uu____1451
+              FStar_Parser_AST.Discrim uu___2 in
+            mk uu___1
           else
             if
               FStar_Util.starts_with s
@@ -523,64 +515,63 @@ let rec (resugar_term' :
                    let r1 =
                      FStar_Ident.mk_ident (snd, (t.FStar_Syntax_Syntax.pos)) in
                    mk (FStar_Parser_AST.Projector (l, r1))
-               | uu____1462 -> failwith "wrong projector format")
+               | uu___2 -> failwith "wrong projector format")
             else
-              (let uu____1466 =
+              (let uu___3 =
                  FStar_Ident.lid_equals a FStar_Parser_Const.smtpat_lid in
-               if uu____1466
+               if uu___3
                then
-                 let uu____1467 =
-                   let uu____1468 =
-                     let uu____1469 =
-                       let uu____1474 = FStar_Ident.range_of_lid a in
-                       ("SMTPat", uu____1474) in
-                     FStar_Ident.mk_ident uu____1469 in
-                   FStar_Parser_AST.Tvar uu____1468 in
-                 mk uu____1467
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Ident.range_of_lid a in
+                       ("SMTPat", uu___7) in
+                     FStar_Ident.mk_ident uu___6 in
+                   FStar_Parser_AST.Tvar uu___5 in
+                 mk uu___4
                else
-                 (let uu____1476 =
+                 (let uu___5 =
                     FStar_Ident.lid_equals a FStar_Parser_Const.smtpatOr_lid in
-                  if uu____1476
+                  if uu___5
                   then
-                    let uu____1477 =
-                      let uu____1478 =
-                        let uu____1479 =
-                          let uu____1484 = FStar_Ident.range_of_lid a in
-                          ("SMTPatOr", uu____1484) in
-                        FStar_Ident.mk_ident uu____1479 in
-                      FStar_Parser_AST.Tvar uu____1478 in
-                    mk uu____1477
+                    let uu___6 =
+                      let uu___7 =
+                        let uu___8 =
+                          let uu___9 = FStar_Ident.range_of_lid a in
+                          ("SMTPatOr", uu___9) in
+                        FStar_Ident.mk_ident uu___8 in
+                      FStar_Parser_AST.Tvar uu___7 in
+                    mk uu___6
                   else
-                    (let uu____1486 =
+                    (let uu___7 =
                        ((FStar_Ident.lid_equals a
                            FStar_Parser_Const.assert_lid)
                           ||
                           (FStar_Ident.lid_equals a
                              FStar_Parser_Const.assume_lid))
                          ||
-                         (let uu____1489 =
-                            let uu____1490 =
-                              FStar_String.get s Prims.int_zero in
-                            FStar_Char.uppercase uu____1490 in
-                          let uu____1491 = FStar_String.get s Prims.int_zero in
-                          uu____1489 <> uu____1491) in
-                     if uu____1486
+                         (let uu___8 =
+                            let uu___9 = FStar_String.get s Prims.int_zero in
+                            FStar_Char.uppercase uu___9 in
+                          let uu___9 = FStar_String.get s Prims.int_zero in
+                          uu___8 <> uu___9) in
+                     if uu___7
                      then
-                       let uu____1492 =
-                         let uu____1493 = maybe_shorten_fv env fv in
-                         FStar_Parser_AST.Var uu____1493 in
-                       mk uu____1492
+                       let uu___8 =
+                         let uu___9 = maybe_shorten_fv env fv in
+                         FStar_Parser_AST.Var uu___9 in
+                       mk uu___8
                      else
-                       (let uu____1495 =
-                          let uu____1496 =
-                            let uu____1507 = maybe_shorten_fv env fv in
-                            (uu____1507, []) in
-                          FStar_Parser_AST.Construct uu____1496 in
-                        mk uu____1495))))
+                       (let uu___9 =
+                          let uu___10 =
+                            let uu___11 = maybe_shorten_fv env fv in
+                            (uu___11, []) in
+                          FStar_Parser_AST.Construct uu___10 in
+                        mk uu___9))))
       | FStar_Syntax_Syntax.Tm_uinst (e, universes) ->
           let e1 = resugar_term' env e in
-          let uu____1525 = FStar_Options.print_universes () in
-          if uu____1525
+          let uu___1 = FStar_Options.print_universes () in
+          if uu___1
           then
             let univs =
               FStar_List.map
@@ -590,13 +581,13 @@ let rec (resugar_term' :
              | { FStar_Parser_AST.tm = FStar_Parser_AST.Construct (hd, args);
                  FStar_Parser_AST.range = r; FStar_Parser_AST.level = l;_} ->
                  let args1 =
-                   let uu____1554 =
+                   let uu___2 =
                      FStar_List.map (fun u -> (u, FStar_Parser_AST.UnivApp))
                        univs in
-                   FStar_List.append args uu____1554 in
+                   FStar_List.append args uu___2 in
                  FStar_Parser_AST.mk_term
                    (FStar_Parser_AST.Construct (hd, args1)) r l
-             | uu____1577 ->
+             | uu___2 ->
                  FStar_List.fold_left
                    (fun acc ->
                       fun u ->
@@ -605,80 +596,77 @@ let rec (resugar_term' :
                              (acc, u, FStar_Parser_AST.UnivApp))) e1 univs)
           else e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____1584 = FStar_Syntax_Syntax.is_teff t in
-          if uu____1584
+          let uu___1 = FStar_Syntax_Syntax.is_teff t in
+          if uu___1
           then
-            let uu____1585 = name "Effect" t.FStar_Syntax_Syntax.pos in
-            mk uu____1585
+            let uu___2 = name "Effect" t.FStar_Syntax_Syntax.pos in mk uu___2
           else mk (FStar_Parser_AST.Const c)
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____1588 =
+          let uu___1 =
             match u with
             | FStar_Syntax_Syntax.U_zero -> ("Type0", false)
             | FStar_Syntax_Syntax.U_unknown -> ("Type", false)
-            | uu____1597 -> ("Type", true) in
-          (match uu____1588 with
+            | uu___2 -> ("Type", true) in
+          (match uu___1 with
            | (nm, needs_app) ->
                let typ =
-                 let uu____1601 = name nm t.FStar_Syntax_Syntax.pos in
-                 mk uu____1601 in
-               let uu____1602 =
-                 needs_app && (FStar_Options.print_universes ()) in
-               if uu____1602
+                 let uu___2 = name nm t.FStar_Syntax_Syntax.pos in mk uu___2 in
+               let uu___2 = needs_app && (FStar_Options.print_universes ()) in
+               if uu___2
                then
-                 let uu____1603 =
-                   let uu____1604 =
-                     let uu____1611 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
                        resugar_universe u t.FStar_Syntax_Syntax.pos in
-                     (typ, uu____1611, FStar_Parser_AST.UnivApp) in
-                   FStar_Parser_AST.App uu____1604 in
-                 mk uu____1603
+                     (typ, uu___5, FStar_Parser_AST.UnivApp) in
+                   FStar_Parser_AST.App uu___4 in
+                 mk uu___3
                else typ)
-      | FStar_Syntax_Syntax.Tm_abs (xs, body, uu____1615) ->
-          let uu____1640 = FStar_Syntax_Subst.open_term xs body in
-          (match uu____1640 with
+      | FStar_Syntax_Syntax.Tm_abs (xs, body, uu___1) ->
+          let uu___2 = FStar_Syntax_Subst.open_term xs body in
+          (match uu___2 with
            | (xs1, body1) ->
                let xs2 =
-                 let uu____1656 = FStar_Options.print_implicits () in
-                 if uu____1656 then xs1 else filter_imp xs1 in
+                 let uu___3 = FStar_Options.print_implicits () in
+                 if uu___3 then xs1 else filter_imp xs1 in
                let body_bv = FStar_Syntax_Free.names body1 in
                let patterns =
                  FStar_All.pipe_right xs2
                    (FStar_List.choose
-                      (fun uu____1691 ->
-                         match uu____1691 with
+                      (fun uu___3 ->
+                         match uu___3 with
                          | (x, qual) -> resugar_bv_as_pat env x qual body_bv)) in
                let body2 = resugar_term' env body1 in
                mk (FStar_Parser_AST.Abs (patterns, body2)))
-      | FStar_Syntax_Syntax.Tm_arrow uu____1709 ->
-          let uu____1724 =
-            let uu____1729 =
-              let uu____1730 =
-                let uu____1733 = FStar_Syntax_Util.canon_arrow t in
-                FStar_Syntax_Subst.compress uu____1733 in
-              uu____1730.FStar_Syntax_Syntax.n in
-            match uu____1729 with
+      | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Util.canon_arrow t in
+                FStar_Syntax_Subst.compress uu___5 in
+              uu___4.FStar_Syntax_Syntax.n in
+            match uu___3 with
             | FStar_Syntax_Syntax.Tm_arrow (xs, body) -> (xs, body)
-            | uu____1760 -> failwith "impossible: Tm_arrow in resugar_term" in
-          (match uu____1724 with
+            | uu___4 -> failwith "impossible: Tm_arrow in resugar_term" in
+          (match uu___2 with
            | (xs, body) ->
-               let uu____1767 = FStar_Syntax_Subst.open_comp xs body in
-               (match uu____1767 with
+               let uu___3 = FStar_Syntax_Subst.open_comp xs body in
+               (match uu___3 with
                 | (xs1, body1) ->
                     let xs2 =
-                      let uu____1777 = FStar_Options.print_implicits () in
-                      if uu____1777 then xs1 else filter_imp xs1 in
+                      let uu___4 = FStar_Options.print_implicits () in
+                      if uu___4 then xs1 else filter_imp xs1 in
                     let body2 = resugar_comp' env body1 in
                     let xs3 =
-                      let uu____1785 =
+                      let uu___4 =
                         FStar_All.pipe_right xs2
                           ((map_opt ())
                              (fun b ->
                                 resugar_binder' env b
                                   t.FStar_Syntax_Syntax.pos)) in
-                      FStar_All.pipe_right uu____1785 FStar_List.rev in
-                    let rec aux body3 uu___2_1810 =
-                      match uu___2_1810 with
+                      FStar_All.pipe_right uu___4 FStar_List.rev in
+                    let rec aux body3 uu___4 =
+                      match uu___4 with
                       | [] -> body3
                       | hd::tl ->
                           let body4 =
@@ -686,62 +674,61 @@ let rec (resugar_term' :
                           aux body4 tl in
                     aux body2 xs3))
       | FStar_Syntax_Syntax.Tm_refine (x, phi) ->
-          let uu____1826 =
-            let uu____1831 =
-              let uu____1832 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____1832] in
-            FStar_Syntax_Subst.open_term uu____1831 phi in
-          (match uu____1826 with
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.mk_binder x in [uu___3] in
+            FStar_Syntax_Subst.open_term uu___2 phi in
+          (match uu___1 with
            | (x1, phi1) ->
                let b =
-                 let uu____1854 =
-                   let uu____1857 = FStar_List.hd x1 in
-                   resugar_binder' env uu____1857 t.FStar_Syntax_Syntax.pos in
-                 FStar_Util.must uu____1854 in
-               let uu____1864 =
-                 let uu____1865 =
-                   let uu____1870 = resugar_term' env phi1 in (b, uu____1870) in
-                 FStar_Parser_AST.Refine uu____1865 in
-               mk uu____1864)
+                 let uu___2 =
+                   let uu___3 = FStar_List.hd x1 in
+                   resugar_binder' env uu___3 t.FStar_Syntax_Syntax.pos in
+                 FStar_Util.must uu___2 in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = resugar_term' env phi1 in (b, uu___4) in
+                 FStar_Parser_AST.Refine uu___3 in
+               mk uu___2)
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____1872;
-             FStar_Syntax_Syntax.vars = uu____1873;_},
-           (e, uu____1875)::[])
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
+           (e, uu___3)::[])
           when
-          (let uu____1916 = FStar_Options.print_implicits () in
-           Prims.op_Negation uu____1916) &&
+          (let uu___4 = FStar_Options.print_implicits () in
+           Prims.op_Negation uu___4) &&
             (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid)
           -> resugar_term' env e
       | FStar_Syntax_Syntax.Tm_app (e, args) ->
-          let rec last uu___3_1964 =
-            match uu___3_1964 with
+          let rec last uu___1 =
+            match uu___1 with
             | hd::[] -> [hd]
             | hd::tl -> last tl
-            | uu____2034 -> failwith "last of an empty list" in
+            | uu___2 -> failwith "last of an empty list" in
           let first_two_explicit args1 =
             let rec drop_implicits args2 =
               match args2 with
-              | (uu____2119, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____2120))::tl ->
+              | (uu___1, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___2))::tl ->
                   drop_implicits tl
-              | uu____2138 -> args2 in
-            let uu____2147 = drop_implicits args1 in
-            match uu____2147 with
+              | uu___1 -> args2 in
+            let uu___1 = drop_implicits args1 in
+            match uu___1 with
             | [] -> failwith "not_enough explicit_arguments"
-            | uu____2178::[] -> failwith "not_enough explicit_arguments"
-            | a1::a2::uu____2207 -> [a1; a2] in
+            | uu___2::[] -> failwith "not_enough explicit_arguments"
+            | a1::a2::uu___2 -> [a1; a2] in
           let resugar_as_app e1 args1 =
             let args2 =
               FStar_List.map
-                (fun uu____2307 ->
-                   match uu____2307 with
+                (fun uu___1 ->
+                   match uu___1 with
                    | (e2, qual) ->
-                       let uu____2324 = resugar_term' env e2 in
-                       let uu____2325 = resugar_imp env qual in
-                       (uu____2324, uu____2325)) args1 in
-            let uu____2326 = resugar_term' env e1 in
-            match uu____2326 with
+                       let uu___2 = resugar_term' env e2 in
+                       let uu___3 = resugar_imp env qual in (uu___2, uu___3))
+                args1 in
+            let uu___1 = resugar_term' env e1 in
+            match uu___1 with
             | {
                 FStar_Parser_AST.tm = FStar_Parser_AST.Construct
                   (hd, previous_args);
@@ -752,62 +739,62 @@ let rec (resugar_term' :
             | e2 ->
                 FStar_List.fold_left
                   (fun acc ->
-                     fun uu____2363 ->
-                       match uu____2363 with
+                     fun uu___2 ->
+                       match uu___2 with
                        | (x, qual) ->
                            mk (FStar_Parser_AST.App (acc, x, qual))) e2 args2 in
           let args1 =
-            let uu____2379 = FStar_Options.print_implicits () in
-            if uu____2379 then args else filter_imp args in
-          let uu____2391 = resugar_term_as_op e in
-          (match uu____2391 with
+            let uu___1 = FStar_Options.print_implicits () in
+            if uu___1 then args else filter_imp args in
+          let uu___1 = resugar_term_as_op e in
+          (match uu___1 with
            | FStar_Pervasives_Native.None -> resugar_as_app e args1
-           | FStar_Pervasives_Native.Some ("calc_finish", uu____2402) ->
-               let uu____2407 = resugar_calc env t in
-               (match uu____2407 with
+           | FStar_Pervasives_Native.Some ("calc_finish", uu___2) ->
+               let uu___3 = resugar_calc env t in
+               (match uu___3 with
                 | FStar_Pervasives_Native.Some r -> r
-                | uu____2411 -> resugar_as_app e args1)
-           | FStar_Pervasives_Native.Some ("tuple", uu____2414) ->
+                | uu___4 -> resugar_as_app e args1)
+           | FStar_Pervasives_Native.Some ("tuple", uu___2) ->
                let out =
                  FStar_List.fold_left
-                   (fun out ->
-                      fun uu____2436 ->
-                        match uu____2436 with
-                        | (x, uu____2448) ->
+                   (fun out1 ->
+                      fun uu___3 ->
+                        match uu___3 with
+                        | (x, uu___4) ->
                             let x1 = resugar_term' env x in
-                            (match out with
+                            (match out1 with
                              | FStar_Pervasives_Native.None ->
                                  FStar_Pervasives_Native.Some x1
                              | FStar_Pervasives_Native.Some prefix ->
-                                 let uu____2457 =
-                                   let uu____2458 =
-                                     let uu____2459 =
-                                       let uu____2466 =
+                                 let uu___5 =
+                                   let uu___6 =
+                                     let uu___7 =
+                                       let uu___8 =
                                          FStar_Ident.id_of_text "*" in
-                                       (uu____2466, [prefix; x1]) in
-                                     FStar_Parser_AST.Op uu____2459 in
-                                   mk uu____2458 in
-                                 FStar_Pervasives_Native.Some uu____2457))
+                                       (uu___8, [prefix; x1]) in
+                                     FStar_Parser_AST.Op uu___7 in
+                                   mk uu___6 in
+                                 FStar_Pervasives_Native.Some uu___5))
                    FStar_Pervasives_Native.None args1 in
                FStar_Option.get out
-           | FStar_Pervasives_Native.Some ("dtuple", uu____2469) when
+           | FStar_Pervasives_Native.Some ("dtuple", uu___2) when
                (FStar_List.length args1) > Prims.int_zero ->
                let args2 = last args1 in
                let body =
                  match args2 with
-                 | (b, uu____2491)::[] -> b
-                 | uu____2508 -> failwith "wrong arguments to dtuple" in
-               let uu____2517 =
-                 let uu____2518 = FStar_Syntax_Subst.compress body in
-                 uu____2518.FStar_Syntax_Syntax.n in
-               (match uu____2517 with
-                | FStar_Syntax_Syntax.Tm_abs (xs, body1, uu____2523) ->
-                    let uu____2548 = FStar_Syntax_Subst.open_term xs body1 in
-                    (match uu____2548 with
+                 | (b, uu___3)::[] -> b
+                 | uu___3 -> failwith "wrong arguments to dtuple" in
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Subst.compress body in
+                 uu___4.FStar_Syntax_Syntax.n in
+               (match uu___3 with
+                | FStar_Syntax_Syntax.Tm_abs (xs, body1, uu___4) ->
+                    let uu___5 = FStar_Syntax_Subst.open_term xs body1 in
+                    (match uu___5 with
                      | (xs1, body2) ->
                          let xs2 =
-                           let uu____2558 = FStar_Options.print_implicits () in
-                           if uu____2558 then xs1 else filter_imp xs1 in
+                           let uu___6 = FStar_Options.print_implicits () in
+                           if uu___6 then xs1 else filter_imp xs1 in
                          let xs3 =
                            FStar_All.pipe_right xs2
                              ((map_opt ())
@@ -815,21 +802,20 @@ let rec (resugar_term' :
                                    resugar_binder' env b
                                      t.FStar_Syntax_Syntax.pos)) in
                          let body3 = resugar_term' env body2 in
-                         let uu____2572 =
-                           let uu____2573 =
-                             let uu____2584 =
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
                                FStar_List.map
-                                 (fun uu____2595 -> FStar_Util.Inl uu____2595)
-                                 xs3 in
-                             (uu____2584, body3) in
-                           FStar_Parser_AST.Sum uu____2573 in
-                         mk uu____2572)
-                | uu____2602 ->
+                                 (fun uu___9 -> FStar_Util.Inl uu___9) xs3 in
+                             (uu___8, body3) in
+                           FStar_Parser_AST.Sum uu___7 in
+                         mk uu___6)
+                | uu___4 ->
                     let args3 =
                       FStar_All.pipe_right args2
                         (FStar_List.map
-                           (fun uu____2625 ->
-                              match uu____2625 with
+                           (fun uu___5 ->
+                              match uu___5 with
                               | (e1, qual) -> resugar_term' env e1)) in
                     let e1 = resugar_term' env e in
                     FStar_List.fold_left
@@ -838,99 +824,94 @@ let rec (resugar_term' :
                            mk
                              (FStar_Parser_AST.App
                                 (acc, x, FStar_Parser_AST.Nothing))) e1 args3)
-           | FStar_Pervasives_Native.Some ("dtuple", uu____2643) ->
+           | FStar_Pervasives_Native.Some ("dtuple", uu___2) ->
                resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (ref_read, uu____2649) when
-               let uu____2654 =
+           | FStar_Pervasives_Native.Some (ref_read, uu___2) when
+               let uu___3 =
                  FStar_Ident.string_of_lid FStar_Parser_Const.sread_lid in
-               ref_read = uu____2654 ->
-               let uu____2655 = FStar_List.hd args1 in
-               (match uu____2655 with
-                | (t1, uu____2669) ->
-                    let uu____2674 =
-                      let uu____2675 = FStar_Syntax_Subst.compress t1 in
-                      uu____2675.FStar_Syntax_Syntax.n in
-                    (match uu____2674 with
+               ref_read = uu___3 ->
+               let uu___3 = FStar_List.hd args1 in
+               (match uu___3 with
+                | (t1, uu___4) ->
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Subst.compress t1 in
+                      uu___6.FStar_Syntax_Syntax.n in
+                    (match uu___5 with
                      | FStar_Syntax_Syntax.Tm_fvar fv when
-                         let uu____2679 =
+                         let uu___6 =
                            FStar_Ident.string_of_lid
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                          FStar_Syntax_Util.field_projector_contains_constructor
-                           uu____2679
+                           uu___6
                          ->
                          let f =
-                           let uu____2681 =
-                             let uu____2682 =
+                           let uu___6 =
+                             let uu___7 =
                                FStar_Ident.string_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                             [uu____2682] in
-                           FStar_Ident.lid_of_path uu____2681
+                             [uu___7] in
+                           FStar_Ident.lid_of_path uu___6
                              t1.FStar_Syntax_Syntax.pos in
-                         let uu____2683 =
-                           let uu____2684 =
-                             let uu____2689 = resugar_term' env t1 in
-                             (uu____2689, f) in
-                           FStar_Parser_AST.Project uu____2684 in
-                         mk uu____2683
-                     | uu____2690 -> resugar_term' env t1))
-           | FStar_Pervasives_Native.Some ("try_with", uu____2691) when
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 = resugar_term' env t1 in (uu___8, f) in
+                           FStar_Parser_AST.Project uu___7 in
+                         mk uu___6
+                     | uu___6 -> resugar_term' env t1))
+           | FStar_Pervasives_Native.Some ("try_with", uu___2) when
                (FStar_List.length args1) > Prims.int_one ->
                (try
-                  (fun uu___441_2714 ->
+                  (fun uu___3 ->
                      match () with
                      | () ->
                          let new_args = first_two_explicit args1 in
-                         let uu____2724 =
+                         let uu___4 =
                            match new_args with
-                           | (a1, uu____2734)::(a2, uu____2736)::[] ->
-                               (a1, a2)
-                           | uu____2763 ->
-                               failwith "wrong arguments to try_with" in
-                         (match uu____2724 with
+                           | (a1, uu___5)::(a2, uu___6)::[] -> (a1, a2)
+                           | uu___5 -> failwith "wrong arguments to try_with" in
+                         (match uu___4 with
                           | (body, handler) ->
                               let decomp term =
-                                let uu____2784 =
-                                  let uu____2785 =
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Syntax_Subst.compress term in
-                                  uu____2785.FStar_Syntax_Syntax.n in
-                                match uu____2784 with
-                                | FStar_Syntax_Syntax.Tm_abs
-                                    (x, e1, uu____2790) ->
-                                    let uu____2815 =
+                                  uu___6.FStar_Syntax_Syntax.n in
+                                match uu___5 with
+                                | FStar_Syntax_Syntax.Tm_abs (x, e1, uu___6)
+                                    ->
+                                    let uu___7 =
                                       FStar_Syntax_Subst.open_term x e1 in
-                                    (match uu____2815 with | (x1, e2) -> e2)
-                                | uu____2822 ->
-                                    let uu____2823 =
-                                      let uu____2824 =
-                                        let uu____2825 =
-                                          resugar_term' env term in
+                                    (match uu___7 with | (x1, e2) -> e2)
+                                | uu___6 ->
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 = resugar_term' env term in
                                         FStar_Parser_AST.term_to_string
-                                          uu____2825 in
+                                          uu___9 in
                                       Prims.op_Hat
                                         "wrong argument format to try_with: "
-                                        uu____2824 in
-                                    failwith uu____2823 in
+                                        uu___8 in
+                                    failwith uu___7 in
                               let body1 =
-                                let uu____2827 = decomp body in
-                                resugar_term' env uu____2827 in
+                                let uu___5 = decomp body in
+                                resugar_term' env uu___5 in
                               let handler1 =
-                                let uu____2829 = decomp handler in
-                                resugar_term' env uu____2829 in
+                                let uu___5 = decomp handler in
+                                resugar_term' env uu___5 in
                               let rec resugar_body t1 =
                                 match t1.FStar_Parser_AST.tm with
                                 | FStar_Parser_AST.Match
-                                    (e1, (uu____2837, uu____2838, b)::[]) ->
+                                    (e1, (uu___5, uu___6, b)::[]) -> b
+                                | FStar_Parser_AST.Let (uu___5, uu___6, b) ->
                                     b
-                                | FStar_Parser_AST.Let
-                                    (uu____2870, uu____2871, b) -> b
                                 | FStar_Parser_AST.Ascribed (t11, t2, t3) ->
-                                    let uu____2908 =
-                                      let uu____2909 =
-                                        let uu____2918 = resugar_body t11 in
-                                        (uu____2918, t2, t3) in
-                                      FStar_Parser_AST.Ascribed uu____2909 in
-                                    mk uu____2908
-                                | uu____2921 ->
+                                    let uu___5 =
+                                      let uu___6 =
+                                        let uu___7 = resugar_body t11 in
+                                        (uu___7, t2, t3) in
+                                      FStar_Parser_AST.Ascribed uu___6 in
+                                    mk uu___5
+                                | uu___5 ->
                                     failwith
                                       "unexpected body format to try_with" in
                               let e1 = resugar_body body1 in
@@ -940,14 +921,14 @@ let rec (resugar_term' :
                                     branches
                                 | FStar_Parser_AST.Ascribed (t11, t2, t3) ->
                                     resugar_branches t11
-                                | uu____2978 -> [] in
+                                | uu___5 -> [] in
                               let branches = resugar_branches handler1 in
                               mk (FStar_Parser_AST.TryWith (e1, branches))))
                     ()
-                with | uu____3011 -> resugar_as_app e args1)
-           | FStar_Pervasives_Native.Some ("try_with", uu____3012) ->
+                with | uu___4 -> resugar_as_app e args1)
+           | FStar_Pervasives_Native.Some ("try_with", uu___2) ->
                resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (op, uu____3018) when
+           | FStar_Pervasives_Native.Some (op, uu___2) when
                (((((((op = "=") || (op = "==")) || (op = "===")) ||
                      (op = "@"))
                     || (op = ":="))
@@ -955,142 +936,138 @@ let rec (resugar_term' :
                   || (op = "<<"))
                  && (FStar_Options.print_implicits ())
                -> resugar_as_app e args1
-           | FStar_Pervasives_Native.Some (op, uu____3024) when
+           | FStar_Pervasives_Native.Some (op, uu___2) when
                (op = "forall") || (op = "exists") ->
                let rec uncurry xs pats t1 =
                  match t1.FStar_Parser_AST.tm with
-                 | FStar_Parser_AST.QExists (xs', (uu____3082, pats'), body)
-                     ->
+                 | FStar_Parser_AST.QExists (xs', (uu___3, pats'), body) ->
                      uncurry (FStar_List.append xs xs')
                        (FStar_List.append pats pats') body
-                 | FStar_Parser_AST.QForall (xs', (uu____3114, pats'), body)
-                     ->
+                 | FStar_Parser_AST.QForall (xs', (uu___3, pats'), body) ->
                      uncurry (FStar_List.append xs xs')
                        (FStar_List.append pats pats') body
-                 | uu____3145 -> (xs, pats, t1) in
+                 | uu___3 -> (xs, pats, t1) in
                let resugar_forall_body body =
-                 let uu____3158 =
-                   let uu____3159 = FStar_Syntax_Subst.compress body in
-                   uu____3159.FStar_Syntax_Syntax.n in
-                 match uu____3158 with
-                 | FStar_Syntax_Syntax.Tm_abs (xs, body1, uu____3164) ->
-                     let uu____3189 = FStar_Syntax_Subst.open_term xs body1 in
-                     (match uu____3189 with
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Subst.compress body in
+                   uu___4.FStar_Syntax_Syntax.n in
+                 match uu___3 with
+                 | FStar_Syntax_Syntax.Tm_abs (xs, body1, uu___4) ->
+                     let uu___5 = FStar_Syntax_Subst.open_term xs body1 in
+                     (match uu___5 with
                       | (xs1, body2) ->
                           let xs2 =
-                            let uu____3199 = FStar_Options.print_implicits () in
-                            if uu____3199 then xs1 else filter_imp xs1 in
+                            let uu___6 = FStar_Options.print_implicits () in
+                            if uu___6 then xs1 else filter_imp xs1 in
                           let xs3 =
                             FStar_All.pipe_right xs2
                               ((map_opt ())
                                  (fun b ->
                                     resugar_binder' env b
                                       t.FStar_Syntax_Syntax.pos)) in
-                          let uu____3212 =
-                            let uu____3221 =
-                              let uu____3222 =
-                                FStar_Syntax_Subst.compress body2 in
-                              uu____3222.FStar_Syntax_Syntax.n in
-                            match uu____3221 with
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 = FStar_Syntax_Subst.compress body2 in
+                              uu___8.FStar_Syntax_Syntax.n in
+                            match uu___7 with
                             | FStar_Syntax_Syntax.Tm_meta (e1, m) ->
                                 let body3 = resugar_term' env e1 in
-                                let uu____3240 =
+                                let uu___8 =
                                   match m with
                                   | FStar_Syntax_Syntax.Meta_pattern
-                                      (uu____3257, pats) ->
-                                      let uu____3291 =
+                                      (uu___9, pats) ->
+                                      let uu___10 =
                                         FStar_List.map
                                           (fun es ->
                                              FStar_All.pipe_right es
                                                (FStar_List.map
-                                                  (fun uu____3335 ->
-                                                     match uu____3335 with
-                                                     | (e2, uu____3343) ->
+                                                  (fun uu___11 ->
+                                                     match uu___11 with
+                                                     | (e2, uu___12) ->
                                                          resugar_term' env e2)))
                                           pats in
-                                      (uu____3291, body3)
+                                      (uu___10, body3)
                                   | FStar_Syntax_Syntax.Meta_labeled
                                       (s, r, p) ->
-                                      let uu____3355 =
+                                      let uu___9 =
                                         mk
                                           (FStar_Parser_AST.Labeled
                                              (body3, s, p)) in
-                                      ([], uu____3355)
-                                  | uu____3362 ->
+                                      ([], uu___9)
+                                  | uu___9 ->
                                       failwith
                                         "wrong pattern format for QForall/QExists" in
-                                (match uu____3240 with
+                                (match uu___8 with
                                  | (pats, body4) -> (pats, body4))
-                            | uu____3393 ->
-                                let uu____3394 = resugar_term' env body2 in
-                                ([], uu____3394) in
-                          (match uu____3212 with
+                            | uu___8 ->
+                                let uu___9 = resugar_term' env body2 in
+                                ([], uu___9) in
+                          (match uu___6 with
                            | (pats, body3) ->
-                               let uu____3411 = uncurry xs3 pats body3 in
-                               (match uu____3411 with
+                               let uu___7 = uncurry xs3 pats body3 in
+                               (match uu___7 with
                                 | (xs4, pats1, body4) ->
                                     if op = "forall"
                                     then
-                                      let uu____3439 =
-                                        let uu____3440 =
-                                          let uu____3459 =
-                                            let uu____3470 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_Parser_AST.idents_of_binders
                                                 xs4 t.FStar_Syntax_Syntax.pos in
-                                            (uu____3470, pats1) in
-                                          (xs4, uu____3459, body4) in
-                                        FStar_Parser_AST.QForall uu____3440 in
-                                      mk uu____3439
+                                            (uu___11, pats1) in
+                                          (xs4, uu___10, body4) in
+                                        FStar_Parser_AST.QForall uu___9 in
+                                      mk uu___8
                                     else
-                                      (let uu____3492 =
-                                         let uu____3493 =
-                                           let uu____3512 =
-                                             let uu____3523 =
+                                      (let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 =
+                                             let uu___12 =
                                                FStar_Parser_AST.idents_of_binders
                                                  xs4
                                                  t.FStar_Syntax_Syntax.pos in
-                                             (uu____3523, pats1) in
-                                           (xs4, uu____3512, body4) in
-                                         FStar_Parser_AST.QExists uu____3493 in
-                                       mk uu____3492))))
-                 | uu____3544 ->
+                                             (uu___12, pats1) in
+                                           (xs4, uu___11, body4) in
+                                         FStar_Parser_AST.QExists uu___10 in
+                                       mk uu___9))))
+                 | uu___4 ->
                      if op = "forall"
                      then
-                       let uu____3545 =
-                         let uu____3546 =
-                           let uu____3565 = resugar_term' env body in
-                           ([], ([], []), uu____3565) in
-                         FStar_Parser_AST.QForall uu____3546 in
-                       mk uu____3545
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 = resugar_term' env body in
+                           ([], ([], []), uu___7) in
+                         FStar_Parser_AST.QForall uu___6 in
+                       mk uu___5
                      else
-                       (let uu____3587 =
-                          let uu____3588 =
-                            let uu____3607 = resugar_term' env body in
-                            ([], ([], []), uu____3607) in
-                          FStar_Parser_AST.QExists uu____3588 in
-                        mk uu____3587) in
+                       (let uu___6 =
+                          let uu___7 =
+                            let uu___8 = resugar_term' env body in
+                            ([], ([], []), uu___8) in
+                          FStar_Parser_AST.QExists uu___7 in
+                        mk uu___6) in
                if (FStar_List.length args1) > Prims.int_zero
                then
                  let args2 = last args1 in
                  (match args2 with
-                  | (b, uu____3644)::[] -> resugar_forall_body b
-                  | uu____3661 -> failwith "wrong args format to QForall")
+                  | (b, uu___3)::[] -> resugar_forall_body b
+                  | uu___3 -> failwith "wrong args format to QForall")
                else resugar_as_app e args1
-           | FStar_Pervasives_Native.Some ("alloc", uu____3671) ->
-               let uu____3676 = FStar_List.hd args1 in
-               (match uu____3676 with
-                | (e1, uu____3690) -> resugar_term' env e1)
+           | FStar_Pervasives_Native.Some ("alloc", uu___2) ->
+               let uu___3 = FStar_List.hd args1 in
+               (match uu___3 with | (e1, uu___4) -> resugar_term' env e1)
            | FStar_Pervasives_Native.Some (op, expected_arity1) ->
                let op1 = FStar_Ident.id_of_text op in
                let resugar args2 =
                  FStar_All.pipe_right args2
                    (FStar_List.map
-                      (fun uu____3759 ->
-                         match uu____3759 with
+                      (fun uu___2 ->
+                         match uu___2 with
                          | (e1, qual) ->
-                             let uu____3776 = resugar_term' env e1 in
-                             let uu____3777 = resugar_imp env qual in
-                             (uu____3776, uu____3777))) in
+                             let uu___3 = resugar_term' env e1 in
+                             let uu___4 = resugar_imp env qual in
+                             (uu___3, uu___4))) in
                (match expected_arity1 with
                 | FStar_Pervasives_Native.None ->
                     let resugared_args = resugar args1 in
@@ -1098,23 +1075,22 @@ let rec (resugar_term' :
                       FStar_Parser_ToDocument.handleable_args_length op1 in
                     if (FStar_List.length resugared_args) >= expect_n
                     then
-                      let uu____3790 =
-                        FStar_Util.first_N expect_n resugared_args in
-                      (match uu____3790 with
+                      let uu___2 = FStar_Util.first_N expect_n resugared_args in
+                      (match uu___2 with
                        | (op_args, rest) ->
                            let head =
-                             let uu____3838 =
-                               let uu____3839 =
-                                 let uu____3846 =
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 =
                                    FStar_List.map FStar_Pervasives_Native.fst
                                      op_args in
-                                 (op1, uu____3846) in
-                               FStar_Parser_AST.Op uu____3839 in
-                             mk uu____3838 in
+                                 (op1, uu___5) in
+                               FStar_Parser_AST.Op uu___4 in
+                             mk uu___3 in
                            FStar_List.fold_left
                              (fun head1 ->
-                                fun uu____3864 ->
-                                  match uu____3864 with
+                                fun uu___3 ->
+                                  match uu___3 with
                                   | (arg, qual) ->
                                       mk
                                         (FStar_Parser_AST.App
@@ -1122,51 +1098,47 @@ let rec (resugar_term' :
                     else resugar_as_app e args1
                 | FStar_Pervasives_Native.Some n when
                     (FStar_List.length args1) = n ->
-                    let uu____3879 =
-                      let uu____3880 =
-                        let uu____3887 =
-                          let uu____3890 = resugar args1 in
-                          FStar_List.map FStar_Pervasives_Native.fst
-                            uu____3890 in
-                        (op1, uu____3887) in
-                      FStar_Parser_AST.Op uu____3880 in
-                    mk uu____3879
-                | uu____3903 -> resugar_as_app e args1))
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = resugar args1 in
+                          FStar_List.map FStar_Pervasives_Native.fst uu___5 in
+                        (op1, uu___4) in
+                      FStar_Parser_AST.Op uu___3 in
+                    mk uu___2
+                | uu___2 -> resugar_as_app e args1))
       | FStar_Syntax_Syntax.Tm_match (e, (pat, wopt, t1)::[]) ->
-          let uu____3972 = FStar_Syntax_Subst.open_branch (pat, wopt, t1) in
-          (match uu____3972 with
+          let uu___1 = FStar_Syntax_Subst.open_branch (pat, wopt, t1) in
+          (match uu___1 with
            | (pat1, wopt1, t2) ->
                let branch_bv = FStar_Syntax_Free.names t2 in
                let bnds =
-                 let uu____4018 =
-                   let uu____4031 =
-                     let uu____4036 = resugar_pat' env pat1 branch_bv in
-                     let uu____4037 = resugar_term' env e in
-                     (uu____4036, uu____4037) in
-                   (FStar_Pervasives_Native.None, uu____4031) in
-                 [uu____4018] in
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = resugar_pat' env pat1 branch_bv in
+                     let uu___5 = resugar_term' env e in (uu___4, uu___5) in
+                   (FStar_Pervasives_Native.None, uu___3) in
+                 [uu___2] in
                let body = resugar_term' env t2 in
                mk
                  (FStar_Parser_AST.Let
                     (FStar_Parser_AST.NoLetQualifier, bnds, body)))
       | FStar_Syntax_Syntax.Tm_match
-          (e, (pat1, uu____4089, t1)::(pat2, uu____4092, t2)::[]) when
+          (e, (pat1, uu___1, t1)::(pat2, uu___2, t2)::[]) when
           (is_true_pat pat1) && (is_wild_pat pat2) ->
-          let uu____4188 =
-            let uu____4189 =
-              let uu____4196 = resugar_term' env e in
-              let uu____4197 = resugar_term' env t1 in
-              let uu____4198 = resugar_term' env t2 in
-              (uu____4196, uu____4197, uu____4198) in
-            FStar_Parser_AST.If uu____4189 in
-          mk uu____4188
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = resugar_term' env e in
+              let uu___6 = resugar_term' env t1 in
+              let uu___7 = resugar_term' env t2 in (uu___5, uu___6, uu___7) in
+            FStar_Parser_AST.If uu___4 in
+          mk uu___3
       | FStar_Syntax_Syntax.Tm_match (e, branches) ->
-          let resugar_branch uu____4264 =
-            match uu____4264 with
+          let resugar_branch uu___1 =
+            match uu___1 with
             | (pat, wopt, b) ->
-                let uu____4306 =
-                  FStar_Syntax_Subst.open_branch (pat, wopt, b) in
-                (match uu____4306 with
+                let uu___2 = FStar_Syntax_Subst.open_branch (pat, wopt, b) in
+                (match uu___2 with
                  | (pat1, wopt1, b1) ->
                      let branch_bv = FStar_Syntax_Free.names b1 in
                      let pat2 = resugar_pat' env pat1 branch_bv in
@@ -1175,85 +1147,78 @@ let rec (resugar_term' :
                        | FStar_Pervasives_Native.None ->
                            FStar_Pervasives_Native.None
                        | FStar_Pervasives_Native.Some e1 ->
-                           let uu____4358 = resugar_term' env e1 in
-                           FStar_Pervasives_Native.Some uu____4358 in
+                           let uu___3 = resugar_term' env e1 in
+                           FStar_Pervasives_Native.Some uu___3 in
                      let b2 = resugar_term' env b1 in (pat2, wopt2, b2)) in
-          let uu____4362 =
-            let uu____4363 =
-              let uu____4378 = resugar_term' env e in
-              let uu____4379 = FStar_List.map resugar_branch branches in
-              (uu____4378, uu____4379) in
-            FStar_Parser_AST.Match uu____4363 in
-          mk uu____4362
-      | FStar_Syntax_Syntax.Tm_ascribed (e, (asc, tac_opt), uu____4425) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = resugar_term' env e in
+              let uu___4 = FStar_List.map resugar_branch branches in
+              (uu___3, uu___4) in
+            FStar_Parser_AST.Match uu___2 in
+          mk uu___1
+      | FStar_Syntax_Syntax.Tm_ascribed (e, (asc, tac_opt), uu___1) ->
           let term =
             match asc with
             | FStar_Util.Inl n -> resugar_term' env n
             | FStar_Util.Inr n -> resugar_comp' env n in
           let tac_opt1 = FStar_Option.map (resugar_term' env) tac_opt in
-          let uu____4494 =
-            let uu____4495 =
-              let uu____4504 = resugar_term' env e in
-              (uu____4504, term, tac_opt1) in
-            FStar_Parser_AST.Ascribed uu____4495 in
-          mk uu____4494
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = resugar_term' env e in (uu___4, term, tac_opt1) in
+            FStar_Parser_AST.Ascribed uu___3 in
+          mk uu___2
       | FStar_Syntax_Syntax.Tm_let ((is_rec, source_lbs), body) ->
           let mk_pat a =
             FStar_Parser_AST.mk_pattern a t.FStar_Syntax_Syntax.pos in
-          let uu____4530 = FStar_Syntax_Subst.open_let_rec source_lbs body in
-          (match uu____4530 with
+          let uu___1 = FStar_Syntax_Subst.open_let_rec source_lbs body in
+          (match uu___1 with
            | (source_lbs1, body1) ->
                let resugar_one_binding bnd =
                  let attrs_opt =
                    match bnd.FStar_Syntax_Syntax.lbattrs with
                    | [] -> FStar_Pervasives_Native.None
                    | tms ->
-                       let uu____4583 =
-                         FStar_List.map (resugar_term' env) tms in
-                       FStar_Pervasives_Native.Some uu____4583 in
-                 let uu____4590 =
-                   let uu____4595 =
+                       let uu___2 = FStar_List.map (resugar_term' env) tms in
+                       FStar_Pervasives_Native.Some uu___2 in
+                 let uu___2 =
+                   let uu___3 =
                      FStar_Syntax_Util.mk_conj bnd.FStar_Syntax_Syntax.lbtyp
                        bnd.FStar_Syntax_Syntax.lbdef in
                    FStar_Syntax_Subst.open_univ_vars
-                     bnd.FStar_Syntax_Syntax.lbunivs uu____4595 in
-                 match uu____4590 with
+                     bnd.FStar_Syntax_Syntax.lbunivs uu___3 in
+                 match uu___2 with
                  | (univs, td) ->
-                     let uu____4614 =
-                       let uu____4621 =
-                         let uu____4622 = FStar_Syntax_Subst.compress td in
-                         uu____4622.FStar_Syntax_Syntax.n in
-                       match uu____4621 with
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = FStar_Syntax_Subst.compress td in
+                         uu___5.FStar_Syntax_Syntax.n in
+                       match uu___4 with
                        | FStar_Syntax_Syntax.Tm_app
-                           (uu____4631,
-                            (t1, uu____4633)::(d, uu____4635)::[])
-                           -> (t1, d)
-                       | uu____4692 -> failwith "wrong let binding format" in
-                     (match uu____4614 with
+                           (uu___5, (t1, uu___6)::(d, uu___7)::[]) -> 
+                           (t1, d)
+                       | uu___5 -> failwith "wrong let binding format" in
+                     (match uu___3 with
                       | (typ, def) ->
-                          let uu____4721 =
-                            let uu____4736 =
-                              let uu____4737 =
-                                FStar_Syntax_Subst.compress def in
-                              uu____4737.FStar_Syntax_Syntax.n in
-                            match uu____4736 with
-                            | FStar_Syntax_Syntax.Tm_abs (b, t1, uu____4756)
-                                ->
-                                let uu____4781 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 = FStar_Syntax_Subst.compress def in
+                              uu___6.FStar_Syntax_Syntax.n in
+                            match uu___5 with
+                            | FStar_Syntax_Syntax.Tm_abs (b, t1, uu___6) ->
+                                let uu___7 =
                                   FStar_Syntax_Subst.open_term b t1 in
-                                (match uu____4781 with
+                                (match uu___7 with
                                  | (b1, t2) ->
                                      let b2 =
-                                       let uu____4811 =
+                                       let uu___8 =
                                          FStar_Options.print_implicits () in
-                                       if uu____4811
-                                       then b1
-                                       else filter_imp b1 in
+                                       if uu___8 then b1 else filter_imp b1 in
                                      (b2, t2, true))
-                            | uu____4829 -> ([], def, false) in
-                          (match uu____4721 with
+                            | uu___6 -> ([], def, false) in
+                          (match uu___4 with
                            | (binders, term, is_pat_app) ->
-                               let uu____4879 =
+                               let uu___5 =
                                  match bnd.FStar_Syntax_Syntax.lbname with
                                  | FStar_Util.Inr fv ->
                                      ((mk_pat
@@ -1261,71 +1226,67 @@ let rec (resugar_term' :
                                             ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))),
                                        term)
                                  | FStar_Util.Inl bv ->
-                                     let uu____4890 =
-                                       let uu____4891 =
-                                         let uu____4892 =
-                                           let uu____4899 =
-                                             bv_as_unique_ident bv in
-                                           (uu____4899,
+                                     let uu___6 =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           let uu___9 = bv_as_unique_ident bv in
+                                           (uu___9,
                                              FStar_Pervasives_Native.None) in
-                                         FStar_Parser_AST.PatVar uu____4892 in
-                                       mk_pat uu____4891 in
-                                     (uu____4890, term) in
-                               (match uu____4879 with
+                                         FStar_Parser_AST.PatVar uu___8 in
+                                       mk_pat uu___7 in
+                                     (uu___6, term) in
+                               (match uu___5 with
                                 | (pat, term1) ->
-                                    let uu____4920 =
+                                    let uu___6 =
                                       if is_pat_app
                                       then
                                         let args =
                                           FStar_All.pipe_right binders
                                             ((map_opt ())
-                                               (fun uu____4960 ->
-                                                  match uu____4960 with
+                                               (fun uu___7 ->
+                                                  match uu___7 with
                                                   | (bv, q) ->
-                                                      let uu____4975 =
+                                                      let uu___8 =
                                                         resugar_arg_qual env
                                                           q in
                                                       FStar_Util.map_opt
-                                                        uu____4975
+                                                        uu___8
                                                         (fun q1 ->
-                                                           let uu____4987 =
-                                                             let uu____4988 =
-                                                               let uu____4995
-                                                                 =
+                                                           let uu___9 =
+                                                             let uu___10 =
+                                                               let uu___11 =
                                                                  bv_as_unique_ident
                                                                    bv in
-                                                               (uu____4995,
-                                                                 q1) in
+                                                               (uu___11, q1) in
                                                              FStar_Parser_AST.PatVar
-                                                               uu____4988 in
-                                                           mk_pat uu____4987))) in
-                                        let uu____4998 =
-                                          let uu____5003 =
+                                                               uu___10 in
+                                                           mk_pat uu___9))) in
+                                        let uu___7 =
+                                          let uu___8 =
                                             resugar_term' env term1 in
                                           ((mk_pat
                                               (FStar_Parser_AST.PatApp
-                                                 (pat, args))), uu____5003) in
-                                        let uu____5006 =
-                                          universe_to_string univs in
-                                        (uu____4998, uu____5006)
+                                                 (pat, args))), uu___8) in
+                                        let uu___8 = universe_to_string univs in
+                                        (uu___7, uu___8)
                                       else
-                                        (let uu____5012 =
-                                           let uu____5017 =
+                                        (let uu___8 =
+                                           let uu___9 =
                                              resugar_term' env term1 in
-                                           (pat, uu____5017) in
-                                         let uu____5018 =
+                                           (pat, uu___9) in
+                                         let uu___9 =
                                            universe_to_string univs in
-                                         (uu____5012, uu____5018)) in
-                                    (attrs_opt, uu____4920)))) in
+                                         (uu___8, uu___9)) in
+                                    (attrs_opt, uu___6)))) in
                let r = FStar_List.map resugar_one_binding source_lbs1 in
                let bnds =
-                 let f uu____5118 =
-                   match uu____5118 with
+                 let f uu___2 =
+                   match uu___2 with
                    | (attrs, (pb, univs)) ->
-                       let uu____5174 =
-                         let uu____5175 = FStar_Options.print_universes () in
-                         Prims.op_Negation uu____5175 in
-                       if uu____5174
+                       let uu___3 =
+                         let uu___4 = FStar_Options.print_universes () in
+                         Prims.op_Negation uu___4 in
+                       if uu___3
                        then (attrs, pb)
                        else
                          (attrs,
@@ -1338,65 +1299,61 @@ let rec (resugar_term' :
                     ((if is_rec
                       then FStar_Parser_AST.Rec
                       else FStar_Parser_AST.NoLetQualifier), bnds, body2)))
-      | FStar_Syntax_Syntax.Tm_uvar (u, uu____5250) ->
+      | FStar_Syntax_Syntax.Tm_uvar (u, uu___1) ->
           let s =
-            let uu____5268 =
-              let uu____5269 =
+            let uu___2 =
+              let uu___3 =
                 FStar_Syntax_Unionfind.uvar_id
                   u.FStar_Syntax_Syntax.ctx_uvar_head in
-              FStar_All.pipe_right uu____5269 FStar_Util.string_of_int in
-            Prims.op_Hat "?u" uu____5268 in
-          let uu____5270 = mk FStar_Parser_AST.Wild in label s uu____5270
+              FStar_All.pipe_right uu___3 FStar_Util.string_of_int in
+            Prims.op_Hat "?u" uu___2 in
+          let uu___2 = mk FStar_Parser_AST.Wild in label s uu___2
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
           let qi1 =
             match qi.FStar_Syntax_Syntax.qkind with
             | FStar_Syntax_Syntax.Quote_static -> FStar_Parser_AST.Static
             | FStar_Syntax_Syntax.Quote_dynamic -> FStar_Parser_AST.Dynamic in
-          let uu____5278 =
-            let uu____5279 =
-              let uu____5284 = resugar_term' env tm in (uu____5284, qi1) in
-            FStar_Parser_AST.Quote uu____5279 in
-          mk uu____5278
+          let uu___1 =
+            let uu___2 = let uu___3 = resugar_term' env tm in (uu___3, qi1) in
+            FStar_Parser_AST.Quote uu___2 in
+          mk uu___1
       | FStar_Syntax_Syntax.Tm_meta (e, m) ->
-          let resugar_meta_desugared uu___4_5296 =
-            match uu___4_5296 with
+          let resugar_meta_desugared uu___1 =
+            match uu___1 with
             | FStar_Syntax_Syntax.Sequence ->
                 let term = resugar_term' env e in
                 let rec resugar_seq t1 =
                   match t1.FStar_Parser_AST.tm with
-                  | FStar_Parser_AST.Let
-                      (uu____5304, (uu____5305, (p, t11))::[], t2) ->
-                      mk (FStar_Parser_AST.Seq (t11, t2))
+                  | FStar_Parser_AST.Let (uu___2, (uu___3, (p, t11))::[], t2)
+                      -> mk (FStar_Parser_AST.Seq (t11, t2))
                   | FStar_Parser_AST.Ascribed (t11, t2, t3) ->
-                      let uu____5366 =
-                        let uu____5367 =
-                          let uu____5376 = resugar_seq t11 in
-                          (uu____5376, t2, t3) in
-                        FStar_Parser_AST.Ascribed uu____5367 in
-                      mk uu____5366
-                  | uu____5379 -> t1 in
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = resugar_seq t11 in (uu___4, t2, t3) in
+                        FStar_Parser_AST.Ascribed uu___3 in
+                      mk uu___2
+                  | uu___2 -> t1 in
                 resugar_seq term
             | FStar_Syntax_Syntax.Primop -> resugar_term' env e
             | FStar_Syntax_Syntax.Masked_effect -> resugar_term' env e
             | FStar_Syntax_Syntax.Meta_smt_pat -> resugar_term' env e in
           (match m with
-           | FStar_Syntax_Syntax.Meta_pattern (uu____5380, pats) ->
+           | FStar_Syntax_Syntax.Meta_pattern (uu___1, pats) ->
                let pats1 =
                  FStar_All.pipe_right (FStar_List.flatten pats)
                    (FStar_List.map
-                      (fun uu____5444 ->
-                         match uu____5444 with
-                         | (x, uu____5452) -> resugar_term' env x)) in
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | (x, uu___3) -> resugar_term' env x)) in
                mk (FStar_Parser_AST.Attributes pats1)
-           | FStar_Syntax_Syntax.Meta_labeled uu____5457 ->
-               resugar_term' env e
+           | FStar_Syntax_Syntax.Meta_labeled uu___1 -> resugar_term' env e
            | FStar_Syntax_Syntax.Meta_desugared i -> resugar_meta_desugared i
            | FStar_Syntax_Syntax.Meta_named t1 ->
                mk (FStar_Parser_AST.Name t1)
-           | FStar_Syntax_Syntax.Meta_monadic (uu____5466, t1) ->
+           | FStar_Syntax_Syntax.Meta_monadic (uu___1, t1) ->
                resugar_term' env e
-           | FStar_Syntax_Syntax.Meta_monadic_lift
-               (uu____5472, uu____5473, t1) -> resugar_term' env e)
+           | FStar_Syntax_Syntax.Meta_monadic_lift (uu___1, uu___2, t1) ->
+               resugar_term' env e)
       | FStar_Syntax_Syntax.Tm_unknown -> mk FStar_Parser_AST.Wild
 and (resugar_calc :
   FStar_Syntax_DsEnv.env ->
@@ -1409,230 +1366,228 @@ and (resugar_calc :
         FStar_Parser_AST.mk_term a t0.FStar_Syntax_Syntax.pos
           FStar_Parser_AST.Un in
       let resugar_calc_finish t =
-        let uu____5507 = FStar_Syntax_Util.head_and_args t in
-        match uu____5507 with
+        let uu___ = FStar_Syntax_Util.head_and_args t in
+        match uu___ with
         | (hd, args) ->
-            let uu____5556 =
-              let uu____5571 =
-                let uu____5572 =
-                  let uu____5575 = FStar_Syntax_Util.un_uinst hd in
-                  FStar_Syntax_Subst.compress uu____5575 in
-                uu____5572.FStar_Syntax_Syntax.n in
-              (uu____5571, args) in
-            (match uu____5556 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Util.un_uinst hd in
+                  FStar_Syntax_Subst.compress uu___4 in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____5593, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____5594))::(rel,
-                                                              FStar_Pervasives_Native.None)::
-                (uu____5596, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____5597))::(uu____5598,
-                                                              FStar_Pervasives_Native.Some
-                                                              (FStar_Syntax_Syntax.Implicit
-                                                              uu____5599))::
-                (pf, FStar_Pervasives_Native.None)::[]) when
+                (uu___2, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___3))::(rel,
+                                                          FStar_Pervasives_Native.None)::
+                (uu___4, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___5))::(uu___6,
+                                                          FStar_Pervasives_Native.Some
+                                                          (FStar_Syntax_Syntax.Implicit
+                                                          uu___7))::(pf,
+                                                                    FStar_Pervasives_Native.None)::[])
+                 when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.calc_finish_lid
                  ->
                  let pf1 = FStar_Syntax_Util.unthunk pf in
                  FStar_Pervasives_Native.Some (rel, pf1)
-             | uu____5694 -> FStar_Pervasives_Native.None) in
+             | uu___2 -> FStar_Pervasives_Native.None) in
       let un_eta_rel rel =
         let bv_eq_tm b t =
-          let uu____5734 =
-            let uu____5735 = FStar_Syntax_Subst.compress t in
-            uu____5735.FStar_Syntax_Syntax.n in
-          match uu____5734 with
+          let uu___ =
+            let uu___1 = FStar_Syntax_Subst.compress t in
+            uu___1.FStar_Syntax_Syntax.n in
+          match uu___ with
           | FStar_Syntax_Syntax.Tm_name b' when
               FStar_Syntax_Syntax.bv_eq b b' -> true
-          | uu____5739 -> false in
-        let uu____5740 =
-          let uu____5741 = FStar_Syntax_Subst.compress rel in
-          uu____5741.FStar_Syntax_Syntax.n in
-        match uu____5740 with
-        | FStar_Syntax_Syntax.Tm_abs (b1::b2::[], body, uu____5749) ->
-            let uu____5796 = FStar_Syntax_Subst.open_term [b1; b2] body in
-            (match uu____5796 with
+          | uu___1 -> false in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress rel in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_abs (b1::b2::[], body, uu___1) ->
+            let uu___2 = FStar_Syntax_Subst.open_term [b1; b2] body in
+            (match uu___2 with
              | (b11::b21::[], body1) ->
                  let body2 = FStar_Syntax_Util.unascribe body1 in
                  let body3 =
-                   let uu____5856 = FStar_Syntax_Util.unb2t body2 in
-                   match uu____5856 with
-                   | FStar_Pervasives_Native.Some body3 -> body3
+                   let uu___3 = FStar_Syntax_Util.unb2t body2 in
+                   match uu___3 with
+                   | FStar_Pervasives_Native.Some body4 -> body4
                    | FStar_Pervasives_Native.None -> body2 in
-                 let uu____5860 =
-                   let uu____5861 = FStar_Syntax_Subst.compress body3 in
-                   uu____5861.FStar_Syntax_Syntax.n in
-                 (match uu____5860 with
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Subst.compress body3 in
+                   uu___4.FStar_Syntax_Syntax.n in
+                 (match uu___3 with
                   | FStar_Syntax_Syntax.Tm_app (e, args) when
                       (FStar_List.length args) >= (Prims.of_int (2)) ->
                       (match FStar_List.rev args with
                        | (a1, FStar_Pervasives_Native.None)::(a2,
                                                               FStar_Pervasives_Native.None)::rest
                            ->
-                           let uu____5951 =
+                           let uu___4 =
                              (bv_eq_tm (FStar_Pervasives_Native.fst b11) a2)
                                &&
                                (bv_eq_tm (FStar_Pervasives_Native.fst b21) a1) in
-                           if uu____5951
+                           if uu___4
                            then
-                             let uu____5958 =
+                             let uu___5 =
                                FStar_Syntax_Util.mk_app e
                                  (FStar_List.rev rest) in
                              FStar_All.pipe_left
-                               (fun uu____5969 ->
-                                  FStar_Pervasives_Native.Some uu____5969)
-                               uu____5958
+                               (fun uu___6 ->
+                                  FStar_Pervasives_Native.Some uu___6) uu___5
                            else FStar_Pervasives_Native.Some rel
-                       | uu____5971 -> FStar_Pervasives_Native.Some rel)
-                  | uu____5982 -> FStar_Pervasives_Native.Some rel))
-        | uu____5983 -> FStar_Pervasives_Native.Some rel in
+                       | uu___4 -> FStar_Pervasives_Native.Some rel)
+                  | uu___4 -> FStar_Pervasives_Native.Some rel))
+        | uu___1 -> FStar_Pervasives_Native.Some rel in
       let resugar_step pack =
-        let uu____6010 = FStar_Syntax_Util.head_and_args pack in
-        match uu____6010 with
+        let uu___ = FStar_Syntax_Util.head_and_args pack in
+        match uu___ with
         | (hd, args) ->
-            let uu____6063 =
-              let uu____6078 =
-                let uu____6079 =
-                  let uu____6082 = FStar_Syntax_Util.un_uinst hd in
-                  FStar_Syntax_Subst.compress uu____6082 in
-                uu____6079.FStar_Syntax_Syntax.n in
-              (uu____6078, args) in
-            (match uu____6063 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Util.un_uinst hd in
+                  FStar_Syntax_Subst.compress uu___4 in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____6104, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____6105))::(uu____6106,
-                                                              FStar_Pervasives_Native.Some
-                                                              (FStar_Syntax_Syntax.Implicit
-                                                              uu____6107))::
-                (uu____6108, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____6109))::(rel,
-                                                              FStar_Pervasives_Native.None)::
-                (z, FStar_Pervasives_Native.None)::(pf,
-                                                    FStar_Pervasives_Native.None)::
-                (j, FStar_Pervasives_Native.None)::[]) when
+                (uu___2, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___3))::(uu___4,
+                                                          FStar_Pervasives_Native.Some
+                                                          (FStar_Syntax_Syntax.Implicit
+                                                          uu___5))::(uu___6,
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (FStar_Syntax_Syntax.Implicit
+                                                                    uu___7))::
+                (rel, FStar_Pervasives_Native.None)::(z,
+                                                      FStar_Pervasives_Native.None)::
+                (pf, FStar_Pervasives_Native.None)::(j,
+                                                     FStar_Pervasives_Native.None)::[])
+                 when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.calc_step_lid
                  ->
                  let pf1 = FStar_Syntax_Util.unthunk pf in
                  let j1 = FStar_Syntax_Util.unthunk j in
                  FStar_Pervasives_Native.Some (z, rel, j1, pf1)
-             | uu____6240 -> FStar_Pervasives_Native.None) in
+             | uu___2 -> FStar_Pervasives_Native.None) in
       let resugar_init pack =
-        let uu____6273 = FStar_Syntax_Util.head_and_args pack in
-        match uu____6273 with
+        let uu___ = FStar_Syntax_Util.head_and_args pack in
+        match uu___ with
         | (hd, args) ->
-            let uu____6318 =
-              let uu____6333 =
-                let uu____6334 =
-                  let uu____6337 = FStar_Syntax_Util.un_uinst hd in
-                  FStar_Syntax_Subst.compress uu____6337 in
-                uu____6334.FStar_Syntax_Syntax.n in
-              (uu____6333, args) in
-            (match uu____6318 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Util.un_uinst hd in
+                  FStar_Syntax_Subst.compress uu___4 in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____6351, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____6352))::(x,
-                                                              FStar_Pervasives_Native.None)::[])
+                (uu___2, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___3))::(x,
+                                                          FStar_Pervasives_Native.None)::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.calc_init_lid
                  -> FStar_Pervasives_Native.Some x
-             | uu____6400 -> FStar_Pervasives_Native.None) in
+             | uu___2 -> FStar_Pervasives_Native.None) in
       let rec resugar_all_steps pack =
-        let uu____6449 = resugar_step pack in
-        match uu____6449 with
+        let uu___ = resugar_step pack in
+        match uu___ with
         | FStar_Pervasives_Native.Some (t, r, j, k) ->
-            let uu____6486 = resugar_all_steps k in
-            FStar_Util.bind_opt uu____6486
-              (fun uu____6528 ->
-                 match uu____6528 with
+            let uu___1 = resugar_all_steps k in
+            FStar_Util.bind_opt uu___1
+              (fun uu___2 ->
+                 match uu___2 with
                  | (steps, k1) ->
                      FStar_Pervasives_Native.Some (((t, r, j) :: steps), k1))
         | FStar_Pervasives_Native.None ->
             FStar_Pervasives_Native.Some ([], pack) in
       let resugar_rel rel =
         let rel1 =
-          let uu____6640 = un_eta_rel rel in
-          match uu____6640 with
-          | FStar_Pervasives_Native.Some rel1 -> rel1
+          let uu___ = un_eta_rel rel in
+          match uu___ with
+          | FStar_Pervasives_Native.Some rel2 -> rel2
           | FStar_Pervasives_Native.None -> rel in
-        let fallback uu____6649 =
-          let uu____6650 =
-            let uu____6651 = resugar_term' env rel1 in
-            FStar_Parser_AST.Paren uu____6651 in
-          mk uu____6650 in
-        let uu____6652 = FStar_Syntax_Util.head_and_args rel1 in
-        match uu____6652 with
+        let fallback uu___ =
+          let uu___1 =
+            let uu___2 = resugar_term' env rel1 in
+            FStar_Parser_AST.Paren uu___2 in
+          mk uu___1 in
+        let uu___ = FStar_Syntax_Util.head_and_args rel1 in
+        match uu___ with
         | (hd, args) ->
-            let uu____6695 =
+            let uu___1 =
               (FStar_Options.print_implicits ()) &&
                 (FStar_List.existsb
-                   (fun uu____6705 ->
-                      match uu____6705 with
-                      | (uu____6712, q) -> FStar_Syntax_Syntax.is_implicit q)
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (uu___3, q) -> FStar_Syntax_Syntax.is_implicit q)
                    args) in
-            if uu____6695
+            if uu___1
             then fallback ()
             else
-              (let uu____6719 = resugar_term_as_op hd in
-               match uu____6719 with
+              (let uu___3 = resugar_term_as_op hd in
+               match uu___3 with
                | FStar_Pervasives_Native.Some
                    (s, FStar_Pervasives_Native.None) ->
-                   let uu____6731 =
-                     let uu____6732 =
-                       let uu____6739 = FStar_Ident.id_of_text s in
-                       (uu____6739, []) in
-                     FStar_Parser_AST.Op uu____6732 in
-                   mk uu____6731
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_Ident.id_of_text s in (uu___6, []) in
+                     FStar_Parser_AST.Op uu___5 in
+                   mk uu___4
                | FStar_Pervasives_Native.Some
-                   (s, FStar_Pervasives_Native.Some uu____6747) when
-                   uu____6747 = (Prims.of_int (2)) ->
-                   let uu____6748 =
-                     let uu____6749 =
-                       let uu____6756 = FStar_Ident.id_of_text s in
-                       (uu____6756, []) in
-                     FStar_Parser_AST.Op uu____6749 in
-                   mk uu____6748
-               | uu____6759 -> fallback ()) in
+                   (s, FStar_Pervasives_Native.Some uu___4) when
+                   uu___4 = (Prims.of_int (2)) ->
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Ident.id_of_text s in (uu___7, []) in
+                     FStar_Parser_AST.Op uu___6 in
+                   mk uu___5
+               | uu___4 -> fallback ()) in
       let build_calc rel x0 steps =
         let r = resugar_term' env in
-        let uu____6803 =
-          let uu____6804 =
-            let uu____6813 = resugar_rel rel in
-            let uu____6814 = r x0 in
-            let uu____6815 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 = resugar_rel rel in
+            let uu___3 = r x0 in
+            let uu___4 =
               FStar_List.map
-                (fun uu____6829 ->
-                   match uu____6829 with
+                (fun uu___5 ->
+                   match uu___5 with
                    | (z, rel1, j) ->
-                       let uu____6839 =
-                         let uu____6846 = resugar_rel rel1 in
-                         let uu____6847 = r j in
-                         let uu____6848 = r z in
-                         (uu____6846, uu____6847, uu____6848) in
-                       FStar_Parser_AST.CalcStep uu____6839) steps in
-            (uu____6813, uu____6814, uu____6815) in
-          FStar_Parser_AST.CalcProof uu____6804 in
-        mk uu____6803 in
-      let uu____6851 = resugar_calc_finish t0 in
-      FStar_Util.bind_opt uu____6851
-        (fun uu____6866 ->
-           match uu____6866 with
+                       let uu___6 =
+                         let uu___7 = resugar_rel rel1 in
+                         let uu___8 = r j in
+                         let uu___9 = r z in (uu___7, uu___8, uu___9) in
+                       FStar_Parser_AST.CalcStep uu___6) steps in
+            (uu___2, uu___3, uu___4) in
+          FStar_Parser_AST.CalcProof uu___1 in
+        mk uu___ in
+      let uu___ = resugar_calc_finish t0 in
+      FStar_Util.bind_opt uu___
+        (fun uu___1 ->
+           match uu___1 with
            | (rel, pack) ->
-               let uu____6875 = resugar_all_steps pack in
-               FStar_Util.bind_opt uu____6875
-                 (fun uu____6906 ->
-                    match uu____6906 with
+               let uu___2 = resugar_all_steps pack in
+               FStar_Util.bind_opt uu___2
+                 (fun uu___3 ->
+                    match uu___3 with
                     | (steps, k) ->
-                        let uu____6939 = resugar_init k in
-                        FStar_Util.bind_opt uu____6939
+                        let uu___4 = resugar_init k in
+                        FStar_Util.bind_opt uu___4
                           (fun x0 ->
-                             let uu____6945 =
+                             let uu___5 =
                                build_calc rel x0 (FStar_List.rev steps) in
                              FStar_All.pipe_left
-                               (fun uu____6954 ->
-                                  FStar_Pervasives_Native.Some uu____6954)
-                               uu____6945)))
+                               (fun uu___6 ->
+                                  FStar_Pervasives_Native.Some uu___6) uu___5)))
 and (resugar_comp' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term)
   =
@@ -1651,8 +1606,8 @@ and (resugar_comp' :
                     (FStar_Parser_Const.effect_Tot_lid,
                       [(t, FStar_Parser_AST.Nothing)]))
            | FStar_Pervasives_Native.Some u1 ->
-               let uu____6989 = FStar_Options.print_universes () in
-               if uu____6989
+               let uu___ = FStar_Options.print_universes () in
+               if uu___
                then
                  let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos in
                  mk
@@ -1674,8 +1629,8 @@ and (resugar_comp' :
                     (FStar_Parser_Const.effect_GTot_lid,
                       [(t, FStar_Parser_AST.Nothing)]))
            | FStar_Pervasives_Native.Some u1 ->
-               let uu____7050 = FStar_Options.print_universes () in
-               if uu____7050
+               let uu___ = FStar_Options.print_universes () in
+               if uu___
                then
                  let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos in
                  mk
@@ -1690,65 +1645,64 @@ and (resugar_comp' :
                         [(t, FStar_Parser_AST.Nothing)])))
       | FStar_Syntax_Syntax.Comp c1 ->
           let result =
-            let uu____7091 =
-              resugar_term' env c1.FStar_Syntax_Syntax.result_typ in
-            (uu____7091, FStar_Parser_AST.Nothing) in
-          let uu____7092 =
+            let uu___ = resugar_term' env c1.FStar_Syntax_Syntax.result_typ in
+            (uu___, FStar_Parser_AST.Nothing) in
+          let uu___ =
             (FStar_Options.print_effect_args ()) ||
               (FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
                  FStar_Parser_Const.effect_Lemma_lid) in
-          if uu____7092
+          if uu___
           then
             let universe =
               FStar_List.map (fun u -> resugar_universe u)
                 c1.FStar_Syntax_Syntax.comp_univs in
             let args =
-              let uu____7113 =
+              let uu___1 =
                 FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_Lemma_lid in
-              if uu____7113
+              if uu___1
               then
                 match c1.FStar_Syntax_Syntax.effect_args with
                 | pre::post::pats::[] ->
                     let post1 =
-                      let uu____7196 =
+                      let uu___2 =
                         FStar_Syntax_Util.unthunk_lemma_post
                           (FStar_Pervasives_Native.fst post) in
-                      (uu____7196, (FStar_Pervasives_Native.snd post)) in
-                    let uu____7207 =
-                      let uu____7216 =
+                      (uu___2, (FStar_Pervasives_Native.snd post)) in
+                    let uu___2 =
+                      let uu___3 =
                         FStar_Syntax_Util.is_fvar FStar_Parser_Const.true_lid
                           (FStar_Pervasives_Native.fst pre) in
-                      if uu____7216 then [] else [pre] in
-                    let uu____7248 =
-                      let uu____7257 =
-                        let uu____7266 =
+                      if uu___3 then [] else [pre] in
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Syntax_Util.is_fvar
                             FStar_Parser_Const.nil_lid
                             (FStar_Pervasives_Native.fst pats) in
-                        if uu____7266 then [] else [pats] in
-                      FStar_List.append [post1] uu____7257 in
-                    FStar_List.append uu____7207 uu____7248
-                | uu____7322 -> c1.FStar_Syntax_Syntax.effect_args
+                        if uu___5 then [] else [pats] in
+                      FStar_List.append [post1] uu___4 in
+                    FStar_List.append uu___2 uu___3
+                | uu___2 -> c1.FStar_Syntax_Syntax.effect_args
               else c1.FStar_Syntax_Syntax.effect_args in
             let args1 =
               FStar_List.map
-                (fun uu____7355 ->
-                   match uu____7355 with
-                   | (e, uu____7367) ->
-                       let uu____7372 = resugar_term' env e in
-                       (uu____7372, FStar_Parser_AST.Nothing)) args in
-            let rec aux l uu___5_7397 =
-              match uu___5_7397 with
+                (fun uu___1 ->
+                   match uu___1 with
+                   | (e, uu___2) ->
+                       let uu___3 = resugar_term' env e in
+                       (uu___3, FStar_Parser_AST.Nothing)) args in
+            let rec aux l uu___1 =
+              match uu___1 with
               | [] -> l
               | hd::tl ->
                   (match hd with
                    | FStar_Syntax_Syntax.DECREASES e ->
                        let e1 =
-                         let uu____7430 = resugar_term' env e in
-                         (uu____7430, FStar_Parser_AST.Nothing) in
+                         let uu___2 = resugar_term' env e in
+                         (uu___2, FStar_Parser_AST.Nothing) in
                        aux (e1 :: l) tl
-                   | uu____7435 -> aux l tl) in
+                   | uu___2 -> aux l tl) in
             let decrease = aux [] c1.FStar_Syntax_Syntax.flags in
             mk
               (FStar_Parser_AST.Construct
@@ -1767,33 +1721,32 @@ and (resugar_binder' :
   fun env ->
     fun b ->
       fun r ->
-        let uu____7481 = b in
-        match uu____7481 with
+        let uu___ = b in
+        match uu___ with
         | (x, aq) ->
-            let uu____7490 = resugar_arg_qual env aq in
-            FStar_Util.map_opt uu____7490
+            let uu___1 = resugar_arg_qual env aq in
+            FStar_Util.map_opt uu___1
               (fun imp ->
                  let e = resugar_term' env x.FStar_Syntax_Syntax.sort in
                  match e.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Wild ->
-                     let uu____7504 =
-                       let uu____7505 = bv_as_unique_ident x in
-                       FStar_Parser_AST.Variable uu____7505 in
-                     FStar_Parser_AST.mk_binder uu____7504 r
+                     let uu___2 =
+                       let uu___3 = bv_as_unique_ident x in
+                       FStar_Parser_AST.Variable uu___3 in
+                     FStar_Parser_AST.mk_binder uu___2 r
                        FStar_Parser_AST.Type_level imp
-                 | uu____7506 ->
-                     let uu____7507 = FStar_Syntax_Syntax.is_null_bv x in
-                     if uu____7507
+                 | uu___2 ->
+                     let uu___3 = FStar_Syntax_Syntax.is_null_bv x in
+                     if uu___3
                      then
                        FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName e)
                          r FStar_Parser_AST.Type_level imp
                      else
-                       (let uu____7509 =
-                          let uu____7510 =
-                            let uu____7515 = bv_as_unique_ident x in
-                            (uu____7515, e) in
-                          FStar_Parser_AST.Annotated uu____7510 in
-                        FStar_Parser_AST.mk_binder uu____7509 r
+                       (let uu___5 =
+                          let uu___6 =
+                            let uu___7 = bv_as_unique_ident x in (uu___7, e) in
+                          FStar_Parser_AST.Annotated uu___6 in
+                        FStar_Parser_AST.mk_binder uu___5 r
                           FStar_Parser_AST.Type_level imp))
 and (resugar_bv_as_pat' :
   FStar_Syntax_DsEnv.env ->
@@ -1809,38 +1762,37 @@ and (resugar_bv_as_pat' :
         fun body_bv ->
           fun typ_opt ->
             let mk a =
-              let uu____7535 = FStar_Syntax_Syntax.range_of_bv v in
-              FStar_Parser_AST.mk_pattern a uu____7535 in
+              let uu___ = FStar_Syntax_Syntax.range_of_bv v in
+              FStar_Parser_AST.mk_pattern a uu___ in
             let used = FStar_Util.set_mem v body_bv in
             let pat =
-              let uu____7538 =
+              let uu___ =
                 if used
                 then
-                  let uu____7539 =
-                    let uu____7546 = bv_as_unique_ident v in
-                    (uu____7546, aqual) in
-                  FStar_Parser_AST.PatVar uu____7539
+                  let uu___1 =
+                    let uu___2 = bv_as_unique_ident v in (uu___2, aqual) in
+                  FStar_Parser_AST.PatVar uu___1
                 else FStar_Parser_AST.PatWild aqual in
-              mk uu____7538 in
+              mk uu___ in
             match typ_opt with
             | FStar_Pervasives_Native.None -> pat
             | FStar_Pervasives_Native.Some
                 { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_unknown;
-                  FStar_Syntax_Syntax.pos = uu____7552;
-                  FStar_Syntax_Syntax.vars = uu____7553;_}
+                  FStar_Syntax_Syntax.pos = uu___;
+                  FStar_Syntax_Syntax.vars = uu___1;_}
                 -> pat
             | FStar_Pervasives_Native.Some typ ->
-                let uu____7563 = FStar_Options.print_bound_var_types () in
-                if uu____7563
+                let uu___ = FStar_Options.print_bound_var_types () in
+                if uu___
                 then
-                  let uu____7564 =
-                    let uu____7565 =
-                      let uu____7576 =
-                        let uu____7583 = resugar_term' env typ in
-                        (uu____7583, FStar_Pervasives_Native.None) in
-                      (pat, uu____7576) in
-                    FStar_Parser_AST.PatAscribed uu____7565 in
-                  mk uu____7564
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = resugar_term' env typ in
+                        (uu___4, FStar_Pervasives_Native.None) in
+                      (pat, uu___3) in
+                    FStar_Parser_AST.PatAscribed uu___2 in
+                  mk uu___1
                 else pat
 and (resugar_bv_as_pat :
   FStar_Syntax_DsEnv.env ->
@@ -1853,16 +1805,15 @@ and (resugar_bv_as_pat :
     fun x ->
       fun qual ->
         fun body_bv ->
-          let uu____7603 = resugar_arg_qual env qual in
-          FStar_Util.map_opt uu____7603
+          let uu___ = resugar_arg_qual env qual in
+          FStar_Util.map_opt uu___
             (fun aqual ->
-               let uu____7615 =
-                 let uu____7620 =
+               let uu___1 =
+                 let uu___2 =
                    FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort in
                  FStar_All.pipe_left
-                   (fun uu____7631 -> FStar_Pervasives_Native.Some uu____7631)
-                   uu____7620 in
-               resugar_bv_as_pat' env x aqual body_bv uu____7615)
+                   (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2 in
+               resugar_bv_as_pat' env x aqual body_bv uu___1)
 and (resugar_pat' :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.pat ->
@@ -1879,23 +1830,23 @@ and (resugar_pat' :
                then FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit
                else FStar_Pervasives_Native.None) in
         let may_drop_implicits args =
-          (let uu____7684 = FStar_Options.print_implicits () in
-           Prims.op_Negation uu____7684) &&
-            (let uu____7686 =
+          (let uu___ = FStar_Options.print_implicits () in
+           Prims.op_Negation uu___) &&
+            (let uu___ =
                FStar_List.existsML
-                 (fun uu____7697 ->
-                    match uu____7697 with
+                 (fun uu___1 ->
+                    match uu___1 with
                     | (pattern, is_implicit) ->
                         let might_be_used =
                           match pattern.FStar_Syntax_Syntax.v with
                           | FStar_Syntax_Syntax.Pat_var bv ->
                               FStar_Util.set_mem bv branch_bv
-                          | FStar_Syntax_Syntax.Pat_dot_term (bv, uu____7713)
-                              -> FStar_Util.set_mem bv branch_bv
-                          | FStar_Syntax_Syntax.Pat_wild uu____7718 -> false
-                          | uu____7719 -> true in
+                          | FStar_Syntax_Syntax.Pat_dot_term (bv, uu___2) ->
+                              FStar_Util.set_mem bv branch_bv
+                          | FStar_Syntax_Syntax.Pat_wild uu___2 -> false
+                          | uu___2 -> true in
                         is_implicit && might_be_used) args in
-             Prims.op_Negation uu____7686) in
+             Prims.op_Negation uu___) in
         let resugar_plain_pat_cons' fv args =
           mk
             (FStar_Parser_AST.PatApp
@@ -1905,12 +1856,12 @@ and (resugar_pat' :
                  args)) in
         let rec resugar_plain_pat_cons fv args =
           let args1 =
-            let uu____7782 = may_drop_implicits args in
-            if uu____7782 then filter_pattern_imp args else args in
+            let uu___ = may_drop_implicits args in
+            if uu___ then filter_pattern_imp args else args in
           let args2 =
             FStar_List.map
-              (fun uu____7802 ->
-                 match uu____7802 with
+              (fun uu___ ->
+                 match uu___ with
                  | (p1, b) -> aux p1 (FStar_Pervasives_Native.Some b)) args1 in
           resugar_plain_pat_cons' fv args2
         and aux p1 imp_opt =
@@ -1927,12 +1878,12 @@ and (resugar_pat' :
                  FStar_Parser_Const.nil_lid)
                 && (may_drop_implicits args)
               ->
-              ((let uu____7848 =
-                  let uu____7849 =
-                    let uu____7850 = filter_pattern_imp args in
-                    FStar_List.isEmpty uu____7850 in
-                  Prims.op_Negation uu____7849 in
-                if uu____7848
+              ((let uu___1 =
+                  let uu___2 =
+                    let uu___3 = filter_pattern_imp args in
+                    FStar_List.isEmpty uu___3 in
+                  Prims.op_Negation uu___2 in
+                if uu___1
                 then
                   FStar_Errors.log_issue p1.FStar_Syntax_Syntax.p
                     (FStar_Errors.Warning_NilGivenExplicitArgs,
@@ -1945,31 +1896,28 @@ and (resugar_pat' :
                  FStar_Parser_Const.cons_lid)
                 && (may_drop_implicits args)
               ->
-              let uu____7886 = filter_pattern_imp args in
-              (match uu____7886 with
+              let uu___ = filter_pattern_imp args in
+              (match uu___ with
                | (hd, false)::(tl, false)::[] ->
                    let hd' = aux hd (FStar_Pervasives_Native.Some false) in
-                   let uu____7926 =
-                     aux tl (FStar_Pervasives_Native.Some false) in
-                   (match uu____7926 with
+                   let uu___1 = aux tl (FStar_Pervasives_Native.Some false) in
+                   (match uu___1 with
                     | { FStar_Parser_AST.pat = FStar_Parser_AST.PatList tl';
                         FStar_Parser_AST.prange = p2;_} ->
                         FStar_Parser_AST.mk_pattern
                           (FStar_Parser_AST.PatList (hd' :: tl')) p2
                     | tl' -> resugar_plain_pat_cons' fv [hd'; tl'])
                | args' ->
-                   ((let uu____7942 =
-                       let uu____7947 =
-                         let uu____7948 =
+                   ((let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_All.pipe_left FStar_Util.string_of_int
                              (FStar_List.length args') in
                          FStar_Util.format1
                            "Prims.Cons applied to %s explicit arguments"
-                           uu____7948 in
-                       (FStar_Errors.Warning_ConsAppliedExplicitArgs,
-                         uu____7947) in
-                     FStar_Errors.log_issue p1.FStar_Syntax_Syntax.p
-                       uu____7942);
+                           uu___4 in
+                       (FStar_Errors.Warning_ConsAppliedExplicitArgs, uu___3) in
+                     FStar_Errors.log_issue p1.FStar_Syntax_Syntax.p uu___2);
                     resugar_plain_pat_cons fv args))
           | FStar_Syntax_Syntax.Pat_cons (fv, args) when
               (is_tuple_constructor_lid
@@ -1979,85 +1927,85 @@ and (resugar_pat' :
               let args1 =
                 FStar_All.pipe_right args
                   (FStar_List.filter_map
-                     (fun uu____7991 ->
-                        match uu____7991 with
+                     (fun uu___ ->
+                        match uu___ with
                         | (p2, is_implicit) ->
                             if is_implicit
                             then FStar_Pervasives_Native.None
                             else
-                              (let uu____8003 =
+                              (let uu___2 =
                                  aux p2 (FStar_Pervasives_Native.Some false) in
-                               FStar_Pervasives_Native.Some uu____8003))) in
+                               FStar_Pervasives_Native.Some uu___2))) in
               let is_dependent_tuple =
                 FStar_Parser_Const.is_dtuple_data_lid'
                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
               mk (FStar_Parser_AST.PatTuple (args1, is_dependent_tuple))
           | FStar_Syntax_Syntax.Pat_cons
-              ({ FStar_Syntax_Syntax.fv_name = uu____8007;
-                 FStar_Syntax_Syntax.fv_delta = uu____8008;
+              ({ FStar_Syntax_Syntax.fv_name = uu___;
+                 FStar_Syntax_Syntax.fv_delta = uu___1;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Record_ctor (name, fields));_},
                args)
               ->
               let fields1 =
-                let uu____8035 =
+                let uu___2 =
                   FStar_All.pipe_right fields
                     (FStar_List.map (fun f -> FStar_Ident.lid_of_ids [f])) in
-                FStar_All.pipe_right uu____8035 FStar_List.rev in
+                FStar_All.pipe_right uu___2 FStar_List.rev in
               let args1 =
-                let uu____8051 =
+                let uu___2 =
                   FStar_All.pipe_right args
                     (FStar_List.map
-                       (fun uu____8069 ->
-                          match uu____8069 with
+                       (fun uu___3 ->
+                          match uu___3 with
                           | (p2, b) ->
                               aux p2 (FStar_Pervasives_Native.Some b))) in
-                FStar_All.pipe_right uu____8051 FStar_List.rev in
+                FStar_All.pipe_right uu___2 FStar_List.rev in
               let rec map2 l1 l2 =
                 match (l1, l2) with
                 | ([], []) -> []
                 | ([], hd::tl) -> []
                 | (hd::tl, []) ->
-                    let uu____8143 = map2 tl [] in
+                    let uu___2 = map2 tl [] in
                     (hd,
                       (mk
                          (FStar_Parser_AST.PatWild
                             FStar_Pervasives_Native.None)))
-                      :: uu____8143
+                      :: uu___2
                 | (hd1::tl1, hd2::tl2) ->
-                    let uu____8166 = map2 tl1 tl2 in (hd1, hd2) :: uu____8166 in
+                    let uu___2 = map2 tl1 tl2 in (hd1, hd2) :: uu___2 in
               let args2 =
-                let uu____8184 = map2 fields1 args1 in
-                FStar_All.pipe_right uu____8184 FStar_List.rev in
+                let uu___2 = map2 fields1 args1 in
+                FStar_All.pipe_right uu___2 FStar_List.rev in
               mk (FStar_Parser_AST.PatRecord args2)
           | FStar_Syntax_Syntax.Pat_cons (fv, args) ->
               resugar_plain_pat_cons fv args
           | FStar_Syntax_Syntax.Pat_var v ->
-              let uu____8226 =
-                let uu____8235 =
+              let uu___ =
+                let uu___1 =
                   FStar_Ident.string_of_id v.FStar_Syntax_Syntax.ppname in
-                string_to_op uu____8235 in
-              (match uu____8226 with
-               | FStar_Pervasives_Native.Some (op, uu____8237) ->
-                   let uu____8248 =
-                     let uu____8249 =
-                       let uu____8250 =
-                         let uu____8255 =
+                string_to_op uu___1 in
+              (match uu___ with
+               | FStar_Pervasives_Native.Some (op, uu___1) ->
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
                            FStar_Ident.range_of_id
                              v.FStar_Syntax_Syntax.ppname in
-                         (op, uu____8255) in
-                       FStar_Ident.mk_ident uu____8250 in
-                     FStar_Parser_AST.PatOp uu____8249 in
-                   mk uu____8248
+                         (op, uu___5) in
+                       FStar_Ident.mk_ident uu___4 in
+                     FStar_Parser_AST.PatOp uu___3 in
+                   mk uu___2
                | FStar_Pervasives_Native.None ->
-                   let uu____8262 = to_arg_qual imp_opt in
-                   resugar_bv_as_pat' env v uu____8262 branch_bv
+                   let uu___1 = to_arg_qual imp_opt in
+                   resugar_bv_as_pat' env v uu___1 branch_bv
                      FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Pat_wild uu____8267 ->
-              let uu____8268 =
-                let uu____8269 = to_arg_qual imp_opt in
-                FStar_Parser_AST.PatWild uu____8269 in
-              mk uu____8268
+          | FStar_Syntax_Syntax.Pat_wild uu___ ->
+              let uu___1 =
+                let uu___2 = to_arg_qual imp_opt in
+                FStar_Parser_AST.PatWild uu___2 in
+              mk uu___1
           | FStar_Syntax_Syntax.Pat_dot_term (bv, term) ->
               resugar_bv_as_pat' env bv
                 (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)
@@ -2085,24 +2033,24 @@ and (resugar_arg_qual :
             (FStar_Pervasives_Native.Some FStar_Parser_AST.Equality)
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-          let uu____8305 =
-            let uu____8308 =
-              let uu____8309 =
-                let uu____8310 = resugar_term' env t in
-                FStar_Parser_AST.Arg_qualifier_meta_tac uu____8310 in
-              FStar_Parser_AST.Meta uu____8309 in
-            FStar_Pervasives_Native.Some uu____8308 in
-          FStar_Pervasives_Native.Some uu____8305
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = resugar_term' env t in
+                FStar_Parser_AST.Arg_qualifier_meta_tac uu___3 in
+              FStar_Parser_AST.Meta uu___2 in
+            FStar_Pervasives_Native.Some uu___1 in
+          FStar_Pervasives_Native.Some uu___
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-          let uu____8316 =
-            let uu____8319 =
-              let uu____8320 =
-                let uu____8321 = resugar_term' env t in
-                FStar_Parser_AST.Arg_qualifier_meta_attr uu____8321 in
-              FStar_Parser_AST.Meta uu____8320 in
-            FStar_Pervasives_Native.Some uu____8319 in
-          FStar_Pervasives_Native.Some uu____8316
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = resugar_term' env t in
+                FStar_Parser_AST.Arg_qualifier_meta_attr uu___3 in
+              FStar_Parser_AST.Meta uu___2 in
+            FStar_Pervasives_Native.Some uu___1 in
+          FStar_Pervasives_Native.Some uu___
 and (resugar_imp :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
@@ -2118,14 +2066,14 @@ and (resugar_imp :
           FStar_Parser_AST.Nothing
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (true)) ->
           FStar_Parser_AST.Nothing
-      | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta uu____8328) ->
+      | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta uu___) ->
           FStar_Parser_AST.Nothing
 let (resugar_qualifier :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Parser_AST.qualifier FStar_Pervasives_Native.option)
   =
-  fun uu___6_8335 ->
-    match uu___6_8335 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Assumption ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Assumption
     | FStar_Syntax_Syntax.New ->
@@ -2151,17 +2099,15 @@ let (resugar_qualifier :
     | FStar_Syntax_Syntax.Logic -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Reifiable ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Reifiable
-    | FStar_Syntax_Syntax.Reflectable uu____8342 ->
+    | FStar_Syntax_Syntax.Reflectable uu___1 ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Reflectable
-    | FStar_Syntax_Syntax.Discriminator uu____8343 ->
+    | FStar_Syntax_Syntax.Discriminator uu___1 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Projector uu____8344 ->
+    | FStar_Syntax_Syntax.Projector uu___1 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.RecordType uu___1 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.RecordConstructor uu___1 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.RecordType uu____8349 ->
-        FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.RecordConstructor uu____8358 ->
-        FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Action uu____8367 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Action uu___1 -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.ExceptionConstructor ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.HasMaskedEffect -> FStar_Pervasives_Native.None
@@ -2170,8 +2116,8 @@ let (resugar_qualifier :
     | FStar_Syntax_Syntax.OnlyName -> FStar_Pervasives_Native.None
 let (resugar_pragma : FStar_Syntax_Syntax.pragma -> FStar_Parser_AST.pragma)
   =
-  fun uu___7_8372 ->
-    match uu___7_8372 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.SetOptions s -> FStar_Parser_AST.SetOptions s
     | FStar_Syntax_Syntax.ResetOptions s -> FStar_Parser_AST.ResetOptions s
     | FStar_Syntax_Syntax.PushOptions s -> FStar_Parser_AST.PushOptions s
@@ -2189,97 +2135,91 @@ let (resugar_typ :
       fun se ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (tylid, uvs, bs, t, uu____8411, datacons) ->
-            let uu____8421 =
+            (tylid, uvs, bs, t, uu___, datacons) ->
+            let uu___1 =
               FStar_All.pipe_right datacon_ses
                 (FStar_List.partition
                    (fun se1 ->
                       match se1.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_datacon
-                          (uu____8448, uu____8449, uu____8450, inductive_lid,
-                           uu____8452, uu____8453)
+                          (uu___2, uu___3, uu___4, inductive_lid, uu___5,
+                           uu___6)
                           -> FStar_Ident.lid_equals inductive_lid tylid
-                      | uu____8458 -> failwith "unexpected")) in
-            (match uu____8421 with
+                      | uu___2 -> failwith "unexpected")) in
+            (match uu___1 with
              | (current_datacons, other_datacons) ->
                  let bs1 =
-                   let uu____8477 = FStar_Options.print_implicits () in
-                   if uu____8477 then bs else filter_imp bs in
+                   let uu___3 = FStar_Options.print_implicits () in
+                   if uu___3 then bs else filter_imp bs in
                  let bs2 =
                    FStar_All.pipe_right bs1
                      ((map_opt ())
                         (fun b ->
                            resugar_binder' env b t.FStar_Syntax_Syntax.pos)) in
                  let tyc =
-                   let uu____8491 =
+                   let uu___3 =
                      FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                        (FStar_Util.for_some
-                          (fun uu___8_8496 ->
-                             match uu___8_8496 with
-                             | FStar_Syntax_Syntax.RecordType uu____8497 ->
-                                 true
-                             | uu____8506 -> false)) in
-                   if uu____8491
+                          (fun uu___4 ->
+                             match uu___4 with
+                             | FStar_Syntax_Syntax.RecordType uu___5 -> true
+                             | uu___5 -> false)) in
+                   if uu___3
                    then
                      let resugar_datacon_as_fields fields se1 =
                        match se1.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_datacon
-                           (uu____8542, univs, term, uu____8545, num,
-                            uu____8547)
-                           ->
-                           let uu____8552 =
-                             let uu____8553 =
-                               FStar_Syntax_Subst.compress term in
-                             uu____8553.FStar_Syntax_Syntax.n in
-                           (match uu____8552 with
-                            | FStar_Syntax_Syntax.Tm_arrow (bs3, uu____8563)
-                                ->
+                           (uu___4, univs, term, uu___5, num, uu___6) ->
+                           let uu___7 =
+                             let uu___8 = FStar_Syntax_Subst.compress term in
+                             uu___8.FStar_Syntax_Syntax.n in
+                           (match uu___7 with
+                            | FStar_Syntax_Syntax.Tm_arrow (bs3, uu___8) ->
                                 let mfields =
                                   FStar_All.pipe_right bs3
                                     (FStar_List.map
-                                       (fun uu____8620 ->
-                                          match uu____8620 with
+                                       (fun uu___9 ->
+                                          match uu___9 with
                                           | (b, qual) ->
-                                              let uu____8637 =
+                                              let uu___10 =
                                                 bv_as_unique_ident b in
-                                              let uu____8638 =
+                                              let uu___11 =
                                                 resugar_term' env
                                                   b.FStar_Syntax_Syntax.sort in
-                                              (uu____8637, uu____8638))) in
+                                              (uu___10, uu___11))) in
                                 FStar_List.append mfields fields
-                            | uu____8643 -> failwith "unexpected")
-                       | uu____8650 -> failwith "unexpected" in
+                            | uu___8 -> failwith "unexpected")
+                       | uu___4 -> failwith "unexpected" in
                      let fields =
                        FStar_List.fold_left resugar_datacon_as_fields []
                          current_datacons in
-                     let uu____8674 =
-                       let uu____8693 = FStar_Ident.ident_of_lid tylid in
-                       (uu____8693, bs2, FStar_Pervasives_Native.None,
-                         fields) in
-                     FStar_Parser_AST.TyconRecord uu____8674
+                     let uu___4 =
+                       let uu___5 = FStar_Ident.ident_of_lid tylid in
+                       (uu___5, bs2, FStar_Pervasives_Native.None, fields) in
+                     FStar_Parser_AST.TyconRecord uu___4
                    else
                      (let resugar_datacon constructors se1 =
                         match se1.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_datacon
-                            (l, univs, term, uu____8759, num, uu____8761) ->
+                            (l, univs, term, uu___5, num, uu___6) ->
                             let c =
-                              let uu____8775 = FStar_Ident.ident_of_lid l in
-                              let uu____8776 =
-                                let uu____8779 = resugar_term' env term in
-                                FStar_Pervasives_Native.Some uu____8779 in
-                              (uu____8775, uu____8776, false) in
+                              let uu___7 = FStar_Ident.ident_of_lid l in
+                              let uu___8 =
+                                let uu___9 = resugar_term' env term in
+                                FStar_Pervasives_Native.Some uu___9 in
+                              (uu___7, uu___8, false) in
                             c :: constructors
-                        | uu____8790 -> failwith "unexpected" in
+                        | uu___5 -> failwith "unexpected" in
                       let constructors =
                         FStar_List.fold_left resugar_datacon []
                           current_datacons in
-                      let uu____8830 =
-                        let uu____8853 = FStar_Ident.ident_of_lid tylid in
-                        (uu____8853, bs2, FStar_Pervasives_Native.None,
+                      let uu___5 =
+                        let uu___6 = FStar_Ident.ident_of_lid tylid in
+                        (uu___6, bs2, FStar_Pervasives_Native.None,
                           constructors) in
-                      FStar_Parser_AST.TyconVariant uu____8830) in
+                      FStar_Parser_AST.TyconVariant uu___5) in
                  (other_datacons, tyc))
-        | uu____8868 ->
+        | uu___ ->
             failwith
               "Impossible : only Sig_inductive_typ can be resugared as types"
 let (mk_decl :
@@ -2290,11 +2230,11 @@ let (mk_decl :
   fun r ->
     fun q ->
       fun d' ->
-        let uu____8892 = FStar_List.choose resugar_qualifier q in
+        let uu___ = FStar_List.choose resugar_qualifier q in
         {
           FStar_Parser_AST.d = d';
           FStar_Parser_AST.drange = r;
-          FStar_Parser_AST.quals = uu____8892;
+          FStar_Parser_AST.quals = uu___;
           FStar_Parser_AST.attrs = []
         }
 let (decl'_to_decl :
@@ -2312,23 +2252,23 @@ let (resugar_tscheme'' :
   fun env ->
     fun name ->
       fun ts ->
-        let uu____8918 = ts in
-        match uu____8918 with
+        let uu___ = ts in
+        match uu___ with
         | (univs, typ) ->
             let name1 =
               FStar_Ident.mk_ident (name, (typ.FStar_Syntax_Syntax.pos)) in
-            let uu____8930 =
-              let uu____8931 =
-                let uu____8940 =
-                  let uu____8943 =
-                    let uu____8944 =
-                      let uu____8957 = resugar_term' env typ in
-                      (name1, [], FStar_Pervasives_Native.None, uu____8957) in
-                    FStar_Parser_AST.TyconAbbrev uu____8944 in
-                  [uu____8943] in
-                (false, false, uu____8940) in
-              FStar_Parser_AST.Tycon uu____8931 in
-            mk_decl typ.FStar_Syntax_Syntax.pos [] uu____8930
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = resugar_term' env typ in
+                      (name1, [], FStar_Pervasives_Native.None, uu___6) in
+                    FStar_Parser_AST.TyconAbbrev uu___5 in
+                  [uu___4] in
+                (false, false, uu___3) in
+              FStar_Parser_AST.Tycon uu___2 in
+            mk_decl typ.FStar_Syntax_Syntax.pos [] uu___1
 let (resugar_tscheme' :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl)
@@ -2345,7 +2285,7 @@ let (resugar_wp_eff_combinators :
         let resugar_opt name tsopt =
           match tsopt with
           | FStar_Pervasives_Native.Some ts ->
-              let uu____9011 = resugar_tscheme'' env name ts in [uu____9011]
+              let uu___ = resugar_tscheme'' env name ts in [uu___]
           | FStar_Pervasives_Native.None -> [] in
         let repr = resugar_opt "repr" combs.FStar_Syntax_Syntax.repr in
         let return_repr =
@@ -2355,41 +2295,41 @@ let (resugar_wp_eff_combinators :
         if for_free
         then FStar_List.append repr (FStar_List.append return_repr bind_repr)
         else
-          (let uu____9024 =
+          (let uu___1 =
              resugar_tscheme'' env "ret_wp" combs.FStar_Syntax_Syntax.ret_wp in
-           let uu____9025 =
-             let uu____9028 =
+           let uu___2 =
+             let uu___3 =
                resugar_tscheme'' env "bind_wp"
                  combs.FStar_Syntax_Syntax.bind_wp in
-             let uu____9029 =
-               let uu____9032 =
+             let uu___4 =
+               let uu___5 =
                  resugar_tscheme'' env "stronger"
                    combs.FStar_Syntax_Syntax.stronger in
-               let uu____9033 =
-                 let uu____9036 =
+               let uu___6 =
+                 let uu___7 =
                    resugar_tscheme'' env "if_then_else"
                      combs.FStar_Syntax_Syntax.if_then_else in
-                 let uu____9037 =
-                   let uu____9040 =
+                 let uu___8 =
+                   let uu___9 =
                      resugar_tscheme'' env "ite_wp"
                        combs.FStar_Syntax_Syntax.ite_wp in
-                   let uu____9041 =
-                     let uu____9044 =
+                   let uu___10 =
+                     let uu___11 =
                        resugar_tscheme'' env "close_wp"
                          combs.FStar_Syntax_Syntax.close_wp in
-                     let uu____9045 =
-                       let uu____9048 =
+                     let uu___12 =
+                       let uu___13 =
                          resugar_tscheme'' env "trivial"
                            combs.FStar_Syntax_Syntax.trivial in
-                       uu____9048 ::
+                       uu___13 ::
                          (FStar_List.append repr
                             (FStar_List.append return_repr bind_repr)) in
-                     uu____9044 :: uu____9045 in
-                   uu____9040 :: uu____9041 in
-                 uu____9036 :: uu____9037 in
-               uu____9032 :: uu____9033 in
-             uu____9028 :: uu____9029 in
-           uu____9024 :: uu____9025)
+                     uu___11 :: uu___12 in
+                   uu___9 :: uu___10 in
+                 uu___7 :: uu___8 in
+               uu___5 :: uu___6 in
+             uu___3 :: uu___4 in
+           uu___1 :: uu___2)
 let (resugar_layered_eff_combinators :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.layered_eff_combinators ->
@@ -2397,26 +2337,25 @@ let (resugar_layered_eff_combinators :
   =
   fun env ->
     fun combs ->
-      let resugar name uu____9075 =
-        match uu____9075 with
-        | (ts, uu____9081) -> resugar_tscheme'' env name ts in
-      let uu____9082 = resugar "repr" combs.FStar_Syntax_Syntax.l_repr in
-      let uu____9083 =
-        let uu____9086 = resugar "return" combs.FStar_Syntax_Syntax.l_return in
-        let uu____9087 =
-          let uu____9090 = resugar "bind" combs.FStar_Syntax_Syntax.l_bind in
-          let uu____9091 =
-            let uu____9094 =
+      let resugar name uu___ =
+        match uu___ with | (ts, uu___1) -> resugar_tscheme'' env name ts in
+      let uu___ = resugar "repr" combs.FStar_Syntax_Syntax.l_repr in
+      let uu___1 =
+        let uu___2 = resugar "return" combs.FStar_Syntax_Syntax.l_return in
+        let uu___3 =
+          let uu___4 = resugar "bind" combs.FStar_Syntax_Syntax.l_bind in
+          let uu___5 =
+            let uu___6 =
               resugar "subcomp" combs.FStar_Syntax_Syntax.l_subcomp in
-            let uu____9095 =
-              let uu____9098 =
+            let uu___7 =
+              let uu___8 =
                 resugar "if_then_else"
                   combs.FStar_Syntax_Syntax.l_if_then_else in
-              [uu____9098] in
-            uu____9094 :: uu____9095 in
-          uu____9090 :: uu____9091 in
-        uu____9086 :: uu____9087 in
-      uu____9082 :: uu____9083
+              [uu___8] in
+            uu___6 :: uu___7 in
+          uu___4 :: uu___5 in
+        uu___2 :: uu___3 in
+      uu___ :: uu___1
 let (resugar_combinators :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.eff_combinators -> FStar_Parser_AST.decl Prims.list)
@@ -2444,90 +2383,89 @@ let (resugar_eff_decl' :
             let action_params =
               FStar_Syntax_Subst.open_binders
                 d.FStar_Syntax_Syntax.action_params in
-            let uu____9152 =
+            let uu___ =
               FStar_Syntax_Subst.open_term action_params
                 d.FStar_Syntax_Syntax.action_defn in
-            match uu____9152 with
+            match uu___ with
             | (bs, action_defn) ->
-                let uu____9159 =
+                let uu___1 =
                   FStar_Syntax_Subst.open_term action_params
                     d.FStar_Syntax_Syntax.action_typ in
-                (match uu____9159 with
+                (match uu___1 with
                  | (bs1, action_typ) ->
                      let action_params1 =
-                       let uu____9169 = FStar_Options.print_implicits () in
-                       if uu____9169
+                       let uu___2 = FStar_Options.print_implicits () in
+                       if uu___2
                        then action_params
                        else filter_imp action_params in
                      let action_params2 =
-                       let uu____9176 =
+                       let uu___2 =
                          FStar_All.pipe_right action_params1
                            ((map_opt ()) (fun b -> resugar_binder' env b r)) in
-                       FStar_All.pipe_right uu____9176 FStar_List.rev in
+                       FStar_All.pipe_right uu___2 FStar_List.rev in
                      let action_defn1 = resugar_term' env action_defn in
                      let action_typ1 = resugar_term' env action_typ in
                      if for_free
                      then
                        let a =
-                         let uu____9192 =
-                           let uu____9203 =
-                             FStar_Ident.lid_of_str "construct" in
-                           (uu____9203,
+                         let uu___2 =
+                           let uu___3 = FStar_Ident.lid_of_str "construct" in
+                           (uu___3,
                              [(action_defn1, FStar_Parser_AST.Nothing);
                              (action_typ1, FStar_Parser_AST.Nothing)]) in
-                         FStar_Parser_AST.Construct uu____9192 in
+                         FStar_Parser_AST.Construct uu___2 in
                        let t =
                          FStar_Parser_AST.mk_term a r FStar_Parser_AST.Un in
-                       let uu____9223 =
-                         let uu____9224 =
-                           let uu____9233 =
-                             let uu____9236 =
-                               let uu____9237 =
-                                 let uu____9250 =
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Ident.ident_of_lid
                                      d.FStar_Syntax_Syntax.action_name in
-                                 (uu____9250, action_params2,
+                                 (uu___7, action_params2,
                                    FStar_Pervasives_Native.None, t) in
-                               FStar_Parser_AST.TyconAbbrev uu____9237 in
-                             [uu____9236] in
-                           (false, false, uu____9233) in
-                         FStar_Parser_AST.Tycon uu____9224 in
-                       mk_decl r q uu____9223
+                               FStar_Parser_AST.TyconAbbrev uu___6 in
+                             [uu___5] in
+                           (false, false, uu___4) in
+                         FStar_Parser_AST.Tycon uu___3 in
+                       mk_decl r q uu___2
                      else
-                       (let uu____9258 =
-                          let uu____9259 =
-                            let uu____9268 =
-                              let uu____9271 =
-                                let uu____9272 =
-                                  let uu____9285 =
+                       (let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
                                     FStar_Ident.ident_of_lid
                                       d.FStar_Syntax_Syntax.action_name in
-                                  (uu____9285, action_params2,
+                                  (uu___8, action_params2,
                                     FStar_Pervasives_Native.None,
                                     action_defn1) in
-                                FStar_Parser_AST.TyconAbbrev uu____9272 in
-                              [uu____9271] in
-                            (false, false, uu____9268) in
-                          FStar_Parser_AST.Tycon uu____9259 in
-                        mk_decl r q uu____9258)) in
+                                FStar_Parser_AST.TyconAbbrev uu___7 in
+                              [uu___6] in
+                            (false, false, uu___5) in
+                          FStar_Parser_AST.Tycon uu___4 in
+                        mk_decl r q uu___3)) in
           let eff_name =
             FStar_Ident.ident_of_lid ed.FStar_Syntax_Syntax.mname in
-          let uu____9293 =
-            let uu____9298 =
+          let uu___ =
+            let uu___1 =
               FStar_All.pipe_right ed.FStar_Syntax_Syntax.signature
                 FStar_Pervasives_Native.snd in
             FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-              uu____9298 in
-          match uu____9293 with
+              uu___1 in
+          match uu___ with
           | (eff_binders, eff_typ) ->
               let eff_binders1 =
-                let uu____9316 = FStar_Options.print_implicits () in
-                if uu____9316 then eff_binders else filter_imp eff_binders in
+                let uu___1 = FStar_Options.print_implicits () in
+                if uu___1 then eff_binders else filter_imp eff_binders in
               let eff_binders2 =
-                let uu____9323 =
+                let uu___1 =
                   FStar_All.pipe_right eff_binders1
                     ((map_opt ()) (fun b -> resugar_binder' env b r)) in
-                FStar_All.pipe_right uu____9323 FStar_List.rev in
+                FStar_All.pipe_right uu___1 FStar_List.rev in
               let eff_typ1 = resugar_term' env eff_typ in
               let mandatory_members_decls =
                 resugar_combinators env ed.FStar_Syntax_Syntax.combinators in
@@ -2547,72 +2485,65 @@ let (resugar_sigelt' :
   fun env ->
     fun se ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses, uu____9371) ->
-          let uu____9380 =
+      | FStar_Syntax_Syntax.Sig_bundle (ses, uu___) ->
+          let uu___1 =
             FStar_All.pipe_right ses
               (FStar_List.partition
                  (fun se1 ->
                     match se1.FStar_Syntax_Syntax.sigel with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ uu____9402 ->
-                        true
-                    | FStar_Syntax_Syntax.Sig_declare_typ uu____9419 -> true
-                    | FStar_Syntax_Syntax.Sig_datacon uu____9426 -> false
-                    | uu____9441 ->
+                    | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 -> true
+                    | FStar_Syntax_Syntax.Sig_declare_typ uu___2 -> true
+                    | FStar_Syntax_Syntax.Sig_datacon uu___2 -> false
+                    | uu___2 ->
                         failwith
                           "Found a sigelt which is neither a type declaration or a data constructor in a sigelt")) in
-          (match uu____9380 with
+          (match uu___1 with
            | (decl_typ_ses, datacon_ses) ->
-               let retrieve_datacons_and_resugar uu____9477 se1 =
-                 match uu____9477 with
+               let retrieve_datacons_and_resugar uu___2 se1 =
+                 match uu___2 with
                  | (datacon_ses1, tycons) ->
-                     let uu____9503 = resugar_typ env datacon_ses1 se1 in
-                     (match uu____9503 with
+                     let uu___3 = resugar_typ env datacon_ses1 se1 in
+                     (match uu___3 with
                       | (datacon_ses2, tyc) ->
                           (datacon_ses2, (tyc :: tycons))) in
-               let uu____9518 =
+               let uu___2 =
                  FStar_List.fold_left retrieve_datacons_and_resugar
                    (datacon_ses, []) decl_typ_ses in
-               (match uu____9518 with
+               (match uu___2 with
                 | (leftover_datacons, tycons) ->
                     (match leftover_datacons with
                      | [] ->
-                         let uu____9553 =
+                         let uu___3 =
                            decl'_to_decl se
                              (FStar_Parser_AST.Tycon (false, false, tycons)) in
-                         FStar_Pervasives_Native.Some uu____9553
+                         FStar_Pervasives_Native.Some uu___3
                      | se1::[] ->
                          (match se1.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_datacon
-                              (l, uu____9560, uu____9561, uu____9562,
-                               uu____9563, uu____9564)
-                              ->
-                              let uu____9569 =
-                                let uu____9570 =
-                                  let uu____9571 =
-                                    let uu____9578 =
-                                      FStar_Ident.ident_of_lid l in
-                                    (uu____9578,
-                                      FStar_Pervasives_Native.None) in
-                                  FStar_Parser_AST.Exception uu____9571 in
-                                decl'_to_decl se1 uu____9570 in
-                              FStar_Pervasives_Native.Some uu____9569
-                          | uu____9581 ->
+                              (l, uu___3, uu___4, uu___5, uu___6, uu___7) ->
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
+                                    let uu___11 = FStar_Ident.ident_of_lid l in
+                                    (uu___11, FStar_Pervasives_Native.None) in
+                                  FStar_Parser_AST.Exception uu___10 in
+                                decl'_to_decl se1 uu___9 in
+                              FStar_Pervasives_Native.Some uu___8
+                          | uu___3 ->
                               failwith
                                 "wrong format for resguar to Exception")
-                     | uu____9584 -> failwith "Should not happen hopefully")))
-      | FStar_Syntax_Syntax.Sig_fail uu____9589 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu____9601) ->
-          let uu____9606 =
+                     | uu___3 -> failwith "Should not happen hopefully")))
+      | FStar_Syntax_Syntax.Sig_fail uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Sig_let (lbs, uu___) ->
+          let uu___1 =
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some
-                 (fun uu___9_9612 ->
-                    match uu___9_9612 with
-                    | FStar_Syntax_Syntax.Projector (uu____9613, uu____9614)
-                        -> true
-                    | FStar_Syntax_Syntax.Discriminator uu____9615 -> true
-                    | uu____9616 -> false)) in
-          if uu____9606
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | FStar_Syntax_Syntax.Projector (uu___3, uu___4) -> true
+                    | FStar_Syntax_Syntax.Discriminator uu___3 -> true
+                    | uu___3 -> false)) in
+          if uu___1
           then FStar_Pervasives_Native.None
           else
             (let mk e =
@@ -2621,47 +2552,46 @@ let (resugar_sigelt' :
              let desugared_let = mk (FStar_Syntax_Syntax.Tm_let (lbs, dummy)) in
              let t = resugar_term' env desugared_let in
              match t.FStar_Parser_AST.tm with
-             | FStar_Parser_AST.Let (isrec, lets, uu____9647) ->
-                 let uu____9676 =
-                   let uu____9677 =
-                     let uu____9678 =
-                       let uu____9689 =
+             | FStar_Parser_AST.Let (isrec, lets, uu___3) ->
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 =
                          FStar_List.map FStar_Pervasives_Native.snd lets in
-                       (isrec, uu____9689) in
-                     FStar_Parser_AST.TopLevelLet uu____9678 in
-                   decl'_to_decl se uu____9677 in
-                 FStar_Pervasives_Native.Some uu____9676
-             | uu____9726 -> failwith "Should not happen hopefully")
-      | FStar_Syntax_Syntax.Sig_assume (lid, uu____9730, fml) ->
-          let uu____9732 =
-            let uu____9733 =
-              let uu____9734 =
-                let uu____9739 = FStar_Ident.ident_of_lid lid in
-                let uu____9740 = resugar_term' env fml in
-                (uu____9739, uu____9740) in
-              FStar_Parser_AST.Assume uu____9734 in
-            decl'_to_decl se uu____9733 in
-          FStar_Pervasives_Native.Some uu____9732
+                       (isrec, uu___7) in
+                     FStar_Parser_AST.TopLevelLet uu___6 in
+                   decl'_to_decl se uu___5 in
+                 FStar_Pervasives_Native.Some uu___4
+             | uu___3 -> failwith "Should not happen hopefully")
+      | FStar_Syntax_Syntax.Sig_assume (lid, uu___, fml) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Ident.ident_of_lid lid in
+                let uu___5 = resugar_term' env fml in (uu___4, uu___5) in
+              FStar_Parser_AST.Assume uu___3 in
+            decl'_to_decl se uu___2 in
+          FStar_Pervasives_Native.Some uu___1
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____9742 =
+          let uu___ =
             resugar_eff_decl' env se.FStar_Syntax_Syntax.sigrng
               se.FStar_Syntax_Syntax.sigquals ed in
-          FStar_Pervasives_Native.Some uu____9742
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Sig_sub_effect e ->
           let src = e.FStar_Syntax_Syntax.source in
           let dst = e.FStar_Syntax_Syntax.target in
           let lift_wp =
             match e.FStar_Syntax_Syntax.lift_wp with
-            | FStar_Pervasives_Native.Some (uu____9751, t) ->
-                let uu____9761 = resugar_term' env t in
-                FStar_Pervasives_Native.Some uu____9761
-            | uu____9762 -> FStar_Pervasives_Native.None in
+            | FStar_Pervasives_Native.Some (uu___, t) ->
+                let uu___1 = resugar_term' env t in
+                FStar_Pervasives_Native.Some uu___1
+            | uu___ -> FStar_Pervasives_Native.None in
           let lift =
             match e.FStar_Syntax_Syntax.lift with
-            | FStar_Pervasives_Native.Some (uu____9770, t) ->
-                let uu____9780 = resugar_term' env t in
-                FStar_Pervasives_Native.Some uu____9780
-            | uu____9781 -> FStar_Pervasives_Native.None in
+            | FStar_Pervasives_Native.Some (uu___, t) ->
+                let uu___1 = resugar_term' env t in
+                FStar_Pervasives_Native.Some uu___1
+            | uu___ -> FStar_Pervasives_Native.None in
           let op =
             match (lift_wp, lift) with
             | (FStar_Pervasives_Native.Some t, FStar_Pervasives_Native.None)
@@ -2670,8 +2600,8 @@ let (resugar_sigelt' :
                t) -> FStar_Parser_AST.ReifiableLift (wp, t)
             | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some t)
                 -> FStar_Parser_AST.LiftForFree t
-            | uu____9805 -> failwith "Should not happen hopefully" in
-          let uu____9814 =
+            | uu___ -> failwith "Should not happen hopefully" in
+          let uu___ =
             decl'_to_decl se
               (FStar_Parser_AST.SubEffect
                  {
@@ -2679,140 +2609,129 @@ let (resugar_sigelt' :
                    FStar_Parser_AST.mdest = dst;
                    FStar_Parser_AST.lift_op = op
                  }) in
-          FStar_Pervasives_Native.Some uu____9814
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, vs, bs, c, flags) ->
-          let uu____9824 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____9824 with
+          let uu___ = FStar_Syntax_Subst.open_comp bs c in
+          (match uu___ with
            | (bs1, c1) ->
                let bs2 =
-                 let uu____9836 = FStar_Options.print_implicits () in
-                 if uu____9836 then bs1 else filter_imp bs1 in
+                 let uu___1 = FStar_Options.print_implicits () in
+                 if uu___1 then bs1 else filter_imp bs1 in
                let bs3 =
                  FStar_All.pipe_right bs2
                    ((map_opt ())
                       (fun b ->
                          resugar_binder' env b se.FStar_Syntax_Syntax.sigrng)) in
-               let uu____9849 =
-                 let uu____9850 =
-                   let uu____9851 =
-                     let uu____9860 =
-                       let uu____9863 =
-                         let uu____9864 =
-                           let uu____9877 = FStar_Ident.ident_of_lid lid in
-                           let uu____9878 = resugar_comp' env c1 in
-                           (uu____9877, bs3, FStar_Pervasives_Native.None,
-                             uu____9878) in
-                         FStar_Parser_AST.TyconAbbrev uu____9864 in
-                       [uu____9863] in
-                     (false, false, uu____9860) in
-                   FStar_Parser_AST.Tycon uu____9851 in
-                 decl'_to_decl se uu____9850 in
-               FStar_Pervasives_Native.Some uu____9849)
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 = FStar_Ident.ident_of_lid lid in
+                           let uu___8 = resugar_comp' env c1 in
+                           (uu___7, bs3, FStar_Pervasives_Native.None,
+                             uu___8) in
+                         FStar_Parser_AST.TyconAbbrev uu___6 in
+                       [uu___5] in
+                     (false, false, uu___4) in
+                   FStar_Parser_AST.Tycon uu___3 in
+                 decl'_to_decl se uu___2 in
+               FStar_Pervasives_Native.Some uu___1)
       | FStar_Syntax_Syntax.Sig_pragma p ->
-          let uu____9886 =
+          let uu___ =
             decl'_to_decl se (FStar_Parser_AST.Pragma (resugar_pragma p)) in
-          FStar_Pervasives_Native.Some uu____9886
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t) ->
-          let uu____9890 =
+          let uu___ =
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some
-                 (fun uu___10_9896 ->
-                    match uu___10_9896 with
-                    | FStar_Syntax_Syntax.Projector (uu____9897, uu____9898)
-                        -> true
-                    | FStar_Syntax_Syntax.Discriminator uu____9899 -> true
-                    | uu____9900 -> false)) in
-          if uu____9890
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | FStar_Syntax_Syntax.Projector (uu___2, uu___3) -> true
+                    | FStar_Syntax_Syntax.Discriminator uu___2 -> true
+                    | uu___2 -> false)) in
+          if uu___
           then FStar_Pervasives_Native.None
           else
             (let t' =
-               let uu____9905 =
-                 (let uu____9908 = FStar_Options.print_universes () in
-                  Prims.op_Negation uu____9908) || (FStar_List.isEmpty uvs) in
-               if uu____9905
+               let uu___2 =
+                 (let uu___3 = FStar_Options.print_universes () in
+                  Prims.op_Negation uu___3) || (FStar_List.isEmpty uvs) in
+               if uu___2
                then resugar_term' env t
                else
-                 (let uu____9910 = FStar_Syntax_Subst.open_univ_vars uvs t in
-                  match uu____9910 with
+                 (let uu___4 = FStar_Syntax_Subst.open_univ_vars uvs t in
+                  match uu___4 with
                   | (uvs1, t1) ->
                       let universes = universe_to_string uvs1 in
-                      let uu____9918 = resugar_term' env t1 in
-                      label universes uu____9918) in
-             let uu____9919 =
-               let uu____9920 =
-                 let uu____9921 =
-                   let uu____9926 = FStar_Ident.ident_of_lid lid in
-                   (uu____9926, t') in
-                 FStar_Parser_AST.Val uu____9921 in
-               decl'_to_decl se uu____9920 in
-             FStar_Pervasives_Native.Some uu____9919)
+                      let uu___5 = resugar_term' env t1 in
+                      label universes uu___5) in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = FStar_Ident.ident_of_lid lid in (uu___5, t') in
+                 FStar_Parser_AST.Val uu___4 in
+               decl'_to_decl se uu___3 in
+             FStar_Pervasives_Native.Some uu___2)
       | FStar_Syntax_Syntax.Sig_splice (ids, t) ->
-          let uu____9933 =
-            let uu____9934 =
-              let uu____9935 =
-                let uu____9942 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
                   FStar_List.map (fun l -> FStar_Ident.ident_of_lid l) ids in
-                let uu____9947 = resugar_term' env t in
-                (uu____9942, uu____9947) in
-              FStar_Parser_AST.Splice uu____9935 in
-            decl'_to_decl se uu____9934 in
-          FStar_Pervasives_Native.Some uu____9933
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____9950 ->
+                let uu___4 = resugar_term' env t in (uu___3, uu___4) in
+              FStar_Parser_AST.Splice uu___2 in
+            decl'_to_decl se uu___1 in
+          FStar_Pervasives_Native.Some uu___
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu___ ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Sig_datacon uu____9967 ->
-          FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Sig_datacon uu___ -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Sig_polymonadic_bind
-          (m, n, p, (uu____9985, t), uu____9987) ->
-          let uu____9996 =
-            let uu____9997 =
-              let uu____9998 =
-                let uu____10007 = resugar_term' env t in
-                (m, n, p, uu____10007) in
-              FStar_Parser_AST.Polymonadic_bind uu____9998 in
-            decl'_to_decl se uu____9997 in
-          FStar_Pervasives_Native.Some uu____9996
+          (m, n, p, (uu___, t), uu___1) ->
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = resugar_term' env t in (m, n, p, uu___5) in
+              FStar_Parser_AST.Polymonadic_bind uu___4 in
+            decl'_to_decl se uu___3 in
+          FStar_Pervasives_Native.Some uu___2
       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-          (m, n, (uu____10010, t), uu____10012) ->
-          let uu____10021 =
-            let uu____10022 =
-              let uu____10023 =
-                let uu____10030 = resugar_term' env t in (m, n, uu____10030) in
-              FStar_Parser_AST.Polymonadic_subcomp uu____10023 in
-            decl'_to_decl se uu____10022 in
-          FStar_Pervasives_Native.Some uu____10021
+          (m, n, (uu___, t), uu___1) ->
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = let uu___5 = resugar_term' env t in (m, n, uu___5) in
+              FStar_Parser_AST.Polymonadic_subcomp uu___4 in
+            decl'_to_decl se uu___3 in
+          FStar_Pervasives_Native.Some uu___2
 let (empty_env : FStar_Syntax_DsEnv.env) =
   FStar_Syntax_DsEnv.empty_env FStar_Parser_Dep.empty_deps
 let noenv : 'a . (FStar_Syntax_DsEnv.env -> 'a) -> 'a = fun f -> f empty_env
 let (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
-  fun t -> let uu____10051 = noenv resugar_term' in uu____10051 t
+  fun t -> let uu___ = noenv resugar_term' in uu___ t
 let (resugar_sigelt :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Parser_AST.decl FStar_Pervasives_Native.option)
-  = fun se -> let uu____10068 = noenv resugar_sigelt' in uu____10068 se
+  = fun se -> let uu___ = noenv resugar_sigelt' in uu___ se
 let (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
-  fun c -> let uu____10085 = noenv resugar_comp' in uu____10085 c
+  fun c -> let uu___ = noenv resugar_comp' in uu___ c
 let (resugar_pat :
   FStar_Syntax_Syntax.pat ->
     FStar_Syntax_Syntax.bv FStar_Util.set -> FStar_Parser_AST.pattern)
   =
   fun p ->
-    fun branch_bv ->
-      let uu____10107 = noenv resugar_pat' in uu____10107 p branch_bv
+    fun branch_bv -> let uu___ = noenv resugar_pat' in uu___ p branch_bv
 let (resugar_binder :
   FStar_Syntax_Syntax.binder ->
     FStar_Range.range ->
       FStar_Parser_AST.binder FStar_Pervasives_Native.option)
-  =
-  fun b ->
-    fun r -> let uu____10140 = noenv resugar_binder' in uu____10140 b r
+  = fun b -> fun r -> let uu___ = noenv resugar_binder' in uu___ b r
 let (resugar_tscheme : FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl)
-  = fun ts -> let uu____10164 = noenv resugar_tscheme' in uu____10164 ts
+  = fun ts -> let uu___ = noenv resugar_tscheme' in uu___ ts
 let (resugar_eff_decl :
   FStar_Range.range ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
       FStar_Syntax_Syntax.eff_decl -> FStar_Parser_AST.decl)
   =
   fun r ->
-    fun q ->
-      fun ed ->
-        let uu____10191 = noenv resugar_eff_decl' in uu____10191 r q ed
+    fun q -> fun ed -> let uu___ = noenv resugar_eff_decl' in uu___ r q ed

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -1,62 +1,59 @@
 open Prims
 let subst_to_string :
-  'uuuuuu4 . (FStar_Syntax_Syntax.bv * 'uuuuuu4) Prims.list -> Prims.string =
+  'uuuuu . (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list -> Prims.string =
   fun s ->
-    let uu____22 =
+    let uu___ =
       FStar_All.pipe_right s
         (FStar_List.map
-           (fun uu____40 ->
-              match uu____40 with
-              | (b, uu____46) ->
+           (fun uu___1 ->
+              match uu___1 with
+              | (b, uu___2) ->
                   FStar_Ident.string_of_id b.FStar_Syntax_Syntax.ppname)) in
-    FStar_All.pipe_right uu____22 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let rec apply_until_some :
-  'uuuuuu57 'uuuuuu58 .
-    ('uuuuuu57 -> 'uuuuuu58 FStar_Pervasives_Native.option) ->
-      'uuuuuu57 Prims.list ->
-        ('uuuuuu57 Prims.list * 'uuuuuu58) FStar_Pervasives_Native.option
+  'uuuuu 'uuuuu1 .
+    ('uuuuu -> 'uuuuu1 FStar_Pervasives_Native.option) ->
+      'uuuuu Prims.list ->
+        ('uuuuu Prims.list * 'uuuuu1) FStar_Pervasives_Native.option
   =
   fun f ->
     fun s ->
       match s with
       | [] -> FStar_Pervasives_Native.None
       | s0::rest ->
-          let uu____100 = f s0 in
-          (match uu____100 with
+          let uu___ = f s0 in
+          (match uu___ with
            | FStar_Pervasives_Native.None -> apply_until_some f rest
            | FStar_Pervasives_Native.Some st ->
                FStar_Pervasives_Native.Some (rest, st))
 let map_some_curry :
-  'uuuuuu132 'uuuuuu133 'uuuuuu134 .
-    ('uuuuuu132 -> 'uuuuuu133 -> 'uuuuuu134) ->
-      'uuuuuu134 ->
-        ('uuuuuu132 * 'uuuuuu133) FStar_Pervasives_Native.option ->
-          'uuuuuu134
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    ('uuuuu -> 'uuuuu1 -> 'uuuuu2) ->
+      'uuuuu2 -> ('uuuuu * 'uuuuu1) FStar_Pervasives_Native.option -> 'uuuuu2
   =
   fun f ->
     fun x ->
-      fun uu___0_161 ->
-        match uu___0_161 with
+      fun uu___ ->
+        match uu___ with
         | FStar_Pervasives_Native.None -> x
         | FStar_Pervasives_Native.Some (a, b) -> f a b
 let apply_until_some_then_map :
-  'uuuuuu196 'uuuuuu197 'uuuuuu198 .
-    ('uuuuuu196 -> 'uuuuuu197 FStar_Pervasives_Native.option) ->
-      'uuuuuu196 Prims.list ->
-        ('uuuuuu196 Prims.list -> 'uuuuuu197 -> 'uuuuuu198) ->
-          'uuuuuu198 -> 'uuuuuu198
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    ('uuuuu -> 'uuuuu1 FStar_Pervasives_Native.option) ->
+      'uuuuu Prims.list ->
+        ('uuuuu Prims.list -> 'uuuuu1 -> 'uuuuu2) -> 'uuuuu2 -> 'uuuuu2
   =
   fun f ->
     fun s ->
       fun g ->
         fun t ->
-          let uu____246 = apply_until_some f s in
-          FStar_All.pipe_right uu____246 (map_some_curry g t)
+          let uu___ = apply_until_some f s in
+          FStar_All.pipe_right uu___ (map_some_curry g t)
 let compose_subst :
-  'uuuuuu271 .
-    ('uuuuuu271 Prims.list * FStar_Syntax_Syntax.maybe_set_use_range) ->
-      ('uuuuuu271 Prims.list * FStar_Syntax_Syntax.maybe_set_use_range) ->
-        ('uuuuuu271 Prims.list * FStar_Syntax_Syntax.maybe_set_use_range)
+  'uuuuu .
+    ('uuuuu Prims.list * FStar_Syntax_Syntax.maybe_set_use_range) ->
+      ('uuuuu Prims.list * FStar_Syntax_Syntax.maybe_set_use_range) ->
+        ('uuuuu Prims.list * FStar_Syntax_Syntax.maybe_set_use_range)
   =
   fun s1 ->
     fun s2 ->
@@ -65,9 +62,9 @@ let compose_subst :
           (FStar_Pervasives_Native.fst s2) in
       let ropt =
         match FStar_Pervasives_Native.snd s2 with
-        | FStar_Syntax_Syntax.SomeUseRange uu____322 ->
+        | FStar_Syntax_Syntax.SomeUseRange uu___ ->
             FStar_Pervasives_Native.snd s2
-        | uu____325 -> FStar_Pervasives_Native.snd s1 in
+        | uu___ -> FStar_Pervasives_Native.snd s1 in
       (s, ropt)
 let (delay :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -80,7 +77,7 @@ let (delay :
       | FStar_Syntax_Syntax.Tm_delayed (t', s') ->
           FStar_Syntax_Syntax.mk_Tm_delayed (t', (compose_subst s' s))
             t.FStar_Syntax_Syntax.pos
-      | uu____384 ->
+      | uu___ ->
           FStar_Syntax_Syntax.mk_Tm_delayed (t, s) t.FStar_Syntax_Syntax.pos
 let rec (force_uvar' :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -90,32 +87,31 @@ let rec (force_uvar' :
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_uvar
         ({ FStar_Syntax_Syntax.ctx_uvar_head = uv;
-           FStar_Syntax_Syntax.ctx_uvar_gamma = uu____407;
-           FStar_Syntax_Syntax.ctx_uvar_binders = uu____408;
-           FStar_Syntax_Syntax.ctx_uvar_typ = uu____409;
-           FStar_Syntax_Syntax.ctx_uvar_reason = uu____410;
-           FStar_Syntax_Syntax.ctx_uvar_should_check = uu____411;
-           FStar_Syntax_Syntax.ctx_uvar_range = uu____412;
-           FStar_Syntax_Syntax.ctx_uvar_meta = uu____413;_},
+           FStar_Syntax_Syntax.ctx_uvar_gamma = uu___;
+           FStar_Syntax_Syntax.ctx_uvar_binders = uu___1;
+           FStar_Syntax_Syntax.ctx_uvar_typ = uu___2;
+           FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
+           FStar_Syntax_Syntax.ctx_uvar_should_check = uu___4;
+           FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
+           FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
          s)
         ->
-        let uu____457 = FStar_Syntax_Unionfind.find uv in
-        (match uu____457 with
+        let uu___7 = FStar_Syntax_Unionfind.find uv in
+        (match uu___7 with
          | FStar_Pervasives_Native.Some t' ->
-             let uu____467 =
-               let uu____470 =
-                 let uu____477 = delay t' s in force_uvar' uu____477 in
-               FStar_Pervasives_Native.fst uu____470 in
-             (uu____467, true)
-         | uu____484 -> (t, false))
-    | uu____489 -> (t, false)
+             let uu___8 =
+               let uu___9 = let uu___10 = delay t' s in force_uvar' uu___10 in
+               FStar_Pervasives_Native.fst uu___9 in
+             (uu___8, true)
+         | uu___8 -> (t, false))
+    | uu___ -> (t, false)
 let (force_uvar :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t ->
-    let uu____503 = force_uvar' t in
-    match uu____503 with
+    let uu___ = force_uvar' t in
+    match uu___ with
     | (t', forced) ->
         if forced
         then
@@ -128,11 +124,11 @@ let rec (compress_univ :
   fun u ->
     match u with
     | FStar_Syntax_Syntax.U_unif u' ->
-        let uu____543 = FStar_Syntax_Unionfind.univ_find u' in
-        (match uu____543 with
+        let uu___ = FStar_Syntax_Unionfind.univ_find u' in
+        (match uu___ with
          | FStar_Pervasives_Native.Some u1 -> compress_univ u1
-         | uu____547 -> u)
-    | uu____550 -> u
+         | uu___1 -> u)
+    | uu___ -> u
 let (subst_bv :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -141,17 +137,17 @@ let (subst_bv :
   fun a ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___1_571 ->
-           match uu___1_571 with
+        (fun uu___ ->
+           match uu___ with
            | FStar_Syntax_Syntax.DB (i, x) when
                i = a.FStar_Syntax_Syntax.index ->
-               let uu____576 =
-                 let uu____577 =
-                   let uu____578 = FStar_Syntax_Syntax.range_of_bv a in
-                   FStar_Syntax_Syntax.set_range_of_bv x uu____578 in
-                 FStar_Syntax_Syntax.bv_to_name uu____577 in
-               FStar_Pervasives_Native.Some uu____576
-           | uu____579 -> FStar_Pervasives_Native.None)
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Syntax.range_of_bv a in
+                   FStar_Syntax_Syntax.set_range_of_bv x uu___3 in
+                 FStar_Syntax_Syntax.bv_to_name uu___2 in
+               FStar_Pervasives_Native.Some uu___1
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (subst_nm :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -161,24 +157,24 @@ let (subst_nm :
   fun a ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___2_604 ->
-           match uu___2_604 with
+        (fun uu___ ->
+           match uu___ with
            | FStar_Syntax_Syntax.NM (x, i) when FStar_Syntax_Syntax.bv_eq a x
                ->
-               let uu____611 =
+               let uu___1 =
                  FStar_Syntax_Syntax.bv_to_tm
-                   (let uu___91_616 = a in
+                   (let uu___2 = a in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___91_616.FStar_Syntax_Syntax.ppname);
+                        (uu___2.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index = i;
                       FStar_Syntax_Syntax.sort =
-                        (uu___91_616.FStar_Syntax_Syntax.sort)
+                        (uu___2.FStar_Syntax_Syntax.sort)
                     }) in
-               FStar_Pervasives_Native.Some uu____611
+               FStar_Pervasives_Native.Some uu___1
            | FStar_Syntax_Syntax.NT (x, t) when FStar_Syntax_Syntax.bv_eq a x
                -> FStar_Pervasives_Native.Some t
-           | uu____627 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (subst_univ_bv :
   Prims.int ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -187,11 +183,11 @@ let (subst_univ_bv :
   fun x ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___3_649 ->
-           match uu___3_649 with
+        (fun uu___ ->
+           match uu___ with
            | FStar_Syntax_Syntax.UN (y, t) when x = y ->
                FStar_Pervasives_Native.Some t
-           | uu____654 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (subst_univ_nm :
   FStar_Syntax_Syntax.univ_name ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -200,11 +196,11 @@ let (subst_univ_nm :
   fun x ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___4_674 ->
-           match uu___4_674 with
+        (fun uu___ ->
+           match uu___ with
            | FStar_Syntax_Syntax.UD (y, i) when FStar_Ident.ident_equals x y
                -> FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.U_bvar i)
-           | uu____679 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
 let rec (subst_univ :
   FStar_Syntax_Syntax.subst_elt Prims.list Prims.list ->
     FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
@@ -219,17 +215,16 @@ let rec (subst_univ :
           apply_until_some_then_map (subst_univ_nm x) s subst_univ u1
       | FStar_Syntax_Syntax.U_zero -> u1
       | FStar_Syntax_Syntax.U_unknown -> u1
-      | FStar_Syntax_Syntax.U_unif uu____705 -> u1
+      | FStar_Syntax_Syntax.U_unif uu___ -> u1
       | FStar_Syntax_Syntax.U_succ u2 ->
-          let uu____717 = subst_univ s u2 in
-          FStar_Syntax_Syntax.U_succ uu____717
+          let uu___ = subst_univ s u2 in FStar_Syntax_Syntax.U_succ uu___
       | FStar_Syntax_Syntax.U_max us ->
-          let uu____721 = FStar_List.map (subst_univ s) us in
-          FStar_Syntax_Syntax.U_max uu____721
+          let uu___ = FStar_List.map (subst_univ s) us in
+          FStar_Syntax_Syntax.U_max uu___
 let tag_with_range :
-  'uuuuuu730 .
+  'uuuuu .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      ('uuuuuu730 * FStar_Syntax_Syntax.maybe_set_use_range) ->
+      ('uuuuu * FStar_Syntax_Syntax.maybe_set_use_range) ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t ->
@@ -237,56 +232,54 @@ let tag_with_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange -> t
       | FStar_Syntax_Syntax.SomeUseRange r ->
-          let uu____756 =
-            let uu____757 = FStar_Range.use_range t.FStar_Syntax_Syntax.pos in
-            let uu____758 = FStar_Range.use_range r in
-            FStar_Range.rng_included uu____757 uu____758 in
-          if uu____756
+          let uu___ =
+            let uu___1 = FStar_Range.use_range t.FStar_Syntax_Syntax.pos in
+            let uu___2 = FStar_Range.use_range r in
+            FStar_Range.rng_included uu___1 uu___2 in
+          if uu___
           then t
           else
             (let r1 =
-               let uu____763 = FStar_Range.use_range r in
-               FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu____763 in
+               let uu___2 = FStar_Range.use_range r in
+               FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu___2 in
              let t' =
                match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_bvar bv ->
-                   let uu____766 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
-                   FStar_Syntax_Syntax.Tm_bvar uu____766
+                   let uu___2 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
+                   FStar_Syntax_Syntax.Tm_bvar uu___2
                | FStar_Syntax_Syntax.Tm_name bv ->
-                   let uu____768 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
-                   FStar_Syntax_Syntax.Tm_name uu____768
+                   let uu___2 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
+                   FStar_Syntax_Syntax.Tm_name uu___2
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv in
                    let v =
-                     let uu___143_774 = fv.FStar_Syntax_Syntax.fv_name in
-                     let uu____775 = FStar_Ident.set_lid_range l r1 in
+                     let uu___2 = fv.FStar_Syntax_Syntax.fv_name in
+                     let uu___3 = FStar_Ident.set_lid_range l r1 in
                      {
-                       FStar_Syntax_Syntax.v = uu____775;
-                       FStar_Syntax_Syntax.p =
-                         (uu___143_774.FStar_Syntax_Syntax.p)
+                       FStar_Syntax_Syntax.v = uu___3;
+                       FStar_Syntax_Syntax.p = (uu___2.FStar_Syntax_Syntax.p)
                      } in
                    let fv1 =
-                     let uu___146_777 = fv in
+                     let uu___2 = fv in
                      {
                        FStar_Syntax_Syntax.fv_name = v;
                        FStar_Syntax_Syntax.fv_delta =
-                         (uu___146_777.FStar_Syntax_Syntax.fv_delta);
+                         (uu___2.FStar_Syntax_Syntax.fv_delta);
                        FStar_Syntax_Syntax.fv_qual =
-                         (uu___146_777.FStar_Syntax_Syntax.fv_qual)
+                         (uu___2.FStar_Syntax_Syntax.fv_qual)
                      } in
                    FStar_Syntax_Syntax.Tm_fvar fv1
-               | t' -> t' in
-             let uu___151_779 = t in
+               | t'1 -> t'1 in
+             let uu___2 = t in
              {
                FStar_Syntax_Syntax.n = t';
                FStar_Syntax_Syntax.pos = r1;
-               FStar_Syntax_Syntax.vars =
-                 (uu___151_779.FStar_Syntax_Syntax.vars)
+               FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars)
              })
 let tag_lid_with_range :
-  'uuuuuu788 .
+  'uuuuu .
     FStar_Ident.lident ->
-      ('uuuuuu788 * FStar_Syntax_Syntax.maybe_set_use_range) ->
+      ('uuuuu * FStar_Syntax_Syntax.maybe_set_use_range) ->
         FStar_Ident.lident
   =
   fun l ->
@@ -294,20 +287,20 @@ let tag_lid_with_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange -> l
       | FStar_Syntax_Syntax.SomeUseRange r ->
-          let uu____808 =
-            let uu____809 =
-              let uu____810 = FStar_Ident.range_of_lid l in
-              FStar_Range.use_range uu____810 in
-            let uu____811 = FStar_Range.use_range r in
-            FStar_Range.rng_included uu____809 uu____811 in
-          if uu____808
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Ident.range_of_lid l in
+              FStar_Range.use_range uu___2 in
+            let uu___2 = FStar_Range.use_range r in
+            FStar_Range.rng_included uu___1 uu___2 in
+          if uu___
           then l
           else
-            (let uu____813 =
-               let uu____814 = FStar_Ident.range_of_lid l in
-               let uu____815 = FStar_Range.use_range r in
-               FStar_Range.set_use_range uu____814 uu____815 in
-             FStar_Ident.set_lid_range l uu____813)
+            (let uu___2 =
+               let uu___3 = FStar_Ident.range_of_lid l in
+               let uu___4 = FStar_Range.use_range r in
+               FStar_Range.set_use_range uu___3 uu___4 in
+             FStar_Ident.set_lid_range l uu___2)
 let (mk_range :
   FStar_Range.range -> FStar_Syntax_Syntax.subst_ts -> FStar_Range.range) =
   fun r ->
@@ -315,15 +308,15 @@ let (mk_range :
       match FStar_Pervasives_Native.snd s with
       | FStar_Syntax_Syntax.NoUseRange -> r
       | FStar_Syntax_Syntax.SomeUseRange r' ->
-          let uu____831 =
-            let uu____832 = FStar_Range.use_range r in
-            let uu____833 = FStar_Range.use_range r' in
-            FStar_Range.rng_included uu____832 uu____833 in
-          if uu____831
+          let uu___ =
+            let uu___1 = FStar_Range.use_range r in
+            let uu___2 = FStar_Range.use_range r' in
+            FStar_Range.rng_included uu___1 uu___2 in
+          if uu___
           then r
           else
-            (let uu____835 = FStar_Range.use_range r' in
-             FStar_Range.set_use_range r uu____835)
+            (let uu___2 = FStar_Range.use_range r' in
+             FStar_Range.set_use_range r uu___2)
 let rec (subst' :
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -334,12 +327,12 @@ let rec (subst' :
       match s with
       | ([], FStar_Syntax_Syntax.NoUseRange) -> t
       | ([]::[], FStar_Syntax_Syntax.NoUseRange) -> t
-      | uu____887 ->
+      | uu___ ->
           let t0 = t in
           (match t0.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown -> tag_with_range t0 s
-           | FStar_Syntax_Syntax.Tm_constant uu____893 -> tag_with_range t0 s
-           | FStar_Syntax_Syntax.Tm_fvar uu____898 -> tag_with_range t0 s
+           | FStar_Syntax_Syntax.Tm_constant uu___1 -> tag_with_range t0 s
+           | FStar_Syntax_Syntax.Tm_fvar uu___1 -> tag_with_range t0 s
            | FStar_Syntax_Syntax.Tm_delayed (t', s') ->
                FStar_Syntax_Syntax.mk_Tm_delayed (t', (compose_subst s' s))
                  t.FStar_Syntax_Syntax.pos
@@ -350,14 +343,14 @@ let rec (subst' :
                apply_until_some_then_map (subst_nm a)
                  (FStar_Pervasives_Native.fst s) subst_tail t0
            | FStar_Syntax_Syntax.Tm_type u ->
-               let uu____944 =
-                 let uu____945 = subst_univ (FStar_Pervasives_Native.fst s) u in
-                 FStar_Syntax_Syntax.Tm_type uu____945 in
-               let uu____950 = mk_range t0.FStar_Syntax_Syntax.pos s in
-               FStar_Syntax_Syntax.mk uu____944 uu____950
-           | uu____951 ->
-               let uu____952 = mk_range t.FStar_Syntax_Syntax.pos s in
-               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____952)
+               let uu___1 =
+                 let uu___2 = subst_univ (FStar_Pervasives_Native.fst s) u in
+                 FStar_Syntax_Syntax.Tm_type uu___2 in
+               let uu___2 = mk_range t0.FStar_Syntax_Syntax.pos s in
+               FStar_Syntax_Syntax.mk uu___1 uu___2
+           | uu___1 ->
+               let uu___2 = mk_range t.FStar_Syntax_Syntax.pos s in
+               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu___2)
 let (subst_flags' :
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.cflag Prims.list ->
@@ -367,11 +360,11 @@ let (subst_flags' :
     fun flags ->
       FStar_All.pipe_right flags
         (FStar_List.map
-           (fun uu___5_976 ->
-              match uu___5_976 with
+           (fun uu___ ->
+              match uu___ with
               | FStar_Syntax_Syntax.DECREASES a ->
-                  let uu____980 = subst' s a in
-                  FStar_Syntax_Syntax.DECREASES uu____980
+                  let uu___1 = subst' s a in
+                  FStar_Syntax_Syntax.DECREASES uu___1
               | f -> f))
 let (subst_imp' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -383,20 +376,20 @@ let (subst_imp' :
       match i with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-          let uu____1005 =
-            let uu____1006 =
-              let uu____1007 = subst' s t in
-              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____1007 in
-            FStar_Syntax_Syntax.Meta uu____1006 in
-          FStar_Pervasives_Native.Some uu____1005
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t in
+              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu___2 in
+            FStar_Syntax_Syntax.Meta uu___1 in
+          FStar_Pervasives_Native.Some uu___
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
           (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-          let uu____1013 =
-            let uu____1014 =
-              let uu____1015 = subst' s t in
-              FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____1015 in
-            FStar_Syntax_Syntax.Meta uu____1014 in
-          FStar_Pervasives_Native.Some uu____1013
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t in
+              FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu___2 in
+            FStar_Syntax_Syntax.Meta uu___1 in
+          FStar_Pervasives_Native.Some uu___
       | i1 -> i1
 let (subst_comp_typ' :
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list *
@@ -408,30 +401,28 @@ let (subst_comp_typ' :
       match s with
       | ([], FStar_Syntax_Syntax.NoUseRange) -> t
       | ([]::[], FStar_Syntax_Syntax.NoUseRange) -> t
-      | uu____1061 ->
-          let uu___221_1070 = t in
-          let uu____1071 =
+      | uu___ ->
+          let uu___1 = t in
+          let uu___2 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s))
               t.FStar_Syntax_Syntax.comp_univs in
-          let uu____1076 =
-            tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s in
-          let uu____1081 = subst' s t.FStar_Syntax_Syntax.result_typ in
-          let uu____1084 =
+          let uu___3 = tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s in
+          let uu___4 = subst' s t.FStar_Syntax_Syntax.result_typ in
+          let uu___5 =
             FStar_List.map
-              (fun uu____1112 ->
-                 match uu____1112 with
+              (fun uu___6 ->
+                 match uu___6 with
                  | (t1, imp) ->
-                     let uu____1131 = subst' s t1 in
-                     let uu____1132 = subst_imp' s imp in
-                     (uu____1131, uu____1132))
+                     let uu___7 = subst' s t1 in
+                     let uu___8 = subst_imp' s imp in (uu___7, uu___8))
               t.FStar_Syntax_Syntax.effect_args in
-          let uu____1137 = subst_flags' s t.FStar_Syntax_Syntax.flags in
+          let uu___6 = subst_flags' s t.FStar_Syntax_Syntax.flags in
           {
-            FStar_Syntax_Syntax.comp_univs = uu____1071;
-            FStar_Syntax_Syntax.effect_name = uu____1076;
-            FStar_Syntax_Syntax.result_typ = uu____1081;
-            FStar_Syntax_Syntax.effect_args = uu____1084;
-            FStar_Syntax_Syntax.flags = uu____1137
+            FStar_Syntax_Syntax.comp_univs = uu___2;
+            FStar_Syntax_Syntax.effect_name = uu___3;
+            FStar_Syntax_Syntax.result_typ = uu___4;
+            FStar_Syntax_Syntax.effect_args = uu___5;
+            FStar_Syntax_Syntax.flags = uu___6
           }
 let (subst_comp' :
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list *
@@ -444,23 +435,23 @@ let (subst_comp' :
       match s with
       | ([], FStar_Syntax_Syntax.NoUseRange) -> t
       | ([]::[], FStar_Syntax_Syntax.NoUseRange) -> t
-      | uu____1188 ->
+      | uu___ ->
           (match t.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Total (t1, uopt) ->
-               let uu____1209 = subst' s t1 in
-               let uu____1210 =
+               let uu___1 = subst' s t1 in
+               let uu___2 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt in
-               FStar_Syntax_Syntax.mk_Total' uu____1209 uu____1210
+               FStar_Syntax_Syntax.mk_Total' uu___1 uu___2
            | FStar_Syntax_Syntax.GTotal (t1, uopt) ->
-               let uu____1227 = subst' s t1 in
-               let uu____1228 =
+               let uu___1 = subst' s t1 in
+               let uu___2 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt in
-               FStar_Syntax_Syntax.mk_GTotal' uu____1227 uu____1228
+               FStar_Syntax_Syntax.mk_GTotal' uu___1 uu___2
            | FStar_Syntax_Syntax.Comp ct ->
-               let uu____1236 = subst_comp_typ' s ct in
-               FStar_Syntax_Syntax.mk_Comp uu____1236)
+               let uu___1 = subst_comp_typ' s ct in
+               FStar_Syntax_Syntax.mk_Comp uu___1)
 let (shift :
   Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt)
   =
@@ -471,22 +462,22 @@ let (shift :
       | FStar_Syntax_Syntax.UN (i, t) -> FStar_Syntax_Syntax.UN ((i + n), t)
       | FStar_Syntax_Syntax.NM (x, i) -> FStar_Syntax_Syntax.NM (x, (i + n))
       | FStar_Syntax_Syntax.UD (x, i) -> FStar_Syntax_Syntax.UD (x, (i + n))
-      | FStar_Syntax_Syntax.NT uu____1255 -> s
+      | FStar_Syntax_Syntax.NT uu___ -> s
 let (shift_subst :
   Prims.int -> FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_t) =
   fun n -> fun s -> FStar_List.map (shift n) s
 let shift_subst' :
-  'uuuuuu1278 .
+  'uuuuu .
     Prims.int ->
-      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1278) ->
-        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1278)
+      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuu) ->
+        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuu)
   =
   fun n ->
     fun s ->
-      let uu____1307 =
+      let uu___ =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
           (FStar_List.map (shift_subst n)) in
-      (uu____1307, (FStar_Pervasives_Native.snd s))
+      (uu___, (FStar_Pervasives_Native.snd s))
 let (subst_binder' :
   FStar_Syntax_Syntax.subst_ts ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -495,20 +486,19 @@ let (subst_binder' :
         FStar_Pervasives_Native.option))
   =
   fun s ->
-    fun uu____1341 ->
-      match uu____1341 with
+    fun uu___ ->
+      match uu___ with
       | (x, imp) ->
-          let uu____1360 =
-            let uu___274_1361 = x in
-            let uu____1362 = subst' s x.FStar_Syntax_Syntax.sort in
+          let uu___1 =
+            let uu___2 = x in
+            let uu___3 = subst' s x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___274_1361.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___274_1361.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____1362
+                (uu___2.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___2.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___3
             } in
-          let uu____1365 = subst_imp' s imp in (uu____1360, uu____1365)
+          let uu___2 = subst_imp' s imp in (uu___1, uu___2)
 let (subst_binders' :
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list *
     FStar_Syntax_Syntax.maybe_set_use_range) ->
@@ -526,28 +516,26 @@ let (subst_binders' :
                 if i = Prims.int_zero
                 then subst_binder' s b
                 else
-                  (let uu____1465 = shift_subst' i s in
-                   subst_binder' uu____1465 b)))
+                  (let uu___1 = shift_subst' i s in subst_binder' uu___1 b)))
 let (subst_binders :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
   =
   fun s -> fun bs -> subst_binders' ([s], FStar_Syntax_Syntax.NoUseRange) bs
 let subst_arg' :
-  'uuuuuu1494 .
+  'uuuuu .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1494) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1494)
+      (FStar_Syntax_Syntax.term * 'uuuuu) ->
+        (FStar_Syntax_Syntax.term * 'uuuuu)
   =
   fun s ->
-    fun uu____1512 ->
-      match uu____1512 with
-      | (t, imp) -> let uu____1519 = subst' s t in (uu____1519, imp)
+    fun uu___ ->
+      match uu___ with | (t, imp) -> let uu___1 = subst' s t in (uu___1, imp)
 let subst_args' :
-  'uuuuuu1525 .
+  'uuuuu .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1525) Prims.list ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1525) Prims.list
+      (FStar_Syntax_Syntax.term * 'uuuuu) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuu) Prims.list
   = fun s -> FStar_List.map (subst_arg' s)
 let (subst_pat' :
   (FStar_Syntax_Syntax.subst_t Prims.list *
@@ -559,81 +547,77 @@ let (subst_pat' :
     fun p ->
       let rec aux n p1 =
         match p1.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_constant uu____1612 -> (p1, n)
+        | FStar_Syntax_Syntax.Pat_constant uu___ -> (p1, n)
         | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-            let uu____1631 =
+            let uu___ =
               FStar_All.pipe_right pats
                 (FStar_List.fold_left
-                   (fun uu____1685 ->
-                      fun uu____1686 ->
-                        match (uu____1685, uu____1686) with
+                   (fun uu___1 ->
+                      fun uu___2 ->
+                        match (uu___1, uu___2) with
                         | ((pats1, n1), (p2, imp)) ->
-                            let uu____1765 = aux n1 p2 in
-                            (match uu____1765 with
+                            let uu___3 = aux n1 p2 in
+                            (match uu___3 with
                              | (p3, m) -> (((p3, imp) :: pats1), m))) 
                    ([], n)) in
-            (match uu____1631 with
+            (match uu___ with
              | (pats1, n1) ->
-                 ((let uu___311_1821 = p1 in
+                 ((let uu___1 = p1 in
                    {
                      FStar_Syntax_Syntax.v =
                        (FStar_Syntax_Syntax.Pat_cons
                           (fv, (FStar_List.rev pats1)));
-                     FStar_Syntax_Syntax.p =
-                       (uu___311_1821.FStar_Syntax_Syntax.p)
+                     FStar_Syntax_Syntax.p = (uu___1.FStar_Syntax_Syntax.p)
                    }), n1))
         | FStar_Syntax_Syntax.Pat_var x ->
             let s1 = shift_subst' n s in
             let x1 =
-              let uu___316_1845 = x in
-              let uu____1846 = subst' s1 x.FStar_Syntax_Syntax.sort in
+              let uu___ = x in
+              let uu___1 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___316_1845.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___316_1845.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1846
+                  (uu___.FStar_Syntax_Syntax.ppname);
+                FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu___1
               } in
-            ((let uu___319_1850 = p1 in
+            ((let uu___ = p1 in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-                FStar_Syntax_Syntax.p = (uu___319_1850.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_wild x ->
             let s1 = shift_subst' n s in
             let x1 =
-              let uu___324_1862 = x in
-              let uu____1863 = subst' s1 x.FStar_Syntax_Syntax.sort in
+              let uu___ = x in
+              let uu___1 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___324_1862.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___324_1862.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1863
+                  (uu___.FStar_Syntax_Syntax.ppname);
+                FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu___1
               } in
-            ((let uu___327_1867 = p1 in
+            ((let uu___ = p1 in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-                FStar_Syntax_Syntax.p = (uu___327_1867.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
             let s1 = shift_subst' n s in
             let x1 =
-              let uu___334_1884 = x in
-              let uu____1885 = subst' s1 x.FStar_Syntax_Syntax.sort in
+              let uu___ = x in
+              let uu___1 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___334_1884.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___334_1884.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____1885
+                  (uu___.FStar_Syntax_Syntax.ppname);
+                FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu___1
               } in
             let t01 = subst' s1 t0 in
-            ((let uu___338_1890 = p1 in
+            ((let uu___ = p1 in
               {
                 FStar_Syntax_Syntax.v =
                   (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-                FStar_Syntax_Syntax.p = (uu___338_1890.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }), n) in
       aux Prims.int_zero p
 let (push_subst_lcomp :
@@ -646,19 +630,19 @@ let (push_subst_lcomp :
       match lopt with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
-          let uu____1914 =
-            let uu___345_1915 = rc in
-            let uu____1916 =
+          let uu___ =
+            let uu___1 = rc in
+            let uu___2 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (subst' s) in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___345_1915.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____1916;
+                (uu___1.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu___2;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___345_1915.FStar_Syntax_Syntax.residual_flags)
+                (uu___1.FStar_Syntax_Syntax.residual_flags)
             } in
-          FStar_Pervasives_Native.Some uu____1914
+          FStar_Pervasives_Native.Some uu___
 let (compose_uvar_subst :
   FStar_Syntax_Syntax.ctx_uvar ->
     FStar_Syntax_Syntax.subst_ts ->
@@ -670,44 +654,44 @@ let (compose_uvar_subst :
         let should_retain x =
           FStar_All.pipe_right u.FStar_Syntax_Syntax.ctx_uvar_binders
             (FStar_Util.for_some
-               (fun uu____1963 ->
-                  match uu____1963 with
-                  | (x', uu____1971) -> FStar_Syntax_Syntax.bv_eq x x')) in
-        let rec aux uu___7_1987 =
-          match uu___7_1987 with
+               (fun uu___ ->
+                  match uu___ with
+                  | (x', uu___1) -> FStar_Syntax_Syntax.bv_eq x x')) in
+        let rec aux uu___ =
+          match uu___ with
           | [] -> []
           | hd_subst::rest ->
               let hd =
                 FStar_All.pipe_right hd_subst
                   (FStar_List.collect
-                     (fun uu___6_2018 ->
-                        match uu___6_2018 with
+                     (fun uu___1 ->
+                        match uu___1 with
                         | FStar_Syntax_Syntax.NT (x, t) ->
-                            let uu____2027 = should_retain x in
-                            if uu____2027
+                            let uu___2 = should_retain x in
+                            if uu___2
                             then
-                              let uu____2030 =
-                                let uu____2031 =
-                                  let uu____2038 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     delay t
                                       (rest, FStar_Syntax_Syntax.NoUseRange) in
-                                  (x, uu____2038) in
-                                FStar_Syntax_Syntax.NT uu____2031 in
-                              [uu____2030]
+                                  (x, uu___5) in
+                                FStar_Syntax_Syntax.NT uu___4 in
+                              [uu___3]
                             else []
                         | FStar_Syntax_Syntax.NM (x, i) ->
-                            let uu____2050 = should_retain x in
-                            if uu____2050
+                            let uu___2 = should_retain x in
+                            if uu___2
                             then
                               let x_i =
                                 FStar_Syntax_Syntax.bv_to_tm
-                                  (let uu___372_2056 = x in
+                                  (let uu___3 = x in
                                    {
                                      FStar_Syntax_Syntax.ppname =
-                                       (uu___372_2056.FStar_Syntax_Syntax.ppname);
+                                       (uu___3.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index = i;
                                      FStar_Syntax_Syntax.sort =
-                                       (uu___372_2056.FStar_Syntax_Syntax.sort)
+                                       (uu___3.FStar_Syntax_Syntax.sort)
                                    }) in
                               let t =
                                 subst' (rest, FStar_Syntax_Syntax.NoUseRange)
@@ -716,16 +700,15 @@ let (compose_uvar_subst :
                                | FStar_Syntax_Syntax.Tm_bvar x_j ->
                                    [FStar_Syntax_Syntax.NM
                                       (x, (x_j.FStar_Syntax_Syntax.index))]
-                               | uu____2065 ->
-                                   [FStar_Syntax_Syntax.NT (x, t)])
+                               | uu___3 -> [FStar_Syntax_Syntax.NT (x, t)])
                             else []
-                        | uu____2069 -> [])) in
-              let uu____2070 = aux rest in FStar_List.append hd uu____2070 in
-        let uu____2073 =
+                        | uu___2 -> [])) in
+              let uu___1 = aux rest in FStar_List.append hd uu___1 in
+        let uu___ =
           aux
             (FStar_List.append (FStar_Pervasives_Native.fst s0)
                (FStar_Pervasives_Native.fst s)) in
-        match uu____2073 with
+        match uu___ with
         | [] -> ([], (FStar_Pervasives_Native.snd s))
         | s' -> ([s'], (FStar_Pervasives_Native.snd s))
 let rec (push_subst :
@@ -736,124 +719,118 @@ let rec (push_subst :
   fun s ->
     fun t ->
       let mk t' =
-        let uu____2135 = mk_range t.FStar_Syntax_Syntax.pos s in
-        FStar_Syntax_Syntax.mk t' uu____2135 in
+        let uu___ = mk_range t.FStar_Syntax_Syntax.pos s in
+        FStar_Syntax_Syntax.mk t' uu___ in
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____2138 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
           (match i.FStar_Syntax_Syntax.lkind with
-           | FStar_Syntax_Syntax.Lazy_embedding uu____2158 ->
+           | FStar_Syntax_Syntax.Lazy_embedding uu___ ->
                let t1 =
-                 let uu____2168 =
-                   let uu____2177 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
-                   FStar_Util.must uu____2177 in
-                 uu____2168 i.FStar_Syntax_Syntax.lkind i in
+                   FStar_Util.must uu___2 in
+                 uu___1 i.FStar_Syntax_Syntax.lkind i in
                push_subst s t1
-           | uu____2214 -> tag_with_range t s)
-      | FStar_Syntax_Syntax.Tm_constant uu____2219 -> tag_with_range t s
-      | FStar_Syntax_Syntax.Tm_fvar uu____2224 -> tag_with_range t s
+           | uu___ -> tag_with_range t s)
+      | FStar_Syntax_Syntax.Tm_constant uu___ -> tag_with_range t s
+      | FStar_Syntax_Syntax.Tm_fvar uu___ -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_unknown -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_uvar (uv, s0) ->
-          let uu____2251 =
+          let uu___ =
             FStar_Syntax_Unionfind.find uv.FStar_Syntax_Syntax.ctx_uvar_head in
-          (match uu____2251 with
+          (match uu___ with
            | FStar_Pervasives_Native.None ->
-               let uu____2256 =
-                 let uu___405_2259 = t in
-                 let uu____2262 =
-                   let uu____2263 =
-                     let uu____2276 = compose_uvar_subst uv s0 s in
-                     (uv, uu____2276) in
-                   FStar_Syntax_Syntax.Tm_uvar uu____2263 in
+               let uu___1 =
+                 let uu___2 = t in
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = compose_uvar_subst uv s0 s in (uv, uu___5) in
+                   FStar_Syntax_Syntax.Tm_uvar uu___4 in
                  {
-                   FStar_Syntax_Syntax.n = uu____2262;
-                   FStar_Syntax_Syntax.pos =
-                     (uu___405_2259.FStar_Syntax_Syntax.pos);
+                   FStar_Syntax_Syntax.n = uu___3;
+                   FStar_Syntax_Syntax.pos = (uu___2.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
-                     (uu___405_2259.FStar_Syntax_Syntax.vars)
+                     (uu___2.FStar_Syntax_Syntax.vars)
                  } in
-               tag_with_range uu____2256 s
+               tag_with_range uu___1 s
            | FStar_Pervasives_Native.Some t1 ->
                push_subst (compose_subst s0 s) t1)
-      | FStar_Syntax_Syntax.Tm_type uu____2300 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_bvar uu____2301 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_name uu____2302 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_type uu___ -> subst' s t
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> subst' s t
+      | FStar_Syntax_Syntax.Tm_name uu___ -> subst' s t
       | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
           let us1 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s)) us in
-          let uu____2316 = mk (FStar_Syntax_Syntax.Tm_uinst (t', us1)) in
-          tag_with_range uu____2316 s
+          let uu___ = mk (FStar_Syntax_Syntax.Tm_uinst (t', us1)) in
+          tag_with_range uu___ s
       | FStar_Syntax_Syntax.Tm_app (t0, args) ->
-          let uu____2351 =
-            let uu____2352 =
-              let uu____2369 = subst' s t0 in
-              let uu____2372 = subst_args' s args in (uu____2369, uu____2372) in
-            FStar_Syntax_Syntax.Tm_app uu____2352 in
-          mk uu____2351
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t0 in
+              let uu___3 = subst_args' s args in (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_app uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_ascribed (t0, (annot, topt), lopt) ->
           let annot1 =
             match annot with
             | FStar_Util.Inl t1 ->
-                let uu____2473 = subst' s t1 in FStar_Util.Inl uu____2473
+                let uu___ = subst' s t1 in FStar_Util.Inl uu___
             | FStar_Util.Inr c ->
-                let uu____2487 = subst_comp' s c in FStar_Util.Inr uu____2487 in
-          let uu____2494 =
-            let uu____2495 =
-              let uu____2522 = subst' s t0 in
-              let uu____2525 =
-                let uu____2542 = FStar_Util.map_opt topt (subst' s) in
-                (annot1, uu____2542) in
-              (uu____2522, uu____2525, lopt) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____2495 in
-          mk uu____2494
+                let uu___ = subst_comp' s c in FStar_Util.Inr uu___ in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t0 in
+              let uu___3 =
+                let uu___4 = FStar_Util.map_opt topt (subst' s) in
+                (annot1, uu___4) in
+              (uu___2, uu___3, lopt) in
+            FStar_Syntax_Syntax.Tm_ascribed uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
           let n = FStar_List.length bs in
           let s' = shift_subst' n s in
-          let uu____2624 =
-            let uu____2625 =
-              let uu____2644 = subst_binders' s bs in
-              let uu____2653 = subst' s' body in
-              let uu____2656 = push_subst_lcomp s' lopt in
-              (uu____2644, uu____2653, uu____2656) in
-            FStar_Syntax_Syntax.Tm_abs uu____2625 in
-          mk uu____2624
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst_binders' s bs in
+              let uu___3 = subst' s' body in
+              let uu___4 = push_subst_lcomp s' lopt in
+              (uu___2, uu___3, uu___4) in
+            FStar_Syntax_Syntax.Tm_abs uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_arrow (bs, comp) ->
           let n = FStar_List.length bs in
-          let uu____2700 =
-            let uu____2701 =
-              let uu____2716 = subst_binders' s bs in
-              let uu____2725 =
-                let uu____2728 = shift_subst' n s in
-                subst_comp' uu____2728 comp in
-              (uu____2716, uu____2725) in
-            FStar_Syntax_Syntax.Tm_arrow uu____2701 in
-          mk uu____2700
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst_binders' s bs in
+              let uu___3 =
+                let uu___4 = shift_subst' n s in subst_comp' uu___4 comp in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_arrow uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_refine (x, phi) ->
           let x1 =
-            let uu___452_2754 = x in
-            let uu____2755 = subst' s x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst' s x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___452_2754.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___452_2754.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2755
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let phi1 =
-            let uu____2759 = shift_subst' Prims.int_one s in
-            subst' uu____2759 phi in
+            let uu___ = shift_subst' Prims.int_one s in subst' uu___ phi in
           mk (FStar_Syntax_Syntax.Tm_refine (x1, phi1))
       | FStar_Syntax_Syntax.Tm_match (t0, pats) ->
           let t01 = subst' s t0 in
           let pats1 =
             FStar_All.pipe_right pats
               (FStar_List.map
-                 (fun uu____2874 ->
-                    match uu____2874 with
+                 (fun uu___ ->
+                    match uu___ with
                     | (pat, wopt, branch) ->
-                        let uu____2904 = subst_pat' s pat in
-                        (match uu____2904 with
+                        let uu___1 = subst_pat' s pat in
+                        (match uu___1 with
                          | (pat1, n) ->
                              let s1 = shift_subst' n s in
                              let wopt1 =
@@ -861,8 +838,8 @@ let rec (push_subst :
                                | FStar_Pervasives_Native.None ->
                                    FStar_Pervasives_Native.None
                                | FStar_Pervasives_Native.Some w ->
-                                   let uu____2932 = subst' s1 w in
-                                   FStar_Pervasives_Native.Some uu____2932 in
+                                   let uu___2 = subst' s1 w in
+                                   FStar_Pervasives_Native.Some uu___2 in
                              let branch1 = subst' s1 branch in
                              (pat1, wopt1, branch1)))) in
           mk (FStar_Syntax_Syntax.Tm_match (t01, pats1))
@@ -876,97 +853,94 @@ let rec (push_subst :
                  (fun lb ->
                     let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp in
                     let lbd =
-                      let uu____2998 =
+                      let uu___ =
                         is_rec &&
                           (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname) in
-                      if uu____2998
+                      if uu___
                       then subst' sn lb.FStar_Syntax_Syntax.lbdef
                       else subst' s lb.FStar_Syntax_Syntax.lbdef in
                     let lbname =
                       match lb.FStar_Syntax_Syntax.lbname with
                       | FStar_Util.Inl x ->
                           FStar_Util.Inl
-                            (let uu___490_3013 = x in
+                            (let uu___ = x in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___490_3013.FStar_Syntax_Syntax.ppname);
+                                 (uu___.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___490_3013.FStar_Syntax_Syntax.index);
+                                 (uu___.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = lbt
                              })
                       | FStar_Util.Inr fv -> FStar_Util.Inr fv in
                     let lbattrs =
                       FStar_List.map (subst' s)
                         lb.FStar_Syntax_Syntax.lbattrs in
-                    let uu___496_3024 = lb in
+                    let uu___ = lb in
                     {
                       FStar_Syntax_Syntax.lbname = lbname;
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___496_3024.FStar_Syntax_Syntax.lbunivs);
+                        (uu___.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbt;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___496_3024.FStar_Syntax_Syntax.lbeff);
+                        (uu___.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbd;
                       FStar_Syntax_Syntax.lbattrs = lbattrs;
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___496_3024.FStar_Syntax_Syntax.lbpos)
+                        (uu___.FStar_Syntax_Syntax.lbpos)
                     })) in
           mk (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs1), body1))
       | FStar_Syntax_Syntax.Tm_meta
           (t0, FStar_Syntax_Syntax.Meta_pattern (bs, ps)) ->
-          let uu____3074 =
-            let uu____3075 =
-              let uu____3082 = subst' s t0 in
-              let uu____3085 =
-                let uu____3086 =
-                  let uu____3107 = FStar_List.map (subst' s) bs in
-                  let uu____3116 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t0 in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_List.map (subst' s) bs in
+                  let uu___6 =
                     FStar_All.pipe_right ps (FStar_List.map (subst_args' s)) in
-                  (uu____3107, uu____3116) in
-                FStar_Syntax_Syntax.Meta_pattern uu____3086 in
-              (uu____3082, uu____3085) in
-            FStar_Syntax_Syntax.Tm_meta uu____3075 in
-          mk uu____3074
+                  (uu___5, uu___6) in
+                FStar_Syntax_Syntax.Meta_pattern uu___4 in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_meta
           (t0, FStar_Syntax_Syntax.Meta_monadic (m, t1)) ->
-          let uu____3198 =
-            let uu____3199 =
-              let uu____3206 = subst' s t0 in
-              let uu____3209 =
-                let uu____3210 =
-                  let uu____3217 = subst' s t1 in (m, uu____3217) in
-                FStar_Syntax_Syntax.Meta_monadic uu____3210 in
-              (uu____3206, uu____3209) in
-            FStar_Syntax_Syntax.Tm_meta uu____3199 in
-          mk uu____3198
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t0 in
+              let uu___3 =
+                let uu___4 = let uu___5 = subst' s t1 in (m, uu___5) in
+                FStar_Syntax_Syntax.Meta_monadic uu___4 in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_meta
           (t0, FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t1)) ->
-          let uu____3236 =
-            let uu____3237 =
-              let uu____3244 = subst' s t0 in
-              let uu____3247 =
-                let uu____3248 =
-                  let uu____3257 = subst' s t1 in (m1, m2, uu____3257) in
-                FStar_Syntax_Syntax.Meta_monadic_lift uu____3248 in
-              (uu____3244, uu____3247) in
-            FStar_Syntax_Syntax.Tm_meta uu____3237 in
-          mk uu____3236
+          let uu___ =
+            let uu___1 =
+              let uu___2 = subst' s t0 in
+              let uu___3 =
+                let uu___4 = let uu___5 = subst' s t1 in (m1, m2, uu___5) in
+                FStar_Syntax_Syntax.Meta_monadic_lift uu___4 in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
           (match qi.FStar_Syntax_Syntax.qkind with
            | FStar_Syntax_Syntax.Quote_dynamic ->
-               let uu____3272 =
-                 let uu____3273 =
-                   let uu____3280 = subst' s tm in (uu____3280, qi) in
-                 FStar_Syntax_Syntax.Tm_quoted uu____3273 in
-               mk uu____3272
+               let uu___ =
+                 let uu___1 = let uu___2 = subst' s tm in (uu___2, qi) in
+                 FStar_Syntax_Syntax.Tm_quoted uu___1 in
+               mk uu___
            | FStar_Syntax_Syntax.Quote_static ->
                let qi1 = FStar_Syntax_Syntax.on_antiquoted (subst' s) qi in
                mk (FStar_Syntax_Syntax.Tm_quoted (tm, qi1)))
       | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
-          let uu____3294 =
-            let uu____3295 = let uu____3302 = subst' s t1 in (uu____3302, m) in
-            FStar_Syntax_Syntax.Tm_meta uu____3295 in
-          mk uu____3294
+          let uu___ =
+            let uu___1 = let uu___2 = subst' s t1 in (uu___2, m) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk uu___
 let rec (compress_slow :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -975,16 +949,16 @@ let rec (compress_slow :
     let t1 = force_uvar t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed (t', s) ->
-        let uu____3345 = push_subst s t' in compress uu____3345
-    | uu____3346 -> t1
+        let uu___ = push_subst s t' in compress uu___
+    | uu___ -> t1
 and (compress : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed (uu____3348, uu____3349) ->
+    | FStar_Syntax_Syntax.Tm_delayed (uu___, uu___1) ->
         let r = compress_slow t in r
-    | FStar_Syntax_Syntax.Tm_uvar (uu____3373, uu____3374) ->
+    | FStar_Syntax_Syntax.Tm_uvar (uu___, uu___1) ->
         let r = compress_slow t in r
-    | uu____3394 -> t
+    | uu___ -> t
 let (subst :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -994,14 +968,14 @@ let (set_use_range :
   =
   fun r ->
     fun t ->
-      let uu____3427 =
-        let uu____3428 =
-          let uu____3429 =
-            let uu____3430 = FStar_Range.use_range r in
-            FStar_Range.set_def_range r uu____3430 in
-          FStar_Syntax_Syntax.SomeUseRange uu____3429 in
-        ([], uu____3428) in
-      subst' uu____3427 t
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Range.use_range r in
+            FStar_Range.set_def_range r uu___3 in
+          FStar_Syntax_Syntax.SomeUseRange uu___2 in
+        ([], uu___1) in
+      subst' uu___ t
 let (subst_comp :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -1013,15 +987,15 @@ let (subst_imp :
 let (closing_subst :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list) =
   fun bs ->
-    let uu____3488 =
+    let uu___ =
       FStar_List.fold_right
-        (fun uu____3513 ->
-           fun uu____3514 ->
-             match (uu____3513, uu____3514) with
-             | ((x, uu____3546), (subst1, n)) ->
+        (fun uu___1 ->
+           fun uu___2 ->
+             match (uu___1, uu___2) with
+             | ((x, uu___3), (subst1, n)) ->
                  (((FStar_Syntax_Syntax.NM (x, n)) :: subst1),
                    (n + Prims.int_one))) bs ([], Prims.int_zero) in
-    FStar_All.pipe_right uu____3488 FStar_Pervasives_Native.fst
+    FStar_All.pipe_right uu___ FStar_Pervasives_Native.fst
 let (open_binders' :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.subst_t))
@@ -1032,27 +1006,23 @@ let (open_binders' :
       | [] -> ([], o)
       | (x, imp)::bs' ->
           let x' =
-            let uu___575_3673 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____3674 = subst o x.FStar_Syntax_Syntax.sort in
+            let uu___ = FStar_Syntax_Syntax.freshen_bv x in
+            let uu___1 = subst o x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___575_3673.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___575_3673.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3674
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let imp1 = subst_imp o imp in
           let o1 =
-            let uu____3681 = shift_subst Prims.int_one o in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____3681 in
-          let uu____3684 = aux bs' o1 in
-          (match uu____3684 with | (bs'1, o2) -> (((x', imp1) :: bs'1), o2)) in
+            let uu___ = shift_subst Prims.int_one o in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu___ in
+          let uu___ = aux bs' o1 in
+          (match uu___ with | (bs'1, o2) -> (((x', imp1) :: bs'1), o2)) in
     aux bs []
 let (open_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
-  fun bs ->
-    let uu____3744 = open_binders' bs in
-    FStar_Pervasives_Native.fst uu____3744
+  fun bs -> let uu___ = open_binders' bs in FStar_Pervasives_Native.fst uu___
 let (open_term' :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
@@ -1061,10 +1031,10 @@ let (open_term' :
   =
   fun bs ->
     fun t ->
-      let uu____3765 = open_binders' bs in
-      match uu____3765 with
+      let uu___ = open_binders' bs in
+      match uu___ with
       | (bs', opening) ->
-          let uu____3778 = subst opening t in (bs', uu____3778, opening)
+          let uu___1 = subst opening t in (bs', uu___1, opening)
 let (open_term :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
@@ -1072,8 +1042,8 @@ let (open_term :
   =
   fun bs ->
     fun t ->
-      let uu____3793 = open_term' bs t in
-      match uu____3793 with | (b, t1, uu____3806) -> (b, t1)
+      let uu___ = open_term' bs t in
+      match uu___ with | (b, t1, uu___1) -> (b, t1)
 let (open_comp :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.comp ->
@@ -1081,10 +1051,9 @@ let (open_comp :
   =
   fun bs ->
     fun t ->
-      let uu____3821 = open_binders' bs in
-      match uu____3821 with
-      | (bs', opening) ->
-          let uu____3832 = subst_comp opening t in (bs', uu____3832)
+      let uu___ = open_binders' bs in
+      match uu___ with
+      | (bs', opening) -> let uu___1 = subst_comp opening t in (bs', uu___1)
 let (open_pat :
   FStar_Syntax_Syntax.pat ->
     (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.subst_t))
@@ -1092,119 +1061,108 @@ let (open_pat :
   fun p ->
     let rec open_pat_aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____3881 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu___ -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-          let uu____3904 =
+          let uu___ =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____3970 ->
-                    fun uu____3971 ->
-                      match (uu____3970, uu____3971) with
+                 (fun uu___1 ->
+                    fun uu___2 ->
+                      match (uu___1, uu___2) with
                       | ((pats1, sub1), (p2, imp)) ->
-                          let uu____4074 = open_pat_aux sub1 p2 in
-                          (match uu____4074 with
+                          let uu___3 = open_pat_aux sub1 p2 in
+                          (match uu___3 with
                            | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub)) in
-          (match uu____3904 with
+          (match uu___ with
            | (pats1, sub1) ->
-               ((let uu___622_4176 = p1 in
+               ((let uu___1 = p1 in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
-                   FStar_Syntax_Syntax.p =
-                     (uu___622_4176.FStar_Syntax_Syntax.p)
+                   FStar_Syntax_Syntax.p = (uu___1.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x' =
-            let uu___626_4195 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____4196 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = FStar_Syntax_Syntax.freshen_bv x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___626_4195.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___626_4195.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4196
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let sub1 =
-            let uu____4202 = shift_subst Prims.int_one sub in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4202 in
-          ((let uu___630_4210 = p1 in
+            let uu___ = shift_subst Prims.int_one sub in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu___ in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x');
-              FStar_Syntax_Syntax.p = (uu___630_4210.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x' =
-            let uu___634_4215 = FStar_Syntax_Syntax.freshen_bv x in
-            let uu____4216 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = FStar_Syntax_Syntax.freshen_bv x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___634_4215.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___634_4215.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4216
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let sub1 =
-            let uu____4222 = shift_subst Prims.int_one sub in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4222 in
-          ((let uu___638_4230 = p1 in
+            let uu___ = shift_subst Prims.int_one sub in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu___ in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
-              FStar_Syntax_Syntax.p = (uu___638_4230.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
           let x1 =
-            let uu___644_4240 = x in
-            let uu____4241 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___644_4240.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___644_4240.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4241
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let t01 = subst sub t0 in
-          ((let uu___648_4250 = p1 in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___648_4250.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub) in
     open_pat_aux [] p
 let (open_branch' :
   FStar_Syntax_Syntax.branch ->
     (FStar_Syntax_Syntax.branch * FStar_Syntax_Syntax.subst_t))
   =
-  fun uu____4263 ->
-    match uu____4263 with
+  fun uu___ ->
+    match uu___ with
     | (p, wopt, e) ->
-        let uu____4287 = open_pat p in
-        (match uu____4287 with
+        let uu___1 = open_pat p in
+        (match uu___1 with
          | (p1, opening) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____4316 = subst opening w in
-                   FStar_Pervasives_Native.Some uu____4316 in
+                   let uu___2 = subst opening w in
+                   FStar_Pervasives_Native.Some uu___2 in
              let e1 = subst opening e in ((p1, wopt1, e1), opening))
 let (open_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
   fun br ->
-    let uu____4335 = open_branch' br in
-    match uu____4335 with | (br1, uu____4341) -> br1
+    let uu___ = open_branch' br in match uu___ with | (br1, uu___1) -> br1
 let (close :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  =
-  fun bs -> fun t -> let uu____4352 = closing_subst bs in subst uu____4352 t
+  = fun bs -> fun t -> let uu___ = closing_subst bs in subst uu___ t
 let (close_comp :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
-  =
-  fun bs ->
-    fun c -> let uu____4365 = closing_subst bs in subst_comp uu____4365 c
+  = fun bs -> fun c -> let uu___ = closing_subst bs in subst_comp uu___ c
 let (close_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
   fun bs ->
@@ -1213,20 +1171,18 @@ let (close_binders :
       | [] -> []
       | (x, imp)::tl ->
           let x1 =
-            let uu___680_4432 = x in
-            let uu____4433 = subst s x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst s x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___680_4432.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___680_4432.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4433
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let imp1 = subst_imp s imp in
           let s' =
-            let uu____4440 = shift_subst Prims.int_one s in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4440 in
-          let uu____4443 = aux s' tl in (x1, imp1) :: uu____4443 in
+            let uu___ = shift_subst Prims.int_one s in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu___ in
+          let uu___ = aux s' tl in (x1, imp1) :: uu___ in
     aux [] bs
 let (close_pat :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t ->
@@ -1236,100 +1192,93 @@ let (close_pat :
   fun p ->
     let rec aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____4506 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu___ -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-          let uu____4529 =
+          let uu___ =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____4595 ->
-                    fun uu____4596 ->
-                      match (uu____4595, uu____4596) with
+                 (fun uu___1 ->
+                    fun uu___2 ->
+                      match (uu___1, uu___2) with
                       | ((pats1, sub1), (p2, imp)) ->
-                          let uu____4699 = aux sub1 p2 in
-                          (match uu____4699 with
+                          let uu___3 = aux sub1 p2 in
+                          (match uu___3 with
                            | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub)) in
-          (match uu____4529 with
+          (match uu___ with
            | (pats1, sub1) ->
-               ((let uu___707_4801 = p1 in
+               ((let uu___1 = p1 in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
-                   FStar_Syntax_Syntax.p =
-                     (uu___707_4801.FStar_Syntax_Syntax.p)
+                   FStar_Syntax_Syntax.p = (uu___1.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x1 =
-            let uu___711_4820 = x in
-            let uu____4821 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___711_4820.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___711_4820.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4821
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let sub1 =
-            let uu____4827 = shift_subst Prims.int_one sub in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4827 in
-          ((let uu___715_4835 = p1 in
+            let uu___ = shift_subst Prims.int_one sub in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu___ in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-              FStar_Syntax_Syntax.p = (uu___715_4835.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x1 =
-            let uu___719_4840 = x in
-            let uu____4841 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___719_4840.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___719_4840.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4841
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let sub1 =
-            let uu____4847 = shift_subst Prims.int_one sub in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4847 in
-          ((let uu___723_4855 = p1 in
+            let uu___ = shift_subst Prims.int_one sub in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu___ in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-              FStar_Syntax_Syntax.p = (uu___723_4855.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
           let x1 =
-            let uu___729_4865 = x in
-            let uu____4866 = subst sub x.FStar_Syntax_Syntax.sort in
+            let uu___ = x in
+            let uu___1 = subst sub x.FStar_Syntax_Syntax.sort in
             {
-              FStar_Syntax_Syntax.ppname =
-                (uu___729_4865.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___729_4865.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4866
+              FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu___1
             } in
           let t01 = subst sub t0 in
-          ((let uu___733_4875 = p1 in
+          ((let uu___ = p1 in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___733_4875.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
             }), sub) in
     aux [] p
 let (close_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
-  fun uu____4884 ->
-    match uu____4884 with
+  fun uu___ ->
+    match uu___ with
     | (p, wopt, e) ->
-        let uu____4904 = close_pat p in
-        (match uu____4904 with
+        let uu___1 = close_pat p in
+        (match uu___1 with
          | (p1, closing) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____4941 = subst closing w in
-                   FStar_Pervasives_Native.Some uu____4941 in
+                   let uu___2 = subst closing w in
+                   FStar_Pervasives_Native.Some uu___2 in
              let e1 = subst closing e in (p1, wopt1, e1))
 let (univ_var_opening :
   FStar_Syntax_Syntax.univ_names ->
@@ -1361,8 +1310,8 @@ let (open_univ_vars :
   =
   fun us ->
     fun t ->
-      let uu____5018 = univ_var_opening us in
-      match uu____5018 with | (s, us') -> let t1 = subst s t in (us', t1)
+      let uu___ = univ_var_opening us in
+      match uu___ with | (s, us') -> let t1 = subst s t in (us', t1)
 let (open_univ_vars_comp :
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.comp ->
@@ -1370,9 +1319,9 @@ let (open_univ_vars_comp :
   =
   fun us ->
     fun c ->
-      let uu____5060 = univ_var_opening us in
-      match uu____5060 with
-      | (s, us') -> let uu____5083 = subst_comp s c in (us', uu____5083)
+      let uu___ = univ_var_opening us in
+      match uu___ with
+      | (s, us') -> let uu___1 = subst_comp s c in (us', uu___1)
 let (close_univ_vars :
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -1396,49 +1345,49 @@ let (open_let_rec :
   =
   fun lbs ->
     fun t ->
-      let uu____5139 =
-        let uu____5150 = FStar_Syntax_Syntax.is_top_level lbs in
-        if uu____5150
+      let uu___ =
+        let uu___1 = FStar_Syntax_Syntax.is_top_level lbs in
+        if uu___1
         then (Prims.int_zero, lbs, [])
         else
           FStar_List.fold_right
             (fun lb ->
-               fun uu____5183 ->
-                 match uu____5183 with
+               fun uu___3 ->
+                 match uu___3 with
                  | (i, lbs1, out) ->
                      let x =
-                       let uu____5216 =
+                       let uu___4 =
                          FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                       FStar_Syntax_Syntax.freshen_bv uu____5216 in
+                       FStar_Syntax_Syntax.freshen_bv uu___4 in
                      ((i + Prims.int_one),
-                       ((let uu___785_5222 = lb in
+                       ((let uu___4 = lb in
                          {
                            FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbunivs);
+                             (uu___4.FStar_Syntax_Syntax.lbunivs);
                            FStar_Syntax_Syntax.lbtyp =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbtyp);
+                             (uu___4.FStar_Syntax_Syntax.lbtyp);
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbeff);
+                             (uu___4.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbdef);
+                             (uu___4.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbattrs);
+                             (uu___4.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___785_5222.FStar_Syntax_Syntax.lbpos)
+                             (uu___4.FStar_Syntax_Syntax.lbpos)
                          }) :: lbs1), ((FStar_Syntax_Syntax.DB (i, x)) ::
                        out))) lbs (Prims.int_zero, [], []) in
-      match uu____5139 with
+      match uu___ with
       | (n_let_recs, lbs1, let_rec_opening) ->
           let lbs2 =
             FStar_All.pipe_right lbs1
               (FStar_List.map
                  (fun lb ->
-                    let uu____5260 =
+                    let uu___1 =
                       FStar_List.fold_right
                         (fun u ->
-                           fun uu____5288 ->
-                             match uu____5288 with
+                           fun uu___2 ->
+                             match uu___2 with
                              | (i, us, out) ->
                                  let u1 =
                                    FStar_Syntax_Syntax.new_univ_name
@@ -1448,27 +1397,27 @@ let (open_let_rec :
                                        (i, (FStar_Syntax_Syntax.U_name u1)))
                                    :: out))) lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, [], let_rec_opening) in
-                    match uu____5260 with
-                    | (uu____5329, us, u_let_rec_opening) ->
-                        let uu___802_5340 = lb in
-                        let uu____5341 =
+                    match uu___1 with
+                    | (uu___2, us, u_let_rec_opening) ->
+                        let uu___3 = lb in
+                        let uu___4 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbtyp in
-                        let uu____5344 =
+                        let uu___5 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbdef in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___802_5340.FStar_Syntax_Syntax.lbname);
+                            (uu___3.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = us;
-                          FStar_Syntax_Syntax.lbtyp = uu____5341;
+                          FStar_Syntax_Syntax.lbtyp = uu___4;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___802_5340.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5344;
+                            (uu___3.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu___5;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___802_5340.FStar_Syntax_Syntax.lbattrs);
+                            (uu___3.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___802_5340.FStar_Syntax_Syntax.lbpos)
+                            (uu___3.FStar_Syntax_Syntax.lbpos)
                         })) in
           let t1 = subst let_rec_opening t in (lbs2, t1)
 let (close_let_rec :
@@ -1478,64 +1427,63 @@ let (close_let_rec :
   =
   fun lbs ->
     fun t ->
-      let uu____5370 =
-        let uu____5377 = FStar_Syntax_Syntax.is_top_level lbs in
-        if uu____5377
+      let uu___ =
+        let uu___1 = FStar_Syntax_Syntax.is_top_level lbs in
+        if uu___1
         then (Prims.int_zero, [])
         else
           FStar_List.fold_right
             (fun lb ->
-               fun uu____5399 ->
-                 match uu____5399 with
+               fun uu___3 ->
+                 match uu___3 with
                  | (i, out) ->
-                     let uu____5418 =
-                       let uu____5421 =
-                         let uu____5422 =
-                           let uu____5427 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                           (uu____5427, i) in
-                         FStar_Syntax_Syntax.NM uu____5422 in
-                       uu____5421 :: out in
-                     ((i + Prims.int_one), uu____5418)) lbs
-            (Prims.int_zero, []) in
-      match uu____5370 with
+                           (uu___7, i) in
+                         FStar_Syntax_Syntax.NM uu___6 in
+                       uu___5 :: out in
+                     ((i + Prims.int_one), uu___4)) lbs (Prims.int_zero, []) in
+      match uu___ with
       | (n_let_recs, let_rec_closing) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb ->
-                    let uu____5459 =
+                    let uu___1 =
                       FStar_List.fold_right
                         (fun u ->
-                           fun uu____5477 ->
-                             match uu____5477 with
+                           fun uu___2 ->
+                             match uu___2 with
                              | (i, out) ->
                                  ((i + Prims.int_one),
                                    ((FStar_Syntax_Syntax.UD (u, i)) :: out)))
                         lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, let_rec_closing) in
-                    match uu____5459 with
-                    | (uu____5500, u_let_rec_closing) ->
-                        let uu___824_5506 = lb in
-                        let uu____5507 =
+                    match uu___1 with
+                    | (uu___2, u_let_rec_closing) ->
+                        let uu___3 = lb in
+                        let uu___4 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbtyp in
-                        let uu____5510 =
+                        let uu___5 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbdef in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___824_5506.FStar_Syntax_Syntax.lbname);
+                            (uu___3.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___824_5506.FStar_Syntax_Syntax.lbunivs);
-                          FStar_Syntax_Syntax.lbtyp = uu____5507;
+                            (uu___3.FStar_Syntax_Syntax.lbunivs);
+                          FStar_Syntax_Syntax.lbtyp = uu___4;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___824_5506.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5510;
+                            (uu___3.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu___5;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___824_5506.FStar_Syntax_Syntax.lbattrs);
+                            (uu___3.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___824_5506.FStar_Syntax_Syntax.lbpos)
+                            (uu___3.FStar_Syntax_Syntax.lbpos)
                         })) in
           let t1 = subst let_rec_closing t in (lbs1, t1)
 let (close_tscheme :
@@ -1543,26 +1491,26 @@ let (close_tscheme :
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun binders ->
-    fun uu____5525 ->
-      match uu____5525 with
+    fun uu___ ->
+      match uu___ with
       | (us, t) ->
           let n = (FStar_List.length binders) - Prims.int_one in
           let k = FStar_List.length us in
           let s =
             FStar_List.mapi
               (fun i ->
-                 fun uu____5558 ->
-                   match uu____5558 with
-                   | (x, uu____5566) ->
-                       FStar_Syntax_Syntax.NM (x, (k + (n - i)))) binders in
+                 fun uu___1 ->
+                   match uu___1 with
+                   | (x, uu___2) -> FStar_Syntax_Syntax.NM (x, (k + (n - i))))
+              binders in
           let t1 = subst s t in (us, t1)
 let (close_univ_vars_tscheme :
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun us ->
-    fun uu____5585 ->
-      match uu____5585 with
+    fun uu___ ->
+      match uu___ with
       | (us', t) ->
           let n = (FStar_List.length us) - Prims.int_one in
           let k = FStar_List.length us' in
@@ -1570,17 +1518,17 @@ let (close_univ_vars_tscheme :
             FStar_List.mapi
               (fun i -> fun x -> FStar_Syntax_Syntax.UD (x, (k + (n - i))))
               us in
-          let uu____5605 = subst s t in (us', uu____5605)
+          let uu___1 = subst s t in (us', uu___1)
 let (subst_tscheme :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun s ->
-    fun uu____5623 ->
-      match uu____5623 with
+    fun uu___ ->
+      match uu___ with
       | (us, t) ->
           let s1 = shift_subst (FStar_List.length us) s in
-          let uu____5637 = subst s1 t in (us, uu____5637)
+          let uu___1 = subst s1 t in (us, uu___1)
 let (opening_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
   fun bs ->
@@ -1588,9 +1536,9 @@ let (opening_of_binders :
     FStar_All.pipe_right bs
       (FStar_List.mapi
          (fun i ->
-            fun uu____5675 ->
-              match uu____5675 with
-              | (x, uu____5683) -> FStar_Syntax_Syntax.DB ((n - i), x)))
+            fun uu___ ->
+              match uu___ with
+              | (x, uu___1) -> FStar_Syntax_Syntax.DB ((n - i), x)))
 let (closing_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
   fun bs -> closing_subst bs
@@ -1601,10 +1549,10 @@ let (open_term_1 :
   =
   fun b ->
     fun t ->
-      let uu____5707 = open_term [b] t in
-      match uu____5707 with
+      let uu___ = open_term [b] t in
+      match uu___ with
       | (b1::[], t1) -> (b1, t1)
-      | uu____5748 -> failwith "impossible: open_term_1"
+      | uu___1 -> failwith "impossible: open_term_1"
 let (open_term_bvs :
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.term ->
@@ -1612,13 +1560,13 @@ let (open_term_bvs :
   =
   fun bvs ->
     fun t ->
-      let uu____5777 =
-        let uu____5782 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
-        open_term uu____5782 t in
-      match uu____5777 with
+      let uu___ =
+        let uu___1 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
+        open_term uu___1 t in
+      match uu___ with
       | (bs, t1) ->
-          let uu____5797 = FStar_List.map FStar_Pervasives_Native.fst bs in
-          (uu____5797, t1)
+          let uu___1 = FStar_List.map FStar_Pervasives_Native.fst bs in
+          (uu___1, t1)
 let (open_term_bv :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term ->
@@ -1626,7 +1574,7 @@ let (open_term_bv :
   =
   fun bv ->
     fun t ->
-      let uu____5824 = open_term_bvs [bv] t in
-      match uu____5824 with
+      let uu___ = open_term_bvs [bv] t in
+      match uu___ with
       | (bv1::[], t1) -> (bv1, t1)
-      | uu____5839 -> failwith "impossible: open_term_bv"
+      | uu___1 -> failwith "impossible: open_term_bv"

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -17,30 +17,28 @@ type pragma =
   | LightOff [@@deriving yojson,show]
 let (uu___is_SetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | SetOptions _0 -> true | uu____169 -> false
+    match projectee with | SetOptions _0 -> true | uu___ -> false
 let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
   fun projectee -> match projectee with | SetOptions _0 -> _0
 let (uu___is_ResetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | ResetOptions _0 -> true | uu____184 -> false
+    match projectee with | ResetOptions _0 -> true | uu___ -> false
 let (__proj__ResetOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | ResetOptions _0 -> _0
 let (uu___is_PushOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | PushOptions _0 -> true | uu____205 -> false
+    match projectee with | PushOptions _0 -> true | uu___ -> false
 let (__proj__PushOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | PushOptions _0 -> _0
 let (uu___is_PopOptions : pragma -> Prims.bool) =
-  fun projectee ->
-    match projectee with | PopOptions -> true | uu____223 -> false
+  fun projectee -> match projectee with | PopOptions -> true | uu___ -> false
 let (uu___is_RestartSolver : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | RestartSolver -> true | uu____229 -> false
+    match projectee with | RestartSolver -> true | uu___ -> false
 let (uu___is_LightOff : pragma -> Prims.bool) =
-  fun projectee ->
-    match projectee with | LightOff -> true | uu____235 -> false
+  fun projectee -> match projectee with | LightOff -> true | uu___ -> false
 type 'a memo =
   (('a FStar_Pervasives_Native.option FStar_ST.ref)[@printer
                                                      fun fmt ->
@@ -54,15 +52,13 @@ type emb_typ =
   | ET_app of (Prims.string * emb_typ Prims.list) 
 let (uu___is_ET_abstract : emb_typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | ET_abstract -> true | uu____269 -> false
+    match projectee with | ET_abstract -> true | uu___ -> false
 let (uu___is_ET_fun : emb_typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ET_fun _0 -> true | uu____280 -> false
+  fun projectee -> match projectee with | ET_fun _0 -> true | uu___ -> false
 let (__proj__ET_fun__item___0 : emb_typ -> (emb_typ * emb_typ)) =
   fun projectee -> match projectee with | ET_fun _0 -> _0
 let (uu___is_ET_app : emb_typ -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ET_app _0 -> true | uu____311 -> false
+  fun projectee -> match projectee with | ET_app _0 -> true | uu___ -> false
 let (__proj__ET_app__item___0 :
   emb_typ -> (Prims.string * emb_typ Prims.list)) =
   fun projectee -> match projectee with | ET_app _0 -> _0
@@ -83,38 +79,32 @@ type universe =
   * version * FStar_Range.range) 
   | U_unknown [@@deriving yojson,show]
 let (uu___is_U_zero : universe -> Prims.bool) =
-  fun projectee -> match projectee with | U_zero -> true | uu____402 -> false
+  fun projectee -> match projectee with | U_zero -> true | uu___ -> false
 let (uu___is_U_succ : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_succ _0 -> true | uu____409 -> false
+  fun projectee -> match projectee with | U_succ _0 -> true | uu___ -> false
 let (__proj__U_succ__item___0 : universe -> universe) =
   fun projectee -> match projectee with | U_succ _0 -> _0
 let (uu___is_U_max : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_max _0 -> true | uu____424 -> false
+  fun projectee -> match projectee with | U_max _0 -> true | uu___ -> false
 let (__proj__U_max__item___0 : universe -> universe Prims.list) =
   fun projectee -> match projectee with | U_max _0 -> _0
 let (uu___is_U_bvar : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_bvar _0 -> true | uu____443 -> false
+  fun projectee -> match projectee with | U_bvar _0 -> true | uu___ -> false
 let (__proj__U_bvar__item___0 : universe -> Prims.int) =
   fun projectee -> match projectee with | U_bvar _0 -> _0
 let (uu___is_U_name : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_name _0 -> true | uu____456 -> false
+  fun projectee -> match projectee with | U_name _0 -> true | uu___ -> false
 let (__proj__U_name__item___0 : universe -> FStar_Ident.ident) =
   fun projectee -> match projectee with | U_name _0 -> _0
 let (uu___is_U_unif : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_unif _0 -> true | uu____479 -> false
+  fun projectee -> match projectee with | U_unif _0 -> true | uu___ -> false
 let (__proj__U_unif__item___0 :
   universe ->
     (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version
       * FStar_Range.range))
   = fun projectee -> match projectee with | U_unif _0 -> _0
 let (uu___is_U_unknown : universe -> Prims.bool) =
-  fun projectee ->
-    match projectee with | U_unknown -> true | uu____521 -> false
+  fun projectee -> match projectee with | U_unknown -> true | uu___ -> false
 type univ_name = FStar_Ident.ident[@@deriving yojson,show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version *
@@ -127,19 +117,18 @@ type quote_kind =
   | Quote_dynamic [@@deriving yojson,show]
 let (uu___is_Quote_static : quote_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Quote_static -> true | uu____541 -> false
+    match projectee with | Quote_static -> true | uu___ -> false
 let (uu___is_Quote_dynamic : quote_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Quote_dynamic -> true | uu____547 -> false
+    match projectee with | Quote_dynamic -> true | uu___ -> false
 type maybe_set_use_range =
   | NoUseRange 
   | SomeUseRange of FStar_Range.range [@@deriving yojson,show]
 let (uu___is_NoUseRange : maybe_set_use_range -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoUseRange -> true | uu____558 -> false
+  fun projectee -> match projectee with | NoUseRange -> true | uu___ -> false
 let (uu___is_SomeUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee ->
-    match projectee with | SomeUseRange _0 -> true | uu____565 -> false
+    match projectee with | SomeUseRange _0 -> true | uu___ -> false
 let (__proj__SomeUseRange__item___0 :
   maybe_set_use_range -> FStar_Range.range) =
   fun projectee -> match projectee with | SomeUseRange _0 -> _0
@@ -151,20 +140,20 @@ let (uu___is_Delta_constant_at_level : delta_depth -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Delta_constant_at_level _0 -> true
-    | uu____593 -> false
+    | uu___ -> false
 let (__proj__Delta_constant_at_level__item___0 : delta_depth -> Prims.int) =
   fun projectee -> match projectee with | Delta_constant_at_level _0 -> _0
 let (uu___is_Delta_equational_at_level : delta_depth -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Delta_equational_at_level _0 -> true
-    | uu____606 -> false
+    | uu___ -> false
 let (__proj__Delta_equational_at_level__item___0 : delta_depth -> Prims.int)
   =
   fun projectee -> match projectee with | Delta_equational_at_level _0 -> _0
 let (uu___is_Delta_abstract : delta_depth -> Prims.bool) =
   fun projectee ->
-    match projectee with | Delta_abstract _0 -> true | uu____619 -> false
+    match projectee with | Delta_abstract _0 -> true | uu___ -> false
 let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
   fun projectee -> match projectee with | Delta_abstract _0 -> _0
 type should_check_uvar =
@@ -173,12 +162,12 @@ type should_check_uvar =
   | Strict [@@deriving yojson,show]
 let (uu___is_Allow_unresolved : should_check_uvar -> Prims.bool) =
   fun projectee ->
-    match projectee with | Allow_unresolved -> true | uu____631 -> false
+    match projectee with | Allow_unresolved -> true | uu___ -> false
 let (uu___is_Allow_untyped : should_check_uvar -> Prims.bool) =
   fun projectee ->
-    match projectee with | Allow_untyped -> true | uu____637 -> false
+    match projectee with | Allow_untyped -> true | uu___ -> false
 let (uu___is_Strict : should_check_uvar -> Prims.bool) =
-  fun projectee -> match projectee with | Strict -> true | uu____643 -> false
+  fun projectee -> match projectee with | Strict -> true | uu___ -> false
 type term' =
   | Tm_bvar of bv 
   | Tm_name of bv 
@@ -345,38 +334,33 @@ and arg_qualifier_meta_t =
   | Arg_qualifier_meta_tac of term' syntax 
   | Arg_qualifier_meta_attr of term' syntax 
 let (uu___is_Tm_bvar : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_bvar _0 -> true | uu____1503 -> false
+  fun projectee -> match projectee with | Tm_bvar _0 -> true | uu___ -> false
 let (__proj__Tm_bvar__item___0 : term' -> bv) =
   fun projectee -> match projectee with | Tm_bvar _0 -> _0
 let (uu___is_Tm_name : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_name _0 -> true | uu____1516 -> false
+  fun projectee -> match projectee with | Tm_name _0 -> true | uu___ -> false
 let (__proj__Tm_name__item___0 : term' -> bv) =
   fun projectee -> match projectee with | Tm_name _0 -> _0
 let (uu___is_Tm_fvar : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_fvar _0 -> true | uu____1529 -> false
+  fun projectee -> match projectee with | Tm_fvar _0 -> true | uu___ -> false
 let (__proj__Tm_fvar__item___0 : term' -> fv) =
   fun projectee -> match projectee with | Tm_fvar _0 -> _0
 let (uu___is_Tm_uinst : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_uinst _0 -> true | uu____1548 -> false
+    match projectee with | Tm_uinst _0 -> true | uu___ -> false
 let (__proj__Tm_uinst__item___0 : term' -> (term' syntax * universes)) =
   fun projectee -> match projectee with | Tm_uinst _0 -> _0
 let (uu___is_Tm_constant : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_constant _0 -> true | uu____1579 -> false
+    match projectee with | Tm_constant _0 -> true | uu___ -> false
 let (__proj__Tm_constant__item___0 : term' -> sconst) =
   fun projectee -> match projectee with | Tm_constant _0 -> _0
 let (uu___is_Tm_type : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_type _0 -> true | uu____1592 -> false
+  fun projectee -> match projectee with | Tm_type _0 -> true | uu___ -> false
 let (__proj__Tm_type__item___0 : term' -> universe) =
   fun projectee -> match projectee with | Tm_type _0 -> _0
 let (uu___is_Tm_abs : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_abs _0 -> true | uu____1623 -> false
+  fun projectee -> match projectee with | Tm_abs _0 -> true | uu___ -> false
 let (__proj__Tm_abs__item___0 :
   term' ->
     ((bv * arg_qualifier FStar_Pervasives_Native.option) Prims.list * term'
@@ -384,7 +368,7 @@ let (__proj__Tm_abs__item___0 :
   = fun projectee -> match projectee with | Tm_abs _0 -> _0
 let (uu___is_Tm_arrow : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_arrow _0 -> true | uu____1704 -> false
+    match projectee with | Tm_arrow _0 -> true | uu___ -> false
 let (__proj__Tm_arrow__item___0 :
   term' ->
     ((bv * arg_qualifier FStar_Pervasives_Native.option) Prims.list * comp'
@@ -392,12 +376,11 @@ let (__proj__Tm_arrow__item___0 :
   = fun projectee -> match projectee with | Tm_arrow _0 -> _0
 let (uu___is_Tm_refine : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_refine _0 -> true | uu____1765 -> false
+    match projectee with | Tm_refine _0 -> true | uu___ -> false
 let (__proj__Tm_refine__item___0 : term' -> (bv * term' syntax)) =
   fun projectee -> match projectee with | Tm_refine _0 -> _0
 let (uu___is_Tm_app : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_app _0 -> true | uu____1812 -> false
+  fun projectee -> match projectee with | Tm_app _0 -> true | uu___ -> false
 let (__proj__Tm_app__item___0 :
   term' ->
     (term' syntax * (term' syntax * arg_qualifier
@@ -405,7 +388,7 @@ let (__proj__Tm_app__item___0 :
   = fun projectee -> match projectee with | Tm_app _0 -> _0
 let (uu___is_Tm_match : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_match _0 -> true | uu____1895 -> false
+    match projectee with | Tm_match _0 -> true | uu___ -> false
 let (__proj__Tm_match__item___0 :
   term' ->
     (term' syntax * (pat' withinfo_t * term' syntax
@@ -413,7 +396,7 @@ let (__proj__Tm_match__item___0 :
   = fun projectee -> match projectee with | Tm_match _0 -> _0
 let (uu___is_Tm_ascribed : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_ascribed _0 -> true | uu____2000 -> false
+    match projectee with | Tm_ascribed _0 -> true | uu___ -> false
 let (__proj__Tm_ascribed__item___0 :
   term' ->
     (term' syntax * ((term' syntax, comp' syntax) FStar_Util.either * term'
@@ -421,43 +404,38 @@ let (__proj__Tm_ascribed__item___0 :
       FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | Tm_ascribed _0 -> _0
 let (uu___is_Tm_let : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_let _0 -> true | uu____2103 -> false
+  fun projectee -> match projectee with | Tm_let _0 -> true | uu___ -> false
 let (__proj__Tm_let__item___0 :
   term' -> ((Prims.bool * letbinding Prims.list) * term' syntax)) =
   fun projectee -> match projectee with | Tm_let _0 -> _0
 let (uu___is_Tm_uvar : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_uvar _0 -> true | uu____2164 -> false
+  fun projectee -> match projectee with | Tm_uvar _0 -> true | uu___ -> false
 let (__proj__Tm_uvar__item___0 :
   term' ->
     (ctx_uvar * (subst_elt Prims.list Prims.list * maybe_set_use_range)))
   = fun projectee -> match projectee with | Tm_uvar _0 -> _0
 let (uu___is_Tm_delayed : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_delayed _0 -> true | uu____2227 -> false
+    match projectee with | Tm_delayed _0 -> true | uu___ -> false
 let (__proj__Tm_delayed__item___0 :
   term' ->
     (term' syntax * (subst_elt Prims.list Prims.list * maybe_set_use_range)))
   = fun projectee -> match projectee with | Tm_delayed _0 -> _0
 let (uu___is_Tm_meta : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_meta _0 -> true | uu____2288 -> false
+  fun projectee -> match projectee with | Tm_meta _0 -> true | uu___ -> false
 let (__proj__Tm_meta__item___0 : term' -> (term' syntax * metadata)) =
   fun projectee -> match projectee with | Tm_meta _0 -> _0
 let (uu___is_Tm_lazy : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_lazy _0 -> true | uu____2319 -> false
+  fun projectee -> match projectee with | Tm_lazy _0 -> true | uu___ -> false
 let (__proj__Tm_lazy__item___0 : term' -> lazyinfo) =
   fun projectee -> match projectee with | Tm_lazy _0 -> _0
 let (uu___is_Tm_quoted : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_quoted _0 -> true | uu____2338 -> false
+    match projectee with | Tm_quoted _0 -> true | uu___ -> false
 let (__proj__Tm_quoted__item___0 : term' -> (term' syntax * quoteinfo)) =
   fun projectee -> match projectee with | Tm_quoted _0 -> _0
 let (uu___is_Tm_unknown : term' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tm_unknown -> true | uu____2368 -> false
+  fun projectee -> match projectee with | Tm_unknown -> true | uu___ -> false
 let (__proj__Mkctx_uvar__item__ctx_uvar_head :
   ctx_uvar ->
     (term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar *
@@ -518,41 +496,38 @@ let (__proj__Mkctx_uvar__item__ctx_uvar_meta :
         ctx_uvar_meta;_} -> ctx_uvar_meta
 let (uu___is_Ctx_uvar_meta_tac : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Ctx_uvar_meta_tac _0 -> true | uu____2745 -> false
+    match projectee with | Ctx_uvar_meta_tac _0 -> true | uu___ -> false
 let (__proj__Ctx_uvar_meta_tac__item___0 :
   ctx_uvar_meta_t -> (FStar_Dyn.dyn * term' syntax)) =
   fun projectee -> match projectee with | Ctx_uvar_meta_tac _0 -> _0
 let (uu___is_Ctx_uvar_meta_attr : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Ctx_uvar_meta_attr _0 -> true
-    | uu____2778 -> false
+    match projectee with | Ctx_uvar_meta_attr _0 -> true | uu___ -> false
 let (__proj__Ctx_uvar_meta_attr__item___0 : ctx_uvar_meta_t -> term' syntax)
   = fun projectee -> match projectee with | Ctx_uvar_meta_attr _0 -> _0
 let (uu___is_Pat_constant : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_constant _0 -> true | uu____2797 -> false
+    match projectee with | Pat_constant _0 -> true | uu___ -> false
 let (__proj__Pat_constant__item___0 : pat' -> sconst) =
   fun projectee -> match projectee with | Pat_constant _0 -> _0
 let (uu___is_Pat_cons : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_cons _0 -> true | uu____2822 -> false
+    match projectee with | Pat_cons _0 -> true | uu___ -> false
 let (__proj__Pat_cons__item___0 :
   pat' -> (fv * (pat' withinfo_t * Prims.bool) Prims.list)) =
   fun projectee -> match projectee with | Pat_cons _0 -> _0
 let (uu___is_Pat_var : pat' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Pat_var _0 -> true | uu____2871 -> false
+  fun projectee -> match projectee with | Pat_var _0 -> true | uu___ -> false
 let (__proj__Pat_var__item___0 : pat' -> bv) =
   fun projectee -> match projectee with | Pat_var _0 -> _0
 let (uu___is_Pat_wild : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_wild _0 -> true | uu____2884 -> false
+    match projectee with | Pat_wild _0 -> true | uu___ -> false
 let (__proj__Pat_wild__item___0 : pat' -> bv) =
   fun projectee -> match projectee with | Pat_wild _0 -> _0
 let (uu___is_Pat_dot_term : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_dot_term _0 -> true | uu____2903 -> false
+    match projectee with | Pat_dot_term _0 -> true | uu___ -> false
 let (__proj__Pat_dot_term__item___0 : pat' -> (bv * term' syntax)) =
   fun projectee -> match projectee with | Pat_dot_term _0 -> _0
 let (__proj__Mkletbinding__item__lbname :
@@ -621,56 +596,49 @@ let (__proj__Mkcomp_typ__item__flags : comp_typ -> cflag Prims.list) =
     match projectee with
     | { comp_univs; effect_name; result_typ; effect_args; flags;_} -> flags
 let (uu___is_Total : comp' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Total _0 -> true | uu____3346 -> false
+  fun projectee -> match projectee with | Total _0 -> true | uu___ -> false
 let (__proj__Total__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Total _0 -> _0
 let (uu___is_GTotal : comp' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | GTotal _0 -> true | uu____3391 -> false
+  fun projectee -> match projectee with | GTotal _0 -> true | uu___ -> false
 let (__proj__GTotal__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | GTotal _0 -> _0
 let (uu___is_Comp : comp' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Comp _0 -> true | uu____3428 -> false
+  fun projectee -> match projectee with | Comp _0 -> true | uu___ -> false
 let (__proj__Comp__item___0 : comp' -> comp_typ) =
   fun projectee -> match projectee with | Comp _0 -> _0
 let (uu___is_TOTAL : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | TOTAL -> true | uu____3440 -> false
+  fun projectee -> match projectee with | TOTAL -> true | uu___ -> false
 let (uu___is_MLEFFECT : cflag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLEFFECT -> true | uu____3446 -> false
+  fun projectee -> match projectee with | MLEFFECT -> true | uu___ -> false
 let (uu___is_LEMMA : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | LEMMA -> true | uu____3452 -> false
+  fun projectee -> match projectee with | LEMMA -> true | uu___ -> false
 let (uu___is_RETURN : cflag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | RETURN -> true | uu____3458 -> false
+  fun projectee -> match projectee with | RETURN -> true | uu___ -> false
 let (uu___is_PARTIAL_RETURN : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | PARTIAL_RETURN -> true | uu____3464 -> false
+    match projectee with | PARTIAL_RETURN -> true | uu___ -> false
 let (uu___is_SOMETRIVIAL : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SOMETRIVIAL -> true | uu____3470 -> false
+    match projectee with | SOMETRIVIAL -> true | uu___ -> false
 let (uu___is_TRIVIAL_POSTCONDITION : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | TRIVIAL_POSTCONDITION -> true
-    | uu____3476 -> false
+    match projectee with | TRIVIAL_POSTCONDITION -> true | uu___ -> false
 let (uu___is_SHOULD_NOT_INLINE : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SHOULD_NOT_INLINE -> true | uu____3482 -> false
+    match projectee with | SHOULD_NOT_INLINE -> true | uu___ -> false
 let (uu___is_CPS : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | CPS -> true | uu____3488 -> false
+  fun projectee -> match projectee with | CPS -> true | uu___ -> false
 let (uu___is_DECREASES : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | DECREASES _0 -> true | uu____3497 -> false
+    match projectee with | DECREASES _0 -> true | uu___ -> false
 let (__proj__DECREASES__item___0 : cflag -> term' syntax) =
   fun projectee -> match projectee with | DECREASES _0 -> _0
 let (uu___is_Meta_pattern : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_pattern _0 -> true | uu____3536 -> false
+    match projectee with | Meta_pattern _0 -> true | uu___ -> false
 let (__proj__Meta_pattern__item___0 :
   metadata ->
     (term' syntax Prims.list * (term' syntax * arg_qualifier
@@ -678,77 +646,74 @@ let (__proj__Meta_pattern__item___0 :
   = fun projectee -> match projectee with | Meta_pattern _0 -> _0
 let (uu___is_Meta_named : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_named _0 -> true | uu____3609 -> false
+    match projectee with | Meta_named _0 -> true | uu___ -> false
 let (__proj__Meta_named__item___0 : metadata -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Meta_named _0 -> _0
 let (uu___is_Meta_labeled : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_labeled _0 -> true | uu____3628 -> false
+    match projectee with | Meta_labeled _0 -> true | uu___ -> false
 let (__proj__Meta_labeled__item___0 :
   metadata -> (Prims.string * FStar_Range.range * Prims.bool)) =
   fun projectee -> match projectee with | Meta_labeled _0 -> _0
 let (uu___is_Meta_desugared : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_desugared _0 -> true | uu____3659 -> false
+    match projectee with | Meta_desugared _0 -> true | uu___ -> false
 let (__proj__Meta_desugared__item___0 : metadata -> meta_source_info) =
   fun projectee -> match projectee with | Meta_desugared _0 -> _0
 let (uu___is_Meta_monadic : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_monadic _0 -> true | uu____3678 -> false
+    match projectee with | Meta_monadic _0 -> true | uu___ -> false
 let (__proj__Meta_monadic__item___0 :
   metadata -> (monad_name * term' syntax)) =
   fun projectee -> match projectee with | Meta_monadic _0 -> _0
 let (uu___is_Meta_monadic_lift : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_monadic_lift _0 -> true | uu____3717 -> false
+    match projectee with | Meta_monadic_lift _0 -> true | uu___ -> false
 let (__proj__Meta_monadic_lift__item___0 :
   metadata -> (monad_name * monad_name * term' syntax)) =
   fun projectee -> match projectee with | Meta_monadic_lift _0 -> _0
 let (uu___is_Sequence : meta_source_info -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Sequence -> true | uu____3753 -> false
+  fun projectee -> match projectee with | Sequence -> true | uu___ -> false
 let (uu___is_Primop : meta_source_info -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Primop -> true | uu____3759 -> false
+  fun projectee -> match projectee with | Primop -> true | uu___ -> false
 let (uu___is_Masked_effect : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Masked_effect -> true | uu____3765 -> false
+    match projectee with | Masked_effect -> true | uu___ -> false
 let (uu___is_Meta_smt_pat : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_smt_pat -> true | uu____3771 -> false
+    match projectee with | Meta_smt_pat -> true | uu___ -> false
 let (uu___is_Data_ctor : fv_qual -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Data_ctor -> true | uu____3777 -> false
+  fun projectee -> match projectee with | Data_ctor -> true | uu___ -> false
 let (uu___is_Record_projector : fv_qual -> Prims.bool) =
   fun projectee ->
-    match projectee with | Record_projector _0 -> true | uu____3788 -> false
+    match projectee with | Record_projector _0 -> true | uu___ -> false
 let (__proj__Record_projector__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Record_projector _0 -> _0
 let (uu___is_Record_ctor : fv_qual -> Prims.bool) =
   fun projectee ->
-    match projectee with | Record_ctor _0 -> true | uu____3819 -> false
+    match projectee with | Record_ctor _0 -> true | uu___ -> false
 let (__proj__Record_ctor__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident Prims.list)) =
   fun projectee -> match projectee with | Record_ctor _0 -> _0
 let (uu___is_DB : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | DB _0 -> true | uu____3854 -> false
+  fun projectee -> match projectee with | DB _0 -> true | uu___ -> false
 let (__proj__DB__item___0 : subst_elt -> (Prims.int * bv)) =
   fun projectee -> match projectee with | DB _0 -> _0
 let (uu___is_NM : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | NM _0 -> true | uu____3883 -> false
+  fun projectee -> match projectee with | NM _0 -> true | uu___ -> false
 let (__proj__NM__item___0 : subst_elt -> (bv * Prims.int)) =
   fun projectee -> match projectee with | NM _0 -> _0
 let (uu___is_NT : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | NT _0 -> true | uu____3914 -> false
+  fun projectee -> match projectee with | NT _0 -> true | uu___ -> false
 let (__proj__NT__item___0 : subst_elt -> (bv * term' syntax)) =
   fun projectee -> match projectee with | NT _0 -> _0
 let (uu___is_UN : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | UN _0 -> true | uu____3949 -> false
+  fun projectee -> match projectee with | UN _0 -> true | uu___ -> false
 let (__proj__UN__item___0 : subst_elt -> (Prims.int * universe)) =
   fun projectee -> match projectee with | UN _0 -> _0
 let (uu___is_UD : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | UD _0 -> true | uu____3978 -> false
+  fun projectee -> match projectee with | UD _0 -> true | uu___ -> false
 let (__proj__UD__item___0 : subst_elt -> (univ_name * Prims.int)) =
   fun projectee -> match projectee with | UD _0 -> _0
 let __proj__Mksyntax__item__n : 'a . 'a syntax -> 'a =
@@ -821,78 +786,67 @@ let (__proj__Mklazyinfo__item__ltyp : lazyinfo -> term' syntax) =
 let (__proj__Mklazyinfo__item__rng : lazyinfo -> FStar_Range.range) =
   fun projectee -> match projectee with | { blob; lkind; ltyp; rng;_} -> rng
 let (uu___is_BadLazy : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BadLazy -> true | uu____4315 -> false
+  fun projectee -> match projectee with | BadLazy -> true | uu___ -> false
 let (uu___is_Lazy_bv : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_bv -> true | uu____4321 -> false
+  fun projectee -> match projectee with | Lazy_bv -> true | uu___ -> false
 let (uu___is_Lazy_binder : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_binder -> true | uu____4327 -> false
+    match projectee with | Lazy_binder -> true | uu___ -> false
 let (uu___is_Lazy_optionstate : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_optionstate -> true | uu____4333 -> false
+    match projectee with | Lazy_optionstate -> true | uu___ -> false
 let (uu___is_Lazy_fvar : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_fvar -> true | uu____4339 -> false
+  fun projectee -> match projectee with | Lazy_fvar -> true | uu___ -> false
 let (uu___is_Lazy_comp : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_comp -> true | uu____4345 -> false
+  fun projectee -> match projectee with | Lazy_comp -> true | uu___ -> false
 let (uu___is_Lazy_env : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_env -> true | uu____4351 -> false
+  fun projectee -> match projectee with | Lazy_env -> true | uu___ -> false
 let (uu___is_Lazy_proofstate : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_proofstate -> true | uu____4357 -> false
+    match projectee with | Lazy_proofstate -> true | uu___ -> false
 let (uu___is_Lazy_goal : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_goal -> true | uu____4363 -> false
+  fun projectee -> match projectee with | Lazy_goal -> true | uu___ -> false
 let (uu___is_Lazy_sigelt : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_sigelt -> true | uu____4369 -> false
+    match projectee with | Lazy_sigelt -> true | uu___ -> false
 let (uu___is_Lazy_uvar : lazy_kind -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy_uvar -> true | uu____4375 -> false
+  fun projectee -> match projectee with | Lazy_uvar -> true | uu___ -> false
 let (uu___is_Lazy_embedding : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_embedding _0 -> true | uu____4390 -> false
+    match projectee with | Lazy_embedding _0 -> true | uu___ -> false
 let (__proj__Lazy_embedding__item___0 :
   lazy_kind -> (emb_typ * term' syntax FStar_Thunk.t)) =
   fun projectee -> match projectee with | Lazy_embedding _0 -> _0
 let (uu___is_Binding_var : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_var _0 -> true | uu____4427 -> false
+    match projectee with | Binding_var _0 -> true | uu___ -> false
 let (__proj__Binding_var__item___0 : binding -> bv) =
   fun projectee -> match projectee with | Binding_var _0 -> _0
 let (uu___is_Binding_lid : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_lid _0 -> true | uu____4452 -> false
+    match projectee with | Binding_lid _0 -> true | uu___ -> false
 let (__proj__Binding_lid__item___0 :
   binding -> (FStar_Ident.lident * (univ_name Prims.list * term' syntax))) =
   fun projectee -> match projectee with | Binding_lid _0 -> _0
 let (uu___is_Binding_univ : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_univ _0 -> true | uu____4501 -> false
+    match projectee with | Binding_univ _0 -> true | uu___ -> false
 let (__proj__Binding_univ__item___0 : binding -> univ_name) =
   fun projectee -> match projectee with | Binding_univ _0 -> _0
 let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Implicit _0 -> true | uu____4514 -> false
+    match projectee with | Implicit _0 -> true | uu___ -> false
 let (__proj__Implicit__item___0 : arg_qualifier -> Prims.bool) =
   fun projectee -> match projectee with | Implicit _0 -> _0
 let (uu___is_Meta : arg_qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Meta _0 -> true | uu____4527 -> false
+  fun projectee -> match projectee with | Meta _0 -> true | uu___ -> false
 let (__proj__Meta__item___0 : arg_qualifier -> arg_qualifier_meta_t) =
   fun projectee -> match projectee with | Meta _0 -> _0
 let (uu___is_Equality : arg_qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Equality -> true | uu____4539 -> false
+  fun projectee -> match projectee with | Equality -> true | uu___ -> false
 let (uu___is_Arg_qualifier_meta_tac : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Arg_qualifier_meta_tac _0 -> true
-    | uu____4548 -> false
+    match projectee with | Arg_qualifier_meta_tac _0 -> true | uu___ -> false
 let (__proj__Arg_qualifier_meta_tac__item___0 :
   arg_qualifier_meta_t -> term' syntax) =
   fun projectee -> match projectee with | Arg_qualifier_meta_tac _0 -> _0
@@ -900,7 +854,7 @@ let (uu___is_Arg_qualifier_meta_attr : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Arg_qualifier_meta_attr _0 -> true
-    | uu____4569 -> false
+    | uu___ -> false
 let (__proj__Arg_qualifier_meta_attr__item___0 :
   arg_qualifier_meta_t -> term' syntax) =
   fun projectee -> match projectee with | Arg_qualifier_meta_attr _0 -> _0
@@ -967,90 +921,80 @@ type qualifier =
   | Effect 
   | OnlyName 
 let (uu___is_Assumption : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Assumption -> true | uu____4813 -> false
+  fun projectee -> match projectee with | Assumption -> true | uu___ -> false
 let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | New -> true | uu____4819 -> false
+  fun projectee -> match projectee with | New -> true | uu___ -> false
 let (uu___is_Private : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Private -> true | uu____4825 -> false
+  fun projectee -> match projectee with | Private -> true | uu___ -> false
 let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Unfold_for_unification_and_vcgen -> true
-    | uu____4831 -> false
+    | uu___ -> false
 let (uu___is_Visible_default : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Visible_default -> true | uu____4837 -> false
+    match projectee with | Visible_default -> true | uu___ -> false
 let (uu___is_Irreducible : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Irreducible -> true | uu____4843 -> false
+    match projectee with | Irreducible -> true | uu___ -> false
 let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Inline_for_extraction -> true
-    | uu____4849 -> false
+    match projectee with | Inline_for_extraction -> true | uu___ -> false
 let (uu___is_NoExtract : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoExtract -> true | uu____4855 -> false
+  fun projectee -> match projectee with | NoExtract -> true | uu___ -> false
 let (uu___is_Noeq : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Noeq -> true | uu____4861 -> false
+  fun projectee -> match projectee with | Noeq -> true | uu___ -> false
 let (uu___is_Unopteq : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unopteq -> true | uu____4867 -> false
+  fun projectee -> match projectee with | Unopteq -> true | uu___ -> false
 let (uu___is_TotalEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | TotalEffect -> true | uu____4873 -> false
+    match projectee with | TotalEffect -> true | uu___ -> false
 let (uu___is_Logic : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Logic -> true | uu____4879 -> false
+  fun projectee -> match projectee with | Logic -> true | uu___ -> false
 let (uu___is_Reifiable : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Reifiable -> true | uu____4885 -> false
+  fun projectee -> match projectee with | Reifiable -> true | uu___ -> false
 let (uu___is_Reflectable : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Reflectable _0 -> true | uu____4892 -> false
+    match projectee with | Reflectable _0 -> true | uu___ -> false
 let (__proj__Reflectable__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Reflectable _0 -> _0
 let (uu___is_Discriminator : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Discriminator _0 -> true | uu____4905 -> false
+    match projectee with | Discriminator _0 -> true | uu___ -> false
 let (__proj__Discriminator__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Discriminator _0 -> _0
 let (uu___is_Projector : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Projector _0 -> true | uu____4922 -> false
+    match projectee with | Projector _0 -> true | uu___ -> false
 let (__proj__Projector__item___0 :
   qualifier -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Projector _0 -> _0
 let (uu___is_RecordType : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordType _0 -> true | uu____4955 -> false
+    match projectee with | RecordType _0 -> true | uu___ -> false
 let (__proj__RecordType__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordType _0 -> _0
 let (uu___is_RecordConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordConstructor _0 -> true | uu____5000 -> false
+    match projectee with | RecordConstructor _0 -> true | uu___ -> false
 let (__proj__RecordConstructor__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordConstructor _0 -> _0
 let (uu___is_Action : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Action _0 -> true | uu____5037 -> false
+  fun projectee -> match projectee with | Action _0 -> true | uu___ -> false
 let (__proj__Action__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Action _0 -> _0
 let (uu___is_ExceptionConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | ExceptionConstructor -> true | uu____5049 -> false
+    match projectee with | ExceptionConstructor -> true | uu___ -> false
 let (uu___is_HasMaskedEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | HasMaskedEffect -> true | uu____5055 -> false
+    match projectee with | HasMaskedEffect -> true | uu___ -> false
 let (uu___is_Effect : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Effect -> true | uu____5061 -> false
+  fun projectee -> match projectee with | Effect -> true | uu___ -> false
 let (uu___is_OnlyName : qualifier -> Prims.bool) =
-  fun projectee ->
-    match projectee with | OnlyName -> true | uu____5067 -> false
+  fun projectee -> match projectee with | OnlyName -> true | uu___ -> false
 type tycon = (FStar_Ident.lident * binders * typ)
 type monad_abbrev = {
   mabbrev: FStar_Ident.lident ;
@@ -1233,17 +1177,17 @@ type eff_combinators =
   | Layered_eff of layered_eff_combinators 
 let (uu___is_Primitive_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | Primitive_eff _0 -> true | uu____5827 -> false
+    match projectee with | Primitive_eff _0 -> true | uu___ -> false
 let (__proj__Primitive_eff__item___0 : eff_combinators -> wp_eff_combinators)
   = fun projectee -> match projectee with | Primitive_eff _0 -> _0
 let (uu___is_DM4F_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | DM4F_eff _0 -> true | uu____5840 -> false
+    match projectee with | DM4F_eff _0 -> true | uu___ -> false
 let (__proj__DM4F_eff__item___0 : eff_combinators -> wp_eff_combinators) =
   fun projectee -> match projectee with | DM4F_eff _0 -> _0
 let (uu___is_Layered_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | Layered_eff _0 -> true | uu____5853 -> false
+    match projectee with | Layered_eff _0 -> true | uu___ -> false
 let (__proj__Layered_eff__item___0 :
   eff_combinators -> layered_eff_combinators) =
   fun projectee -> match projectee with | Layered_eff _0 -> _0
@@ -1351,7 +1295,7 @@ and sigelt =
   sigopts: FStar_Options.optionstate FStar_Pervasives_Native.option }
 let (uu___is_Sig_inductive_typ : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_inductive_typ _0 -> true | uu____6351 -> false
+    match projectee with | Sig_inductive_typ _0 -> true | uu___ -> false
 let (__proj__Sig_inductive_typ__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * binders * typ * FStar_Ident.lident
@@ -1359,13 +1303,13 @@ let (__proj__Sig_inductive_typ__item___0 :
   = fun projectee -> match projectee with | Sig_inductive_typ _0 -> _0
 let (uu___is_Sig_bundle : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_bundle _0 -> true | uu____6420 -> false
+    match projectee with | Sig_bundle _0 -> true | uu___ -> false
 let (__proj__Sig_bundle__item___0 :
   sigelt' -> (sigelt Prims.list * FStar_Ident.lident Prims.list)) =
   fun projectee -> match projectee with | Sig_bundle _0 -> _0
 let (uu___is_Sig_datacon : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_datacon _0 -> true | uu____6471 -> false
+    match projectee with | Sig_datacon _0 -> true | uu___ -> false
 let (__proj__Sig_datacon__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * typ * FStar_Ident.lident * Prims.int *
@@ -1373,55 +1317,52 @@ let (__proj__Sig_datacon__item___0 :
   = fun projectee -> match projectee with | Sig_datacon _0 -> _0
 let (uu___is_Sig_declare_typ : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_declare_typ _0 -> true | uu____6532 -> false
+    match projectee with | Sig_declare_typ _0 -> true | uu___ -> false
 let (__proj__Sig_declare_typ__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * typ)) =
   fun projectee -> match projectee with | Sig_declare_typ _0 -> _0
 let (uu___is_Sig_let : sigelt' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Sig_let _0 -> true | uu____6569 -> false
+  fun projectee -> match projectee with | Sig_let _0 -> true | uu___ -> false
 let (__proj__Sig_let__item___0 :
   sigelt' -> (letbindings * FStar_Ident.lident Prims.list)) =
   fun projectee -> match projectee with | Sig_let _0 -> _0
 let (uu___is_Sig_assume : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_assume _0 -> true | uu____6606 -> false
+    match projectee with | Sig_assume _0 -> true | uu___ -> false
 let (__proj__Sig_assume__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * formula)) =
   fun projectee -> match projectee with | Sig_assume _0 -> _0
 let (uu___is_Sig_new_effect : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_new_effect _0 -> true | uu____6637 -> false
+    match projectee with | Sig_new_effect _0 -> true | uu___ -> false
 let (__proj__Sig_new_effect__item___0 : sigelt' -> eff_decl) =
   fun projectee -> match projectee with | Sig_new_effect _0 -> _0
 let (uu___is_Sig_sub_effect : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_sub_effect _0 -> true | uu____6650 -> false
+    match projectee with | Sig_sub_effect _0 -> true | uu___ -> false
 let (__proj__Sig_sub_effect__item___0 : sigelt' -> sub_eff) =
   fun projectee -> match projectee with | Sig_sub_effect _0 -> _0
 let (uu___is_Sig_effect_abbrev : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_effect_abbrev _0 -> true | uu____6675 -> false
+    match projectee with | Sig_effect_abbrev _0 -> true | uu___ -> false
 let (__proj__Sig_effect_abbrev__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * binders * comp * cflag Prims.list))
   = fun projectee -> match projectee with | Sig_effect_abbrev _0 -> _0
 let (uu___is_Sig_pragma : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_pragma _0 -> true | uu____6724 -> false
+    match projectee with | Sig_pragma _0 -> true | uu___ -> false
 let (__proj__Sig_pragma__item___0 : sigelt' -> pragma) =
   fun projectee -> match projectee with | Sig_pragma _0 -> _0
 let (uu___is_Sig_splice : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_splice _0 -> true | uu____6743 -> false
+    match projectee with | Sig_splice _0 -> true | uu___ -> false
 let (__proj__Sig_splice__item___0 :
   sigelt' -> (FStar_Ident.lident Prims.list * term)) =
   fun projectee -> match projectee with | Sig_splice _0 -> _0
 let (uu___is_Sig_polymonadic_bind : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | Sig_polymonadic_bind _0 -> true
-    | uu____6784 -> false
+    match projectee with | Sig_polymonadic_bind _0 -> true | uu___ -> false
 let (__proj__Sig_polymonadic_bind__item___0 :
   sigelt' ->
     (FStar_Ident.lident * FStar_Ident.lident * FStar_Ident.lident * tscheme *
@@ -1431,13 +1372,13 @@ let (uu___is_Sig_polymonadic_subcomp : sigelt' -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Sig_polymonadic_subcomp _0 -> true
-    | uu____6835 -> false
+    | uu___ -> false
 let (__proj__Sig_polymonadic_subcomp__item___0 :
   sigelt' -> (FStar_Ident.lident * FStar_Ident.lident * tscheme * tscheme)) =
   fun projectee -> match projectee with | Sig_polymonadic_subcomp _0 -> _0
 let (uu___is_Sig_fail : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_fail _0 -> true | uu____6882 -> false
+    match projectee with | Sig_fail _0 -> true | uu___ -> false
 let (__proj__Sig_fail__item___0 :
   sigelt' -> (Prims.int Prims.list * Prims.bool * sigelt Prims.list)) =
   fun projectee -> match projectee with | Sig_fail _0 -> _0
@@ -1489,10 +1430,8 @@ type subst_t = subst_elt Prims.list
 let (contains_reflectable : qualifier Prims.list -> Prims.bool) =
   fun l ->
     FStar_Util.for_some
-      (fun uu___0_7094 ->
-         match uu___0_7094 with
-         | Reflectable uu____7095 -> true
-         | uu____7096 -> false) l
+      (fun uu___ ->
+         match uu___ with | Reflectable uu___1 -> true | uu___1 -> false) l
 let withinfo : 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
   fun v -> fun r -> { v; p = r }
 let withsort : 'a . 'a -> 'a withinfo_t =
@@ -1506,22 +1445,22 @@ let (order_bv : bv -> bv -> Prims.int) =
   fun x ->
     fun y ->
       let i =
-        let uu____7149 = FStar_Ident.string_of_id x.ppname in
-        let uu____7150 = FStar_Ident.string_of_id y.ppname in
-        FStar_String.compare uu____7149 uu____7150 in
+        let uu___ = FStar_Ident.string_of_id x.ppname in
+        let uu___1 = FStar_Ident.string_of_id y.ppname in
+        FStar_String.compare uu___ uu___1 in
       if i = Prims.int_zero then x.index - y.index else i
 let (order_ident : FStar_Ident.ident -> FStar_Ident.ident -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____7162 = FStar_Ident.string_of_id x in
-      let uu____7163 = FStar_Ident.string_of_id y in
-      FStar_String.compare uu____7162 uu____7163
+      let uu___ = FStar_Ident.string_of_id x in
+      let uu___1 = FStar_Ident.string_of_id y in
+      FStar_String.compare uu___ uu___1
 let (order_fv : FStar_Ident.lident -> FStar_Ident.lident -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____7174 = FStar_Ident.string_of_lid x in
-      let uu____7175 = FStar_Ident.string_of_lid y in
-      FStar_String.compare uu____7174 uu____7175
+      let uu___ = FStar_Ident.string_of_lid x in
+      let uu___1 = FStar_Ident.string_of_lid y in
+      FStar_String.compare uu___ uu___1
 let (range_of_lbname : lbname -> FStar_Range.range) =
   fun l ->
     match l with
@@ -1532,73 +1471,63 @@ let (range_of_bv : bv -> FStar_Range.range) =
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x ->
     fun r ->
-      let uu___414_7198 = x in
-      let uu____7199 = FStar_Ident.set_id_range r x.ppname in
-      {
-        ppname = uu____7199;
-        index = (uu___414_7198.index);
-        sort = (uu___414_7198.sort)
-      }
+      let uu___ = x in
+      let uu___1 = FStar_Ident.set_id_range r x.ppname in
+      { ppname = uu___1; index = (uu___.index); sort = (uu___.sort) }
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
   fun f ->
     fun qi ->
       let aq =
         FStar_List.map
-          (fun uu____7234 ->
-             match uu____7234 with
-             | (bv1, t) -> let uu____7245 = f t in (bv1, uu____7245))
+          (fun uu___ ->
+             match uu___ with | (bv1, t) -> let uu___1 = f t in (bv1, uu___1))
           qi.antiquotes in
-      let uu___422_7246 = qi in
-      { qkind = (uu___422_7246.qkind); antiquotes = aq }
+      let uu___ = qi in { qkind = (uu___.qkind); antiquotes = aq }
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
   fun bv1 ->
     fun aq ->
-      let uu____7261 =
+      let uu___ =
         FStar_List.tryFind
-          (fun uu____7279 ->
-             match uu____7279 with | (bv', uu____7287) -> bv_eq bv1 bv') aq in
-      match uu____7261 with
-      | FStar_Pervasives_Native.Some (uu____7294, e) ->
+          (fun uu___1 -> match uu___1 with | (bv', uu___2) -> bv_eq bv1 bv')
+          aq in
+      match uu___ with
+      | FStar_Pervasives_Native.Some (uu___1, e) ->
           FStar_Pervasives_Native.Some e
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let syn :
-  'uuuuuu7324 'uuuuuu7325 'uuuuuu7326 .
-    'uuuuuu7324 ->
-      'uuuuuu7325 ->
-        ('uuuuuu7325 -> 'uuuuuu7324 -> 'uuuuuu7326) -> 'uuuuuu7326
+  'uuuuu 'uuuuu1 'uuuuu2 .
+    'uuuuu -> 'uuuuu1 -> ('uuuuu1 -> 'uuuuu -> 'uuuuu2) -> 'uuuuu2
   = fun p -> fun k -> fun f -> f k p
 let mk_fvs :
-  'uuuuuu7356 .
-    unit -> 'uuuuuu7356 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____7365 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+  'uuuuu . unit -> 'uuuuu FStar_Pervasives_Native.option FStar_ST.ref =
+  fun uu___ -> FStar_Util.mk_ref FStar_Pervasives_Native.None
 let mk_uvs :
-  'uuuuuu7372 .
-    unit -> 'uuuuuu7372 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____7381 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+  'uuuuu . unit -> 'uuuuu FStar_Pervasives_Native.option FStar_ST.ref =
+  fun uu___ -> FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (new_bv_set : unit -> bv FStar_Util.set) =
-  fun uu____7390 -> FStar_Util.new_set order_bv
+  fun uu___ -> FStar_Util.new_set order_bv
 let (new_id_set : unit -> FStar_Ident.ident FStar_Util.set) =
-  fun uu____7399 -> FStar_Util.new_set order_ident
+  fun uu___ -> FStar_Util.new_set order_ident
 let (new_fv_set : unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____7408 -> FStar_Util.new_set order_fv
+  fun uu___ -> FStar_Util.new_set order_fv
 let (order_univ_name : univ_name -> univ_name -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____7421 = FStar_Ident.string_of_id x in
-      let uu____7422 = FStar_Ident.string_of_id y in
-      FStar_String.compare uu____7421 uu____7422
+      let uu___ = FStar_Ident.string_of_id x in
+      let uu___1 = FStar_Ident.string_of_id y in
+      FStar_String.compare uu___ uu___1
 let (new_universe_names_set : unit -> univ_name FStar_Util.set) =
-  fun uu____7429 -> FStar_Util.new_set order_univ_name
+  fun uu___ -> FStar_Util.new_set order_univ_name
 let (eq_binding : binding -> binding -> Prims.bool) =
   fun b1 ->
     fun b2 ->
       match (b1, b2) with
       | (Binding_var bv1, Binding_var bv2) -> bv_eq bv1 bv2
-      | (Binding_lid (lid1, uu____7445), Binding_lid (lid2, uu____7447)) ->
+      | (Binding_lid (lid1, uu___), Binding_lid (lid2, uu___1)) ->
           FStar_Ident.lid_equals lid1 lid2
       | (Binding_univ u1, Binding_univ u2) -> FStar_Ident.ident_equals u1 u2
-      | uu____7482 -> false
+      | uu___ -> false
 let (no_names : freenames) = new_bv_set ()
 let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set ()
 let (no_universe_names : univ_name FStar_Util.set) =
@@ -1610,30 +1539,29 @@ let (list_of_freenames : freenames -> bv Prims.list) =
 let mk : 'a . 'a -> FStar_Range.range -> 'a syntax =
   fun t ->
     fun r ->
-      let uu____7528 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-      { n = t; pos = r; vars = uu____7528 }
+      let uu___ = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+      { n = t; pos = r; vars = uu___ }
 let (bv_to_tm : bv -> term) =
-  fun bv1 -> let uu____7538 = range_of_bv bv1 in mk (Tm_bvar bv1) uu____7538
+  fun bv1 -> let uu___ = range_of_bv bv1 in mk (Tm_bvar bv1) uu___
 let (bv_to_name : bv -> term) =
-  fun bv1 -> let uu____7544 = range_of_bv bv1 in mk (Tm_name bv1) uu____7544
+  fun bv1 -> let uu___ = range_of_bv bv1 in mk (Tm_name bv1) uu___
 let (binders_to_names : binders -> term Prims.list) =
   fun bs ->
     FStar_All.pipe_right bs
       (FStar_List.map
-         (fun uu____7573 ->
-            match uu____7573 with | (x, uu____7581) -> bv_to_name x))
+         (fun uu___ -> match uu___ with | (x, uu___1) -> bv_to_name x))
 let (mk_Tm_app : term -> args -> FStar_Range.range -> term) =
   fun t1 ->
     fun args1 ->
       fun p ->
-        match args1 with | [] -> t1 | uu____7603 -> mk (Tm_app (t1, args1)) p
+        match args1 with | [] -> t1 | uu___ -> mk (Tm_app (t1, args1)) p
 let (mk_Tm_uinst : term -> universes -> term) =
   fun t ->
     fun us ->
       match t.n with
-      | Tm_fvar uu____7628 ->
+      | Tm_fvar uu___ ->
           (match us with | [] -> t | us1 -> mk (Tm_uinst (t, us1)) t.pos)
-      | uu____7632 -> failwith "Unexpected universe instantiation"
+      | uu___ -> failwith "Unexpected universe instantiation"
 let (extend_app_n : term -> args -> FStar_Range.range -> term) =
   fun t ->
     fun args' ->
@@ -1641,7 +1569,7 @@ let (extend_app_n : term -> args -> FStar_Range.range -> term) =
         match t.n with
         | Tm_app (head, args1) ->
             mk_Tm_app head (FStar_List.append args1 args') r
-        | uu____7682 -> mk_Tm_app t args' r
+        | uu___ -> mk_Tm_app t args' r
 let (extend_app : term -> arg -> FStar_Range.range -> term) =
   fun t -> fun arg1 -> fun r -> extend_app_n t [arg1] r
 let (mk_Tm_delayed : (term * subst_ts) -> FStar_Range.range -> term) =
@@ -1659,8 +1587,8 @@ let (mk_lb :
   (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term *
     attribute Prims.list * FStar_Range.range) -> letbinding)
   =
-  fun uu____7805 ->
-    match uu____7805 with
+  fun uu___ ->
+    match uu___ with
     | (x, univs, eff, t, e, attrs, pos) ->
         {
           lbname = x;
@@ -1705,86 +1633,82 @@ let (is_teff : term -> Prims.bool) =
   fun t ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect) -> true
-    | uu____7890 -> false
+    | uu___ -> false
 let (is_type : term -> Prims.bool) =
-  fun t -> match t.n with | Tm_type uu____7896 -> true | uu____7897 -> false
+  fun t -> match t.n with | Tm_type uu___ -> true | uu___ -> false
 let (null_id : FStar_Ident.ident) =
   FStar_Ident.mk_ident ("_", FStar_Range.dummyRange)
 let (null_bv : term -> bv) =
   fun k -> { ppname = null_id; index = Prims.int_zero; sort = k }
 let (mk_binder : bv -> binder) = fun a -> (a, FStar_Pervasives_Native.None)
 let (null_binder : term -> binder) =
-  fun t ->
-    let uu____7915 = null_bv t in (uu____7915, FStar_Pervasives_Native.None)
+  fun t -> let uu___ = null_bv t in (uu___, FStar_Pervasives_Native.None)
 let (imp_tag : arg_qualifier) = Implicit false
 let (iarg : term -> arg) =
   fun t -> (t, (FStar_Pervasives_Native.Some imp_tag))
 let (as_arg : term -> arg) = fun t -> (t, FStar_Pervasives_Native.None)
 let (is_null_bv : bv -> Prims.bool) =
   fun b ->
-    let uu____7941 = FStar_Ident.string_of_id b.ppname in
-    let uu____7942 = FStar_Ident.string_of_id null_id in
-    uu____7941 = uu____7942
+    let uu___ = FStar_Ident.string_of_id b.ppname in
+    let uu___1 = FStar_Ident.string_of_id null_id in uu___ = uu___1
 let (is_null_binder : binder -> Prims.bool) =
   fun b -> is_null_bv (FStar_Pervasives_Native.fst b)
 let (is_top_level : letbinding Prims.list -> Prims.bool) =
-  fun uu___1_7956 ->
-    match uu___1_7956 with
-    | { lbname = FStar_Util.Inr uu____7959; lbunivs = uu____7960;
-        lbtyp = uu____7961; lbeff = uu____7962; lbdef = uu____7963;
-        lbattrs = uu____7964; lbpos = uu____7965;_}::uu____7966 -> true
-    | uu____7979 -> false
+  fun uu___ ->
+    match uu___ with
+    | { lbname = FStar_Util.Inr uu___1; lbunivs = uu___2; lbtyp = uu___3;
+        lbeff = uu___4; lbdef = uu___5; lbattrs = uu___6; lbpos = uu___7;_}::uu___8
+        -> true
+    | uu___1 -> false
 let (freenames_of_binders : binders -> freenames) =
   fun bs ->
     FStar_List.fold_right
-      (fun uu____7999 ->
+      (fun uu___ ->
          fun out ->
-           match uu____7999 with
-           | (x, uu____8012) -> FStar_Util.set_add x out) bs no_names
+           match uu___ with | (x, uu___1) -> FStar_Util.set_add x out) bs
+      no_names
 let (binders_of_list : bv Prims.list -> binders) =
   fun fvs ->
     FStar_All.pipe_right fvs
       (FStar_List.map (fun t -> (t, FStar_Pervasives_Native.None)))
 let (binders_of_freenames : freenames -> binders) =
   fun fvs ->
-    let uu____8043 = FStar_Util.set_elements fvs in
-    FStar_All.pipe_right uu____8043 binders_of_list
+    let uu___ = FStar_Util.set_elements fvs in
+    FStar_All.pipe_right uu___ binders_of_list
 let (is_implicit : aqual -> Prims.bool) =
-  fun uu___2_8052 ->
-    match uu___2_8052 with
-    | FStar_Pervasives_Native.Some (Implicit uu____8053) -> true
-    | uu____8054 -> false
+  fun uu___ ->
+    match uu___ with
+    | FStar_Pervasives_Native.Some (Implicit uu___1) -> true
+    | uu___1 -> false
 let (is_implicit_or_meta : aqual -> Prims.bool) =
-  fun uu___3_8059 ->
-    match uu___3_8059 with
-    | FStar_Pervasives_Native.Some (Implicit uu____8060) -> true
-    | FStar_Pervasives_Native.Some (Meta uu____8061) -> true
-    | uu____8062 -> false
+  fun uu___ ->
+    match uu___ with
+    | FStar_Pervasives_Native.Some (Implicit uu___1) -> true
+    | FStar_Pervasives_Native.Some (Meta uu___1) -> true
+    | uu___1 -> false
 let (as_implicit : Prims.bool -> aqual) =
-  fun uu___4_8067 ->
-    if uu___4_8067
+  fun uu___ ->
+    if uu___
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
 let (pat_bvs : pat -> bv Prims.list) =
   fun p ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____8101 -> b
-      | Pat_constant uu____8108 -> b
+      | Pat_dot_term uu___ -> b
+      | Pat_constant uu___ -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____8111, pats) ->
+      | Pat_cons (uu___, pats) ->
           FStar_List.fold_left
             (fun b1 ->
-               fun uu____8142 ->
-                 match uu____8142 with | (p2, uu____8154) -> aux b1 p2) b
+               fun uu___1 -> match uu___1 with | (p2, uu___2) -> aux b1 p2) b
             pats in
-    let uu____8159 = aux [] p in
-    FStar_All.pipe_left FStar_List.rev uu____8159
+    let uu___ = aux [] p in FStar_All.pipe_left FStar_List.rev uu___
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_8172 ->
-    match uu___5_8172 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
 let (gen_bv :
@@ -1795,42 +1719,37 @@ let (gen_bv :
     fun r ->
       fun t ->
         let id = FStar_Ident.mk_ident (s, (range_of_ropt r)) in
-        let uu____8207 = FStar_Ident.next_id () in
-        { ppname = id; index = uu____8207; sort = t }
+        let uu___ = FStar_Ident.next_id () in
+        { ppname = id; index = uu___; sort = t }
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt -> fun t -> gen_bv FStar_Ident.reserved_prefix ropt t
 let (freshen_bv : bv -> bv) =
   fun bv1 ->
-    let uu____8227 = is_null_bv bv1 in
-    if uu____8227
+    let uu___ = is_null_bv bv1 in
+    if uu___
     then
-      let uu____8228 =
-        let uu____8231 = range_of_bv bv1 in
-        FStar_Pervasives_Native.Some uu____8231 in
-      new_bv uu____8228 bv1.sort
+      let uu___1 =
+        let uu___2 = range_of_bv bv1 in FStar_Pervasives_Native.Some uu___2 in
+      new_bv uu___1 bv1.sort
     else
-      (let uu___608_8233 = bv1 in
-       let uu____8234 = FStar_Ident.next_id () in
-       {
-         ppname = (uu___608_8233.ppname);
-         index = uu____8234;
-         sort = (uu___608_8233.sort)
-       })
+      (let uu___2 = bv1 in
+       let uu___3 = FStar_Ident.next_id () in
+       { ppname = (uu___2.ppname); index = uu___3; sort = (uu___2.sort) })
 let (freshen_binder : binder -> binder) =
   fun b ->
-    let uu____8240 = b in
-    match uu____8240 with
-    | (bv1, aq) -> let uu____8247 = freshen_bv bv1 in (uu____8247, aq)
+    let uu___ = b in
+    match uu___ with
+    | (bv1, aq) -> let uu___1 = freshen_bv bv1 in (uu___1, aq)
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt ->
     let id = FStar_Ident.next_id () in
-    let uu____8260 =
-      let uu____8265 =
-        let uu____8266 = FStar_Util.string_of_int id in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____8266 in
-      (uu____8265, (range_of_ropt ropt)) in
-    FStar_Ident.mk_ident uu____8260
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Util.string_of_int id in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu___2 in
+      (uu___1, (range_of_ropt ropt)) in
+    FStar_Ident.mk_ident uu___
 let (lbname_eq :
   (bv, FStar_Ident.lident) FStar_Util.either ->
     (bv, FStar_Ident.lident) FStar_Util.either -> Prims.bool)
@@ -1840,7 +1759,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x, FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l, FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____8321 -> false
+      | uu___ -> false
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1 ->
     fun fv2 -> FStar_Ident.lid_equals (fv1.fv_name).v (fv2.fv_name).v
@@ -1849,13 +1768,9 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv1 ->
     fun r ->
-      let uu___635_8364 = bv1 in
-      let uu____8365 = FStar_Ident.set_id_range r bv1.ppname in
-      {
-        ppname = uu____8365;
-        index = (uu___635_8364.index);
-        sort = (uu___635_8364.sort)
-      }
+      let uu___ = bv1 in
+      let uu___1 = FStar_Ident.set_id_range r bv1.ppname in
+      { ppname = uu___1; index = (uu___.index); sort = (uu___.sort) }
 let (lid_as_fv :
   FStar_Ident.lident ->
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> fv)
@@ -1863,69 +1778,65 @@ let (lid_as_fv :
   fun l ->
     fun dd ->
       fun dq ->
-        let uu____8385 =
-          let uu____8386 = FStar_Ident.range_of_lid l in
-          withinfo l uu____8386 in
-        { fv_name = uu____8385; fv_delta = dd; fv_qual = dq }
+        let uu___ =
+          let uu___1 = FStar_Ident.range_of_lid l in withinfo l uu___1 in
+        { fv_name = uu___; fv_delta = dd; fv_qual = dq }
 let (fv_to_tm : fv -> term) =
   fun fv1 ->
-    let uu____8392 = FStar_Ident.range_of_lid (fv1.fv_name).v in
-    mk (Tm_fvar fv1) uu____8392
+    let uu___ = FStar_Ident.range_of_lid (fv1.fv_name).v in
+    mk (Tm_fvar fv1) uu___
 let (fvar :
   FStar_Ident.lident ->
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> term)
   =
   fun l ->
-    fun dd ->
-      fun dq -> let uu____8412 = lid_as_fv l dd dq in fv_to_tm uu____8412
+    fun dd -> fun dq -> let uu___ = lid_as_fv l dd dq in fv_to_tm uu___
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1 -> (fv1.fv_name).v
 let (range_of_fv : fv -> FStar_Range.range) =
-  fun fv1 ->
-    let uu____8423 = lid_of_fv fv1 in FStar_Ident.range_of_lid uu____8423
+  fun fv1 -> let uu___ = lid_of_fv fv1 in FStar_Ident.range_of_lid uu___
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv1 ->
     fun r ->
-      let uu___648_8434 = fv1 in
-      let uu____8435 =
-        let uu___650_8436 = fv1.fv_name in
-        let uu____8437 =
-          let uu____8438 = lid_of_fv fv1 in
-          FStar_Ident.set_lid_range uu____8438 r in
-        { v = uu____8437; p = (uu___650_8436.p) } in
+      let uu___ = fv1 in
+      let uu___1 =
+        let uu___2 = fv1.fv_name in
+        let uu___3 =
+          let uu___4 = lid_of_fv fv1 in FStar_Ident.set_lid_range uu___4 r in
+        { v = uu___3; p = (uu___2.p) } in
       {
-        fv_name = uu____8435;
-        fv_delta = (uu___648_8434.fv_delta);
-        fv_qual = (uu___648_8434.fv_qual)
+        fv_name = uu___1;
+        fv_delta = (uu___.fv_delta);
+        fv_qual = (uu___.fv_qual)
       }
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l ->
     fun s ->
       FStar_List.existsb
-        (fun uu___6_8460 ->
-           match uu___6_8460 with
-           | { n = Tm_constant (FStar_Const.Const_string (data, uu____8464));
-               pos = uu____8465; vars = uu____8466;_} when data = s -> true
-           | uu____8469 -> false) l
+        (fun uu___ ->
+           match uu___ with
+           | { n = Tm_constant (FStar_Const.Const_string (data, uu___1));
+               pos = uu___2; vars = uu___3;_} when data = s -> true
+           | uu___1 -> false) l
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1 ->
     fun p2 ->
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1, Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1, as1), Pat_cons (fv2, as2)) ->
-          let uu____8520 = fv_eq fv1 fv2 in
-          if uu____8520
+          let uu___ = fv_eq fv1 fv2 in
+          if uu___
           then
-            let uu____8522 = FStar_List.zip as1 as2 in
-            FStar_All.pipe_right uu____8522
+            let uu___2 = FStar_List.zip as1 as2 in
+            FStar_All.pipe_right uu___2
               (FStar_List.for_all
-                 (fun uu____8580 ->
-                    match uu____8580 with
+                 (fun uu___3 ->
+                    match uu___3 with
                     | ((p11, b1), (p21, b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____8606, Pat_var uu____8607) -> true
-      | (Pat_wild uu____8608, Pat_wild uu____8609) -> true
+      | (Pat_var uu___, Pat_var uu___1) -> true
+      | (Pat_wild uu___, Pat_wild uu___1) -> true
       | (Pat_dot_term (bv1, t1), Pat_dot_term (bv2, t2)) -> true
-      | (uu____8622, uu____8623) -> false
+      | (uu___, uu___1) -> false
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero
 let (delta_equational : delta_depth) =
   Delta_equational_at_level Prims.int_zero
@@ -1933,21 +1844,21 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l -> lid_as_fv l delta_constant FStar_Pervasives_Native.None
 let (tconst : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____8634 = let uu____8635 = fvconst l in Tm_fvar uu____8635 in
-    mk uu____8634 FStar_Range.dummyRange
+    let uu___ = let uu___1 = fvconst l in Tm_fvar uu___1 in
+    mk uu___ FStar_Range.dummyRange
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____8641 =
-      let uu____8642 =
+    let uu___ =
+      let uu___1 =
         lid_as_fv l (Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None in
-      Tm_fvar uu____8642 in
-    mk uu____8641 FStar_Range.dummyRange
+      Tm_fvar uu___1 in
+    mk uu___ FStar_Range.dummyRange
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____8648 =
+    let uu___ =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor) in
-    fv_to_tm uu____8648
+    fv_to_tm uu___
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid
 let (t_int : term) = tconst FStar_Parser_Const.int_lid
@@ -1969,58 +1880,55 @@ let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid
 let (t_tac_of : term -> term -> term) =
   fun a ->
     fun b ->
-      let uu____8659 =
-        let uu____8660 = tabbrev FStar_Parser_Const.tac_lid in
-        mk_Tm_uinst uu____8660 [U_zero; U_zero] in
-      let uu____8661 =
-        let uu____8662 = as_arg a in
-        let uu____8671 = let uu____8682 = as_arg b in [uu____8682] in
-        uu____8662 :: uu____8671 in
-      mk_Tm_app uu____8659 uu____8661 FStar_Range.dummyRange
+      let uu___ =
+        let uu___1 = tabbrev FStar_Parser_Const.tac_lid in
+        mk_Tm_uinst uu___1 [U_zero; U_zero] in
+      let uu___1 =
+        let uu___2 = as_arg a in
+        let uu___3 = let uu___4 = as_arg b in [uu___4] in uu___2 :: uu___3 in
+      mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (t_tactic_of : term -> term) =
   fun t ->
-    let uu____8720 =
-      let uu____8721 = tabbrev FStar_Parser_Const.tactic_lid in
-      mk_Tm_uinst uu____8721 [U_zero] in
-    let uu____8722 = let uu____8723 = as_arg t in [uu____8723] in
-    mk_Tm_app uu____8720 uu____8722 FStar_Range.dummyRange
+    let uu___ =
+      let uu___1 = tabbrev FStar_Parser_Const.tactic_lid in
+      mk_Tm_uinst uu___1 [U_zero] in
+    let uu___1 = let uu___2 = as_arg t in [uu___2] in
+    mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (t_tactic_unit : term) = t_tactic_of t_unit
 let (t_list_of : term -> term) =
   fun t ->
-    let uu____8753 =
-      let uu____8754 = tabbrev FStar_Parser_Const.list_lid in
-      mk_Tm_uinst uu____8754 [U_zero] in
-    let uu____8755 = let uu____8756 = as_arg t in [uu____8756] in
-    mk_Tm_app uu____8753 uu____8755 FStar_Range.dummyRange
+    let uu___ =
+      let uu___1 = tabbrev FStar_Parser_Const.list_lid in
+      mk_Tm_uinst uu___1 [U_zero] in
+    let uu___1 = let uu___2 = as_arg t in [uu___2] in
+    mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (t_option_of : term -> term) =
   fun t ->
-    let uu____8786 =
-      let uu____8787 = tabbrev FStar_Parser_Const.option_lid in
-      mk_Tm_uinst uu____8787 [U_zero] in
-    let uu____8788 = let uu____8789 = as_arg t in [uu____8789] in
-    mk_Tm_app uu____8786 uu____8788 FStar_Range.dummyRange
+    let uu___ =
+      let uu___1 = tabbrev FStar_Parser_Const.option_lid in
+      mk_Tm_uinst uu___1 [U_zero] in
+    let uu___1 = let uu___2 = as_arg t in [uu___2] in
+    mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (t_tuple2_of : term -> term -> term) =
   fun t1 ->
     fun t2 ->
-      let uu____8824 =
-        let uu____8825 = tabbrev FStar_Parser_Const.lid_tuple2 in
-        mk_Tm_uinst uu____8825 [U_zero; U_zero] in
-      let uu____8826 =
-        let uu____8827 = as_arg t1 in
-        let uu____8836 = let uu____8847 = as_arg t2 in [uu____8847] in
-        uu____8827 :: uu____8836 in
-      mk_Tm_app uu____8824 uu____8826 FStar_Range.dummyRange
+      let uu___ =
+        let uu___1 = tabbrev FStar_Parser_Const.lid_tuple2 in
+        mk_Tm_uinst uu___1 [U_zero; U_zero] in
+      let uu___1 =
+        let uu___2 = as_arg t1 in
+        let uu___3 = let uu___4 = as_arg t2 in [uu___4] in uu___2 :: uu___3 in
+      mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (t_either_of : term -> term -> term) =
   fun t1 ->
     fun t2 ->
-      let uu____8890 =
-        let uu____8891 = tabbrev FStar_Parser_Const.either_lid in
-        mk_Tm_uinst uu____8891 [U_zero; U_zero] in
-      let uu____8892 =
-        let uu____8893 = as_arg t1 in
-        let uu____8902 = let uu____8913 = as_arg t2 in [uu____8913] in
-        uu____8893 :: uu____8902 in
-      mk_Tm_app uu____8890 uu____8892 FStar_Range.dummyRange
+      let uu___ =
+        let uu___1 = tabbrev FStar_Parser_Const.either_lid in
+        mk_Tm_uinst uu___1 [U_zero; U_zero] in
+      let uu___1 =
+        let uu___2 = as_arg t1 in
+        let uu___3 = let uu___4 = as_arg t2 in [uu___4] in uu___2 :: uu___3 in
+      mk_Tm_app uu___ uu___1 FStar_Range.dummyRange
 let (unit_const_with_range : FStar_Range.range -> term) =
   fun r -> mk (Tm_constant FStar_Const.Const_unit) r
 let (unit_const : term) = unit_const_with_range FStar_Range.dummyRange

--- a/src/ocaml-output/FStar_Syntax_Unionfind.ml
+++ b/src/ocaml-output/FStar_Syntax_Unionfind.ml
@@ -14,19 +14,17 @@ let (__proj__Mkvops_t__item__next_minor :
 let (vops : vops_t) =
   let major = FStar_Util.mk_ref Prims.int_zero in
   let minor = FStar_Util.mk_ref Prims.int_zero in
-  let next_major uu____78 =
+  let next_major uu___ =
     FStar_ST.op_Colon_Equals minor Prims.int_zero;
-    (let uu____86 = FStar_Util.incr major; FStar_ST.op_Bang major in
+    (let uu___2 = FStar_Util.incr major; FStar_ST.op_Bang major in
      {
-       FStar_Syntax_Syntax.major = uu____86;
+       FStar_Syntax_Syntax.major = uu___2;
        FStar_Syntax_Syntax.minor = Prims.int_zero
      }) in
-  let next_minor uu____99 =
-    let uu____100 = FStar_ST.op_Bang major in
-    let uu____107 = FStar_Util.incr minor; FStar_ST.op_Bang minor in
-    {
-      FStar_Syntax_Syntax.major = uu____100;
-      FStar_Syntax_Syntax.minor = uu____107
+  let next_minor uu___ =
+    let uu___1 = FStar_ST.op_Bang major in
+    let uu___2 = FStar_Util.incr minor; FStar_ST.op_Bang minor in
+    { FStar_Syntax_Syntax.major = uu___1; FStar_Syntax_Syntax.minor = uu___2
     } in
   { next_major; next_minor }
 type tgraph =
@@ -57,63 +55,62 @@ let (__proj__Mkuf__item__ro : uf -> Prims.bool) =
     match projectee with | { term_graph; univ_graph; version; ro;_} -> ro
 let (empty : FStar_Syntax_Syntax.version -> uf) =
   fun v ->
-    let uu____184 = FStar_Unionfind.puf_empty () in
-    let uu____187 = FStar_Unionfind.puf_empty () in
-    { term_graph = uu____184; univ_graph = uu____187; version = v; ro = false
-    }
+    let uu___ = FStar_Unionfind.puf_empty () in
+    let uu___1 = FStar_Unionfind.puf_empty () in
+    { term_graph = uu___; univ_graph = uu___1; version = v; ro = false }
 let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
   fun v ->
-    let uu____195 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major in
-    let uu____196 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor in
-    FStar_Util.format2 "%s.%s" uu____195 uu____196
+    let uu___ = FStar_Util.string_of_int v.FStar_Syntax_Syntax.major in
+    let uu___1 = FStar_Util.string_of_int v.FStar_Syntax_Syntax.minor in
+    FStar_Util.format2 "%s.%s" uu___ uu___1
 let (state : uf FStar_ST.ref) =
-  let uu____199 = let uu____200 = vops.next_major () in empty uu____200 in
-  FStar_Util.mk_ref uu____199
+  let uu___ = let uu___1 = vops.next_major () in empty uu___1 in
+  FStar_Util.mk_ref uu___
 type tx =
   | TX of uf 
 let (uu___is_TX : tx -> Prims.bool) = fun projectee -> true
 let (__proj__TX__item___0 : tx -> uf) =
   fun projectee -> match projectee with | TX _0 -> _0
-let (get : unit -> uf) = fun uu____221 -> FStar_ST.op_Bang state
+let (get : unit -> uf) = fun uu___ -> FStar_ST.op_Bang state
 let (set_ro : unit -> unit) =
-  fun uu____232 ->
+  fun uu___ ->
     let s = get () in
     FStar_ST.op_Colon_Equals state
-      (let uu___34_241 = s in
+      (let uu___1 = s in
        {
-         term_graph = (uu___34_241.term_graph);
-         univ_graph = (uu___34_241.univ_graph);
-         version = (uu___34_241.version);
+         term_graph = (uu___1.term_graph);
+         univ_graph = (uu___1.univ_graph);
+         version = (uu___1.version);
          ro = true
        })
 let (set_rw : unit -> unit) =
-  fun uu____246 ->
+  fun uu___ ->
     let s = get () in
     FStar_ST.op_Colon_Equals state
-      (let uu___38_255 = s in
+      (let uu___1 = s in
        {
-         term_graph = (uu___38_255.term_graph);
-         univ_graph = (uu___38_255.univ_graph);
-         version = (uu___38_255.version);
+         term_graph = (uu___1.term_graph);
+         univ_graph = (uu___1.univ_graph);
+         version = (uu___1.version);
          ro = false
        })
 let with_uf_enabled : 'a . (unit -> 'a) -> 'a =
   fun f ->
     let s = get () in
     set_rw ();
-    (let restore uu____278 = if s.ro then set_ro () else () in
+    (let restore uu___1 = if s.ro then set_ro () else () in
      let r =
-       let uu____281 = FStar_Options.trace_error () in
-       if uu____281
+       let uu___1 = FStar_Options.trace_error () in
+       if uu___1
        then f ()
        else
-         (try (fun uu___50_284 -> match () with | () -> f ()) ()
-          with | uu___49_287 -> (restore (); FStar_Exn.raise uu___49_287)) in
+         (try (fun uu___3 -> match () with | () -> f ()) ()
+          with | uu___3 -> (restore (); FStar_Exn.raise uu___3)) in
      restore (); r)
 let (fail_if_ro : unit -> unit) =
-  fun uu____294 ->
-    let uu____295 = let uu____296 = get () in uu____296.ro in
-    if uu____295
+  fun uu___ ->
+    let uu___1 = let uu___2 = get () in uu___2.ro in
+    if uu___1
     then
       FStar_Errors.raise_error
         (FStar_Errors.Fatal_BadUvar,
@@ -123,51 +120,51 @@ let (fail_if_ro : unit -> unit) =
 let (set : uf -> unit) =
   fun u -> fail_if_ro (); FStar_ST.op_Colon_Equals state u
 let (reset : unit -> unit) =
-  fun uu____314 ->
+  fun uu___ ->
     fail_if_ro ();
     (let v = vops.next_major () in
-     let uu____317 =
-       let uu___65_318 = empty v in
+     let uu___2 =
+       let uu___3 = empty v in
        {
-         term_graph = (uu___65_318.term_graph);
-         univ_graph = (uu___65_318.univ_graph);
-         version = (uu___65_318.version);
+         term_graph = (uu___3.term_graph);
+         univ_graph = (uu___3.univ_graph);
+         version = (uu___3.version);
          ro = false
        } in
-     set uu____317)
+     set uu___2)
 let (new_transaction : unit -> tx) =
-  fun uu____323 ->
-    let tx1 = let uu____325 = get () in TX uu____325 in
-    (let uu____327 =
-       let uu___69_328 = get () in
-       let uu____329 = vops.next_minor () in
+  fun uu___ ->
+    let tx1 = let uu___1 = get () in TX uu___1 in
+    (let uu___2 =
+       let uu___3 = get () in
+       let uu___4 = vops.next_minor () in
        {
-         term_graph = (uu___69_328.term_graph);
-         univ_graph = (uu___69_328.univ_graph);
-         version = uu____329;
-         ro = (uu___69_328.ro)
+         term_graph = (uu___3.term_graph);
+         univ_graph = (uu___3.univ_graph);
+         version = uu___4;
+         ro = (uu___3.ro)
        } in
-     set uu____327);
+     set uu___2);
     tx1
 let (commit : tx -> unit) = fun tx1 -> ()
 let (rollback : tx -> unit) =
-  fun uu____339 -> match uu____339 with | TX uf1 -> set uf1
+  fun uu___ -> match uu___ with | TX uf1 -> set uf1
 let update_in_tx : 'a . 'a FStar_ST.ref -> 'a -> unit = fun r -> fun x -> ()
 let (get_term_graph : unit -> tgraph) =
-  fun uu____366 -> let uu____367 = get () in uu____367.term_graph
+  fun uu___ -> let uu___1 = get () in uu___1.term_graph
 let (get_version : unit -> FStar_Syntax_Syntax.version) =
-  fun uu____372 -> let uu____373 = get () in uu____373.version
+  fun uu___ -> let uu___1 = get () in uu___1.version
 let (set_term_graph : tgraph -> unit) =
   fun tg ->
-    let uu____379 =
-      let uu___82_380 = get () in
+    let uu___ =
+      let uu___1 = get () in
       {
         term_graph = tg;
-        univ_graph = (uu___82_380.univ_graph);
-        version = (uu___82_380.version);
-        ro = (uu___82_380.ro)
+        univ_graph = (uu___1.univ_graph);
+        version = (uu___1.version);
+        ro = (uu___1.ro)
       } in
-    set uu____379
+    set uu___
 let (chk_v_t :
   (FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
     FStar_Unionfind.p_uvar * FStar_Syntax_Syntax.version * FStar_Range.range)
@@ -175,16 +172,16 @@ let (chk_v_t :
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
       FStar_Unionfind.p_uvar)
   =
-  fun uu____399 ->
-    match uu____399 with
+  fun uu___ ->
+    match uu___ with
     | (u, v, rng) ->
         let uvar_to_string u1 =
-          let uu____439 =
-            let uu____440 =
-              let uu____441 = get_term_graph () in
-              FStar_Unionfind.puf_id uu____441 u1 in
-            FStar_All.pipe_right uu____440 FStar_Util.string_of_int in
-          Prims.op_Hat "?" uu____439 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = get_term_graph () in
+              FStar_Unionfind.puf_id uu___3 u1 in
+            FStar_All.pipe_right uu___2 FStar_Util.string_of_int in
+          Prims.op_Hat "?" uu___1 in
         let expected = get_version () in
         if
           (v.FStar_Syntax_Syntax.major = expected.FStar_Syntax_Syntax.major)
@@ -193,62 +190,62 @@ let (chk_v_t :
                expected.FStar_Syntax_Syntax.minor)
         then u
         else
-          (let uu____454 =
-             let uu____459 =
-               let uu____460 = uvar_to_string u in
-               let uu____461 = version_to_string expected in
-               let uu____462 = version_to_string v in
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = uvar_to_string u in
+               let uu___5 = version_to_string expected in
+               let uu___6 = version_to_string v in
                FStar_Util.format3
                  "Internal error: incompatible version for term unification variable %s: current version is %s; got version %s"
-                 uu____460 uu____461 uu____462 in
-             (FStar_Errors.Fatal_BadUvar, uu____459) in
-           FStar_Errors.raise_error uu____454 rng)
+                 uu___4 uu___5 uu___6 in
+             (FStar_Errors.Fatal_BadUvar, uu___3) in
+           FStar_Errors.raise_error uu___2 rng)
 let (uvar_id : FStar_Syntax_Syntax.uvar -> Prims.int) =
   fun u ->
-    let uu____472 = get_term_graph () in
-    let uu____477 = chk_v_t u in FStar_Unionfind.puf_id uu____472 uu____477
+    let uu___ = get_term_graph () in
+    let uu___1 = chk_v_t u in FStar_Unionfind.puf_id uu___ uu___1
 let (fresh : FStar_Range.range -> FStar_Syntax_Syntax.uvar) =
   fun rng ->
     fail_if_ro ();
-    (let uu____490 =
-       let uu____497 = get_term_graph () in
-       FStar_Unionfind.puf_fresh uu____497 FStar_Pervasives_Native.None in
-     let uu____504 = get_version () in (uu____490, uu____504, rng))
+    (let uu___1 =
+       let uu___2 = get_term_graph () in
+       FStar_Unionfind.puf_fresh uu___2 FStar_Pervasives_Native.None in
+     let uu___2 = get_version () in (uu___1, uu___2, rng))
 let (find :
   FStar_Syntax_Syntax.uvar ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
   =
   fun u ->
-    let uu____518 = get_term_graph () in
-    let uu____523 = chk_v_t u in FStar_Unionfind.puf_find uu____518 uu____523
+    let uu___ = get_term_graph () in
+    let uu___1 = chk_v_t u in FStar_Unionfind.puf_find uu___ uu___1
 let (change : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit) =
   fun u ->
     fun t ->
-      let uu____540 =
-        let uu____541 = get_term_graph () in
-        let uu____546 = chk_v_t u in
-        FStar_Unionfind.puf_change uu____541 uu____546
+      let uu___ =
+        let uu___1 = get_term_graph () in
+        let uu___2 = chk_v_t u in
+        FStar_Unionfind.puf_change uu___1 uu___2
           (FStar_Pervasives_Native.Some t) in
-      set_term_graph uu____540
+      set_term_graph uu___
 let (equiv :
   FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> Prims.bool) =
   fun u ->
     fun v ->
-      let uu____563 = get_term_graph () in
-      let uu____568 = chk_v_t u in
-      let uu____573 = chk_v_t v in
-      FStar_Unionfind.puf_equivalent uu____563 uu____568 uu____573
+      let uu___ = get_term_graph () in
+      let uu___1 = chk_v_t u in
+      let uu___2 = chk_v_t v in
+      FStar_Unionfind.puf_equivalent uu___ uu___1 uu___2
 let (union : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> unit) =
   fun u ->
     fun v ->
-      let uu____590 =
-        let uu____591 = get_term_graph () in
-        let uu____596 = chk_v_t u in
-        let uu____601 = chk_v_t v in
-        FStar_Unionfind.puf_union uu____591 uu____596 uu____601 in
-      set_term_graph uu____590
+      let uu___ =
+        let uu___1 = get_term_graph () in
+        let uu___2 = chk_v_t u in
+        let uu___3 = chk_v_t v in
+        FStar_Unionfind.puf_union uu___1 uu___2 uu___3 in
+      set_term_graph uu___
 let (get_univ_graph : unit -> ugraph) =
-  fun uu____612 -> let uu____613 = get () in uu____613.univ_graph
+  fun uu___ -> let uu___1 = get () in uu___1.univ_graph
 let (chk_v_u :
   (FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
     FStar_Unionfind.p_uvar * FStar_Syntax_Syntax.version * FStar_Range.range)
@@ -256,16 +253,16 @@ let (chk_v_u :
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
       FStar_Unionfind.p_uvar)
   =
-  fun uu____632 ->
-    match uu____632 with
+  fun uu___ ->
+    match uu___ with
     | (u, v, rng) ->
         let uvar_to_string u1 =
-          let uu____672 =
-            let uu____673 =
-              let uu____674 = get_univ_graph () in
-              FStar_Unionfind.puf_id uu____674 u1 in
-            FStar_All.pipe_right uu____673 FStar_Util.string_of_int in
-          Prims.op_Hat "?" uu____672 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = get_univ_graph () in
+              FStar_Unionfind.puf_id uu___3 u1 in
+            FStar_All.pipe_right uu___2 FStar_Util.string_of_int in
+          Prims.op_Hat "?" uu___1 in
         let expected = get_version () in
         if
           (v.FStar_Syntax_Syntax.major = expected.FStar_Syntax_Syntax.major)
@@ -274,75 +271,75 @@ let (chk_v_u :
                expected.FStar_Syntax_Syntax.minor)
         then u
         else
-          (let uu____687 =
-             let uu____692 =
-               let uu____693 = uvar_to_string u in
-               let uu____694 = version_to_string expected in
-               let uu____695 = version_to_string v in
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = uvar_to_string u in
+               let uu___5 = version_to_string expected in
+               let uu___6 = version_to_string v in
                FStar_Util.format3
                  "Internal error: incompatible version for universe unification variable %s: current version is %s; got version %s"
-                 uu____693 uu____694 uu____695 in
-             (FStar_Errors.Fatal_BadUvar, uu____692) in
-           FStar_Errors.raise_error uu____687 rng)
+                 uu___4 uu___5 uu___6 in
+             (FStar_Errors.Fatal_BadUvar, uu___3) in
+           FStar_Errors.raise_error uu___2 rng)
 let (set_univ_graph : ugraph -> unit) =
   fun ug ->
-    let uu____705 =
-      let uu___112_706 = get () in
+    let uu___ =
+      let uu___1 = get () in
       {
-        term_graph = (uu___112_706.term_graph);
+        term_graph = (uu___1.term_graph);
         univ_graph = ug;
-        version = (uu___112_706.version);
-        ro = (uu___112_706.ro)
+        version = (uu___1.version);
+        ro = (uu___1.ro)
       } in
-    set uu____705
+    set uu___
 let (univ_uvar_id : FStar_Syntax_Syntax.universe_uvar -> Prims.int) =
   fun u ->
-    let uu____712 = get_univ_graph () in
-    let uu____717 = chk_v_u u in FStar_Unionfind.puf_id uu____712 uu____717
+    let uu___ = get_univ_graph () in
+    let uu___1 = chk_v_u u in FStar_Unionfind.puf_id uu___ uu___1
 let (univ_fresh : FStar_Range.range -> FStar_Syntax_Syntax.universe_uvar) =
   fun rng ->
     fail_if_ro ();
-    (let uu____730 =
-       let uu____735 = get_univ_graph () in
-       FStar_Unionfind.puf_fresh uu____735 FStar_Pervasives_Native.None in
-     let uu____742 = get_version () in (uu____730, uu____742, rng))
+    (let uu___1 =
+       let uu___2 = get_univ_graph () in
+       FStar_Unionfind.puf_fresh uu___2 FStar_Pervasives_Native.None in
+     let uu___2 = get_version () in (uu___1, uu___2, rng))
 let (univ_find :
   FStar_Syntax_Syntax.universe_uvar ->
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
   =
   fun u ->
-    let uu____754 = get_univ_graph () in
-    let uu____759 = chk_v_u u in FStar_Unionfind.puf_find uu____754 uu____759
+    let uu___ = get_univ_graph () in
+    let uu___1 = chk_v_u u in FStar_Unionfind.puf_find uu___ uu___1
 let (univ_change :
   FStar_Syntax_Syntax.universe_uvar -> FStar_Syntax_Syntax.universe -> unit)
   =
   fun u ->
     fun t ->
-      let uu____776 =
-        let uu____777 = get_univ_graph () in
-        let uu____782 = chk_v_u u in
-        FStar_Unionfind.puf_change uu____777 uu____782
+      let uu___ =
+        let uu___1 = get_univ_graph () in
+        let uu___2 = chk_v_u u in
+        FStar_Unionfind.puf_change uu___1 uu___2
           (FStar_Pervasives_Native.Some t) in
-      set_univ_graph uu____776
+      set_univ_graph uu___
 let (univ_equiv :
   FStar_Syntax_Syntax.universe_uvar ->
     FStar_Syntax_Syntax.universe_uvar -> Prims.bool)
   =
   fun u ->
     fun v ->
-      let uu____799 = get_univ_graph () in
-      let uu____804 = chk_v_u u in
-      let uu____809 = chk_v_u v in
-      FStar_Unionfind.puf_equivalent uu____799 uu____804 uu____809
+      let uu___ = get_univ_graph () in
+      let uu___1 = chk_v_u u in
+      let uu___2 = chk_v_u v in
+      FStar_Unionfind.puf_equivalent uu___ uu___1 uu___2
 let (univ_union :
   FStar_Syntax_Syntax.universe_uvar ->
     FStar_Syntax_Syntax.universe_uvar -> unit)
   =
   fun u ->
     fun v ->
-      let uu____826 =
-        let uu____827 = get_univ_graph () in
-        let uu____832 = chk_v_u u in
-        let uu____837 = chk_v_u v in
-        FStar_Unionfind.puf_union uu____827 uu____832 uu____837 in
-      set_univ_graph uu____826
+      let uu___ =
+        let uu___1 = get_univ_graph () in
+        let uu___2 = chk_v_u u in
+        let uu___3 = chk_v_u v in
+        FStar_Unionfind.puf_union uu___1 uu___2 uu___3 in
+      set_univ_graph uu___

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -5,47 +5,45 @@ let (tts_f :
   = FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (tts : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t ->
-    let uu____20 = FStar_ST.op_Bang tts_f in
-    match uu____20 with
+    let uu___ = FStar_ST.op_Bang tts_f in
+    match uu___ with
     | FStar_Pervasives_Native.None -> "<<hook unset>>"
     | FStar_Pervasives_Native.Some f -> f t
 let (mk_discriminator : FStar_Ident.lident -> FStar_Ident.lident) =
   fun lid ->
-    let uu____57 =
-      let uu____58 = FStar_Ident.ns_of_lid lid in
-      let uu____61 =
-        let uu____64 =
-          let uu____65 =
-            let uu____70 =
-              let uu____71 =
-                let uu____72 =
-                  let uu____73 = FStar_Ident.ident_of_lid lid in
-                  FStar_Ident.string_of_id uu____73 in
-                Prims.op_Hat "is_" uu____72 in
-              Prims.op_Hat FStar_Ident.reserved_prefix uu____71 in
-            let uu____74 = FStar_Ident.range_of_lid lid in
-            (uu____70, uu____74) in
-          FStar_Ident.mk_ident uu____65 in
-        [uu____64] in
-      FStar_List.append uu____58 uu____61 in
-    FStar_Ident.lid_of_ids uu____57
+    let uu___ =
+      let uu___1 = FStar_Ident.ns_of_lid lid in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 = FStar_Ident.ident_of_lid lid in
+                  FStar_Ident.string_of_id uu___8 in
+                Prims.op_Hat "is_" uu___7 in
+              Prims.op_Hat FStar_Ident.reserved_prefix uu___6 in
+            let uu___6 = FStar_Ident.range_of_lid lid in (uu___5, uu___6) in
+          FStar_Ident.mk_ident uu___4 in
+        [uu___3] in
+      FStar_List.append uu___1 uu___2 in
+    FStar_Ident.lid_of_ids uu___
 let (is_name : FStar_Ident.lident -> Prims.bool) =
   fun lid ->
     let c =
-      let uu____81 =
-        let uu____82 = FStar_Ident.ident_of_lid lid in
-        FStar_Ident.string_of_id uu____82 in
-      FStar_Util.char_at uu____81 Prims.int_zero in
+      let uu___ =
+        let uu___1 = FStar_Ident.ident_of_lid lid in
+        FStar_Ident.string_of_id uu___1 in
+      FStar_Util.char_at uu___ Prims.int_zero in
     FStar_Util.is_upper c
 let arg_of_non_null_binder :
-  'uuuuuu87 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu87) ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu87)
+  'uuuuu .
+    (FStar_Syntax_Syntax.bv * 'uuuuu) -> (FStar_Syntax_Syntax.term * 'uuuuu)
   =
-  fun uu____100 ->
-    match uu____100 with
+  fun uu___ ->
+    match uu___ with
     | (b, imp) ->
-        let uu____107 = FStar_Syntax_Syntax.bv_to_name b in (uu____107, imp)
+        let uu___1 = FStar_Syntax_Syntax.bv_to_name b in (uu___1, imp)
 let (args_of_non_null_binders :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
@@ -55,31 +53,30 @@ let (args_of_non_null_binders :
     FStar_All.pipe_right binders
       (FStar_List.collect
          (fun b ->
-            let uu____158 = FStar_Syntax_Syntax.is_null_binder b in
-            if uu____158
+            let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+            if uu___
             then []
-            else (let uu____174 = arg_of_non_null_binder b in [uu____174])))
+            else (let uu___2 = arg_of_non_null_binder b in [uu___2])))
 let (args_of_binders :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.args))
   =
   fun binders ->
-    let uu____208 =
+    let uu___ =
       FStar_All.pipe_right binders
         (FStar_List.map
            (fun b ->
-              let uu____290 = FStar_Syntax_Syntax.is_null_binder b in
-              if uu____290
+              let uu___1 = FStar_Syntax_Syntax.is_null_binder b in
+              if uu___1
               then
                 let b1 =
-                  let uu____314 =
+                  let uu___2 =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                  (uu____314, (FStar_Pervasives_Native.snd b)) in
-                let uu____321 = arg_of_non_null_binder b1 in (b1, uu____321)
-              else
-                (let uu____343 = arg_of_non_null_binder b in (b, uu____343)))) in
-    FStar_All.pipe_right uu____208 FStar_List.unzip
+                  (uu___2, (FStar_Pervasives_Native.snd b)) in
+                let uu___2 = arg_of_non_null_binder b1 in (b1, uu___2)
+              else (let uu___3 = arg_of_non_null_binder b in (b, uu___3)))) in
+    FStar_All.pipe_right uu___ FStar_List.unzip
 let (name_binders :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) Prims.list ->
@@ -91,17 +88,17 @@ let (name_binders :
       (FStar_List.mapi
          (fun i ->
             fun b ->
-              let uu____475 = FStar_Syntax_Syntax.is_null_binder b in
-              if uu____475
+              let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+              if uu___
               then
-                let uu____482 = b in
-                match uu____482 with
+                let uu___1 = b in
+                match uu___1 with
                 | (a, imp) ->
                     let b1 =
-                      let uu____502 =
-                        let uu____503 = FStar_Util.string_of_int i in
-                        Prims.op_Hat "_" uu____503 in
-                      FStar_Ident.id_of_text uu____502 in
+                      let uu___2 =
+                        let uu___3 = FStar_Util.string_of_int i in
+                        Prims.op_Hat "_" uu___3 in
+                      FStar_Ident.id_of_text uu___2 in
                     let b2 =
                       {
                         FStar_Syntax_Syntax.ppname = b1;
@@ -118,12 +115,11 @@ let (name_function_binders :
   fun t ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (binders, comp) ->
-        let uu____543 =
-          let uu____544 =
-            let uu____559 = name_binders binders in (uu____559, comp) in
-          FStar_Syntax_Syntax.Tm_arrow uu____544 in
-        FStar_Syntax_Syntax.mk uu____543 t.FStar_Syntax_Syntax.pos
-    | uu____578 -> t
+        let uu___ =
+          let uu___1 = let uu___2 = name_binders binders in (uu___2, comp) in
+          FStar_Syntax_Syntax.Tm_arrow uu___1 in
+        FStar_Syntax_Syntax.mk uu___ t.FStar_Syntax_Syntax.pos
+    | uu___ -> t
 let (null_binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
     FStar_Syntax_Syntax.binders)
@@ -131,13 +127,13 @@ let (null_binders_of_tks :
   fun tks ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____614 ->
-            match uu____614 with
+         (fun uu___ ->
+            match uu___ with
             | (t, imp) ->
-                let uu____625 =
-                  let uu____626 = FStar_Syntax_Syntax.null_binder t in
-                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____626 in
-                (uu____625, imp)))
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Syntax.null_binder t in
+                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu___2 in
+                (uu___1, imp)))
 let (binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
     FStar_Syntax_Syntax.binders)
@@ -145,24 +141,22 @@ let (binders_of_tks :
   fun tks ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____680 ->
-            match uu____680 with
+         (fun uu___ ->
+            match uu___ with
             | (t, imp) ->
-                let uu____697 =
+                let uu___1 =
                   FStar_Syntax_Syntax.new_bv
                     (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))
                     t in
-                (uu____697, imp)))
+                (uu___1, imp)))
 let (binders_of_freevars :
   FStar_Syntax_Syntax.bv FStar_Util.set ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun fvs ->
-    let uu____709 = FStar_Util.set_elements fvs in
-    FStar_All.pipe_right uu____709
-      (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-let mk_subst : 'uuuuuu720 . 'uuuuuu720 -> 'uuuuuu720 Prims.list =
-  fun s -> [s]
+    let uu___ = FStar_Util.set_elements fvs in
+    FStar_All.pipe_right uu___ (FStar_List.map FStar_Syntax_Syntax.mk_binder)
+let mk_subst : 'uuuuu . 'uuuuu -> 'uuuuu Prims.list = fun s -> [s]
 let (subst_of_list :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.subst_t)
@@ -189,22 +183,22 @@ let (rename_binders :
       if (FStar_List.length replace_xs) = (FStar_List.length with_ys)
       then
         FStar_List.map2
-          (fun uu____840 ->
-             fun uu____841 ->
-               match (uu____840, uu____841) with
-               | ((x, uu____867), (y, uu____869)) ->
-                   let uu____890 =
-                     let uu____897 = FStar_Syntax_Syntax.bv_to_name y in
-                     (x, uu____897) in
-                   FStar_Syntax_Syntax.NT uu____890) replace_xs with_ys
+          (fun uu___ ->
+             fun uu___1 ->
+               match (uu___, uu___1) with
+               | ((x, uu___2), (y, uu___3)) ->
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Syntax.bv_to_name y in
+                     (x, uu___5) in
+                   FStar_Syntax_Syntax.NT uu___4) replace_xs with_ys
       else failwith "Ill-formed substitution"
 let rec (unmeta : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e ->
     let e1 = FStar_Syntax_Subst.compress e in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_meta (e2, uu____910) -> unmeta e2
-    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu____916, uu____917) -> unmeta e2
-    | uu____958 -> e1
+    | FStar_Syntax_Syntax.Tm_meta (e2, uu___) -> unmeta e2
+    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu___, uu___1) -> unmeta e2
+    | uu___ -> e1
 let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun e ->
@@ -212,39 +206,37 @@ let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (e', m) ->
         (match m with
-         | FStar_Syntax_Syntax.Meta_monadic uu____971 -> e1
-         | FStar_Syntax_Syntax.Meta_monadic_lift uu____978 -> e1
-         | uu____987 -> unmeta_safe e')
-    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu____989, uu____990) ->
-        unmeta_safe e2
-    | uu____1031 -> e1
+         | FStar_Syntax_Syntax.Meta_monadic uu___ -> e1
+         | FStar_Syntax_Syntax.Meta_monadic_lift uu___ -> e1
+         | uu___ -> unmeta_safe e')
+    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu___, uu___1) -> unmeta_safe e2
+    | uu___ -> e1
 let (unmeta_lift : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____1037 =
-      let uu____1038 = FStar_Syntax_Subst.compress t in
-      uu____1038.FStar_Syntax_Syntax.n in
-    match uu____1037 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_meta
-        (t1, FStar_Syntax_Syntax.Meta_monadic_lift uu____1042) -> t1
-    | uu____1055 -> t
+        (t1, FStar_Syntax_Syntax.Meta_monadic_lift uu___1) -> t1
+    | uu___1 -> t
 let rec (univ_kernel :
   FStar_Syntax_Syntax.universe -> (FStar_Syntax_Syntax.universe * Prims.int))
   =
   fun u ->
     match u with
     | FStar_Syntax_Syntax.U_unknown -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_name uu____1069 -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_unif uu____1070 -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_max uu____1081 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_name uu___ -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_unif uu___ -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_max uu___ -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_zero -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____1085 = univ_kernel u1 in
-        (match uu____1085 with | (k, n) -> (k, (n + Prims.int_one)))
-    | FStar_Syntax_Syntax.U_bvar uu____1096 ->
+        let uu___ = univ_kernel u1 in
+        (match uu___ with | (k, n) -> (k, (n + Prims.int_one)))
+    | FStar_Syntax_Syntax.U_bvar uu___ ->
         failwith "Imposible: univ_kernel (U_bvar _)"
 let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
-  fun u ->
-    let uu____1106 = univ_kernel u in FStar_Pervasives_Native.snd uu____1106
+  fun u -> let uu___ = univ_kernel u in FStar_Pervasives_Native.snd uu___
 let rec (compare_univs :
   FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int)
   =
@@ -252,38 +244,34 @@ let rec (compare_univs :
     fun u2 ->
       let rec compare_kernel uk1 uk2 =
         match (uk1, uk2) with
-        | (FStar_Syntax_Syntax.U_bvar uu____1132, uu____1133) ->
+        | (FStar_Syntax_Syntax.U_bvar uu___, uu___1) ->
             failwith "Impossible: compare_kernel bvar"
-        | (uu____1134, FStar_Syntax_Syntax.U_bvar uu____1135) ->
+        | (uu___, FStar_Syntax_Syntax.U_bvar uu___1) ->
             failwith "Impossible: compare_kernel bvar"
-        | (FStar_Syntax_Syntax.U_succ uu____1136, uu____1137) ->
+        | (FStar_Syntax_Syntax.U_succ uu___, uu___1) ->
             failwith "Impossible: compare_kernel succ"
-        | (uu____1138, FStar_Syntax_Syntax.U_succ uu____1139) ->
+        | (uu___, FStar_Syntax_Syntax.U_succ uu___1) ->
             failwith "Impossible: compare_kernel succ"
         | (FStar_Syntax_Syntax.U_unknown, FStar_Syntax_Syntax.U_unknown) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_unknown, uu____1140) -> ~- Prims.int_one
-        | (uu____1141, FStar_Syntax_Syntax.U_unknown) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_unknown, uu___) -> ~- Prims.int_one
+        | (uu___, FStar_Syntax_Syntax.U_unknown) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_zero, uu____1142) -> ~- Prims.int_one
-        | (uu____1143, FStar_Syntax_Syntax.U_zero) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_zero, uu___) -> ~- Prims.int_one
+        | (uu___, FStar_Syntax_Syntax.U_zero) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_name u11, FStar_Syntax_Syntax.U_name u21) ->
-            let uu____1146 = FStar_Ident.string_of_id u11 in
-            let uu____1147 = FStar_Ident.string_of_id u21 in
-            FStar_String.compare uu____1146 uu____1147
-        | (FStar_Syntax_Syntax.U_name uu____1148, uu____1149) ->
-            ~- Prims.int_one
-        | (uu____1150, FStar_Syntax_Syntax.U_name uu____1151) ->
-            Prims.int_one
+            let uu___ = FStar_Ident.string_of_id u11 in
+            let uu___1 = FStar_Ident.string_of_id u21 in
+            FStar_String.compare uu___ uu___1
+        | (FStar_Syntax_Syntax.U_name uu___, uu___1) -> ~- Prims.int_one
+        | (uu___, FStar_Syntax_Syntax.U_name uu___1) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_unif u11, FStar_Syntax_Syntax.U_unif u21) ->
-            let uu____1174 = FStar_Syntax_Unionfind.univ_uvar_id u11 in
-            let uu____1175 = FStar_Syntax_Unionfind.univ_uvar_id u21 in
-            uu____1174 - uu____1175
-        | (FStar_Syntax_Syntax.U_unif uu____1176, uu____1177) ->
-            ~- Prims.int_one
-        | (uu____1188, FStar_Syntax_Syntax.U_unif uu____1189) ->
-            Prims.int_one
+            let uu___ = FStar_Syntax_Unionfind.univ_uvar_id u11 in
+            let uu___1 = FStar_Syntax_Unionfind.univ_uvar_id u21 in
+            uu___ - uu___1
+        | (FStar_Syntax_Syntax.U_unif uu___, uu___1) -> ~- Prims.int_one
+        | (uu___, FStar_Syntax_Syntax.U_unif uu___1) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_max us1, FStar_Syntax_Syntax.U_max us2) ->
             let n1 = FStar_List.length us1 in
             let n2 = FStar_List.length us2 in
@@ -291,10 +279,10 @@ let rec (compare_univs :
             then n1 - n2
             else
               (let copt =
-                 let uu____1212 = FStar_List.zip us1 us2 in
-                 FStar_Util.find_map uu____1212
-                   (fun uu____1227 ->
-                      match uu____1227 with
+                 let uu___1 = FStar_List.zip us1 us2 in
+                 FStar_Util.find_map uu___1
+                   (fun uu___2 ->
+                      match uu___2 with
                       | (u11, u21) ->
                           let c = compare_univs u11 u21 in
                           if c <> Prims.int_zero
@@ -303,58 +291,54 @@ let rec (compare_univs :
                match copt with
                | FStar_Pervasives_Native.None -> Prims.int_zero
                | FStar_Pervasives_Native.Some c -> c) in
-      let uu____1241 = univ_kernel u1 in
-      match uu____1241 with
+      let uu___ = univ_kernel u1 in
+      match uu___ with
       | (uk1, n1) ->
-          let uu____1248 = univ_kernel u2 in
-          (match uu____1248 with
+          let uu___1 = univ_kernel u2 in
+          (match uu___1 with
            | (uk2, n2) ->
-               let uu____1255 = compare_kernel uk1 uk2 in
-               (match uu____1255 with
-                | uu____1256 when uu____1256 = Prims.int_zero -> n1 - n2
+               let uu___2 = compare_kernel uk1 uk2 in
+               (match uu___2 with
+                | uu___3 when uu___3 = Prims.int_zero -> n1 - n2
                 | n -> n))
 let (eq_univs :
   FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.bool)
   =
   fun u1 ->
-    fun u2 ->
-      let uu____1268 = compare_univs u1 u2 in uu____1268 = Prims.int_zero
+    fun u2 -> let uu___ = compare_univs u1 u2 in uu___ = Prims.int_zero
 let (ml_comp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Range.range -> FStar_Syntax_Syntax.comp)
   =
   fun t ->
     fun r ->
-      let uu____1283 =
-        let uu____1284 =
+      let uu___ =
+        let uu___1 =
           FStar_Ident.set_lid_range FStar_Parser_Const.effect_ML_lid r in
         {
           FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_zero];
-          FStar_Syntax_Syntax.effect_name = uu____1284;
+          FStar_Syntax_Syntax.effect_name = uu___1;
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = [FStar_Syntax_Syntax.MLEFFECT]
         } in
-      FStar_Syntax_Syntax.mk_Comp uu____1283
+      FStar_Syntax_Syntax.mk_Comp uu___
 let (comp_effect_name :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-    | FStar_Syntax_Syntax.Total uu____1303 ->
-        FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.GTotal uu____1312 ->
-        FStar_Parser_Const.effect_GTot_lid
+    | FStar_Syntax_Syntax.Total uu___ -> FStar_Parser_Const.effect_Tot_lid
+    | FStar_Syntax_Syntax.GTotal uu___ -> FStar_Parser_Const.effect_GTot_lid
 let (comp_flags :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1334 -> [FStar_Syntax_Syntax.TOTAL]
-    | FStar_Syntax_Syntax.GTotal uu____1343 ->
-        [FStar_Syntax_Syntax.SOMETRIVIAL]
+    | FStar_Syntax_Syntax.Total uu___ -> [FStar_Syntax_Syntax.TOTAL]
+    | FStar_Syntax_Syntax.GTotal uu___ -> [FStar_Syntax_Syntax.SOMETRIVIAL]
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.flags
 let (comp_to_comp_typ_nouniv :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
@@ -362,22 +346,22 @@ let (comp_to_comp_typ_nouniv :
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1
     | FStar_Syntax_Syntax.Total (t, u_opt) ->
-        let uu____1369 =
-          let uu____1370 = FStar_Util.map_opt u_opt (fun x -> [x]) in
-          FStar_Util.dflt [] uu____1370 in
+        let uu___ =
+          let uu___1 = FStar_Util.map_opt u_opt (fun x -> [x]) in
+          FStar_Util.dflt [] uu___1 in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1369;
+          FStar_Syntax_Syntax.comp_univs = uu___;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
     | FStar_Syntax_Syntax.GTotal (t, u_opt) ->
-        let uu____1399 =
-          let uu____1400 = FStar_Util.map_opt u_opt (fun x -> [x]) in
-          FStar_Util.dflt [] uu____1400 in
+        let uu___ =
+          let uu___1 = FStar_Util.map_opt u_opt (fun x -> [x]) in
+          FStar_Util.dflt [] uu___1 in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1399;
+          FStar_Syntax_Syntax.comp_univs = uu___;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
@@ -390,26 +374,26 @@ let (comp_set_flags :
   =
   fun c ->
     fun f ->
-      let uu___239_1435 = c in
-      let uu____1436 =
-        let uu____1437 =
-          let uu___241_1438 = comp_to_comp_typ_nouniv c in
+      let uu___ = c in
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = comp_to_comp_typ_nouniv c in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___241_1438.FStar_Syntax_Syntax.comp_univs);
+              (uu___3.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___241_1438.FStar_Syntax_Syntax.effect_name);
+              (uu___3.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___241_1438.FStar_Syntax_Syntax.result_typ);
+              (uu___3.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args =
-              (uu___241_1438.FStar_Syntax_Syntax.effect_args);
+              (uu___3.FStar_Syntax_Syntax.effect_args);
             FStar_Syntax_Syntax.flags = f
           } in
-        FStar_Syntax_Syntax.Comp uu____1437 in
+        FStar_Syntax_Syntax.Comp uu___2 in
       {
-        FStar_Syntax_Syntax.n = uu____1436;
-        FStar_Syntax_Syntax.pos = (uu___239_1435.FStar_Syntax_Syntax.pos);
-        FStar_Syntax_Syntax.vars = (uu___239_1435.FStar_Syntax_Syntax.vars)
+        FStar_Syntax_Syntax.n = uu___1;
+        FStar_Syntax_Syntax.pos = (uu___.FStar_Syntax_Syntax.pos);
+        FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
       }
 let (comp_to_comp_typ :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
@@ -432,8 +416,7 @@ let (comp_to_comp_typ :
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
-    | uu____1477 ->
-        failwith "Assertion failed: Computation type without universe"
+    | uu___ -> failwith "Assertion failed: Computation type without universe"
 let (effect_indices_from_repr :
   FStar_Syntax_Syntax.term ->
     Prims.bool ->
@@ -444,26 +427,26 @@ let (effect_indices_from_repr :
     fun is_layered ->
       fun r ->
         fun err ->
-          let err1 uu____1509 =
+          let err1 uu___ =
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEffect, err) r in
           let repr1 = FStar_Syntax_Subst.compress repr in
           if is_layered
           then
             match repr1.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_app (uu____1517, uu____1518::is) ->
+            | FStar_Syntax_Syntax.Tm_app (uu___, uu___1::is) ->
                 FStar_All.pipe_right is
                   (FStar_List.map FStar_Pervasives_Native.fst)
-            | uu____1586 -> err1 ()
+            | uu___ -> err1 ()
           else
             (match repr1.FStar_Syntax_Syntax.n with
-             | FStar_Syntax_Syntax.Tm_arrow (uu____1590, c) ->
-                 let uu____1612 = FStar_All.pipe_right c comp_to_comp_typ in
-                 FStar_All.pipe_right uu____1612
+             | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
+                 let uu___2 = FStar_All.pipe_right c comp_to_comp_typ in
+                 FStar_All.pipe_right uu___2
                    (fun ct ->
                       FStar_All.pipe_right ct.FStar_Syntax_Syntax.effect_args
                         (FStar_List.map FStar_Pervasives_Native.fst))
-             | uu____1647 -> err1 ())
+             | uu___1 -> err1 ())
 let (destruct_comp :
   FStar_Syntax_Syntax.comp_typ ->
     (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ *
@@ -472,22 +455,22 @@ let (destruct_comp :
   fun c ->
     let wp =
       match c.FStar_Syntax_Syntax.effect_args with
-      | (wp, uu____1667)::[] -> wp
-      | uu____1692 ->
-          let uu____1703 =
-            let uu____1704 =
+      | (wp1, uu___)::[] -> wp1
+      | uu___ ->
+          let uu___1 =
+            let uu___2 =
               FStar_Ident.string_of_lid c.FStar_Syntax_Syntax.effect_name in
-            let uu____1705 =
-              let uu____1706 =
+            let uu___3 =
+              let uu___4 =
                 FStar_All.pipe_right c.FStar_Syntax_Syntax.effect_args
                   FStar_List.length in
-              FStar_All.pipe_right uu____1706 FStar_Util.string_of_int in
+              FStar_All.pipe_right uu___4 FStar_Util.string_of_int in
             FStar_Util.format2
-              "Impossible: Got a computation %s with %s effect args"
-              uu____1704 uu____1705 in
-          failwith uu____1703 in
-    let uu____1725 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs in
-    (uu____1725, (c.FStar_Syntax_Syntax.result_typ), wp)
+              "Impossible: Got a computation %s with %s effect args" uu___2
+              uu___3 in
+          failwith uu___1 in
+    let uu___ = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs in
+    (uu___, (c.FStar_Syntax_Syntax.result_typ), wp)
 let (is_named_tot :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -495,8 +478,8 @@ let (is_named_tot :
     | FStar_Syntax_Syntax.Comp c1 ->
         FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.Total uu____1736 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1745 -> false
+    | FStar_Syntax_Syntax.Total uu___ -> true
+    | FStar_Syntax_Syntax.GTotal uu___ -> false
 let (is_total_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -505,21 +488,21 @@ let (is_total_comp :
       ||
       (FStar_All.pipe_right (comp_flags c)
          (FStar_Util.for_some
-            (fun uu___0_1766 ->
-               match uu___0_1766 with
+            (fun uu___ ->
+               match uu___ with
                | FStar_Syntax_Syntax.TOTAL -> true
                | FStar_Syntax_Syntax.RETURN -> true
-               | uu____1767 -> false)))
+               | uu___1 -> false)))
 let (is_partial_return :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___1_1780 ->
-            match uu___1_1780 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.RETURN -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
-            | uu____1781 -> false))
+            | uu___1 -> false))
 let (is_tot_or_gtot_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -535,18 +518,18 @@ let (is_pure_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1805 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1814 -> false
+    | FStar_Syntax_Syntax.Total uu___ -> true
+    | FStar_Syntax_Syntax.GTotal uu___ -> false
     | FStar_Syntax_Syntax.Comp ct ->
         ((is_total_comp c) ||
            (is_pure_effect ct.FStar_Syntax_Syntax.effect_name))
           ||
           (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___2_1827 ->
-                   match uu___2_1827 with
+                (fun uu___ ->
+                   match uu___ with
                    | FStar_Syntax_Syntax.LEMMA -> true
-                   | uu____1828 -> false)))
+                   | uu___1 -> false)))
 let (is_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l ->
     ((FStar_Ident.lid_equals FStar_Parser_Const.effect_GTot_lid l) ||
@@ -564,12 +547,12 @@ let (is_pure_or_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l -> (is_pure_effect l) || (is_ghost_effect l)
 let (is_pure_or_ghost_function : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1858 =
-      let uu____1859 = FStar_Syntax_Subst.compress t in
-      uu____1859.FStar_Syntax_Syntax.n in
-    match uu____1858 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1862, c) -> is_pure_or_ghost_comp c
-    | uu____1884 -> true
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) -> is_pure_or_ghost_comp c
+    | uu___1 -> true
 let (is_lemma_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -577,28 +560,27 @@ let (is_lemma_comp :
     | FStar_Syntax_Syntax.Comp ct ->
         FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Lemma_lid
-    | uu____1895 -> false
+    | uu___ -> false
 let (is_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1901 =
-      let uu____1902 = FStar_Syntax_Subst.compress t in
-      uu____1902.FStar_Syntax_Syntax.n in
-    match uu____1901 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1905, c) -> is_lemma_comp c
-    | uu____1927 -> false
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) -> is_lemma_comp c
+    | uu___1 -> false
 let rec (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____1933 =
-      let uu____1934 = FStar_Syntax_Subst.compress t in
-      uu____1934.FStar_Syntax_Syntax.n in
-    match uu____1933 with
-    | FStar_Syntax_Syntax.Tm_app (t1, uu____1938) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_match (t1, uu____1964) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_abs (uu____2001, t1, uu____2003) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu____2029, uu____2030) ->
-        head_of t1
-    | FStar_Syntax_Syntax.Tm_meta (t1, uu____2072) -> head_of t1
-    | uu____2077 -> t
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_app (t1, uu___1) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_match (t1, uu___1) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_abs (uu___1, t1, uu___2) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu___1, uu___2) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_meta (t1, uu___1) -> head_of t1
+    | uu___1 -> t
 let (head_and_args :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -610,7 +592,7 @@ let (head_and_args :
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head, args) -> (head, args)
-    | uu____2154 -> (t1, [])
+    | uu___ -> (t1, [])
 let rec (head_and_args' :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.term'
@@ -621,17 +603,17 @@ let rec (head_and_args' :
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head, args) ->
-        let uu____2235 = head_and_args' head in
-        (match uu____2235 with
+        let uu___ = head_and_args' head in
+        (match uu___ with
          | (head1, args') -> (head1, (FStar_List.append args' args)))
-    | uu____2304 -> (t1, [])
+    | uu___ -> (t1, [])
 let (un_uinst : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_uinst (t2, uu____2330) ->
+    | FStar_Syntax_Syntax.Tm_uinst (t2, uu___) ->
         FStar_Syntax_Subst.compress t2
-    | uu____2335 -> t1
+    | uu___ -> t1
 let (is_ml_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -642,19 +624,19 @@ let (is_ml_comp :
           ||
           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___3_2349 ->
-                   match uu___3_2349 with
+                (fun uu___ ->
+                   match uu___ with
                    | FStar_Syntax_Syntax.MLEFFECT -> true
-                   | uu____2350 -> false)))
-    | uu____2351 -> false
+                   | uu___1 -> false)))
+    | uu___ -> false
 let (comp_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t, uu____2366) -> t
-    | FStar_Syntax_Syntax.GTotal (t, uu____2376) -> t
+    | FStar_Syntax_Syntax.Total (t, uu___) -> t
+    | FStar_Syntax_Syntax.GTotal (t, uu___) -> t
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
 let (set_result_typ :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -664,40 +646,37 @@ let (set_result_typ :
   fun c ->
     fun t ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____2404 ->
-          FStar_Syntax_Syntax.mk_Total t
-      | FStar_Syntax_Syntax.GTotal uu____2413 ->
-          FStar_Syntax_Syntax.mk_GTotal t
+      | FStar_Syntax_Syntax.Total uu___ -> FStar_Syntax_Syntax.mk_Total t
+      | FStar_Syntax_Syntax.GTotal uu___ -> FStar_Syntax_Syntax.mk_GTotal t
       | FStar_Syntax_Syntax.Comp ct ->
           FStar_Syntax_Syntax.mk_Comp
-            (let uu___401_2425 = ct in
+            (let uu___ = ct in
              {
                FStar_Syntax_Syntax.comp_univs =
-                 (uu___401_2425.FStar_Syntax_Syntax.comp_univs);
+                 (uu___.FStar_Syntax_Syntax.comp_univs);
                FStar_Syntax_Syntax.effect_name =
-                 (uu___401_2425.FStar_Syntax_Syntax.effect_name);
+                 (uu___.FStar_Syntax_Syntax.effect_name);
                FStar_Syntax_Syntax.result_typ = t;
                FStar_Syntax_Syntax.effect_args =
-                 (uu___401_2425.FStar_Syntax_Syntax.effect_args);
-               FStar_Syntax_Syntax.flags =
-                 (uu___401_2425.FStar_Syntax_Syntax.flags)
+                 (uu___.FStar_Syntax_Syntax.effect_args);
+               FStar_Syntax_Syntax.flags = (uu___.FStar_Syntax_Syntax.flags)
              })
 let (is_trivial_wp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___4_2438 ->
-            match uu___4_2438 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.TOTAL -> true
             | FStar_Syntax_Syntax.RETURN -> true
-            | uu____2439 -> false))
+            | uu___1 -> false))
 let (comp_effect_args : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.args)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2445 -> []
-    | FStar_Syntax_Syntax.GTotal uu____2462 -> []
+    | FStar_Syntax_Syntax.Total uu___ -> []
+    | FStar_Syntax_Syntax.GTotal uu___ -> []
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.effect_args
 let (primops : FStar_Ident.lident Prims.list) =
   [FStar_Parser_Const.op_Eq;
@@ -725,14 +704,13 @@ let (is_primop :
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         is_primop_lid (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____2499 -> false
+    | uu___ -> false
 let rec (unascribe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e ->
     let e1 = FStar_Syntax_Subst.compress e in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu____2507, uu____2508) ->
-        unascribe e2
-    | uu____2549 -> e1
+    | FStar_Syntax_Syntax.Tm_ascribed (e2, uu___, uu___1) -> unascribe e2
+    | uu___ -> e1
 let rec (ascribe :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
@@ -744,9 +722,8 @@ let rec (ascribe :
   fun t ->
     fun k ->
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_ascribed (t', uu____2601, uu____2602) ->
-          ascribe t' k
-      | uu____2643 ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t', uu___, uu___1) -> ascribe t' k
+      | uu___ ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (t, k, FStar_Pervasives_Native.None))
@@ -754,33 +731,31 @@ let rec (ascribe :
 let (unfold_lazy : FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term)
   =
   fun i ->
-    let uu____2669 =
-      let uu____2678 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
-      FStar_Util.must uu____2678 in
-    uu____2669 i.FStar_Syntax_Syntax.lkind i
+    let uu___ =
+      let uu___1 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
+      FStar_Util.must uu___1 in
+    uu___ i.FStar_Syntax_Syntax.lkind i
 let rec (unlazy : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____2720 =
-      let uu____2721 = FStar_Syntax_Subst.compress t in
-      uu____2721.FStar_Syntax_Syntax.n in
-    match uu____2720 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____2725 = unfold_lazy i in
-        FStar_All.pipe_left unlazy uu____2725
-    | uu____2726 -> t
+        let uu___1 = unfold_lazy i in FStar_All.pipe_left unlazy uu___1
+    | uu___1 -> t
 let (unlazy_emb : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____2732 =
-      let uu____2733 = FStar_Syntax_Subst.compress t in
-      uu____2733.FStar_Syntax_Syntax.n in
-    match uu____2732 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy i ->
         (match i.FStar_Syntax_Syntax.lkind with
-         | FStar_Syntax_Syntax.Lazy_embedding uu____2737 ->
-             let uu____2746 = unfold_lazy i in
-             FStar_All.pipe_left unlazy uu____2746
-         | uu____2747 -> t)
-    | uu____2748 -> t
+         | FStar_Syntax_Syntax.Lazy_embedding uu___1 ->
+             let uu___2 = unfold_lazy i in FStar_All.pipe_left unlazy uu___2
+         | uu___1 -> t)
+    | uu___1 -> t
 let (eq_lazy_kind :
   FStar_Syntax_Syntax.lazy_kind ->
     FStar_Syntax_Syntax.lazy_kind -> Prims.bool)
@@ -807,23 +782,23 @@ let (eq_lazy_kind :
           true
       | (FStar_Syntax_Syntax.Lazy_uvar, FStar_Syntax_Syntax.Lazy_uvar) ->
           true
-      | uu____2759 -> false
+      | uu___ -> false
 let unlazy_as_t :
-  'uuuuuu2770 .
-    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuuu2770
+  'uuuuu .
+    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuu
   =
   fun k ->
     fun t ->
-      let uu____2781 =
-        let uu____2782 = FStar_Syntax_Subst.compress t in
-        uu____2782.FStar_Syntax_Syntax.n in
-      match uu____2781 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_lazy
           { FStar_Syntax_Syntax.blob = v; FStar_Syntax_Syntax.lkind = k';
-            FStar_Syntax_Syntax.ltyp = uu____2787;
-            FStar_Syntax_Syntax.rng = uu____2788;_}
+            FStar_Syntax_Syntax.ltyp = uu___1;
+            FStar_Syntax_Syntax.rng = uu___2;_}
           when eq_lazy_kind k k' -> FStar_Dyn.undyn v
-      | uu____2791 -> failwith "Not a Tm_lazy of the expected kind"
+      | uu___1 -> failwith "Not a Tm_lazy of the expected kind"
 let mk_lazy :
   'a .
     'a ->
@@ -841,9 +816,9 @@ let mk_lazy :
             | FStar_Pervasives_Native.Some r1 -> r1
             | FStar_Pervasives_Native.None -> FStar_Range.dummyRange in
           let i =
-            let uu____2830 = FStar_Dyn.mkdyn t in
+            let uu___ = FStar_Dyn.mkdyn t in
             {
-              FStar_Syntax_Syntax.blob = uu____2830;
+              FStar_Syntax_Syntax.blob = uu___;
               FStar_Syntax_Syntax.lkind = k;
               FStar_Syntax_Syntax.ltyp = typ;
               FStar_Syntax_Syntax.rng = rng
@@ -854,9 +829,8 @@ let (canon_app :
     FStar_Syntax_Syntax.term)
   =
   fun t ->
-    let uu____2840 =
-      let uu____2855 = unascribe t in head_and_args' uu____2855 in
-    match uu____2840 with
+    let uu___ = let uu___1 = unascribe t in head_and_args' uu___1 in
+    match uu___ with
     | (hd, args) ->
         FStar_Syntax_Syntax.mk_Tm_app hd args t.FStar_Syntax_Syntax.pos
 type eq_result =
@@ -864,13 +838,11 @@ type eq_result =
   | NotEqual 
   | Unknown 
 let (uu___is_Equal : eq_result -> Prims.bool) =
-  fun projectee -> match projectee with | Equal -> true | uu____2883 -> false
+  fun projectee -> match projectee with | Equal -> true | uu___ -> false
 let (uu___is_NotEqual : eq_result -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NotEqual -> true | uu____2889 -> false
+  fun projectee -> match projectee with | NotEqual -> true | uu___ -> false
 let (uu___is_Unknown : eq_result -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unknown -> true | uu____2895 -> false
+  fun projectee -> match projectee with | Unknown -> true | uu___ -> false
 let (injectives : Prims.string Prims.list) =
   ["FStar.Int8.int_to_t";
   "FStar.Int16.int_to_t";
@@ -893,53 +865,53 @@ let (eq_inj : eq_result -> eq_result -> eq_result) =
     fun g ->
       match (f, g) with
       | (Equal, Equal) -> Equal
-      | (NotEqual, uu____2908) -> NotEqual
-      | (uu____2909, NotEqual) -> NotEqual
-      | (Unknown, uu____2910) -> Unknown
-      | (uu____2911, Unknown) -> Unknown
+      | (NotEqual, uu___) -> NotEqual
+      | (uu___, NotEqual) -> NotEqual
+      | (Unknown, uu___) -> Unknown
+      | (uu___, Unknown) -> Unknown
 let rec (eq_tm :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
   fun t1 ->
     fun t2 ->
       let t11 = canon_app t1 in
       let t21 = canon_app t2 in
-      let equal_if uu___5_3013 = if uu___5_3013 then Equal else Unknown in
-      let equal_iff uu___6_3020 = if uu___6_3020 then Equal else NotEqual in
-      let eq_and f g = match f with | Equal -> g () | uu____3038 -> Unknown in
+      let equal_if uu___ = if uu___ then Equal else Unknown in
+      let equal_iff uu___ = if uu___ then Equal else NotEqual in
+      let eq_and f g = match f with | Equal -> g () | uu___ -> Unknown in
       let equal_data f1 args1 f2 args2 =
-        let uu____3060 = FStar_Syntax_Syntax.fv_eq f1 f2 in
-        if uu____3060
+        let uu___ = FStar_Syntax_Syntax.fv_eq f1 f2 in
+        if uu___
         then
-          let uu____3062 = FStar_List.zip args1 args2 in
+          let uu___2 = FStar_List.zip args1 args2 in
           FStar_All.pipe_left
             (FStar_List.fold_left
                (fun acc ->
-                  fun uu____3139 ->
-                    match uu____3139 with
+                  fun uu___3 ->
+                    match uu___3 with
                     | ((a1, q1), (a2, q2)) ->
-                        let uu____3180 = eq_tm a1 a2 in eq_inj acc uu____3180)
-               Equal) uu____3062
+                        let uu___4 = eq_tm a1 a2 in eq_inj acc uu___4) Equal)
+            uu___2
         else NotEqual in
       let heads_and_args_in_case_both_data =
-        let uu____3193 =
-          let uu____3210 = FStar_All.pipe_right t11 unmeta in
-          FStar_All.pipe_right uu____3210 head_and_args in
-        match uu____3193 with
+        let uu___ =
+          let uu___1 = FStar_All.pipe_right t11 unmeta in
+          FStar_All.pipe_right uu___1 head_and_args in
+        match uu___ with
         | (head1, args1) ->
-            let uu____3263 =
-              let uu____3280 = FStar_All.pipe_right t21 unmeta in
-              FStar_All.pipe_right uu____3280 head_and_args in
-            (match uu____3263 with
+            let uu___1 =
+              let uu___2 = FStar_All.pipe_right t21 unmeta in
+              FStar_All.pipe_right uu___2 head_and_args in
+            (match uu___1 with
              | (head2, args2) ->
-                 let uu____3333 =
-                   let uu____3338 =
-                     let uu____3339 = un_uinst head1 in
-                     uu____3339.FStar_Syntax_Syntax.n in
-                   let uu____3342 =
-                     let uu____3343 = un_uinst head2 in
-                     uu____3343.FStar_Syntax_Syntax.n in
-                   (uu____3338, uu____3342) in
-                 (match uu____3333 with
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = un_uinst head1 in
+                     uu___4.FStar_Syntax_Syntax.n in
+                   let uu___4 =
+                     let uu___5 = un_uinst head2 in
+                     uu___5.FStar_Syntax_Syntax.n in
+                   (uu___3, uu___4) in
+                 (match uu___2 with
                   | (FStar_Syntax_Syntax.Tm_fvar f,
                      FStar_Syntax_Syntax.Tm_fvar g) when
                       (f.FStar_Syntax_Syntax.fv_qual =
@@ -950,101 +922,96 @@ let rec (eq_tm :
                            (FStar_Pervasives_Native.Some
                               FStar_Syntax_Syntax.Data_ctor))
                       -> FStar_Pervasives_Native.Some (f, args1, g, args2)
-                  | uu____3370 -> FStar_Pervasives_Native.None)) in
+                  | uu___3 -> FStar_Pervasives_Native.None)) in
       let t12 = unmeta t11 in
       let t22 = unmeta t21 in
       match ((t12.FStar_Syntax_Syntax.n), (t22.FStar_Syntax_Syntax.n)) with
       | (FStar_Syntax_Syntax.Tm_bvar bv1, FStar_Syntax_Syntax.Tm_bvar bv2) ->
           equal_if
             (bv1.FStar_Syntax_Syntax.index = bv2.FStar_Syntax_Syntax.index)
-      | (FStar_Syntax_Syntax.Tm_lazy uu____3387, uu____3388) ->
-          let uu____3389 = unlazy t12 in eq_tm uu____3389 t22
-      | (uu____3390, FStar_Syntax_Syntax.Tm_lazy uu____3391) ->
-          let uu____3392 = unlazy t22 in eq_tm t12 uu____3392
+      | (FStar_Syntax_Syntax.Tm_lazy uu___, uu___1) ->
+          let uu___2 = unlazy t12 in eq_tm uu___2 t22
+      | (uu___, FStar_Syntax_Syntax.Tm_lazy uu___1) ->
+          let uu___2 = unlazy t22 in eq_tm t12 uu___2
       | (FStar_Syntax_Syntax.Tm_name a, FStar_Syntax_Syntax.Tm_name b) ->
-          let uu____3395 = FStar_Syntax_Syntax.bv_eq a b in
-          equal_if uu____3395
-      | uu____3396 when
+          let uu___ = FStar_Syntax_Syntax.bv_eq a b in equal_if uu___
+      | uu___ when
           FStar_All.pipe_right heads_and_args_in_case_both_data
             FStar_Util.is_some
           ->
-          let uu____3419 =
+          let uu___1 =
             FStar_All.pipe_right heads_and_args_in_case_both_data
               FStar_Util.must in
-          FStar_All.pipe_right uu____3419
-            (fun uu____3467 ->
-               match uu____3467 with
+          FStar_All.pipe_right uu___1
+            (fun uu___2 ->
+               match uu___2 with
                | (f, args1, g, args2) -> equal_data f args1 g args2)
       | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
-          let uu____3482 = FStar_Syntax_Syntax.fv_eq f g in
-          equal_if uu____3482
+          let uu___ = FStar_Syntax_Syntax.fv_eq f g in equal_if uu___
       | (FStar_Syntax_Syntax.Tm_uinst (f, us), FStar_Syntax_Syntax.Tm_uinst
          (g, vs)) ->
-          let uu____3495 = eq_tm f g in
-          eq_and uu____3495
-            (fun uu____3498 ->
-               let uu____3499 = eq_univs_list us vs in equal_if uu____3499)
-      | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3500), uu____3501) -> Unknown
-      | (uu____3502, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3503)) -> Unknown
+          let uu___ = eq_tm f g in
+          eq_and uu___
+            (fun uu___1 ->
+               let uu___2 = eq_univs_list us vs in equal_if uu___2)
+      | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range uu___),
+         uu___1) -> Unknown
+      | (uu___, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
+         uu___1)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_constant c, FStar_Syntax_Syntax.Tm_constant
-         d) ->
-          let uu____3506 = FStar_Const.eq_const c d in equal_iff uu____3506
-      | (FStar_Syntax_Syntax.Tm_uvar (u1, ([], uu____3508)),
-         FStar_Syntax_Syntax.Tm_uvar (u2, ([], uu____3510))) ->
-          let uu____3539 =
+         d) -> let uu___ = FStar_Const.eq_const c d in equal_iff uu___
+      | (FStar_Syntax_Syntax.Tm_uvar (u1, ([], uu___)),
+         FStar_Syntax_Syntax.Tm_uvar (u2, ([], uu___1))) ->
+          let uu___2 =
             FStar_Syntax_Unionfind.equiv u1.FStar_Syntax_Syntax.ctx_uvar_head
               u2.FStar_Syntax_Syntax.ctx_uvar_head in
-          equal_if uu____3539
+          equal_if uu___2
       | (FStar_Syntax_Syntax.Tm_app (h1, args1), FStar_Syntax_Syntax.Tm_app
          (h2, args2)) ->
-          let uu____3592 =
-            let uu____3597 =
-              let uu____3598 = un_uinst h1 in
-              uu____3598.FStar_Syntax_Syntax.n in
-            let uu____3601 =
-              let uu____3602 = un_uinst h2 in
-              uu____3602.FStar_Syntax_Syntax.n in
-            (uu____3597, uu____3601) in
-          (match uu____3592 with
+          let uu___ =
+            let uu___1 =
+              let uu___2 = un_uinst h1 in uu___2.FStar_Syntax_Syntax.n in
+            let uu___2 =
+              let uu___3 = un_uinst h2 in uu___3.FStar_Syntax_Syntax.n in
+            (uu___1, uu___2) in
+          (match uu___ with
            | (FStar_Syntax_Syntax.Tm_fvar f1, FStar_Syntax_Syntax.Tm_fvar f2)
                when
                (FStar_Syntax_Syntax.fv_eq f1 f2) &&
-                 (let uu____3608 =
-                    let uu____3609 = FStar_Syntax_Syntax.lid_of_fv f1 in
-                    FStar_Ident.string_of_lid uu____3609 in
-                  FStar_List.mem uu____3608 injectives)
+                 (let uu___1 =
+                    let uu___2 = FStar_Syntax_Syntax.lid_of_fv f1 in
+                    FStar_Ident.string_of_lid uu___2 in
+                  FStar_List.mem uu___1 injectives)
                -> equal_data f1 args1 f2 args2
-           | uu____3610 ->
-               let uu____3615 = eq_tm h1 h2 in
-               eq_and uu____3615 (fun uu____3617 -> eq_args args1 args2))
+           | uu___1 ->
+               let uu___2 = eq_tm h1 h2 in
+               eq_and uu___2 (fun uu___3 -> eq_args args1 args2))
       | (FStar_Syntax_Syntax.Tm_match (t13, bs1),
          FStar_Syntax_Syntax.Tm_match (t23, bs2)) ->
           if (FStar_List.length bs1) = (FStar_List.length bs2)
           then
-            let uu____3722 = FStar_List.zip bs1 bs2 in
-            let uu____3785 = eq_tm t13 t23 in
+            let uu___ = FStar_List.zip bs1 bs2 in
+            let uu___1 = eq_tm t13 t23 in
             FStar_List.fold_right
-              (fun uu____3822 ->
+              (fun uu___2 ->
                  fun a ->
-                   match uu____3822 with
+                   match uu___2 with
                    | (b1, b2) ->
-                       eq_and a (fun uu____3915 -> branch_matches b1 b2))
-              uu____3722 uu____3785
+                       eq_and a (fun uu___3 -> branch_matches b1 b2)) uu___
+              uu___1
           else Unknown
       | (FStar_Syntax_Syntax.Tm_type u, FStar_Syntax_Syntax.Tm_type v) ->
-          let uu____3919 = eq_univs u v in equal_if uu____3919
+          let uu___ = eq_univs u v in equal_if uu___
       | (FStar_Syntax_Syntax.Tm_quoted (t13, q1),
          FStar_Syntax_Syntax.Tm_quoted (t23, q2)) ->
-          let uu____3932 = eq_quoteinfo q1 q2 in
-          eq_and uu____3932 (fun uu____3934 -> eq_tm t13 t23)
+          let uu___ = eq_quoteinfo q1 q2 in
+          eq_and uu___ (fun uu___1 -> eq_tm t13 t23)
       | (FStar_Syntax_Syntax.Tm_refine (t13, phi1),
          FStar_Syntax_Syntax.Tm_refine (t23, phi2)) ->
-          let uu____3947 =
+          let uu___ =
             eq_tm t13.FStar_Syntax_Syntax.sort t23.FStar_Syntax_Syntax.sort in
-          eq_and uu____3947 (fun uu____3949 -> eq_tm phi1 phi2)
-      | uu____3950 -> Unknown
+          eq_and uu___ (fun uu___1 -> eq_tm phi1 phi2)
+      | uu___ -> Unknown
 and (eq_quoteinfo :
   FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
   =
@@ -1065,23 +1032,23 @@ and (eq_antiquotes :
     fun a2 ->
       match (a1, a2) with
       | ([], []) -> Equal
-      | ([], uu____4020) -> NotEqual
-      | (uu____4051, []) -> NotEqual
+      | ([], uu___) -> NotEqual
+      | (uu___, []) -> NotEqual
       | ((x1, t1)::a11, (x2, t2)::a21) ->
-          let uu____4140 =
-            let uu____4141 = FStar_Syntax_Syntax.bv_eq x1 x2 in
-            Prims.op_Negation uu____4141 in
-          if uu____4140
+          let uu___ =
+            let uu___1 = FStar_Syntax_Syntax.bv_eq x1 x2 in
+            Prims.op_Negation uu___1 in
+          if uu___
           then NotEqual
           else
-            (let uu____4143 = eq_tm t1 t2 in
-             match uu____4143 with
+            (let uu___2 = eq_tm t1 t2 in
+             match uu___2 with
              | NotEqual -> NotEqual
              | Unknown ->
-                 let uu____4144 = eq_antiquotes a11 a21 in
-                 (match uu____4144 with
+                 let uu___3 = eq_antiquotes a11 a21 in
+                 (match uu___3 with
                   | NotEqual -> NotEqual
-                  | uu____4145 -> Unknown)
+                  | uu___4 -> Unknown)
              | Equal -> eq_antiquotes a11 a21)
 and (branch_matches :
   (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t *
@@ -1101,24 +1068,24 @@ and (branch_matches :
             true
         | (FStar_Pervasives_Native.Some x, FStar_Pervasives_Native.Some y) ->
             f x y
-        | (uu____4224, uu____4225) -> false in
-      let uu____4234 = b1 in
-      match uu____4234 with
+        | (uu___, uu___1) -> false in
+      let uu___ = b1 in
+      match uu___ with
       | (p1, w1, t1) ->
-          let uu____4268 = b2 in
-          (match uu____4268 with
+          let uu___1 = b2 in
+          (match uu___1 with
            | (p2, w2, t2) ->
-               let uu____4302 = FStar_Syntax_Syntax.eq_pat p1 p2 in
-               if uu____4302
+               let uu___2 = FStar_Syntax_Syntax.eq_pat p1 p2 in
+               if uu___2
                then
-                 let uu____4303 =
-                   (let uu____4306 = eq_tm t1 t2 in uu____4306 = Equal) &&
+                 let uu___3 =
+                   (let uu___4 = eq_tm t1 t2 in uu___4 = Equal) &&
                      (related_by
                         (fun t11 ->
                            fun t21 ->
-                             let uu____4315 = eq_tm t11 t21 in
-                             uu____4315 = Equal) w1 w2) in
-                 (if uu____4303 then Equal else Unknown)
+                             let uu___4 = eq_tm t11 t21 in uu___4 = Equal) w1
+                        w2) in
+                 (if uu___3 then Equal else Unknown)
                else Unknown)
 and (eq_args :
   FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.args -> eq_result) =
@@ -1126,12 +1093,10 @@ and (eq_args :
     fun a2 ->
       match (a1, a2) with
       | ([], []) -> Equal
-      | ((a, uu____4377)::a11, (b, uu____4380)::b1) ->
-          let uu____4454 = eq_tm a b in
-          (match uu____4454 with
-           | Equal -> eq_args a11 b1
-           | uu____4455 -> Unknown)
-      | uu____4456 -> Unknown
+      | ((a, uu___)::a11, (b, uu___1)::b1) ->
+          let uu___2 = eq_tm a b in
+          (match uu___2 with | Equal -> eq_args a11 b1 | uu___3 -> Unknown)
+      | uu___ -> Unknown
 and (eq_univs_list :
   FStar_Syntax_Syntax.universes ->
     FStar_Syntax_Syntax.universes -> Prims.bool)
@@ -1149,8 +1114,8 @@ let (eq_aqual :
     fun a2 ->
       match (a1, a2) with
       | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) -> Equal
-      | (FStar_Pervasives_Native.None, uu____4509) -> NotEqual
-      | (uu____4516, FStar_Pervasives_Native.None) -> NotEqual
+      | (FStar_Pervasives_Native.None, uu___) -> NotEqual
+      | (uu___, FStar_Pervasives_Native.None) -> NotEqual
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit b1),
          FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit b2)) when
           b1 = b2 -> Equal
@@ -1165,80 +1130,76 @@ let (eq_aqual :
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality),
          FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality)) ->
           Equal
-      | uu____4553 -> NotEqual
+      | uu___ -> NotEqual
 let rec (unrefine : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x, uu____4569) ->
+    | FStar_Syntax_Syntax.Tm_refine (x, uu___) ->
         unrefine x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____4575, uu____4576) ->
-        unrefine t2
-    | uu____4617 -> t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) -> unrefine t2
+    | uu___ -> t1
 let rec (is_uvar : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4623 =
-      let uu____4624 = FStar_Syntax_Subst.compress t in
-      uu____4624.FStar_Syntax_Syntax.n in
-    match uu____4623 with
-    | FStar_Syntax_Syntax.Tm_uvar uu____4627 -> true
-    | FStar_Syntax_Syntax.Tm_uinst (t1, uu____4641) -> is_uvar t1
-    | FStar_Syntax_Syntax.Tm_app uu____4646 ->
-        let uu____4663 =
-          let uu____4664 = FStar_All.pipe_right t head_and_args in
-          FStar_All.pipe_right uu____4664 FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____4663 is_uvar
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu____4726, uu____4727) ->
-        is_uvar t1
-    | uu____4768 -> false
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_uvar uu___1 -> true
+    | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> is_uvar t1
+    | FStar_Syntax_Syntax.Tm_app uu___1 ->
+        let uu___2 =
+          let uu___3 = FStar_All.pipe_right t head_and_args in
+          FStar_All.pipe_right uu___3 FStar_Pervasives_Native.fst in
+        FStar_All.pipe_right uu___2 is_uvar
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu___1, uu___2) -> is_uvar t1
+    | uu___1 -> false
 let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4774 =
-      let uu____4775 = unrefine t in uu____4775.FStar_Syntax_Syntax.n in
-    match uu____4774 with
+    let uu___ = let uu___1 = unrefine t in uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
           ||
           (FStar_Syntax_Syntax.fv_eq_lid fv
              FStar_Parser_Const.auto_squash_lid)
-    | FStar_Syntax_Syntax.Tm_app (head, uu____4780) -> is_unit head
-    | FStar_Syntax_Syntax.Tm_uinst (t1, uu____4806) -> is_unit t1
-    | uu____4811 -> false
+    | FStar_Syntax_Syntax.Tm_app (head, uu___1) -> is_unit head
+    | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> is_unit t1
+    | uu___1 -> false
 let (is_eqtype_no_unrefine : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4817 =
-      let uu____4818 = FStar_Syntax_Subst.compress t in
-      uu____4818.FStar_Syntax_Syntax.n in
-    match uu____4817 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.eqtype_lid
-    | uu____4822 -> false
+    | uu___1 -> false
 let (is_fun : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
-    let uu____4828 =
-      let uu____4829 = FStar_Syntax_Subst.compress e in
-      uu____4829.FStar_Syntax_Syntax.n in
-    match uu____4828 with
-    | FStar_Syntax_Syntax.Tm_abs uu____4832 -> true
-    | uu____4851 -> false
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress e in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_abs uu___1 -> true
+    | uu___1 -> false
 let (is_function_typ : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4857 =
-      let uu____4858 = FStar_Syntax_Subst.compress t in
-      uu____4858.FStar_Syntax_Syntax.n in
-    match uu____4857 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____4861 -> true
-    | uu____4876 -> false
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_arrow uu___1 -> true
+    | uu___1 -> false
 let rec (pre_typ : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x, uu____4884) ->
+    | FStar_Syntax_Syntax.Tm_refine (x, uu___) ->
         pre_typ x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____4890, uu____4891) ->
-        pre_typ t2
-    | uu____4932 -> t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) -> pre_typ t2
+    | uu___ -> t1
 let (destruct :
   FStar_Syntax_Syntax.term ->
     FStar_Ident.lident ->
@@ -1249,44 +1210,40 @@ let (destruct :
   fun typ ->
     fun lid ->
       let typ1 = FStar_Syntax_Subst.compress typ in
-      let uu____4956 =
-        let uu____4957 = un_uinst typ1 in uu____4957.FStar_Syntax_Syntax.n in
-      match uu____4956 with
+      let uu___ = let uu___1 = un_uinst typ1 in uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_app (head, args) ->
           let head1 = un_uinst head in
           (match head1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_fvar tc when
                FStar_Syntax_Syntax.fv_eq_lid tc lid ->
                FStar_Pervasives_Native.Some args
-           | uu____5022 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar tc when
           FStar_Syntax_Syntax.fv_eq_lid tc lid ->
           FStar_Pervasives_Native.Some []
-      | uu____5052 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (lids_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let (uu____5072, lids) -> lids
-    | FStar_Syntax_Syntax.Sig_splice (lids, uu____5079) -> lids
-    | FStar_Syntax_Syntax.Sig_bundle (uu____5084, lids) -> lids
+    | FStar_Syntax_Syntax.Sig_let (uu___, lids) -> lids
+    | FStar_Syntax_Syntax.Sig_splice (lids, uu___) -> lids
+    | FStar_Syntax_Syntax.Sig_bundle (uu___, lids) -> lids
     | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid, uu____5095, uu____5096, uu____5097, uu____5098, uu____5099) ->
-        [lid]
+        (lid, uu___, uu___1, uu___2, uu___3, uu___4) -> [lid]
     | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (lid, uu____5109, uu____5110, uu____5111, uu____5112) -> [lid]
+        (lid, uu___, uu___1, uu___2, uu___3) -> [lid]
     | FStar_Syntax_Syntax.Sig_datacon
-        (lid, uu____5118, uu____5119, uu____5120, uu____5121, uu____5122) ->
-        [lid]
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____5128, uu____5129) ->
-        [lid]
-    | FStar_Syntax_Syntax.Sig_assume (lid, uu____5131, uu____5132) -> [lid]
+        (lid, uu___, uu___1, uu___2, uu___3, uu___4) -> [lid]
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___, uu___1) -> [lid]
+    | FStar_Syntax_Syntax.Sig_assume (lid, uu___, uu___1) -> [lid]
     | FStar_Syntax_Syntax.Sig_new_effect n -> [n.FStar_Syntax_Syntax.mname]
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____5134 -> []
-    | FStar_Syntax_Syntax.Sig_pragma uu____5135 -> []
-    | FStar_Syntax_Syntax.Sig_fail uu____5136 -> []
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5147 -> []
-    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____5158 -> []
+    | FStar_Syntax_Syntax.Sig_sub_effect uu___ -> []
+    | FStar_Syntax_Syntax.Sig_pragma uu___ -> []
+    | FStar_Syntax_Syntax.Sig_fail uu___ -> []
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___ -> []
+    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___ -> []
 let (lid_of_sigelt :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Ident.lident FStar_Pervasives_Native.option)
@@ -1294,7 +1251,7 @@ let (lid_of_sigelt :
   fun se ->
     match lids_of_sigelt se with
     | l::[] -> FStar_Pervasives_Native.Some l
-    | uu____5179 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (quals_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun x -> x.FStar_Syntax_Syntax.sigquals
@@ -1304,22 +1261,20 @@ let (range_of_lbname :
   (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Range.range)
   =
-  fun uu___7_5202 ->
-    match uu___7_5202 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Util.Inl x -> FStar_Syntax_Syntax.range_of_bv x
     | FStar_Util.Inr fv ->
         FStar_Ident.range_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
 let range_of_arg :
-  'uuuuuu5215 'uuuuuu5216 .
-    ('uuuuuu5215 FStar_Syntax_Syntax.syntax * 'uuuuuu5216) ->
-      FStar_Range.range
+  'uuuuu 'uuuuu1 .
+    ('uuuuu FStar_Syntax_Syntax.syntax * 'uuuuu1) -> FStar_Range.range
   =
-  fun uu____5227 ->
-    match uu____5227 with | (hd, uu____5235) -> hd.FStar_Syntax_Syntax.pos
+  fun uu___ -> match uu___ with | (hd, uu___1) -> hd.FStar_Syntax_Syntax.pos
 let range_of_args :
-  'uuuuuu5248 'uuuuuu5249 .
-    ('uuuuuu5248 FStar_Syntax_Syntax.syntax * 'uuuuuu5249) Prims.list ->
+  'uuuuu 'uuuuu1 .
+    ('uuuuu FStar_Syntax_Syntax.syntax * 'uuuuu1) Prims.list ->
       FStar_Range.range -> FStar_Range.range
   =
   fun args ->
@@ -1338,7 +1293,7 @@ let (mk_app :
     fun args ->
       match args with
       | [] -> f
-      | uu____5346 ->
+      | uu___ ->
           let r = range_of_args args f.FStar_Syntax_Syntax.pos in
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args)) r
 let (mk_app_binders :
@@ -1349,14 +1304,14 @@ let (mk_app_binders :
   =
   fun f ->
     fun bs ->
-      let uu____5404 =
+      let uu___ =
         FStar_List.map
-          (fun uu____5431 ->
-             match uu____5431 with
+          (fun uu___1 ->
+             match uu___1 with
              | (bv, aq) ->
-                 let uu____5450 = FStar_Syntax_Syntax.bv_to_name bv in
-                 (uu____5450, aq)) bs in
-      mk_app f uu____5404
+                 let uu___2 = FStar_Syntax_Syntax.bv_to_name bv in
+                 (uu___2, aq)) bs in
+      mk_app f uu___
 let (field_projector_prefix : Prims.string) = "__proj__"
 let (field_projector_sep : Prims.string) = "__item__"
 let (field_projector_contains_constructor : Prims.string -> Prims.bool) =
@@ -1376,19 +1331,18 @@ let (mk_field_projector_name_from_ident :
         if field_projector_contains_constructor itext
         then i
         else
-          (let uu____5481 =
-             let uu____5486 =
-               let uu____5487 =
-                 let uu____5488 = FStar_Ident.ident_of_lid lid in
-                 FStar_Ident.string_of_id uu____5488 in
-               mk_field_projector_name_from_string uu____5487 itext in
-             let uu____5489 = FStar_Ident.range_of_id i in
-             (uu____5486, uu____5489) in
-           FStar_Ident.mk_ident uu____5481) in
-      let uu____5490 =
-        let uu____5491 = FStar_Ident.ns_of_lid lid in
-        FStar_List.append uu____5491 [newi] in
-      FStar_Ident.lid_of_ids uu____5490
+          (let uu___1 =
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Ident.ident_of_lid lid in
+                 FStar_Ident.string_of_id uu___4 in
+               mk_field_projector_name_from_string uu___3 itext in
+             let uu___3 = FStar_Ident.range_of_id i in (uu___2, uu___3) in
+           FStar_Ident.mk_ident uu___1) in
+      let uu___ =
+        let uu___1 = FStar_Ident.ns_of_lid lid in
+        FStar_List.append uu___1 [newi] in
+      FStar_Ident.lid_of_ids uu___
 let (mk_field_projector_name :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.bv -> Prims.int -> FStar_Ident.lident)
@@ -1397,38 +1351,38 @@ let (mk_field_projector_name :
     fun x ->
       fun i ->
         let nm =
-          let uu____5510 = FStar_Syntax_Syntax.is_null_bv x in
-          if uu____5510
+          let uu___ = FStar_Syntax_Syntax.is_null_bv x in
+          if uu___
           then
-            let uu____5511 =
-              let uu____5516 =
-                let uu____5517 = FStar_Util.string_of_int i in
-                Prims.op_Hat "_" uu____5517 in
-              let uu____5518 = FStar_Syntax_Syntax.range_of_bv x in
-              (uu____5516, uu____5518) in
-            FStar_Ident.mk_ident uu____5511
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Util.string_of_int i in
+                Prims.op_Hat "_" uu___3 in
+              let uu___3 = FStar_Syntax_Syntax.range_of_bv x in
+              (uu___2, uu___3) in
+            FStar_Ident.mk_ident uu___1
           else x.FStar_Syntax_Syntax.ppname in
         mk_field_projector_name_from_ident lid nm
 let (ses_of_sigbundle :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_bundle (ses, uu____5530) -> ses
-    | uu____5539 -> failwith "ses_of_sigbundle: not a Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_bundle (ses, uu___) -> ses
+    | uu___ -> failwith "ses_of_sigbundle: not a Sig_bundle"
 let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
   =
   fun uv ->
     fun t ->
-      let uu____5552 = FStar_Syntax_Unionfind.find uv in
-      match uu____5552 with
-      | FStar_Pervasives_Native.Some uu____5555 ->
-          let uu____5556 =
-            let uu____5557 =
-              let uu____5558 = FStar_Syntax_Unionfind.uvar_id uv in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____5558 in
-            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5557 in
-          failwith uu____5556
-      | uu____5559 -> FStar_Syntax_Unionfind.change uv t
+      let uu___ = FStar_Syntax_Unionfind.find uv in
+      match uu___ with
+      | FStar_Pervasives_Native.Some uu___1 ->
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Syntax_Unionfind.uvar_id uv in
+              FStar_All.pipe_left FStar_Util.string_of_int uu___4 in
+            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu___3 in
+          failwith uu___2
+      | uu___1 -> FStar_Syntax_Unionfind.change uv t
 let (qualifier_equal :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Syntax_Syntax.qualifier -> Prims.bool)
@@ -1442,44 +1396,43 @@ let (qualifier_equal :
       | (FStar_Syntax_Syntax.Projector (l1a, l1b),
          FStar_Syntax_Syntax.Projector (l2a, l2b)) ->
           (FStar_Ident.lid_equals l1a l2a) &&
-            (let uu____5580 = FStar_Ident.string_of_id l1b in
-             let uu____5581 = FStar_Ident.string_of_id l2b in
-             uu____5580 = uu____5581)
+            (let uu___ = FStar_Ident.string_of_id l1b in
+             let uu___1 = FStar_Ident.string_of_id l2b in uu___ = uu___1)
       | (FStar_Syntax_Syntax.RecordType (ns1, f1),
          FStar_Syntax_Syntax.RecordType (ns2, f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1 ->
                     fun x2 ->
-                      let uu____5608 = FStar_Ident.string_of_id x1 in
-                      let uu____5609 = FStar_Ident.string_of_id x2 in
-                      uu____5608 = uu____5609) f1 f2))
+                      let uu___ = FStar_Ident.string_of_id x1 in
+                      let uu___1 = FStar_Ident.string_of_id x2 in
+                      uu___ = uu___1) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1 ->
                   fun x2 ->
-                    let uu____5616 = FStar_Ident.string_of_id x1 in
-                    let uu____5617 = FStar_Ident.string_of_id x2 in
-                    uu____5616 = uu____5617) f1 f2)
+                    let uu___ = FStar_Ident.string_of_id x1 in
+                    let uu___1 = FStar_Ident.string_of_id x2 in
+                    uu___ = uu___1) f1 f2)
       | (FStar_Syntax_Syntax.RecordConstructor (ns1, f1),
          FStar_Syntax_Syntax.RecordConstructor (ns2, f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1 ->
                     fun x2 ->
-                      let uu____5644 = FStar_Ident.string_of_id x1 in
-                      let uu____5645 = FStar_Ident.string_of_id x2 in
-                      uu____5644 = uu____5645) f1 f2))
+                      let uu___ = FStar_Ident.string_of_id x1 in
+                      let uu___1 = FStar_Ident.string_of_id x2 in
+                      uu___ = uu___1) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1 ->
                   fun x2 ->
-                    let uu____5652 = FStar_Ident.string_of_id x1 in
-                    let uu____5653 = FStar_Ident.string_of_id x2 in
-                    uu____5652 = uu____5653) f1 f2)
-      | uu____5654 -> q1 = q2
+                    let uu___ = FStar_Ident.string_of_id x1 in
+                    let uu___1 = FStar_Ident.string_of_id x2 in
+                    uu___ = uu___1) f1 f2)
+      | uu___ -> q1 = q2
 let (abs :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -1493,44 +1446,42 @@ let (abs :
           match lopt1 with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some rc ->
-              let uu____5699 =
-                let uu___1040_5700 = rc in
-                let uu____5701 =
+              let uu___ =
+                let uu___1 = rc in
+                let uu___2 =
                   FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                     (FStar_Syntax_Subst.close bs) in
                 {
                   FStar_Syntax_Syntax.residual_effect =
-                    (uu___1040_5700.FStar_Syntax_Syntax.residual_effect);
-                  FStar_Syntax_Syntax.residual_typ = uu____5701;
+                    (uu___1.FStar_Syntax_Syntax.residual_effect);
+                  FStar_Syntax_Syntax.residual_typ = uu___2;
                   FStar_Syntax_Syntax.residual_flags =
-                    (uu___1040_5700.FStar_Syntax_Syntax.residual_flags)
+                    (uu___1.FStar_Syntax_Syntax.residual_flags)
                 } in
-              FStar_Pervasives_Native.Some uu____5699 in
+              FStar_Pervasives_Native.Some uu___ in
         match bs with
         | [] -> t
-        | uu____5718 ->
+        | uu___ ->
             let body =
-              let uu____5720 = FStar_Syntax_Subst.close bs t in
-              FStar_Syntax_Subst.compress uu____5720 in
+              let uu___1 = FStar_Syntax_Subst.close bs t in
+              FStar_Syntax_Subst.compress uu___1 in
             (match body.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_abs (bs', t1, lopt') ->
-                 let uu____5750 =
-                   let uu____5751 =
-                     let uu____5770 =
-                       let uu____5779 = FStar_Syntax_Subst.close_binders bs in
-                       FStar_List.append uu____5779 bs' in
-                     let uu____5794 = close_lopt lopt' in
-                     (uu____5770, t1, uu____5794) in
-                   FStar_Syntax_Syntax.Tm_abs uu____5751 in
-                 FStar_Syntax_Syntax.mk uu____5750 t1.FStar_Syntax_Syntax.pos
-             | uu____5809 ->
-                 let uu____5810 =
-                   let uu____5811 =
-                     let uu____5830 = FStar_Syntax_Subst.close_binders bs in
-                     let uu____5839 = close_lopt lopt in
-                     (uu____5830, body, uu____5839) in
-                   FStar_Syntax_Syntax.Tm_abs uu____5811 in
-                 FStar_Syntax_Syntax.mk uu____5810 t.FStar_Syntax_Syntax.pos)
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Subst.close_binders bs in
+                       FStar_List.append uu___4 bs' in
+                     let uu___4 = close_lopt lopt' in (uu___3, t1, uu___4) in
+                   FStar_Syntax_Syntax.Tm_abs uu___2 in
+                 FStar_Syntax_Syntax.mk uu___1 t1.FStar_Syntax_Syntax.pos
+             | uu___1 ->
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Subst.close_binders bs in
+                     let uu___5 = close_lopt lopt in (uu___4, body, uu___5) in
+                   FStar_Syntax_Syntax.Tm_abs uu___3 in
+                 FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos)
 let (arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) Prims.list ->
@@ -1541,14 +1492,14 @@ let (arrow :
     fun c ->
       match bs with
       | [] -> comp_result c
-      | uu____5894 ->
-          let uu____5903 =
-            let uu____5904 =
-              let uu____5919 = FStar_Syntax_Subst.close_binders bs in
-              let uu____5928 = FStar_Syntax_Subst.close_comp bs c in
-              (uu____5919, uu____5928) in
-            FStar_Syntax_Syntax.Tm_arrow uu____5904 in
-          FStar_Syntax_Syntax.mk uu____5903 c.FStar_Syntax_Syntax.pos
+      | uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.close_binders bs in
+              let uu___4 = FStar_Syntax_Subst.close_comp bs c in
+              (uu___3, uu___4) in
+            FStar_Syntax_Syntax.Tm_arrow uu___2 in
+          FStar_Syntax_Syntax.mk uu___1 c.FStar_Syntax_Syntax.pos
 let (flat_arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) Prims.list ->
@@ -1558,53 +1509,50 @@ let (flat_arrow :
   fun bs ->
     fun c ->
       let t = arrow bs c in
-      let uu____5976 =
-        let uu____5977 = FStar_Syntax_Subst.compress t in
-        uu____5977.FStar_Syntax_Syntax.n in
-      match uu____5976 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_arrow (bs1, c1) ->
           (match c1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (tres, uu____6007) ->
-               let uu____6016 =
-                 let uu____6017 = FStar_Syntax_Subst.compress tres in
-                 uu____6017.FStar_Syntax_Syntax.n in
-               (match uu____6016 with
+           | FStar_Syntax_Syntax.Total (tres, uu___1) ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress tres in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs', c') ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow
                          ((FStar_List.append bs1 bs'), c'))
                       t.FStar_Syntax_Syntax.pos
-                | uu____6060 -> t)
-           | uu____6061 -> t)
-      | uu____6062 -> t
+                | uu___3 -> t)
+           | uu___1 -> t)
+      | uu___1 -> t
 let rec (canon_arrow :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t ->
-    let uu____6074 =
-      let uu____6075 = FStar_Syntax_Subst.compress t in
-      uu____6075.FStar_Syntax_Syntax.n in
-    match uu____6074 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
         let cn =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Total (t1, u) ->
-              let uu____6113 =
-                let uu____6122 = canon_arrow t1 in (uu____6122, u) in
-              FStar_Syntax_Syntax.Total uu____6113
-          | uu____6129 -> c.FStar_Syntax_Syntax.n in
+              let uu___1 = let uu___2 = canon_arrow t1 in (uu___2, u) in
+              FStar_Syntax_Syntax.Total uu___1
+          | uu___1 -> c.FStar_Syntax_Syntax.n in
         let c1 =
-          let uu___1084_6133 = c in
+          let uu___1 = c in
           {
             FStar_Syntax_Syntax.n = cn;
-            FStar_Syntax_Syntax.pos =
-              (uu___1084_6133.FStar_Syntax_Syntax.pos);
-            FStar_Syntax_Syntax.vars =
-              (uu___1084_6133.FStar_Syntax_Syntax.vars)
+            FStar_Syntax_Syntax.pos = (uu___1.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
           } in
         flat_arrow bs c1
-    | uu____6136 -> t
+    | uu___1 -> t
 let (refine :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -1612,37 +1560,36 @@ let (refine :
   =
   fun b ->
     fun t ->
-      let uu____6153 =
-        let uu____6154 =
-          let uu____6161 =
-            let uu____6164 =
-              let uu____6165 = FStar_Syntax_Syntax.mk_binder b in
-              [uu____6165] in
-            FStar_Syntax_Subst.close uu____6164 t in
-          (b, uu____6161) in
-        FStar_Syntax_Syntax.Tm_refine uu____6154 in
-      let uu____6186 =
-        let uu____6187 = FStar_Syntax_Syntax.range_of_bv b in
-        FStar_Range.union_ranges uu____6187 t.FStar_Syntax_Syntax.pos in
-      FStar_Syntax_Syntax.mk uu____6153 uu____6186
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Syntax_Syntax.mk_binder b in [uu___4] in
+            FStar_Syntax_Subst.close uu___3 t in
+          (b, uu___2) in
+        FStar_Syntax_Syntax.Tm_refine uu___1 in
+      let uu___1 =
+        let uu___2 = FStar_Syntax_Syntax.range_of_bv b in
+        FStar_Range.union_ranges uu___2 t.FStar_Syntax_Syntax.pos in
+      FStar_Syntax_Syntax.mk uu___ uu___1
 let (branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch) =
   fun b -> FStar_Syntax_Subst.close_branch b
 let (has_decreases : FStar_Syntax_Syntax.comp -> Prims.bool) =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____6199 =
+        let uu___ =
           FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
             (FStar_Util.find_opt
-               (fun uu___8_6208 ->
-                  match uu___8_6208 with
-                  | FStar_Syntax_Syntax.DECREASES uu____6209 -> true
-                  | uu____6212 -> false)) in
-        (match uu____6199 with
+               (fun uu___1 ->
+                  match uu___1 with
+                  | FStar_Syntax_Syntax.DECREASES uu___2 -> true
+                  | uu___2 -> false)) in
+        (match uu___ with
          | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES d) ->
              true
-         | uu____6216 -> false)
-    | uu____6219 -> false
+         | uu___1 -> false)
+    | uu___ -> false
 let rec (arrow_formals_comp_ln :
   FStar_Syntax_Syntax.term ->
     ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1652,47 +1599,43 @@ let rec (arrow_formals_comp_ln :
     let k1 = FStar_Syntax_Subst.compress k in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-        let uu____6272 =
+        let uu___ =
           (is_total_comp c) &&
-            (let uu____6274 = has_decreases c in Prims.op_Negation uu____6274) in
-        if uu____6272
+            (let uu___1 = has_decreases c in Prims.op_Negation uu___1) in
+        if uu___
         then
-          let uu____6287 = arrow_formals_comp_ln (comp_result c) in
-          (match uu____6287 with
-           | (bs', k2) -> ((FStar_List.append bs bs'), k2))
+          let uu___1 = arrow_formals_comp_ln (comp_result c) in
+          (match uu___1 with | (bs', k2) -> ((FStar_List.append bs bs'), k2))
         else (bs, c)
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____6353;
-           FStar_Syntax_Syntax.index = uu____6354;
+        ({ FStar_Syntax_Syntax.ppname = uu___;
+           FStar_Syntax_Syntax.index = uu___1;
            FStar_Syntax_Syntax.sort = s;_},
-         uu____6356)
+         uu___2)
         ->
         let rec aux s1 k2 =
-          let uu____6386 =
-            let uu____6387 = FStar_Syntax_Subst.compress s1 in
-            uu____6387.FStar_Syntax_Syntax.n in
-          match uu____6386 with
-          | FStar_Syntax_Syntax.Tm_arrow uu____6402 ->
-              arrow_formals_comp_ln s1
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Subst.compress s1 in
+            uu___4.FStar_Syntax_Syntax.n in
+          match uu___3 with
+          | FStar_Syntax_Syntax.Tm_arrow uu___4 -> arrow_formals_comp_ln s1
           | FStar_Syntax_Syntax.Tm_refine
-              ({ FStar_Syntax_Syntax.ppname = uu____6417;
-                 FStar_Syntax_Syntax.index = uu____6418;
+              ({ FStar_Syntax_Syntax.ppname = uu___4;
+                 FStar_Syntax_Syntax.index = uu___5;
                  FStar_Syntax_Syntax.sort = s2;_},
-               uu____6420)
+               uu___6)
               -> aux s2 k2
-          | uu____6427 ->
-              let uu____6428 = FStar_Syntax_Syntax.mk_Total k2 in
-              ([], uu____6428) in
+          | uu___4 ->
+              let uu___5 = FStar_Syntax_Syntax.mk_Total k2 in ([], uu___5) in
         aux s k1
-    | uu____6443 ->
-        let uu____6444 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____6444)
+    | uu___ -> let uu___1 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu___1)
 let (arrow_formals_comp :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun k ->
-    let uu____6468 = arrow_formals_comp_ln k in
-    match uu____6468 with | (bs, c) -> FStar_Syntax_Subst.open_comp bs c
+    let uu___ = arrow_formals_comp_ln k in
+    match uu___ with | (bs, c) -> FStar_Syntax_Subst.open_comp bs c
 let (arrow_formals_ln :
   FStar_Syntax_Syntax.term ->
     ((FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1700,16 +1643,16 @@ let (arrow_formals_ln :
       FStar_Syntax_Syntax.syntax))
   =
   fun k ->
-    let uu____6522 = arrow_formals_comp_ln k in
-    match uu____6522 with | (bs, c) -> (bs, (comp_result c))
+    let uu___ = arrow_formals_comp_ln k in
+    match uu___ with | (bs, c) -> (bs, (comp_result c))
 let (arrow_formals :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.term'
       FStar_Syntax_Syntax.syntax))
   =
   fun k ->
-    let uu____6588 = arrow_formals_comp k in
-    match uu____6588 with | (bs, c) -> (bs, (comp_result c))
+    let uu___ = arrow_formals_comp k in
+    match uu___ with | (bs, c) -> (bs, (comp_result c))
 let (let_rec_arity :
   FStar_Syntax_Syntax.letbinding ->
     (Prims.int * Prims.bool Prims.list FStar_Pervasives_Native.option))
@@ -1719,53 +1662,53 @@ let (let_rec_arity :
       let k1 = FStar_Syntax_Subst.compress k in
       match k1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____6685 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____6685 with
+          let uu___ = FStar_Syntax_Subst.open_comp bs c in
+          (match uu___ with
            | (bs1, c1) ->
                let ct = comp_to_comp_typ c1 in
-               let uu____6709 =
+               let uu___1 =
                  FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                    (FStar_Util.find_opt
-                      (fun uu___9_6718 ->
-                         match uu___9_6718 with
-                         | FStar_Syntax_Syntax.DECREASES uu____6719 -> true
-                         | uu____6722 -> false)) in
-               (match uu____6709 with
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | FStar_Syntax_Syntax.DECREASES uu___3 -> true
+                         | uu___3 -> false)) in
+               (match uu___1 with
                 | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                     d) -> (bs1, (FStar_Pervasives_Native.Some d))
-                | uu____6756 ->
-                    let uu____6759 = is_total_comp c1 in
-                    if uu____6759
+                | uu___2 ->
+                    let uu___3 = is_total_comp c1 in
+                    if uu___3
                     then
-                      let uu____6776 = arrow_until_decreases (comp_result c1) in
-                      (match uu____6776 with
+                      let uu___4 = arrow_until_decreases (comp_result c1) in
+                      (match uu___4 with
                        | (bs', d) -> ((FStar_List.append bs1 bs'), d))
                     else (bs1, FStar_Pervasives_Native.None)))
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____6868;
-             FStar_Syntax_Syntax.index = uu____6869;
+          ({ FStar_Syntax_Syntax.ppname = uu___;
+             FStar_Syntax_Syntax.index = uu___1;
              FStar_Syntax_Syntax.sort = k2;_},
-           uu____6871)
+           uu___2)
           -> arrow_until_decreases k2
-      | uu____6878 -> ([], FStar_Pervasives_Native.None) in
-    let uu____6899 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp in
-    match uu____6899 with
+      | uu___ -> ([], FStar_Pervasives_Native.None) in
+    let uu___ = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp in
+    match uu___ with
     | (bs, dopt) ->
         let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs in
-        let uu____6951 =
+        let uu___1 =
           FStar_Util.map_opt dopt
             (fun d ->
                let d_bvs = FStar_Syntax_Free.names d in
-               let uu____6970 =
-                 FStar_Common.tabulate n_univs (fun uu____6974 -> false) in
-               let uu____6975 =
+               let uu___2 =
+                 FStar_Common.tabulate n_univs (fun uu___3 -> false) in
+               let uu___3 =
                  FStar_All.pipe_right bs
                    (FStar_List.map
-                      (fun uu____6997 ->
-                         match uu____6997 with
-                         | (x, uu____7005) -> FStar_Util.set_mem x d_bvs)) in
-               FStar_List.append uu____6970 uu____6975) in
-        ((n_univs + (FStar_List.length bs)), uu____6951)
+                      (fun uu___4 ->
+                         match uu___4 with
+                         | (x, uu___5) -> FStar_Util.set_mem x d_bvs)) in
+               FStar_List.append uu___2 uu___3) in
+        ((n_univs + (FStar_List.length bs)), uu___1)
 let (abs_formals :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.term *
@@ -1775,44 +1718,44 @@ let (abs_formals :
     let subst_lcomp_opt s l =
       match l with
       | FStar_Pervasives_Native.Some rc ->
-          let uu____7057 =
-            let uu___1194_7058 = rc in
-            let uu____7059 =
+          let uu___ =
+            let uu___1 = rc in
+            let uu___2 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (FStar_Syntax_Subst.subst s) in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___1194_7058.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____7059;
+                (uu___1.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu___2;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___1194_7058.FStar_Syntax_Syntax.residual_flags)
+                (uu___1.FStar_Syntax_Syntax.residual_flags)
             } in
-          FStar_Pervasives_Native.Some uu____7057
-      | uu____7068 -> l in
+          FStar_Pervasives_Native.Some uu___
+      | uu___ -> l in
     let rec aux t1 abs_body_lcomp =
-      let uu____7102 =
-        let uu____7103 =
-          let uu____7106 = FStar_Syntax_Subst.compress t1 in
-          FStar_All.pipe_left unascribe uu____7106 in
-        uu____7103.FStar_Syntax_Syntax.n in
-      match uu____7102 with
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t1 in
+          FStar_All.pipe_left unascribe uu___2 in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_abs (bs, t2, what) ->
-          let uu____7152 = aux t2 what in
-          (match uu____7152 with
+          let uu___1 = aux t2 what in
+          (match uu___1 with
            | (bs', t3, what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____7224 -> ([], t1, abs_body_lcomp) in
-    let uu____7241 = aux t FStar_Pervasives_Native.None in
-    match uu____7241 with
+      | uu___1 -> ([], t1, abs_body_lcomp) in
+    let uu___ = aux t FStar_Pervasives_Native.None in
+    match uu___ with
     | (bs, t1, abs_body_lcomp) ->
-        let uu____7289 = FStar_Syntax_Subst.open_term' bs t1 in
-        (match uu____7289 with
+        let uu___1 = FStar_Syntax_Subst.open_term' bs t1 in
+        (match uu___1 with
          | (bs1, t2, opening) ->
              let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp in
              (bs1, t2, abs_body_lcomp1))
 let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let no_acc uu____7322 =
-      match uu____7322 with
+    let no_acc uu___ =
+      match uu___ with
       | (b, aq) ->
           let aq1 =
             match aq with
@@ -1820,19 +1763,19 @@ let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
                 (true)) ->
                 FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Implicit false)
-            | uu____7334 -> aq in
+            | uu___1 -> aq in
           (b, aq1) in
-    let uu____7339 = arrow_formals_comp_ln t in
-    match uu____7339 with
+    let uu___ = arrow_formals_comp_ln t in
+    match uu___ with
     | (bs, c) ->
         (match bs with
          | [] -> t
-         | uu____7376 ->
-             let uu____7385 =
-               let uu____7386 =
-                 let uu____7401 = FStar_List.map no_acc bs in (uu____7401, c) in
-               FStar_Syntax_Syntax.Tm_arrow uu____7386 in
-             FStar_Syntax_Syntax.mk uu____7385 t.FStar_Syntax_Syntax.pos)
+         | uu___1 ->
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_List.map no_acc bs in (uu___4, c) in
+               FStar_Syntax_Syntax.Tm_arrow uu___3 in
+             FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos)
 let (mk_letbinding :
   (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -1878,14 +1821,14 @@ let (close_univs_and_mk_letbinding :
                 fun pos ->
                   let def1 =
                     match (recs, univ_vars) with
-                    | (FStar_Pervasives_Native.None, uu____7570) -> def
-                    | (uu____7581, []) -> def
-                    | (FStar_Pervasives_Native.Some fvs, uu____7593) ->
+                    | (FStar_Pervasives_Native.None, uu___) -> def
+                    | (uu___, []) -> def
+                    | (FStar_Pervasives_Native.Some fvs, uu___) ->
                         let universes =
                           FStar_All.pipe_right univ_vars
                             (FStar_List.map
-                               (fun uu____7609 ->
-                                  FStar_Syntax_Syntax.U_name uu____7609)) in
+                               (fun uu___1 ->
+                                  FStar_Syntax_Syntax.U_name uu___1)) in
                         let inst =
                           FStar_All.pipe_right fvs
                             (FStar_List.map
@@ -1911,36 +1854,36 @@ let (open_univ_vars_binders_and_comp :
       fun c ->
         match binders with
         | [] ->
-            let uu____7690 = FStar_Syntax_Subst.open_univ_vars_comp uvs c in
-            (match uu____7690 with | (uvs1, c1) -> (uvs1, [], c1))
-        | uu____7725 ->
+            let uu___ = FStar_Syntax_Subst.open_univ_vars_comp uvs c in
+            (match uu___ with | (uvs1, c1) -> (uvs1, [], c1))
+        | uu___ ->
             let t' = arrow binders c in
-            let uu____7737 = FStar_Syntax_Subst.open_univ_vars uvs t' in
-            (match uu____7737 with
+            let uu___1 = FStar_Syntax_Subst.open_univ_vars uvs t' in
+            (match uu___1 with
              | (uvs1, t'1) ->
-                 let uu____7758 =
-                   let uu____7759 = FStar_Syntax_Subst.compress t'1 in
-                   uu____7759.FStar_Syntax_Syntax.n in
-                 (match uu____7758 with
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t'1 in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (match uu___2 with
                   | FStar_Syntax_Syntax.Tm_arrow (binders1, c1) ->
                       (uvs1, binders1, c1)
-                  | uu____7808 -> failwith "Impossible"))
+                  | uu___3 -> failwith "Impossible"))
 let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
-        let uu____7829 =
+        let uu___ =
           FStar_Ident.string_of_lid
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        FStar_Parser_Const.is_tuple_constructor_string uu____7829
-    | uu____7830 -> false
+        FStar_Parser_Const.is_tuple_constructor_string uu___
+    | uu___ -> false
 let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_dtuple_constructor_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____7837 -> false
+    | uu___ -> false
 let (is_lid_equality : FStar_Ident.lident -> Prims.bool) =
   fun x -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid
 let (is_forall : FStar_Ident.lident -> Prims.bool) =
@@ -1964,26 +1907,23 @@ let (is_constructor :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t ->
     fun lid ->
-      let uu____7885 =
-        let uu____7886 = pre_typ t in uu____7886.FStar_Syntax_Syntax.n in
-      match uu____7885 with
+      let uu___ = let uu___1 = pre_typ t in uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar tc ->
           FStar_Ident.lid_equals
             (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
-      | uu____7890 -> false
+      | uu___1 -> false
 let rec (is_constructed_typ :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t ->
     fun lid ->
-      let uu____7901 =
-        let uu____7902 = pre_typ t in uu____7902.FStar_Syntax_Syntax.n in
-      match uu____7901 with
-      | FStar_Syntax_Syntax.Tm_fvar uu____7905 -> is_constructor t lid
-      | FStar_Syntax_Syntax.Tm_app (t1, uu____7907) ->
+      let uu___ = let uu___1 = pre_typ t in uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_fvar uu___1 -> is_constructor t lid
+      | FStar_Syntax_Syntax.Tm_app (t1, uu___1) -> is_constructed_typ t1 lid
+      | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) ->
           is_constructed_typ t1 lid
-      | FStar_Syntax_Syntax.Tm_uinst (t1, uu____7933) ->
-          is_constructed_typ t1 lid
-      | uu____7938 -> false
+      | uu___1 -> false
 let rec (get_tycon :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
@@ -1991,34 +1931,30 @@ let rec (get_tycon :
   fun t ->
     let t1 = pre_typ t in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar uu____7949 ->
-        FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_name uu____7950 ->
-        FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____7951 ->
-        FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_app (t2, uu____7953) -> get_tycon t2
-    | uu____7978 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Tm_bvar uu___ -> FStar_Pervasives_Native.Some t1
+    | FStar_Syntax_Syntax.Tm_name uu___ -> FStar_Pervasives_Native.Some t1
+    | FStar_Syntax_Syntax.Tm_fvar uu___ -> FStar_Pervasives_Native.Some t1
+    | FStar_Syntax_Syntax.Tm_app (t2, uu___) -> get_tycon t2
+    | uu___ -> FStar_Pervasives_Native.None
 let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____7984 =
-      let uu____7985 = un_uinst t in uu____7985.FStar_Syntax_Syntax.n in
-    match uu____7984 with
+    let uu___ = let uu___1 = un_uinst t in uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
-    | uu____7989 -> false
+    | uu___1 -> false
 let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
   fun md ->
     let path = FStar_Ident.path_of_lid md in
     if (FStar_List.length path) > (Prims.of_int (2))
     then
-      let uu____7996 =
-        let uu____7999 = FStar_List.splitAt (Prims.of_int (2)) path in
-        FStar_Pervasives_Native.fst uu____7999 in
-      match uu____7996 with
+      let uu___ =
+        let uu___1 = FStar_List.splitAt (Prims.of_int (2)) path in
+        FStar_Pervasives_Native.fst uu___1 in
+      match uu___ with
       | "FStar"::"Tactics"::[] -> true
       | "FStar"::"Reflection"::[] -> true
-      | uu____8012 -> false
+      | uu___1 -> false
     else false
 let (ktype : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
@@ -2030,33 +1966,32 @@ let (ktype0 : FStar_Syntax_Syntax.term) =
     FStar_Range.dummyRange
 let (type_u :
   unit -> (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.universe)) =
-  fun uu____8024 ->
+  fun uu___ ->
     let u =
-      let uu____8030 =
-        FStar_Syntax_Unionfind.univ_fresh FStar_Range.dummyRange in
-      FStar_All.pipe_left
-        (fun uu____8051 -> FStar_Syntax_Syntax.U_unif uu____8051) uu____8030 in
-    let uu____8052 =
+      let uu___1 = FStar_Syntax_Unionfind.univ_fresh FStar_Range.dummyRange in
+      FStar_All.pipe_left (fun uu___2 -> FStar_Syntax_Syntax.U_unif uu___2)
+        uu___1 in
+    let uu___1 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
         FStar_Range.dummyRange in
-    (uu____8052, u)
+    (uu___1, u)
 let (attr_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun a ->
     fun a' ->
-      let uu____8063 = eq_tm a a' in
-      match uu____8063 with | Equal -> true | uu____8064 -> false
+      let uu___ = eq_tm a a' in
+      match uu___ with | Equal -> true | uu___1 -> false
 let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
-  let uu____8067 =
-    let uu____8068 =
-      let uu____8069 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
           FStar_Range.dummyRange in
-      FStar_Syntax_Syntax.lid_as_fv uu____8069
-        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-    FStar_Syntax_Syntax.Tm_fvar uu____8068 in
-  FStar_Syntax_Syntax.mk uu____8067 FStar_Range.dummyRange
+      FStar_Syntax_Syntax.lid_as_fv uu___2 FStar_Syntax_Syntax.delta_constant
+        FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.Tm_fvar uu___1 in
+  FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (exp_true_bool : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
@@ -2133,22 +2068,21 @@ let (mk_conj_opt :
       match phi1 with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.Some phi2
       | FStar_Pervasives_Native.Some phi11 ->
-          let uu____8139 =
-            let uu____8142 =
-              let uu____8143 =
-                let uu____8160 =
-                  let uu____8171 = FStar_Syntax_Syntax.as_arg phi11 in
-                  let uu____8180 =
-                    let uu____8191 = FStar_Syntax_Syntax.as_arg phi2 in
-                    [uu____8191] in
-                  uu____8171 :: uu____8180 in
-                (tand, uu____8160) in
-              FStar_Syntax_Syntax.Tm_app uu____8143 in
-            let uu____8236 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Syntax.as_arg phi11 in
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Syntax.as_arg phi2 in [uu___6] in
+                  uu___4 :: uu___5 in
+                (tand, uu___3) in
+              FStar_Syntax_Syntax.Tm_app uu___2 in
+            let uu___2 =
               FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
                 phi2.FStar_Syntax_Syntax.pos in
-            FStar_Syntax_Syntax.mk uu____8142 uu____8236 in
-          FStar_Pervasives_Native.Some uu____8139
+            FStar_Syntax_Syntax.mk uu___1 uu___2 in
+          FStar_Pervasives_Native.Some uu___
 let (mk_binop :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2158,32 +2092,30 @@ let (mk_binop :
   fun op_t ->
     fun phi1 ->
       fun phi2 ->
-        let uu____8268 =
-          let uu____8269 =
-            let uu____8286 =
-              let uu____8297 = FStar_Syntax_Syntax.as_arg phi1 in
-              let uu____8306 =
-                let uu____8317 = FStar_Syntax_Syntax.as_arg phi2 in
-                [uu____8317] in
-              uu____8297 :: uu____8306 in
-            (op_t, uu____8286) in
-          FStar_Syntax_Syntax.Tm_app uu____8269 in
-        let uu____8362 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.as_arg phi1 in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg phi2 in [uu___5] in
+              uu___3 :: uu___4 in
+            (op_t, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        let uu___1 =
           FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
             phi2.FStar_Syntax_Syntax.pos in
-        FStar_Syntax_Syntax.mk uu____8268 uu____8362
+        FStar_Syntax_Syntax.mk uu___ uu___1
 let (mk_neg :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun phi ->
-    let uu____8374 =
-      let uu____8375 =
-        let uu____8392 =
-          let uu____8403 = FStar_Syntax_Syntax.as_arg phi in [uu____8403] in
-        (t_not, uu____8392) in
-      FStar_Syntax_Syntax.Tm_app uu____8375 in
-    FStar_Syntax_Syntax.mk uu____8374 phi.FStar_Syntax_Syntax.pos
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = FStar_Syntax_Syntax.as_arg phi in [uu___3] in
+        (t_not, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___1 in
+    FStar_Syntax_Syntax.mk uu___ phi.FStar_Syntax_Syntax.pos
 let (mk_conj :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2227,39 +2159,37 @@ let (b2t :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun e ->
-    let uu____8593 =
-      let uu____8594 =
-        let uu____8611 =
-          let uu____8622 = FStar_Syntax_Syntax.as_arg e in [uu____8622] in
-        (b2t_v, uu____8611) in
-      FStar_Syntax_Syntax.Tm_app uu____8594 in
-    FStar_Syntax_Syntax.mk uu____8593 e.FStar_Syntax_Syntax.pos
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = FStar_Syntax_Syntax.as_arg e in [uu___3] in
+        (b2t_v, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___1 in
+    FStar_Syntax_Syntax.mk uu___ e.FStar_Syntax_Syntax.pos
 let (unb2t :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
   =
   fun e ->
-    let uu____8668 = head_and_args e in
-    match uu____8668 with
+    let uu___ = head_and_args e in
+    match uu___ with
     | (hd, args) ->
-        let uu____8713 =
-          let uu____8728 =
-            let uu____8729 = FStar_Syntax_Subst.compress hd in
-            uu____8729.FStar_Syntax_Syntax.n in
-          (uu____8728, args) in
-        (match uu____8713 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (e1, uu____8746)::[]) when
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Subst.compress hd in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (e1, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid ->
              FStar_Pervasives_Native.Some e1
-         | uu____8781 -> FStar_Pervasives_Native.None)
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (is_t_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____8801 =
-      let uu____8802 = unmeta t in uu____8802.FStar_Syntax_Syntax.n in
-    match uu____8801 with
+    let uu___ = let uu___1 = unmeta t in uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-    | uu____8806 -> false
+    | uu___1 -> false
 let (mk_conj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2267,12 +2197,11 @@ let (mk_conj_simp :
   =
   fun t1 ->
     fun t2 ->
-      let uu____8827 = is_t_true t1 in
-      if uu____8827
+      let uu___ = is_t_true t1 in
+      if uu___
       then t2
       else
-        (let uu____8831 = is_t_true t2 in
-         if uu____8831 then t1 else mk_conj t1 t2)
+        (let uu___2 = is_t_true t2 in if uu___2 then t1 else mk_conj t1 t2)
 let (mk_disj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2280,12 +2209,12 @@ let (mk_disj_simp :
   =
   fun t1 ->
     fun t2 ->
-      let uu____8855 = is_t_true t1 in
-      if uu____8855
+      let uu___ = is_t_true t1 in
+      if uu___
       then t_true
       else
-        (let uu____8859 = is_t_true t2 in
-         if uu____8859 then t_true else mk_disj t1 t2)
+        (let uu___2 = is_t_true t2 in
+         if uu___2 then t_true else mk_disj t1 t2)
 let (teq : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.eq2_lid
 let (mk_untyped_eq2 :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2294,19 +2223,19 @@ let (mk_untyped_eq2 :
   =
   fun e1 ->
     fun e2 ->
-      let uu____8883 =
-        let uu____8884 =
-          let uu____8901 =
-            let uu____8912 = FStar_Syntax_Syntax.as_arg e1 in
-            let uu____8921 =
-              let uu____8932 = FStar_Syntax_Syntax.as_arg e2 in [uu____8932] in
-            uu____8912 :: uu____8921 in
-          (teq, uu____8901) in
-        FStar_Syntax_Syntax.Tm_app uu____8884 in
-      let uu____8977 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Syntax.as_arg e1 in
+            let uu___4 =
+              let uu___5 = FStar_Syntax_Syntax.as_arg e2 in [uu___5] in
+            uu___3 :: uu___4 in
+          (teq, uu___2) in
+        FStar_Syntax_Syntax.Tm_app uu___1 in
+      let uu___1 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
           e2.FStar_Syntax_Syntax.pos in
-      FStar_Syntax_Syntax.mk uu____8883 uu____8977
+      FStar_Syntax_Syntax.mk uu___ uu___1
 let (mk_eq2 :
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.typ ->
@@ -2318,23 +2247,22 @@ let (mk_eq2 :
       fun e1 ->
         fun e2 ->
           let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u] in
-          let uu____8999 =
-            let uu____9000 =
-              let uu____9017 =
-                let uu____9028 = FStar_Syntax_Syntax.iarg t in
-                let uu____9037 =
-                  let uu____9048 = FStar_Syntax_Syntax.as_arg e1 in
-                  let uu____9057 =
-                    let uu____9068 = FStar_Syntax_Syntax.as_arg e2 in
-                    [uu____9068] in
-                  uu____9048 :: uu____9057 in
-                uu____9028 :: uu____9037 in
-              (eq_inst, uu____9017) in
-            FStar_Syntax_Syntax.Tm_app uu____9000 in
-          let uu____9121 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Syntax.iarg t in
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Syntax.as_arg e1 in
+                  let uu___6 =
+                    let uu___7 = FStar_Syntax_Syntax.as_arg e2 in [uu___7] in
+                  uu___5 :: uu___6 in
+                uu___3 :: uu___4 in
+              (eq_inst, uu___2) in
+            FStar_Syntax_Syntax.Tm_app uu___1 in
+          let uu___1 =
             FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
               e2.FStar_Syntax_Syntax.pos in
-          FStar_Syntax_Syntax.mk uu____8999 uu____9121
+          FStar_Syntax_Syntax.mk uu___ uu___1
 let (mk_has_type :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
@@ -2351,20 +2279,19 @@ let (mk_has_type :
                (t_has_type,
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]))
             FStar_Range.dummyRange in
-        let uu____9145 =
-          let uu____9146 =
-            let uu____9163 =
-              let uu____9174 = FStar_Syntax_Syntax.iarg t in
-              let uu____9183 =
-                let uu____9194 = FStar_Syntax_Syntax.as_arg x in
-                let uu____9203 =
-                  let uu____9214 = FStar_Syntax_Syntax.as_arg t' in
-                  [uu____9214] in
-                uu____9194 :: uu____9203 in
-              uu____9174 :: uu____9183 in
-            (t_has_type1, uu____9163) in
-          FStar_Syntax_Syntax.Tm_app uu____9146 in
-        FStar_Syntax_Syntax.mk uu____9145 FStar_Range.dummyRange
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.iarg t in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg x in
+                let uu___6 =
+                  let uu___7 = FStar_Syntax_Syntax.as_arg t' in [uu___7] in
+                uu___5 :: uu___6 in
+              uu___3 :: uu___4 in
+            (t_has_type1, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (mk_with_type :
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
@@ -2381,28 +2308,28 @@ let (mk_with_type :
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
             FStar_Range.dummyRange in
-        let uu____9290 =
-          let uu____9291 =
-            let uu____9308 =
-              let uu____9319 = FStar_Syntax_Syntax.iarg t in
-              let uu____9328 =
-                let uu____9339 = FStar_Syntax_Syntax.as_arg e in [uu____9339] in
-              uu____9319 :: uu____9328 in
-            (t_with_type1, uu____9308) in
-          FStar_Syntax_Syntax.Tm_app uu____9291 in
-        FStar_Syntax_Syntax.mk uu____9290 FStar_Range.dummyRange
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.iarg t in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg e in [uu___5] in
+              uu___3 :: uu___4 in
+            (t_with_type1, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (lex_t : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.lex_t_lid
 let (lex_top : FStar_Syntax_Syntax.term) =
-  let uu____9384 =
-    let uu____9385 =
-      let uu____9392 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
           FStar_Syntax_Syntax.delta_constant
           (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
-      (uu____9392, [FStar_Syntax_Syntax.U_zero]) in
-    FStar_Syntax_Syntax.Tm_uinst uu____9385 in
-  FStar_Syntax_Syntax.mk uu____9384 FStar_Range.dummyRange
+      (uu___2, [FStar_Syntax_Syntax.U_zero]) in
+    FStar_Syntax_Syntax.Tm_uinst uu___1 in
+  FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (lex_pair : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.delta_constant
@@ -2425,23 +2352,22 @@ let (mk_decidable_eq :
   fun t ->
     fun e1 ->
       fun e2 ->
-        let uu____9422 =
-          let uu____9423 =
-            let uu____9440 =
-              let uu____9451 = FStar_Syntax_Syntax.iarg t in
-              let uu____9460 =
-                let uu____9471 = FStar_Syntax_Syntax.as_arg e1 in
-                let uu____9480 =
-                  let uu____9491 = FStar_Syntax_Syntax.as_arg e2 in
-                  [uu____9491] in
-                uu____9471 :: uu____9480 in
-              uu____9451 :: uu____9460 in
-            (decidable_eq, uu____9440) in
-          FStar_Syntax_Syntax.Tm_app uu____9423 in
-        let uu____9544 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.iarg t in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg e1 in
+                let uu___6 =
+                  let uu___7 = FStar_Syntax_Syntax.as_arg e2 in [uu___7] in
+                uu___5 :: uu___6 in
+              uu___3 :: uu___4 in
+            (decidable_eq, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        let uu___1 =
           FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
             e2.FStar_Syntax_Syntax.pos in
-        FStar_Syntax_Syntax.mk uu____9422 uu____9544
+        FStar_Syntax_Syntax.mk uu___ uu___1
 let (b_and : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.op_And
 let (mk_and :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2450,19 +2376,19 @@ let (mk_and :
   =
   fun e1 ->
     fun e2 ->
-      let uu____9565 =
-        let uu____9566 =
-          let uu____9583 =
-            let uu____9594 = FStar_Syntax_Syntax.as_arg e1 in
-            let uu____9603 =
-              let uu____9614 = FStar_Syntax_Syntax.as_arg e2 in [uu____9614] in
-            uu____9594 :: uu____9603 in
-          (b_and, uu____9583) in
-        FStar_Syntax_Syntax.Tm_app uu____9566 in
-      let uu____9659 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Syntax.as_arg e1 in
+            let uu___4 =
+              let uu___5 = FStar_Syntax_Syntax.as_arg e2 in [uu___5] in
+            uu___3 :: uu___4 in
+          (b_and, uu___2) in
+        FStar_Syntax_Syntax.Tm_app uu___1 in
+      let uu___1 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
           e2.FStar_Syntax_Syntax.pos in
-      FStar_Syntax_Syntax.mk uu____9565 uu____9659
+      FStar_Syntax_Syntax.mk uu___ uu___1
 let (mk_and_l :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -2514,25 +2440,25 @@ let (mk_forall_aux :
   fun fa ->
     fun x ->
       fun body ->
-        let uu____9763 =
-          let uu____9764 =
-            let uu____9781 =
-              let uu____9792 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort in
-              let uu____9801 =
-                let uu____9812 =
-                  let uu____9821 =
-                    let uu____9822 =
-                      let uu____9823 = FStar_Syntax_Syntax.mk_binder x in
-                      [uu____9823] in
-                    abs uu____9822 body
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu___8] in
+                    abs uu___7 body
                       (FStar_Pervasives_Native.Some (residual_tot ktype0)) in
-                  FStar_Syntax_Syntax.as_arg uu____9821 in
-                [uu____9812] in
-              uu____9792 :: uu____9801 in
-            (fa, uu____9781) in
-          FStar_Syntax_Syntax.Tm_app uu____9764 in
-        FStar_Syntax_Syntax.mk uu____9763 FStar_Range.dummyRange
+                  FStar_Syntax_Syntax.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            (fa, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (mk_forall_no_univ :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
@@ -2557,16 +2483,16 @@ let (close_forall_no_univs :
       FStar_List.fold_right
         (fun b ->
            fun f1 ->
-             let uu____9947 = FStar_Syntax_Syntax.is_null_binder b in
-             if uu____9947
+             let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+             if uu___
              then f1
              else mk_forall_no_univ (FStar_Pervasives_Native.fst b) f1) bs f
 let (is_wild_pat :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
   fun p ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____9960 -> true
-    | uu____9961 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu___ -> true
+    | uu___ -> false
 let (if_then_else :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2577,25 +2503,25 @@ let (if_then_else :
     fun t1 ->
       fun t2 ->
         let then_branch =
-          let uu____10006 =
+          let uu___ =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
               t1.FStar_Syntax_Syntax.pos in
-          (uu____10006, FStar_Pervasives_Native.None, t1) in
+          (uu___, FStar_Pervasives_Native.None, t1) in
         let else_branch =
-          let uu____10034 =
+          let uu___ =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant
                  (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos in
-          (uu____10034, FStar_Pervasives_Native.None, t2) in
-        let uu____10047 =
-          let uu____10048 =
+          (uu___, FStar_Pervasives_Native.None, t2) in
+        let uu___ =
+          let uu___1 =
             FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
               t2.FStar_Syntax_Syntax.pos in
-          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10048 in
+          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu___1 in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch]))
-          uu____10047
+          uu___
 let (mk_squash :
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
@@ -2607,10 +2533,9 @@ let (mk_squash :
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.squash_lid
           (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None in
-      let uu____10122 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
-      let uu____10125 =
-        let uu____10136 = FStar_Syntax_Syntax.as_arg p in [uu____10136] in
-      mk_app uu____10122 uu____10125
+      let uu___ = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
+      let uu___1 = let uu___2 = FStar_Syntax_Syntax.as_arg p in [uu___2] in
+      mk_app uu___ uu___1
 let (mk_auto_squash :
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
@@ -2622,28 +2547,27 @@ let (mk_auto_squash :
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.auto_squash_lid
           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
           FStar_Pervasives_Native.None in
-      let uu____10174 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
-      let uu____10177 =
-        let uu____10188 = FStar_Syntax_Syntax.as_arg p in [uu____10188] in
-      mk_app uu____10174 uu____10177
+      let uu___ = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
+      let uu___1 = let uu___2 = FStar_Syntax_Syntax.as_arg p in [uu___2] in
+      mk_app uu___ uu___1
 let (un_squash :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
       FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____10222 = head_and_args t in
-    match uu____10222 with
+    let uu___ = head_and_args t in
+    match uu___ with
     | (head, args) ->
         let head1 = unascribe head in
         let head2 = un_uinst head1 in
-        let uu____10271 =
-          let uu____10286 =
-            let uu____10287 = FStar_Syntax_Subst.compress head2 in
-            uu____10287.FStar_Syntax_Syntax.n in
-          (uu____10286, args) in
-        (match uu____10271 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv, (p, uu____10306)::[]) when
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Subst.compress head2 in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv, (p, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some p
          | (FStar_Syntax_Syntax.Tm_refine (b, p), []) ->
@@ -2652,84 +2576,83 @@ let (un_squash :
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.unit_lid
                   ->
-                  let uu____10372 =
-                    let uu____10377 =
-                      let uu____10378 = FStar_Syntax_Syntax.mk_binder b in
-                      [uu____10378] in
-                    FStar_Syntax_Subst.open_term uu____10377 p in
-                  (match uu____10372 with
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Syntax.mk_binder b in
+                      [uu___4] in
+                    FStar_Syntax_Subst.open_term uu___3 p in
+                  (match uu___2 with
                    | (bs, p1) ->
                        let b1 =
                          match bs with
-                         | b1::[] -> b1
-                         | uu____10435 -> failwith "impossible" in
-                       let uu____10442 =
-                         let uu____10443 = FStar_Syntax_Free.names p1 in
+                         | b2::[] -> b2
+                         | uu___3 -> failwith "impossible" in
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Free.names p1 in
                          FStar_Util.set_mem (FStar_Pervasives_Native.fst b1)
-                           uu____10443 in
-                       if uu____10442
+                           uu___4 in
+                       if uu___3
                        then FStar_Pervasives_Native.None
                        else FStar_Pervasives_Native.Some p1)
-              | uu____10457 -> FStar_Pervasives_Native.None)
-         | uu____10460 -> FStar_Pervasives_Native.None)
+              | uu___2 -> FStar_Pervasives_Native.None)
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (is_squash :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.term'
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____10490 = head_and_args t in
-    match uu____10490 with
+    let uu___ = head_and_args t in
+    match uu___ with
     | (head, args) ->
-        let uu____10541 =
-          let uu____10556 =
-            let uu____10557 = FStar_Syntax_Subst.compress head in
-            uu____10557.FStar_Syntax_Syntax.n in
-          (uu____10556, args) in
-        (match uu____10541 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Subst.compress head in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10579;
-               FStar_Syntax_Syntax.vars = uu____10580;_},
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;_},
              u::[]),
-            (t1, uu____10583)::[]) when
+            (t1, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10630 -> FStar_Pervasives_Native.None)
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (is_auto_squash :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.term'
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____10664 = head_and_args t in
-    match uu____10664 with
+    let uu___ = head_and_args t in
+    match uu___ with
     | (head, args) ->
-        let uu____10715 =
-          let uu____10730 =
-            let uu____10731 = FStar_Syntax_Subst.compress head in
-            uu____10731.FStar_Syntax_Syntax.n in
-          (uu____10730, args) in
-        (match uu____10715 with
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Subst.compress head in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10753;
-               FStar_Syntax_Syntax.vars = uu____10754;_},
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;_},
              u::[]),
-            (t1, uu____10757)::[]) when
+            (t1, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10804 -> FStar_Pervasives_Native.None)
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____10830 = let uu____10847 = unmeta t in head_and_args uu____10847 in
-    match uu____10830 with
-    | (head, uu____10849) ->
-        let uu____10874 =
-          let uu____10875 = un_uinst head in
-          uu____10875.FStar_Syntax_Syntax.n in
-        (match uu____10874 with
+    let uu___ = let uu___1 = unmeta t in head_and_args uu___1 in
+    match uu___ with
+    | (head, uu___1) ->
+        let uu___2 =
+          let uu___3 = un_uinst head in uu___3.FStar_Syntax_Syntax.n in
+        (match uu___2 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              (((((((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.squash_lid)
@@ -2784,47 +2707,46 @@ let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
                ||
                (FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.precedes_lid)
-         | uu____10879 -> false)
+         | uu___3 -> false)
 let (arrow_one_ln :
   FStar_Syntax_Syntax.typ ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.comp)
       FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____10897 =
-      let uu____10898 = FStar_Syntax_Subst.compress t in
-      uu____10898.FStar_Syntax_Syntax.n in
-    match uu____10897 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_arrow ([], c) ->
         failwith "fatal: empty binders on arrow?"
     | FStar_Syntax_Syntax.Tm_arrow (b::[], c) ->
         FStar_Pervasives_Native.Some (b, c)
     | FStar_Syntax_Syntax.Tm_arrow (b::bs, c) ->
-        let uu____11003 =
-          let uu____11008 =
-            let uu____11009 = arrow bs c in
-            FStar_Syntax_Syntax.mk_Total uu____11009 in
-          (b, uu____11008) in
-        FStar_Pervasives_Native.Some uu____11003
-    | uu____11014 -> FStar_Pervasives_Native.None
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = arrow bs c in FStar_Syntax_Syntax.mk_Total uu___3 in
+          (b, uu___2) in
+        FStar_Pervasives_Native.Some uu___1
+    | uu___1 -> FStar_Pervasives_Native.None
 let (arrow_one :
   FStar_Syntax_Syntax.typ ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.comp)
       FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____11036 = arrow_one_ln t in
-    FStar_Util.bind_opt uu____11036
-      (fun uu____11064 ->
-         match uu____11064 with
+    let uu___ = arrow_one_ln t in
+    FStar_Util.bind_opt uu___
+      (fun uu___1 ->
+         match uu___1 with
          | (b, c) ->
-             let uu____11083 = FStar_Syntax_Subst.open_comp [b] c in
-             (match uu____11083 with
+             let uu___2 = FStar_Syntax_Subst.open_comp [b] c in
+             (match uu___2 with
               | (bs, c1) ->
                   let b1 =
                     match bs with
-                    | b1::[] -> b1
-                    | uu____11146 ->
+                    | b2::[] -> b2
+                    | uu___3 ->
                         failwith
                           "impossible: open_comp returned different amount of binders" in
                   FStar_Pervasives_Native.Some (b1, c1)))
@@ -2832,30 +2754,27 @@ let (is_free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv ->
     fun t ->
-      let uu____11179 = FStar_Syntax_Free.names t in
-      FStar_Util.set_mem bv uu____11179
+      let uu___ = FStar_Syntax_Free.names t in FStar_Util.set_mem bv uu___
 type qpats = FStar_Syntax_Syntax.args Prims.list
 type connective =
   | QAll of (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ) 
   | QEx of (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ) 
   | BaseConn of (FStar_Ident.lident * FStar_Syntax_Syntax.args) 
 let (uu___is_QAll : connective -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QAll _0 -> true | uu____11227 -> false
+  fun projectee -> match projectee with | QAll _0 -> true | uu___ -> false
 let (__proj__QAll__item___0 :
   connective ->
     (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ))
   = fun projectee -> match projectee with | QAll _0 -> _0
 let (uu___is_QEx : connective -> Prims.bool) =
-  fun projectee ->
-    match projectee with | QEx _0 -> true | uu____11264 -> false
+  fun projectee -> match projectee with | QEx _0 -> true | uu___ -> false
 let (__proj__QEx__item___0 :
   connective ->
     (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ))
   = fun projectee -> match projectee with | QEx _0 -> _0
 let (uu___is_BaseConn : connective -> Prims.bool) =
   fun projectee ->
-    match projectee with | BaseConn _0 -> true | uu____11299 -> false
+    match projectee with | BaseConn _0 -> true | uu___ -> false
 let (__proj__BaseConn__item___0 :
   connective -> (FStar_Ident.lident * FStar_Syntax_Syntax.args)) =
   fun projectee -> match projectee with | BaseConn _0 -> _0
@@ -2900,26 +2819,24 @@ let (destruct_typ_as_formula :
       let f2 = FStar_Syntax_Subst.compress f1 in
       match f2.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t, FStar_Syntax_Syntax.Meta_monadic uu____11649) ->
-          unmeta_monadic t
+          (t, FStar_Syntax_Syntax.Meta_monadic uu___) -> unmeta_monadic t
       | FStar_Syntax_Syntax.Tm_meta
-          (t, FStar_Syntax_Syntax.Meta_monadic_lift uu____11661) ->
+          (t, FStar_Syntax_Syntax.Meta_monadic_lift uu___) ->
           unmeta_monadic t
-      | uu____11674 -> f2 in
+      | uu___ -> f2 in
     let lookup_arity_lid table target_lid args =
       let arg_len = FStar_List.length args in
-      let aux uu____11743 =
-        match uu____11743 with
+      let aux uu___ =
+        match uu___ with
         | (arity, lids) ->
             if arg_len = arity
             then
               FStar_Util.find_map lids
-                (fun uu____11780 ->
-                   match uu____11780 with
+                (fun uu___1 ->
+                   match uu___1 with
                    | (lid, out_lid) ->
-                       let uu____11789 =
-                         FStar_Ident.lid_equals target_lid lid in
-                       if uu____11789
+                       let uu___2 = FStar_Ident.lid_equals target_lid lid in
+                       if uu___2
                        then
                          FStar_Pervasives_Native.Some
                            (BaseConn (out_lid, args))
@@ -2927,256 +2844,248 @@ let (destruct_typ_as_formula :
             else FStar_Pervasives_Native.None in
       FStar_Util.find_map table aux in
     let destruct_base_conn t =
-      let uu____11812 = head_and_args t in
-      match uu____11812 with
+      let uu___ = head_and_args t in
+      match uu___ with
       | (hd, args) ->
-          let uu____11857 =
-            let uu____11858 = un_uinst hd in
-            uu____11858.FStar_Syntax_Syntax.n in
-          (match uu____11857 with
+          let uu___1 =
+            let uu___2 = un_uinst hd in uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                lookup_arity_lid destruct_base_table
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v args
-           | uu____11864 -> FStar_Pervasives_Native.None) in
+           | uu___2 -> FStar_Pervasives_Native.None) in
     let destruct_sq_base_conn t =
-      let uu____11873 = un_squash t in
-      FStar_Util.bind_opt uu____11873
+      let uu___ = un_squash t in
+      FStar_Util.bind_opt uu___
         (fun t1 ->
-           let uu____11889 = head_and_args' t1 in
-           match uu____11889 with
+           let uu___1 = head_and_args' t1 in
+           match uu___1 with
            | (hd, args) ->
-               let uu____11928 =
-                 let uu____11929 = un_uinst hd in
-                 uu____11929.FStar_Syntax_Syntax.n in
-               (match uu____11928 with
+               let uu___2 =
+                 let uu___3 = un_uinst hd in uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     lookup_arity_lid destruct_sq_base_table
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       args
-                | uu____11935 -> FStar_Pervasives_Native.None)) in
+                | uu___3 -> FStar_Pervasives_Native.None)) in
     let patterns t =
       let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t2, FStar_Syntax_Syntax.Meta_pattern (uu____11976, pats)) ->
-          let uu____12014 = FStar_Syntax_Subst.compress t2 in
-          (pats, uu____12014)
-      | uu____12027 -> ([], t1) in
+          (t2, FStar_Syntax_Syntax.Meta_pattern (uu___, pats)) ->
+          let uu___1 = FStar_Syntax_Subst.compress t2 in (pats, uu___1)
+      | uu___ -> ([], t1) in
     let destruct_q_conn t =
       let is_q fa fv =
         if fa
         then is_forall (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
         else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
       let flat t1 =
-        let uu____12088 = head_and_args t1 in
-        match uu____12088 with
+        let uu___ = head_and_args t1 in
+        match uu___ with
         | (t2, args) ->
-            let uu____12143 = un_uinst t2 in
-            let uu____12144 =
+            let uu___1 = un_uinst t2 in
+            let uu___2 =
               FStar_All.pipe_right args
                 (FStar_List.map
-                   (fun uu____12185 ->
-                      match uu____12185 with
+                   (fun uu___3 ->
+                      match uu___3 with
                       | (t3, imp) ->
-                          let uu____12204 = unascribe t3 in
-                          (uu____12204, imp))) in
-            (uu____12143, uu____12144) in
+                          let uu___4 = unascribe t3 in (uu___4, imp))) in
+            (uu___1, uu___2) in
       let rec aux qopt out t1 =
-        let uu____12253 = let uu____12276 = flat t1 in (qopt, uu____12276) in
-        match uu____12253 with
+        let uu___ = let uu___1 = flat t1 in (qopt, uu___1) in
+        match uu___ with
         | (FStar_Pervasives_Native.Some fa,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-              FStar_Syntax_Syntax.pos = uu____12315;
-              FStar_Syntax_Syntax.vars = uu____12316;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                 (b::[], t2, uu____12319);
-               FStar_Syntax_Syntax.pos = uu____12320;
-               FStar_Syntax_Syntax.vars = uu____12321;_},
-             uu____12322)::[]))
+                 (b::[], t2, uu___3);
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.vars = uu___5;_},
+             uu___6)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.Some fa,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-              FStar_Syntax_Syntax.pos = uu____12421;
-              FStar_Syntax_Syntax.vars = uu____12422;_},
-            uu____12423::({
-                            FStar_Syntax_Syntax.n =
-                              FStar_Syntax_Syntax.Tm_abs
-                              (b::[], t2, uu____12426);
-                            FStar_Syntax_Syntax.pos = uu____12427;
-                            FStar_Syntax_Syntax.vars = uu____12428;_},
-                          uu____12429)::[]))
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            uu___3::({
+                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
+                         (b::[], t2, uu___4);
+                       FStar_Syntax_Syntax.pos = uu___5;
+                       FStar_Syntax_Syntax.vars = uu___6;_},
+                     uu___7)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.None,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-              FStar_Syntax_Syntax.pos = uu____12543;
-              FStar_Syntax_Syntax.vars = uu____12544;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                 (b::[], t2, uu____12547);
-               FStar_Syntax_Syntax.pos = uu____12548;
-               FStar_Syntax_Syntax.vars = uu____12549;_},
-             uu____12550)::[]))
+                 (b::[], t2, uu___3);
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.vars = uu___5;_},
+             uu___6)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____12641 =
-              let uu____12644 =
+            let uu___7 =
+              let uu___8 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              FStar_Pervasives_Native.Some uu____12644 in
-            aux uu____12641 (b :: out) t2
+              FStar_Pervasives_Native.Some uu___8 in
+            aux uu___7 (b :: out) t2
         | (FStar_Pervasives_Native.None,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-              FStar_Syntax_Syntax.pos = uu____12652;
-              FStar_Syntax_Syntax.vars = uu____12653;_},
-            uu____12654::({
-                            FStar_Syntax_Syntax.n =
-                              FStar_Syntax_Syntax.Tm_abs
-                              (b::[], t2, uu____12657);
-                            FStar_Syntax_Syntax.pos = uu____12658;
-                            FStar_Syntax_Syntax.vars = uu____12659;_},
-                          uu____12660)::[]))
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            uu___3::({
+                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
+                         (b::[], t2, uu___4);
+                       FStar_Syntax_Syntax.pos = uu___5;
+                       FStar_Syntax_Syntax.vars = uu___6;_},
+                     uu___7)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____12767 =
-              let uu____12770 =
+            let uu___8 =
+              let uu___9 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              FStar_Pervasives_Native.Some uu____12770 in
-            aux uu____12767 (b :: out) t2
-        | (FStar_Pervasives_Native.Some b, uu____12778) ->
+              FStar_Pervasives_Native.Some uu___9 in
+            aux uu___8 (b :: out) t2
+        | (FStar_Pervasives_Native.Some b, uu___1) ->
             let bs = FStar_List.rev out in
-            let uu____12828 = FStar_Syntax_Subst.open_term bs t1 in
-            (match uu____12828 with
+            let uu___2 = FStar_Syntax_Subst.open_term bs t1 in
+            (match uu___2 with
              | (bs1, t2) ->
-                 let uu____12837 = patterns t2 in
-                 (match uu____12837 with
+                 let uu___3 = patterns t2 in
+                 (match uu___3 with
                   | (pats, body) ->
                       if b
                       then
                         FStar_Pervasives_Native.Some (QAll (bs1, pats, body))
                       else
                         FStar_Pervasives_Native.Some (QEx (bs1, pats, body))))
-        | uu____12885 -> FStar_Pervasives_Native.None in
+        | uu___1 -> FStar_Pervasives_Native.None in
       aux FStar_Pervasives_Native.None [] t in
     let rec destruct_sq_forall t =
-      let uu____12938 = un_squash t in
-      FStar_Util.bind_opt uu____12938
+      let uu___ = un_squash t in
+      FStar_Util.bind_opt uu___
         (fun t1 ->
-           let uu____12953 = arrow_one t1 in
-           match uu____12953 with
+           let uu___1 = arrow_one t1 in
+           match uu___1 with
            | FStar_Pervasives_Native.Some (b, c) ->
-               let uu____12968 =
-                 let uu____12969 = is_tot_or_gtot_comp c in
-                 Prims.op_Negation uu____12969 in
-               if uu____12968
+               let uu___2 =
+                 let uu___3 = is_tot_or_gtot_comp c in
+                 Prims.op_Negation uu___3 in
+               if uu___2
                then FStar_Pervasives_Native.None
                else
                  (let q =
-                    let uu____12976 = comp_to_comp_typ_nouniv c in
-                    uu____12976.FStar_Syntax_Syntax.result_typ in
-                  let uu____12977 =
-                    is_free_in (FStar_Pervasives_Native.fst b) q in
-                  if uu____12977
+                    let uu___4 = comp_to_comp_typ_nouniv c in
+                    uu___4.FStar_Syntax_Syntax.result_typ in
+                  let uu___4 = is_free_in (FStar_Pervasives_Native.fst b) q in
+                  if uu___4
                   then
-                    let uu____12982 = patterns q in
-                    match uu____12982 with
+                    let uu___5 = patterns q in
+                    match uu___5 with
                     | (pats, q1) ->
                         FStar_All.pipe_left maybe_collect
                           (FStar_Pervasives_Native.Some
                              (QAll ([b], pats, q1)))
                   else
-                    (let uu____13044 =
-                       let uu____13045 =
-                         let uu____13050 =
-                           let uu____13051 =
+                    (let uu___6 =
+                       let uu___7 =
+                         let uu___8 =
+                           let uu___9 =
                              FStar_Syntax_Syntax.as_arg
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                           let uu____13062 =
-                             let uu____13073 = FStar_Syntax_Syntax.as_arg q in
-                             [uu____13073] in
-                           uu____13051 :: uu____13062 in
-                         (FStar_Parser_Const.imp_lid, uu____13050) in
-                       BaseConn uu____13045 in
-                     FStar_Pervasives_Native.Some uu____13044))
-           | uu____13106 -> FStar_Pervasives_Native.None)
+                           let uu___10 =
+                             let uu___11 = FStar_Syntax_Syntax.as_arg q in
+                             [uu___11] in
+                           uu___9 :: uu___10 in
+                         (FStar_Parser_Const.imp_lid, uu___8) in
+                       BaseConn uu___7 in
+                     FStar_Pervasives_Native.Some uu___6))
+           | uu___2 -> FStar_Pervasives_Native.None)
     and destruct_sq_exists t =
-      let uu____13114 = un_squash t in
-      FStar_Util.bind_opt uu____13114
+      let uu___ = un_squash t in
+      FStar_Util.bind_opt uu___
         (fun t1 ->
-           let uu____13145 = head_and_args' t1 in
-           match uu____13145 with
+           let uu___1 = head_and_args' t1 in
+           match uu___1 with
            | (hd, args) ->
-               let uu____13184 =
-                 let uu____13199 =
-                   let uu____13200 = un_uinst hd in
-                   uu____13200.FStar_Syntax_Syntax.n in
-                 (uu____13199, args) in
-               (match uu____13184 with
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = un_uinst hd in uu___4.FStar_Syntax_Syntax.n in
+                 (uu___3, args) in
+               (match uu___2 with
                 | (FStar_Syntax_Syntax.Tm_fvar fv,
-                   (a1, uu____13217)::(a2, uu____13219)::[]) when
+                   (a1, uu___3)::(a2, uu___4)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.dtuple2_lid
                     ->
-                    let uu____13270 =
-                      let uu____13271 = FStar_Syntax_Subst.compress a2 in
-                      uu____13271.FStar_Syntax_Syntax.n in
-                    (match uu____13270 with
-                     | FStar_Syntax_Syntax.Tm_abs (b::[], q, uu____13278) ->
-                         let uu____13313 = FStar_Syntax_Subst.open_term [b] q in
-                         (match uu____13313 with
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Subst.compress a2 in
+                      uu___6.FStar_Syntax_Syntax.n in
+                    (match uu___5 with
+                     | FStar_Syntax_Syntax.Tm_abs (b::[], q, uu___6) ->
+                         let uu___7 = FStar_Syntax_Subst.open_term [b] q in
+                         (match uu___7 with
                           | (bs, q1) ->
                               let b1 =
                                 match bs with
-                                | b1::[] -> b1
-                                | uu____13366 -> failwith "impossible" in
-                              let uu____13373 = patterns q1 in
-                              (match uu____13373 with
+                                | b2::[] -> b2
+                                | uu___8 -> failwith "impossible" in
+                              let uu___8 = patterns q1 in
+                              (match uu___8 with
                                | (pats, q2) ->
                                    FStar_All.pipe_left maybe_collect
                                      (FStar_Pervasives_Native.Some
                                         (QEx ([b1], pats, q2)))))
-                     | uu____13434 -> FStar_Pervasives_Native.None)
-                | uu____13435 -> FStar_Pervasives_Native.None))
+                     | uu___6 -> FStar_Pervasives_Native.None)
+                | uu___3 -> FStar_Pervasives_Native.None))
     and maybe_collect f1 =
       match f1 with
       | FStar_Pervasives_Native.Some (QAll (bs, pats, phi)) ->
-          let uu____13458 = destruct_sq_forall phi in
-          (match uu____13458 with
+          let uu___ = destruct_sq_forall phi in
+          (match uu___ with
            | FStar_Pervasives_Native.Some (QAll (bs', pats', psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13468 -> FStar_Pervasives_Native.Some uu____13468)
+                 (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
                  (QAll
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13475 -> f1)
+           | uu___1 -> f1)
       | FStar_Pervasives_Native.Some (QEx (bs, pats, phi)) ->
-          let uu____13481 = destruct_sq_exists phi in
-          (match uu____13481 with
+          let uu___ = destruct_sq_exists phi in
+          (match uu___ with
            | FStar_Pervasives_Native.Some (QEx (bs', pats', psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13491 -> FStar_Pervasives_Native.Some uu____13491)
+                 (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
                  (QEx
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13498 -> f1)
-      | uu____13501 -> f1 in
+           | uu___1 -> f1)
+      | uu___ -> f1 in
     let phi = unmeta_monadic f in
-    let uu____13505 = destruct_base_conn phi in
-    FStar_Util.catch_opt uu____13505
-      (fun uu____13510 ->
-         let uu____13511 = destruct_q_conn phi in
-         FStar_Util.catch_opt uu____13511
-           (fun uu____13516 ->
-              let uu____13517 = destruct_sq_base_conn phi in
-              FStar_Util.catch_opt uu____13517
-                (fun uu____13522 ->
-                   let uu____13523 = destruct_sq_forall phi in
-                   FStar_Util.catch_opt uu____13523
-                     (fun uu____13528 ->
-                        let uu____13529 = destruct_sq_exists phi in
-                        FStar_Util.catch_opt uu____13529
-                          (fun uu____13533 -> FStar_Pervasives_Native.None)))))
+    let uu___ = destruct_base_conn phi in
+    FStar_Util.catch_opt uu___
+      (fun uu___1 ->
+         let uu___2 = destruct_q_conn phi in
+         FStar_Util.catch_opt uu___2
+           (fun uu___3 ->
+              let uu___4 = destruct_sq_base_conn phi in
+              FStar_Util.catch_opt uu___4
+                (fun uu___5 ->
+                   let uu___6 = destruct_sq_forall phi in
+                   FStar_Util.catch_opt uu___6
+                     (fun uu___7 ->
+                        let uu___8 = destruct_sq_exists phi in
+                        FStar_Util.catch_opt uu___8
+                          (fun uu___9 -> FStar_Pervasives_Native.None)))))
 let (action_as_lb :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.action ->
@@ -3186,22 +3095,22 @@ let (action_as_lb :
     fun a ->
       fun pos ->
         let lb =
-          let uu____13550 =
-            let uu____13555 =
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
                 FStar_Syntax_Syntax.delta_equational
                 FStar_Pervasives_Native.None in
-            FStar_Util.Inr uu____13555 in
-          let uu____13556 =
-            let uu____13557 =
+            FStar_Util.Inr uu___1 in
+          let uu___1 =
+            let uu___2 =
               FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ in
-            arrow a.FStar_Syntax_Syntax.action_params uu____13557 in
-          let uu____13560 =
+            arrow a.FStar_Syntax_Syntax.action_params uu___2 in
+          let uu___2 =
             abs a.FStar_Syntax_Syntax.action_params
               a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None in
-          close_univs_and_mk_letbinding FStar_Pervasives_Native.None
-            uu____13550 a.FStar_Syntax_Syntax.action_univs uu____13556
-            FStar_Parser_Const.effect_Tot_lid uu____13560 [] pos in
+          close_univs_and_mk_letbinding FStar_Pervasives_Native.None uu___
+            a.FStar_Syntax_Syntax.action_univs uu___1
+            FStar_Parser_Const.effect_Tot_lid uu___2 [] pos in
         {
           FStar_Syntax_Syntax.sigel =
             (FStar_Syntax_Syntax.Sig_let
@@ -3224,72 +3133,68 @@ let (mk_reify :
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify)
         t.FStar_Syntax_Syntax.pos in
-    let uu____13583 =
-      let uu____13584 =
-        let uu____13601 =
-          let uu____13612 = FStar_Syntax_Syntax.as_arg t in [uu____13612] in
-        (reify_, uu____13601) in
-      FStar_Syntax_Syntax.Tm_app uu____13584 in
-    FStar_Syntax_Syntax.mk uu____13583 t.FStar_Syntax_Syntax.pos
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = FStar_Syntax_Syntax.as_arg t in [uu___3] in
+        (reify_, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___1 in
+    FStar_Syntax_Syntax.mk uu___ t.FStar_Syntax_Syntax.pos
 let (mk_reflect :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t ->
     let reflect_ =
-      let uu____13663 =
-        let uu____13664 =
-          let uu____13665 = FStar_Ident.lid_of_str "Bogus.Effect" in
-          FStar_Const.Const_reflect uu____13665 in
-        FStar_Syntax_Syntax.Tm_constant uu____13664 in
-      FStar_Syntax_Syntax.mk uu____13663 t.FStar_Syntax_Syntax.pos in
-    let uu____13666 =
-      let uu____13667 =
-        let uu____13684 =
-          let uu____13695 = FStar_Syntax_Syntax.as_arg t in [uu____13695] in
-        (reflect_, uu____13684) in
-      FStar_Syntax_Syntax.Tm_app uu____13667 in
-    FStar_Syntax_Syntax.mk uu____13666 t.FStar_Syntax_Syntax.pos
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Ident.lid_of_str "Bogus.Effect" in
+          FStar_Const.Const_reflect uu___2 in
+        FStar_Syntax_Syntax.Tm_constant uu___1 in
+      FStar_Syntax_Syntax.mk uu___ t.FStar_Syntax_Syntax.pos in
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = FStar_Syntax_Syntax.as_arg t in [uu___3] in
+        (reflect_, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___1 in
+    FStar_Syntax_Syntax.mk uu___ t.FStar_Syntax_Syntax.pos
 let rec (delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t ->
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____13738 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____13754 = unfold_lazy i in delta_qualifier uu____13754
+        let uu___ = unfold_lazy i in delta_qualifier uu___
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
-    | FStar_Syntax_Syntax.Tm_bvar uu____13756 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu___ ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_name uu____13757 ->
+    | FStar_Syntax_Syntax.Tm_name uu___ ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_match uu____13758 ->
+    | FStar_Syntax_Syntax.Tm_match uu___ ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_uvar uu____13781 ->
+    | FStar_Syntax_Syntax.Tm_uvar uu___ ->
         FStar_Syntax_Syntax.delta_equational
     | FStar_Syntax_Syntax.Tm_unknown -> FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_type uu____13794 ->
+    | FStar_Syntax_Syntax.Tm_type uu___ -> FStar_Syntax_Syntax.delta_constant
+    | FStar_Syntax_Syntax.Tm_quoted uu___ ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_quoted uu____13795 ->
+    | FStar_Syntax_Syntax.Tm_constant uu___ ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_constant uu____13802 ->
+    | FStar_Syntax_Syntax.Tm_arrow uu___ ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_arrow uu____13803 ->
-        FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_uinst (t2, uu____13819) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_uinst (t2, uu___) -> delta_qualifier t2
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____13824;
-           FStar_Syntax_Syntax.index = uu____13825;
+        ({ FStar_Syntax_Syntax.ppname = uu___;
+           FStar_Syntax_Syntax.index = uu___1;
            FStar_Syntax_Syntax.sort = t2;_},
-         uu____13827)
+         uu___2)
         -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_meta (t2, uu____13835) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____13841, uu____13842) ->
+    | FStar_Syntax_Syntax.Tm_meta (t2, uu___) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_app (t2, uu____13884) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_abs (uu____13909, t2, uu____13911) ->
-        delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_let (uu____13936, t2) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_app (t2, uu___) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_abs (uu___, t2, uu___1) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_let (uu___, t2) -> delta_qualifier t2
 let rec (incr_delta_depth :
   FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth) =
   fun d ->
@@ -3301,27 +3206,23 @@ let rec (incr_delta_depth :
     | FStar_Syntax_Syntax.Delta_abstract d1 -> incr_delta_depth d1
 let (incr_delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
-  fun t ->
-    let uu____13967 = delta_qualifier t in incr_delta_depth uu____13967
+  fun t -> let uu___ = delta_qualifier t in incr_delta_depth uu___
 let (is_unknown : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____13973 =
-      let uu____13974 = FStar_Syntax_Subst.compress t in
-      uu____13974.FStar_Syntax_Syntax.n in
-    match uu____13973 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_unknown -> true
-    | uu____13977 -> false
+    | uu___1 -> false
 let rec apply_last :
-  'uuuuuu13984 .
-    ('uuuuuu13984 -> 'uuuuuu13984) ->
-      'uuuuuu13984 Prims.list -> 'uuuuuu13984 Prims.list
-  =
+  'uuuuu . ('uuuuu -> 'uuuuu) -> 'uuuuu Prims.list -> 'uuuuu Prims.list =
   fun f ->
     fun l ->
       match l with
       | [] -> failwith "apply_last: got empty list"
-      | a::[] -> let uu____14009 = f a in [uu____14009]
-      | x::xs -> let uu____14014 = apply_last f xs in x :: uu____14014
+      | a::[] -> let uu___ = f a in [uu___]
+      | x::xs -> let uu___ = apply_last f xs in x :: uu___
 let (dm4f_lid :
   FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident) =
   fun ed ->
@@ -3342,42 +3243,40 @@ let (mk_list :
     fun rng ->
       fun l ->
         let ctor l1 =
-          let uu____14060 =
-            let uu____14061 =
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Syntax.lid_as_fv l1
                 FStar_Syntax_Syntax.delta_constant
                 (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
-            FStar_Syntax_Syntax.Tm_fvar uu____14061 in
-          FStar_Syntax_Syntax.mk uu____14060 rng in
+            FStar_Syntax_Syntax.Tm_fvar uu___1 in
+          FStar_Syntax_Syntax.mk uu___ rng in
         let cons args pos =
-          let uu____14073 =
-            let uu____14074 = ctor FStar_Parser_Const.cons_lid in
-            FStar_Syntax_Syntax.mk_Tm_uinst uu____14074
+          let uu___ =
+            let uu___1 = ctor FStar_Parser_Const.cons_lid in
+            FStar_Syntax_Syntax.mk_Tm_uinst uu___1
               [FStar_Syntax_Syntax.U_zero] in
-          FStar_Syntax_Syntax.mk_Tm_app uu____14073 args pos in
+          FStar_Syntax_Syntax.mk_Tm_app uu___ args pos in
         let nil args pos =
-          let uu____14086 =
-            let uu____14087 = ctor FStar_Parser_Const.nil_lid in
-            FStar_Syntax_Syntax.mk_Tm_uinst uu____14087
+          let uu___ =
+            let uu___1 = ctor FStar_Parser_Const.nil_lid in
+            FStar_Syntax_Syntax.mk_Tm_uinst uu___1
               [FStar_Syntax_Syntax.U_zero] in
-          FStar_Syntax_Syntax.mk_Tm_app uu____14086 args pos in
-        let uu____14088 =
-          let uu____14089 =
-            let uu____14090 = FStar_Syntax_Syntax.iarg typ in [uu____14090] in
-          nil uu____14089 rng in
+          FStar_Syntax_Syntax.mk_Tm_app uu___ args pos in
+        let uu___ =
+          let uu___1 = let uu___2 = FStar_Syntax_Syntax.iarg typ in [uu___2] in
+          nil uu___1 rng in
         FStar_List.fold_right
           (fun t ->
              fun a ->
-               let uu____14124 =
-                 let uu____14125 = FStar_Syntax_Syntax.iarg typ in
-                 let uu____14134 =
-                   let uu____14145 = FStar_Syntax_Syntax.as_arg t in
-                   let uu____14154 =
-                     let uu____14165 = FStar_Syntax_Syntax.as_arg a in
-                     [uu____14165] in
-                   uu____14145 :: uu____14154 in
-                 uu____14125 :: uu____14134 in
-               cons uu____14124 t.FStar_Syntax_Syntax.pos) l uu____14088
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Syntax.iarg typ in
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Syntax.as_arg t in
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Syntax.as_arg a in [uu___6] in
+                   uu___4 :: uu___5 in
+                 uu___2 :: uu___3 in
+               cons uu___1 t.FStar_Syntax_Syntax.pos) l uu___
 let rec eqlist :
   'a .
     ('a -> 'a -> Prims.bool) -> 'a Prims.list -> 'a Prims.list -> Prims.bool
@@ -3388,7 +3287,7 @@ let rec eqlist :
         match (xs, ys) with
         | ([], []) -> true
         | (x::xs1, y::ys1) -> (eq x y) && (eqlist eq xs1 ys1)
-        | uu____14269 -> false
+        | uu___ -> false
 let eqsum :
   'a 'b .
     ('a -> 'a -> Prims.bool) ->
@@ -3403,7 +3302,7 @@ let eqsum :
           match (x, y) with
           | (FStar_Util.Inl x1, FStar_Util.Inl y1) -> e1 x1 y1
           | (FStar_Util.Inr x1, FStar_Util.Inr y1) -> e2 x1 y1
-          | uu____14376 -> false
+          | uu___ -> false
 let eqprod :
   'a 'b .
     ('a -> 'a -> Prims.bool) ->
@@ -3427,7 +3326,7 @@ let eqopt :
         match (x, y) with
         | (FStar_Pervasives_Native.Some x1, FStar_Pervasives_Native.Some y1)
             -> e x1 y1
-        | uu____14531 -> false
+        | uu___ -> false
 let (debug_term_eq : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false
 let (check : Prims.string -> Prims.bool -> Prims.bool) =
   fun msg ->
@@ -3435,8 +3334,8 @@ let (check : Prims.string -> Prims.bool -> Prims.bool) =
       if cond
       then true
       else
-        ((let uu____14554 = FStar_ST.op_Bang debug_term_eq in
-          if uu____14554
+        ((let uu___2 = FStar_ST.op_Bang debug_term_eq in
+          if uu___2
           then FStar_Util.print1 ">>> term_eq failing: %s\n" msg
           else ());
          false)
@@ -3448,32 +3347,30 @@ let rec (term_eq_dbg :
   fun dbg ->
     fun t1 ->
       fun t2 ->
-        let t11 = let uu____14703 = unmeta_safe t1 in canon_app uu____14703 in
-        let t21 = let uu____14707 = unmeta_safe t2 in canon_app uu____14707 in
-        let uu____14710 =
-          let uu____14715 =
-            let uu____14716 =
-              let uu____14719 = un_uinst t11 in
-              FStar_Syntax_Subst.compress uu____14719 in
-            uu____14716.FStar_Syntax_Syntax.n in
-          let uu____14720 =
-            let uu____14721 =
-              let uu____14724 = un_uinst t21 in
-              FStar_Syntax_Subst.compress uu____14724 in
-            uu____14721.FStar_Syntax_Syntax.n in
-          (uu____14715, uu____14720) in
-        match uu____14710 with
-        | (FStar_Syntax_Syntax.Tm_uinst uu____14725, uu____14726) ->
+        let t11 = let uu___ = unmeta_safe t1 in canon_app uu___ in
+        let t21 = let uu___ = unmeta_safe t2 in canon_app uu___ in
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = un_uinst t11 in FStar_Syntax_Subst.compress uu___3 in
+            uu___2.FStar_Syntax_Syntax.n in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = un_uinst t21 in FStar_Syntax_Subst.compress uu___4 in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___1, uu___2) in
+        match uu___ with
+        | (FStar_Syntax_Syntax.Tm_uinst uu___1, uu___2) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____14733, FStar_Syntax_Syntax.Tm_uinst uu____14734) ->
+        | (uu___1, FStar_Syntax_Syntax.Tm_uinst uu___2) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_delayed uu____14741, uu____14742) ->
+        | (FStar_Syntax_Syntax.Tm_delayed uu___1, uu___2) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____14757, FStar_Syntax_Syntax.Tm_delayed uu____14758) ->
+        | (uu___1, FStar_Syntax_Syntax.Tm_delayed uu___2) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_ascribed uu____14773, uu____14774) ->
+        | (FStar_Syntax_Syntax.Tm_ascribed uu___1, uu___2) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____14801, FStar_Syntax_Syntax.Tm_ascribed uu____14802) ->
+        | (uu___1, FStar_Syntax_Syntax.Tm_ascribed uu___2) ->
             failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_bvar x, FStar_Syntax_Syntax.Tm_bvar y) ->
             check "bvar"
@@ -3482,147 +3379,118 @@ let rec (term_eq_dbg :
             check "name"
               (x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index)
         | (FStar_Syntax_Syntax.Tm_fvar x, FStar_Syntax_Syntax.Tm_fvar y) ->
-            let uu____14835 = FStar_Syntax_Syntax.fv_eq x y in
-            check "fvar" uu____14835
+            let uu___1 = FStar_Syntax_Syntax.fv_eq x y in check "fvar" uu___1
         | (FStar_Syntax_Syntax.Tm_constant c1,
            FStar_Syntax_Syntax.Tm_constant c2) ->
-            let uu____14838 = FStar_Const.eq_const c1 c2 in
-            check "const" uu____14838
-        | (FStar_Syntax_Syntax.Tm_type uu____14839,
-           FStar_Syntax_Syntax.Tm_type uu____14840) -> true
+            let uu___1 = FStar_Const.eq_const c1 c2 in check "const" uu___1
+        | (FStar_Syntax_Syntax.Tm_type uu___1, FStar_Syntax_Syntax.Tm_type
+           uu___2) -> true
         | (FStar_Syntax_Syntax.Tm_abs (b1, t12, k1),
            FStar_Syntax_Syntax.Tm_abs (b2, t22, k2)) ->
-            (let uu____14897 = eqlist (binder_eq_dbg dbg) b1 b2 in
-             check "abs binders" uu____14897) &&
-              (let uu____14905 = term_eq_dbg dbg t12 t22 in
-               check "abs bodies" uu____14905)
+            (let uu___1 = eqlist (binder_eq_dbg dbg) b1 b2 in
+             check "abs binders" uu___1) &&
+              (let uu___1 = term_eq_dbg dbg t12 t22 in
+               check "abs bodies" uu___1)
         | (FStar_Syntax_Syntax.Tm_arrow (b1, c1),
            FStar_Syntax_Syntax.Tm_arrow (b2, c2)) ->
-            (let uu____14952 = eqlist (binder_eq_dbg dbg) b1 b2 in
-             check "arrow binders" uu____14952) &&
-              (let uu____14960 = comp_eq_dbg dbg c1 c2 in
-               check "arrow comp" uu____14960)
+            (let uu___1 = eqlist (binder_eq_dbg dbg) b1 b2 in
+             check "arrow binders" uu___1) &&
+              (let uu___1 = comp_eq_dbg dbg c1 c2 in
+               check "arrow comp" uu___1)
         | (FStar_Syntax_Syntax.Tm_refine (b1, t12),
            FStar_Syntax_Syntax.Tm_refine (b2, t22)) ->
-            (let uu____14975 =
+            (let uu___1 =
                term_eq_dbg dbg b1.FStar_Syntax_Syntax.sort
                  b2.FStar_Syntax_Syntax.sort in
-             check "refine bv sort" uu____14975) &&
-              (let uu____14977 = term_eq_dbg dbg t12 t22 in
-               check "refine formula" uu____14977)
+             check "refine bv sort" uu___1) &&
+              (let uu___1 = term_eq_dbg dbg t12 t22 in
+               check "refine formula" uu___1)
         | (FStar_Syntax_Syntax.Tm_app (f1, a1), FStar_Syntax_Syntax.Tm_app
            (f2, a2)) ->
-            (let uu____15032 = term_eq_dbg dbg f1 f2 in
-             check "app head" uu____15032) &&
-              (let uu____15034 = eqlist (arg_eq_dbg dbg) a1 a2 in
-               check "app args" uu____15034)
+            (let uu___1 = term_eq_dbg dbg f1 f2 in check "app head" uu___1)
+              &&
+              (let uu___1 = eqlist (arg_eq_dbg dbg) a1 a2 in
+               check "app args" uu___1)
         | (FStar_Syntax_Syntax.Tm_match (t12, bs1),
            FStar_Syntax_Syntax.Tm_match (t22, bs2)) ->
-            (let uu____15121 = term_eq_dbg dbg t12 t22 in
-             check "match head" uu____15121) &&
-              (let uu____15123 = eqlist (branch_eq_dbg dbg) bs1 bs2 in
-               check "match branches" uu____15123)
-        | (FStar_Syntax_Syntax.Tm_lazy uu____15138, uu____15139) ->
-            let uu____15140 =
-              let uu____15141 = unlazy t11 in term_eq_dbg dbg uu____15141 t21 in
-            check "lazy_l" uu____15140
-        | (uu____15142, FStar_Syntax_Syntax.Tm_lazy uu____15143) ->
-            let uu____15144 =
-              let uu____15145 = unlazy t21 in term_eq_dbg dbg t11 uu____15145 in
-            check "lazy_r" uu____15144
+            (let uu___1 = term_eq_dbg dbg t12 t22 in
+             check "match head" uu___1) &&
+              (let uu___1 = eqlist (branch_eq_dbg dbg) bs1 bs2 in
+               check "match branches" uu___1)
+        | (FStar_Syntax_Syntax.Tm_lazy uu___1, uu___2) ->
+            let uu___3 =
+              let uu___4 = unlazy t11 in term_eq_dbg dbg uu___4 t21 in
+            check "lazy_l" uu___3
+        | (uu___1, FStar_Syntax_Syntax.Tm_lazy uu___2) ->
+            let uu___3 =
+              let uu___4 = unlazy t21 in term_eq_dbg dbg t11 uu___4 in
+            check "lazy_r" uu___3
         | (FStar_Syntax_Syntax.Tm_let ((b1, lbs1), t12),
            FStar_Syntax_Syntax.Tm_let ((b2, lbs2), t22)) ->
             ((check "let flag" (b1 = b2)) &&
-               (let uu____15181 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2 in
-                check "let lbs" uu____15181))
+               (let uu___1 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2 in
+                check "let lbs" uu___1))
               &&
-              (let uu____15183 = term_eq_dbg dbg t12 t22 in
-               check "let body" uu____15183)
-        | (FStar_Syntax_Syntax.Tm_uvar (u1, uu____15185),
-           FStar_Syntax_Syntax.Tm_uvar (u2, uu____15187)) ->
+              (let uu___1 = term_eq_dbg dbg t12 t22 in
+               check "let body" uu___1)
+        | (FStar_Syntax_Syntax.Tm_uvar (u1, uu___1),
+           FStar_Syntax_Syntax.Tm_uvar (u2, uu___2)) ->
             check "uvar"
               (u1.FStar_Syntax_Syntax.ctx_uvar_head =
                  u2.FStar_Syntax_Syntax.ctx_uvar_head)
         | (FStar_Syntax_Syntax.Tm_quoted (qt1, qi1),
            FStar_Syntax_Syntax.Tm_quoted (qt2, qi2)) ->
-            (let uu____15246 =
-               let uu____15247 = eq_quoteinfo qi1 qi2 in uu____15247 = Equal in
-             check "tm_quoted qi" uu____15246) &&
-              (let uu____15249 = term_eq_dbg dbg qt1 qt2 in
-               check "tm_quoted payload" uu____15249)
+            (let uu___1 = let uu___2 = eq_quoteinfo qi1 qi2 in uu___2 = Equal in
+             check "tm_quoted qi" uu___1) &&
+              (let uu___1 = term_eq_dbg dbg qt1 qt2 in
+               check "tm_quoted payload" uu___1)
         | (FStar_Syntax_Syntax.Tm_meta (t12, m1), FStar_Syntax_Syntax.Tm_meta
            (t22, m2)) ->
             (match (m1, m2) with
              | (FStar_Syntax_Syntax.Meta_monadic (n1, ty1),
                 FStar_Syntax_Syntax.Meta_monadic (n2, ty2)) ->
-                 (let uu____15276 = FStar_Ident.lid_equals n1 n2 in
-                  check "meta_monadic lid" uu____15276) &&
-                   (let uu____15278 = term_eq_dbg dbg ty1 ty2 in
-                    check "meta_monadic type" uu____15278)
+                 (let uu___1 = FStar_Ident.lid_equals n1 n2 in
+                  check "meta_monadic lid" uu___1) &&
+                   (let uu___1 = term_eq_dbg dbg ty1 ty2 in
+                    check "meta_monadic type" uu___1)
              | (FStar_Syntax_Syntax.Meta_monadic_lift (s1, t13, ty1),
                 FStar_Syntax_Syntax.Meta_monadic_lift (s2, t23, ty2)) ->
-                 ((let uu____15295 = FStar_Ident.lid_equals s1 s2 in
-                   check "meta_monadic_lift src" uu____15295) &&
-                    (let uu____15297 = FStar_Ident.lid_equals t13 t23 in
-                     check "meta_monadic_lift tgt" uu____15297))
+                 ((let uu___1 = FStar_Ident.lid_equals s1 s2 in
+                   check "meta_monadic_lift src" uu___1) &&
+                    (let uu___1 = FStar_Ident.lid_equals t13 t23 in
+                     check "meta_monadic_lift tgt" uu___1))
                    &&
-                   (let uu____15299 = term_eq_dbg dbg ty1 ty2 in
-                    check "meta_monadic_lift type" uu____15299)
-             | uu____15300 -> fail "metas")
-        | (FStar_Syntax_Syntax.Tm_unknown, uu____15305) -> fail "unk"
-        | (uu____15306, FStar_Syntax_Syntax.Tm_unknown) -> fail "unk"
-        | (FStar_Syntax_Syntax.Tm_bvar uu____15307, uu____15308) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_name uu____15309, uu____15310) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_fvar uu____15311, uu____15312) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_constant uu____15313, uu____15314) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_type uu____15315, uu____15316) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_abs uu____15317, uu____15318) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_arrow uu____15337, uu____15338) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_refine uu____15353, uu____15354) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_app uu____15361, uu____15362) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_match uu____15379, uu____15380) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_let uu____15403, uu____15404) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_uvar uu____15417, uu____15418) ->
-            fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_meta uu____15431, uu____15432) ->
-            fail "bottom"
-        | (uu____15439, FStar_Syntax_Syntax.Tm_bvar uu____15440) ->
-            fail "bottom"
-        | (uu____15441, FStar_Syntax_Syntax.Tm_name uu____15442) ->
-            fail "bottom"
-        | (uu____15443, FStar_Syntax_Syntax.Tm_fvar uu____15444) ->
-            fail "bottom"
-        | (uu____15445, FStar_Syntax_Syntax.Tm_constant uu____15446) ->
-            fail "bottom"
-        | (uu____15447, FStar_Syntax_Syntax.Tm_type uu____15448) ->
-            fail "bottom"
-        | (uu____15449, FStar_Syntax_Syntax.Tm_abs uu____15450) ->
-            fail "bottom"
-        | (uu____15469, FStar_Syntax_Syntax.Tm_arrow uu____15470) ->
-            fail "bottom"
-        | (uu____15485, FStar_Syntax_Syntax.Tm_refine uu____15486) ->
-            fail "bottom"
-        | (uu____15493, FStar_Syntax_Syntax.Tm_app uu____15494) ->
-            fail "bottom"
-        | (uu____15511, FStar_Syntax_Syntax.Tm_match uu____15512) ->
-            fail "bottom"
-        | (uu____15535, FStar_Syntax_Syntax.Tm_let uu____15536) ->
-            fail "bottom"
-        | (uu____15549, FStar_Syntax_Syntax.Tm_uvar uu____15550) ->
-            fail "bottom"
-        | (uu____15563, FStar_Syntax_Syntax.Tm_meta uu____15564) ->
-            fail "bottom"
+                   (let uu___1 = term_eq_dbg dbg ty1 ty2 in
+                    check "meta_monadic_lift type" uu___1)
+             | uu___1 -> fail "metas")
+        | (FStar_Syntax_Syntax.Tm_unknown, uu___1) -> fail "unk"
+        | (uu___1, FStar_Syntax_Syntax.Tm_unknown) -> fail "unk"
+        | (FStar_Syntax_Syntax.Tm_bvar uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_name uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_fvar uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_constant uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_type uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_abs uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_arrow uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_refine uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_app uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_match uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_let uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_uvar uu___1, uu___2) -> fail "bottom"
+        | (FStar_Syntax_Syntax.Tm_meta uu___1, uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_bvar uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_name uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_fvar uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_constant uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_type uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_abs uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_arrow uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_refine uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_app uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_match uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_let uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_uvar uu___2) -> fail "bottom"
+        | (uu___1, FStar_Syntax_Syntax.Tm_meta uu___2) -> fail "bottom"
 and (arg_eq_dbg :
   Prims.bool ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -3637,13 +3505,11 @@ and (arg_eq_dbg :
         eqprod
           (fun t1 ->
              fun t2 ->
-               let uu____15597 = term_eq_dbg dbg t1 t2 in
-               check "arg tm" uu____15597)
+               let uu___ = term_eq_dbg dbg t1 t2 in check "arg tm" uu___)
           (fun q1 ->
              fun q2 ->
-               let uu____15607 =
-                 let uu____15608 = eq_aqual q1 q2 in uu____15608 = Equal in
-               check "arg qual" uu____15607) a1 a2
+               let uu___ = let uu___1 = eq_aqual q1 q2 in uu___1 = Equal in
+               check "arg qual" uu___) a1 a2
 and (binder_eq_dbg :
   Prims.bool ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -3657,15 +3523,14 @@ and (binder_eq_dbg :
         eqprod
           (fun b11 ->
              fun b21 ->
-               let uu____15631 =
+               let uu___ =
                  term_eq_dbg dbg b11.FStar_Syntax_Syntax.sort
                    b21.FStar_Syntax_Syntax.sort in
-               check "binder sort" uu____15631)
+               check "binder sort" uu___)
           (fun q1 ->
              fun q2 ->
-               let uu____15641 =
-                 let uu____15642 = eq_aqual q1 q2 in uu____15642 = Equal in
-               check "binder qual" uu____15641) b1 b2
+               let uu___ = let uu___1 = eq_aqual q1 q2 in uu___1 = Equal in
+               check "binder qual" uu___) b1 b2
 and (comp_eq_dbg :
   Prims.bool ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -3676,14 +3541,14 @@ and (comp_eq_dbg :
       fun c2 ->
         let c11 = comp_to_comp_typ_nouniv c1 in
         let c21 = comp_to_comp_typ_nouniv c2 in
-        ((let uu____15654 =
+        ((let uu___ =
             FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
               c21.FStar_Syntax_Syntax.effect_name in
-          check "comp eff" uu____15654) &&
-           (let uu____15656 =
+          check "comp eff" uu___) &&
+           (let uu___ =
               term_eq_dbg dbg c11.FStar_Syntax_Syntax.result_typ
                 c21.FStar_Syntax_Syntax.result_typ in
-            check "comp result typ" uu____15656))
+            check "comp result typ" uu___))
           && true
 and (branch_eq_dbg :
   Prims.bool ->
@@ -3697,23 +3562,23 @@ and (branch_eq_dbg :
         FStar_Syntax_Syntax.syntax) -> Prims.bool)
   =
   fun dbg ->
-    fun uu____15658 ->
-      fun uu____15659 ->
-        match (uu____15658, uu____15659) with
+    fun uu___ ->
+      fun uu___1 ->
+        match (uu___, uu___1) with
         | ((p1, w1, t1), (p2, w2, t2)) ->
-            ((let uu____15784 = FStar_Syntax_Syntax.eq_pat p1 p2 in
-              check "branch pat" uu____15784) &&
-               (let uu____15786 = term_eq_dbg dbg t1 t2 in
-                check "branch body" uu____15786))
+            ((let uu___2 = FStar_Syntax_Syntax.eq_pat p1 p2 in
+              check "branch pat" uu___2) &&
+               (let uu___2 = term_eq_dbg dbg t1 t2 in
+                check "branch body" uu___2))
               &&
-              (let uu____15788 =
+              (let uu___2 =
                  match (w1, w2) with
                  | (FStar_Pervasives_Native.Some x,
                     FStar_Pervasives_Native.Some y) -> term_eq_dbg dbg x y
                  | (FStar_Pervasives_Native.None,
                     FStar_Pervasives_Native.None) -> true
-                 | uu____15827 -> false in
-               check "branch when" uu____15788)
+                 | uu___3 -> false in
+               check "branch when" uu___2)
 and (letbinding_eq_dbg :
   Prims.bool ->
     FStar_Syntax_Syntax.letbinding ->
@@ -3722,76 +3587,72 @@ and (letbinding_eq_dbg :
   fun dbg ->
     fun lb1 ->
       fun lb2 ->
-        ((let uu____15845 =
+        ((let uu___ =
             eqsum (fun bv1 -> fun bv2 -> true) FStar_Syntax_Syntax.fv_eq
               lb1.FStar_Syntax_Syntax.lbname lb2.FStar_Syntax_Syntax.lbname in
-          check "lb bv" uu____15845) &&
-           (let uu____15851 =
+          check "lb bv" uu___) &&
+           (let uu___ =
               term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbtyp
                 lb2.FStar_Syntax_Syntax.lbtyp in
-            check "lb typ" uu____15851))
+            check "lb typ" uu___))
           &&
-          (let uu____15853 =
+          (let uu___ =
              term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbdef
                lb2.FStar_Syntax_Syntax.lbdef in
-           check "lb def" uu____15853)
+           check "lb def" uu___)
 let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1 ->
     fun t2 ->
       let r =
-        let uu____15865 = FStar_ST.op_Bang debug_term_eq in
-        term_eq_dbg uu____15865 t1 t2 in
+        let uu___ = FStar_ST.op_Bang debug_term_eq in term_eq_dbg uu___ t1 t2 in
       FStar_ST.op_Colon_Equals debug_term_eq false; r
 let rec (sizeof : FStar_Syntax_Syntax.term -> Prims.int) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____15884 ->
-        let uu____15899 =
-          let uu____15900 = FStar_Syntax_Subst.compress t in
-          sizeof uu____15900 in
-        Prims.int_one + uu____15899
+    | FStar_Syntax_Syntax.Tm_delayed uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t in sizeof uu___2 in
+        Prims.int_one + uu___1
     | FStar_Syntax_Syntax.Tm_bvar bv ->
-        let uu____15902 = sizeof bv.FStar_Syntax_Syntax.sort in
-        Prims.int_one + uu____15902
+        let uu___ = sizeof bv.FStar_Syntax_Syntax.sort in
+        Prims.int_one + uu___
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____15904 = sizeof bv.FStar_Syntax_Syntax.sort in
-        Prims.int_one + uu____15904
+        let uu___ = sizeof bv.FStar_Syntax_Syntax.sort in
+        Prims.int_one + uu___
     | FStar_Syntax_Syntax.Tm_uinst (t1, us) ->
-        let uu____15911 = sizeof t1 in (FStar_List.length us) + uu____15911
-    | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu____15914) ->
-        let uu____15939 = sizeof t1 in
-        let uu____15940 =
+        let uu___ = sizeof t1 in (FStar_List.length us) + uu___
+    | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu___) ->
+        let uu___1 = sizeof t1 in
+        let uu___2 =
           FStar_List.fold_left
             (fun acc ->
-               fun uu____15953 ->
-                 match uu____15953 with
-                 | (bv, uu____15961) ->
-                     let uu____15966 = sizeof bv.FStar_Syntax_Syntax.sort in
-                     acc + uu____15966) Prims.int_zero bs in
-        uu____15939 + uu____15940
+               fun uu___3 ->
+                 match uu___3 with
+                 | (bv, uu___4) ->
+                     let uu___5 = sizeof bv.FStar_Syntax_Syntax.sort in
+                     acc + uu___5) Prims.int_zero bs in
+        uu___1 + uu___2
     | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-        let uu____15993 = sizeof hd in
-        let uu____15994 =
+        let uu___ = sizeof hd in
+        let uu___1 =
           FStar_List.fold_left
             (fun acc ->
-               fun uu____16007 ->
-                 match uu____16007 with
-                 | (arg, uu____16015) ->
-                     let uu____16020 = sizeof arg in acc + uu____16020)
+               fun uu___2 ->
+                 match uu___2 with
+                 | (arg, uu___3) -> let uu___4 = sizeof arg in acc + uu___4)
             Prims.int_zero args in
-        uu____15993 + uu____15994
-    | uu____16021 -> Prims.int_one
+        uu___ + uu___1
+    | uu___ -> Prims.int_one
 let (is_fvar : FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool)
   =
   fun lid ->
     fun t ->
-      let uu____16032 =
-        let uu____16033 = un_uinst t in uu____16033.FStar_Syntax_Syntax.n in
-      match uu____16032 with
+      let uu___ = let uu___1 = un_uinst t in uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Syntax_Syntax.fv_eq_lid fv lid
-      | uu____16037 -> false
+      | uu___1 -> false
 let (is_synth_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t -> is_fvar FStar_Parser_Const.synth_lid t
 let (has_attribute :
@@ -3807,17 +3668,17 @@ let (get_attribute :
     fun attrs ->
       FStar_List.tryPick
         (fun t ->
-           let uu____16092 = head_and_args t in
-           match uu____16092 with
+           let uu___ = head_and_args t in
+           match uu___ with
            | (head, args) ->
-               let uu____16147 =
-                 let uu____16148 = FStar_Syntax_Subst.compress head in
-                 uu____16148.FStar_Syntax_Syntax.n in
-               (match uu____16147 with
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress head in
+                 uu___2.FStar_Syntax_Syntax.n in
+               (match uu___1 with
                 | FStar_Syntax_Syntax.Tm_fvar fv when
                     FStar_Syntax_Syntax.fv_eq_lid fv attr ->
                     FStar_Pervasives_Native.Some args
-                | uu____16174 -> FStar_Pervasives_Native.None)) attrs
+                | uu___2 -> FStar_Pervasives_Native.None)) attrs
 let (remove_attr :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.attribute Prims.list ->
@@ -3826,8 +3687,7 @@ let (remove_attr :
   fun attr ->
     fun attrs ->
       FStar_List.filter
-        (fun a ->
-           let uu____16206 = is_fvar attr a in Prims.op_Negation uu____16206)
+        (fun a -> let uu___ = is_fvar attr a in Prims.op_Negation uu___)
         attrs
 let (process_pragma :
   FStar_Syntax_Syntax.pragma -> FStar_Range.range -> unit) =
@@ -3836,8 +3696,8 @@ let (process_pragma :
       FStar_Errors.set_option_warning_callback_range
         (FStar_Pervasives_Native.Some r);
       (let set_options s =
-         let uu____16224 = FStar_Options.set_options s in
-         match uu____16224 with
+         let uu___1 = FStar_Options.set_options s in
+         match uu___1 with
          | FStar_Getopt.Success -> ()
          | FStar_Getopt.Help ->
              FStar_Errors.raise_error
@@ -3852,8 +3712,8 @@ let (process_pragma :
        | FStar_Syntax_Syntax.LightOff -> FStar_Options.set_ml_ish ()
        | FStar_Syntax_Syntax.SetOptions o -> set_options o
        | FStar_Syntax_Syntax.ResetOptions sopt ->
-           ((let uu____16231 = FStar_Options.restore_cmd_line_options false in
-             FStar_All.pipe_right uu____16231 (fun uu____16232 -> ()));
+           ((let uu___2 = FStar_Options.restore_cmd_line_options false in
+             FStar_All.pipe_right uu___2 (fun uu___3 -> ()));
             (match sopt with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some s -> set_options s))
@@ -3864,8 +3724,8 @@ let (process_pragma :
              | FStar_Pervasives_Native.Some s -> set_options s))
        | FStar_Syntax_Syntax.RestartSolver -> ()
        | FStar_Syntax_Syntax.PopOptions ->
-           let uu____16239 = FStar_Options.internal_pop () in
-           if uu____16239
+           let uu___1 = FStar_Options.internal_pop () in
+           if uu___1
            then ()
            else
              FStar_Errors.raise_error
@@ -3878,159 +3738,155 @@ let rec (unbound_variables :
   fun tm ->
     let t = FStar_Syntax_Subst.compress tm in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16265 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name x -> []
-    | FStar_Syntax_Syntax.Tm_uvar uu____16283 -> []
+    | FStar_Syntax_Syntax.Tm_uvar uu___ -> []
     | FStar_Syntax_Syntax.Tm_type u -> []
     | FStar_Syntax_Syntax.Tm_bvar x -> [x]
-    | FStar_Syntax_Syntax.Tm_fvar uu____16298 -> []
-    | FStar_Syntax_Syntax.Tm_constant uu____16299 -> []
-    | FStar_Syntax_Syntax.Tm_lazy uu____16300 -> []
+    | FStar_Syntax_Syntax.Tm_fvar uu___ -> []
+    | FStar_Syntax_Syntax.Tm_constant uu___ -> []
+    | FStar_Syntax_Syntax.Tm_lazy uu___ -> []
     | FStar_Syntax_Syntax.Tm_unknown -> []
     | FStar_Syntax_Syntax.Tm_uinst (t1, us) -> unbound_variables t1
-    | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu____16309) ->
-        let uu____16334 = FStar_Syntax_Subst.open_term bs t1 in
-        (match uu____16334 with
+    | FStar_Syntax_Syntax.Tm_abs (bs, t1, uu___) ->
+        let uu___1 = FStar_Syntax_Subst.open_term bs t1 in
+        (match uu___1 with
          | (bs1, t2) ->
-             let uu____16343 =
+             let uu___2 =
                FStar_List.collect
-                 (fun uu____16355 ->
-                    match uu____16355 with
-                    | (b, uu____16365) ->
+                 (fun uu___3 ->
+                    match uu___3 with
+                    | (b, uu___4) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1 in
-             let uu____16370 = unbound_variables t2 in
-             FStar_List.append uu____16343 uu____16370)
+             let uu___3 = unbound_variables t2 in
+             FStar_List.append uu___2 uu___3)
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-        let uu____16395 = FStar_Syntax_Subst.open_comp bs c in
-        (match uu____16395 with
+        let uu___ = FStar_Syntax_Subst.open_comp bs c in
+        (match uu___ with
          | (bs1, c1) ->
-             let uu____16404 =
+             let uu___1 =
                FStar_List.collect
-                 (fun uu____16416 ->
-                    match uu____16416 with
-                    | (b, uu____16426) ->
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | (b, uu___3) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1 in
-             let uu____16431 = unbound_variables_comp c1 in
-             FStar_List.append uu____16404 uu____16431)
+             let uu___2 = unbound_variables_comp c1 in
+             FStar_List.append uu___1 uu___2)
     | FStar_Syntax_Syntax.Tm_refine (b, t1) ->
-        let uu____16440 =
+        let uu___ =
           FStar_Syntax_Subst.open_term [(b, FStar_Pervasives_Native.None)] t1 in
-        (match uu____16440 with
+        (match uu___ with
          | (bs, t2) ->
-             let uu____16463 =
+             let uu___1 =
                FStar_List.collect
-                 (fun uu____16475 ->
-                    match uu____16475 with
-                    | (b1, uu____16485) ->
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | (b1, uu___3) ->
                         unbound_variables b1.FStar_Syntax_Syntax.sort) bs in
-             let uu____16490 = unbound_variables t2 in
-             FStar_List.append uu____16463 uu____16490)
+             let uu___2 = unbound_variables t2 in
+             FStar_List.append uu___1 uu___2)
     | FStar_Syntax_Syntax.Tm_app (t1, args) ->
-        let uu____16519 =
+        let uu___ =
           FStar_List.collect
-            (fun uu____16533 ->
-               match uu____16533 with
-               | (x, uu____16545) -> unbound_variables x) args in
-        let uu____16554 = unbound_variables t1 in
-        FStar_List.append uu____16519 uu____16554
+            (fun uu___1 ->
+               match uu___1 with | (x, uu___2) -> unbound_variables x) args in
+        let uu___1 = unbound_variables t1 in FStar_List.append uu___ uu___1
     | FStar_Syntax_Syntax.Tm_match (t1, pats) ->
-        let uu____16595 = unbound_variables t1 in
-        let uu____16598 =
+        let uu___ = unbound_variables t1 in
+        let uu___1 =
           FStar_All.pipe_right pats
             (FStar_List.collect
                (fun br ->
-                  let uu____16613 = FStar_Syntax_Subst.open_branch br in
-                  match uu____16613 with
+                  let uu___2 = FStar_Syntax_Subst.open_branch br in
+                  match uu___2 with
                   | (p, wopt, t2) ->
-                      let uu____16635 = unbound_variables t2 in
-                      let uu____16638 =
+                      let uu___3 = unbound_variables t2 in
+                      let uu___4 =
                         match wopt with
                         | FStar_Pervasives_Native.None -> []
                         | FStar_Pervasives_Native.Some t3 ->
                             unbound_variables t3 in
-                      FStar_List.append uu____16635 uu____16638)) in
-        FStar_List.append uu____16595 uu____16598
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____16652) ->
-        let uu____16693 = unbound_variables t1 in
-        let uu____16696 =
-          let uu____16699 =
+                      FStar_List.append uu___3 uu___4)) in
+        FStar_List.append uu___ uu___1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu___) ->
+        let uu___1 = unbound_variables t1 in
+        let uu___2 =
+          let uu___3 =
             match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> unbound_variables t2
             | FStar_Util.Inr c2 -> unbound_variables_comp c2 in
-          let uu____16730 =
+          let uu___4 =
             match FStar_Pervasives_Native.snd asc with
             | FStar_Pervasives_Native.None -> []
             | FStar_Pervasives_Native.Some tac -> unbound_variables tac in
-          FStar_List.append uu____16699 uu____16730 in
-        FStar_List.append uu____16693 uu____16696
+          FStar_List.append uu___3 uu___4 in
+        FStar_List.append uu___1 uu___2
     | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), t1) ->
-        let uu____16768 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp in
-        let uu____16771 =
-          let uu____16774 = unbound_variables lb.FStar_Syntax_Syntax.lbdef in
-          let uu____16777 =
+        let uu___ = unbound_variables lb.FStar_Syntax_Syntax.lbtyp in
+        let uu___1 =
+          let uu___2 = unbound_variables lb.FStar_Syntax_Syntax.lbdef in
+          let uu___3 =
             match lb.FStar_Syntax_Syntax.lbname with
-            | FStar_Util.Inr uu____16782 -> unbound_variables t1
+            | FStar_Util.Inr uu___4 -> unbound_variables t1
             | FStar_Util.Inl bv ->
-                let uu____16784 =
+                let uu___4 =
                   FStar_Syntax_Subst.open_term
                     [(bv, FStar_Pervasives_Native.None)] t1 in
-                (match uu____16784 with
-                 | (uu____16805, t2) -> unbound_variables t2) in
-          FStar_List.append uu____16774 uu____16777 in
-        FStar_List.append uu____16768 uu____16771
-    | FStar_Syntax_Syntax.Tm_let ((uu____16807, lbs), t1) ->
-        let uu____16824 = FStar_Syntax_Subst.open_let_rec lbs t1 in
-        (match uu____16824 with
+                (match uu___4 with | (uu___5, t2) -> unbound_variables t2) in
+          FStar_List.append uu___2 uu___3 in
+        FStar_List.append uu___ uu___1
+    | FStar_Syntax_Syntax.Tm_let ((uu___, lbs), t1) ->
+        let uu___1 = FStar_Syntax_Subst.open_let_rec lbs t1 in
+        (match uu___1 with
          | (lbs1, t2) ->
-             let uu____16839 = unbound_variables t2 in
-             let uu____16842 =
+             let uu___2 = unbound_variables t2 in
+             let uu___3 =
                FStar_List.collect
                  (fun lb ->
-                    let uu____16849 =
+                    let uu___4 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbtyp in
-                    let uu____16852 =
+                    let uu___5 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbdef in
-                    FStar_List.append uu____16849 uu____16852) lbs1 in
-             FStar_List.append uu____16839 uu____16842)
+                    FStar_List.append uu___4 uu___5) lbs1 in
+             FStar_List.append uu___2 uu___3)
     | FStar_Syntax_Syntax.Tm_quoted (tm1, qi) ->
         (match qi.FStar_Syntax_Syntax.qkind with
          | FStar_Syntax_Syntax.Quote_static -> []
          | FStar_Syntax_Syntax.Quote_dynamic -> unbound_variables tm1)
     | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
-        let uu____16869 = unbound_variables t1 in
-        let uu____16872 =
+        let uu___ = unbound_variables t1 in
+        let uu___1 =
           match m with
-          | FStar_Syntax_Syntax.Meta_pattern (uu____16877, args) ->
+          | FStar_Syntax_Syntax.Meta_pattern (uu___2, args) ->
               FStar_List.collect
                 (FStar_List.collect
-                   (fun uu____16932 ->
-                      match uu____16932 with
-                      | (a, uu____16944) -> unbound_variables a)) args
-          | FStar_Syntax_Syntax.Meta_monadic_lift
-              (uu____16953, uu____16954, t') -> unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_monadic (uu____16960, t') ->
+                   (fun uu___3 ->
+                      match uu___3 with | (a, uu___4) -> unbound_variables a))
+                args
+          | FStar_Syntax_Syntax.Meta_monadic_lift (uu___2, uu___3, t') ->
               unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_labeled uu____16966 -> []
-          | FStar_Syntax_Syntax.Meta_desugared uu____16973 -> []
-          | FStar_Syntax_Syntax.Meta_named uu____16974 -> [] in
-        FStar_List.append uu____16869 uu____16872
+          | FStar_Syntax_Syntax.Meta_monadic (uu___2, t') ->
+              unbound_variables t'
+          | FStar_Syntax_Syntax.Meta_labeled uu___2 -> []
+          | FStar_Syntax_Syntax.Meta_desugared uu___2 -> []
+          | FStar_Syntax_Syntax.Meta_named uu___2 -> [] in
+        FStar_List.append uu___ uu___1
 and (unbound_variables_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.bv Prims.list)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.GTotal (t, uu____16981) -> unbound_variables t
-    | FStar_Syntax_Syntax.Total (t, uu____16991) -> unbound_variables t
+    | FStar_Syntax_Syntax.GTotal (t, uu___) -> unbound_variables t
+    | FStar_Syntax_Syntax.Total (t, uu___) -> unbound_variables t
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____17001 = unbound_variables ct.FStar_Syntax_Syntax.result_typ in
-        let uu____17004 =
+        let uu___ = unbound_variables ct.FStar_Syntax_Syntax.result_typ in
+        let uu___1 =
           FStar_List.collect
-            (fun uu____17018 ->
-               match uu____17018 with
-               | (a, uu____17030) -> unbound_variables a)
+            (fun uu___2 ->
+               match uu___2 with | (a, uu___3) -> unbound_variables a)
             ct.FStar_Syntax_Syntax.effect_args in
-        FStar_List.append uu____17001 uu____17004
+        FStar_List.append uu___ uu___1
 let (extract_attr' :
   FStar_Ident.lid ->
     FStar_Syntax_Syntax.term Prims.list ->
@@ -4043,18 +3899,18 @@ let (extract_attr' :
         match attrs1 with
         | [] -> FStar_Pervasives_Native.None
         | h::t ->
-            let uu____17144 = head_and_args h in
-            (match uu____17144 with
+            let uu___ = head_and_args h in
+            (match uu___ with
              | (head, args) ->
-                 let uu____17205 =
-                   let uu____17206 = FStar_Syntax_Subst.compress head in
-                   uu____17206.FStar_Syntax_Syntax.n in
-                 (match uu____17205 with
+                 let uu___1 =
+                   let uu___2 = FStar_Syntax_Subst.compress head in
+                   uu___2.FStar_Syntax_Syntax.n in
+                 (match uu___1 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv attr_lid ->
                       let attrs' = FStar_List.rev_acc acc t in
                       FStar_Pervasives_Native.Some (attrs', args)
-                  | uu____17259 -> aux (h :: acc) t)) in
+                  | uu___2 -> aux (h :: acc) t)) in
       aux [] attrs
 let (extract_attr :
   FStar_Ident.lid ->
@@ -4064,106 +3920,101 @@ let (extract_attr :
   =
   fun attr_lid ->
     fun se ->
-      let uu____17282 =
-        extract_attr' attr_lid se.FStar_Syntax_Syntax.sigattrs in
-      match uu____17282 with
+      let uu___ = extract_attr' attr_lid se.FStar_Syntax_Syntax.sigattrs in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (attrs', t) ->
           FStar_Pervasives_Native.Some
-            ((let uu___2557_17324 = se in
+            ((let uu___1 = se in
               {
                 FStar_Syntax_Syntax.sigel =
-                  (uu___2557_17324.FStar_Syntax_Syntax.sigel);
+                  (uu___1.FStar_Syntax_Syntax.sigel);
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___2557_17324.FStar_Syntax_Syntax.sigrng);
+                  (uu___1.FStar_Syntax_Syntax.sigrng);
                 FStar_Syntax_Syntax.sigquals =
-                  (uu___2557_17324.FStar_Syntax_Syntax.sigquals);
+                  (uu___1.FStar_Syntax_Syntax.sigquals);
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___2557_17324.FStar_Syntax_Syntax.sigmeta);
+                  (uu___1.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs = attrs';
                 FStar_Syntax_Syntax.sigopts =
-                  (uu___2557_17324.FStar_Syntax_Syntax.sigopts)
+                  (uu___1.FStar_Syntax_Syntax.sigopts)
               }), t)
 let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____17330 =
-      let uu____17331 = FStar_Syntax_Subst.compress t in
-      uu____17331.FStar_Syntax_Syntax.n in
-    match uu____17330 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____17334, c) ->
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
         (match c.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Comp ct when
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Lemma_lid
              ->
              (match ct.FStar_Syntax_Syntax.effect_args with
-              | _req::_ens::(pats, uu____17360)::uu____17361 ->
+              | _req::_ens::(pats, uu___2)::uu___3 ->
                   let pats' = unmeta pats in
-                  let uu____17421 = head_and_args pats' in
-                  (match uu____17421 with
-                   | (head, uu____17439) ->
-                       let uu____17464 =
-                         let uu____17465 = un_uinst head in
-                         uu____17465.FStar_Syntax_Syntax.n in
-                       (match uu____17464 with
+                  let uu___4 = head_and_args pats' in
+                  (match uu___4 with
+                   | (head, uu___5) ->
+                       let uu___6 =
+                         let uu___7 = un_uinst head in
+                         uu___7.FStar_Syntax_Syntax.n in
+                       (match uu___6 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.cons_lid
-                        | uu____17469 -> false))
-              | uu____17470 -> false)
-         | uu____17481 -> false)
-    | uu____17482 -> false
+                        | uu___7 -> false))
+              | uu___2 -> false)
+         | uu___2 -> false)
+    | uu___1 -> false
 let rec (list_elements :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
   =
   fun e ->
-    let uu____17496 = let uu____17513 = unmeta e in head_and_args uu____17513 in
-    match uu____17496 with
+    let uu___ = let uu___1 = unmeta e in head_and_args uu___1 in
+    match uu___ with
     | (head, args) ->
-        let uu____17544 =
-          let uu____17559 =
-            let uu____17560 = un_uinst head in
-            uu____17560.FStar_Syntax_Syntax.n in
-          (uu____17559, args) in
-        (match uu____17544 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv, uu____17578) when
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = un_uinst head in uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
              FStar_Pervasives_Native.Some []
          | (FStar_Syntax_Syntax.Tm_fvar fv,
-            uu____17602::(hd, uu____17604)::(tl, uu____17606)::[]) when
+            uu___2::(hd, uu___3)::(tl, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid ->
-             let uu____17673 =
-               let uu____17676 =
-                 let uu____17679 = list_elements tl in
-                 FStar_Util.must uu____17679 in
-               hd :: uu____17676 in
-             FStar_Pervasives_Native.Some uu____17673
-         | uu____17688 -> FStar_Pervasives_Native.None)
+             let uu___5 =
+               let uu___6 =
+                 let uu___7 = list_elements tl in FStar_Util.must uu___7 in
+               hd :: uu___6 in
+             FStar_Pervasives_Native.Some uu___5
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (unthunk : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____17710 =
-      let uu____17711 = FStar_Syntax_Subst.compress t in
-      uu____17711.FStar_Syntax_Syntax.n in
-    match uu____17710 with
-    | FStar_Syntax_Syntax.Tm_abs (b::[], e, uu____17716) ->
-        let uu____17751 = FStar_Syntax_Subst.open_term [b] e in
-        (match uu____17751 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_abs (b::[], e, uu___1) ->
+        let uu___2 = FStar_Syntax_Subst.open_term [b] e in
+        (match uu___2 with
          | (bs, e1) ->
              let b1 = FStar_List.hd bs in
-             let uu____17783 = is_free_in (FStar_Pervasives_Native.fst b1) e1 in
-             if uu____17783
+             let uu___3 = is_free_in (FStar_Pervasives_Native.fst b1) e1 in
+             if uu___3
              then
-               let uu____17786 =
-                 let uu____17797 = FStar_Syntax_Syntax.as_arg exp_unit in
-                 [uu____17797] in
-               mk_app t uu____17786
+               let uu___4 =
+                 let uu___5 = FStar_Syntax_Syntax.as_arg exp_unit in [uu___5] in
+               mk_app t uu___4
              else e1)
-    | uu____17823 ->
-        let uu____17824 =
-          let uu____17835 = FStar_Syntax_Syntax.as_arg exp_unit in
-          [uu____17835] in
-        mk_app t uu____17824
+    | uu___1 ->
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Syntax.as_arg exp_unit in [uu___3] in
+        mk_app t uu___2
 let (unthunk_lemma_post :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) = fun t -> unthunk t
 let (smt_lemma_as_forall :
@@ -4174,8 +4025,8 @@ let (smt_lemma_as_forall :
   fun t ->
     fun universe_of_binders ->
       let list_elements1 e =
-        let uu____17894 = list_elements e in
-        match uu____17894 with
+        let uu___ = list_elements e in
+        match uu___ with
         | FStar_Pervasives_Native.Some l -> l
         | FStar_Pervasives_Native.None ->
             (FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
@@ -4183,134 +4034,126 @@ let (smt_lemma_as_forall :
                  "SMT pattern is not a list literal; ignoring the pattern");
              []) in
       let one_pat p =
-        let uu____17927 =
-          let uu____17944 = unmeta p in
-          FStar_All.pipe_right uu____17944 head_and_args in
-        match uu____17927 with
+        let uu___ =
+          let uu___1 = unmeta p in FStar_All.pipe_right uu___1 head_and_args in
+        match uu___ with
         | (head, args) ->
-            let uu____17995 =
-              let uu____18010 =
-                let uu____18011 = un_uinst head in
-                uu____18011.FStar_Syntax_Syntax.n in
-              (uu____18010, args) in
-            (match uu____17995 with
-             | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____18033, uu____18034)::arg::[]) when
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = un_uinst head in uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
+             | (FStar_Syntax_Syntax.Tm_fvar fv, (uu___2, uu___3)::arg::[])
+                 when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> arg
-             | uu____18086 ->
-                 let uu____18101 =
-                   let uu____18106 =
-                     let uu____18107 = tts p in
+             | uu___2 ->
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = tts p in
                      FStar_Util.format1
                        "Not an atomic SMT pattern: %s; patterns on lemmas must be a list of simple SMTPat's or a single SMTPatOr containing a list of lists of patterns"
-                       uu____18107 in
-                   (FStar_Errors.Error_IllSMTPat, uu____18106) in
-                 FStar_Errors.raise_error uu____18101
-                   p.FStar_Syntax_Syntax.pos) in
+                       uu___5 in
+                   (FStar_Errors.Error_IllSMTPat, uu___4) in
+                 FStar_Errors.raise_error uu___3 p.FStar_Syntax_Syntax.pos) in
       let lemma_pats p =
         let elts = list_elements1 p in
         let smt_pat_or t1 =
-          let uu____18147 =
-            let uu____18164 = unmeta t1 in
-            FStar_All.pipe_right uu____18164 head_and_args in
-          match uu____18147 with
+          let uu___ =
+            let uu___1 = unmeta t1 in
+            FStar_All.pipe_right uu___1 head_and_args in
+          match uu___ with
           | (head, args) ->
-              let uu____18211 =
-                let uu____18226 =
-                  let uu____18227 = un_uinst head in
-                  uu____18227.FStar_Syntax_Syntax.n in
-                (uu____18226, args) in
-              (match uu____18211 with
-               | (FStar_Syntax_Syntax.Tm_fvar fv, (e, uu____18246)::[]) when
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = un_uinst head in uu___3.FStar_Syntax_Syntax.n in
+                (uu___2, args) in
+              (match uu___1 with
+               | (FStar_Syntax_Syntax.Tm_fvar fv, (e, uu___2)::[]) when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.smtpatOr_lid
                    -> FStar_Pervasives_Native.Some e
-               | uu____18283 -> FStar_Pervasives_Native.None) in
+               | uu___2 -> FStar_Pervasives_Native.None) in
         match elts with
         | t1::[] ->
-            let uu____18313 = smt_pat_or t1 in
-            (match uu____18313 with
+            let uu___ = smt_pat_or t1 in
+            (match uu___ with
              | FStar_Pervasives_Native.Some e ->
-                 let uu____18335 = list_elements1 e in
-                 FStar_All.pipe_right uu____18335
+                 let uu___1 = list_elements1 e in
+                 FStar_All.pipe_right uu___1
                    (FStar_List.map
                       (fun branch1 ->
-                         let uu____18365 = list_elements1 branch1 in
-                         FStar_All.pipe_right uu____18365
-                           (FStar_List.map one_pat)))
-             | uu____18394 ->
-                 let uu____18399 =
+                         let uu___2 = list_elements1 branch1 in
+                         FStar_All.pipe_right uu___2 (FStar_List.map one_pat)))
+             | uu___1 ->
+                 let uu___2 =
                    FStar_All.pipe_right elts (FStar_List.map one_pat) in
-                 [uu____18399])
-        | uu____18454 ->
-            let uu____18457 =
-              FStar_All.pipe_right elts (FStar_List.map one_pat) in
-            [uu____18457] in
-      let uu____18512 =
-        let uu____18543 =
-          let uu____18544 = FStar_Syntax_Subst.compress t in
-          uu____18544.FStar_Syntax_Syntax.n in
-        match uu____18543 with
+                 [uu___2])
+        | uu___ ->
+            let uu___1 = FStar_All.pipe_right elts (FStar_List.map one_pat) in
+            [uu___1] in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t in
+          uu___2.FStar_Syntax_Syntax.n in
+        match uu___1 with
         | FStar_Syntax_Syntax.Tm_arrow (binders, c) ->
-            let uu____18599 = FStar_Syntax_Subst.open_comp binders c in
-            (match uu____18599 with
+            let uu___2 = FStar_Syntax_Subst.open_comp binders c in
+            (match uu___2 with
              | (binders1, c1) ->
                  (match c1.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Comp
-                      { FStar_Syntax_Syntax.comp_univs = uu____18666;
-                        FStar_Syntax_Syntax.effect_name = uu____18667;
-                        FStar_Syntax_Syntax.result_typ = uu____18668;
+                      { FStar_Syntax_Syntax.comp_univs = uu___3;
+                        FStar_Syntax_Syntax.effect_name = uu___4;
+                        FStar_Syntax_Syntax.result_typ = uu___5;
                         FStar_Syntax_Syntax.effect_args =
-                          (pre, uu____18670)::(post, uu____18672)::(pats,
-                                                                    uu____18674)::[];
-                        FStar_Syntax_Syntax.flags = uu____18675;_}
+                          (pre, uu___6)::(post, uu___7)::(pats, uu___8)::[];
+                        FStar_Syntax_Syntax.flags = uu___9;_}
                       ->
-                      let uu____18736 = lemma_pats pats in
-                      (binders1, pre, post, uu____18736)
-                  | uu____18771 -> failwith "impos"))
-        | uu____18802 -> failwith "Impos" in
-      match uu____18512 with
+                      let uu___10 = lemma_pats pats in
+                      (binders1, pre, post, uu___10)
+                  | uu___3 -> failwith "impos"))
+        | uu___2 -> failwith "Impos" in
+      match uu___ with
       | (binders, pre, post, patterns) ->
           let post1 = unthunk_lemma_post post in
           let body =
-            let uu____18885 =
-              let uu____18886 =
-                let uu____18893 = mk_imp pre post1 in
-                let uu____18896 =
-                  let uu____18897 =
-                    let uu____18918 =
-                      FStar_Syntax_Syntax.binders_to_names binders in
-                    (uu____18918, patterns) in
-                  FStar_Syntax_Syntax.Meta_pattern uu____18897 in
-                (uu____18893, uu____18896) in
-              FStar_Syntax_Syntax.Tm_meta uu____18886 in
-            FStar_Syntax_Syntax.mk uu____18885 t.FStar_Syntax_Syntax.pos in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = mk_imp pre post1 in
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Syntax.binders_to_names binders in
+                    (uu___6, patterns) in
+                  FStar_Syntax_Syntax.Meta_pattern uu___5 in
+                (uu___3, uu___4) in
+              FStar_Syntax_Syntax.Tm_meta uu___2 in
+            FStar_Syntax_Syntax.mk uu___1 t.FStar_Syntax_Syntax.pos in
           let quant =
-            let uu____18942 = universe_of_binders binders in
+            let uu___1 = universe_of_binders binders in
             FStar_List.fold_right2
               (fun b ->
                  fun u ->
                    fun out -> mk_forall u (FStar_Pervasives_Native.fst b) out)
-              binders uu____18942 body in
+              binders uu___1 body in
           quant
 let (eff_decl_of_new_effect :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.eff_decl) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_new_effect ne -> ne
-    | uu____18971 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
+    | uu___ -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
 let (is_layered : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Layered_eff uu____18977 -> true
-    | uu____18978 -> false
+    | FStar_Syntax_Syntax.Layered_eff uu___ -> true
+    | uu___ -> false
 let (is_dm4f : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.DM4F_eff uu____18984 -> true
-    | uu____18985 -> false
+    | FStar_Syntax_Syntax.DM4F_eff uu___ -> true
+    | uu___ -> false
 let (apply_wp_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
     FStar_Syntax_Syntax.wp_eff_combinators ->
@@ -4318,30 +4161,29 @@ let (apply_wp_eff_combinators :
   =
   fun f ->
     fun combs ->
-      let uu____19001 = f combs.FStar_Syntax_Syntax.ret_wp in
-      let uu____19002 = f combs.FStar_Syntax_Syntax.bind_wp in
-      let uu____19003 = f combs.FStar_Syntax_Syntax.stronger in
-      let uu____19004 = f combs.FStar_Syntax_Syntax.if_then_else in
-      let uu____19005 = f combs.FStar_Syntax_Syntax.ite_wp in
-      let uu____19006 = f combs.FStar_Syntax_Syntax.close_wp in
-      let uu____19007 = f combs.FStar_Syntax_Syntax.trivial in
-      let uu____19008 =
-        FStar_Util.map_option f combs.FStar_Syntax_Syntax.repr in
-      let uu____19011 =
+      let uu___ = f combs.FStar_Syntax_Syntax.ret_wp in
+      let uu___1 = f combs.FStar_Syntax_Syntax.bind_wp in
+      let uu___2 = f combs.FStar_Syntax_Syntax.stronger in
+      let uu___3 = f combs.FStar_Syntax_Syntax.if_then_else in
+      let uu___4 = f combs.FStar_Syntax_Syntax.ite_wp in
+      let uu___5 = f combs.FStar_Syntax_Syntax.close_wp in
+      let uu___6 = f combs.FStar_Syntax_Syntax.trivial in
+      let uu___7 = FStar_Util.map_option f combs.FStar_Syntax_Syntax.repr in
+      let uu___8 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.return_repr in
-      let uu____19014 =
+      let uu___9 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.bind_repr in
       {
-        FStar_Syntax_Syntax.ret_wp = uu____19001;
-        FStar_Syntax_Syntax.bind_wp = uu____19002;
-        FStar_Syntax_Syntax.stronger = uu____19003;
-        FStar_Syntax_Syntax.if_then_else = uu____19004;
-        FStar_Syntax_Syntax.ite_wp = uu____19005;
-        FStar_Syntax_Syntax.close_wp = uu____19006;
-        FStar_Syntax_Syntax.trivial = uu____19007;
-        FStar_Syntax_Syntax.repr = uu____19008;
-        FStar_Syntax_Syntax.return_repr = uu____19011;
-        FStar_Syntax_Syntax.bind_repr = uu____19014
+        FStar_Syntax_Syntax.ret_wp = uu___;
+        FStar_Syntax_Syntax.bind_wp = uu___1;
+        FStar_Syntax_Syntax.stronger = uu___2;
+        FStar_Syntax_Syntax.if_then_else = uu___3;
+        FStar_Syntax_Syntax.ite_wp = uu___4;
+        FStar_Syntax_Syntax.close_wp = uu___5;
+        FStar_Syntax_Syntax.trivial = uu___6;
+        FStar_Syntax_Syntax.repr = uu___7;
+        FStar_Syntax_Syntax.return_repr = uu___8;
+        FStar_Syntax_Syntax.bind_repr = uu___9
       }
 let (apply_layered_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
@@ -4350,22 +4192,21 @@ let (apply_layered_eff_combinators :
   =
   fun f ->
     fun combs ->
-      let map_tuple uu____19045 =
-        match uu____19045 with
+      let map_tuple uu___ =
+        match uu___ with
         | (ts1, ts2) ->
-            let uu____19056 = f ts1 in
-            let uu____19057 = f ts2 in (uu____19056, uu____19057) in
-      let uu____19058 = map_tuple combs.FStar_Syntax_Syntax.l_repr in
-      let uu____19063 = map_tuple combs.FStar_Syntax_Syntax.l_return in
-      let uu____19068 = map_tuple combs.FStar_Syntax_Syntax.l_bind in
-      let uu____19073 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp in
-      let uu____19078 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else in
+            let uu___1 = f ts1 in let uu___2 = f ts2 in (uu___1, uu___2) in
+      let uu___ = map_tuple combs.FStar_Syntax_Syntax.l_repr in
+      let uu___1 = map_tuple combs.FStar_Syntax_Syntax.l_return in
+      let uu___2 = map_tuple combs.FStar_Syntax_Syntax.l_bind in
+      let uu___3 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp in
+      let uu___4 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else in
       {
-        FStar_Syntax_Syntax.l_repr = uu____19058;
-        FStar_Syntax_Syntax.l_return = uu____19063;
-        FStar_Syntax_Syntax.l_bind = uu____19068;
-        FStar_Syntax_Syntax.l_subcomp = uu____19073;
-        FStar_Syntax_Syntax.l_if_then_else = uu____19078
+        FStar_Syntax_Syntax.l_repr = uu___;
+        FStar_Syntax_Syntax.l_return = uu___1;
+        FStar_Syntax_Syntax.l_bind = uu___2;
+        FStar_Syntax_Syntax.l_subcomp = uu___3;
+        FStar_Syntax_Syntax.l_if_then_else = uu___4
       }
 let (apply_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
@@ -4376,14 +4217,14 @@ let (apply_eff_combinators :
     fun combs ->
       match combs with
       | FStar_Syntax_Syntax.Primitive_eff combs1 ->
-          let uu____19099 = apply_wp_eff_combinators f combs1 in
-          FStar_Syntax_Syntax.Primitive_eff uu____19099
+          let uu___ = apply_wp_eff_combinators f combs1 in
+          FStar_Syntax_Syntax.Primitive_eff uu___
       | FStar_Syntax_Syntax.DM4F_eff combs1 ->
-          let uu____19101 = apply_wp_eff_combinators f combs1 in
-          FStar_Syntax_Syntax.DM4F_eff uu____19101
+          let uu___ = apply_wp_eff_combinators f combs1 in
+          FStar_Syntax_Syntax.DM4F_eff uu___
       | FStar_Syntax_Syntax.Layered_eff combs1 ->
-          let uu____19103 = apply_layered_eff_combinators f combs1 in
-          FStar_Syntax_Syntax.Layered_eff uu____19103
+          let uu___ = apply_layered_eff_combinators f combs1 in
+          FStar_Syntax_Syntax.Layered_eff uu___
 let (get_wp_close_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4394,7 +4235,7 @@ let (get_wp_close_combinator :
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
-    | uu____19117 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_eff_repr :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4405,11 +4246,11 @@ let (get_eff_repr :
         combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.DM4F_eff combs -> combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19130 =
+        let uu___ =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_repr
             FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____19130
-          (fun uu____19137 -> FStar_Pervasives_Native.Some uu____19137)
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
 let (get_bind_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
   fun ed ->
@@ -4441,11 +4282,11 @@ let (get_bind_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.bind_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19174 =
+        let uu___ =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_bind
             FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____19174
-          (fun uu____19181 -> FStar_Pervasives_Native.Some uu____19181)
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
 let (get_return_repr :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4457,11 +4298,11 @@ let (get_return_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.return_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19194 =
+        let uu___ =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_return
             FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____19194
-          (fun uu____19201 -> FStar_Pervasives_Native.Some uu____19201)
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
 let (get_wp_trivial_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4470,11 +4311,11 @@ let (get_wp_trivial_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____19214 -> FStar_Pervasives_Native.Some uu____19214)
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____19218 -> FStar_Pervasives_Native.Some uu____19218)
-    | uu____19219 -> FStar_Pervasives_Native.None
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_layered_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4482,12 +4323,12 @@ let (get_layered_if_then_else_combinator :
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19230 =
+        let uu___ =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_if_then_else
             FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____19230
-          (fun uu____19237 -> FStar_Pervasives_Native.Some uu____19237)
-    | uu____19238 -> FStar_Pervasives_Native.None
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_wp_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4496,11 +4337,11 @@ let (get_wp_if_then_else_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____19251 -> FStar_Pervasives_Native.Some uu____19251)
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____19255 -> FStar_Pervasives_Native.Some uu____19255)
-    | uu____19256 -> FStar_Pervasives_Native.None
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_wp_ite_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -4509,11 +4350,11 @@ let (get_wp_ite_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____19269 -> FStar_Pervasives_Native.Some uu____19269)
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____19273 -> FStar_Pervasives_Native.Some uu____19273)
-    | uu____19274 -> FStar_Pervasives_Native.None
+          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_stronger_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
   fun ed ->
@@ -4531,13 +4372,11 @@ let (get_stronger_repr :
   =
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Primitive_eff uu____19296 ->
-        FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.DM4F_eff uu____19297 ->
-        FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Primitive_eff uu___ -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.DM4F_eff uu___ -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____19299 =
+        let uu___ =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_subcomp
             FStar_Pervasives_Native.fst in
-        FStar_All.pipe_right uu____19299
-          (fun uu____19306 -> FStar_Pervasives_Native.Some uu____19306)
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -30,99 +30,95 @@ let (term_to_string :
       FStar_Syntax_Print.term_to_string' e.FStar_TypeChecker_Env.dsenv t
 let (bnorm_goal : FStar_Tactics_Types.goal -> FStar_Tactics_Types.goal) =
   fun g ->
-    let uu____58 =
-      let uu____59 = FStar_Tactics_Types.goal_env g in
-      let uu____60 = FStar_Tactics_Types.goal_type g in
-      bnorm uu____59 uu____60 in
-    FStar_Tactics_Types.goal_with_type g uu____58
+    let uu___ =
+      let uu___1 = FStar_Tactics_Types.goal_env g in
+      let uu___2 = FStar_Tactics_Types.goal_type g in bnorm uu___1 uu___2 in
+    FStar_Tactics_Types.goal_with_type g uu___
 let (tacprint : Prims.string -> unit) =
   fun s -> FStar_Util.print1 "TAC>> %s\n" s
 let (tacprint1 : Prims.string -> Prims.string -> unit) =
   fun s ->
     fun x ->
-      let uu____76 = FStar_Util.format1 s x in
-      FStar_Util.print1 "TAC>> %s\n" uu____76
+      let uu___ = FStar_Util.format1 s x in
+      FStar_Util.print1 "TAC>> %s\n" uu___
 let (tacprint2 : Prims.string -> Prims.string -> Prims.string -> unit) =
   fun s ->
     fun x ->
       fun y ->
-        let uu____92 = FStar_Util.format2 s x y in
-        FStar_Util.print1 "TAC>> %s\n" uu____92
+        let uu___ = FStar_Util.format2 s x y in
+        FStar_Util.print1 "TAC>> %s\n" uu___
 let (tacprint3 :
   Prims.string -> Prims.string -> Prims.string -> Prims.string -> unit) =
   fun s ->
     fun x ->
       fun y ->
         fun z ->
-          let uu____113 = FStar_Util.format3 s x y z in
-          FStar_Util.print1 "TAC>> %s\n" uu____113
+          let uu___ = FStar_Util.format3 s x y z in
+          FStar_Util.print1 "TAC>> %s\n" uu___
 let (print : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun msg ->
-    (let uu____124 =
-       let uu____125 = FStar_Options.silent () in Prims.op_Negation uu____125 in
-     if uu____124 then tacprint msg else ());
+    (let uu___1 =
+       let uu___2 = FStar_Options.silent () in Prims.op_Negation uu___2 in
+     if uu___1 then tacprint msg else ());
     FStar_Tactics_Monad.ret ()
 let (debugging : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____133 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
-         let uu____139 =
+         let uu___1 =
            FStar_TypeChecker_Env.debug ps.FStar_Tactics_Types.main_context
              (FStar_Options.Other "Tac") in
-         FStar_Tactics_Monad.ret uu____139)
+         FStar_Tactics_Monad.ret uu___1)
 let (dump : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun msg ->
     FStar_Tactics_Monad.mk_tac
       (fun ps ->
          let psc = ps.FStar_Tactics_Types.psc in
          let subst = FStar_TypeChecker_Cfg.psc_subst psc in
-         (let uu____157 = FStar_Tactics_Types.subst_proof_state subst ps in
-          FStar_Tactics_Printing.do_dump_proofstate uu____157 msg);
+         (let uu___1 = FStar_Tactics_Types.subst_proof_state subst ps in
+          FStar_Tactics_Printing.do_dump_proofstate uu___1 msg);
          FStar_Tactics_Result.Success ((), ps))
 let fail1 :
-  'uuuuuu164 .
-    Prims.string -> Prims.string -> 'uuuuuu164 FStar_Tactics_Monad.tac
-  =
+  'uuuuu . Prims.string -> Prims.string -> 'uuuuu FStar_Tactics_Monad.tac =
   fun msg ->
     fun x ->
-      let uu____177 = FStar_Util.format1 msg x in
-      FStar_Tactics_Monad.fail uu____177
+      let uu___ = FStar_Util.format1 msg x in FStar_Tactics_Monad.fail uu___
 let fail2 :
-  'uuuuuu186 .
+  'uuuuu .
     Prims.string ->
-      Prims.string -> Prims.string -> 'uuuuuu186 FStar_Tactics_Monad.tac
+      Prims.string -> Prims.string -> 'uuuuu FStar_Tactics_Monad.tac
   =
   fun msg ->
     fun x ->
       fun y ->
-        let uu____204 = FStar_Util.format2 msg x y in
-        FStar_Tactics_Monad.fail uu____204
+        let uu___ = FStar_Util.format2 msg x y in
+        FStar_Tactics_Monad.fail uu___
 let fail3 :
-  'uuuuuu215 .
+  'uuuuu .
     Prims.string ->
       Prims.string ->
-        Prims.string -> Prims.string -> 'uuuuuu215 FStar_Tactics_Monad.tac
+        Prims.string -> Prims.string -> 'uuuuu FStar_Tactics_Monad.tac
   =
   fun msg ->
     fun x ->
       fun y ->
         fun z ->
-          let uu____238 = FStar_Util.format3 msg x y z in
-          FStar_Tactics_Monad.fail uu____238
+          let uu___ = FStar_Util.format3 msg x y z in
+          FStar_Tactics_Monad.fail uu___
 let fail4 :
-  'uuuuuu251 .
+  'uuuuu .
     Prims.string ->
       Prims.string ->
         Prims.string ->
-          Prims.string -> Prims.string -> 'uuuuuu251 FStar_Tactics_Monad.tac
+          Prims.string -> Prims.string -> 'uuuuu FStar_Tactics_Monad.tac
   =
   fun msg ->
     fun x ->
       fun y ->
         fun z ->
           fun w ->
-            let uu____279 = FStar_Util.format4 msg x y z w in
-            FStar_Tactics_Monad.fail uu____279
+            let uu___ = FStar_Util.format4 msg x y z w in
+            FStar_Tactics_Monad.fail uu___
 let catch :
   'a .
     'a FStar_Tactics_Monad.tac ->
@@ -132,40 +128,39 @@ let catch :
     FStar_Tactics_Monad.mk_tac
       (fun ps ->
          let tx = FStar_Syntax_Unionfind.new_transaction () in
-         let uu____312 = FStar_Tactics_Monad.run t ps in
-         match uu____312 with
+         let uu___ = FStar_Tactics_Monad.run t ps in
+         match uu___ with
          | FStar_Tactics_Result.Success (a1, q) ->
              (FStar_Syntax_Unionfind.commit tx;
               FStar_Tactics_Result.Success ((FStar_Util.Inr a1), q))
          | FStar_Tactics_Result.Failed (m, q) ->
              (FStar_Syntax_Unionfind.rollback tx;
               (let ps1 =
-                 let uu___68_336 = ps in
+                 let uu___2 = ps in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___68_336.FStar_Tactics_Types.main_context);
+                     (uu___2.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___68_336.FStar_Tactics_Types.all_implicits);
+                     (uu___2.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___68_336.FStar_Tactics_Types.goals);
+                     (uu___2.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___68_336.FStar_Tactics_Types.smt_goals);
+                     (uu___2.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___68_336.FStar_Tactics_Types.depth);
+                     (uu___2.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___68_336.FStar_Tactics_Types.__dump);
-                   FStar_Tactics_Types.psc =
-                     (uu___68_336.FStar_Tactics_Types.psc);
+                     (uu___2.FStar_Tactics_Types.__dump);
+                   FStar_Tactics_Types.psc = (uu___2.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___68_336.FStar_Tactics_Types.entry_range);
+                     (uu___2.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___68_336.FStar_Tactics_Types.guard_policy);
+                     (uu___2.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
                      (q.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___68_336.FStar_Tactics_Types.tac_verb_dbg);
+                     (uu___2.FStar_Tactics_Types.tac_verb_dbg);
                    FStar_Tactics_Types.local_state =
-                     (uu___68_336.FStar_Tactics_Types.local_state)
+                     (uu___2.FStar_Tactics_Types.local_state)
                  } in
                FStar_Tactics_Result.Success ((FStar_Util.Inl m), ps1))))
 let recover :
@@ -176,8 +171,8 @@ let recover :
   fun t ->
     FStar_Tactics_Monad.mk_tac
       (fun ps ->
-         let uu____374 = FStar_Tactics_Monad.run t ps in
-         match uu____374 with
+         let uu___ = FStar_Tactics_Monad.run t ps in
+         match uu___ with
          | FStar_Tactics_Result.Success (a1, q) ->
              FStar_Tactics_Result.Success ((FStar_Util.Inr a1), q)
          | FStar_Tactics_Result.Failed (m, q) ->
@@ -188,13 +183,13 @@ let trytac :
       'a FStar_Pervasives_Native.option FStar_Tactics_Monad.tac
   =
   fun t ->
-    let uu____421 = catch t in
-    FStar_Tactics_Monad.bind uu____421
+    let uu___ = catch t in
+    FStar_Tactics_Monad.bind uu___
       (fun r ->
          match r with
          | FStar_Util.Inr v ->
              FStar_Tactics_Monad.ret (FStar_Pervasives_Native.Some v)
-         | FStar_Util.Inl uu____448 ->
+         | FStar_Util.Inl uu___1 ->
              FStar_Tactics_Monad.ret FStar_Pervasives_Native.None)
 let trytac_exn :
   'a .
@@ -205,21 +200,19 @@ let trytac_exn :
     FStar_Tactics_Monad.mk_tac
       (fun ps ->
          try
-           (fun uu___94_479 ->
+           (fun uu___ ->
               match () with
               | () ->
-                  let uu____484 = trytac t in
-                  FStar_Tactics_Monad.run uu____484 ps) ()
+                  let uu___1 = trytac t in FStar_Tactics_Monad.run uu___1 ps)
+             ()
          with
-         | FStar_Errors.Err (uu____500, msg) ->
+         | FStar_Errors.Err (uu___1, msg) ->
              (FStar_Tactics_Monad.log ps
-                (fun uu____504 ->
-                   FStar_Util.print1 "trytac_exn error: (%s)" msg);
+                (fun uu___3 -> FStar_Util.print1 "trytac_exn error: (%s)" msg);
               FStar_Tactics_Result.Success (FStar_Pervasives_Native.None, ps))
-         | FStar_Errors.Error (uu____509, msg, uu____511) ->
+         | FStar_Errors.Error (uu___1, msg, uu___2) ->
              (FStar_Tactics_Monad.log ps
-                (fun uu____514 ->
-                   FStar_Util.print1 "trytac_exn error: (%s)" msg);
+                (fun uu___4 -> FStar_Util.print1 "trytac_exn error: (%s)" msg);
               FStar_Tactics_Result.Success (FStar_Pervasives_Native.None, ps)))
 let (destruct_eq' :
   FStar_Reflection_Data.typ ->
@@ -227,55 +220,55 @@ let (destruct_eq' :
       FStar_Pervasives_Native.option)
   =
   fun typ ->
-    let uu____536 = FStar_Syntax_Util.destruct_typ_as_formula typ in
-    match uu____536 with
+    let uu___ = FStar_Syntax_Util.destruct_typ_as_formula typ in
+    match uu___ with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
         (l,
-         uu____546::(e1, FStar_Pervasives_Native.None)::(e2,
-                                                         FStar_Pervasives_Native.None)::[]))
+         uu___1::(e1, FStar_Pervasives_Native.None)::(e2,
+                                                      FStar_Pervasives_Native.None)::[]))
         when
         (FStar_Ident.lid_equals l FStar_Parser_Const.eq2_lid) ||
           (FStar_Ident.lid_equals l FStar_Parser_Const.c_eq2_lid)
         -> FStar_Pervasives_Native.Some (e1, e2)
     | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-        (l, uu____606::uu____607::(e1, uu____609)::(e2, uu____611)::[])) when
+        (l, uu___1::uu___2::(e1, uu___3)::(e2, uu___4)::[])) when
         FStar_Ident.lid_equals l FStar_Parser_Const.eq3_lid ->
         FStar_Pervasives_Native.Some (e1, e2)
-    | uu____688 ->
-        let uu____691 = FStar_Syntax_Util.unb2t typ in
-        (match uu____691 with
+    | uu___1 ->
+        let uu___2 = FStar_Syntax_Util.unb2t typ in
+        (match uu___2 with
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some t ->
-             let uu____705 = FStar_Syntax_Util.head_and_args t in
-             (match uu____705 with
+             let uu___3 = FStar_Syntax_Util.head_and_args t in
+             (match uu___3 with
               | (hd, args) ->
-                  let uu____754 =
-                    let uu____769 =
-                      let uu____770 = FStar_Syntax_Subst.compress hd in
-                      uu____770.FStar_Syntax_Syntax.n in
-                    (uu____769, args) in
-                  (match uu____754 with
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Subst.compress hd in
+                      uu___6.FStar_Syntax_Syntax.n in
+                    (uu___5, args) in
+                  (match uu___4 with
                    | (FStar_Syntax_Syntax.Tm_fvar fv,
-                      (uu____790, FStar_Pervasives_Native.Some
-                       (FStar_Syntax_Syntax.Implicit uu____791))::(e1,
-                                                                   FStar_Pervasives_Native.None)::
+                      (uu___5, FStar_Pervasives_Native.Some
+                       (FStar_Syntax_Syntax.Implicit uu___6))::(e1,
+                                                                FStar_Pervasives_Native.None)::
                       (e2, FStar_Pervasives_Native.None)::[]) when
                        FStar_Syntax_Syntax.fv_eq_lid fv
                          FStar_Parser_Const.op_Eq
                        -> FStar_Pervasives_Native.Some (e1, e2)
-                   | uu____858 -> FStar_Pervasives_Native.None)))
+                   | uu___5 -> FStar_Pervasives_Native.None)))
 let (destruct_eq :
   FStar_Reflection_Data.typ ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
       FStar_Pervasives_Native.option)
   =
   fun typ ->
-    let uu____894 = destruct_eq' typ in
-    match uu____894 with
+    let uu___ = destruct_eq' typ in
+    match uu___ with
     | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None ->
-        let uu____924 = FStar_Syntax_Util.un_squash typ in
-        (match uu____924 with
+        let uu___1 = FStar_Syntax_Util.un_squash typ in
+        (match uu___1 with
          | FStar_Pervasives_Native.Some typ1 -> destruct_eq' typ1
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
 let (__do_unify :
@@ -286,57 +279,54 @@ let (__do_unify :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        (let uu____966 =
+        (let uu___1 =
            FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "1346") in
-         if uu____966
+         if uu___1
          then
-           let uu____967 = FStar_Syntax_Print.term_to_string t1 in
-           let uu____968 = FStar_Syntax_Print.term_to_string t2 in
-           FStar_Util.print2 "%%%%%%%%do_unify %s =? %s\n" uu____967
-             uu____968
+           let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+           let uu___3 = FStar_Syntax_Print.term_to_string t2 in
+           FStar_Util.print2 "%%%%%%%%do_unify %s =? %s\n" uu___2 uu___3
          else ());
         (try
-           (fun uu___170_975 ->
+           (fun uu___1 ->
               match () with
               | () ->
                   let res = FStar_TypeChecker_Rel.teq_nosmt env1 t1 t2 in
-                  ((let uu____982 =
+                  ((let uu___3 =
                       FStar_TypeChecker_Env.debug env1
                         (FStar_Options.Other "1346") in
-                    if uu____982
+                    if uu___3
                     then
-                      let uu____983 =
+                      let uu___4 =
                         FStar_Common.string_of_option
                           (FStar_TypeChecker_Rel.guard_to_string env1) res in
-                      let uu____984 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____985 = FStar_Syntax_Print.term_to_string t2 in
+                      let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu___6 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.print3
-                        "%%%%%%%%do_unify (RESULT %s) %s =? %s\n" uu____983
-                        uu____984 uu____985
+                        "%%%%%%%%do_unify (RESULT %s) %s =? %s\n" uu___4
+                        uu___5 uu___6
                     else ());
                    (match res with
                     | FStar_Pervasives_Native.None ->
                         FStar_Tactics_Monad.ret false
                     | FStar_Pervasives_Native.Some g ->
-                        let uu____990 =
+                        let uu___3 =
                           FStar_Tactics_Monad.add_implicits
                             g.FStar_TypeChecker_Common.implicits in
-                        FStar_Tactics_Monad.bind uu____990
-                          (fun uu____994 -> FStar_Tactics_Monad.ret true))))
-             ()
+                        FStar_Tactics_Monad.bind uu___3
+                          (fun uu___4 -> FStar_Tactics_Monad.ret true)))) ()
          with
-         | FStar_Errors.Err (uu____1001, msg) ->
+         | FStar_Errors.Err (uu___2, msg) ->
              FStar_Tactics_Monad.mlog
-               (fun uu____1004 ->
+               (fun uu___3 ->
                   FStar_Util.print1 ">> do_unify error, (%s)\n" msg)
-               (fun uu____1006 -> FStar_Tactics_Monad.ret false)
-         | FStar_Errors.Error (uu____1007, msg, r) ->
+               (fun uu___3 -> FStar_Tactics_Monad.ret false)
+         | FStar_Errors.Error (uu___2, msg, r) ->
              FStar_Tactics_Monad.mlog
-               (fun uu____1012 ->
-                  let uu____1013 = FStar_Range.string_of_range r in
+               (fun uu___3 ->
+                  let uu___4 = FStar_Range.string_of_range r in
                   FStar_Util.print2 ">> do_unify error, (%s) at (%s)\n" msg
-                    uu____1013)
-               (fun uu____1015 -> FStar_Tactics_Monad.ret false))
+                    uu___4) (fun uu___3 -> FStar_Tactics_Monad.ret false))
 let (do_unify :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -346,24 +336,24 @@ let (do_unify :
     fun t1 ->
       fun t2 ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____1038 ->
-             (let uu____1040 =
+          (fun uu___ ->
+             (let uu___2 =
                 FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "1346") in
-              if uu____1040
+              if uu___2
               then
                 (FStar_Options.push ();
-                 (let uu____1042 =
+                 (let uu___4 =
                     FStar_Options.set_options
                       "--debug_level Rel --debug_level RelCheck" in
                   ()))
               else ());
-             (let uu____1044 = __do_unify env1 t1 t2 in
-              FStar_Tactics_Monad.bind uu____1044
+             (let uu___2 = __do_unify env1 t1 t2 in
+              FStar_Tactics_Monad.bind uu___2
                 (fun r ->
-                   (let uu____1051 =
+                   (let uu___4 =
                       FStar_TypeChecker_Env.debug env1
                         (FStar_Options.Other "1346") in
-                    if uu____1051 then FStar_Options.pop () else ());
+                    if uu___4 then FStar_Options.pop () else ());
                    FStar_Tactics_Monad.ret r)))
 let (do_match :
   FStar_TypeChecker_Env.env ->
@@ -373,24 +363,24 @@ let (do_match :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1072 =
+        let uu___ =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1072
+        FStar_Tactics_Monad.bind uu___
           (fun tx ->
              let uvs1 = FStar_Syntax_Free.uvars_uncached t1 in
-             let uu____1086 = do_unify env1 t1 t2 in
-             FStar_Tactics_Monad.bind uu____1086
+             let uu___1 = do_unify env1 t1 t2 in
+             FStar_Tactics_Monad.bind uu___1
                (fun r ->
                   if r
                   then
                     let uvs2 = FStar_Syntax_Free.uvars_uncached t1 in
-                    let uu____1099 =
-                      let uu____1100 = FStar_Util.set_eq uvs1 uvs2 in
-                      Prims.op_Negation uu____1100 in
-                    (if uu____1099
+                    let uu___2 =
+                      let uu___3 = FStar_Util.set_eq uvs1 uvs2 in
+                      Prims.op_Negation uu___3 in
+                    (if uu___2
                      then
                        (FStar_Syntax_Unionfind.rollback tx;
                         FStar_Tactics_Monad.ret false)
@@ -404,29 +394,29 @@ let (do_match_on_lhs :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1125 =
+        let uu___ =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1125
+        FStar_Tactics_Monad.bind uu___
           (fun tx ->
-             let uu____1135 = destruct_eq t1 in
-             match uu____1135 with
+             let uu___1 = destruct_eq t1 in
+             match uu___1 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "do_match_on_lhs: not an eq"
-             | FStar_Pervasives_Native.Some (lhs, uu____1149) ->
+             | FStar_Pervasives_Native.Some (lhs, uu___2) ->
                  let uvs1 = FStar_Syntax_Free.uvars_uncached lhs in
-                 let uu____1157 = do_unify env1 t1 t2 in
-                 FStar_Tactics_Monad.bind uu____1157
+                 let uu___3 = do_unify env1 t1 t2 in
+                 FStar_Tactics_Monad.bind uu___3
                    (fun r ->
                       if r
                       then
                         let uvs2 = FStar_Syntax_Free.uvars_uncached lhs in
-                        let uu____1170 =
-                          let uu____1171 = FStar_Util.set_eq uvs1 uvs2 in
-                          Prims.op_Negation uu____1171 in
-                        (if uu____1170
+                        let uu___4 =
+                          let uu___5 = FStar_Util.set_eq uvs1 uvs2 in
+                          Prims.op_Negation uu___5 in
+                        (if uu___4
                          then
                            (FStar_Syntax_Unionfind.rollback tx;
                             FStar_Tactics_Monad.ret false)
@@ -438,16 +428,15 @@ let (set_solution :
   =
   fun goal ->
     fun solution ->
-      let uu____1191 =
+      let uu___ =
         FStar_Syntax_Unionfind.find
           (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-      match uu____1191 with
-      | FStar_Pervasives_Native.Some uu____1196 ->
-          let uu____1197 =
-            let uu____1198 =
-              FStar_Tactics_Printing.goal_to_string_verbose goal in
-            FStar_Util.format1 "Goal %s is already solved" uu____1198 in
-          FStar_Tactics_Monad.fail uu____1197
+      match uu___ with
+      | FStar_Pervasives_Native.Some uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Tactics_Printing.goal_to_string_verbose goal in
+            FStar_Util.format1 "Goal %s is already solved" uu___3 in
+          FStar_Tactics_Monad.fail uu___2
       | FStar_Pervasives_Native.None ->
           (FStar_Syntax_Unionfind.change
              (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head
@@ -459,9 +448,9 @@ let (trysolve :
   =
   fun goal ->
     fun solution ->
-      let uu____1214 = FStar_Tactics_Types.goal_env goal in
-      let uu____1215 = FStar_Tactics_Types.goal_witness goal in
-      do_unify uu____1214 solution uu____1215
+      let uu___ = FStar_Tactics_Types.goal_env goal in
+      let uu___1 = FStar_Tactics_Types.goal_witness goal in
+      do_unify uu___ solution uu___1
 let (solve :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -470,140 +459,135 @@ let (solve :
     fun solution ->
       let e = FStar_Tactics_Types.goal_env goal in
       FStar_Tactics_Monad.mlog
-        (fun uu____1234 ->
-           let uu____1235 =
-             let uu____1236 = FStar_Tactics_Types.goal_witness goal in
-             FStar_Syntax_Print.term_to_string uu____1236 in
-           let uu____1237 = FStar_Syntax_Print.term_to_string solution in
-           FStar_Util.print2 "solve %s := %s\n" uu____1235 uu____1237)
-        (fun uu____1240 ->
-           let uu____1241 = trysolve goal solution in
-           FStar_Tactics_Monad.bind uu____1241
+        (fun uu___ ->
+           let uu___1 =
+             let uu___2 = FStar_Tactics_Types.goal_witness goal in
+             FStar_Syntax_Print.term_to_string uu___2 in
+           let uu___2 = FStar_Syntax_Print.term_to_string solution in
+           FStar_Util.print2 "solve %s := %s\n" uu___1 uu___2)
+        (fun uu___ ->
+           let uu___1 = trysolve goal solution in
+           FStar_Tactics_Monad.bind uu___1
              (fun b ->
                 if b
                 then
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____1249 ->
-                       FStar_Tactics_Monad.remove_solved_goals)
+                    (fun uu___2 -> FStar_Tactics_Monad.remove_solved_goals)
                 else
-                  (let uu____1251 =
-                     let uu____1252 =
-                       let uu____1253 = FStar_Tactics_Types.goal_env goal in
-                       tts uu____1253 solution in
-                     let uu____1254 =
-                       let uu____1255 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1256 = FStar_Tactics_Types.goal_witness goal in
-                       tts uu____1255 uu____1256 in
-                     let uu____1257 =
-                       let uu____1258 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1259 = FStar_Tactics_Types.goal_type goal in
-                       tts uu____1258 uu____1259 in
-                     FStar_Util.format3 "%s does not solve %s : %s"
-                       uu____1252 uu____1254 uu____1257 in
-                   FStar_Tactics_Monad.fail uu____1251)))
+                  (let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Tactics_Types.goal_env goal in
+                       tts uu___5 solution in
+                     let uu___5 =
+                       let uu___6 = FStar_Tactics_Types.goal_env goal in
+                       let uu___7 = FStar_Tactics_Types.goal_witness goal in
+                       tts uu___6 uu___7 in
+                     let uu___6 =
+                       let uu___7 = FStar_Tactics_Types.goal_env goal in
+                       let uu___8 = FStar_Tactics_Types.goal_type goal in
+                       tts uu___7 uu___8 in
+                     FStar_Util.format3 "%s does not solve %s : %s" uu___4
+                       uu___5 uu___6 in
+                   FStar_Tactics_Monad.fail uu___3)))
 let (solve' :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
   =
   fun goal ->
     fun solution ->
-      let uu____1274 = set_solution goal solution in
-      FStar_Tactics_Monad.bind uu____1274
-        (fun uu____1278 ->
+      let uu___ = set_solution goal solution in
+      FStar_Tactics_Monad.bind uu___
+        (fun uu___1 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-             (fun uu____1280 -> FStar_Tactics_Monad.remove_solved_goals))
+             (fun uu___2 -> FStar_Tactics_Monad.remove_solved_goals))
 let (is_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____1287 = FStar_Syntax_Util.un_squash t1 in
-    match uu____1287 with
+    let uu___ = FStar_Syntax_Util.un_squash t1 in
+    match uu___ with
     | FStar_Pervasives_Native.Some t' ->
         let t'1 = FStar_Syntax_Util.unascribe t' in
-        let uu____1298 =
-          let uu____1299 = FStar_Syntax_Subst.compress t'1 in
-          uu____1299.FStar_Syntax_Syntax.n in
-        (match uu____1298 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t'1 in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-         | uu____1303 -> false)
-    | uu____1304 -> false
+         | uu___2 -> false)
+    | uu___1 -> false
 let (is_false : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1314 = FStar_Syntax_Util.un_squash t in
-    match uu____1314 with
+    let uu___ = FStar_Syntax_Util.un_squash t in
+    match uu___ with
     | FStar_Pervasives_Native.Some t' ->
-        let uu____1324 =
-          let uu____1325 = FStar_Syntax_Subst.compress t' in
-          uu____1325.FStar_Syntax_Syntax.n in
-        (match uu____1324 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t' in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid
-         | uu____1329 -> false)
-    | uu____1330 -> false
+         | uu___2 -> false)
+    | uu___1 -> false
 let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____1344 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                (let uu____1353 =
-                   let uu____1354 = FStar_Tactics_Types.goal_type g in
-                   uu____1354.FStar_Syntax_Syntax.pos in
-                 let uu____1357 =
-                   let uu____1362 =
-                     let uu____1363 =
+                (let uu___2 =
+                   let uu___3 = FStar_Tactics_Types.goal_type g in
+                   uu___3.FStar_Syntax_Syntax.pos in
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
                        FStar_Tactics_Printing.goal_to_string ""
                          FStar_Pervasives_Native.None ps g in
                      FStar_Util.format1 "Tactics admitted goal <%s>\n\n"
-                       uu____1363 in
-                   (FStar_Errors.Warning_TacAdmit, uu____1362) in
-                 FStar_Errors.log_issue uu____1353 uu____1357);
+                       uu___5 in
+                   (FStar_Errors.Warning_TacAdmit, uu___4) in
+                 FStar_Errors.log_issue uu___2 uu___3);
                 solve' g t)) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu____1344
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu___
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1378 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          let n = ps.FStar_Tactics_Types.freshness in
          let ps1 =
-           let uu___277_1388 = ps in
+           let uu___1 = ps in
            {
              FStar_Tactics_Types.main_context =
-               (uu___277_1388.FStar_Tactics_Types.main_context);
+               (uu___1.FStar_Tactics_Types.main_context);
              FStar_Tactics_Types.all_implicits =
-               (uu___277_1388.FStar_Tactics_Types.all_implicits);
-             FStar_Tactics_Types.goals =
-               (uu___277_1388.FStar_Tactics_Types.goals);
+               (uu___1.FStar_Tactics_Types.all_implicits);
+             FStar_Tactics_Types.goals = (uu___1.FStar_Tactics_Types.goals);
              FStar_Tactics_Types.smt_goals =
-               (uu___277_1388.FStar_Tactics_Types.smt_goals);
-             FStar_Tactics_Types.depth =
-               (uu___277_1388.FStar_Tactics_Types.depth);
-             FStar_Tactics_Types.__dump =
-               (uu___277_1388.FStar_Tactics_Types.__dump);
-             FStar_Tactics_Types.psc =
-               (uu___277_1388.FStar_Tactics_Types.psc);
+               (uu___1.FStar_Tactics_Types.smt_goals);
+             FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
+             FStar_Tactics_Types.__dump = (uu___1.FStar_Tactics_Types.__dump);
+             FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
              FStar_Tactics_Types.entry_range =
-               (uu___277_1388.FStar_Tactics_Types.entry_range);
+               (uu___1.FStar_Tactics_Types.entry_range);
              FStar_Tactics_Types.guard_policy =
-               (uu___277_1388.FStar_Tactics_Types.guard_policy);
+               (uu___1.FStar_Tactics_Types.guard_policy);
              FStar_Tactics_Types.freshness = (n + Prims.int_one);
              FStar_Tactics_Types.tac_verb_dbg =
-               (uu___277_1388.FStar_Tactics_Types.tac_verb_dbg);
+               (uu___1.FStar_Tactics_Types.tac_verb_dbg);
              FStar_Tactics_Types.local_state =
-               (uu___277_1388.FStar_Tactics_Types.local_state)
+               (uu___1.FStar_Tactics_Types.local_state)
            } in
-         let uu____1389 = FStar_Tactics_Monad.set ps1 in
-         FStar_Tactics_Monad.bind uu____1389
-           (fun uu____1394 ->
-              let uu____1395 = FStar_BigInt.of_int_fs n in
-              FStar_Tactics_Monad.ret uu____1395))
+         let uu___1 = FStar_Tactics_Monad.set ps1 in
+         FStar_Tactics_Monad.bind uu___1
+           (fun uu___2 ->
+              let uu___3 = FStar_BigInt.of_int_fs n in
+              FStar_Tactics_Monad.ret uu___3))
 let (curms : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1402 ->
-    let uu____1405 =
-      let uu____1406 = FStar_Util.now_ms () in
-      FStar_All.pipe_right uu____1406 FStar_BigInt.of_int_fs in
-    FStar_Tactics_Monad.ret uu____1405
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_Util.now_ms () in
+      FStar_All.pipe_right uu___2 FStar_BigInt.of_int_fs in
+    FStar_Tactics_Monad.ret uu___1
 let (__tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -615,131 +599,131 @@ let (__tc :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1449 ->
-                let uu____1450 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc(%s)\n" uu____1450)
-             (fun uu____1453 ->
+             (fun uu___ ->
+                let uu___1 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc(%s)\n" uu___1)
+             (fun uu___ ->
                 let e1 =
-                  let uu___286_1455 = e in
+                  let uu___1 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___286_1455.FStar_TypeChecker_Env.solver);
+                      (uu___1.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___286_1455.FStar_TypeChecker_Env.range);
+                      (uu___1.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___286_1455.FStar_TypeChecker_Env.curmodule);
+                      (uu___1.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma);
+                      (uu___1.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___1.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___1.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___286_1455.FStar_TypeChecker_Env.modules);
+                      (uu___1.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___286_1455.FStar_TypeChecker_Env.expected_typ);
+                      (uu___1.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___286_1455.FStar_TypeChecker_Env.sigtab);
+                      (uu___1.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___286_1455.FStar_TypeChecker_Env.attrtab);
+                      (uu___1.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___286_1455.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___286_1455.FStar_TypeChecker_Env.effects);
+                      (uu___1.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___286_1455.FStar_TypeChecker_Env.generalize);
+                      (uu___1.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___286_1455.FStar_TypeChecker_Env.letrecs);
+                      (uu___1.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___286_1455.FStar_TypeChecker_Env.top_level);
+                      (uu___1.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___286_1455.FStar_TypeChecker_Env.check_uvars);
+                      (uu___1.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_eq);
+                      (uu___1.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___286_1455.FStar_TypeChecker_Env.is_iface);
+                      (uu___1.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___286_1455.FStar_TypeChecker_Env.admit);
+                      (uu___1.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___286_1455.FStar_TypeChecker_Env.lax);
+                      (uu___1.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___286_1455.FStar_TypeChecker_Env.lax_universes);
+                      (uu___1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___286_1455.FStar_TypeChecker_Env.phase1);
+                      (uu___1.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___286_1455.FStar_TypeChecker_Env.failhard);
+                      (uu___1.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___286_1455.FStar_TypeChecker_Env.nosynth);
+                      (uu___1.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___286_1455.FStar_TypeChecker_Env.tc_term);
+                      (uu___1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.type_of);
+                      (uu___1.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.universe_of);
+                      (uu___1.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.check_type_of);
+                      (uu___1.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___286_1455.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___286_1455.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___286_1455.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___286_1455.FStar_TypeChecker_Env.proof_ns);
+                      (uu___1.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___286_1455.FStar_TypeChecker_Env.synth_hook);
+                      (uu___1.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___286_1455.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___286_1455.FStar_TypeChecker_Env.splice);
+                      (uu___1.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___286_1455.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___1.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___286_1455.FStar_TypeChecker_Env.postprocess);
+                      (uu___1.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___286_1455.FStar_TypeChecker_Env.identifier_info);
+                      (uu___1.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___286_1455.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___1.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___286_1455.FStar_TypeChecker_Env.dsenv);
+                      (uu___1.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___286_1455.FStar_TypeChecker_Env.nbe);
+                      (uu___1.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___286_1455.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___286_1455.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___286_1455.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___290_1466 ->
+                  (fun uu___1 ->
                      match () with
                      | () ->
-                         let uu____1475 =
+                         let uu___2 =
                            FStar_TypeChecker_TcTerm.type_of_tot_term e1 t in
-                         FStar_Tactics_Monad.ret uu____1475) ()
+                         FStar_Tactics_Monad.ret uu___2) ()
                 with
-                | FStar_Errors.Err (uu____1502, msg) ->
-                    let uu____1504 = tts e1 t in
-                    let uu____1505 =
-                      let uu____1506 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1506
+                | FStar_Errors.Err (uu___2, msg) ->
+                    let uu___3 = tts e1 t in
+                    let uu___4 =
+                      let uu___5 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu___5
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1504 uu____1505 msg
-                | FStar_Errors.Error (uu____1513, msg, uu____1515) ->
-                    let uu____1516 = tts e1 t in
-                    let uu____1517 =
-                      let uu____1518 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1518
+                      uu___3 uu___4 msg
+                | FStar_Errors.Error (uu___2, msg, uu___3) ->
+                    let uu___4 = tts e1 t in
+                    let uu___5 =
+                      let uu___6 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu___6
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1516 uu____1517 msg))
+                      uu___4 uu___5 msg))
 let (__tc_ghost :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -751,135 +735,135 @@ let (__tc_ghost :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1567 ->
-                let uu____1568 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu____1568)
-             (fun uu____1571 ->
+             (fun uu___ ->
+                let uu___1 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu___1)
+             (fun uu___ ->
                 let e1 =
-                  let uu___307_1573 = e in
+                  let uu___1 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___307_1573.FStar_TypeChecker_Env.solver);
+                      (uu___1.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___307_1573.FStar_TypeChecker_Env.range);
+                      (uu___1.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___307_1573.FStar_TypeChecker_Env.curmodule);
+                      (uu___1.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma);
+                      (uu___1.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___1.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___1.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___307_1573.FStar_TypeChecker_Env.modules);
+                      (uu___1.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___307_1573.FStar_TypeChecker_Env.expected_typ);
+                      (uu___1.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___307_1573.FStar_TypeChecker_Env.sigtab);
+                      (uu___1.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___307_1573.FStar_TypeChecker_Env.attrtab);
+                      (uu___1.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___307_1573.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___307_1573.FStar_TypeChecker_Env.effects);
+                      (uu___1.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___307_1573.FStar_TypeChecker_Env.generalize);
+                      (uu___1.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___307_1573.FStar_TypeChecker_Env.letrecs);
+                      (uu___1.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___307_1573.FStar_TypeChecker_Env.top_level);
+                      (uu___1.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___307_1573.FStar_TypeChecker_Env.check_uvars);
+                      (uu___1.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_eq);
+                      (uu___1.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___307_1573.FStar_TypeChecker_Env.is_iface);
+                      (uu___1.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___307_1573.FStar_TypeChecker_Env.admit);
+                      (uu___1.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___307_1573.FStar_TypeChecker_Env.lax);
+                      (uu___1.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___307_1573.FStar_TypeChecker_Env.lax_universes);
+                      (uu___1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___307_1573.FStar_TypeChecker_Env.phase1);
+                      (uu___1.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___307_1573.FStar_TypeChecker_Env.failhard);
+                      (uu___1.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___307_1573.FStar_TypeChecker_Env.nosynth);
+                      (uu___1.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___307_1573.FStar_TypeChecker_Env.tc_term);
+                      (uu___1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.type_of);
+                      (uu___1.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.universe_of);
+                      (uu___1.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.check_type_of);
+                      (uu___1.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___307_1573.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___307_1573.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___307_1573.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___307_1573.FStar_TypeChecker_Env.proof_ns);
+                      (uu___1.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___307_1573.FStar_TypeChecker_Env.synth_hook);
+                      (uu___1.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___307_1573.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___307_1573.FStar_TypeChecker_Env.splice);
+                      (uu___1.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___307_1573.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___1.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___307_1573.FStar_TypeChecker_Env.postprocess);
+                      (uu___1.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___307_1573.FStar_TypeChecker_Env.identifier_info);
+                      (uu___1.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___307_1573.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___1.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___307_1573.FStar_TypeChecker_Env.dsenv);
+                      (uu___1.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___307_1573.FStar_TypeChecker_Env.nbe);
+                      (uu___1.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___307_1573.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___307_1573.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___307_1573.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___311_1587 ->
+                  (fun uu___1 ->
                      match () with
                      | () ->
-                         let uu____1596 =
+                         let uu___2 =
                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term e1 t in
-                         (match uu____1596 with
+                         (match uu___2 with
                           | (t1, lc, g) ->
                               FStar_Tactics_Monad.ret
                                 (t1, (lc.FStar_TypeChecker_Common.res_typ),
                                   g))) ()
                 with
-                | FStar_Errors.Err (uu____1634, msg) ->
-                    let uu____1636 = tts e1 t in
-                    let uu____1637 =
-                      let uu____1638 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1638
+                | FStar_Errors.Err (uu___2, msg) ->
+                    let uu___3 = tts e1 t in
+                    let uu___4 =
+                      let uu___5 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu___5
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1636 uu____1637 msg
-                | FStar_Errors.Error (uu____1645, msg, uu____1647) ->
-                    let uu____1648 = tts e1 t in
-                    let uu____1649 =
-                      let uu____1650 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1650
+                      uu___3 uu___4 msg
+                | FStar_Errors.Error (uu___2, msg, uu___3) ->
+                    let uu___4 = tts e1 t in
+                    let uu___5 =
+                      let uu___6 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu___6
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1648 uu____1649 msg))
+                      uu___4 uu___5 msg))
 let (__tc_lax :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -891,228 +875,227 @@ let (__tc_lax :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1699 ->
-                let uu____1700 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu____1700)
-             (fun uu____1704 ->
+             (fun uu___ ->
+                let uu___1 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu___1)
+             (fun uu___ ->
                 let e1 =
-                  let uu___332_1706 = e in
+                  let uu___1 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___332_1706.FStar_TypeChecker_Env.solver);
+                      (uu___1.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___332_1706.FStar_TypeChecker_Env.range);
+                      (uu___1.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___332_1706.FStar_TypeChecker_Env.curmodule);
+                      (uu___1.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma);
+                      (uu___1.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___1.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___1.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___332_1706.FStar_TypeChecker_Env.modules);
+                      (uu___1.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___332_1706.FStar_TypeChecker_Env.expected_typ);
+                      (uu___1.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___332_1706.FStar_TypeChecker_Env.sigtab);
+                      (uu___1.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___332_1706.FStar_TypeChecker_Env.attrtab);
+                      (uu___1.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___332_1706.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___332_1706.FStar_TypeChecker_Env.effects);
+                      (uu___1.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___332_1706.FStar_TypeChecker_Env.generalize);
+                      (uu___1.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___332_1706.FStar_TypeChecker_Env.letrecs);
+                      (uu___1.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___332_1706.FStar_TypeChecker_Env.top_level);
+                      (uu___1.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___332_1706.FStar_TypeChecker_Env.check_uvars);
+                      (uu___1.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_eq);
+                      (uu___1.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___332_1706.FStar_TypeChecker_Env.is_iface);
+                      (uu___1.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___332_1706.FStar_TypeChecker_Env.admit);
+                      (uu___1.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___332_1706.FStar_TypeChecker_Env.lax);
+                      (uu___1.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___332_1706.FStar_TypeChecker_Env.lax_universes);
+                      (uu___1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___332_1706.FStar_TypeChecker_Env.phase1);
+                      (uu___1.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___332_1706.FStar_TypeChecker_Env.failhard);
+                      (uu___1.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___332_1706.FStar_TypeChecker_Env.nosynth);
+                      (uu___1.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___332_1706.FStar_TypeChecker_Env.tc_term);
+                      (uu___1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.type_of);
+                      (uu___1.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.universe_of);
+                      (uu___1.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.check_type_of);
+                      (uu___1.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___332_1706.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___332_1706.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___332_1706.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___332_1706.FStar_TypeChecker_Env.proof_ns);
+                      (uu___1.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___332_1706.FStar_TypeChecker_Env.synth_hook);
+                      (uu___1.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___332_1706.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___332_1706.FStar_TypeChecker_Env.splice);
+                      (uu___1.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___332_1706.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___1.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___332_1706.FStar_TypeChecker_Env.postprocess);
+                      (uu___1.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___332_1706.FStar_TypeChecker_Env.identifier_info);
+                      (uu___1.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___332_1706.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___1.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___332_1706.FStar_TypeChecker_Env.dsenv);
+                      (uu___1.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___332_1706.FStar_TypeChecker_Env.nbe);
+                      (uu___1.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___332_1706.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___332_1706.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___332_1706.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 let e2 =
-                  let uu___335_1708 = e1 in
+                  let uu___1 = e1 in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___335_1708.FStar_TypeChecker_Env.solver);
+                      (uu___1.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___335_1708.FStar_TypeChecker_Env.range);
+                      (uu___1.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___335_1708.FStar_TypeChecker_Env.curmodule);
+                      (uu___1.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma);
+                      (uu___1.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___1.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___1.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___335_1708.FStar_TypeChecker_Env.modules);
+                      (uu___1.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___335_1708.FStar_TypeChecker_Env.expected_typ);
+                      (uu___1.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___335_1708.FStar_TypeChecker_Env.sigtab);
+                      (uu___1.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___335_1708.FStar_TypeChecker_Env.attrtab);
+                      (uu___1.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___335_1708.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___335_1708.FStar_TypeChecker_Env.effects);
+                      (uu___1.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___335_1708.FStar_TypeChecker_Env.generalize);
+                      (uu___1.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___335_1708.FStar_TypeChecker_Env.letrecs);
+                      (uu___1.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___335_1708.FStar_TypeChecker_Env.top_level);
+                      (uu___1.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___335_1708.FStar_TypeChecker_Env.check_uvars);
+                      (uu___1.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_eq);
+                      (uu___1.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___335_1708.FStar_TypeChecker_Env.is_iface);
+                      (uu___1.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___335_1708.FStar_TypeChecker_Env.admit);
+                      (uu___1.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax = true;
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___335_1708.FStar_TypeChecker_Env.lax_universes);
+                      (uu___1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___335_1708.FStar_TypeChecker_Env.phase1);
+                      (uu___1.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___335_1708.FStar_TypeChecker_Env.failhard);
+                      (uu___1.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___335_1708.FStar_TypeChecker_Env.nosynth);
+                      (uu___1.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping =
-                      (uu___335_1708.FStar_TypeChecker_Env.uvar_subtyping);
+                      (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___335_1708.FStar_TypeChecker_Env.tc_term);
+                      (uu___1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.type_of);
+                      (uu___1.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.universe_of);
+                      (uu___1.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.check_type_of);
+                      (uu___1.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___335_1708.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___335_1708.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___335_1708.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___335_1708.FStar_TypeChecker_Env.proof_ns);
+                      (uu___1.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___335_1708.FStar_TypeChecker_Env.synth_hook);
+                      (uu___1.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___335_1708.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___335_1708.FStar_TypeChecker_Env.splice);
+                      (uu___1.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___335_1708.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___1.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___335_1708.FStar_TypeChecker_Env.postprocess);
+                      (uu___1.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___335_1708.FStar_TypeChecker_Env.identifier_info);
+                      (uu___1.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___335_1708.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___1.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___335_1708.FStar_TypeChecker_Env.dsenv);
+                      (uu___1.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___335_1708.FStar_TypeChecker_Env.nbe);
+                      (uu___1.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___335_1708.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___335_1708.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___335_1708.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___339_1719 ->
+                  (fun uu___1 ->
                      match () with
                      | () ->
-                         let uu____1728 =
-                           FStar_TypeChecker_TcTerm.tc_term e2 t in
-                         FStar_Tactics_Monad.ret uu____1728) ()
+                         let uu___2 = FStar_TypeChecker_TcTerm.tc_term e2 t in
+                         FStar_Tactics_Monad.ret uu___2) ()
                 with
-                | FStar_Errors.Err (uu____1755, msg) ->
-                    let uu____1757 = tts e2 t in
-                    let uu____1758 =
-                      let uu____1759 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1759
+                | FStar_Errors.Err (uu___2, msg) ->
+                    let uu___3 = tts e2 t in
+                    let uu___4 =
+                      let uu___5 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu___5
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1757 uu____1758 msg
-                | FStar_Errors.Error (uu____1766, msg, uu____1768) ->
-                    let uu____1769 = tts e2 t in
-                    let uu____1770 =
-                      let uu____1771 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1771
+                      uu___3 uu___4 msg
+                | FStar_Errors.Error (uu___2, msg, uu___3) ->
+                    let uu___4 = tts e2 t in
+                    let uu___5 =
+                      let uu___6 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu___6
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1769 uu____1770 msg))
+                      uu___4 uu___5 msg))
 let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
     fun t ->
@@ -1126,7 +1109,7 @@ let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
       let t1 = normalize steps e t in is_true t1
 let (get_guard_policy :
   unit -> FStar_Tactics_Types.guard_policy FStar_Tactics_Monad.tac) =
-  fun uu____1798 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps -> FStar_Tactics_Monad.ret ps.FStar_Tactics_Types.guard_policy)
 let (set_guard_policy :
@@ -1135,31 +1118,27 @@ let (set_guard_policy :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_Tactics_Monad.set
-           (let uu___360_1816 = ps in
+           (let uu___ = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___360_1816.FStar_Tactics_Types.main_context);
+                (uu___.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___360_1816.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals =
-                (uu___360_1816.FStar_Tactics_Types.goals);
+                (uu___.FStar_Tactics_Types.all_implicits);
+              FStar_Tactics_Types.goals = (uu___.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
-                (uu___360_1816.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___360_1816.FStar_Tactics_Types.depth);
-              FStar_Tactics_Types.__dump =
-                (uu___360_1816.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___360_1816.FStar_Tactics_Types.psc);
+                (uu___.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.__dump = (uu___.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___360_1816.FStar_Tactics_Types.entry_range);
+                (uu___.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy = pol;
               FStar_Tactics_Types.freshness =
-                (uu___360_1816.FStar_Tactics_Types.freshness);
+                (uu___.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___360_1816.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___360_1816.FStar_Tactics_Types.local_state)
+                (uu___.FStar_Tactics_Types.local_state)
             }))
 let with_policy :
   'a .
@@ -1168,27 +1147,27 @@ let with_policy :
   =
   fun pol ->
     fun t ->
-      let uu____1840 = get_guard_policy () in
-      FStar_Tactics_Monad.bind uu____1840
+      let uu___ = get_guard_policy () in
+      FStar_Tactics_Monad.bind uu___
         (fun old_pol ->
-           let uu____1846 = set_guard_policy pol in
-           FStar_Tactics_Monad.bind uu____1846
-             (fun uu____1850 ->
+           let uu___1 = set_guard_policy pol in
+           FStar_Tactics_Monad.bind uu___1
+             (fun uu___2 ->
                 FStar_Tactics_Monad.bind t
                   (fun r ->
-                     let uu____1854 = set_guard_policy old_pol in
-                     FStar_Tactics_Monad.bind uu____1854
-                       (fun uu____1858 -> FStar_Tactics_Monad.ret r))))
+                     let uu___3 = set_guard_policy old_pol in
+                     FStar_Tactics_Monad.bind uu___3
+                       (fun uu___4 -> FStar_Tactics_Monad.ret r))))
 let (getopts : FStar_Options.optionstate FStar_Tactics_Monad.tac) =
-  let uu____1861 = trytac FStar_Tactics_Monad.cur_goal in
-  FStar_Tactics_Monad.bind uu____1861
-    (fun uu___0_1870 ->
-       match uu___0_1870 with
+  let uu___ = trytac FStar_Tactics_Monad.cur_goal in
+  FStar_Tactics_Monad.bind uu___
+    (fun uu___1 ->
+       match uu___1 with
        | FStar_Pervasives_Native.Some g ->
            FStar_Tactics_Monad.ret g.FStar_Tactics_Types.opts
        | FStar_Pervasives_Native.None ->
-           let uu____1876 = FStar_Options.peek () in
-           FStar_Tactics_Monad.ret uu____1876)
+           let uu___2 = FStar_Options.peek () in
+           FStar_Tactics_Monad.ret uu___2)
 let (proc_guard :
   Prims.string ->
     env -> FStar_TypeChecker_Common.guard_t -> unit FStar_Tactics_Monad.tac)
@@ -1197,27 +1176,27 @@ let (proc_guard :
     fun e ->
       fun g ->
         FStar_Tactics_Monad.mlog
-          (fun uu____1898 ->
-             let uu____1899 = FStar_TypeChecker_Rel.guard_to_string e g in
-             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu____1899)
-          (fun uu____1902 ->
-             let uu____1903 =
+          (fun uu___ ->
+             let uu___1 = FStar_TypeChecker_Rel.guard_to_string e g in
+             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu___1)
+          (fun uu___ ->
+             let uu___1 =
                FStar_Tactics_Monad.add_implicits
                  g.FStar_TypeChecker_Common.implicits in
-             FStar_Tactics_Monad.bind uu____1903
-               (fun uu____1907 ->
+             FStar_Tactics_Monad.bind uu___1
+               (fun uu___2 ->
                   FStar_Tactics_Monad.bind getopts
                     (fun opts ->
-                       let uu____1911 =
-                         let uu____1912 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_TypeChecker_Rel.simplify_guard e g in
-                         uu____1912.FStar_TypeChecker_Common.guard_f in
-                       match uu____1911 with
+                         uu___4.FStar_TypeChecker_Common.guard_f in
+                       match uu___3 with
                        | FStar_TypeChecker_Common.Trivial ->
                            FStar_Tactics_Monad.ret ()
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____1916 = istrivial e f in
-                           if uu____1916
+                           let uu___4 = istrivial e f in
+                           if uu___4
                            then FStar_Tactics_Monad.ret ()
                            else
                              FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
@@ -1225,127 +1204,125 @@ let (proc_guard :
                                   match ps.FStar_Tactics_Types.guard_policy
                                   with
                                   | FStar_Tactics_Types.Drop ->
-                                      ((let uu____1926 =
-                                          let uu____1931 =
-                                            let uu____1932 =
+                                      ((let uu___7 =
+                                          let uu___8 =
+                                            let uu___9 =
                                               FStar_TypeChecker_Rel.guard_to_string
                                                 e g in
                                             FStar_Util.format1
                                               "Tactics admitted guard <%s>\n\n"
-                                              uu____1932 in
+                                              uu___9 in
                                           (FStar_Errors.Warning_TacAdmit,
-                                            uu____1931) in
+                                            uu___8) in
                                         FStar_Errors.log_issue
                                           e.FStar_TypeChecker_Env.range
-                                          uu____1926);
+                                          uu___7);
                                        FStar_Tactics_Monad.ret ())
                                   | FStar_Tactics_Types.Goal ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1935 ->
-                                           let uu____1936 =
+                                        (fun uu___6 ->
+                                           let uu___7 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Making guard (%s:%s) into a goal\n"
-                                             reason uu____1936)
-                                        (fun uu____1939 ->
-                                           let uu____1940 =
+                                             reason uu___7)
+                                        (fun uu___6 ->
+                                           let uu___7 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
-                                           FStar_Tactics_Monad.bind
-                                             uu____1940
+                                           FStar_Tactics_Monad.bind uu___7
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___389_1947 = goal in
+                                                  let uu___8 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___8.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___8.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.opts);
+                                                      (uu___8.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.label)
+                                                      (uu___8.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.SMT ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1950 ->
-                                           let uu____1951 =
+                                        (fun uu___6 ->
+                                           let uu___7 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Sending guard (%s:%s) to SMT goal\n"
-                                             reason uu____1951)
-                                        (fun uu____1954 ->
-                                           let uu____1955 =
+                                             reason uu___7)
+                                        (fun uu___6 ->
+                                           let uu___7 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
-                                           FStar_Tactics_Monad.bind
-                                             uu____1955
+                                           FStar_Tactics_Monad.bind uu___7
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___396_1962 = goal in
+                                                  let uu___8 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___8.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___8.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.opts);
+                                                      (uu___8.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.label)
+                                                      (uu___8.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_smt_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.Force ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1965 ->
-                                           let uu____1966 =
+                                        (fun uu___6 ->
+                                           let uu___7 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Forcing guard (%s:%s)\n" reason
-                                             uu____1966)
-                                        (fun uu____1968 ->
+                                             uu___7)
+                                        (fun uu___6 ->
                                            try
-                                             (fun uu___403_1973 ->
+                                             (fun uu___7 ->
                                                 match () with
                                                 | () ->
-                                                    let uu____1976 =
-                                                      let uu____1977 =
-                                                        let uu____1978 =
+                                                    let uu___8 =
+                                                      let uu___9 =
+                                                        let uu___10 =
                                                           FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                             e g in
                                                         FStar_All.pipe_left
                                                           FStar_TypeChecker_Env.is_trivial
-                                                          uu____1978 in
+                                                          uu___10 in
                                                       Prims.op_Negation
-                                                        uu____1977 in
-                                                    if uu____1976
+                                                        uu___9 in
+                                                    if uu___8
                                                     then
                                                       FStar_Tactics_Monad.mlog
-                                                        (fun uu____1983 ->
-                                                           let uu____1984 =
+                                                        (fun uu___9 ->
+                                                           let uu___10 =
                                                              FStar_TypeChecker_Rel.guard_to_string
                                                                e g in
                                                            FStar_Util.print1
                                                              "guard = %s\n"
-                                                             uu____1984)
-                                                        (fun uu____1986 ->
+                                                             uu___10)
+                                                        (fun uu___9 ->
                                                            fail1
                                                              "Forcing the guard failed (%s)"
                                                              reason)
@@ -1353,16 +1330,15 @@ let (proc_guard :
                                                       FStar_Tactics_Monad.ret
                                                         ()) ()
                                            with
-                                           | uu___402_1989 ->
+                                           | uu___7 ->
                                                FStar_Tactics_Monad.mlog
-                                                 (fun uu____1994 ->
-                                                    let uu____1995 =
+                                                 (fun uu___8 ->
+                                                    let uu___9 =
                                                       FStar_TypeChecker_Rel.guard_to_string
                                                         e g in
                                                     FStar_Util.print1
-                                                      "guard = %s\n"
-                                                      uu____1995)
-                                                 (fun uu____1997 ->
+                                                      "guard = %s\n" uu___9)
+                                                 (fun uu___8 ->
                                                     fail1
                                                       "Forcing the guard failed (%s)"
                                                       reason))))))
@@ -1373,18 +1349,17 @@ let (tcc :
   =
   fun e ->
     fun t ->
-      let uu____2012 =
-        let uu____2015 = __tc_lax e t in
-        FStar_Tactics_Monad.bind uu____2015
-          (fun uu____2035 ->
-             match uu____2035 with
-             | (uu____2044, lc, uu____2046) ->
-                 let uu____2047 =
-                   let uu____2048 = FStar_TypeChecker_Common.lcomp_comp lc in
-                   FStar_All.pipe_right uu____2048
-                     FStar_Pervasives_Native.fst in
-                 FStar_Tactics_Monad.ret uu____2047) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu____2012
+      let uu___ =
+        let uu___1 = __tc_lax e t in
+        FStar_Tactics_Monad.bind uu___1
+          (fun uu___2 ->
+             match uu___2 with
+             | (uu___3, lc, uu___4) ->
+                 let uu___5 =
+                   let uu___6 = FStar_TypeChecker_Common.lcomp_comp lc in
+                   FStar_All.pipe_right uu___6 FStar_Pervasives_Native.fst in
+                 FStar_Tactics_Monad.ret uu___5) in
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu___
 let (tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -1392,27 +1367,27 @@ let (tc :
   =
   fun e ->
     fun t ->
-      let uu____2075 =
-        let uu____2080 = tcc e t in
-        FStar_Tactics_Monad.bind uu____2080
+      let uu___ =
+        let uu___1 = tcc e t in
+        FStar_Tactics_Monad.bind uu___1
           (fun c -> FStar_Tactics_Monad.ret (FStar_Syntax_Util.comp_result c)) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu____2075
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu___
 let (trivial : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____2103 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____2109 =
-           let uu____2110 = FStar_Tactics_Types.goal_env goal in
-           let uu____2111 = FStar_Tactics_Types.goal_type goal in
-           istrivial uu____2110 uu____2111 in
-         if uu____2109
+         let uu___1 =
+           let uu___2 = FStar_Tactics_Types.goal_env goal in
+           let uu___3 = FStar_Tactics_Types.goal_type goal in
+           istrivial uu___2 uu___3 in
+         if uu___1
          then solve' goal FStar_Syntax_Util.exp_unit
          else
-           (let uu____2115 =
-              let uu____2116 = FStar_Tactics_Types.goal_env goal in
-              let uu____2117 = FStar_Tactics_Types.goal_type goal in
-              tts uu____2116 uu____2117 in
-            fail1 "Not a trivial goal: %s" uu____2115))
+           (let uu___3 =
+              let uu___4 = FStar_Tactics_Types.goal_env goal in
+              let uu___5 = FStar_Tactics_Types.goal_type goal in
+              tts uu___4 uu___5 in
+            fail1 "Not a trivial goal: %s" uu___3))
 let divide :
   'a 'b .
     FStar_BigInt.t ->
@@ -1424,101 +1399,100 @@ let divide :
       fun r ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun p ->
-             let uu____2166 =
+             let uu___ =
                try
-                 (fun uu___454_2189 ->
+                 (fun uu___1 ->
                     match () with
                     | () ->
-                        let uu____2200 =
-                          let uu____2209 = FStar_BigInt.to_int_fs n in
-                          FStar_List.splitAt uu____2209
+                        let uu___2 =
+                          let uu___3 = FStar_BigInt.to_int_fs n in
+                          FStar_List.splitAt uu___3
                             p.FStar_Tactics_Types.goals in
-                        FStar_Tactics_Monad.ret uu____2200) ()
+                        FStar_Tactics_Monad.ret uu___2) ()
                with
-               | uu___453_2219 ->
+               | uu___1 ->
                    FStar_Tactics_Monad.fail "divide: not enough goals" in
-             FStar_Tactics_Monad.bind uu____2166
-               (fun uu____2255 ->
-                  match uu____2255 with
+             FStar_Tactics_Monad.bind uu___
+               (fun uu___1 ->
+                  match uu___1 with
                   | (lgs, rgs) ->
                       let lp =
-                        let uu___436_2281 = p in
+                        let uu___2 = p in
                         {
                           FStar_Tactics_Types.main_context =
-                            (uu___436_2281.FStar_Tactics_Types.main_context);
+                            (uu___2.FStar_Tactics_Types.main_context);
                           FStar_Tactics_Types.all_implicits =
-                            (uu___436_2281.FStar_Tactics_Types.all_implicits);
+                            (uu___2.FStar_Tactics_Types.all_implicits);
                           FStar_Tactics_Types.goals = lgs;
                           FStar_Tactics_Types.smt_goals = [];
                           FStar_Tactics_Types.depth =
-                            (uu___436_2281.FStar_Tactics_Types.depth);
+                            (uu___2.FStar_Tactics_Types.depth);
                           FStar_Tactics_Types.__dump =
-                            (uu___436_2281.FStar_Tactics_Types.__dump);
+                            (uu___2.FStar_Tactics_Types.__dump);
                           FStar_Tactics_Types.psc =
-                            (uu___436_2281.FStar_Tactics_Types.psc);
+                            (uu___2.FStar_Tactics_Types.psc);
                           FStar_Tactics_Types.entry_range =
-                            (uu___436_2281.FStar_Tactics_Types.entry_range);
+                            (uu___2.FStar_Tactics_Types.entry_range);
                           FStar_Tactics_Types.guard_policy =
-                            (uu___436_2281.FStar_Tactics_Types.guard_policy);
+                            (uu___2.FStar_Tactics_Types.guard_policy);
                           FStar_Tactics_Types.freshness =
-                            (uu___436_2281.FStar_Tactics_Types.freshness);
+                            (uu___2.FStar_Tactics_Types.freshness);
                           FStar_Tactics_Types.tac_verb_dbg =
-                            (uu___436_2281.FStar_Tactics_Types.tac_verb_dbg);
+                            (uu___2.FStar_Tactics_Types.tac_verb_dbg);
                           FStar_Tactics_Types.local_state =
-                            (uu___436_2281.FStar_Tactics_Types.local_state)
+                            (uu___2.FStar_Tactics_Types.local_state)
                         } in
-                      let uu____2282 = FStar_Tactics_Monad.set lp in
-                      FStar_Tactics_Monad.bind uu____2282
-                        (fun uu____2290 ->
+                      let uu___2 = FStar_Tactics_Monad.set lp in
+                      FStar_Tactics_Monad.bind uu___2
+                        (fun uu___3 ->
                            FStar_Tactics_Monad.bind l
                              (fun a1 ->
                                 FStar_Tactics_Monad.bind
                                   FStar_Tactics_Monad.get
                                   (fun lp' ->
                                      let rp =
-                                       let uu___442_2306 = lp' in
+                                       let uu___4 = lp' in
                                        {
                                          FStar_Tactics_Types.main_context =
-                                           (uu___442_2306.FStar_Tactics_Types.main_context);
+                                           (uu___4.FStar_Tactics_Types.main_context);
                                          FStar_Tactics_Types.all_implicits =
-                                           (uu___442_2306.FStar_Tactics_Types.all_implicits);
+                                           (uu___4.FStar_Tactics_Types.all_implicits);
                                          FStar_Tactics_Types.goals = rgs;
                                          FStar_Tactics_Types.smt_goals = [];
                                          FStar_Tactics_Types.depth =
-                                           (uu___442_2306.FStar_Tactics_Types.depth);
+                                           (uu___4.FStar_Tactics_Types.depth);
                                          FStar_Tactics_Types.__dump =
-                                           (uu___442_2306.FStar_Tactics_Types.__dump);
+                                           (uu___4.FStar_Tactics_Types.__dump);
                                          FStar_Tactics_Types.psc =
-                                           (uu___442_2306.FStar_Tactics_Types.psc);
+                                           (uu___4.FStar_Tactics_Types.psc);
                                          FStar_Tactics_Types.entry_range =
-                                           (uu___442_2306.FStar_Tactics_Types.entry_range);
+                                           (uu___4.FStar_Tactics_Types.entry_range);
                                          FStar_Tactics_Types.guard_policy =
-                                           (uu___442_2306.FStar_Tactics_Types.guard_policy);
+                                           (uu___4.FStar_Tactics_Types.guard_policy);
                                          FStar_Tactics_Types.freshness =
-                                           (uu___442_2306.FStar_Tactics_Types.freshness);
+                                           (uu___4.FStar_Tactics_Types.freshness);
                                          FStar_Tactics_Types.tac_verb_dbg =
-                                           (uu___442_2306.FStar_Tactics_Types.tac_verb_dbg);
+                                           (uu___4.FStar_Tactics_Types.tac_verb_dbg);
                                          FStar_Tactics_Types.local_state =
-                                           (uu___442_2306.FStar_Tactics_Types.local_state)
+                                           (uu___4.FStar_Tactics_Types.local_state)
                                        } in
-                                     let uu____2307 =
-                                       FStar_Tactics_Monad.set rp in
-                                     FStar_Tactics_Monad.bind uu____2307
-                                       (fun uu____2315 ->
+                                     let uu___4 = FStar_Tactics_Monad.set rp in
+                                     FStar_Tactics_Monad.bind uu___4
+                                       (fun uu___5 ->
                                           FStar_Tactics_Monad.bind r
                                             (fun b1 ->
                                                FStar_Tactics_Monad.bind
                                                  FStar_Tactics_Monad.get
                                                  (fun rp' ->
                                                     let p' =
-                                                      let uu___448_2331 = rp' in
+                                                      let uu___6 = rp' in
                                                       {
                                                         FStar_Tactics_Types.main_context
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.main_context);
+                                                          (uu___6.FStar_Tactics_Types.main_context);
                                                         FStar_Tactics_Types.all_implicits
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.all_implicits);
+                                                          (uu___6.FStar_Tactics_Types.all_implicits);
                                                         FStar_Tactics_Types.goals
                                                           =
                                                           (FStar_List.append
@@ -1533,46 +1507,46 @@ let divide :
                                                                 p.FStar_Tactics_Types.smt_goals));
                                                         FStar_Tactics_Types.depth
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.depth);
+                                                          (uu___6.FStar_Tactics_Types.depth);
                                                         FStar_Tactics_Types.__dump
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.__dump);
+                                                          (uu___6.FStar_Tactics_Types.__dump);
                                                         FStar_Tactics_Types.psc
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.psc);
+                                                          (uu___6.FStar_Tactics_Types.psc);
                                                         FStar_Tactics_Types.entry_range
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.entry_range);
+                                                          (uu___6.FStar_Tactics_Types.entry_range);
                                                         FStar_Tactics_Types.guard_policy
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.guard_policy);
+                                                          (uu___6.FStar_Tactics_Types.guard_policy);
                                                         FStar_Tactics_Types.freshness
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.freshness);
+                                                          (uu___6.FStar_Tactics_Types.freshness);
                                                         FStar_Tactics_Types.tac_verb_dbg
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.tac_verb_dbg);
+                                                          (uu___6.FStar_Tactics_Types.tac_verb_dbg);
                                                         FStar_Tactics_Types.local_state
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.local_state)
+                                                          (uu___6.FStar_Tactics_Types.local_state)
                                                       } in
-                                                    let uu____2332 =
+                                                    let uu___6 =
                                                       FStar_Tactics_Monad.set
                                                         p' in
                                                     FStar_Tactics_Monad.bind
-                                                      uu____2332
-                                                      (fun uu____2340 ->
+                                                      uu___6
+                                                      (fun uu___7 ->
                                                          FStar_Tactics_Monad.bind
                                                            FStar_Tactics_Monad.remove_solved_goals
-                                                           (fun uu____2346 ->
+                                                           (fun uu___8 ->
                                                               FStar_Tactics_Monad.ret
                                                                 (a1, b1)))))))))))
 let focus : 'a . 'a FStar_Tactics_Monad.tac -> 'a FStar_Tactics_Monad.tac =
   fun f ->
-    let uu____2367 = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
-    FStar_Tactics_Monad.bind uu____2367
-      (fun uu____2380 ->
-         match uu____2380 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
+    let uu___ = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
+    FStar_Tactics_Monad.bind uu___
+      (fun uu___1 ->
+         match uu___1 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
 let rec map :
   'a . 'a FStar_Tactics_Monad.tac -> 'a Prims.list FStar_Tactics_Monad.tac =
   fun tau ->
@@ -1580,13 +1554,12 @@ let rec map :
       (fun p ->
          match p.FStar_Tactics_Types.goals with
          | [] -> FStar_Tactics_Monad.ret []
-         | uu____2417::uu____2418 ->
-             let uu____2421 =
-               let uu____2430 = map tau in
-               divide FStar_BigInt.one tau uu____2430 in
-             FStar_Tactics_Monad.bind uu____2421
-               (fun uu____2448 ->
-                  match uu____2448 with
+         | uu___::uu___1 ->
+             let uu___2 =
+               let uu___3 = map tau in divide FStar_BigInt.one tau uu___3 in
+             FStar_Tactics_Monad.bind uu___2
+               (fun uu___3 ->
+                  match uu___3 with
                   | (h, t) -> FStar_Tactics_Monad.ret (h :: t)))
 let (seq :
   unit FStar_Tactics_Monad.tac ->
@@ -1594,168 +1567,164 @@ let (seq :
   =
   fun t1 ->
     fun t2 ->
-      let uu____2489 =
+      let uu___ =
         FStar_Tactics_Monad.bind t1
-          (fun uu____2494 ->
-             let uu____2495 = map t2 in
-             FStar_Tactics_Monad.bind uu____2495
-               (fun uu____2503 -> FStar_Tactics_Monad.ret ())) in
-      focus uu____2489
+          (fun uu___1 ->
+             let uu___2 = map t2 in
+             FStar_Tactics_Monad.bind uu___2
+               (fun uu___3 -> FStar_Tactics_Monad.ret ())) in
+      focus uu___
 let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
-  fun uu____2512 ->
-    let uu____2515 =
+  fun uu___ ->
+    let uu___1 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____2524 =
-             let uu____2531 =
-               let uu____2532 = FStar_Tactics_Types.goal_env goal in
-               let uu____2533 = FStar_Tactics_Types.goal_type goal in
-               whnf uu____2532 uu____2533 in
-             FStar_Syntax_Util.arrow_one uu____2531 in
-           match uu____2524 with
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Tactics_Types.goal_env goal in
+               let uu___5 = FStar_Tactics_Types.goal_type goal in
+               whnf uu___4 uu___5 in
+             FStar_Syntax_Util.arrow_one uu___3 in
+           match uu___2 with
            | FStar_Pervasives_Native.Some (b, c) ->
-               let uu____2542 =
-                 let uu____2543 = FStar_Syntax_Util.is_total_comp c in
-                 Prims.op_Negation uu____2543 in
-               if uu____2542
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Util.is_total_comp c in
+                 Prims.op_Negation uu___4 in
+               if uu___3
                then FStar_Tactics_Monad.fail "Codomain is effectful"
                else
                  (let env' =
-                    let uu____2548 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.push_binders uu____2548 [b] in
+                    let uu___5 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.push_binders uu___5 [b] in
                   let typ' = FStar_Syntax_Util.comp_result c in
-                  let uu____2564 =
-                    FStar_Tactics_Monad.new_uvar "intro" env' typ' in
-                  FStar_Tactics_Monad.bind uu____2564
-                    (fun uu____2580 ->
-                       match uu____2580 with
+                  let uu___5 = FStar_Tactics_Monad.new_uvar "intro" env' typ' in
+                  FStar_Tactics_Monad.bind uu___5
+                    (fun uu___6 ->
+                       match uu___6 with
                        | (body, ctx_uvar) ->
                            let sol =
                              FStar_Syntax_Util.abs [b] body
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)) in
-                           let uu____2604 = set_solution goal sol in
-                           FStar_Tactics_Monad.bind uu____2604
-                             (fun uu____2610 ->
+                           let uu___7 = set_solution goal sol in
+                           FStar_Tactics_Monad.bind uu___7
+                             (fun uu___8 ->
                                 let g =
                                   FStar_Tactics_Types.mk_goal env' ctx_uvar
                                     goal.FStar_Tactics_Types.opts
                                     goal.FStar_Tactics_Types.is_guard
                                     goal.FStar_Tactics_Types.label in
-                                let uu____2612 =
-                                  let uu____2615 = bnorm_goal g in
-                                  FStar_Tactics_Monad.replace_cur uu____2615 in
-                                FStar_Tactics_Monad.bind uu____2612
-                                  (fun uu____2617 ->
-                                     FStar_Tactics_Monad.ret b))))
+                                let uu___9 =
+                                  let uu___10 = bnorm_goal g in
+                                  FStar_Tactics_Monad.replace_cur uu___10 in
+                                FStar_Tactics_Monad.bind uu___9
+                                  (fun uu___10 -> FStar_Tactics_Monad.ret b))))
            | FStar_Pervasives_Native.None ->
-               let uu____2622 =
-                 let uu____2623 = FStar_Tactics_Types.goal_env goal in
-                 let uu____2624 = FStar_Tactics_Types.goal_type goal in
-                 tts uu____2623 uu____2624 in
-               fail1 "goal is not an arrow (%s)" uu____2622) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu____2515
+               let uu___3 =
+                 let uu___4 = FStar_Tactics_Types.goal_env goal in
+                 let uu___5 = FStar_Tactics_Types.goal_type goal in
+                 tts uu___4 uu___5 in
+               fail1 "goal is not an arrow (%s)" uu___3) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu___1
 let (intro_rec :
   unit ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.binder)
       FStar_Tactics_Monad.tac)
   =
-  fun uu____2639 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Util.print_string
            "WARNING (intro_rec): calling this is known to cause normalizer loops\n";
          FStar_Util.print_string
            "WARNING (intro_rec): proceed at your own risk...\n";
-         (let uu____2660 =
-            let uu____2667 =
-              let uu____2668 = FStar_Tactics_Types.goal_env goal in
-              let uu____2669 = FStar_Tactics_Types.goal_type goal in
-              whnf uu____2668 uu____2669 in
-            FStar_Syntax_Util.arrow_one uu____2667 in
-          match uu____2660 with
+         (let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_Tactics_Types.goal_env goal in
+              let uu___6 = FStar_Tactics_Types.goal_type goal in
+              whnf uu___5 uu___6 in
+            FStar_Syntax_Util.arrow_one uu___4 in
+          match uu___3 with
           | FStar_Pervasives_Native.Some (b, c) ->
-              let uu____2682 =
-                let uu____2683 = FStar_Syntax_Util.is_total_comp c in
-                Prims.op_Negation uu____2683 in
-              if uu____2682
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Util.is_total_comp c in
+                Prims.op_Negation uu___5 in
+              if uu___4
               then FStar_Tactics_Monad.fail "Codomain is effectful"
               else
                 (let bv =
-                   let uu____2696 = FStar_Tactics_Types.goal_type goal in
+                   let uu___6 = FStar_Tactics_Types.goal_type goal in
                    FStar_Syntax_Syntax.gen_bv "__recf"
-                     FStar_Pervasives_Native.None uu____2696 in
+                     FStar_Pervasives_Native.None uu___6 in
                  let bs =
-                   let uu____2706 = FStar_Syntax_Syntax.mk_binder bv in
-                   [uu____2706; b] in
+                   let uu___6 = FStar_Syntax_Syntax.mk_binder bv in
+                   [uu___6; b] in
                  let env' =
-                   let uu____2732 = FStar_Tactics_Types.goal_env goal in
-                   FStar_TypeChecker_Env.push_binders uu____2732 bs in
-                 let uu____2733 =
+                   let uu___6 = FStar_Tactics_Types.goal_env goal in
+                   FStar_TypeChecker_Env.push_binders uu___6 bs in
+                 let uu___6 =
                    FStar_Tactics_Monad.new_uvar "intro_rec" env'
                      (FStar_Syntax_Util.comp_result c) in
-                 FStar_Tactics_Monad.bind uu____2733
-                   (fun uu____2758 ->
-                      match uu____2758 with
+                 FStar_Tactics_Monad.bind uu___6
+                   (fun uu___7 ->
+                      match uu___7 with
                       | (u, ctx_uvar_u) ->
                           let lb =
-                            let uu____2772 =
-                              FStar_Tactics_Types.goal_type goal in
-                            let uu____2775 =
+                            let uu___8 = FStar_Tactics_Types.goal_type goal in
+                            let uu___9 =
                               FStar_Syntax_Util.abs [b] u
                                 FStar_Pervasives_Native.None in
                             FStar_Syntax_Util.mk_letbinding
-                              (FStar_Util.Inl bv) [] uu____2772
-                              FStar_Parser_Const.effect_Tot_lid uu____2775 []
+                              (FStar_Util.Inl bv) [] uu___8
+                              FStar_Parser_Const.effect_Tot_lid uu___9 []
                               FStar_Range.dummyRange in
                           let body = FStar_Syntax_Syntax.bv_to_name bv in
-                          let uu____2793 =
+                          let uu___8 =
                             FStar_Syntax_Subst.close_let_rec [lb] body in
-                          (match uu____2793 with
+                          (match uu___8 with
                            | (lbs, body1) ->
                                let tm =
-                                 let uu____2815 =
-                                   let uu____2816 =
+                                 let uu___9 =
+                                   let uu___10 =
                                      FStar_Tactics_Types.goal_witness goal in
-                                   uu____2816.FStar_Syntax_Syntax.pos in
+                                   uu___10.FStar_Syntax_Syntax.pos in
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
-                                      ((true, lbs), body1)) uu____2815 in
-                               let uu____2829 = set_solution goal tm in
-                               FStar_Tactics_Monad.bind uu____2829
-                                 (fun uu____2838 ->
-                                    let uu____2839 =
-                                      let uu____2842 =
+                                      ((true, lbs), body1)) uu___9 in
+                               let uu___9 = set_solution goal tm in
+                               FStar_Tactics_Monad.bind uu___9
+                                 (fun uu___10 ->
+                                    let uu___11 =
+                                      let uu___12 =
                                         bnorm_goal
-                                          (let uu___519_2845 = goal in
+                                          (let uu___13 = goal in
                                            {
                                              FStar_Tactics_Types.goal_main_env
                                                =
-                                               (uu___519_2845.FStar_Tactics_Types.goal_main_env);
+                                               (uu___13.FStar_Tactics_Types.goal_main_env);
                                              FStar_Tactics_Types.goal_ctx_uvar
                                                = ctx_uvar_u;
                                              FStar_Tactics_Types.opts =
-                                               (uu___519_2845.FStar_Tactics_Types.opts);
+                                               (uu___13.FStar_Tactics_Types.opts);
                                              FStar_Tactics_Types.is_guard =
-                                               (uu___519_2845.FStar_Tactics_Types.is_guard);
+                                               (uu___13.FStar_Tactics_Types.is_guard);
                                              FStar_Tactics_Types.label =
-                                               (uu___519_2845.FStar_Tactics_Types.label)
+                                               (uu___13.FStar_Tactics_Types.label)
                                            }) in
-                                      FStar_Tactics_Monad.replace_cur
-                                        uu____2842 in
-                                    FStar_Tactics_Monad.bind uu____2839
-                                      (fun uu____2852 ->
-                                         let uu____2853 =
-                                           let uu____2858 =
+                                      FStar_Tactics_Monad.replace_cur uu___12 in
+                                    FStar_Tactics_Monad.bind uu___11
+                                      (fun uu___12 ->
+                                         let uu___13 =
+                                           let uu___14 =
                                              FStar_Syntax_Syntax.mk_binder bv in
-                                           (uu____2858, b) in
-                                         FStar_Tactics_Monad.ret uu____2853)))))
+                                           (uu___14, b) in
+                                         FStar_Tactics_Monad.ret uu___13)))))
           | FStar_Pervasives_Native.None ->
-              let uu____2867 =
-                let uu____2868 = FStar_Tactics_Types.goal_env goal in
-                let uu____2869 = FStar_Tactics_Types.goal_type goal in
-                tts uu____2868 uu____2869 in
-              fail1 "intro_rec: goal is not an arrow (%s)" uu____2867))
+              let uu___4 =
+                let uu___5 = FStar_Tactics_Types.goal_env goal in
+                let uu___6 = FStar_Tactics_Types.goal_type goal in
+                tts uu___5 uu___6 in
+              fail1 "intro_rec: goal is not an arrow (%s)" uu___4))
 let (norm :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     unit FStar_Tactics_Monad.tac)
@@ -1764,23 +1733,23 @@ let (norm :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____2891 ->
-              let uu____2892 =
-                let uu____2893 = FStar_Tactics_Types.goal_witness goal in
-                FStar_Syntax_Print.term_to_string uu____2893 in
-              FStar_Util.print1 "norm: witness = %s\n" uu____2892)
-           (fun uu____2898 ->
+           (fun uu___ ->
+              let uu___1 =
+                let uu___2 = FStar_Tactics_Types.goal_witness goal in
+                FStar_Syntax_Print.term_to_string uu___2 in
+              FStar_Util.print1 "norm: witness = %s\n" uu___1)
+           (fun uu___ ->
               let steps =
-                let uu____2902 = FStar_TypeChecker_Normalize.tr_norm_steps s in
+                let uu___1 = FStar_TypeChecker_Normalize.tr_norm_steps s in
                 FStar_List.append
                   [FStar_TypeChecker_Env.Reify;
-                  FStar_TypeChecker_Env.UnfoldTac] uu____2902 in
+                  FStar_TypeChecker_Env.UnfoldTac] uu___1 in
               let t =
-                let uu____2906 = FStar_Tactics_Types.goal_env goal in
-                let uu____2907 = FStar_Tactics_Types.goal_type goal in
-                normalize steps uu____2906 uu____2907 in
-              let uu____2908 = FStar_Tactics_Types.goal_with_type goal t in
-              FStar_Tactics_Monad.replace_cur uu____2908))
+                let uu___1 = FStar_Tactics_Types.goal_env goal in
+                let uu___2 = FStar_Tactics_Types.goal_type goal in
+                normalize steps uu___1 uu___2 in
+              let uu___1 = FStar_Tactics_Types.goal_with_type goal t in
+              FStar_Tactics_Monad.replace_cur uu___1))
 let (norm_term_env :
   env ->
     FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -1790,92 +1759,90 @@ let (norm_term_env :
   fun e ->
     fun s ->
       fun t ->
-        let uu____2932 =
+        let uu___ =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let opts =
                  match ps.FStar_Tactics_Types.goals with
-                 | g::uu____2940 -> g.FStar_Tactics_Types.opts
-                 | uu____2943 -> FStar_Options.peek () in
+                 | g::uu___1 -> g.FStar_Tactics_Types.opts
+                 | uu___1 -> FStar_Options.peek () in
                FStar_Tactics_Monad.mlog
-                 (fun uu____2948 ->
-                    let uu____2949 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1 "norm_term_env: t = %s\n" uu____2949)
-                 (fun uu____2952 ->
-                    let uu____2953 = __tc_lax e t in
-                    FStar_Tactics_Monad.bind uu____2953
-                      (fun uu____2974 ->
-                         match uu____2974 with
-                         | (t1, uu____2984, uu____2985) ->
+                 (fun uu___1 ->
+                    let uu___2 = FStar_Syntax_Print.term_to_string t in
+                    FStar_Util.print1 "norm_term_env: t = %s\n" uu___2)
+                 (fun uu___1 ->
+                    let uu___2 = __tc_lax e t in
+                    FStar_Tactics_Monad.bind uu___2
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | (t1, uu___4, uu___5) ->
                              let steps =
-                               let uu____2989 =
+                               let uu___6 =
                                  FStar_TypeChecker_Normalize.tr_norm_steps s in
                                FStar_List.append
                                  [FStar_TypeChecker_Env.Reify;
-                                 FStar_TypeChecker_Env.UnfoldTac] uu____2989 in
+                                 FStar_TypeChecker_Env.UnfoldTac] uu___6 in
                              let t2 =
                                normalize steps
                                  ps.FStar_Tactics_Types.main_context t1 in
                              FStar_Tactics_Monad.mlog
-                               (fun uu____2995 ->
-                                  let uu____2996 =
+                               (fun uu___6 ->
+                                  let uu___7 =
                                     FStar_Syntax_Print.term_to_string t2 in
                                   FStar_Util.print1
-                                    "norm_term_env: t' = %s\n" uu____2996)
-                               (fun uu____2998 -> FStar_Tactics_Monad.ret t2)))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_term")
-          uu____2932
+                                    "norm_term_env: t' = %s\n" uu___7)
+                               (fun uu___6 -> FStar_Tactics_Monad.ret t2)))) in
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_term") uu___
 let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____3009 ->
-    let uu____3012 =
+  fun uu___ ->
+    let uu___1 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____3019 =
-             let uu____3030 = FStar_Tactics_Types.goal_env g in
-             let uu____3031 = FStar_Tactics_Types.goal_type g in
-             FStar_TypeChecker_Rel.base_and_refinement uu____3030 uu____3031 in
-           match uu____3019 with
-           | (uu____3034, FStar_Pervasives_Native.None) ->
+           let uu___2 =
+             let uu___3 = FStar_Tactics_Types.goal_env g in
+             let uu___4 = FStar_Tactics_Types.goal_type g in
+             FStar_TypeChecker_Rel.base_and_refinement uu___3 uu___4 in
+           match uu___2 with
+           | (uu___3, FStar_Pervasives_Native.None) ->
                FStar_Tactics_Monad.fail "not a refinement"
            | (t, FStar_Pervasives_Native.Some (bv, phi)) ->
                let g1 = FStar_Tactics_Types.goal_with_type g t in
-               let uu____3059 =
-                 let uu____3064 =
-                   let uu____3069 =
-                     let uu____3070 = FStar_Syntax_Syntax.mk_binder bv in
-                     [uu____3070] in
-                   FStar_Syntax_Subst.open_term uu____3069 phi in
-                 match uu____3064 with
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Syntax.mk_binder bv in
+                     [uu___6] in
+                   FStar_Syntax_Subst.open_term uu___5 phi in
+                 match uu___4 with
                  | (bvs, phi1) ->
-                     let uu____3095 =
-                       let uu____3096 = FStar_List.hd bvs in
-                       FStar_Pervasives_Native.fst uu____3096 in
-                     (uu____3095, phi1) in
-               (match uu____3059 with
+                     let uu___5 =
+                       let uu___6 = FStar_List.hd bvs in
+                       FStar_Pervasives_Native.fst uu___6 in
+                     (uu___5, phi1) in
+               (match uu___3 with
                 | (bv1, phi1) ->
-                    let uu____3115 =
-                      let uu____3118 = FStar_Tactics_Types.goal_env g in
-                      let uu____3119 =
-                        let uu____3120 =
-                          let uu____3123 =
-                            let uu____3124 =
-                              let uu____3131 =
+                    let uu___4 =
+                      let uu___5 = FStar_Tactics_Types.goal_env g in
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 =
+                              let uu___10 =
                                 FStar_Tactics_Types.goal_witness g in
-                              (bv1, uu____3131) in
-                            FStar_Syntax_Syntax.NT uu____3124 in
-                          [uu____3123] in
-                        FStar_Syntax_Subst.subst uu____3120 phi1 in
+                              (bv1, uu___10) in
+                            FStar_Syntax_Syntax.NT uu___9 in
+                          [uu___8] in
+                        FStar_Syntax_Subst.subst uu___7 phi1 in
                       FStar_Tactics_Monad.mk_irrelevant_goal
-                        "refine_intro refinement" uu____3118 uu____3119
+                        "refine_intro refinement" uu___5 uu___6
                         g.FStar_Tactics_Types.opts
                         g.FStar_Tactics_Types.label in
-                    FStar_Tactics_Monad.bind uu____3115
+                    FStar_Tactics_Monad.bind uu___4
                       (fun g2 ->
                          FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                           (fun uu____3139 ->
+                           (fun uu___5 ->
                               FStar_Tactics_Monad.add_goals [g1; g2])))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "refine_intro")
-      uu____3012
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "refine_intro") uu___1
 let (__exact_now :
   Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun set_expected_typ ->
@@ -1885,86 +1852,82 @@ let (__exact_now :
            let env1 =
              if set_expected_typ
              then
-               let uu____3163 = FStar_Tactics_Types.goal_env goal in
-               let uu____3164 = FStar_Tactics_Types.goal_type goal in
-               FStar_TypeChecker_Env.set_expected_typ uu____3163 uu____3164
+               let uu___ = FStar_Tactics_Types.goal_env goal in
+               let uu___1 = FStar_Tactics_Types.goal_type goal in
+               FStar_TypeChecker_Env.set_expected_typ uu___ uu___1
              else FStar_Tactics_Types.goal_env goal in
-           let uu____3166 = __tc env1 t in
-           FStar_Tactics_Monad.bind uu____3166
-             (fun uu____3185 ->
-                match uu____3185 with
+           let uu___ = __tc env1 t in
+           FStar_Tactics_Monad.bind uu___
+             (fun uu___1 ->
+                match uu___1 with
                 | (t1, typ, guard) ->
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3200 ->
-                         let uu____3201 =
-                           FStar_Syntax_Print.term_to_string typ in
-                         let uu____3202 =
-                           let uu____3203 = FStar_Tactics_Types.goal_env goal in
-                           FStar_TypeChecker_Rel.guard_to_string uu____3203
-                             guard in
+                      (fun uu___2 ->
+                         let uu___3 = FStar_Syntax_Print.term_to_string typ in
+                         let uu___4 =
+                           let uu___5 = FStar_Tactics_Types.goal_env goal in
+                           FStar_TypeChecker_Rel.guard_to_string uu___5 guard in
                          FStar_Util.print2
                            "__exact_now: got type %s\n__exact_now: and guard %s\n"
-                           uu____3201 uu____3202)
-                      (fun uu____3206 ->
-                         let uu____3207 =
-                           let uu____3210 = FStar_Tactics_Types.goal_env goal in
-                           proc_guard "__exact typing" uu____3210 guard in
-                         FStar_Tactics_Monad.bind uu____3207
-                           (fun uu____3212 ->
+                           uu___3 uu___4)
+                      (fun uu___2 ->
+                         let uu___3 =
+                           let uu___4 = FStar_Tactics_Types.goal_env goal in
+                           proc_guard "__exact typing" uu___4 guard in
+                         FStar_Tactics_Monad.bind uu___3
+                           (fun uu___4 ->
                               FStar_Tactics_Monad.mlog
-                                (fun uu____3216 ->
-                                   let uu____3217 =
+                                (fun uu___5 ->
+                                   let uu___6 =
                                      FStar_Syntax_Print.term_to_string typ in
-                                   let uu____3218 =
-                                     let uu____3219 =
+                                   let uu___7 =
+                                     let uu___8 =
                                        FStar_Tactics_Types.goal_type goal in
-                                     FStar_Syntax_Print.term_to_string
-                                       uu____3219 in
+                                     FStar_Syntax_Print.term_to_string uu___8 in
                                    FStar_Util.print2
                                      "__exact_now: unifying %s and %s\n"
-                                     uu____3217 uu____3218)
-                                (fun uu____3222 ->
-                                   let uu____3223 =
-                                     let uu____3226 =
+                                     uu___6 uu___7)
+                                (fun uu___5 ->
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_Tactics_Types.goal_env goal in
-                                     let uu____3227 =
+                                     let uu___8 =
                                        FStar_Tactics_Types.goal_type goal in
-                                     do_unify uu____3226 typ uu____3227 in
-                                   FStar_Tactics_Monad.bind uu____3223
+                                     do_unify uu___7 typ uu___8 in
+                                   FStar_Tactics_Monad.bind uu___6
                                      (fun b ->
                                         if b
                                         then solve goal t1
                                         else
-                                          (let uu____3233 =
-                                             let uu____3238 =
-                                               let uu____3243 =
+                                          (let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
                                                  FStar_Tactics_Types.goal_env
                                                    goal in
-                                               tts uu____3243 in
-                                             let uu____3244 =
+                                               tts uu___10 in
+                                             let uu___10 =
                                                FStar_Tactics_Types.goal_type
                                                  goal in
                                              FStar_TypeChecker_Err.print_discrepancy
-                                               uu____3238 typ uu____3244 in
-                                           match uu____3233 with
+                                               uu___9 typ uu___10 in
+                                           match uu___8 with
                                            | (typ1, goalt) ->
-                                               let uu____3249 =
-                                                 let uu____3250 =
+                                               let uu___9 =
+                                                 let uu___10 =
                                                    FStar_Tactics_Types.goal_env
                                                      goal in
-                                                 tts uu____3250 t1 in
-                                               let uu____3251 =
-                                                 let uu____3252 =
+                                                 tts uu___10 t1 in
+                                               let uu___10 =
+                                                 let uu___11 =
                                                    FStar_Tactics_Types.goal_env
                                                      goal in
-                                                 let uu____3253 =
+                                                 let uu___12 =
                                                    FStar_Tactics_Types.goal_witness
                                                      goal in
-                                                 tts uu____3252 uu____3253 in
+                                                 tts uu___11 uu___12 in
                                                fail4
                                                  "%s : %s does not exactly solve the goal %s (witness = %s)"
-                                                 uu____3249 typ1 goalt
-                                                 uu____3251)))))))
+                                                 uu___9 typ1 goalt uu___10)))))))
 let (t_exact :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -1972,56 +1935,55 @@ let (t_exact :
   fun try_refine ->
     fun set_expected_typ ->
       fun tm ->
-        let uu____3273 =
+        let uu___ =
           FStar_Tactics_Monad.mlog
-            (fun uu____3278 ->
-               let uu____3279 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_exact: tm = %s\n" uu____3279)
-            (fun uu____3282 ->
-               let uu____3283 =
-                 let uu____3290 = __exact_now set_expected_typ tm in
-                 catch uu____3290 in
-               FStar_Tactics_Monad.bind uu____3283
-                 (fun uu___2_3299 ->
-                    match uu___2_3299 with
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_exact: tm = %s\n" uu___2)
+            (fun uu___1 ->
+               let uu___2 =
+                 let uu___3 = __exact_now set_expected_typ tm in catch uu___3 in
+               FStar_Tactics_Monad.bind uu___2
+                 (fun uu___3 ->
+                    match uu___3 with
                     | FStar_Util.Inr r -> FStar_Tactics_Monad.ret ()
                     | FStar_Util.Inl e when Prims.op_Negation try_refine ->
                         FStar_Tactics_Monad.traise e
                     | FStar_Util.Inl e ->
                         FStar_Tactics_Monad.mlog
-                          (fun uu____3310 ->
+                          (fun uu___4 ->
                              FStar_Util.print_string
                                "__exact_now failed, trying refine...\n")
-                          (fun uu____3313 ->
-                             let uu____3314 =
-                               let uu____3321 =
-                                 let uu____3324 =
+                          (fun uu___4 ->
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    norm [FStar_Syntax_Embeddings.Delta] in
-                                 FStar_Tactics_Monad.bind uu____3324
-                                   (fun uu____3329 ->
-                                      let uu____3330 = refine_intro () in
-                                      FStar_Tactics_Monad.bind uu____3330
-                                        (fun uu____3334 ->
+                                 FStar_Tactics_Monad.bind uu___7
+                                   (fun uu___8 ->
+                                      let uu___9 = refine_intro () in
+                                      FStar_Tactics_Monad.bind uu___9
+                                        (fun uu___10 ->
                                            __exact_now set_expected_typ tm)) in
-                               catch uu____3321 in
-                             FStar_Tactics_Monad.bind uu____3314
-                               (fun uu___1_3341 ->
-                                  match uu___1_3341 with
+                               catch uu___6 in
+                             FStar_Tactics_Monad.bind uu___5
+                               (fun uu___6 ->
+                                  match uu___6 with
                                   | FStar_Util.Inr r ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____3350 ->
+                                        (fun uu___7 ->
                                            FStar_Util.print_string
                                              "__exact_now: failed after refining too\n")
-                                        (fun uu____3352 ->
+                                        (fun uu___7 ->
                                            FStar_Tactics_Monad.ret ())
-                                  | FStar_Util.Inl uu____3353 ->
+                                  | FStar_Util.Inl uu___7 ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____3355 ->
+                                        (fun uu___8 ->
                                            FStar_Util.print_string
                                              "__exact_now: was not a refinement\n")
-                                        (fun uu____3357 ->
+                                        (fun uu___8 ->
                                            FStar_Tactics_Monad.traise e))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu____3273
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu___
 let rec (__try_unify_by_application :
   Prims.bool ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual *
@@ -2039,42 +2001,41 @@ let rec (__try_unify_by_application :
         fun ty1 ->
           fun ty2 ->
             let f = if only_match then do_match else do_unify in
-            let uu____3450 = f e ty2 ty1 in
-            FStar_Tactics_Monad.bind uu____3450
-              (fun uu___3_3462 ->
-                 if uu___3_3462
+            let uu___ = f e ty2 ty1 in
+            FStar_Tactics_Monad.bind uu___
+              (fun uu___1 ->
+                 if uu___1
                  then FStar_Tactics_Monad.ret acc
                  else
-                   (let uu____3481 = FStar_Syntax_Util.arrow_one ty1 in
-                    match uu____3481 with
+                   (let uu___2 = FStar_Syntax_Util.arrow_one ty1 in
+                    match uu___2 with
                     | FStar_Pervasives_Native.None ->
-                        let uu____3502 = term_to_string e ty1 in
-                        let uu____3503 = term_to_string e ty2 in
-                        fail2 "Could not instantiate, %s to %s" uu____3502
-                          uu____3503
+                        let uu___3 = term_to_string e ty1 in
+                        let uu___4 = term_to_string e ty2 in
+                        fail2 "Could not instantiate, %s to %s" uu___3 uu___4
                     | FStar_Pervasives_Native.Some (b, c) ->
-                        let uu____3518 =
-                          let uu____3519 = FStar_Syntax_Util.is_total_comp c in
-                          Prims.op_Negation uu____3519 in
-                        if uu____3518
+                        let uu___3 =
+                          let uu___4 = FStar_Syntax_Util.is_total_comp c in
+                          Prims.op_Negation uu___4 in
+                        if uu___3
                         then FStar_Tactics_Monad.fail "Codomain is effectful"
                         else
-                          (let uu____3539 =
+                          (let uu___5 =
                              FStar_Tactics_Monad.new_uvar "apply arg" e
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                           FStar_Tactics_Monad.bind uu____3539
-                             (fun uu____3563 ->
-                                match uu____3563 with
+                           FStar_Tactics_Monad.bind uu___5
+                             (fun uu___6 ->
+                                match uu___6 with
                                 | (uvt, uv) ->
                                     FStar_Tactics_Monad.mlog
-                                      (fun uu____3590 ->
-                                         let uu____3591 =
+                                      (fun uu___7 ->
+                                         let uu___8 =
                                            FStar_Syntax_Print.ctx_uvar_to_string
                                              uv in
                                          FStar_Util.print1
                                            "t_apply: generated uvar %s\n"
-                                           uu____3591)
-                                      (fun uu____3595 ->
+                                           uu___8)
+                                      (fun uu___7 ->
                                          let typ =
                                            FStar_Syntax_Util.comp_result c in
                                          let typ' =
@@ -2106,158 +2067,152 @@ let (t_apply :
   fun uopt ->
     fun only_match ->
       fun tm ->
-        let uu____3677 =
+        let uu___ =
           FStar_Tactics_Monad.mlog
-            (fun uu____3682 ->
-               let uu____3683 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_apply: tm = %s\n" uu____3683)
-            (fun uu____3685 ->
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_apply: tm = %s\n" uu___2)
+            (fun uu___1 ->
                FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                  (fun goal ->
                     let e = FStar_Tactics_Types.goal_env goal in
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3694 ->
-                         let uu____3695 =
-                           FStar_Syntax_Print.term_to_string tm in
-                         let uu____3696 =
+                      (fun uu___2 ->
+                         let uu___3 = FStar_Syntax_Print.term_to_string tm in
+                         let uu___4 =
                            FStar_Tactics_Printing.goal_to_string_verbose goal in
-                         let uu____3697 =
+                         let uu___5 =
                            FStar_TypeChecker_Env.print_gamma
                              e.FStar_TypeChecker_Env.gamma in
                          FStar_Util.print3
                            "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
-                           uu____3695 uu____3696 uu____3697)
-                      (fun uu____3700 ->
-                         let uu____3701 = __tc e tm in
-                         FStar_Tactics_Monad.bind uu____3701
-                           (fun uu____3722 ->
-                              match uu____3722 with
+                           uu___3 uu___4 uu___5)
+                      (fun uu___2 ->
+                         let uu___3 = __tc e tm in
+                         FStar_Tactics_Monad.bind uu___3
+                           (fun uu___4 ->
+                              match uu___4 with
                               | (tm1, typ, guard) ->
                                   let typ1 = bnorm e typ in
-                                  let uu____3735 =
-                                    let uu____3746 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       FStar_Tactics_Types.goal_type goal in
                                     try_unify_by_application only_match e
-                                      typ1 uu____3746 in
-                                  FStar_Tactics_Monad.bind uu____3735
+                                      typ1 uu___6 in
+                                  FStar_Tactics_Monad.bind uu___5
                                     (fun uvs ->
                                        FStar_Tactics_Monad.mlog
-                                         (fun uu____3767 ->
-                                            let uu____3768 =
+                                         (fun uu___6 ->
+                                            let uu___7 =
                                               FStar_Common.string_of_list
-                                                (fun uu____3779 ->
-                                                   match uu____3779 with
-                                                   | (t, uu____3787,
-                                                      uu____3788) ->
+                                                (fun uu___8 ->
+                                                   match uu___8 with
+                                                   | (t, uu___9, uu___10) ->
                                                        FStar_Syntax_Print.term_to_string
                                                          t) uvs in
                                             FStar_Util.print1
                                               "t_apply: found args = %s\n"
-                                              uu____3768)
-                                         (fun uu____3795 ->
+                                              uu___7)
+                                         (fun uu___6 ->
                                             let fix_qual q =
                                               match q with
                                               | FStar_Pervasives_Native.Some
                                                   (FStar_Syntax_Syntax.Meta
-                                                  uu____3810) ->
+                                                  uu___7) ->
                                                   FStar_Pervasives_Native.Some
                                                     (FStar_Syntax_Syntax.Implicit
                                                        false)
-                                              | uu____3811 -> q in
+                                              | uu___7 -> q in
                                             let w =
                                               FStar_List.fold_right
-                                                (fun uu____3834 ->
-                                                   fun w ->
-                                                     match uu____3834 with
-                                                     | (uvt, q, uu____3852)
-                                                         ->
+                                                (fun uu___7 ->
+                                                   fun w1 ->
+                                                     match uu___7 with
+                                                     | (uvt, q, uu___8) ->
                                                          FStar_Syntax_Util.mk_app
-                                                           w
+                                                           w1
                                                            [(uvt,
                                                               (fix_qual q))])
                                                 uvs tm1 in
                                             let uvset =
-                                              let uu____3884 =
+                                              let uu___7 =
                                                 FStar_Syntax_Free.new_uv_set
                                                   () in
                                               FStar_List.fold_right
-                                                (fun uu____3901 ->
+                                                (fun uu___8 ->
                                                    fun s ->
-                                                     match uu____3901 with
-                                                     | (uu____3913,
-                                                        uu____3914, uv) ->
-                                                         let uu____3916 =
+                                                     match uu___8 with
+                                                     | (uu___9, uu___10, uv)
+                                                         ->
+                                                         let uu___11 =
                                                            FStar_Syntax_Free.uvars
                                                              uv.FStar_Syntax_Syntax.ctx_uvar_typ in
                                                          FStar_Util.set_union
-                                                           s uu____3916) uvs
-                                                uu____3884 in
+                                                           s uu___11) uvs
+                                                uu___7 in
                                             let free_in_some_goal uv =
                                               FStar_Util.set_mem uv uvset in
-                                            let uu____3925 = solve' goal w in
-                                            FStar_Tactics_Monad.bind
-                                              uu____3925
-                                              (fun uu____3930 ->
-                                                 let uu____3931 =
+                                            let uu___7 = solve' goal w in
+                                            FStar_Tactics_Monad.bind uu___7
+                                              (fun uu___8 ->
+                                                 let uu___9 =
                                                    FStar_Tactics_Monad.mapM
-                                                     (fun uu____3948 ->
-                                                        match uu____3948 with
+                                                     (fun uu___10 ->
+                                                        match uu___10 with
                                                         | (uvt, q, uv) ->
-                                                            let uu____3960 =
+                                                            let uu___11 =
                                                               FStar_Syntax_Unionfind.find
                                                                 uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                            (match uu____3960
+                                                            (match uu___11
                                                              with
                                                              | FStar_Pervasives_Native.Some
-                                                                 uu____3965
-                                                                 ->
+                                                                 uu___12 ->
                                                                  FStar_Tactics_Monad.ret
                                                                    ()
                                                              | FStar_Pervasives_Native.None
                                                                  ->
-                                                                 let uu____3966
+                                                                 let uu___12
                                                                    =
                                                                    uopt &&
                                                                     (free_in_some_goal
                                                                     uv) in
-                                                                 if
-                                                                   uu____3966
+                                                                 if uu___12
                                                                  then
                                                                    FStar_Tactics_Monad.ret
                                                                     ()
                                                                  else
-                                                                   (let uu____3970
+                                                                   (let uu___14
                                                                     =
-                                                                    let uu____3973
+                                                                    let uu___15
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___682_3976
+                                                                    (let uu___16
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___16.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     = uv;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.opts);
+                                                                    (uu___16.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     = false;
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.label)
+                                                                    (uu___16.FStar_Tactics_Types.label)
                                                                     }) in
-                                                                    [uu____3973] in
+                                                                    [uu___15] in
                                                                     FStar_Tactics_Monad.add_goals
-                                                                    uu____3970)))
+                                                                    uu___14)))
                                                      uvs in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____3931
-                                                   (fun uu____3980 ->
+                                                   uu___9
+                                                   (fun uu___10 ->
                                                       proc_guard
                                                         "apply guard" e guard)))))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu____3677
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu___
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
@@ -2265,37 +2220,37 @@ let (lemma_or_sq :
   =
   fun c ->
     let ct = FStar_Syntax_Util.comp_to_comp_typ_nouniv c in
-    let uu____4005 =
+    let uu___ =
       FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
         FStar_Parser_Const.effect_Lemma_lid in
-    if uu____4005
+    if uu___
     then
-      let uu____4012 =
+      let uu___1 =
         match ct.FStar_Syntax_Syntax.effect_args with
-        | pre::post::uu____4027 ->
+        | pre::post::uu___2 ->
             ((FStar_Pervasives_Native.fst pre),
               (FStar_Pervasives_Native.fst post))
-        | uu____4080 -> failwith "apply_lemma: impossible: not a lemma" in
-      match uu____4012 with
+        | uu___2 -> failwith "apply_lemma: impossible: not a lemma" in
+      match uu___1 with
       | (pre, post) ->
           let post1 =
-            let uu____4112 =
-              let uu____4123 =
+            let uu___2 =
+              let uu___3 =
                 FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit in
-              [uu____4123] in
-            FStar_Syntax_Util.mk_app post uu____4112 in
+              [uu___3] in
+            FStar_Syntax_Util.mk_app post uu___2 in
           FStar_Pervasives_Native.Some (pre, post1)
     else
-      (let uu____4153 =
+      (let uu___2 =
          (FStar_Syntax_Util.is_pure_effect ct.FStar_Syntax_Syntax.effect_name)
            ||
            (FStar_Syntax_Util.is_ghost_effect
               ct.FStar_Syntax_Syntax.effect_name) in
-       if uu____4153
+       if uu___2
        then
-         let uu____4160 =
+         let uu___3 =
            FStar_Syntax_Util.un_squash ct.FStar_Syntax_Syntax.result_typ in
-         FStar_Util.map_opt uu____4160
+         FStar_Util.map_opt uu___3
            (fun post -> (FStar_Syntax_Util.t_true, post))
        else FStar_Pervasives_Native.None)
 let rec fold_left :
@@ -2309,9 +2264,8 @@ let rec fold_left :
         match xs with
         | [] -> FStar_Tactics_Monad.ret e
         | x::xs1 ->
-            let uu____4237 = f x e in
-            FStar_Tactics_Monad.bind uu____4237
-              (fun e' -> fold_left f e' xs1)
+            let uu___ = f x e in
+            FStar_Tactics_Monad.bind uu___ (fun e' -> fold_left f e' xs1)
 let (t_apply_lemma :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -2319,50 +2273,49 @@ let (t_apply_lemma :
   fun noinst ->
     fun noinst_lhs ->
       fun tm ->
-        let uu____4261 =
-          let uu____4264 =
+        let uu___ =
+          let uu___1 =
             FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
               (fun ps ->
                  FStar_Tactics_Monad.mlog
-                   (fun uu____4271 ->
-                      let uu____4272 = FStar_Syntax_Print.term_to_string tm in
-                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu____4272)
-                   (fun uu____4275 ->
+                   (fun uu___2 ->
+                      let uu___3 = FStar_Syntax_Print.term_to_string tm in
+                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu___3)
+                   (fun uu___2 ->
                       let is_unit_t t =
-                        let uu____4282 =
-                          let uu____4283 = FStar_Syntax_Subst.compress t in
-                          uu____4283.FStar_Syntax_Syntax.n in
-                        match uu____4282 with
+                        let uu___3 =
+                          let uu___4 = FStar_Syntax_Subst.compress t in
+                          uu___4.FStar_Syntax_Syntax.n in
+                        match uu___3 with
                         | FStar_Syntax_Syntax.Tm_fvar fv when
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.unit_lid
                             -> true
-                        | uu____4287 -> false in
+                        | uu___4 -> false in
                       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                         (fun goal ->
                            let env1 = FStar_Tactics_Types.goal_env goal in
-                           let uu____4293 = __tc env1 tm in
-                           FStar_Tactics_Monad.bind uu____4293
-                             (fun uu____4316 ->
-                                match uu____4316 with
+                           let uu___3 = __tc env1 tm in
+                           FStar_Tactics_Monad.bind uu___3
+                             (fun uu___4 ->
+                                match uu___4 with
                                 | (tm1, t, guard) ->
-                                    let uu____4328 =
+                                    let uu___5 =
                                       FStar_Syntax_Util.arrow_formals_comp t in
-                                    (match uu____4328 with
+                                    (match uu___5 with
                                      | (bs, comp) ->
-                                         let uu____4337 = lemma_or_sq comp in
-                                         (match uu____4337 with
+                                         let uu___6 = lemma_or_sq comp in
+                                         (match uu___6 with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Tactics_Monad.fail
                                                 "not a lemma or squashed function"
                                           | FStar_Pervasives_Native.Some
                                               (pre, post) ->
-                                              let uu____4356 =
+                                              let uu___7 =
                                                 fold_left
-                                                  (fun uu____4418 ->
-                                                     fun uu____4419 ->
-                                                       match (uu____4418,
-                                                               uu____4419)
+                                                  (fun uu___8 ->
+                                                     fun uu___9 ->
+                                                       match (uu___8, uu___9)
                                                        with
                                                        | ((b, aq),
                                                           (uvs, imps, subst))
@@ -2371,9 +2324,9 @@ let (t_apply_lemma :
                                                              FStar_Syntax_Subst.subst
                                                                subst
                                                                b.FStar_Syntax_Syntax.sort in
-                                                           let uu____4570 =
+                                                           let uu___10 =
                                                              is_unit_t b_t in
-                                                           if uu____4570
+                                                           if uu___10
                                                            then
                                                              FStar_All.pipe_left
                                                                FStar_Tactics_Monad.ret
@@ -2385,17 +2338,15 @@ let (t_apply_lemma :
                                                                     FStar_Syntax_Util.exp_unit))
                                                                  :: subst))
                                                            else
-                                                             (let uu____4690
-                                                                =
+                                                             (let uu___12 =
                                                                 FStar_Tactics_Monad.new_uvar
                                                                   "apply_lemma"
                                                                   env1 b_t in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____4690
-                                                                (fun
-                                                                   uu____4726
+                                                                uu___12
+                                                                (fun uu___13
                                                                    ->
-                                                                   match uu____4726
+                                                                   match uu___13
                                                                    with
                                                                    | 
                                                                    (t1, u) ->
@@ -2411,10 +2362,9 @@ let (t_apply_lemma :
                                                                     ::
                                                                     subst)))))
                                                   ([], [], []) bs in
-                                              FStar_Tactics_Monad.bind
-                                                uu____4356
-                                                (fun uu____4914 ->
-                                                   match uu____4914 with
+                                              FStar_Tactics_Monad.bind uu___7
+                                                (fun uu___8 ->
+                                                   match uu___8 with
                                                    | (uvs, implicits1, subst)
                                                        ->
                                                        let implicits2 =
@@ -2439,77 +2389,71 @@ let (t_apply_lemma :
                                                            then
                                                              do_match_on_lhs
                                                            else do_unify in
-                                                       let uu____5042 =
-                                                         let uu____5045 =
+                                                       let uu___9 =
+                                                         let uu___10 =
                                                            FStar_Tactics_Types.goal_type
                                                              goal in
-                                                         let uu____5046 =
+                                                         let uu___11 =
                                                            FStar_Syntax_Util.mk_squash
                                                              post_u post1 in
                                                          cmp_func env1
-                                                           uu____5045
-                                                           uu____5046 in
+                                                           uu___10 uu___11 in
                                                        FStar_Tactics_Monad.bind
-                                                         uu____5042
+                                                         uu___9
                                                          (fun b ->
                                                             if
                                                               Prims.op_Negation
                                                                 b
                                                             then
-                                                              let uu____5055
-                                                                =
-                                                                let uu____5060
-                                                                  =
+                                                              let uu___10 =
+                                                                let uu___11 =
                                                                   FStar_Syntax_Util.mk_squash
                                                                     post_u
                                                                     post1 in
-                                                                let uu____5061
-                                                                  =
+                                                                let uu___12 =
                                                                   FStar_Tactics_Types.goal_type
                                                                     goal in
                                                                 FStar_TypeChecker_Err.print_discrepancy
                                                                   (tts env1)
-                                                                  uu____5060
-                                                                  uu____5061 in
-                                                              match uu____5055
+                                                                  uu___11
+                                                                  uu___12 in
+                                                              match uu___10
                                                               with
                                                               | (post2,
                                                                  goalt) ->
-                                                                  let uu____5066
+                                                                  let uu___11
                                                                     =
                                                                     tts env1
                                                                     tm1 in
                                                                   fail3
                                                                     "Cannot instantiate lemma %s (with postcondition: %s) to match goal (%s)"
-                                                                    uu____5066
+                                                                    uu___11
                                                                     post2
                                                                     goalt
                                                             else
-                                                              (let uu____5068
-                                                                 =
+                                                              (let uu___11 =
                                                                  solve' goal
                                                                    FStar_Syntax_Util.exp_unit in
                                                                FStar_Tactics_Monad.bind
-                                                                 uu____5068
-                                                                 (fun
-                                                                    uu____5076
+                                                                 uu___11
+                                                                 (fun uu___12
                                                                     ->
                                                                     let is_free_uvar
                                                                     uv t1 =
                                                                     let free_uvars
                                                                     =
-                                                                    let uu____5103
+                                                                    let uu___13
                                                                     =
-                                                                    let uu____5106
+                                                                    let uu___14
                                                                     =
                                                                     FStar_Syntax_Free.uvars
                                                                     t1 in
                                                                     FStar_Util.set_elements
-                                                                    uu____5106 in
+                                                                    uu___14 in
                                                                     FStar_List.map
                                                                     (fun x ->
                                                                     x.FStar_Syntax_Syntax.ctx_uvar_head)
-                                                                    uu____5103 in
+                                                                    uu___13 in
                                                                     FStar_List.existsML
                                                                     (fun u ->
                                                                     FStar_Syntax_Unionfind.equiv
@@ -2521,26 +2465,26 @@ let (t_apply_lemma :
                                                                     FStar_List.existsML
                                                                     (fun g'
                                                                     ->
-                                                                    let uu____5143
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Tactics_Types.goal_type
                                                                     g' in
                                                                     is_free_uvar
                                                                     uv
-                                                                    uu____5143)
+                                                                    uu___13)
                                                                     goals in
                                                                     let checkone
                                                                     t1 goals
                                                                     =
-                                                                    let uu____5159
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     t1 in
-                                                                    match uu____5159
+                                                                    match uu___13
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5177)
+                                                                    uu___14)
                                                                     ->
                                                                     (match 
                                                                     hd.FStar_Syntax_Syntax.n
@@ -2548,98 +2492,98 @@ let (t_apply_lemma :
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (uv,
-                                                                    uu____5203)
+                                                                    uu___15)
                                                                     ->
                                                                     appears
                                                                     uv.FStar_Syntax_Syntax.ctx_uvar_head
                                                                     goals
                                                                     | 
-                                                                    uu____5220
+                                                                    uu___15
                                                                     -> false) in
-                                                                    let uu____5221
+                                                                    let uu___13
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     implicits2
                                                                     (FStar_Tactics_Monad.mapM
                                                                     (fun imp
                                                                     ->
-                                                                    let uu____5262
+                                                                    let uu___14
                                                                     = imp in
-                                                                    match uu____5262
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     (term,
                                                                     ctx_uvar)
                                                                     ->
-                                                                    let uu____5273
+                                                                    let uu___15
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     term in
-                                                                    (match uu____5273
+                                                                    (match uu___15
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5295)
+                                                                    uu___16)
                                                                     ->
-                                                                    let uu____5320
+                                                                    let uu___17
                                                                     =
-                                                                    let uu____5321
+                                                                    let uu___18
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     hd in
-                                                                    uu____5321.FStar_Syntax_Syntax.n in
-                                                                    (match uu____5320
+                                                                    uu___18.FStar_Syntax_Syntax.n in
+                                                                    (match uu___17
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (ctx_uvar1,
-                                                                    uu____5329)
+                                                                    uu___18)
                                                                     ->
                                                                     let goal1
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___808_5349
+                                                                    (let uu___19
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___19.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     =
                                                                     ctx_uvar1;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.opts);
+                                                                    (uu___19.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.is_guard);
+                                                                    (uu___19.FStar_Tactics_Types.is_guard);
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.label)
+                                                                    (uu___19.FStar_Tactics_Types.label)
                                                                     }) in
                                                                     FStar_Tactics_Monad.ret
                                                                     [goal1]
                                                                     | 
-                                                                    uu____5352
+                                                                    uu___18
                                                                     ->
                                                                     FStar_Tactics_Monad.mlog
                                                                     (fun
-                                                                    uu____5358
+                                                                    uu___19
                                                                     ->
-                                                                    let uu____5359
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Print.uvar_to_string
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                                    let uu____5360
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.print2
                                                                     "apply_lemma: arg %s unified to (%s)\n"
-                                                                    uu____5359
-                                                                    uu____5360)
+                                                                    uu___20
+                                                                    uu___21)
                                                                     (fun
-                                                                    uu____5364
+                                                                    uu___19
                                                                     ->
                                                                     let g_typ
                                                                     =
@@ -2647,40 +2591,40 @@ let (t_apply_lemma :
                                                                     true env1
                                                                     term
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                                    let uu____5366
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____5369
+                                                                    let uu___21
                                                                     =
                                                                     if
                                                                     ps.FStar_Tactics_Types.tac_verb_dbg
                                                                     then
-                                                                    let uu____5370
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Syntax_Print.ctx_uvar_to_string
                                                                     ctx_uvar in
-                                                                    let uu____5371
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.format2
                                                                     "apply_lemma solved arg %s to %s\n"
-                                                                    uu____5370
-                                                                    uu____5371
+                                                                    uu___22
+                                                                    uu___23
                                                                     else
                                                                     "apply_lemma solved arg" in
                                                                     proc_guard
-                                                                    uu____5369
+                                                                    uu___21
                                                                     env1
                                                                     g_typ in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5366
+                                                                    uu___20
                                                                     (fun
-                                                                    uu____5376
+                                                                    uu___21
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     [])))))) in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5221
+                                                                    uu___13
                                                                     (fun
                                                                     sub_goals
                                                                     ->
@@ -2696,17 +2640,17 @@ let (t_apply_lemma :
                                                                     [] -> []
                                                                     | 
                                                                     x::xs1 ->
-                                                                    let uu____5438
+                                                                    let uu___14
                                                                     = f x xs1 in
                                                                     if
-                                                                    uu____5438
+                                                                    uu___14
                                                                     then
-                                                                    let uu____5441
+                                                                    let uu___15
                                                                     =
                                                                     filter' f
                                                                     xs1 in x
                                                                     ::
-                                                                    uu____5441
+                                                                    uu___15
                                                                     else
                                                                     filter' f
                                                                     xs1 in
@@ -2716,51 +2660,51 @@ let (t_apply_lemma :
                                                                     (fun g ->
                                                                     fun goals
                                                                     ->
-                                                                    let uu____5455
+                                                                    let uu___14
                                                                     =
-                                                                    let uu____5456
+                                                                    let uu___15
                                                                     =
                                                                     FStar_Tactics_Types.goal_witness
                                                                     g in
                                                                     checkone
-                                                                    uu____5456
+                                                                    uu___15
                                                                     goals in
                                                                     Prims.op_Negation
-                                                                    uu____5455)
+                                                                    uu___14)
                                                                     sub_goals1 in
-                                                                    let uu____5457
+                                                                    let uu___14
                                                                     =
                                                                     proc_guard
                                                                     "apply_lemma guard"
                                                                     env1
                                                                     guard in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5457
+                                                                    uu___14
                                                                     (fun
-                                                                    uu____5463
+                                                                    uu___15
                                                                     ->
                                                                     let pre_u
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 pre1 in
-                                                                    let uu____5465
+                                                                    let uu___16
                                                                     =
-                                                                    let uu____5468
+                                                                    let uu___17
                                                                     =
-                                                                    let uu____5469
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____5470
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Util.mk_squash
                                                                     pre_u
                                                                     pre1 in
                                                                     istrivial
                                                                     env1
-                                                                    uu____5470 in
+                                                                    uu___19 in
                                                                     Prims.op_Negation
-                                                                    uu____5469 in
+                                                                    uu___18 in
                                                                     if
-                                                                    uu____5468
+                                                                    uu___17
                                                                     then
                                                                     FStar_Tactics_Monad.add_irrelevant_goal
                                                                     goal
@@ -2770,15 +2714,15 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.ret
                                                                     () in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5465
+                                                                    uu___16
                                                                     (fun
-                                                                    uu____5475
+                                                                    uu___17
                                                                     ->
                                                                     FStar_Tactics_Monad.add_goals
                                                                     sub_goals2))))))))))))) in
-          focus uu____4264 in
+          focus uu___1 in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply_lemma")
-          uu____4261
+          uu___
 let (split_env :
   FStar_Syntax_Syntax.bv ->
     env ->
@@ -2788,23 +2732,23 @@ let (split_env :
   fun bvar ->
     fun e ->
       let rec aux e1 =
-        let uu____5526 = FStar_TypeChecker_Env.pop_bv e1 in
-        match uu____5526 with
+        let uu___ = FStar_TypeChecker_Env.pop_bv e1 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (bv', e') ->
-            let uu____5561 = FStar_Syntax_Syntax.bv_eq bvar bv' in
-            if uu____5561
+            let uu___1 = FStar_Syntax_Syntax.bv_eq bvar bv' in
+            if uu___1
             then FStar_Pervasives_Native.Some (e', bv', [])
             else
-              (let uu____5583 = aux e' in
-               FStar_Util.map_opt uu____5583
-                 (fun uu____5614 ->
-                    match uu____5614 with
+              (let uu___3 = aux e' in
+               FStar_Util.map_opt uu___3
+                 (fun uu___4 ->
+                    match uu___4 with
                     | (e'', bv, bvs) -> (e'', bv, (bv' :: bvs)))) in
-      let uu____5640 = aux e in
-      FStar_Util.map_opt uu____5640
-        (fun uu____5671 ->
-           match uu____5671 with
+      let uu___ = aux e in
+      FStar_Util.map_opt uu___
+        (fun uu___1 ->
+           match uu___1 with
            | (e', bv, bvs) -> (e', bv, (FStar_List.rev bvs)))
 let (push_bvs :
   FStar_TypeChecker_Env.env ->
@@ -2824,39 +2768,36 @@ let (subst_goal :
   fun b1 ->
     fun b2 ->
       fun g ->
-        let uu____5746 =
-          let uu____5757 = FStar_Tactics_Types.goal_env g in
-          split_env b1 uu____5757 in
-        match uu____5746 with
+        let uu___ =
+          let uu___1 = FStar_Tactics_Types.goal_env g in split_env b1 uu___1 in
+        match uu___ with
         | FStar_Pervasives_Native.Some (e0, b11, bvs) ->
             let bs =
               FStar_List.map FStar_Syntax_Syntax.mk_binder (b11 :: bvs) in
             let t = FStar_Tactics_Types.goal_type g in
-            let uu____5797 =
-              let uu____5810 = FStar_Syntax_Subst.close_binders bs in
-              let uu____5819 = FStar_Syntax_Subst.close bs t in
-              (uu____5810, uu____5819) in
-            (match uu____5797 with
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Subst.close_binders bs in
+              let uu___3 = FStar_Syntax_Subst.close bs t in (uu___2, uu___3) in
+            (match uu___1 with
              | (bs', t') ->
                  let bs'1 =
-                   let uu____5863 = FStar_Syntax_Syntax.mk_binder b2 in
-                   let uu____5870 = FStar_List.tail bs' in uu____5863 ::
-                     uu____5870 in
-                 let uu____5891 = FStar_Syntax_Subst.open_term bs'1 t' in
-                 (match uu____5891 with
+                   let uu___2 = FStar_Syntax_Syntax.mk_binder b2 in
+                   let uu___3 = FStar_List.tail bs' in uu___2 :: uu___3 in
+                 let uu___2 = FStar_Syntax_Subst.open_term bs'1 t' in
+                 (match uu___2 with
                   | (bs'', t'') ->
                       let b21 =
-                        let uu____5907 = FStar_List.hd bs'' in
-                        FStar_Pervasives_Native.fst uu____5907 in
+                        let uu___3 = FStar_List.hd bs'' in
+                        FStar_Pervasives_Native.fst uu___3 in
                       let new_env =
-                        let uu____5923 =
+                        let uu___3 =
                           FStar_List.map FStar_Pervasives_Native.fst bs'' in
-                        push_bvs e0 uu____5923 in
-                      let uu____5934 =
+                        push_bvs e0 uu___3 in
+                      let uu___3 =
                         FStar_Tactics_Monad.new_uvar "subst_goal" new_env t'' in
-                      FStar_Tactics_Monad.bind uu____5934
-                        (fun uu____5957 ->
-                           match uu____5957 with
+                      FStar_Tactics_Monad.bind uu___3
+                        (fun uu___4 ->
+                           match uu___4 with
                            | (uvt, uv) ->
                                let goal' =
                                  FStar_Tactics_Types.mk_goal new_env uv
@@ -2864,24 +2805,23 @@ let (subst_goal :
                                    g.FStar_Tactics_Types.is_guard
                                    g.FStar_Tactics_Types.label in
                                let sol =
-                                 let uu____5976 =
+                                 let uu___5 =
                                    FStar_Syntax_Util.abs bs'' uvt
                                      FStar_Pervasives_Native.None in
-                                 let uu____5979 =
+                                 let uu___6 =
                                    FStar_List.map
-                                     (fun uu____6000 ->
-                                        match uu____6000 with
+                                     (fun uu___7 ->
+                                        match uu___7 with
                                         | (bv, q) ->
-                                            let uu____6013 =
+                                            let uu___8 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 bv in
-                                            FStar_Syntax_Syntax.as_arg
-                                              uu____6013) bs in
-                                 FStar_Syntax_Util.mk_app uu____5976
-                                   uu____5979 in
-                               let uu____6014 = set_solution g sol in
-                               FStar_Tactics_Monad.bind uu____6014
-                                 (fun uu____6024 ->
+                                            FStar_Syntax_Syntax.as_arg uu___8)
+                                     bs in
+                                 FStar_Syntax_Util.mk_app uu___5 uu___6 in
+                               let uu___5 = set_solution g sol in
+                               FStar_Tactics_Monad.bind uu___5
+                                 (fun uu___6 ->
                                     FStar_Tactics_Monad.ret
                                       (FStar_Pervasives_Native.Some
                                          (b21, goal'))))))
@@ -2889,82 +2829,80 @@ let (subst_goal :
             FStar_Tactics_Monad.ret FStar_Pervasives_Native.None
 let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun h ->
-    let uu____6062 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6070 = h in
-           match uu____6070 with
-           | (bv, uu____6074) ->
+           let uu___1 = h in
+           match uu___1 with
+           | (bv, uu___2) ->
                FStar_Tactics_Monad.mlog
-                 (fun uu____6082 ->
-                    let uu____6083 = FStar_Syntax_Print.bv_to_string bv in
-                    let uu____6084 =
+                 (fun uu___3 ->
+                    let uu___4 = FStar_Syntax_Print.bv_to_string bv in
+                    let uu___5 =
                       FStar_Syntax_Print.term_to_string
                         bv.FStar_Syntax_Syntax.sort in
-                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6083
-                      uu____6084)
-                 (fun uu____6087 ->
-                    let uu____6088 =
-                      let uu____6099 = FStar_Tactics_Types.goal_env goal in
-                      split_env bv uu____6099 in
-                    match uu____6088 with
+                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu___4 uu___5)
+                 (fun uu___3 ->
+                    let uu___4 =
+                      let uu___5 = FStar_Tactics_Types.goal_env goal in
+                      split_env bv uu___5 in
+                    match uu___4 with
                     | FStar_Pervasives_Native.None ->
                         FStar_Tactics_Monad.fail
                           "binder not found in environment"
                     | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                        let uu____6125 =
-                          let uu____6132 =
-                            whnf e0 bv1.FStar_Syntax_Syntax.sort in
-                          destruct_eq uu____6132 in
-                        (match uu____6125 with
+                        let uu___5 =
+                          let uu___6 = whnf e0 bv1.FStar_Syntax_Syntax.sort in
+                          destruct_eq uu___6 in
+                        (match uu___5 with
                          | FStar_Pervasives_Native.Some (x, e) ->
-                             let uu____6141 =
-                               let uu____6142 = FStar_Syntax_Subst.compress x in
-                               uu____6142.FStar_Syntax_Syntax.n in
-                             (match uu____6141 with
+                             let uu___6 =
+                               let uu___7 = FStar_Syntax_Subst.compress x in
+                               uu___7.FStar_Syntax_Syntax.n in
+                             (match uu___6 with
                               | FStar_Syntax_Syntax.Tm_name x1 ->
                                   let s = [FStar_Syntax_Syntax.NT (x1, e)] in
                                   let t = FStar_Tactics_Types.goal_type goal in
                                   let bs =
                                     FStar_List.map
                                       FStar_Syntax_Syntax.mk_binder bvs in
-                                  let uu____6169 =
-                                    let uu____6174 =
+                                  let uu___7 =
+                                    let uu___8 =
                                       FStar_Syntax_Subst.close_binders bs in
-                                    let uu____6175 =
+                                    let uu___9 =
                                       FStar_Syntax_Subst.close bs t in
-                                    (uu____6174, uu____6175) in
-                                  (match uu____6169 with
+                                    (uu___8, uu___9) in
+                                  (match uu___7 with
                                    | (bs', t') ->
-                                       let uu____6180 =
-                                         let uu____6185 =
+                                       let uu___8 =
+                                         let uu___9 =
                                            FStar_Syntax_Subst.subst_binders s
                                              bs' in
-                                         let uu____6186 =
+                                         let uu___10 =
                                            FStar_Syntax_Subst.subst s t in
-                                         (uu____6185, uu____6186) in
-                                       (match uu____6180 with
+                                         (uu___9, uu___10) in
+                                       (match uu___8 with
                                         | (bs'1, t'1) ->
-                                            let uu____6191 =
+                                            let uu___9 =
                                               FStar_Syntax_Subst.open_term
                                                 bs'1 t'1 in
-                                            (match uu____6191 with
+                                            (match uu___9 with
                                              | (bs'', t'') ->
                                                  let new_env =
-                                                   let uu____6201 =
-                                                     let uu____6204 =
+                                                   let uu___10 =
+                                                     let uu___11 =
                                                        FStar_List.map
                                                          FStar_Pervasives_Native.fst
                                                          bs'' in
-                                                     bv1 :: uu____6204 in
-                                                   push_bvs e0 uu____6201 in
-                                                 let uu____6215 =
+                                                     bv1 :: uu___11 in
+                                                   push_bvs e0 uu___10 in
+                                                 let uu___10 =
                                                    FStar_Tactics_Monad.new_uvar
                                                      "rewrite" new_env t'' in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____6215
-                                                   (fun uu____6232 ->
-                                                      match uu____6232 with
+                                                   uu___10
+                                                   (fun uu___11 ->
+                                                      match uu___11 with
                                                       | (uvt, uv) ->
                                                           let goal' =
                                                             FStar_Tactics_Types.mk_goal
@@ -2973,172 +2911,164 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                                               goal.FStar_Tactics_Types.is_guard
                                                               goal.FStar_Tactics_Types.label in
                                                           let sol =
-                                                            let uu____6245 =
+                                                            let uu___12 =
                                                               FStar_Syntax_Util.abs
                                                                 bs'' uvt
                                                                 FStar_Pervasives_Native.None in
-                                                            let uu____6248 =
+                                                            let uu___13 =
                                                               FStar_List.map
-                                                                (fun
-                                                                   uu____6269
+                                                                (fun uu___14
                                                                    ->
-                                                                   match uu____6269
+                                                                   match uu___14
                                                                    with
                                                                    | 
                                                                    (bv2,
-                                                                    uu____6277)
+                                                                    uu___15)
                                                                     ->
-                                                                    let uu____6282
+                                                                    let uu___16
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv2 in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____6282)
+                                                                    uu___16)
                                                                 bs in
                                                             FStar_Syntax_Util.mk_app
-                                                              uu____6245
-                                                              uu____6248 in
-                                                          let uu____6283 =
+                                                              uu___12 uu___13 in
+                                                          let uu___12 =
                                                             set_solution goal
                                                               sol in
                                                           FStar_Tactics_Monad.bind
-                                                            uu____6283
-                                                            (fun uu____6287
-                                                               ->
+                                                            uu___12
+                                                            (fun uu___13 ->
                                                                FStar_Tactics_Monad.replace_cur
                                                                  goal')))))
-                              | uu____6288 ->
+                              | uu___7 ->
                                   FStar_Tactics_Monad.fail
                                     "Not an equality hypothesis with a variable on the LHS")
-                         | uu____6289 ->
+                         | uu___6 ->
                              FStar_Tactics_Monad.fail
                                "Not an equality hypothesis"))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6062
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu___
 let (rename_to :
   FStar_Syntax_Syntax.binder ->
     Prims.string -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac)
   =
   fun b ->
     fun s ->
-      let uu____6314 =
+      let uu___ =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6336 = b in
-             match uu____6336 with
+             let uu___1 = b in
+             match uu___1 with
              | (bv, q) ->
                  let bv' =
-                   let uu____6352 =
-                     let uu___930_6353 = bv in
-                     let uu____6354 =
-                       let uu____6355 =
-                         let uu____6360 =
+                   let uu___2 =
+                     let uu___3 = bv in
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_Ident.range_of_id
                              bv.FStar_Syntax_Syntax.ppname in
-                         (s, uu____6360) in
-                       FStar_Ident.mk_ident uu____6355 in
+                         (s, uu___6) in
+                       FStar_Ident.mk_ident uu___5 in
                      {
-                       FStar_Syntax_Syntax.ppname = uu____6354;
+                       FStar_Syntax_Syntax.ppname = uu___4;
                        FStar_Syntax_Syntax.index =
-                         (uu___930_6353.FStar_Syntax_Syntax.index);
+                         (uu___3.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort =
-                         (uu___930_6353.FStar_Syntax_Syntax.sort)
+                         (uu___3.FStar_Syntax_Syntax.sort)
                      } in
-                   FStar_Syntax_Syntax.freshen_bv uu____6352 in
-                 let uu____6361 = subst_goal bv bv' goal in
-                 FStar_Tactics_Monad.bind uu____6361
-                   (fun uu___4_6383 ->
-                      match uu___4_6383 with
+                   FStar_Syntax_Syntax.freshen_bv uu___2 in
+                 let uu___2 = subst_goal bv bv' goal in
+                 FStar_Tactics_Monad.bind uu___2
+                   (fun uu___3 ->
+                      match uu___3 with
                       | FStar_Pervasives_Native.None ->
                           FStar_Tactics_Monad.fail
                             "binder not found in environment"
                       | FStar_Pervasives_Native.Some (bv'1, goal1) ->
-                          let uu____6414 =
-                            FStar_Tactics_Monad.replace_cur goal1 in
-                          FStar_Tactics_Monad.bind uu____6414
-                            (fun uu____6424 ->
-                               FStar_Tactics_Monad.ret (bv'1, q)))) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rename_to")
-        uu____6314
+                          let uu___4 = FStar_Tactics_Monad.replace_cur goal1 in
+                          FStar_Tactics_Monad.bind uu___4
+                            (fun uu___5 -> FStar_Tactics_Monad.ret (bv'1, q)))) in
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rename_to") uu___
 let (binder_retype :
   FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
-    let uu____6458 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6467 = b in
-           match uu____6467 with
-           | (bv, uu____6471) ->
-               let uu____6476 =
-                 let uu____6487 = FStar_Tactics_Types.goal_env goal in
-                 split_env bv uu____6487 in
-               (match uu____6476 with
+           let uu___1 = b in
+           match uu___1 with
+           | (bv, uu___2) ->
+               let uu___3 =
+                 let uu___4 = FStar_Tactics_Types.goal_env goal in
+                 split_env bv uu___4 in
+               (match uu___3 with
                 | FStar_Pervasives_Native.None ->
                     FStar_Tactics_Monad.fail
                       "binder is not present in environment"
                 | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                    let uu____6513 = FStar_Syntax_Util.type_u () in
-                    (match uu____6513 with
+                    let uu___4 = FStar_Syntax_Util.type_u () in
+                    (match uu___4 with
                      | (ty, u) ->
-                         let uu____6522 =
+                         let uu___5 =
                            FStar_Tactics_Monad.new_uvar "binder_retype" e0 ty in
-                         FStar_Tactics_Monad.bind uu____6522
-                           (fun uu____6540 ->
-                              match uu____6540 with
+                         FStar_Tactics_Monad.bind uu___5
+                           (fun uu___6 ->
+                              match uu___6 with
                               | (t', u_t') ->
                                   let bv'' =
-                                    let uu___957_6550 = bv1 in
+                                    let uu___7 = bv1 in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___957_6550.FStar_Syntax_Syntax.ppname);
+                                        (uu___7.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___957_6550.FStar_Syntax_Syntax.index);
+                                        (uu___7.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t'
                                     } in
                                   let s =
-                                    let uu____6554 =
-                                      let uu____6555 =
-                                        let uu____6562 =
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_Syntax_Syntax.bv_to_name bv'' in
-                                        (bv1, uu____6562) in
-                                      FStar_Syntax_Syntax.NT uu____6555 in
-                                    [uu____6554] in
+                                        (bv1, uu___9) in
+                                      FStar_Syntax_Syntax.NT uu___8 in
+                                    [uu___7] in
                                   let bvs1 =
                                     FStar_List.map
                                       (fun b1 ->
-                                         let uu___962_6574 = b1 in
-                                         let uu____6575 =
+                                         let uu___7 = b1 in
+                                         let uu___8 =
                                            FStar_Syntax_Subst.subst s
                                              b1.FStar_Syntax_Syntax.sort in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___962_6574.FStar_Syntax_Syntax.ppname);
+                                             (uu___7.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___962_6574.FStar_Syntax_Syntax.index);
-                                           FStar_Syntax_Syntax.sort =
-                                             uu____6575
+                                             (uu___7.FStar_Syntax_Syntax.index);
+                                           FStar_Syntax_Syntax.sort = uu___8
                                          }) bvs in
                                   let env' = push_bvs e0 (bv'' :: bvs1) in
                                   FStar_Tactics_Monad.bind
                                     FStar_Tactics_Monad.dismiss
-                                    (fun uu____6582 ->
+                                    (fun uu___7 ->
                                        let new_goal =
-                                         let uu____6584 =
+                                         let uu___8 =
                                            FStar_Tactics_Types.goal_with_env
                                              goal env' in
-                                         let uu____6585 =
-                                           let uu____6586 =
+                                         let uu___9 =
+                                           let uu___10 =
                                              FStar_Tactics_Types.goal_type
                                                goal in
-                                           FStar_Syntax_Subst.subst s
-                                             uu____6586 in
+                                           FStar_Syntax_Subst.subst s uu___10 in
                                          FStar_Tactics_Types.goal_with_type
-                                           uu____6584 uu____6585 in
-                                       let uu____6587 =
+                                           uu___8 uu___9 in
+                                       let uu___8 =
                                          FStar_Tactics_Monad.add_goals
                                            [new_goal] in
-                                       FStar_Tactics_Monad.bind uu____6587
-                                         (fun uu____6592 ->
-                                            let uu____6593 =
+                                       FStar_Tactics_Monad.bind uu___8
+                                         (fun uu___9 ->
+                                            let uu___10 =
                                               FStar_Syntax_Util.mk_eq2
                                                 (FStar_Syntax_Syntax.U_succ u)
                                                 ty
@@ -3146,91 +3076,87 @@ let (binder_retype :
                                                 t' in
                                             FStar_Tactics_Monad.add_irrelevant_goal
                                               goal "binder_retype equation"
-                                              e0 uu____6593)))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "binder_retype")
-      uu____6458
+                                              e0 uu___10)))))) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "binder_retype") uu___
 let (norm_binder_type :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac)
   =
   fun s ->
     fun b ->
-      let uu____6616 =
+      let uu___ =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6625 = b in
-             match uu____6625 with
-             | (bv, uu____6629) ->
-                 let uu____6634 =
-                   let uu____6645 = FStar_Tactics_Types.goal_env goal in
-                   split_env bv uu____6645 in
-                 (match uu____6634 with
+             let uu___1 = b in
+             match uu___1 with
+             | (bv, uu___2) ->
+                 let uu___3 =
+                   let uu___4 = FStar_Tactics_Types.goal_env goal in
+                   split_env bv uu___4 in
+                 (match uu___3 with
                   | FStar_Pervasives_Native.None ->
                       FStar_Tactics_Monad.fail
                         "binder is not present in environment"
                   | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
                       let steps =
-                        let uu____6674 =
+                        let uu___4 =
                           FStar_TypeChecker_Normalize.tr_norm_steps s in
                         FStar_List.append
                           [FStar_TypeChecker_Env.Reify;
-                          FStar_TypeChecker_Env.UnfoldTac] uu____6674 in
+                          FStar_TypeChecker_Env.UnfoldTac] uu___4 in
                       let sort' =
                         normalize steps e0 bv1.FStar_Syntax_Syntax.sort in
                       let bv' =
-                        let uu___983_6679 = bv1 in
+                        let uu___4 = bv1 in
                         {
                           FStar_Syntax_Syntax.ppname =
-                            (uu___983_6679.FStar_Syntax_Syntax.ppname);
+                            (uu___4.FStar_Syntax_Syntax.ppname);
                           FStar_Syntax_Syntax.index =
-                            (uu___983_6679.FStar_Syntax_Syntax.index);
+                            (uu___4.FStar_Syntax_Syntax.index);
                           FStar_Syntax_Syntax.sort = sort'
                         } in
                       let env' = push_bvs e0 (bv' :: bvs) in
-                      let uu____6681 =
+                      let uu___4 =
                         FStar_Tactics_Types.goal_with_env goal env' in
-                      FStar_Tactics_Monad.replace_cur uu____6681)) in
+                      FStar_Tactics_Monad.replace_cur uu___4)) in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_binder_type")
-        uu____6616
+        uu___
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6692 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6698 =
-           let uu____6705 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6705 in
-         match uu____6698 with
+         let uu___1 =
+           let uu___2 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu___2 in
+         match uu___1 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot revert; empty context"
          | FStar_Pervasives_Native.Some (x, env') ->
              let typ' =
-               let uu____6721 =
-                 let uu____6724 = FStar_Tactics_Types.goal_type goal in
-                 FStar_Syntax_Syntax.mk_Total uu____6724 in
+               let uu___2 =
+                 let uu___3 = FStar_Tactics_Types.goal_type goal in
+                 FStar_Syntax_Syntax.mk_Total uu___3 in
                FStar_Syntax_Util.arrow [(x, FStar_Pervasives_Native.None)]
-                 uu____6721 in
-             let uu____6739 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
-             FStar_Tactics_Monad.bind uu____6739
-               (fun uu____6754 ->
-                  match uu____6754 with
+                 uu___2 in
+             let uu___2 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
+             FStar_Tactics_Monad.bind uu___2
+               (fun uu___3 ->
+                  match uu___3 with
                   | (r, u_r) ->
-                      let uu____6763 =
-                        let uu____6766 =
-                          let uu____6767 =
-                            let uu____6768 =
-                              let uu____6777 =
-                                FStar_Syntax_Syntax.bv_to_name x in
-                              FStar_Syntax_Syntax.as_arg uu____6777 in
-                            [uu____6768] in
-                          let uu____6794 =
-                            let uu____6795 =
-                              FStar_Tactics_Types.goal_type goal in
-                            uu____6795.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.mk_Tm_app r uu____6767
-                            uu____6794 in
-                        set_solution goal uu____6766 in
-                      FStar_Tactics_Monad.bind uu____6763
-                        (fun uu____6800 ->
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 = FStar_Syntax_Syntax.bv_to_name x in
+                              FStar_Syntax_Syntax.as_arg uu___8 in
+                            [uu___7] in
+                          let uu___7 =
+                            let uu___8 = FStar_Tactics_Types.goal_type goal in
+                            uu___8.FStar_Syntax_Syntax.pos in
+                          FStar_Syntax_Syntax.mk_Tm_app r uu___6 uu___7 in
+                        set_solution goal uu___5 in
+                      FStar_Tactics_Monad.bind uu___4
+                        (fun uu___5 ->
                            let g =
                              FStar_Tactics_Types.mk_goal env' u_r
                                goal.FStar_Tactics_Types.opts
@@ -3241,30 +3167,29 @@ let (free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv ->
     fun t ->
-      let uu____6812 = FStar_Syntax_Free.names t in
-      FStar_Util.set_mem bv uu____6812
+      let uu___ = FStar_Syntax_Free.names t in FStar_Util.set_mem bv uu___
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     let bv = FStar_Pervasives_Native.fst b in
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____6832 ->
-              let uu____6833 = FStar_Syntax_Print.binder_to_string b in
-              let uu____6834 =
-                let uu____6835 =
-                  let uu____6836 =
-                    let uu____6845 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.all_binders uu____6845 in
-                  FStar_All.pipe_right uu____6836 FStar_List.length in
-                FStar_All.pipe_right uu____6835 FStar_Util.string_of_int in
-              FStar_Util.print2 "Clear of (%s), env has %s binders\n"
-                uu____6833 uu____6834)
-           (fun uu____6862 ->
-              let uu____6863 =
-                let uu____6874 = FStar_Tactics_Types.goal_env goal in
-                split_env bv uu____6874 in
-              match uu____6863 with
+           (fun uu___ ->
+              let uu___1 = FStar_Syntax_Print.binder_to_string b in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.all_binders uu___5 in
+                  FStar_All.pipe_right uu___4 FStar_List.length in
+                FStar_All.pipe_right uu___3 FStar_Util.string_of_int in
+              FStar_Util.print2 "Clear of (%s), env has %s binders\n" uu___1
+                uu___2)
+           (fun uu___ ->
+              let uu___1 =
+                let uu___2 = FStar_Tactics_Types.goal_env goal in
+                split_env bv uu___2 in
+              match uu___1 with
               | FStar_Pervasives_Native.None ->
                   FStar_Tactics_Monad.fail
                     "Cannot clear; binder not in environment"
@@ -3273,71 +3198,67 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     match bvs1 with
                     | [] -> FStar_Tactics_Monad.ret ()
                     | bv'::bvs2 ->
-                        let uu____6918 =
-                          free_in bv1 bv'.FStar_Syntax_Syntax.sort in
-                        if uu____6918
+                        let uu___2 = free_in bv1 bv'.FStar_Syntax_Syntax.sort in
+                        if uu___2
                         then
-                          let uu____6921 =
-                            let uu____6922 =
-                              FStar_Syntax_Print.bv_to_string bv' in
+                          let uu___3 =
+                            let uu___4 = FStar_Syntax_Print.bv_to_string bv' in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____6922 in
-                          FStar_Tactics_Monad.fail uu____6921
+                              uu___4 in
+                          FStar_Tactics_Monad.fail uu___3
                         else check bvs2 in
-                  let uu____6924 =
-                    let uu____6925 = FStar_Tactics_Types.goal_type goal in
-                    free_in bv1 uu____6925 in
-                  if uu____6924
+                  let uu___2 =
+                    let uu___3 = FStar_Tactics_Types.goal_type goal in
+                    free_in bv1 uu___3 in
+                  if uu___2
                   then
                     FStar_Tactics_Monad.fail
                       "Cannot clear; binder present in goal"
                   else
-                    (let uu____6929 = check bvs in
-                     FStar_Tactics_Monad.bind uu____6929
-                       (fun uu____6935 ->
+                    (let uu___4 = check bvs in
+                     FStar_Tactics_Monad.bind uu___4
+                       (fun uu___5 ->
                           let env' = push_bvs e' bvs in
-                          let uu____6937 =
-                            let uu____6944 =
-                              FStar_Tactics_Types.goal_type goal in
+                          let uu___6 =
+                            let uu___7 = FStar_Tactics_Types.goal_type goal in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu____6944 in
-                          FStar_Tactics_Monad.bind uu____6937
-                            (fun uu____6953 ->
-                               match uu____6953 with
+                              uu___7 in
+                          FStar_Tactics_Monad.bind uu___6
+                            (fun uu___7 ->
+                               match uu___7 with
                                | (ut, uvar_ut) ->
-                                   let uu____6962 = set_solution goal ut in
-                                   FStar_Tactics_Monad.bind uu____6962
-                                     (fun uu____6967 ->
-                                        let uu____6968 =
+                                   let uu___8 = set_solution goal ut in
+                                   FStar_Tactics_Monad.bind uu___8
+                                     (fun uu___9 ->
+                                        let uu___10 =
                                           FStar_Tactics_Types.mk_goal env'
                                             uvar_ut
                                             goal.FStar_Tactics_Types.opts
                                             goal.FStar_Tactics_Types.is_guard
                                             goal.FStar_Tactics_Types.label in
                                         FStar_Tactics_Monad.replace_cur
-                                          uu____6968))))))
+                                          uu___10))))))
 let (clear_top : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6975 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6981 =
-           let uu____6988 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6988 in
-         match uu____6981 with
+         let uu___1 =
+           let uu___2 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu___2 in
+         match uu___1 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot clear; empty context"
-         | FStar_Pervasives_Native.Some (x, uu____6996) ->
-             let uu____7001 = FStar_Syntax_Syntax.mk_binder x in
-             clear uu____7001)
+         | FStar_Pervasives_Native.Some (x, uu___2) ->
+             let uu___3 = FStar_Syntax_Syntax.mk_binder x in clear uu___3)
 let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7018 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7018 in
+           let uu___ = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.rem_proof_ns ctx uu___ in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
@@ -3346,8 +3267,8 @@ let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7036 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.add_proof_ns ctx uu____7036 in
+           let uu___ = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.add_proof_ns ctx uu___ in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (_trefl :
@@ -3358,112 +3279,108 @@ let (_trefl :
     fun r ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7055 =
-             let uu____7058 = FStar_Tactics_Types.goal_env g in
-             do_unify uu____7058 l r in
-           FStar_Tactics_Monad.bind uu____7055
+           let uu___ =
+             let uu___1 = FStar_Tactics_Types.goal_env g in
+             do_unify uu___1 l r in
+           FStar_Tactics_Monad.bind uu___
              (fun b ->
                 if b
                 then solve' g FStar_Syntax_Util.exp_unit
                 else
                   (let l1 =
-                     let uu____7065 = FStar_Tactics_Types.goal_env g in
+                     let uu___2 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7065 l in
+                       FStar_TypeChecker_Env.UnfoldTac] uu___2 l in
                    let r1 =
-                     let uu____7067 = FStar_Tactics_Types.goal_env g in
+                     let uu___2 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7067 r in
-                   let uu____7068 =
-                     let uu____7071 = FStar_Tactics_Types.goal_env g in
-                     do_unify uu____7071 l1 r1 in
-                   FStar_Tactics_Monad.bind uu____7068
+                       FStar_TypeChecker_Env.UnfoldTac] uu___2 r in
+                   let uu___2 =
+                     let uu___3 = FStar_Tactics_Types.goal_env g in
+                     do_unify uu___3 l1 r1 in
+                   FStar_Tactics_Monad.bind uu___2
                      (fun b1 ->
                         if b1
                         then solve' g FStar_Syntax_Util.exp_unit
                         else
-                          (let uu____7077 =
-                             let uu____7082 =
-                               let uu____7087 =
-                                 FStar_Tactics_Types.goal_env g in
-                               tts uu____7087 in
-                             FStar_TypeChecker_Err.print_discrepancy
-                               uu____7082 l1 r1 in
-                           match uu____7077 with
+                          (let uu___4 =
+                             let uu___5 =
+                               let uu___6 = FStar_Tactics_Types.goal_env g in
+                               tts uu___6 in
+                             FStar_TypeChecker_Err.print_discrepancy uu___5
+                               l1 r1 in
+                           match uu___4 with
                            | (ls, rs) ->
                                fail2 "not a trivial equality ((%s) vs (%s))"
                                  ls rs)))))
 let (trefl : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7098 ->
-    let uu____7101 =
+  fun uu___ ->
+    let uu___1 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7109 =
-             let uu____7116 =
-               let uu____7117 = FStar_Tactics_Types.goal_env g in
-               let uu____7118 = FStar_Tactics_Types.goal_type g in
-               whnf uu____7117 uu____7118 in
-             destruct_eq uu____7116 in
-           match uu____7109 with
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Tactics_Types.goal_env g in
+               let uu___5 = FStar_Tactics_Types.goal_type g in
+               whnf uu___4 uu___5 in
+             destruct_eq uu___3 in
+           match uu___2 with
            | FStar_Pervasives_Native.Some (l, r) -> _trefl l r
            | FStar_Pervasives_Native.None ->
-               let uu____7131 =
-                 let uu____7132 = FStar_Tactics_Types.goal_env g in
-                 let uu____7133 = FStar_Tactics_Types.goal_type g in
-                 tts uu____7132 uu____7133 in
-               fail1 "not an equality (%s)" uu____7131) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7101
+               let uu___3 =
+                 let uu___4 = FStar_Tactics_Types.goal_env g in
+                 let uu___5 = FStar_Tactics_Types.goal_type g in
+                 tts uu___4 uu___5 in
+               fail1 "not an equality (%s)" uu___3) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu___1
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7144 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let env1 = FStar_Tactics_Types.goal_env g in
-         let uu____7152 =
-           let uu____7159 = FStar_Tactics_Types.goal_type g in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7159 in
-         FStar_Tactics_Monad.bind uu____7152
-           (fun uu____7168 ->
-              match uu____7168 with
+         let uu___1 =
+           let uu___2 = FStar_Tactics_Types.goal_type g in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu___2 in
+         FStar_Tactics_Monad.bind uu___1
+           (fun uu___2 ->
+              match uu___2 with
               | (u, u_uvar) ->
                   let g' =
-                    let uu___1069_7178 = g in
+                    let uu___3 = g in
                     {
                       FStar_Tactics_Types.goal_main_env =
-                        (uu___1069_7178.FStar_Tactics_Types.goal_main_env);
+                        (uu___3.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
                       FStar_Tactics_Types.opts =
-                        (uu___1069_7178.FStar_Tactics_Types.opts);
+                        (uu___3.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
-                        (uu___1069_7178.FStar_Tactics_Types.is_guard);
+                        (uu___3.FStar_Tactics_Types.is_guard);
                       FStar_Tactics_Types.label =
-                        (uu___1069_7178.FStar_Tactics_Types.label)
+                        (uu___3.FStar_Tactics_Types.label)
                     } in
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____7182 ->
+                    (fun uu___3 ->
                        let t_eq =
-                         let uu____7184 =
-                           let uu____7185 = FStar_Tactics_Types.goal_type g in
-                           env1.FStar_TypeChecker_Env.universe_of env1
-                             uu____7185 in
-                         let uu____7186 = FStar_Tactics_Types.goal_type g in
-                         let uu____7187 = FStar_Tactics_Types.goal_witness g in
-                         FStar_Syntax_Util.mk_eq2 uu____7184 uu____7186 u
-                           uu____7187 in
-                       let uu____7188 =
+                         let uu___4 =
+                           let uu___5 = FStar_Tactics_Types.goal_type g in
+                           env1.FStar_TypeChecker_Env.universe_of env1 uu___5 in
+                         let uu___5 = FStar_Tactics_Types.goal_type g in
+                         let uu___6 = FStar_Tactics_Types.goal_witness g in
+                         FStar_Syntax_Util.mk_eq2 uu___4 uu___5 u uu___6 in
+                       let uu___4 =
                          FStar_Tactics_Monad.add_irrelevant_goal g
                            "dup equation" env1 t_eq in
-                       FStar_Tactics_Monad.bind uu____7188
-                         (fun uu____7193 ->
-                            let uu____7194 =
-                              FStar_Tactics_Monad.add_goals [g'] in
-                            FStar_Tactics_Monad.bind uu____7194
-                              (fun uu____7198 -> FStar_Tactics_Monad.ret ())))))
+                       FStar_Tactics_Monad.bind uu___4
+                         (fun uu___5 ->
+                            let uu___6 = FStar_Tactics_Monad.add_goals [g'] in
+                            FStar_Tactics_Monad.bind uu___6
+                              (fun uu___7 -> FStar_Tactics_Monad.ret ())))))
 let longest_prefix :
   'a .
     ('a -> 'a -> Prims.bool) ->
@@ -3476,11 +3393,11 @@ let longest_prefix :
         let rec aux acc l11 l21 =
           match (l11, l21) with
           | (x::xs, y::ys) ->
-              let uu____7321 = f x y in
-              if uu____7321 then aux (x :: acc) xs ys else (acc, xs, ys)
-          | uu____7341 -> (acc, l11, l21) in
-        let uu____7356 = aux [] l1 l2 in
-        match uu____7356 with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
+              let uu___ = f x y in
+              if uu___ then aux (x :: acc) xs ys else (acc, xs, ys)
+          | uu___ -> (acc, l11, l21) in
+        let uu___ = aux [] l1 l2 in
+        match uu___ with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
 let (join_goals :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.goal ->
@@ -3494,13 +3411,13 @@ let (join_goals :
              fun f1 ->
                FStar_Syntax_Util.mk_forall_no_univ
                  (FStar_Pervasives_Native.fst b) f1) bs f in
-      let uu____7461 = FStar_Tactics_Types.get_phi g1 in
-      match uu____7461 with
+      let uu___ = FStar_Tactics_Types.get_phi g1 in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           FStar_Tactics_Monad.fail "goal 1 is not irrelevant"
       | FStar_Pervasives_Native.Some phi1 ->
-          let uu____7467 = FStar_Tactics_Types.get_phi g2 in
-          (match uu____7467 with
+          let uu___1 = FStar_Tactics_Types.get_phi g2 in
+          (match uu___1 with
            | FStar_Pervasives_Native.None ->
                FStar_Tactics_Monad.fail "goal 2 is not irrelevant"
            | FStar_Pervasives_Native.Some phi2 ->
@@ -3508,244 +3425,240 @@ let (join_goals :
                  (g1.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
                let gamma2 =
                  (g2.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
-               let uu____7479 =
+               let uu___2 =
                  longest_prefix FStar_Syntax_Syntax.eq_binding
                    (FStar_List.rev gamma1) (FStar_List.rev gamma2) in
-               (match uu____7479 with
+               (match uu___2 with
                 | (gamma, r1, r2) ->
                     let t1 =
-                      let uu____7510 =
+                      let uu___3 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r1) in
-                      close_forall_no_univs uu____7510 phi1 in
+                      close_forall_no_univs uu___3 phi1 in
                     let t2 =
-                      let uu____7520 =
+                      let uu___3 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r2) in
-                      close_forall_no_univs uu____7520 phi2 in
-                    let uu____7529 =
-                      set_solution g1 FStar_Syntax_Util.exp_unit in
-                    FStar_Tactics_Monad.bind uu____7529
-                      (fun uu____7534 ->
-                         let uu____7535 =
+                      close_forall_no_univs uu___3 phi2 in
+                    let uu___3 = set_solution g1 FStar_Syntax_Util.exp_unit in
+                    FStar_Tactics_Monad.bind uu___3
+                      (fun uu___4 ->
+                         let uu___5 =
                            set_solution g2 FStar_Syntax_Util.exp_unit in
-                         FStar_Tactics_Monad.bind uu____7535
-                           (fun uu____7542 ->
+                         FStar_Tactics_Monad.bind uu___5
+                           (fun uu___6 ->
                               let ng = FStar_Syntax_Util.mk_conj t1 t2 in
                               let nenv =
-                                let uu___1121_7547 =
-                                  FStar_Tactics_Types.goal_env g1 in
-                                let uu____7548 =
+                                let uu___7 = FStar_Tactics_Types.goal_env g1 in
+                                let uu___8 =
                                   FStar_Util.smap_create (Prims.of_int (100)) in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.solver);
+                                    (uu___7.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.range);
+                                    (uu___7.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.curmodule);
+                                    (uu___7.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
                                     (FStar_List.rev gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.gamma_sig);
-                                  FStar_TypeChecker_Env.gamma_cache =
-                                    uu____7548;
+                                    (uu___7.FStar_TypeChecker_Env.gamma_sig);
+                                  FStar_TypeChecker_Env.gamma_cache = uu___8;
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.modules);
+                                    (uu___7.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___7.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.sigtab);
+                                    (uu___7.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.attrtab);
+                                    (uu___7.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.effects);
+                                    (uu___7.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.generalize);
+                                    (uu___7.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.letrecs);
+                                    (uu___7.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.top_level);
+                                    (uu___7.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___7.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq);
+                                    (uu___7.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.is_iface);
+                                    (uu___7.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.admit);
+                                    (uu___7.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.lax);
+                                    (uu___7.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___7.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.phase1);
+                                    (uu___7.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.failhard);
+                                    (uu___7.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.nosynth);
+                                    (uu___7.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_term);
+                                    (uu___7.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.type_of);
+                                    (uu___7.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.universe_of);
+                                    (uu___7.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___7.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___7.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___7.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.splice);
+                                    (uu___7.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___7.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.postprocess);
+                                    (uu___7.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___7.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___7.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.dsenv);
+                                    (uu___7.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.nbe);
+                                    (uu___7.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.erasable_types_tab);
+                                    (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                                 } in
-                              let uu____7551 =
+                              let uu___7 =
                                 FStar_Tactics_Monad.mk_irrelevant_goal
                                   "joined" nenv ng
                                   g1.FStar_Tactics_Types.opts
                                   g1.FStar_Tactics_Types.label in
-                              FStar_Tactics_Monad.bind uu____7551
+                              FStar_Tactics_Monad.bind uu___7
                                 (fun goal ->
                                    FStar_Tactics_Monad.mlog
-                                     (fun uu____7560 ->
-                                        let uu____7561 =
+                                     (fun uu___8 ->
+                                        let uu___9 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g1 in
-                                        let uu____7562 =
+                                        let uu___10 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g2 in
-                                        let uu____7563 =
+                                        let uu___11 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             goal in
                                         FStar_Util.print3
                                           "join_goals of\n(%s)\nand\n(%s)\n= (%s)\n"
-                                          uu____7561 uu____7562 uu____7563)
-                                     (fun uu____7565 ->
+                                          uu___9 uu___10 uu___11)
+                                     (fun uu___8 ->
                                         FStar_Tactics_Monad.ret goal))))))
 let (join : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7572 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          match ps.FStar_Tactics_Types.goals with
          | g1::g2::gs ->
-             let uu____7588 =
+             let uu___1 =
                FStar_Tactics_Monad.set
-                 (let uu___1136_7593 = ps in
+                 (let uu___2 = ps in
                   {
                     FStar_Tactics_Types.main_context =
-                      (uu___1136_7593.FStar_Tactics_Types.main_context);
+                      (uu___2.FStar_Tactics_Types.main_context);
                     FStar_Tactics_Types.all_implicits =
-                      (uu___1136_7593.FStar_Tactics_Types.all_implicits);
+                      (uu___2.FStar_Tactics_Types.all_implicits);
                     FStar_Tactics_Types.goals = gs;
                     FStar_Tactics_Types.smt_goals =
-                      (uu___1136_7593.FStar_Tactics_Types.smt_goals);
+                      (uu___2.FStar_Tactics_Types.smt_goals);
                     FStar_Tactics_Types.depth =
-                      (uu___1136_7593.FStar_Tactics_Types.depth);
+                      (uu___2.FStar_Tactics_Types.depth);
                     FStar_Tactics_Types.__dump =
-                      (uu___1136_7593.FStar_Tactics_Types.__dump);
+                      (uu___2.FStar_Tactics_Types.__dump);
                     FStar_Tactics_Types.psc =
-                      (uu___1136_7593.FStar_Tactics_Types.psc);
+                      (uu___2.FStar_Tactics_Types.psc);
                     FStar_Tactics_Types.entry_range =
-                      (uu___1136_7593.FStar_Tactics_Types.entry_range);
+                      (uu___2.FStar_Tactics_Types.entry_range);
                     FStar_Tactics_Types.guard_policy =
-                      (uu___1136_7593.FStar_Tactics_Types.guard_policy);
+                      (uu___2.FStar_Tactics_Types.guard_policy);
                     FStar_Tactics_Types.freshness =
-                      (uu___1136_7593.FStar_Tactics_Types.freshness);
+                      (uu___2.FStar_Tactics_Types.freshness);
                     FStar_Tactics_Types.tac_verb_dbg =
-                      (uu___1136_7593.FStar_Tactics_Types.tac_verb_dbg);
+                      (uu___2.FStar_Tactics_Types.tac_verb_dbg);
                     FStar_Tactics_Types.local_state =
-                      (uu___1136_7593.FStar_Tactics_Types.local_state)
+                      (uu___2.FStar_Tactics_Types.local_state)
                   }) in
-             FStar_Tactics_Monad.bind uu____7588
-               (fun uu____7596 ->
-                  let uu____7597 = join_goals g1 g2 in
-                  FStar_Tactics_Monad.bind uu____7597
+             FStar_Tactics_Monad.bind uu___1
+               (fun uu___2 ->
+                  let uu___3 = join_goals g1 g2 in
+                  FStar_Tactics_Monad.bind uu___3
                     (fun g12 -> FStar_Tactics_Monad.add_goals [g12]))
-         | uu____7602 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
+         | uu___1 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
 let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
-    let uu____7614 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
            FStar_Options.push ();
-           (let uu____7627 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
-            FStar_Options.set uu____7627);
+           (let uu___3 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
+            FStar_Options.set uu___3);
            (let res = FStar_Options.set_options s in
             let opts' = FStar_Options.peek () in
             FStar_Options.pop ();
             (match res with
              | FStar_Getopt.Success ->
                  let g' =
-                   let uu___1147_7634 = g in
+                   let uu___4 = g in
                    {
                      FStar_Tactics_Types.goal_main_env =
-                       (uu___1147_7634.FStar_Tactics_Types.goal_main_env);
+                       (uu___4.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
-                       (uu___1147_7634.FStar_Tactics_Types.goal_ctx_uvar);
+                       (uu___4.FStar_Tactics_Types.goal_ctx_uvar);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
-                       (uu___1147_7634.FStar_Tactics_Types.is_guard);
+                       (uu___4.FStar_Tactics_Types.is_guard);
                      FStar_Tactics_Types.label =
-                       (uu___1147_7634.FStar_Tactics_Types.label)
+                       (uu___4.FStar_Tactics_Types.label)
                    } in
                  FStar_Tactics_Monad.replace_cur g'
              | FStar_Getopt.Error err ->
                  fail2 "Setting options `%s` failed: %s" s err
              | FStar_Getopt.Help ->
                  fail1 "Setting options `%s` failed (got `Help`?)" s))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options")
-      uu____7614
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options") uu___
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
-  fun uu____7646 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_All.pipe_left FStar_Tactics_Monad.ret
            ps.FStar_Tactics_Types.main_context)
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____7659 ->
+  fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
-         let uu____7665 =
+         let uu___1 =
            (FStar_Options.lax ()) ||
-             (let uu____7667 = FStar_Tactics_Types.goal_env g in
-              uu____7667.FStar_TypeChecker_Env.lax) in
-         FStar_Tactics_Monad.ret uu____7665)
+             (let uu___2 = FStar_Tactics_Types.goal_env g in
+              uu___2.FStar_TypeChecker_Env.lax) in
+         FStar_Tactics_Monad.ret uu___1)
 let (unquote :
   FStar_Reflection_Data.typ ->
     FStar_Syntax_Syntax.term ->
@@ -3753,42 +3666,42 @@ let (unquote :
   =
   fun ty ->
     fun tm ->
-      let uu____7682 =
+      let uu___ =
         FStar_Tactics_Monad.mlog
-          (fun uu____7687 ->
-             let uu____7688 = FStar_Syntax_Print.term_to_string tm in
-             FStar_Util.print1 "unquote: tm = %s\n" uu____7688)
-          (fun uu____7690 ->
+          (fun uu___1 ->
+             let uu___2 = FStar_Syntax_Print.term_to_string tm in
+             FStar_Util.print1 "unquote: tm = %s\n" uu___2)
+          (fun uu___1 ->
              FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                (fun goal ->
                   let env1 =
-                    let uu____7696 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.set_expected_typ uu____7696 ty in
-                  let uu____7697 = __tc_ghost env1 tm in
-                  FStar_Tactics_Monad.bind uu____7697
-                    (fun uu____7716 ->
-                       match uu____7716 with
+                    let uu___2 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.set_expected_typ uu___2 ty in
+                  let uu___2 = __tc_ghost env1 tm in
+                  FStar_Tactics_Monad.bind uu___2
+                    (fun uu___3 ->
+                       match uu___3 with
                        | (tm1, typ, guard) ->
                            FStar_Tactics_Monad.mlog
-                             (fun uu____7730 ->
-                                let uu____7731 =
+                             (fun uu___4 ->
+                                let uu___5 =
                                   FStar_Syntax_Print.term_to_string tm1 in
                                 FStar_Util.print1 "unquote: tm' = %s\n"
-                                  uu____7731)
-                             (fun uu____7733 ->
+                                  uu___5)
+                             (fun uu___4 ->
                                 FStar_Tactics_Monad.mlog
-                                  (fun uu____7736 ->
-                                     let uu____7737 =
+                                  (fun uu___5 ->
+                                     let uu___6 =
                                        FStar_Syntax_Print.term_to_string typ in
                                      FStar_Util.print1 "unquote: typ = %s\n"
-                                       uu____7737)
-                                  (fun uu____7740 ->
-                                     let uu____7741 =
+                                       uu___6)
+                                  (fun uu___5 ->
+                                     let uu___6 =
                                        proc_guard "unquote" env1 guard in
-                                     FStar_Tactics_Monad.bind uu____7741
-                                       (fun uu____7745 ->
+                                     FStar_Tactics_Monad.bind uu___6
+                                       (fun uu___7 ->
                                           FStar_Tactics_Monad.ret tm1)))))) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____7682
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu___
 let (uvar_env :
   env ->
     FStar_Reflection_Data.typ FStar_Pervasives_Native.option ->
@@ -3796,148 +3709,147 @@ let (uvar_env :
   =
   fun env1 ->
     fun ty ->
-      let uu____7768 =
+      let uu___ =
         match ty with
         | FStar_Pervasives_Native.Some ty1 -> FStar_Tactics_Monad.ret ty1
         | FStar_Pervasives_Native.None ->
-            let uu____7774 =
-              let uu____7781 =
-                let uu____7782 = FStar_Syntax_Util.type_u () in
-                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7782 in
-              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____7781 in
-            FStar_Tactics_Monad.bind uu____7774
-              (fun uu____7798 ->
-                 match uu____7798 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Util.type_u () in
+                FStar_All.pipe_left FStar_Pervasives_Native.fst uu___3 in
+              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu___2 in
+            FStar_Tactics_Monad.bind uu___1
+              (fun uu___2 ->
+                 match uu___2 with
                  | (typ, uvar_typ) -> FStar_Tactics_Monad.ret typ) in
-      FStar_Tactics_Monad.bind uu____7768
+      FStar_Tactics_Monad.bind uu___
         (fun typ ->
-           let uu____7810 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
-           FStar_Tactics_Monad.bind uu____7810
-             (fun uu____7824 ->
-                match uu____7824 with
-                | (t, uvar_t) -> FStar_Tactics_Monad.ret t))
+           let uu___1 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
+           FStar_Tactics_Monad.bind uu___1
+             (fun uu___2 ->
+                match uu___2 with | (t, uvar_t) -> FStar_Tactics_Monad.ret t))
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____7842 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            let env1 = ps.FStar_Tactics_Types.main_context in
            let opts =
              match ps.FStar_Tactics_Types.goals with
-             | g::uu____7861 -> g.FStar_Tactics_Types.opts
-             | uu____7864 -> FStar_Options.peek () in
-           let uu____7867 = FStar_Syntax_Util.head_and_args t in
-           match uu____7867 with
+             | g::uu___1 -> g.FStar_Tactics_Types.opts
+             | uu___1 -> FStar_Options.peek () in
+           let uu___1 = FStar_Syntax_Util.head_and_args t in
+           match uu___1 with
            | ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                  (ctx_uvar, uu____7887);
-                FStar_Syntax_Syntax.pos = uu____7888;
-                FStar_Syntax_Syntax.vars = uu____7889;_},
-              uu____7890) ->
+                  (ctx_uvar, uu___2);
+                FStar_Syntax_Syntax.pos = uu___3;
+                FStar_Syntax_Syntax.vars = uu___4;_},
+              uu___5) ->
                let env2 =
-                 let uu___1201_7932 = env1 in
+                 let uu___6 = env1 in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___1201_7932.FStar_TypeChecker_Env.solver);
+                     (uu___6.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___1201_7932.FStar_TypeChecker_Env.range);
+                     (uu___6.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___1201_7932.FStar_TypeChecker_Env.curmodule);
+                     (uu___6.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
                      (ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___6.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___6.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___1201_7932.FStar_TypeChecker_Env.modules);
+                     (uu___6.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___1201_7932.FStar_TypeChecker_Env.expected_typ);
+                     (uu___6.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.sigtab);
+                     (uu___6.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.attrtab);
+                     (uu___6.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___1201_7932.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___1201_7932.FStar_TypeChecker_Env.effects);
+                     (uu___6.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___1201_7932.FStar_TypeChecker_Env.generalize);
+                     (uu___6.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___1201_7932.FStar_TypeChecker_Env.letrecs);
+                     (uu___6.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level =
-                     (uu___1201_7932.FStar_TypeChecker_Env.top_level);
+                     (uu___6.FStar_TypeChecker_Env.top_level);
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___1201_7932.FStar_TypeChecker_Env.check_uvars);
+                     (uu___6.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq);
+                     (uu___6.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___1201_7932.FStar_TypeChecker_Env.is_iface);
+                     (uu___6.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___1201_7932.FStar_TypeChecker_Env.admit);
+                     (uu___6.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___1201_7932.FStar_TypeChecker_Env.lax);
+                     (uu___6.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___1201_7932.FStar_TypeChecker_Env.lax_universes);
+                     (uu___6.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___1201_7932.FStar_TypeChecker_Env.phase1);
+                     (uu___6.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___1201_7932.FStar_TypeChecker_Env.failhard);
+                     (uu___6.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___1201_7932.FStar_TypeChecker_Env.nosynth);
+                     (uu___6.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___1201_7932.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___1201_7932.FStar_TypeChecker_Env.tc_term);
+                     (uu___6.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.type_of);
+                     (uu___6.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.universe_of);
+                     (uu___6.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.check_type_of);
+                     (uu___6.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___1201_7932.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___1201_7932.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___1201_7932.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___1201_7932.FStar_TypeChecker_Env.proof_ns);
+                     (uu___6.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___1201_7932.FStar_TypeChecker_Env.synth_hook);
+                     (uu___6.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___1201_7932.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___1201_7932.FStar_TypeChecker_Env.splice);
+                     (uu___6.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___1201_7932.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___6.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___1201_7932.FStar_TypeChecker_Env.postprocess);
+                     (uu___6.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___1201_7932.FStar_TypeChecker_Env.identifier_info);
+                     (uu___6.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___1201_7932.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___6.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___1201_7932.FStar_TypeChecker_Env.dsenv);
+                     (uu___6.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___1201_7932.FStar_TypeChecker_Env.nbe);
+                     (uu___6.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.erasable_types_tab);
+                     (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                    FStar_TypeChecker_Env.enable_defer_to_tac =
-                     (uu___1201_7932.FStar_TypeChecker_Env.enable_defer_to_tac)
+                     (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                  } in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
-               let uu____7934 = let uu____7937 = bnorm_goal g in [uu____7937] in
-               FStar_Tactics_Monad.add_goals uu____7934
-           | uu____7938 -> FStar_Tactics_Monad.fail "not a uvar") in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____7842
+               let uu___6 = let uu___7 = bnorm_goal g in [uu___7] in
+               FStar_Tactics_Monad.add_goals uu___6
+           | uu___2 -> FStar_Tactics_Monad.fail "not a uvar") in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu___
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
     Prims.bool FStar_Tactics_Monad.tac -> Prims.bool FStar_Tactics_Monad.tac)
@@ -3947,16 +3859,16 @@ let (tac_and :
       let comp =
         FStar_Tactics_Monad.bind t1
           (fun b ->
-             let uu____7987 = if b then t2 else FStar_Tactics_Monad.ret false in
-             FStar_Tactics_Monad.bind uu____7987
+             let uu___ = if b then t2 else FStar_Tactics_Monad.ret false in
+             FStar_Tactics_Monad.bind uu___
                (fun b' ->
                   if b'
                   then FStar_Tactics_Monad.ret b'
                   else FStar_Tactics_Monad.fail "")) in
-      let uu____7998 = trytac comp in
-      FStar_Tactics_Monad.bind uu____7998
-        (fun uu___5_8006 ->
-           match uu___5_8006 with
+      let uu___ = trytac comp in
+      FStar_Tactics_Monad.bind uu___
+        (fun uu___1 ->
+           match uu___1 with
            | FStar_Pervasives_Native.Some (true) ->
                FStar_Tactics_Monad.ret true
            | FStar_Pervasives_Native.Some (false) -> failwith "impossible"
@@ -3969,34 +3881,30 @@ let (match_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8032 =
+        let uu___ =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8038 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8038
-                 (fun uu____8058 ->
-                    match uu____8058 with
+               let uu___1 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu___1
+                 (fun uu___2 ->
+                    match uu___2 with
                     | (t11, ty1, g1) ->
-                        let uu____8070 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8070
-                          (fun uu____8090 ->
-                             match uu____8090 with
+                        let uu___3 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu___3
+                          (fun uu___4 ->
+                             match uu___4 with
                              | (t21, ty2, g2) ->
-                                 let uu____8102 =
-                                   proc_guard "match_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8102
-                                   (fun uu____8107 ->
-                                      let uu____8108 =
+                                 let uu___5 = proc_guard "match_env g1" e g1 in
+                                 FStar_Tactics_Monad.bind uu___5
+                                   (fun uu___6 ->
+                                      let uu___7 =
                                         proc_guard "match_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8108
-                                        (fun uu____8114 ->
-                                           let uu____8115 =
-                                             do_match e ty1 ty2 in
-                                           let uu____8118 =
-                                             do_match e t11 t21 in
-                                           tac_and uu____8115 uu____8118))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "match_env")
-          uu____8032
+                                      FStar_Tactics_Monad.bind uu___7
+                                        (fun uu___8 ->
+                                           let uu___9 = do_match e ty1 ty2 in
+                                           let uu___10 = do_match e t11 t21 in
+                                           tac_and uu___9 uu___10))))) in
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "match_env") uu___
 let (unify_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -4005,34 +3913,30 @@ let (unify_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8144 =
+        let uu___ =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8150 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8150
-                 (fun uu____8170 ->
-                    match uu____8170 with
+               let uu___1 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu___1
+                 (fun uu___2 ->
+                    match uu___2 with
                     | (t11, ty1, g1) ->
-                        let uu____8182 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8182
-                          (fun uu____8202 ->
-                             match uu____8202 with
+                        let uu___3 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu___3
+                          (fun uu___4 ->
+                             match uu___4 with
                              | (t21, ty2, g2) ->
-                                 let uu____8214 =
-                                   proc_guard "unify_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8214
-                                   (fun uu____8219 ->
-                                      let uu____8220 =
+                                 let uu___5 = proc_guard "unify_env g1" e g1 in
+                                 FStar_Tactics_Monad.bind uu___5
+                                   (fun uu___6 ->
+                                      let uu___7 =
                                         proc_guard "unify_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8220
-                                        (fun uu____8226 ->
-                                           let uu____8227 =
-                                             do_unify e ty1 ty2 in
-                                           let uu____8230 =
-                                             do_unify e t11 t21 in
-                                           tac_and uu____8227 uu____8230))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env")
-          uu____8144
+                                      FStar_Tactics_Monad.bind uu___7
+                                        (fun uu___8 ->
+                                           let uu___9 = do_unify e ty1 ty2 in
+                                           let uu___10 = do_unify e t11 t21 in
+                                           tac_and uu___9 uu___10))))) in
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env") uu___
 let (launch_process :
   Prims.string ->
     Prims.string Prims.list ->
@@ -4042,9 +3946,9 @@ let (launch_process :
     fun args ->
       fun input ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____8263 ->
-             let uu____8264 = FStar_Options.unsafe_tactic_exec () in
-             if uu____8264
+          (fun uu___ ->
+             let uu___1 = FStar_Options.unsafe_tactic_exec () in
+             if uu___1
              then
                let s =
                  FStar_Util.run_process "tactic_launch" prog args
@@ -4061,47 +3965,44 @@ let (fresh_bv_named :
   fun nm ->
     fun t ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-        (fun uu____8285 ->
-           let uu____8286 =
+        (fun uu___ ->
+           let uu___1 =
              FStar_Syntax_Syntax.gen_bv nm FStar_Pervasives_Native.None t in
-           FStar_Tactics_Monad.ret uu____8286)
+           FStar_Tactics_Monad.ret uu___1)
 let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
   fun ty ->
-    let uu____8296 =
+    let uu___ =
       FStar_Tactics_Monad.mlog
-        (fun uu____8301 ->
-           let uu____8302 = FStar_Syntax_Print.term_to_string ty in
-           FStar_Util.print1 "change: ty = %s\n" uu____8302)
-        (fun uu____8304 ->
+        (fun uu___1 ->
+           let uu___2 = FStar_Syntax_Print.term_to_string ty in
+           FStar_Util.print1 "change: ty = %s\n" uu___2)
+        (fun uu___1 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                let uu____8308 =
-                  let uu____8317 = FStar_Tactics_Types.goal_env g in
-                  __tc uu____8317 ty in
-                FStar_Tactics_Monad.bind uu____8308
-                  (fun uu____8329 ->
-                     match uu____8329 with
-                     | (ty1, uu____8339, guard) ->
-                         let uu____8341 =
-                           let uu____8344 = FStar_Tactics_Types.goal_env g in
-                           proc_guard "change" uu____8344 guard in
-                         FStar_Tactics_Monad.bind uu____8341
-                           (fun uu____8347 ->
-                              let uu____8348 =
-                                let uu____8351 =
-                                  FStar_Tactics_Types.goal_env g in
-                                let uu____8352 =
-                                  FStar_Tactics_Types.goal_type g in
-                                do_unify uu____8351 uu____8352 ty1 in
-                              FStar_Tactics_Monad.bind uu____8348
+                let uu___2 =
+                  let uu___3 = FStar_Tactics_Types.goal_env g in
+                  __tc uu___3 ty in
+                FStar_Tactics_Monad.bind uu___2
+                  (fun uu___3 ->
+                     match uu___3 with
+                     | (ty1, uu___4, guard) ->
+                         let uu___5 =
+                           let uu___6 = FStar_Tactics_Types.goal_env g in
+                           proc_guard "change" uu___6 guard in
+                         FStar_Tactics_Monad.bind uu___5
+                           (fun uu___6 ->
+                              let uu___7 =
+                                let uu___8 = FStar_Tactics_Types.goal_env g in
+                                let uu___9 = FStar_Tactics_Types.goal_type g in
+                                do_unify uu___8 uu___9 ty1 in
+                              FStar_Tactics_Monad.bind uu___7
                                 (fun bb ->
                                    if bb
                                    then
-                                     let uu____8358 =
+                                     let uu___8 =
                                        FStar_Tactics_Types.goal_with_type g
                                          ty1 in
-                                     FStar_Tactics_Monad.replace_cur
-                                       uu____8358
+                                     FStar_Tactics_Monad.replace_cur uu___8
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4109,32 +4010,32 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                           FStar_Syntax_Syntax.delta_constant;
                                         FStar_TypeChecker_Env.Primops] in
                                       let ng =
-                                        let uu____8364 =
+                                        let uu___9 =
                                           FStar_Tactics_Types.goal_env g in
-                                        let uu____8365 =
+                                        let uu___10 =
                                           FStar_Tactics_Types.goal_type g in
-                                        normalize steps uu____8364 uu____8365 in
+                                        normalize steps uu___9 uu___10 in
                                       let nty =
-                                        let uu____8367 =
+                                        let uu___9 =
                                           FStar_Tactics_Types.goal_env g in
-                                        normalize steps uu____8367 ty1 in
-                                      let uu____8368 =
-                                        let uu____8371 =
+                                        normalize steps uu___9 ty1 in
+                                      let uu___9 =
+                                        let uu___10 =
                                           FStar_Tactics_Types.goal_env g in
-                                        do_unify uu____8371 ng nty in
-                                      FStar_Tactics_Monad.bind uu____8368
+                                        do_unify uu___10 ng nty in
+                                      FStar_Tactics_Monad.bind uu___9
                                         (fun b ->
                                            if b
                                            then
-                                             let uu____8377 =
+                                             let uu___10 =
                                                FStar_Tactics_Types.goal_with_type
                                                  g ty1 in
                                              FStar_Tactics_Monad.replace_cur
-                                               uu____8377
+                                               uu___10
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8296
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu___
 let failwhen :
   'a .
     Prims.bool ->
@@ -4149,66 +4050,64 @@ let (t_destruct :
       FStar_Tactics_Monad.tac)
   =
   fun s_tm ->
-    let uu____8440 =
+    let uu___ =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____8458 =
-             let uu____8467 = FStar_Tactics_Types.goal_env g in
-             __tc uu____8467 s_tm in
-           FStar_Tactics_Monad.bind uu____8458
-             (fun uu____8485 ->
-                match uu____8485 with
+           let uu___1 =
+             let uu___2 = FStar_Tactics_Types.goal_env g in __tc uu___2 s_tm in
+           FStar_Tactics_Monad.bind uu___1
+             (fun uu___2 ->
+                match uu___2 with
                 | (s_tm1, s_ty, guard) ->
-                    let uu____8503 =
-                      let uu____8506 = FStar_Tactics_Types.goal_env g in
-                      proc_guard "destruct" uu____8506 guard in
-                    FStar_Tactics_Monad.bind uu____8503
-                      (fun uu____8519 ->
+                    let uu___3 =
+                      let uu___4 = FStar_Tactics_Types.goal_env g in
+                      proc_guard "destruct" uu___4 guard in
+                    FStar_Tactics_Monad.bind uu___3
+                      (fun uu___4 ->
                          let s_ty1 =
-                           let uu____8521 = FStar_Tactics_Types.goal_env g in
+                           let uu___5 = FStar_Tactics_Types.goal_env g in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.UnfoldTac;
                              FStar_TypeChecker_Env.Weak;
                              FStar_TypeChecker_Env.HNF;
                              FStar_TypeChecker_Env.UnfoldUntil
-                               FStar_Syntax_Syntax.delta_constant] uu____8521
+                               FStar_Syntax_Syntax.delta_constant] uu___5
                              s_ty in
-                         let uu____8522 =
-                           let uu____8537 = FStar_Syntax_Util.unrefine s_ty1 in
-                           FStar_Syntax_Util.head_and_args' uu____8537 in
-                         match uu____8522 with
+                         let uu___5 =
+                           let uu___6 = FStar_Syntax_Util.unrefine s_ty1 in
+                           FStar_Syntax_Util.head_and_args' uu___6 in
+                         match uu___5 with
                          | (h, args) ->
-                             let uu____8568 =
-                               let uu____8575 =
-                                 let uu____8576 =
-                                   FStar_Syntax_Subst.compress h in
-                                 uu____8576.FStar_Syntax_Syntax.n in
-                               match uu____8575 with
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 = FStar_Syntax_Subst.compress h in
+                                 uu___8.FStar_Syntax_Syntax.n in
+                               match uu___7 with
                                | FStar_Syntax_Syntax.Tm_fvar fv ->
                                    FStar_Tactics_Monad.ret (fv, [])
                                | FStar_Syntax_Syntax.Tm_uinst
                                    ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_fvar fv;
-                                      FStar_Syntax_Syntax.pos = uu____8591;
-                                      FStar_Syntax_Syntax.vars = uu____8592;_},
+                                      FStar_Syntax_Syntax.pos = uu___8;
+                                      FStar_Syntax_Syntax.vars = uu___9;_},
                                     us)
                                    -> FStar_Tactics_Monad.ret (fv, us)
-                               | uu____8602 ->
+                               | uu___8 ->
                                    FStar_Tactics_Monad.fail
                                      "type is not an fv" in
-                             FStar_Tactics_Monad.bind uu____8568
-                               (fun uu____8622 ->
-                                  match uu____8622 with
+                             FStar_Tactics_Monad.bind uu___6
+                               (fun uu___7 ->
+                                  match uu___7 with
                                   | (fv, a_us) ->
                                       let t_lid =
                                         FStar_Syntax_Syntax.lid_of_fv fv in
-                                      let uu____8638 =
-                                        let uu____8641 =
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_Tactics_Types.goal_env g in
                                         FStar_TypeChecker_Env.lookup_sigelt
-                                          uu____8641 t_lid in
-                                      (match uu____8638 with
+                                          uu___9 t_lid in
+                                      (match uu___8 with
                                        | FStar_Pervasives_Native.None ->
                                            FStar_Tactics_Monad.fail
                                              "type not found in environment"
@@ -4223,16 +4122,16 @@ let (t_destruct :
                                                   FStar_Syntax_Util.has_attribute
                                                     se.FStar_Syntax_Syntax.sigattrs
                                                     FStar_Parser_Const.erasable_attr in
-                                                let uu____8680 =
+                                                let uu___9 =
                                                   erasable &&
-                                                    (let uu____8682 =
+                                                    (let uu___10 =
                                                        FStar_Tactics_Types.is_irrelevant
                                                          g in
                                                      Prims.op_Negation
-                                                       uu____8682) in
-                                                failwhen uu____8680
+                                                       uu___10) in
+                                                failwhen uu___9
                                                   "cannot destruct erasable type to solve proof-relevant goal"
-                                                  (fun uu____8690 ->
+                                                  (fun uu___10 ->
                                                      failwhen
                                                        ((FStar_List.length
                                                            a_us)
@@ -4240,28 +4139,26 @@ let (t_destruct :
                                                           (FStar_List.length
                                                              t_us))
                                                        "t_us don't match?"
-                                                       (fun uu____8702 ->
-                                                          let uu____8703 =
+                                                       (fun uu___11 ->
+                                                          let uu___12 =
                                                             FStar_Syntax_Subst.open_term
                                                               t_ps t_ty in
-                                                          match uu____8703
-                                                          with
+                                                          match uu___12 with
                                                           | (t_ps1, t_ty1) ->
-                                                              let uu____8718
-                                                                =
+                                                              let uu___13 =
                                                                 FStar_Tactics_Monad.mapM
                                                                   (fun c_lid
                                                                     ->
-                                                                    let uu____8746
+                                                                    let uu___14
                                                                     =
-                                                                    let uu____8749
+                                                                    let uu___15
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g in
                                                                     FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____8749
+                                                                    uu___15
                                                                     c_lid in
-                                                                    match uu____8746
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -4295,7 +4192,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____8822
+                                                                    uu___15
                                                                     ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -4304,26 +4201,26 @@ let (t_destruct :
                                                                     =
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty in
-                                                                    let uu____8827
+                                                                    let uu___16
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1) in
-                                                                    match uu____8827
+                                                                    match uu___16
                                                                     with
                                                                     | 
                                                                     (c_us1,
                                                                     c_ty2) ->
-                                                                    let uu____8850
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2 in
-                                                                    (match uu____8850
+                                                                    (match uu___17
                                                                     with
                                                                     | 
                                                                     (bs,
                                                                     comp) ->
-                                                                    let uu____8869
+                                                                    let uu___18
                                                                     =
                                                                     let rename_bv
                                                                     bv =
@@ -4332,123 +4229,123 @@ let (t_destruct :
                                                                     bv.FStar_Syntax_Syntax.ppname in
                                                                     let ppname1
                                                                     =
-                                                                    let uu____8892
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____8897
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____8898
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.string_of_id
                                                                     ppname in
                                                                     Prims.op_Hat
                                                                     "a"
-                                                                    uu____8898 in
-                                                                    let uu____8899
+                                                                    uu___21 in
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.range_of_id
                                                                     ppname in
-                                                                    (uu____8897,
-                                                                    uu____8899) in
+                                                                    (uu___20,
+                                                                    uu___21) in
                                                                     FStar_Ident.mk_ident
-                                                                    uu____8892 in
+                                                                    uu___19 in
                                                                     FStar_Syntax_Syntax.freshen_bv
-                                                                    (let uu___1343_8902
+                                                                    (let uu___19
                                                                     = bv in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     = ppname1;
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1343_8902.FStar_Syntax_Syntax.index);
+                                                                    (uu___19.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    (uu___1343_8902.FStar_Syntax_Syntax.sort)
+                                                                    (uu___19.FStar_Syntax_Syntax.sort)
                                                                     }) in
                                                                     let bs' =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____8928
+                                                                    uu___19
                                                                     ->
-                                                                    match uu____8928
+                                                                    match uu___19
                                                                     with
                                                                     | 
                                                                     (bv, aq)
                                                                     ->
-                                                                    let uu____8947
+                                                                    let uu___20
                                                                     =
                                                                     rename_bv
                                                                     bv in
-                                                                    (uu____8947,
+                                                                    (uu___20,
                                                                     aq)) bs in
                                                                     let subst
                                                                     =
                                                                     FStar_List.map2
                                                                     (fun
-                                                                    uu____8972
+                                                                    uu___19
                                                                     ->
                                                                     fun
-                                                                    uu____8973
+                                                                    uu___20
                                                                     ->
                                                                     match 
-                                                                    (uu____8972,
-                                                                    uu____8973)
+                                                                    (uu___19,
+                                                                    uu___20)
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____8999),
+                                                                    uu___21),
                                                                     (bv',
-                                                                    uu____9001))
+                                                                    uu___22))
                                                                     ->
-                                                                    let uu____9022
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____9029
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv' in
                                                                     (bv,
-                                                                    uu____9029) in
+                                                                    uu___24) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____9022)
+                                                                    uu___23)
                                                                     bs bs' in
-                                                                    let uu____9034
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Subst.subst_binders
                                                                     subst bs' in
-                                                                    let uu____9043
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     comp in
-                                                                    (uu____9034,
-                                                                    uu____9043) in
-                                                                    (match uu____8869
+                                                                    (uu___19,
+                                                                    uu___20) in
+                                                                    (match uu___18
                                                                     with
                                                                     | 
                                                                     (bs1,
                                                                     comp1) ->
-                                                                    let uu____9090
+                                                                    let uu___19
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     bs1 in
-                                                                    (match uu____9090
+                                                                    (match uu___19
                                                                     with
                                                                     | 
                                                                     (d_ps,
                                                                     bs2) ->
-                                                                    let uu____9163
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____9164
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp1 in
                                                                     Prims.op_Negation
-                                                                    uu____9164 in
+                                                                    uu___21 in
                                                                     failwhen
-                                                                    uu____9163
+                                                                    uu___20
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____9181
+                                                                    uu___21
                                                                     ->
                                                                     let mk_pat
                                                                     p =
@@ -4460,24 +4357,23 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     } in
                                                                     let is_imp
-                                                                    uu___6_9197
-                                                                    =
-                                                                    match uu___6_9197
+                                                                    uu___22 =
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____9200)
+                                                                    uu___23)
                                                                     -> true
                                                                     | 
-                                                                    uu____9201
+                                                                    uu___23
                                                                     -> false in
-                                                                    let uu____9204
+                                                                    let uu___22
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args in
-                                                                    match uu____9204
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     (a_ps,
@@ -4489,7 +4385,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____9339
+                                                                    uu___23
                                                                     ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -4499,15 +4395,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9401
+                                                                    uu___24
                                                                     ->
-                                                                    match uu____9401
+                                                                    match uu___24
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9421),
+                                                                    uu___25),
                                                                     (t,
-                                                                    uu____9423))
+                                                                    uu___26))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -4519,15 +4415,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9491
+                                                                    uu___24
                                                                     ->
-                                                                    match uu____9491
+                                                                    match uu___24
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9517),
+                                                                    uu___25),
                                                                     (t,
-                                                                    uu____9519))
+                                                                    uu___26))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -4538,9 +4434,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9574
+                                                                    uu___24
                                                                     ->
-                                                                    match uu____9574
+                                                                    match uu___24
                                                                     with
                                                                     | 
                                                                     (bv, aq)
@@ -4571,171 +4467,171 @@ let (t_destruct :
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1
                                                                     s_ty1 in
-                                                                    let uu____9624
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1402_9647
+                                                                    (let uu___25
                                                                     = env1 in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.solver);
+                                                                    (uu___25.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.range);
+                                                                    (uu___25.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___25.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___25.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___25.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___25.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.modules);
+                                                                    (uu___25.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___25.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___25.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___25.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___25.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.effects);
+                                                                    (uu___25.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___25.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___25.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___25.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___25.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___25.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.use_eq_strict
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    (uu___25.FStar_TypeChecker_Env.use_eq_strict);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___25.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.admit);
+                                                                    (uu___25.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___25.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___25.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___25.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___25.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___25.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___25.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___25.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___25.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___25.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___25.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___25.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___25.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___25.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___25.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___25.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    (uu___25.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.splice);
+                                                                    (uu___25.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.mpreprocess
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.mpreprocess);
+                                                                    (uu___25.FStar_TypeChecker_Env.mpreprocess);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___25.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___25.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___25.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___25.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___25.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    (uu___25.FStar_TypeChecker_Env.strict_args_tab);
                                                                     FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                    (uu___25.FStar_TypeChecker_Env.erasable_types_tab);
                                                                     FStar_TypeChecker_Env.enable_defer_to_tac
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                    (uu___25.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                                     }) s_ty1
                                                                     pat in
-                                                                    match uu____9624
+                                                                    match uu___24
                                                                     with
                                                                     | 
-                                                                    (uu____9660,
-                                                                    uu____9661,
-                                                                    uu____9662,
-                                                                    uu____9663,
+                                                                    (uu___25,
+                                                                    uu___26,
+                                                                    uu___27,
+                                                                    uu___28,
                                                                     pat_t,
-                                                                    uu____9665,
+                                                                    uu___29,
                                                                     _guard_pat,
                                                                     _erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____9677
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____9678
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty1
@@ -4743,46 +4639,46 @@ let (t_destruct :
                                                                     pat_t in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____9678 in
+                                                                    uu___31 in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____9677 in
+                                                                    uu___30 in
                                                                     let cod1
                                                                     =
-                                                                    let uu____9682
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____9691
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b in
-                                                                    [uu____9691] in
-                                                                    let uu____9710
+                                                                    [uu___31] in
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____9682
-                                                                    uu____9710 in
+                                                                    uu___30
+                                                                    uu___31 in
                                                                     let nty =
-                                                                    let uu____9716
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs3
-                                                                    uu____9716 in
-                                                                    let uu____9719
+                                                                    uu___30 in
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Tactics_Monad.new_uvar
                                                                     "destruct branch"
                                                                     env1 nty in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9719
+                                                                    uu___30
                                                                     (fun
-                                                                    uu____9748
+                                                                    uu___31
                                                                     ->
-                                                                    match uu____9748
+                                                                    match uu___31
                                                                     with
                                                                     | 
                                                                     (uvt, uv)
@@ -4798,51 +4694,51 @@ let (t_destruct :
                                                                     uvt bs3 in
                                                                     let brt1
                                                                     =
-                                                                    let uu____9774
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____9785
+                                                                    let uu___33
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit in
-                                                                    [uu____9785] in
+                                                                    [uu___33] in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____9774 in
+                                                                    uu___32 in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1) in
-                                                                    let uu____9821
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____9832
+                                                                    let uu___33
                                                                     =
-                                                                    let uu____9837
+                                                                    let uu___34
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs3) in
                                                                     (fv1,
-                                                                    uu____9837) in
+                                                                    uu___34) in
                                                                     (g', br,
-                                                                    uu____9832) in
+                                                                    uu___33) in
                                                                     FStar_Tactics_Monad.ret
-                                                                    uu____9821)))))))
+                                                                    uu___32)))))))
                                                                     | 
-                                                                    uu____9858
+                                                                    uu___15
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "impossible: not a ctor"))
                                                                   c_lids in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____8718
+                                                                uu___13
                                                                 (fun goal_brs
                                                                    ->
-                                                                   let uu____9907
+                                                                   let uu___14
                                                                     =
                                                                     FStar_List.unzip3
                                                                     goal_brs in
-                                                                   match uu____9907
+                                                                   match uu___14
                                                                    with
                                                                    | 
                                                                    (goals,
@@ -4854,56 +4750,56 @@ let (t_destruct :
                                                                     (s_tm1,
                                                                     brs))
                                                                     s_tm1.FStar_Syntax_Syntax.pos in
-                                                                    let uu____9980
+                                                                    let uu___15
                                                                     =
                                                                     solve' g
                                                                     w in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9980
+                                                                    uu___15
                                                                     (fun
-                                                                    uu____9991
+                                                                    uu___16
                                                                     ->
-                                                                    let uu____9992
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9992
+                                                                    uu___17
                                                                     (fun
-                                                                    uu____10002
+                                                                    uu___18
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos)))))
-                                            | uu____10009 ->
+                                            | uu___9 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type")))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8440
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu___
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____10054::xs -> last xs
+    | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____10082 = init xs in x :: uu____10082
+    | x::xs -> let uu___ = init xs in x :: uu___
 let rec (inspect :
   FStar_Syntax_Syntax.term ->
     FStar_Reflection_Data.term_view FStar_Tactics_Monad.tac)
   =
   fun t ->
-    let uu____10094 =
-      let uu____10097 = top_env () in
-      FStar_Tactics_Monad.bind uu____10097
+    let uu___ =
+      let uu___1 = top_env () in
+      FStar_Tactics_Monad.bind uu___1
         (fun e ->
            let t1 = FStar_Syntax_Util.unascribe t in
            let t2 = FStar_Syntax_Util.un_uinst t1 in
            let t3 = FStar_Syntax_Util.unlazy_emb t2 in
            match t3.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_meta (t4, uu____10113) -> inspect t4
+           | FStar_Syntax_Syntax.Tm_meta (t4, uu___2) -> inspect t4
            | FStar_Syntax_Syntax.Tm_name bv ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Var bv)
@@ -4916,75 +4812,74 @@ let rec (inspect :
            | FStar_Syntax_Syntax.Tm_app (hd, []) ->
                failwith "empty arguments on Tm_app"
            | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-               let uu____10178 = last args in
-               (match uu____10178 with
+               let uu___2 = last args in
+               (match uu___2 with
                 | (a, q) ->
                     let q' = FStar_Reflection_Basic.inspect_aqual q in
-                    let uu____10208 =
-                      let uu____10209 =
-                        let uu____10214 =
-                          let uu____10215 = init args in
-                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10215
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = init args in
+                          FStar_Syntax_Syntax.mk_Tm_app hd uu___6
                             t3.FStar_Syntax_Syntax.pos in
-                        (uu____10214, (a, q')) in
-                      FStar_Reflection_Data.Tv_App uu____10209 in
-                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10208)
-           | FStar_Syntax_Syntax.Tm_abs ([], uu____10226, uu____10227) ->
+                        (uu___5, (a, q')) in
+                      FStar_Reflection_Data.Tv_App uu___4 in
+                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu___3)
+           | FStar_Syntax_Syntax.Tm_abs ([], uu___2, uu___3) ->
                failwith "empty arguments on Tm_abs"
            | FStar_Syntax_Syntax.Tm_abs (bs, t4, k) ->
-               let uu____10279 = FStar_Syntax_Subst.open_term bs t4 in
-               (match uu____10279 with
+               let uu___2 = FStar_Syntax_Subst.open_term bs t4 in
+               (match uu___2 with
                 | (bs1, t5) ->
                     (match bs1 with
                      | [] -> failwith "impossible"
                      | b::bs2 ->
-                         let uu____10320 =
-                           let uu____10321 =
-                             let uu____10326 = FStar_Syntax_Util.abs bs2 t5 k in
-                             (b, uu____10326) in
-                           FStar_Reflection_Data.Tv_Abs uu____10321 in
-                         FStar_All.pipe_left FStar_Tactics_Monad.ret
-                           uu____10320))
-           | FStar_Syntax_Syntax.Tm_type uu____10329 ->
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 = FStar_Syntax_Util.abs bs2 t5 k in
+                             (b, uu___5) in
+                           FStar_Reflection_Data.Tv_Abs uu___4 in
+                         FStar_All.pipe_left FStar_Tactics_Monad.ret uu___3))
+           | FStar_Syntax_Syntax.Tm_type uu___2 ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Type ())
            | FStar_Syntax_Syntax.Tm_arrow ([], k) ->
                failwith "empty binders on arrow"
-           | FStar_Syntax_Syntax.Tm_arrow uu____10353 ->
-               let uu____10368 = FStar_Syntax_Util.arrow_one t3 in
-               (match uu____10368 with
+           | FStar_Syntax_Syntax.Tm_arrow uu___2 ->
+               let uu___3 = FStar_Syntax_Util.arrow_one t3 in
+               (match uu___3 with
                 | FStar_Pervasives_Native.Some (b, c) ->
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None -> failwith "impossible")
            | FStar_Syntax_Syntax.Tm_refine (bv, t4) ->
                let b = FStar_Syntax_Syntax.mk_binder bv in
-               let uu____10398 = FStar_Syntax_Subst.open_term [b] t4 in
-               (match uu____10398 with
+               let uu___2 = FStar_Syntax_Subst.open_term [b] t4 in
+               (match uu___2 with
                 | (b', t5) ->
                     let b1 =
                       match b' with
                       | b'1::[] -> b'1
-                      | uu____10451 -> failwith "impossible" in
+                      | uu___3 -> failwith "impossible" in
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Refine
                          ((FStar_Pervasives_Native.fst b1), t5)))
            | FStar_Syntax_Syntax.Tm_constant c ->
-               let uu____10463 =
-                 let uu____10464 = FStar_Reflection_Basic.inspect_const c in
-                 FStar_Reflection_Data.Tv_Const uu____10464 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10463
+               let uu___2 =
+                 let uu___3 = FStar_Reflection_Basic.inspect_const c in
+                 FStar_Reflection_Data.Tv_Const uu___3 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu___2
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u, s) ->
-               let uu____10485 =
-                 let uu____10486 =
-                   let uu____10491 =
-                     let uu____10492 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
                        FStar_Syntax_Unionfind.uvar_id
                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                     FStar_BigInt.of_int_fs uu____10492 in
-                   (uu____10491, (ctx_u, s)) in
-                 FStar_Reflection_Data.Tv_Uvar uu____10486 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10485
+                     FStar_BigInt.of_int_fs uu___5 in
+                   (uu___4, (ctx_u, s)) in
+                 FStar_Reflection_Data.Tv_Uvar uu___3 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu___2
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), t21) ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
@@ -4992,18 +4887,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10526 ->
+                  | FStar_Util.Inr uu___3 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv in
-                      let uu____10531 = FStar_Syntax_Subst.open_term [b] t21 in
-                      (match uu____10531 with
+                      let uu___3 = FStar_Syntax_Subst.open_term [b] t21 in
+                      (match uu___3 with
                        | (bs, t22) ->
                            let b1 =
                              match bs with
-                             | b1::[] -> b1
-                             | uu____10584 ->
+                             | b2::[] -> b2
+                             | uu___4 ->
                                  failwith
                                    "impossible: open_term returned different amount of binders" in
                            FStar_All.pipe_left FStar_Tactics_Monad.ret
@@ -5018,18 +4913,17 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10620 ->
+                  | FStar_Util.Inr uu___3 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
-                      let uu____10624 =
-                        FStar_Syntax_Subst.open_let_rec [lb] t21 in
-                      (match uu____10624 with
+                      let uu___3 = FStar_Syntax_Subst.open_let_rec [lb] t21 in
+                      (match uu___3 with
                        | (lbs, t22) ->
                            (match lbs with
                             | lb1::[] ->
                                 (match lb1.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____10644 ->
+                                 | FStar_Util.Inr uu___4 ->
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_Data.Tv_Unknown
                                  | FStar_Util.Inl bv1 ->
@@ -5041,26 +4935,26 @@ let rec (inspect :
                                             bv1,
                                             (lb1.FStar_Syntax_Syntax.lbdef),
                                             t22)))
-                            | uu____10650 ->
+                            | uu___4 ->
                                 failwith
                                   "impossible: open_term returned different amount of binders")))
            | FStar_Syntax_Syntax.Tm_match (t4, brs) ->
                let rec inspect_pat p =
                  match p.FStar_Syntax_Syntax.v with
                  | FStar_Syntax_Syntax.Pat_constant c ->
-                     let uu____10704 = FStar_Reflection_Basic.inspect_const c in
-                     FStar_Reflection_Data.Pat_Constant uu____10704
+                     let uu___2 = FStar_Reflection_Basic.inspect_const c in
+                     FStar_Reflection_Data.Pat_Constant uu___2
                  | FStar_Syntax_Syntax.Pat_cons (fv, ps) ->
-                     let uu____10723 =
-                       let uu____10734 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_List.map
-                           (fun uu____10755 ->
-                              match uu____10755 with
+                           (fun uu___4 ->
+                              match uu___4 with
                               | (p1, b) ->
-                                  let uu____10772 = inspect_pat p1 in
-                                  (uu____10772, b)) ps in
-                       (fv, uu____10734) in
-                     FStar_Reflection_Data.Pat_Cons uu____10723
+                                  let uu___5 = inspect_pat p1 in (uu___5, b))
+                           ps in
+                       (fv, uu___3) in
+                     FStar_Reflection_Data.Pat_Cons uu___2
                  | FStar_Syntax_Syntax.Pat_var bv ->
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -5070,30 +4964,28 @@ let rec (inspect :
                let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs in
                let brs2 =
                  FStar_List.map
-                   (fun uu___7_10866 ->
-                      match uu___7_10866 with
-                      | (pat, uu____10888, t5) ->
-                          let uu____10906 = inspect_pat pat in
-                          (uu____10906, t5)) brs1 in
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (pat, uu___3, t5) ->
+                          let uu___4 = inspect_pat pat in (uu___4, t5)) brs1 in
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Match (t4, brs2))
            | FStar_Syntax_Syntax.Tm_unknown ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____10915 ->
-               ((let uu____10917 =
-                   let uu____10922 =
-                     let uu____10923 = FStar_Syntax_Print.tag_of_term t3 in
-                     let uu____10924 = term_to_string e t3 in
+           | uu___2 ->
+               ((let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.tag_of_term t3 in
+                     let uu___7 = term_to_string e t3 in
                      FStar_Util.format2
                        "inspect: outside of expected syntax (%s, %s)\n"
-                       uu____10923 uu____10924 in
-                   (FStar_Errors.Warning_CantInspect, uu____10922) in
-                 FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos
-                   uu____10917);
+                       uu___6 uu___7 in
+                   (FStar_Errors.Warning_CantInspect, uu___5) in
+                 FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu___4);
                 FStar_All.pipe_left FStar_Tactics_Monad.ret
                   FStar_Reflection_Data.Tv_Unknown)) in
-    FStar_Tactics_Monad.wrap_err "inspect" uu____10094
+    FStar_Tactics_Monad.wrap_err "inspect" uu___
 let (pack :
   FStar_Reflection_Data.term_view ->
     FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
@@ -5101,72 +4993,70 @@ let (pack :
   fun tv ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____10937 = FStar_Syntax_Syntax.bv_to_name bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10937
+        let uu___ = FStar_Syntax_Syntax.bv_to_name bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____10941 = FStar_Syntax_Syntax.bv_to_tm bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10941
+        let uu___ = FStar_Syntax_Syntax.bv_to_tm bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____10945 = FStar_Syntax_Syntax.fv_to_tm fv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10945
+        let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_App (l, (r, q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q in
-        let uu____10952 = FStar_Syntax_Util.mk_app l [(r, q')] in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10952
+        let uu___ = FStar_Syntax_Util.mk_app l [(r, q')] in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Abs (b, t) ->
-        let uu____10977 =
-          FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10977
+        let uu___ = FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Arrow (b, c) ->
-        let uu____10994 = FStar_Syntax_Util.arrow [b] c in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10994
+        let uu___ = FStar_Syntax_Util.arrow [b] c in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left FStar_Tactics_Monad.ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv, t) ->
-        let uu____11013 = FStar_Syntax_Util.refine bv t in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11013
+        let uu___ = FStar_Syntax_Util.refine bv t in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____11017 =
-          let uu____11018 =
-            let uu____11019 = FStar_Reflection_Basic.pack_const c in
-            FStar_Syntax_Syntax.Tm_constant uu____11019 in
-          FStar_Syntax_Syntax.mk uu____11018 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11017
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Reflection_Basic.pack_const c in
+            FStar_Syntax_Syntax.Tm_constant uu___2 in
+          FStar_Syntax_Syntax.mk uu___1 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Uvar (_u, ctx_u_s) ->
-        let uu____11024 =
+        let uu___ =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11024
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Let (false, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11036 =
-          let uu____11037 =
-            let uu____11038 =
-              let uu____11051 =
-                let uu____11054 =
-                  let uu____11055 = FStar_Syntax_Syntax.mk_binder bv in
-                  [uu____11055] in
-                FStar_Syntax_Subst.close uu____11054 t2 in
-              ((false, [lb]), uu____11051) in
-            FStar_Syntax_Syntax.Tm_let uu____11038 in
-          FStar_Syntax_Syntax.mk uu____11037 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11036
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Syntax.mk_binder bv in [uu___5] in
+                FStar_Syntax_Subst.close uu___4 t2 in
+              ((false, [lb]), uu___3) in
+            FStar_Syntax_Syntax.Tm_let uu___2 in
+          FStar_Syntax_Syntax.mk uu___1 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Let (true, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11095 = FStar_Syntax_Subst.close_let_rec [lb] t2 in
-        (match uu____11095 with
+        let uu___ = FStar_Syntax_Subst.close_let_rec [lb] t2 in
+        (match uu___ with
          | (lbs, body) ->
-             let uu____11110 =
+             let uu___1 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Range.dummyRange in
-             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11110)
+             FStar_All.pipe_left FStar_Tactics_Monad.ret uu___1)
     | FStar_Reflection_Data.Tv_Match (t, brs) ->
         let wrap v =
           {
@@ -5176,23 +5066,22 @@ let (pack :
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____11144 =
-                let uu____11145 = FStar_Reflection_Basic.pack_const c in
-                FStar_Syntax_Syntax.Pat_constant uu____11145 in
-              FStar_All.pipe_left wrap uu____11144
+              let uu___ =
+                let uu___1 = FStar_Reflection_Basic.pack_const c in
+                FStar_Syntax_Syntax.Pat_constant uu___1 in
+              FStar_All.pipe_left wrap uu___
           | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-              let uu____11160 =
-                let uu____11161 =
-                  let uu____11174 =
+              let uu___ =
+                let uu___1 =
+                  let uu___2 =
                     FStar_List.map
-                      (fun uu____11195 ->
-                         match uu____11195 with
-                         | (p1, b) ->
-                             let uu____11206 = pack_pat p1 in
-                             (uu____11206, b)) ps in
-                  (fv, uu____11174) in
-                FStar_Syntax_Syntax.Pat_cons uu____11161 in
-              FStar_All.pipe_left wrap uu____11160
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | (p1, b) -> let uu___4 = pack_pat p1 in (uu___4, b))
+                      ps in
+                  (fv, uu___2) in
+                FStar_Syntax_Syntax.Pat_cons uu___1 in
+              FStar_All.pipe_left wrap uu___
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -5202,51 +5091,51 @@ let (pack :
                 (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
         let brs1 =
           FStar_List.map
-            (fun uu___8_11252 ->
-               match uu___8_11252 with
+            (fun uu___ ->
+               match uu___ with
                | (pat, t1) ->
-                   let uu____11269 = pack_pat pat in
-                   (uu____11269, FStar_Pervasives_Native.None, t1)) brs in
+                   let uu___1 = pack_pat pat in
+                   (uu___1, FStar_Pervasives_Native.None, t1)) brs in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1 in
-        let uu____11317 =
+        let uu___ =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11317
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_AscribedT (e, t, tacopt) ->
-        let uu____11345 =
+        let uu___ =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11345
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_AscribedC (e, c, tacopt) ->
-        let uu____11391 =
+        let uu___ =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11391
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
     | FStar_Reflection_Data.Tv_Unknown ->
-        let uu____11430 =
+        let uu___ =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11430
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu___
 let (lget :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
   =
   fun ty ->
     fun k ->
-      let uu____11447 =
+      let uu___ =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun ps ->
-             let uu____11453 =
+             let uu___1 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k in
-             match uu____11453 with
+             match uu___1 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____11447
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu___
 let (lset :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -5254,41 +5143,40 @@ let (lset :
   fun _ty ->
     fun k ->
       fun t ->
-        let uu____11482 =
+        let uu___ =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let ps1 =
-                 let uu___1707_11489 = ps in
-                 let uu____11490 =
+                 let uu___1 = ps in
+                 let uu___2 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___1707_11489.FStar_Tactics_Types.main_context);
+                     (uu___1.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___1707_11489.FStar_Tactics_Types.all_implicits);
+                     (uu___1.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___1707_11489.FStar_Tactics_Types.goals);
+                     (uu___1.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___1707_11489.FStar_Tactics_Types.smt_goals);
+                     (uu___1.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___1707_11489.FStar_Tactics_Types.depth);
+                     (uu___1.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___1707_11489.FStar_Tactics_Types.__dump);
-                   FStar_Tactics_Types.psc =
-                     (uu___1707_11489.FStar_Tactics_Types.psc);
+                     (uu___1.FStar_Tactics_Types.__dump);
+                   FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___1707_11489.FStar_Tactics_Types.entry_range);
+                     (uu___1.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___1707_11489.FStar_Tactics_Types.guard_policy);
+                     (uu___1.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___1707_11489.FStar_Tactics_Types.freshness);
+                     (uu___1.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___1707_11489.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____11490
+                     (uu___1.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu___2
                  } in
                FStar_Tactics_Monad.set ps1) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____11482
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu___
 let (goal_of_goal_ty :
   env ->
     FStar_Reflection_Data.typ ->
@@ -5296,314 +5184,307 @@ let (goal_of_goal_ty :
   =
   fun env1 ->
     fun typ ->
-      let uu____11515 =
+      let uu___ =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env1 typ
           FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None in
-      match uu____11515 with
+      match uu___ with
       | (u, ctx_uvars, g_u) ->
-          let uu____11547 = FStar_List.hd ctx_uvars in
-          (match uu____11547 with
-           | (ctx_uvar, uu____11561) ->
+          let uu___1 = FStar_List.hd ctx_uvars in
+          (match uu___1 with
+           | (ctx_uvar, uu___2) ->
                let g =
-                 let uu____11563 = FStar_Options.peek () in
-                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____11563 false
-                   "" in
+                 let uu___3 = FStar_Options.peek () in
+                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu___3 false "" in
                (g, g_u))
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1 ->
-    let uu____11569 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-    match uu____11569 with
-    | (env2, uu____11577) ->
+    let uu___ = FStar_TypeChecker_Env.clear_expected_typ env1 in
+    match uu___ with
+    | (env2, uu___1) ->
         let env3 =
-          let uu___1724_11583 = env2 in
+          let uu___2 = env2 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1724_11583.FStar_TypeChecker_Env.solver);
+              (uu___2.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1724_11583.FStar_TypeChecker_Env.range);
+              (uu___2.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1724_11583.FStar_TypeChecker_Env.curmodule);
+              (uu___2.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma);
+              (uu___2.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma_sig);
+              (uu___2.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma_cache);
+              (uu___2.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1724_11583.FStar_TypeChecker_Env.modules);
+              (uu___2.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1724_11583.FStar_TypeChecker_Env.expected_typ);
+              (uu___2.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1724_11583.FStar_TypeChecker_Env.sigtab);
+              (uu___2.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1724_11583.FStar_TypeChecker_Env.attrtab);
+              (uu___2.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp = false;
             FStar_TypeChecker_Env.effects =
-              (uu___1724_11583.FStar_TypeChecker_Env.effects);
+              (uu___2.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1724_11583.FStar_TypeChecker_Env.generalize);
+              (uu___2.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1724_11583.FStar_TypeChecker_Env.letrecs);
+              (uu___2.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1724_11583.FStar_TypeChecker_Env.top_level);
+              (uu___2.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1724_11583.FStar_TypeChecker_Env.check_uvars);
+              (uu___2.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_eq);
+              (uu___2.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___2.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1724_11583.FStar_TypeChecker_Env.is_iface);
+              (uu___2.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1724_11583.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___1724_11583.FStar_TypeChecker_Env.lax);
+              (uu___2.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax = (uu___2.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1724_11583.FStar_TypeChecker_Env.lax_universes);
+              (uu___2.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1724_11583.FStar_TypeChecker_Env.phase1);
+              (uu___2.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1724_11583.FStar_TypeChecker_Env.failhard);
+              (uu___2.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1724_11583.FStar_TypeChecker_Env.nosynth);
+              (uu___2.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1724_11583.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1724_11583.FStar_TypeChecker_Env.tc_term);
+              (uu___2.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.type_of);
+              (uu___2.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.universe_of);
+              (uu___2.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.check_type_of);
+              (uu___2.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1724_11583.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1724_11583.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1724_11583.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1724_11583.FStar_TypeChecker_Env.proof_ns);
+              (uu___2.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1724_11583.FStar_TypeChecker_Env.synth_hook);
+              (uu___2.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1724_11583.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1724_11583.FStar_TypeChecker_Env.splice);
+              (uu___2.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1724_11583.FStar_TypeChecker_Env.mpreprocess);
+              (uu___2.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1724_11583.FStar_TypeChecker_Env.postprocess);
+              (uu___2.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1724_11583.FStar_TypeChecker_Env.identifier_info);
+              (uu___2.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1724_11583.FStar_TypeChecker_Env.tc_hooks);
+              (uu___2.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1724_11583.FStar_TypeChecker_Env.dsenv);
-            FStar_TypeChecker_Env.nbe =
-              (uu___1724_11583.FStar_TypeChecker_Env.nbe);
+              (uu___2.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (uu___2.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1724_11583.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___2.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1724_11583.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1724_11583.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
         let env4 =
-          let uu___1727_11585 = env3 in
+          let uu___2 = env3 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1727_11585.FStar_TypeChecker_Env.solver);
+              (uu___2.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1727_11585.FStar_TypeChecker_Env.range);
+              (uu___2.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1727_11585.FStar_TypeChecker_Env.curmodule);
+              (uu___2.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma);
+              (uu___2.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma_sig);
+              (uu___2.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma_cache);
+              (uu___2.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1727_11585.FStar_TypeChecker_Env.modules);
+              (uu___2.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1727_11585.FStar_TypeChecker_Env.expected_typ);
+              (uu___2.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1727_11585.FStar_TypeChecker_Env.sigtab);
+              (uu___2.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1727_11585.FStar_TypeChecker_Env.attrtab);
+              (uu___2.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1727_11585.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___2.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1727_11585.FStar_TypeChecker_Env.effects);
+              (uu___2.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1727_11585.FStar_TypeChecker_Env.generalize);
+              (uu___2.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1727_11585.FStar_TypeChecker_Env.letrecs);
+              (uu___2.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1727_11585.FStar_TypeChecker_Env.top_level);
+              (uu___2.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1727_11585.FStar_TypeChecker_Env.check_uvars);
+              (uu___2.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_eq);
+              (uu___2.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___2.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1727_11585.FStar_TypeChecker_Env.is_iface);
+              (uu___2.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1727_11585.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___1727_11585.FStar_TypeChecker_Env.lax);
+              (uu___2.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax = (uu___2.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1727_11585.FStar_TypeChecker_Env.lax_universes);
+              (uu___2.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1727_11585.FStar_TypeChecker_Env.phase1);
+              (uu___2.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard = true;
             FStar_TypeChecker_Env.nosynth =
-              (uu___1727_11585.FStar_TypeChecker_Env.nosynth);
+              (uu___2.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1727_11585.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1727_11585.FStar_TypeChecker_Env.tc_term);
+              (uu___2.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.type_of);
+              (uu___2.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.universe_of);
+              (uu___2.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.check_type_of);
+              (uu___2.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1727_11585.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1727_11585.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1727_11585.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1727_11585.FStar_TypeChecker_Env.proof_ns);
+              (uu___2.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1727_11585.FStar_TypeChecker_Env.synth_hook);
+              (uu___2.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1727_11585.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1727_11585.FStar_TypeChecker_Env.splice);
+              (uu___2.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1727_11585.FStar_TypeChecker_Env.mpreprocess);
+              (uu___2.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1727_11585.FStar_TypeChecker_Env.postprocess);
+              (uu___2.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1727_11585.FStar_TypeChecker_Env.identifier_info);
+              (uu___2.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1727_11585.FStar_TypeChecker_Env.tc_hooks);
+              (uu___2.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1727_11585.FStar_TypeChecker_Env.dsenv);
-            FStar_TypeChecker_Env.nbe =
-              (uu___1727_11585.FStar_TypeChecker_Env.nbe);
+              (uu___2.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (uu___2.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1727_11585.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___2.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1727_11585.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1727_11585.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
         let env5 =
-          let uu___1730_11587 = env4 in
+          let uu___2 = env4 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1730_11587.FStar_TypeChecker_Env.solver);
+              (uu___2.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1730_11587.FStar_TypeChecker_Env.range);
+              (uu___2.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1730_11587.FStar_TypeChecker_Env.curmodule);
+              (uu___2.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1730_11587.FStar_TypeChecker_Env.gamma);
+              (uu___2.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1730_11587.FStar_TypeChecker_Env.gamma_sig);
+              (uu___2.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1730_11587.FStar_TypeChecker_Env.gamma_cache);
+              (uu___2.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1730_11587.FStar_TypeChecker_Env.modules);
+              (uu___2.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1730_11587.FStar_TypeChecker_Env.expected_typ);
+              (uu___2.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1730_11587.FStar_TypeChecker_Env.sigtab);
+              (uu___2.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1730_11587.FStar_TypeChecker_Env.attrtab);
+              (uu___2.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1730_11587.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___2.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1730_11587.FStar_TypeChecker_Env.effects);
+              (uu___2.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1730_11587.FStar_TypeChecker_Env.generalize);
+              (uu___2.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1730_11587.FStar_TypeChecker_Env.letrecs);
+              (uu___2.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1730_11587.FStar_TypeChecker_Env.top_level);
+              (uu___2.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1730_11587.FStar_TypeChecker_Env.check_uvars);
+              (uu___2.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1730_11587.FStar_TypeChecker_Env.use_eq);
+              (uu___2.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1730_11587.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___2.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1730_11587.FStar_TypeChecker_Env.is_iface);
+              (uu___2.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1730_11587.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___1730_11587.FStar_TypeChecker_Env.lax);
+              (uu___2.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax = (uu___2.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1730_11587.FStar_TypeChecker_Env.lax_universes);
+              (uu___2.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1730_11587.FStar_TypeChecker_Env.phase1);
+              (uu___2.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1730_11587.FStar_TypeChecker_Env.failhard);
+              (uu___2.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1730_11587.FStar_TypeChecker_Env.nosynth);
+              (uu___2.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1730_11587.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1730_11587.FStar_TypeChecker_Env.tc_term);
+              (uu___2.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1730_11587.FStar_TypeChecker_Env.type_of);
+              (uu___2.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1730_11587.FStar_TypeChecker_Env.universe_of);
+              (uu___2.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1730_11587.FStar_TypeChecker_Env.check_type_of);
+              (uu___2.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1730_11587.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1730_11587.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1730_11587.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1730_11587.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1730_11587.FStar_TypeChecker_Env.proof_ns);
+              (uu___2.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1730_11587.FStar_TypeChecker_Env.synth_hook);
+              (uu___2.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1730_11587.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1730_11587.FStar_TypeChecker_Env.splice);
+              (uu___2.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1730_11587.FStar_TypeChecker_Env.mpreprocess);
+              (uu___2.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1730_11587.FStar_TypeChecker_Env.postprocess);
+              (uu___2.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1730_11587.FStar_TypeChecker_Env.identifier_info);
+              (uu___2.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1730_11587.FStar_TypeChecker_Env.tc_hooks);
+              (uu___2.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1730_11587.FStar_TypeChecker_Env.dsenv);
-            FStar_TypeChecker_Env.nbe =
-              (uu___1730_11587.FStar_TypeChecker_Env.nbe);
+              (uu___2.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (uu___2.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1730_11587.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___2.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1730_11587.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac = false
           } in
         env5
@@ -5620,10 +5501,10 @@ let (proofstate_of_goals :
         fun imps ->
           let env2 = tac_env env1 in
           let ps =
-            let uu____11618 =
+            let uu___ =
               FStar_TypeChecker_Env.debug env2
                 (FStar_Options.Other "TacVerbose") in
-            let uu____11619 = FStar_Util.psmap_empty () in
+            let uu___1 = FStar_Util.psmap_empty () in
             {
               FStar_Tactics_Types.main_context = env2;
               FStar_Tactics_Types.all_implicits = imps;
@@ -5636,8 +5517,8 @@ let (proofstate_of_goals :
               FStar_Tactics_Types.entry_range = rng;
               FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
               FStar_Tactics_Types.freshness = Prims.int_zero;
-              FStar_Tactics_Types.tac_verb_dbg = uu____11618;
-              FStar_Tactics_Types.local_state = uu____11619
+              FStar_Tactics_Types.tac_verb_dbg = uu___;
+              FStar_Tactics_Types.local_state = uu___1
             } in
           ps
 let (proofstate_of_goal_ty :
@@ -5650,119 +5531,113 @@ let (proofstate_of_goal_ty :
     fun env1 ->
       fun typ ->
         let env2 = tac_env env1 in
-        let uu____11642 = goal_of_goal_ty env2 typ in
-        match uu____11642 with
+        let uu___ = goal_of_goal_ty env2 typ in
+        match uu___ with
         | (g, g_u) ->
             let ps =
               proofstate_of_goals rng env2 [g]
                 g_u.FStar_TypeChecker_Common.implicits in
-            let uu____11654 = FStar_Tactics_Types.goal_witness g in
-            (ps, uu____11654)
+            let uu___1 = FStar_Tactics_Types.goal_witness g in (ps, uu___1)
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.implicit -> FStar_Tactics_Types.goal)
   =
   fun env1 ->
     fun i ->
-      let uu____11665 = FStar_Options.peek () in
+      let uu___ = FStar_Options.peek () in
       FStar_Tactics_Types.mk_goal
-        (let uu___1749_11668 = env1 in
+        (let uu___1 = env1 in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___1749_11668.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___1749_11668.FStar_TypeChecker_Env.range);
+             (uu___1.FStar_TypeChecker_Env.solver);
+           FStar_TypeChecker_Env.range = (uu___1.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___1749_11668.FStar_TypeChecker_Env.curmodule);
+             (uu___1.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
              ((i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___1749_11668.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___1749_11668.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___1749_11668.FStar_TypeChecker_Env.modules);
+             (uu___1.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___1749_11668.FStar_TypeChecker_Env.expected_typ);
+             (uu___1.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___1749_11668.FStar_TypeChecker_Env.sigtab);
+             (uu___1.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___1749_11668.FStar_TypeChecker_Env.attrtab);
+             (uu___1.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___1749_11668.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___1749_11668.FStar_TypeChecker_Env.effects);
+             (uu___1.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___1749_11668.FStar_TypeChecker_Env.generalize);
+             (uu___1.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___1749_11668.FStar_TypeChecker_Env.letrecs);
+             (uu___1.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___1749_11668.FStar_TypeChecker_Env.top_level);
+             (uu___1.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___1749_11668.FStar_TypeChecker_Env.check_uvars);
+             (uu___1.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___1749_11668.FStar_TypeChecker_Env.use_eq);
+             (uu___1.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___1749_11668.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___1749_11668.FStar_TypeChecker_Env.is_iface);
-           FStar_TypeChecker_Env.admit =
-             (uu___1749_11668.FStar_TypeChecker_Env.admit);
-           FStar_TypeChecker_Env.lax =
-             (uu___1749_11668.FStar_TypeChecker_Env.lax);
+             (uu___1.FStar_TypeChecker_Env.is_iface);
+           FStar_TypeChecker_Env.admit = (uu___1.FStar_TypeChecker_Env.admit);
+           FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___1749_11668.FStar_TypeChecker_Env.lax_universes);
+             (uu___1.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___1749_11668.FStar_TypeChecker_Env.phase1);
+             (uu___1.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___1749_11668.FStar_TypeChecker_Env.failhard);
+             (uu___1.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___1749_11668.FStar_TypeChecker_Env.nosynth);
+             (uu___1.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___1749_11668.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___1749_11668.FStar_TypeChecker_Env.tc_term);
+             (uu___1.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___1749_11668.FStar_TypeChecker_Env.type_of);
+             (uu___1.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___1749_11668.FStar_TypeChecker_Env.universe_of);
+             (uu___1.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___1749_11668.FStar_TypeChecker_Env.check_type_of);
+             (uu___1.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___1749_11668.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___1749_11668.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___1749_11668.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___1749_11668.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___1749_11668.FStar_TypeChecker_Env.proof_ns);
+             (uu___1.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___1749_11668.FStar_TypeChecker_Env.synth_hook);
+             (uu___1.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___1749_11668.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___1749_11668.FStar_TypeChecker_Env.splice);
+             (uu___1.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___1749_11668.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___1749_11668.FStar_TypeChecker_Env.postprocess);
+             (uu___1.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___1749_11668.FStar_TypeChecker_Env.identifier_info);
+             (uu___1.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___1749_11668.FStar_TypeChecker_Env.tc_hooks);
-           FStar_TypeChecker_Env.dsenv =
-             (uu___1749_11668.FStar_TypeChecker_Env.dsenv);
-           FStar_TypeChecker_Env.nbe =
-             (uu___1749_11668.FStar_TypeChecker_Env.nbe);
+             (uu___1.FStar_TypeChecker_Env.tc_hooks);
+           FStar_TypeChecker_Env.dsenv = (uu___1.FStar_TypeChecker_Env.dsenv);
+           FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___1749_11668.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___1749_11668.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___1749_11668.FStar_TypeChecker_Env.enable_defer_to_tac)
-         }) i.FStar_TypeChecker_Common.imp_uvar uu____11665 false
+             (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
+         }) i.FStar_TypeChecker_Common.imp_uvar uu___ false
         i.FStar_TypeChecker_Common.imp_reason
 let (proofstate_of_all_implicits :
   FStar_Range.range ->
@@ -5776,13 +5651,13 @@ let (proofstate_of_all_implicits :
         let env2 = tac_env env1 in
         let goals = FStar_List.map (goal_of_implicit env2) imps in
         let w =
-          let uu____11693 = FStar_List.hd goals in
-          FStar_Tactics_Types.goal_witness uu____11693 in
+          let uu___ = FStar_List.hd goals in
+          FStar_Tactics_Types.goal_witness uu___ in
         let ps =
-          let uu____11695 =
+          let uu___ =
             FStar_TypeChecker_Env.debug env2
               (FStar_Options.Other "TacVerbose") in
-          let uu____11696 = FStar_Util.psmap_empty () in
+          let uu___1 = FStar_Util.psmap_empty () in
           {
             FStar_Tactics_Types.main_context = env2;
             FStar_Tactics_Types.all_implicits = imps;
@@ -5790,13 +5665,13 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.smt_goals = [];
             FStar_Tactics_Types.depth = Prims.int_zero;
             FStar_Tactics_Types.__dump =
-              (fun ps ->
-                 fun msg -> FStar_Tactics_Printing.do_dump_proofstate ps msg);
+              (fun ps1 ->
+                 fun msg -> FStar_Tactics_Printing.do_dump_proofstate ps1 msg);
             FStar_Tactics_Types.psc = FStar_TypeChecker_Cfg.null_psc;
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
             FStar_Tactics_Types.freshness = Prims.int_zero;
-            FStar_Tactics_Types.tac_verb_dbg = uu____11695;
-            FStar_Tactics_Types.local_state = uu____11696
+            FStar_Tactics_Types.tac_verb_dbg = uu___;
+            FStar_Tactics_Types.local_state = uu___1
           } in
         (ps, w)

--- a/src/ocaml-output/FStar_Tactics_Common.ml
+++ b/src/ocaml-output/FStar_Tactics_Common.ml
@@ -2,16 +2,15 @@ open Prims
 exception NotAListLiteral 
 let (uu___is_NotAListLiteral : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | NotAListLiteral -> true | uu____5 -> false
+    match projectee with | NotAListLiteral -> true | uu___ -> false
 exception TacticFailure of Prims.string 
 let (uu___is_TacticFailure : Prims.exn -> Prims.bool) =
   fun projectee ->
-    match projectee with | TacticFailure uu____15 -> true | uu____16 -> false
+    match projectee with | TacticFailure uu___ -> true | uu___ -> false
 let (__proj__TacticFailure__item__uu___ : Prims.exn -> Prims.string) =
-  fun projectee -> match projectee with | TacticFailure uu____22 -> uu____22
+  fun projectee -> match projectee with | TacticFailure uu___ -> uu___
 exception EExn of FStar_Syntax_Syntax.term 
 let (uu___is_EExn : Prims.exn -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EExn uu____32 -> true | uu____33 -> false
+  fun projectee -> match projectee with | EExn uu___ -> true | uu___ -> false
 let (__proj__EExn__item__uu___ : Prims.exn -> FStar_Syntax_Syntax.term) =
-  fun projectee -> match projectee with | EExn uu____39 -> uu____39
+  fun projectee -> match projectee with | EExn uu___ -> uu___

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -14,162 +14,161 @@ let (__do_rewrite :
     fun rewriter ->
       fun env ->
         fun tm ->
-          let uu____35 =
+          let uu___ =
             env.FStar_TypeChecker_Env.tc_term
-              (let uu___6_43 = env in
+              (let uu___1 = env in
                {
                  FStar_TypeChecker_Env.solver =
-                   (uu___6_43.FStar_TypeChecker_Env.solver);
+                   (uu___1.FStar_TypeChecker_Env.solver);
                  FStar_TypeChecker_Env.range =
-                   (uu___6_43.FStar_TypeChecker_Env.range);
+                   (uu___1.FStar_TypeChecker_Env.range);
                  FStar_TypeChecker_Env.curmodule =
-                   (uu___6_43.FStar_TypeChecker_Env.curmodule);
+                   (uu___1.FStar_TypeChecker_Env.curmodule);
                  FStar_TypeChecker_Env.gamma =
-                   (uu___6_43.FStar_TypeChecker_Env.gamma);
+                   (uu___1.FStar_TypeChecker_Env.gamma);
                  FStar_TypeChecker_Env.gamma_sig =
-                   (uu___6_43.FStar_TypeChecker_Env.gamma_sig);
+                   (uu___1.FStar_TypeChecker_Env.gamma_sig);
                  FStar_TypeChecker_Env.gamma_cache =
-                   (uu___6_43.FStar_TypeChecker_Env.gamma_cache);
+                   (uu___1.FStar_TypeChecker_Env.gamma_cache);
                  FStar_TypeChecker_Env.modules =
-                   (uu___6_43.FStar_TypeChecker_Env.modules);
+                   (uu___1.FStar_TypeChecker_Env.modules);
                  FStar_TypeChecker_Env.expected_typ =
-                   (uu___6_43.FStar_TypeChecker_Env.expected_typ);
+                   (uu___1.FStar_TypeChecker_Env.expected_typ);
                  FStar_TypeChecker_Env.sigtab =
-                   (uu___6_43.FStar_TypeChecker_Env.sigtab);
+                   (uu___1.FStar_TypeChecker_Env.sigtab);
                  FStar_TypeChecker_Env.attrtab =
-                   (uu___6_43.FStar_TypeChecker_Env.attrtab);
+                   (uu___1.FStar_TypeChecker_Env.attrtab);
                  FStar_TypeChecker_Env.instantiate_imp =
-                   (uu___6_43.FStar_TypeChecker_Env.instantiate_imp);
+                   (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                  FStar_TypeChecker_Env.effects =
-                   (uu___6_43.FStar_TypeChecker_Env.effects);
+                   (uu___1.FStar_TypeChecker_Env.effects);
                  FStar_TypeChecker_Env.generalize =
-                   (uu___6_43.FStar_TypeChecker_Env.generalize);
+                   (uu___1.FStar_TypeChecker_Env.generalize);
                  FStar_TypeChecker_Env.letrecs =
-                   (uu___6_43.FStar_TypeChecker_Env.letrecs);
+                   (uu___1.FStar_TypeChecker_Env.letrecs);
                  FStar_TypeChecker_Env.top_level =
-                   (uu___6_43.FStar_TypeChecker_Env.top_level);
+                   (uu___1.FStar_TypeChecker_Env.top_level);
                  FStar_TypeChecker_Env.check_uvars =
-                   (uu___6_43.FStar_TypeChecker_Env.check_uvars);
+                   (uu___1.FStar_TypeChecker_Env.check_uvars);
                  FStar_TypeChecker_Env.use_eq =
-                   (uu___6_43.FStar_TypeChecker_Env.use_eq);
+                   (uu___1.FStar_TypeChecker_Env.use_eq);
                  FStar_TypeChecker_Env.use_eq_strict =
-                   (uu___6_43.FStar_TypeChecker_Env.use_eq_strict);
+                   (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                  FStar_TypeChecker_Env.is_iface =
-                   (uu___6_43.FStar_TypeChecker_Env.is_iface);
+                   (uu___1.FStar_TypeChecker_Env.is_iface);
                  FStar_TypeChecker_Env.admit =
-                   (uu___6_43.FStar_TypeChecker_Env.admit);
+                   (uu___1.FStar_TypeChecker_Env.admit);
                  FStar_TypeChecker_Env.lax = true;
                  FStar_TypeChecker_Env.lax_universes =
-                   (uu___6_43.FStar_TypeChecker_Env.lax_universes);
+                   (uu___1.FStar_TypeChecker_Env.lax_universes);
                  FStar_TypeChecker_Env.phase1 =
-                   (uu___6_43.FStar_TypeChecker_Env.phase1);
+                   (uu___1.FStar_TypeChecker_Env.phase1);
                  FStar_TypeChecker_Env.failhard =
-                   (uu___6_43.FStar_TypeChecker_Env.failhard);
+                   (uu___1.FStar_TypeChecker_Env.failhard);
                  FStar_TypeChecker_Env.nosynth =
-                   (uu___6_43.FStar_TypeChecker_Env.nosynth);
+                   (uu___1.FStar_TypeChecker_Env.nosynth);
                  FStar_TypeChecker_Env.uvar_subtyping =
-                   (uu___6_43.FStar_TypeChecker_Env.uvar_subtyping);
+                   (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                  FStar_TypeChecker_Env.tc_term =
-                   (uu___6_43.FStar_TypeChecker_Env.tc_term);
+                   (uu___1.FStar_TypeChecker_Env.tc_term);
                  FStar_TypeChecker_Env.type_of =
-                   (uu___6_43.FStar_TypeChecker_Env.type_of);
+                   (uu___1.FStar_TypeChecker_Env.type_of);
                  FStar_TypeChecker_Env.universe_of =
-                   (uu___6_43.FStar_TypeChecker_Env.universe_of);
+                   (uu___1.FStar_TypeChecker_Env.universe_of);
                  FStar_TypeChecker_Env.check_type_of =
-                   (uu___6_43.FStar_TypeChecker_Env.check_type_of);
+                   (uu___1.FStar_TypeChecker_Env.check_type_of);
                  FStar_TypeChecker_Env.use_bv_sorts =
-                   (uu___6_43.FStar_TypeChecker_Env.use_bv_sorts);
+                   (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                   (uu___6_43.FStar_TypeChecker_Env.qtbl_name_and_index);
+                   (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                  FStar_TypeChecker_Env.normalized_eff_names =
-                   (uu___6_43.FStar_TypeChecker_Env.normalized_eff_names);
+                   (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                  FStar_TypeChecker_Env.fv_delta_depths =
-                   (uu___6_43.FStar_TypeChecker_Env.fv_delta_depths);
+                   (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                  FStar_TypeChecker_Env.proof_ns =
-                   (uu___6_43.FStar_TypeChecker_Env.proof_ns);
+                   (uu___1.FStar_TypeChecker_Env.proof_ns);
                  FStar_TypeChecker_Env.synth_hook =
-                   (uu___6_43.FStar_TypeChecker_Env.synth_hook);
+                   (uu___1.FStar_TypeChecker_Env.synth_hook);
                  FStar_TypeChecker_Env.try_solve_implicits_hook =
-                   (uu___6_43.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                   (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                  FStar_TypeChecker_Env.splice =
-                   (uu___6_43.FStar_TypeChecker_Env.splice);
+                   (uu___1.FStar_TypeChecker_Env.splice);
                  FStar_TypeChecker_Env.mpreprocess =
-                   (uu___6_43.FStar_TypeChecker_Env.mpreprocess);
+                   (uu___1.FStar_TypeChecker_Env.mpreprocess);
                  FStar_TypeChecker_Env.postprocess =
-                   (uu___6_43.FStar_TypeChecker_Env.postprocess);
+                   (uu___1.FStar_TypeChecker_Env.postprocess);
                  FStar_TypeChecker_Env.identifier_info =
-                   (uu___6_43.FStar_TypeChecker_Env.identifier_info);
+                   (uu___1.FStar_TypeChecker_Env.identifier_info);
                  FStar_TypeChecker_Env.tc_hooks =
-                   (uu___6_43.FStar_TypeChecker_Env.tc_hooks);
+                   (uu___1.FStar_TypeChecker_Env.tc_hooks);
                  FStar_TypeChecker_Env.dsenv =
-                   (uu___6_43.FStar_TypeChecker_Env.dsenv);
+                   (uu___1.FStar_TypeChecker_Env.dsenv);
                  FStar_TypeChecker_Env.nbe =
-                   (uu___6_43.FStar_TypeChecker_Env.nbe);
+                   (uu___1.FStar_TypeChecker_Env.nbe);
                  FStar_TypeChecker_Env.strict_args_tab =
-                   (uu___6_43.FStar_TypeChecker_Env.strict_args_tab);
+                   (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                  FStar_TypeChecker_Env.erasable_types_tab =
-                   (uu___6_43.FStar_TypeChecker_Env.erasable_types_tab);
+                   (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                  FStar_TypeChecker_Env.enable_defer_to_tac =
-                   (uu___6_43.FStar_TypeChecker_Env.enable_defer_to_tac)
+                   (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
                }) tm in
-          match uu____35 with
-          | (uu____46, lcomp, g) ->
-              let uu____49 =
-                (let uu____52 =
+          match uu___ with
+          | (uu___1, lcomp, g) ->
+              let uu___2 =
+                (let uu___3 =
                    FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lcomp in
-                 Prims.op_Negation uu____52) ||
-                  (let uu____54 = FStar_TypeChecker_Env.is_trivial g in
-                   Prims.op_Negation uu____54) in
-              if uu____49
+                 Prims.op_Negation uu___3) ||
+                  (let uu___3 = FStar_TypeChecker_Env.is_trivial g in
+                   Prims.op_Negation uu___3) in
+              if uu___2
               then FStar_Tactics_Monad.ret tm
               else
                 (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
-                 let uu____59 =
+                 let uu___4 =
                    FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ in
-                 FStar_Tactics_Monad.bind uu____59
-                   (fun uu____73 ->
-                      match uu____73 with
+                 FStar_Tactics_Monad.bind uu___4
+                   (fun uu___5 ->
+                      match uu___5 with
                       | (ut, uvar_ut) ->
                           FStar_Tactics_Monad.mlog
-                            (fun uu____85 ->
-                               let uu____86 =
+                            (fun uu___6 ->
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string tm in
-                               let uu____87 =
+                               let uu___8 =
                                  FStar_Syntax_Print.term_to_string ut in
                                FStar_Util.print2
                                  "do_rewrite: making equality\n\t%s ==\n\t%s\n"
-                                 uu____86 uu____87)
-                            (fun uu____90 ->
-                               let uu____91 =
-                                 let uu____94 =
-                                   let uu____95 =
+                                 uu___7 uu___8)
+                            (fun uu___6 ->
+                               let uu___7 =
+                                 let uu___8 =
+                                   let uu___9 =
                                      env.FStar_TypeChecker_Env.universe_of
                                        env typ in
-                                   FStar_Syntax_Util.mk_eq2 uu____95 typ tm
-                                     ut in
+                                   FStar_Syntax_Util.mk_eq2 uu___9 typ tm ut in
                                  FStar_Tactics_Monad.add_irrelevant_goal g0
-                                   "do_rewrite.eq" env uu____94 in
-                               FStar_Tactics_Monad.bind uu____91
-                                 (fun uu____98 ->
-                                    let uu____99 =
+                                   "do_rewrite.eq" env uu___8 in
+                               FStar_Tactics_Monad.bind uu___7
+                                 (fun uu___8 ->
+                                    let uu___9 =
                                       FStar_Tactics_Basic.focus rewriter in
-                                    FStar_Tactics_Monad.bind uu____99
-                                      (fun uu____104 ->
+                                    FStar_Tactics_Monad.bind uu___9
+                                      (fun uu___10 ->
                                          let ut1 =
                                            FStar_TypeChecker_Normalize.reduce_uvar_solutions
                                              env ut in
                                          FStar_Tactics_Monad.mlog
-                                           (fun uu____109 ->
-                                              let uu____110 =
+                                           (fun uu___11 ->
+                                              let uu___12 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tm in
-                                              let uu____111 =
+                                              let uu___13 =
                                                 FStar_Syntax_Print.term_to_string
                                                   ut1 in
                                               FStar_Util.print2
                                                 "rewrite_rec: succeeded rewriting\n\t%s to\n\t%s\n"
-                                                uu____110 uu____111)
-                                           (fun uu____113 ->
+                                                uu___12 uu___13)
+                                           (fun uu___11 ->
                                               FStar_Tactics_Monad.ret ut1))))))
 let (do_rewrite :
   FStar_Tactics_Types.goal ->
@@ -182,12 +181,12 @@ let (do_rewrite :
     fun rewriter ->
       fun env ->
         fun tm ->
-          let uu____138 =
-            let uu____145 = __do_rewrite g0 rewriter env tm in
-            FStar_Tactics_Basic.catch uu____145 in
-          FStar_Tactics_Monad.bind uu____138
-            (fun uu___0_153 ->
-               match uu___0_153 with
+          let uu___ =
+            let uu___1 = __do_rewrite g0 rewriter env tm in
+            FStar_Tactics_Basic.catch uu___1 in
+          FStar_Tactics_Monad.bind uu___
+            (fun uu___1 ->
+               match uu___1 with
                | FStar_Util.Inl (FStar_Tactics_Common.TacticFailure "SKIP")
                    -> FStar_Tactics_Monad.ret tm
                | FStar_Util.Inl e -> FStar_Tactics_Monad.traise e
@@ -198,10 +197,10 @@ let seq_ctac : 'a . 'a ctac -> 'a ctac -> 'a ctac =
   fun c1 ->
     fun c2 ->
       fun x ->
-        let uu____208 = c1 x in
-        FStar_Tactics_Monad.bind uu____208
-          (fun uu____226 ->
-             match uu____226 with
+        let uu___ = c1 x in
+        FStar_Tactics_Monad.bind uu___
+          (fun uu___1 ->
+             match uu___1 with
              | (x', flag) ->
                  (match flag with
                   | FStar_Tactics_Types.Abort ->
@@ -213,34 +212,34 @@ let (par_combine :
   (FStar_Tactics_Types.ctrl_flag * FStar_Tactics_Types.ctrl_flag) ->
     FStar_Tactics_Types.ctrl_flag)
   =
-  fun uu___1_261 ->
-    match uu___1_261 with
-    | (FStar_Tactics_Types.Abort, uu____266) -> FStar_Tactics_Types.Abort
-    | (uu____267, FStar_Tactics_Types.Abort) -> FStar_Tactics_Types.Abort
-    | (FStar_Tactics_Types.Skip, uu____268) -> FStar_Tactics_Types.Skip
-    | (uu____269, FStar_Tactics_Types.Skip) -> FStar_Tactics_Types.Skip
+  fun uu___ ->
+    match uu___ with
+    | (FStar_Tactics_Types.Abort, uu___1) -> FStar_Tactics_Types.Abort
+    | (uu___1, FStar_Tactics_Types.Abort) -> FStar_Tactics_Types.Abort
+    | (FStar_Tactics_Types.Skip, uu___1) -> FStar_Tactics_Types.Skip
+    | (uu___1, FStar_Tactics_Types.Skip) -> FStar_Tactics_Types.Skip
     | (FStar_Tactics_Types.Continue, FStar_Tactics_Types.Continue) ->
         FStar_Tactics_Types.Continue
 let par_ctac : 'a 'b . 'a ctac -> 'b ctac -> ('a * 'b) ctac =
   fun cl ->
     fun cr ->
-      fun uu____309 ->
-        match uu____309 with
+      fun uu___ ->
+        match uu___ with
         | (x, y) ->
-            let uu____326 = cl x in
-            FStar_Tactics_Monad.bind uu____326
-              (fun uu____348 ->
-                 match uu____348 with
+            let uu___1 = cl x in
+            FStar_Tactics_Monad.bind uu___1
+              (fun uu___2 ->
+                 match uu___2 with
                  | (x1, flag) ->
                      (match flag with
                       | FStar_Tactics_Types.Abort ->
                           FStar_Tactics_Monad.ret
                             ((x1, y), FStar_Tactics_Types.Abort)
                       | fa ->
-                          let uu____388 = cr y in
-                          FStar_Tactics_Monad.bind uu____388
-                            (fun uu____410 ->
-                               match uu____410 with
+                          let uu___3 = cr y in
+                          FStar_Tactics_Monad.bind uu___3
+                            (fun uu___4 ->
+                               match uu___4 with
                                | (y1, flag1) ->
                                    (match flag1 with
                                     | FStar_Tactics_Types.Abort ->
@@ -256,13 +255,12 @@ let rec map_ctac : 'a . 'a ctac -> 'a Prims.list ctac =
       match xs with
       | [] -> FStar_Tactics_Monad.ret ([], FStar_Tactics_Types.Continue)
       | x::xs1 ->
-          let uu____500 =
-            let uu____513 =
-              let uu____524 = map_ctac c in par_ctac c uu____524 in
-            uu____513 (x, xs1) in
-          FStar_Tactics_Monad.bind uu____500
-            (fun uu____555 ->
-               match uu____555 with
+          let uu___ =
+            let uu___1 = let uu___2 = map_ctac c in par_ctac c uu___2 in
+            uu___1 (x, xs1) in
+          FStar_Tactics_Monad.bind uu___
+            (fun uu___1 ->
+               match uu___1 with
                | ((x1, xs2), flag) ->
                    FStar_Tactics_Monad.ret ((x1 :: xs2), flag))
 let bind_ctac : 'a 'b . 'a ctac -> ('a -> 'b ctac) -> 'b ctac =
@@ -272,7 +270,7 @@ let ctac_id :
   fun x -> FStar_Tactics_Monad.ret (x, FStar_Tactics_Types.Continue)
 let (ctac_args :
   FStar_Syntax_Syntax.term ctac -> FStar_Syntax_Syntax.args ctac) =
-  fun c -> let uu____679 = par_ctac c ctac_id in map_ctac uu____679
+  fun c -> let uu___ = par_ctac c ctac_id in map_ctac uu___
 let (maybe_rewrite :
   FStar_Tactics_Types.goal ->
     controller_ty ->
@@ -287,16 +285,16 @@ let (maybe_rewrite :
       fun rewriter ->
         fun env ->
           fun tm ->
-            let uu____739 = controller tm in
-            FStar_Tactics_Monad.bind uu____739
-              (fun uu____758 ->
-                 match uu____758 with
+            let uu___ = controller tm in
+            FStar_Tactics_Monad.bind uu___
+              (fun uu___1 ->
+                 match uu___1 with
                  | (rw, ctrl_flag) ->
-                     let uu____771 =
+                     let uu___2 =
                        if rw
                        then do_rewrite g0 rewriter env tm
                        else FStar_Tactics_Monad.ret tm in
-                     FStar_Tactics_Monad.bind uu____771
+                     FStar_Tactics_Monad.bind uu___2
                        (fun tm' -> FStar_Tactics_Monad.ret (tm', ctrl_flag)))
 let rec (ctrl_fold_env :
   FStar_Tactics_Types.goal ->
@@ -318,15 +316,15 @@ let rec (ctrl_fold_env :
                 ctrl_fold_env g0 d controller rewriter env tm1 in
               match d with
               | FStar_Tactics_Types.TopDown ->
-                  let uu____880 =
+                  let uu___ =
                     seq_ctac (maybe_rewrite g0 controller rewriter env)
                       (on_subterms g0 d controller rewriter env) in
-                  uu____880 tm
+                  uu___ tm
               | FStar_Tactics_Types.BottomUp ->
-                  let uu____885 =
+                  let uu___ =
                     seq_ctac (on_subterms g0 d controller rewriter env)
                       (maybe_rewrite g0 controller rewriter env) in
-                  uu____885 tm
+                  uu___ tm
 and (on_subterms :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.direction ->
@@ -346,76 +344,74 @@ and (on_subterms :
               let recurse env1 tm1 =
                 ctrl_fold_env g0 d controller rewriter env1 tm1 in
               let rr = recurse env in
-              let go uu____942 =
+              let go uu___ =
                 let tm1 = FStar_Syntax_Subst.compress tm in
                 match tm1.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-                    let uu____982 =
-                      let uu____993 =
-                        let uu____1002 = ctac_args rr in
-                        par_ctac rr uu____1002 in
-                      uu____993 (hd, args) in
-                    FStar_Tactics_Monad.bind uu____982
-                      (fun uu____1023 ->
-                         match uu____1023 with
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = ctac_args rr in par_ctac rr uu___3 in
+                      uu___2 (hd, args) in
+                    FStar_Tactics_Monad.bind uu___1
+                      (fun uu___2 ->
+                         match uu___2 with
                          | ((hd1, args1), flag) ->
                              FStar_Tactics_Monad.ret
                                ((FStar_Syntax_Syntax.Tm_app (hd1, args1)),
                                  flag))
                 | FStar_Syntax_Syntax.Tm_abs (bs, t, k) ->
-                    let uu____1088 = FStar_Syntax_Subst.open_term bs t in
-                    (match uu____1088 with
+                    let uu___1 = FStar_Syntax_Subst.open_term bs t in
+                    (match uu___1 with
                      | (bs1, t1) ->
-                         let uu____1101 =
-                           let uu____1108 =
+                         let uu___2 =
+                           let uu___3 =
                              FStar_TypeChecker_Env.push_binders env bs1 in
-                           recurse uu____1108 t1 in
-                         FStar_Tactics_Monad.bind uu____1101
-                           (fun uu____1121 ->
-                              match uu____1121 with
+                           recurse uu___3 t1 in
+                         FStar_Tactics_Monad.bind uu___2
+                           (fun uu___3 ->
+                              match uu___3 with
                               | (t2, flag) ->
-                                  let uu____1134 =
-                                    let uu____1139 =
-                                      let uu____1140 =
-                                        let uu____1159 =
+                                  let uu___4 =
+                                    let uu___5 =
+                                      let uu___6 =
+                                        let uu___7 =
                                           FStar_Syntax_Subst.close_binders
                                             bs1 in
-                                        let uu____1168 =
+                                        let uu___8 =
                                           FStar_Syntax_Subst.close bs1 t2 in
-                                        (uu____1159, uu____1168, k) in
-                                      FStar_Syntax_Syntax.Tm_abs uu____1140 in
-                                    (uu____1139, flag) in
-                                  FStar_Tactics_Monad.ret uu____1134))
+                                        (uu___7, uu___8, k) in
+                                      FStar_Syntax_Syntax.Tm_abs uu___6 in
+                                    (uu___5, flag) in
+                                  FStar_Tactics_Monad.ret uu___4))
                 | FStar_Syntax_Syntax.Tm_arrow (bs, k) ->
                     FStar_Tactics_Monad.ret
                       ((tm1.FStar_Syntax_Syntax.n),
                         FStar_Tactics_Types.Continue)
                 | FStar_Syntax_Syntax.Tm_match (hd, brs) ->
                     let c_branch br =
-                      let uu____1269 = FStar_Syntax_Subst.open_branch br in
-                      match uu____1269 with
+                      let uu___1 = FStar_Syntax_Subst.open_branch br in
+                      match uu___1 with
                       | (pat, w, e) ->
                           let bvs = FStar_Syntax_Syntax.pat_bvs pat in
-                          let uu____1298 =
-                            let uu____1305 =
+                          let uu___2 =
+                            let uu___3 =
                               FStar_TypeChecker_Env.push_bvs env bvs in
-                            recurse uu____1305 e in
-                          FStar_Tactics_Monad.bind uu____1298
-                            (fun uu____1318 ->
-                               match uu____1318 with
+                            recurse uu___3 e in
+                          FStar_Tactics_Monad.bind uu___2
+                            (fun uu___3 ->
+                               match uu___3 with
                                | (e1, flag) ->
                                    let br1 =
                                      FStar_Syntax_Subst.close_branch
                                        (pat, w, e1) in
                                    FStar_Tactics_Monad.ret (br1, flag)) in
-                    let uu____1344 =
-                      let uu____1357 =
-                        let uu____1368 = map_ctac c_branch in
-                        par_ctac rr uu____1368 in
-                      uu____1357 (hd, brs) in
-                    FStar_Tactics_Monad.bind uu____1344
-                      (fun uu____1397 ->
-                         match uu____1397 with
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = map_ctac c_branch in par_ctac rr uu___3 in
+                      uu___2 (hd, brs) in
+                    FStar_Tactics_Monad.bind uu___1
+                      (fun uu___2 ->
+                         match uu___2 with
                          | ((hd1, brs1), flag) ->
                              FStar_Tactics_Monad.ret
                                ((FStar_Syntax_Syntax.Tm_match (hd1, brs1)),
@@ -423,140 +419,139 @@ and (on_subterms :
                 | FStar_Syntax_Syntax.Tm_let
                     ((false,
                       { FStar_Syntax_Syntax.lbname = FStar_Util.Inl bv;
-                        FStar_Syntax_Syntax.lbunivs = uu____1450;
-                        FStar_Syntax_Syntax.lbtyp = uu____1451;
-                        FStar_Syntax_Syntax.lbeff = uu____1452;
+                        FStar_Syntax_Syntax.lbunivs = uu___1;
+                        FStar_Syntax_Syntax.lbtyp = uu___2;
+                        FStar_Syntax_Syntax.lbeff = uu___3;
                         FStar_Syntax_Syntax.lbdef = def;
-                        FStar_Syntax_Syntax.lbattrs = uu____1454;
-                        FStar_Syntax_Syntax.lbpos = uu____1455;_}::[]),
+                        FStar_Syntax_Syntax.lbattrs = uu___4;
+                        FStar_Syntax_Syntax.lbpos = uu___5;_}::[]),
                      e)
                     ->
                     let lb =
-                      let uu____1480 =
-                        let uu____1481 = FStar_Syntax_Subst.compress tm1 in
-                        uu____1481.FStar_Syntax_Syntax.n in
-                      match uu____1480 with
-                      | FStar_Syntax_Syntax.Tm_let
-                          ((false, lb::[]), uu____1485) -> lb
-                      | uu____1498 -> failwith "impossible" in
-                    let uu____1499 = FStar_Syntax_Subst.open_term_bv bv e in
-                    (match uu____1499 with
+                      let uu___6 =
+                        let uu___7 = FStar_Syntax_Subst.compress tm1 in
+                        uu___7.FStar_Syntax_Syntax.n in
+                      match uu___6 with
+                      | FStar_Syntax_Syntax.Tm_let ((false, lb1::[]), uu___7)
+                          -> lb1
+                      | uu___7 -> failwith "impossible" in
+                    let uu___6 = FStar_Syntax_Subst.open_term_bv bv e in
+                    (match uu___6 with
                      | (bv1, e1) ->
-                         let uu____1512 =
-                           let uu____1523 =
-                             let uu____1532 =
-                               let uu____1537 =
+                         let uu___7 =
+                           let uu___8 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_TypeChecker_Env.push_bv env bv1 in
-                               recurse uu____1537 in
-                             par_ctac rr uu____1532 in
-                           uu____1523 ((lb.FStar_Syntax_Syntax.lbdef), e1) in
-                         FStar_Tactics_Monad.bind uu____1512
-                           (fun uu____1556 ->
-                              match uu____1556 with
+                               recurse uu___10 in
+                             par_ctac rr uu___9 in
+                           uu___8 ((lb.FStar_Syntax_Syntax.lbdef), e1) in
+                         FStar_Tactics_Monad.bind uu___7
+                           (fun uu___8 ->
+                              match uu___8 with
                               | ((lbdef, e2), flag) ->
                                   let lb1 =
-                                    let uu___209_1579 = lb in
+                                    let uu___9 = lb in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbname);
+                                        (uu___9.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___9.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbtyp);
+                                        (uu___9.FStar_Syntax_Syntax.lbtyp);
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbeff);
+                                        (uu___9.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = lbdef;
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___9.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___209_1579.FStar_Syntax_Syntax.lbpos)
+                                        (uu___9.FStar_Syntax_Syntax.lbpos)
                                     } in
                                   let e3 =
-                                    let uu____1581 =
-                                      let uu____1582 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_Syntax_Syntax.mk_binder bv1 in
-                                      [uu____1582] in
-                                    FStar_Syntax_Subst.close uu____1581 e2 in
+                                      [uu___10] in
+                                    FStar_Syntax_Subst.close uu___9 e2 in
                                   FStar_Tactics_Monad.ret
                                     ((FStar_Syntax_Syntax.Tm_let
                                         ((false, [lb1]), e3)), flag)))
                 | FStar_Syntax_Syntax.Tm_let ((true, lbs), e) ->
                     let c_lb lb =
-                      let uu____1649 = rr lb.FStar_Syntax_Syntax.lbdef in
-                      FStar_Tactics_Monad.bind uu____1649
-                        (fun uu____1667 ->
-                           match uu____1667 with
+                      let uu___1 = rr lb.FStar_Syntax_Syntax.lbdef in
+                      FStar_Tactics_Monad.bind uu___1
+                        (fun uu___2 ->
+                           match uu___2 with
                            | (def, flag) ->
                                FStar_Tactics_Monad.ret
-                                 ((let uu___224_1685 = lb in
+                                 ((let uu___3 = lb in
                                    {
                                      FStar_Syntax_Syntax.lbname =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbname);
+                                       (uu___3.FStar_Syntax_Syntax.lbname);
                                      FStar_Syntax_Syntax.lbunivs =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbunivs);
+                                       (uu___3.FStar_Syntax_Syntax.lbunivs);
                                      FStar_Syntax_Syntax.lbtyp =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbtyp);
+                                       (uu___3.FStar_Syntax_Syntax.lbtyp);
                                      FStar_Syntax_Syntax.lbeff =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbeff);
+                                       (uu___3.FStar_Syntax_Syntax.lbeff);
                                      FStar_Syntax_Syntax.lbdef = def;
                                      FStar_Syntax_Syntax.lbattrs =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbattrs);
+                                       (uu___3.FStar_Syntax_Syntax.lbattrs);
                                      FStar_Syntax_Syntax.lbpos =
-                                       (uu___224_1685.FStar_Syntax_Syntax.lbpos)
+                                       (uu___3.FStar_Syntax_Syntax.lbpos)
                                    }), flag)) in
-                    let uu____1686 = FStar_Syntax_Subst.open_let_rec lbs e in
-                    (match uu____1686 with
+                    let uu___1 = FStar_Syntax_Subst.open_let_rec lbs e in
+                    (match uu___1 with
                      | (lbs1, e1) ->
-                         let uu____1705 =
-                           let uu____1718 =
-                             let uu____1729 = map_ctac c_lb in
-                             par_ctac uu____1729 rr in
-                           uu____1718 (lbs1, e1) in
-                         FStar_Tactics_Monad.bind uu____1705
-                           (fun uu____1761 ->
-                              match uu____1761 with
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = map_ctac c_lb in par_ctac uu___4 rr in
+                           uu___3 (lbs1, e1) in
+                         FStar_Tactics_Monad.bind uu___2
+                           (fun uu___3 ->
+                              match uu___3 with
                               | ((lbs2, e2), flag) ->
-                                  let uu____1791 =
+                                  let uu___4 =
                                     FStar_Syntax_Subst.close_let_rec lbs2 e2 in
-                                  (match uu____1791 with
+                                  (match uu___4 with
                                    | (lbs3, e3) ->
                                        FStar_Tactics_Monad.ret
                                          ((FStar_Syntax_Syntax.Tm_let
                                              ((true, lbs3), e3)), flag))))
                 | FStar_Syntax_Syntax.Tm_ascribed (t, asc, eff) ->
-                    let uu____1867 = rr t in
-                    FStar_Tactics_Monad.bind uu____1867
-                      (fun uu____1885 ->
-                         match uu____1885 with
+                    let uu___1 = rr t in
+                    FStar_Tactics_Monad.bind uu___1
+                      (fun uu___2 ->
+                         match uu___2 with
                          | (t1, flag) ->
                              FStar_Tactics_Monad.ret
                                ((FStar_Syntax_Syntax.Tm_ascribed
                                    (t1, asc, eff)), flag))
                 | FStar_Syntax_Syntax.Tm_meta (t, m) ->
-                    let uu____1928 = rr t in
-                    FStar_Tactics_Monad.bind uu____1928
-                      (fun uu____1946 ->
-                         match uu____1946 with
+                    let uu___1 = rr t in
+                    FStar_Tactics_Monad.bind uu___1
+                      (fun uu___2 ->
+                         match uu___2 with
                          | (t1, flag) ->
                              FStar_Tactics_Monad.ret
                                ((FStar_Syntax_Syntax.Tm_meta (t1, m)), flag))
-                | uu____1965 ->
+                | uu___1 ->
                     FStar_Tactics_Monad.ret
                       ((tm1.FStar_Syntax_Syntax.n),
                         FStar_Tactics_Types.Continue) in
-              let uu____1970 = go () in
-              FStar_Tactics_Monad.bind uu____1970
-                (fun uu____1990 ->
-                   match uu____1990 with
+              let uu___ = go () in
+              FStar_Tactics_Monad.bind uu___
+                (fun uu___1 ->
+                   match uu___1 with
                    | (tmn', flag) ->
                        FStar_Tactics_Monad.ret
-                         ((let uu___256_2014 = tm in
+                         ((let uu___2 = tm in
                            {
                              FStar_Syntax_Syntax.n = tmn';
                              FStar_Syntax_Syntax.pos =
-                               (uu___256_2014.FStar_Syntax_Syntax.pos);
+                               (uu___2.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___256_2014.FStar_Syntax_Syntax.vars)
+                               (uu___2.FStar_Syntax_Syntax.vars)
                            }), flag))
 let (do_ctrl_rewrite :
   FStar_Tactics_Types.goal ->
@@ -573,12 +568,11 @@ let (do_ctrl_rewrite :
         fun rewriter ->
           fun env ->
             fun tm ->
-              let uu____2051 =
-                ctrl_fold_env g0 dir controller rewriter env tm in
-              FStar_Tactics_Monad.bind uu____2051
-                (fun uu____2065 ->
-                   match uu____2065 with
-                   | (tm', uu____2073) -> FStar_Tactics_Monad.ret tm')
+              let uu___ = ctrl_fold_env g0 dir controller rewriter env tm in
+              FStar_Tactics_Monad.bind uu___
+                (fun uu___1 ->
+                   match uu___1 with
+                   | (tm', uu___2) -> FStar_Tactics_Monad.ret tm')
 let (ctrl_rewrite :
   FStar_Tactics_Types.direction ->
     controller_ty -> rewriter_ty -> unit FStar_Tactics_Monad.tac)
@@ -586,46 +580,45 @@ let (ctrl_rewrite :
   fun dir ->
     fun controller ->
       fun rewriter ->
-        let uu____2095 =
+        let uu___ =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____2103 =
+               let uu___1 =
                  match ps.FStar_Tactics_Types.goals with
                  | g::gs -> (g, gs)
                  | [] -> failwith "no goals" in
-               match uu____2103 with
+               match uu___1 with
                | (g, gs) ->
                    FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss_all
-                     (fun uu____2140 ->
+                     (fun uu___2 ->
                         let gt = FStar_Tactics_Types.goal_type g in
                         FStar_Tactics_Monad.log ps
-                          (fun uu____2145 ->
-                             let uu____2146 =
+                          (fun uu___4 ->
+                             let uu___5 =
                                FStar_Syntax_Print.term_to_string gt in
                              FStar_Util.print1
-                               "ctrl_rewrite starting with %s\n" uu____2146);
-                        (let uu____2147 =
-                           let uu____2150 = FStar_Tactics_Types.goal_env g in
-                           do_ctrl_rewrite g dir controller rewriter
-                             uu____2150 gt in
-                         FStar_Tactics_Monad.bind uu____2147
+                               "ctrl_rewrite starting with %s\n" uu___5);
+                        (let uu___4 =
+                           let uu___5 = FStar_Tactics_Types.goal_env g in
+                           do_ctrl_rewrite g dir controller rewriter uu___5
+                             gt in
+                         FStar_Tactics_Monad.bind uu___4
                            (fun gt' ->
                               FStar_Tactics_Monad.log ps
-                                (fun uu____2158 ->
-                                   let uu____2159 =
+                                (fun uu___6 ->
+                                   let uu___7 =
                                      FStar_Syntax_Print.term_to_string gt' in
                                    FStar_Util.print1
                                      "ctrl_rewrite seems to have succeded with %s\n"
-                                     uu____2159);
-                              (let uu____2160 =
-                                 FStar_Tactics_Monad.push_goals gs in
-                               FStar_Tactics_Monad.bind uu____2160
-                                 (fun uu____2165 ->
-                                    let uu____2166 =
-                                      let uu____2169 =
+                                     uu___7);
+                              (let uu___6 = FStar_Tactics_Monad.push_goals gs in
+                               FStar_Tactics_Monad.bind uu___6
+                                 (fun uu___7 ->
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Tactics_Types.goal_with_type g
                                           gt' in
-                                      [uu____2169] in
-                                    FStar_Tactics_Monad.add_goals uu____2166)))))) in
+                                      [uu___9] in
+                                    FStar_Tactics_Monad.add_goals uu___8)))))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "ctrl_rewrite")
-          uu____2095
+          uu___

--- a/src/ocaml-output/FStar_Tactics_Embedding.ml
+++ b/src/ocaml-output/FStar_Tactics_Embedding.ml
@@ -4,13 +4,12 @@ let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
   fun s -> FStar_Parser_Const.fstar_tactics_lid' s
 let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l ->
-    let uu____17 =
+    let uu___ =
       FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
         FStar_Pervasives_Native.None in
-    FStar_All.pipe_right uu____17 FStar_Syntax_Syntax.fv_to_tm
+    FStar_All.pipe_right uu___ FStar_Syntax_Syntax.fv_to_tm
 let (mk_tactic_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
-  fun s ->
-    let uu____23 = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu____23
+  fun s -> let uu___ = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu___
 type tac_constant =
   {
   lid: FStar_Ident.lid ;
@@ -29,19 +28,18 @@ let (lid_as_data_fv : FStar_Ident.lident -> FStar_Syntax_Syntax.fv) =
     FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
       (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (lid_as_data_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
-  fun l ->
-    let uu____73 = lid_as_data_fv l in FStar_Syntax_Syntax.fv_to_tm uu____73
+  fun l -> let uu___ = lid_as_data_fv l in FStar_Syntax_Syntax.fv_to_tm uu___
 let (fstar_tactics_data : Prims.string Prims.list -> tac_constant) =
   fun ns ->
     let lid = fstar_tactics_lid' ns in
-    let uu____84 = lid_as_data_fv lid in
-    let uu____85 = lid_as_data_tm lid in { lid; fv = uu____84; t = uu____85 }
+    let uu___ = lid_as_data_fv lid in
+    let uu___1 = lid_as_data_tm lid in { lid; fv = uu___; t = uu___1 }
 let (fstar_tactics_const : Prims.string Prims.list -> tac_constant) =
   fun ns ->
     let lid = fstar_tactics_lid' ns in
-    let uu____96 = FStar_Syntax_Syntax.fvconst lid in
-    let uu____97 = FStar_Syntax_Syntax.tconst lid in
-    { lid; fv = uu____96; t = uu____97 }
+    let uu___ = FStar_Syntax_Syntax.fvconst lid in
+    let uu___1 = FStar_Syntax_Syntax.tconst lid in
+    { lid; fv = uu___; t = uu___1 }
 let (fstar_tactics_proofstate : tac_constant) =
   fstar_tactics_const ["Types"; "proofstate"]
 let (fstar_tactics_goal : tac_constant) =
@@ -87,40 +85,39 @@ let mk_emb :
   fun em ->
     fun un ->
       fun t ->
-        let uu____148 = FStar_Syntax_Embeddings.term_as_fv t in
+        let uu___ = FStar_Syntax_Embeddings.term_as_fv t in
         FStar_Syntax_Embeddings.mk_emb
           (fun x -> fun r -> fun _topt -> fun _norm -> em r x)
-          (fun x -> fun w -> fun _norm -> un w x) uu____148
+          (fun x -> fun w -> fun _norm -> un w x) uu___
 let embed :
-  'uuuuuu173 .
-    'uuuuuu173 FStar_Syntax_Embeddings.embedding ->
-      FStar_Range.range -> 'uuuuuu173 -> FStar_Syntax_Syntax.term
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
+      FStar_Range.range -> 'uuuuu -> FStar_Syntax_Syntax.term
   =
   fun e ->
     fun r ->
       fun x ->
-        let uu____193 = FStar_Syntax_Embeddings.embed e x in
-        uu____193 r FStar_Pervasives_Native.None
+        let uu___ = FStar_Syntax_Embeddings.embed e x in
+        uu___ r FStar_Pervasives_Native.None
           FStar_Syntax_Embeddings.id_norm_cb
 let unembed' :
-  'uuuuuu210 .
+  'uuuuu .
     Prims.bool ->
-      'uuuuuu210 FStar_Syntax_Embeddings.embedding ->
-        FStar_Syntax_Syntax.term -> 'uuuuuu210 FStar_Pervasives_Native.option
+      'uuuuu FStar_Syntax_Embeddings.embedding ->
+        FStar_Syntax_Syntax.term -> 'uuuuu FStar_Pervasives_Native.option
   =
   fun w ->
     fun e ->
       fun x ->
-        let uu____232 = FStar_Syntax_Embeddings.unembed e x in
-        uu____232 w FStar_Syntax_Embeddings.id_norm_cb
+        let uu___ = FStar_Syntax_Embeddings.unembed e x in
+        uu___ w FStar_Syntax_Embeddings.id_norm_cb
 let (t_result_of :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t ->
-    let uu____246 =
-      let uu____257 = FStar_Syntax_Syntax.as_arg t in [uu____257] in
-    FStar_Syntax_Util.mk_app fstar_tactics_result.t uu____246
+    let uu___ = let uu___1 = FStar_Syntax_Syntax.as_arg t in [uu___1] in
+    FStar_Syntax_Util.mk_app fstar_tactics_result.t uu___
 let (hd'_and_args :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term' * (FStar_Syntax_Syntax.term'
@@ -129,42 +126,41 @@ let (hd'_and_args :
   =
   fun tm ->
     let tm1 = FStar_Syntax_Util.unascribe tm in
-    let uu____302 = FStar_Syntax_Util.head_and_args tm1 in
-    match uu____302 with
+    let uu___ = FStar_Syntax_Util.head_and_args tm1 in
+    match uu___ with
     | (hd, args) ->
-        let uu____359 =
-          let uu____360 = FStar_Syntax_Util.un_uinst hd in
-          uu____360.FStar_Syntax_Syntax.n in
-        (uu____359, args)
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Util.un_uinst hd in
+          uu___2.FStar_Syntax_Syntax.n in
+        (uu___1, args)
 let (e_proofstate :
   FStar_Tactics_Types.proofstate FStar_Syntax_Embeddings.embedding) =
   let embed_proofstate rng ps =
     FStar_Syntax_Util.mk_lazy ps fstar_tactics_proofstate.t
       FStar_Syntax_Syntax.Lazy_proofstate (FStar_Pervasives_Native.Some rng) in
   let unembed_proofstate w t =
-    let uu____401 =
-      let uu____402 = FStar_Syntax_Subst.compress t in
-      uu____402.FStar_Syntax_Syntax.n in
-    match uu____401 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_proofstate;
-          FStar_Syntax_Syntax.ltyp = uu____408;
-          FStar_Syntax_Syntax.rng = uu____409;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____412 = FStar_Dyn.undyn b in
+        let uu___3 = FStar_Dyn.undyn b in
         FStar_All.pipe_left
-          (fun uu____415 -> FStar_Pervasives_Native.Some uu____415) uu____412
-    | uu____416 ->
+          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____418 =
-              let uu____423 =
-                let uu____424 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded proofstate: %s\n"
-                  uu____424 in
-              (FStar_Errors.Warning_NotEmbedded, uu____423) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____418)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded proofstate: %s\n" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_proofstate unembed_proofstate fstar_tactics_proofstate.t
@@ -195,26 +191,26 @@ let (mkConstruct :
           (FStar_List.rev ts)
 let (fv_as_emb_typ : FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.emb_typ) =
   fun fv ->
-    let uu____506 =
-      let uu____513 =
+    let uu___ =
+      let uu___1 =
         FStar_Ident.string_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      (uu____513, []) in
-    FStar_Syntax_Syntax.ET_app uu____506
+      (uu___1, []) in
+    FStar_Syntax_Syntax.ET_app uu___
 let (e_proofstate_nbe :
   FStar_Tactics_Types.proofstate FStar_TypeChecker_NBETerm.embedding) =
   let embed_proofstate _cb ps =
     let li =
-      let uu____530 = FStar_Dyn.mkdyn ps in
+      let uu___ = FStar_Dyn.mkdyn ps in
       {
-        FStar_Syntax_Syntax.blob = uu____530;
+        FStar_Syntax_Syntax.blob = uu___;
         FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_proofstate;
         FStar_Syntax_Syntax.ltyp = (fstar_tactics_proofstate.t);
         FStar_Syntax_Syntax.rng = FStar_Range.dummyRange
       } in
     let thunk =
       FStar_Thunk.mk
-        (fun uu____535 ->
+        (fun uu___ ->
            FStar_All.pipe_left FStar_TypeChecker_NBETerm.mk_t
              (FStar_TypeChecker_NBETerm.Constant
                 (FStar_TypeChecker_NBETerm.String
@@ -222,67 +218,67 @@ let (e_proofstate_nbe :
     FStar_TypeChecker_NBETerm.mk_t
       (FStar_TypeChecker_NBETerm.Lazy ((FStar_Util.Inl li), thunk)) in
   let unembed_proofstate _cb t =
-    let uu____565 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____565 with
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
     | FStar_TypeChecker_NBETerm.Lazy
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_proofstate;
-           FStar_Syntax_Syntax.ltyp = uu____569;
-           FStar_Syntax_Syntax.rng = uu____570;_},
-         uu____571)
+           FStar_Syntax_Syntax.ltyp = uu___1;
+           FStar_Syntax_Syntax.rng = uu___2;_},
+         uu___3)
         ->
-        let uu____590 = FStar_Dyn.undyn b in
+        let uu___4 = FStar_Dyn.undyn b in
         FStar_All.pipe_left
-          (fun uu____593 -> FStar_Pervasives_Native.Some uu____593) uu____590
-    | uu____594 ->
-        ((let uu____596 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-          if uu____596
+          (fun uu___5 -> FStar_Pervasives_Native.Some uu___5) uu___4
+    | uu___1 ->
+        ((let uu___3 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+          if uu___3
           then
-            let uu____603 =
-              let uu____608 =
-                let uu____609 = FStar_TypeChecker_NBETerm.t_to_string t in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.t_to_string t in
                 FStar_Util.format1 "Not an embedded NBE proofstate: %s\n"
-                  uu____609 in
-              (FStar_Errors.Warning_NotEmbedded, uu____608) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____603
+                  uu___6 in
+              (FStar_Errors.Warning_NotEmbedded, uu___5) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___4
           else ());
          FStar_Pervasives_Native.None) in
-  let uu____611 = mkFV fstar_tactics_proofstate.fv [] [] in
-  let uu____616 = fv_as_emb_typ fstar_tactics_proofstate.fv in
+  let uu___ = mkFV fstar_tactics_proofstate.fv [] [] in
+  let uu___1 = fv_as_emb_typ fstar_tactics_proofstate.fv in
   {
     FStar_TypeChecker_NBETerm.em = embed_proofstate;
     FStar_TypeChecker_NBETerm.un = unembed_proofstate;
-    FStar_TypeChecker_NBETerm.typ = uu____611;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____616
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
 let (e_goal : FStar_Tactics_Types.goal FStar_Syntax_Embeddings.embedding) =
   let embed_goal rng g =
     FStar_Syntax_Util.mk_lazy g fstar_tactics_goal.t
       FStar_Syntax_Syntax.Lazy_goal (FStar_Pervasives_Native.Some rng) in
   let unembed_goal w t =
-    let uu____645 =
-      let uu____646 = FStar_Syntax_Subst.compress t in
-      uu____646.FStar_Syntax_Syntax.n in
-    match uu____645 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_goal;
-          FStar_Syntax_Syntax.ltyp = uu____652;
-          FStar_Syntax_Syntax.rng = uu____653;_}
+          FStar_Syntax_Syntax.ltyp = uu___1;
+          FStar_Syntax_Syntax.rng = uu___2;_}
         ->
-        let uu____656 = FStar_Dyn.undyn b in
+        let uu___3 = FStar_Dyn.undyn b in
         FStar_All.pipe_left
-          (fun uu____659 -> FStar_Pervasives_Native.Some uu____659) uu____656
-    | uu____660 ->
+          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+    | uu___1 ->
         (if w
          then
-           (let uu____662 =
-              let uu____667 =
-                let uu____668 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded goal: %s" uu____668 in
-              (FStar_Errors.Warning_NotEmbedded, uu____667) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____662)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded goal: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_goal unembed_goal fstar_tactics_goal.t
@@ -293,16 +289,16 @@ let (e_goal_nbe :
   FStar_Tactics_Types.goal FStar_TypeChecker_NBETerm.embedding) =
   let embed_goal _cb ps =
     let li =
-      let uu____689 = FStar_Dyn.mkdyn ps in
+      let uu___ = FStar_Dyn.mkdyn ps in
       {
-        FStar_Syntax_Syntax.blob = uu____689;
+        FStar_Syntax_Syntax.blob = uu___;
         FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_goal;
         FStar_Syntax_Syntax.ltyp = (fstar_tactics_goal.t);
         FStar_Syntax_Syntax.rng = FStar_Range.dummyRange
       } in
     let thunk =
       FStar_Thunk.mk
-        (fun uu____694 ->
+        (fun uu___ ->
            FStar_All.pipe_left FStar_TypeChecker_NBETerm.mk_t
              (FStar_TypeChecker_NBETerm.Constant
                 (FStar_TypeChecker_NBETerm.String
@@ -310,127 +306,126 @@ let (e_goal_nbe :
     FStar_All.pipe_left FStar_TypeChecker_NBETerm.mk_t
       (FStar_TypeChecker_NBETerm.Lazy ((FStar_Util.Inl li), thunk)) in
   let unembed_goal _cb t =
-    let uu____724 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____724 with
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
     | FStar_TypeChecker_NBETerm.Lazy
         (FStar_Util.Inl
          { FStar_Syntax_Syntax.blob = b;
            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_goal;
-           FStar_Syntax_Syntax.ltyp = uu____728;
-           FStar_Syntax_Syntax.rng = uu____729;_},
-         uu____730)
+           FStar_Syntax_Syntax.ltyp = uu___1;
+           FStar_Syntax_Syntax.rng = uu___2;_},
+         uu___3)
         ->
-        let uu____749 = FStar_Dyn.undyn b in
+        let uu___4 = FStar_Dyn.undyn b in
         FStar_All.pipe_left
-          (fun uu____752 -> FStar_Pervasives_Native.Some uu____752) uu____749
-    | uu____753 ->
-        ((let uu____755 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-          if uu____755
+          (fun uu___5 -> FStar_Pervasives_Native.Some uu___5) uu___4
+    | uu___1 ->
+        ((let uu___3 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+          if uu___3
           then
-            let uu____762 =
-              let uu____767 =
-                let uu____768 = FStar_TypeChecker_NBETerm.t_to_string t in
-                FStar_Util.format1 "Not an embedded NBE goal: %s" uu____768 in
-              (FStar_Errors.Warning_NotEmbedded, uu____767) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____762
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.t_to_string t in
+                FStar_Util.format1 "Not an embedded NBE goal: %s" uu___6 in
+              (FStar_Errors.Warning_NotEmbedded, uu___5) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___4
           else ());
          FStar_Pervasives_Native.None) in
-  let uu____770 = mkFV fstar_tactics_goal.fv [] [] in
-  let uu____775 = fv_as_emb_typ fstar_tactics_goal.fv in
+  let uu___ = mkFV fstar_tactics_goal.fv [] [] in
+  let uu___1 = fv_as_emb_typ fstar_tactics_goal.fv in
   {
     FStar_TypeChecker_NBETerm.em = embed_goal;
     FStar_TypeChecker_NBETerm.un = unembed_goal;
-    FStar_TypeChecker_NBETerm.typ = uu____770;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____775
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
 let (e_exn : Prims.exn FStar_Syntax_Embeddings.embedding) =
-  let embed_exn e rng uu____800 uu____801 =
+  let embed_exn e rng uu___ uu___1 =
     match e with
     | FStar_Tactics_Common.TacticFailure s ->
-        let uu____804 =
-          let uu____805 =
-            let uu____814 = embed FStar_Syntax_Embeddings.e_string rng s in
-            FStar_Syntax_Syntax.as_arg uu____814 in
-          [uu____805] in
-        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t uu____804
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = embed FStar_Syntax_Embeddings.e_string rng s in
+            FStar_Syntax_Syntax.as_arg uu___4 in
+          [uu___3] in
+        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t uu___2
           rng
     | FStar_Tactics_Common.EExn t ->
-        let uu___131_832 = t in
+        let uu___2 = t in
         {
-          FStar_Syntax_Syntax.n = (uu___131_832.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___2.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___131_832.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars)
         }
     | e1 ->
         let s =
-          let uu____835 = FStar_Util.message_of_exn e1 in
-          Prims.op_Hat "uncaught exception: " uu____835 in
-        let uu____836 =
-          let uu____837 =
-            let uu____846 = embed FStar_Syntax_Embeddings.e_string rng s in
-            FStar_Syntax_Syntax.as_arg uu____846 in
-          [uu____837] in
-        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t uu____836
+          let uu___2 = FStar_Util.message_of_exn e1 in
+          Prims.op_Hat "uncaught exception: " uu___2 in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = embed FStar_Syntax_Embeddings.e_string rng s in
+            FStar_Syntax_Syntax.as_arg uu___4 in
+          [uu___3] in
+        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t uu___2
           rng in
-  let unembed_exn t w uu____881 =
-    let uu____885 = hd'_and_args t in
-    match uu____885 with
-    | (FStar_Syntax_Syntax.Tm_fvar fv, (s, uu____904)::[]) when
+  let unembed_exn t w uu___ =
+    let uu___1 = hd'_and_args t in
+    match uu___1 with
+    | (FStar_Syntax_Syntax.Tm_fvar fv, (s, uu___2)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_TacticFailure.lid ->
-        let uu____939 = unembed' w FStar_Syntax_Embeddings.e_string s in
-        FStar_Util.bind_opt uu____939
+        let uu___3 = unembed' w FStar_Syntax_Embeddings.e_string s in
+        FStar_Util.bind_opt uu___3
           (fun s1 ->
              FStar_Pervasives_Native.Some
                (FStar_Tactics_Common.TacticFailure s1))
-    | uu____944 -> FStar_Pervasives_Native.Some (FStar_Tactics_Common.EExn t) in
-  let uu____959 =
-    let uu____960 =
-      let uu____967 =
+    | uu___2 -> FStar_Pervasives_Native.Some (FStar_Tactics_Common.EExn t) in
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         FStar_All.pipe_right FStar_Parser_Const.exn_lid
           FStar_Ident.string_of_lid in
-      (uu____967, []) in
-    FStar_Syntax_Syntax.ET_app uu____960 in
+      (uu___2, []) in
+    FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings.mk_emb_full embed_exn unembed_exn
-    FStar_Syntax_Syntax.t_exn (fun uu____971 -> "(exn)") uu____959
+    FStar_Syntax_Syntax.t_exn (fun uu___1 -> "(exn)") uu___
 let (e_exn_nbe : Prims.exn FStar_TypeChecker_NBETerm.embedding) =
   let embed_exn cb e =
     match e with
     | FStar_Tactics_Common.TacticFailure s ->
-        let uu____986 =
-          let uu____993 =
-            let uu____998 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string cb s in
-            FStar_TypeChecker_NBETerm.as_arg uu____998 in
-          [uu____993] in
-        mkConstruct fstar_tactics_TacticFailure.fv [] uu____986
-    | uu____1007 ->
-        let uu____1008 =
-          let uu____1009 = FStar_Util.message_of_exn e in
-          FStar_Util.format1 "cannot embed exn (NBE) : %s" uu____1009 in
-        failwith uu____1008 in
+            FStar_TypeChecker_NBETerm.as_arg uu___2 in
+          [uu___1] in
+        mkConstruct fstar_tactics_TacticFailure.fv [] uu___
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_Util.message_of_exn e in
+          FStar_Util.format1 "cannot embed exn (NBE) : %s" uu___2 in
+        failwith uu___1 in
   let unembed_exn cb t =
-    let uu____1025 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____1025 with
-    | FStar_TypeChecker_NBETerm.Construct
-        (fv, uu____1029, (s, uu____1031)::[]) when
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, (s, uu___2)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_TacticFailure.lid ->
-        let uu____1050 =
+        let uu___3 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb s in
-        FStar_Util.bind_opt uu____1050
+        FStar_Util.bind_opt uu___3
           (fun s1 ->
              FStar_Pervasives_Native.Some
                (FStar_Tactics_Common.TacticFailure s1))
-    | uu____1055 -> FStar_Pervasives_Native.None in
+    | uu___1 -> FStar_Pervasives_Native.None in
   let fv_exn = FStar_Syntax_Syntax.fvconst FStar_Parser_Const.exn_lid in
-  let uu____1057 = mkFV fv_exn [] [] in
-  let uu____1062 = fv_as_emb_typ fv_exn in
+  let uu___ = mkFV fv_exn [] [] in
+  let uu___1 = fv_as_emb_typ fv_exn in
   {
     FStar_TypeChecker_NBETerm.em = embed_exn;
     FStar_TypeChecker_NBETerm.un = unembed_exn;
-    FStar_TypeChecker_NBETerm.typ = uu____1057;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____1062
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
 let e_result :
   'a .
@@ -438,100 +433,96 @@ let e_result :
       'a FStar_Tactics_Result.__result FStar_Syntax_Embeddings.embedding
   =
   fun ea ->
-    let embed_result res rng uu____1103 uu____1104 =
+    let embed_result res rng uu___ uu___1 =
       match res with
       | FStar_Tactics_Result.Success (a1, ps) ->
-          let uu____1110 =
+          let uu___2 =
             FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success.t
               [FStar_Syntax_Syntax.U_zero] in
-          let uu____1111 =
-            let uu____1112 =
-              let uu____1121 = FStar_Syntax_Embeddings.type_of ea in
-              FStar_Syntax_Syntax.iarg uu____1121 in
-            let uu____1122 =
-              let uu____1133 =
-                let uu____1142 = embed ea rng a1 in
-                FStar_Syntax_Syntax.as_arg uu____1142 in
-              let uu____1143 =
-                let uu____1154 =
-                  let uu____1163 = embed e_proofstate rng ps in
-                  FStar_Syntax_Syntax.as_arg uu____1163 in
-                [uu____1154] in
-              uu____1133 :: uu____1143 in
-            uu____1112 :: uu____1122 in
-          FStar_Syntax_Syntax.mk_Tm_app uu____1110 uu____1111 rng
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_Syntax_Embeddings.type_of ea in
+              FStar_Syntax_Syntax.iarg uu___5 in
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = embed ea rng a1 in
+                FStar_Syntax_Syntax.as_arg uu___7 in
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 = embed e_proofstate rng ps in
+                  FStar_Syntax_Syntax.as_arg uu___9 in
+                [uu___8] in
+              uu___6 :: uu___7 in
+            uu___4 :: uu___5 in
+          FStar_Syntax_Syntax.mk_Tm_app uu___2 uu___3 rng
       | FStar_Tactics_Result.Failed (e, ps) ->
-          let uu____1198 =
+          let uu___2 =
             FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed.t
               [FStar_Syntax_Syntax.U_zero] in
-          let uu____1199 =
-            let uu____1200 =
-              let uu____1209 = FStar_Syntax_Embeddings.type_of ea in
-              FStar_Syntax_Syntax.iarg uu____1209 in
-            let uu____1210 =
-              let uu____1221 =
-                let uu____1230 = embed e_exn rng e in
-                FStar_Syntax_Syntax.as_arg uu____1230 in
-              let uu____1231 =
-                let uu____1242 =
-                  let uu____1251 = embed e_proofstate rng ps in
-                  FStar_Syntax_Syntax.as_arg uu____1251 in
-                [uu____1242] in
-              uu____1221 :: uu____1231 in
-            uu____1200 :: uu____1210 in
-          FStar_Syntax_Syntax.mk_Tm_app uu____1198 uu____1199 rng in
-    let unembed_result t w uu____1304 =
-      let uu____1310 = hd'_and_args t in
-      match uu____1310 with
-      | (FStar_Syntax_Syntax.Tm_fvar fv,
-         _t::(a1, uu____1332)::(ps, uu____1334)::[]) when
-          FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success.lid ->
-          let uu____1401 = unembed' w ea a1 in
-          FStar_Util.bind_opt uu____1401
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_Syntax_Embeddings.type_of ea in
+              FStar_Syntax_Syntax.iarg uu___5 in
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = embed e_exn rng e in
+                FStar_Syntax_Syntax.as_arg uu___7 in
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 = embed e_proofstate rng ps in
+                  FStar_Syntax_Syntax.as_arg uu___9 in
+                [uu___8] in
+              uu___6 :: uu___7 in
+            uu___4 :: uu___5 in
+          FStar_Syntax_Syntax.mk_Tm_app uu___2 uu___3 rng in
+    let unembed_result t w uu___ =
+      let uu___1 = hd'_and_args t in
+      match uu___1 with
+      | (FStar_Syntax_Syntax.Tm_fvar fv, _t::(a1, uu___2)::(ps, uu___3)::[])
+          when FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success.lid ->
+          let uu___4 = unembed' w ea a1 in
+          FStar_Util.bind_opt uu___4
             (fun a2 ->
-               let uu____1409 = unembed' w e_proofstate ps in
-               FStar_Util.bind_opt uu____1409
+               let uu___5 = unembed' w e_proofstate ps in
+               FStar_Util.bind_opt uu___5
                  (fun ps1 ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Success (a2, ps1))))
-      | (FStar_Syntax_Syntax.Tm_fvar fv,
-         _t::(e, uu____1421)::(ps, uu____1423)::[]) when
-          FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Failed.lid ->
-          let uu____1490 = unembed' w e_exn e in
-          FStar_Util.bind_opt uu____1490
+      | (FStar_Syntax_Syntax.Tm_fvar fv, _t::(e, uu___2)::(ps, uu___3)::[])
+          when FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Failed.lid ->
+          let uu___4 = unembed' w e_exn e in
+          FStar_Util.bind_opt uu___4
             (fun e1 ->
-               let uu____1498 = unembed' w e_proofstate ps in
-               FStar_Util.bind_opt uu____1498
+               let uu___5 = unembed' w e_proofstate ps in
+               FStar_Util.bind_opt uu___5
                  (fun ps1 ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Failed (e1, ps1))))
-      | uu____1507 ->
+      | uu___2 ->
           (if w
            then
-             (let uu____1523 =
-                let uu____1528 =
-                  let uu____1529 = FStar_Syntax_Print.term_to_string t in
+             (let uu___4 =
+                let uu___5 =
+                  let uu___6 = FStar_Syntax_Print.term_to_string t in
                   FStar_Util.format1 "Not an embedded tactic result: %s"
-                    uu____1529 in
-                (FStar_Errors.Warning_NotEmbedded, uu____1528) in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____1523)
+                    uu___6 in
+                (FStar_Errors.Warning_NotEmbedded, uu___5) in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___4)
            else ();
            FStar_Pervasives_Native.None) in
-    let uu____1533 =
-      let uu____1534 = FStar_Syntax_Embeddings.type_of ea in
-      t_result_of uu____1534 in
-    let uu____1535 =
-      let uu____1536 =
-        let uu____1543 =
+    let uu___ =
+      let uu___1 = FStar_Syntax_Embeddings.type_of ea in t_result_of uu___1 in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
           FStar_All.pipe_right fstar_tactics_result.lid
             FStar_Ident.string_of_lid in
-        let uu____1544 =
-          let uu____1547 = FStar_Syntax_Embeddings.emb_typ_of ea in
-          [uu____1547] in
-        (uu____1543, uu____1544) in
-      FStar_Syntax_Syntax.ET_app uu____1536 in
-    FStar_Syntax_Embeddings.mk_emb_full embed_result unembed_result
-      uu____1533 (fun uu____1553 -> "") uu____1535
+        let uu___4 =
+          let uu___5 = FStar_Syntax_Embeddings.emb_typ_of ea in [uu___5] in
+        (uu___3, uu___4) in
+      FStar_Syntax_Syntax.ET_app uu___2 in
+    FStar_Syntax_Embeddings.mk_emb_full embed_result unembed_result uu___
+      (fun uu___2 -> "") uu___1
 let e_result_nbe :
   'a .
     'a FStar_TypeChecker_NBETerm.embedding ->
@@ -541,79 +532,78 @@ let e_result_nbe :
     let embed_result cb res =
       match res with
       | FStar_Tactics_Result.Failed (e, ps) ->
-          let uu____1591 =
-            let uu____1598 =
-              let uu____1603 = FStar_TypeChecker_NBETerm.type_of ea in
-              FStar_TypeChecker_NBETerm.as_iarg uu____1603 in
-            let uu____1604 =
-              let uu____1611 =
-                let uu____1616 =
-                  FStar_TypeChecker_NBETerm.embed e_exn_nbe cb e in
-                FStar_TypeChecker_NBETerm.as_arg uu____1616 in
-              let uu____1617 =
-                let uu____1624 =
-                  let uu____1629 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.type_of ea in
+              FStar_TypeChecker_NBETerm.as_iarg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.embed e_exn_nbe cb e in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
                     FStar_TypeChecker_NBETerm.embed e_proofstate_nbe cb ps in
-                  FStar_TypeChecker_NBETerm.as_arg uu____1629 in
-                [uu____1624] in
-              uu____1611 :: uu____1617 in
-            uu____1598 :: uu____1604 in
+                  FStar_TypeChecker_NBETerm.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           mkConstruct fstar_tactics_Failed.fv [FStar_Syntax_Syntax.U_zero]
-            uu____1591
+            uu___
       | FStar_Tactics_Result.Success (a1, ps) ->
-          let uu____1648 =
-            let uu____1655 =
-              let uu____1660 = FStar_TypeChecker_NBETerm.type_of ea in
-              FStar_TypeChecker_NBETerm.as_iarg uu____1660 in
-            let uu____1661 =
-              let uu____1668 =
-                let uu____1673 = FStar_TypeChecker_NBETerm.embed ea cb a1 in
-                FStar_TypeChecker_NBETerm.as_arg uu____1673 in
-              let uu____1674 =
-                let uu____1681 =
-                  let uu____1686 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_NBETerm.type_of ea in
+              FStar_TypeChecker_NBETerm.as_iarg uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.embed ea cb a1 in
+                FStar_TypeChecker_NBETerm.as_arg uu___4 in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
                     FStar_TypeChecker_NBETerm.embed e_proofstate_nbe cb ps in
-                  FStar_TypeChecker_NBETerm.as_arg uu____1686 in
-                [uu____1681] in
-              uu____1668 :: uu____1674 in
-            uu____1655 :: uu____1661 in
+                  FStar_TypeChecker_NBETerm.as_arg uu___6 in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            uu___1 :: uu___2 in
           mkConstruct fstar_tactics_Success.fv [FStar_Syntax_Syntax.U_zero]
-            uu____1648 in
+            uu___ in
     let unembed_result cb t =
-      let uu____1722 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-      match uu____1722 with
+      let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+      match uu___ with
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____1728, (ps, uu____1730)::(a1, uu____1732)::_t::[]) when
+          (fv, uu___1, (ps, uu___2)::(a1, uu___3)::_t::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success.lid ->
-          let uu____1764 = FStar_TypeChecker_NBETerm.unembed ea cb a1 in
-          FStar_Util.bind_opt uu____1764
+          let uu___4 = FStar_TypeChecker_NBETerm.unembed ea cb a1 in
+          FStar_Util.bind_opt uu___4
             (fun a2 ->
-               let uu____1772 =
+               let uu___5 =
                  FStar_TypeChecker_NBETerm.unembed e_proofstate_nbe cb ps in
-               FStar_Util.bind_opt uu____1772
+               FStar_Util.bind_opt uu___5
                  (fun ps1 ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Success (a2, ps1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv, uu____1782, (ps, uu____1784)::(e, uu____1786)::_t::[]) when
+          (fv, uu___1, (ps, uu___2)::(e, uu___3)::_t::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Failed.lid ->
-          let uu____1818 = FStar_TypeChecker_NBETerm.unembed e_exn_nbe cb e in
-          FStar_Util.bind_opt uu____1818
+          let uu___4 = FStar_TypeChecker_NBETerm.unembed e_exn_nbe cb e in
+          FStar_Util.bind_opt uu___4
             (fun e1 ->
-               let uu____1826 =
+               let uu___5 =
                  FStar_TypeChecker_NBETerm.unembed e_proofstate_nbe cb ps in
-               FStar_Util.bind_opt uu____1826
+               FStar_Util.bind_opt uu___5
                  (fun ps1 ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Failed (e1, ps1))))
-      | uu____1835 -> FStar_Pervasives_Native.None in
-    let uu____1838 = mkFV fstar_tactics_result.fv [] [] in
-    let uu____1843 = fv_as_emb_typ fstar_tactics_result.fv in
+      | uu___1 -> FStar_Pervasives_Native.None in
+    let uu___ = mkFV fstar_tactics_result.fv [] [] in
+    let uu___1 = fv_as_emb_typ fstar_tactics_result.fv in
     {
       FStar_TypeChecker_NBETerm.em = embed_result;
       FStar_TypeChecker_NBETerm.un = unembed_result;
-      FStar_TypeChecker_NBETerm.typ = uu____1838;
-      FStar_TypeChecker_NBETerm.emb_typ = uu____1843
+      FStar_TypeChecker_NBETerm.typ = uu___;
+      FStar_TypeChecker_NBETerm.emb_typ = uu___1
     }
 let (e_direction :
   FStar_Tactics_Types.direction FStar_Syntax_Embeddings.embedding) =
@@ -622,25 +612,25 @@ let (e_direction :
     | FStar_Tactics_Types.TopDown -> fstar_tactics_topdown.t
     | FStar_Tactics_Types.BottomUp -> fstar_tactics_bottomup.t in
   let unembed_direction w t =
-    let uu____1874 =
-      let uu____1875 = FStar_Syntax_Subst.compress t in
-      uu____1875.FStar_Syntax_Syntax.n in
-    match uu____1874 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_topdown.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.TopDown
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_bottomup.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.BottomUp
-    | uu____1882 ->
+    | uu___1 ->
         (if w
          then
-           (let uu____1884 =
-              let uu____1889 =
-                let uu____1890 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded direction: %s" uu____1890 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1889) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____1884)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded direction: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_direction unembed_direction fstar_tactics_direction.t
@@ -653,33 +643,33 @@ let (e_direction_nbe :
     | FStar_Tactics_Types.BottomUp ->
         mkConstruct fstar_tactics_bottomup.fv [] [] in
   let unembed_direction cb t =
-    let uu____1928 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____1928 with
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____1932, []) when
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_topdown.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.TopDown
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____1948, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_bottomup.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.BottomUp
-    | uu____1963 ->
-        ((let uu____1965 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-          if uu____1965
+    | uu___1 ->
+        ((let uu___3 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+          if uu___3
           then
-            let uu____1972 =
-              let uu____1977 =
-                let uu____1978 = FStar_TypeChecker_NBETerm.t_to_string t in
-                FStar_Util.format1 "Not an embedded direction: %s" uu____1978 in
-              (FStar_Errors.Warning_NotEmbedded, uu____1977) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____1972
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.t_to_string t in
+                FStar_Util.format1 "Not an embedded direction: %s" uu___6 in
+              (FStar_Errors.Warning_NotEmbedded, uu___5) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___4
           else ());
          FStar_Pervasives_Native.None) in
-  let uu____1980 = mkFV fstar_tactics_direction.fv [] [] in
-  let uu____1985 = fv_as_emb_typ fstar_tactics_direction.fv in
+  let uu___ = mkFV fstar_tactics_direction.fv [] [] in
+  let uu___1 = fv_as_emb_typ fstar_tactics_direction.fv in
   {
     FStar_TypeChecker_NBETerm.em = embed_direction;
     FStar_TypeChecker_NBETerm.un = unembed_direction;
-    FStar_TypeChecker_NBETerm.typ = uu____1980;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____1985
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
 let (e_ctrl_flag :
   FStar_Tactics_Types.ctrl_flag FStar_Syntax_Embeddings.embedding) =
@@ -689,10 +679,10 @@ let (e_ctrl_flag :
     | FStar_Tactics_Types.Skip -> fstar_tactics_Skip.t
     | FStar_Tactics_Types.Abort -> fstar_tactics_Abort.t in
   let unembed_ctrl_flag w t =
-    let uu____2014 =
-      let uu____2015 = FStar_Syntax_Subst.compress t in
-      uu____2015.FStar_Syntax_Syntax.n in
-    match uu____2014 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Continue.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Continue
@@ -702,15 +692,15 @@ let (e_ctrl_flag :
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Abort.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Abort
-    | uu____2023 ->
+    | uu___1 ->
         (if w
          then
-           (let uu____2025 =
-              let uu____2030 =
-                let uu____2031 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2031 in
-              (FStar_Errors.Warning_NotEmbedded, uu____2030) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2025)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_ctrl_flag unembed_ctrl_flag fstar_tactics_ctrl_flag.t
@@ -723,36 +713,36 @@ let (e_ctrl_flag_nbe :
     | FStar_Tactics_Types.Skip -> mkConstruct fstar_tactics_Skip.fv [] []
     | FStar_Tactics_Types.Abort -> mkConstruct fstar_tactics_Abort.fv [] [] in
   let unembed_ctrl_flag cb t =
-    let uu____2073 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____2073 with
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2077, []) when
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Continue.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Continue
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2093, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Skip.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Skip
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2109, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Abort.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Abort
-    | uu____2124 ->
-        ((let uu____2126 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-          if uu____2126
+    | uu___1 ->
+        ((let uu___3 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+          if uu___3
           then
-            let uu____2133 =
-              let uu____2138 =
-                let uu____2139 = FStar_TypeChecker_NBETerm.t_to_string t in
-                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2139 in
-              (FStar_Errors.Warning_NotEmbedded, uu____2138) in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____2133
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_NBETerm.t_to_string t in
+                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu___6 in
+              (FStar_Errors.Warning_NotEmbedded, uu___5) in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu___4
           else ());
          FStar_Pervasives_Native.None) in
-  let uu____2141 = mkFV fstar_tactics_ctrl_flag.fv [] [] in
-  let uu____2146 = fv_as_emb_typ fstar_tactics_ctrl_flag.fv in
+  let uu___ = mkFV fstar_tactics_ctrl_flag.fv [] [] in
+  let uu___1 = fv_as_emb_typ fstar_tactics_ctrl_flag.fv in
   {
     FStar_TypeChecker_NBETerm.em = embed_ctrl_flag;
     FStar_TypeChecker_NBETerm.un = unembed_ctrl_flag;
-    FStar_TypeChecker_NBETerm.typ = uu____2141;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____2146
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
 let (e_guard_policy :
   FStar_Tactics_Types.guard_policy FStar_Syntax_Embeddings.embedding) =
@@ -763,10 +753,10 @@ let (e_guard_policy :
     | FStar_Tactics_Types.Force -> fstar_tactics_Force.t
     | FStar_Tactics_Types.Drop -> fstar_tactics_Drop.t in
   let unembed_guard_policy w t =
-    let uu____2175 =
-      let uu____2176 = FStar_Syntax_Subst.compress t in
-      uu____2176.FStar_Syntax_Syntax.n in
-    match uu____2175 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_SMT.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.SMT
@@ -779,16 +769,15 @@ let (e_guard_policy :
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Drop.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Drop
-    | uu____2185 ->
+    | uu___1 ->
         (if w
          then
-           (let uu____2187 =
-              let uu____2192 =
-                let uu____2193 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.format1 "Not an embedded guard_policy: %s"
-                  uu____2193 in
-              (FStar_Errors.Warning_NotEmbedded, uu____2192) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2187)
+           (let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.format1 "Not an embedded guard_policy: %s" uu___5 in
+              (FStar_Errors.Warning_NotEmbedded, uu___4) in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___3)
          else ();
          FStar_Pervasives_Native.None) in
   mk_emb embed_guard_policy unembed_guard_policy fstar_tactics_guard_policy.t
@@ -801,26 +790,26 @@ let (e_guard_policy_nbe :
     | FStar_Tactics_Types.Force -> mkConstruct fstar_tactics_Force.fv [] []
     | FStar_Tactics_Types.Drop -> mkConstruct fstar_tactics_Drop.fv [] [] in
   let unembed_guard_policy cb t =
-    let uu____2239 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
-    match uu____2239 with
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2243, []) when
+    let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+    match uu___ with
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_SMT.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.SMT
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2259, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Goal.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Goal
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2275, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Force.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Force
-    | FStar_TypeChecker_NBETerm.Construct (fv, uu____2291, []) when
+    | FStar_TypeChecker_NBETerm.Construct (fv, uu___1, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Drop.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Drop
-    | uu____2306 -> FStar_Pervasives_Native.None in
-  let uu____2307 = mkFV fstar_tactics_guard_policy.fv [] [] in
-  let uu____2312 = fv_as_emb_typ fstar_tactics_guard_policy.fv in
+    | uu___1 -> FStar_Pervasives_Native.None in
+  let uu___ = mkFV fstar_tactics_guard_policy.fv [] [] in
+  let uu___1 = fv_as_emb_typ fstar_tactics_guard_policy.fv in
   {
     FStar_TypeChecker_NBETerm.em = embed_guard_policy;
     FStar_TypeChecker_NBETerm.un = unembed_guard_policy;
-    FStar_TypeChecker_NBETerm.typ = uu____2307;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____2312
+    FStar_TypeChecker_NBETerm.typ = uu___;
+    FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }

--- a/src/ocaml-output/FStar_Tactics_Hooks.ml
+++ b/src/ocaml-output/FStar_Tactics_Hooks.ml
@@ -13,18 +13,17 @@ let (run_tactic_on_typ :
         fun env ->
           fun typ ->
             let rng =
-              let uu____38 = FStar_Range.use_range rng_goal in
-              let uu____39 = FStar_Range.use_range rng_tac in
-              FStar_Range.range_of_rng uu____38 uu____39 in
-            let uu____40 =
-              FStar_Tactics_Basic.proofstate_of_goal_ty rng env typ in
-            match uu____40 with
+              let uu___ = FStar_Range.use_range rng_goal in
+              let uu___1 = FStar_Range.use_range rng_tac in
+              FStar_Range.range_of_rng uu___ uu___1 in
+            let uu___ = FStar_Tactics_Basic.proofstate_of_goal_ty rng env typ in
+            match uu___ with
             | (ps, w) ->
-                let uu____53 =
+                let uu___1 =
                   FStar_Tactics_Interpreter.run_tactic_on_ps rng_tac rng_goal
                     FStar_Syntax_Embeddings.e_unit ()
                     FStar_Syntax_Embeddings.e_unit tactic ps in
-                (match uu____53 with | (gs, _res) -> (gs, w))
+                (match uu___1 with | (gs, _res) -> (gs, w))
 let (run_tactic_on_all_implicits :
   FStar_Range.range ->
     FStar_Range.range ->
@@ -38,50 +37,48 @@ let (run_tactic_on_all_implicits :
       fun tactic ->
         fun env ->
           fun imps ->
-            let uu____103 =
+            let uu___ =
               FStar_Tactics_Basic.proofstate_of_all_implicits rng_goal env
                 imps in
-            match uu____103 with
-            | (ps, uu____111) ->
-                let uu____112 =
+            match uu___ with
+            | (ps, uu___1) ->
+                let uu___2 =
                   FStar_Tactics_Interpreter.run_tactic_on_ps rng_tac rng_goal
                     FStar_Syntax_Embeddings.e_unit ()
                     FStar_Syntax_Embeddings.e_unit tactic ps in
-                (match uu____112 with | (goals, ()) -> goals)
+                (match uu___2 with | (goals, ()) -> goals)
 type pol =
   | Pos 
   | Neg 
   | Both 
 let (uu___is_Pos : pol -> Prims.bool) =
-  fun projectee -> match projectee with | Pos -> true | uu____131 -> false
+  fun projectee -> match projectee with | Pos -> true | uu___ -> false
 let (uu___is_Neg : pol -> Prims.bool) =
-  fun projectee -> match projectee with | Neg -> true | uu____137 -> false
+  fun projectee -> match projectee with | Neg -> true | uu___ -> false
 let (uu___is_Both : pol -> Prims.bool) =
-  fun projectee -> match projectee with | Both -> true | uu____143 -> false
+  fun projectee -> match projectee with | Both -> true | uu___ -> false
 type 'a tres_m =
   | Unchanged of 'a 
   | Simplified of ('a * FStar_Tactics_Types.goal Prims.list) 
   | Dual of ('a * 'a * FStar_Tactics_Types.goal Prims.list) 
 let uu___is_Unchanged : 'a . 'a tres_m -> Prims.bool =
   fun projectee ->
-    match projectee with | Unchanged _0 -> true | uu____198 -> false
+    match projectee with | Unchanged _0 -> true | uu___ -> false
 let __proj__Unchanged__item___0 : 'a . 'a tres_m -> 'a =
   fun projectee -> match projectee with | Unchanged _0 -> _0
 let uu___is_Simplified : 'a . 'a tres_m -> Prims.bool =
   fun projectee ->
-    match projectee with | Simplified _0 -> true | uu____237 -> false
+    match projectee with | Simplified _0 -> true | uu___ -> false
 let __proj__Simplified__item___0 :
   'a . 'a tres_m -> ('a * FStar_Tactics_Types.goal Prims.list) =
   fun projectee -> match projectee with | Simplified _0 -> _0
 let uu___is_Dual : 'a . 'a tres_m -> Prims.bool =
-  fun projectee ->
-    match projectee with | Dual _0 -> true | uu____290 -> false
+  fun projectee -> match projectee with | Dual _0 -> true | uu___ -> false
 let __proj__Dual__item___0 :
   'a . 'a tres_m -> ('a * 'a * FStar_Tactics_Types.goal Prims.list) =
   fun projectee -> match projectee with | Dual _0 -> _0
 type tres = FStar_Syntax_Syntax.term tres_m
-let tpure : 'uuuuuu330 . 'uuuuuu330 -> 'uuuuuu330 tres_m =
-  fun x -> Unchanged x
+let tpure : 'uuuuu . 'uuuuu -> 'uuuuu tres_m = fun x -> Unchanged x
 let (flip : pol -> pol) =
   fun p -> match p with | Pos -> Neg | Neg -> Pos | Both -> Both
 let (by_tactic_interp :
@@ -89,15 +86,15 @@ let (by_tactic_interp :
   fun pol1 ->
     fun e ->
       fun t ->
-        let uu____358 = FStar_Syntax_Util.head_and_args t in
-        match uu____358 with
+        let uu___ = FStar_Syntax_Util.head_and_args t in
+        match uu___ with
         | (hd, args) ->
-            let uu____401 =
-              let uu____416 =
-                let uu____417 = FStar_Syntax_Util.un_uinst hd in
-                uu____417.FStar_Syntax_Syntax.n in
-              (uu____416, args) in
-            (match uu____401 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,
                 (tactic, FStar_Pervasives_Native.None)::(assertion,
                                                          FStar_Pervasives_Native.None)::[])
@@ -107,20 +104,20 @@ let (by_tactic_interp :
                  ->
                  (match pol1 with
                   | Pos ->
-                      let uu____479 =
+                      let uu___2 =
                         run_tactic_on_typ tactic.FStar_Syntax_Syntax.pos
                           assertion.FStar_Syntax_Syntax.pos tactic e
                           assertion in
-                      (match uu____479 with
-                       | (gs, uu____487) ->
+                      (match uu___2 with
+                       | (gs, uu___3) ->
                            Simplified (FStar_Syntax_Util.t_true, gs))
                   | Both ->
-                      let uu____494 =
+                      let uu___2 =
                         run_tactic_on_typ tactic.FStar_Syntax_Syntax.pos
                           assertion.FStar_Syntax_Syntax.pos tactic e
                           assertion in
-                      (match uu____494 with
-                       | (gs, uu____502) ->
+                      (match uu___2 with
+                       | (gs, uu___3) ->
                            Dual (assertion, FStar_Syntax_Util.t_true, gs))
                   | Neg -> Simplified (assertion, []))
              | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -130,29 +127,29 @@ let (by_tactic_interp :
                  ->
                  (match pol1 with
                   | Pos ->
-                      let uu____545 =
-                        let uu____552 =
-                          let uu____555 =
-                            let uu____556 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
                               FStar_Tactics_Basic.goal_of_goal_ty e assertion in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____556 in
-                          [uu____555] in
-                        (FStar_Syntax_Util.t_true, uu____552) in
-                      Simplified uu____545
+                              uu___5 in
+                          [uu___4] in
+                        (FStar_Syntax_Util.t_true, uu___3) in
+                      Simplified uu___2
                   | Both ->
-                      let uu____567 =
-                        let uu____576 =
-                          let uu____579 =
-                            let uu____580 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
                               FStar_Tactics_Basic.goal_of_goal_ty e assertion in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____580 in
-                          [uu____579] in
-                        (assertion, FStar_Syntax_Util.t_true, uu____576) in
-                      Dual uu____567
+                              uu___5 in
+                          [uu___4] in
+                        (assertion, FStar_Syntax_Util.t_true, uu___3) in
+                      Dual uu___2
                   | Neg -> Simplified (assertion, []))
-             | uu____593 -> Unchanged t)
+             | uu___2 -> Unchanged t)
 let explode :
   'a . 'a tres_m -> ('a * 'a * FStar_Tactics_Types.goal Prims.list) =
   fun t ->
@@ -162,17 +159,15 @@ let explode :
     | Dual (tn, tp, gs) -> (tn, tp, gs)
 let comb1 : 'a 'b . ('a -> 'b) -> 'a tres_m -> 'b tres_m =
   fun f ->
-    fun uu___0_683 ->
-      match uu___0_683 with
-      | Unchanged t -> let uu____689 = f t in Unchanged uu____689
+    fun uu___ ->
+      match uu___ with
+      | Unchanged t -> let uu___1 = f t in Unchanged uu___1
       | Simplified (t, gs) ->
-          let uu____696 = let uu____703 = f t in (uu____703, gs) in
-          Simplified uu____696
+          let uu___1 = let uu___2 = f t in (uu___2, gs) in Simplified uu___1
       | Dual (tn, tp, gs) ->
-          let uu____713 =
-            let uu____722 = f tn in
-            let uu____723 = f tp in (uu____722, uu____723, gs) in
-          Dual uu____713
+          let uu___1 =
+            let uu___2 = f tn in let uu___3 = f tp in (uu___2, uu___3, gs) in
+          Dual uu___1
 let comb2 :
   'a 'b 'c . ('a -> 'b -> 'c) -> 'a tres_m -> 'b tres_m -> 'c tres_m =
   fun f ->
@@ -180,43 +175,40 @@ let comb2 :
       fun y ->
         match (x, y) with
         | (Unchanged t1, Unchanged t2) ->
-            let uu____786 = f t1 t2 in Unchanged uu____786
+            let uu___ = f t1 t2 in Unchanged uu___
         | (Unchanged t1, Simplified (t2, gs)) ->
-            let uu____798 = let uu____805 = f t1 t2 in (uu____805, gs) in
-            Simplified uu____798
+            let uu___ = let uu___1 = f t1 t2 in (uu___1, gs) in
+            Simplified uu___
         | (Simplified (t1, gs), Unchanged t2) ->
-            let uu____819 = let uu____826 = f t1 t2 in (uu____826, gs) in
-            Simplified uu____819
+            let uu___ = let uu___1 = f t1 t2 in (uu___1, gs) in
+            Simplified uu___
         | (Simplified (t1, gs1), Simplified (t2, gs2)) ->
-            let uu____845 =
-              let uu____852 = f t1 t2 in
-              (uu____852, (FStar_List.append gs1 gs2)) in
-            Simplified uu____845
-        | uu____855 ->
-            let uu____864 = explode x in
-            (match uu____864 with
+            let uu___ =
+              let uu___1 = f t1 t2 in (uu___1, (FStar_List.append gs1 gs2)) in
+            Simplified uu___
+        | uu___ ->
+            let uu___1 = explode x in
+            (match uu___1 with
              | (n1, p1, gs1) ->
-                 let uu____882 = explode y in
-                 (match uu____882 with
+                 let uu___2 = explode y in
+                 (match uu___2 with
                   | (n2, p2, gs2) ->
-                      let uu____900 =
-                        let uu____909 = f n1 n2 in
-                        let uu____910 = f p1 p2 in
-                        (uu____909, uu____910, (FStar_List.append gs1 gs2)) in
-                      Dual uu____900))
+                      let uu___3 =
+                        let uu___4 = f n1 n2 in
+                        let uu___5 = f p1 p2 in
+                        (uu___4, uu___5, (FStar_List.append gs1 gs2)) in
+                      Dual uu___3))
 let comb_list : 'a . 'a tres_m Prims.list -> 'a Prims.list tres_m =
   fun rs ->
     let rec aux rs1 acc =
       match rs1 with
       | [] -> acc
       | hd::tl ->
-          let uu____982 = comb2 (fun l -> fun r -> l :: r) hd acc in
-          aux tl uu____982 in
+          let uu___ = comb2 (fun l -> fun r -> l :: r) hd acc in aux tl uu___ in
     aux (FStar_List.rev rs) (tpure [])
 let emit : 'a . FStar_Tactics_Types.goal Prims.list -> 'a tres_m -> 'a tres_m
   =
-  fun gs ->
-    fun m -> comb2 (fun uu____1030 -> fun x -> x) (Simplified ((), gs)) m
+  fun gs -> fun m -> comb2 (fun uu___ -> fun x -> x) (Simplified ((), gs)) m
 let rec (traverse :
   (pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres) ->
     pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres)
@@ -226,25 +218,25 @@ let rec (traverse :
       fun e ->
         fun t ->
           let r =
-            let uu____1072 =
-              let uu____1073 = FStar_Syntax_Subst.compress t in
-              uu____1073.FStar_Syntax_Syntax.n in
-            match uu____1072 with
+            let uu___ =
+              let uu___1 = FStar_Syntax_Subst.compress t in
+              uu___1.FStar_Syntax_Syntax.n in
+            match uu___ with
             | FStar_Syntax_Syntax.Tm_uinst (t1, us) ->
                 let tr = traverse f pol1 e t1 in
-                let uu____1085 =
+                let uu___1 =
                   comb1 (fun t' -> FStar_Syntax_Syntax.Tm_uinst (t', us)) in
-                uu____1085 tr
+                uu___1 tr
             | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
                 let tr = traverse f pol1 e t1 in
-                let uu____1111 =
+                let uu___1 =
                   comb1 (fun t' -> FStar_Syntax_Syntax.Tm_meta (t', m)) in
-                uu____1111 tr
+                uu___1 tr
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.pos = uu____1131;
-                   FStar_Syntax_Syntax.vars = uu____1132;_},
-                 (p, uu____1134)::(q, uu____1136)::[])
+                   FStar_Syntax_Syntax.pos = uu___1;
+                   FStar_Syntax_Syntax.vars = uu___2;_},
+                 (p, uu___3)::(q, uu___4)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                 ->
@@ -252,18 +244,18 @@ let rec (traverse :
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None p in
                 let r1 = traverse f (flip pol1) e p in
                 let r2 =
-                  let uu____1194 = FStar_TypeChecker_Env.push_bv e x in
-                  traverse f pol1 uu____1194 q in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e x in
+                  traverse f pol1 uu___5 q in
                 comb2
                   (fun l ->
-                     fun r ->
-                       let uu____1208 = FStar_Syntax_Util.mk_imp l r in
-                       uu____1208.FStar_Syntax_Syntax.n) r1 r2
+                     fun r3 ->
+                       let uu___5 = FStar_Syntax_Util.mk_imp l r3 in
+                       uu___5.FStar_Syntax_Syntax.n) r1 r2
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.pos = uu____1212;
-                   FStar_Syntax_Syntax.vars = uu____1213;_},
-                 (p, uu____1215)::(q, uu____1217)::[])
+                   FStar_Syntax_Syntax.pos = uu___1;
+                   FStar_Syntax_Syntax.vars = uu___2;_},
+                 (p, uu___3)::(q, uu___4)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.iff_lid
                 ->
@@ -272,32 +264,29 @@ let rec (traverse :
                 let xq =
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None q in
                 let r1 =
-                  let uu____1275 = FStar_TypeChecker_Env.push_bv e xq in
-                  traverse f Both uu____1275 p in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e xq in
+                  traverse f Both uu___5 p in
                 let r2 =
-                  let uu____1277 = FStar_TypeChecker_Env.push_bv e xp in
-                  traverse f Both uu____1277 q in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e xp in
+                  traverse f Both uu___5 q in
                 (match (r1, r2) with
-                 | (Unchanged uu____1284, Unchanged uu____1285) ->
+                 | (Unchanged uu___5, Unchanged uu___6) ->
                      comb2
                        (fun l ->
-                          fun r ->
-                            let uu____1303 = FStar_Syntax_Util.mk_iff l r in
-                            uu____1303.FStar_Syntax_Syntax.n) r1 r2
-                 | uu____1306 ->
-                     let uu____1315 = explode r1 in
-                     (match uu____1315 with
+                          fun r3 ->
+                            let uu___7 = FStar_Syntax_Util.mk_iff l r3 in
+                            uu___7.FStar_Syntax_Syntax.n) r1 r2
+                 | uu___5 ->
+                     let uu___6 = explode r1 in
+                     (match uu___6 with
                       | (pn, pp, gs1) ->
-                          let uu____1333 = explode r2 in
-                          (match uu____1333 with
+                          let uu___7 = explode r2 in
+                          (match uu___7 with
                            | (qn, qp, gs2) ->
                                let t1 =
-                                 let uu____1354 =
-                                   FStar_Syntax_Util.mk_imp pn qp in
-                                 let uu____1357 =
-                                   FStar_Syntax_Util.mk_imp qn pp in
-                                 FStar_Syntax_Util.mk_conj uu____1354
-                                   uu____1357 in
+                                 let uu___8 = FStar_Syntax_Util.mk_imp pn qp in
+                                 let uu___9 = FStar_Syntax_Util.mk_imp qn pp in
+                                 FStar_Syntax_Util.mk_conj uu___8 uu___9 in
                                Simplified
                                  ((t1.FStar_Syntax_Syntax.n),
                                    (FStar_List.append gs1 gs2)))))
@@ -305,124 +294,123 @@ let rec (traverse :
                 let r0 = traverse f pol1 e hd in
                 let r1 =
                   FStar_List.fold_right
-                    (fun uu____1421 ->
-                       fun r ->
-                         match uu____1421 with
+                    (fun uu___1 ->
+                       fun r2 ->
+                         match uu___1 with
                          | (a, q) ->
                              let r' = traverse f pol1 e a in
                              comb2 (fun a1 -> fun args1 -> (a1, q) :: args1)
-                               r' r) args (tpure []) in
+                               r' r2) args (tpure []) in
                 comb2
                   (fun hd1 ->
                      fun args1 -> FStar_Syntax_Syntax.Tm_app (hd1, args1)) r0
                   r1
             | FStar_Syntax_Syntax.Tm_abs (bs, t1, k) ->
-                let uu____1573 = FStar_Syntax_Subst.open_term bs t1 in
-                (match uu____1573 with
+                let uu___1 = FStar_Syntax_Subst.open_term bs t1 in
+                (match uu___1 with
                  | (bs1, topen) ->
                      let e' = FStar_TypeChecker_Env.push_binders e bs1 in
                      let r0 =
                        FStar_List.map
-                         (fun uu____1613 ->
-                            match uu____1613 with
+                         (fun uu___2 ->
+                            match uu___2 with
                             | (bv, aq) ->
-                                let r =
+                                let r1 =
                                   traverse f (flip pol1) e
                                     bv.FStar_Syntax_Syntax.sort in
-                                let uu____1635 =
+                                let uu___3 =
                                   comb1
                                     (fun s' ->
-                                       ((let uu___256_1667 = bv in
+                                       ((let uu___4 = bv in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___256_1667.FStar_Syntax_Syntax.ppname);
+                                             (uu___4.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___256_1667.FStar_Syntax_Syntax.index);
+                                             (uu___4.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort = s'
                                          }), aq)) in
-                                uu____1635 r) bs1 in
+                                uu___3 r1) bs1 in
                      let rbs = comb_list r0 in
                      let rt = traverse f pol1 e' topen in
                      comb2
                        (fun bs2 ->
                           fun t2 ->
-                            let uu____1695 = FStar_Syntax_Util.abs bs2 t2 k in
-                            uu____1695.FStar_Syntax_Syntax.n) rbs rt)
+                            let uu___2 = FStar_Syntax_Util.abs bs2 t2 k in
+                            uu___2.FStar_Syntax_Syntax.n) rbs rt)
             | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, ef) ->
-                let uu____1741 = traverse f pol1 e t1 in
-                let uu____1746 =
+                let uu___1 = traverse f pol1 e t1 in
+                let uu___2 =
                   comb1
                     (fun t2 -> FStar_Syntax_Syntax.Tm_ascribed (t2, asc, ef)) in
-                uu____1746 uu____1741
+                uu___2 uu___1
             | FStar_Syntax_Syntax.Tm_match (sc, brs) ->
-                let uu____1821 = traverse f pol1 e sc in
-                let uu____1826 =
-                  let uu____1845 =
+                let uu___1 = traverse f pol1 e sc in
+                let uu___2 =
+                  let uu___3 =
                     FStar_List.map
                       (fun br ->
-                         let uu____1862 = FStar_Syntax_Subst.open_branch br in
-                         match uu____1862 with
+                         let uu___4 = FStar_Syntax_Subst.open_branch br in
+                         match uu___4 with
                          | (pat, w, exp) ->
                              let bvs = FStar_Syntax_Syntax.pat_bvs pat in
                              let e1 = FStar_TypeChecker_Env.push_bvs e bvs in
-                             let r = traverse f pol1 e1 exp in
-                             let uu____1889 =
+                             let r1 = traverse f pol1 e1 exp in
+                             let uu___5 =
                                comb1
                                  (fun exp1 ->
                                     FStar_Syntax_Subst.close_branch
                                       (pat, w, exp1)) in
-                             uu____1889 r) brs in
-                  comb_list uu____1845 in
+                             uu___5 r1) brs in
+                  comb_list uu___3 in
                 comb2
                   (fun sc1 ->
                      fun brs1 -> FStar_Syntax_Syntax.Tm_match (sc1, brs1))
-                  uu____1821 uu____1826
+                  uu___1 uu___2
             | x -> tpure x in
           match r with
           | Unchanged tn' ->
               f pol1 e
-                (let uu___288_1975 = t in
+                (let uu___ = t in
                  {
                    FStar_Syntax_Syntax.n = tn';
-                   FStar_Syntax_Syntax.pos =
-                     (uu___288_1975.FStar_Syntax_Syntax.pos);
+                   FStar_Syntax_Syntax.pos = (uu___.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
-                     (uu___288_1975.FStar_Syntax_Syntax.vars)
+                     (uu___.FStar_Syntax_Syntax.vars)
                  })
           | Simplified (tn', gs) ->
-              let uu____1982 =
+              let uu___ =
                 f pol1 e
-                  (let uu___294_1986 = t in
+                  (let uu___1 = t in
                    {
                      FStar_Syntax_Syntax.n = tn';
                      FStar_Syntax_Syntax.pos =
-                       (uu___294_1986.FStar_Syntax_Syntax.pos);
+                       (uu___1.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___294_1986.FStar_Syntax_Syntax.vars)
+                       (uu___1.FStar_Syntax_Syntax.vars)
                    }) in
-              emit gs uu____1982
+              emit gs uu___
           | Dual (tn, tp, gs) ->
               let rp =
                 f pol1 e
-                  (let uu___301_1996 = t in
+                  (let uu___ = t in
                    {
                      FStar_Syntax_Syntax.n = tp;
                      FStar_Syntax_Syntax.pos =
-                       (uu___301_1996.FStar_Syntax_Syntax.pos);
+                       (uu___.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___301_1996.FStar_Syntax_Syntax.vars)
+                       (uu___.FStar_Syntax_Syntax.vars)
                    }) in
-              let uu____1997 = explode rp in
-              (match uu____1997 with
-               | (uu____2006, p', gs') ->
+              let uu___ = explode rp in
+              (match uu___ with
+               | (uu___1, p', gs') ->
                    Dual
-                     ((let uu___308_2016 = t in
+                     ((let uu___2 = t in
                        {
                          FStar_Syntax_Syntax.n = tn;
                          FStar_Syntax_Syntax.pos =
-                           (uu___308_2016.FStar_Syntax_Syntax.pos);
+                           (uu___2.FStar_Syntax_Syntax.pos);
                          FStar_Syntax_Syntax.vars =
-                           (uu___308_2016.FStar_Syntax_Syntax.vars)
+                           (uu___2.FStar_Syntax_Syntax.vars)
                        }), p', (FStar_List.append gs gs')))
 let (getprop :
   FStar_TypeChecker_Env.env ->
@@ -446,127 +434,116 @@ let (preprocess :
   =
   fun env ->
     fun goal ->
-      (let uu____2059 =
+      (let uu___1 =
          FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
-       FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu____2059);
-      (let uu____2067 = FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
-       if uu____2067
+       FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu___1);
+      (let uu___2 = FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
+       if uu___2
        then
-         let uu____2074 =
-           let uu____2075 = FStar_TypeChecker_Env.all_binders env in
-           FStar_All.pipe_right uu____2075
+         let uu___3 =
+           let uu___4 = FStar_TypeChecker_Env.all_binders env in
+           FStar_All.pipe_right uu___4
              (FStar_Syntax_Print.binders_to_string ",") in
-         let uu____2076 = FStar_Syntax_Print.term_to_string goal in
-         FStar_Util.print2 "About to preprocess %s |= %s\n" uu____2074
-           uu____2076
+         let uu___4 = FStar_Syntax_Print.term_to_string goal in
+         FStar_Util.print2 "About to preprocess %s |= %s\n" uu___3 uu___4
        else ());
       (let initial = (Prims.int_one, []) in
-       let uu____2105 =
-         let uu____2114 = traverse by_tactic_interp Pos env goal in
-         match uu____2114 with
+       let uu___2 =
+         let uu___3 = traverse by_tactic_interp Pos env goal in
+         match uu___3 with
          | Unchanged t' -> (t', [])
          | Simplified (t', gs) -> (t', gs)
-         | uu____2138 ->
+         | uu___4 ->
              failwith "preprocess: impossible, traverse returned a Dual" in
-       match uu____2105 with
+       match uu___2 with
        | (t', gs) ->
-           ((let uu____2166 =
-               FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
-             if uu____2166
+           ((let uu___4 = FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
+             if uu___4
              then
-               let uu____2173 =
-                 let uu____2174 = FStar_TypeChecker_Env.all_binders env in
-                 FStar_All.pipe_right uu____2174
+               let uu___5 =
+                 let uu___6 = FStar_TypeChecker_Env.all_binders env in
+                 FStar_All.pipe_right uu___6
                    (FStar_Syntax_Print.binders_to_string ", ") in
-               let uu____2175 = FStar_Syntax_Print.term_to_string t' in
-               FStar_Util.print2 "Main goal simplified to: %s |- %s\n"
-                 uu____2173 uu____2175
+               let uu___6 = FStar_Syntax_Print.term_to_string t' in
+               FStar_Util.print2 "Main goal simplified to: %s |- %s\n" uu___5
+                 uu___6
              else ());
             (let s = initial in
              let s1 =
                FStar_List.fold_left
-                 (fun uu____2224 ->
+                 (fun uu___4 ->
                     fun g ->
-                      match uu____2224 with
+                      match uu___4 with
                       | (n, gs1) ->
                           let phi =
-                            let uu____2269 =
-                              let uu____2272 = FStar_Tactics_Types.goal_env g in
-                              let uu____2273 =
-                                FStar_Tactics_Types.goal_type g in
-                              getprop uu____2272 uu____2273 in
-                            match uu____2269 with
+                            let uu___5 =
+                              let uu___6 = FStar_Tactics_Types.goal_env g in
+                              let uu___7 = FStar_Tactics_Types.goal_type g in
+                              getprop uu___6 uu___7 in
+                            match uu___5 with
                             | FStar_Pervasives_Native.None ->
-                                let uu____2274 =
-                                  let uu____2279 =
-                                    let uu____2280 =
-                                      let uu____2281 =
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Tactics_Types.goal_type g in
                                       FStar_Syntax_Print.term_to_string
-                                        uu____2281 in
+                                        uu___9 in
                                     FStar_Util.format1
                                       "Tactic returned proof-relevant goal: %s"
-                                      uu____2280 in
+                                      uu___8 in
                                   (FStar_Errors.Fatal_TacticProofRelevantGoal,
-                                    uu____2279) in
-                                FStar_Errors.raise_error uu____2274
+                                    uu___7) in
+                                FStar_Errors.raise_error uu___6
                                   env.FStar_TypeChecker_Env.range
-                            | FStar_Pervasives_Native.Some phi -> phi in
-                          ((let uu____2284 =
+                            | FStar_Pervasives_Native.Some phi1 -> phi1 in
+                          ((let uu___6 =
                               FStar_ST.op_Bang
                                 FStar_Tactics_Interpreter.tacdbg in
-                            if uu____2284
+                            if uu___6
                             then
-                              let uu____2291 = FStar_Util.string_of_int n in
-                              let uu____2292 =
-                                let uu____2293 =
-                                  FStar_Tactics_Types.goal_type g in
-                                FStar_Syntax_Print.term_to_string uu____2293 in
-                              FStar_Util.print2 "Got goal #%s: %s\n"
-                                uu____2291 uu____2292
+                              let uu___7 = FStar_Util.string_of_int n in
+                              let uu___8 =
+                                let uu___9 = FStar_Tactics_Types.goal_type g in
+                                FStar_Syntax_Print.term_to_string uu___9 in
+                              FStar_Util.print2 "Got goal #%s: %s\n" uu___7
+                                uu___8
                             else ());
                            (let label =
-                              let uu____2296 =
-                                let uu____2297 =
-                                  FStar_Tactics_Types.get_label g in
-                                uu____2297 = "" in
-                              if uu____2296
+                              let uu___6 =
+                                let uu___7 = FStar_Tactics_Types.get_label g in
+                                uu___7 = "" in
+                              if uu___6
                               then
-                                let uu____2298 = FStar_Util.string_of_int n in
-                                Prims.op_Hat "Could not prove goal #"
-                                  uu____2298
+                                let uu___7 = FStar_Util.string_of_int n in
+                                Prims.op_Hat "Could not prove goal #" uu___7
                               else
-                                (let uu____2300 =
-                                   let uu____2301 =
-                                     FStar_Util.string_of_int n in
-                                   let uu____2302 =
-                                     let uu____2303 =
-                                       let uu____2304 =
+                                (let uu___8 =
+                                   let uu___9 = FStar_Util.string_of_int n in
+                                   let uu___10 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_Tactics_Types.get_label g in
-                                       Prims.op_Hat uu____2304 ")" in
-                                     Prims.op_Hat " (" uu____2303 in
-                                   Prims.op_Hat uu____2301 uu____2302 in
-                                 Prims.op_Hat "Could not prove goal #"
-                                   uu____2300) in
+                                       Prims.op_Hat uu___12 ")" in
+                                     Prims.op_Hat " (" uu___11 in
+                                   Prims.op_Hat uu___9 uu___10 in
+                                 Prims.op_Hat "Could not prove goal #" uu___8) in
                             let gt' =
                               FStar_TypeChecker_Util.label label
                                 goal.FStar_Syntax_Syntax.pos phi in
-                            let uu____2306 =
-                              let uu____2315 =
-                                let uu____2322 =
-                                  FStar_Tactics_Types.goal_env g in
-                                (uu____2322, gt',
-                                  (g.FStar_Tactics_Types.opts)) in
-                              uu____2315 :: gs1 in
-                            ((n + Prims.int_one), uu____2306)))) s gs in
-             let uu____2337 = s1 in
-             match uu____2337 with
-             | (uu____2358, gs1) ->
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Tactics_Types.goal_env g in
+                                (uu___8, gt', (g.FStar_Tactics_Types.opts)) in
+                              uu___7 :: gs1 in
+                            ((n + Prims.int_one), uu___6)))) s gs in
+             let uu___4 = s1 in
+             match uu___4 with
+             | (uu___5, gs1) ->
                  let gs2 = FStar_List.rev gs1 in
-                 let uu____2391 =
-                   let uu____2398 = FStar_Options.peek () in
-                   (env, t', uu____2398) in
-                 uu____2391 :: gs2)))
+                 let uu___6 =
+                   let uu___7 = FStar_Options.peek () in (env, t', uu___7) in
+                 uu___6 :: gs2)))
 let (synthesize :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -577,42 +554,41 @@ let (synthesize :
       fun tau ->
         if env.FStar_TypeChecker_Env.nosynth
         then
-          let uu____2420 =
+          let uu___ =
             FStar_TypeChecker_Util.fvar_const env
               FStar_Parser_Const.magic_lid in
-          let uu____2421 =
-            let uu____2422 =
+          let uu___1 =
+            let uu___2 =
               FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit in
-            [uu____2422] in
-          FStar_Syntax_Syntax.mk_Tm_app uu____2420 uu____2421
+            [uu___2] in
+          FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1
             typ.FStar_Syntax_Syntax.pos
         else
-          ((let uu____2449 =
+          ((let uu___2 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
-            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2449);
-           (let uu____2456 =
+            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu___2);
+           (let uu___2 =
               run_tactic_on_typ tau.FStar_Syntax_Syntax.pos
                 typ.FStar_Syntax_Syntax.pos tau env typ in
-            match uu____2456 with
+            match uu___2 with
             | (gs, w) ->
                 (FStar_List.iter
                    (fun g ->
-                      let uu____2477 =
-                        let uu____2480 = FStar_Tactics_Types.goal_env g in
-                        let uu____2481 = FStar_Tactics_Types.goal_type g in
-                        getprop uu____2480 uu____2481 in
-                      match uu____2477 with
+                      let uu___4 =
+                        let uu___5 = FStar_Tactics_Types.goal_env g in
+                        let uu___6 = FStar_Tactics_Types.goal_type g in
+                        getprop uu___5 uu___6 in
+                      match uu___4 with
                       | FStar_Pervasives_Native.Some vc ->
-                          ((let uu____2484 =
+                          ((let uu___6 =
                               FStar_ST.op_Bang
                                 FStar_Tactics_Interpreter.tacdbg in
-                            if uu____2484
+                            if uu___6
                             then
-                              let uu____2491 =
+                              let uu___7 =
                                 FStar_Syntax_Print.term_to_string vc in
                               FStar_Util.print1 "Synthesis left a goal: %s\n"
-                                uu____2491
+                                uu___7
                             else ());
                            (let guard =
                               {
@@ -624,9 +600,9 @@ let (synthesize :
                                   ([], []);
                                 FStar_TypeChecker_Common.implicits = []
                               } in
-                            let uu____2506 = FStar_Tactics_Types.goal_env g in
-                            FStar_TypeChecker_Rel.force_trivial_guard
-                              uu____2506 guard))
+                            let uu___6 = FStar_Tactics_Types.goal_env g in
+                            FStar_TypeChecker_Rel.force_trivial_guard uu___6
+                              guard))
                       | FStar_Pervasives_Native.None ->
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_OpenGoalsInSynthesis,
@@ -643,31 +619,29 @@ let (solve_implicits :
         if env.FStar_TypeChecker_Env.nosynth
         then ()
         else
-          ((let uu____2524 =
+          ((let uu___2 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
-            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2524);
+            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu___2);
            (let gs =
-              let uu____2534 = FStar_TypeChecker_Env.get_range env in
-              run_tactic_on_all_implicits tau.FStar_Syntax_Syntax.pos
-                uu____2534 tau env imps in
+              let uu___2 = FStar_TypeChecker_Env.get_range env in
+              run_tactic_on_all_implicits tau.FStar_Syntax_Syntax.pos uu___2
+                tau env imps in
             FStar_All.pipe_right gs
               (FStar_List.iter
                  (fun g ->
-                    let uu____2545 =
-                      let uu____2548 = FStar_Tactics_Types.goal_env g in
-                      let uu____2549 = FStar_Tactics_Types.goal_type g in
-                      getprop uu____2548 uu____2549 in
-                    match uu____2545 with
+                    let uu___3 =
+                      let uu___4 = FStar_Tactics_Types.goal_env g in
+                      let uu___5 = FStar_Tactics_Types.goal_type g in
+                      getprop uu___4 uu___5 in
+                    match uu___3 with
                     | FStar_Pervasives_Native.Some vc ->
-                        ((let uu____2552 =
+                        ((let uu___5 =
                             FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
-                          if uu____2552
+                          if uu___5
                           then
-                            let uu____2559 =
-                              FStar_Syntax_Print.term_to_string vc in
+                            let uu___6 = FStar_Syntax_Print.term_to_string vc in
                             FStar_Util.print1 "Synthesis left a goal: %s\n"
-                              uu____2559
+                              uu___6
                           else ());
                          (let guard =
                             {
@@ -678,14 +652,14 @@ let (solve_implicits :
                               FStar_TypeChecker_Common.univ_ineqs = ([], []);
                               FStar_TypeChecker_Common.implicits = []
                             } in
-                          let uu____2574 = FStar_Tactics_Types.goal_env g in
-                          FStar_TypeChecker_Rel.force_trivial_guard
-                            uu____2574 guard))
+                          let uu___5 = FStar_Tactics_Types.goal_env g in
+                          FStar_TypeChecker_Rel.force_trivial_guard uu___5
+                            guard))
                     | FStar_Pervasives_Native.None ->
-                        let uu____2575 = FStar_TypeChecker_Env.get_range env in
+                        let uu___4 = FStar_TypeChecker_Env.get_range env in
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_OpenGoalsInSynthesis,
-                            "synthesis left open goals") uu____2575))))
+                            "synthesis left open goals") uu___4))))
 let (splice :
   FStar_TypeChecker_Env.env ->
     FStar_Range.range ->
@@ -697,90 +671,89 @@ let (splice :
         if env.FStar_TypeChecker_Env.nosynth
         then []
         else
-          ((let uu____2597 =
+          ((let uu___2 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
-            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2597);
+            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu___2);
            (let typ = FStar_Syntax_Syntax.t_decls in
             let ps =
               FStar_Tactics_Basic.proofstate_of_goals
                 tau.FStar_Syntax_Syntax.pos env [] [] in
-            let uu____2606 =
-              let uu____2615 =
+            let uu___2 =
+              let uu___3 =
                 FStar_Syntax_Embeddings.e_list
                   FStar_Reflection_Embeddings.e_sigelt in
               FStar_Tactics_Interpreter.run_tactic_on_ps
                 tau.FStar_Syntax_Syntax.pos tau.FStar_Syntax_Syntax.pos
-                FStar_Syntax_Embeddings.e_unit () uu____2615 tau ps in
-            match uu____2606 with
+                FStar_Syntax_Embeddings.e_unit () uu___3 tau ps in
+            match uu___2 with
             | (gs, sigelts) ->
-                ((let uu____2635 =
+                ((let uu___4 =
                     FStar_List.existsML
                       (fun g ->
-                         let uu____2639 =
-                           let uu____2640 =
-                             let uu____2643 = FStar_Tactics_Types.goal_env g in
-                             let uu____2644 = FStar_Tactics_Types.goal_type g in
-                             getprop uu____2643 uu____2644 in
-                           FStar_Option.isSome uu____2640 in
-                         Prims.op_Negation uu____2639) gs in
-                  if uu____2635
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 = FStar_Tactics_Types.goal_env g in
+                             let uu___8 = FStar_Tactics_Types.goal_type g in
+                             getprop uu___7 uu___8 in
+                           FStar_Option.isSome uu___6 in
+                         Prims.op_Negation uu___5) gs in
+                  if uu___4
                   then
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_OpenGoalsInSynthesis,
                         "splice left open goals") typ.FStar_Syntax_Syntax.pos
                   else ());
-                 (let uu____2647 =
+                 (let uu___5 =
                     FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg in
-                  if uu____2647
+                  if uu___5
                   then
-                    let uu____2654 =
+                    let uu___6 =
                       FStar_Common.string_of_list
                         FStar_Syntax_Print.sigelt_to_string sigelts in
-                    FStar_Util.print1 "splice: got decls = %s\n" uu____2654
+                    FStar_Util.print1 "splice: got decls = %s\n" uu___6
                   else ());
                  (let sigelts1 =
                     FStar_All.pipe_right sigelts
                       (FStar_List.map
                          (fun se ->
                             (match se.FStar_Syntax_Syntax.sigel with
-                             | FStar_Syntax_Syntax.Sig_datacon uu____2668 ->
-                                 let uu____2683 =
-                                   let uu____2688 =
-                                     let uu____2689 =
+                             | FStar_Syntax_Syntax.Sig_datacon uu___6 ->
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Syntax_Print.sigelt_to_string_short
                                          se in
                                      FStar_Util.format1
                                        "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
-                                       uu____2689 in
-                                   (FStar_Errors.Error_BadSplice, uu____2688) in
-                                 FStar_Errors.raise_error uu____2683 rng
-                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                 uu____2690 ->
-                                 let uu____2707 =
-                                   let uu____2712 =
-                                     let uu____2713 =
+                                       uu___9 in
+                                   (FStar_Errors.Error_BadSplice, uu___8) in
+                                 FStar_Errors.raise_error uu___7 rng
+                             | FStar_Syntax_Syntax.Sig_inductive_typ uu___6
+                                 ->
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Syntax_Print.sigelt_to_string_short
                                          se in
                                      FStar_Util.format1
                                        "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
-                                       uu____2713 in
-                                   (FStar_Errors.Error_BadSplice, uu____2712) in
-                                 FStar_Errors.raise_error uu____2707 rng
-                             | uu____2714 -> ());
-                            (let uu___402_2715 = se in
+                                       uu___9 in
+                                   (FStar_Errors.Error_BadSplice, uu___8) in
+                                 FStar_Errors.raise_error uu___7 rng
+                             | uu___6 -> ());
+                            (let uu___6 = se in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___402_2715.FStar_Syntax_Syntax.sigel);
+                                 (uu___6.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng = rng;
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___402_2715.FStar_Syntax_Syntax.sigquals);
+                                 (uu___6.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___402_2715.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___6.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___402_2715.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___6.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___402_2715.FStar_Syntax_Syntax.sigopts)
+                                 (uu___6.FStar_Syntax_Syntax.sigopts)
                              }))) in
                   sigelts1))))
 let (mpreprocess :
@@ -794,19 +767,18 @@ let (mpreprocess :
         if env.FStar_TypeChecker_Env.nosynth
         then tm
         else
-          ((let uu____2733 =
+          ((let uu___2 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
-            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2733);
+            FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg uu___2);
            (let ps =
               FStar_Tactics_Basic.proofstate_of_goals
                 tm.FStar_Syntax_Syntax.pos env [] [] in
-            let uu____2741 =
+            let uu___2 =
               FStar_Tactics_Interpreter.run_tactic_on_ps
                 tau.FStar_Syntax_Syntax.pos tm.FStar_Syntax_Syntax.pos
                 FStar_Reflection_Embeddings.e_term tm
                 FStar_Reflection_Embeddings.e_term tau ps in
-            match uu____2741 with | (gs, tm1) -> tm1))
+            match uu___2 with | (gs, tm1) -> tm1))
 let (postprocess :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -820,47 +792,45 @@ let (postprocess :
           if env.FStar_TypeChecker_Env.nosynth
           then tm
           else
-            ((let uu____2776 =
+            ((let uu___2 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
               FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-                uu____2776);
-             (let uu____2783 =
+                uu___2);
+             (let uu___2 =
                 FStar_TypeChecker_Env.new_implicit_var_aux "postprocess RHS"
                   tm.FStar_Syntax_Syntax.pos env typ
                   FStar_Syntax_Syntax.Allow_untyped
                   FStar_Pervasives_Native.None in
-              match uu____2783 with
-              | (uvtm, uu____2797, g_imp) ->
+              match uu___2 with
+              | (uvtm, uu___3, g_imp) ->
                   let u = env.FStar_TypeChecker_Env.universe_of env typ in
                   let goal =
-                    let uu____2815 = FStar_Syntax_Util.mk_eq2 u typ tm uvtm in
+                    let uu___4 = FStar_Syntax_Util.mk_eq2 u typ tm uvtm in
                     FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero
-                      uu____2815 in
-                  let uu____2816 =
+                      uu___4 in
+                  let uu___4 =
                     run_tactic_on_typ tau.FStar_Syntax_Syntax.pos
                       tm.FStar_Syntax_Syntax.pos tau env goal in
-                  (match uu____2816 with
+                  (match uu___4 with
                    | (gs, w) ->
                        (FStar_List.iter
                           (fun g ->
-                             let uu____2837 =
-                               let uu____2840 =
-                                 FStar_Tactics_Types.goal_env g in
-                               let uu____2841 =
-                                 FStar_Tactics_Types.goal_type g in
-                               getprop uu____2840 uu____2841 in
-                             match uu____2837 with
+                             let uu___6 =
+                               let uu___7 = FStar_Tactics_Types.goal_env g in
+                               let uu___8 = FStar_Tactics_Types.goal_type g in
+                               getprop uu___7 uu___8 in
+                             match uu___6 with
                              | FStar_Pervasives_Native.Some vc ->
-                                 ((let uu____2844 =
+                                 ((let uu___8 =
                                      FStar_ST.op_Bang
                                        FStar_Tactics_Interpreter.tacdbg in
-                                   if uu____2844
+                                   if uu___8
                                    then
-                                     let uu____2851 =
+                                     let uu___9 =
                                        FStar_Syntax_Print.term_to_string vc in
                                      FStar_Util.print1
                                        "Postprocessing left a goal: %s\n"
-                                       uu____2851
+                                       uu___9
                                    else ());
                                   (let guard =
                                      {
@@ -875,10 +845,10 @@ let (postprocess :
                                        FStar_TypeChecker_Common.implicits =
                                          []
                                      } in
-                                   let uu____2866 =
+                                   let uu___8 =
                                      FStar_Tactics_Types.goal_env g in
                                    FStar_TypeChecker_Rel.force_trivial_guard
-                                     uu____2866 guard))
+                                     uu___8 guard))
                              | FStar_Pervasives_Native.None ->
                                  FStar_Errors.raise_error
                                    (FStar_Errors.Fatal_OpenGoalsInSynthesis,

--- a/src/ocaml-output/FStar_Tactics_InterpFuns.ml
+++ b/src/ocaml-output/FStar_Tactics_InterpFuns.ml
@@ -1,30 +1,28 @@
 open Prims
 let unembed :
-  'uuuuuu8 .
-    'uuuuuu8 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Embeddings.norm_cb ->
-          'uuuuuu8 FStar_Pervasives_Native.option
+          'uuuuu FStar_Pervasives_Native.option
   =
   fun e ->
     fun t ->
       fun n ->
-        let uu____32 = FStar_Syntax_Embeddings.unembed e t in uu____32 true n
+        let uu___ = FStar_Syntax_Embeddings.unembed e t in uu___ true n
 let embed :
-  'uuuuuu49 .
-    'uuuuuu49 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Range.range ->
-        'uuuuuu49 ->
-          FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
+        'uuuuu -> FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
   =
   fun e ->
     fun rng ->
       fun t ->
         fun n ->
-          let uu____76 = FStar_Syntax_Embeddings.embed e t in
-          uu____76 rng FStar_Pervasives_Native.None n
-let rec drop :
-  'uuuuuu91 . Prims.int -> 'uuuuuu91 Prims.list -> 'uuuuuu91 Prims.list =
+          let uu___ = FStar_Syntax_Embeddings.embed e t in
+          uu___ rng FStar_Pervasives_Native.None n
+let rec drop : 'uuuuu . Prims.int -> 'uuuuu Prims.list -> 'uuuuu Prims.list =
   fun n ->
     fun l ->
       if n = Prims.int_zero
@@ -32,20 +30,19 @@ let rec drop :
       else
         (match l with
          | [] -> failwith "drop: impossible"
-         | uu____113::xs -> drop (n - Prims.int_one) xs)
+         | uu___1::xs -> drop (n - Prims.int_one) xs)
 let timing_int :
-  'uuuuuu135 'uuuuuu136 'uuuuuu137 'uuuuuu138 .
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 .
     FStar_Ident.lid ->
-      ('uuuuuu135 -> 'uuuuuu136 -> 'uuuuuu137 -> 'uuuuuu138) ->
-        'uuuuuu135 -> 'uuuuuu136 -> 'uuuuuu137 -> 'uuuuuu138
+      ('uuuuu -> 'uuuuu1 -> 'uuuuu2 -> 'uuuuu3) ->
+        'uuuuu -> 'uuuuu1 -> 'uuuuu2 -> 'uuuuu3
   =
   fun l ->
     fun f -> fun psc -> fun cb -> fun args -> let r = f psc cb args in r
 let timing_nbe :
-  'uuuuuu194 'uuuuuu195 'uuuuuu196 .
+  'uuuuu 'uuuuu1 'uuuuu2 .
     FStar_Ident.lid ->
-      ('uuuuuu194 -> 'uuuuuu195 -> 'uuuuuu196) ->
-        'uuuuuu194 -> 'uuuuuu195 -> 'uuuuuu196
+      ('uuuuu -> 'uuuuu1 -> 'uuuuu2) -> 'uuuuu -> 'uuuuu1 -> 'uuuuu2
   = fun l -> fun f -> fun nbe_cbs -> fun args -> let r = f nbe_cbs args in r
 let (mk :
   Prims.string ->
@@ -128,16 +125,16 @@ let mk_total_interpretation_1_psc :
           fun ncb ->
             fun args ->
               match args with
-              | (a1, uu____431)::[] ->
-                  let uu____456 = unembed e1 a1 ncb in
-                  FStar_Util.bind_opt uu____456
+              | (a1, uu___)::[] ->
+                  let uu___1 = unembed e1 a1 ncb in
+                  FStar_Util.bind_opt uu___1
                     (fun a11 ->
                        let r1 = f psc a11 in
-                       let uu____464 =
-                         let uu____465 = FStar_TypeChecker_Cfg.psc_range psc in
-                         embed er uu____465 r1 ncb in
-                       FStar_Pervasives_Native.Some uu____464)
-              | uu____466 -> FStar_Pervasives_Native.None
+                       let uu___2 =
+                         let uu___3 = FStar_TypeChecker_Cfg.psc_range psc in
+                         embed er uu___3 r1 ncb in
+                       FStar_Pervasives_Native.Some uu___2)
+              | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_1_psc :
   'r 't1 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -153,14 +150,14 @@ let mk_total_nbe_interpretation_1_psc :
         fun er ->
           fun args ->
             match args with
-            | (a1, uu____529)::[] ->
-                let uu____538 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                FStar_Util.bind_opt uu____538
+            | (a1, uu___)::[] ->
+                let uu___1 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                FStar_Util.bind_opt uu___1
                   (fun a11 ->
                      let r1 = f FStar_TypeChecker_Cfg.null_psc a11 in
-                     let uu____546 = FStar_TypeChecker_NBETerm.embed er cb r1 in
-                     FStar_Pervasives_Native.Some uu____546)
-            | uu____547 -> FStar_Pervasives_Native.None
+                     let uu___2 = FStar_TypeChecker_NBETerm.embed er cb r1 in
+                     FStar_Pervasives_Native.Some uu___2)
+            | uu___ -> FStar_Pervasives_Native.None
 let mk_total_step_1_psc :
   'a 'na 'nr 'r .
     Prims.int ->
@@ -185,9 +182,9 @@ let mk_total_step_1_psc :
                     (mk_total_interpretation_1_psc f ea er)
                     (fun cb ->
                        fun args ->
-                         let uu____657 = drop nunivs args in
+                         let uu___ = drop nunivs args in
                          mk_total_nbe_interpretation_1_psc cb nf nea ner
-                           uu____657)
+                           uu___)
 let (max_tac_arity : Prims.int) = (Prims.of_int (20))
 let mk_tactic_interpretation_1 :
   'r 't1 .
@@ -206,26 +203,26 @@ let mk_tactic_interpretation_1 :
           fun ncb ->
             fun args ->
               match args with
-              | (a1, uu____732)::(a2, uu____734)::[] ->
-                  let uu____775 = unembed e1 a1 ncb in
-                  FStar_Util.bind_opt uu____775
+              | (a1, uu___)::(a2, uu___1)::[] ->
+                  let uu___2 = unembed e1 a1 ncb in
+                  FStar_Util.bind_opt uu___2
                     (fun a11 ->
-                       let uu____781 =
+                       let uu___3 =
                          unembed FStar_Tactics_Embedding.e_proofstate a2 ncb in
-                       FStar_Util.bind_opt uu____781
+                       FStar_Util.bind_opt uu___3
                          (fun ps ->
                             let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                             let r1 =
-                              let uu____793 = t a11 in
-                              FStar_Tactics_Monad.run_safe uu____793 ps1 in
-                            let uu____796 =
-                              let uu____797 =
+                              let uu___4 = t a11 in
+                              FStar_Tactics_Monad.run_safe uu___4 ps1 in
+                            let uu___4 =
+                              let uu___5 =
                                 FStar_Tactics_Embedding.e_result er in
-                              let uu____802 =
+                              let uu___6 =
                                 FStar_TypeChecker_Cfg.psc_range psc in
-                              embed uu____797 uu____802 r1 ncb in
-                            FStar_Pervasives_Native.Some uu____796))
-              | uu____805 -> FStar_Pervasives_Native.None
+                              embed uu___5 uu___6 r1 ncb in
+                            FStar_Pervasives_Native.Some uu___4))
+              | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_2 :
   'r 't1 't2 .
     ('t1 -> 't2 -> 'r FStar_Tactics_Monad.tac) ->
@@ -245,32 +242,31 @@ let mk_tactic_interpretation_2 :
             fun ncb ->
               fun args ->
                 match args with
-                | (a1, uu____895)::(a2, uu____897)::(a3, uu____899)::[] ->
-                    let uu____956 = unembed e1 a1 ncb in
-                    FStar_Util.bind_opt uu____956
+                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::[] ->
+                    let uu___3 = unembed e1 a1 ncb in
+                    FStar_Util.bind_opt uu___3
                       (fun a11 ->
-                         let uu____962 = unembed e2 a2 ncb in
-                         FStar_Util.bind_opt uu____962
+                         let uu___4 = unembed e2 a2 ncb in
+                         FStar_Util.bind_opt uu___4
                            (fun a21 ->
-                              let uu____968 =
+                              let uu___5 =
                                 unembed FStar_Tactics_Embedding.e_proofstate
                                   a3 ncb in
-                              FStar_Util.bind_opt uu____968
+                              FStar_Util.bind_opt uu___5
                                 (fun ps ->
                                    let ps1 =
                                      FStar_Tactics_Types.set_ps_psc psc ps in
                                    let r1 =
-                                     let uu____980 = t a11 a21 in
-                                     FStar_Tactics_Monad.run_safe uu____980
-                                       ps1 in
-                                   let uu____983 =
-                                     let uu____984 =
+                                     let uu___6 = t a11 a21 in
+                                     FStar_Tactics_Monad.run_safe uu___6 ps1 in
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_Tactics_Embedding.e_result er in
-                                     let uu____989 =
+                                     let uu___8 =
                                        FStar_TypeChecker_Cfg.psc_range psc in
-                                     embed uu____984 uu____989 r1 ncb in
-                                   FStar_Pervasives_Native.Some uu____983)))
-                | uu____992 -> FStar_Pervasives_Native.None
+                                     embed uu___7 uu___8 r1 ncb in
+                                   FStar_Pervasives_Native.Some uu___6)))
+                | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_3 :
   'r 't1 't2 't3 .
     ('t1 -> 't2 -> 't3 -> 'r FStar_Tactics_Monad.tac) ->
@@ -292,42 +288,40 @@ let mk_tactic_interpretation_3 :
               fun ncb ->
                 fun args ->
                   match args with
-                  | (a1, uu____1101)::(a2, uu____1103)::(a3, uu____1105)::
-                      (a4, uu____1107)::[] ->
-                      let uu____1180 = unembed e1 a1 ncb in
-                      FStar_Util.bind_opt uu____1180
+                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::[]
+                      ->
+                      let uu___4 = unembed e1 a1 ncb in
+                      FStar_Util.bind_opt uu___4
                         (fun a11 ->
-                           let uu____1186 = unembed e2 a2 ncb in
-                           FStar_Util.bind_opt uu____1186
+                           let uu___5 = unembed e2 a2 ncb in
+                           FStar_Util.bind_opt uu___5
                              (fun a21 ->
-                                let uu____1192 = unembed e3 a3 ncb in
-                                FStar_Util.bind_opt uu____1192
+                                let uu___6 = unembed e3 a3 ncb in
+                                FStar_Util.bind_opt uu___6
                                   (fun a31 ->
-                                     let uu____1198 =
+                                     let uu___7 =
                                        unembed
                                          FStar_Tactics_Embedding.e_proofstate
                                          a4 ncb in
-                                     FStar_Util.bind_opt uu____1198
+                                     FStar_Util.bind_opt uu___7
                                        (fun ps ->
                                           let ps1 =
                                             FStar_Tactics_Types.set_ps_psc
                                               psc ps in
                                           let r1 =
-                                            let uu____1210 = t a11 a21 a31 in
+                                            let uu___8 = t a11 a21 a31 in
                                             FStar_Tactics_Monad.run_safe
-                                              uu____1210 ps1 in
-                                          let uu____1213 =
-                                            let uu____1214 =
+                                              uu___8 ps1 in
+                                          let uu___8 =
+                                            let uu___9 =
                                               FStar_Tactics_Embedding.e_result
                                                 er in
-                                            let uu____1219 =
+                                            let uu___10 =
                                               FStar_TypeChecker_Cfg.psc_range
                                                 psc in
-                                            embed uu____1214 uu____1219 r1
-                                              ncb in
-                                          FStar_Pervasives_Native.Some
-                                            uu____1213))))
-                  | uu____1222 -> FStar_Pervasives_Native.None
+                                            embed uu___9 uu___10 r1 ncb in
+                                          FStar_Pervasives_Native.Some uu___8))))
+                  | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_4 :
   'r 't1 't2 't3 't4 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 'r FStar_Tactics_Monad.tac) ->
@@ -351,46 +345,46 @@ let mk_tactic_interpretation_4 :
                 fun ncb ->
                   fun args ->
                     match args with
-                    | (a1, uu____1350)::(a2, uu____1352)::(a3, uu____1354)::
-                        (a4, uu____1356)::(a5, uu____1358)::[] ->
-                        let uu____1447 = unembed e1 a1 ncb in
-                        FStar_Util.bind_opt uu____1447
+                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                        (a5, uu___4)::[] ->
+                        let uu___5 = unembed e1 a1 ncb in
+                        FStar_Util.bind_opt uu___5
                           (fun a11 ->
-                             let uu____1453 = unembed e2 a2 ncb in
-                             FStar_Util.bind_opt uu____1453
+                             let uu___6 = unembed e2 a2 ncb in
+                             FStar_Util.bind_opt uu___6
                                (fun a21 ->
-                                  let uu____1459 = unembed e3 a3 ncb in
-                                  FStar_Util.bind_opt uu____1459
+                                  let uu___7 = unembed e3 a3 ncb in
+                                  FStar_Util.bind_opt uu___7
                                     (fun a31 ->
-                                       let uu____1465 = unembed e4 a4 ncb in
-                                       FStar_Util.bind_opt uu____1465
+                                       let uu___8 = unembed e4 a4 ncb in
+                                       FStar_Util.bind_opt uu___8
                                          (fun a41 ->
-                                            let uu____1471 =
+                                            let uu___9 =
                                               unembed
                                                 FStar_Tactics_Embedding.e_proofstate
                                                 a5 ncb in
-                                            FStar_Util.bind_opt uu____1471
+                                            FStar_Util.bind_opt uu___9
                                               (fun ps ->
                                                  let ps1 =
                                                    FStar_Tactics_Types.set_ps_psc
                                                      psc ps in
                                                  let r1 =
-                                                   let uu____1483 =
+                                                   let uu___10 =
                                                      t a11 a21 a31 a41 in
                                                    FStar_Tactics_Monad.run_safe
-                                                     uu____1483 ps1 in
-                                                 let uu____1486 =
-                                                   let uu____1487 =
+                                                     uu___10 ps1 in
+                                                 let uu___10 =
+                                                   let uu___11 =
                                                      FStar_Tactics_Embedding.e_result
                                                        er in
-                                                   let uu____1492 =
+                                                   let uu___12 =
                                                      FStar_TypeChecker_Cfg.psc_range
                                                        psc in
-                                                   embed uu____1487
-                                                     uu____1492 r1 ncb in
+                                                   embed uu___11 uu___12 r1
+                                                     ncb in
                                                  FStar_Pervasives_Native.Some
-                                                   uu____1486)))))
-                    | uu____1495 -> FStar_Pervasives_Native.None
+                                                   uu___10)))))
+                    | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_5 :
   'r 't1 't2 't3 't4 't5 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 'r FStar_Tactics_Monad.tac) ->
@@ -417,54 +411,51 @@ let mk_tactic_interpretation_5 :
                   fun ncb ->
                     fun args ->
                       match args with
-                      | (a1, uu____1642)::(a2, uu____1644)::(a3, uu____1646)::
-                          (a4, uu____1648)::(a5, uu____1650)::(a6,
-                                                               uu____1652)::[]
-                          ->
-                          let uu____1757 = unembed e1 a1 ncb in
-                          FStar_Util.bind_opt uu____1757
+                      | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                          (a5, uu___4)::(a6, uu___5)::[] ->
+                          let uu___6 = unembed e1 a1 ncb in
+                          FStar_Util.bind_opt uu___6
                             (fun a11 ->
-                               let uu____1763 = unembed e2 a2 ncb in
-                               FStar_Util.bind_opt uu____1763
+                               let uu___7 = unembed e2 a2 ncb in
+                               FStar_Util.bind_opt uu___7
                                  (fun a21 ->
-                                    let uu____1769 = unembed e3 a3 ncb in
-                                    FStar_Util.bind_opt uu____1769
+                                    let uu___8 = unembed e3 a3 ncb in
+                                    FStar_Util.bind_opt uu___8
                                       (fun a31 ->
-                                         let uu____1775 = unembed e4 a4 ncb in
-                                         FStar_Util.bind_opt uu____1775
+                                         let uu___9 = unembed e4 a4 ncb in
+                                         FStar_Util.bind_opt uu___9
                                            (fun a41 ->
-                                              let uu____1781 =
-                                                unembed e5 a5 ncb in
-                                              FStar_Util.bind_opt uu____1781
+                                              let uu___10 = unembed e5 a5 ncb in
+                                              FStar_Util.bind_opt uu___10
                                                 (fun a51 ->
-                                                   let uu____1787 =
+                                                   let uu___11 =
                                                      unembed
                                                        FStar_Tactics_Embedding.e_proofstate
                                                        a6 ncb in
                                                    FStar_Util.bind_opt
-                                                     uu____1787
+                                                     uu___11
                                                      (fun ps ->
                                                         let ps1 =
                                                           FStar_Tactics_Types.set_ps_psc
                                                             psc ps in
                                                         let r1 =
-                                                          let uu____1799 =
+                                                          let uu___12 =
                                                             t a11 a21 a31 a41
                                                               a51 in
                                                           FStar_Tactics_Monad.run_safe
-                                                            uu____1799 ps1 in
-                                                        let uu____1802 =
-                                                          let uu____1803 =
+                                                            uu___12 ps1 in
+                                                        let uu___12 =
+                                                          let uu___13 =
                                                             FStar_Tactics_Embedding.e_result
                                                               er in
-                                                          let uu____1808 =
+                                                          let uu___14 =
                                                             FStar_TypeChecker_Cfg.psc_range
                                                               psc in
-                                                          embed uu____1803
-                                                            uu____1808 r1 ncb in
+                                                          embed uu___13
+                                                            uu___14 r1 ncb in
                                                         FStar_Pervasives_Native.Some
-                                                          uu____1802))))))
-                      | uu____1811 -> FStar_Pervasives_Native.None
+                                                          uu___12))))))
+                      | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_6 :
   'r 't1 't2 't3 't4 't5 't6 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 't6 -> 'r FStar_Tactics_Monad.tac) ->
@@ -493,69 +484,65 @@ let mk_tactic_interpretation_6 :
                     fun ncb ->
                       fun args ->
                         match args with
-                        | (a1, uu____1977)::(a2, uu____1979)::(a3,
-                                                               uu____1981)::
-                            (a4, uu____1983)::(a5, uu____1985)::(a6,
-                                                                 uu____1987)::
-                            (a7, uu____1989)::[] ->
-                            let uu____2110 = unembed e1 a1 ncb in
-                            FStar_Util.bind_opt uu____2110
+                        | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4,
+                                                                    uu___3)::
+                            (a5, uu___4)::(a6, uu___5)::(a7, uu___6)::[] ->
+                            let uu___7 = unembed e1 a1 ncb in
+                            FStar_Util.bind_opt uu___7
                               (fun a11 ->
-                                 let uu____2116 = unembed e2 a2 ncb in
-                                 FStar_Util.bind_opt uu____2116
+                                 let uu___8 = unembed e2 a2 ncb in
+                                 FStar_Util.bind_opt uu___8
                                    (fun a21 ->
-                                      let uu____2122 = unembed e3 a3 ncb in
-                                      FStar_Util.bind_opt uu____2122
+                                      let uu___9 = unembed e3 a3 ncb in
+                                      FStar_Util.bind_opt uu___9
                                         (fun a31 ->
-                                           let uu____2128 = unembed e4 a4 ncb in
-                                           FStar_Util.bind_opt uu____2128
+                                           let uu___10 = unembed e4 a4 ncb in
+                                           FStar_Util.bind_opt uu___10
                                              (fun a41 ->
-                                                let uu____2134 =
+                                                let uu___11 =
                                                   unembed e5 a5 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____2134
+                                                FStar_Util.bind_opt uu___11
                                                   (fun a51 ->
-                                                     let uu____2140 =
+                                                     let uu___12 =
                                                        unembed e6 a6 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____2140
+                                                       uu___12
                                                        (fun a61 ->
-                                                          let uu____2146 =
+                                                          let uu___13 =
                                                             unembed
                                                               FStar_Tactics_Embedding.e_proofstate
                                                               a7 ncb in
                                                           FStar_Util.bind_opt
-                                                            uu____2146
+                                                            uu___13
                                                             (fun ps ->
                                                                let ps1 =
                                                                  FStar_Tactics_Types.set_ps_psc
                                                                    psc ps in
                                                                let r1 =
-                                                                 let uu____2158
+                                                                 let uu___14
                                                                    =
                                                                    t a11 a21
                                                                     a31 a41
                                                                     a51 a61 in
                                                                  FStar_Tactics_Monad.run_safe
-                                                                   uu____2158
+                                                                   uu___14
                                                                    ps1 in
-                                                               let uu____2161
-                                                                 =
-                                                                 let uu____2162
+                                                               let uu___14 =
+                                                                 let uu___15
                                                                    =
                                                                    FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                 let uu____2167
+                                                                 let uu___16
                                                                    =
                                                                    FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                  embed
-                                                                   uu____2162
-                                                                   uu____2167
-                                                                   r1 ncb in
+                                                                   uu___15
+                                                                   uu___16 r1
+                                                                   ncb in
                                                                FStar_Pervasives_Native.Some
-                                                                 uu____2161)))))))
-                        | uu____2170 -> FStar_Pervasives_Native.None
+                                                                 uu___14)))))))
+                        | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_7 :
   'r 't1 't2 't3 't4 't5 't6 't7 .
     ('t1 ->
@@ -588,78 +575,74 @@ let mk_tactic_interpretation_7 :
                       fun ncb ->
                         fun args ->
                           match args with
-                          | (a1, uu____2355)::(a2, uu____2357)::(a3,
-                                                                 uu____2359)::
-                              (a4, uu____2361)::(a5, uu____2363)::(a6,
-                                                                   uu____2365)::
-                              (a7, uu____2367)::(a8, uu____2369)::[] ->
-                              let uu____2506 = unembed e1 a1 ncb in
-                              FStar_Util.bind_opt uu____2506
+                          | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                              (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                              (a7, uu___6)::(a8, uu___7)::[] ->
+                              let uu___8 = unembed e1 a1 ncb in
+                              FStar_Util.bind_opt uu___8
                                 (fun a11 ->
-                                   let uu____2512 = unembed e2 a2 ncb in
-                                   FStar_Util.bind_opt uu____2512
+                                   let uu___9 = unembed e2 a2 ncb in
+                                   FStar_Util.bind_opt uu___9
                                      (fun a21 ->
-                                        let uu____2518 = unembed e3 a3 ncb in
-                                        FStar_Util.bind_opt uu____2518
+                                        let uu___10 = unembed e3 a3 ncb in
+                                        FStar_Util.bind_opt uu___10
                                           (fun a31 ->
-                                             let uu____2524 =
-                                               unembed e4 a4 ncb in
-                                             FStar_Util.bind_opt uu____2524
+                                             let uu___11 = unembed e4 a4 ncb in
+                                             FStar_Util.bind_opt uu___11
                                                (fun a41 ->
-                                                  let uu____2530 =
+                                                  let uu___12 =
                                                     unembed e5 a5 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____2530
+                                                  FStar_Util.bind_opt uu___12
                                                     (fun a51 ->
-                                                       let uu____2536 =
+                                                       let uu___13 =
                                                          unembed e6 a6 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____2536
+                                                         uu___13
                                                          (fun a61 ->
-                                                            let uu____2542 =
+                                                            let uu___14 =
                                                               unembed e7 a7
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____2542
+                                                              uu___14
                                                               (fun a71 ->
-                                                                 let uu____2548
+                                                                 let uu___15
                                                                    =
                                                                    unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a8 ncb in
                                                                  FStar_Util.bind_opt
-                                                                   uu____2548
+                                                                   uu___15
                                                                    (fun ps ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____2560
+                                                                    let uu___16
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____2560
+                                                                    uu___16
                                                                     ps1 in
-                                                                    let uu____2563
+                                                                    let uu___16
                                                                     =
-                                                                    let uu____2564
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____2569
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____2564
-                                                                    uu____2569
+                                                                    uu___17
+                                                                    uu___18
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____2563))))))))
-                          | uu____2572 -> FStar_Pervasives_Native.None
+                                                                    uu___16))))))))
+                          | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_8 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 .
     ('t1 ->
@@ -695,90 +678,86 @@ let mk_tactic_interpretation_8 :
                         fun ncb ->
                           fun args ->
                             match args with
-                            | (a1, uu____2776)::(a2, uu____2778)::(a3,
-                                                                   uu____2780)::
-                                (a4, uu____2782)::(a5, uu____2784)::(a6,
-                                                                    uu____2786)::
-                                (a7, uu____2788)::(a8, uu____2790)::(a9,
-                                                                    uu____2792)::[]
+                            | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::[]
                                 ->
-                                let uu____2945 = unembed e1 a1 ncb in
-                                FStar_Util.bind_opt uu____2945
+                                let uu___9 = unembed e1 a1 ncb in
+                                FStar_Util.bind_opt uu___9
                                   (fun a11 ->
-                                     let uu____2951 = unembed e2 a2 ncb in
-                                     FStar_Util.bind_opt uu____2951
+                                     let uu___10 = unembed e2 a2 ncb in
+                                     FStar_Util.bind_opt uu___10
                                        (fun a21 ->
-                                          let uu____2957 = unembed e3 a3 ncb in
-                                          FStar_Util.bind_opt uu____2957
+                                          let uu___11 = unembed e3 a3 ncb in
+                                          FStar_Util.bind_opt uu___11
                                             (fun a31 ->
-                                               let uu____2963 =
+                                               let uu___12 =
                                                  unembed e4 a4 ncb in
-                                               FStar_Util.bind_opt uu____2963
+                                               FStar_Util.bind_opt uu___12
                                                  (fun a41 ->
-                                                    let uu____2969 =
+                                                    let uu___13 =
                                                       unembed e5 a5 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____2969
+                                                      uu___13
                                                       (fun a51 ->
-                                                         let uu____2975 =
+                                                         let uu___14 =
                                                            unembed e6 a6 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____2975
+                                                           uu___14
                                                            (fun a61 ->
-                                                              let uu____2981
-                                                                =
+                                                              let uu___15 =
                                                                 unembed e7 a7
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____2981
+                                                                uu___15
                                                                 (fun a71 ->
-                                                                   let uu____2987
+                                                                   let uu___16
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____2987
+                                                                    uu___16
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____2993
+                                                                    let uu___17
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____2993
+                                                                    uu___17
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____3005
+                                                                    let uu___18
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 a81 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____3005
+                                                                    uu___18
                                                                     ps1 in
-                                                                    let uu____3008
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____3009
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____3014
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____3009
-                                                                    uu____3014
+                                                                    uu___19
+                                                                    uu___20
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____3008)))))))))
-                            | uu____3017 -> FStar_Pervasives_Native.None
+                                                                    uu___18)))))))))
+                            | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_9 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -818,75 +797,70 @@ let mk_tactic_interpretation_9 :
                           fun ncb ->
                             fun args ->
                               match args with
-                              | (a1, uu____3240)::(a2, uu____3242)::(a3,
-                                                                    uu____3244)::
-                                  (a4, uu____3246)::(a5, uu____3248)::
-                                  (a6, uu____3250)::(a7, uu____3252)::
-                                  (a8, uu____3254)::(a9, uu____3256)::
-                                  (a10, uu____3258)::[] ->
-                                  let uu____3427 = unembed e1 a1 ncb in
-                                  FStar_Util.bind_opt uu____3427
+                              | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                  (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                  (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                  (a10, uu___9)::[] ->
+                                  let uu___10 = unembed e1 a1 ncb in
+                                  FStar_Util.bind_opt uu___10
                                     (fun a11 ->
-                                       let uu____3433 = unembed e2 a2 ncb in
-                                       FStar_Util.bind_opt uu____3433
+                                       let uu___11 = unembed e2 a2 ncb in
+                                       FStar_Util.bind_opt uu___11
                                          (fun a21 ->
-                                            let uu____3439 =
-                                              unembed e3 a3 ncb in
-                                            FStar_Util.bind_opt uu____3439
+                                            let uu___12 = unembed e3 a3 ncb in
+                                            FStar_Util.bind_opt uu___12
                                               (fun a31 ->
-                                                 let uu____3445 =
+                                                 let uu___13 =
                                                    unembed e4 a4 ncb in
-                                                 FStar_Util.bind_opt
-                                                   uu____3445
+                                                 FStar_Util.bind_opt uu___13
                                                    (fun a41 ->
-                                                      let uu____3451 =
+                                                      let uu___14 =
                                                         unembed e5 a5 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____3451
+                                                        uu___14
                                                         (fun a51 ->
-                                                           let uu____3457 =
+                                                           let uu___15 =
                                                              unembed e6 a6
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____3457
+                                                             uu___15
                                                              (fun a61 ->
-                                                                let uu____3463
-                                                                  =
+                                                                let uu___16 =
                                                                   unembed e7
                                                                     a7 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____3463
+                                                                  uu___16
                                                                   (fun a71 ->
-                                                                    let uu____3469
+                                                                    let uu___17
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____3469
+                                                                    uu___17
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____3475
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____3475
+                                                                    uu___18
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____3481
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a10 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____3481
+                                                                    uu___19
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____3493
+                                                                    let uu___20
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
@@ -894,25 +868,25 @@ let mk_tactic_interpretation_9 :
                                                                     a71 a81
                                                                     a91 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____3493
+                                                                    uu___20
                                                                     ps1 in
-                                                                    let uu____3496
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____3497
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____3502
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____3497
-                                                                    uu____3502
+                                                                    uu___21
+                                                                    uu___22
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____3496))))))))))
-                              | uu____3505 -> FStar_Pervasives_Native.None
+                                                                    uu___20))))))))))
+                              | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_10 :
   'r 't1 't10 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -955,86 +929,83 @@ let mk_tactic_interpretation_10 :
                             fun ncb ->
                               fun args ->
                                 match args with
-                                | (a1, uu____3747)::(a2, uu____3749)::
-                                    (a3, uu____3751)::(a4, uu____3753)::
-                                    (a5, uu____3755)::(a6, uu____3757)::
-                                    (a7, uu____3759)::(a8, uu____3761)::
-                                    (a9, uu____3763)::(a10, uu____3765)::
-                                    (a11, uu____3767)::[] ->
-                                    let uu____3952 = unembed e1 a1 ncb in
-                                    FStar_Util.bind_opt uu____3952
+                                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                    (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                    (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                    (a10, uu___9)::(a11, uu___10)::[] ->
+                                    let uu___11 = unembed e1 a1 ncb in
+                                    FStar_Util.bind_opt uu___11
                                       (fun a12 ->
-                                         let uu____3958 = unembed e2 a2 ncb in
-                                         FStar_Util.bind_opt uu____3958
+                                         let uu___12 = unembed e2 a2 ncb in
+                                         FStar_Util.bind_opt uu___12
                                            (fun a21 ->
-                                              let uu____3964 =
-                                                unembed e3 a3 ncb in
-                                              FStar_Util.bind_opt uu____3964
+                                              let uu___13 = unembed e3 a3 ncb in
+                                              FStar_Util.bind_opt uu___13
                                                 (fun a31 ->
-                                                   let uu____3970 =
+                                                   let uu___14 =
                                                      unembed e4 a4 ncb in
                                                    FStar_Util.bind_opt
-                                                     uu____3970
+                                                     uu___14
                                                      (fun a41 ->
-                                                        let uu____3976 =
+                                                        let uu___15 =
                                                           unembed e5 a5 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____3976
+                                                          uu___15
                                                           (fun a51 ->
-                                                             let uu____3982 =
+                                                             let uu___16 =
                                                                unembed e6 a6
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____3982
+                                                               uu___16
                                                                (fun a61 ->
-                                                                  let uu____3988
+                                                                  let uu___17
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____3988
+                                                                    uu___17
                                                                     (
                                                                     fun a71
                                                                     ->
-                                                                    let uu____3994
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____3994
+                                                                    uu___18
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____4000
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4000
+                                                                    uu___19
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____4006
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4006
+                                                                    uu___20
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____4012
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a11 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4012
+                                                                    uu___21
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____4024
+                                                                    let uu___22
                                                                     =
                                                                     t a12 a21
                                                                     a31 a41
@@ -1042,25 +1013,25 @@ let mk_tactic_interpretation_10 :
                                                                     a71 a81
                                                                     a91 a101 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____4024
+                                                                    uu___22
                                                                     ps1 in
-                                                                    let uu____4027
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____4028
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____4033
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____4028
-                                                                    uu____4033
+                                                                    uu___23
+                                                                    uu___24
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____4027)))))))))))
-                                | uu____4036 -> FStar_Pervasives_Native.None
+                                                                    uu___22)))))))))))
+                                | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_11 :
   'r 't1 't10 't11 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -1107,97 +1078,95 @@ let mk_tactic_interpretation_11 :
                               fun ncb ->
                                 fun args ->
                                   match args with
-                                  | (a1, uu____4297)::(a2, uu____4299)::
-                                      (a3, uu____4301)::(a4, uu____4303)::
-                                      (a5, uu____4305)::(a6, uu____4307)::
-                                      (a7, uu____4309)::(a8, uu____4311)::
-                                      (a9, uu____4313)::(a10, uu____4315)::
-                                      (a11, uu____4317)::(a12, uu____4319)::[]
-                                      ->
-                                      let uu____4520 = unembed e1 a1 ncb in
-                                      FStar_Util.bind_opt uu____4520
+                                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                      (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                      (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                   uu___8)::
+                                      (a10, uu___9)::(a11, uu___10)::
+                                      (a12, uu___11)::[] ->
+                                      let uu___12 = unembed e1 a1 ncb in
+                                      FStar_Util.bind_opt uu___12
                                         (fun a13 ->
-                                           let uu____4526 = unembed e2 a2 ncb in
-                                           FStar_Util.bind_opt uu____4526
+                                           let uu___13 = unembed e2 a2 ncb in
+                                           FStar_Util.bind_opt uu___13
                                              (fun a21 ->
-                                                let uu____4532 =
+                                                let uu___14 =
                                                   unembed e3 a3 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____4532
+                                                FStar_Util.bind_opt uu___14
                                                   (fun a31 ->
-                                                     let uu____4538 =
+                                                     let uu___15 =
                                                        unembed e4 a4 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____4538
+                                                       uu___15
                                                        (fun a41 ->
-                                                          let uu____4544 =
+                                                          let uu___16 =
                                                             unembed e5 a5 ncb in
                                                           FStar_Util.bind_opt
-                                                            uu____4544
+                                                            uu___16
                                                             (fun a51 ->
-                                                               let uu____4550
-                                                                 =
+                                                               let uu___17 =
                                                                  unembed e6
                                                                    a6 ncb in
                                                                FStar_Util.bind_opt
-                                                                 uu____4550
+                                                                 uu___17
                                                                  (fun a61 ->
-                                                                    let uu____4556
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4556
+                                                                    uu___18
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____4562
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4562
+                                                                    uu___19
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____4568
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4568
+                                                                    uu___20
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____4574
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4574
+                                                                    uu___21
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____4580
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4580
+                                                                    uu___22
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____4586
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a12 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____4586
+                                                                    uu___23
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____4598
+                                                                    let uu___24
                                                                     =
                                                                     t a13 a21
                                                                     a31 a41
@@ -1206,26 +1175,25 @@ let mk_tactic_interpretation_11 :
                                                                     a91 a101
                                                                     a111 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____4598
+                                                                    uu___24
                                                                     ps1 in
-                                                                    let uu____4601
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____4602
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____4607
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____4602
-                                                                    uu____4607
+                                                                    uu___25
+                                                                    uu___26
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____4601))))))))))))
-                                  | uu____4610 ->
-                                      FStar_Pervasives_Native.None
+                                                                    uu___24))))))))))))
+                                  | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_12 :
   'r 't1 't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -1276,109 +1244,107 @@ let mk_tactic_interpretation_12 :
                                 fun ncb ->
                                   fun args ->
                                     match args with
-                                    | (a1, uu____4890)::(a2, uu____4892)::
-                                        (a3, uu____4894)::(a4, uu____4896)::
-                                        (a5, uu____4898)::(a6, uu____4900)::
-                                        (a7, uu____4902)::(a8, uu____4904)::
-                                        (a9, uu____4906)::(a10, uu____4908)::
-                                        (a11, uu____4910)::(a12, uu____4912)::
-                                        (a13, uu____4914)::[] ->
-                                        let uu____5131 = unembed e1 a1 ncb in
-                                        FStar_Util.bind_opt uu____5131
+                                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                        (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                        (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                    uu___8)::
+                                        (a10, uu___9)::(a11, uu___10)::
+                                        (a12, uu___11)::(a13, uu___12)::[] ->
+                                        let uu___13 = unembed e1 a1 ncb in
+                                        FStar_Util.bind_opt uu___13
                                           (fun a14 ->
-                                             let uu____5137 =
-                                               unembed e2 a2 ncb in
-                                             FStar_Util.bind_opt uu____5137
+                                             let uu___14 = unembed e2 a2 ncb in
+                                             FStar_Util.bind_opt uu___14
                                                (fun a21 ->
-                                                  let uu____5143 =
+                                                  let uu___15 =
                                                     unembed e3 a3 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____5143
+                                                  FStar_Util.bind_opt uu___15
                                                     (fun a31 ->
-                                                       let uu____5149 =
+                                                       let uu___16 =
                                                          unembed e4 a4 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____5149
+                                                         uu___16
                                                          (fun a41 ->
-                                                            let uu____5155 =
+                                                            let uu___17 =
                                                               unembed e5 a5
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____5155
+                                                              uu___17
                                                               (fun a51 ->
-                                                                 let uu____5161
+                                                                 let uu___18
                                                                    =
                                                                    unembed e6
                                                                     a6 ncb in
                                                                  FStar_Util.bind_opt
-                                                                   uu____5161
+                                                                   uu___18
                                                                    (fun a61
                                                                     ->
-                                                                    let uu____5167
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5167
+                                                                    uu___19
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____5173
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5173
+                                                                    uu___20
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____5179
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5179
+                                                                    uu___21
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____5185
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5185
+                                                                    uu___22
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____5191
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5191
+                                                                    uu___23
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____5197
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5197
+                                                                    uu___24
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____5203
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a13 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5203
+                                                                    uu___25
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____5215
+                                                                    let uu___26
                                                                     =
                                                                     t a14 a21
                                                                     a31 a41
@@ -1387,26 +1353,25 @@ let mk_tactic_interpretation_12 :
                                                                     a91 a101
                                                                     a111 a121 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____5215
+                                                                    uu___26
                                                                     ps1 in
-                                                                    let uu____5218
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____5219
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____5224
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____5219
-                                                                    uu____5224
+                                                                    uu___27
+                                                                    uu___28
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____5218)))))))))))))
-                                    | uu____5227 ->
-                                        FStar_Pervasives_Native.None
+                                                                    uu___26)))))))))))))
+                                    | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_13 :
   'r 't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -1460,122 +1425,119 @@ let mk_tactic_interpretation_13 :
                                   fun ncb ->
                                     fun args ->
                                       match args with
-                                      | (a1, uu____5526)::(a2, uu____5528)::
-                                          (a3, uu____5530)::(a4, uu____5532)::
-                                          (a5, uu____5534)::(a6, uu____5536)::
-                                          (a7, uu____5538)::(a8, uu____5540)::
-                                          (a9, uu____5542)::(a10, uu____5544)::
-                                          (a11, uu____5546)::(a12,
-                                                              uu____5548)::
-                                          (a13, uu____5550)::(a14,
-                                                              uu____5552)::[]
-                                          ->
-                                          let uu____5785 = unembed e1 a1 ncb in
-                                          FStar_Util.bind_opt uu____5785
+                                      | (a1, uu___)::(a2, uu___1)::(a3,
+                                                                    uu___2)::
+                                          (a4, uu___3)::(a5, uu___4)::
+                                          (a6, uu___5)::(a7, uu___6)::
+                                          (a8, uu___7)::(a9, uu___8)::
+                                          (a10, uu___9)::(a11, uu___10)::
+                                          (a12, uu___11)::(a13, uu___12)::
+                                          (a14, uu___13)::[] ->
+                                          let uu___14 = unembed e1 a1 ncb in
+                                          FStar_Util.bind_opt uu___14
                                             (fun a15 ->
-                                               let uu____5791 =
+                                               let uu___15 =
                                                  unembed e2 a2 ncb in
-                                               FStar_Util.bind_opt uu____5791
+                                               FStar_Util.bind_opt uu___15
                                                  (fun a21 ->
-                                                    let uu____5797 =
+                                                    let uu___16 =
                                                       unembed e3 a3 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____5797
+                                                      uu___16
                                                       (fun a31 ->
-                                                         let uu____5803 =
+                                                         let uu___17 =
                                                            unembed e4 a4 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____5803
+                                                           uu___17
                                                            (fun a41 ->
-                                                              let uu____5809
-                                                                =
+                                                              let uu___18 =
                                                                 unembed e5 a5
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____5809
+                                                                uu___18
                                                                 (fun a51 ->
-                                                                   let uu____5815
+                                                                   let uu___19
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____5815
+                                                                    uu___19
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____5821
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5821
+                                                                    uu___20
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____5827
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5827
+                                                                    uu___21
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____5833
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5833
+                                                                    uu___22
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____5839
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5839
+                                                                    uu___23
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____5845
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5845
+                                                                    uu___24
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____5851
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5851
+                                                                    uu___25
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____5857
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5857
+                                                                    uu___26
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____5863
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a14 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____5863
+                                                                    uu___27
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____5875
+                                                                    let uu___28
                                                                     =
                                                                     t a15 a21
                                                                     a31 a41
@@ -1585,26 +1547,25 @@ let mk_tactic_interpretation_13 :
                                                                     a111 a121
                                                                     a131 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____5875
+                                                                    uu___28
                                                                     ps1 in
-                                                                    let uu____5878
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____5879
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____5884
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____5879
-                                                                    uu____5884
+                                                                    uu___29
+                                                                    uu___30
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____5878))))))))))))))
-                                      | uu____5887 ->
-                                          FStar_Pervasives_Native.None
+                                                                    uu___28))))))))))))))
+                                      | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_interpretation_14 :
   'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -1661,138 +1622,129 @@ let mk_tactic_interpretation_14 :
                                     fun ncb ->
                                       fun args ->
                                         match args with
-                                        | (a1, uu____6205)::(a2, uu____6207)::
-                                            (a3, uu____6209)::(a4,
-                                                               uu____6211)::
-                                            (a5, uu____6213)::(a6,
-                                                               uu____6215)::
-                                            (a7, uu____6217)::(a8,
-                                                               uu____6219)::
-                                            (a9, uu____6221)::(a10,
-                                                               uu____6223)::
-                                            (a11, uu____6225)::(a12,
-                                                                uu____6227)::
-                                            (a13, uu____6229)::(a14,
-                                                                uu____6231)::
-                                            (a15, uu____6233)::[] ->
-                                            let uu____6482 =
-                                              unembed e1 a1 ncb in
-                                            FStar_Util.bind_opt uu____6482
+                                        | (a1, uu___)::(a2, uu___1)::
+                                            (a3, uu___2)::(a4, uu___3)::
+                                            (a5, uu___4)::(a6, uu___5)::
+                                            (a7, uu___6)::(a8, uu___7)::
+                                            (a9, uu___8)::(a10, uu___9)::
+                                            (a11, uu___10)::(a12, uu___11)::
+                                            (a13, uu___12)::(a14, uu___13)::
+                                            (a15, uu___14)::[] ->
+                                            let uu___15 = unembed e1 a1 ncb in
+                                            FStar_Util.bind_opt uu___15
                                               (fun a16 ->
-                                                 let uu____6488 =
+                                                 let uu___16 =
                                                    unembed e2 a2 ncb in
-                                                 FStar_Util.bind_opt
-                                                   uu____6488
+                                                 FStar_Util.bind_opt uu___16
                                                    (fun a21 ->
-                                                      let uu____6494 =
+                                                      let uu___17 =
                                                         unembed e3 a3 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____6494
+                                                        uu___17
                                                         (fun a31 ->
-                                                           let uu____6500 =
+                                                           let uu___18 =
                                                              unembed e4 a4
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____6500
+                                                             uu___18
                                                              (fun a41 ->
-                                                                let uu____6506
-                                                                  =
+                                                                let uu___19 =
                                                                   unembed e5
                                                                     a5 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____6506
+                                                                  uu___19
                                                                   (fun a51 ->
-                                                                    let uu____6512
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6512
+                                                                    uu___20
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____6518
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6518
+                                                                    uu___21
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____6524
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6524
+                                                                    uu___22
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____6530
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6530
+                                                                    uu___23
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____6536
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6536
+                                                                    uu___24
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____6542
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6542
+                                                                    uu___25
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____6548
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6548
+                                                                    uu___26
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____6554
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6554
+                                                                    uu___27
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____6560
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6560
+                                                                    uu___28
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____6566
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a15 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____6566
+                                                                    uu___29
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____6578
+                                                                    let uu___30
                                                                     =
                                                                     t a16 a21
                                                                     a31 a41
@@ -1802,25 +1754,25 @@ let mk_tactic_interpretation_14 :
                                                                     a111 a121
                                                                     a131 a141 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____6578
+                                                                    uu___30
                                                                     ps1 in
-                                                                    let uu____6581
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____6582
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____6587
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____6582
-                                                                    uu____6587
+                                                                    uu___31
+                                                                    uu___32
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____6581)))))))))))))))
-                                        | uu____6590 ->
+                                                                    uu___30)))))))))))))))
+                                        | uu___ ->
                                             FStar_Pervasives_Native.None
 let mk_tactic_interpretation_15 :
   'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -1882,152 +1834,143 @@ let mk_tactic_interpretation_15 :
                                       fun ncb ->
                                         fun args ->
                                           match args with
-                                          | (a1, uu____6927)::(a2,
-                                                               uu____6929)::
-                                              (a3, uu____6931)::(a4,
-                                                                 uu____6933)::
-                                              (a5, uu____6935)::(a6,
-                                                                 uu____6937)::
-                                              (a7, uu____6939)::(a8,
-                                                                 uu____6941)::
-                                              (a9, uu____6943)::(a10,
-                                                                 uu____6945)::
-                                              (a11, uu____6947)::(a12,
-                                                                  uu____6949)::
-                                              (a13, uu____6951)::(a14,
-                                                                  uu____6953)::
-                                              (a15, uu____6955)::(a16,
-                                                                  uu____6957)::[]
+                                          | (a1, uu___)::(a2, uu___1)::
+                                              (a3, uu___2)::(a4, uu___3)::
+                                              (a5, uu___4)::(a6, uu___5)::
+                                              (a7, uu___6)::(a8, uu___7)::
+                                              (a9, uu___8)::(a10, uu___9)::
+                                              (a11, uu___10)::(a12, uu___11)::
+                                              (a13, uu___12)::(a14, uu___13)::
+                                              (a15, uu___14)::(a16, uu___15)::[]
                                               ->
-                                              let uu____7222 =
-                                                unembed e1 a1 ncb in
-                                              FStar_Util.bind_opt uu____7222
+                                              let uu___16 = unembed e1 a1 ncb in
+                                              FStar_Util.bind_opt uu___16
                                                 (fun a17 ->
-                                                   let uu____7228 =
+                                                   let uu___17 =
                                                      unembed e2 a2 ncb in
                                                    FStar_Util.bind_opt
-                                                     uu____7228
+                                                     uu___17
                                                      (fun a21 ->
-                                                        let uu____7234 =
+                                                        let uu___18 =
                                                           unembed e3 a3 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____7234
+                                                          uu___18
                                                           (fun a31 ->
-                                                             let uu____7240 =
+                                                             let uu___19 =
                                                                unembed e4 a4
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____7240
+                                                               uu___19
                                                                (fun a41 ->
-                                                                  let uu____7246
+                                                                  let uu___20
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____7246
+                                                                    uu___20
                                                                     (
                                                                     fun a51
                                                                     ->
-                                                                    let uu____7252
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7252
+                                                                    uu___21
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____7258
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7258
+                                                                    uu___22
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____7264
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7264
+                                                                    uu___23
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____7270
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7270
+                                                                    uu___24
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____7276
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7276
+                                                                    uu___25
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____7282
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7282
+                                                                    uu___26
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____7288
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7288
+                                                                    uu___27
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____7294
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7294
+                                                                    uu___28
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____7300
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7300
+                                                                    uu___29
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____7306
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7306
+                                                                    uu___30
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____7312
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a16 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____7312
+                                                                    uu___31
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____7324
+                                                                    let uu___32
                                                                     =
                                                                     t a17 a21
                                                                     a31 a41
@@ -2038,25 +1981,25 @@ let mk_tactic_interpretation_15 :
                                                                     a131 a141
                                                                     a151 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____7324
+                                                                    uu___32
                                                                     ps1 in
-                                                                    let uu____7327
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____7328
+                                                                    let uu___33
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____7333
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____7328
-                                                                    uu____7333
+                                                                    uu___33
+                                                                    uu___34
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____7327))))))))))))))))
-                                          | uu____7336 ->
+                                                                    uu___32))))))))))))))))
+                                          | uu___ ->
                                               FStar_Pervasives_Native.None
 let mk_tactic_interpretation_16 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -2121,162 +2064,155 @@ let mk_tactic_interpretation_16 :
                                         fun ncb ->
                                           fun args ->
                                             match args with
-                                            | (a1, uu____7692)::(a2,
-                                                                 uu____7694)::
-                                                (a3, uu____7696)::(a4,
-                                                                   uu____7698)::
-                                                (a5, uu____7700)::(a6,
-                                                                   uu____7702)::
-                                                (a7, uu____7704)::(a8,
-                                                                   uu____7706)::
-                                                (a9, uu____7708)::(a10,
-                                                                   uu____7710)::
-                                                (a11, uu____7712)::(a12,
-                                                                    uu____7714)::
-                                                (a13, uu____7716)::(a14,
-                                                                    uu____7718)::
-                                                (a15, uu____7720)::(a16,
-                                                                    uu____7722)::
-                                                (a17, uu____7724)::[] ->
-                                                let uu____8005 =
+                                            | (a1, uu___)::(a2, uu___1)::
+                                                (a3, uu___2)::(a4, uu___3)::
+                                                (a5, uu___4)::(a6, uu___5)::
+                                                (a7, uu___6)::(a8, uu___7)::
+                                                (a9, uu___8)::(a10, uu___9)::
+                                                (a11, uu___10)::(a12,
+                                                                 uu___11)::
+                                                (a13, uu___12)::(a14,
+                                                                 uu___13)::
+                                                (a15, uu___14)::(a16,
+                                                                 uu___15)::
+                                                (a17, uu___16)::[] ->
+                                                let uu___17 =
                                                   unembed e1 a1 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____8005
+                                                FStar_Util.bind_opt uu___17
                                                   (fun a18 ->
-                                                     let uu____8011 =
+                                                     let uu___18 =
                                                        unembed e2 a2 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____8011
+                                                       uu___18
                                                        (fun a21 ->
-                                                          let uu____8017 =
+                                                          let uu___19 =
                                                             unembed e3 a3 ncb in
                                                           FStar_Util.bind_opt
-                                                            uu____8017
+                                                            uu___19
                                                             (fun a31 ->
-                                                               let uu____8023
-                                                                 =
+                                                               let uu___20 =
                                                                  unembed e4
                                                                    a4 ncb in
                                                                FStar_Util.bind_opt
-                                                                 uu____8023
+                                                                 uu___20
                                                                  (fun a41 ->
-                                                                    let uu____8029
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8029
+                                                                    uu___21
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____8035
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8035
+                                                                    uu___22
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____8041
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8041
+                                                                    uu___23
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____8047
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8047
+                                                                    uu___24
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____8053
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8053
+                                                                    uu___25
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____8059
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8059
+                                                                    uu___26
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____8065
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8065
+                                                                    uu___27
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____8071
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8071
+                                                                    uu___28
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____8077
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8077
+                                                                    uu___29
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____8083
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8083
+                                                                    uu___30
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____8089
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8089
+                                                                    uu___31
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____8095
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8095
+                                                                    uu___32
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____8101
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a17 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8101
+                                                                    uu___33
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____8113
+                                                                    let uu___34
                                                                     =
                                                                     t a18 a21
                                                                     a31 a41
@@ -2287,25 +2223,25 @@ let mk_tactic_interpretation_16 :
                                                                     a131 a141
                                                                     a151 a161 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____8113
+                                                                    uu___34
                                                                     ps1 in
-                                                                    let uu____8116
+                                                                    let uu___34
                                                                     =
-                                                                    let uu____8117
+                                                                    let uu___35
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____8122
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____8117
-                                                                    uu____8122
+                                                                    uu___35
+                                                                    uu___36
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____8116)))))))))))))))))
-                                            | uu____8125 ->
+                                                                    uu___34)))))))))))))))))
+                                            | uu___ ->
                                                 FStar_Pervasives_Native.None
 let mk_tactic_interpretation_17 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't2 't3 't4 't5 't6 't7 't8
@@ -2377,174 +2313,169 @@ let mk_tactic_interpretation_17 :
                                           fun ncb ->
                                             fun args ->
                                               match args with
-                                              | (a1, uu____8500)::(a2,
-                                                                   uu____8502)::
-                                                  (a3, uu____8504)::(a4,
-                                                                    uu____8506)::
-                                                  (a5, uu____8508)::(a6,
-                                                                    uu____8510)::
-                                                  (a7, uu____8512)::(a8,
-                                                                    uu____8514)::
-                                                  (a9, uu____8516)::(a10,
-                                                                    uu____8518)::
-                                                  (a11, uu____8520)::
-                                                  (a12, uu____8522)::
-                                                  (a13, uu____8524)::
-                                                  (a14, uu____8526)::
-                                                  (a15, uu____8528)::
-                                                  (a16, uu____8530)::
-                                                  (a17, uu____8532)::
-                                                  (a18, uu____8534)::[] ->
-                                                  let uu____8831 =
+                                              | (a1, uu___)::(a2, uu___1)::
+                                                  (a3, uu___2)::(a4, uu___3)::
+                                                  (a5, uu___4)::(a6, uu___5)::
+                                                  (a7, uu___6)::(a8, uu___7)::
+                                                  (a9, uu___8)::(a10, uu___9)::
+                                                  (a11, uu___10)::(a12,
+                                                                   uu___11)::
+                                                  (a13, uu___12)::(a14,
+                                                                   uu___13)::
+                                                  (a15, uu___14)::(a16,
+                                                                   uu___15)::
+                                                  (a17, uu___16)::(a18,
+                                                                   uu___17)::[]
+                                                  ->
+                                                  let uu___18 =
                                                     unembed e1 a1 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____8831
+                                                  FStar_Util.bind_opt uu___18
                                                     (fun a19 ->
-                                                       let uu____8837 =
+                                                       let uu___19 =
                                                          unembed e2 a2 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____8837
+                                                         uu___19
                                                          (fun a21 ->
-                                                            let uu____8843 =
+                                                            let uu___20 =
                                                               unembed e3 a3
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____8843
+                                                              uu___20
                                                               (fun a31 ->
-                                                                 let uu____8849
+                                                                 let uu___21
                                                                    =
                                                                    unembed e4
                                                                     a4 ncb in
                                                                  FStar_Util.bind_opt
-                                                                   uu____8849
+                                                                   uu___21
                                                                    (fun a41
                                                                     ->
-                                                                    let uu____8855
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8855
+                                                                    uu___22
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____8861
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8861
+                                                                    uu___23
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____8867
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8867
+                                                                    uu___24
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____8873
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8873
+                                                                    uu___25
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____8879
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8879
+                                                                    uu___26
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____8885
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8885
+                                                                    uu___27
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____8891
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8891
+                                                                    uu___28
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____8897
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8897
+                                                                    uu___29
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____8903
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8903
+                                                                    uu___30
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____8909
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8909
+                                                                    uu___31
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____8915
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8915
+                                                                    uu___32
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____8921
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8921
+                                                                    uu___33
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____8927
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8927
+                                                                    uu___34
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____8933
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a18 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____8933
+                                                                    uu___35
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____8945
+                                                                    let uu___36
                                                                     =
                                                                     t a19 a21
                                                                     a31 a41
@@ -2556,25 +2487,25 @@ let mk_tactic_interpretation_17 :
                                                                     a151 a161
                                                                     a171 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____8945
+                                                                    uu___36
                                                                     ps1 in
-                                                                    let uu____8948
+                                                                    let uu___36
                                                                     =
-                                                                    let uu____8949
+                                                                    let uu___37
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____8954
+                                                                    let uu___38
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____8949
-                                                                    uu____8954
+                                                                    uu___37
+                                                                    uu___38
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____8948))))))))))))))))))
-                                              | uu____8957 ->
+                                                                    uu___36))))))))))))))))))
+                                              | uu___ ->
                                                   FStar_Pervasives_Native.None
 let mk_tactic_interpretation_18 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't2 't3 't4 't5 't6 't7
@@ -2653,185 +2584,183 @@ let mk_tactic_interpretation_18 :
                                             fun ncb ->
                                               fun args ->
                                                 match args with
-                                                | (a1, uu____9351)::(a2,
-                                                                    uu____9353)::
-                                                    (a3, uu____9355)::
-                                                    (a4, uu____9357)::
-                                                    (a5, uu____9359)::
-                                                    (a6, uu____9361)::
-                                                    (a7, uu____9363)::
-                                                    (a8, uu____9365)::
-                                                    (a9, uu____9367)::
-                                                    (a10, uu____9369)::
-                                                    (a11, uu____9371)::
-                                                    (a12, uu____9373)::
-                                                    (a13, uu____9375)::
-                                                    (a14, uu____9377)::
-                                                    (a15, uu____9379)::
-                                                    (a16, uu____9381)::
-                                                    (a17, uu____9383)::
-                                                    (a18, uu____9385)::
-                                                    (a19, uu____9387)::[] ->
-                                                    let uu____9700 =
+                                                | (a1, uu___)::(a2, uu___1)::
+                                                    (a3, uu___2)::(a4,
+                                                                   uu___3)::
+                                                    (a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                                    (a7, uu___6)::(a8,
+                                                                   uu___7)::
+                                                    (a9, uu___8)::(a10,
+                                                                   uu___9)::
+                                                    (a11, uu___10)::(a12,
+                                                                    uu___11)::
+                                                    (a13, uu___12)::(a14,
+                                                                    uu___13)::
+                                                    (a15, uu___14)::(a16,
+                                                                    uu___15)::
+                                                    (a17, uu___16)::(a18,
+                                                                    uu___17)::
+                                                    (a19, uu___18)::[] ->
+                                                    let uu___19 =
                                                       unembed e1 a1 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____9700
+                                                      uu___19
                                                       (fun a110 ->
-                                                         let uu____9706 =
+                                                         let uu___20 =
                                                            unembed e2 a2 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____9706
+                                                           uu___20
                                                            (fun a21 ->
-                                                              let uu____9712
-                                                                =
+                                                              let uu___21 =
                                                                 unembed e3 a3
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____9712
+                                                                uu___21
                                                                 (fun a31 ->
-                                                                   let uu____9718
+                                                                   let uu___22
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____9718
+                                                                    uu___22
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____9724
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9724
+                                                                    uu___23
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____9730
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9730
+                                                                    uu___24
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____9736
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9736
+                                                                    uu___25
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____9742
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9742
+                                                                    uu___26
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____9748
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9748
+                                                                    uu___27
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____9754
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9754
+                                                                    uu___28
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____9760
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9760
+                                                                    uu___29
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____9766
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9766
+                                                                    uu___30
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____9772
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9772
+                                                                    uu___31
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____9778
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9778
+                                                                    uu___32
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____9784
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9784
+                                                                    uu___33
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____9790
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9790
+                                                                    uu___34
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____9796
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9796
+                                                                    uu___35
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____9802
+                                                                    let uu___36
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9802
+                                                                    uu___36
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____9808
+                                                                    let uu___37
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a19 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____9808
+                                                                    uu___37
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____9820
+                                                                    let uu___38
                                                                     =
                                                                     t a110
                                                                     a21 a31
@@ -2844,25 +2773,25 @@ let mk_tactic_interpretation_18 :
                                                                     a161 a171
                                                                     a181 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____9820
+                                                                    uu___38
                                                                     ps1 in
-                                                                    let uu____9823
+                                                                    let uu___38
                                                                     =
-                                                                    let uu____9824
+                                                                    let uu___39
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____9829
+                                                                    let uu___40
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____9824
-                                                                    uu____9829
+                                                                    uu___39
+                                                                    uu___40
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____9823)))))))))))))))))))
-                                                | uu____9832 ->
+                                                                    uu___38)))))))))))))))))))
+                                                | uu___ ->
                                                     FStar_Pervasives_Native.None
 let mk_tactic_interpretation_19 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't3 't4 't5
@@ -2946,197 +2875,194 @@ let mk_tactic_interpretation_19 :
                                               fun ncb ->
                                                 fun args ->
                                                   match args with
-                                                  | (a1, uu____10245)::
-                                                      (a2, uu____10247)::
-                                                      (a3, uu____10249)::
-                                                      (a4, uu____10251)::
-                                                      (a5, uu____10253)::
-                                                      (a6, uu____10255)::
-                                                      (a7, uu____10257)::
-                                                      (a8, uu____10259)::
-                                                      (a9, uu____10261)::
-                                                      (a10, uu____10263)::
-                                                      (a11, uu____10265)::
-                                                      (a12, uu____10267)::
-                                                      (a13, uu____10269)::
-                                                      (a14, uu____10271)::
-                                                      (a15, uu____10273)::
-                                                      (a16, uu____10275)::
-                                                      (a17, uu____10277)::
-                                                      (a18, uu____10279)::
-                                                      (a19, uu____10281)::
-                                                      (a20, uu____10283)::[]
-                                                      ->
-                                                      let uu____10612 =
+                                                  | (a1, uu___)::(a2, uu___1)::
+                                                      (a3, uu___2)::(a4,
+                                                                    uu___3)::
+                                                      (a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                                      (a7, uu___6)::(a8,
+                                                                    uu___7)::
+                                                      (a9, uu___8)::(a10,
+                                                                    uu___9)::
+                                                      (a11, uu___10)::
+                                                      (a12, uu___11)::
+                                                      (a13, uu___12)::
+                                                      (a14, uu___13)::
+                                                      (a15, uu___14)::
+                                                      (a16, uu___15)::
+                                                      (a17, uu___16)::
+                                                      (a18, uu___17)::
+                                                      (a19, uu___18)::
+                                                      (a20, uu___19)::[] ->
+                                                      let uu___20 =
                                                         unembed e1 a1 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____10612
+                                                        uu___20
                                                         (fun a110 ->
-                                                           let uu____10618 =
+                                                           let uu___21 =
                                                              unembed e2 a2
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____10618
+                                                             uu___21
                                                              (fun a21 ->
-                                                                let uu____10624
-                                                                  =
+                                                                let uu___22 =
                                                                   unembed e3
                                                                     a3 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____10624
+                                                                  uu___22
                                                                   (fun a31 ->
-                                                                    let uu____10630
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10630
+                                                                    uu___23
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____10636
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10636
+                                                                    uu___24
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____10642
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10642
+                                                                    uu___25
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____10648
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10648
+                                                                    uu___26
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____10654
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10654
+                                                                    uu___27
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____10660
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10660
+                                                                    uu___28
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____10666
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10666
+                                                                    uu___29
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____10672
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10672
+                                                                    uu___30
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____10678
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10678
+                                                                    uu___31
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____10684
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10684
+                                                                    uu___32
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____10690
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10690
+                                                                    uu___33
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____10696
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10696
+                                                                    uu___34
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____10702
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10702
+                                                                    uu___35
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____10708
+                                                                    let uu___36
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10708
+                                                                    uu___36
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____10714
+                                                                    let uu___37
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10714
+                                                                    uu___37
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____10720
+                                                                    let uu___38
                                                                     =
                                                                     unembed
                                                                     e19 a19
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10720
+                                                                    uu___38
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____10726
+                                                                    let uu___39
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a20 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____10726
+                                                                    uu___39
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____10738
+                                                                    let uu___40
                                                                     =
                                                                     t a110
                                                                     a21 a31
@@ -3149,25 +3075,25 @@ let mk_tactic_interpretation_19 :
                                                                     a161 a171
                                                                     a181 a191 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____10738
+                                                                    uu___40
                                                                     ps1 in
-                                                                    let uu____10741
+                                                                    let uu___40
                                                                     =
-                                                                    let uu____10742
+                                                                    let uu___41
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____10747
+                                                                    let uu___42
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____10742
-                                                                    uu____10747
+                                                                    uu___41
+                                                                    uu___42
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____10741))))))))))))))))))))
-                                                  | uu____10750 ->
+                                                                    uu___40))))))))))))))))))))
+                                                  | uu___ ->
                                                       FStar_Pervasives_Native.None
 let mk_tactic_interpretation_20 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't20 't3 't4
@@ -3257,210 +3183,208 @@ let mk_tactic_interpretation_20 :
                                                 fun ncb ->
                                                   fun args ->
                                                     match args with
-                                                    | (a1, uu____11182)::
-                                                        (a2, uu____11184)::
-                                                        (a3, uu____11186)::
-                                                        (a4, uu____11188)::
-                                                        (a5, uu____11190)::
-                                                        (a6, uu____11192)::
-                                                        (a7, uu____11194)::
-                                                        (a8, uu____11196)::
-                                                        (a9, uu____11198)::
-                                                        (a10, uu____11200)::
-                                                        (a11, uu____11202)::
-                                                        (a12, uu____11204)::
-                                                        (a13, uu____11206)::
-                                                        (a14, uu____11208)::
-                                                        (a15, uu____11210)::
-                                                        (a16, uu____11212)::
-                                                        (a17, uu____11214)::
-                                                        (a18, uu____11216)::
-                                                        (a19, uu____11218)::
-                                                        (a20, uu____11220)::
-                                                        (a21, uu____11222)::[]
-                                                        ->
-                                                        let uu____11567 =
+                                                    | (a1, uu___)::(a2,
+                                                                    uu___1)::
+                                                        (a3, uu___2)::
+                                                        (a4, uu___3)::
+                                                        (a5, uu___4)::
+                                                        (a6, uu___5)::
+                                                        (a7, uu___6)::
+                                                        (a8, uu___7)::
+                                                        (a9, uu___8)::
+                                                        (a10, uu___9)::
+                                                        (a11, uu___10)::
+                                                        (a12, uu___11)::
+                                                        (a13, uu___12)::
+                                                        (a14, uu___13)::
+                                                        (a15, uu___14)::
+                                                        (a16, uu___15)::
+                                                        (a17, uu___16)::
+                                                        (a18, uu___17)::
+                                                        (a19, uu___18)::
+                                                        (a20, uu___19)::
+                                                        (a21, uu___20)::[] ->
+                                                        let uu___21 =
                                                           unembed e1 a1 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____11567
+                                                          uu___21
                                                           (fun a110 ->
-                                                             let uu____11573
-                                                               =
+                                                             let uu___22 =
                                                                unembed e2 a2
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____11573
+                                                               uu___22
                                                                (fun a22 ->
-                                                                  let uu____11579
+                                                                  let uu___23
                                                                     =
                                                                     unembed
                                                                     e3 a3 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____11579
+                                                                    uu___23
                                                                     (
                                                                     fun a31
                                                                     ->
-                                                                    let uu____11585
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11585
+                                                                    uu___24
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____11591
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11591
+                                                                    uu___25
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____11597
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11597
+                                                                    uu___26
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____11603
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11603
+                                                                    uu___27
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____11609
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11609
+                                                                    uu___28
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____11615
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11615
+                                                                    uu___29
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____11621
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11621
+                                                                    uu___30
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____11627
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11627
+                                                                    uu___31
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____11633
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11633
+                                                                    uu___32
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____11639
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11639
+                                                                    uu___33
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____11645
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11645
+                                                                    uu___34
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____11651
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11651
+                                                                    uu___35
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____11657
+                                                                    let uu___36
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11657
+                                                                    uu___36
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____11663
+                                                                    let uu___37
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11663
+                                                                    uu___37
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____11669
+                                                                    let uu___38
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11669
+                                                                    uu___38
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____11675
+                                                                    let uu___39
                                                                     =
                                                                     unembed
                                                                     e19 a19
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11675
+                                                                    uu___39
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____11681
+                                                                    let uu___40
                                                                     =
                                                                     unembed
                                                                     e20 a20
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11681
+                                                                    uu___40
                                                                     (fun a201
                                                                     ->
-                                                                    let uu____11687
+                                                                    let uu___41
                                                                     =
                                                                     unembed
                                                                     FStar_Tactics_Embedding.e_proofstate
                                                                     a21 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____11687
+                                                                    uu___41
                                                                     (fun ps
                                                                     ->
                                                                     let ps1 =
                                                                     FStar_Tactics_Types.set_ps_psc
                                                                     psc ps in
                                                                     let r1 =
-                                                                    let uu____11699
+                                                                    let uu___42
                                                                     =
                                                                     t a110
                                                                     a22 a31
@@ -3474,25 +3398,25 @@ let mk_tactic_interpretation_20 :
                                                                     a181 a191
                                                                     a201 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____11699
+                                                                    uu___42
                                                                     ps1 in
-                                                                    let uu____11702
+                                                                    let uu___42
                                                                     =
-                                                                    let uu____11703
+                                                                    let uu___43
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result
                                                                     er in
-                                                                    let uu____11708
+                                                                    let uu___44
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed
-                                                                    uu____11703
-                                                                    uu____11708
+                                                                    uu___43
+                                                                    uu___44
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____11702)))))))))))))))))))))
-                                                    | uu____11711 ->
+                                                                    uu___42)))))))))))))))))))))
+                                                    | uu___ ->
                                                         FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_1 :
   'r 't1 .
@@ -3509,24 +3433,24 @@ let mk_tactic_nbe_interpretation_1 :
         fun er ->
           fun args ->
             match args with
-            | (a1, uu____11773)::(a2, uu____11775)::[] ->
-                let uu____11788 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                FStar_Util.bind_opt uu____11788
+            | (a1, uu___)::(a2, uu___1)::[] ->
+                let uu___2 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                FStar_Util.bind_opt uu___2
                   (fun a11 ->
-                     let uu____11794 =
+                     let uu___3 =
                        FStar_TypeChecker_NBETerm.unembed
                          FStar_Tactics_Embedding.e_proofstate_nbe cb a2 in
-                     FStar_Util.bind_opt uu____11794
+                     FStar_Util.bind_opt uu___3
                        (fun ps ->
                           let r1 =
-                            let uu____11804 = t a11 in
-                            FStar_Tactics_Monad.run_safe uu____11804 ps in
-                          let uu____11807 =
-                            let uu____11808 =
+                            let uu___4 = t a11 in
+                            FStar_Tactics_Monad.run_safe uu___4 ps in
+                          let uu___4 =
+                            let uu___5 =
                               FStar_Tactics_Embedding.e_result_nbe er in
-                            FStar_TypeChecker_NBETerm.embed uu____11808 cb r1 in
-                          FStar_Pervasives_Native.Some uu____11807))
-            | uu____11815 -> FStar_Pervasives_Native.None
+                            FStar_TypeChecker_NBETerm.embed uu___5 cb r1 in
+                          FStar_Pervasives_Native.Some uu___4))
+            | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_2 :
   'r 't1 't2 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3544,33 +3468,30 @@ let mk_tactic_nbe_interpretation_2 :
           fun er ->
             fun args ->
               match args with
-              | (a1, uu____11896)::(a2, uu____11898)::(a3, uu____11900)::[]
-                  ->
-                  let uu____11917 =
-                    FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                  FStar_Util.bind_opt uu____11917
+              | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::[] ->
+                  let uu___3 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                  FStar_Util.bind_opt uu___3
                     (fun a11 ->
-                       let uu____11923 =
+                       let uu___4 =
                          FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                       FStar_Util.bind_opt uu____11923
+                       FStar_Util.bind_opt uu___4
                          (fun a21 ->
-                            let uu____11929 =
+                            let uu___5 =
                               FStar_TypeChecker_NBETerm.unembed
                                 FStar_Tactics_Embedding.e_proofstate_nbe cb
                                 a3 in
-                            FStar_Util.bind_opt uu____11929
+                            FStar_Util.bind_opt uu___5
                               (fun ps ->
                                  let r1 =
-                                   let uu____11939 = t a11 a21 in
-                                   FStar_Tactics_Monad.run_safe uu____11939
-                                     ps in
-                                 let uu____11942 =
-                                   let uu____11943 =
+                                   let uu___6 = t a11 a21 in
+                                   FStar_Tactics_Monad.run_safe uu___6 ps in
+                                 let uu___6 =
+                                   let uu___7 =
                                      FStar_Tactics_Embedding.e_result_nbe er in
-                                   FStar_TypeChecker_NBETerm.embed
-                                     uu____11943 cb r1 in
-                                 FStar_Pervasives_Native.Some uu____11942)))
-              | uu____11950 -> FStar_Pervasives_Native.None
+                                   FStar_TypeChecker_NBETerm.embed uu___7 cb
+                                     r1 in
+                                 FStar_Pervasives_Native.Some uu___6)))
+              | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_3 :
   'r 't1 't2 't3 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3590,39 +3511,37 @@ let mk_tactic_nbe_interpretation_3 :
             fun er ->
               fun args ->
                 match args with
-                | (a1, uu____12050)::(a2, uu____12052)::(a3, uu____12054)::
-                    (a4, uu____12056)::[] ->
-                    let uu____12077 =
-                      FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                    FStar_Util.bind_opt uu____12077
+                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::[]
+                    ->
+                    let uu___4 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                    FStar_Util.bind_opt uu___4
                       (fun a11 ->
-                         let uu____12083 =
+                         let uu___5 =
                            FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                         FStar_Util.bind_opt uu____12083
+                         FStar_Util.bind_opt uu___5
                            (fun a21 ->
-                              let uu____12089 =
+                              let uu___6 =
                                 FStar_TypeChecker_NBETerm.unembed e3 cb a3 in
-                              FStar_Util.bind_opt uu____12089
+                              FStar_Util.bind_opt uu___6
                                 (fun a31 ->
-                                   let uu____12095 =
+                                   let uu___7 =
                                      FStar_TypeChecker_NBETerm.unembed
                                        FStar_Tactics_Embedding.e_proofstate_nbe
                                        cb a4 in
-                                   FStar_Util.bind_opt uu____12095
+                                   FStar_Util.bind_opt uu___7
                                      (fun ps ->
                                         let r1 =
-                                          let uu____12105 = t a11 a21 a31 in
-                                          FStar_Tactics_Monad.run_safe
-                                            uu____12105 ps in
-                                        let uu____12108 =
-                                          let uu____12109 =
+                                          let uu___8 = t a11 a21 a31 in
+                                          FStar_Tactics_Monad.run_safe uu___8
+                                            ps in
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_Tactics_Embedding.e_result_nbe
                                               er in
                                           FStar_TypeChecker_NBETerm.embed
-                                            uu____12109 cb r1 in
-                                        FStar_Pervasives_Native.Some
-                                          uu____12108))))
-                | uu____12116 -> FStar_Pervasives_Native.None
+                                            uu___9 cb r1 in
+                                        FStar_Pervasives_Native.Some uu___8))))
+                | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_4 :
   'r 't1 't2 't3 't4 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3645,45 +3564,44 @@ let mk_tactic_nbe_interpretation_4 :
               fun er ->
                 fun args ->
                   match args with
-                  | (a1, uu____12235)::(a2, uu____12237)::(a3, uu____12239)::
-                      (a4, uu____12241)::(a5, uu____12243)::[] ->
-                      let uu____12268 =
-                        FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                      FStar_Util.bind_opt uu____12268
+                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                      (a5, uu___4)::[] ->
+                      let uu___5 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                      FStar_Util.bind_opt uu___5
                         (fun a11 ->
-                           let uu____12274 =
+                           let uu___6 =
                              FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                           FStar_Util.bind_opt uu____12274
+                           FStar_Util.bind_opt uu___6
                              (fun a21 ->
-                                let uu____12280 =
+                                let uu___7 =
                                   FStar_TypeChecker_NBETerm.unembed e3 cb a3 in
-                                FStar_Util.bind_opt uu____12280
+                                FStar_Util.bind_opt uu___7
                                   (fun a31 ->
-                                     let uu____12286 =
+                                     let uu___8 =
                                        FStar_TypeChecker_NBETerm.unembed e4
                                          cb a4 in
-                                     FStar_Util.bind_opt uu____12286
+                                     FStar_Util.bind_opt uu___8
                                        (fun a41 ->
-                                          let uu____12292 =
+                                          let uu___9 =
                                             FStar_TypeChecker_NBETerm.unembed
                                               FStar_Tactics_Embedding.e_proofstate_nbe
                                               cb a5 in
-                                          FStar_Util.bind_opt uu____12292
+                                          FStar_Util.bind_opt uu___9
                                             (fun ps ->
                                                let r1 =
-                                                 let uu____12302 =
+                                                 let uu___10 =
                                                    t a11 a21 a31 a41 in
                                                  FStar_Tactics_Monad.run_safe
-                                                   uu____12302 ps in
-                                               let uu____12305 =
-                                                 let uu____12306 =
+                                                   uu___10 ps in
+                                               let uu___10 =
+                                                 let uu___11 =
                                                    FStar_Tactics_Embedding.e_result_nbe
                                                      er in
                                                  FStar_TypeChecker_NBETerm.embed
-                                                   uu____12306 cb r1 in
+                                                   uu___11 cb r1 in
                                                FStar_Pervasives_Native.Some
-                                                 uu____12305)))))
-                  | uu____12313 -> FStar_Pervasives_Native.None
+                                                 uu___10)))))
+                  | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_5 :
   'r 't1 't2 't3 't4 't5 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3708,55 +3626,52 @@ let mk_tactic_nbe_interpretation_5 :
                 fun er ->
                   fun args ->
                     match args with
-                    | (a1, uu____12451)::(a2, uu____12453)::(a3, uu____12455)::
-                        (a4, uu____12457)::(a5, uu____12459)::(a6,
-                                                               uu____12461)::[]
-                        ->
-                        let uu____12490 =
+                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                        (a5, uu___4)::(a6, uu___5)::[] ->
+                        let uu___6 =
                           FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                        FStar_Util.bind_opt uu____12490
+                        FStar_Util.bind_opt uu___6
                           (fun a11 ->
-                             let uu____12496 =
+                             let uu___7 =
                                FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                             FStar_Util.bind_opt uu____12496
+                             FStar_Util.bind_opt uu___7
                                (fun a21 ->
-                                  let uu____12502 =
+                                  let uu___8 =
                                     FStar_TypeChecker_NBETerm.unembed e3 cb
                                       a3 in
-                                  FStar_Util.bind_opt uu____12502
+                                  FStar_Util.bind_opt uu___8
                                     (fun a31 ->
-                                       let uu____12508 =
+                                       let uu___9 =
                                          FStar_TypeChecker_NBETerm.unembed e4
                                            cb a4 in
-                                       FStar_Util.bind_opt uu____12508
+                                       FStar_Util.bind_opt uu___9
                                          (fun a41 ->
-                                            let uu____12514 =
+                                            let uu___10 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e5 cb a5 in
-                                            FStar_Util.bind_opt uu____12514
+                                            FStar_Util.bind_opt uu___10
                                               (fun a51 ->
-                                                 let uu____12520 =
+                                                 let uu___11 =
                                                    FStar_TypeChecker_NBETerm.unembed
                                                      FStar_Tactics_Embedding.e_proofstate_nbe
                                                      cb a6 in
-                                                 FStar_Util.bind_opt
-                                                   uu____12520
+                                                 FStar_Util.bind_opt uu___11
                                                    (fun ps ->
                                                       let r1 =
-                                                        let uu____12530 =
+                                                        let uu___12 =
                                                           t a11 a21 a31 a41
                                                             a51 in
                                                         FStar_Tactics_Monad.run_safe
-                                                          uu____12530 ps in
-                                                      let uu____12533 =
-                                                        let uu____12534 =
+                                                          uu___12 ps in
+                                                      let uu___12 =
+                                                        let uu___13 =
                                                           FStar_Tactics_Embedding.e_result_nbe
                                                             er in
                                                         FStar_TypeChecker_NBETerm.embed
-                                                          uu____12534 cb r1 in
+                                                          uu___13 cb r1 in
                                                       FStar_Pervasives_Native.Some
-                                                        uu____12533))))))
-                    | uu____12541 -> FStar_Pervasives_Native.None
+                                                        uu___12))))))
+                    | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_6 :
   'r 't1 't2 't3 't4 't5 't6 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3784,68 +3699,61 @@ let mk_tactic_nbe_interpretation_6 :
                   fun er ->
                     fun args ->
                       match args with
-                      | (a1, uu____12698)::(a2, uu____12700)::(a3,
-                                                               uu____12702)::
-                          (a4, uu____12704)::(a5, uu____12706)::(a6,
-                                                                 uu____12708)::
-                          (a7, uu____12710)::[] ->
-                          let uu____12743 =
+                      | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                          (a5, uu___4)::(a6, uu___5)::(a7, uu___6)::[] ->
+                          let uu___7 =
                             FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                          FStar_Util.bind_opt uu____12743
+                          FStar_Util.bind_opt uu___7
                             (fun a11 ->
-                               let uu____12749 =
+                               let uu___8 =
                                  FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                               FStar_Util.bind_opt uu____12749
+                               FStar_Util.bind_opt uu___8
                                  (fun a21 ->
-                                    let uu____12755 =
+                                    let uu___9 =
                                       FStar_TypeChecker_NBETerm.unembed e3 cb
                                         a3 in
-                                    FStar_Util.bind_opt uu____12755
+                                    FStar_Util.bind_opt uu___9
                                       (fun a31 ->
-                                         let uu____12761 =
+                                         let uu___10 =
                                            FStar_TypeChecker_NBETerm.unembed
                                              e4 cb a4 in
-                                         FStar_Util.bind_opt uu____12761
+                                         FStar_Util.bind_opt uu___10
                                            (fun a41 ->
-                                              let uu____12767 =
+                                              let uu___11 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e5 cb a5 in
-                                              FStar_Util.bind_opt uu____12767
+                                              FStar_Util.bind_opt uu___11
                                                 (fun a51 ->
-                                                   let uu____12773 =
+                                                   let uu___12 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e6 cb a6 in
                                                    FStar_Util.bind_opt
-                                                     uu____12773
+                                                     uu___12
                                                      (fun a61 ->
-                                                        let uu____12779 =
+                                                        let uu___13 =
                                                           FStar_TypeChecker_NBETerm.unembed
                                                             FStar_Tactics_Embedding.e_proofstate_nbe
                                                             cb a7 in
                                                         FStar_Util.bind_opt
-                                                          uu____12779
+                                                          uu___13
                                                           (fun ps ->
                                                              let r1 =
-                                                               let uu____12789
-                                                                 =
+                                                               let uu___14 =
                                                                  t a11 a21
                                                                    a31 a41
                                                                    a51 a61 in
                                                                FStar_Tactics_Monad.run_safe
-                                                                 uu____12789
-                                                                 ps in
-                                                             let uu____12792
-                                                               =
-                                                               let uu____12793
-                                                                 =
+                                                                 uu___14 ps in
+                                                             let uu___14 =
+                                                               let uu___15 =
                                                                  FStar_Tactics_Embedding.e_result_nbe
                                                                    er in
                                                                FStar_TypeChecker_NBETerm.embed
-                                                                 uu____12793
-                                                                 cb r1 in
+                                                                 uu___15 cb
+                                                                 r1 in
                                                              FStar_Pervasives_Native.Some
-                                                               uu____12792)))))))
-                      | uu____12800 -> FStar_Pervasives_Native.None
+                                                               uu___14)))))))
+                      | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_7 :
   'r 't1 't2 't3 't4 't5 't6 't7 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3876,77 +3784,74 @@ let mk_tactic_nbe_interpretation_7 :
                     fun er ->
                       fun args ->
                         match args with
-                        | (a1, uu____12976)::(a2, uu____12978)::(a3,
-                                                                 uu____12980)::
-                            (a4, uu____12982)::(a5, uu____12984)::(a6,
-                                                                   uu____12986)::
-                            (a7, uu____12988)::(a8, uu____12990)::[] ->
-                            let uu____13027 =
+                        | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4,
+                                                                    uu___3)::
+                            (a5, uu___4)::(a6, uu___5)::(a7, uu___6)::
+                            (a8, uu___7)::[] ->
+                            let uu___8 =
                               FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                            FStar_Util.bind_opt uu____13027
+                            FStar_Util.bind_opt uu___8
                               (fun a11 ->
-                                 let uu____13033 =
+                                 let uu___9 =
                                    FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                                 FStar_Util.bind_opt uu____13033
+                                 FStar_Util.bind_opt uu___9
                                    (fun a21 ->
-                                      let uu____13039 =
+                                      let uu___10 =
                                         FStar_TypeChecker_NBETerm.unembed e3
                                           cb a3 in
-                                      FStar_Util.bind_opt uu____13039
+                                      FStar_Util.bind_opt uu___10
                                         (fun a31 ->
-                                           let uu____13045 =
+                                           let uu___11 =
                                              FStar_TypeChecker_NBETerm.unembed
                                                e4 cb a4 in
-                                           FStar_Util.bind_opt uu____13045
+                                           FStar_Util.bind_opt uu___11
                                              (fun a41 ->
-                                                let uu____13051 =
+                                                let uu___12 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e5 cb a5 in
-                                                FStar_Util.bind_opt
-                                                  uu____13051
+                                                FStar_Util.bind_opt uu___12
                                                   (fun a51 ->
-                                                     let uu____13057 =
+                                                     let uu___13 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e6 cb a6 in
                                                      FStar_Util.bind_opt
-                                                       uu____13057
+                                                       uu___13
                                                        (fun a61 ->
-                                                          let uu____13063 =
+                                                          let uu___14 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e7 cb a7 in
                                                           FStar_Util.bind_opt
-                                                            uu____13063
+                                                            uu___14
                                                             (fun a71 ->
-                                                               let uu____13069
-                                                                 =
+                                                               let uu___15 =
                                                                  FStar_TypeChecker_NBETerm.unembed
                                                                    FStar_Tactics_Embedding.e_proofstate_nbe
                                                                    cb a8 in
                                                                FStar_Util.bind_opt
-                                                                 uu____13069
+                                                                 uu___15
                                                                  (fun ps ->
                                                                     let r1 =
-                                                                    let uu____13079
+                                                                    let uu___16
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____13079
+                                                                    uu___16
                                                                     ps in
-                                                                    let uu____13082
+                                                                    let uu___16
                                                                     =
-                                                                    let uu____13083
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____13083
+                                                                    uu___17
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____13082))))))))
-                        | uu____13090 -> FStar_Pervasives_Native.None
+                                                                    uu___16))))))))
+                        | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_8 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -3981,89 +3886,84 @@ let mk_tactic_nbe_interpretation_8 :
                       fun er ->
                         fun args ->
                           match args with
-                          | (a1, uu____13285)::(a2, uu____13287)::(a3,
-                                                                   uu____13289)::
-                              (a4, uu____13291)::(a5, uu____13293)::(a6,
-                                                                    uu____13295)::
-                              (a7, uu____13297)::(a8, uu____13299)::(a9,
-                                                                    uu____13301)::[]
-                              ->
-                              let uu____13342 =
+                          | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                              (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                              (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::[] ->
+                              let uu___9 =
                                 FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                              FStar_Util.bind_opt uu____13342
+                              FStar_Util.bind_opt uu___9
                                 (fun a11 ->
-                                   let uu____13348 =
+                                   let uu___10 =
                                      FStar_TypeChecker_NBETerm.unembed e2 cb
                                        a2 in
-                                   FStar_Util.bind_opt uu____13348
+                                   FStar_Util.bind_opt uu___10
                                      (fun a21 ->
-                                        let uu____13354 =
+                                        let uu___11 =
                                           FStar_TypeChecker_NBETerm.unembed
                                             e3 cb a3 in
-                                        FStar_Util.bind_opt uu____13354
+                                        FStar_Util.bind_opt uu___11
                                           (fun a31 ->
-                                             let uu____13360 =
+                                             let uu___12 =
                                                FStar_TypeChecker_NBETerm.unembed
                                                  e4 cb a4 in
-                                             FStar_Util.bind_opt uu____13360
+                                             FStar_Util.bind_opt uu___12
                                                (fun a41 ->
-                                                  let uu____13366 =
+                                                  let uu___13 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e5 cb a5 in
-                                                  FStar_Util.bind_opt
-                                                    uu____13366
+                                                  FStar_Util.bind_opt uu___13
                                                     (fun a51 ->
-                                                       let uu____13372 =
+                                                       let uu___14 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e6 cb a6 in
                                                        FStar_Util.bind_opt
-                                                         uu____13372
+                                                         uu___14
                                                          (fun a61 ->
-                                                            let uu____13378 =
+                                                            let uu___15 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e7 cb a7 in
                                                             FStar_Util.bind_opt
-                                                              uu____13378
+                                                              uu___15
                                                               (fun a71 ->
-                                                                 let uu____13384
+                                                                 let uu___16
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____13384
+                                                                   uu___16
                                                                    (fun a81
                                                                     ->
-                                                                    let uu____13390
+                                                                    let uu___17
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____13390
+                                                                    uu___17
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____13400
+                                                                    let uu___18
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 a81 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____13400
+                                                                    uu___18
                                                                     ps in
-                                                                    let uu____13403
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____13404
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____13404
+                                                                    uu___19
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____13403)))))))))
-                          | uu____13411 -> FStar_Pervasives_Native.None
+                                                                    uu___18)))))))))
+                          | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_9 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4101,78 +4001,74 @@ let mk_tactic_nbe_interpretation_9 :
                         fun er ->
                           fun args ->
                             match args with
-                            | (a1, uu____13625)::(a2, uu____13627)::(a3,
-                                                                    uu____13629)::
-                                (a4, uu____13631)::(a5, uu____13633)::
-                                (a6, uu____13635)::(a7, uu____13637)::
-                                (a8, uu____13639)::(a9, uu____13641)::
-                                (a10, uu____13643)::[] ->
-                                let uu____13688 =
+                            | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                (a10, uu___9)::[] ->
+                                let uu___10 =
                                   FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                                FStar_Util.bind_opt uu____13688
+                                FStar_Util.bind_opt uu___10
                                   (fun a11 ->
-                                     let uu____13694 =
+                                     let uu___11 =
                                        FStar_TypeChecker_NBETerm.unembed e2
                                          cb a2 in
-                                     FStar_Util.bind_opt uu____13694
+                                     FStar_Util.bind_opt uu___11
                                        (fun a21 ->
-                                          let uu____13700 =
+                                          let uu___12 =
                                             FStar_TypeChecker_NBETerm.unembed
                                               e3 cb a3 in
-                                          FStar_Util.bind_opt uu____13700
+                                          FStar_Util.bind_opt uu___12
                                             (fun a31 ->
-                                               let uu____13706 =
+                                               let uu___13 =
                                                  FStar_TypeChecker_NBETerm.unembed
                                                    e4 cb a4 in
-                                               FStar_Util.bind_opt
-                                                 uu____13706
+                                               FStar_Util.bind_opt uu___13
                                                  (fun a41 ->
-                                                    let uu____13712 =
+                                                    let uu___14 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e5 cb a5 in
                                                     FStar_Util.bind_opt
-                                                      uu____13712
+                                                      uu___14
                                                       (fun a51 ->
-                                                         let uu____13718 =
+                                                         let uu___15 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e6 cb a6 in
                                                          FStar_Util.bind_opt
-                                                           uu____13718
+                                                           uu___15
                                                            (fun a61 ->
-                                                              let uu____13724
-                                                                =
+                                                              let uu___16 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e7 cb a7 in
                                                               FStar_Util.bind_opt
-                                                                uu____13724
+                                                                uu___16
                                                                 (fun a71 ->
-                                                                   let uu____13730
+                                                                   let uu___17
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____13730
+                                                                    uu___17
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____13736
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____13736
+                                                                    uu___18
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____13742
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____13742
+                                                                    uu___19
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____13752
+                                                                    let uu___20
                                                                     =
                                                                     t a11 a21
                                                                     a31 a41
@@ -4180,20 +4076,20 @@ let mk_tactic_nbe_interpretation_9 :
                                                                     a71 a81
                                                                     a91 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____13752
+                                                                    uu___20
                                                                     ps in
-                                                                    let uu____13755
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____13756
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____13756
+                                                                    uu___21
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____13755))))))))))
-                            | uu____13763 -> FStar_Pervasives_Native.None
+                                                                    uu___20))))))))))
+                            | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_10 :
   'r 't1 't10 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4235,88 +4131,84 @@ let mk_tactic_nbe_interpretation_10 :
                           fun er ->
                             fun args ->
                               match args with
-                              | (a1, uu____13996)::(a2, uu____13998)::
-                                  (a3, uu____14000)::(a4, uu____14002)::
-                                  (a5, uu____14004)::(a6, uu____14006)::
-                                  (a7, uu____14008)::(a8, uu____14010)::
-                                  (a9, uu____14012)::(a10, uu____14014)::
-                                  (a11, uu____14016)::[] ->
-                                  let uu____14065 =
+                              | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                  (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                  (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                  (a10, uu___9)::(a11, uu___10)::[] ->
+                                  let uu___11 =
                                     FStar_TypeChecker_NBETerm.unembed e1 cb
                                       a1 in
-                                  FStar_Util.bind_opt uu____14065
+                                  FStar_Util.bind_opt uu___11
                                     (fun a12 ->
-                                       let uu____14071 =
+                                       let uu___12 =
                                          FStar_TypeChecker_NBETerm.unembed e2
                                            cb a2 in
-                                       FStar_Util.bind_opt uu____14071
+                                       FStar_Util.bind_opt uu___12
                                          (fun a21 ->
-                                            let uu____14077 =
+                                            let uu___13 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e3 cb a3 in
-                                            FStar_Util.bind_opt uu____14077
+                                            FStar_Util.bind_opt uu___13
                                               (fun a31 ->
-                                                 let uu____14083 =
+                                                 let uu___14 =
                                                    FStar_TypeChecker_NBETerm.unembed
                                                      e4 cb a4 in
-                                                 FStar_Util.bind_opt
-                                                   uu____14083
+                                                 FStar_Util.bind_opt uu___14
                                                    (fun a41 ->
-                                                      let uu____14089 =
+                                                      let uu___15 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e5 cb a5 in
                                                       FStar_Util.bind_opt
-                                                        uu____14089
+                                                        uu___15
                                                         (fun a51 ->
-                                                           let uu____14095 =
+                                                           let uu___16 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e6 cb a6 in
                                                            FStar_Util.bind_opt
-                                                             uu____14095
+                                                             uu___16
                                                              (fun a61 ->
-                                                                let uu____14101
-                                                                  =
+                                                                let uu___17 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____14101
+                                                                  uu___17
                                                                   (fun a71 ->
-                                                                    let uu____14107
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14107
+                                                                    uu___18
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____14113
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14113
+                                                                    uu___19
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____14119
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14119
+                                                                    uu___20
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____14125
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14125
+                                                                    uu___21
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____14135
+                                                                    let uu___22
                                                                     =
                                                                     t a12 a21
                                                                     a31 a41
@@ -4324,20 +4216,20 @@ let mk_tactic_nbe_interpretation_10 :
                                                                     a71 a81
                                                                     a91 a101 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____14135
+                                                                    uu___22
                                                                     ps in
-                                                                    let uu____14138
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____14139
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____14139
+                                                                    uu___23
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____14138)))))))))))
-                              | uu____14146 -> FStar_Pervasives_Native.None
+                                                                    uu___22)))))))))))
+                              | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_11 :
   'r 't1 't10 't11 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4382,101 +4274,99 @@ let mk_tactic_nbe_interpretation_11 :
                             fun er ->
                               fun args ->
                                 match args with
-                                | (a1, uu____14398)::(a2, uu____14400)::
-                                    (a3, uu____14402)::(a4, uu____14404)::
-                                    (a5, uu____14406)::(a6, uu____14408)::
-                                    (a7, uu____14410)::(a8, uu____14412)::
-                                    (a9, uu____14414)::(a10, uu____14416)::
-                                    (a11, uu____14418)::(a12, uu____14420)::[]
+                                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                    (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                    (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                    (a10, uu___9)::(a11, uu___10)::(a12,
+                                                                    uu___11)::[]
                                     ->
-                                    let uu____14473 =
+                                    let uu___12 =
                                       FStar_TypeChecker_NBETerm.unembed e1 cb
                                         a1 in
-                                    FStar_Util.bind_opt uu____14473
+                                    FStar_Util.bind_opt uu___12
                                       (fun a13 ->
-                                         let uu____14479 =
+                                         let uu___13 =
                                            FStar_TypeChecker_NBETerm.unembed
                                              e2 cb a2 in
-                                         FStar_Util.bind_opt uu____14479
+                                         FStar_Util.bind_opt uu___13
                                            (fun a21 ->
-                                              let uu____14485 =
+                                              let uu___14 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e3 cb a3 in
-                                              FStar_Util.bind_opt uu____14485
+                                              FStar_Util.bind_opt uu___14
                                                 (fun a31 ->
-                                                   let uu____14491 =
+                                                   let uu___15 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e4 cb a4 in
                                                    FStar_Util.bind_opt
-                                                     uu____14491
+                                                     uu___15
                                                      (fun a41 ->
-                                                        let uu____14497 =
+                                                        let uu___16 =
                                                           FStar_TypeChecker_NBETerm.unembed
                                                             e5 cb a5 in
                                                         FStar_Util.bind_opt
-                                                          uu____14497
+                                                          uu___16
                                                           (fun a51 ->
-                                                             let uu____14503
-                                                               =
+                                                             let uu___17 =
                                                                FStar_TypeChecker_NBETerm.unembed
                                                                  e6 cb a6 in
                                                              FStar_Util.bind_opt
-                                                               uu____14503
+                                                               uu___17
                                                                (fun a61 ->
-                                                                  let uu____14509
+                                                                  let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                   FStar_Util.bind_opt
-                                                                    uu____14509
+                                                                    uu___18
                                                                     (
                                                                     fun a71
                                                                     ->
-                                                                    let uu____14515
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14515
+                                                                    uu___19
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____14521
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14521
+                                                                    uu___20
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____14527
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14527
+                                                                    uu___21
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____14533
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14533
+                                                                    uu___22
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____14539
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14539
+                                                                    uu___23
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____14549
+                                                                    let uu___24
                                                                     =
                                                                     t a13 a21
                                                                     a31 a41
@@ -4485,20 +4375,20 @@ let mk_tactic_nbe_interpretation_11 :
                                                                     a91 a101
                                                                     a111 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____14549
+                                                                    uu___24
                                                                     ps in
-                                                                    let uu____14552
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____14553
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____14553
+                                                                    uu___25
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____14552))))))))))))
-                                | uu____14560 -> FStar_Pervasives_Native.None
+                                                                    uu___24))))))))))))
+                                | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_12 :
   'r 't1 't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4547,110 +4437,108 @@ let mk_tactic_nbe_interpretation_12 :
                               fun er ->
                                 fun args ->
                                   match args with
-                                  | (a1, uu____14831)::(a2, uu____14833)::
-                                      (a3, uu____14835)::(a4, uu____14837)::
-                                      (a5, uu____14839)::(a6, uu____14841)::
-                                      (a7, uu____14843)::(a8, uu____14845)::
-                                      (a9, uu____14847)::(a10, uu____14849)::
-                                      (a11, uu____14851)::(a12, uu____14853)::
-                                      (a13, uu____14855)::[] ->
-                                      let uu____14912 =
+                                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                      (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                      (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                   uu___8)::
+                                      (a10, uu___9)::(a11, uu___10)::
+                                      (a12, uu___11)::(a13, uu___12)::[] ->
+                                      let uu___13 =
                                         FStar_TypeChecker_NBETerm.unembed e1
                                           cb a1 in
-                                      FStar_Util.bind_opt uu____14912
+                                      FStar_Util.bind_opt uu___13
                                         (fun a14 ->
-                                           let uu____14918 =
+                                           let uu___14 =
                                              FStar_TypeChecker_NBETerm.unembed
                                                e2 cb a2 in
-                                           FStar_Util.bind_opt uu____14918
+                                           FStar_Util.bind_opt uu___14
                                              (fun a21 ->
-                                                let uu____14924 =
+                                                let uu___15 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e3 cb a3 in
-                                                FStar_Util.bind_opt
-                                                  uu____14924
+                                                FStar_Util.bind_opt uu___15
                                                   (fun a31 ->
-                                                     let uu____14930 =
+                                                     let uu___16 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e4 cb a4 in
                                                      FStar_Util.bind_opt
-                                                       uu____14930
+                                                       uu___16
                                                        (fun a41 ->
-                                                          let uu____14936 =
+                                                          let uu___17 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e5 cb a5 in
                                                           FStar_Util.bind_opt
-                                                            uu____14936
+                                                            uu___17
                                                             (fun a51 ->
-                                                               let uu____14942
-                                                                 =
+                                                               let uu___18 =
                                                                  FStar_TypeChecker_NBETerm.unembed
                                                                    e6 cb a6 in
                                                                FStar_Util.bind_opt
-                                                                 uu____14942
+                                                                 uu___18
                                                                  (fun a61 ->
-                                                                    let uu____14948
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14948
+                                                                    uu___19
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____14954
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14954
+                                                                    uu___20
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____14960
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14960
+                                                                    uu___21
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____14966
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14966
+                                                                    uu___22
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____14972
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14972
+                                                                    uu___23
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____14978
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14978
+                                                                    uu___24
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____14984
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____14984
+                                                                    uu___25
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____14994
+                                                                    let uu___26
                                                                     =
                                                                     t a14 a21
                                                                     a31 a41
@@ -4659,21 +4547,20 @@ let mk_tactic_nbe_interpretation_12 :
                                                                     a91 a101
                                                                     a111 a121 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____14994
+                                                                    uu___26
                                                                     ps in
-                                                                    let uu____14997
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____14998
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____14998
+                                                                    uu___27
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____14997)))))))))))))
-                                  | uu____15005 ->
-                                      FStar_Pervasives_Native.None
+                                                                    uu___26)))))))))))))
+                                  | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_13 :
   'r 't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4725,123 +4612,120 @@ let mk_tactic_nbe_interpretation_13 :
                                 fun er ->
                                   fun args ->
                                     match args with
-                                    | (a1, uu____15295)::(a2, uu____15297)::
-                                        (a3, uu____15299)::(a4, uu____15301)::
-                                        (a5, uu____15303)::(a6, uu____15305)::
-                                        (a7, uu____15307)::(a8, uu____15309)::
-                                        (a9, uu____15311)::(a10, uu____15313)::
-                                        (a11, uu____15315)::(a12,
-                                                             uu____15317)::
-                                        (a13, uu____15319)::(a14,
-                                                             uu____15321)::[]
-                                        ->
-                                        let uu____15382 =
+                                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                        (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                        (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                    uu___8)::
+                                        (a10, uu___9)::(a11, uu___10)::
+                                        (a12, uu___11)::(a13, uu___12)::
+                                        (a14, uu___13)::[] ->
+                                        let uu___14 =
                                           FStar_TypeChecker_NBETerm.unembed
                                             e1 cb a1 in
-                                        FStar_Util.bind_opt uu____15382
+                                        FStar_Util.bind_opt uu___14
                                           (fun a15 ->
-                                             let uu____15388 =
+                                             let uu___15 =
                                                FStar_TypeChecker_NBETerm.unembed
                                                  e2 cb a2 in
-                                             FStar_Util.bind_opt uu____15388
+                                             FStar_Util.bind_opt uu___15
                                                (fun a21 ->
-                                                  let uu____15394 =
+                                                  let uu___16 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e3 cb a3 in
-                                                  FStar_Util.bind_opt
-                                                    uu____15394
+                                                  FStar_Util.bind_opt uu___16
                                                     (fun a31 ->
-                                                       let uu____15400 =
+                                                       let uu___17 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e4 cb a4 in
                                                        FStar_Util.bind_opt
-                                                         uu____15400
+                                                         uu___17
                                                          (fun a41 ->
-                                                            let uu____15406 =
+                                                            let uu___18 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e5 cb a5 in
                                                             FStar_Util.bind_opt
-                                                              uu____15406
+                                                              uu___18
                                                               (fun a51 ->
-                                                                 let uu____15412
+                                                                 let uu___19
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____15412
+                                                                   uu___19
                                                                    (fun a61
                                                                     ->
-                                                                    let uu____15418
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15418
+                                                                    uu___20
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____15424
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15424
+                                                                    uu___21
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____15430
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15430
+                                                                    uu___22
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____15436
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15436
+                                                                    uu___23
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____15442
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15442
+                                                                    uu___24
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____15448
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15448
+                                                                    uu___25
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____15454
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15454
+                                                                    uu___26
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____15460
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15460
+                                                                    uu___27
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____15470
+                                                                    let uu___28
                                                                     =
                                                                     t a15 a21
                                                                     a31 a41
@@ -4851,21 +4735,20 @@ let mk_tactic_nbe_interpretation_13 :
                                                                     a111 a121
                                                                     a131 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____15470
+                                                                    uu___28
                                                                     ps in
-                                                                    let uu____15473
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____15474
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____15474
+                                                                    uu___29
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____15473))))))))))))))
-                                    | uu____15481 ->
-                                        FStar_Pervasives_Native.None
+                                                                    uu___28))))))))))))))
+                                    | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_14 :
   'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -4921,138 +4804,131 @@ let mk_tactic_nbe_interpretation_14 :
                                   fun er ->
                                     fun args ->
                                       match args with
-                                      | (a1, uu____15790)::(a2, uu____15792)::
-                                          (a3, uu____15794)::(a4,
-                                                              uu____15796)::
-                                          (a5, uu____15798)::(a6,
-                                                              uu____15800)::
-                                          (a7, uu____15802)::(a8,
-                                                              uu____15804)::
-                                          (a9, uu____15806)::(a10,
-                                                              uu____15808)::
-                                          (a11, uu____15810)::(a12,
-                                                               uu____15812)::
-                                          (a13, uu____15814)::(a14,
-                                                               uu____15816)::
-                                          (a15, uu____15818)::[] ->
-                                          let uu____15883 =
+                                      | (a1, uu___)::(a2, uu___1)::(a3,
+                                                                    uu___2)::
+                                          (a4, uu___3)::(a5, uu___4)::
+                                          (a6, uu___5)::(a7, uu___6)::
+                                          (a8, uu___7)::(a9, uu___8)::
+                                          (a10, uu___9)::(a11, uu___10)::
+                                          (a12, uu___11)::(a13, uu___12)::
+                                          (a14, uu___13)::(a15, uu___14)::[]
+                                          ->
+                                          let uu___15 =
                                             FStar_TypeChecker_NBETerm.unembed
                                               e1 cb a1 in
-                                          FStar_Util.bind_opt uu____15883
+                                          FStar_Util.bind_opt uu___15
                                             (fun a16 ->
-                                               let uu____15889 =
+                                               let uu___16 =
                                                  FStar_TypeChecker_NBETerm.unembed
                                                    e2 cb a2 in
-                                               FStar_Util.bind_opt
-                                                 uu____15889
+                                               FStar_Util.bind_opt uu___16
                                                  (fun a21 ->
-                                                    let uu____15895 =
+                                                    let uu___17 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e3 cb a3 in
                                                     FStar_Util.bind_opt
-                                                      uu____15895
+                                                      uu___17
                                                       (fun a31 ->
-                                                         let uu____15901 =
+                                                         let uu___18 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e4 cb a4 in
                                                          FStar_Util.bind_opt
-                                                           uu____15901
+                                                           uu___18
                                                            (fun a41 ->
-                                                              let uu____15907
-                                                                =
+                                                              let uu___19 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e5 cb a5 in
                                                               FStar_Util.bind_opt
-                                                                uu____15907
+                                                                uu___19
                                                                 (fun a51 ->
-                                                                   let uu____15913
+                                                                   let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____15913
+                                                                    uu___20
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____15919
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15919
+                                                                    uu___21
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____15925
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15925
+                                                                    uu___22
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____15931
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15931
+                                                                    uu___23
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____15937
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15937
+                                                                    uu___24
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____15943
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15943
+                                                                    uu___25
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____15949
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15949
+                                                                    uu___26
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____15955
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15955
+                                                                    uu___27
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____15961
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15961
+                                                                    uu___28
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____15967
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____15967
+                                                                    uu___29
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____15977
+                                                                    let uu___30
                                                                     =
                                                                     t a16 a21
                                                                     a31 a41
@@ -5062,21 +4938,20 @@ let mk_tactic_nbe_interpretation_14 :
                                                                     a111 a121
                                                                     a131 a141 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____15977
+                                                                    uu___30
                                                                     ps in
-                                                                    let uu____15980
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____15981
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____15981
+                                                                    uu___31
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____15980)))))))))))))))
-                                      | uu____15988 ->
-                                          FStar_Pervasives_Native.None
+                                                                    uu___30)))))))))))))))
+                                      | uu___ -> FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_15 :
   'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -5137,150 +5012,140 @@ let mk_tactic_nbe_interpretation_15 :
                                     fun er ->
                                       fun args ->
                                         match args with
-                                        | (a1, uu____16316)::(a2,
-                                                              uu____16318)::
-                                            (a3, uu____16320)::(a4,
-                                                                uu____16322)::
-                                            (a5, uu____16324)::(a6,
-                                                                uu____16326)::
-                                            (a7, uu____16328)::(a8,
-                                                                uu____16330)::
-                                            (a9, uu____16332)::(a10,
-                                                                uu____16334)::
-                                            (a11, uu____16336)::(a12,
-                                                                 uu____16338)::
-                                            (a13, uu____16340)::(a14,
-                                                                 uu____16342)::
-                                            (a15, uu____16344)::(a16,
-                                                                 uu____16346)::[]
+                                        | (a1, uu___)::(a2, uu___1)::
+                                            (a3, uu___2)::(a4, uu___3)::
+                                            (a5, uu___4)::(a6, uu___5)::
+                                            (a7, uu___6)::(a8, uu___7)::
+                                            (a9, uu___8)::(a10, uu___9)::
+                                            (a11, uu___10)::(a12, uu___11)::
+                                            (a13, uu___12)::(a14, uu___13)::
+                                            (a15, uu___14)::(a16, uu___15)::[]
                                             ->
-                                            let uu____16415 =
+                                            let uu___16 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e1 cb a1 in
-                                            FStar_Util.bind_opt uu____16415
+                                            FStar_Util.bind_opt uu___16
                                               (fun a17 ->
-                                                 let uu____16421 =
+                                                 let uu___17 =
                                                    FStar_TypeChecker_NBETerm.unembed
                                                      e2 cb a2 in
-                                                 FStar_Util.bind_opt
-                                                   uu____16421
+                                                 FStar_Util.bind_opt uu___17
                                                    (fun a21 ->
-                                                      let uu____16427 =
+                                                      let uu___18 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e3 cb a3 in
                                                       FStar_Util.bind_opt
-                                                        uu____16427
+                                                        uu___18
                                                         (fun a31 ->
-                                                           let uu____16433 =
+                                                           let uu___19 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e4 cb a4 in
                                                            FStar_Util.bind_opt
-                                                             uu____16433
+                                                             uu___19
                                                              (fun a41 ->
-                                                                let uu____16439
-                                                                  =
+                                                                let uu___20 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____16439
+                                                                  uu___20
                                                                   (fun a51 ->
-                                                                    let uu____16445
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16445
+                                                                    uu___21
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____16451
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16451
+                                                                    uu___22
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____16457
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16457
+                                                                    uu___23
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____16463
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16463
+                                                                    uu___24
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____16469
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16469
+                                                                    uu___25
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____16475
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16475
+                                                                    uu___26
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____16481
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16481
+                                                                    uu___27
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____16487
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16487
+                                                                    uu___28
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____16493
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16493
+                                                                    uu___29
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____16499
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16499
+                                                                    uu___30
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____16505
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____16505
+                                                                    uu___31
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____16515
+                                                                    let uu___32
                                                                     =
                                                                     t a17 a21
                                                                     a31 a41
@@ -5291,20 +5156,20 @@ let mk_tactic_nbe_interpretation_15 :
                                                                     a131 a141
                                                                     a151 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____16515
+                                                                    uu___32
                                                                     ps in
-                                                                    let uu____16518
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____16519
+                                                                    let uu___33
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____16519
+                                                                    uu___33
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____16518))))))))))))))))
-                                        | uu____16526 ->
+                                                                    uu___32))))))))))))))))
+                                        | uu___ ->
                                             FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_16 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -5372,162 +5237,153 @@ let mk_tactic_nbe_interpretation_16 :
                                       fun er ->
                                         fun args ->
                                           match args with
-                                          | (a1, uu____16873)::(a2,
-                                                                uu____16875)::
-                                              (a3, uu____16877)::(a4,
-                                                                  uu____16879)::
-                                              (a5, uu____16881)::(a6,
-                                                                  uu____16883)::
-                                              (a7, uu____16885)::(a8,
-                                                                  uu____16887)::
-                                              (a9, uu____16889)::(a10,
-                                                                  uu____16891)::
-                                              (a11, uu____16893)::(a12,
-                                                                   uu____16895)::
-                                              (a13, uu____16897)::(a14,
-                                                                   uu____16899)::
-                                              (a15, uu____16901)::(a16,
-                                                                   uu____16903)::
-                                              (a17, uu____16905)::[] ->
-                                              let uu____16978 =
+                                          | (a1, uu___)::(a2, uu___1)::
+                                              (a3, uu___2)::(a4, uu___3)::
+                                              (a5, uu___4)::(a6, uu___5)::
+                                              (a7, uu___6)::(a8, uu___7)::
+                                              (a9, uu___8)::(a10, uu___9)::
+                                              (a11, uu___10)::(a12, uu___11)::
+                                              (a13, uu___12)::(a14, uu___13)::
+                                              (a15, uu___14)::(a16, uu___15)::
+                                              (a17, uu___16)::[] ->
+                                              let uu___17 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e1 cb a1 in
-                                              FStar_Util.bind_opt uu____16978
+                                              FStar_Util.bind_opt uu___17
                                                 (fun a18 ->
-                                                   let uu____16984 =
+                                                   let uu___18 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e2 cb a2 in
                                                    FStar_Util.bind_opt
-                                                     uu____16984
+                                                     uu___18
                                                      (fun a21 ->
-                                                        let uu____16990 =
+                                                        let uu___19 =
                                                           FStar_TypeChecker_NBETerm.unembed
                                                             e3 cb a3 in
                                                         FStar_Util.bind_opt
-                                                          uu____16990
+                                                          uu___19
                                                           (fun a31 ->
-                                                             let uu____16996
-                                                               =
+                                                             let uu___20 =
                                                                FStar_TypeChecker_NBETerm.unembed
                                                                  e4 cb a4 in
                                                              FStar_Util.bind_opt
-                                                               uu____16996
+                                                               uu___20
                                                                (fun a41 ->
-                                                                  let uu____17002
+                                                                  let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                   FStar_Util.bind_opt
-                                                                    uu____17002
+                                                                    uu___21
                                                                     (
                                                                     fun a51
                                                                     ->
-                                                                    let uu____17008
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17008
+                                                                    uu___22
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____17014
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17014
+                                                                    uu___23
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____17020
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17020
+                                                                    uu___24
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____17026
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17026
+                                                                    uu___25
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____17032
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17032
+                                                                    uu___26
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____17038
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17038
+                                                                    uu___27
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____17044
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17044
+                                                                    uu___28
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____17050
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17050
+                                                                    uu___29
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____17056
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17056
+                                                                    uu___30
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____17062
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17062
+                                                                    uu___31
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____17068
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17068
+                                                                    uu___32
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____17074
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17074
+                                                                    uu___33
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____17084
+                                                                    let uu___34
                                                                     =
                                                                     t a18 a21
                                                                     a31 a41
@@ -5538,20 +5394,20 @@ let mk_tactic_nbe_interpretation_16 :
                                                                     a131 a141
                                                                     a151 a161 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____17084
+                                                                    uu___34
                                                                     ps in
-                                                                    let uu____17087
+                                                                    let uu___34
                                                                     =
-                                                                    let uu____17088
+                                                                    let uu___35
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____17088
+                                                                    uu___35
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____17087)))))))))))))))))
-                                          | uu____17095 ->
+                                                                    uu___34)))))))))))))))))
+                                          | uu___ ->
                                               FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_17 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't2 't3 't4 't5 't6 't7 't8
@@ -5626,173 +5482,166 @@ let mk_tactic_nbe_interpretation_17 :
                                         fun er ->
                                           fun args ->
                                             match args with
-                                            | (a1, uu____17461)::(a2,
-                                                                  uu____17463)::
-                                                (a3, uu____17465)::(a4,
-                                                                    uu____17467)::
-                                                (a5, uu____17469)::(a6,
-                                                                    uu____17471)::
-                                                (a7, uu____17473)::(a8,
-                                                                    uu____17475)::
-                                                (a9, uu____17477)::(a10,
-                                                                    uu____17479)::
-                                                (a11, uu____17481)::(a12,
-                                                                    uu____17483)::
-                                                (a13, uu____17485)::(a14,
-                                                                    uu____17487)::
-                                                (a15, uu____17489)::(a16,
-                                                                    uu____17491)::
-                                                (a17, uu____17493)::(a18,
-                                                                    uu____17495)::[]
+                                            | (a1, uu___)::(a2, uu___1)::
+                                                (a3, uu___2)::(a4, uu___3)::
+                                                (a5, uu___4)::(a6, uu___5)::
+                                                (a7, uu___6)::(a8, uu___7)::
+                                                (a9, uu___8)::(a10, uu___9)::
+                                                (a11, uu___10)::(a12,
+                                                                 uu___11)::
+                                                (a13, uu___12)::(a14,
+                                                                 uu___13)::
+                                                (a15, uu___14)::(a16,
+                                                                 uu___15)::
+                                                (a17, uu___16)::(a18,
+                                                                 uu___17)::[]
                                                 ->
-                                                let uu____17572 =
+                                                let uu___18 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e1 cb a1 in
-                                                FStar_Util.bind_opt
-                                                  uu____17572
+                                                FStar_Util.bind_opt uu___18
                                                   (fun a19 ->
-                                                     let uu____17578 =
+                                                     let uu___19 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e2 cb a2 in
                                                      FStar_Util.bind_opt
-                                                       uu____17578
+                                                       uu___19
                                                        (fun a21 ->
-                                                          let uu____17584 =
+                                                          let uu___20 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e3 cb a3 in
                                                           FStar_Util.bind_opt
-                                                            uu____17584
+                                                            uu___20
                                                             (fun a31 ->
-                                                               let uu____17590
-                                                                 =
+                                                               let uu___21 =
                                                                  FStar_TypeChecker_NBETerm.unembed
                                                                    e4 cb a4 in
                                                                FStar_Util.bind_opt
-                                                                 uu____17590
+                                                                 uu___21
                                                                  (fun a41 ->
-                                                                    let uu____17596
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17596
+                                                                    uu___22
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____17602
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17602
+                                                                    uu___23
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____17608
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17608
+                                                                    uu___24
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____17614
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17614
+                                                                    uu___25
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____17620
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17620
+                                                                    uu___26
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____17626
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17626
+                                                                    uu___27
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____17632
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17632
+                                                                    uu___28
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____17638
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17638
+                                                                    uu___29
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____17644
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17644
+                                                                    uu___30
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____17650
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17650
+                                                                    uu___31
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____17656
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17656
+                                                                    uu___32
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____17662
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17662
+                                                                    uu___33
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____17668
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17668
+                                                                    uu___34
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____17674
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____17674
+                                                                    uu___35
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____17684
+                                                                    let uu___36
                                                                     =
                                                                     t a19 a21
                                                                     a31 a41
@@ -5804,20 +5653,20 @@ let mk_tactic_nbe_interpretation_17 :
                                                                     a151 a161
                                                                     a171 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____17684
+                                                                    uu___36
                                                                     ps in
-                                                                    let uu____17687
+                                                                    let uu___36
                                                                     =
-                                                                    let uu____17688
+                                                                    let uu___37
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____17688
+                                                                    uu___37
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____17687))))))))))))))))))
-                                            | uu____17695 ->
+                                                                    uu___36))))))))))))))))))
+                                            | uu___ ->
                                                 FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_18 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't2 't3 't4 't5 't6 't7
@@ -5898,183 +5747,177 @@ let mk_tactic_nbe_interpretation_18 :
                                           fun er ->
                                             fun args ->
                                               match args with
-                                              | (a1, uu____18080)::(a2,
-                                                                    uu____18082)::
-                                                  (a3, uu____18084)::
-                                                  (a4, uu____18086)::
-                                                  (a5, uu____18088)::
-                                                  (a6, uu____18090)::
-                                                  (a7, uu____18092)::
-                                                  (a8, uu____18094)::
-                                                  (a9, uu____18096)::
-                                                  (a10, uu____18098)::
-                                                  (a11, uu____18100)::
-                                                  (a12, uu____18102)::
-                                                  (a13, uu____18104)::
-                                                  (a14, uu____18106)::
-                                                  (a15, uu____18108)::
-                                                  (a16, uu____18110)::
-                                                  (a17, uu____18112)::
-                                                  (a18, uu____18114)::
-                                                  (a19, uu____18116)::[] ->
-                                                  let uu____18197 =
+                                              | (a1, uu___)::(a2, uu___1)::
+                                                  (a3, uu___2)::(a4, uu___3)::
+                                                  (a5, uu___4)::(a6, uu___5)::
+                                                  (a7, uu___6)::(a8, uu___7)::
+                                                  (a9, uu___8)::(a10, uu___9)::
+                                                  (a11, uu___10)::(a12,
+                                                                   uu___11)::
+                                                  (a13, uu___12)::(a14,
+                                                                   uu___13)::
+                                                  (a15, uu___14)::(a16,
+                                                                   uu___15)::
+                                                  (a17, uu___16)::(a18,
+                                                                   uu___17)::
+                                                  (a19, uu___18)::[] ->
+                                                  let uu___19 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e1 cb a1 in
-                                                  FStar_Util.bind_opt
-                                                    uu____18197
+                                                  FStar_Util.bind_opt uu___19
                                                     (fun a110 ->
-                                                       let uu____18203 =
+                                                       let uu___20 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e2 cb a2 in
                                                        FStar_Util.bind_opt
-                                                         uu____18203
+                                                         uu___20
                                                          (fun a21 ->
-                                                            let uu____18209 =
+                                                            let uu___21 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e3 cb a3 in
                                                             FStar_Util.bind_opt
-                                                              uu____18209
+                                                              uu___21
                                                               (fun a31 ->
-                                                                 let uu____18215
+                                                                 let uu___22
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____18215
+                                                                   uu___22
                                                                    (fun a41
                                                                     ->
-                                                                    let uu____18221
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18221
+                                                                    uu___23
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____18227
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18227
+                                                                    uu___24
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____18233
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18233
+                                                                    uu___25
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____18239
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18239
+                                                                    uu___26
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____18245
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18245
+                                                                    uu___27
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____18251
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18251
+                                                                    uu___28
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____18257
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18257
+                                                                    uu___29
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____18263
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18263
+                                                                    uu___30
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____18269
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18269
+                                                                    uu___31
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____18275
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18275
+                                                                    uu___32
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____18281
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18281
+                                                                    uu___33
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____18287
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18287
+                                                                    uu___34
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____18293
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18293
+                                                                    uu___35
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____18299
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18299
+                                                                    uu___36
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____18305
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a19 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18305
+                                                                    uu___37
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____18315
+                                                                    let uu___38
                                                                     =
                                                                     t a110
                                                                     a21 a31
@@ -6087,20 +5930,20 @@ let mk_tactic_nbe_interpretation_18 :
                                                                     a161 a171
                                                                     a181 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____18315
+                                                                    uu___38
                                                                     ps in
-                                                                    let uu____18318
+                                                                    let uu___38
                                                                     =
-                                                                    let uu____18319
+                                                                    let uu___39
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____18319
+                                                                    uu___39
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____18318)))))))))))))))))))
-                                              | uu____18326 ->
+                                                                    uu___38)))))))))))))))))))
+                                              | uu___ ->
                                                   FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_19 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't3 't4 't5
@@ -6186,194 +6029,193 @@ let mk_tactic_nbe_interpretation_19 :
                                             fun er ->
                                               fun args ->
                                                 match args with
-                                                | (a1, uu____18730)::
-                                                    (a2, uu____18732)::
-                                                    (a3, uu____18734)::
-                                                    (a4, uu____18736)::
-                                                    (a5, uu____18738)::
-                                                    (a6, uu____18740)::
-                                                    (a7, uu____18742)::
-                                                    (a8, uu____18744)::
-                                                    (a9, uu____18746)::
-                                                    (a10, uu____18748)::
-                                                    (a11, uu____18750)::
-                                                    (a12, uu____18752)::
-                                                    (a13, uu____18754)::
-                                                    (a14, uu____18756)::
-                                                    (a15, uu____18758)::
-                                                    (a16, uu____18760)::
-                                                    (a17, uu____18762)::
-                                                    (a18, uu____18764)::
-                                                    (a19, uu____18766)::
-                                                    (a20, uu____18768)::[] ->
-                                                    let uu____18853 =
+                                                | (a1, uu___)::(a2, uu___1)::
+                                                    (a3, uu___2)::(a4,
+                                                                   uu___3)::
+                                                    (a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                                    (a7, uu___6)::(a8,
+                                                                   uu___7)::
+                                                    (a9, uu___8)::(a10,
+                                                                   uu___9)::
+                                                    (a11, uu___10)::(a12,
+                                                                    uu___11)::
+                                                    (a13, uu___12)::(a14,
+                                                                    uu___13)::
+                                                    (a15, uu___14)::(a16,
+                                                                    uu___15)::
+                                                    (a17, uu___16)::(a18,
+                                                                    uu___17)::
+                                                    (a19, uu___18)::(a20,
+                                                                    uu___19)::[]
+                                                    ->
+                                                    let uu___20 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e1 cb a1 in
                                                     FStar_Util.bind_opt
-                                                      uu____18853
+                                                      uu___20
                                                       (fun a110 ->
-                                                         let uu____18859 =
+                                                         let uu___21 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e2 cb a2 in
                                                          FStar_Util.bind_opt
-                                                           uu____18859
+                                                           uu___21
                                                            (fun a21 ->
-                                                              let uu____18865
-                                                                =
+                                                              let uu___22 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e3 cb a3 in
                                                               FStar_Util.bind_opt
-                                                                uu____18865
+                                                                uu___22
                                                                 (fun a31 ->
-                                                                   let uu____18871
+                                                                   let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____18871
+                                                                    uu___23
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____18877
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18877
+                                                                    uu___24
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____18883
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18883
+                                                                    uu___25
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____18889
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18889
+                                                                    uu___26
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____18895
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18895
+                                                                    uu___27
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____18901
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18901
+                                                                    uu___28
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____18907
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18907
+                                                                    uu___29
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____18913
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18913
+                                                                    uu___30
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____18919
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18919
+                                                                    uu___31
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____18925
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18925
+                                                                    uu___32
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____18931
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18931
+                                                                    uu___33
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____18937
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18937
+                                                                    uu___34
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____18943
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18943
+                                                                    uu___35
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____18949
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18949
+                                                                    uu___36
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____18955
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18955
+                                                                    uu___37
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____18961
+                                                                    let uu___38
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e19 cb
                                                                     a19 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18961
+                                                                    uu___38
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____18967
+                                                                    let uu___39
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a20 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____18967
+                                                                    uu___39
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____18977
+                                                                    let uu___40
                                                                     =
                                                                     t a110
                                                                     a21 a31
@@ -6386,20 +6228,20 @@ let mk_tactic_nbe_interpretation_19 :
                                                                     a161 a171
                                                                     a181 a191 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____18977
+                                                                    uu___40
                                                                     ps in
-                                                                    let uu____18980
+                                                                    let uu___40
                                                                     =
-                                                                    let uu____18981
+                                                                    let uu___41
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____18981
+                                                                    uu___41
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____18980))))))))))))))))))))
-                                                | uu____18988 ->
+                                                                    uu___40))))))))))))))))))))
+                                                | uu___ ->
                                                     FStar_Pervasives_Native.None
 let mk_tactic_nbe_interpretation_20 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't20 't3 't4
@@ -6491,205 +6333,202 @@ let mk_tactic_nbe_interpretation_20 :
                                               fun er ->
                                                 fun args ->
                                                   match args with
-                                                  | (a1, uu____19411)::
-                                                      (a2, uu____19413)::
-                                                      (a3, uu____19415)::
-                                                      (a4, uu____19417)::
-                                                      (a5, uu____19419)::
-                                                      (a6, uu____19421)::
-                                                      (a7, uu____19423)::
-                                                      (a8, uu____19425)::
-                                                      (a9, uu____19427)::
-                                                      (a10, uu____19429)::
-                                                      (a11, uu____19431)::
-                                                      (a12, uu____19433)::
-                                                      (a13, uu____19435)::
-                                                      (a14, uu____19437)::
-                                                      (a15, uu____19439)::
-                                                      (a16, uu____19441)::
-                                                      (a17, uu____19443)::
-                                                      (a18, uu____19445)::
-                                                      (a19, uu____19447)::
-                                                      (a20, uu____19449)::
-                                                      (a21, uu____19451)::[]
-                                                      ->
-                                                      let uu____19540 =
+                                                  | (a1, uu___)::(a2, uu___1)::
+                                                      (a3, uu___2)::(a4,
+                                                                    uu___3)::
+                                                      (a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                                      (a7, uu___6)::(a8,
+                                                                    uu___7)::
+                                                      (a9, uu___8)::(a10,
+                                                                    uu___9)::
+                                                      (a11, uu___10)::
+                                                      (a12, uu___11)::
+                                                      (a13, uu___12)::
+                                                      (a14, uu___13)::
+                                                      (a15, uu___14)::
+                                                      (a16, uu___15)::
+                                                      (a17, uu___16)::
+                                                      (a18, uu___17)::
+                                                      (a19, uu___18)::
+                                                      (a20, uu___19)::
+                                                      (a21, uu___20)::[] ->
+                                                      let uu___21 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e1 cb a1 in
                                                       FStar_Util.bind_opt
-                                                        uu____19540
+                                                        uu___21
                                                         (fun a110 ->
-                                                           let uu____19546 =
+                                                           let uu___22 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e2 cb a2 in
                                                            FStar_Util.bind_opt
-                                                             uu____19546
+                                                             uu___22
                                                              (fun a22 ->
-                                                                let uu____19552
-                                                                  =
+                                                                let uu___23 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e3 cb a3 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____19552
+                                                                  uu___23
                                                                   (fun a31 ->
-                                                                    let uu____19558
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19558
+                                                                    uu___24
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____19564
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19564
+                                                                    uu___25
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____19570
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19570
+                                                                    uu___26
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____19576
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19576
+                                                                    uu___27
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____19582
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19582
+                                                                    uu___28
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____19588
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19588
+                                                                    uu___29
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____19594
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19594
+                                                                    uu___30
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____19600
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19600
+                                                                    uu___31
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____19606
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19606
+                                                                    uu___32
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____19612
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19612
+                                                                    uu___33
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____19618
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19618
+                                                                    uu___34
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____19624
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19624
+                                                                    uu___35
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____19630
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19630
+                                                                    uu___36
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____19636
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19636
+                                                                    uu___37
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____19642
+                                                                    let uu___38
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19642
+                                                                    uu___38
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____19648
+                                                                    let uu___39
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e19 cb
                                                                     a19 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19648
+                                                                    uu___39
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____19654
+                                                                    let uu___40
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e20 cb
                                                                     a20 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19654
+                                                                    uu___40
                                                                     (fun a201
                                                                     ->
-                                                                    let uu____19660
+                                                                    let uu___41
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     FStar_Tactics_Embedding.e_proofstate_nbe
                                                                     cb a21 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____19660
+                                                                    uu___41
                                                                     (fun ps
                                                                     ->
                                                                     let r1 =
-                                                                    let uu____19670
+                                                                    let uu___42
                                                                     =
                                                                     t a110
                                                                     a22 a31
@@ -6703,20 +6542,20 @@ let mk_tactic_nbe_interpretation_20 :
                                                                     a181 a191
                                                                     a201 in
                                                                     FStar_Tactics_Monad.run_safe
-                                                                    uu____19670
+                                                                    uu___42
                                                                     ps in
-                                                                    let uu____19673
+                                                                    let uu___42
                                                                     =
-                                                                    let uu____19674
+                                                                    let uu___43
                                                                     =
                                                                     FStar_Tactics_Embedding.e_result_nbe
                                                                     er in
                                                                     FStar_TypeChecker_NBETerm.embed
-                                                                    uu____19674
+                                                                    uu___43
                                                                     cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____19673)))))))))))))))))))))
-                                                  | uu____19681 ->
+                                                                    uu___42)))))))))))))))))))))
+                                                  | uu___ ->
                                                       FStar_Pervasives_Native.None
 let mk_total_interpretation_1 :
   'r 't1 .
@@ -6735,17 +6574,16 @@ let mk_total_interpretation_1 :
           fun ncb ->
             fun args ->
               match args with
-              | (a1, uu____19748)::[] ->
-                  let uu____19773 = unembed e1 a1 ncb in
-                  FStar_Util.bind_opt uu____19773
+              | (a1, uu___)::[] ->
+                  let uu___1 = unembed e1 a1 ncb in
+                  FStar_Util.bind_opt uu___1
                     (fun a11 ->
                        let r1 = f a11 in
-                       let uu____19781 =
-                         let uu____19782 =
-                           FStar_TypeChecker_Cfg.psc_range psc in
-                         embed er uu____19782 r1 ncb in
-                       FStar_Pervasives_Native.Some uu____19781)
-              | uu____19783 -> FStar_Pervasives_Native.None
+                       let uu___2 =
+                         let uu___3 = FStar_TypeChecker_Cfg.psc_range psc in
+                         embed er uu___3 r1 ncb in
+                       FStar_Pervasives_Native.Some uu___2)
+              | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_2 :
   'r 't1 't2 .
     ('t1 -> 't2 -> 'r) ->
@@ -6765,20 +6603,20 @@ let mk_total_interpretation_2 :
             fun ncb ->
               fun args ->
                 match args with
-                | (a1, uu____19869)::(a2, uu____19871)::[] ->
-                    let uu____19912 = unembed e1 a1 ncb in
-                    FStar_Util.bind_opt uu____19912
+                | (a1, uu___)::(a2, uu___1)::[] ->
+                    let uu___2 = unembed e1 a1 ncb in
+                    FStar_Util.bind_opt uu___2
                       (fun a11 ->
-                         let uu____19918 = unembed e2 a2 ncb in
-                         FStar_Util.bind_opt uu____19918
+                         let uu___3 = unembed e2 a2 ncb in
+                         FStar_Util.bind_opt uu___3
                            (fun a21 ->
                               let r1 = f a11 a21 in
-                              let uu____19926 =
-                                let uu____19927 =
+                              let uu___4 =
+                                let uu___5 =
                                   FStar_TypeChecker_Cfg.psc_range psc in
-                                embed er uu____19927 r1 ncb in
-                              FStar_Pervasives_Native.Some uu____19926))
-                | uu____19928 -> FStar_Pervasives_Native.None
+                                embed er uu___5 r1 ncb in
+                              FStar_Pervasives_Native.Some uu___4))
+                | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_3 :
   'r 't1 't2 't3 .
     ('t1 -> 't2 -> 't3 -> 'r) ->
@@ -6800,24 +6638,23 @@ let mk_total_interpretation_3 :
               fun ncb ->
                 fun args ->
                   match args with
-                  | (a1, uu____20033)::(a2, uu____20035)::(a3, uu____20037)::[]
-                      ->
-                      let uu____20094 = unembed e1 a1 ncb in
-                      FStar_Util.bind_opt uu____20094
+                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::[] ->
+                      let uu___3 = unembed e1 a1 ncb in
+                      FStar_Util.bind_opt uu___3
                         (fun a11 ->
-                           let uu____20100 = unembed e2 a2 ncb in
-                           FStar_Util.bind_opt uu____20100
+                           let uu___4 = unembed e2 a2 ncb in
+                           FStar_Util.bind_opt uu___4
                              (fun a21 ->
-                                let uu____20106 = unembed e3 a3 ncb in
-                                FStar_Util.bind_opt uu____20106
+                                let uu___5 = unembed e3 a3 ncb in
+                                FStar_Util.bind_opt uu___5
                                   (fun a31 ->
                                      let r1 = f a11 a21 a31 in
-                                     let uu____20114 =
-                                       let uu____20115 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_TypeChecker_Cfg.psc_range psc in
-                                       embed er uu____20115 r1 ncb in
-                                     FStar_Pervasives_Native.Some uu____20114)))
-                  | uu____20116 -> FStar_Pervasives_Native.None
+                                       embed er uu___7 r1 ncb in
+                                     FStar_Pervasives_Native.Some uu___6)))
+                  | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_4 :
   'r 't1 't2 't3 't4 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 'r) ->
@@ -6841,29 +6678,29 @@ let mk_total_interpretation_4 :
                 fun ncb ->
                   fun args ->
                     match args with
-                    | (a1, uu____20240)::(a2, uu____20242)::(a3, uu____20244)::
-                        (a4, uu____20246)::[] ->
-                        let uu____20319 = unembed e1 a1 ncb in
-                        FStar_Util.bind_opt uu____20319
+                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::[]
+                        ->
+                        let uu___4 = unembed e1 a1 ncb in
+                        FStar_Util.bind_opt uu___4
                           (fun a11 ->
-                             let uu____20325 = unembed e2 a2 ncb in
-                             FStar_Util.bind_opt uu____20325
+                             let uu___5 = unembed e2 a2 ncb in
+                             FStar_Util.bind_opt uu___5
                                (fun a21 ->
-                                  let uu____20331 = unembed e3 a3 ncb in
-                                  FStar_Util.bind_opt uu____20331
+                                  let uu___6 = unembed e3 a3 ncb in
+                                  FStar_Util.bind_opt uu___6
                                     (fun a31 ->
-                                       let uu____20337 = unembed e4 a4 ncb in
-                                       FStar_Util.bind_opt uu____20337
+                                       let uu___7 = unembed e4 a4 ncb in
+                                       FStar_Util.bind_opt uu___7
                                          (fun a41 ->
                                             let r1 = f a11 a21 a31 a41 in
-                                            let uu____20345 =
-                                              let uu____20346 =
+                                            let uu___8 =
+                                              let uu___9 =
                                                 FStar_TypeChecker_Cfg.psc_range
                                                   psc in
-                                              embed er uu____20346 r1 ncb in
+                                              embed er uu___9 r1 ncb in
                                             FStar_Pervasives_Native.Some
-                                              uu____20345))))
-                    | uu____20347 -> FStar_Pervasives_Native.None
+                                              uu___8))))
+                    | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_5 :
   'r 't1 't2 't3 't4 't5 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 'r) ->
@@ -6890,36 +6727,33 @@ let mk_total_interpretation_5 :
                   fun ncb ->
                     fun args ->
                       match args with
-                      | (a1, uu____20490)::(a2, uu____20492)::(a3,
-                                                               uu____20494)::
-                          (a4, uu____20496)::(a5, uu____20498)::[] ->
-                          let uu____20587 = unembed e1 a1 ncb in
-                          FStar_Util.bind_opt uu____20587
+                      | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                          (a5, uu___4)::[] ->
+                          let uu___5 = unembed e1 a1 ncb in
+                          FStar_Util.bind_opt uu___5
                             (fun a11 ->
-                               let uu____20593 = unembed e2 a2 ncb in
-                               FStar_Util.bind_opt uu____20593
+                               let uu___6 = unembed e2 a2 ncb in
+                               FStar_Util.bind_opt uu___6
                                  (fun a21 ->
-                                    let uu____20599 = unembed e3 a3 ncb in
-                                    FStar_Util.bind_opt uu____20599
+                                    let uu___7 = unembed e3 a3 ncb in
+                                    FStar_Util.bind_opt uu___7
                                       (fun a31 ->
-                                         let uu____20605 = unembed e4 a4 ncb in
-                                         FStar_Util.bind_opt uu____20605
+                                         let uu___8 = unembed e4 a4 ncb in
+                                         FStar_Util.bind_opt uu___8
                                            (fun a41 ->
-                                              let uu____20611 =
-                                                unembed e5 a5 ncb in
-                                              FStar_Util.bind_opt uu____20611
+                                              let uu___9 = unembed e5 a5 ncb in
+                                              FStar_Util.bind_opt uu___9
                                                 (fun a51 ->
                                                    let r1 =
                                                      f a11 a21 a31 a41 a51 in
-                                                   let uu____20619 =
-                                                     let uu____20620 =
+                                                   let uu___10 =
+                                                     let uu___11 =
                                                        FStar_TypeChecker_Cfg.psc_range
                                                          psc in
-                                                     embed er uu____20620 r1
-                                                       ncb in
+                                                     embed er uu___11 r1 ncb in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____20619)))))
-                      | uu____20621 -> FStar_Pervasives_Native.None
+                                                     uu___10)))))
+                      | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_6 :
   'r 't1 't2 't3 't4 't5 't6 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 't6 -> 'r) ->
@@ -6948,47 +6782,42 @@ let mk_total_interpretation_6 :
                     fun ncb ->
                       fun args ->
                         match args with
-                        | (a1, uu____20783)::(a2, uu____20785)::(a3,
-                                                                 uu____20787)::
-                            (a4, uu____20789)::(a5, uu____20791)::(a6,
-                                                                   uu____20793)::[]
-                            ->
-                            let uu____20898 = unembed e1 a1 ncb in
-                            FStar_Util.bind_opt uu____20898
+                        | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4,
+                                                                    uu___3)::
+                            (a5, uu___4)::(a6, uu___5)::[] ->
+                            let uu___6 = unembed e1 a1 ncb in
+                            FStar_Util.bind_opt uu___6
                               (fun a11 ->
-                                 let uu____20904 = unembed e2 a2 ncb in
-                                 FStar_Util.bind_opt uu____20904
+                                 let uu___7 = unembed e2 a2 ncb in
+                                 FStar_Util.bind_opt uu___7
                                    (fun a21 ->
-                                      let uu____20910 = unembed e3 a3 ncb in
-                                      FStar_Util.bind_opt uu____20910
+                                      let uu___8 = unembed e3 a3 ncb in
+                                      FStar_Util.bind_opt uu___8
                                         (fun a31 ->
-                                           let uu____20916 =
-                                             unembed e4 a4 ncb in
-                                           FStar_Util.bind_opt uu____20916
+                                           let uu___9 = unembed e4 a4 ncb in
+                                           FStar_Util.bind_opt uu___9
                                              (fun a41 ->
-                                                let uu____20922 =
+                                                let uu___10 =
                                                   unembed e5 a5 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____20922
+                                                FStar_Util.bind_opt uu___10
                                                   (fun a51 ->
-                                                     let uu____20928 =
+                                                     let uu___11 =
                                                        unembed e6 a6 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____20928
+                                                       uu___11
                                                        (fun a61 ->
                                                           let r1 =
                                                             f a11 a21 a31 a41
                                                               a51 a61 in
-                                                          let uu____20936 =
-                                                            let uu____20937 =
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               FStar_TypeChecker_Cfg.psc_range
                                                                 psc in
-                                                            embed er
-                                                              uu____20937 r1
-                                                              ncb in
+                                                            embed er uu___13
+                                                              r1 ncb in
                                                           FStar_Pervasives_Native.Some
-                                                            uu____20936))))))
-                        | uu____20938 -> FStar_Pervasives_Native.None
+                                                            uu___12))))))
+                        | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_7 :
   'r 't1 't2 't3 't4 't5 't6 't7 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 't6 -> 't7 -> 'r) ->
@@ -7019,57 +6848,53 @@ let mk_total_interpretation_7 :
                       fun ncb ->
                         fun args ->
                           match args with
-                          | (a1, uu____21119)::(a2, uu____21121)::(a3,
-                                                                   uu____21123)::
-                              (a4, uu____21125)::(a5, uu____21127)::(a6,
-                                                                    uu____21129)::
-                              (a7, uu____21131)::[] ->
-                              let uu____21252 = unembed e1 a1 ncb in
-                              FStar_Util.bind_opt uu____21252
+                          | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                              (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                              (a7, uu___6)::[] ->
+                              let uu___7 = unembed e1 a1 ncb in
+                              FStar_Util.bind_opt uu___7
                                 (fun a11 ->
-                                   let uu____21258 = unembed e2 a2 ncb in
-                                   FStar_Util.bind_opt uu____21258
+                                   let uu___8 = unembed e2 a2 ncb in
+                                   FStar_Util.bind_opt uu___8
                                      (fun a21 ->
-                                        let uu____21264 = unembed e3 a3 ncb in
-                                        FStar_Util.bind_opt uu____21264
+                                        let uu___9 = unembed e3 a3 ncb in
+                                        FStar_Util.bind_opt uu___9
                                           (fun a31 ->
-                                             let uu____21270 =
-                                               unembed e4 a4 ncb in
-                                             FStar_Util.bind_opt uu____21270
+                                             let uu___10 = unembed e4 a4 ncb in
+                                             FStar_Util.bind_opt uu___10
                                                (fun a41 ->
-                                                  let uu____21276 =
+                                                  let uu___11 =
                                                     unembed e5 a5 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____21276
+                                                  FStar_Util.bind_opt uu___11
                                                     (fun a51 ->
-                                                       let uu____21282 =
+                                                       let uu___12 =
                                                          unembed e6 a6 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____21282
+                                                         uu___12
                                                          (fun a61 ->
-                                                            let uu____21288 =
+                                                            let uu___13 =
                                                               unembed e7 a7
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____21288
+                                                              uu___13
                                                               (fun a71 ->
                                                                  let r1 =
                                                                    f a11 a21
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 in
-                                                                 let uu____21296
+                                                                 let uu___14
                                                                    =
-                                                                   let uu____21297
+                                                                   let uu___15
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                    embed er
-                                                                    uu____21297
+                                                                    uu___15
                                                                     r1 ncb in
                                                                  FStar_Pervasives_Native.Some
-                                                                   uu____21296)))))))
-                          | uu____21298 -> FStar_Pervasives_Native.None
+                                                                   uu___14)))))))
+                          | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_8 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 't6 -> 't7 -> 't8 -> 'r) ->
@@ -7102,48 +6927,44 @@ let mk_total_interpretation_8 :
                         fun ncb ->
                           fun args ->
                             match args with
-                            | (a1, uu____21498)::(a2, uu____21500)::(a3,
-                                                                    uu____21502)::
-                                (a4, uu____21504)::(a5, uu____21506)::
-                                (a6, uu____21508)::(a7, uu____21510)::
-                                (a8, uu____21512)::[] ->
-                                let uu____21649 = unembed e1 a1 ncb in
-                                FStar_Util.bind_opt uu____21649
+                            | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                (a7, uu___6)::(a8, uu___7)::[] ->
+                                let uu___8 = unembed e1 a1 ncb in
+                                FStar_Util.bind_opt uu___8
                                   (fun a11 ->
-                                     let uu____21655 = unembed e2 a2 ncb in
-                                     FStar_Util.bind_opt uu____21655
+                                     let uu___9 = unembed e2 a2 ncb in
+                                     FStar_Util.bind_opt uu___9
                                        (fun a21 ->
-                                          let uu____21661 = unembed e3 a3 ncb in
-                                          FStar_Util.bind_opt uu____21661
+                                          let uu___10 = unembed e3 a3 ncb in
+                                          FStar_Util.bind_opt uu___10
                                             (fun a31 ->
-                                               let uu____21667 =
+                                               let uu___11 =
                                                  unembed e4 a4 ncb in
-                                               FStar_Util.bind_opt
-                                                 uu____21667
+                                               FStar_Util.bind_opt uu___11
                                                  (fun a41 ->
-                                                    let uu____21673 =
+                                                    let uu___12 =
                                                       unembed e5 a5 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____21673
+                                                      uu___12
                                                       (fun a51 ->
-                                                         let uu____21679 =
+                                                         let uu___13 =
                                                            unembed e6 a6 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____21679
+                                                           uu___13
                                                            (fun a61 ->
-                                                              let uu____21685
-                                                                =
+                                                              let uu___14 =
                                                                 unembed e7 a7
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____21685
+                                                                uu___14
                                                                 (fun a71 ->
-                                                                   let uu____21691
+                                                                   let uu___15
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____21691
+                                                                    uu___15
                                                                     (fun a81
                                                                     ->
                                                                     let r1 =
@@ -7151,18 +6972,18 @@ let mk_total_interpretation_8 :
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 a81 in
-                                                                    let uu____21699
+                                                                    let uu___16
                                                                     =
-                                                                    let uu____21700
+                                                                    let uu___17
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____21700
+                                                                    uu___17
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____21699))))))))
-                            | uu____21701 -> FStar_Pervasives_Native.None
+                                                                    uu___16))))))))
+                            | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_9 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 -> 't2 -> 't3 -> 't4 -> 't5 -> 't6 -> 't7 -> 't8 -> 't9 -> 'r) ->
@@ -7197,58 +7018,54 @@ let mk_total_interpretation_9 :
                           fun ncb ->
                             fun args ->
                               match args with
-                              | (a1, uu____21920)::(a2, uu____21922)::
-                                  (a3, uu____21924)::(a4, uu____21926)::
-                                  (a5, uu____21928)::(a6, uu____21930)::
-                                  (a7, uu____21932)::(a8, uu____21934)::
-                                  (a9, uu____21936)::[] ->
-                                  let uu____22089 = unembed e1 a1 ncb in
-                                  FStar_Util.bind_opt uu____22089
+                              | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                  (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                  (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::[]
+                                  ->
+                                  let uu___9 = unembed e1 a1 ncb in
+                                  FStar_Util.bind_opt uu___9
                                     (fun a11 ->
-                                       let uu____22095 = unembed e2 a2 ncb in
-                                       FStar_Util.bind_opt uu____22095
+                                       let uu___10 = unembed e2 a2 ncb in
+                                       FStar_Util.bind_opt uu___10
                                          (fun a21 ->
-                                            let uu____22101 =
-                                              unembed e3 a3 ncb in
-                                            FStar_Util.bind_opt uu____22101
+                                            let uu___11 = unembed e3 a3 ncb in
+                                            FStar_Util.bind_opt uu___11
                                               (fun a31 ->
-                                                 let uu____22107 =
+                                                 let uu___12 =
                                                    unembed e4 a4 ncb in
-                                                 FStar_Util.bind_opt
-                                                   uu____22107
+                                                 FStar_Util.bind_opt uu___12
                                                    (fun a41 ->
-                                                      let uu____22113 =
+                                                      let uu___13 =
                                                         unembed e5 a5 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____22113
+                                                        uu___13
                                                         (fun a51 ->
-                                                           let uu____22119 =
+                                                           let uu___14 =
                                                              unembed e6 a6
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____22119
+                                                             uu___14
                                                              (fun a61 ->
-                                                                let uu____22125
-                                                                  =
+                                                                let uu___15 =
                                                                   unembed e7
                                                                     a7 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____22125
+                                                                  uu___15
                                                                   (fun a71 ->
-                                                                    let uu____22131
+                                                                    let uu___16
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____22131
+                                                                    uu___16
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____22137
+                                                                    let uu___17
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____22137
+                                                                    uu___17
                                                                     (fun a91
                                                                     ->
                                                                     let r1 =
@@ -7257,18 +7074,18 @@ let mk_total_interpretation_9 :
                                                                     a51 a61
                                                                     a71 a81
                                                                     a91 in
-                                                                    let uu____22145
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____22146
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____22146
+                                                                    uu___19
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____22145)))))))))
-                              | uu____22147 -> FStar_Pervasives_Native.None
+                                                                    uu___18)))))))))
+                              | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_10 :
   'r 't1 't10 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -7307,71 +7124,67 @@ let mk_total_interpretation_10 :
                             fun ncb ->
                               fun args ->
                                 match args with
-                                | (a1, uu____22385)::(a2, uu____22387)::
-                                    (a3, uu____22389)::(a4, uu____22391)::
-                                    (a5, uu____22393)::(a6, uu____22395)::
-                                    (a7, uu____22397)::(a8, uu____22399)::
-                                    (a9, uu____22401)::(a10, uu____22403)::[]
-                                    ->
-                                    let uu____22572 = unembed e1 a1 ncb in
-                                    FStar_Util.bind_opt uu____22572
+                                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                    (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                    (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                    (a10, uu___9)::[] ->
+                                    let uu___10 = unembed e1 a1 ncb in
+                                    FStar_Util.bind_opt uu___10
                                       (fun a11 ->
-                                         let uu____22578 = unembed e2 a2 ncb in
-                                         FStar_Util.bind_opt uu____22578
+                                         let uu___11 = unembed e2 a2 ncb in
+                                         FStar_Util.bind_opt uu___11
                                            (fun a21 ->
-                                              let uu____22584 =
-                                                unembed e3 a3 ncb in
-                                              FStar_Util.bind_opt uu____22584
+                                              let uu___12 = unembed e3 a3 ncb in
+                                              FStar_Util.bind_opt uu___12
                                                 (fun a31 ->
-                                                   let uu____22590 =
+                                                   let uu___13 =
                                                      unembed e4 a4 ncb in
                                                    FStar_Util.bind_opt
-                                                     uu____22590
+                                                     uu___13
                                                      (fun a41 ->
-                                                        let uu____22596 =
+                                                        let uu___14 =
                                                           unembed e5 a5 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____22596
+                                                          uu___14
                                                           (fun a51 ->
-                                                             let uu____22602
-                                                               =
+                                                             let uu___15 =
                                                                unembed e6 a6
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____22602
+                                                               uu___15
                                                                (fun a61 ->
-                                                                  let uu____22608
+                                                                  let uu___16
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____22608
+                                                                    uu___16
                                                                     (
                                                                     fun a71
                                                                     ->
-                                                                    let uu____22614
+                                                                    let uu___17
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____22614
+                                                                    uu___17
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____22620
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____22620
+                                                                    uu___18
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____22626
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____22626
+                                                                    uu___19
                                                                     (fun a101
                                                                     ->
                                                                     let r1 =
@@ -7380,18 +7193,18 @@ let mk_total_interpretation_10 :
                                                                     a51 a61
                                                                     a71 a81
                                                                     a91 a101 in
-                                                                    let uu____22634
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____22635
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____22635
+                                                                    uu___21
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____22634))))))))))
-                                | uu____22636 -> FStar_Pervasives_Native.None
+                                                                    uu___20))))))))))
+                                | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_11 :
   'r 't1 't10 't11 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -7433,81 +7246,78 @@ let mk_total_interpretation_11 :
                               fun ncb ->
                                 fun args ->
                                   match args with
-                                  | (a1, uu____22893)::(a2, uu____22895)::
-                                      (a3, uu____22897)::(a4, uu____22899)::
-                                      (a5, uu____22901)::(a6, uu____22903)::
-                                      (a7, uu____22905)::(a8, uu____22907)::
-                                      (a9, uu____22909)::(a10, uu____22911)::
-                                      (a11, uu____22913)::[] ->
-                                      let uu____23098 = unembed e1 a1 ncb in
-                                      FStar_Util.bind_opt uu____23098
+                                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                      (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                      (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                   uu___8)::
+                                      (a10, uu___9)::(a11, uu___10)::[] ->
+                                      let uu___11 = unembed e1 a1 ncb in
+                                      FStar_Util.bind_opt uu___11
                                         (fun a12 ->
-                                           let uu____23104 =
-                                             unembed e2 a2 ncb in
-                                           FStar_Util.bind_opt uu____23104
+                                           let uu___12 = unembed e2 a2 ncb in
+                                           FStar_Util.bind_opt uu___12
                                              (fun a21 ->
-                                                let uu____23110 =
+                                                let uu___13 =
                                                   unembed e3 a3 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____23110
+                                                FStar_Util.bind_opt uu___13
                                                   (fun a31 ->
-                                                     let uu____23116 =
+                                                     let uu___14 =
                                                        unembed e4 a4 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____23116
+                                                       uu___14
                                                        (fun a41 ->
-                                                          let uu____23122 =
+                                                          let uu___15 =
                                                             unembed e5 a5 ncb in
                                                           FStar_Util.bind_opt
-                                                            uu____23122
+                                                            uu___15
                                                             (fun a51 ->
-                                                               let uu____23128
-                                                                 =
+                                                               let uu___16 =
                                                                  unembed e6
                                                                    a6 ncb in
                                                                FStar_Util.bind_opt
-                                                                 uu____23128
+                                                                 uu___16
                                                                  (fun a61 ->
-                                                                    let uu____23134
+                                                                    let uu___17
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23134
+                                                                    uu___17
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____23140
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23140
+                                                                    uu___18
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____23146
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23146
+                                                                    uu___19
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____23152
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23152
+                                                                    uu___20
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____23158
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23158
+                                                                    uu___21
                                                                     (fun a111
                                                                     ->
                                                                     let r1 =
@@ -7517,19 +7327,18 @@ let mk_total_interpretation_11 :
                                                                     a71 a81
                                                                     a91 a101
                                                                     a111 in
-                                                                    let uu____23166
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____23167
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____23167
+                                                                    uu___23
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____23166)))))))))))
-                                  | uu____23168 ->
-                                      FStar_Pervasives_Native.None
+                                                                    uu___22)))))))))))
+                                  | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_12 :
   'r 't1 't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -7575,94 +7384,91 @@ let mk_total_interpretation_12 :
                                 fun ncb ->
                                   fun args ->
                                     match args with
-                                    | (a1, uu____23444)::(a2, uu____23446)::
-                                        (a3, uu____23448)::(a4, uu____23450)::
-                                        (a5, uu____23452)::(a6, uu____23454)::
-                                        (a7, uu____23456)::(a8, uu____23458)::
-                                        (a9, uu____23460)::(a10, uu____23462)::
-                                        (a11, uu____23464)::(a12,
-                                                             uu____23466)::[]
-                                        ->
-                                        let uu____23667 = unembed e1 a1 ncb in
-                                        FStar_Util.bind_opt uu____23667
+                                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                        (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                        (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                    uu___8)::
+                                        (a10, uu___9)::(a11, uu___10)::
+                                        (a12, uu___11)::[] ->
+                                        let uu___12 = unembed e1 a1 ncb in
+                                        FStar_Util.bind_opt uu___12
                                           (fun a13 ->
-                                             let uu____23673 =
-                                               unembed e2 a2 ncb in
-                                             FStar_Util.bind_opt uu____23673
+                                             let uu___13 = unembed e2 a2 ncb in
+                                             FStar_Util.bind_opt uu___13
                                                (fun a21 ->
-                                                  let uu____23679 =
+                                                  let uu___14 =
                                                     unembed e3 a3 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____23679
+                                                  FStar_Util.bind_opt uu___14
                                                     (fun a31 ->
-                                                       let uu____23685 =
+                                                       let uu___15 =
                                                          unembed e4 a4 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____23685
+                                                         uu___15
                                                          (fun a41 ->
-                                                            let uu____23691 =
+                                                            let uu___16 =
                                                               unembed e5 a5
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____23691
+                                                              uu___16
                                                               (fun a51 ->
-                                                                 let uu____23697
+                                                                 let uu___17
                                                                    =
                                                                    unembed e6
                                                                     a6 ncb in
                                                                  FStar_Util.bind_opt
-                                                                   uu____23697
+                                                                   uu___17
                                                                    (fun a61
                                                                     ->
-                                                                    let uu____23703
+                                                                    let uu___18
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23703
+                                                                    uu___18
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____23709
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23709
+                                                                    uu___19
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____23715
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23715
+                                                                    uu___20
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____23721
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23721
+                                                                    uu___21
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____23727
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23727
+                                                                    uu___22
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____23733
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____23733
+                                                                    uu___23
                                                                     (fun a121
                                                                     ->
                                                                     let r1 =
@@ -7672,19 +7478,18 @@ let mk_total_interpretation_12 :
                                                                     a71 a81
                                                                     a91 a101
                                                                     a111 a121 in
-                                                                    let uu____23741
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____23742
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____23742
+                                                                    uu___25
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____23741))))))))))))
-                                    | uu____23743 ->
-                                        FStar_Pervasives_Native.None
+                                                                    uu___24))))))))))))
+                                    | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_13 :
   'r 't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -7733,109 +7538,103 @@ let mk_total_interpretation_13 :
                                   fun ncb ->
                                     fun args ->
                                       match args with
-                                      | (a1, uu____24038)::(a2, uu____24040)::
-                                          (a3, uu____24042)::(a4,
-                                                              uu____24044)::
-                                          (a5, uu____24046)::(a6,
-                                                              uu____24048)::
-                                          (a7, uu____24050)::(a8,
-                                                              uu____24052)::
-                                          (a9, uu____24054)::(a10,
-                                                              uu____24056)::
-                                          (a11, uu____24058)::(a12,
-                                                               uu____24060)::
-                                          (a13, uu____24062)::[] ->
-                                          let uu____24279 = unembed e1 a1 ncb in
-                                          FStar_Util.bind_opt uu____24279
+                                      | (a1, uu___)::(a2, uu___1)::(a3,
+                                                                    uu___2)::
+                                          (a4, uu___3)::(a5, uu___4)::
+                                          (a6, uu___5)::(a7, uu___6)::
+                                          (a8, uu___7)::(a9, uu___8)::
+                                          (a10, uu___9)::(a11, uu___10)::
+                                          (a12, uu___11)::(a13, uu___12)::[]
+                                          ->
+                                          let uu___13 = unembed e1 a1 ncb in
+                                          FStar_Util.bind_opt uu___13
                                             (fun a14 ->
-                                               let uu____24285 =
+                                               let uu___14 =
                                                  unembed e2 a2 ncb in
-                                               FStar_Util.bind_opt
-                                                 uu____24285
+                                               FStar_Util.bind_opt uu___14
                                                  (fun a21 ->
-                                                    let uu____24291 =
+                                                    let uu___15 =
                                                       unembed e3 a3 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____24291
+                                                      uu___15
                                                       (fun a31 ->
-                                                         let uu____24297 =
+                                                         let uu___16 =
                                                            unembed e4 a4 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____24297
+                                                           uu___16
                                                            (fun a41 ->
-                                                              let uu____24303
-                                                                =
+                                                              let uu___17 =
                                                                 unembed e5 a5
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____24303
+                                                                uu___17
                                                                 (fun a51 ->
-                                                                   let uu____24309
+                                                                   let uu___18
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____24309
+                                                                    uu___18
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____24315
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24315
+                                                                    uu___19
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____24321
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24321
+                                                                    uu___20
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____24327
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24327
+                                                                    uu___21
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____24333
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24333
+                                                                    uu___22
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____24339
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24339
+                                                                    uu___23
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____24345
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24345
+                                                                    uu___24
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____24351
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24351
+                                                                    uu___25
                                                                     (fun a131
                                                                     ->
                                                                     let r1 =
@@ -7846,19 +7645,18 @@ let mk_total_interpretation_13 :
                                                                     a91 a101
                                                                     a111 a121
                                                                     a131 in
-                                                                    let uu____24359
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____24360
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____24360
+                                                                    uu___27
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____24359)))))))))))))
-                                      | uu____24361 ->
-                                          FStar_Pervasives_Native.None
+                                                                    uu___26)))))))))))))
+                                      | uu___ -> FStar_Pervasives_Native.None
 let mk_total_interpretation_14 :
   'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
     ('t1 ->
@@ -7911,123 +7709,113 @@ let mk_total_interpretation_14 :
                                     fun ncb ->
                                       fun args ->
                                         match args with
-                                        | (a1, uu____24675)::(a2,
-                                                              uu____24677)::
-                                            (a3, uu____24679)::(a4,
-                                                                uu____24681)::
-                                            (a5, uu____24683)::(a6,
-                                                                uu____24685)::
-                                            (a7, uu____24687)::(a8,
-                                                                uu____24689)::
-                                            (a9, uu____24691)::(a10,
-                                                                uu____24693)::
-                                            (a11, uu____24695)::(a12,
-                                                                 uu____24697)::
-                                            (a13, uu____24699)::(a14,
-                                                                 uu____24701)::[]
+                                        | (a1, uu___)::(a2, uu___1)::
+                                            (a3, uu___2)::(a4, uu___3)::
+                                            (a5, uu___4)::(a6, uu___5)::
+                                            (a7, uu___6)::(a8, uu___7)::
+                                            (a9, uu___8)::(a10, uu___9)::
+                                            (a11, uu___10)::(a12, uu___11)::
+                                            (a13, uu___12)::(a14, uu___13)::[]
                                             ->
-                                            let uu____24934 =
-                                              unembed e1 a1 ncb in
-                                            FStar_Util.bind_opt uu____24934
+                                            let uu___14 = unembed e1 a1 ncb in
+                                            FStar_Util.bind_opt uu___14
                                               (fun a15 ->
-                                                 let uu____24940 =
+                                                 let uu___15 =
                                                    unembed e2 a2 ncb in
-                                                 FStar_Util.bind_opt
-                                                   uu____24940
+                                                 FStar_Util.bind_opt uu___15
                                                    (fun a21 ->
-                                                      let uu____24946 =
+                                                      let uu___16 =
                                                         unembed e3 a3 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____24946
+                                                        uu___16
                                                         (fun a31 ->
-                                                           let uu____24952 =
+                                                           let uu___17 =
                                                              unembed e4 a4
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____24952
+                                                             uu___17
                                                              (fun a41 ->
-                                                                let uu____24958
-                                                                  =
+                                                                let uu___18 =
                                                                   unembed e5
                                                                     a5 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____24958
+                                                                  uu___18
                                                                   (fun a51 ->
-                                                                    let uu____24964
+                                                                    let uu___19
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24964
+                                                                    uu___19
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____24970
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24970
+                                                                    uu___20
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____24976
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24976
+                                                                    uu___21
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____24982
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24982
+                                                                    uu___22
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____24988
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24988
+                                                                    uu___23
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____24994
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____24994
+                                                                    uu___24
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____25000
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25000
+                                                                    uu___25
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____25006
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25006
+                                                                    uu___26
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____25012
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25012
+                                                                    uu___27
                                                                     (fun a141
                                                                     ->
                                                                     let r1 =
@@ -8038,18 +7826,18 @@ let mk_total_interpretation_14 :
                                                                     a91 a101
                                                                     a111 a121
                                                                     a131 a141 in
-                                                                    let uu____25020
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____25021
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____25021
+                                                                    uu___29
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____25020))))))))))))))
-                                        | uu____25022 ->
+                                                                    uu___28))))))))))))))
+                                        | uu___ ->
                                             FStar_Pervasives_Native.None
 let mk_total_interpretation_15 :
   'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -8107,135 +7895,126 @@ let mk_total_interpretation_15 :
                                       fun ncb ->
                                         fun args ->
                                           match args with
-                                          | (a1, uu____25355)::(a2,
-                                                                uu____25357)::
-                                              (a3, uu____25359)::(a4,
-                                                                  uu____25361)::
-                                              (a5, uu____25363)::(a6,
-                                                                  uu____25365)::
-                                              (a7, uu____25367)::(a8,
-                                                                  uu____25369)::
-                                              (a9, uu____25371)::(a10,
-                                                                  uu____25373)::
-                                              (a11, uu____25375)::(a12,
-                                                                   uu____25377)::
-                                              (a13, uu____25379)::(a14,
-                                                                   uu____25381)::
-                                              (a15, uu____25383)::[] ->
-                                              let uu____25632 =
-                                                unembed e1 a1 ncb in
-                                              FStar_Util.bind_opt uu____25632
+                                          | (a1, uu___)::(a2, uu___1)::
+                                              (a3, uu___2)::(a4, uu___3)::
+                                              (a5, uu___4)::(a6, uu___5)::
+                                              (a7, uu___6)::(a8, uu___7)::
+                                              (a9, uu___8)::(a10, uu___9)::
+                                              (a11, uu___10)::(a12, uu___11)::
+                                              (a13, uu___12)::(a14, uu___13)::
+                                              (a15, uu___14)::[] ->
+                                              let uu___15 = unembed e1 a1 ncb in
+                                              FStar_Util.bind_opt uu___15
                                                 (fun a16 ->
-                                                   let uu____25638 =
+                                                   let uu___16 =
                                                      unembed e2 a2 ncb in
                                                    FStar_Util.bind_opt
-                                                     uu____25638
+                                                     uu___16
                                                      (fun a21 ->
-                                                        let uu____25644 =
+                                                        let uu___17 =
                                                           unembed e3 a3 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____25644
+                                                          uu___17
                                                           (fun a31 ->
-                                                             let uu____25650
-                                                               =
+                                                             let uu___18 =
                                                                unembed e4 a4
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____25650
+                                                               uu___18
                                                                (fun a41 ->
-                                                                  let uu____25656
+                                                                  let uu___19
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____25656
+                                                                    uu___19
                                                                     (
                                                                     fun a51
                                                                     ->
-                                                                    let uu____25662
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25662
+                                                                    uu___20
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____25668
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25668
+                                                                    uu___21
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____25674
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25674
+                                                                    uu___22
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____25680
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25680
+                                                                    uu___23
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____25686
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25686
+                                                                    uu___24
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____25692
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25692
+                                                                    uu___25
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____25698
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25698
+                                                                    uu___26
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____25704
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25704
+                                                                    uu___27
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____25710
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25710
+                                                                    uu___28
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____25716
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____25716
+                                                                    uu___29
                                                                     (fun a151
                                                                     ->
                                                                     let r1 =
@@ -8247,18 +8026,18 @@ let mk_total_interpretation_15 :
                                                                     a111 a121
                                                                     a131 a141
                                                                     a151 in
-                                                                    let uu____25724
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____25725
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____25725
+                                                                    uu___31
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____25724)))))))))))))))
-                                          | uu____25726 ->
+                                                                    uu___30)))))))))))))))
+                                          | uu___ ->
                                               FStar_Pervasives_Native.None
 let mk_total_interpretation_16 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -8319,146 +8098,139 @@ let mk_total_interpretation_16 :
                                         fun ncb ->
                                           fun args ->
                                             match args with
-                                            | (a1, uu____26078)::(a2,
-                                                                  uu____26080)::
-                                                (a3, uu____26082)::(a4,
-                                                                    uu____26084)::
-                                                (a5, uu____26086)::(a6,
-                                                                    uu____26088)::
-                                                (a7, uu____26090)::(a8,
-                                                                    uu____26092)::
-                                                (a9, uu____26094)::(a10,
-                                                                    uu____26096)::
-                                                (a11, uu____26098)::(a12,
-                                                                    uu____26100)::
-                                                (a13, uu____26102)::(a14,
-                                                                    uu____26104)::
-                                                (a15, uu____26106)::(a16,
-                                                                    uu____26108)::[]
+                                            | (a1, uu___)::(a2, uu___1)::
+                                                (a3, uu___2)::(a4, uu___3)::
+                                                (a5, uu___4)::(a6, uu___5)::
+                                                (a7, uu___6)::(a8, uu___7)::
+                                                (a9, uu___8)::(a10, uu___9)::
+                                                (a11, uu___10)::(a12,
+                                                                 uu___11)::
+                                                (a13, uu___12)::(a14,
+                                                                 uu___13)::
+                                                (a15, uu___14)::(a16,
+                                                                 uu___15)::[]
                                                 ->
-                                                let uu____26373 =
+                                                let uu___16 =
                                                   unembed e1 a1 ncb in
-                                                FStar_Util.bind_opt
-                                                  uu____26373
+                                                FStar_Util.bind_opt uu___16
                                                   (fun a17 ->
-                                                     let uu____26379 =
+                                                     let uu___17 =
                                                        unembed e2 a2 ncb in
                                                      FStar_Util.bind_opt
-                                                       uu____26379
+                                                       uu___17
                                                        (fun a21 ->
-                                                          let uu____26385 =
+                                                          let uu___18 =
                                                             unembed e3 a3 ncb in
                                                           FStar_Util.bind_opt
-                                                            uu____26385
+                                                            uu___18
                                                             (fun a31 ->
-                                                               let uu____26391
-                                                                 =
+                                                               let uu___19 =
                                                                  unembed e4
                                                                    a4 ncb in
                                                                FStar_Util.bind_opt
-                                                                 uu____26391
+                                                                 uu___19
                                                                  (fun a41 ->
-                                                                    let uu____26397
+                                                                    let uu___20
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26397
+                                                                    uu___20
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____26403
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26403
+                                                                    uu___21
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____26409
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26409
+                                                                    uu___22
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____26415
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26415
+                                                                    uu___23
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____26421
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26421
+                                                                    uu___24
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____26427
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26427
+                                                                    uu___25
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____26433
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26433
+                                                                    uu___26
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____26439
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26439
+                                                                    uu___27
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____26445
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26445
+                                                                    uu___28
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____26451
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26451
+                                                                    uu___29
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____26457
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26457
+                                                                    uu___30
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____26463
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____26463
+                                                                    uu___31
                                                                     (fun a161
                                                                     ->
                                                                     let r1 =
@@ -8470,18 +8242,18 @@ let mk_total_interpretation_16 :
                                                                     a111 a121
                                                                     a131 a141
                                                                     a151 a161 in
-                                                                    let uu____26471
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____26472
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____26472
+                                                                    uu___33
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____26471))))))))))))))))
-                                            | uu____26473 ->
+                                                                    uu___32))))))))))))))))
+                                            | uu___ ->
                                                 FStar_Pervasives_Native.None
 let mk_total_interpretation_17 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't2 't3 't4 't5 't6 't7 't8
@@ -8549,157 +8321,151 @@ let mk_total_interpretation_17 :
                                           fun ncb ->
                                             fun args ->
                                               match args with
-                                              | (a1, uu____26844)::(a2,
-                                                                    uu____26846)::
-                                                  (a3, uu____26848)::
-                                                  (a4, uu____26850)::
-                                                  (a5, uu____26852)::
-                                                  (a6, uu____26854)::
-                                                  (a7, uu____26856)::
-                                                  (a8, uu____26858)::
-                                                  (a9, uu____26860)::
-                                                  (a10, uu____26862)::
-                                                  (a11, uu____26864)::
-                                                  (a12, uu____26866)::
-                                                  (a13, uu____26868)::
-                                                  (a14, uu____26870)::
-                                                  (a15, uu____26872)::
-                                                  (a16, uu____26874)::
-                                                  (a17, uu____26876)::[] ->
-                                                  let uu____27157 =
+                                              | (a1, uu___)::(a2, uu___1)::
+                                                  (a3, uu___2)::(a4, uu___3)::
+                                                  (a5, uu___4)::(a6, uu___5)::
+                                                  (a7, uu___6)::(a8, uu___7)::
+                                                  (a9, uu___8)::(a10, uu___9)::
+                                                  (a11, uu___10)::(a12,
+                                                                   uu___11)::
+                                                  (a13, uu___12)::(a14,
+                                                                   uu___13)::
+                                                  (a15, uu___14)::(a16,
+                                                                   uu___15)::
+                                                  (a17, uu___16)::[] ->
+                                                  let uu___17 =
                                                     unembed e1 a1 ncb in
-                                                  FStar_Util.bind_opt
-                                                    uu____27157
+                                                  FStar_Util.bind_opt uu___17
                                                     (fun a18 ->
-                                                       let uu____27163 =
+                                                       let uu___18 =
                                                          unembed e2 a2 ncb in
                                                        FStar_Util.bind_opt
-                                                         uu____27163
+                                                         uu___18
                                                          (fun a21 ->
-                                                            let uu____27169 =
+                                                            let uu___19 =
                                                               unembed e3 a3
                                                                 ncb in
                                                             FStar_Util.bind_opt
-                                                              uu____27169
+                                                              uu___19
                                                               (fun a31 ->
-                                                                 let uu____27175
+                                                                 let uu___20
                                                                    =
                                                                    unembed e4
                                                                     a4 ncb in
                                                                  FStar_Util.bind_opt
-                                                                   uu____27175
+                                                                   uu___20
                                                                    (fun a41
                                                                     ->
-                                                                    let uu____27181
+                                                                    let uu___21
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27181
+                                                                    uu___21
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____27187
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27187
+                                                                    uu___22
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____27193
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27193
+                                                                    uu___23
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____27199
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27199
+                                                                    uu___24
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____27205
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27205
+                                                                    uu___25
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____27211
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27211
+                                                                    uu___26
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____27217
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27217
+                                                                    uu___27
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____27223
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27223
+                                                                    uu___28
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____27229
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27229
+                                                                    uu___29
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____27235
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27235
+                                                                    uu___30
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____27241
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27241
+                                                                    uu___31
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____27247
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27247
+                                                                    uu___32
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____27253
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____27253
+                                                                    uu___33
                                                                     (fun a171
                                                                     ->
                                                                     let r1 =
@@ -8712,18 +8478,18 @@ let mk_total_interpretation_17 :
                                                                     a131 a141
                                                                     a151 a161
                                                                     a171 in
-                                                                    let uu____27261
+                                                                    let uu___34
                                                                     =
-                                                                    let uu____27262
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____27262
+                                                                    uu___35
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____27261)))))))))))))))))
-                                              | uu____27263 ->
+                                                                    uu___34)))))))))))))))))
+                                              | uu___ ->
                                                   FStar_Pervasives_Native.None
 let mk_total_interpretation_18 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't2 't3 't4 't5 't6 't7
@@ -8798,168 +8564,167 @@ let mk_total_interpretation_18 :
                                             fun ncb ->
                                               fun args ->
                                                 match args with
-                                                | (a1, uu____27653)::
-                                                    (a2, uu____27655)::
-                                                    (a3, uu____27657)::
-                                                    (a4, uu____27659)::
-                                                    (a5, uu____27661)::
-                                                    (a6, uu____27663)::
-                                                    (a7, uu____27665)::
-                                                    (a8, uu____27667)::
-                                                    (a9, uu____27669)::
-                                                    (a10, uu____27671)::
-                                                    (a11, uu____27673)::
-                                                    (a12, uu____27675)::
-                                                    (a13, uu____27677)::
-                                                    (a14, uu____27679)::
-                                                    (a15, uu____27681)::
-                                                    (a16, uu____27683)::
-                                                    (a17, uu____27685)::
-                                                    (a18, uu____27687)::[] ->
-                                                    let uu____27984 =
+                                                | (a1, uu___)::(a2, uu___1)::
+                                                    (a3, uu___2)::(a4,
+                                                                   uu___3)::
+                                                    (a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                                    (a7, uu___6)::(a8,
+                                                                   uu___7)::
+                                                    (a9, uu___8)::(a10,
+                                                                   uu___9)::
+                                                    (a11, uu___10)::(a12,
+                                                                    uu___11)::
+                                                    (a13, uu___12)::(a14,
+                                                                    uu___13)::
+                                                    (a15, uu___14)::(a16,
+                                                                    uu___15)::
+                                                    (a17, uu___16)::(a18,
+                                                                    uu___17)::[]
+                                                    ->
+                                                    let uu___18 =
                                                       unembed e1 a1 ncb in
                                                     FStar_Util.bind_opt
-                                                      uu____27984
+                                                      uu___18
                                                       (fun a19 ->
-                                                         let uu____27990 =
+                                                         let uu___19 =
                                                            unembed e2 a2 ncb in
                                                          FStar_Util.bind_opt
-                                                           uu____27990
+                                                           uu___19
                                                            (fun a21 ->
-                                                              let uu____27996
-                                                                =
+                                                              let uu___20 =
                                                                 unembed e3 a3
                                                                   ncb in
                                                               FStar_Util.bind_opt
-                                                                uu____27996
+                                                                uu___20
                                                                 (fun a31 ->
-                                                                   let uu____28002
+                                                                   let uu___21
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                    FStar_Util.bind_opt
-                                                                    uu____28002
+                                                                    uu___21
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____28008
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28008
+                                                                    uu___22
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____28014
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28014
+                                                                    uu___23
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____28020
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28020
+                                                                    uu___24
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____28026
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28026
+                                                                    uu___25
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____28032
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28032
+                                                                    uu___26
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____28038
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28038
+                                                                    uu___27
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____28044
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28044
+                                                                    uu___28
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____28050
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28050
+                                                                    uu___29
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____28056
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28056
+                                                                    uu___30
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____28062
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28062
+                                                                    uu___31
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____28068
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28068
+                                                                    uu___32
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____28074
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28074
+                                                                    uu___33
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____28080
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28080
+                                                                    uu___34
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____28086
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28086
+                                                                    uu___35
                                                                     (fun a181
                                                                     ->
                                                                     let r1 =
@@ -8972,18 +8737,18 @@ let mk_total_interpretation_18 :
                                                                     a131 a141
                                                                     a151 a161
                                                                     a171 a181 in
-                                                                    let uu____28094
+                                                                    let uu___36
                                                                     =
-                                                                    let uu____28095
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____28095
+                                                                    uu___37
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____28094))))))))))))))))))
-                                                | uu____28096 ->
+                                                                    uu___36))))))))))))))))))
+                                                | uu___ ->
                                                     FStar_Pervasives_Native.None
 let mk_total_interpretation_19 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't3 't4 't5
@@ -9063,180 +8828,177 @@ let mk_total_interpretation_19 :
                                               fun ncb ->
                                                 fun args ->
                                                   match args with
-                                                  | (a1, uu____28505)::
-                                                      (a2, uu____28507)::
-                                                      (a3, uu____28509)::
-                                                      (a4, uu____28511)::
-                                                      (a5, uu____28513)::
-                                                      (a6, uu____28515)::
-                                                      (a7, uu____28517)::
-                                                      (a8, uu____28519)::
-                                                      (a9, uu____28521)::
-                                                      (a10, uu____28523)::
-                                                      (a11, uu____28525)::
-                                                      (a12, uu____28527)::
-                                                      (a13, uu____28529)::
-                                                      (a14, uu____28531)::
-                                                      (a15, uu____28533)::
-                                                      (a16, uu____28535)::
-                                                      (a17, uu____28537)::
-                                                      (a18, uu____28539)::
-                                                      (a19, uu____28541)::[]
-                                                      ->
-                                                      let uu____28854 =
+                                                  | (a1, uu___)::(a2, uu___1)::
+                                                      (a3, uu___2)::(a4,
+                                                                    uu___3)::
+                                                      (a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                                      (a7, uu___6)::(a8,
+                                                                    uu___7)::
+                                                      (a9, uu___8)::(a10,
+                                                                    uu___9)::
+                                                      (a11, uu___10)::
+                                                      (a12, uu___11)::
+                                                      (a13, uu___12)::
+                                                      (a14, uu___13)::
+                                                      (a15, uu___14)::
+                                                      (a16, uu___15)::
+                                                      (a17, uu___16)::
+                                                      (a18, uu___17)::
+                                                      (a19, uu___18)::[] ->
+                                                      let uu___19 =
                                                         unembed e1 a1 ncb in
                                                       FStar_Util.bind_opt
-                                                        uu____28854
+                                                        uu___19
                                                         (fun a110 ->
-                                                           let uu____28860 =
+                                                           let uu___20 =
                                                              unembed e2 a2
                                                                ncb in
                                                            FStar_Util.bind_opt
-                                                             uu____28860
+                                                             uu___20
                                                              (fun a21 ->
-                                                                let uu____28866
-                                                                  =
+                                                                let uu___21 =
                                                                   unembed e3
                                                                     a3 ncb in
                                                                 FStar_Util.bind_opt
-                                                                  uu____28866
+                                                                  uu___21
                                                                   (fun a31 ->
-                                                                    let uu____28872
+                                                                    let uu___22
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28872
+                                                                    uu___22
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____28878
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28878
+                                                                    uu___23
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____28884
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28884
+                                                                    uu___24
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____28890
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28890
+                                                                    uu___25
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____28896
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28896
+                                                                    uu___26
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____28902
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28902
+                                                                    uu___27
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____28908
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28908
+                                                                    uu___28
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____28914
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28914
+                                                                    uu___29
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____28920
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28920
+                                                                    uu___30
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____28926
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28926
+                                                                    uu___31
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____28932
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28932
+                                                                    uu___32
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____28938
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28938
+                                                                    uu___33
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____28944
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28944
+                                                                    uu___34
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____28950
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28950
+                                                                    uu___35
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____28956
+                                                                    let uu___36
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28956
+                                                                    uu___36
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____28962
+                                                                    let uu___37
                                                                     =
                                                                     unembed
                                                                     e19 a19
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____28962
+                                                                    uu___37
                                                                     (fun a191
                                                                     ->
                                                                     let r1 =
@@ -9250,18 +9012,18 @@ let mk_total_interpretation_19 :
                                                                     a141 a151
                                                                     a161 a171
                                                                     a181 a191 in
-                                                                    let uu____28970
+                                                                    let uu___38
                                                                     =
-                                                                    let uu____28971
+                                                                    let uu___39
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____28971
+                                                                    uu___39
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____28970)))))))))))))))))))
-                                                  | uu____28972 ->
+                                                                    uu___38)))))))))))))))))))
+                                                  | uu___ ->
                                                       FStar_Pervasives_Native.None
 let mk_total_interpretation_20 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't20 't3 't4
@@ -9347,193 +9109,191 @@ let mk_total_interpretation_20 :
                                                 fun ncb ->
                                                   fun args ->
                                                     match args with
-                                                    | (a1, uu____29400)::
-                                                        (a2, uu____29402)::
-                                                        (a3, uu____29404)::
-                                                        (a4, uu____29406)::
-                                                        (a5, uu____29408)::
-                                                        (a6, uu____29410)::
-                                                        (a7, uu____29412)::
-                                                        (a8, uu____29414)::
-                                                        (a9, uu____29416)::
-                                                        (a10, uu____29418)::
-                                                        (a11, uu____29420)::
-                                                        (a12, uu____29422)::
-                                                        (a13, uu____29424)::
-                                                        (a14, uu____29426)::
-                                                        (a15, uu____29428)::
-                                                        (a16, uu____29430)::
-                                                        (a17, uu____29432)::
-                                                        (a18, uu____29434)::
-                                                        (a19, uu____29436)::
-                                                        (a20, uu____29438)::[]
-                                                        ->
-                                                        let uu____29767 =
+                                                    | (a1, uu___)::(a2,
+                                                                    uu___1)::
+                                                        (a3, uu___2)::
+                                                        (a4, uu___3)::
+                                                        (a5, uu___4)::
+                                                        (a6, uu___5)::
+                                                        (a7, uu___6)::
+                                                        (a8, uu___7)::
+                                                        (a9, uu___8)::
+                                                        (a10, uu___9)::
+                                                        (a11, uu___10)::
+                                                        (a12, uu___11)::
+                                                        (a13, uu___12)::
+                                                        (a14, uu___13)::
+                                                        (a15, uu___14)::
+                                                        (a16, uu___15)::
+                                                        (a17, uu___16)::
+                                                        (a18, uu___17)::
+                                                        (a19, uu___18)::
+                                                        (a20, uu___19)::[] ->
+                                                        let uu___20 =
                                                           unembed e1 a1 ncb in
                                                         FStar_Util.bind_opt
-                                                          uu____29767
+                                                          uu___20
                                                           (fun a110 ->
-                                                             let uu____29773
-                                                               =
+                                                             let uu___21 =
                                                                unembed e2 a2
                                                                  ncb in
                                                              FStar_Util.bind_opt
-                                                               uu____29773
+                                                               uu___21
                                                                (fun a21 ->
-                                                                  let uu____29779
+                                                                  let uu___22
                                                                     =
                                                                     unembed
                                                                     e3 a3 ncb in
                                                                   FStar_Util.bind_opt
-                                                                    uu____29779
+                                                                    uu___22
                                                                     (
                                                                     fun a31
                                                                     ->
-                                                                    let uu____29785
+                                                                    let uu___23
                                                                     =
                                                                     unembed
                                                                     e4 a4 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29785
+                                                                    uu___23
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____29791
+                                                                    let uu___24
                                                                     =
                                                                     unembed
                                                                     e5 a5 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29791
+                                                                    uu___24
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____29797
+                                                                    let uu___25
                                                                     =
                                                                     unembed
                                                                     e6 a6 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29797
+                                                                    uu___25
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____29803
+                                                                    let uu___26
                                                                     =
                                                                     unembed
                                                                     e7 a7 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29803
+                                                                    uu___26
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____29809
+                                                                    let uu___27
                                                                     =
                                                                     unembed
                                                                     e8 a8 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29809
+                                                                    uu___27
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____29815
+                                                                    let uu___28
                                                                     =
                                                                     unembed
                                                                     e9 a9 ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29815
+                                                                    uu___28
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____29821
+                                                                    let uu___29
                                                                     =
                                                                     unembed
                                                                     e10 a10
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29821
+                                                                    uu___29
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____29827
+                                                                    let uu___30
                                                                     =
                                                                     unembed
                                                                     e11 a11
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29827
+                                                                    uu___30
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____29833
+                                                                    let uu___31
                                                                     =
                                                                     unembed
                                                                     e12 a12
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29833
+                                                                    uu___31
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____29839
+                                                                    let uu___32
                                                                     =
                                                                     unembed
                                                                     e13 a13
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29839
+                                                                    uu___32
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____29845
+                                                                    let uu___33
                                                                     =
                                                                     unembed
                                                                     e14 a14
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29845
+                                                                    uu___33
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____29851
+                                                                    let uu___34
                                                                     =
                                                                     unembed
                                                                     e15 a15
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29851
+                                                                    uu___34
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____29857
+                                                                    let uu___35
                                                                     =
                                                                     unembed
                                                                     e16 a16
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29857
+                                                                    uu___35
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____29863
+                                                                    let uu___36
                                                                     =
                                                                     unembed
                                                                     e17 a17
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29863
+                                                                    uu___36
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____29869
+                                                                    let uu___37
                                                                     =
                                                                     unembed
                                                                     e18 a18
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29869
+                                                                    uu___37
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____29875
+                                                                    let uu___38
                                                                     =
                                                                     unembed
                                                                     e19 a19
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29875
+                                                                    uu___38
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____29881
+                                                                    let uu___39
                                                                     =
                                                                     unembed
                                                                     e20 a20
                                                                     ncb in
                                                                     FStar_Util.bind_opt
-                                                                    uu____29881
+                                                                    uu___39
                                                                     (fun a201
                                                                     ->
                                                                     let r1 =
@@ -9548,18 +9308,18 @@ let mk_total_interpretation_20 :
                                                                     a161 a171
                                                                     a181 a191
                                                                     a201 in
-                                                                    let uu____29889
+                                                                    let uu___40
                                                                     =
-                                                                    let uu____29890
+                                                                    let uu___41
                                                                     =
                                                                     FStar_TypeChecker_Cfg.psc_range
                                                                     psc in
                                                                     embed er
-                                                                    uu____29890
+                                                                    uu___41
                                                                     r1 ncb in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____29889))))))))))))))))))))
-                                                    | uu____29891 ->
+                                                                    uu___40))))))))))))))))))))
+                                                    | uu___ ->
                                                         FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_1 :
   'r 't1 .
@@ -9576,15 +9336,14 @@ let mk_total_nbe_interpretation_1 :
         fun er ->
           fun args ->
             match args with
-            | (a1, uu____29949)::[] ->
-                let uu____29958 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                FStar_Util.bind_opt uu____29958
+            | (a1, uu___)::[] ->
+                let uu___1 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                FStar_Util.bind_opt uu___1
                   (fun a11 ->
                      let r1 = f a11 in
-                     let uu____29966 =
-                       FStar_TypeChecker_NBETerm.embed er cb r1 in
-                     FStar_Pervasives_Native.Some uu____29966)
-            | uu____29967 -> FStar_Pervasives_Native.None
+                     let uu___2 = FStar_TypeChecker_NBETerm.embed er cb r1 in
+                     FStar_Pervasives_Native.Some uu___2)
+            | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_2 :
   'r 't1 't2 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9602,20 +9361,19 @@ let mk_total_nbe_interpretation_2 :
           fun er ->
             fun args ->
               match args with
-              | (a1, uu____30044)::(a2, uu____30046)::[] ->
-                  let uu____30059 =
-                    FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                  FStar_Util.bind_opt uu____30059
+              | (a1, uu___)::(a2, uu___1)::[] ->
+                  let uu___2 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                  FStar_Util.bind_opt uu___2
                     (fun a11 ->
-                       let uu____30065 =
+                       let uu___3 =
                          FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                       FStar_Util.bind_opt uu____30065
+                       FStar_Util.bind_opt uu___3
                          (fun a21 ->
                             let r1 = f a11 a21 in
-                            let uu____30073 =
+                            let uu___4 =
                               FStar_TypeChecker_NBETerm.embed er cb r1 in
-                            FStar_Pervasives_Native.Some uu____30073))
-              | uu____30074 -> FStar_Pervasives_Native.None
+                            FStar_Pervasives_Native.Some uu___4))
+              | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_3 :
   'r 't1 't2 't3 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9635,25 +9393,23 @@ let mk_total_nbe_interpretation_3 :
             fun er ->
               fun args ->
                 match args with
-                | (a1, uu____30170)::(a2, uu____30172)::(a3, uu____30174)::[]
-                    ->
-                    let uu____30191 =
-                      FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                    FStar_Util.bind_opt uu____30191
+                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::[] ->
+                    let uu___3 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                    FStar_Util.bind_opt uu___3
                       (fun a11 ->
-                         let uu____30197 =
+                         let uu___4 =
                            FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                         FStar_Util.bind_opt uu____30197
+                         FStar_Util.bind_opt uu___4
                            (fun a21 ->
-                              let uu____30203 =
+                              let uu___5 =
                                 FStar_TypeChecker_NBETerm.unembed e3 cb a3 in
-                              FStar_Util.bind_opt uu____30203
+                              FStar_Util.bind_opt uu___5
                                 (fun a31 ->
                                    let r1 = f a11 a21 a31 in
-                                   let uu____30211 =
+                                   let uu___6 =
                                      FStar_TypeChecker_NBETerm.embed er cb r1 in
-                                   FStar_Pervasives_Native.Some uu____30211)))
-                | uu____30212 -> FStar_Pervasives_Native.None
+                                   FStar_Pervasives_Native.Some uu___6)))
+                | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_4 :
   'r 't1 't2 't3 't4 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9676,32 +9432,30 @@ let mk_total_nbe_interpretation_4 :
               fun er ->
                 fun args ->
                   match args with
-                  | (a1, uu____30327)::(a2, uu____30329)::(a3, uu____30331)::
-                      (a4, uu____30333)::[] ->
-                      let uu____30354 =
-                        FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                      FStar_Util.bind_opt uu____30354
+                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::[]
+                      ->
+                      let uu___4 = FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
+                      FStar_Util.bind_opt uu___4
                         (fun a11 ->
-                           let uu____30360 =
+                           let uu___5 =
                              FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                           FStar_Util.bind_opt uu____30360
+                           FStar_Util.bind_opt uu___5
                              (fun a21 ->
-                                let uu____30366 =
+                                let uu___6 =
                                   FStar_TypeChecker_NBETerm.unembed e3 cb a3 in
-                                FStar_Util.bind_opt uu____30366
+                                FStar_Util.bind_opt uu___6
                                   (fun a31 ->
-                                     let uu____30372 =
+                                     let uu___7 =
                                        FStar_TypeChecker_NBETerm.unembed e4
                                          cb a4 in
-                                     FStar_Util.bind_opt uu____30372
+                                     FStar_Util.bind_opt uu___7
                                        (fun a41 ->
                                           let r1 = f a11 a21 a31 a41 in
-                                          let uu____30380 =
+                                          let uu___8 =
                                             FStar_TypeChecker_NBETerm.embed
                                               er cb r1 in
-                                          FStar_Pervasives_Native.Some
-                                            uu____30380))))
-                  | uu____30381 -> FStar_Pervasives_Native.None
+                                          FStar_Pervasives_Native.Some uu___8))))
+                  | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_5 :
   'r 't1 't2 't3 't4 't5 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9726,39 +9480,39 @@ let mk_total_nbe_interpretation_5 :
                 fun er ->
                   fun args ->
                     match args with
-                    | (a1, uu____30515)::(a2, uu____30517)::(a3, uu____30519)::
-                        (a4, uu____30521)::(a5, uu____30523)::[] ->
-                        let uu____30548 =
+                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                        (a5, uu___4)::[] ->
+                        let uu___5 =
                           FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                        FStar_Util.bind_opt uu____30548
+                        FStar_Util.bind_opt uu___5
                           (fun a11 ->
-                             let uu____30554 =
+                             let uu___6 =
                                FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                             FStar_Util.bind_opt uu____30554
+                             FStar_Util.bind_opt uu___6
                                (fun a21 ->
-                                  let uu____30560 =
+                                  let uu___7 =
                                     FStar_TypeChecker_NBETerm.unembed e3 cb
                                       a3 in
-                                  FStar_Util.bind_opt uu____30560
+                                  FStar_Util.bind_opt uu___7
                                     (fun a31 ->
-                                       let uu____30566 =
+                                       let uu___8 =
                                          FStar_TypeChecker_NBETerm.unembed e4
                                            cb a4 in
-                                       FStar_Util.bind_opt uu____30566
+                                       FStar_Util.bind_opt uu___8
                                          (fun a41 ->
-                                            let uu____30572 =
+                                            let uu___9 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e5 cb a5 in
-                                            FStar_Util.bind_opt uu____30572
+                                            FStar_Util.bind_opt uu___9
                                               (fun a51 ->
                                                  let r1 =
                                                    f a11 a21 a31 a41 a51 in
-                                                 let uu____30580 =
+                                                 let uu___10 =
                                                    FStar_TypeChecker_NBETerm.embed
                                                      er cb r1 in
                                                  FStar_Pervasives_Native.Some
-                                                   uu____30580)))))
-                    | uu____30581 -> FStar_Pervasives_Native.None
+                                                   uu___10)))))
+                    | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_6 :
   'r 't1 't2 't3 't4 't5 't6 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9785,49 +9539,46 @@ let mk_total_nbe_interpretation_6 :
                   fun er ->
                     fun args ->
                       match args with
-                      | (a1, uu____30734)::(a2, uu____30736)::(a3,
-                                                               uu____30738)::
-                          (a4, uu____30740)::(a5, uu____30742)::(a6,
-                                                                 uu____30744)::[]
-                          ->
-                          let uu____30773 =
+                      | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4, uu___3)::
+                          (a5, uu___4)::(a6, uu___5)::[] ->
+                          let uu___6 =
                             FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                          FStar_Util.bind_opt uu____30773
+                          FStar_Util.bind_opt uu___6
                             (fun a11 ->
-                               let uu____30779 =
+                               let uu___7 =
                                  FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                               FStar_Util.bind_opt uu____30779
+                               FStar_Util.bind_opt uu___7
                                  (fun a21 ->
-                                    let uu____30785 =
+                                    let uu___8 =
                                       FStar_TypeChecker_NBETerm.unembed e3 cb
                                         a3 in
-                                    FStar_Util.bind_opt uu____30785
+                                    FStar_Util.bind_opt uu___8
                                       (fun a31 ->
-                                         let uu____30791 =
+                                         let uu___9 =
                                            FStar_TypeChecker_NBETerm.unembed
                                              e4 cb a4 in
-                                         FStar_Util.bind_opt uu____30791
+                                         FStar_Util.bind_opt uu___9
                                            (fun a41 ->
-                                              let uu____30797 =
+                                              let uu___10 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e5 cb a5 in
-                                              FStar_Util.bind_opt uu____30797
+                                              FStar_Util.bind_opt uu___10
                                                 (fun a51 ->
-                                                   let uu____30803 =
+                                                   let uu___11 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e6 cb a6 in
                                                    FStar_Util.bind_opt
-                                                     uu____30803
+                                                     uu___11
                                                      (fun a61 ->
                                                         let r1 =
                                                           f a11 a21 a31 a41
                                                             a51 a61 in
-                                                        let uu____30811 =
+                                                        let uu___12 =
                                                           FStar_TypeChecker_NBETerm.embed
                                                             er cb r1 in
                                                         FStar_Pervasives_Native.Some
-                                                          uu____30811))))))
-                      | uu____30812 -> FStar_Pervasives_Native.None
+                                                          uu___12))))))
+                      | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_7 :
   'r 't1 't2 't3 't4 't5 't6 't7 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9856,59 +9607,55 @@ let mk_total_nbe_interpretation_7 :
                     fun er ->
                       fun args ->
                         match args with
-                        | (a1, uu____30984)::(a2, uu____30986)::(a3,
-                                                                 uu____30988)::
-                            (a4, uu____30990)::(a5, uu____30992)::(a6,
-                                                                   uu____30994)::
-                            (a7, uu____30996)::[] ->
-                            let uu____31029 =
+                        | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::(a4,
+                                                                    uu___3)::
+                            (a5, uu___4)::(a6, uu___5)::(a7, uu___6)::[] ->
+                            let uu___7 =
                               FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                            FStar_Util.bind_opt uu____31029
+                            FStar_Util.bind_opt uu___7
                               (fun a11 ->
-                                 let uu____31035 =
+                                 let uu___8 =
                                    FStar_TypeChecker_NBETerm.unembed e2 cb a2 in
-                                 FStar_Util.bind_opt uu____31035
+                                 FStar_Util.bind_opt uu___8
                                    (fun a21 ->
-                                      let uu____31041 =
+                                      let uu___9 =
                                         FStar_TypeChecker_NBETerm.unembed e3
                                           cb a3 in
-                                      FStar_Util.bind_opt uu____31041
+                                      FStar_Util.bind_opt uu___9
                                         (fun a31 ->
-                                           let uu____31047 =
+                                           let uu___10 =
                                              FStar_TypeChecker_NBETerm.unembed
                                                e4 cb a4 in
-                                           FStar_Util.bind_opt uu____31047
+                                           FStar_Util.bind_opt uu___10
                                              (fun a41 ->
-                                                let uu____31053 =
+                                                let uu___11 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e5 cb a5 in
-                                                FStar_Util.bind_opt
-                                                  uu____31053
+                                                FStar_Util.bind_opt uu___11
                                                   (fun a51 ->
-                                                     let uu____31059 =
+                                                     let uu___12 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e6 cb a6 in
                                                      FStar_Util.bind_opt
-                                                       uu____31059
+                                                       uu___12
                                                        (fun a61 ->
-                                                          let uu____31065 =
+                                                          let uu___13 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e7 cb a7 in
                                                           FStar_Util.bind_opt
-                                                            uu____31065
+                                                            uu___13
                                                             (fun a71 ->
                                                                let r1 =
                                                                  f a11 a21
                                                                    a31 a41
                                                                    a51 a61
                                                                    a71 in
-                                                               let uu____31073
-                                                                 =
+                                                               let uu___14 =
                                                                  FStar_TypeChecker_NBETerm.embed
                                                                    er cb r1 in
                                                                FStar_Pervasives_Native.Some
-                                                                 uu____31073)))))))
-                        | uu____31074 -> FStar_Pervasives_Native.None
+                                                                 uu___14)))))))
+                        | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_8 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -9939,54 +9686,51 @@ let mk_total_nbe_interpretation_8 :
                       fun er ->
                         fun args ->
                           match args with
-                          | (a1, uu____31265)::(a2, uu____31267)::(a3,
-                                                                   uu____31269)::
-                              (a4, uu____31271)::(a5, uu____31273)::(a6,
-                                                                    uu____31275)::
-                              (a7, uu____31277)::(a8, uu____31279)::[] ->
-                              let uu____31316 =
+                          | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                              (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                              (a7, uu___6)::(a8, uu___7)::[] ->
+                              let uu___8 =
                                 FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                              FStar_Util.bind_opt uu____31316
+                              FStar_Util.bind_opt uu___8
                                 (fun a11 ->
-                                   let uu____31322 =
+                                   let uu___9 =
                                      FStar_TypeChecker_NBETerm.unembed e2 cb
                                        a2 in
-                                   FStar_Util.bind_opt uu____31322
+                                   FStar_Util.bind_opt uu___9
                                      (fun a21 ->
-                                        let uu____31328 =
+                                        let uu___10 =
                                           FStar_TypeChecker_NBETerm.unembed
                                             e3 cb a3 in
-                                        FStar_Util.bind_opt uu____31328
+                                        FStar_Util.bind_opt uu___10
                                           (fun a31 ->
-                                             let uu____31334 =
+                                             let uu___11 =
                                                FStar_TypeChecker_NBETerm.unembed
                                                  e4 cb a4 in
-                                             FStar_Util.bind_opt uu____31334
+                                             FStar_Util.bind_opt uu___11
                                                (fun a41 ->
-                                                  let uu____31340 =
+                                                  let uu___12 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e5 cb a5 in
-                                                  FStar_Util.bind_opt
-                                                    uu____31340
+                                                  FStar_Util.bind_opt uu___12
                                                     (fun a51 ->
-                                                       let uu____31346 =
+                                                       let uu___13 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e6 cb a6 in
                                                        FStar_Util.bind_opt
-                                                         uu____31346
+                                                         uu___13
                                                          (fun a61 ->
-                                                            let uu____31352 =
+                                                            let uu___14 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e7 cb a7 in
                                                             FStar_Util.bind_opt
-                                                              uu____31352
+                                                              uu___14
                                                               (fun a71 ->
-                                                                 let uu____31358
+                                                                 let uu___15
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____31358
+                                                                   uu___15
                                                                    (fun a81
                                                                     ->
                                                                     let r1 =
@@ -9994,13 +9738,13 @@ let mk_total_nbe_interpretation_8 :
                                                                     a31 a41
                                                                     a51 a61
                                                                     a71 a81 in
-                                                                    let uu____31366
+                                                                    let uu___16
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____31366))))))))
-                          | uu____31367 -> FStar_Pervasives_Native.None
+                                                                    uu___16))))))))
+                          | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_9 :
   'r 't1 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10033,64 +9777,61 @@ let mk_total_nbe_interpretation_9 :
                         fun er ->
                           fun args ->
                             match args with
-                            | (a1, uu____31577)::(a2, uu____31579)::(a3,
-                                                                    uu____31581)::
-                                (a4, uu____31583)::(a5, uu____31585)::
-                                (a6, uu____31587)::(a7, uu____31589)::
-                                (a8, uu____31591)::(a9, uu____31593)::[] ->
-                                let uu____31634 =
+                            | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::[]
+                                ->
+                                let uu___9 =
                                   FStar_TypeChecker_NBETerm.unembed e1 cb a1 in
-                                FStar_Util.bind_opt uu____31634
+                                FStar_Util.bind_opt uu___9
                                   (fun a11 ->
-                                     let uu____31640 =
+                                     let uu___10 =
                                        FStar_TypeChecker_NBETerm.unembed e2
                                          cb a2 in
-                                     FStar_Util.bind_opt uu____31640
+                                     FStar_Util.bind_opt uu___10
                                        (fun a21 ->
-                                          let uu____31646 =
+                                          let uu___11 =
                                             FStar_TypeChecker_NBETerm.unembed
                                               e3 cb a3 in
-                                          FStar_Util.bind_opt uu____31646
+                                          FStar_Util.bind_opt uu___11
                                             (fun a31 ->
-                                               let uu____31652 =
+                                               let uu___12 =
                                                  FStar_TypeChecker_NBETerm.unembed
                                                    e4 cb a4 in
-                                               FStar_Util.bind_opt
-                                                 uu____31652
+                                               FStar_Util.bind_opt uu___12
                                                  (fun a41 ->
-                                                    let uu____31658 =
+                                                    let uu___13 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e5 cb a5 in
                                                     FStar_Util.bind_opt
-                                                      uu____31658
+                                                      uu___13
                                                       (fun a51 ->
-                                                         let uu____31664 =
+                                                         let uu___14 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e6 cb a6 in
                                                          FStar_Util.bind_opt
-                                                           uu____31664
+                                                           uu___14
                                                            (fun a61 ->
-                                                              let uu____31670
-                                                                =
+                                                              let uu___15 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e7 cb a7 in
                                                               FStar_Util.bind_opt
-                                                                uu____31670
+                                                                uu___15
                                                                 (fun a71 ->
-                                                                   let uu____31676
+                                                                   let uu___16
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____31676
+                                                                    uu___16
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____31682
+                                                                    let uu___17
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____31682
+                                                                    uu___17
                                                                     (fun a91
                                                                     ->
                                                                     let r1 =
@@ -10099,13 +9840,13 @@ let mk_total_nbe_interpretation_9 :
                                                                     a51 a61
                                                                     a71 a81
                                                                     a91 in
-                                                                    let uu____31690
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____31690)))))))))
-                            | uu____31691 -> FStar_Pervasives_Native.None
+                                                                    uu___18)))))))))
+                            | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_10 :
   'r 't1 't10 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10142,75 +9883,71 @@ let mk_total_nbe_interpretation_10 :
                           fun er ->
                             fun args ->
                               match args with
-                              | (a1, uu____31920)::(a2, uu____31922)::
-                                  (a3, uu____31924)::(a4, uu____31926)::
-                                  (a5, uu____31928)::(a6, uu____31930)::
-                                  (a7, uu____31932)::(a8, uu____31934)::
-                                  (a9, uu____31936)::(a10, uu____31938)::[]
-                                  ->
-                                  let uu____31983 =
+                              | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                  (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                  (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                  (a10, uu___9)::[] ->
+                                  let uu___10 =
                                     FStar_TypeChecker_NBETerm.unembed e1 cb
                                       a1 in
-                                  FStar_Util.bind_opt uu____31983
+                                  FStar_Util.bind_opt uu___10
                                     (fun a11 ->
-                                       let uu____31989 =
+                                       let uu___11 =
                                          FStar_TypeChecker_NBETerm.unembed e2
                                            cb a2 in
-                                       FStar_Util.bind_opt uu____31989
+                                       FStar_Util.bind_opt uu___11
                                          (fun a21 ->
-                                            let uu____31995 =
+                                            let uu___12 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e3 cb a3 in
-                                            FStar_Util.bind_opt uu____31995
+                                            FStar_Util.bind_opt uu___12
                                               (fun a31 ->
-                                                 let uu____32001 =
+                                                 let uu___13 =
                                                    FStar_TypeChecker_NBETerm.unembed
                                                      e4 cb a4 in
-                                                 FStar_Util.bind_opt
-                                                   uu____32001
+                                                 FStar_Util.bind_opt uu___13
                                                    (fun a41 ->
-                                                      let uu____32007 =
+                                                      let uu___14 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e5 cb a5 in
                                                       FStar_Util.bind_opt
-                                                        uu____32007
+                                                        uu___14
                                                         (fun a51 ->
-                                                           let uu____32013 =
+                                                           let uu___15 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e6 cb a6 in
                                                            FStar_Util.bind_opt
-                                                             uu____32013
+                                                             uu___15
                                                              (fun a61 ->
-                                                                let uu____32019
-                                                                  =
+                                                                let uu___16 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____32019
+                                                                  uu___16
                                                                   (fun a71 ->
-                                                                    let uu____32025
+                                                                    let uu___17
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32025
+                                                                    uu___17
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____32031
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32031
+                                                                    uu___18
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____32037
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32037
+                                                                    uu___19
                                                                     (fun a101
                                                                     ->
                                                                     let r1 =
@@ -10219,13 +9956,13 @@ let mk_total_nbe_interpretation_10 :
                                                                     a51 a61
                                                                     a71 a81
                                                                     a91 a101 in
-                                                                    let uu____32045
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____32045))))))))))
-                              | uu____32046 -> FStar_Pervasives_Native.None
+                                                                    uu___20))))))))))
+                              | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_11 :
   'r 't1 't10 't11 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10266,87 +10003,84 @@ let mk_total_nbe_interpretation_11 :
                             fun er ->
                               fun args ->
                                 match args with
-                                | (a1, uu____32294)::(a2, uu____32296)::
-                                    (a3, uu____32298)::(a4, uu____32300)::
-                                    (a5, uu____32302)::(a6, uu____32304)::
-                                    (a7, uu____32306)::(a8, uu____32308)::
-                                    (a9, uu____32310)::(a10, uu____32312)::
-                                    (a11, uu____32314)::[] ->
-                                    let uu____32363 =
+                                | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                    (a4, uu___3)::(a5, uu___4)::(a6, uu___5)::
+                                    (a7, uu___6)::(a8, uu___7)::(a9, uu___8)::
+                                    (a10, uu___9)::(a11, uu___10)::[] ->
+                                    let uu___11 =
                                       FStar_TypeChecker_NBETerm.unembed e1 cb
                                         a1 in
-                                    FStar_Util.bind_opt uu____32363
+                                    FStar_Util.bind_opt uu___11
                                       (fun a12 ->
-                                         let uu____32369 =
+                                         let uu___12 =
                                            FStar_TypeChecker_NBETerm.unembed
                                              e2 cb a2 in
-                                         FStar_Util.bind_opt uu____32369
+                                         FStar_Util.bind_opt uu___12
                                            (fun a21 ->
-                                              let uu____32375 =
+                                              let uu___13 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e3 cb a3 in
-                                              FStar_Util.bind_opt uu____32375
+                                              FStar_Util.bind_opt uu___13
                                                 (fun a31 ->
-                                                   let uu____32381 =
+                                                   let uu___14 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e4 cb a4 in
                                                    FStar_Util.bind_opt
-                                                     uu____32381
+                                                     uu___14
                                                      (fun a41 ->
-                                                        let uu____32387 =
+                                                        let uu___15 =
                                                           FStar_TypeChecker_NBETerm.unembed
                                                             e5 cb a5 in
                                                         FStar_Util.bind_opt
-                                                          uu____32387
+                                                          uu___15
                                                           (fun a51 ->
-                                                             let uu____32393
-                                                               =
+                                                             let uu___16 =
                                                                FStar_TypeChecker_NBETerm.unembed
                                                                  e6 cb a6 in
                                                              FStar_Util.bind_opt
-                                                               uu____32393
+                                                               uu___16
                                                                (fun a61 ->
-                                                                  let uu____32399
+                                                                  let uu___17
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                   FStar_Util.bind_opt
-                                                                    uu____32399
+                                                                    uu___17
                                                                     (
                                                                     fun a71
                                                                     ->
-                                                                    let uu____32405
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32405
+                                                                    uu___18
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____32411
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32411
+                                                                    uu___19
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____32417
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32417
+                                                                    uu___20
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____32423
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32423
+                                                                    uu___21
                                                                     (fun a111
                                                                     ->
                                                                     let r1 =
@@ -10356,13 +10090,13 @@ let mk_total_nbe_interpretation_11 :
                                                                     a71 a81
                                                                     a91 a101
                                                                     a111 in
-                                                                    let uu____32431
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____32431)))))))))))
-                                | uu____32432 -> FStar_Pervasives_Native.None
+                                                                    uu___22)))))))))))
+                                | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_12 :
   'r 't1 't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10406,97 +10140,95 @@ let mk_total_nbe_interpretation_12 :
                               fun er ->
                                 fun args ->
                                   match args with
-                                  | (a1, uu____32699)::(a2, uu____32701)::
-                                      (a3, uu____32703)::(a4, uu____32705)::
-                                      (a5, uu____32707)::(a6, uu____32709)::
-                                      (a7, uu____32711)::(a8, uu____32713)::
-                                      (a9, uu____32715)::(a10, uu____32717)::
-                                      (a11, uu____32719)::(a12, uu____32721)::[]
-                                      ->
-                                      let uu____32774 =
+                                  | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                      (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                      (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                   uu___8)::
+                                      (a10, uu___9)::(a11, uu___10)::
+                                      (a12, uu___11)::[] ->
+                                      let uu___12 =
                                         FStar_TypeChecker_NBETerm.unembed e1
                                           cb a1 in
-                                      FStar_Util.bind_opt uu____32774
+                                      FStar_Util.bind_opt uu___12
                                         (fun a13 ->
-                                           let uu____32780 =
+                                           let uu___13 =
                                              FStar_TypeChecker_NBETerm.unembed
                                                e2 cb a2 in
-                                           FStar_Util.bind_opt uu____32780
+                                           FStar_Util.bind_opt uu___13
                                              (fun a21 ->
-                                                let uu____32786 =
+                                                let uu___14 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e3 cb a3 in
-                                                FStar_Util.bind_opt
-                                                  uu____32786
+                                                FStar_Util.bind_opt uu___14
                                                   (fun a31 ->
-                                                     let uu____32792 =
+                                                     let uu___15 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e4 cb a4 in
                                                      FStar_Util.bind_opt
-                                                       uu____32792
+                                                       uu___15
                                                        (fun a41 ->
-                                                          let uu____32798 =
+                                                          let uu___16 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e5 cb a5 in
                                                           FStar_Util.bind_opt
-                                                            uu____32798
+                                                            uu___16
                                                             (fun a51 ->
-                                                               let uu____32804
-                                                                 =
+                                                               let uu___17 =
                                                                  FStar_TypeChecker_NBETerm.unembed
                                                                    e6 cb a6 in
                                                                FStar_Util.bind_opt
-                                                                 uu____32804
+                                                                 uu___17
                                                                  (fun a61 ->
-                                                                    let uu____32810
+                                                                    let uu___18
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32810
+                                                                    uu___18
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____32816
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32816
+                                                                    uu___19
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____32822
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32822
+                                                                    uu___20
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____32828
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32828
+                                                                    uu___21
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____32834
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32834
+                                                                    uu___22
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____32840
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____32840
+                                                                    uu___23
                                                                     (fun a121
                                                                     ->
                                                                     let r1 =
@@ -10506,14 +10238,13 @@ let mk_total_nbe_interpretation_12 :
                                                                     a71 a81
                                                                     a91 a101
                                                                     a111 a121 in
-                                                                    let uu____32848
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____32848))))))))))))
-                                  | uu____32849 ->
-                                      FStar_Pervasives_Native.None
+                                                                    uu___24))))))))))))
+                                  | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_13 :
   'r 't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10561,108 +10292,106 @@ let mk_total_nbe_interpretation_13 :
                                 fun er ->
                                   fun args ->
                                     match args with
-                                    | (a1, uu____33135)::(a2, uu____33137)::
-                                        (a3, uu____33139)::(a4, uu____33141)::
-                                        (a5, uu____33143)::(a6, uu____33145)::
-                                        (a7, uu____33147)::(a8, uu____33149)::
-                                        (a9, uu____33151)::(a10, uu____33153)::
-                                        (a11, uu____33155)::(a12,
-                                                             uu____33157)::
-                                        (a13, uu____33159)::[] ->
-                                        let uu____33216 =
+                                    | (a1, uu___)::(a2, uu___1)::(a3, uu___2)::
+                                        (a4, uu___3)::(a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                        (a7, uu___6)::(a8, uu___7)::(a9,
+                                                                    uu___8)::
+                                        (a10, uu___9)::(a11, uu___10)::
+                                        (a12, uu___11)::(a13, uu___12)::[] ->
+                                        let uu___13 =
                                           FStar_TypeChecker_NBETerm.unembed
                                             e1 cb a1 in
-                                        FStar_Util.bind_opt uu____33216
+                                        FStar_Util.bind_opt uu___13
                                           (fun a14 ->
-                                             let uu____33222 =
+                                             let uu___14 =
                                                FStar_TypeChecker_NBETerm.unembed
                                                  e2 cb a2 in
-                                             FStar_Util.bind_opt uu____33222
+                                             FStar_Util.bind_opt uu___14
                                                (fun a21 ->
-                                                  let uu____33228 =
+                                                  let uu___15 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e3 cb a3 in
-                                                  FStar_Util.bind_opt
-                                                    uu____33228
+                                                  FStar_Util.bind_opt uu___15
                                                     (fun a31 ->
-                                                       let uu____33234 =
+                                                       let uu___16 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e4 cb a4 in
                                                        FStar_Util.bind_opt
-                                                         uu____33234
+                                                         uu___16
                                                          (fun a41 ->
-                                                            let uu____33240 =
+                                                            let uu___17 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e5 cb a5 in
                                                             FStar_Util.bind_opt
-                                                              uu____33240
+                                                              uu___17
                                                               (fun a51 ->
-                                                                 let uu____33246
+                                                                 let uu___18
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____33246
+                                                                   uu___18
                                                                    (fun a61
                                                                     ->
-                                                                    let uu____33252
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33252
+                                                                    uu___19
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____33258
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33258
+                                                                    uu___20
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____33264
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33264
+                                                                    uu___21
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____33270
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33270
+                                                                    uu___22
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____33276
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33276
+                                                                    uu___23
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____33282
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33282
+                                                                    uu___24
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____33288
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33288
+                                                                    uu___25
                                                                     (fun a131
                                                                     ->
                                                                     let r1 =
@@ -10673,14 +10402,13 @@ let mk_total_nbe_interpretation_13 :
                                                                     a91 a101
                                                                     a111 a121
                                                                     a131 in
-                                                                    let uu____33296
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____33296)))))))))))))
-                                    | uu____33297 ->
-                                        FStar_Pervasives_Native.None
+                                                                    uu___26)))))))))))))
+                                    | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_14 :
   'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10731,125 +10459,117 @@ let mk_total_nbe_interpretation_14 :
                                   fun er ->
                                     fun args ->
                                       match args with
-                                      | (a1, uu____33602)::(a2, uu____33604)::
-                                          (a3, uu____33606)::(a4,
-                                                              uu____33608)::
-                                          (a5, uu____33610)::(a6,
-                                                              uu____33612)::
-                                          (a7, uu____33614)::(a8,
-                                                              uu____33616)::
-                                          (a9, uu____33618)::(a10,
-                                                              uu____33620)::
-                                          (a11, uu____33622)::(a12,
-                                                               uu____33624)::
-                                          (a13, uu____33626)::(a14,
-                                                               uu____33628)::[]
-                                          ->
-                                          let uu____33689 =
+                                      | (a1, uu___)::(a2, uu___1)::(a3,
+                                                                    uu___2)::
+                                          (a4, uu___3)::(a5, uu___4)::
+                                          (a6, uu___5)::(a7, uu___6)::
+                                          (a8, uu___7)::(a9, uu___8)::
+                                          (a10, uu___9)::(a11, uu___10)::
+                                          (a12, uu___11)::(a13, uu___12)::
+                                          (a14, uu___13)::[] ->
+                                          let uu___14 =
                                             FStar_TypeChecker_NBETerm.unembed
                                               e1 cb a1 in
-                                          FStar_Util.bind_opt uu____33689
+                                          FStar_Util.bind_opt uu___14
                                             (fun a15 ->
-                                               let uu____33695 =
+                                               let uu___15 =
                                                  FStar_TypeChecker_NBETerm.unembed
                                                    e2 cb a2 in
-                                               FStar_Util.bind_opt
-                                                 uu____33695
+                                               FStar_Util.bind_opt uu___15
                                                  (fun a21 ->
-                                                    let uu____33701 =
+                                                    let uu___16 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e3 cb a3 in
                                                     FStar_Util.bind_opt
-                                                      uu____33701
+                                                      uu___16
                                                       (fun a31 ->
-                                                         let uu____33707 =
+                                                         let uu___17 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e4 cb a4 in
                                                          FStar_Util.bind_opt
-                                                           uu____33707
+                                                           uu___17
                                                            (fun a41 ->
-                                                              let uu____33713
-                                                                =
+                                                              let uu___18 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e5 cb a5 in
                                                               FStar_Util.bind_opt
-                                                                uu____33713
+                                                                uu___18
                                                                 (fun a51 ->
-                                                                   let uu____33719
+                                                                   let uu___19
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____33719
+                                                                    uu___19
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____33725
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33725
+                                                                    uu___20
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____33731
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33731
+                                                                    uu___21
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____33737
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33737
+                                                                    uu___22
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____33743
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33743
+                                                                    uu___23
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____33749
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33749
+                                                                    uu___24
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____33755
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33755
+                                                                    uu___25
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____33761
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33761
+                                                                    uu___26
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____33767
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____33767
+                                                                    uu___27
                                                                     (fun a141
                                                                     ->
                                                                     let r1 =
@@ -10860,14 +10580,13 @@ let mk_total_nbe_interpretation_14 :
                                                                     a91 a101
                                                                     a111 a121
                                                                     a131 a141 in
-                                                                    let uu____33775
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____33775))))))))))))))
-                                      | uu____33776 ->
-                                          FStar_Pervasives_Native.None
+                                                                    uu___28))))))))))))))
+                                      | uu___ -> FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_15 :
   'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7 't8 't9 .
     FStar_TypeChecker_NBETerm.nbe_cbs ->
@@ -10924,135 +10643,126 @@ let mk_total_nbe_interpretation_15 :
                                     fun er ->
                                       fun args ->
                                         match args with
-                                        | (a1, uu____34100)::(a2,
-                                                              uu____34102)::
-                                            (a3, uu____34104)::(a4,
-                                                                uu____34106)::
-                                            (a5, uu____34108)::(a6,
-                                                                uu____34110)::
-                                            (a7, uu____34112)::(a8,
-                                                                uu____34114)::
-                                            (a9, uu____34116)::(a10,
-                                                                uu____34118)::
-                                            (a11, uu____34120)::(a12,
-                                                                 uu____34122)::
-                                            (a13, uu____34124)::(a14,
-                                                                 uu____34126)::
-                                            (a15, uu____34128)::[] ->
-                                            let uu____34193 =
+                                        | (a1, uu___)::(a2, uu___1)::
+                                            (a3, uu___2)::(a4, uu___3)::
+                                            (a5, uu___4)::(a6, uu___5)::
+                                            (a7, uu___6)::(a8, uu___7)::
+                                            (a9, uu___8)::(a10, uu___9)::
+                                            (a11, uu___10)::(a12, uu___11)::
+                                            (a13, uu___12)::(a14, uu___13)::
+                                            (a15, uu___14)::[] ->
+                                            let uu___15 =
                                               FStar_TypeChecker_NBETerm.unembed
                                                 e1 cb a1 in
-                                            FStar_Util.bind_opt uu____34193
+                                            FStar_Util.bind_opt uu___15
                                               (fun a16 ->
-                                                 let uu____34199 =
+                                                 let uu___16 =
                                                    FStar_TypeChecker_NBETerm.unembed
                                                      e2 cb a2 in
-                                                 FStar_Util.bind_opt
-                                                   uu____34199
+                                                 FStar_Util.bind_opt uu___16
                                                    (fun a21 ->
-                                                      let uu____34205 =
+                                                      let uu___17 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e3 cb a3 in
                                                       FStar_Util.bind_opt
-                                                        uu____34205
+                                                        uu___17
                                                         (fun a31 ->
-                                                           let uu____34211 =
+                                                           let uu___18 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e4 cb a4 in
                                                            FStar_Util.bind_opt
-                                                             uu____34211
+                                                             uu___18
                                                              (fun a41 ->
-                                                                let uu____34217
-                                                                  =
+                                                                let uu___19 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____34217
+                                                                  uu___19
                                                                   (fun a51 ->
-                                                                    let uu____34223
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34223
+                                                                    uu___20
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____34229
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34229
+                                                                    uu___21
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____34235
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34235
+                                                                    uu___22
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____34241
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34241
+                                                                    uu___23
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____34247
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34247
+                                                                    uu___24
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____34253
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34253
+                                                                    uu___25
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____34259
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34259
+                                                                    uu___26
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____34265
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34265
+                                                                    uu___27
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____34271
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34271
+                                                                    uu___28
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____34277
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34277
+                                                                    uu___29
                                                                     (fun a151
                                                                     ->
                                                                     let r1 =
@@ -11064,13 +10774,13 @@ let mk_total_nbe_interpretation_15 :
                                                                     a111 a121
                                                                     a131 a141
                                                                     a151 in
-                                                                    let uu____34285
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____34285)))))))))))))))
-                                        | uu____34286 ->
+                                                                    uu___30)))))))))))))))
+                                        | uu___ ->
                                             FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_16 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -11134,149 +10844,140 @@ let mk_total_nbe_interpretation_16 :
                                       fun er ->
                                         fun args ->
                                           match args with
-                                          | (a1, uu____34629)::(a2,
-                                                                uu____34631)::
-                                              (a3, uu____34633)::(a4,
-                                                                  uu____34635)::
-                                              (a5, uu____34637)::(a6,
-                                                                  uu____34639)::
-                                              (a7, uu____34641)::(a8,
-                                                                  uu____34643)::
-                                              (a9, uu____34645)::(a10,
-                                                                  uu____34647)::
-                                              (a11, uu____34649)::(a12,
-                                                                   uu____34651)::
-                                              (a13, uu____34653)::(a14,
-                                                                   uu____34655)::
-                                              (a15, uu____34657)::(a16,
-                                                                   uu____34659)::[]
+                                          | (a1, uu___)::(a2, uu___1)::
+                                              (a3, uu___2)::(a4, uu___3)::
+                                              (a5, uu___4)::(a6, uu___5)::
+                                              (a7, uu___6)::(a8, uu___7)::
+                                              (a9, uu___8)::(a10, uu___9)::
+                                              (a11, uu___10)::(a12, uu___11)::
+                                              (a13, uu___12)::(a14, uu___13)::
+                                              (a15, uu___14)::(a16, uu___15)::[]
                                               ->
-                                              let uu____34728 =
+                                              let uu___16 =
                                                 FStar_TypeChecker_NBETerm.unembed
                                                   e1 cb a1 in
-                                              FStar_Util.bind_opt uu____34728
+                                              FStar_Util.bind_opt uu___16
                                                 (fun a17 ->
-                                                   let uu____34734 =
+                                                   let uu___17 =
                                                      FStar_TypeChecker_NBETerm.unembed
                                                        e2 cb a2 in
                                                    FStar_Util.bind_opt
-                                                     uu____34734
+                                                     uu___17
                                                      (fun a21 ->
-                                                        let uu____34740 =
+                                                        let uu___18 =
                                                           FStar_TypeChecker_NBETerm.unembed
                                                             e3 cb a3 in
                                                         FStar_Util.bind_opt
-                                                          uu____34740
+                                                          uu___18
                                                           (fun a31 ->
-                                                             let uu____34746
-                                                               =
+                                                             let uu___19 =
                                                                FStar_TypeChecker_NBETerm.unembed
                                                                  e4 cb a4 in
                                                              FStar_Util.bind_opt
-                                                               uu____34746
+                                                               uu___19
                                                                (fun a41 ->
-                                                                  let uu____34752
+                                                                  let uu___20
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                   FStar_Util.bind_opt
-                                                                    uu____34752
+                                                                    uu___20
                                                                     (
                                                                     fun a51
                                                                     ->
-                                                                    let uu____34758
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34758
+                                                                    uu___21
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____34764
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34764
+                                                                    uu___22
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____34770
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34770
+                                                                    uu___23
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____34776
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34776
+                                                                    uu___24
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____34782
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34782
+                                                                    uu___25
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____34788
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34788
+                                                                    uu___26
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____34794
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34794
+                                                                    uu___27
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____34800
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34800
+                                                                    uu___28
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____34806
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34806
+                                                                    uu___29
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____34812
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34812
+                                                                    uu___30
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____34818
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____34818
+                                                                    uu___31
                                                                     (fun a161
                                                                     ->
                                                                     let r1 =
@@ -11288,13 +10989,13 @@ let mk_total_nbe_interpretation_16 :
                                                                     a111 a121
                                                                     a131 a141
                                                                     a151 a161 in
-                                                                    let uu____34826
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____34826))))))))))))))))
-                                          | uu____34827 ->
+                                                                    uu___32))))))))))))))))
+                                          | uu___ ->
                                               FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_17 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't2 't3 't4 't5 't6 't7 't8
@@ -11365,158 +11066,151 @@ let mk_total_nbe_interpretation_17 :
                                         fun er ->
                                           fun args ->
                                             match args with
-                                            | (a1, uu____35189)::(a2,
-                                                                  uu____35191)::
-                                                (a3, uu____35193)::(a4,
-                                                                    uu____35195)::
-                                                (a5, uu____35197)::(a6,
-                                                                    uu____35199)::
-                                                (a7, uu____35201)::(a8,
-                                                                    uu____35203)::
-                                                (a9, uu____35205)::(a10,
-                                                                    uu____35207)::
-                                                (a11, uu____35209)::(a12,
-                                                                    uu____35211)::
-                                                (a13, uu____35213)::(a14,
-                                                                    uu____35215)::
-                                                (a15, uu____35217)::(a16,
-                                                                    uu____35219)::
-                                                (a17, uu____35221)::[] ->
-                                                let uu____35294 =
+                                            | (a1, uu___)::(a2, uu___1)::
+                                                (a3, uu___2)::(a4, uu___3)::
+                                                (a5, uu___4)::(a6, uu___5)::
+                                                (a7, uu___6)::(a8, uu___7)::
+                                                (a9, uu___8)::(a10, uu___9)::
+                                                (a11, uu___10)::(a12,
+                                                                 uu___11)::
+                                                (a13, uu___12)::(a14,
+                                                                 uu___13)::
+                                                (a15, uu___14)::(a16,
+                                                                 uu___15)::
+                                                (a17, uu___16)::[] ->
+                                                let uu___17 =
                                                   FStar_TypeChecker_NBETerm.unembed
                                                     e1 cb a1 in
-                                                FStar_Util.bind_opt
-                                                  uu____35294
+                                                FStar_Util.bind_opt uu___17
                                                   (fun a18 ->
-                                                     let uu____35300 =
+                                                     let uu___18 =
                                                        FStar_TypeChecker_NBETerm.unembed
                                                          e2 cb a2 in
                                                      FStar_Util.bind_opt
-                                                       uu____35300
+                                                       uu___18
                                                        (fun a21 ->
-                                                          let uu____35306 =
+                                                          let uu___19 =
                                                             FStar_TypeChecker_NBETerm.unembed
                                                               e3 cb a3 in
                                                           FStar_Util.bind_opt
-                                                            uu____35306
+                                                            uu___19
                                                             (fun a31 ->
-                                                               let uu____35312
-                                                                 =
+                                                               let uu___20 =
                                                                  FStar_TypeChecker_NBETerm.unembed
                                                                    e4 cb a4 in
                                                                FStar_Util.bind_opt
-                                                                 uu____35312
+                                                                 uu___20
                                                                  (fun a41 ->
-                                                                    let uu____35318
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35318
+                                                                    uu___21
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____35324
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35324
+                                                                    uu___22
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____35330
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35330
+                                                                    uu___23
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____35336
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35336
+                                                                    uu___24
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____35342
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35342
+                                                                    uu___25
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____35348
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35348
+                                                                    uu___26
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____35354
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35354
+                                                                    uu___27
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____35360
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35360
+                                                                    uu___28
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____35366
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35366
+                                                                    uu___29
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____35372
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35372
+                                                                    uu___30
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____35378
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35378
+                                                                    uu___31
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____35384
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35384
+                                                                    uu___32
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____35390
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35390
+                                                                    uu___33
                                                                     (fun a171
                                                                     ->
                                                                     let r1 =
@@ -11529,13 +11223,13 @@ let mk_total_nbe_interpretation_17 :
                                                                     a131 a141
                                                                     a151 a161
                                                                     a171 in
-                                                                    let uu____35398
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____35398)))))))))))))))))
-                                            | uu____35399 ->
+                                                                    uu___34)))))))))))))))))
+                                            | uu___ ->
                                                 FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_18 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't2 't3 't4 't5 't6 't7
@@ -11612,169 +11306,164 @@ let mk_total_nbe_interpretation_18 :
                                           fun er ->
                                             fun args ->
                                               match args with
-                                              | (a1, uu____35780)::(a2,
-                                                                    uu____35782)::
-                                                  (a3, uu____35784)::
-                                                  (a4, uu____35786)::
-                                                  (a5, uu____35788)::
-                                                  (a6, uu____35790)::
-                                                  (a7, uu____35792)::
-                                                  (a8, uu____35794)::
-                                                  (a9, uu____35796)::
-                                                  (a10, uu____35798)::
-                                                  (a11, uu____35800)::
-                                                  (a12, uu____35802)::
-                                                  (a13, uu____35804)::
-                                                  (a14, uu____35806)::
-                                                  (a15, uu____35808)::
-                                                  (a16, uu____35810)::
-                                                  (a17, uu____35812)::
-                                                  (a18, uu____35814)::[] ->
-                                                  let uu____35891 =
+                                              | (a1, uu___)::(a2, uu___1)::
+                                                  (a3, uu___2)::(a4, uu___3)::
+                                                  (a5, uu___4)::(a6, uu___5)::
+                                                  (a7, uu___6)::(a8, uu___7)::
+                                                  (a9, uu___8)::(a10, uu___9)::
+                                                  (a11, uu___10)::(a12,
+                                                                   uu___11)::
+                                                  (a13, uu___12)::(a14,
+                                                                   uu___13)::
+                                                  (a15, uu___14)::(a16,
+                                                                   uu___15)::
+                                                  (a17, uu___16)::(a18,
+                                                                   uu___17)::[]
+                                                  ->
+                                                  let uu___18 =
                                                     FStar_TypeChecker_NBETerm.unembed
                                                       e1 cb a1 in
-                                                  FStar_Util.bind_opt
-                                                    uu____35891
+                                                  FStar_Util.bind_opt uu___18
                                                     (fun a19 ->
-                                                       let uu____35897 =
+                                                       let uu___19 =
                                                          FStar_TypeChecker_NBETerm.unembed
                                                            e2 cb a2 in
                                                        FStar_Util.bind_opt
-                                                         uu____35897
+                                                         uu___19
                                                          (fun a21 ->
-                                                            let uu____35903 =
+                                                            let uu___20 =
                                                               FStar_TypeChecker_NBETerm.unembed
                                                                 e3 cb a3 in
                                                             FStar_Util.bind_opt
-                                                              uu____35903
+                                                              uu___20
                                                               (fun a31 ->
-                                                                 let uu____35909
+                                                                 let uu___21
                                                                    =
                                                                    FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                  FStar_Util.bind_opt
-                                                                   uu____35909
+                                                                   uu___21
                                                                    (fun a41
                                                                     ->
-                                                                    let uu____35915
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35915
+                                                                    uu___22
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____35921
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35921
+                                                                    uu___23
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____35927
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35927
+                                                                    uu___24
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____35933
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35933
+                                                                    uu___25
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____35939
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35939
+                                                                    uu___26
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____35945
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35945
+                                                                    uu___27
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____35951
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35951
+                                                                    uu___28
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____35957
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35957
+                                                                    uu___29
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____35963
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35963
+                                                                    uu___30
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____35969
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35969
+                                                                    uu___31
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____35975
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35975
+                                                                    uu___32
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____35981
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35981
+                                                                    uu___33
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____35987
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35987
+                                                                    uu___34
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____35993
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____35993
+                                                                    uu___35
                                                                     (fun a181
                                                                     ->
                                                                     let r1 =
@@ -11787,13 +11476,13 @@ let mk_total_nbe_interpretation_18 :
                                                                     a131 a141
                                                                     a151 a161
                                                                     a171 a181 in
-                                                                    let uu____36001
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____36001))))))))))))))))))
-                                              | uu____36002 ->
+                                                                    uu___36))))))))))))))))))
+                                              | uu___ ->
                                                   FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_19 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't3 't4 't5
@@ -11875,180 +11564,178 @@ let mk_total_nbe_interpretation_19 :
                                             fun er ->
                                               fun args ->
                                                 match args with
-                                                | (a1, uu____36402)::
-                                                    (a2, uu____36404)::
-                                                    (a3, uu____36406)::
-                                                    (a4, uu____36408)::
-                                                    (a5, uu____36410)::
-                                                    (a6, uu____36412)::
-                                                    (a7, uu____36414)::
-                                                    (a8, uu____36416)::
-                                                    (a9, uu____36418)::
-                                                    (a10, uu____36420)::
-                                                    (a11, uu____36422)::
-                                                    (a12, uu____36424)::
-                                                    (a13, uu____36426)::
-                                                    (a14, uu____36428)::
-                                                    (a15, uu____36430)::
-                                                    (a16, uu____36432)::
-                                                    (a17, uu____36434)::
-                                                    (a18, uu____36436)::
-                                                    (a19, uu____36438)::[] ->
-                                                    let uu____36519 =
+                                                | (a1, uu___)::(a2, uu___1)::
+                                                    (a3, uu___2)::(a4,
+                                                                   uu___3)::
+                                                    (a5, uu___4)::(a6,
+                                                                   uu___5)::
+                                                    (a7, uu___6)::(a8,
+                                                                   uu___7)::
+                                                    (a9, uu___8)::(a10,
+                                                                   uu___9)::
+                                                    (a11, uu___10)::(a12,
+                                                                    uu___11)::
+                                                    (a13, uu___12)::(a14,
+                                                                    uu___13)::
+                                                    (a15, uu___14)::(a16,
+                                                                    uu___15)::
+                                                    (a17, uu___16)::(a18,
+                                                                    uu___17)::
+                                                    (a19, uu___18)::[] ->
+                                                    let uu___19 =
                                                       FStar_TypeChecker_NBETerm.unembed
                                                         e1 cb a1 in
                                                     FStar_Util.bind_opt
-                                                      uu____36519
+                                                      uu___19
                                                       (fun a110 ->
-                                                         let uu____36525 =
+                                                         let uu___20 =
                                                            FStar_TypeChecker_NBETerm.unembed
                                                              e2 cb a2 in
                                                          FStar_Util.bind_opt
-                                                           uu____36525
+                                                           uu___20
                                                            (fun a21 ->
-                                                              let uu____36531
-                                                                =
+                                                              let uu___21 =
                                                                 FStar_TypeChecker_NBETerm.unembed
                                                                   e3 cb a3 in
                                                               FStar_Util.bind_opt
-                                                                uu____36531
+                                                                uu___21
                                                                 (fun a31 ->
-                                                                   let uu____36537
+                                                                   let uu___22
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                    FStar_Util.bind_opt
-                                                                    uu____36537
+                                                                    uu___22
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____36543
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36543
+                                                                    uu___23
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____36549
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36549
+                                                                    uu___24
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____36555
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36555
+                                                                    uu___25
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____36561
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36561
+                                                                    uu___26
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____36567
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36567
+                                                                    uu___27
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____36573
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36573
+                                                                    uu___28
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____36579
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36579
+                                                                    uu___29
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____36585
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36585
+                                                                    uu___30
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____36591
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36591
+                                                                    uu___31
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____36597
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36597
+                                                                    uu___32
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____36603
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36603
+                                                                    uu___33
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____36609
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36609
+                                                                    uu___34
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____36615
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36615
+                                                                    uu___35
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____36621
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36621
+                                                                    uu___36
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____36627
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e19 cb
                                                                     a19 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____36627
+                                                                    uu___37
                                                                     (fun a191
                                                                     ->
                                                                     let r1 =
@@ -12062,13 +11749,13 @@ let mk_total_nbe_interpretation_19 :
                                                                     a141 a151
                                                                     a161 a171
                                                                     a181 a191 in
-                                                                    let uu____36635
+                                                                    let uu___38
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____36635)))))))))))))))))))
-                                                | uu____36636 ->
+                                                                    uu___38)))))))))))))))))))
+                                                | uu___ ->
                                                     FStar_Pervasives_Native.None
 let mk_total_nbe_interpretation_20 :
   'r 't1 't10 't11 't12 't13 't14 't15 't16 't17 't18 't19 't2 't20 't3 't4
@@ -12156,191 +11843,188 @@ let mk_total_nbe_interpretation_20 :
                                               fun er ->
                                                 fun args ->
                                                   match args with
-                                                  | (a1, uu____37055)::
-                                                      (a2, uu____37057)::
-                                                      (a3, uu____37059)::
-                                                      (a4, uu____37061)::
-                                                      (a5, uu____37063)::
-                                                      (a6, uu____37065)::
-                                                      (a7, uu____37067)::
-                                                      (a8, uu____37069)::
-                                                      (a9, uu____37071)::
-                                                      (a10, uu____37073)::
-                                                      (a11, uu____37075)::
-                                                      (a12, uu____37077)::
-                                                      (a13, uu____37079)::
-                                                      (a14, uu____37081)::
-                                                      (a15, uu____37083)::
-                                                      (a16, uu____37085)::
-                                                      (a17, uu____37087)::
-                                                      (a18, uu____37089)::
-                                                      (a19, uu____37091)::
-                                                      (a20, uu____37093)::[]
-                                                      ->
-                                                      let uu____37178 =
+                                                  | (a1, uu___)::(a2, uu___1)::
+                                                      (a3, uu___2)::(a4,
+                                                                    uu___3)::
+                                                      (a5, uu___4)::(a6,
+                                                                    uu___5)::
+                                                      (a7, uu___6)::(a8,
+                                                                    uu___7)::
+                                                      (a9, uu___8)::(a10,
+                                                                    uu___9)::
+                                                      (a11, uu___10)::
+                                                      (a12, uu___11)::
+                                                      (a13, uu___12)::
+                                                      (a14, uu___13)::
+                                                      (a15, uu___14)::
+                                                      (a16, uu___15)::
+                                                      (a17, uu___16)::
+                                                      (a18, uu___17)::
+                                                      (a19, uu___18)::
+                                                      (a20, uu___19)::[] ->
+                                                      let uu___20 =
                                                         FStar_TypeChecker_NBETerm.unembed
                                                           e1 cb a1 in
                                                       FStar_Util.bind_opt
-                                                        uu____37178
+                                                        uu___20
                                                         (fun a110 ->
-                                                           let uu____37184 =
+                                                           let uu___21 =
                                                              FStar_TypeChecker_NBETerm.unembed
                                                                e2 cb a2 in
                                                            FStar_Util.bind_opt
-                                                             uu____37184
+                                                             uu___21
                                                              (fun a21 ->
-                                                                let uu____37190
-                                                                  =
+                                                                let uu___22 =
                                                                   FStar_TypeChecker_NBETerm.unembed
                                                                     e3 cb a3 in
                                                                 FStar_Util.bind_opt
-                                                                  uu____37190
+                                                                  uu___22
                                                                   (fun a31 ->
-                                                                    let uu____37196
+                                                                    let uu___23
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e4 cb a4 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37196
+                                                                    uu___23
                                                                     (fun a41
                                                                     ->
-                                                                    let uu____37202
+                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e5 cb a5 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37202
+                                                                    uu___24
                                                                     (fun a51
                                                                     ->
-                                                                    let uu____37208
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e6 cb a6 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37208
+                                                                    uu___25
                                                                     (fun a61
                                                                     ->
-                                                                    let uu____37214
+                                                                    let uu___26
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e7 cb a7 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37214
+                                                                    uu___26
                                                                     (fun a71
                                                                     ->
-                                                                    let uu____37220
+                                                                    let uu___27
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e8 cb a8 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37220
+                                                                    uu___27
                                                                     (fun a81
                                                                     ->
-                                                                    let uu____37226
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e9 cb a9 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37226
+                                                                    uu___28
                                                                     (fun a91
                                                                     ->
-                                                                    let uu____37232
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e10 cb
                                                                     a10 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37232
+                                                                    uu___29
                                                                     (fun a101
                                                                     ->
-                                                                    let uu____37238
+                                                                    let uu___30
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e11 cb
                                                                     a11 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37238
+                                                                    uu___30
                                                                     (fun a111
                                                                     ->
-                                                                    let uu____37244
+                                                                    let uu___31
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e12 cb
                                                                     a12 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37244
+                                                                    uu___31
                                                                     (fun a121
                                                                     ->
-                                                                    let uu____37250
+                                                                    let uu___32
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e13 cb
                                                                     a13 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37250
+                                                                    uu___32
                                                                     (fun a131
                                                                     ->
-                                                                    let uu____37256
+                                                                    let uu___33
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e14 cb
                                                                     a14 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37256
+                                                                    uu___33
                                                                     (fun a141
                                                                     ->
-                                                                    let uu____37262
+                                                                    let uu___34
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e15 cb
                                                                     a15 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37262
+                                                                    uu___34
                                                                     (fun a151
                                                                     ->
-                                                                    let uu____37268
+                                                                    let uu___35
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e16 cb
                                                                     a16 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37268
+                                                                    uu___35
                                                                     (fun a161
                                                                     ->
-                                                                    let uu____37274
+                                                                    let uu___36
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e17 cb
                                                                     a17 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37274
+                                                                    uu___36
                                                                     (fun a171
                                                                     ->
-                                                                    let uu____37280
+                                                                    let uu___37
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e18 cb
                                                                     a18 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37280
+                                                                    uu___37
                                                                     (fun a181
                                                                     ->
-                                                                    let uu____37286
+                                                                    let uu___38
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e19 cb
                                                                     a19 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37286
+                                                                    uu___38
                                                                     (fun a191
                                                                     ->
-                                                                    let uu____37292
+                                                                    let uu___39
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.unembed
                                                                     e20 cb
                                                                     a20 in
                                                                     FStar_Util.bind_opt
-                                                                    uu____37292
+                                                                    uu___39
                                                                     (fun a201
                                                                     ->
                                                                     let r1 =
@@ -12355,13 +12039,13 @@ let mk_total_nbe_interpretation_20 :
                                                                     a161 a171
                                                                     a181 a191
                                                                     a201 in
-                                                                    let uu____37300
+                                                                    let uu___40
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.embed
                                                                     er cb r1 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____37300))))))))))))))))))))
-                                                  | uu____37301 ->
+                                                                    uu___40))))))))))))))))))))
+                                                  | uu___ ->
                                                       FStar_Pervasives_Native.None
 let mk_tac_step_1 :
   'nr 'nt1 'r 't1 .
@@ -12387,9 +12071,8 @@ let mk_tac_step_1 :
                     (mk_tactic_interpretation_1 t e1 er)
                     (fun cb ->
                        fun args ->
-                         let uu____37409 = drop nunivs args in
-                         mk_tactic_nbe_interpretation_1 cb nt ne1 ner
-                           uu____37409)
+                         let uu___ = drop nunivs args in
+                         mk_tactic_nbe_interpretation_1 cb nt ne1 ner uu___)
 let mk_tac_step_2 :
   'nr 'nt1 'nt2 'r 't1 't2 .
     Prims.int ->
@@ -12418,9 +12101,9 @@ let mk_tac_step_2 :
                         (mk_tactic_interpretation_2 t e1 e2 er)
                         (fun cb ->
                            fun args ->
-                             let uu____37559 = drop nunivs args in
+                             let uu___ = drop nunivs args in
                              mk_tactic_nbe_interpretation_2 cb nt ne1 ne2 ner
-                               uu____37559)
+                               uu___)
 let mk_tac_step_3 :
   'nr 'nt1 'nt2 'nt3 'r 't1 't2 't3 .
     Prims.int ->
@@ -12453,9 +12136,9 @@ let mk_tac_step_3 :
                             (mk_tactic_interpretation_3 t e1 e2 e3 er)
                             (fun cb ->
                                fun args ->
-                                 let uu____37747 = drop nunivs args in
+                                 let uu___ = drop nunivs args in
                                  mk_tactic_nbe_interpretation_3 cb nt ne1 ne2
-                                   ne3 ner uu____37747)
+                                   ne3 ner uu___)
 let mk_tac_step_4 :
   'nr 'nt1 'nt2 'nt3 'nt4 'r 't1 't2 't3 't4 .
     Prims.int ->
@@ -12494,9 +12177,9 @@ let mk_tac_step_4 :
                                 (mk_tactic_interpretation_4 t e1 e2 e3 e4 er)
                                 (fun cb ->
                                    fun args ->
-                                     let uu____37973 = drop nunivs args in
+                                     let uu___ = drop nunivs args in
                                      mk_tactic_nbe_interpretation_4 cb nt ne1
-                                       ne2 ne3 ne4 ner uu____37973)
+                                       ne2 ne3 ne4 ner uu___)
 let mk_tac_step_5 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'r 't1 't2 't3 't4 't5 .
     Prims.int ->
@@ -12542,10 +12225,9 @@ let mk_tac_step_5 :
                                        e5 er)
                                     (fun cb ->
                                        fun args ->
-                                         let uu____38237 = drop nunivs args in
+                                         let uu___ = drop nunivs args in
                                          mk_tactic_nbe_interpretation_5 cb nt
-                                           ne1 ne2 ne3 ne4 ne5 ner
-                                           uu____38237)
+                                           ne1 ne2 ne3 ne4 ne5 ner uu___)
 let mk_tac_step_6 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'r 't1 't2 't3 't4 't5 't6 .
     Prims.int ->
@@ -12599,11 +12281,10 @@ let mk_tac_step_6 :
                                            e3 e4 e5 e6 er)
                                         (fun cb ->
                                            fun args ->
-                                             let uu____38539 =
-                                               drop nunivs args in
+                                             let uu___ = drop nunivs args in
                                              mk_tactic_nbe_interpretation_6
                                                cb nt ne1 ne2 ne3 ne4 ne5 ne6
-                                               ner uu____38539)
+                                               ner uu___)
 let mk_tac_step_7 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'r 't1 't2 't3 't4 't5 't6 't7 .
     Prims.int ->
@@ -12670,11 +12351,10 @@ let mk_tac_step_7 :
                                                e2 e3 e4 e5 e6 e7 er)
                                             (fun cb ->
                                                fun args ->
-                                                 let uu____38879 =
-                                                   drop nunivs args in
+                                                 let uu___ = drop nunivs args in
                                                  mk_tactic_nbe_interpretation_7
                                                    cb nt ne1 ne2 ne3 ne4 ne5
-                                                   ne6 ne7 ner uu____38879)
+                                                   ne6 ne7 ner uu___)
 let mk_tac_step_8 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'r 't1 't2 't3 't4 't5 't6 't7
     't8 .
@@ -12754,12 +12434,12 @@ let mk_tac_step_8 :
                                                    e1 e2 e3 e4 e5 e6 e7 e8 er)
                                                 (fun cb ->
                                                    fun args ->
-                                                     let uu____39257 =
+                                                     let uu___ =
                                                        drop nunivs args in
                                                      mk_tactic_nbe_interpretation_8
                                                        cb nt ne1 ne2 ne3 ne4
                                                        ne5 ne6 ne7 ne8 ner
-                                                       uu____39257)
+                                                       uu___)
 let mk_tac_step_9 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't2 't3 't4 't5 't6
     't7 't8 't9 .
@@ -12851,13 +12531,12 @@ let mk_tac_step_9 :
                                                        e8 e9 er)
                                                     (fun cb ->
                                                        fun args ->
-                                                         let uu____39673 =
+                                                         let uu___ =
                                                            drop nunivs args in
                                                          mk_tactic_nbe_interpretation_9
                                                            cb nt ne1 ne2 ne3
                                                            ne4 ne5 ne6 ne7
-                                                           ne8 ne9 ner
-                                                           uu____39673)
+                                                           ne8 ne9 ner uu___)
 let mk_tac_step_10 :
   'nr 'nt1 'nt10 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't2 't3
     't4 't5 't6 't7 't8 't9 .
@@ -12961,8 +12640,7 @@ let mk_tac_step_10 :
                                                            e6 e7 e8 e9 e10 er)
                                                         (fun cb ->
                                                            fun args ->
-                                                             let uu____40127
-                                                               =
+                                                             let uu___ =
                                                                drop nunivs
                                                                  args in
                                                              mk_tactic_nbe_interpretation_10
@@ -12970,7 +12648,7 @@ let mk_tac_step_10 :
                                                                ne3 ne4 ne5
                                                                ne6 ne7 ne8
                                                                ne9 ne10 ner
-                                                               uu____40127)
+                                                               uu___)
 let mk_tac_step_11 :
   'nr 'nt1 'nt10 'nt11 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10
     't11 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -13086,8 +12764,7 @@ let mk_tac_step_11 :
                                                                e10 e11 er)
                                                             (fun cb ->
                                                                fun args ->
-                                                                 let uu____40619
-                                                                   =
+                                                                 let uu___ =
                                                                    drop
                                                                     nunivs
                                                                     args in
@@ -13098,8 +12775,7 @@ let mk_tac_step_11 :
                                                                    ne6 ne7
                                                                    ne8 ne9
                                                                    ne10 ne11
-                                                                   ner
-                                                                   uu____40619)
+                                                                   ner uu___)
 let mk_tac_step_12 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1
     't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -13227,7 +12903,7 @@ let mk_tac_step_12 :
                                                                 (fun cb ->
                                                                    fun args
                                                                     ->
-                                                                    let uu____41149
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -13240,7 +12916,7 @@ let mk_tac_step_12 :
                                                                     ne8 ne9
                                                                     ne10 ne11
                                                                     ne12 ner
-                                                                    uu____41149)
+                                                                    uu___)
 let mk_tac_step_13 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r
     't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -13380,7 +13056,7 @@ let mk_tac_step_13 :
                                                                     fun cb ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____41717
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -13393,8 +13069,7 @@ let mk_tac_step_13 :
                                                                     ne8 ne9
                                                                     ne10 ne11
                                                                     ne12 ne13
-                                                                    ner
-                                                                    uu____41717)
+                                                                    ner uu___)
 let mk_tac_step_14 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8
     'nt9 'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -13543,7 +13218,7 @@ let mk_tac_step_14 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____42323
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -13557,7 +13232,7 @@ let mk_tac_step_14 :
                                                                     ne10 ne11
                                                                     ne12 ne13
                                                                     ne14 ner
-                                                                    uu____42323)
+                                                                    uu___)
 let mk_tac_step_15 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7
     'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7
@@ -13719,7 +13394,7 @@ let mk_tac_step_15 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____42967
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -13733,8 +13408,7 @@ let mk_tac_step_15 :
                                                                     ne10 ne11
                                                                     ne12 ne13
                                                                     ne14 ne15
-                                                                    ner
-                                                                    uu____42967)
+                                                                    ner uu___)
 let mk_tac_step_16 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt2 'nt3 'nt4 'nt5 'nt6
     'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5
@@ -13911,7 +13585,7 @@ let mk_tac_step_16 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____43649
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -13926,7 +13600,7 @@ let mk_tac_step_16 :
                                                                     ne12 ne13
                                                                     ne14 ne15
                                                                     ne16 ner
-                                                                    uu____43649)
+                                                                    uu___)
 let mk_tac_step_17 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt2 'nt3 'nt4
     'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16 't17
@@ -14115,7 +13789,7 @@ let mk_tac_step_17 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____44369
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -14130,8 +13804,7 @@ let mk_tac_step_17 :
                                                                     ne12 ne13
                                                                     ne14 ne15
                                                                     ne16 ne17
-                                                                    ner
-                                                                    uu____44369)
+                                                                    ner uu___)
 let mk_tac_step_18 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt2 'nt3
     'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16
@@ -14333,7 +14006,7 @@ let mk_tac_step_18 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____45127
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -14349,7 +14022,7 @@ let mk_tac_step_18 :
                                                                     ne14 ne15
                                                                     ne16 ne17
                                                                     ne18 ner
-                                                                    uu____45127)
+                                                                    uu___)
 let mk_tac_step_19 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt19 'nt2
     'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15
@@ -14564,7 +14237,7 @@ let mk_tac_step_19 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____45923
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -14580,8 +14253,7 @@ let mk_tac_step_19 :
                                                                     ne14 ne15
                                                                     ne16 ne17
                                                                     ne18 ne19
-                                                                    ner
-                                                                    uu____45923)
+                                                                    ner uu___)
 let mk_tac_step_20 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt19 'nt2
     'nt20 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14
@@ -14809,7 +14481,7 @@ let mk_tac_step_20 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____46757
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -14826,7 +14498,7 @@ let mk_tac_step_20 :
                                                                     ne16 ne17
                                                                     ne18 ne19
                                                                     ne20 ner
-                                                                    uu____46757)
+                                                                    uu___)
 let mk_total_step_1 :
   'nr 'nt1 'r 't1 .
     Prims.int ->
@@ -14851,9 +14523,8 @@ let mk_total_step_1 :
                     (mk_total_interpretation_1 f e1 er)
                     (fun cb ->
                        fun args ->
-                         let uu____46861 = drop nunivs args in
-                         mk_total_nbe_interpretation_1 cb nf ne1 ner
-                           uu____46861)
+                         let uu___ = drop nunivs args in
+                         mk_total_nbe_interpretation_1 cb nf ne1 ner uu___)
 let mk_total_step_2 :
   'nr 'nt1 'nt2 'r 't1 't2 .
     Prims.int ->
@@ -14882,9 +14553,9 @@ let mk_total_step_2 :
                         (mk_total_interpretation_2 f e1 e2 er)
                         (fun cb ->
                            fun args ->
-                             let uu____47003 = drop nunivs args in
+                             let uu___ = drop nunivs args in
                              mk_total_nbe_interpretation_2 cb nf ne1 ne2 ner
-                               uu____47003)
+                               uu___)
 let mk_total_step_3 :
   'nr 'nt1 'nt2 'nt3 'r 't1 't2 't3 .
     Prims.int ->
@@ -14917,9 +14588,9 @@ let mk_total_step_3 :
                             (mk_total_interpretation_3 f e1 e2 e3 er)
                             (fun cb ->
                                fun args ->
-                                 let uu____47183 = drop nunivs args in
+                                 let uu___ = drop nunivs args in
                                  mk_total_nbe_interpretation_3 cb nf ne1 ne2
-                                   ne3 ner uu____47183)
+                                   ne3 ner uu___)
 let mk_total_step_4 :
   'nr 'nt1 'nt2 'nt3 'nt4 'r 't1 't2 't3 't4 .
     Prims.int ->
@@ -14956,9 +14627,9 @@ let mk_total_step_4 :
                                 (mk_total_interpretation_4 f e1 e2 e3 e4 er)
                                 (fun cb ->
                                    fun args ->
-                                     let uu____47401 = drop nunivs args in
+                                     let uu___ = drop nunivs args in
                                      mk_total_nbe_interpretation_4 cb nf ne1
-                                       ne2 ne3 ne4 ner uu____47401)
+                                       ne2 ne3 ne4 ner uu___)
 let mk_total_step_5 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'r 't1 't2 't3 't4 't5 .
     Prims.int ->
@@ -15000,10 +14671,9 @@ let mk_total_step_5 :
                                        e5 er)
                                     (fun cb ->
                                        fun args ->
-                                         let uu____47657 = drop nunivs args in
+                                         let uu___ = drop nunivs args in
                                          mk_total_nbe_interpretation_5 cb nf
-                                           ne1 ne2 ne3 ne4 ne5 ner
-                                           uu____47657)
+                                           ne1 ne2 ne3 ne4 ne5 ner uu___)
 let mk_total_step_6 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'r 't1 't2 't3 't4 't5 't6 .
     Prims.int ->
@@ -15052,11 +14722,10 @@ let mk_total_step_6 :
                                            e4 e5 e6 er)
                                         (fun cb ->
                                            fun args ->
-                                             let uu____47951 =
-                                               drop nunivs args in
+                                             let uu___ = drop nunivs args in
                                              mk_total_nbe_interpretation_6 cb
                                                nf ne1 ne2 ne3 ne4 ne5 ne6 ner
-                                               uu____47951)
+                                               uu___)
 let mk_total_step_7 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'r 't1 't2 't3 't4 't5 't6 't7 .
     Prims.int ->
@@ -15116,11 +14785,10 @@ let mk_total_step_7 :
                                                e2 e3 e4 e5 e6 e7 er)
                                             (fun cb ->
                                                fun args ->
-                                                 let uu____48283 =
-                                                   drop nunivs args in
+                                                 let uu___ = drop nunivs args in
                                                  mk_total_nbe_interpretation_7
                                                    cb nf ne1 ne2 ne3 ne4 ne5
-                                                   ne6 ne7 ner uu____48283)
+                                                   ne6 ne7 ner uu___)
 let mk_total_step_8 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'r 't1 't2 't3 't4 't5 't6 't7
     't8 .
@@ -15192,12 +14860,12 @@ let mk_total_step_8 :
                                                    e1 e2 e3 e4 e5 e6 e7 e8 er)
                                                 (fun cb ->
                                                    fun args ->
-                                                     let uu____48653 =
+                                                     let uu___ =
                                                        drop nunivs args in
                                                      mk_total_nbe_interpretation_8
                                                        cb nf ne1 ne2 ne3 ne4
                                                        ne5 ne6 ne7 ne8 ner
-                                                       uu____48653)
+                                                       uu___)
 let mk_total_step_9 :
   'nr 'nt1 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't2 't3 't4 't5 't6
     't7 't8 't9 .
@@ -15280,13 +14948,12 @@ let mk_total_step_9 :
                                                        e8 e9 er)
                                                     (fun cb ->
                                                        fun args ->
-                                                         let uu____49061 =
+                                                         let uu___ =
                                                            drop nunivs args in
                                                          mk_total_nbe_interpretation_9
                                                            cb nf ne1 ne2 ne3
                                                            ne4 ne5 ne6 ne7
-                                                           ne8 ne9 ner
-                                                           uu____49061)
+                                                           ne8 ne9 ner uu___)
 let mk_total_step_10 :
   'nr 'nt1 'nt10 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't2 't3
     't4 't5 't6 't7 't8 't9 .
@@ -15381,8 +15048,7 @@ let mk_total_step_10 :
                                                            e6 e7 e8 e9 e10 er)
                                                         (fun cb ->
                                                            fun args ->
-                                                             let uu____49507
-                                                               =
+                                                             let uu___ =
                                                                drop nunivs
                                                                  args in
                                                              mk_total_nbe_interpretation_10
@@ -15390,7 +15056,7 @@ let mk_total_step_10 :
                                                                ne3 ne4 ne5
                                                                ne6 ne7 ne8
                                                                ne9 ne10 ner
-                                                               uu____49507)
+                                                               uu___)
 let mk_total_step_11 :
   'nr 'nt1 'nt10 'nt11 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10
     't11 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -15498,8 +15164,7 @@ let mk_total_step_11 :
                                                                e10 e11 er)
                                                             (fun cb ->
                                                                fun args ->
-                                                                 let uu____49991
-                                                                   =
+                                                                 let uu___ =
                                                                    drop
                                                                     nunivs
                                                                     args in
@@ -15510,8 +15175,7 @@ let mk_total_step_11 :
                                                                    ne6 ne7
                                                                    ne8 ne9
                                                                    ne10 ne11
-                                                                   ner
-                                                                   uu____49991)
+                                                                   ner uu___)
 let mk_total_step_12 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1
     't10 't11 't12 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -15633,7 +15297,7 @@ let mk_total_step_12 :
                                                                 (fun cb ->
                                                                    fun args
                                                                     ->
-                                                                    let uu____50513
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -15646,7 +15310,7 @@ let mk_total_step_12 :
                                                                     ne8 ne9
                                                                     ne10 ne11
                                                                     ne12 ner
-                                                                    uu____50513)
+                                                                    uu___)
 let mk_total_step_13 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r
     't1 't10 't11 't12 't13 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -15779,7 +15443,7 @@ let mk_total_step_13 :
                                                                     fun cb ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____51073
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -15792,8 +15456,7 @@ let mk_total_step_13 :
                                                                     ne8 ne9
                                                                     ne10 ne11
                                                                     ne12 ne13
-                                                                    ner
-                                                                    uu____51073)
+                                                                    ner uu___)
 let mk_total_step_14 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8
     'nt9 'r 't1 't10 't11 't12 't13 't14 't2 't3 't4 't5 't6 't7 't8 't9 .
@@ -15937,7 +15600,7 @@ let mk_total_step_14 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____51671
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -15951,7 +15614,7 @@ let mk_total_step_14 :
                                                                     ne10 ne11
                                                                     ne12 ne13
                                                                     ne14 ner
-                                                                    uu____51671)
+                                                                    uu___)
 let mk_total_step_15 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt2 'nt3 'nt4 'nt5 'nt6 'nt7
     'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't2 't3 't4 't5 't6 't7
@@ -16108,7 +15771,7 @@ let mk_total_step_15 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____52307
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -16122,8 +15785,7 @@ let mk_total_step_15 :
                                                                     ne10 ne11
                                                                     ne12 ne13
                                                                     ne14 ne15
-                                                                    ner
-                                                                    uu____52307)
+                                                                    ner uu___)
 let mk_total_step_16 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt2 'nt3 'nt4 'nt5 'nt6
     'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16 't2 't3 't4 't5
@@ -16295,7 +15957,7 @@ let mk_total_step_16 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____52981
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -16310,7 +15972,7 @@ let mk_total_step_16 :
                                                                     ne12 ne13
                                                                     ne14 ne15
                                                                     ne16 ner
-                                                                    uu____52981)
+                                                                    uu___)
 let mk_total_step_17 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt2 'nt3 'nt4
     'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16 't17
@@ -16494,7 +16156,7 @@ let mk_total_step_17 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____53693
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -16509,8 +16171,7 @@ let mk_total_step_17 :
                                                                     ne12 ne13
                                                                     ne14 ne15
                                                                     ne16 ne17
-                                                                    ner
-                                                                    uu____53693)
+                                                                    ner uu___)
 let mk_total_step_18 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt2 'nt3
     'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15 't16
@@ -16707,7 +16368,7 @@ let mk_total_step_18 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____54443
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -16723,7 +16384,7 @@ let mk_total_step_18 :
                                                                     ne14 ne15
                                                                     ne16 ne17
                                                                     ne18 ner
-                                                                    uu____54443)
+                                                                    uu___)
 let mk_total_step_19 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt19 'nt2
     'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14 't15
@@ -16933,7 +16594,7 @@ let mk_total_step_19 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____55231
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -16949,8 +16610,7 @@ let mk_total_step_19 :
                                                                     ne14 ne15
                                                                     ne16 ne17
                                                                     ne18 ne19
-                                                                    ner
-                                                                    uu____55231)
+                                                                    ner uu___)
 let mk_total_step_20 :
   'nr 'nt1 'nt10 'nt11 'nt12 'nt13 'nt14 'nt15 'nt16 'nt17 'nt18 'nt19 'nt2
     'nt20 'nt3 'nt4 'nt5 'nt6 'nt7 'nt8 'nt9 'r 't1 't10 't11 't12 't13 't14
@@ -17173,7 +16833,7 @@ let mk_total_step_20 :
                                                                     ->
                                                                     fun args
                                                                     ->
-                                                                    let uu____56057
+                                                                    let uu___
                                                                     =
                                                                     drop
                                                                     nunivs
@@ -17190,4 +16850,4 @@ let mk_total_step_20 :
                                                                     ne16 ne17
                                                                     ne18 ne19
                                                                     ne20 ner
-                                                                    uu____56057)
+                                                                    uu___)

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1,33 +1,32 @@
 open Prims
 let (tacdbg : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false
 let unembed :
-  'uuuuuu10 .
-    'uuuuuu10 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Embeddings.norm_cb ->
-          'uuuuuu10 FStar_Pervasives_Native.option
+          'uuuuu FStar_Pervasives_Native.option
   =
   fun ea ->
     fun a ->
       fun norm_cb ->
-        let uu____34 = FStar_Syntax_Embeddings.unembed ea a in
-        uu____34 true norm_cb
+        let uu___ = FStar_Syntax_Embeddings.unembed ea a in
+        uu___ true norm_cb
 let embed :
-  'uuuuuu51 .
-    'uuuuuu51 FStar_Syntax_Embeddings.embedding ->
+  'uuuuu .
+    'uuuuu FStar_Syntax_Embeddings.embedding ->
       FStar_Range.range ->
-        'uuuuuu51 ->
-          FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
+        'uuuuu -> FStar_Syntax_Embeddings.norm_cb -> FStar_Syntax_Syntax.term
   =
   fun ea ->
     fun r ->
       fun x ->
         fun norm_cb ->
-          let uu____78 = FStar_Syntax_Embeddings.embed ea x in
-          uu____78 r FStar_Pervasives_Native.None norm_cb
+          let uu___ = FStar_Syntax_Embeddings.embed ea x in
+          uu___ r FStar_Pervasives_Native.None norm_cb
 let (native_tactics_steps :
   unit -> FStar_TypeChecker_Cfg.primitive_step Prims.list) =
-  fun uu____93 ->
+  fun uu___ ->
     let step_from_native_step s =
       {
         FStar_TypeChecker_Cfg.name = (s.FStar_Tactics_Native.name);
@@ -46,18 +45,18 @@ let (native_tactics_steps :
              FStar_TypeChecker_NBETerm.dummy_interp
                s.FStar_Tactics_Native.name)
       } in
-    let uu____102 = FStar_Tactics_Native.list_all () in
-    FStar_List.map step_from_native_step uu____102
+    let uu___1 = FStar_Tactics_Native.list_all () in
+    FStar_List.map step_from_native_step uu___1
 let mk_total_step_1' :
-  'uuuuuu129 'uuuuuu130 'uuuuuu131 'uuuuuu132 .
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 .
     Prims.int ->
       Prims.string ->
-        ('uuuuuu129 -> 'uuuuuu130) ->
-          'uuuuuu129 FStar_Syntax_Embeddings.embedding ->
-            'uuuuuu130 FStar_Syntax_Embeddings.embedding ->
-              ('uuuuuu131 -> 'uuuuuu132) ->
-                'uuuuuu131 FStar_TypeChecker_NBETerm.embedding ->
-                  'uuuuuu132 FStar_TypeChecker_NBETerm.embedding ->
+        ('uuuuu -> 'uuuuu1) ->
+          'uuuuu FStar_Syntax_Embeddings.embedding ->
+            'uuuuu1 FStar_Syntax_Embeddings.embedding ->
+              ('uuuuu2 -> 'uuuuu3) ->
+                'uuuuu2 FStar_TypeChecker_NBETerm.embedding ->
+                  'uuuuu3 FStar_TypeChecker_NBETerm.embedding ->
                     FStar_TypeChecker_Cfg.primitive_step
   =
   fun uarity ->
@@ -68,39 +67,39 @@ let mk_total_step_1' :
             fun nf ->
               fun ena ->
                 fun enr ->
-                  let uu___19_199 =
+                  let uu___ =
                     FStar_Tactics_InterpFuns.mk_total_step_1 uarity nm f ea
                       er nf ena enr in
-                  let uu____200 =
+                  let uu___1 =
                     FStar_Ident.lid_of_str
                       (Prims.op_Hat "FStar.Tactics.Types." nm) in
                   {
-                    FStar_TypeChecker_Cfg.name = uu____200;
+                    FStar_TypeChecker_Cfg.name = uu___1;
                     FStar_TypeChecker_Cfg.arity =
-                      (uu___19_199.FStar_TypeChecker_Cfg.arity);
+                      (uu___.FStar_TypeChecker_Cfg.arity);
                     FStar_TypeChecker_Cfg.univ_arity =
-                      (uu___19_199.FStar_TypeChecker_Cfg.univ_arity);
+                      (uu___.FStar_TypeChecker_Cfg.univ_arity);
                     FStar_TypeChecker_Cfg.auto_reflect =
-                      (uu___19_199.FStar_TypeChecker_Cfg.auto_reflect);
+                      (uu___.FStar_TypeChecker_Cfg.auto_reflect);
                     FStar_TypeChecker_Cfg.strong_reduction_ok =
-                      (uu___19_199.FStar_TypeChecker_Cfg.strong_reduction_ok);
+                      (uu___.FStar_TypeChecker_Cfg.strong_reduction_ok);
                     FStar_TypeChecker_Cfg.requires_binder_substitution =
-                      (uu___19_199.FStar_TypeChecker_Cfg.requires_binder_substitution);
+                      (uu___.FStar_TypeChecker_Cfg.requires_binder_substitution);
                     FStar_TypeChecker_Cfg.interpretation =
-                      (uu___19_199.FStar_TypeChecker_Cfg.interpretation);
+                      (uu___.FStar_TypeChecker_Cfg.interpretation);
                     FStar_TypeChecker_Cfg.interpretation_nbe =
-                      (uu___19_199.FStar_TypeChecker_Cfg.interpretation_nbe)
+                      (uu___.FStar_TypeChecker_Cfg.interpretation_nbe)
                   }
 let mk_total_step_1'_psc :
-  'uuuuuu225 'uuuuuu226 'uuuuuu227 'uuuuuu228 .
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 .
     Prims.int ->
       Prims.string ->
-        (FStar_TypeChecker_Cfg.psc -> 'uuuuuu225 -> 'uuuuuu226) ->
-          'uuuuuu225 FStar_Syntax_Embeddings.embedding ->
-            'uuuuuu226 FStar_Syntax_Embeddings.embedding ->
-              (FStar_TypeChecker_Cfg.psc -> 'uuuuuu227 -> 'uuuuuu228) ->
-                'uuuuuu227 FStar_TypeChecker_NBETerm.embedding ->
-                  'uuuuuu228 FStar_TypeChecker_NBETerm.embedding ->
+        (FStar_TypeChecker_Cfg.psc -> 'uuuuu -> 'uuuuu1) ->
+          'uuuuu FStar_Syntax_Embeddings.embedding ->
+            'uuuuu1 FStar_Syntax_Embeddings.embedding ->
+              (FStar_TypeChecker_Cfg.psc -> 'uuuuu2 -> 'uuuuu3) ->
+                'uuuuu2 FStar_TypeChecker_NBETerm.embedding ->
+                  'uuuuu3 FStar_TypeChecker_NBETerm.embedding ->
                     FStar_TypeChecker_Cfg.primitive_step
   =
   fun uarity ->
@@ -111,41 +110,41 @@ let mk_total_step_1'_psc :
             fun nf ->
               fun ena ->
                 fun enr ->
-                  let uu___29_305 =
+                  let uu___ =
                     FStar_Tactics_InterpFuns.mk_total_step_1_psc uarity nm f
                       ea er nf ena enr in
-                  let uu____306 =
+                  let uu___1 =
                     FStar_Ident.lid_of_str
                       (Prims.op_Hat "FStar.Tactics.Types." nm) in
                   {
-                    FStar_TypeChecker_Cfg.name = uu____306;
+                    FStar_TypeChecker_Cfg.name = uu___1;
                     FStar_TypeChecker_Cfg.arity =
-                      (uu___29_305.FStar_TypeChecker_Cfg.arity);
+                      (uu___.FStar_TypeChecker_Cfg.arity);
                     FStar_TypeChecker_Cfg.univ_arity =
-                      (uu___29_305.FStar_TypeChecker_Cfg.univ_arity);
+                      (uu___.FStar_TypeChecker_Cfg.univ_arity);
                     FStar_TypeChecker_Cfg.auto_reflect =
-                      (uu___29_305.FStar_TypeChecker_Cfg.auto_reflect);
+                      (uu___.FStar_TypeChecker_Cfg.auto_reflect);
                     FStar_TypeChecker_Cfg.strong_reduction_ok =
-                      (uu___29_305.FStar_TypeChecker_Cfg.strong_reduction_ok);
+                      (uu___.FStar_TypeChecker_Cfg.strong_reduction_ok);
                     FStar_TypeChecker_Cfg.requires_binder_substitution =
-                      (uu___29_305.FStar_TypeChecker_Cfg.requires_binder_substitution);
+                      (uu___.FStar_TypeChecker_Cfg.requires_binder_substitution);
                     FStar_TypeChecker_Cfg.interpretation =
-                      (uu___29_305.FStar_TypeChecker_Cfg.interpretation);
+                      (uu___.FStar_TypeChecker_Cfg.interpretation);
                     FStar_TypeChecker_Cfg.interpretation_nbe =
-                      (uu___29_305.FStar_TypeChecker_Cfg.interpretation_nbe)
+                      (uu___.FStar_TypeChecker_Cfg.interpretation_nbe)
                   }
 let mk_total_step_2' :
-  'uuuuuu339 'uuuuuu340 'uuuuuu341 'uuuuuu342 'uuuuuu343 'uuuuuu344 .
+  'uuuuu 'uuuuu1 'uuuuu2 'uuuuu3 'uuuuu4 'uuuuu5 .
     Prims.int ->
       Prims.string ->
-        ('uuuuuu339 -> 'uuuuuu340 -> 'uuuuuu341) ->
-          'uuuuuu339 FStar_Syntax_Embeddings.embedding ->
-            'uuuuuu340 FStar_Syntax_Embeddings.embedding ->
-              'uuuuuu341 FStar_Syntax_Embeddings.embedding ->
-                ('uuuuuu342 -> 'uuuuuu343 -> 'uuuuuu344) ->
-                  'uuuuuu342 FStar_TypeChecker_NBETerm.embedding ->
-                    'uuuuuu343 FStar_TypeChecker_NBETerm.embedding ->
-                      'uuuuuu344 FStar_TypeChecker_NBETerm.embedding ->
+        ('uuuuu -> 'uuuuu1 -> 'uuuuu2) ->
+          'uuuuu FStar_Syntax_Embeddings.embedding ->
+            'uuuuu1 FStar_Syntax_Embeddings.embedding ->
+              'uuuuu2 FStar_Syntax_Embeddings.embedding ->
+                ('uuuuu3 -> 'uuuuu4 -> 'uuuuu5) ->
+                  'uuuuu3 FStar_TypeChecker_NBETerm.embedding ->
+                    'uuuuu4 FStar_TypeChecker_NBETerm.embedding ->
+                      'uuuuu5 FStar_TypeChecker_NBETerm.embedding ->
                         FStar_TypeChecker_Cfg.primitive_step
   =
   fun uarity ->
@@ -158,28 +157,28 @@ let mk_total_step_2' :
                 fun ena ->
                   fun enb ->
                     fun enr ->
-                      let uu___41_439 =
+                      let uu___ =
                         FStar_Tactics_InterpFuns.mk_total_step_2 uarity nm f
                           ea eb er nf ena enb enr in
-                      let uu____440 =
+                      let uu___1 =
                         FStar_Ident.lid_of_str
                           (Prims.op_Hat "FStar.Tactics.Types." nm) in
                       {
-                        FStar_TypeChecker_Cfg.name = uu____440;
+                        FStar_TypeChecker_Cfg.name = uu___1;
                         FStar_TypeChecker_Cfg.arity =
-                          (uu___41_439.FStar_TypeChecker_Cfg.arity);
+                          (uu___.FStar_TypeChecker_Cfg.arity);
                         FStar_TypeChecker_Cfg.univ_arity =
-                          (uu___41_439.FStar_TypeChecker_Cfg.univ_arity);
+                          (uu___.FStar_TypeChecker_Cfg.univ_arity);
                         FStar_TypeChecker_Cfg.auto_reflect =
-                          (uu___41_439.FStar_TypeChecker_Cfg.auto_reflect);
+                          (uu___.FStar_TypeChecker_Cfg.auto_reflect);
                         FStar_TypeChecker_Cfg.strong_reduction_ok =
-                          (uu___41_439.FStar_TypeChecker_Cfg.strong_reduction_ok);
+                          (uu___.FStar_TypeChecker_Cfg.strong_reduction_ok);
                         FStar_TypeChecker_Cfg.requires_binder_substitution =
-                          (uu___41_439.FStar_TypeChecker_Cfg.requires_binder_substitution);
+                          (uu___.FStar_TypeChecker_Cfg.requires_binder_substitution);
                         FStar_TypeChecker_Cfg.interpretation =
-                          (uu___41_439.FStar_TypeChecker_Cfg.interpretation);
+                          (uu___.FStar_TypeChecker_Cfg.interpretation);
                         FStar_TypeChecker_Cfg.interpretation_nbe =
-                          (uu___41_439.FStar_TypeChecker_Cfg.interpretation_nbe)
+                          (uu___.FStar_TypeChecker_Cfg.interpretation_nbe)
                       }
 let (__primitive_steps_ref :
   FStar_TypeChecker_Cfg.primitive_step Prims.list
@@ -187,12 +186,11 @@ let (__primitive_steps_ref :
   = FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (primitive_steps :
   unit -> FStar_TypeChecker_Cfg.primitive_step Prims.list) =
-  fun uu____459 ->
-    let uu____462 =
-      let uu____465 = FStar_ST.op_Bang __primitive_steps_ref in
-      FStar_Util.must uu____465 in
-    let uu____486 = native_tactics_steps () in
-    FStar_List.append uu____462 uu____486
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = FStar_ST.op_Bang __primitive_steps_ref in
+      FStar_Util.must uu___2 in
+    let uu___2 = native_tactics_steps () in FStar_List.append uu___1 uu___2
 let unembed_tactic_0 :
   'b .
     'b FStar_Syntax_Embeddings.embedding ->
@@ -207,14 +205,14 @@ let unembed_tactic_0 :
              let rng = embedded_tac_b.FStar_Syntax_Syntax.pos in
              let embedded_tac_b1 = FStar_Syntax_Util.mk_reify embedded_tac_b in
              let tm =
-               let uu____538 =
-                 let uu____539 =
-                   let uu____548 =
+               let uu___ =
+                 let uu___1 =
+                   let uu___2 =
                      embed FStar_Tactics_Embedding.e_proofstate rng
                        proof_state ncb in
-                   FStar_Syntax_Syntax.as_arg uu____548 in
-                 [uu____539] in
-               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b1 uu____538 rng in
+                   FStar_Syntax_Syntax.as_arg uu___2 in
+                 [uu___1] in
+               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b1 uu___ rng in
              let steps =
                [FStar_TypeChecker_Env.Weak;
                FStar_TypeChecker_Env.Reify;
@@ -224,38 +222,38 @@ let unembed_tactic_0 :
                FStar_TypeChecker_Env.Primops;
                FStar_TypeChecker_Env.Unascribe] in
              let norm_f =
-               let uu____589 = FStar_Options.tactics_nbe () in
-               if uu____589
+               let uu___ = FStar_Options.tactics_nbe () in
+               if uu___
                then FStar_TypeChecker_NBE.normalize
                else
                  FStar_TypeChecker_Normalize.normalize_with_primitive_steps in
              let result =
-               let uu____608 = primitive_steps () in
-               norm_f uu____608 steps
+               let uu___ = primitive_steps () in
+               norm_f uu___ steps
                  proof_state.FStar_Tactics_Types.main_context tm in
              let res =
-               let uu____616 = FStar_Tactics_Embedding.e_result eb in
-               unembed uu____616 result ncb in
+               let uu___ = FStar_Tactics_Embedding.e_result eb in
+               unembed uu___ result ncb in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Success
                  (b1, ps)) ->
-                 let uu____629 = FStar_Tactics_Monad.set ps in
-                 FStar_Tactics_Monad.bind uu____629
-                   (fun uu____633 -> FStar_Tactics_Monad.ret b1)
+                 let uu___ = FStar_Tactics_Monad.set ps in
+                 FStar_Tactics_Monad.bind uu___
+                   (fun uu___1 -> FStar_Tactics_Monad.ret b1)
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Failed
                  (e, ps)) ->
-                 let uu____638 = FStar_Tactics_Monad.set ps in
-                 FStar_Tactics_Monad.bind uu____638
-                   (fun uu____642 -> FStar_Tactics_Monad.traise e)
+                 let uu___ = FStar_Tactics_Monad.set ps in
+                 FStar_Tactics_Monad.bind uu___
+                   (fun uu___1 -> FStar_Tactics_Monad.traise e)
              | FStar_Pervasives_Native.None ->
-                 let uu____645 =
-                   let uu____650 =
-                     let uu____651 = FStar_Syntax_Print.term_to_string result in
+                 let uu___ =
+                   let uu___1 =
+                     let uu___2 = FStar_Syntax_Print.term_to_string result in
                      FStar_Util.format1
                        "Tactic got stuck! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____651 in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____650) in
-                 FStar_Errors.raise_error uu____645
+                       uu___2 in
+                   (FStar_Errors.Fatal_TacticGotStuck, uu___1) in
+                 FStar_Errors.raise_error uu___
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)
 let unembed_tactic_nbe_0 :
   'b .
@@ -269,39 +267,39 @@ let unembed_tactic_nbe_0 :
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun proof_state ->
              let result =
-               let uu____692 =
-                 let uu____693 =
-                   let uu____698 =
+               let uu___ =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_TypeChecker_NBETerm.embed
                        FStar_Tactics_Embedding.e_proofstate_nbe cb
                        proof_state in
-                   FStar_TypeChecker_NBETerm.as_arg uu____698 in
-                 [uu____693] in
-               FStar_TypeChecker_NBETerm.iapp_cb cb embedded_tac_b uu____692 in
+                   FStar_TypeChecker_NBETerm.as_arg uu___2 in
+                 [uu___1] in
+               FStar_TypeChecker_NBETerm.iapp_cb cb embedded_tac_b uu___ in
              let res =
-               let uu____712 = FStar_Tactics_Embedding.e_result_nbe eb in
-               FStar_TypeChecker_NBETerm.unembed uu____712 cb result in
+               let uu___ = FStar_Tactics_Embedding.e_result_nbe eb in
+               FStar_TypeChecker_NBETerm.unembed uu___ cb result in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Success
                  (b1, ps)) ->
-                 let uu____725 = FStar_Tactics_Monad.set ps in
-                 FStar_Tactics_Monad.bind uu____725
-                   (fun uu____729 -> FStar_Tactics_Monad.ret b1)
+                 let uu___ = FStar_Tactics_Monad.set ps in
+                 FStar_Tactics_Monad.bind uu___
+                   (fun uu___1 -> FStar_Tactics_Monad.ret b1)
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Failed
                  (e, ps)) ->
-                 let uu____734 = FStar_Tactics_Monad.set ps in
-                 FStar_Tactics_Monad.bind uu____734
-                   (fun uu____738 -> FStar_Tactics_Monad.traise e)
+                 let uu___ = FStar_Tactics_Monad.set ps in
+                 FStar_Tactics_Monad.bind uu___
+                   (fun uu___1 -> FStar_Tactics_Monad.traise e)
              | FStar_Pervasives_Native.None ->
-                 let uu____741 =
-                   let uu____746 =
-                     let uu____747 =
+                 let uu___ =
+                   let uu___1 =
+                     let uu___2 =
                        FStar_TypeChecker_NBETerm.t_to_string result in
                      FStar_Util.format1
                        "Tactic got stuck (in NBE)! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____747 in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____746) in
-                 FStar_Errors.raise_error uu____741
+                       uu___2 in
+                   (FStar_Errors.Fatal_TacticGotStuck, uu___1) in
+                 FStar_Errors.raise_error uu___
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)
 let unembed_tactic_1 :
   'a 'r .
@@ -318,10 +316,9 @@ let unembed_tactic_1 :
             let rng = FStar_Range.dummyRange in
             let x_tm = embed ea rng x ncb in
             let app =
-              let uu____803 =
-                let uu____804 = FStar_Syntax_Syntax.as_arg x_tm in
-                [uu____804] in
-              FStar_Syntax_Syntax.mk_Tm_app f uu____803 rng in
+              let uu___ =
+                let uu___1 = FStar_Syntax_Syntax.as_arg x_tm in [uu___1] in
+              FStar_Syntax_Syntax.mk_Tm_app f uu___ rng in
             unembed_tactic_0 er app ncb
 let unembed_tactic_nbe_1 :
   'a 'r .
@@ -337,10 +334,10 @@ let unembed_tactic_nbe_1 :
           fun x ->
             let x_tm = FStar_TypeChecker_NBETerm.embed ea cb x in
             let app =
-              let uu____879 =
-                let uu____880 = FStar_TypeChecker_NBETerm.as_arg x_tm in
-                [uu____880] in
-              FStar_TypeChecker_NBETerm.iapp_cb cb f uu____879 in
+              let uu___ =
+                let uu___1 = FStar_TypeChecker_NBETerm.as_arg x_tm in
+                [uu___1] in
+              FStar_TypeChecker_NBETerm.iapp_cb cb f uu___ in
             unembed_tactic_nbe_0 er cb app
 let e_tactic_thunk :
   'r .
@@ -348,44 +345,41 @@ let e_tactic_thunk :
       'r FStar_Tactics_Monad.tac FStar_Syntax_Embeddings.embedding
   =
   fun er ->
-    let uu____911 =
-      FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit in
+    let uu___ = FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit in
     FStar_Syntax_Embeddings.mk_emb
-      (fun uu____918 ->
-         fun uu____919 ->
-           fun uu____920 ->
-             fun uu____921 ->
-               failwith "Impossible: embedding tactic (thunk)?")
+      (fun uu___1 ->
+         fun uu___2 ->
+           fun uu___3 ->
+             fun uu___4 -> failwith "Impossible: embedding tactic (thunk)?")
       (fun t ->
          fun w ->
            fun cb ->
-             let uu____933 =
-               let uu____936 =
+             let uu___1 =
+               let uu___2 =
                  unembed_tactic_1 FStar_Syntax_Embeddings.e_unit er t cb in
-               uu____936 () in
-             FStar_Pervasives_Native.Some uu____933) uu____911
+               uu___2 () in
+             FStar_Pervasives_Native.Some uu___1) uu___
 let e_tactic_nbe_thunk :
   'r .
     'r FStar_TypeChecker_NBETerm.embedding ->
       'r FStar_Tactics_Monad.tac FStar_TypeChecker_NBETerm.embedding
   =
   fun er ->
-    let uu____963 =
+    let uu___ =
       FStar_TypeChecker_NBETerm.mk_t
         (FStar_TypeChecker_NBETerm.Constant FStar_TypeChecker_NBETerm.Unit) in
-    let uu____964 =
+    let uu___1 =
       FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit in
     FStar_TypeChecker_NBETerm.mk_emb
       (fun cb ->
-         fun uu____970 ->
-           failwith "Impossible: NBE embedding tactic (thunk)?")
+         fun uu___2 -> failwith "Impossible: NBE embedding tactic (thunk)?")
       (fun cb ->
          fun t ->
-           let uu____978 =
-             let uu____981 =
+           let uu___2 =
+             let uu___3 =
                unembed_tactic_nbe_1 FStar_TypeChecker_NBETerm.e_unit er cb t in
-             uu____981 () in
-           FStar_Pervasives_Native.Some uu____978) uu____963 uu____964
+             uu___3 () in
+           FStar_Pervasives_Native.Some uu___2) uu___ uu___1
 let e_tactic_1 :
   'a 'r .
     'a FStar_Syntax_Embeddings.embedding ->
@@ -394,18 +388,18 @@ let e_tactic_1 :
   =
   fun ea ->
     fun er ->
-      let uu____1025 =
+      let uu___ =
         FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit in
       FStar_Syntax_Embeddings.mk_emb
-        (fun uu____1035 ->
-           fun uu____1036 ->
-             fun uu____1037 ->
-               fun uu____1038 -> failwith "Impossible: embedding tactic (1)?")
+        (fun uu___1 ->
+           fun uu___2 ->
+             fun uu___3 ->
+               fun uu___4 -> failwith "Impossible: embedding tactic (1)?")
         (fun t ->
            fun w ->
              fun cb ->
-               let uu____1052 = unembed_tactic_1 ea er t cb in
-               FStar_Pervasives_Native.Some uu____1052) uu____1025
+               let uu___1 = unembed_tactic_1 ea er t cb in
+               FStar_Pervasives_Native.Some uu___1) uu___
 let e_tactic_nbe_1 :
   'a 'r .
     'a FStar_TypeChecker_NBETerm.embedding ->
@@ -415,29 +409,29 @@ let e_tactic_nbe_1 :
   =
   fun ea ->
     fun er ->
-      let uu____1099 =
+      let uu___ =
         FStar_TypeChecker_NBETerm.mk_t
           (FStar_TypeChecker_NBETerm.Constant FStar_TypeChecker_NBETerm.Unit) in
-      let uu____1100 =
+      let uu___1 =
         FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit in
       FStar_TypeChecker_NBETerm.mk_emb
         (fun cb ->
-           fun uu____1109 -> failwith "Impossible: NBE embedding tactic (1)?")
+           fun uu___2 -> failwith "Impossible: NBE embedding tactic (1)?")
         (fun cb ->
            fun t ->
-             let uu____1119 = unembed_tactic_nbe_1 ea er cb t in
-             FStar_Pervasives_Native.Some uu____1119) uu____1099 uu____1100
+             let uu___2 = unembed_tactic_nbe_1 ea er cb t in
+             FStar_Pervasives_Native.Some uu___2) uu___ uu___1
 let (uu___143 : unit) =
-  let uu____1131 =
-    let uu____1136 =
-      let uu____1139 =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
         mk_total_step_1'_psc Prims.int_zero "tracepoint"
           FStar_Tactics_Types.tracepoint FStar_Tactics_Embedding.e_proofstate
           FStar_Syntax_Embeddings.e_unit FStar_Tactics_Types.tracepoint
           FStar_Tactics_Embedding.e_proofstate_nbe
           FStar_TypeChecker_NBETerm.e_unit in
-      let uu____1140 =
-        let uu____1143 =
+      let uu___3 =
+        let uu___4 =
           mk_total_step_2' Prims.int_zero "set_proofstate_range"
             FStar_Tactics_Types.set_proofstate_range
             FStar_Tactics_Embedding.e_proofstate
@@ -447,8 +441,8 @@ let (uu___143 : unit) =
             FStar_Tactics_Embedding.e_proofstate_nbe
             FStar_TypeChecker_NBETerm.e_range
             FStar_Tactics_Embedding.e_proofstate_nbe in
-        let uu____1144 =
-          let uu____1147 =
+        let uu___5 =
+          let uu___6 =
             mk_total_step_1' Prims.int_zero "incr_depth"
               FStar_Tactics_Types.incr_depth
               FStar_Tactics_Embedding.e_proofstate
@@ -456,8 +450,8 @@ let (uu___143 : unit) =
               FStar_Tactics_Types.incr_depth
               FStar_Tactics_Embedding.e_proofstate_nbe
               FStar_Tactics_Embedding.e_proofstate_nbe in
-          let uu____1148 =
-            let uu____1151 =
+          let uu___7 =
+            let uu___8 =
               mk_total_step_1' Prims.int_zero "decr_depth"
                 FStar_Tactics_Types.decr_depth
                 FStar_Tactics_Embedding.e_proofstate
@@ -465,34 +459,34 @@ let (uu___143 : unit) =
                 FStar_Tactics_Types.decr_depth
                 FStar_Tactics_Embedding.e_proofstate_nbe
                 FStar_Tactics_Embedding.e_proofstate_nbe in
-            let uu____1152 =
-              let uu____1155 =
-                let uu____1156 =
+            let uu___9 =
+              let uu___10 =
+                let uu___11 =
                   FStar_Syntax_Embeddings.e_list
                     FStar_Tactics_Embedding.e_goal in
-                let uu____1161 =
+                let uu___12 =
                   FStar_TypeChecker_NBETerm.e_list
                     FStar_Tactics_Embedding.e_goal_nbe in
                 mk_total_step_1' Prims.int_zero "goals_of"
                   FStar_Tactics_Types.goals_of
-                  FStar_Tactics_Embedding.e_proofstate uu____1156
+                  FStar_Tactics_Embedding.e_proofstate uu___11
                   FStar_Tactics_Types.goals_of
-                  FStar_Tactics_Embedding.e_proofstate_nbe uu____1161 in
-              let uu____1170 =
-                let uu____1173 =
-                  let uu____1174 =
+                  FStar_Tactics_Embedding.e_proofstate_nbe uu___12 in
+              let uu___11 =
+                let uu___12 =
+                  let uu___13 =
                     FStar_Syntax_Embeddings.e_list
                       FStar_Tactics_Embedding.e_goal in
-                  let uu____1179 =
+                  let uu___14 =
                     FStar_TypeChecker_NBETerm.e_list
                       FStar_Tactics_Embedding.e_goal_nbe in
                   mk_total_step_1' Prims.int_zero "smt_goals_of"
                     FStar_Tactics_Types.smt_goals_of
-                    FStar_Tactics_Embedding.e_proofstate uu____1174
+                    FStar_Tactics_Embedding.e_proofstate uu___13
                     FStar_Tactics_Types.smt_goals_of
-                    FStar_Tactics_Embedding.e_proofstate_nbe uu____1179 in
-                let uu____1188 =
-                  let uu____1191 =
+                    FStar_Tactics_Embedding.e_proofstate_nbe uu___14 in
+                let uu___13 =
+                  let uu___14 =
                     mk_total_step_1' Prims.int_zero "goal_env"
                       FStar_Tactics_Types.goal_env
                       FStar_Tactics_Embedding.e_goal
@@ -500,8 +494,8 @@ let (uu___143 : unit) =
                       FStar_Tactics_Types.goal_env
                       FStar_Tactics_Embedding.e_goal_nbe
                       FStar_Reflection_NBEEmbeddings.e_env in
-                  let uu____1192 =
-                    let uu____1195 =
+                  let uu___15 =
+                    let uu___16 =
                       mk_total_step_1' Prims.int_zero "goal_type"
                         FStar_Tactics_Types.goal_type
                         FStar_Tactics_Embedding.e_goal
@@ -509,8 +503,8 @@ let (uu___143 : unit) =
                         FStar_Tactics_Types.goal_type
                         FStar_Tactics_Embedding.e_goal_nbe
                         FStar_Reflection_NBEEmbeddings.e_term in
-                    let uu____1196 =
-                      let uu____1199 =
+                    let uu___17 =
+                      let uu___18 =
                         mk_total_step_1' Prims.int_zero "goal_witness"
                           FStar_Tactics_Types.goal_witness
                           FStar_Tactics_Embedding.e_goal
@@ -518,8 +512,8 @@ let (uu___143 : unit) =
                           FStar_Tactics_Types.goal_witness
                           FStar_Tactics_Embedding.e_goal_nbe
                           FStar_Reflection_NBEEmbeddings.e_term in
-                      let uu____1200 =
-                        let uu____1203 =
+                      let uu___19 =
+                        let uu___20 =
                           mk_total_step_1' Prims.int_zero "is_guard"
                             FStar_Tactics_Types.is_guard
                             FStar_Tactics_Embedding.e_goal
@@ -527,8 +521,8 @@ let (uu___143 : unit) =
                             FStar_Tactics_Types.is_guard
                             FStar_Tactics_Embedding.e_goal_nbe
                             FStar_TypeChecker_NBETerm.e_bool in
-                        let uu____1204 =
-                          let uu____1207 =
+                        let uu___21 =
+                          let uu___22 =
                             mk_total_step_1' Prims.int_zero "get_label"
                               FStar_Tactics_Types.get_label
                               FStar_Tactics_Embedding.e_goal
@@ -536,8 +530,8 @@ let (uu___143 : unit) =
                               FStar_Tactics_Types.get_label
                               FStar_Tactics_Embedding.e_goal_nbe
                               FStar_TypeChecker_NBETerm.e_string in
-                          let uu____1208 =
-                            let uu____1211 =
+                          let uu___23 =
+                            let uu___24 =
                               mk_total_step_2' Prims.int_zero "set_label"
                                 FStar_Tactics_Types.set_label
                                 FStar_Syntax_Embeddings.e_string
@@ -547,37 +541,36 @@ let (uu___143 : unit) =
                                 FStar_TypeChecker_NBETerm.e_string
                                 FStar_Tactics_Embedding.e_goal_nbe
                                 FStar_Tactics_Embedding.e_goal_nbe in
-                            let uu____1212 =
-                              let uu____1215 =
-                                let uu____1216 =
+                            let uu___25 =
+                              let uu___26 =
+                                let uu___27 =
                                   FStar_Syntax_Embeddings.e_list
                                     FStar_Tactics_Embedding.e_goal in
-                                let uu____1221 =
+                                let uu___28 =
                                   FStar_TypeChecker_NBETerm.e_list
                                     FStar_Tactics_Embedding.e_goal_nbe in
                                 FStar_Tactics_InterpFuns.mk_tac_step_1
                                   Prims.int_zero "set_goals"
-                                  FStar_Tactics_Monad.set_goals uu____1216
+                                  FStar_Tactics_Monad.set_goals uu___27
                                   FStar_Syntax_Embeddings.e_unit
-                                  FStar_Tactics_Monad.set_goals uu____1221
+                                  FStar_Tactics_Monad.set_goals uu___28
                                   FStar_TypeChecker_NBETerm.e_unit in
-                              let uu____1230 =
-                                let uu____1233 =
-                                  let uu____1234 =
+                              let uu___27 =
+                                let uu___28 =
+                                  let uu___29 =
                                     FStar_Syntax_Embeddings.e_list
                                       FStar_Tactics_Embedding.e_goal in
-                                  let uu____1239 =
+                                  let uu___30 =
                                     FStar_TypeChecker_NBETerm.e_list
                                       FStar_Tactics_Embedding.e_goal_nbe in
                                   FStar_Tactics_InterpFuns.mk_tac_step_1
                                     Prims.int_zero "set_smt_goals"
-                                    FStar_Tactics_Monad.set_smt_goals
-                                    uu____1234 FStar_Syntax_Embeddings.e_unit
-                                    FStar_Tactics_Monad.set_smt_goals
-                                    uu____1239
+                                    FStar_Tactics_Monad.set_smt_goals uu___29
+                                    FStar_Syntax_Embeddings.e_unit
+                                    FStar_Tactics_Monad.set_smt_goals uu___30
                                     FStar_TypeChecker_NBETerm.e_unit in
-                                let uu____1248 =
-                                  let uu____1251 =
+                                let uu___29 =
+                                  let uu___30 =
                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                       Prims.int_zero "trivial"
                                       FStar_Tactics_Basic.trivial
@@ -586,60 +579,60 @@ let (uu___143 : unit) =
                                       FStar_Tactics_Basic.trivial
                                       FStar_TypeChecker_NBETerm.e_unit
                                       FStar_TypeChecker_NBETerm.e_unit in
-                                  let uu____1252 =
-                                    let uu____1255 =
-                                      let uu____1256 =
+                                  let uu___31 =
+                                    let uu___32 =
+                                      let uu___33 =
                                         e_tactic_thunk
                                           FStar_Syntax_Embeddings.e_any in
-                                      let uu____1261 =
+                                      let uu___34 =
                                         FStar_Syntax_Embeddings.e_either
                                           FStar_Tactics_Embedding.e_exn
                                           FStar_Syntax_Embeddings.e_any in
-                                      let uu____1268 =
+                                      let uu___35 =
                                         e_tactic_nbe_thunk
                                           FStar_TypeChecker_NBETerm.e_any in
-                                      let uu____1273 =
+                                      let uu___36 =
                                         FStar_TypeChecker_NBETerm.e_either
                                           FStar_Tactics_Embedding.e_exn_nbe
                                           FStar_TypeChecker_NBETerm.e_any in
                                       FStar_Tactics_InterpFuns.mk_tac_step_2
                                         Prims.int_one "catch"
-                                        (fun uu____1293 ->
+                                        (fun uu___37 ->
                                            FStar_Tactics_Basic.catch)
-                                        FStar_Syntax_Embeddings.e_any
-                                        uu____1256 uu____1261
-                                        (fun uu____1295 ->
+                                        FStar_Syntax_Embeddings.e_any uu___33
+                                        uu___34
+                                        (fun uu___37 ->
                                            FStar_Tactics_Basic.catch)
                                         FStar_TypeChecker_NBETerm.e_any
-                                        uu____1268 uu____1273 in
-                                    let uu____1296 =
-                                      let uu____1299 =
-                                        let uu____1300 =
+                                        uu___35 uu___36 in
+                                    let uu___33 =
+                                      let uu___34 =
+                                        let uu___35 =
                                           e_tactic_thunk
                                             FStar_Syntax_Embeddings.e_any in
-                                        let uu____1305 =
+                                        let uu___36 =
                                           FStar_Syntax_Embeddings.e_either
                                             FStar_Tactics_Embedding.e_exn
                                             FStar_Syntax_Embeddings.e_any in
-                                        let uu____1312 =
+                                        let uu___37 =
                                           e_tactic_nbe_thunk
                                             FStar_TypeChecker_NBETerm.e_any in
-                                        let uu____1317 =
+                                        let uu___38 =
                                           FStar_TypeChecker_NBETerm.e_either
                                             FStar_Tactics_Embedding.e_exn_nbe
                                             FStar_TypeChecker_NBETerm.e_any in
                                         FStar_Tactics_InterpFuns.mk_tac_step_2
                                           Prims.int_one "recover"
-                                          (fun uu____1337 ->
+                                          (fun uu___39 ->
                                              FStar_Tactics_Basic.recover)
                                           FStar_Syntax_Embeddings.e_any
-                                          uu____1300 uu____1305
-                                          (fun uu____1339 ->
+                                          uu___35 uu___36
+                                          (fun uu___39 ->
                                              FStar_Tactics_Basic.recover)
                                           FStar_TypeChecker_NBETerm.e_any
-                                          uu____1312 uu____1317 in
-                                      let uu____1340 =
-                                        let uu____1343 =
+                                          uu___37 uu___38 in
+                                      let uu___35 =
+                                        let uu___36 =
                                           FStar_Tactics_InterpFuns.mk_tac_step_1
                                             Prims.int_zero "intro"
                                             FStar_Tactics_Basic.intro
@@ -648,13 +641,13 @@ let (uu___143 : unit) =
                                             FStar_Tactics_Basic.intro
                                             FStar_TypeChecker_NBETerm.e_unit
                                             FStar_Reflection_NBEEmbeddings.e_binder in
-                                        let uu____1344 =
-                                          let uu____1347 =
-                                            let uu____1348 =
+                                        let uu___37 =
+                                          let uu___38 =
+                                            let uu___39 =
                                               FStar_Syntax_Embeddings.e_tuple2
                                                 FStar_Reflection_Embeddings.e_binder
                                                 FStar_Reflection_Embeddings.e_binder in
-                                            let uu____1355 =
+                                            let uu___40 =
                                               FStar_TypeChecker_NBETerm.e_tuple2
                                                 FStar_Reflection_NBEEmbeddings.e_binder
                                                 FStar_Reflection_NBEEmbeddings.e_binder in
@@ -662,32 +655,32 @@ let (uu___143 : unit) =
                                               Prims.int_zero "intro_rec"
                                               FStar_Tactics_Basic.intro_rec
                                               FStar_Syntax_Embeddings.e_unit
-                                              uu____1348
+                                              uu___39
                                               FStar_Tactics_Basic.intro_rec
                                               FStar_TypeChecker_NBETerm.e_unit
-                                              uu____1355 in
-                                          let uu____1370 =
-                                            let uu____1373 =
-                                              let uu____1374 =
+                                              uu___40 in
+                                          let uu___39 =
+                                            let uu___40 =
+                                              let uu___41 =
                                                 FStar_Syntax_Embeddings.e_list
                                                   FStar_Syntax_Embeddings.e_norm_step in
-                                              let uu____1379 =
+                                              let uu___42 =
                                                 FStar_TypeChecker_NBETerm.e_list
                                                   FStar_TypeChecker_NBETerm.e_norm_step in
                                               FStar_Tactics_InterpFuns.mk_tac_step_1
                                                 Prims.int_zero "norm"
                                                 FStar_Tactics_Basic.norm
-                                                uu____1374
+                                                uu___41
                                                 FStar_Syntax_Embeddings.e_unit
                                                 FStar_Tactics_Basic.norm
-                                                uu____1379
+                                                uu___42
                                                 FStar_TypeChecker_NBETerm.e_unit in
-                                            let uu____1388 =
-                                              let uu____1391 =
-                                                let uu____1392 =
+                                            let uu___41 =
+                                              let uu___42 =
+                                                let uu___43 =
                                                   FStar_Syntax_Embeddings.e_list
                                                     FStar_Syntax_Embeddings.e_norm_step in
-                                                let uu____1397 =
+                                                let uu___44 =
                                                   FStar_TypeChecker_NBETerm.e_list
                                                     FStar_TypeChecker_NBETerm.e_norm_step in
                                                 FStar_Tactics_InterpFuns.mk_tac_step_3
@@ -695,35 +688,35 @@ let (uu___143 : unit) =
                                                   "norm_term_env"
                                                   FStar_Tactics_Basic.norm_term_env
                                                   FStar_Reflection_Embeddings.e_env
-                                                  uu____1392
+                                                  uu___43
                                                   FStar_Reflection_Embeddings.e_term
                                                   FStar_Reflection_Embeddings.e_term
                                                   FStar_Tactics_Basic.norm_term_env
                                                   FStar_Reflection_NBEEmbeddings.e_env
-                                                  uu____1397
+                                                  uu___44
                                                   FStar_Reflection_NBEEmbeddings.e_term
                                                   FStar_Reflection_NBEEmbeddings.e_term in
-                                              let uu____1406 =
-                                                let uu____1409 =
-                                                  let uu____1410 =
+                                              let uu___43 =
+                                                let uu___44 =
+                                                  let uu___45 =
                                                     FStar_Syntax_Embeddings.e_list
                                                       FStar_Syntax_Embeddings.e_norm_step in
-                                                  let uu____1415 =
+                                                  let uu___46 =
                                                     FStar_TypeChecker_NBETerm.e_list
                                                       FStar_TypeChecker_NBETerm.e_norm_step in
                                                   FStar_Tactics_InterpFuns.mk_tac_step_2
                                                     Prims.int_zero
                                                     "norm_binder_type"
                                                     FStar_Tactics_Basic.norm_binder_type
-                                                    uu____1410
+                                                    uu___45
                                                     FStar_Reflection_Embeddings.e_binder
                                                     FStar_Syntax_Embeddings.e_unit
                                                     FStar_Tactics_Basic.norm_binder_type
-                                                    uu____1415
+                                                    uu___46
                                                     FStar_Reflection_NBEEmbeddings.e_binder
                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                let uu____1424 =
-                                                  let uu____1427 =
+                                                let uu___45 =
+                                                  let uu___46 =
                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                       Prims.int_zero
                                                       "rename_to"
@@ -735,8 +728,8 @@ let (uu___143 : unit) =
                                                       FStar_Reflection_NBEEmbeddings.e_binder
                                                       FStar_TypeChecker_NBETerm.e_string
                                                       FStar_Reflection_NBEEmbeddings.e_binder in
-                                                  let uu____1428 =
-                                                    let uu____1431 =
+                                                  let uu___47 =
+                                                    let uu___48 =
                                                       FStar_Tactics_InterpFuns.mk_tac_step_1
                                                         Prims.int_zero
                                                         "binder_retype"
@@ -746,8 +739,8 @@ let (uu___143 : unit) =
                                                         FStar_Tactics_Basic.binder_retype
                                                         FStar_Reflection_NBEEmbeddings.e_binder
                                                         FStar_TypeChecker_NBETerm.e_unit in
-                                                    let uu____1432 =
-                                                      let uu____1435 =
+                                                    let uu___49 =
+                                                      let uu___50 =
                                                         FStar_Tactics_InterpFuns.mk_tac_step_1
                                                           Prims.int_zero
                                                           "revert"
@@ -757,8 +750,8 @@ let (uu___143 : unit) =
                                                           FStar_Tactics_Basic.revert
                                                           FStar_TypeChecker_NBETerm.e_unit
                                                           FStar_TypeChecker_NBETerm.e_unit in
-                                                      let uu____1436 =
-                                                        let uu____1439 =
+                                                      let uu___51 =
+                                                        let uu___52 =
                                                           FStar_Tactics_InterpFuns.mk_tac_step_1
                                                             Prims.int_zero
                                                             "clear_top"
@@ -768,8 +761,8 @@ let (uu___143 : unit) =
                                                             FStar_Tactics_Basic.clear_top
                                                             FStar_TypeChecker_NBETerm.e_unit
                                                             FStar_TypeChecker_NBETerm.e_unit in
-                                                        let uu____1440 =
-                                                          let uu____1443 =
+                                                        let uu___53 =
+                                                          let uu___54 =
                                                             FStar_Tactics_InterpFuns.mk_tac_step_1
                                                               Prims.int_zero
                                                               "clear"
@@ -779,8 +772,8 @@ let (uu___143 : unit) =
                                                               FStar_Tactics_Basic.clear
                                                               FStar_Reflection_NBEEmbeddings.e_binder
                                                               FStar_TypeChecker_NBETerm.e_unit in
-                                                          let uu____1444 =
-                                                            let uu____1447 =
+                                                          let uu___55 =
+                                                            let uu___56 =
                                                               FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                 Prims.int_zero
                                                                 "rewrite"
@@ -790,9 +783,8 @@ let (uu___143 : unit) =
                                                                 FStar_Tactics_Basic.rewrite
                                                                 FStar_Reflection_NBEEmbeddings.e_binder
                                                                 FStar_TypeChecker_NBETerm.e_unit in
-                                                            let uu____1448 =
-                                                              let uu____1451
-                                                                =
+                                                            let uu___57 =
+                                                              let uu___58 =
                                                                 FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                   Prims.int_zero
                                                                   "refine_intro"
@@ -802,10 +794,8 @@ let (uu___143 : unit) =
                                                                   FStar_Tactics_Basic.refine_intro
                                                                   FStar_TypeChecker_NBETerm.e_unit
                                                                   FStar_TypeChecker_NBETerm.e_unit in
-                                                              let uu____1452
-                                                                =
-                                                                let uu____1455
-                                                                  =
+                                                              let uu___59 =
+                                                                let uu___60 =
                                                                   FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "t_exact"
@@ -819,9 +809,8 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                let uu____1456
-                                                                  =
-                                                                  let uu____1459
+                                                                let uu___61 =
+                                                                  let uu___62
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -836,9 +825,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                  let uu____1460
+                                                                  let uu___63
                                                                     =
-                                                                    let uu____1463
+                                                                    let uu___64
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -853,9 +842,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1464
+                                                                    let uu___65
                                                                     =
-                                                                    let uu____1467
+                                                                    let uu___66
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -866,9 +855,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.set_options
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1468
+                                                                    let uu___67
                                                                     =
-                                                                    let uu____1471
+                                                                    let uu___68
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -881,9 +870,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_comp in
-                                                                    let uu____1472
+                                                                    let uu___69
                                                                     =
-                                                                    let uu____1475
+                                                                    let uu___70
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -896,9 +885,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term in
-                                                                    let uu____1476
+                                                                    let uu___71
                                                                     =
-                                                                    let uu____1479
+                                                                    let uu___72
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -909,9 +898,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.unshelve
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1480
+                                                                    let uu___73
                                                                     =
-                                                                    let uu____1483
+                                                                    let uu___74
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_one
@@ -921,19 +910,19 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     (fun
-                                                                    uu____1486
+                                                                    uu___75
                                                                     ->
                                                                     fun
-                                                                    uu____1487
+                                                                    uu___76
                                                                     ->
                                                                     failwith
                                                                     "NBE unquote")
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_any in
-                                                                    let uu____1490
+                                                                    let uu___75
                                                                     =
-                                                                    let uu____1493
+                                                                    let uu___76
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -944,9 +933,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.prune
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1494
+                                                                    let uu___77
                                                                     =
-                                                                    let uu____1497
+                                                                    let uu___78
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -957,9 +946,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.addns
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1498
+                                                                    let uu___79
                                                                     =
-                                                                    let uu____1501
+                                                                    let uu___80
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -970,9 +959,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.print
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1502
+                                                                    let uu___81
                                                                     =
-                                                                    let uu____1505
+                                                                    let uu___82
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -983,9 +972,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.debugging
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool in
-                                                                    let uu____1506
+                                                                    let uu___83
                                                                     =
-                                                                    let uu____1509
+                                                                    let uu___84
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -996,35 +985,35 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.dump
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1510
+                                                                    let uu___85
                                                                     =
-                                                                    let uu____1513
+                                                                    let uu___86
                                                                     =
-                                                                    let uu____1514
+                                                                    let uu___87
                                                                     =
-                                                                    let uu____1526
+                                                                    let uu___88
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Syntax_Embeddings.e_bool
                                                                     FStar_Tactics_Embedding.e_ctrl_flag in
                                                                     e_tactic_1
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    uu____1526 in
-                                                                    let uu____1537
+                                                                    uu___88 in
+                                                                    let uu___88
                                                                     =
                                                                     e_tactic_thunk
                                                                     FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu____1542
+                                                                    let uu___89
                                                                     =
-                                                                    let uu____1554
+                                                                    let uu___90
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_Tactics_Embedding.e_ctrl_flag_nbe in
                                                                     e_tactic_nbe_1
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    uu____1554 in
-                                                                    let uu____1565
+                                                                    uu___90 in
+                                                                    let uu___90
                                                                     =
                                                                     e_tactic_nbe_thunk
                                                                     FStar_TypeChecker_NBETerm.e_unit in
@@ -1033,17 +1022,17 @@ let (uu___143 : unit) =
                                                                     "ctrl_rewrite"
                                                                     FStar_Tactics_CtrlRewrite.ctrl_rewrite
                                                                     FStar_Tactics_Embedding.e_direction
-                                                                    uu____1514
-                                                                    uu____1537
+                                                                    uu___87
+                                                                    uu___88
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Tactics_CtrlRewrite.ctrl_rewrite
                                                                     FStar_Tactics_Embedding.e_direction_nbe
-                                                                    uu____1542
-                                                                    uu____1565
+                                                                    uu___89
+                                                                    uu___90
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1592
+                                                                    let uu___87
                                                                     =
-                                                                    let uu____1595
+                                                                    let uu___88
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1054,9 +1043,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.trefl
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1596
+                                                                    let uu___89
                                                                     =
-                                                                    let uu____1599
+                                                                    let uu___90
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1067,9 +1056,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.dup
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1600
+                                                                    let uu___91
                                                                     =
-                                                                    let uu____1603
+                                                                    let uu___92
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1080,9 +1069,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.tadmit_t
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1604
+                                                                    let uu___93
                                                                     =
-                                                                    let uu____1607
+                                                                    let uu___94
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1093,40 +1082,40 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.join
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1608
+                                                                    let uu___95
                                                                     =
-                                                                    let uu____1611
+                                                                    let uu___96
                                                                     =
-                                                                    let uu____1612
+                                                                    let uu___97
                                                                     =
-                                                                    let uu____1621
+                                                                    let uu___98
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Reflection_Embeddings.e_fv
                                                                     FStar_Syntax_Embeddings.e_int in
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    uu____1621 in
-                                                                    let uu____1632
+                                                                    uu___98 in
+                                                                    let uu___98
                                                                     =
-                                                                    let uu____1641
+                                                                    let uu___99
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_Reflection_NBEEmbeddings.e_fv
                                                                     FStar_TypeChecker_NBETerm.e_int in
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    uu____1641 in
+                                                                    uu___99 in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "t_destruct"
                                                                     FStar_Tactics_Basic.t_destruct
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    uu____1612
+                                                                    uu___97
                                                                     FStar_Tactics_Basic.t_destruct
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    uu____1632 in
-                                                                    let uu____1664
+                                                                    uu___98 in
+                                                                    let uu___97
                                                                     =
-                                                                    let uu____1667
+                                                                    let uu___98
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1137,9 +1126,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.top_env
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Reflection_NBEEmbeddings.e_env in
-                                                                    let uu____1668
+                                                                    let uu___99
                                                                     =
-                                                                    let uu____1671
+                                                                    let uu___100
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1150,9 +1139,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.inspect
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term_view in
-                                                                    let uu____1672
+                                                                    let uu___101
                                                                     =
-                                                                    let uu____1675
+                                                                    let uu___102
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1163,9 +1152,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.pack
                                                                     FStar_Reflection_NBEEmbeddings.e_term_view
                                                                     FStar_Reflection_NBEEmbeddings.e_term in
-                                                                    let uu____1676
+                                                                    let uu___103
                                                                     =
-                                                                    let uu____1679
+                                                                    let uu___104
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1176,9 +1165,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.fresh
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_int in
-                                                                    let uu____1680
+                                                                    let uu___105
                                                                     =
-                                                                    let uu____1683
+                                                                    let uu___106
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1189,15 +1178,15 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.curms
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_int in
-                                                                    let uu____1684
+                                                                    let uu___107
                                                                     =
-                                                                    let uu____1687
+                                                                    let uu___108
                                                                     =
-                                                                    let uu____1688
+                                                                    let uu___109
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
                                                                     FStar_Reflection_Embeddings.e_term in
-                                                                    let uu____1693
+                                                                    let uu___110
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
                                                                     FStar_Reflection_NBEEmbeddings.e_term in
@@ -1206,15 +1195,15 @@ let (uu___143 : unit) =
                                                                     "uvar_env"
                                                                     FStar_Tactics_Basic.uvar_env
                                                                     FStar_Reflection_Embeddings.e_env
-                                                                    uu____1688
+                                                                    uu___109
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Tactics_Basic.uvar_env
                                                                     FStar_Reflection_NBEEmbeddings.e_env
-                                                                    uu____1693
+                                                                    uu___110
                                                                     FStar_Reflection_NBEEmbeddings.e_term in
-                                                                    let uu____1702
+                                                                    let uu___109
                                                                     =
-                                                                    let uu____1705
+                                                                    let uu___110
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -1229,9 +1218,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_bool in
-                                                                    let uu____1706
+                                                                    let uu___111
                                                                     =
-                                                                    let uu____1709
+                                                                    let uu___112
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -1246,15 +1235,15 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_bool in
-                                                                    let uu____1710
+                                                                    let uu___113
                                                                     =
-                                                                    let uu____1713
+                                                                    let uu___114
                                                                     =
-                                                                    let uu____1714
+                                                                    let uu___115
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu____1719
+                                                                    let uu___116
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
@@ -1263,17 +1252,17 @@ let (uu___143 : unit) =
                                                                     "launch_process"
                                                                     FStar_Tactics_Basic.launch_process
                                                                     FStar_Syntax_Embeddings.e_string
-                                                                    uu____1714
+                                                                    uu___115
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Tactics_Basic.launch_process
                                                                     FStar_TypeChecker_NBETerm.e_string
-                                                                    uu____1719
+                                                                    uu___116
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_string in
-                                                                    let uu____1728
+                                                                    let uu___115
                                                                     =
-                                                                    let uu____1731
+                                                                    let uu___116
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -1286,9 +1275,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_bv in
-                                                                    let uu____1732
+                                                                    let uu___117
                                                                     =
-                                                                    let uu____1735
+                                                                    let uu___118
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1299,9 +1288,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.change
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1736
+                                                                    let uu___119
                                                                     =
-                                                                    let uu____1739
+                                                                    let uu___120
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1312,9 +1301,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.get_guard_policy
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Tactics_Embedding.e_guard_policy_nbe in
-                                                                    let uu____1740
+                                                                    let uu___121
                                                                     =
-                                                                    let uu____1743
+                                                                    let uu___122
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1325,9 +1314,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.set_guard_policy
                                                                     FStar_Tactics_Embedding.e_guard_policy_nbe
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu____1744
+                                                                    let uu___123
                                                                     =
-                                                                    let uu____1747
+                                                                    let uu___124
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1338,9 +1327,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.lax_on
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool in
-                                                                    let uu____1748
+                                                                    let uu___125
                                                                     =
-                                                                    let uu____1751
+                                                                    let uu___126
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_one
@@ -1350,19 +1339,19 @@ let (uu___143 : unit) =
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     (fun
-                                                                    uu____1754
+                                                                    uu___127
                                                                     ->
                                                                     fun
-                                                                    uu____1755
+                                                                    uu___128
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "sorry, `lget` does not work in NBE")
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_any in
-                                                                    let uu____1756
+                                                                    let uu___127
                                                                     =
-                                                                    let uu____1759
+                                                                    let uu___128
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_one
@@ -1373,13 +1362,13 @@ let (uu___143 : unit) =
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     (fun
-                                                                    uu____1763
+                                                                    uu___129
                                                                     ->
                                                                     fun
-                                                                    uu____1764
+                                                                    uu___130
                                                                     ->
                                                                     fun
-                                                                    uu____1765
+                                                                    uu___131
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "sorry, `lset` does not work in NBE")
@@ -1387,145 +1376,141 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    [uu____1759] in
-                                                                    uu____1751
+                                                                    [uu___128] in
+                                                                    uu___126
                                                                     ::
-                                                                    uu____1756 in
-                                                                    uu____1747
+                                                                    uu___127 in
+                                                                    uu___124
                                                                     ::
-                                                                    uu____1748 in
-                                                                    uu____1743
+                                                                    uu___125 in
+                                                                    uu___122
                                                                     ::
-                                                                    uu____1744 in
-                                                                    uu____1739
+                                                                    uu___123 in
+                                                                    uu___120
                                                                     ::
-                                                                    uu____1740 in
-                                                                    uu____1735
+                                                                    uu___121 in
+                                                                    uu___118
                                                                     ::
-                                                                    uu____1736 in
-                                                                    uu____1731
+                                                                    uu___119 in
+                                                                    uu___116
                                                                     ::
-                                                                    uu____1732 in
-                                                                    uu____1713
+                                                                    uu___117 in
+                                                                    uu___114
                                                                     ::
-                                                                    uu____1728 in
-                                                                    uu____1709
+                                                                    uu___115 in
+                                                                    uu___112
                                                                     ::
-                                                                    uu____1710 in
-                                                                    uu____1705
+                                                                    uu___113 in
+                                                                    uu___110
                                                                     ::
-                                                                    uu____1706 in
-                                                                    uu____1687
+                                                                    uu___111 in
+                                                                    uu___108
                                                                     ::
-                                                                    uu____1702 in
-                                                                    uu____1683
+                                                                    uu___109 in
+                                                                    uu___106
                                                                     ::
-                                                                    uu____1684 in
-                                                                    uu____1679
+                                                                    uu___107 in
+                                                                    uu___104
                                                                     ::
-                                                                    uu____1680 in
-                                                                    uu____1675
+                                                                    uu___105 in
+                                                                    uu___102
                                                                     ::
-                                                                    uu____1676 in
-                                                                    uu____1671
+                                                                    uu___103 in
+                                                                    uu___100
                                                                     ::
-                                                                    uu____1672 in
-                                                                    uu____1667
+                                                                    uu___101 in
+                                                                    uu___98
                                                                     ::
-                                                                    uu____1668 in
-                                                                    uu____1611
+                                                                    uu___99 in
+                                                                    uu___96
                                                                     ::
-                                                                    uu____1664 in
-                                                                    uu____1607
+                                                                    uu___97 in
+                                                                    uu___94
                                                                     ::
-                                                                    uu____1608 in
-                                                                    uu____1603
+                                                                    uu___95 in
+                                                                    uu___92
                                                                     ::
-                                                                    uu____1604 in
-                                                                    uu____1599
+                                                                    uu___93 in
+                                                                    uu___90
                                                                     ::
-                                                                    uu____1600 in
-                                                                    uu____1595
+                                                                    uu___91 in
+                                                                    uu___88
                                                                     ::
-                                                                    uu____1596 in
-                                                                    uu____1513
+                                                                    uu___89 in
+                                                                    uu___86
                                                                     ::
-                                                                    uu____1592 in
-                                                                    uu____1509
+                                                                    uu___87 in
+                                                                    uu___84
                                                                     ::
-                                                                    uu____1510 in
-                                                                    uu____1505
+                                                                    uu___85 in
+                                                                    uu___82
                                                                     ::
-                                                                    uu____1506 in
-                                                                    uu____1501
+                                                                    uu___83 in
+                                                                    uu___80
                                                                     ::
-                                                                    uu____1502 in
-                                                                    uu____1497
+                                                                    uu___81 in
+                                                                    uu___78
                                                                     ::
-                                                                    uu____1498 in
-                                                                    uu____1493
+                                                                    uu___79 in
+                                                                    uu___76
                                                                     ::
-                                                                    uu____1494 in
-                                                                    uu____1483
+                                                                    uu___77 in
+                                                                    uu___74
                                                                     ::
-                                                                    uu____1490 in
-                                                                    uu____1479
+                                                                    uu___75 in
+                                                                    uu___72
                                                                     ::
-                                                                    uu____1480 in
-                                                                    uu____1475
+                                                                    uu___73 in
+                                                                    uu___70
                                                                     ::
-                                                                    uu____1476 in
-                                                                    uu____1471
+                                                                    uu___71 in
+                                                                    uu___68
                                                                     ::
-                                                                    uu____1472 in
-                                                                    uu____1467
+                                                                    uu___69 in
+                                                                    uu___66
                                                                     ::
-                                                                    uu____1468 in
-                                                                    uu____1463
+                                                                    uu___67 in
+                                                                    uu___64
                                                                     ::
-                                                                    uu____1464 in
-                                                                  uu____1459
-                                                                    ::
-                                                                    uu____1460 in
-                                                                uu____1455 ::
-                                                                  uu____1456 in
-                                                              uu____1451 ::
-                                                                uu____1452 in
-                                                            uu____1447 ::
-                                                              uu____1448 in
-                                                          uu____1443 ::
-                                                            uu____1444 in
-                                                        uu____1439 ::
-                                                          uu____1440 in
-                                                      uu____1435 ::
-                                                        uu____1436 in
-                                                    uu____1431 :: uu____1432 in
-                                                  uu____1427 :: uu____1428 in
-                                                uu____1409 :: uu____1424 in
-                                              uu____1391 :: uu____1406 in
-                                            uu____1373 :: uu____1388 in
-                                          uu____1347 :: uu____1370 in
-                                        uu____1343 :: uu____1344 in
-                                      uu____1299 :: uu____1340 in
-                                    uu____1255 :: uu____1296 in
-                                  uu____1251 :: uu____1252 in
-                                uu____1233 :: uu____1248 in
-                              uu____1215 :: uu____1230 in
-                            uu____1211 :: uu____1212 in
-                          uu____1207 :: uu____1208 in
-                        uu____1203 :: uu____1204 in
-                      uu____1199 :: uu____1200 in
-                    uu____1195 :: uu____1196 in
-                  uu____1191 :: uu____1192 in
-                uu____1173 :: uu____1188 in
-              uu____1155 :: uu____1170 in
-            uu____1151 :: uu____1152 in
-          uu____1147 :: uu____1148 in
-        uu____1143 :: uu____1144 in
-      uu____1139 :: uu____1140 in
-    FStar_All.pipe_left
-      (fun uu____1774 -> FStar_Pervasives_Native.Some uu____1774) uu____1136 in
-  FStar_ST.op_Colon_Equals __primitive_steps_ref uu____1131
+                                                                    uu___65 in
+                                                                  uu___62 ::
+                                                                    uu___63 in
+                                                                uu___60 ::
+                                                                  uu___61 in
+                                                              uu___58 ::
+                                                                uu___59 in
+                                                            uu___56 ::
+                                                              uu___57 in
+                                                          uu___54 :: uu___55 in
+                                                        uu___52 :: uu___53 in
+                                                      uu___50 :: uu___51 in
+                                                    uu___48 :: uu___49 in
+                                                  uu___46 :: uu___47 in
+                                                uu___44 :: uu___45 in
+                                              uu___42 :: uu___43 in
+                                            uu___40 :: uu___41 in
+                                          uu___38 :: uu___39 in
+                                        uu___36 :: uu___37 in
+                                      uu___34 :: uu___35 in
+                                    uu___32 :: uu___33 in
+                                  uu___30 :: uu___31 in
+                                uu___28 :: uu___29 in
+                              uu___26 :: uu___27 in
+                            uu___24 :: uu___25 in
+                          uu___22 :: uu___23 in
+                        uu___20 :: uu___21 in
+                      uu___18 :: uu___19 in
+                    uu___16 :: uu___17 in
+                  uu___14 :: uu___15 in
+                uu___12 :: uu___13 in
+              uu___10 :: uu___11 in
+            uu___8 :: uu___9 in
+          uu___6 :: uu___7 in
+        uu___4 :: uu___5 in
+      uu___2 :: uu___3 in
+    FStar_All.pipe_left (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+      uu___1 in
+  FStar_ST.op_Colon_Equals __primitive_steps_ref uu___
 
 let unembed_tactic_1_alt :
   'a 'r .
@@ -1544,10 +1529,9 @@ let unembed_tactic_1_alt :
                let rng = FStar_Range.dummyRange in
                let x_tm = embed ea rng x ncb in
                let app =
-                 let uu____1853 =
-                   let uu____1854 = FStar_Syntax_Syntax.as_arg x_tm in
-                   [uu____1854] in
-                 FStar_Syntax_Syntax.mk_Tm_app f uu____1853 rng in
+                 let uu___ =
+                   let uu___1 = FStar_Syntax_Syntax.as_arg x_tm in [uu___1] in
+                 FStar_Syntax_Syntax.mk_Tm_app f uu___ rng in
                unembed_tactic_0 er app ncb)
 let e_tactic_1_alt :
   'a 'r .
@@ -1559,19 +1543,18 @@ let e_tactic_1_alt :
   =
   fun ea ->
     fun er ->
-      let em uu____1943 uu____1944 uu____1945 uu____1946 =
+      let em uu___ uu___1 uu___2 uu___3 =
         failwith "Impossible: embedding tactic (1)?" in
       let un t0 w n =
-        let uu____1992 = unembed_tactic_1_alt ea er t0 n in
-        match uu____1992 with
+        let uu___ = unembed_tactic_1_alt ea er t0 n in
+        match uu___ with
         | FStar_Pervasives_Native.Some f ->
             FStar_Pervasives_Native.Some
-              ((fun x ->
-                  let uu____2032 = f x in FStar_Tactics_Monad.run uu____2032))
+              ((fun x -> let uu___1 = f x in FStar_Tactics_Monad.run uu___1))
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
-      let uu____2048 =
+      let uu___ =
         FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit in
-      FStar_Syntax_Embeddings.mk_emb em un uu____2048
+      FStar_Syntax_Embeddings.mk_emb em un uu___
 let (report_implicits :
   FStar_Range.range -> FStar_TypeChecker_Env.implicits -> unit) =
   fun rng ->
@@ -1579,19 +1562,18 @@ let (report_implicits :
       let errs =
         FStar_List.map
           (fun imp ->
-             let uu____2085 =
-               let uu____2086 =
+             let uu___ =
+               let uu___1 =
                  FStar_Syntax_Print.uvar_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-               let uu____2087 =
+               let uu___2 =
                  FStar_Syntax_Print.term_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
                FStar_Util.format3
                  "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                 uu____2086 uu____2087
-                 imp.FStar_TypeChecker_Common.imp_reason in
-             (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
-               uu____2085, rng)) is in
+                 uu___1 uu___2 imp.FStar_TypeChecker_Common.imp_reason in
+             (FStar_Errors.Error_UninstantiatedUnificationVarInTactic, uu___,
+               rng)) is in
       FStar_Errors.add_errors errs; FStar_Errors.stop_if_err ()
 let run_tactic_on_ps :
   'a 'b .
@@ -1612,94 +1594,91 @@ let run_tactic_on_ps :
             fun tactic ->
               fun ps ->
                 let env = ps.FStar_Tactics_Types.main_context in
-                (let uu____2160 = FStar_ST.op_Bang tacdbg in
-                 if uu____2160
+                (let uu___1 = FStar_ST.op_Bang tacdbg in
+                 if uu___1
                  then
-                   let uu____2167 = FStar_Syntax_Print.term_to_string tactic in
-                   FStar_Util.print1 "Typechecking tactic: (%s) {\n"
-                     uu____2167
+                   let uu___2 = FStar_Syntax_Print.term_to_string tactic in
+                   FStar_Util.print1 "Typechecking tactic: (%s) {\n" uu___2
                  else ());
-                (let uu____2169 =
-                   let uu____2176 = FStar_Syntax_Embeddings.type_of e_arg in
-                   let uu____2177 = FStar_Syntax_Embeddings.type_of e_res in
-                   FStar_TypeChecker_TcTerm.tc_tactic uu____2176 uu____2177
-                     env tactic in
-                 match uu____2169 with
-                 | (uu____2184, uu____2185, g) ->
-                     ((let uu____2188 = FStar_ST.op_Bang tacdbg in
-                       if uu____2188
-                       then FStar_Util.print_string "}\n"
-                       else ());
+                (let uu___1 =
+                   let uu___2 = FStar_Syntax_Embeddings.type_of e_arg in
+                   let uu___3 = FStar_Syntax_Embeddings.type_of e_res in
+                   FStar_TypeChecker_TcTerm.tc_tactic uu___2 uu___3 env
+                     tactic in
+                 match uu___1 with
+                 | (uu___2, uu___3, g) ->
+                     ((let uu___5 = FStar_ST.op_Bang tacdbg in
+                       if uu___5 then FStar_Util.print_string "}\n" else ());
                       FStar_TypeChecker_Rel.force_trivial_guard env g;
                       FStar_Errors.stop_if_err ();
                       (let tau =
                          unembed_tactic_1 e_arg e_res tactic
                            FStar_Syntax_Embeddings.id_norm_cb in
-                       let uu____2205 =
+                       let uu___7 =
                          FStar_Util.record_time
-                           (fun uu____2216 ->
-                              let uu____2217 = tau arg in
-                              FStar_Tactics_Monad.run_safe uu____2217 ps) in
-                       match uu____2205 with
+                           (fun uu___8 ->
+                              let uu___9 = tau arg in
+                              FStar_Tactics_Monad.run_safe uu___9 ps) in
+                       match uu___7 with
                        | (res, ms) ->
-                           ((let uu____2233 = FStar_ST.op_Bang tacdbg in
-                             if uu____2233
+                           ((let uu___9 = FStar_ST.op_Bang tacdbg in
+                             if uu___9
                              then FStar_Util.print_string "}\n"
                              else ());
-                            (let uu____2242 =
+                            (let uu___10 =
                                (FStar_ST.op_Bang tacdbg) ||
                                  (FStar_Options.tactics_info ()) in
-                             if uu____2242
+                             if uu___10
                              then
-                               let uu____2249 =
+                               let uu___11 =
                                  FStar_Syntax_Print.term_to_string tactic in
-                               let uu____2250 = FStar_Util.string_of_int ms in
-                               let uu____2251 =
+                               let uu___12 = FStar_Util.string_of_int ms in
+                               let uu___13 =
                                  FStar_Syntax_Print.lid_to_string
                                    env.FStar_TypeChecker_Env.curmodule in
                                FStar_Util.print3
-                                 "Tactic %s ran in %s ms (%s)\n" uu____2249
-                                 uu____2250 uu____2251
+                                 "Tactic %s ran in %s ms (%s)\n" uu___11
+                                 uu___12 uu___13
                              else ());
                             (match res with
                              | FStar_Tactics_Result.Success (ret, ps1) ->
                                  (FStar_List.iter
                                     (fun g1 ->
-                                       let uu____2266 =
+                                       let uu___11 =
                                          FStar_Tactics_Types.is_irrelevant g1 in
-                                       if uu____2266
+                                       if uu___11
                                        then
-                                         let uu____2267 =
-                                           let uu____2268 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_Tactics_Types.goal_env g1 in
-                                           let uu____2269 =
+                                           let uu___14 =
                                              FStar_Tactics_Types.goal_witness
                                                g1 in
                                            FStar_TypeChecker_Rel.teq_nosmt_force
-                                             uu____2268 uu____2269
+                                             uu___13 uu___14
                                              FStar_Syntax_Util.exp_unit in
-                                         (if uu____2267
+                                         (if uu___12
                                           then ()
                                           else
-                                            (let uu____2271 =
-                                               let uu____2272 =
-                                                 let uu____2273 =
+                                            (let uu___14 =
+                                               let uu___15 =
+                                                 let uu___16 =
                                                    FStar_Tactics_Types.goal_witness
                                                      g1 in
                                                  FStar_Syntax_Print.term_to_string
-                                                   uu____2273 in
+                                                   uu___16 in
                                                FStar_Util.format1
                                                  "Irrelevant tactic witness does not unify with (): %s"
-                                                 uu____2272 in
-                                             failwith uu____2271))
+                                                 uu___15 in
+                                             failwith uu___14))
                                        else ())
                                     (FStar_List.append
                                        ps1.FStar_Tactics_Types.goals
                                        ps1.FStar_Tactics_Types.smt_goals);
-                                  (let uu____2276 = FStar_ST.op_Bang tacdbg in
-                                   if uu____2276
+                                  (let uu___12 = FStar_ST.op_Bang tacdbg in
+                                   if uu___12
                                    then
-                                     let uu____2283 =
+                                     let uu___13 =
                                        FStar_Common.string_of_list
                                          (fun imp ->
                                             FStar_Syntax_Print.ctx_uvar_to_string
@@ -1707,35 +1686,35 @@ let run_tactic_on_ps :
                                          ps1.FStar_Tactics_Types.all_implicits in
                                      FStar_Util.print1
                                        "About to check tactic implicits: %s\n"
-                                       uu____2283
+                                       uu___13
                                    else ());
                                   (let g1 =
-                                     let uu___231_2288 =
+                                     let uu___12 =
                                        FStar_TypeChecker_Env.trivial_guard in
                                      {
                                        FStar_TypeChecker_Common.guard_f =
-                                         (uu___231_2288.FStar_TypeChecker_Common.guard_f);
+                                         (uu___12.FStar_TypeChecker_Common.guard_f);
                                        FStar_TypeChecker_Common.deferred_to_tac
                                          =
-                                         (uu___231_2288.FStar_TypeChecker_Common.deferred_to_tac);
+                                         (uu___12.FStar_TypeChecker_Common.deferred_to_tac);
                                        FStar_TypeChecker_Common.deferred =
-                                         (uu___231_2288.FStar_TypeChecker_Common.deferred);
+                                         (uu___12.FStar_TypeChecker_Common.deferred);
                                        FStar_TypeChecker_Common.univ_ineqs =
-                                         (uu___231_2288.FStar_TypeChecker_Common.univ_ineqs);
+                                         (uu___12.FStar_TypeChecker_Common.univ_ineqs);
                                        FStar_TypeChecker_Common.implicits =
                                          (ps1.FStar_Tactics_Types.all_implicits)
                                      } in
                                    let g2 =
                                      FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env g1 in
-                                   (let uu____2291 = FStar_ST.op_Bang tacdbg in
-                                    if uu____2291
+                                   (let uu___13 = FStar_ST.op_Bang tacdbg in
+                                    if uu___13
                                     then
-                                      let uu____2298 =
+                                      let uu___14 =
                                         FStar_Util.string_of_int
                                           (FStar_List.length
                                              ps1.FStar_Tactics_Types.all_implicits) in
-                                      let uu____2299 =
+                                      let uu___15 =
                                         FStar_Common.string_of_list
                                           (fun imp ->
                                              FStar_Syntax_Print.ctx_uvar_to_string
@@ -1743,19 +1722,19 @@ let run_tactic_on_ps :
                                           ps1.FStar_Tactics_Types.all_implicits in
                                       FStar_Util.print2
                                         "Checked %s implicits (1): %s\n"
-                                        uu____2298 uu____2299
+                                        uu___14 uu___15
                                     else ());
                                    (let g3 =
                                       FStar_TypeChecker_Rel.resolve_implicits_tac
                                         env g2 in
-                                    (let uu____2305 = FStar_ST.op_Bang tacdbg in
-                                     if uu____2305
+                                    (let uu___14 = FStar_ST.op_Bang tacdbg in
+                                     if uu___14
                                      then
-                                       let uu____2312 =
+                                       let uu___15 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length
                                               ps1.FStar_Tactics_Types.all_implicits) in
-                                       let uu____2313 =
+                                       let uu___16 =
                                          FStar_Common.string_of_list
                                            (fun imp ->
                                               FStar_Syntax_Print.ctx_uvar_to_string
@@ -1763,52 +1742,52 @@ let run_tactic_on_ps :
                                            ps1.FStar_Tactics_Types.all_implicits in
                                        FStar_Util.print2
                                          "Checked %s implicits (2): %s\n"
-                                         uu____2312 uu____2313
+                                         uu___15 uu___16
                                      else ());
                                     report_implicits rng_goal
                                       g3.FStar_TypeChecker_Common.implicits;
-                                    (let uu____2319 = FStar_ST.op_Bang tacdbg in
-                                     if uu____2319
+                                    (let uu___16 = FStar_ST.op_Bang tacdbg in
+                                     if uu___16
                                      then
-                                       let uu____2326 =
-                                         let uu____2327 =
+                                       let uu___17 =
+                                         let uu___18 =
                                            FStar_TypeChecker_Cfg.psc_subst
                                              ps1.FStar_Tactics_Types.psc in
                                          FStar_Tactics_Types.subst_proof_state
-                                           uu____2327 ps1 in
+                                           uu___18 ps1 in
                                        FStar_Tactics_Printing.do_dump_proofstate
-                                         uu____2326 "at the finish line"
+                                         uu___17 "at the finish line"
                                      else ());
                                     ((FStar_List.append
                                         ps1.FStar_Tactics_Types.goals
                                         ps1.FStar_Tactics_Types.smt_goals),
                                       ret))))
                              | FStar_Tactics_Result.Failed (e, ps1) ->
-                                 ((let uu____2334 =
-                                     let uu____2335 =
+                                 ((let uu___11 =
+                                     let uu___12 =
                                        FStar_TypeChecker_Cfg.psc_subst
                                          ps1.FStar_Tactics_Types.psc in
                                      FStar_Tactics_Types.subst_proof_state
-                                       uu____2335 ps1 in
+                                       uu___12 ps1 in
                                    FStar_Tactics_Printing.do_dump_proofstate
-                                     uu____2334 "at the time of failure");
+                                     uu___11 "at the time of failure");
                                   (let texn_to_string e1 =
                                      match e1 with
                                      | FStar_Tactics_Common.TacticFailure s
                                          -> s
                                      | FStar_Tactics_Common.EExn t ->
-                                         let uu____2344 =
+                                         let uu___11 =
                                            FStar_Syntax_Print.term_to_string
                                              t in
                                          Prims.op_Hat "uncaught exception: "
-                                           uu____2344
+                                           uu___11
                                      | e2 -> FStar_Exn.raise e2 in
-                                   let uu____2346 =
-                                     let uu____2351 =
-                                       let uu____2352 = texn_to_string e in
+                                   let uu___11 =
+                                     let uu___12 =
+                                       let uu___13 = texn_to_string e in
                                        FStar_Util.format1
-                                         "user tactic failed: %s" uu____2352 in
+                                         "user tactic failed: %s" uu___13 in
                                      (FStar_Errors.Fatal_UserTacticFailure,
-                                       uu____2351) in
-                                   FStar_Errors.raise_error uu____2346
+                                       uu___12) in
+                                   FStar_Errors.raise_error uu___11
                                      ps1.FStar_Tactics_Types.entry_range)))))))

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -24,16 +24,16 @@ let run_safe :
   =
   fun t ->
     fun ps ->
-      let uu____111 = FStar_Options.tactics_failhard () in
-      if uu____111
+      let uu___ = FStar_Options.tactics_failhard () in
+      if uu___
       then run t ps
       else
-        (try (fun uu___20_118 -> match () with | () -> run t ps) ()
+        (try (fun uu___2 -> match () with | () -> run t ps) ()
          with
-         | FStar_Errors.Err (uu____127, msg) ->
+         | FStar_Errors.Err (uu___3, msg) ->
              FStar_Tactics_Result.Failed
                ((FStar_Tactics_Common.TacticFailure msg), ps)
-         | FStar_Errors.Error (uu____129, msg, uu____131) ->
+         | FStar_Errors.Error (uu___3, msg, uu___4) ->
              FStar_Tactics_Result.Failed
                ((FStar_Tactics_Common.TacticFailure msg), ps)
          | e -> FStar_Tactics_Result.Failed (e, ps))
@@ -44,15 +44,15 @@ let bind : 'a 'b . 'a tac -> ('a -> 'b tac) -> 'b tac =
     fun t2 ->
       mk_tac
         (fun ps ->
-           let uu____188 = run t1 ps in
-           match uu____188 with
+           let uu___ = run t1 ps in
+           match uu___ with
            | FStar_Tactics_Result.Success (a1, q) ->
-               let uu____195 = t2 a1 in run uu____195 q
+               let uu___1 = t2 a1 in run uu___1 q
            | FStar_Tactics_Result.Failed (msg, q) ->
                FStar_Tactics_Result.Failed (msg, q))
 let (idtac : unit tac) = ret ()
 let (set : FStar_Tactics_Types.proofstate -> unit tac) =
-  fun ps -> mk_tac (fun uu____214 -> FStar_Tactics_Result.Success ((), ps))
+  fun ps -> mk_tac (fun uu___ -> FStar_Tactics_Result.Success ((), ps))
 let (get : FStar_Tactics_Types.proofstate tac) =
   mk_tac (fun ps -> FStar_Tactics_Result.Success (ps, ps))
 let traise : 'a . Prims.exn -> 'a tac =
@@ -61,10 +61,10 @@ let fail : 'a . Prims.string -> 'a tac =
   fun msg ->
     mk_tac
       (fun ps ->
-         (let uu____251 =
+         (let uu___1 =
             FStar_TypeChecker_Env.debug ps.FStar_Tactics_Types.main_context
               (FStar_Options.Other "TacFail") in
-          if uu____251
+          if uu___1
           then
             FStar_Tactics_Printing.do_dump_proofstate ps
               (Prims.op_Hat "TACTIC FAILING: " msg)
@@ -77,143 +77,134 @@ let rec mapM : 'a 'b . ('a -> 'b tac) -> 'a Prims.list -> 'b Prims.list tac =
       match l with
       | [] -> ret []
       | x::xs ->
-          let uu____298 = f x in
-          bind uu____298
+          let uu___ = f x in
+          bind uu___
             (fun y ->
-               let uu____306 = mapM f xs in
-               bind uu____306 (fun ys -> ret (y :: ys)))
+               let uu___1 = mapM f xs in
+               bind uu___1 (fun ys -> ret (y :: ys)))
 let (nwarn : Prims.int FStar_ST.ref) = FStar_Util.mk_ref Prims.int_zero
 let (check_valid_goal : FStar_Tactics_Types.goal -> unit) =
   fun g ->
-    let uu____328 = FStar_Options.defensive () in
-    if uu____328
+    let uu___ = FStar_Options.defensive () in
+    if uu___
     then
       let b = true in
       let env = FStar_Tactics_Types.goal_env g in
       let b1 =
         b &&
-          (let uu____333 = FStar_Tactics_Types.goal_witness g in
-           FStar_TypeChecker_Env.closed env uu____333) in
+          (let uu___1 = FStar_Tactics_Types.goal_witness g in
+           FStar_TypeChecker_Env.closed env uu___1) in
       let b2 =
         b1 &&
-          (let uu____336 = FStar_Tactics_Types.goal_type g in
-           FStar_TypeChecker_Env.closed env uu____336) in
+          (let uu___1 = FStar_Tactics_Types.goal_type g in
+           FStar_TypeChecker_Env.closed env uu___1) in
       let rec aux b3 e =
-        let uu____348 = FStar_TypeChecker_Env.pop_bv e in
-        match uu____348 with
+        let uu___1 = FStar_TypeChecker_Env.pop_bv e in
+        match uu___1 with
         | FStar_Pervasives_Native.None -> b3
         | FStar_Pervasives_Native.Some (bv, e1) ->
             let b4 =
               b3 &&
                 (FStar_TypeChecker_Env.closed e1 bv.FStar_Syntax_Syntax.sort) in
             aux b4 e1 in
-      let uu____366 =
-        (let uu____369 = aux b2 env in Prims.op_Negation uu____369) &&
-          (let uu____371 = FStar_ST.op_Bang nwarn in
-           uu____371 < (Prims.of_int (5))) in
-      (if uu____366
+      let uu___1 =
+        (let uu___2 = aux b2 env in Prims.op_Negation uu___2) &&
+          (let uu___2 = FStar_ST.op_Bang nwarn in uu___2 < (Prims.of_int (5))) in
+      (if uu___1
        then
-         ((let uu____379 =
-             let uu____380 = FStar_Tactics_Types.goal_type g in
-             uu____380.FStar_Syntax_Syntax.pos in
-           let uu____383 =
-             let uu____388 =
-               let uu____389 =
-                 FStar_Tactics_Printing.goal_to_string_verbose g in
+         ((let uu___3 =
+             let uu___4 = FStar_Tactics_Types.goal_type g in
+             uu___4.FStar_Syntax_Syntax.pos in
+           let uu___4 =
+             let uu___5 =
+               let uu___6 = FStar_Tactics_Printing.goal_to_string_verbose g in
                FStar_Util.format1
                  "The following goal is ill-formed. Keeping calm and carrying on...\n<%s>\n\n"
-                 uu____389 in
-             (FStar_Errors.Warning_IllFormedGoal, uu____388) in
-           FStar_Errors.log_issue uu____379 uu____383);
-          (let uu____390 =
-             let uu____391 = FStar_ST.op_Bang nwarn in
-             uu____391 + Prims.int_one in
-           FStar_ST.op_Colon_Equals nwarn uu____390))
+                 uu___6 in
+             (FStar_Errors.Warning_IllFormedGoal, uu___5) in
+           FStar_Errors.log_issue uu___3 uu___4);
+          (let uu___3 =
+             let uu___4 = FStar_ST.op_Bang nwarn in uu___4 + Prims.int_one in
+           FStar_ST.op_Colon_Equals nwarn uu___3))
        else ())
     else ()
 let (check_valid_goals : FStar_Tactics_Types.goal Prims.list -> unit) =
   fun gs ->
-    let uu____415 = FStar_Options.defensive () in
-    if uu____415 then FStar_List.iter check_valid_goal gs else ()
+    let uu___ = FStar_Options.defensive () in
+    if uu___ then FStar_List.iter check_valid_goal gs else ()
 let (set_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
     bind get
       (fun ps ->
          set
-           (let uu___96_434 = ps in
+           (let uu___ = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___96_434.FStar_Tactics_Types.main_context);
+                (uu___.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___96_434.FStar_Tactics_Types.all_implicits);
+                (uu___.FStar_Tactics_Types.all_implicits);
               FStar_Tactics_Types.goals = gs;
               FStar_Tactics_Types.smt_goals =
-                (uu___96_434.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___96_434.FStar_Tactics_Types.depth);
-              FStar_Tactics_Types.__dump =
-                (uu___96_434.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc = (uu___96_434.FStar_Tactics_Types.psc);
+                (uu___.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.__dump = (uu___.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___96_434.FStar_Tactics_Types.entry_range);
+                (uu___.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___96_434.FStar_Tactics_Types.guard_policy);
+                (uu___.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___96_434.FStar_Tactics_Types.freshness);
+                (uu___.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___96_434.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___96_434.FStar_Tactics_Types.local_state)
+                (uu___.FStar_Tactics_Types.local_state)
             }))
 let (set_smt_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
     bind get
       (fun ps ->
          set
-           (let uu___100_452 = ps in
+           (let uu___ = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___100_452.FStar_Tactics_Types.main_context);
+                (uu___.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___100_452.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals =
-                (uu___100_452.FStar_Tactics_Types.goals);
+                (uu___.FStar_Tactics_Types.all_implicits);
+              FStar_Tactics_Types.goals = (uu___.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals = gs;
-              FStar_Tactics_Types.depth =
-                (uu___100_452.FStar_Tactics_Types.depth);
-              FStar_Tactics_Types.__dump =
-                (uu___100_452.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___100_452.FStar_Tactics_Types.psc);
+              FStar_Tactics_Types.depth = (uu___.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.__dump = (uu___.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___100_452.FStar_Tactics_Types.entry_range);
+                (uu___.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___100_452.FStar_Tactics_Types.guard_policy);
+                (uu___.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___100_452.FStar_Tactics_Types.freshness);
+                (uu___.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___100_452.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___100_452.FStar_Tactics_Types.local_state)
+                (uu___.FStar_Tactics_Types.local_state)
             }))
 let (cur_goals : FStar_Tactics_Types.goal Prims.list tac) =
   bind get (fun ps -> ret ps.FStar_Tactics_Types.goals)
 let (cur_goal : FStar_Tactics_Types.goal tac) =
   bind cur_goals
-    (fun uu___0_470 ->
-       match uu___0_470 with
+    (fun uu___ ->
+       match uu___ with
        | [] -> fail "No more goals"
        | hd::tl ->
-           let uu____479 = FStar_Tactics_Types.check_goal_solved' hd in
-           (match uu____479 with
+           let uu___1 = FStar_Tactics_Types.check_goal_solved' hd in
+           (match uu___1 with
             | FStar_Pervasives_Native.None -> ret hd
             | FStar_Pervasives_Native.Some t ->
-                ((let uu____486 =
+                ((let uu___3 =
                     FStar_Tactics_Printing.goal_to_string_verbose hd in
-                  let uu____487 = FStar_Syntax_Print.term_to_string t in
+                  let uu___4 = FStar_Syntax_Print.term_to_string t in
                   FStar_Util.print2
                     "!!!!!!!!!!!! GOAL IS ALREADY SOLVED! %s\nsol is %s\n"
-                    uu____486 uu____487);
+                    uu___3 uu___4);
                  ret hd)))
 let (remove_solved_goals : unit tac) =
   bind cur_goals
@@ -221,109 +212,103 @@ let (remove_solved_goals : unit tac) =
        let gs1 =
          FStar_List.filter
            (fun g ->
-              let uu____505 = FStar_Tactics_Types.check_goal_solved g in
-              Prims.op_Negation uu____505) gs in
+              let uu___ = FStar_Tactics_Types.check_goal_solved g in
+              Prims.op_Negation uu___) gs in
        set_goals gs1)
 let (dismiss_all : unit tac) = set_goals []
 let (dismiss : unit tac) =
   bind get
     (fun ps ->
-       let uu____517 =
-         let uu___116_518 = ps in
-         let uu____519 = FStar_List.tl ps.FStar_Tactics_Types.goals in
+       let uu___ =
+         let uu___1 = ps in
+         let uu___2 = FStar_List.tl ps.FStar_Tactics_Types.goals in
          {
            FStar_Tactics_Types.main_context =
-             (uu___116_518.FStar_Tactics_Types.main_context);
+             (uu___1.FStar_Tactics_Types.main_context);
            FStar_Tactics_Types.all_implicits =
-             (uu___116_518.FStar_Tactics_Types.all_implicits);
-           FStar_Tactics_Types.goals = uu____519;
+             (uu___1.FStar_Tactics_Types.all_implicits);
+           FStar_Tactics_Types.goals = uu___2;
            FStar_Tactics_Types.smt_goals =
-             (uu___116_518.FStar_Tactics_Types.smt_goals);
-           FStar_Tactics_Types.depth =
-             (uu___116_518.FStar_Tactics_Types.depth);
-           FStar_Tactics_Types.__dump =
-             (uu___116_518.FStar_Tactics_Types.__dump);
-           FStar_Tactics_Types.psc = (uu___116_518.FStar_Tactics_Types.psc);
+             (uu___1.FStar_Tactics_Types.smt_goals);
+           FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
+           FStar_Tactics_Types.__dump = (uu___1.FStar_Tactics_Types.__dump);
+           FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
            FStar_Tactics_Types.entry_range =
-             (uu___116_518.FStar_Tactics_Types.entry_range);
+             (uu___1.FStar_Tactics_Types.entry_range);
            FStar_Tactics_Types.guard_policy =
-             (uu___116_518.FStar_Tactics_Types.guard_policy);
+             (uu___1.FStar_Tactics_Types.guard_policy);
            FStar_Tactics_Types.freshness =
-             (uu___116_518.FStar_Tactics_Types.freshness);
+             (uu___1.FStar_Tactics_Types.freshness);
            FStar_Tactics_Types.tac_verb_dbg =
-             (uu___116_518.FStar_Tactics_Types.tac_verb_dbg);
+             (uu___1.FStar_Tactics_Types.tac_verb_dbg);
            FStar_Tactics_Types.local_state =
-             (uu___116_518.FStar_Tactics_Types.local_state)
+             (uu___1.FStar_Tactics_Types.local_state)
          } in
-       set uu____517)
+       set uu___)
 let (replace_cur : FStar_Tactics_Types.goal -> unit tac) =
   fun g ->
     bind get
       (fun ps ->
          check_valid_goal g;
-         (let uu____536 =
-            let uu___121_537 = ps in
-            let uu____538 =
-              let uu____541 = FStar_List.tl ps.FStar_Tactics_Types.goals in g
-                :: uu____541 in
+         (let uu___1 =
+            let uu___2 = ps in
+            let uu___3 =
+              let uu___4 = FStar_List.tl ps.FStar_Tactics_Types.goals in g ::
+                uu___4 in
             {
               FStar_Tactics_Types.main_context =
-                (uu___121_537.FStar_Tactics_Types.main_context);
+                (uu___2.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___121_537.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals = uu____538;
+                (uu___2.FStar_Tactics_Types.all_implicits);
+              FStar_Tactics_Types.goals = uu___3;
               FStar_Tactics_Types.smt_goals =
-                (uu___121_537.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___121_537.FStar_Tactics_Types.depth);
+                (uu___2.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___2.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___121_537.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___121_537.FStar_Tactics_Types.psc);
+                (uu___2.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___2.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___121_537.FStar_Tactics_Types.entry_range);
+                (uu___2.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___121_537.FStar_Tactics_Types.guard_policy);
+                (uu___2.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___121_537.FStar_Tactics_Types.freshness);
+                (uu___2.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___121_537.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___2.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___121_537.FStar_Tactics_Types.local_state)
+                (uu___2.FStar_Tactics_Types.local_state)
             } in
-          set uu____536))
+          set uu___1))
 let (add_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
     bind get
       (fun ps ->
          check_valid_goals gs;
          set
-           (let uu___126_563 = ps in
+           (let uu___1 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___126_563.FStar_Tactics_Types.main_context);
+                (uu___1.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___126_563.FStar_Tactics_Types.all_implicits);
+                (uu___1.FStar_Tactics_Types.all_implicits);
               FStar_Tactics_Types.goals =
                 (FStar_List.append gs ps.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
-                (uu___126_563.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___126_563.FStar_Tactics_Types.depth);
+                (uu___1.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___126_563.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___126_563.FStar_Tactics_Types.psc);
+                (uu___1.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___126_563.FStar_Tactics_Types.entry_range);
+                (uu___1.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___126_563.FStar_Tactics_Types.guard_policy);
+                (uu___1.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___126_563.FStar_Tactics_Types.freshness);
+                (uu___1.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___126_563.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___1.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___126_563.FStar_Tactics_Types.local_state)
+                (uu___1.FStar_Tactics_Types.local_state)
             }))
 let (add_smt_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
@@ -331,32 +316,29 @@ let (add_smt_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
       (fun ps ->
          check_valid_goals gs;
          set
-           (let uu___131_583 = ps in
+           (let uu___1 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___131_583.FStar_Tactics_Types.main_context);
+                (uu___1.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___131_583.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals =
-                (uu___131_583.FStar_Tactics_Types.goals);
+                (uu___1.FStar_Tactics_Types.all_implicits);
+              FStar_Tactics_Types.goals = (uu___1.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
                 (FStar_List.append gs ps.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___131_583.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___131_583.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___131_583.FStar_Tactics_Types.psc);
+                (uu___1.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___131_583.FStar_Tactics_Types.entry_range);
+                (uu___1.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___131_583.FStar_Tactics_Types.guard_policy);
+                (uu___1.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___131_583.FStar_Tactics_Types.freshness);
+                (uu___1.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___131_583.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___1.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___131_583.FStar_Tactics_Types.local_state)
+                (uu___1.FStar_Tactics_Types.local_state)
             }))
 let (push_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
@@ -364,32 +346,30 @@ let (push_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
       (fun ps ->
          check_valid_goals gs;
          set
-           (let uu___136_603 = ps in
+           (let uu___1 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___136_603.FStar_Tactics_Types.main_context);
+                (uu___1.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___136_603.FStar_Tactics_Types.all_implicits);
+                (uu___1.FStar_Tactics_Types.all_implicits);
               FStar_Tactics_Types.goals =
                 (FStar_List.append ps.FStar_Tactics_Types.goals gs);
               FStar_Tactics_Types.smt_goals =
-                (uu___136_603.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___136_603.FStar_Tactics_Types.depth);
+                (uu___1.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___136_603.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___136_603.FStar_Tactics_Types.psc);
+                (uu___1.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___136_603.FStar_Tactics_Types.entry_range);
+                (uu___1.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___136_603.FStar_Tactics_Types.guard_policy);
+                (uu___1.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___136_603.FStar_Tactics_Types.freshness);
+                (uu___1.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___136_603.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___1.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___136_603.FStar_Tactics_Types.local_state)
+                (uu___1.FStar_Tactics_Types.local_state)
             }))
 let (push_smt_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
   fun gs ->
@@ -397,64 +377,57 @@ let (push_smt_goals : FStar_Tactics_Types.goal Prims.list -> unit tac) =
       (fun ps ->
          check_valid_goals gs;
          set
-           (let uu___141_623 = ps in
+           (let uu___1 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___141_623.FStar_Tactics_Types.main_context);
+                (uu___1.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___141_623.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals =
-                (uu___141_623.FStar_Tactics_Types.goals);
+                (uu___1.FStar_Tactics_Types.all_implicits);
+              FStar_Tactics_Types.goals = (uu___1.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
                 (FStar_List.append ps.FStar_Tactics_Types.smt_goals gs);
-              FStar_Tactics_Types.depth =
-                (uu___141_623.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.depth = (uu___1.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___141_623.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___141_623.FStar_Tactics_Types.psc);
+                (uu___1.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___1.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___141_623.FStar_Tactics_Types.entry_range);
+                (uu___1.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___141_623.FStar_Tactics_Types.guard_policy);
+                (uu___1.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___141_623.FStar_Tactics_Types.freshness);
+                (uu___1.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___141_623.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___1.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___141_623.FStar_Tactics_Types.local_state)
+                (uu___1.FStar_Tactics_Types.local_state)
             }))
 let (add_implicits : FStar_TypeChecker_Env.implicits -> unit tac) =
   fun i ->
     bind get
       (fun ps ->
          set
-           (let uu___145_637 = ps in
+           (let uu___ = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___145_637.FStar_Tactics_Types.main_context);
+                (uu___.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
                 (FStar_List.append i ps.FStar_Tactics_Types.all_implicits);
-              FStar_Tactics_Types.goals =
-                (uu___145_637.FStar_Tactics_Types.goals);
+              FStar_Tactics_Types.goals = (uu___.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
-                (uu___145_637.FStar_Tactics_Types.smt_goals);
-              FStar_Tactics_Types.depth =
-                (uu___145_637.FStar_Tactics_Types.depth);
-              FStar_Tactics_Types.__dump =
-                (uu___145_637.FStar_Tactics_Types.__dump);
-              FStar_Tactics_Types.psc =
-                (uu___145_637.FStar_Tactics_Types.psc);
+                (uu___.FStar_Tactics_Types.smt_goals);
+              FStar_Tactics_Types.depth = (uu___.FStar_Tactics_Types.depth);
+              FStar_Tactics_Types.__dump = (uu___.FStar_Tactics_Types.__dump);
+              FStar_Tactics_Types.psc = (uu___.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___145_637.FStar_Tactics_Types.entry_range);
+                (uu___.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy =
-                (uu___145_637.FStar_Tactics_Types.guard_policy);
+                (uu___.FStar_Tactics_Types.guard_policy);
               FStar_Tactics_Types.freshness =
-                (uu___145_637.FStar_Tactics_Types.freshness);
+                (uu___.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___145_637.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___145_637.FStar_Tactics_Types.local_state)
+                (uu___.FStar_Tactics_Types.local_state)
             }))
 let (new_uvar :
   Prims.string ->
@@ -465,22 +438,21 @@ let (new_uvar :
   fun reason ->
     fun env ->
       fun typ ->
-        let uu____665 =
+        let uu___ =
           FStar_TypeChecker_Env.new_implicit_var_aux reason
             typ.FStar_Syntax_Syntax.pos env typ
             FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None in
-        match uu____665 with
+        match uu___ with
         | (u, ctx_uvar, g_u) ->
-            let uu____699 =
-              add_implicits g_u.FStar_TypeChecker_Common.implicits in
-            bind uu____699
-              (fun uu____708 ->
-                 let uu____709 =
-                   let uu____714 =
-                     let uu____715 = FStar_List.hd ctx_uvar in
-                     FStar_Pervasives_Native.fst uu____715 in
-                   (u, uu____714) in
-                 ret uu____709)
+            let uu___1 = add_implicits g_u.FStar_TypeChecker_Common.implicits in
+            bind uu___1
+              (fun uu___2 ->
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_List.hd ctx_uvar in
+                     FStar_Pervasives_Native.fst uu___5 in
+                   (u, uu___4) in
+                 ret uu___3)
 let (mk_irrelevant_goal :
   Prims.string ->
     FStar_TypeChecker_Env.env ->
@@ -494,13 +466,13 @@ let (mk_irrelevant_goal :
         fun opts ->
           fun label ->
             let typ =
-              let uu____760 = env.FStar_TypeChecker_Env.universe_of env phi in
-              FStar_Syntax_Util.mk_squash uu____760 phi in
-            let uu____761 = new_uvar reason env typ in
-            bind uu____761
-              (fun uu____776 ->
-                 match uu____776 with
-                 | (uu____783, ctx_uvar) ->
+              let uu___ = env.FStar_TypeChecker_Env.universe_of env phi in
+              FStar_Syntax_Util.mk_squash uu___ phi in
+            let uu___ = new_uvar reason env typ in
+            bind uu___
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (uu___2, ctx_uvar) ->
                      let goal =
                        FStar_Tactics_Types.mk_goal env ctx_uvar opts false
                          label in
@@ -516,8 +488,8 @@ let (add_irrelevant_goal' :
       fun phi ->
         fun opts ->
           fun label ->
-            let uu____815 = mk_irrelevant_goal reason env phi opts label in
-            bind uu____815 (fun goal -> add_goals [goal])
+            let uu___ = mk_irrelevant_goal reason env phi opts label in
+            bind uu___ (fun goal -> add_goals [goal])
 let (add_irrelevant_goal :
   FStar_Tactics_Types.goal ->
     Prims.string ->
@@ -535,8 +507,8 @@ let wrap_err : 'a . Prims.string -> 'a tac -> 'a tac =
     fun t ->
       mk_tac
         (fun ps ->
-           let uu____872 = run t ps in
-           match uu____872 with
+           let uu___ = run t ps in
+           match uu___ with
            | FStar_Tactics_Result.Success (a1, q) ->
                FStar_Tactics_Result.Success (a1, q)
            | FStar_Tactics_Result.Failed
@@ -555,46 +527,43 @@ let (compress_implicits : unit tac) =
     (fun ps ->
        let imps = ps.FStar_Tactics_Types.all_implicits in
        let g =
-         let uu___204_948 = FStar_TypeChecker_Env.trivial_guard in
+         let uu___ = FStar_TypeChecker_Env.trivial_guard in
          {
            FStar_TypeChecker_Common.guard_f =
-             (uu___204_948.FStar_TypeChecker_Common.guard_f);
+             (uu___.FStar_TypeChecker_Common.guard_f);
            FStar_TypeChecker_Common.deferred_to_tac =
-             (uu___204_948.FStar_TypeChecker_Common.deferred_to_tac);
+             (uu___.FStar_TypeChecker_Common.deferred_to_tac);
            FStar_TypeChecker_Common.deferred =
-             (uu___204_948.FStar_TypeChecker_Common.deferred);
+             (uu___.FStar_TypeChecker_Common.deferred);
            FStar_TypeChecker_Common.univ_ineqs =
-             (uu___204_948.FStar_TypeChecker_Common.univ_ineqs);
+             (uu___.FStar_TypeChecker_Common.univ_ineqs);
            FStar_TypeChecker_Common.implicits = imps
          } in
        let g1 =
          FStar_TypeChecker_Rel.resolve_implicits_tac
            ps.FStar_Tactics_Types.main_context g in
        let ps' =
-         let uu___208_951 = ps in
+         let uu___ = ps in
          {
            FStar_Tactics_Types.main_context =
-             (uu___208_951.FStar_Tactics_Types.main_context);
+             (uu___.FStar_Tactics_Types.main_context);
            FStar_Tactics_Types.all_implicits =
              (g1.FStar_TypeChecker_Common.implicits);
-           FStar_Tactics_Types.goals =
-             (uu___208_951.FStar_Tactics_Types.goals);
+           FStar_Tactics_Types.goals = (uu___.FStar_Tactics_Types.goals);
            FStar_Tactics_Types.smt_goals =
-             (uu___208_951.FStar_Tactics_Types.smt_goals);
-           FStar_Tactics_Types.depth =
-             (uu___208_951.FStar_Tactics_Types.depth);
-           FStar_Tactics_Types.__dump =
-             (uu___208_951.FStar_Tactics_Types.__dump);
-           FStar_Tactics_Types.psc = (uu___208_951.FStar_Tactics_Types.psc);
+             (uu___.FStar_Tactics_Types.smt_goals);
+           FStar_Tactics_Types.depth = (uu___.FStar_Tactics_Types.depth);
+           FStar_Tactics_Types.__dump = (uu___.FStar_Tactics_Types.__dump);
+           FStar_Tactics_Types.psc = (uu___.FStar_Tactics_Types.psc);
            FStar_Tactics_Types.entry_range =
-             (uu___208_951.FStar_Tactics_Types.entry_range);
+             (uu___.FStar_Tactics_Types.entry_range);
            FStar_Tactics_Types.guard_policy =
-             (uu___208_951.FStar_Tactics_Types.guard_policy);
+             (uu___.FStar_Tactics_Types.guard_policy);
            FStar_Tactics_Types.freshness =
-             (uu___208_951.FStar_Tactics_Types.freshness);
+             (uu___.FStar_Tactics_Types.freshness);
            FStar_Tactics_Types.tac_verb_dbg =
-             (uu___208_951.FStar_Tactics_Types.tac_verb_dbg);
+             (uu___.FStar_Tactics_Types.tac_verb_dbg);
            FStar_Tactics_Types.local_state =
-             (uu___208_951.FStar_Tactics_Types.local_state)
+             (uu___.FStar_Tactics_Types.local_state)
          } in
        set ps')

--- a/src/ocaml-output/FStar_Tactics_Printing.ml
+++ b/src/ocaml-output/FStar_Tactics_Printing.ml
@@ -6,19 +6,19 @@ let (term_to_string :
       FStar_Syntax_Print.term_to_string' e.FStar_TypeChecker_Env.dsenv t
 let (goal_to_string_verbose : FStar_Tactics_Types.goal -> Prims.string) =
   fun g ->
-    let uu____15 =
+    let uu___ =
       FStar_Syntax_Print.ctx_uvar_to_string
         g.FStar_Tactics_Types.goal_ctx_uvar in
-    let uu____16 =
-      let uu____17 = FStar_Tactics_Types.check_goal_solved' g in
-      match uu____17 with
+    let uu___1 =
+      let uu___2 = FStar_Tactics_Types.check_goal_solved' g in
+      match uu___2 with
       | FStar_Pervasives_Native.None -> ""
       | FStar_Pervasives_Native.Some t ->
-          let uu____21 =
-            let uu____22 = FStar_Tactics_Types.goal_env g in
-            term_to_string uu____22 t in
-          FStar_Util.format1 "\tGOAL ALREADY SOLVED!: %s" uu____21 in
-    FStar_Util.format2 "%s%s\n" uu____15 uu____16
+          let uu___3 =
+            let uu___4 = FStar_Tactics_Types.goal_env g in
+            term_to_string uu___4 t in
+          FStar_Util.format1 "\tGOAL ALREADY SOLVED!: %s" uu___3 in
+    FStar_Util.format2 "%s%s\n" uu___ uu___1
 let (unshadow :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
@@ -28,51 +28,49 @@ let (unshadow :
     fun t ->
       let s b = FStar_Ident.string_of_id b.FStar_Syntax_Syntax.ppname in
       let sset bv s1 =
-        let uu____58 =
-          let uu____61 =
-            FStar_Ident.range_of_id bv.FStar_Syntax_Syntax.ppname in
-          FStar_Pervasives_Native.Some uu____61 in
-        FStar_Syntax_Syntax.gen_bv s1 uu____58 bv.FStar_Syntax_Syntax.sort in
+        let uu___ =
+          let uu___1 = FStar_Ident.range_of_id bv.FStar_Syntax_Syntax.ppname in
+          FStar_Pervasives_Native.Some uu___1 in
+        FStar_Syntax_Syntax.gen_bv s1 uu___ bv.FStar_Syntax_Syntax.sort in
       let fresh_until b f =
         let rec aux i =
           let t1 =
-            let uu____85 =
-              let uu____86 = FStar_Util.string_of_int i in
-              Prims.op_Hat "'" uu____86 in
-            Prims.op_Hat b uu____85 in
-          let uu____87 = f t1 in
-          if uu____87 then t1 else aux (i + Prims.int_one) in
-        let uu____89 = f b in if uu____89 then b else aux Prims.int_zero in
+            let uu___ =
+              let uu___1 = FStar_Util.string_of_int i in
+              Prims.op_Hat "'" uu___1 in
+            Prims.op_Hat b uu___ in
+          let uu___ = f t1 in if uu___ then t1 else aux (i + Prims.int_one) in
+        let uu___ = f b in if uu___ then b else aux Prims.int_zero in
       let rec go seen subst bs1 bs' t1 =
         match bs1 with
         | [] ->
-            let uu____187 = FStar_Syntax_Subst.subst subst t1 in
-            ((FStar_List.rev bs'), uu____187)
+            let uu___ = FStar_Syntax_Subst.subst subst t1 in
+            ((FStar_List.rev bs'), uu___)
         | b::bs2 ->
             let b1 =
-              let uu____231 = FStar_Syntax_Subst.subst_binders subst [b] in
-              match uu____231 with
-              | b1::[] -> b1
-              | uu____269 -> failwith "impossible: unshadow subst_binders" in
-            let uu____276 = b1 in
-            (match uu____276 with
+              let uu___ = FStar_Syntax_Subst.subst_binders subst [b] in
+              match uu___ with
+              | b2::[] -> b2
+              | uu___1 -> failwith "impossible: unshadow subst_binders" in
+            let uu___ = b1 in
+            (match uu___ with
              | (bv0, q) ->
                  let nbs =
-                   let uu____302 = s bv0 in
-                   fresh_until uu____302
+                   let uu___1 = s bv0 in
+                   fresh_until uu___1
                      (fun s1 -> Prims.op_Negation (FStar_List.mem s1 seen)) in
                  let bv = sset bv0 nbs in
                  let b2 = (bv, q) in
-                 let uu____315 =
-                   let uu____318 =
-                     let uu____321 =
-                       let uu____322 =
-                         let uu____329 = FStar_Syntax_Syntax.bv_to_name bv in
-                         (bv0, uu____329) in
-                       FStar_Syntax_Syntax.NT uu____322 in
-                     [uu____321] in
-                   FStar_List.append subst uu____318 in
-                 go (nbs :: seen) uu____315 bs2 (b2 :: bs') t1) in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = FStar_Syntax_Syntax.bv_to_name bv in
+                         (bv0, uu___5) in
+                       FStar_Syntax_Syntax.NT uu___4 in
+                     [uu___3] in
+                   FStar_List.append subst uu___2 in
+                 go (nbs :: seen) uu___1 bs2 (b2 :: bs') t1) in
       go [] [] bs [] t
 let (goal_to_string :
   Prims.string ->
@@ -85,27 +83,27 @@ let (goal_to_string :
       fun ps ->
         fun g ->
           let w =
-            let uu____379 = FStar_Options.print_implicits () in
-            if uu____379
+            let uu___ = FStar_Options.print_implicits () in
+            if uu___
             then
-              let uu____380 = FStar_Tactics_Types.goal_env g in
-              let uu____381 = FStar_Tactics_Types.goal_witness g in
-              term_to_string uu____380 uu____381
+              let uu___1 = FStar_Tactics_Types.goal_env g in
+              let uu___2 = FStar_Tactics_Types.goal_witness g in
+              term_to_string uu___1 uu___2
             else
-              (let uu____383 = FStar_Tactics_Types.check_goal_solved' g in
-               match uu____383 with
+              (let uu___2 = FStar_Tactics_Types.check_goal_solved' g in
+               match uu___2 with
                | FStar_Pervasives_Native.None -> "_"
                | FStar_Pervasives_Native.Some t ->
-                   let uu____387 = FStar_Tactics_Types.goal_env g in
-                   let uu____388 = FStar_Tactics_Types.goal_witness g in
-                   term_to_string uu____387 uu____388) in
+                   let uu___3 = FStar_Tactics_Types.goal_env g in
+                   let uu___4 = FStar_Tactics_Types.goal_witness g in
+                   term_to_string uu___3 uu___4) in
           let num =
             match maybe_num with
             | FStar_Pervasives_Native.None -> ""
             | FStar_Pervasives_Native.Some (i, n) ->
-                let uu____400 = FStar_Util.string_of_int i in
-                let uu____401 = FStar_Util.string_of_int n in
-                FStar_Util.format2 " %s/%s" uu____400 uu____401 in
+                let uu___ = FStar_Util.string_of_int i in
+                let uu___1 = FStar_Util.string_of_int n in
+                FStar_Util.format2 " %s/%s" uu___ uu___1 in
           let maybe_label =
             match g.FStar_Tactics_Types.label with
             | "" -> ""
@@ -114,25 +112,25 @@ let (goal_to_string :
             (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
           let goal_ty =
             (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
-          let uu____416 = unshadow goal_binders goal_ty in
-          match uu____416 with
+          let uu___ = unshadow goal_binders goal_ty in
+          match uu___ with
           | (goal_binders1, goal_ty1) ->
               let actual_goal =
                 if ps.FStar_Tactics_Types.tac_verb_dbg
                 then goal_to_string_verbose g
                 else
-                  (let uu____425 =
+                  (let uu___2 =
                      FStar_Syntax_Print.binders_to_string ", " goal_binders1 in
-                   let uu____426 =
-                     let uu____427 = FStar_Tactics_Types.goal_env g in
-                     term_to_string uu____427 goal_ty1 in
-                   FStar_Util.format3 "%s |- %s : %s\n" uu____425 w uu____426) in
+                   let uu___3 =
+                     let uu___4 = FStar_Tactics_Types.goal_env g in
+                     term_to_string uu___4 goal_ty1 in
+                   FStar_Util.format3 "%s |- %s : %s\n" uu___2 w uu___3) in
               FStar_Util.format4 "%s%s%s:\n%s\n" kind num maybe_label
                 actual_goal
 let (ps_to_string :
   (Prims.string * FStar_Tactics_Types.proofstate) -> Prims.string) =
-  fun uu____436 ->
-    match uu____436 with
+  fun uu___ ->
+    match uu___ with
     | (msg, ps) ->
         let p_imp imp =
           FStar_Syntax_Print.uvar_to_string
@@ -140,49 +138,48 @@ let (ps_to_string :
         let n_active = FStar_List.length ps.FStar_Tactics_Types.goals in
         let n_smt = FStar_List.length ps.FStar_Tactics_Types.smt_goals in
         let n = n_active + n_smt in
-        let uu____452 =
-          let uu____455 =
-            let uu____458 =
-              let uu____459 =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_Util.string_of_int ps.FStar_Tactics_Types.depth in
-              FStar_Util.format2 "State dump @ depth %s (%s):\n" uu____459
-                msg in
-            let uu____460 =
-              let uu____463 =
+              FStar_Util.format2 "State dump @ depth %s (%s):\n" uu___4 msg in
+            let uu___4 =
+              let uu___5 =
                 if
                   ps.FStar_Tactics_Types.entry_range <>
                     FStar_Range.dummyRange
                 then
-                  let uu____464 =
+                  let uu___6 =
                     FStar_Range.string_of_def_range
                       ps.FStar_Tactics_Types.entry_range in
-                  FStar_Util.format1 "Location: %s\n" uu____464
+                  FStar_Util.format1 "Location: %s\n" uu___6
                 else "" in
-              let uu____466 =
-                let uu____469 =
-                  let uu____470 =
+              let uu___6 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_TypeChecker_Env.debug
                       ps.FStar_Tactics_Types.main_context
                       (FStar_Options.Other "Imp") in
-                  if uu____470
+                  if uu___8
                   then
-                    let uu____471 =
+                    let uu___9 =
                       FStar_Common.string_of_list p_imp
                         ps.FStar_Tactics_Types.all_implicits in
-                    FStar_Util.format1 "Imps: %s\n" uu____471
+                    FStar_Util.format1 "Imps: %s\n" uu___9
                   else "" in
-                [uu____469] in
-              uu____463 :: uu____466 in
-            uu____458 :: uu____460 in
-          let uu____473 =
-            let uu____476 =
+                [uu___7] in
+              uu___5 :: uu___6 in
+            uu___3 :: uu___4 in
+          let uu___3 =
+            let uu___4 =
               FStar_List.mapi
                 (fun i ->
                    fun g ->
                      goal_to_string "Goal"
                        (FStar_Pervasives_Native.Some ((Prims.int_one + i), n))
                        ps g) ps.FStar_Tactics_Types.goals in
-            let uu____487 =
+            let uu___5 =
               FStar_List.mapi
                 (fun i ->
                    fun g ->
@@ -190,104 +187,103 @@ let (ps_to_string :
                        (FStar_Pervasives_Native.Some
                           (((Prims.int_one + n_active) + i), n)) ps g)
                 ps.FStar_Tactics_Types.smt_goals in
-            FStar_List.append uu____476 uu____487 in
-          FStar_List.append uu____455 uu____473 in
-        FStar_String.concat "" uu____452
+            FStar_List.append uu___4 uu___5 in
+          FStar_List.append uu___2 uu___3 in
+        FStar_String.concat "" uu___1
 let (goal_to_json : FStar_Tactics_Types.goal -> FStar_Util.json) =
   fun g ->
     let g_binders =
       (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
     let g_type = FStar_Tactics_Types.goal_type g in
-    let uu____513 = unshadow g_binders g_type in
-    match uu____513 with
+    let uu___ = unshadow g_binders g_type in
+    match uu___ with
     | (g_binders1, g_type1) ->
         let j_binders =
-          let uu____521 =
-            let uu____522 = FStar_Tactics_Types.goal_env g in
-            FStar_TypeChecker_Env.dsenv uu____522 in
-          FStar_Syntax_Print.binders_to_json uu____521 g_binders1 in
-        let uu____523 =
-          let uu____530 =
-            let uu____537 =
-              let uu____542 =
-                let uu____543 =
-                  let uu____550 =
-                    let uu____555 =
-                      let uu____556 =
-                        let uu____557 = FStar_Tactics_Types.goal_env g in
-                        let uu____558 = FStar_Tactics_Types.goal_witness g in
-                        term_to_string uu____557 uu____558 in
-                      FStar_Util.JsonStr uu____556 in
-                    ("witness", uu____555) in
-                  let uu____559 =
-                    let uu____566 =
-                      let uu____571 =
-                        let uu____572 =
-                          let uu____573 = FStar_Tactics_Types.goal_env g in
-                          term_to_string uu____573 g_type1 in
-                        FStar_Util.JsonStr uu____572 in
-                      ("type", uu____571) in
-                    [uu____566;
+          let uu___1 =
+            let uu___2 = FStar_Tactics_Types.goal_env g in
+            FStar_TypeChecker_Env.dsenv uu___2 in
+          FStar_Syntax_Print.binders_to_json uu___1 g_binders1 in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 = FStar_Tactics_Types.goal_env g in
+                        let uu___10 = FStar_Tactics_Types.goal_witness g in
+                        term_to_string uu___9 uu___10 in
+                      FStar_Util.JsonStr uu___8 in
+                    ("witness", uu___7) in
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 = FStar_Tactics_Types.goal_env g in
+                          term_to_string uu___11 g_type1 in
+                        FStar_Util.JsonStr uu___10 in
+                      ("type", uu___9) in
+                    [uu___8;
                     ("label",
                       (FStar_Util.JsonStr (g.FStar_Tactics_Types.label)))] in
-                  uu____550 :: uu____559 in
-                FStar_Util.JsonAssoc uu____543 in
-              ("goal", uu____542) in
-            [uu____537] in
-          ("hyps", j_binders) :: uu____530 in
-        FStar_Util.JsonAssoc uu____523
+                  uu___6 :: uu___7 in
+                FStar_Util.JsonAssoc uu___5 in
+              ("goal", uu___4) in
+            [uu___3] in
+          ("hyps", j_binders) :: uu___2 in
+        FStar_Util.JsonAssoc uu___1
 let (ps_to_json :
   (Prims.string * FStar_Tactics_Types.proofstate) -> FStar_Util.json) =
-  fun uu____610 ->
-    match uu____610 with
+  fun uu___ ->
+    match uu___ with
     | (msg, ps) ->
-        let uu____617 =
-          let uu____624 =
-            let uu____631 =
-              let uu____638 =
-                let uu____645 =
-                  let uu____650 =
-                    let uu____651 =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
                       FStar_List.map goal_to_json
                         ps.FStar_Tactics_Types.goals in
-                    FStar_Util.JsonList uu____651 in
-                  ("goals", uu____650) in
-                let uu____654 =
-                  let uu____661 =
-                    let uu____666 =
-                      let uu____667 =
+                    FStar_Util.JsonList uu___7 in
+                  ("goals", uu___6) in
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 =
                         FStar_List.map goal_to_json
                           ps.FStar_Tactics_Types.smt_goals in
-                      FStar_Util.JsonList uu____667 in
-                    ("smt-goals", uu____666) in
-                  [uu____661] in
-                uu____645 :: uu____654 in
+                      FStar_Util.JsonList uu___9 in
+                    ("smt-goals", uu___8) in
+                  [uu___7] in
+                uu___5 :: uu___6 in
               ("depth", (FStar_Util.JsonInt (ps.FStar_Tactics_Types.depth)))
-                :: uu____638 in
-            ("label", (FStar_Util.JsonStr msg)) :: uu____631 in
-          let uu____690 =
+                :: uu___4 in
+            ("label", (FStar_Util.JsonStr msg)) :: uu___3 in
+          let uu___3 =
             if ps.FStar_Tactics_Types.entry_range <> FStar_Range.dummyRange
             then
-              let uu____703 =
-                let uu____708 =
+              let uu___4 =
+                let uu___5 =
                   FStar_Range.json_of_def_range
                     ps.FStar_Tactics_Types.entry_range in
-                ("location", uu____708) in
-              [uu____703]
+                ("location", uu___5) in
+              [uu___4]
             else [] in
-          FStar_List.append uu____624 uu____690 in
-        FStar_Util.JsonAssoc uu____617
+          FStar_List.append uu___2 uu___3 in
+        FStar_Util.JsonAssoc uu___1
 let (do_dump_proofstate :
   FStar_Tactics_Types.proofstate -> Prims.string -> unit) =
   fun ps ->
     fun msg ->
-      let uu____736 =
-        let uu____737 = FStar_Options.silent () in
-        Prims.op_Negation uu____737 in
-      if uu____736
+      let uu___ =
+        let uu___1 = FStar_Options.silent () in Prims.op_Negation uu___1 in
+      if uu___
       then
         FStar_Options.with_saved_options
-          (fun uu____741 ->
+          (fun uu___1 ->
              FStar_Options.set_option "print_effect_args"
                (FStar_Options.Bool true);
              FStar_Util.print_generic "proof-state" ps_to_string ps_to_json

--- a/src/ocaml-output/FStar_Tactics_Result.ml
+++ b/src/ocaml-output/FStar_Tactics_Result.ml
@@ -3,14 +3,12 @@ type 'a __result =
   | Success of ('a * FStar_Tactics_Types.proofstate) 
   | Failed of (Prims.exn * FStar_Tactics_Types.proofstate) 
 let uu___is_Success : 'a . 'a __result -> Prims.bool =
-  fun projectee ->
-    match projectee with | Success _0 -> true | uu____44 -> false
+  fun projectee -> match projectee with | Success _0 -> true | uu___ -> false
 let __proj__Success__item___0 :
   'a . 'a __result -> ('a * FStar_Tactics_Types.proofstate) =
   fun projectee -> match projectee with | Success _0 -> _0
 let uu___is_Failed : 'a . 'a __result -> Prims.bool =
-  fun projectee ->
-    match projectee with | Failed _0 -> true | uu____89 -> false
+  fun projectee -> match projectee with | Failed _0 -> true | uu___ -> false
 let __proj__Failed__item___0 :
   'a . 'a __result -> (Prims.exn * FStar_Tactics_Types.proofstate) =
   fun projectee -> match projectee with | Failed _0 -> _0

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -44,63 +44,63 @@ let (goal_with_type : goal -> FStar_Syntax_Syntax.term -> goal) =
     fun t ->
       let c = g.goal_ctx_uvar in
       let c' =
-        let uu___22_133 = c in
+        let uu___ = c in
         {
           FStar_Syntax_Syntax.ctx_uvar_head =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_head);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_head);
           FStar_Syntax_Syntax.ctx_uvar_gamma =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_gamma);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_gamma);
           FStar_Syntax_Syntax.ctx_uvar_binders =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_binders);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_binders);
           FStar_Syntax_Syntax.ctx_uvar_typ = t;
           FStar_Syntax_Syntax.ctx_uvar_reason =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_reason);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_reason);
           FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_should_check);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_should_check);
           FStar_Syntax_Syntax.ctx_uvar_range =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_range);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_range);
           FStar_Syntax_Syntax.ctx_uvar_meta =
-            (uu___22_133.FStar_Syntax_Syntax.ctx_uvar_meta)
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_meta)
         } in
-      let uu___25_134 = g in
+      let uu___ = g in
       {
-        goal_main_env = (uu___25_134.goal_main_env);
+        goal_main_env = (uu___.goal_main_env);
         goal_ctx_uvar = c';
-        opts = (uu___25_134.opts);
-        is_guard = (uu___25_134.is_guard);
-        label = (uu___25_134.label)
+        opts = (uu___.opts);
+        is_guard = (uu___.is_guard);
+        label = (uu___.label)
       }
 let (goal_with_env : goal -> FStar_TypeChecker_Env.env -> goal) =
   fun g ->
     fun env ->
       let c = g.goal_ctx_uvar in
       let c' =
-        let uu___30_147 = c in
-        let uu____148 = FStar_TypeChecker_Env.all_binders env in
+        let uu___ = c in
+        let uu___1 = FStar_TypeChecker_Env.all_binders env in
         {
           FStar_Syntax_Syntax.ctx_uvar_head =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_head);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_head);
           FStar_Syntax_Syntax.ctx_uvar_gamma =
             (env.FStar_TypeChecker_Env.gamma);
-          FStar_Syntax_Syntax.ctx_uvar_binders = uu____148;
+          FStar_Syntax_Syntax.ctx_uvar_binders = uu___1;
           FStar_Syntax_Syntax.ctx_uvar_typ =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_typ);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_typ);
           FStar_Syntax_Syntax.ctx_uvar_reason =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_reason);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_reason);
           FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_should_check);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_should_check);
           FStar_Syntax_Syntax.ctx_uvar_range =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_range);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_range);
           FStar_Syntax_Syntax.ctx_uvar_meta =
-            (uu___30_147.FStar_Syntax_Syntax.ctx_uvar_meta)
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_meta)
         } in
-      let uu___33_157 = g in
+      let uu___ = g in
       {
         goal_main_env = env;
         goal_ctx_uvar = c';
-        opts = (uu___33_157.opts);
-        is_guard = (uu___33_157.is_guard);
-        label = (uu___33_157.label)
+        opts = (uu___.opts);
+        is_guard = (uu___.is_guard);
+        label = (uu___.label)
       }
 let (mk_goal :
   FStar_TypeChecker_Env.env ->
@@ -120,75 +120,75 @@ let (mk_goal :
               label = l
             }
 let rename_binders :
-  'uuuuuu189 .
+  'uuuuu .
     FStar_Syntax_Syntax.subst_elt Prims.list ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu189) Prims.list ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu189) Prims.list
+      (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
+        (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list
   =
   fun subst ->
     fun bs ->
       FStar_All.pipe_right bs
         (FStar_List.map
-           (fun uu___0_249 ->
-              match uu___0_249 with
+           (fun uu___ ->
+              match uu___ with
               | (x, imp) ->
                   let y =
-                    let uu____261 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Subst.subst subst uu____261 in
-                  let uu____262 =
-                    let uu____263 = FStar_Syntax_Subst.compress y in
-                    uu____263.FStar_Syntax_Syntax.n in
-                  (match uu____262 with
+                    let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
+                    FStar_Syntax_Subst.subst subst uu___1 in
+                  let uu___1 =
+                    let uu___2 = FStar_Syntax_Subst.compress y in
+                    uu___2.FStar_Syntax_Syntax.n in
+                  (match uu___1 with
                    | FStar_Syntax_Syntax.Tm_name y1 ->
-                       let uu____271 =
-                         let uu___49_272 = y1 in
-                         let uu____273 =
+                       let uu___2 =
+                         let uu___3 = y1 in
+                         let uu___4 =
                            FStar_Syntax_Subst.subst subst
                              x.FStar_Syntax_Syntax.sort in
                          {
                            FStar_Syntax_Syntax.ppname =
-                             (uu___49_272.FStar_Syntax_Syntax.ppname);
+                             (uu___3.FStar_Syntax_Syntax.ppname);
                            FStar_Syntax_Syntax.index =
-                             (uu___49_272.FStar_Syntax_Syntax.index);
-                           FStar_Syntax_Syntax.sort = uu____273
+                             (uu___3.FStar_Syntax_Syntax.index);
+                           FStar_Syntax_Syntax.sort = uu___4
                          } in
-                       (uu____271, imp)
-                   | uu____276 -> failwith "Not a renaming")))
+                       (uu___2, imp)
+                   | uu___2 -> failwith "Not a renaming")))
 let (subst_goal : FStar_Syntax_Syntax.subst_elt Prims.list -> goal -> goal) =
   fun subst ->
     fun goal1 ->
       let g = goal1.goal_ctx_uvar in
       let ctx_uvar =
-        let uu___55_297 = g in
-        let uu____298 =
+        let uu___ = g in
+        let uu___1 =
           FStar_TypeChecker_Env.rename_gamma subst
             g.FStar_Syntax_Syntax.ctx_uvar_gamma in
-        let uu____301 =
+        let uu___2 =
           rename_binders subst g.FStar_Syntax_Syntax.ctx_uvar_binders in
-        let uu____312 =
+        let uu___3 =
           FStar_Syntax_Subst.subst subst g.FStar_Syntax_Syntax.ctx_uvar_typ in
         {
           FStar_Syntax_Syntax.ctx_uvar_head =
-            (uu___55_297.FStar_Syntax_Syntax.ctx_uvar_head);
-          FStar_Syntax_Syntax.ctx_uvar_gamma = uu____298;
-          FStar_Syntax_Syntax.ctx_uvar_binders = uu____301;
-          FStar_Syntax_Syntax.ctx_uvar_typ = uu____312;
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_head);
+          FStar_Syntax_Syntax.ctx_uvar_gamma = uu___1;
+          FStar_Syntax_Syntax.ctx_uvar_binders = uu___2;
+          FStar_Syntax_Syntax.ctx_uvar_typ = uu___3;
           FStar_Syntax_Syntax.ctx_uvar_reason =
-            (uu___55_297.FStar_Syntax_Syntax.ctx_uvar_reason);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_reason);
           FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (uu___55_297.FStar_Syntax_Syntax.ctx_uvar_should_check);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_should_check);
           FStar_Syntax_Syntax.ctx_uvar_range =
-            (uu___55_297.FStar_Syntax_Syntax.ctx_uvar_range);
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_range);
           FStar_Syntax_Syntax.ctx_uvar_meta =
-            (uu___55_297.FStar_Syntax_Syntax.ctx_uvar_meta)
+            (uu___.FStar_Syntax_Syntax.ctx_uvar_meta)
         } in
-      let uu___58_315 = goal1 in
+      let uu___ = goal1 in
       {
-        goal_main_env = (uu___58_315.goal_main_env);
+        goal_main_env = (uu___.goal_main_env);
         goal_ctx_uvar = ctx_uvar;
-        opts = (uu___58_315.opts);
-        is_guard = (uu___58_315.is_guard);
-        label = (uu___58_315.label)
+        opts = (uu___.opts);
+        is_guard = (uu___.is_guard);
+        label = (uu___.label)
       }
 type guard_policy =
   | Goal 
@@ -196,13 +196,13 @@ type guard_policy =
   | Force 
   | Drop 
 let (uu___is_Goal : guard_policy -> Prims.bool) =
-  fun projectee -> match projectee with | Goal -> true | uu____321 -> false
+  fun projectee -> match projectee with | Goal -> true | uu___ -> false
 let (uu___is_SMT : guard_policy -> Prims.bool) =
-  fun projectee -> match projectee with | SMT -> true | uu____327 -> false
+  fun projectee -> match projectee with | SMT -> true | uu___ -> false
 let (uu___is_Force : guard_policy -> Prims.bool) =
-  fun projectee -> match projectee with | Force -> true | uu____333 -> false
+  fun projectee -> match projectee with | Force -> true | uu___ -> false
 let (uu___is_Drop : guard_policy -> Prims.bool) =
-  fun projectee -> match projectee with | Drop -> true | uu____339 -> false
+  fun projectee -> match projectee with | Drop -> true | uu___ -> false
 type proofstate =
   {
   main_context: FStar_TypeChecker_Env.env ;
@@ -299,112 +299,110 @@ let (subst_proof_state :
   FStar_Syntax_Syntax.subst_t -> proofstate -> proofstate) =
   fun subst ->
     fun ps ->
-      let uu____800 = FStar_Options.tactic_raw_binders () in
-      if uu____800
+      let uu___ = FStar_Options.tactic_raw_binders () in
+      if uu___
       then ps
       else
-        (let uu___99_802 = ps in
-         let uu____803 = FStar_List.map (subst_goal subst) ps.goals in
+        (let uu___2 = ps in
+         let uu___3 = FStar_List.map (subst_goal subst) ps.goals in
          {
-           main_context = (uu___99_802.main_context);
-           all_implicits = (uu___99_802.all_implicits);
-           goals = uu____803;
-           smt_goals = (uu___99_802.smt_goals);
-           depth = (uu___99_802.depth);
-           __dump = (uu___99_802.__dump);
-           psc = (uu___99_802.psc);
-           entry_range = (uu___99_802.entry_range);
-           guard_policy = (uu___99_802.guard_policy);
-           freshness = (uu___99_802.freshness);
-           tac_verb_dbg = (uu___99_802.tac_verb_dbg);
-           local_state = (uu___99_802.local_state)
+           main_context = (uu___2.main_context);
+           all_implicits = (uu___2.all_implicits);
+           goals = uu___3;
+           smt_goals = (uu___2.smt_goals);
+           depth = (uu___2.depth);
+           __dump = (uu___2.__dump);
+           psc = (uu___2.psc);
+           entry_range = (uu___2.entry_range);
+           guard_policy = (uu___2.guard_policy);
+           freshness = (uu___2.freshness);
+           tac_verb_dbg = (uu___2.tac_verb_dbg);
+           local_state = (uu___2.local_state)
          })
 let (decr_depth : proofstate -> proofstate) =
   fun ps ->
-    let uu___102_811 = ps in
+    let uu___ = ps in
     {
-      main_context = (uu___102_811.main_context);
-      all_implicits = (uu___102_811.all_implicits);
-      goals = (uu___102_811.goals);
-      smt_goals = (uu___102_811.smt_goals);
+      main_context = (uu___.main_context);
+      all_implicits = (uu___.all_implicits);
+      goals = (uu___.goals);
+      smt_goals = (uu___.smt_goals);
       depth = (ps.depth - Prims.int_one);
-      __dump = (uu___102_811.__dump);
-      psc = (uu___102_811.psc);
-      entry_range = (uu___102_811.entry_range);
-      guard_policy = (uu___102_811.guard_policy);
-      freshness = (uu___102_811.freshness);
-      tac_verb_dbg = (uu___102_811.tac_verb_dbg);
-      local_state = (uu___102_811.local_state)
+      __dump = (uu___.__dump);
+      psc = (uu___.psc);
+      entry_range = (uu___.entry_range);
+      guard_policy = (uu___.guard_policy);
+      freshness = (uu___.freshness);
+      tac_verb_dbg = (uu___.tac_verb_dbg);
+      local_state = (uu___.local_state)
     }
 let (incr_depth : proofstate -> proofstate) =
   fun ps ->
-    let uu___105_817 = ps in
+    let uu___ = ps in
     {
-      main_context = (uu___105_817.main_context);
-      all_implicits = (uu___105_817.all_implicits);
-      goals = (uu___105_817.goals);
-      smt_goals = (uu___105_817.smt_goals);
+      main_context = (uu___.main_context);
+      all_implicits = (uu___.all_implicits);
+      goals = (uu___.goals);
+      smt_goals = (uu___.smt_goals);
       depth = (ps.depth + Prims.int_one);
-      __dump = (uu___105_817.__dump);
-      psc = (uu___105_817.psc);
-      entry_range = (uu___105_817.entry_range);
-      guard_policy = (uu___105_817.guard_policy);
-      freshness = (uu___105_817.freshness);
-      tac_verb_dbg = (uu___105_817.tac_verb_dbg);
-      local_state = (uu___105_817.local_state)
+      __dump = (uu___.__dump);
+      psc = (uu___.psc);
+      entry_range = (uu___.entry_range);
+      guard_policy = (uu___.guard_policy);
+      freshness = (uu___.freshness);
+      tac_verb_dbg = (uu___.tac_verb_dbg);
+      local_state = (uu___.local_state)
     }
 let (set_ps_psc : FStar_TypeChecker_Cfg.psc -> proofstate -> proofstate) =
   fun psc ->
     fun ps ->
-      let uu___109_828 = ps in
+      let uu___ = ps in
       {
-        main_context = (uu___109_828.main_context);
-        all_implicits = (uu___109_828.all_implicits);
-        goals = (uu___109_828.goals);
-        smt_goals = (uu___109_828.smt_goals);
-        depth = (uu___109_828.depth);
-        __dump = (uu___109_828.__dump);
+        main_context = (uu___.main_context);
+        all_implicits = (uu___.all_implicits);
+        goals = (uu___.goals);
+        smt_goals = (uu___.smt_goals);
+        depth = (uu___.depth);
+        __dump = (uu___.__dump);
         psc;
-        entry_range = (uu___109_828.entry_range);
-        guard_policy = (uu___109_828.guard_policy);
-        freshness = (uu___109_828.freshness);
-        tac_verb_dbg = (uu___109_828.tac_verb_dbg);
-        local_state = (uu___109_828.local_state)
+        entry_range = (uu___.entry_range);
+        guard_policy = (uu___.guard_policy);
+        freshness = (uu___.freshness);
+        tac_verb_dbg = (uu___.tac_verb_dbg);
+        local_state = (uu___.local_state)
       }
 let (tracepoint : FStar_TypeChecker_Cfg.psc -> proofstate -> unit) =
   fun psc ->
     fun ps ->
-      let uu____839 =
+      let uu___ =
         (FStar_Options.tactic_trace ()) ||
-          (let uu____841 = FStar_Options.tactic_trace_d () in
-           ps.depth <= uu____841) in
-      if uu____839
+          (let uu___1 = FStar_Options.tactic_trace_d () in ps.depth <= uu___1) in
+      if uu___
       then
         let ps1 = set_ps_psc psc ps in
         let subst = FStar_TypeChecker_Cfg.psc_subst ps1.psc in
-        let uu____844 = subst_proof_state subst ps1 in
-        ps1.__dump uu____844 "TRACE"
+        let uu___1 = subst_proof_state subst ps1 in ps1.__dump uu___1 "TRACE"
       else ()
 let (set_proofstate_range : proofstate -> FStar_Range.range -> proofstate) =
   fun ps ->
     fun r ->
-      let uu___118_856 = ps in
-      let uu____857 =
-        let uu____858 = FStar_Range.def_range r in
-        FStar_Range.set_def_range ps.entry_range uu____858 in
+      let uu___ = ps in
+      let uu___1 =
+        let uu___2 = FStar_Range.def_range r in
+        FStar_Range.set_def_range ps.entry_range uu___2 in
       {
-        main_context = (uu___118_856.main_context);
-        all_implicits = (uu___118_856.all_implicits);
-        goals = (uu___118_856.goals);
-        smt_goals = (uu___118_856.smt_goals);
-        depth = (uu___118_856.depth);
-        __dump = (uu___118_856.__dump);
-        psc = (uu___118_856.psc);
-        entry_range = uu____857;
-        guard_policy = (uu___118_856.guard_policy);
-        freshness = (uu___118_856.freshness);
-        tac_verb_dbg = (uu___118_856.tac_verb_dbg);
-        local_state = (uu___118_856.local_state)
+        main_context = (uu___.main_context);
+        all_implicits = (uu___.all_implicits);
+        goals = (uu___.goals);
+        smt_goals = (uu___.smt_goals);
+        depth = (uu___.depth);
+        __dump = (uu___.__dump);
+        psc = (uu___.psc);
+        entry_range = uu___1;
+        guard_policy = (uu___.guard_policy);
+        freshness = (uu___.freshness);
+        tac_verb_dbg = (uu___.tac_verb_dbg);
+        local_state = (uu___.local_state)
       }
 let (goals_of : proofstate -> goal Prims.list) = fun ps -> ps.goals
 let (smt_goals_of : proofstate -> goal Prims.list) = fun ps -> ps.smt_goals
@@ -413,53 +411,50 @@ let (get_label : goal -> Prims.string) = fun g -> g.label
 let (set_label : Prims.string -> goal -> goal) =
   fun l ->
     fun g ->
-      let uu___126_897 = g in
+      let uu___ = g in
       {
-        goal_main_env = (uu___126_897.goal_main_env);
-        goal_ctx_uvar = (uu___126_897.goal_ctx_uvar);
-        opts = (uu___126_897.opts);
-        is_guard = (uu___126_897.is_guard);
+        goal_main_env = (uu___.goal_main_env);
+        goal_ctx_uvar = (uu___.goal_ctx_uvar);
+        opts = (uu___.opts);
+        is_guard = (uu___.is_guard);
         label = l
       }
 type direction =
   | TopDown 
   | BottomUp 
 let (uu___is_TopDown : direction -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TopDown -> true | uu____903 -> false
+  fun projectee -> match projectee with | TopDown -> true | uu___ -> false
 let (uu___is_BottomUp : direction -> Prims.bool) =
-  fun projectee ->
-    match projectee with | BottomUp -> true | uu____909 -> false
+  fun projectee -> match projectee with | BottomUp -> true | uu___ -> false
 type ctrl_flag =
   | Continue 
   | Skip 
   | Abort 
 let (uu___is_Continue : ctrl_flag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Continue -> true | uu____915 -> false
+  fun projectee -> match projectee with | Continue -> true | uu___ -> false
 let (uu___is_Skip : ctrl_flag -> Prims.bool) =
-  fun projectee -> match projectee with | Skip -> true | uu____921 -> false
+  fun projectee -> match projectee with | Skip -> true | uu___ -> false
 let (uu___is_Abort : ctrl_flag -> Prims.bool) =
-  fun projectee -> match projectee with | Abort -> true | uu____927 -> false
+  fun projectee -> match projectee with | Abort -> true | uu___ -> false
 let (check_goal_solved' :
   goal -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option) =
   fun goal1 ->
-    let uu____935 =
+    let uu___ =
       FStar_Syntax_Unionfind.find
         (goal1.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-    match uu____935 with
+    match uu___ with
     | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let (check_goal_solved : goal -> Prims.bool) =
   fun goal1 ->
-    let uu____946 = check_goal_solved' goal1 in FStar_Option.isSome uu____946
+    let uu___ = check_goal_solved' goal1 in FStar_Option.isSome uu___
 let (get_phi :
   goal -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option) =
   fun g ->
-    let uu____958 =
-      let uu____959 = goal_env g in
-      let uu____960 = goal_type g in
-      FStar_TypeChecker_Normalize.unfold_whnf uu____959 uu____960 in
-    FStar_Syntax_Util.un_squash uu____958
+    let uu___ =
+      let uu___1 = goal_env g in
+      let uu___2 = goal_type g in
+      FStar_TypeChecker_Normalize.unfold_whnf uu___1 uu___2 in
+    FStar_Syntax_Util.un_squash uu___
 let (is_irrelevant : goal -> Prims.bool) =
-  fun g -> let uu____966 = get_phi g in FStar_Option.isSome uu____966
+  fun g -> let uu___ = get_phi g in FStar_Option.isSome uu___

--- a/src/ocaml-output/FStar_Tests_Norm.ml
+++ b/src/ocaml-output/FStar_Tests_Norm.ml
@@ -24,8 +24,8 @@ let rec (encode : Prims.int -> FStar_Syntax_Syntax.term) =
     if n = Prims.int_zero
     then z
     else
-      (let uu____10 = let uu____13 = encode (n - Prims.int_one) in [uu____13] in
-       FStar_Tests_Util.app succ uu____10)
+      (let uu___1 = let uu___2 = encode (n - Prims.int_one) in [uu___2] in
+       FStar_Tests_Util.app succ uu___1)
 let (minus :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -40,10 +40,10 @@ let (let_ :
   fun x ->
     fun e ->
       fun e' ->
-        let uu____49 =
-          let uu____52 = let uu____53 = b x in [uu____53] in
-          FStar_Syntax_Util.abs uu____52 e' FStar_Pervasives_Native.None in
-        FStar_Tests_Util.app uu____49 [e]
+        let uu___ =
+          let uu___1 = let uu___2 = b x in [uu___2] in
+          FStar_Syntax_Util.abs uu___1 e' FStar_Pervasives_Native.None in
+        FStar_Tests_Util.app uu___ [e]
 let (mk_let :
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -71,12 +71,12 @@ let (mk_let :
 let (lid : Prims.string -> FStar_Ident.lident) =
   fun x -> FStar_Ident.lid_of_path ["Test"; x] FStar_Range.dummyRange
 let (znat_l : FStar_Syntax_Syntax.fv) =
-  let uu____109 = lid "Z" in
-  FStar_Syntax_Syntax.lid_as_fv uu____109 FStar_Syntax_Syntax.delta_constant
+  let uu___ = lid "Z" in
+  FStar_Syntax_Syntax.lid_as_fv uu___ FStar_Syntax_Syntax.delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (snat_l : FStar_Syntax_Syntax.fv) =
-  let uu____110 = lid "S" in
-  FStar_Syntax_Syntax.lid_as_fv uu____110 FStar_Syntax_Syntax.delta_constant
+  let uu___ = lid "S" in
+  FStar_Syntax_Syntax.lid_as_fv uu___ FStar_Syntax_Syntax.delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (tm_fv :
   FStar_Syntax_Syntax.fv ->
@@ -91,23 +91,21 @@ let (snat :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun s ->
-    let uu____125 =
-      let uu____126 =
-        let uu____143 = tm_fv snat_l in
-        let uu____146 =
-          let uu____157 = FStar_Syntax_Syntax.as_arg s in [uu____157] in
-        (uu____143, uu____146) in
-      FStar_Syntax_Syntax.Tm_app uu____126 in
-    FStar_Syntax_Syntax.mk uu____125 FStar_Range.dummyRange
-let pat :
-  'uuuuuu198 . 'uuuuuu198 -> 'uuuuuu198 FStar_Syntax_Syntax.withinfo_t =
+    let uu___ =
+      let uu___1 =
+        let uu___2 = tm_fv snat_l in
+        let uu___3 = let uu___4 = FStar_Syntax_Syntax.as_arg s in [uu___4] in
+        (uu___2, uu___3) in
+      FStar_Syntax_Syntax.Tm_app uu___1 in
+    FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
+let pat : 'uuuuu . 'uuuuu -> 'uuuuu FStar_Syntax_Syntax.withinfo_t =
   fun p -> FStar_Syntax_Syntax.withinfo p FStar_Range.dummyRange
 let (snat_type : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
-  let uu____208 =
-    let uu____209 = lid "snat" in
-    FStar_Syntax_Syntax.lid_as_fv uu____209
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-  tm_fv uu____208
+  let uu___ =
+    let uu___1 = lid "snat" in
+    FStar_Syntax_Syntax.lid_as_fv uu___1 FStar_Syntax_Syntax.delta_constant
+      FStar_Pervasives_Native.None in
+  tm_fv uu___
 let (mk_match :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.branch Prims.list ->
@@ -126,33 +124,32 @@ let (pred_nat :
   =
   fun s ->
     let zbranch =
-      let uu____309 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
-      (uu____309, FStar_Pervasives_Native.None, znat) in
+      let uu___ = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
+      (uu___, FStar_Pervasives_Native.None, znat) in
     let sbranch =
-      let uu____351 =
-        let uu____354 =
-          let uu____355 =
-            let uu____368 =
-              let uu____377 =
-                let uu____384 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
                   pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.x) in
-                (uu____384, false) in
-              [uu____377] in
-            (snat_l, uu____368) in
-          FStar_Syntax_Syntax.Pat_cons uu____355 in
-        pat uu____354 in
-      let uu____409 =
+                (uu___5, false) in
+              [uu___4] in
+            (snat_l, uu___3) in
+          FStar_Syntax_Syntax.Pat_cons uu___2 in
+        pat uu___1 in
+      let uu___1 =
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_bvar
-             (let uu___21_414 = FStar_Tests_Util.x in
+             (let uu___2 = FStar_Tests_Util.x in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___21_414.FStar_Syntax_Syntax.ppname);
+                  (uu___2.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index = Prims.int_zero;
-                FStar_Syntax_Syntax.sort =
-                  (uu___21_414.FStar_Syntax_Syntax.sort)
+                FStar_Syntax_Syntax.sort = (uu___2.FStar_Syntax_Syntax.sort)
               })) FStar_Range.dummyRange in
-      (uu____351, FStar_Pervasives_Native.None, uu____409) in
+      (uu___, FStar_Pervasives_Native.None, uu___1) in
     mk_match s [zbranch; sbranch]
 let (minus_nat :
   FStar_Syntax_Syntax.term ->
@@ -163,91 +160,85 @@ let (minus_nat :
     fun t2 ->
       let minus1 = FStar_Tests_Util.m in
       let x =
-        let uu___27_439 = FStar_Tests_Util.x in
+        let uu___ = FStar_Tests_Util.x in
         {
-          FStar_Syntax_Syntax.ppname =
-            (uu___27_439.FStar_Syntax_Syntax.ppname);
-          FStar_Syntax_Syntax.index = (uu___27_439.FStar_Syntax_Syntax.index);
+          FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+          FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
           FStar_Syntax_Syntax.sort = snat_type
         } in
       let y =
-        let uu___30_441 = FStar_Tests_Util.y in
+        let uu___ = FStar_Tests_Util.y in
         {
-          FStar_Syntax_Syntax.ppname =
-            (uu___30_441.FStar_Syntax_Syntax.ppname);
-          FStar_Syntax_Syntax.index = (uu___30_441.FStar_Syntax_Syntax.index);
+          FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+          FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
           FStar_Syntax_Syntax.sort = snat_type
         } in
       let zbranch =
-        let uu____457 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
-        let uu____474 = FStar_Tests_Util.nm x in
-        (uu____457, FStar_Pervasives_Native.None, uu____474) in
+        let uu___ = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
+        let uu___1 = FStar_Tests_Util.nm x in
+        (uu___, FStar_Pervasives_Native.None, uu___1) in
       let sbranch =
-        let uu____502 =
-          let uu____505 =
-            let uu____506 =
-              let uu____519 =
-                let uu____528 =
-                  let uu____535 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
                     pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.n) in
-                  (uu____535, false) in
-                [uu____528] in
-              (snat_l, uu____519) in
-            FStar_Syntax_Syntax.Pat_cons uu____506 in
-          pat uu____505 in
-        let uu____560 =
-          let uu____563 = FStar_Tests_Util.nm minus1 in
-          let uu____566 =
-            let uu____569 =
-              let uu____570 = FStar_Tests_Util.nm x in pred_nat uu____570 in
-            let uu____573 =
-              let uu____576 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-              [uu____576] in
-            uu____569 :: uu____573 in
-          FStar_Tests_Util.app uu____563 uu____566 in
-        (uu____502, FStar_Pervasives_Native.None, uu____560) in
+                  (uu___5, false) in
+                [uu___4] in
+              (snat_l, uu___3) in
+            FStar_Syntax_Syntax.Pat_cons uu___2 in
+          pat uu___1 in
+        let uu___1 =
+          let uu___2 = FStar_Tests_Util.nm minus1 in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_Tests_Util.nm x in pred_nat uu___5 in
+            let uu___5 =
+              let uu___6 = FStar_Tests_Util.nm FStar_Tests_Util.n in [uu___6] in
+            uu___4 :: uu___5 in
+          FStar_Tests_Util.app uu___2 uu___3 in
+        (uu___, FStar_Pervasives_Native.None, uu___1) in
       let lb =
-        let uu____588 =
-          FStar_Ident.lid_of_path ["Pure"] FStar_Range.dummyRange in
-        let uu____589 =
-          let uu____592 =
-            let uu____593 =
-              let uu____594 = b x in
-              let uu____601 = let uu____610 = b y in [uu____610] in uu____594
-                :: uu____601 in
-            let uu____635 =
-              let uu____638 = FStar_Tests_Util.nm y in
-              mk_match uu____638 [zbranch; sbranch] in
-            FStar_Syntax_Util.abs uu____593 uu____635
-              FStar_Pervasives_Native.None in
+        let uu___ = FStar_Ident.lid_of_path ["Pure"] FStar_Range.dummyRange in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = b x in
+              let uu___5 = let uu___6 = b y in [uu___6] in uu___4 :: uu___5 in
+            let uu___4 =
+              let uu___5 = FStar_Tests_Util.nm y in
+              mk_match uu___5 [zbranch; sbranch] in
+            FStar_Syntax_Util.abs uu___3 uu___4 FStar_Pervasives_Native.None in
           FStar_Syntax_Subst.subst
-            [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____592 in
+            [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu___2 in
         {
           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl minus1);
           FStar_Syntax_Syntax.lbunivs = [];
           FStar_Syntax_Syntax.lbtyp = FStar_Syntax_Syntax.tun;
-          FStar_Syntax_Syntax.lbeff = uu____588;
-          FStar_Syntax_Syntax.lbdef = uu____589;
+          FStar_Syntax_Syntax.lbeff = uu___;
+          FStar_Syntax_Syntax.lbdef = uu___1;
           FStar_Syntax_Syntax.lbattrs = [];
           FStar_Syntax_Syntax.lbpos = FStar_Range.dummyRange
         } in
-      let uu____643 =
-        let uu____644 =
-          let uu____657 =
-            let uu____660 =
-              let uu____661 = FStar_Tests_Util.nm minus1 in
-              FStar_Tests_Util.app uu____661 [t1; t2] in
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Tests_Util.nm minus1 in
+              FStar_Tests_Util.app uu___4 [t1; t2] in
             FStar_Syntax_Subst.subst
-              [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____660 in
-          ((true, [lb]), uu____657) in
-        FStar_Syntax_Syntax.Tm_let uu____644 in
-      FStar_Syntax_Syntax.mk uu____643 FStar_Range.dummyRange
+              [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu___3 in
+          ((true, [lb]), uu___2) in
+        FStar_Syntax_Syntax.Tm_let uu___1 in
+      FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let (encode_nat : Prims.int -> FStar_Syntax_Syntax.term) =
   fun n ->
     let rec aux out n1 =
       if n1 = Prims.int_zero
       then out
-      else (let uu____691 = snat out in aux uu____691 (n1 - Prims.int_one)) in
+      else (let uu___1 = snat out in aux uu___1 (n1 - Prims.int_one)) in
     aux znat n
 let (tests :
   (Prims.int * FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -292,987 +283,961 @@ let (tests :
   FStar_Tests_Pars.pars_and_tc_fragment "let fst_a (x: 'a) (y: 'a) = x";
   FStar_Tests_Pars.pars_and_tc_fragment "let id_list (x: list 'a) = x";
   FStar_Tests_Pars.pars_and_tc_fragment "let id_list_m (x: list tb) = x";
-  (let uu____729 =
-     let uu____740 =
-       let uu____743 =
-         let uu____746 =
-           let uu____749 =
-             let uu____752 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-             [uu____752] in
-           id :: uu____749 in
-         one :: uu____746 in
-       FStar_Tests_Util.app apply uu____743 in
-     let uu____753 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-     (Prims.int_zero, uu____740, uu____753) in
-   let uu____760 =
-     let uu____773 =
-       let uu____784 =
-         let uu____787 =
-           let uu____790 = FStar_Tests_Util.nm FStar_Tests_Util.x in
-           [uu____790] in
-         FStar_Tests_Util.app id uu____787 in
-       let uu____791 = FStar_Tests_Util.nm FStar_Tests_Util.x in
-       (Prims.int_one, uu____784, uu____791) in
-     let uu____798 =
-       let uu____811 =
-         let uu____822 =
-           let uu____825 =
-             let uu____828 =
-               let uu____831 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-               let uu____832 =
-                 let uu____835 = FStar_Tests_Util.nm FStar_Tests_Util.m in
-                 [uu____835] in
-               uu____831 :: uu____832 in
-             tt :: uu____828 in
-           FStar_Tests_Util.app apply uu____825 in
-         let uu____836 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-         (Prims.int_one, uu____822, uu____836) in
-       let uu____843 =
-         let uu____856 =
-           let uu____867 =
-             let uu____870 =
-               let uu____873 =
-                 let uu____876 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-                 let uu____877 =
-                   let uu____880 = FStar_Tests_Util.nm FStar_Tests_Util.m in
-                   [uu____880] in
-                 uu____876 :: uu____877 in
-               ff :: uu____873 in
-             FStar_Tests_Util.app apply uu____870 in
-           let uu____881 = FStar_Tests_Util.nm FStar_Tests_Util.m in
-           ((Prims.of_int (2)), uu____867, uu____881) in
-         let uu____888 =
-           let uu____901 =
-             let uu____912 =
-               let uu____915 =
-                 let uu____918 =
-                   let uu____921 =
-                     let uu____924 =
-                       let uu____927 =
-                         let uu____930 =
-                           let uu____933 =
-                             let uu____936 =
+  (let uu___25 =
+     let uu___26 =
+       let uu___27 =
+         let uu___28 =
+           let uu___29 =
+             let uu___30 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+             [uu___30] in
+           id :: uu___29 in
+         one :: uu___28 in
+       FStar_Tests_Util.app apply uu___27 in
+     let uu___27 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+     (Prims.int_zero, uu___26, uu___27) in
+   let uu___26 =
+     let uu___27 =
+       let uu___28 =
+         let uu___29 =
+           let uu___30 = FStar_Tests_Util.nm FStar_Tests_Util.x in [uu___30] in
+         FStar_Tests_Util.app id uu___29 in
+       let uu___29 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+       (Prims.int_one, uu___28, uu___29) in
+     let uu___28 =
+       let uu___29 =
+         let uu___30 =
+           let uu___31 =
+             let uu___32 =
+               let uu___33 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+               let uu___34 =
+                 let uu___35 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+                 [uu___35] in
+               uu___33 :: uu___34 in
+             tt :: uu___32 in
+           FStar_Tests_Util.app apply uu___31 in
+         let uu___31 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+         (Prims.int_one, uu___30, uu___31) in
+       let uu___30 =
+         let uu___31 =
+           let uu___32 =
+             let uu___33 =
+               let uu___34 =
+                 let uu___35 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+                 let uu___36 =
+                   let uu___37 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+                   [uu___37] in
+                 uu___35 :: uu___36 in
+               ff :: uu___34 in
+             FStar_Tests_Util.app apply uu___33 in
+           let uu___33 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+           ((Prims.of_int (2)), uu___32, uu___33) in
+         let uu___32 =
+           let uu___33 =
+             let uu___34 =
+               let uu___35 =
+                 let uu___36 =
+                   let uu___37 =
+                     let uu___38 =
+                       let uu___39 =
+                         let uu___40 =
+                           let uu___41 =
+                             let uu___42 =
                                FStar_Tests_Util.nm FStar_Tests_Util.n in
-                             let uu____937 =
-                               let uu____940 =
+                             let uu___43 =
+                               let uu___44 =
                                  FStar_Tests_Util.nm FStar_Tests_Util.m in
-                               [uu____940] in
-                             uu____936 :: uu____937 in
-                           ff :: uu____933 in
-                         apply :: uu____930 in
-                       apply :: uu____927 in
-                     apply :: uu____924 in
-                   apply :: uu____921 in
-                 apply :: uu____918 in
-               FStar_Tests_Util.app apply uu____915 in
-             let uu____941 = FStar_Tests_Util.nm FStar_Tests_Util.m in
-             ((Prims.of_int (3)), uu____912, uu____941) in
-           let uu____948 =
-             let uu____961 =
-               let uu____972 =
-                 let uu____975 =
-                   let uu____978 =
-                     let uu____981 =
-                       let uu____984 = FStar_Tests_Util.nm FStar_Tests_Util.n in
-                       let uu____985 =
-                         let uu____988 =
-                           FStar_Tests_Util.nm FStar_Tests_Util.m in
-                         [uu____988] in
-                       uu____984 :: uu____985 in
-                     ff :: uu____981 in
-                   apply :: uu____978 in
-                 FStar_Tests_Util.app twice uu____975 in
-               let uu____989 = FStar_Tests_Util.nm FStar_Tests_Util.m in
-               ((Prims.of_int (4)), uu____972, uu____989) in
-             let uu____996 =
-               let uu____1009 =
-                 let uu____1020 = minus one z in
-                 ((Prims.of_int (5)), uu____1020, one) in
-               let uu____1027 =
-                 let uu____1040 =
-                   let uu____1051 = FStar_Tests_Util.app pred [one] in
-                   ((Prims.of_int (6)), uu____1051, z) in
-                 let uu____1058 =
-                   let uu____1071 =
-                     let uu____1082 = minus one one in
-                     ((Prims.of_int (7)), uu____1082, z) in
-                   let uu____1089 =
-                     let uu____1102 =
-                       let uu____1113 = FStar_Tests_Util.app mul [one; one] in
-                       ((Prims.of_int (8)), uu____1113, one) in
-                     let uu____1120 =
-                       let uu____1133 =
-                         let uu____1144 = FStar_Tests_Util.app mul [two; one] in
-                         ((Prims.of_int (9)), uu____1144, two) in
-                       let uu____1151 =
-                         let uu____1164 =
-                           let uu____1175 =
-                             let uu____1178 =
-                               let uu____1181 =
-                                 FStar_Tests_Util.app succ [one] in
-                               [uu____1181; one] in
-                             FStar_Tests_Util.app mul uu____1178 in
-                           ((Prims.of_int (10)), uu____1175, two) in
-                         let uu____1186 =
-                           let uu____1199 =
-                             let uu____1210 =
-                               let uu____1213 = encode (Prims.of_int (10)) in
-                               let uu____1214 = encode (Prims.of_int (10)) in
-                               minus uu____1213 uu____1214 in
-                             ((Prims.of_int (11)), uu____1210, z) in
-                           let uu____1221 =
-                             let uu____1234 =
-                               let uu____1245 =
-                                 let uu____1248 = encode (Prims.of_int (100)) in
-                                 let uu____1249 = encode (Prims.of_int (100)) in
-                                 minus uu____1248 uu____1249 in
-                               ((Prims.of_int (12)), uu____1245, z) in
-                             let uu____1256 =
-                               let uu____1269 =
-                                 let uu____1280 =
-                                   let uu____1283 =
-                                     encode (Prims.of_int (100)) in
-                                   let uu____1284 =
-                                     let uu____1287 =
+                               [uu___44] in
+                             uu___42 :: uu___43 in
+                           ff :: uu___41 in
+                         apply :: uu___40 in
+                       apply :: uu___39 in
+                     apply :: uu___38 in
+                   apply :: uu___37 in
+                 apply :: uu___36 in
+               FStar_Tests_Util.app apply uu___35 in
+             let uu___35 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+             ((Prims.of_int (3)), uu___34, uu___35) in
+           let uu___34 =
+             let uu___35 =
+               let uu___36 =
+                 let uu___37 =
+                   let uu___38 =
+                     let uu___39 =
+                       let uu___40 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+                       let uu___41 =
+                         let uu___42 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+                         [uu___42] in
+                       uu___40 :: uu___41 in
+                     ff :: uu___39 in
+                   apply :: uu___38 in
+                 FStar_Tests_Util.app twice uu___37 in
+               let uu___37 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+               ((Prims.of_int (4)), uu___36, uu___37) in
+             let uu___36 =
+               let uu___37 =
+                 let uu___38 = minus one z in
+                 ((Prims.of_int (5)), uu___38, one) in
+               let uu___38 =
+                 let uu___39 =
+                   let uu___40 = FStar_Tests_Util.app pred [one] in
+                   ((Prims.of_int (6)), uu___40, z) in
+                 let uu___40 =
+                   let uu___41 =
+                     let uu___42 = minus one one in
+                     ((Prims.of_int (7)), uu___42, z) in
+                   let uu___42 =
+                     let uu___43 =
+                       let uu___44 = FStar_Tests_Util.app mul [one; one] in
+                       ((Prims.of_int (8)), uu___44, one) in
+                     let uu___44 =
+                       let uu___45 =
+                         let uu___46 = FStar_Tests_Util.app mul [two; one] in
+                         ((Prims.of_int (9)), uu___46, two) in
+                       let uu___46 =
+                         let uu___47 =
+                           let uu___48 =
+                             let uu___49 =
+                               let uu___50 = FStar_Tests_Util.app succ [one] in
+                               [uu___50; one] in
+                             FStar_Tests_Util.app mul uu___49 in
+                           ((Prims.of_int (10)), uu___48, two) in
+                         let uu___48 =
+                           let uu___49 =
+                             let uu___50 =
+                               let uu___51 = encode (Prims.of_int (10)) in
+                               let uu___52 = encode (Prims.of_int (10)) in
+                               minus uu___51 uu___52 in
+                             ((Prims.of_int (11)), uu___50, z) in
+                           let uu___50 =
+                             let uu___51 =
+                               let uu___52 =
+                                 let uu___53 = encode (Prims.of_int (100)) in
+                                 let uu___54 = encode (Prims.of_int (100)) in
+                                 minus uu___53 uu___54 in
+                               ((Prims.of_int (12)), uu___52, z) in
+                             let uu___52 =
+                               let uu___53 =
+                                 let uu___54 =
+                                   let uu___55 = encode (Prims.of_int (100)) in
+                                   let uu___56 =
+                                     let uu___57 =
                                        FStar_Tests_Util.nm FStar_Tests_Util.x in
-                                     let uu____1288 =
+                                     let uu___58 =
                                        FStar_Tests_Util.nm FStar_Tests_Util.x in
-                                     minus uu____1287 uu____1288 in
-                                   let_ FStar_Tests_Util.x uu____1283
-                                     uu____1284 in
-                                 ((Prims.of_int (13)), uu____1280, z) in
-                               let uu____1295 =
-                                 let uu____1308 =
-                                   let uu____1319 =
-                                     let uu____1322 =
+                                     minus uu___57 uu___58 in
+                                   let_ FStar_Tests_Util.x uu___55 uu___56 in
+                                 ((Prims.of_int (13)), uu___54, z) in
+                               let uu___54 =
+                                 let uu___55 =
+                                   let uu___56 =
+                                     let uu___57 =
                                        FStar_Tests_Util.app succ [one] in
-                                     let uu____1323 =
-                                       let uu____1326 =
-                                         let uu____1327 =
-                                           let uu____1330 =
+                                     let uu___58 =
+                                       let uu___59 =
+                                         let uu___60 =
+                                           let uu___61 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.x in
-                                           let uu____1331 =
-                                             let uu____1334 =
+                                           let uu___62 =
+                                             let uu___63 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.x in
-                                             [uu____1334] in
-                                           uu____1330 :: uu____1331 in
-                                         FStar_Tests_Util.app mul uu____1327 in
-                                       let uu____1335 =
-                                         let uu____1338 =
-                                           let uu____1339 =
-                                             let uu____1342 =
+                                             [uu___63] in
+                                           uu___61 :: uu___62 in
+                                         FStar_Tests_Util.app mul uu___60 in
+                                       let uu___60 =
+                                         let uu___61 =
+                                           let uu___62 =
+                                             let uu___63 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.y in
-                                             let uu____1343 =
-                                               let uu____1346 =
+                                             let uu___64 =
+                                               let uu___65 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.y in
-                                               [uu____1346] in
-                                             uu____1342 :: uu____1343 in
-                                           FStar_Tests_Util.app mul
-                                             uu____1339 in
-                                         let uu____1347 =
-                                           let uu____1350 =
+                                               [uu___65] in
+                                             uu___63 :: uu___64 in
+                                           FStar_Tests_Util.app mul uu___62 in
+                                         let uu___62 =
+                                           let uu___63 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.h in
-                                           let uu____1351 =
+                                           let uu___64 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.h in
-                                           minus uu____1350 uu____1351 in
-                                         let_ FStar_Tests_Util.h uu____1338
-                                           uu____1347 in
-                                       let_ FStar_Tests_Util.y uu____1326
-                                         uu____1335 in
-                                     let_ FStar_Tests_Util.x uu____1322
-                                       uu____1323 in
-                                   ((Prims.of_int (15)), uu____1319, z) in
-                                 let uu____1358 =
-                                   let uu____1371 =
-                                     let uu____1382 =
-                                       let uu____1385 =
+                                           minus uu___63 uu___64 in
+                                         let_ FStar_Tests_Util.h uu___61
+                                           uu___62 in
+                                       let_ FStar_Tests_Util.y uu___59
+                                         uu___60 in
+                                     let_ FStar_Tests_Util.x uu___57 uu___58 in
+                                   ((Prims.of_int (15)), uu___56, z) in
+                                 let uu___56 =
+                                   let uu___57 =
+                                     let uu___58 =
+                                       let uu___59 =
                                          FStar_Tests_Util.app succ [one] in
-                                       let uu____1388 =
-                                         let uu____1389 =
-                                           let uu____1392 =
-                                             let uu____1395 =
+                                       let uu___60 =
+                                         let uu___61 =
+                                           let uu___62 =
+                                             let uu___63 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.x in
-                                             let uu____1396 =
-                                               let uu____1399 =
+                                             let uu___64 =
+                                               let uu___65 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.x in
-                                               [uu____1399] in
-                                             uu____1395 :: uu____1396 in
-                                           FStar_Tests_Util.app mul
-                                             uu____1392 in
-                                         let uu____1400 =
-                                           let uu____1401 =
-                                             let uu____1404 =
-                                               let uu____1407 =
+                                               [uu___65] in
+                                             uu___63 :: uu___64 in
+                                           FStar_Tests_Util.app mul uu___62 in
+                                         let uu___62 =
+                                           let uu___63 =
+                                             let uu___64 =
+                                               let uu___65 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.y in
-                                               let uu____1408 =
-                                                 let uu____1411 =
+                                               let uu___66 =
+                                                 let uu___67 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.y in
-                                                 [uu____1411] in
-                                               uu____1407 :: uu____1408 in
-                                             FStar_Tests_Util.app mul
-                                               uu____1404 in
-                                           let uu____1412 =
-                                             let uu____1413 =
+                                                 [uu___67] in
+                                               uu___65 :: uu___66 in
+                                             FStar_Tests_Util.app mul uu___64 in
+                                           let uu___64 =
+                                             let uu___65 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.h in
-                                             let uu____1414 =
+                                             let uu___66 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.h in
-                                             minus uu____1413 uu____1414 in
-                                           mk_let FStar_Tests_Util.h
-                                             uu____1401 uu____1412 in
-                                         mk_let FStar_Tests_Util.y uu____1389
-                                           uu____1400 in
-                                       mk_let FStar_Tests_Util.x uu____1385
-                                         uu____1388 in
-                                     ((Prims.of_int (16)), uu____1382, z) in
-                                   let uu____1421 =
-                                     let uu____1434 =
-                                       let uu____1445 =
-                                         let uu____1448 =
+                                             minus uu___65 uu___66 in
+                                           mk_let FStar_Tests_Util.h uu___63
+                                             uu___64 in
+                                         mk_let FStar_Tests_Util.y uu___61
+                                           uu___62 in
+                                       mk_let FStar_Tests_Util.x uu___59
+                                         uu___60 in
+                                     ((Prims.of_int (16)), uu___58, z) in
+                                   let uu___58 =
+                                     let uu___59 =
+                                       let uu___60 =
+                                         let uu___61 =
                                            FStar_Tests_Util.app succ [one] in
-                                         let uu____1449 =
-                                           let uu____1452 =
-                                             let uu____1453 =
-                                               let uu____1456 =
+                                         let uu___62 =
+                                           let uu___63 =
+                                             let uu___64 =
+                                               let uu___65 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.x in
-                                               let uu____1457 =
-                                                 let uu____1460 =
+                                               let uu___66 =
+                                                 let uu___67 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.x in
-                                                 [uu____1460] in
-                                               uu____1456 :: uu____1457 in
-                                             FStar_Tests_Util.app mul
-                                               uu____1453 in
-                                           let uu____1461 =
-                                             let uu____1464 =
-                                               let uu____1465 =
-                                                 let uu____1468 =
+                                                 [uu___67] in
+                                               uu___65 :: uu___66 in
+                                             FStar_Tests_Util.app mul uu___64 in
+                                           let uu___64 =
+                                             let uu___65 =
+                                               let uu___66 =
+                                                 let uu___67 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.y in
-                                                 let uu____1469 =
-                                                   let uu____1472 =
+                                                 let uu___68 =
+                                                   let uu___69 =
                                                      FStar_Tests_Util.nm
                                                        FStar_Tests_Util.y in
-                                                   [uu____1472] in
-                                                 uu____1468 :: uu____1469 in
+                                                   [uu___69] in
+                                                 uu___67 :: uu___68 in
                                                FStar_Tests_Util.app mul
-                                                 uu____1465 in
-                                             let uu____1473 =
-                                               let uu____1476 =
+                                                 uu___66 in
+                                             let uu___66 =
+                                               let uu___67 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.h in
-                                               let uu____1477 =
+                                               let uu___68 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.h in
-                                               minus uu____1476 uu____1477 in
-                                             let_ FStar_Tests_Util.h
-                                               uu____1464 uu____1473 in
-                                           let_ FStar_Tests_Util.y uu____1452
-                                             uu____1461 in
-                                         let_ FStar_Tests_Util.x uu____1448
-                                           uu____1449 in
-                                       ((Prims.of_int (17)), uu____1445, z) in
-                                     let uu____1484 =
-                                       let uu____1497 =
-                                         let uu____1508 =
-                                           let uu____1511 =
-                                             let uu____1514 = snat znat in
-                                             snat uu____1514 in
-                                           pred_nat uu____1511 in
-                                         let uu____1515 = snat znat in
-                                         ((Prims.of_int (18)), uu____1508,
-                                           uu____1515) in
-                                       let uu____1522 =
-                                         let uu____1535 =
-                                           let uu____1546 =
-                                             let uu____1549 =
-                                               let uu____1550 =
-                                                 let uu____1551 = snat znat in
-                                                 snat uu____1551 in
-                                               let uu____1552 = snat znat in
-                                               minus_nat uu____1550
-                                                 uu____1552 in
+                                               minus uu___67 uu___68 in
+                                             let_ FStar_Tests_Util.h uu___65
+                                               uu___66 in
+                                           let_ FStar_Tests_Util.y uu___63
+                                             uu___64 in
+                                         let_ FStar_Tests_Util.x uu___61
+                                           uu___62 in
+                                       ((Prims.of_int (17)), uu___60, z) in
+                                     let uu___60 =
+                                       let uu___61 =
+                                         let uu___62 =
+                                           let uu___63 =
+                                             let uu___64 = snat znat in
+                                             snat uu___64 in
+                                           pred_nat uu___63 in
+                                         let uu___63 = snat znat in
+                                         ((Prims.of_int (18)), uu___62,
+                                           uu___63) in
+                                       let uu___62 =
+                                         let uu___63 =
+                                           let uu___64 =
+                                             let uu___65 =
+                                               let uu___66 =
+                                                 let uu___67 = snat znat in
+                                                 snat uu___67 in
+                                               let uu___67 = snat znat in
+                                               minus_nat uu___66 uu___67 in
                                              FStar_Tests_Pars.tc_nbe_term
-                                               uu____1549 in
-                                           let uu____1553 = snat znat in
-                                           ((Prims.of_int (19)), uu____1546,
-                                             uu____1553) in
-                                         let uu____1560 =
-                                           let uu____1573 =
-                                             let uu____1584 =
-                                               let uu____1587 =
-                                                 let uu____1588 =
+                                               uu___65 in
+                                           let uu___65 = snat znat in
+                                           ((Prims.of_int (19)), uu___64,
+                                             uu___65) in
+                                         let uu___64 =
+                                           let uu___65 =
+                                             let uu___66 =
+                                               let uu___67 =
+                                                 let uu___68 =
                                                    encode_nat
                                                      (Prims.of_int (10)) in
-                                                 let uu____1589 =
+                                                 let uu___69 =
                                                    encode_nat
                                                      (Prims.of_int (10)) in
-                                                 minus_nat uu____1588
-                                                   uu____1589 in
+                                                 minus_nat uu___68 uu___69 in
                                                FStar_Tests_Pars.tc_nbe_term
-                                                 uu____1587 in
-                                             ((Prims.of_int (20)),
-                                               uu____1584, znat) in
-                                           let uu____1594 =
-                                             let uu____1607 =
-                                               let uu____1618 =
-                                                 let uu____1621 =
-                                                   let uu____1622 =
+                                                 uu___67 in
+                                             ((Prims.of_int (20)), uu___66,
+                                               znat) in
+                                           let uu___66 =
+                                             let uu___67 =
+                                               let uu___68 =
+                                                 let uu___69 =
+                                                   let uu___70 =
                                                      encode_nat
                                                        (Prims.of_int (100)) in
-                                                   let uu____1623 =
+                                                   let uu___71 =
                                                      encode_nat
                                                        (Prims.of_int (100)) in
-                                                   minus_nat uu____1622
-                                                     uu____1623 in
+                                                   minus_nat uu___70 uu___71 in
                                                  FStar_Tests_Pars.tc_nbe_term
-                                                   uu____1621 in
-                                               ((Prims.of_int (21)),
-                                                 uu____1618, znat) in
-                                             let uu____1628 =
-                                               let uu____1641 =
-                                                 let uu____1652 =
+                                                   uu___69 in
+                                               ((Prims.of_int (21)), uu___68,
+                                                 znat) in
+                                             let uu___68 =
+                                               let uu___69 =
+                                                 let uu___70 =
                                                    FStar_Tests_Pars.tc_nbe
                                                      "recons [0;1]" in
-                                                 let uu____1655 =
+                                                 let uu___71 =
                                                    FStar_Tests_Pars.tc_nbe
                                                      "[0;1]" in
                                                  ((Prims.of_int (24)),
-                                                   uu____1652, uu____1655) in
-                                               let uu____1662 =
-                                                 let uu____1675 =
-                                                   let uu____1686 =
+                                                   uu___70, uu___71) in
+                                               let uu___70 =
+                                                 let uu___71 =
+                                                   let uu___72 =
                                                      FStar_Tests_Pars.tc_nbe
                                                        "recons [false;true;false]" in
-                                                   let uu____1689 =
+                                                   let uu___73 =
                                                      FStar_Tests_Pars.tc_nbe
                                                        "[false;true;false]" in
                                                    ((Prims.of_int (241)),
-                                                     uu____1686, uu____1689) in
-                                                 let uu____1696 =
-                                                   let uu____1709 =
-                                                     let uu____1720 =
+                                                     uu___72, uu___73) in
+                                                 let uu___72 =
+                                                   let uu___73 =
+                                                     let uu___74 =
                                                        FStar_Tests_Pars.tc_nbe
                                                          "copy [0;1]" in
-                                                     let uu____1723 =
+                                                     let uu___75 =
                                                        FStar_Tests_Pars.tc_nbe
                                                          "[0;1]" in
                                                      ((Prims.of_int (25)),
-                                                       uu____1720,
-                                                       uu____1723) in
-                                                   let uu____1730 =
-                                                     let uu____1743 =
-                                                       let uu____1754 =
+                                                       uu___74, uu___75) in
+                                                   let uu___74 =
+                                                     let uu___75 =
+                                                       let uu___76 =
                                                          FStar_Tests_Pars.tc_nbe
                                                            "rev [0;1;2;3;4;5;6;7;8;9;10]" in
-                                                       let uu____1757 =
+                                                       let uu___77 =
                                                          FStar_Tests_Pars.tc_nbe
                                                            "[10;9;8;7;6;5;4;3;2;1;0]" in
                                                        ((Prims.of_int (26)),
-                                                         uu____1754,
-                                                         uu____1757) in
-                                                     let uu____1764 =
-                                                       let uu____1777 =
-                                                         let uu____1788 =
+                                                         uu___76, uu___77) in
+                                                     let uu___76 =
+                                                       let uu___77 =
+                                                         let uu___78 =
                                                            FStar_Tests_Pars.tc_nbe
                                                              "(fun x y z q -> z) T T F T" in
-                                                         let uu____1791 =
+                                                         let uu___79 =
                                                            FStar_Tests_Pars.tc_nbe
                                                              "F" in
                                                          ((Prims.of_int (28)),
-                                                           uu____1788,
-                                                           uu____1791) in
-                                                       let uu____1798 =
-                                                         let uu____1811 =
-                                                           let uu____1822 =
+                                                           uu___78, uu___79) in
+                                                       let uu___78 =
+                                                         let uu___79 =
+                                                           let uu___80 =
                                                              FStar_Tests_Pars.tc_nbe
                                                                "[T; F]" in
-                                                           let uu____1825 =
+                                                           let uu___81 =
                                                              FStar_Tests_Pars.tc_nbe
                                                                "[T; F]" in
                                                            ((Prims.of_int (29)),
-                                                             uu____1822,
-                                                             uu____1825) in
-                                                         let uu____1832 =
-                                                           let uu____1845 =
-                                                             let uu____1856 =
+                                                             uu___80,
+                                                             uu___81) in
+                                                         let uu___80 =
+                                                           let uu___81 =
+                                                             let uu___82 =
                                                                FStar_Tests_Pars.tc_nbe
                                                                  "id_tb T" in
-                                                             let uu____1859 =
+                                                             let uu___83 =
                                                                FStar_Tests_Pars.tc_nbe
                                                                  "T" in
                                                              ((Prims.of_int (31)),
-                                                               uu____1856,
-                                                               uu____1859) in
-                                                           let uu____1866 =
-                                                             let uu____1879 =
-                                                               let uu____1890
-                                                                 =
+                                                               uu___82,
+                                                               uu___83) in
+                                                           let uu___82 =
+                                                             let uu___83 =
+                                                               let uu___84 =
                                                                  FStar_Tests_Pars.tc_nbe
                                                                    "(fun #a x -> x) #tb T" in
-                                                               let uu____1893
-                                                                 =
+                                                               let uu___85 =
                                                                  FStar_Tests_Pars.tc_nbe
                                                                    "T" in
                                                                ((Prims.of_int (32)),
-                                                                 uu____1890,
-                                                                 uu____1893) in
-                                                             let uu____1900 =
-                                                               let uu____1913
-                                                                 =
-                                                                 let uu____1924
+                                                                 uu___84,
+                                                                 uu___85) in
+                                                             let uu___84 =
+                                                               let uu___85 =
+                                                                 let uu___86
                                                                    =
                                                                    FStar_Tests_Pars.tc_nbe
                                                                     "revtb T" in
-                                                                 let uu____1927
+                                                                 let uu___87
                                                                    =
                                                                    FStar_Tests_Pars.tc_nbe
                                                                     "F" in
                                                                  ((Prims.of_int (33)),
-                                                                   uu____1924,
-                                                                   uu____1927) in
-                                                               let uu____1934
-                                                                 =
-                                                                 let uu____1947
+                                                                   uu___86,
+                                                                   uu___87) in
+                                                               let uu___86 =
+                                                                 let uu___87
                                                                    =
-                                                                   let uu____1958
+                                                                   let uu___88
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "(fun x y -> x) T F" in
-                                                                   let uu____1961
+                                                                   let uu___89
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T" in
                                                                    ((Prims.of_int (34)),
-                                                                    uu____1958,
-                                                                    uu____1961) in
-                                                                 let uu____1968
+                                                                    uu___88,
+                                                                    uu___89) in
+                                                                 let uu___88
                                                                    =
-                                                                   let uu____1981
+                                                                   let uu___89
                                                                     =
-                                                                    let uu____1992
+                                                                    let uu___90
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "fst_a T F" in
-                                                                    let uu____1995
+                                                                    let uu___91
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T" in
                                                                     ((Prims.of_int (35)),
-                                                                    uu____1992,
-                                                                    uu____1995) in
-                                                                   let uu____2002
+                                                                    uu___90,
+                                                                    uu___91) in
+                                                                   let uu___90
                                                                     =
-                                                                    let uu____2015
+                                                                    let uu___91
                                                                     =
-                                                                    let uu____2026
+                                                                    let uu___92
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "idd T" in
-                                                                    let uu____2029
+                                                                    let uu___93
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T" in
                                                                     ((Prims.of_int (36)),
-                                                                    uu____2026,
-                                                                    uu____2029) in
-                                                                    let uu____2036
+                                                                    uu___92,
+                                                                    uu___93) in
+                                                                    let uu___92
                                                                     =
-                                                                    let uu____2049
+                                                                    let uu___93
                                                                     =
-                                                                    let uu____2060
+                                                                    let uu___94
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "id_list [T]" in
-                                                                    let uu____2063
+                                                                    let uu___95
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]" in
                                                                     ((Prims.of_int (301)),
-                                                                    uu____2060,
-                                                                    uu____2063) in
-                                                                    let uu____2070
+                                                                    uu___94,
+                                                                    uu___95) in
+                                                                    let uu___94
                                                                     =
-                                                                    let uu____2083
+                                                                    let uu___95
                                                                     =
-                                                                    let uu____2094
+                                                                    let uu___96
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "id_list_m [T]" in
-                                                                    let uu____2097
+                                                                    let uu___97
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]" in
                                                                     ((Prims.of_int (3012)),
-                                                                    uu____2094,
-                                                                    uu____2097) in
-                                                                    let uu____2104
+                                                                    uu___96,
+                                                                    uu___97) in
+                                                                    let uu___96
                                                                     =
-                                                                    let uu____2117
+                                                                    let uu___97
                                                                     =
-                                                                    let uu____2128
+                                                                    let uu___98
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "recons_m [T; F]" in
-                                                                    let uu____2131
+                                                                    let uu___99
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T; F]" in
                                                                     ((Prims.of_int (302)),
-                                                                    uu____2128,
-                                                                    uu____2131) in
-                                                                    let uu____2138
+                                                                    uu___98,
+                                                                    uu___99) in
+                                                                    let uu___98
                                                                     =
-                                                                    let uu____2151
+                                                                    let uu___99
                                                                     =
-                                                                    let uu____2162
+                                                                    let uu___100
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select T A1 A3" in
-                                                                    let uu____2165
+                                                                    let uu___101
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "A1" in
                                                                     ((Prims.of_int (303)),
-                                                                    uu____2162,
-                                                                    uu____2165) in
-                                                                    let uu____2172
+                                                                    uu___100,
+                                                                    uu___101) in
+                                                                    let uu___100
                                                                     =
-                                                                    let uu____2185
+                                                                    let uu___101
                                                                     =
-                                                                    let uu____2196
+                                                                    let uu___102
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select T 3 4" in
-                                                                    let uu____2199
+                                                                    let uu___103
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "3" in
                                                                     ((Prims.of_int (3031)),
-                                                                    uu____2196,
-                                                                    uu____2199) in
-                                                                    let uu____2206
+                                                                    uu___102,
+                                                                    uu___103) in
+                                                                    let uu___102
                                                                     =
-                                                                    let uu____2219
+                                                                    let uu___103
                                                                     =
-                                                                    let uu____2230
+                                                                    let uu___104
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_bool false 3 4" in
-                                                                    let uu____2233
+                                                                    let uu___105
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "4" in
                                                                     ((Prims.of_int (3032)),
-                                                                    uu____2230,
-                                                                    uu____2233) in
-                                                                    let uu____2240
+                                                                    uu___104,
+                                                                    uu___105) in
+                                                                    let uu___104
                                                                     =
-                                                                    let uu____2253
+                                                                    let uu___105
                                                                     =
-                                                                    let uu____2264
+                                                                    let uu___106
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_int3 1 7 8 9" in
-                                                                    let uu____2267
+                                                                    let uu___107
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "8" in
                                                                     ((Prims.of_int (3033)),
-                                                                    uu____2264,
-                                                                    uu____2267) in
-                                                                    let uu____2274
+                                                                    uu___106,
+                                                                    uu___107) in
+                                                                    let uu___106
                                                                     =
-                                                                    let uu____2287
+                                                                    let uu___107
                                                                     =
-                                                                    let uu____2298
+                                                                    let uu___108
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[5]" in
-                                                                    let uu____2301
+                                                                    let uu___109
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[5]" in
                                                                     ((Prims.of_int (3034)),
-                                                                    uu____2298,
-                                                                    uu____2301) in
-                                                                    let uu____2308
+                                                                    uu___108,
+                                                                    uu___109) in
+                                                                    let uu___108
                                                                     =
-                                                                    let uu____2321
+                                                                    let uu___109
                                                                     =
-                                                                    let uu____2332
+                                                                    let uu___110
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[\"abcd\"]" in
-                                                                    let uu____2335
+                                                                    let uu___111
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[\"abcd\"]" in
                                                                     ((Prims.of_int (3035)),
-                                                                    uu____2332,
-                                                                    uu____2335) in
-                                                                    let uu____2342
+                                                                    uu___110,
+                                                                    uu___111) in
+                                                                    let uu___110
                                                                     =
-                                                                    let uu____2355
+                                                                    let uu___111
                                                                     =
-                                                                    let uu____2366
+                                                                    let uu___112
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_string3 \"def\" 5 6 7" in
-                                                                    let uu____2369
+                                                                    let uu___113
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "6" in
                                                                     ((Prims.of_int (3036)),
-                                                                    uu____2366,
-                                                                    uu____2369) in
-                                                                    let uu____2376
+                                                                    uu___112,
+                                                                    uu___113) in
+                                                                    let uu___112
                                                                     =
-                                                                    let uu____2389
+                                                                    let uu___113
                                                                     =
-                                                                    let uu____2400
+                                                                    let uu___114
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "idd T" in
-                                                                    let uu____2403
+                                                                    let uu___115
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T" in
                                                                     ((Prims.of_int (305)),
-                                                                    uu____2400,
-                                                                    uu____2403) in
-                                                                    let uu____2410
+                                                                    uu___114,
+                                                                    uu___115) in
+                                                                    let uu___114
                                                                     =
-                                                                    let uu____2423
+                                                                    let uu___115
                                                                     =
-                                                                    let uu____2434
+                                                                    let uu___116
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "recons [T]" in
-                                                                    let uu____2437
+                                                                    let uu___117
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]" in
                                                                     ((Prims.of_int (306)),
-                                                                    uu____2434,
-                                                                    uu____2437) in
-                                                                    let uu____2444
+                                                                    uu___116,
+                                                                    uu___117) in
+                                                                    let uu___116
                                                                     =
-                                                                    let uu____2457
+                                                                    let uu___117
                                                                     =
-                                                                    let uu____2468
+                                                                    let uu___118
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "copy_tb_list_2 [T;F;T;F;T;F;F]" in
-                                                                    let uu____2471
+                                                                    let uu___119
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T;F;T;F;T;F;F]" in
                                                                     ((Prims.of_int (307)),
-                                                                    uu____2468,
-                                                                    uu____2471) in
-                                                                    let uu____2478
+                                                                    uu___118,
+                                                                    uu___119) in
+                                                                    let uu___118
                                                                     =
-                                                                    let uu____2491
+                                                                    let uu___119
                                                                     =
-                                                                    let uu____2502
+                                                                    let uu___120
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "copy_list_2    [T;F;T;F;T;F;F]" in
-                                                                    let uu____2505
+                                                                    let uu___121
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T;F;T;F;T;F;F]" in
                                                                     ((Prims.of_int (308)),
-                                                                    uu____2502,
-                                                                    uu____2505) in
-                                                                    let uu____2512
+                                                                    uu___120,
+                                                                    uu___121) in
+                                                                    let uu___120
                                                                     =
-                                                                    let uu____2525
+                                                                    let uu___121
                                                                     =
-                                                                    let uu____2536
+                                                                    let uu___122
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "rev [T; F; F]" in
-                                                                    let uu____2539
+                                                                    let uu___123
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[F; F; T]" in
                                                                     ((Prims.of_int (304)),
-                                                                    uu____2536,
-                                                                    uu____2539) in
-                                                                    let uu____2546
+                                                                    uu___122,
+                                                                    uu___123) in
+                                                                    let uu___122
                                                                     =
-                                                                    let uu____2559
+                                                                    let uu___123
                                                                     =
-                                                                    let uu____2570
+                                                                    let uu___124
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "rev [[T]; [F; T]]" in
-                                                                    let uu____2573
+                                                                    let uu___125
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[[F; T]; [T]]" in
                                                                     ((Prims.of_int (305)),
-                                                                    uu____2570,
-                                                                    uu____2573) in
-                                                                    let uu____2580
+                                                                    uu___124,
+                                                                    uu___125) in
+                                                                    let uu___124
                                                                     =
-                                                                    let uu____2593
+                                                                    let uu___125
                                                                     =
-                                                                    let uu____2604
+                                                                    let uu___126
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "x1" in
-                                                                    let uu____2607
+                                                                    let uu___127
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "6" in
                                                                     ((Prims.of_int (309)),
-                                                                    uu____2604,
-                                                                    uu____2607) in
-                                                                    let uu____2614
+                                                                    uu___126,
+                                                                    uu___127) in
+                                                                    let uu___126
                                                                     =
-                                                                    let uu____2627
+                                                                    let uu___127
                                                                     =
-                                                                    let uu____2638
+                                                                    let uu___128
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "x2" in
-                                                                    let uu____2641
+                                                                    let uu___129
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "2" in
                                                                     ((Prims.of_int (310)),
-                                                                    uu____2638,
-                                                                    uu____2641) in
-                                                                    let uu____2648
+                                                                    uu___128,
+                                                                    uu___129) in
+                                                                    let uu___128
                                                                     =
-                                                                    let uu____2661
+                                                                    let uu___129
                                                                     =
-                                                                    let uu____2672
+                                                                    let uu___130
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "7 + 3" in
-                                                                    let uu____2675
+                                                                    let uu___131
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "10" in
                                                                     ((Prims.of_int (401)),
-                                                                    uu____2672,
-                                                                    uu____2675) in
-                                                                    let uu____2682
+                                                                    uu___130,
+                                                                    uu___131) in
+                                                                    let uu___130
                                                                     =
-                                                                    let uu____2695
+                                                                    let uu___131
                                                                     =
-                                                                    let uu____2706
+                                                                    let uu___132
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "true && false" in
-                                                                    let uu____2709
+                                                                    let uu___133
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "false" in
                                                                     ((Prims.of_int (402)),
-                                                                    uu____2706,
-                                                                    uu____2709) in
-                                                                    let uu____2716
+                                                                    uu___132,
+                                                                    uu___133) in
+                                                                    let uu___132
                                                                     =
-                                                                    let uu____2729
+                                                                    let uu___133
                                                                     =
-                                                                    let uu____2740
+                                                                    let uu___134
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "3 = 5" in
-                                                                    let uu____2743
+                                                                    let uu___135
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "false" in
                                                                     ((Prims.of_int (403)),
-                                                                    uu____2740,
-                                                                    uu____2743) in
-                                                                    let uu____2750
+                                                                    uu___134,
+                                                                    uu___135) in
+                                                                    let uu___134
                                                                     =
-                                                                    let uu____2763
+                                                                    let uu___135
                                                                     =
-                                                                    let uu____2774
+                                                                    let uu___136
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "\"abc\" ^ \"def\"" in
-                                                                    let uu____2777
+                                                                    let uu___137
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "\"abcdef\"" in
                                                                     ((Prims.of_int (404)),
-                                                                    uu____2774,
-                                                                    uu____2777) in
-                                                                    let uu____2784
+                                                                    uu___136,
+                                                                    uu___137) in
+                                                                    let uu___136
                                                                     =
-                                                                    let uu____2797
+                                                                    let uu___137
                                                                     =
-                                                                    let uu____2808
+                                                                    let uu___138
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "(fun (x:list int) -> match x with | [] -> 0 | hd::tl -> 1) []" in
-                                                                    let uu____2811
+                                                                    let uu___139
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "0" in
                                                                     ((Prims.of_int (405)),
-                                                                    uu____2808,
-                                                                    uu____2811) in
-                                                                    [uu____2797] in
-                                                                    uu____2763
+                                                                    uu___138,
+                                                                    uu___139) in
+                                                                    [uu___137] in
+                                                                    uu___135
                                                                     ::
-                                                                    uu____2784 in
-                                                                    uu____2729
+                                                                    uu___136 in
+                                                                    uu___133
                                                                     ::
-                                                                    uu____2750 in
-                                                                    uu____2695
+                                                                    uu___134 in
+                                                                    uu___131
                                                                     ::
-                                                                    uu____2716 in
-                                                                    uu____2661
+                                                                    uu___132 in
+                                                                    uu___129
                                                                     ::
-                                                                    uu____2682 in
-                                                                    uu____2627
+                                                                    uu___130 in
+                                                                    uu___127
                                                                     ::
-                                                                    uu____2648 in
-                                                                    uu____2593
+                                                                    uu___128 in
+                                                                    uu___125
                                                                     ::
-                                                                    uu____2614 in
-                                                                    uu____2559
+                                                                    uu___126 in
+                                                                    uu___123
                                                                     ::
-                                                                    uu____2580 in
-                                                                    uu____2525
+                                                                    uu___124 in
+                                                                    uu___121
                                                                     ::
-                                                                    uu____2546 in
-                                                                    uu____2491
+                                                                    uu___122 in
+                                                                    uu___119
                                                                     ::
-                                                                    uu____2512 in
-                                                                    uu____2457
+                                                                    uu___120 in
+                                                                    uu___117
                                                                     ::
-                                                                    uu____2478 in
-                                                                    uu____2423
+                                                                    uu___118 in
+                                                                    uu___115
                                                                     ::
-                                                                    uu____2444 in
-                                                                    uu____2389
+                                                                    uu___116 in
+                                                                    uu___113
                                                                     ::
-                                                                    uu____2410 in
-                                                                    uu____2355
+                                                                    uu___114 in
+                                                                    uu___111
                                                                     ::
-                                                                    uu____2376 in
-                                                                    uu____2321
+                                                                    uu___112 in
+                                                                    uu___109
                                                                     ::
-                                                                    uu____2342 in
-                                                                    uu____2287
+                                                                    uu___110 in
+                                                                    uu___107
                                                                     ::
-                                                                    uu____2308 in
-                                                                    uu____2253
+                                                                    uu___108 in
+                                                                    uu___105
                                                                     ::
-                                                                    uu____2274 in
-                                                                    uu____2219
+                                                                    uu___106 in
+                                                                    uu___103
                                                                     ::
-                                                                    uu____2240 in
-                                                                    uu____2185
+                                                                    uu___104 in
+                                                                    uu___101
                                                                     ::
-                                                                    uu____2206 in
-                                                                    uu____2151
+                                                                    uu___102 in
+                                                                    uu___99
                                                                     ::
-                                                                    uu____2172 in
-                                                                    uu____2117
+                                                                    uu___100 in
+                                                                    uu___97
                                                                     ::
-                                                                    uu____2138 in
-                                                                    uu____2083
+                                                                    uu___98 in
+                                                                    uu___95
                                                                     ::
-                                                                    uu____2104 in
-                                                                    uu____2049
+                                                                    uu___96 in
+                                                                    uu___93
                                                                     ::
-                                                                    uu____2070 in
-                                                                    uu____2015
+                                                                    uu___94 in
+                                                                    uu___91
                                                                     ::
-                                                                    uu____2036 in
-                                                                   uu____1981
-                                                                    ::
-                                                                    uu____2002 in
-                                                                 uu____1947
-                                                                   ::
-                                                                   uu____1968 in
-                                                               uu____1913 ::
-                                                                 uu____1934 in
-                                                             uu____1879 ::
-                                                               uu____1900 in
-                                                           uu____1845 ::
-                                                             uu____1866 in
-                                                         uu____1811 ::
-                                                           uu____1832 in
-                                                       uu____1777 ::
-                                                         uu____1798 in
-                                                     uu____1743 :: uu____1764 in
-                                                   uu____1709 :: uu____1730 in
-                                                 uu____1675 :: uu____1696 in
-                                               uu____1641 :: uu____1662 in
-                                             uu____1607 :: uu____1628 in
-                                           uu____1573 :: uu____1594 in
-                                         uu____1535 :: uu____1560 in
-                                       uu____1497 :: uu____1522 in
-                                     uu____1434 :: uu____1484 in
-                                   uu____1371 :: uu____1421 in
-                                 uu____1308 :: uu____1358 in
-                               uu____1269 :: uu____1295 in
-                             uu____1234 :: uu____1256 in
-                           uu____1199 :: uu____1221 in
-                         uu____1164 :: uu____1186 in
-                       uu____1133 :: uu____1151 in
-                     uu____1102 :: uu____1120 in
-                   uu____1071 :: uu____1089 in
-                 uu____1040 :: uu____1058 in
-               uu____1009 :: uu____1027 in
-             uu____961 :: uu____996 in
-           uu____901 :: uu____948 in
-         uu____856 :: uu____888 in
-       uu____811 :: uu____843 in
-     uu____773 :: uu____798 in
-   uu____729 :: uu____760)
+                                                                    uu___92 in
+                                                                   uu___89 ::
+                                                                    uu___90 in
+                                                                 uu___87 ::
+                                                                   uu___88 in
+                                                               uu___85 ::
+                                                                 uu___86 in
+                                                             uu___83 ::
+                                                               uu___84 in
+                                                           uu___81 :: uu___82 in
+                                                         uu___79 :: uu___80 in
+                                                       uu___77 :: uu___78 in
+                                                     uu___75 :: uu___76 in
+                                                   uu___73 :: uu___74 in
+                                                 uu___71 :: uu___72 in
+                                               uu___69 :: uu___70 in
+                                             uu___67 :: uu___68 in
+                                           uu___65 :: uu___66 in
+                                         uu___63 :: uu___64 in
+                                       uu___61 :: uu___62 in
+                                     uu___59 :: uu___60 in
+                                   uu___57 :: uu___58 in
+                                 uu___55 :: uu___56 in
+                               uu___53 :: uu___54 in
+                             uu___51 :: uu___52 in
+                           uu___49 :: uu___50 in
+                         uu___47 :: uu___48 in
+                       uu___45 :: uu___46 in
+                     uu___43 :: uu___44 in
+                   uu___41 :: uu___42 in
+                 uu___39 :: uu___40 in
+               uu___37 :: uu___38 in
+             uu___35 :: uu___36 in
+           uu___33 :: uu___34 in
+         uu___31 :: uu___32 in
+       uu___29 :: uu___30 in
+     uu___27 :: uu___28 in
+   uu___25 :: uu___26)
 let run_either :
-  'uuuuuu3408 .
+  'uuuuu .
     Prims.int ->
-      'uuuuuu3408 ->
+      'uuuuu ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-          (FStar_TypeChecker_Env.env ->
-             'uuuuuu3408 -> FStar_Syntax_Syntax.term)
+          (FStar_TypeChecker_Env.env -> 'uuuuu -> FStar_Syntax_Syntax.term)
             -> unit
   =
   fun i ->
     fun r ->
       fun expected ->
         fun normalizer ->
-          (let uu____3444 = FStar_Util.string_of_int i in
-           FStar_Util.print1 "%s: ... \n\n" uu____3444);
+          (let uu___1 = FStar_Util.string_of_int i in
+           FStar_Util.print1 "%s: ... \n\n" uu___1);
           (let tcenv = FStar_Tests_Pars.init () in
-           (let uu____3447 = FStar_Main.process_args () in
-            FStar_All.pipe_right uu____3447 (fun uu____3460 -> ()));
+           (let uu___2 = FStar_Main.process_args () in
+            FStar_All.pipe_right uu___2 (fun uu___3 -> ()));
            (let x = normalizer tcenv r in
             FStar_Options.init ();
             FStar_Options.set_option "print_universes"
               (FStar_Options.Bool true);
             FStar_Options.set_option "print_implicits"
               (FStar_Options.Bool true);
-            (let uu____3465 =
-               let uu____3466 = FStar_Syntax_Util.unascribe x in
-               FStar_Tests_Util.term_eq uu____3466 expected in
-             FStar_Tests_Util.always i uu____3465)))
+            (let uu___5 =
+               let uu___6 = FStar_Syntax_Util.unascribe x in
+               FStar_Tests_Util.term_eq uu___6 expected in
+             FStar_Tests_Util.always i uu___5)))
 let (run_interpreter :
   Prims.int ->
     FStar_Syntax_Syntax.term ->
@@ -1308,11 +1273,11 @@ let (run_interpreter_with_time :
   fun i ->
     fun r ->
       fun expected ->
-        let interp uu____3535 = run_interpreter i r expected in
-        let uu____3536 =
-          let uu____3537 = FStar_Util.return_execution_time interp in
-          FStar_Pervasives_Native.snd uu____3537 in
-        (i, uu____3536)
+        let interp uu___ = run_interpreter i r expected in
+        let uu___ =
+          let uu___1 = FStar_Util.return_execution_time interp in
+          FStar_Pervasives_Native.snd uu___1 in
+        (i, uu___)
 let (run_nbe_with_time :
   Prims.int ->
     FStar_Syntax_Syntax.term ->
@@ -1322,44 +1287,43 @@ let (run_nbe_with_time :
   fun i ->
     fun r ->
       fun expected ->
-        let nbe uu____3570 = run_nbe i r expected in
-        let uu____3571 =
-          let uu____3572 = FStar_Util.return_execution_time nbe in
-          FStar_Pervasives_Native.snd uu____3572 in
-        (i, uu____3571)
+        let nbe uu___ = run_nbe i r expected in
+        let uu___ =
+          let uu___1 = FStar_Util.return_execution_time nbe in
+          FStar_Pervasives_Native.snd uu___1 in
+        (i, uu___)
 let run_tests :
-  'uuuuuu3581 .
+  'uuuuu .
     (Prims.int ->
        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuuu3581)
-      -> 'uuuuuu3581 Prims.list
+         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuu)
+      -> 'uuuuu Prims.list
   =
   fun run ->
     FStar_Options.__set_unit_tests ();
     (let l =
        FStar_List.map
-         (fun uu___0_3630 ->
-            match uu___0_3630 with | (no, test, res) -> run no test res)
-         tests in
+         (fun uu___1 ->
+            match uu___1 with | (no, test, res) -> run no test res) tests in
      FStar_Options.__clear_unit_tests (); l)
 let (run_all_nbe : unit -> unit) =
-  fun uu____3657 ->
+  fun uu___ ->
     FStar_Util.print_string "Testing NBE\n";
-    (let uu____3659 = run_tests run_nbe in FStar_Util.print_string "NBE ok\n")
+    (let uu___2 = run_tests run_nbe in FStar_Util.print_string "NBE ok\n")
 let (run_all_interpreter : unit -> unit) =
-  fun uu____3666 ->
+  fun uu___ ->
     FStar_Util.print_string "Testing the normalizer\n";
-    (let uu____3668 = run_tests run_interpreter in
+    (let uu___2 = run_tests run_interpreter in
      FStar_Util.print_string "Normalizer ok\n")
 let (run_all_nbe_with_time :
   unit -> (Prims.int * FStar_BaseTypes.float) Prims.list) =
-  fun uu____3681 ->
+  fun uu___ ->
     FStar_Util.print_string "Testing NBE\n";
     (let l = run_tests run_nbe_with_time in
      FStar_Util.print_string "NBE ok\n"; l)
 let (run_all_interpreter_with_time :
   unit -> (Prims.int * FStar_BaseTypes.float) Prims.list) =
-  fun uu____3705 ->
+  fun uu___ ->
     FStar_Util.print_string "Testing the normalizer\n";
     (let l = run_tests run_interpreter_with_time in
      FStar_Util.print_string "Normalizer ok\n"; l)
@@ -1371,23 +1335,23 @@ let (run_both_with_time :
   fun i ->
     fun r ->
       fun expected ->
-        let nbe uu____3743 = run_nbe i r expected in
-        let norm uu____3749 = run_interpreter i r expected in
+        let nbe uu___ = run_nbe i r expected in
+        let norm uu___ = run_interpreter i r expected in
         FStar_Util.measure_execution_time "nbe" nbe;
         FStar_Util.print_string "\n";
         FStar_Util.measure_execution_time "normalizer" norm;
         FStar_Util.print_string "\n"
 let (compare : unit -> unit) =
-  fun uu____3757 ->
+  fun uu___ ->
     FStar_Util.print_string "Comparing times for normalization and nbe\n";
-    (let uu____3759 =
-       let uu____3760 = encode (Prims.of_int (1000)) in
-       let uu____3761 =
-         let uu____3764 = FStar_Tests_Util.nm FStar_Tests_Util.x in
-         let uu____3765 = FStar_Tests_Util.nm FStar_Tests_Util.x in
-         minus uu____3764 uu____3765 in
-       let_ FStar_Tests_Util.x uu____3760 uu____3761 in
-     run_both_with_time (Prims.of_int (14)) uu____3759 z)
+    (let uu___2 =
+       let uu___3 = encode (Prims.of_int (1000)) in
+       let uu___4 =
+         let uu___5 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+         let uu___6 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+         minus uu___5 uu___6 in
+       let_ FStar_Tests_Util.x uu___3 uu___4 in
+     run_both_with_time (Prims.of_int (14)) uu___2 z)
 let (compare_times :
   (Prims.int * FStar_BaseTypes.float) Prims.list ->
     (Prims.int * FStar_BaseTypes.float) Prims.list -> unit)
@@ -1398,24 +1362,24 @@ let (compare_times :
       FStar_List.iter2
         (fun res1 ->
            fun res2 ->
-             let uu____3830 = res1 in
-             match uu____3830 with
+             let uu___1 = res1 in
+             match uu___1 with
              | (t1, time_int) ->
-                 let uu____3837 = res2 in
-                 (match uu____3837 with
+                 let uu___2 = res2 in
+                 (match uu___2 with
                   | (t2, time_nbe) ->
                       if t1 = t2
                       then
-                        let uu____3844 = FStar_Util.string_of_int t1 in
+                        let uu___3 = FStar_Util.string_of_int t1 in
                         FStar_Util.print3 "Test %s\nNBE %s\nInterpreter %s\n"
-                          uu____3844 (FStar_Util.string_of_float time_nbe)
+                          uu___3 (FStar_Util.string_of_float time_nbe)
                           (FStar_Util.string_of_float time_int)
                       else
                         FStar_Util.print_string
                           "Test numbers do not match...\n")) l_int l_nbe
 let (run_all : unit -> unit) =
-  fun uu____3850 ->
-    (let uu____3852 = FStar_Syntax_Print.term_to_string znat in
-     FStar_Util.print1 "%s" uu____3852);
+  fun uu___ ->
+    (let uu___2 = FStar_Syntax_Print.term_to_string znat in
+     FStar_Util.print1 "%s" uu___2);
     (let l_int = run_all_interpreter_with_time () in
      let l_nbe = run_all_nbe_with_time () in compare_times l_int l_nbe)

--- a/src/ocaml-output/FStar_Tests_Pars.ml
+++ b/src/ocaml-output/FStar_Tests_Pars.ml
@@ -20,29 +20,28 @@ let (parse_mod :
   =
   fun mod_name ->
     fun dsenv ->
-      let uu____26 =
+      let uu___ =
         FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename mod_name) in
-      match uu____26 with
-      | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl m, uu____32) ->
-          let uu____47 =
-            let uu____52 = FStar_ToSyntax_ToSyntax.ast_modul_to_modul m in
-            uu____52 dsenv in
-          (match uu____47 with
+      match uu___ with
+      | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl m, uu___1) ->
+          let uu___2 =
+            let uu___3 = FStar_ToSyntax_ToSyntax.ast_modul_to_modul m in
+            uu___3 dsenv in
+          (match uu___2 with
            | (m1, env') ->
-               let uu____63 =
-                 let uu____68 =
+               let uu___3 =
+                 let uu___4 =
                    FStar_Ident.lid_of_path ["Test"] FStar_Range.dummyRange in
                  FStar_Syntax_DsEnv.prepare_module_or_interface false false
-                   env' uu____68 FStar_Syntax_DsEnv.default_mii in
-               (match uu____63 with | (env'1, uu____74) -> (env'1, m1)))
+                   env' uu___4 FStar_Syntax_DsEnv.default_mii in
+               (match uu___3 with | (env'1, uu___4) -> (env'1, m1)))
       | FStar_Parser_ParseIt.ParseError (err, msg, r) ->
           FStar_Exn.raise (FStar_Errors.Error (err, msg, r))
-      | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu____82, uu____83)
-          ->
+      | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu___1, uu___2) ->
           let msg = FStar_Util.format1 "%s: expected a module\n" mod_name in
           FStar_Errors.raise_error (FStar_Errors.Fatal_ModuleExpected, msg)
             FStar_Range.dummyRange
-      | FStar_Parser_ParseIt.Term uu____105 ->
+      | FStar_Parser_ParseIt.Term uu___1 ->
           failwith
             "Impossible: parsing a Filename always results in an ASTFragment"
 let (add_mods :
@@ -55,21 +54,20 @@ let (add_mods :
     fun dsenv ->
       fun env ->
         FStar_List.fold_left
-          (fun uu____147 ->
+          (fun uu___ ->
              fun mod_name ->
-               match uu____147 with
+               match uu___ with
                | (dsenv1, env1) ->
-                   let uu____159 = parse_mod mod_name dsenv1 in
-                   (match uu____159 with
+                   let uu___1 = parse_mod mod_name dsenv1 in
+                   (match uu___1 with
                     | (dsenv2, string_mod) ->
-                        let uu____170 =
+                        let uu___2 =
                           FStar_TypeChecker_Tc.check_module env1 string_mod
                             false in
-                        (match uu____170 with
-                         | (_mod, env2) -> (dsenv2, env2)))) (dsenv, env)
-          mod_names
+                        (match uu___2 with | (_mod, env2) -> (dsenv2, env2))))
+          (dsenv, env) mod_names
 let (init_once : unit -> unit) =
-  fun uu____185 ->
+  fun uu___ ->
     let solver = FStar_SMTEncoding_Solver.dummy in
     let env =
       FStar_TypeChecker_Env.initial_env FStar_Parser_Dep.empty_deps
@@ -80,210 +78,206 @@ let (init_once : unit -> unit) =
         FStar_Parser_Const.prims_lid
         FStar_TypeChecker_NBE.normalize_for_unit_test in
     (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env;
-    (let uu____189 =
-       let uu____194 = FStar_Options.prims () in
-       let uu____195 =
-         FStar_Syntax_DsEnv.empty_env FStar_Parser_Dep.empty_deps in
-       parse_mod uu____194 uu____195 in
-     match uu____189 with
+    (let uu___2 =
+       let uu___3 = FStar_Options.prims () in
+       let uu___4 = FStar_Syntax_DsEnv.empty_env FStar_Parser_Dep.empty_deps in
+       parse_mod uu___3 uu___4 in
+     match uu___2 with
      | (dsenv, prims_mod) ->
          let env1 =
-           let uu___46_199 = env in
+           let uu___3 = env in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___46_199.FStar_TypeChecker_Env.solver);
+               (uu___3.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___46_199.FStar_TypeChecker_Env.range);
+               (uu___3.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___46_199.FStar_TypeChecker_Env.curmodule);
+               (uu___3.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___46_199.FStar_TypeChecker_Env.gamma);
+               (uu___3.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___46_199.FStar_TypeChecker_Env.gamma_sig);
+               (uu___3.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___46_199.FStar_TypeChecker_Env.gamma_cache);
+               (uu___3.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___46_199.FStar_TypeChecker_Env.modules);
+               (uu___3.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___46_199.FStar_TypeChecker_Env.expected_typ);
+               (uu___3.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___46_199.FStar_TypeChecker_Env.sigtab);
+               (uu___3.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___46_199.FStar_TypeChecker_Env.attrtab);
+               (uu___3.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___46_199.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___3.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___46_199.FStar_TypeChecker_Env.effects);
+               (uu___3.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___46_199.FStar_TypeChecker_Env.generalize);
+               (uu___3.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___46_199.FStar_TypeChecker_Env.letrecs);
+               (uu___3.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___46_199.FStar_TypeChecker_Env.top_level);
+               (uu___3.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___46_199.FStar_TypeChecker_Env.check_uvars);
+               (uu___3.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___46_199.FStar_TypeChecker_Env.use_eq);
+               (uu___3.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict =
-               (uu___46_199.FStar_TypeChecker_Env.use_eq_strict);
+               (uu___3.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (uu___46_199.FStar_TypeChecker_Env.is_iface);
+               (uu___3.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___46_199.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax =
-               (uu___46_199.FStar_TypeChecker_Env.lax);
+               (uu___3.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = (uu___3.FStar_TypeChecker_Env.lax);
              FStar_TypeChecker_Env.lax_universes =
-               (uu___46_199.FStar_TypeChecker_Env.lax_universes);
+               (uu___3.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___46_199.FStar_TypeChecker_Env.phase1);
+               (uu___3.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___46_199.FStar_TypeChecker_Env.failhard);
+               (uu___3.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___46_199.FStar_TypeChecker_Env.nosynth);
+               (uu___3.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___46_199.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___46_199.FStar_TypeChecker_Env.tc_term);
+               (uu___3.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___46_199.FStar_TypeChecker_Env.type_of);
+               (uu___3.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___46_199.FStar_TypeChecker_Env.universe_of);
+               (uu___3.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___46_199.FStar_TypeChecker_Env.check_type_of);
+               (uu___3.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___46_199.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___3.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___46_199.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___3.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___46_199.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___3.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___46_199.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___3.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___46_199.FStar_TypeChecker_Env.proof_ns);
+               (uu___3.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___46_199.FStar_TypeChecker_Env.synth_hook);
+               (uu___3.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___46_199.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___3.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___46_199.FStar_TypeChecker_Env.splice);
+               (uu___3.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___46_199.FStar_TypeChecker_Env.mpreprocess);
+               (uu___3.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___46_199.FStar_TypeChecker_Env.postprocess);
+               (uu___3.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___46_199.FStar_TypeChecker_Env.identifier_info);
+               (uu___3.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___46_199.FStar_TypeChecker_Env.tc_hooks);
+               (uu___3.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv = dsenv;
-             FStar_TypeChecker_Env.nbe =
-               (uu___46_199.FStar_TypeChecker_Env.nbe);
+             FStar_TypeChecker_Env.nbe = (uu___3.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___46_199.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___3.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___46_199.FStar_TypeChecker_Env.erasable_types_tab);
+               (uu___3.FStar_TypeChecker_Env.erasable_types_tab);
              FStar_TypeChecker_Env.enable_defer_to_tac =
-               (uu___46_199.FStar_TypeChecker_Env.enable_defer_to_tac)
+               (uu___3.FStar_TypeChecker_Env.enable_defer_to_tac)
            } in
-         let uu____200 =
-           FStar_TypeChecker_Tc.check_module env1 prims_mod false in
-         (match uu____200 with
+         let uu___3 = FStar_TypeChecker_Tc.check_module env1 prims_mod false in
+         (match uu___3 with
           | (_prims_mod, env2) ->
               let env3 =
-                let uu___52_208 = env2 in
+                let uu___4 = env2 in
                 {
                   FStar_TypeChecker_Env.solver =
-                    (uu___52_208.FStar_TypeChecker_Env.solver);
+                    (uu___4.FStar_TypeChecker_Env.solver);
                   FStar_TypeChecker_Env.range =
-                    (uu___52_208.FStar_TypeChecker_Env.range);
+                    (uu___4.FStar_TypeChecker_Env.range);
                   FStar_TypeChecker_Env.curmodule =
-                    (uu___52_208.FStar_TypeChecker_Env.curmodule);
+                    (uu___4.FStar_TypeChecker_Env.curmodule);
                   FStar_TypeChecker_Env.gamma =
-                    (uu___52_208.FStar_TypeChecker_Env.gamma);
+                    (uu___4.FStar_TypeChecker_Env.gamma);
                   FStar_TypeChecker_Env.gamma_sig =
-                    (uu___52_208.FStar_TypeChecker_Env.gamma_sig);
+                    (uu___4.FStar_TypeChecker_Env.gamma_sig);
                   FStar_TypeChecker_Env.gamma_cache =
-                    (uu___52_208.FStar_TypeChecker_Env.gamma_cache);
+                    (uu___4.FStar_TypeChecker_Env.gamma_cache);
                   FStar_TypeChecker_Env.modules =
-                    (uu___52_208.FStar_TypeChecker_Env.modules);
+                    (uu___4.FStar_TypeChecker_Env.modules);
                   FStar_TypeChecker_Env.expected_typ =
-                    (uu___52_208.FStar_TypeChecker_Env.expected_typ);
+                    (uu___4.FStar_TypeChecker_Env.expected_typ);
                   FStar_TypeChecker_Env.sigtab =
-                    (uu___52_208.FStar_TypeChecker_Env.sigtab);
+                    (uu___4.FStar_TypeChecker_Env.sigtab);
                   FStar_TypeChecker_Env.attrtab =
-                    (uu___52_208.FStar_TypeChecker_Env.attrtab);
+                    (uu___4.FStar_TypeChecker_Env.attrtab);
                   FStar_TypeChecker_Env.instantiate_imp =
-                    (uu___52_208.FStar_TypeChecker_Env.instantiate_imp);
+                    (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                   FStar_TypeChecker_Env.effects =
-                    (uu___52_208.FStar_TypeChecker_Env.effects);
+                    (uu___4.FStar_TypeChecker_Env.effects);
                   FStar_TypeChecker_Env.generalize =
-                    (uu___52_208.FStar_TypeChecker_Env.generalize);
+                    (uu___4.FStar_TypeChecker_Env.generalize);
                   FStar_TypeChecker_Env.letrecs =
-                    (uu___52_208.FStar_TypeChecker_Env.letrecs);
+                    (uu___4.FStar_TypeChecker_Env.letrecs);
                   FStar_TypeChecker_Env.top_level =
-                    (uu___52_208.FStar_TypeChecker_Env.top_level);
+                    (uu___4.FStar_TypeChecker_Env.top_level);
                   FStar_TypeChecker_Env.check_uvars =
-                    (uu___52_208.FStar_TypeChecker_Env.check_uvars);
+                    (uu___4.FStar_TypeChecker_Env.check_uvars);
                   FStar_TypeChecker_Env.use_eq =
-                    (uu___52_208.FStar_TypeChecker_Env.use_eq);
+                    (uu___4.FStar_TypeChecker_Env.use_eq);
                   FStar_TypeChecker_Env.use_eq_strict =
-                    (uu___52_208.FStar_TypeChecker_Env.use_eq_strict);
+                    (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                   FStar_TypeChecker_Env.is_iface =
-                    (uu___52_208.FStar_TypeChecker_Env.is_iface);
+                    (uu___4.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
-                    (uu___52_208.FStar_TypeChecker_Env.admit);
+                    (uu___4.FStar_TypeChecker_Env.admit);
                   FStar_TypeChecker_Env.lax =
-                    (uu___52_208.FStar_TypeChecker_Env.lax);
+                    (uu___4.FStar_TypeChecker_Env.lax);
                   FStar_TypeChecker_Env.lax_universes =
-                    (uu___52_208.FStar_TypeChecker_Env.lax_universes);
+                    (uu___4.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
-                    (uu___52_208.FStar_TypeChecker_Env.phase1);
+                    (uu___4.FStar_TypeChecker_Env.phase1);
                   FStar_TypeChecker_Env.failhard =
-                    (uu___52_208.FStar_TypeChecker_Env.failhard);
+                    (uu___4.FStar_TypeChecker_Env.failhard);
                   FStar_TypeChecker_Env.nosynth =
-                    (uu___52_208.FStar_TypeChecker_Env.nosynth);
+                    (uu___4.FStar_TypeChecker_Env.nosynth);
                   FStar_TypeChecker_Env.uvar_subtyping =
-                    (uu___52_208.FStar_TypeChecker_Env.uvar_subtyping);
+                    (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.tc_term =
-                    (uu___52_208.FStar_TypeChecker_Env.tc_term);
+                    (uu___4.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.type_of =
-                    (uu___52_208.FStar_TypeChecker_Env.type_of);
+                    (uu___4.FStar_TypeChecker_Env.type_of);
                   FStar_TypeChecker_Env.universe_of =
-                    (uu___52_208.FStar_TypeChecker_Env.universe_of);
+                    (uu___4.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.check_type_of =
-                    (uu___52_208.FStar_TypeChecker_Env.check_type_of);
+                    (uu___4.FStar_TypeChecker_Env.check_type_of);
                   FStar_TypeChecker_Env.use_bv_sorts =
-                    (uu___52_208.FStar_TypeChecker_Env.use_bv_sorts);
+                    (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                    (uu___52_208.FStar_TypeChecker_Env.qtbl_name_and_index);
+                    (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                   FStar_TypeChecker_Env.normalized_eff_names =
-                    (uu___52_208.FStar_TypeChecker_Env.normalized_eff_names);
+                    (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                   FStar_TypeChecker_Env.fv_delta_depths =
-                    (uu___52_208.FStar_TypeChecker_Env.fv_delta_depths);
+                    (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                   FStar_TypeChecker_Env.proof_ns =
-                    (uu___52_208.FStar_TypeChecker_Env.proof_ns);
+                    (uu___4.FStar_TypeChecker_Env.proof_ns);
                   FStar_TypeChecker_Env.synth_hook =
-                    (uu___52_208.FStar_TypeChecker_Env.synth_hook);
+                    (uu___4.FStar_TypeChecker_Env.synth_hook);
                   FStar_TypeChecker_Env.try_solve_implicits_hook =
-                    (uu___52_208.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                    (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                   FStar_TypeChecker_Env.splice =
-                    (uu___52_208.FStar_TypeChecker_Env.splice);
+                    (uu___4.FStar_TypeChecker_Env.splice);
                   FStar_TypeChecker_Env.mpreprocess =
-                    (uu___52_208.FStar_TypeChecker_Env.mpreprocess);
+                    (uu___4.FStar_TypeChecker_Env.mpreprocess);
                   FStar_TypeChecker_Env.postprocess =
-                    (uu___52_208.FStar_TypeChecker_Env.postprocess);
+                    (uu___4.FStar_TypeChecker_Env.postprocess);
                   FStar_TypeChecker_Env.identifier_info =
-                    (uu___52_208.FStar_TypeChecker_Env.identifier_info);
+                    (uu___4.FStar_TypeChecker_Env.identifier_info);
                   FStar_TypeChecker_Env.tc_hooks =
-                    (uu___52_208.FStar_TypeChecker_Env.tc_hooks);
+                    (uu___4.FStar_TypeChecker_Env.tc_hooks);
                   FStar_TypeChecker_Env.dsenv = dsenv;
                   FStar_TypeChecker_Env.nbe =
-                    (uu___52_208.FStar_TypeChecker_Env.nbe);
+                    (uu___4.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___52_208.FStar_TypeChecker_Env.strict_args_tab);
+                    (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                   FStar_TypeChecker_Env.erasable_types_tab =
-                    (uu___52_208.FStar_TypeChecker_Env.erasable_types_tab);
+                    (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                    (uu___52_208.FStar_TypeChecker_Env.enable_defer_to_tac)
+                    (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                 } in
               let env4 =
                 FStar_TypeChecker_Env.set_current_module env3 test_lid in
@@ -291,11 +285,11 @@ let (init_once : unit -> unit) =
                 (FStar_Pervasives_Native.Some env4)))
 let (uu___56 : unit) = FStar_Main.setup_hooks (); init_once ()
 let (init : unit -> FStar_TypeChecker_Env.env) =
-  fun uu____225 ->
-    let uu____226 = FStar_ST.op_Bang tcenv_ref in
-    match uu____226 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang tcenv_ref in
+    match uu___1 with
     | FStar_Pervasives_Native.Some f -> f
-    | uu____240 ->
+    | uu___2 ->
         failwith
           "Should have already been initialized by the top-level effect"
 let (frag_of_text : Prims.string -> FStar_Parser_ParseIt.input_frag) =
@@ -309,32 +303,32 @@ let (frag_of_text : Prims.string -> FStar_Parser_ParseIt.input_frag) =
 let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s ->
     try
-      (fun uu___65_257 ->
+      (fun uu___ ->
          match () with
          | () ->
              let tcenv = init () in
-             let uu____259 =
-               let uu____260 =
+             let uu___1 =
+               let uu___2 =
                  FStar_All.pipe_left
-                   (fun uu____261 -> FStar_Parser_ParseIt.Fragment uu____261)
+                   (fun uu___3 -> FStar_Parser_ParseIt.Fragment uu___3)
                    (frag_of_text s) in
-               FStar_Parser_ParseIt.parse uu____260 in
-             (match uu____259 with
+               FStar_Parser_ParseIt.parse uu___2 in
+             (match uu___1 with
               | FStar_Parser_ParseIt.Term t ->
                   FStar_ToSyntax_ToSyntax.desugar_term
                     tcenv.FStar_TypeChecker_Env.dsenv t
               | FStar_Parser_ParseIt.ParseError (e, msg, r) ->
                   FStar_Errors.raise_error (e, msg) r
-              | FStar_Parser_ParseIt.ASTFragment uu____266 ->
+              | FStar_Parser_ParseIt.ASTFragment uu___2 ->
                   failwith
                     "Impossible: parsing a Fragment always results in a Term"))
         ()
     with
-    | uu___64_278 ->
+    | uu___ ->
         if
-          let uu____279 = FStar_Options.trace_error () in
-          Prims.op_Negation uu____279
-        then Obj.magic (Obj.repr (FStar_Exn.raise uu___64_278))
+          let uu___1 = FStar_Options.trace_error () in
+          Prims.op_Negation uu___1
+        then Obj.magic (Obj.repr (FStar_Exn.raise uu___))
         else Obj.magic (Obj.repr (failwith "unreachable"))
 let (tc' :
   Prims.string ->
@@ -345,235 +339,200 @@ let (tc' :
     let tm = pars s in
     let tcenv = init () in
     let tcenv1 =
-      let uu___83_294 = tcenv in
+      let uu___ = tcenv in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___83_294.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___83_294.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___83_294.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___83_294.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___83_294.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___83_294.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___83_294.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___83_294.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___83_294.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___83_294.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___83_294.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___83_294.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___83_294.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___83_294.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level = false;
         FStar_TypeChecker_Env.check_uvars =
-          (uu___83_294.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___83_294.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___83_294.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___83_294.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___83_294.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___83_294.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___83_294.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___83_294.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___83_294.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___83_294.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___83_294.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___83_294.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___83_294.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___83_294.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___83_294.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___83_294.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___83_294.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___83_294.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___83_294.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___83_294.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___83_294.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___83_294.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___83_294.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___83_294.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___83_294.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___83_294.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___83_294.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___83_294.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___83_294.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___83_294.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___83_294.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___83_294.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
-    let uu____295 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
-    match uu____295 with | (tm1, uu____309, g) -> (tm1, g, tcenv1)
+    let uu___ = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
+    match uu___ with | (tm1, uu___1, g) -> (tm1, g, tcenv1)
 let (tc : Prims.string -> FStar_Syntax_Syntax.term) =
-  fun s ->
-    let uu____316 = tc' s in
-    match uu____316 with | (tm, uu____324, uu____325) -> tm
+  fun s -> let uu___ = tc' s in match uu___ with | (tm, uu___1, uu___2) -> tm
 let (tc_nbe : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s ->
-    let uu____331 = tc' s in
-    match uu____331 with
+    let uu___ = tc' s in
+    match uu___ with
     | (tm, g, tcenv) ->
         (FStar_TypeChecker_Rel.force_trivial_guard tcenv g; tm)
 let (tc_nbe_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun tm ->
     let tcenv = init () in
     let tcenv1 =
-      let uu___103_349 = tcenv in
+      let uu___ = tcenv in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___103_349.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___103_349.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___103_349.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___103_349.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___103_349.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___103_349.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___103_349.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___103_349.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___103_349.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___103_349.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___103_349.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___103_349.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___103_349.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___103_349.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level = false;
         FStar_TypeChecker_Env.check_uvars =
-          (uu___103_349.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___103_349.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___103_349.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___103_349.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___103_349.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___103_349.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___103_349.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___103_349.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___103_349.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___103_349.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___103_349.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___103_349.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___103_349.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___103_349.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___103_349.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___103_349.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___103_349.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___103_349.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___103_349.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___103_349.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___103_349.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___103_349.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___103_349.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___103_349.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___103_349.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___103_349.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___103_349.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___103_349.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___103_349.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___103_349.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___103_349.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___103_349.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
-    let uu____350 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
-    match uu____350 with
-    | (tm1, uu____358, g) ->
+    let uu___ = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
+    match uu___ with
+    | (tm1, uu___1, g) ->
         (FStar_TypeChecker_Rel.force_trivial_guard tcenv1 g; tm1)
 let (pars_and_tc_fragment : Prims.string -> unit) =
   fun s ->
     FStar_Options.set_option "trace_error" (FStar_Options.Bool true);
-    (let report uu____372 =
-       let uu____373 = FStar_Errors.report_all () in
-       FStar_All.pipe_right uu____373 (fun uu____378 -> ()) in
+    (let report uu___1 =
+       let uu___2 = FStar_Errors.report_all () in
+       FStar_All.pipe_right uu___2 (fun uu___3 -> ()) in
      try
-       (fun uu___116_382 ->
+       (fun uu___1 ->
           match () with
           | () ->
               let tcenv = init () in
               let frag = frag_of_text s in
               (try
-                 (fun uu___124_394 ->
+                 (fun uu___2 ->
                     match () with
                     | () ->
-                        let uu____395 =
-                          let uu____402 = FStar_ST.op_Bang test_mod_ref in
-                          FStar_Universal.tc_one_fragment uu____402 tcenv
-                            frag in
-                        (match uu____395 with
+                        let uu___3 =
+                          let uu___4 = FStar_ST.op_Bang test_mod_ref in
+                          FStar_Universal.tc_one_fragment uu___4 tcenv frag in
+                        (match uu___3 with
                          | (test_mod', tcenv') ->
                              (FStar_ST.op_Colon_Equals test_mod_ref test_mod';
                               FStar_ST.op_Colon_Equals tcenv_ref
@@ -582,26 +541,26 @@ let (pars_and_tc_fragment : Prims.string -> unit) =
                                if n <> Prims.int_zero
                                then
                                  (report ();
-                                  (let uu____445 =
-                                     let uu____450 =
-                                       let uu____451 =
+                                  (let uu___7 =
+                                     let uu___8 =
+                                       let uu___9 =
                                          FStar_Util.string_of_int n in
                                        FStar_Util.format1
-                                         "%s errors were reported" uu____451 in
+                                         "%s errors were reported" uu___9 in
                                      (FStar_Errors.Fatal_ErrorsReported,
-                                       uu____450) in
-                                   FStar_Errors.raise_err uu____445))
+                                       uu___8) in
+                                   FStar_Errors.raise_err uu___7))
                                else ())))) ()
                with
-               | uu___123_455 ->
+               | uu___2 ->
                    (report ();
                     FStar_Errors.raise_err
                       (FStar_Errors.Fatal_TcOneFragmentFailed,
                         (Prims.op_Hat "tc_one_fragment failed: " s))))) ()
      with
-     | uu___115_458 ->
+     | uu___1 ->
          if
-           let uu____459 = FStar_Options.trace_error () in
-           Prims.op_Negation uu____459
-         then Obj.magic (Obj.repr (FStar_Exn.raise uu___115_458))
+           let uu___2 = FStar_Options.trace_error () in
+           Prims.op_Negation uu___2
+         then Obj.magic (Obj.repr (FStar_Exn.raise uu___1))
          else Obj.magic (Obj.repr (failwith "unreachable")))

--- a/src/ocaml-output/FStar_Tests_Test.ml
+++ b/src/ocaml-output/FStar_Tests_Test.ml
@@ -1,25 +1,25 @@
 open Prims
-let main : 'uuuuuu6 'uuuuuu7 . 'uuuuuu6 -> 'uuuuuu7 =
+let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
   fun argv ->
     FStar_Util.print_string "Initializing ...\n";
     (try
-       (fun uu___3_19 ->
+       (fun uu___1 ->
           match () with
           | () ->
               (FStar_Main.setup_hooks ();
-               (let uu____22 = FStar_Tests_Pars.init () in
-                FStar_All.pipe_right uu____22 (fun uu____23 -> ()));
+               (let uu___4 = FStar_Tests_Pars.init () in
+                FStar_All.pipe_right uu___4 (fun uu___5 -> ()));
                FStar_Tests_Norm.run_all ();
-               (let uu____26 = FStar_Tests_Unif.run_all () in
-                if uu____26 then () else FStar_All.exit Prims.int_one);
+               (let uu___6 = FStar_Tests_Unif.run_all () in
+                if uu___6 then () else FStar_All.exit Prims.int_one);
                FStar_All.exit Prims.int_zero)) ()
      with
      | FStar_Errors.Error (err, msg, r) when
-         let uu____37 = FStar_Options.trace_error () in
-         FStar_All.pipe_left Prims.op_Negation uu____37 ->
+         let uu___2 = FStar_Options.trace_error () in
+         FStar_All.pipe_left Prims.op_Negation uu___2 ->
          (if r = FStar_Range.dummyRange
           then FStar_Util.print_string msg
           else
-            (let uu____40 = FStar_Range.string_of_range r in
-             FStar_Util.print2 "%s: %s\n" uu____40 msg);
+            (let uu___4 = FStar_Range.string_of_range r in
+             FStar_Util.print2 "%s: %s\n" uu___4 msg);
           FStar_All.exit Prims.int_one))

--- a/src/ocaml-output/FStar_Tests_Unif.ml
+++ b/src/ocaml-output/FStar_Tests_Unif.ml
@@ -1,14 +1,14 @@
 open Prims
 let (tcenv : unit -> FStar_TypeChecker_Env.env) =
-  fun uu____4 -> FStar_Tests_Pars.init ()
+  fun uu___ -> FStar_Tests_Pars.init ()
 let (guard_to_string :
   FStar_TypeChecker_Common.guard_formula -> Prims.string) =
   fun g ->
     match g with
     | FStar_TypeChecker_Common.Trivial -> "trivial"
     | FStar_TypeChecker_Common.NonTrivial f ->
-        let uu____11 = tcenv () in
-        FStar_TypeChecker_Normalize.term_to_string uu____11 f
+        let uu___ = tcenv () in
+        FStar_TypeChecker_Normalize.term_to_string uu___ f
 let (success : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref true
 let (fail : Prims.string -> unit) =
   fun msg ->
@@ -21,39 +21,39 @@ let (guard_eq :
   fun i ->
     fun g ->
       fun g' ->
-        let uu____41 =
+        let uu___ =
           match (g, g') with
           | (FStar_TypeChecker_Common.Trivial,
              FStar_TypeChecker_Common.Trivial) -> (true, g, g')
           | (FStar_TypeChecker_Common.NonTrivial f,
              FStar_TypeChecker_Common.NonTrivial f') ->
               let f1 =
-                let uu____57 = tcenv () in
+                let uu___1 = tcenv () in
                 FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Env.EraseUniverses] uu____57 f in
+                  [FStar_TypeChecker_Env.EraseUniverses] uu___1 f in
               let f'1 =
-                let uu____59 = tcenv () in
+                let uu___1 = tcenv () in
                 FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Env.EraseUniverses] uu____59 f' in
-              let uu____60 = FStar_Tests_Util.term_eq f1 f'1 in
-              (uu____60, (FStar_TypeChecker_Common.NonTrivial f1),
+                  [FStar_TypeChecker_Env.EraseUniverses] uu___1 f' in
+              let uu___1 = FStar_Tests_Util.term_eq f1 f'1 in
+              (uu___1, (FStar_TypeChecker_Common.NonTrivial f1),
                 (FStar_TypeChecker_Common.NonTrivial f'1))
-          | uu____61 -> (false, g, g') in
-        match uu____41 with
+          | uu___1 -> (false, g, g') in
+        match uu___ with
         | (b, g1, g'1) ->
             (if Prims.op_Negation b
              then
-               (let uu____70 =
-                  let uu____71 = FStar_Util.string_of_int i in
-                  let uu____72 = guard_to_string g'1 in
-                  let uu____73 = guard_to_string g1 in
+               (let uu___2 =
+                  let uu___3 = FStar_Util.string_of_int i in
+                  let uu___4 = guard_to_string g'1 in
+                  let uu___5 = guard_to_string g1 in
                   FStar_Util.format3
                     "Test %s failed:\n\tExpected guard %s;\n\tGot guard      %s\n"
-                    uu____71 uu____72 uu____73 in
-                FStar_All.pipe_left fail uu____70)
+                    uu___3 uu___4 uu___5 in
+                FStar_All.pipe_left fail uu___2)
              else ();
-             (let uu____75 = (FStar_ST.op_Bang success) && b in
-              FStar_ST.op_Colon_Equals success uu____75))
+             (let uu___2 = (FStar_ST.op_Bang success) && b in
+              FStar_ST.op_Colon_Equals success uu___2))
 let (unify :
   Prims.int ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -65,26 +65,26 @@ let (unify :
       fun y ->
         fun g' ->
           fun check ->
-            (let uu____127 = FStar_Util.string_of_int i in
-             FStar_Util.print1 "%s ..." uu____127);
-            (let uu____129 = FStar_Main.process_args () in
-             FStar_All.pipe_right uu____129 (fun uu____142 -> ()));
-            (let uu____144 = FStar_Syntax_Print.term_to_string x in
-             let uu____145 = FStar_Syntax_Print.term_to_string y in
-             FStar_Util.print2 "Unify %s\nand %s\n" uu____144 uu____145);
+            (let uu___1 = FStar_Util.string_of_int i in
+             FStar_Util.print1 "%s ..." uu___1);
+            (let uu___2 = FStar_Main.process_args () in
+             FStar_All.pipe_right uu___2 (fun uu___3 -> ()));
+            (let uu___3 = FStar_Syntax_Print.term_to_string x in
+             let uu___4 = FStar_Syntax_Print.term_to_string y in
+             FStar_Util.print2 "Unify %s\nand %s\n" uu___3 uu___4);
             (let g =
-               let uu____147 =
-                 let uu____148 =
-                   let uu____149 = tcenv () in
-                   FStar_TypeChecker_Rel.teq uu____149 x y in
-                 let uu____150 =
-                   let uu____155 = tcenv () in
-                   FStar_TypeChecker_Rel.solve_deferred_constraints uu____155 in
-                 FStar_All.pipe_right uu____148 uu____150 in
-               let uu____156 =
-                 let uu____161 = tcenv () in
-                 FStar_TypeChecker_Rel.simplify_guard uu____161 in
-               FStar_All.pipe_right uu____147 uu____156 in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = tcenv () in
+                   FStar_TypeChecker_Rel.teq uu___5 x y in
+                 let uu___5 =
+                   let uu___6 = tcenv () in
+                   FStar_TypeChecker_Rel.solve_deferred_constraints uu___6 in
+                 FStar_All.pipe_right uu___4 uu___5 in
+               let uu___4 =
+                 let uu___5 = tcenv () in
+                 FStar_TypeChecker_Rel.simplify_guard uu___5 in
+               FStar_All.pipe_right uu___3 uu___4 in
              guard_eq i g.FStar_TypeChecker_Common.guard_f g';
              check ();
              FStar_Options.init ())
@@ -95,32 +95,31 @@ let (should_fail :
   fun x ->
     fun y ->
       try
-        (fun uu___41_185 ->
+        (fun uu___ ->
            match () with
            | () ->
                let g =
-                 let uu____187 =
-                   let uu____188 = tcenv () in
-                   FStar_TypeChecker_Rel.teq uu____188 x y in
-                 let uu____189 =
-                   let uu____194 = tcenv () in
-                   FStar_TypeChecker_Rel.solve_deferred_constraints uu____194 in
-                 FStar_All.pipe_right uu____187 uu____189 in
+                 let uu___1 =
+                   let uu___2 = tcenv () in
+                   FStar_TypeChecker_Rel.teq uu___2 x y in
+                 let uu___2 =
+                   let uu___3 = tcenv () in
+                   FStar_TypeChecker_Rel.solve_deferred_constraints uu___3 in
+                 FStar_All.pipe_right uu___1 uu___2 in
                (match g.FStar_TypeChecker_Common.guard_f with
                 | FStar_TypeChecker_Common.Trivial ->
-                    let uu____195 =
-                      let uu____196 = FStar_Syntax_Print.term_to_string x in
-                      let uu____197 = FStar_Syntax_Print.term_to_string y in
+                    let uu___1 =
+                      let uu___2 = FStar_Syntax_Print.term_to_string x in
+                      let uu___3 = FStar_Syntax_Print.term_to_string y in
                       FStar_Util.format2
-                        "%s and %s should not be unifiable\n" uu____196
-                        uu____197 in
-                    fail uu____195
+                        "%s and %s should not be unifiable\n" uu___2 uu___3 in
+                    fail uu___1
                 | FStar_TypeChecker_Common.NonTrivial f ->
-                    let uu____199 = FStar_Syntax_Print.term_to_string x in
-                    let uu____200 = FStar_Syntax_Print.term_to_string y in
-                    let uu____201 = FStar_Syntax_Print.term_to_string f in
+                    let uu___1 = FStar_Syntax_Print.term_to_string x in
+                    let uu___2 = FStar_Syntax_Print.term_to_string y in
+                    let uu___3 = FStar_Syntax_Print.term_to_string f in
                     FStar_Util.print3 "%s and %s are unifiable if %s\n"
-                      uu____199 uu____200 uu____201)) ()
+                      uu___1 uu___2 uu___3)) ()
       with | FStar_Errors.Error (e, msg, r) -> FStar_Util.print1 "%s\n" msg
 let (unify' : Prims.string -> Prims.string -> unit) =
   fun x ->
@@ -128,22 +127,20 @@ let (unify' : Prims.string -> Prims.string -> unit) =
       let x1 = FStar_Tests_Pars.pars x in
       let y1 = FStar_Tests_Pars.pars y in
       let g =
-        let uu____223 =
-          let uu____224 = tcenv () in
-          FStar_TypeChecker_Rel.teq uu____224 x1 y1 in
-        let uu____225 =
-          let uu____230 = tcenv () in
-          FStar_TypeChecker_Rel.solve_deferred_constraints uu____230 in
-        FStar_All.pipe_right uu____223 uu____225 in
-      let uu____231 = FStar_Syntax_Print.term_to_string x1 in
-      let uu____232 = FStar_Syntax_Print.term_to_string y1 in
-      let uu____233 = guard_to_string g.FStar_TypeChecker_Common.guard_f in
-      FStar_Util.print3 "%s and %s are unifiable with guard %s\n" uu____231
-        uu____232 uu____233
+        let uu___ =
+          let uu___1 = tcenv () in FStar_TypeChecker_Rel.teq uu___1 x1 y1 in
+        let uu___1 =
+          let uu___2 = tcenv () in
+          FStar_TypeChecker_Rel.solve_deferred_constraints uu___2 in
+        FStar_All.pipe_right uu___ uu___1 in
+      let uu___ = FStar_Syntax_Print.term_to_string x1 in
+      let uu___1 = FStar_Syntax_Print.term_to_string y1 in
+      let uu___2 = guard_to_string g.FStar_TypeChecker_Common.guard_f in
+      FStar_Util.print3 "%s and %s are unifiable with guard %s\n" uu___
+        uu___1 uu___2
 let (norm : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____239 = tcenv () in
-    FStar_TypeChecker_Normalize.normalize [] uu____239 t
+    let uu___ = tcenv () in FStar_TypeChecker_Normalize.normalize [] uu___ t
 let (inst :
   Prims.int ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -155,121 +152,115 @@ let (inst :
         if n1 = Prims.int_zero
         then out
         else
-          (let uu____280 =
-             let uu____293 = FStar_Tests_Pars.init () in
+          (let uu___1 =
+             let uu___2 = FStar_Tests_Pars.init () in
              FStar_TypeChecker_Util.new_implicit_var ""
-               FStar_Range.dummyRange uu____293 FStar_Syntax_Util.ktype0 in
-           match uu____280 with
-           | (t, uu____297, uu____298) ->
-               let uu____311 =
-                 let uu____324 = FStar_Tests_Pars.init () in
+               FStar_Range.dummyRange uu___2 FStar_Syntax_Util.ktype0 in
+           match uu___1 with
+           | (t, uu___2, uu___3) ->
+               let uu___4 =
+                 let uu___5 = FStar_Tests_Pars.init () in
                  FStar_TypeChecker_Util.new_implicit_var ""
-                   FStar_Range.dummyRange uu____324 t in
-               (match uu____311 with
-                | (u, uu____328, uu____329) ->
-                    aux (u :: out) (n1 - Prims.int_one))) in
+                   FStar_Range.dummyRange uu___5 t in
+               (match uu___4 with
+                | (u, uu___5, uu___6) -> aux (u :: out) (n1 - Prims.int_one))) in
       let us = aux [] n in
-      let uu____345 =
-        let uu____346 = FStar_Tests_Util.app tm us in norm uu____346 in
-      (uu____345, us)
+      let uu___ = let uu___1 = FStar_Tests_Util.app tm us in norm uu___1 in
+      (uu___, us)
 let (run_all : unit -> Prims.bool) =
-  fun uu____353 ->
+  fun uu___ ->
     FStar_Util.print_string "Testing the unifier\n";
     FStar_Options.__set_unit_tests ();
     (let unify_check n x y g f = unify n x y g f in
-     let unify1 n x y g = unify n x y g (fun uu____425 -> ()) in
+     let unify1 n x y g = unify n x y g (fun uu___3 -> ()) in
      let int_t = FStar_Tests_Pars.tc "Prims.int" in
      let x =
-       let uu____430 =
+       let uu___3 =
          FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None int_t in
-       FStar_All.pipe_right uu____430 FStar_Syntax_Syntax.bv_to_name in
+       FStar_All.pipe_right uu___3 FStar_Syntax_Syntax.bv_to_name in
      let y =
-       let uu____436 =
+       let uu___3 =
          FStar_Syntax_Syntax.gen_bv "y" FStar_Pervasives_Native.None int_t in
-       FStar_All.pipe_right uu____436 FStar_Syntax_Syntax.bv_to_name in
+       FStar_All.pipe_right uu___3 FStar_Syntax_Syntax.bv_to_name in
      unify1 Prims.int_zero x x FStar_TypeChecker_Common.Trivial;
-     (let uu____441 =
-        let uu____442 =
+     (let uu___5 =
+        let uu___6 =
           FStar_Syntax_Util.mk_eq2 FStar_Syntax_Syntax.U_zero
             FStar_Syntax_Util.t_bool x y in
-        FStar_TypeChecker_Common.NonTrivial uu____442 in
-      unify1 Prims.int_one x y uu____441);
+        FStar_TypeChecker_Common.NonTrivial uu___6 in
+      unify1 Prims.int_one x y uu___5);
      (let id = FStar_Tests_Pars.tc "fun x -> x" in
-      (let uu____445 = FStar_Tests_Util.app id [x] in
-       unify1 (Prims.of_int (2)) x uu____445 FStar_TypeChecker_Common.Trivial);
+      (let uu___6 = FStar_Tests_Util.app id [x] in
+       unify1 (Prims.of_int (2)) x uu___6 FStar_TypeChecker_Common.Trivial);
       (let id1 = FStar_Tests_Pars.tc "fun x -> x" in
        unify1 (Prims.of_int (3)) id1 id1 FStar_TypeChecker_Common.Trivial;
        (let id2 = FStar_Tests_Pars.tc "fun x -> x" in
         let id' = FStar_Tests_Pars.tc "fun y -> y" in
         unify1 (Prims.of_int (4)) id2 id' FStar_TypeChecker_Common.Trivial;
-        (let uu____454 = FStar_Tests_Pars.tc "fun x y -> x" in
-         let uu____457 = FStar_Tests_Pars.tc "fun a b -> a" in
-         unify1 (Prims.of_int (5)) uu____454 uu____457
+        (let uu___9 = FStar_Tests_Pars.tc "fun x y -> x" in
+         let uu___10 = FStar_Tests_Pars.tc "fun a b -> a" in
+         unify1 (Prims.of_int (5)) uu___9 uu___10
            FStar_TypeChecker_Common.Trivial);
-        (let uu____461 = FStar_Tests_Pars.tc "fun x y z -> y" in
-         let uu____464 = FStar_Tests_Pars.tc "fun a b c -> b" in
-         unify1 (Prims.of_int (6)) uu____461 uu____464
+        (let uu___10 = FStar_Tests_Pars.tc "fun x y z -> y" in
+         let uu___11 = FStar_Tests_Pars.tc "fun a b c -> b" in
+         unify1 (Prims.of_int (6)) uu___10 uu___11
            FStar_TypeChecker_Common.Trivial);
-        (let uu____468 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> y" in
-         let uu____471 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> x" in
-         let uu____474 =
-           let uu____475 =
+        (let uu___11 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> y" in
+         let uu___12 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> x" in
+         let uu___13 =
+           let uu___14 =
              FStar_Tests_Pars.tc "(forall (x:int). (forall (y:int). y==x))" in
-           FStar_TypeChecker_Common.NonTrivial uu____475 in
-         unify1 (Prims.of_int (7)) uu____468 uu____471 uu____474);
-        (let uu____477 =
-           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> y" in
-         let uu____480 =
-           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> z" in
-         let uu____483 =
-           let uu____484 =
+           FStar_TypeChecker_Common.NonTrivial uu___14 in
+         unify1 (Prims.of_int (7)) uu___11 uu___12 uu___13);
+        (let uu___12 = FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> y" in
+         let uu___13 = FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> z" in
+         let uu___14 =
+           let uu___15 =
              FStar_Tests_Pars.tc
                "(forall (x:int). (forall (y:int). (forall (z:int). y==z)))" in
-           FStar_TypeChecker_Common.NonTrivial uu____484 in
-         unify1 (Prims.of_int (8)) uu____477 uu____480 uu____483);
-        (let uu____486 = FStar_Main.process_args () in
-         FStar_All.pipe_right uu____486 (fun uu____499 -> ()));
-        (let uu____500 =
-           let uu____507 = FStar_Tests_Pars.tc "fun u x -> u x" in
-           inst Prims.int_one uu____507 in
-         match uu____500 with
+           FStar_TypeChecker_Common.NonTrivial uu___15 in
+         unify1 (Prims.of_int (8)) uu___12 uu___13 uu___14);
+        (let uu___13 = FStar_Main.process_args () in
+         FStar_All.pipe_right uu___13 (fun uu___14 -> ()));
+        (let uu___13 =
+           let uu___14 = FStar_Tests_Pars.tc "fun u x -> u x" in
+           inst Prims.int_one uu___14 in
+         match uu___13 with
          | (tm, us) ->
              let sol = FStar_Tests_Pars.tc "fun x -> c_and x x" in
              (unify_check (Prims.of_int (9)) tm sol
                 FStar_TypeChecker_Common.Trivial
-                (fun uu____520 ->
-                   let uu____521 =
-                     let uu____522 =
-                       let uu____525 = FStar_List.hd us in norm uu____525 in
-                     let uu____526 = norm sol in
-                     FStar_Tests_Util.term_eq uu____522 uu____526 in
-                   FStar_Tests_Util.always (Prims.of_int (9)) uu____521);
-              (let uu____529 =
-                 let uu____536 = FStar_Tests_Pars.tc "fun u x -> u x" in
-                 inst Prims.int_one uu____536 in
-               match uu____529 with
+                (fun uu___15 ->
+                   let uu___16 =
+                     let uu___17 =
+                       let uu___18 = FStar_List.hd us in norm uu___18 in
+                     let uu___18 = norm sol in
+                     FStar_Tests_Util.term_eq uu___17 uu___18 in
+                   FStar_Tests_Util.always (Prims.of_int (9)) uu___16);
+              (let uu___15 =
+                 let uu___16 = FStar_Tests_Pars.tc "fun u x -> u x" in
+                 inst Prims.int_one uu___16 in
+               match uu___15 with
                | (tm1, us1) ->
                    let sol1 = FStar_Tests_Pars.tc "fun x y -> x + y" in
                    (unify_check (Prims.of_int (10)) tm1 sol1
                       FStar_TypeChecker_Common.Trivial
-                      (fun uu____549 ->
-                         let uu____550 =
-                           let uu____551 =
-                             let uu____554 = FStar_List.hd us1 in
-                             norm uu____554 in
-                           let uu____555 = norm sol1 in
-                           FStar_Tests_Util.term_eq uu____551 uu____555 in
-                         FStar_Tests_Util.always (Prims.of_int (10))
-                           uu____550);
+                      (fun uu___17 ->
+                         let uu___18 =
+                           let uu___19 =
+                             let uu___20 = FStar_List.hd us1 in norm uu___20 in
+                           let uu___20 = norm sol1 in
+                           FStar_Tests_Util.term_eq uu___19 uu___20 in
+                         FStar_Tests_Util.always (Prims.of_int (10)) uu___18);
                     (let tm11 =
                        FStar_Tests_Pars.tc "x:int -> y:int{eq2 y x} -> bool" in
                      let tm2 = FStar_Tests_Pars.tc "x:int -> y:int -> bool" in
-                     (let uu____561 =
-                        let uu____562 =
+                     (let uu___18 =
+                        let uu___19 =
                           FStar_Tests_Pars.tc
                             "forall (x:int). (forall (y:int). y==x)" in
-                        FStar_TypeChecker_Common.NonTrivial uu____562 in
-                      unify1 (Prims.of_int (11)) tm11 tm2 uu____561);
+                        FStar_TypeChecker_Common.NonTrivial uu___19 in
+                      unify1 (Prims.of_int (11)) tm11 tm2 uu___18);
                      (let tm12 =
                         FStar_Tests_Pars.tc
                           "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0" in
@@ -278,7 +269,7 @@ let (run_all : unit -> Prims.bool) =
                           "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0" in
                       unify1 (Prims.of_int (12)) tm12 tm21
                         FStar_TypeChecker_Common.Trivial;
-                      (let uu____566 =
+                      (let uu___19 =
                          let int_typ = FStar_Tests_Pars.tc "int" in
                          let x1 =
                            FStar_Syntax_Syntax.new_bv
@@ -291,44 +282,40 @@ let (run_all : unit -> Prims.bool) =
                            FStar_Syntax_Syntax.new_bv
                              FStar_Pervasives_Native.None typ in
                          let tm13 =
-                           let uu____581 =
-                             let uu____582 =
-                               let uu____585 =
-                                 FStar_Syntax_Syntax.bv_to_name q in
-                               [uu____585] in
-                             FStar_Tests_Util.app l uu____582 in
-                           norm uu____581 in
+                           let uu___20 =
+                             let uu___21 =
+                               let uu___22 = FStar_Syntax_Syntax.bv_to_name q in
+                               [uu___22] in
+                             FStar_Tests_Util.app l uu___21 in
+                           norm uu___20 in
                          let l1 =
                            FStar_Tests_Pars.tc "fun (p:unit -> Type0) -> p" in
                          let unit = FStar_Tests_Pars.tc "()" in
                          let env =
-                           let uu____589 = FStar_Tests_Pars.init () in
-                           let uu____590 =
-                             let uu____591 = FStar_Syntax_Syntax.mk_binder x1 in
-                             let uu____598 =
-                               let uu____607 =
-                                 FStar_Syntax_Syntax.mk_binder q in
-                               [uu____607] in
-                             uu____591 :: uu____598 in
-                           FStar_TypeChecker_Env.push_binders uu____589
-                             uu____590 in
-                         let uu____632 =
+                           let uu___20 = FStar_Tests_Pars.init () in
+                           let uu___21 =
+                             let uu___22 = FStar_Syntax_Syntax.mk_binder x1 in
+                             let uu___23 =
+                               let uu___24 = FStar_Syntax_Syntax.mk_binder q in
+                               [uu___24] in
+                             uu___22 :: uu___23 in
+                           FStar_TypeChecker_Env.push_binders uu___20 uu___21 in
+                         let uu___20 =
                            FStar_TypeChecker_Util.new_implicit_var ""
                              FStar_Range.dummyRange env typ in
-                         match uu____632 with
-                         | (u_p, uu____654, uu____655) ->
+                         match uu___20 with
+                         | (u_p, uu___21, uu___22) ->
                              let tm22 =
-                               let uu____671 =
-                                 let uu____674 =
-                                   FStar_Tests_Util.app l1 [u_p] in
-                                 norm uu____674 in
-                               FStar_Tests_Util.app uu____671 [unit] in
+                               let uu___23 =
+                                 let uu___24 = FStar_Tests_Util.app l1 [u_p] in
+                                 norm uu___24 in
+                               FStar_Tests_Util.app uu___23 [unit] in
                              (tm13, tm22) in
-                       match uu____566 with
+                       match uu___19 with
                        | (tm13, tm22) ->
                            (unify1 (Prims.of_int (13)) tm13 tm22
                               FStar_TypeChecker_Common.Trivial;
-                            (let uu____690 =
+                            (let uu___21 =
                                let int_typ = FStar_Tests_Pars.tc "int" in
                                let x1 =
                                  FStar_Syntax_Syntax.new_bv
@@ -341,48 +328,48 @@ let (run_all : unit -> Prims.bool) =
                                  FStar_Syntax_Syntax.new_bv
                                    FStar_Pervasives_Native.None typ in
                                let tm14 =
-                                 let uu____705 =
-                                   let uu____706 =
-                                     let uu____709 =
+                                 let uu___22 =
+                                   let uu___23 =
+                                     let uu___24 =
                                        FStar_Syntax_Syntax.bv_to_name q in
-                                     [uu____709] in
-                                   FStar_Tests_Util.app l uu____706 in
-                                 norm uu____705 in
+                                     [uu___24] in
+                                   FStar_Tests_Util.app l uu___23 in
+                                 norm uu___22 in
                                let l1 =
                                  FStar_Tests_Pars.tc
                                    "fun (p:pure_post unit) -> p" in
                                let unit = FStar_Tests_Pars.tc "()" in
                                let env =
-                                 let uu____713 = FStar_Tests_Pars.init () in
-                                 let uu____714 =
-                                   let uu____715 =
+                                 let uu___22 = FStar_Tests_Pars.init () in
+                                 let uu___23 =
+                                   let uu___24 =
                                      FStar_Syntax_Syntax.mk_binder x1 in
-                                   let uu____722 =
-                                     let uu____731 =
+                                   let uu___25 =
+                                     let uu___26 =
                                        FStar_Syntax_Syntax.mk_binder q in
-                                     [uu____731] in
-                                   uu____715 :: uu____722 in
-                                 FStar_TypeChecker_Env.push_binders uu____713
-                                   uu____714 in
-                               let uu____756 =
+                                     [uu___26] in
+                                   uu___24 :: uu___25 in
+                                 FStar_TypeChecker_Env.push_binders uu___22
+                                   uu___23 in
+                               let uu___22 =
                                  FStar_TypeChecker_Util.new_implicit_var ""
                                    FStar_Range.dummyRange env typ in
-                               match uu____756 with
-                               | (u_p, uu____778, uu____779) ->
+                               match uu___22 with
+                               | (u_p, uu___23, uu___24) ->
                                    let tm23 =
-                                     let uu____795 =
-                                       let uu____798 =
+                                     let uu___25 =
+                                       let uu___26 =
                                          FStar_Tests_Util.app l1 [u_p] in
-                                       norm uu____798 in
-                                     FStar_Tests_Util.app uu____795 [unit] in
+                                       norm uu___26 in
+                                     FStar_Tests_Util.app uu___25 [unit] in
                                    (tm14, tm23) in
-                             match uu____690 with
+                             match uu___21 with
                              | (tm14, tm23) ->
                                  (unify1 (Prims.of_int (14)) tm14 tm23
                                     FStar_TypeChecker_Common.Trivial;
                                   FStar_Options.__clear_unit_tests ();
-                                  (let uu____816 = FStar_ST.op_Bang success in
-                                   if uu____816
+                                  (let uu___25 = FStar_ST.op_Bang success in
+                                   if uu___25
                                    then
                                      FStar_Util.print_string "Unifier ok\n"
                                    else ());

--- a/src/ocaml-output/FStar_Tests_Util.ml
+++ b/src/ocaml-output/FStar_Tests_Util.ml
@@ -5,12 +5,12 @@ let (always : Prims.int -> Prims.bool -> unit) =
       if b
       then ()
       else
-        (let uu____11 =
-           let uu____16 =
-             let uu____17 = FStar_Util.string_of_int id in
-             FStar_Util.format1 "Assertion failed: test %s" uu____17 in
-           (FStar_Errors.Fatal_AssertionFailure, uu____16) in
-         FStar_Errors.raise_error uu____11 FStar_Range.dummyRange)
+        (let uu___1 =
+           let uu___2 =
+             let uu___3 = FStar_Util.string_of_int id in
+             FStar_Util.format1 "Assertion failed: test %s" uu___3 in
+           (FStar_Errors.Fatal_AssertionFailure, uu___2) in
+         FStar_Errors.raise_error uu___1 FStar_Range.dummyRange)
 let (x : FStar_Syntax_Syntax.bv) =
   FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
@@ -26,7 +26,7 @@ let (h : FStar_Syntax_Syntax.bv) =
 let (m : FStar_Syntax_Syntax.bv) =
   FStar_Syntax_Syntax.gen_bv "m" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-let tm : 'uuuuuu22 . 'uuuuuu22 -> 'uuuuuu22 FStar_Syntax_Syntax.syntax =
+let tm : 'uuuuu . 'uuuuu -> 'uuuuu FStar_Syntax_Syntax.syntax =
   fun t -> FStar_Syntax_Syntax.mk t FStar_Range.dummyRange
 let (nm : FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term) =
   fun x1 -> FStar_Syntax_Syntax.bv_to_name x1
@@ -37,12 +37,12 @@ let (app :
   =
   fun x1 ->
     fun ts ->
-      let uu____55 =
-        let uu____56 =
-          let uu____73 = FStar_List.map FStar_Syntax_Syntax.as_arg ts in
-          (x1, uu____73) in
-        FStar_Syntax_Syntax.Tm_app uu____56 in
-      FStar_Syntax_Syntax.mk uu____55 FStar_Range.dummyRange
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_List.map FStar_Syntax_Syntax.as_arg ts in
+          (x1, uu___2) in
+        FStar_Syntax_Syntax.Tm_app uu___1 in
+      FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
 let rec (term_eq' :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool)
@@ -54,26 +54,26 @@ let rec (term_eq' :
       let binders_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
-             (fun uu____149 ->
-                fun uu____150 ->
-                  match (uu____149, uu____150) with
-                  | ((x1, uu____164), (y1, uu____166)) ->
+             (fun uu___ ->
+                fun uu___1 ->
+                  match (uu___, uu___1) with
+                  | ((x1, uu___2), (y1, uu___3)) ->
                       term_eq' x1.FStar_Syntax_Syntax.sort
                         y1.FStar_Syntax_Syntax.sort) xs ys) in
       let args_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
-             (fun uu____276 ->
-                fun uu____277 ->
-                  match (uu____276, uu____277) with
+             (fun uu___ ->
+                fun uu___1 ->
+                  match (uu___, uu___1) with
                   | ((a, imp), (b, imp')) ->
                       (term_eq' a b) &&
-                        (let uu____347 = FStar_Syntax_Util.eq_aqual imp imp' in
-                         uu____347 = FStar_Syntax_Util.Equal)) xs ys) in
+                        (let uu___2 = FStar_Syntax_Util.eq_aqual imp imp' in
+                         uu___2 = FStar_Syntax_Util.Equal)) xs ys) in
       let comp_eq c d =
         match ((c.FStar_Syntax_Syntax.n), (d.FStar_Syntax_Syntax.n)) with
-        | (FStar_Syntax_Syntax.Total (t, uu____360),
-           FStar_Syntax_Syntax.Total (s, uu____362)) -> term_eq' t s
+        | (FStar_Syntax_Syntax.Total (t, uu___), FStar_Syntax_Syntax.Total
+           (s, uu___1)) -> term_eq' t s
         | (FStar_Syntax_Syntax.Comp ct1, FStar_Syntax_Syntax.Comp ct2) ->
             ((FStar_Ident.lid_equals ct1.FStar_Syntax_Syntax.effect_name
                 ct2.FStar_Syntax_Syntax.effect_name)
@@ -83,76 +83,72 @@ let rec (term_eq' :
               &&
               (args_eq ct1.FStar_Syntax_Syntax.effect_args
                  ct2.FStar_Syntax_Syntax.effect_args)
-        | uu____381 -> false in
+        | uu___ -> false in
       match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
-      | (FStar_Syntax_Syntax.Tm_lazy l, uu____387) ->
-          let uu____388 =
-            let uu____391 =
-              let uu____400 =
-                FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
-              FStar_Util.must uu____400 in
-            uu____391 l.FStar_Syntax_Syntax.lkind l in
-          term_eq' uu____388 t21
-      | (uu____437, FStar_Syntax_Syntax.Tm_lazy l) ->
-          let uu____439 =
-            let uu____442 =
-              let uu____451 =
-                FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
-              FStar_Util.must uu____451 in
-            uu____442 l.FStar_Syntax_Syntax.lkind l in
-          term_eq' t11 uu____439
+      | (FStar_Syntax_Syntax.Tm_lazy l, uu___) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
+              FStar_Util.must uu___3 in
+            uu___2 l.FStar_Syntax_Syntax.lkind l in
+          term_eq' uu___1 t21
+      | (uu___, FStar_Syntax_Syntax.Tm_lazy l) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser in
+              FStar_Util.must uu___3 in
+            uu___2 l.FStar_Syntax_Syntax.lkind l in
+          term_eq' t11 uu___1
       | (FStar_Syntax_Syntax.Tm_bvar x1, FStar_Syntax_Syntax.Tm_bvar y1) ->
           x1.FStar_Syntax_Syntax.index = y1.FStar_Syntax_Syntax.index
       | (FStar_Syntax_Syntax.Tm_name x1, FStar_Syntax_Syntax.Tm_name y1) ->
           FStar_Syntax_Syntax.bv_eq x1 y1
       | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
           FStar_Syntax_Syntax.fv_eq f g
-      | (FStar_Syntax_Syntax.Tm_uinst (t, uu____495),
-         FStar_Syntax_Syntax.Tm_uinst (s, uu____497)) -> term_eq' t s
+      | (FStar_Syntax_Syntax.Tm_uinst (t, uu___),
+         FStar_Syntax_Syntax.Tm_uinst (s, uu___1)) -> term_eq' t s
       | (FStar_Syntax_Syntax.Tm_constant c1, FStar_Syntax_Syntax.Tm_constant
          c2) -> FStar_Const.eq_const c1 c2
       | (FStar_Syntax_Syntax.Tm_type u, FStar_Syntax_Syntax.Tm_type v) ->
           u = v
-      | (FStar_Syntax_Syntax.Tm_abs (xs, t, uu____512),
-         FStar_Syntax_Syntax.Tm_abs (ys, u, uu____515)) when
+      | (FStar_Syntax_Syntax.Tm_abs (xs, t, uu___),
+         FStar_Syntax_Syntax.Tm_abs (ys, u, uu___1)) when
           (FStar_List.length xs) = (FStar_List.length ys) ->
           (binders_eq xs ys) && (term_eq' t u)
-      | (FStar_Syntax_Syntax.Tm_abs (xs, t, uu____578),
-         FStar_Syntax_Syntax.Tm_abs (ys, u, uu____581)) ->
+      | (FStar_Syntax_Syntax.Tm_abs (xs, t, uu___),
+         FStar_Syntax_Syntax.Tm_abs (ys, u, uu___1)) ->
           if (FStar_List.length xs) > (FStar_List.length ys)
           then
-            let uu____642 = FStar_Util.first_N (FStar_List.length ys) xs in
-            (match uu____642 with
+            let uu___2 = FStar_Util.first_N (FStar_List.length ys) xs in
+            (match uu___2 with
              | (xs1, xs') ->
                  let t12 =
-                   let uu____712 =
-                     let uu____713 =
-                       let uu____732 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_abs
                               (xs', t, FStar_Pervasives_Native.None))
                            t11.FStar_Syntax_Syntax.pos in
-                       (xs1, uu____732, FStar_Pervasives_Native.None) in
-                     FStar_Syntax_Syntax.Tm_abs uu____713 in
-                   FStar_Syntax_Syntax.mk uu____712
-                     t11.FStar_Syntax_Syntax.pos in
+                       (xs1, uu___5, FStar_Pervasives_Native.None) in
+                     FStar_Syntax_Syntax.Tm_abs uu___4 in
+                   FStar_Syntax_Syntax.mk uu___3 t11.FStar_Syntax_Syntax.pos in
                  term_eq' t12 t21)
           else
-            (let uu____760 = FStar_Util.first_N (FStar_List.length xs) ys in
-             match uu____760 with
+            (let uu___3 = FStar_Util.first_N (FStar_List.length xs) ys in
+             match uu___3 with
              | (ys1, ys') ->
                  let t22 =
-                   let uu____830 =
-                     let uu____831 =
-                       let uu____850 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_abs
                               (ys', u, FStar_Pervasives_Native.None))
                            t21.FStar_Syntax_Syntax.pos in
-                       (ys1, uu____850, FStar_Pervasives_Native.None) in
-                     FStar_Syntax_Syntax.Tm_abs uu____831 in
-                   FStar_Syntax_Syntax.mk uu____830
-                     t21.FStar_Syntax_Syntax.pos in
+                       (ys1, uu___6, FStar_Pervasives_Native.None) in
+                     FStar_Syntax_Syntax.Tm_abs uu___5 in
+                   FStar_Syntax_Syntax.mk uu___4 t21.FStar_Syntax_Syntax.pos in
                  term_eq' t11 t22)
       | (FStar_Syntax_Syntax.Tm_arrow (xs, c), FStar_Syntax_Syntax.Tm_arrow
          (ys, d)) -> (binders_eq xs ys) && (comp_eq c d)
@@ -162,16 +158,16 @@ let rec (term_eq' :
             && (term_eq' t u)
       | (FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_1;
-            FStar_Syntax_Syntax.pos = uu____934;
-            FStar_Syntax_Syntax.vars = uu____935;_},
-          (uu____936, FStar_Pervasives_Native.Some
-           (FStar_Syntax_Syntax.Implicit uu____937))::t12::t22::[]),
+            FStar_Syntax_Syntax.pos = uu___;
+            FStar_Syntax_Syntax.vars = uu___1;_},
+          (uu___2, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
+           uu___3))::t12::t22::[]),
          FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_2;
-            FStar_Syntax_Syntax.pos = uu____941;
-            FStar_Syntax_Syntax.vars = uu____942;_},
-          (uu____943, FStar_Pervasives_Native.Some
-           (FStar_Syntax_Syntax.Implicit uu____944))::s1::s2::[]))
+            FStar_Syntax_Syntax.pos = uu___4;
+            FStar_Syntax_Syntax.vars = uu___5;_},
+          (uu___6, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
+           uu___7))::s1::s2::[]))
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv_eq_1 FStar_Parser_Const.eq2_lid)
             &&
@@ -183,17 +179,16 @@ let rec (term_eq' :
          (t', pats')) ->
           (((FStar_List.length pats) = (FStar_List.length pats')) &&
              (FStar_List.forall2
-                (fun uu____1323 ->
-                   fun uu____1324 ->
-                     match (uu____1323, uu____1324) with
-                     | ((uu____1381, uu____1382, e),
-                        (uu____1384, uu____1385, e')) -> term_eq' e e') pats
-                pats'))
+                (fun uu___ ->
+                   fun uu___1 ->
+                     match (uu___, uu___1) with
+                     | ((uu___2, uu___3, e), (uu___4, uu___5, e')) ->
+                         term_eq' e e') pats pats'))
             && (term_eq' t t')
       | (FStar_Syntax_Syntax.Tm_ascribed
-         (t12, (FStar_Util.Inl t22, uu____1449), uu____1450),
+         (t12, (FStar_Util.Inl t22, uu___), uu___1),
          FStar_Syntax_Syntax.Tm_ascribed
-         (s1, (FStar_Util.Inl s2, uu____1453), uu____1454)) ->
+         (s1, (FStar_Util.Inl s2, uu___2), uu___3)) ->
           (term_eq' t12 s1) && (term_eq' t22 s2)
       | (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs), t),
          FStar_Syntax_Syntax.Tm_let ((is_rec', lbs'), s)) when
@@ -208,29 +203,29 @@ let rec (term_eq' :
                        (term_eq' lb1.FStar_Syntax_Syntax.lbdef
                           lb2.FStar_Syntax_Syntax.lbdef)) lbs lbs'))
             && (term_eq' t s)
-      | (FStar_Syntax_Syntax.Tm_uvar (u, uu____1586),
-         FStar_Syntax_Syntax.Tm_uvar (u', uu____1588)) ->
+      | (FStar_Syntax_Syntax.Tm_uvar (u, uu___), FStar_Syntax_Syntax.Tm_uvar
+         (u', uu___1)) ->
           FStar_Syntax_Unionfind.equiv u.FStar_Syntax_Syntax.ctx_uvar_head
             u'.FStar_Syntax_Syntax.ctx_uvar_head
-      | (FStar_Syntax_Syntax.Tm_meta (t12, uu____1622), uu____1623) ->
+      | (FStar_Syntax_Syntax.Tm_meta (t12, uu___), uu___1) ->
           term_eq' t12 t21
-      | (uu____1628, FStar_Syntax_Syntax.Tm_meta (t22, uu____1630)) ->
+      | (uu___, FStar_Syntax_Syntax.Tm_meta (t22, uu___1)) ->
           term_eq' t11 t22
-      | (FStar_Syntax_Syntax.Tm_delayed uu____1635, uu____1636) ->
-          let uu____1651 =
-            let uu____1652 = FStar_Syntax_Print.tag_of_term t11 in
-            let uu____1653 = FStar_Syntax_Print.tag_of_term t21 in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1652 uu____1653 in
-          failwith uu____1651
-      | (uu____1654, FStar_Syntax_Syntax.Tm_delayed uu____1655) ->
-          let uu____1670 =
-            let uu____1671 = FStar_Syntax_Print.tag_of_term t11 in
-            let uu____1672 = FStar_Syntax_Print.tag_of_term t21 in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1671 uu____1672 in
-          failwith uu____1670
+      | (FStar_Syntax_Syntax.Tm_delayed uu___, uu___1) ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.tag_of_term t11 in
+            let uu___4 = FStar_Syntax_Print.tag_of_term t21 in
+            FStar_Util.format2 "Impossible: %s and %s" uu___3 uu___4 in
+          failwith uu___2
+      | (uu___, FStar_Syntax_Syntax.Tm_delayed uu___1) ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.tag_of_term t11 in
+            let uu___4 = FStar_Syntax_Print.tag_of_term t21 in
+            FStar_Util.format2 "Impossible: %s and %s" uu___3 uu___4 in
+          failwith uu___2
       | (FStar_Syntax_Syntax.Tm_unknown, FStar_Syntax_Syntax.Tm_unknown) ->
           true
-      | uu____1673 -> false
+      | uu___ -> false
 let (term_eq :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool)
@@ -240,9 +235,9 @@ let (term_eq :
       let b = term_eq' t1 t2 in
       if Prims.op_Negation b
       then
-        (let uu____1698 = FStar_Syntax_Print.term_to_string t1 in
-         let uu____1699 = FStar_Syntax_Print.term_to_string t2 in
-         FStar_Util.print2 ">>>>>>>>>>>Term %s is not equal to %s\n"
-           uu____1698 uu____1699)
+        (let uu___1 = FStar_Syntax_Print.term_to_string t1 in
+         let uu___2 = FStar_Syntax_Print.term_to_string t2 in
+         FStar_Util.print2 ">>>>>>>>>>>Term %s is not equal to %s\n" uu___1
+           uu___2)
       else ();
       b

--- a/src/ocaml-output/FStar_Thunk.ml
+++ b/src/ocaml-output/FStar_Thunk.ml
@@ -6,12 +6,11 @@ let mk : 'a . (unit -> 'a) -> 'a thunk =
 let mkv : 'a . 'a -> 'a thunk = fun v -> FStar_Util.mk_ref (FStar_Util.Inr v)
 let force : 'a . 'a thunk -> 'a =
   fun t1 ->
-    let uu____82 = FStar_ST.op_Bang t1 in
-    match uu____82 with
+    let uu___ = FStar_ST.op_Bang t1 in
+    match uu___ with
     | FStar_Util.Inr a1 -> a1
     | FStar_Util.Inl f ->
         let a1 = f () in
         (FStar_ST.op_Colon_Equals t1 (FStar_Util.Inr a1); a1)
 let map : 'a 'b . ('a -> 'b) -> 'a thunk -> 'b thunk =
-  fun f ->
-    fun t1 -> mk (fun uu____179 -> let uu____180 = force t1 in f uu____180)
+  fun f -> fun t1 -> mk (fun uu___ -> let uu___1 = force t1 in f uu___1)

--- a/src/ocaml-output/FStar_ToSyntax_Interleave.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Interleave.ml
@@ -2,62 +2,55 @@ open Prims
 let (id_eq_lid : FStar_Ident.ident -> FStar_Ident.lident -> Prims.bool) =
   fun i ->
     fun l ->
-      let uu____10 = FStar_Ident.string_of_id i in
-      let uu____11 =
-        let uu____12 = FStar_Ident.ident_of_lid l in
-        FStar_Ident.string_of_id uu____12 in
-      uu____10 = uu____11
+      let uu___ = FStar_Ident.string_of_id i in
+      let uu___1 =
+        let uu___2 = FStar_Ident.ident_of_lid l in
+        FStar_Ident.string_of_id uu___2 in
+      uu___ = uu___1
 let (is_val : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x ->
     fun d ->
       match d.FStar_Parser_AST.d with
-      | FStar_Parser_AST.Val (y, uu____24) ->
-          let uu____25 = FStar_Ident.string_of_id x in
-          let uu____26 = FStar_Ident.string_of_id y in uu____25 = uu____26
-      | uu____27 -> false
+      | FStar_Parser_AST.Val (y, uu___) ->
+          let uu___1 = FStar_Ident.string_of_id x in
+          let uu___2 = FStar_Ident.string_of_id y in uu___1 = uu___2
+      | uu___ -> false
 let (is_type : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x ->
     fun d ->
       match d.FStar_Parser_AST.d with
-      | FStar_Parser_AST.Tycon (uu____38, uu____39, tys) ->
+      | FStar_Parser_AST.Tycon (uu___, uu___1, tys) ->
           FStar_All.pipe_right tys
             (FStar_Util.for_some
                (fun t ->
-                  let uu____51 = FStar_Parser_AST.id_of_tycon t in
-                  let uu____52 = FStar_Ident.string_of_id x in
-                  uu____51 = uu____52))
-      | uu____53 -> false
+                  let uu___2 = FStar_Parser_AST.id_of_tycon t in
+                  let uu___3 = FStar_Ident.string_of_id x in uu___2 = uu___3))
+      | uu___ -> false
 let (definition_lids :
   FStar_Parser_AST.decl -> FStar_Ident.lident Prims.list) =
   fun d ->
     match d.FStar_Parser_AST.d with
-    | FStar_Parser_AST.TopLevelLet (uu____63, defs) ->
+    | FStar_Parser_AST.TopLevelLet (uu___, defs) ->
         FStar_Parser_AST.lids_of_let defs
-    | FStar_Parser_AST.Tycon (uu____77, uu____78, tys) ->
+    | FStar_Parser_AST.Tycon (uu___, uu___1, tys) ->
         FStar_All.pipe_right tys
           (FStar_List.collect
-             (fun uu___0_94 ->
-                match uu___0_94 with
-                | FStar_Parser_AST.TyconAbbrev
-                    (id, uu____98, uu____99, uu____100) ->
-                    let uu____109 = FStar_Ident.lid_of_ids [id] in
-                    [uu____109]
-                | FStar_Parser_AST.TyconRecord
-                    (id, uu____111, uu____112, uu____113) ->
-                    let uu____134 = FStar_Ident.lid_of_ids [id] in
-                    [uu____134]
-                | FStar_Parser_AST.TyconVariant
-                    (id, uu____136, uu____137, uu____138) ->
-                    let uu____167 = FStar_Ident.lid_of_ids [id] in
-                    [uu____167]
-                | uu____168 -> []))
-    | uu____169 -> []
+             (fun uu___2 ->
+                match uu___2 with
+                | FStar_Parser_AST.TyconAbbrev (id, uu___3, uu___4, uu___5)
+                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+                | FStar_Parser_AST.TyconRecord (id, uu___3, uu___4, uu___5)
+                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+                | FStar_Parser_AST.TyconVariant (id, uu___3, uu___4, uu___5)
+                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+                | uu___3 -> []))
+    | uu___ -> []
 let (is_definition_of :
   FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
   fun x ->
     fun d ->
-      let uu____180 = definition_lids d in
-      FStar_Util.for_some (id_eq_lid x) uu____180
+      let uu___ = definition_lids d in
+      FStar_Util.for_some (id_eq_lid x) uu___
 let rec (prefix_with_iface_decls :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
@@ -72,11 +65,11 @@ let rec (prefix_with_iface_decls :
                (FStar_Const.Const_string
                   ("KremlinPrivate", (impl1.FStar_Parser_AST.drange))))
             impl1.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
-        let uu___58_220 = impl1 in
+        let uu___ = impl1 in
         {
-          FStar_Parser_AST.d = (uu___58_220.FStar_Parser_AST.d);
-          FStar_Parser_AST.drange = (uu___58_220.FStar_Parser_AST.drange);
-          FStar_Parser_AST.quals = (uu___58_220.FStar_Parser_AST.quals);
+          FStar_Parser_AST.d = (uu___.FStar_Parser_AST.d);
+          FStar_Parser_AST.drange = (uu___.FStar_Parser_AST.drange);
+          FStar_Parser_AST.quals = (uu___.FStar_Parser_AST.quals);
           FStar_Parser_AST.attrs = (krem_private ::
             (impl1.FStar_Parser_AST.attrs))
         } in
@@ -84,13 +77,13 @@ let rec (prefix_with_iface_decls :
       | [] -> ([], [qualify_kremlin_private impl])
       | iface_hd::iface_tl ->
           (match iface_hd.FStar_Parser_AST.d with
-           | FStar_Parser_AST.Tycon (uu____245, uu____246, tys) when
+           | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
                FStar_All.pipe_right tys
                  (FStar_Util.for_some
-                    (fun uu___1_256 ->
-                       match uu___1_256 with
-                       | FStar_Parser_AST.TyconAbstract uu____257 -> true
-                       | uu____268 -> false))
+                    (fun uu___2 ->
+                       match uu___2 with
+                       | FStar_Parser_AST.TyconAbstract uu___3 -> true
+                       | uu___3 -> false))
                ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_AbstractTypeDeclarationInInterface,
@@ -101,32 +94,32 @@ let rec (prefix_with_iface_decls :
                let defines_x = FStar_Util.for_some (id_eq_lid x) def_ids in
                if Prims.op_Negation defines_x
                then
-                 let uu____291 =
+                 let uu___ =
                    FStar_All.pipe_right def_ids
                      (FStar_Util.for_some
                         (fun y ->
-                           let uu____297 =
-                             let uu____304 =
-                               let uu____309 = FStar_Ident.ident_of_lid y in
-                               is_val uu____309 in
-                             FStar_Util.for_some uu____304 in
-                           FStar_All.pipe_right iface_tl uu____297)) in
-                 (if uu____291
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = FStar_Ident.ident_of_lid y in
+                               is_val uu___3 in
+                             FStar_Util.for_some uu___2 in
+                           FStar_All.pipe_right iface_tl uu___1)) in
+                 (if uu___
                   then
-                    let uu____320 =
-                      let uu____325 =
-                        let uu____326 = FStar_Ident.string_of_id x in
-                        let uu____327 =
-                          let uu____328 =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = FStar_Ident.string_of_id x in
+                        let uu___4 =
+                          let uu___5 =
                             FStar_All.pipe_right def_ids
                               (FStar_List.map FStar_Ident.string_of_lid) in
-                          FStar_All.pipe_right uu____328
+                          FStar_All.pipe_right uu___5
                             (FStar_String.concat ", ") in
                         FStar_Util.format2
                           "Expected the definition of %s to precede %s"
-                          uu____326 uu____327 in
-                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu____325) in
-                    FStar_Errors.raise_error uu____320
+                          uu___3 uu___4 in
+                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu___2) in
+                    FStar_Errors.raise_error uu___1
                       impl.FStar_Parser_AST.drange
                   else (iface, [qualify_kremlin_private impl]))
                else
@@ -134,56 +127,55 @@ let rec (prefix_with_iface_decls :
                     FStar_All.pipe_right def_ids
                       (FStar_List.filter
                          (fun y ->
-                            let uu____361 = id_eq_lid x y in
-                            Prims.op_Negation uu____361)) in
+                            let uu___1 = id_eq_lid x y in
+                            Prims.op_Negation uu___1)) in
                   let rec aux mutuals iface1 =
                     match (mutuals, iface1) with
-                    | ([], uu____401) -> ([], iface1)
-                    | (uu____412::uu____413, []) -> ([], [])
+                    | ([], uu___1) -> ([], iface1)
+                    | (uu___1::uu___2, []) -> ([], [])
                     | (y::ys, iface_hd1::iface_tl1) ->
-                        let uu____436 =
-                          let uu____437 = FStar_Ident.ident_of_lid y in
-                          is_val uu____437 iface_hd1 in
-                        if uu____436
+                        let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid y in
+                          is_val uu___2 iface_hd1 in
+                        if uu___1
                         then
-                          let uu____446 = aux ys iface_tl1 in
-                          (match uu____446 with
+                          let uu___2 = aux ys iface_tl1 in
+                          (match uu___2 with
                            | (val_ys, iface2) ->
                                ((iface_hd1 :: val_ys), iface2))
                         else
-                          (let uu____478 =
-                             let uu____479 =
-                               let uu____482 =
-                                 let uu____487 = FStar_Ident.ident_of_lid y in
-                                 is_val uu____487 in
-                               FStar_List.tryFind uu____482 iface_tl1 in
-                             FStar_All.pipe_left FStar_Option.isSome
-                               uu____479 in
-                           if uu____478
+                          (let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 = FStar_Ident.ident_of_lid y in
+                                 is_val uu___6 in
+                               FStar_List.tryFind uu___5 iface_tl1 in
+                             FStar_All.pipe_left FStar_Option.isSome uu___4 in
+                           if uu___3
                            then
-                             let uu____498 =
-                               let uu____503 =
-                                 let uu____504 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_Parser_AST.decl_to_string iface_hd1 in
-                                 let uu____505 = FStar_Ident.string_of_lid y in
+                                 let uu___7 = FStar_Ident.string_of_lid y in
                                  FStar_Util.format2
                                    "%s is out of order with the definition of %s"
-                                   uu____504 uu____505 in
+                                   uu___6 uu___7 in
                                (FStar_Errors.Fatal_WrongDefinitionOrder,
-                                 uu____503) in
-                             FStar_Errors.raise_error uu____498
+                                 uu___5) in
+                             FStar_Errors.raise_error uu___4
                                iface_hd1.FStar_Parser_AST.drange
                            else aux ys iface1) in
-                  let uu____515 = aux mutually_defined_with_x iface_tl in
-                  match uu____515 with
+                  let uu___1 = aux mutually_defined_with_x iface_tl in
+                  match uu___1 with
                   | (take_iface, rest_iface) ->
                       (rest_iface,
                         (FStar_List.append (iface_hd :: take_iface) [impl])))
-           | FStar_Parser_AST.Pragma uu____546 ->
+           | FStar_Parser_AST.Pragma uu___ ->
                prefix_with_iface_decls iface_tl impl
-           | uu____547 ->
-               let uu____548 = prefix_with_iface_decls iface_tl impl in
-               (match uu____548 with
+           | uu___ ->
+               let uu___1 = prefix_with_iface_decls iface_tl impl in
+               (match uu___1 with
                 | (iface1, ds) -> (iface1, (iface_hd :: ds))))
 let (check_initial_interface :
   FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list) =
@@ -193,51 +185,50 @@ let (check_initial_interface :
       | [] -> ()
       | hd::tl ->
           (match hd.FStar_Parser_AST.d with
-           | FStar_Parser_AST.Tycon (uu____604, uu____605, tys) when
+           | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
                FStar_All.pipe_right tys
                  (FStar_Util.for_some
-                    (fun uu___2_615 ->
-                       match uu___2_615 with
-                       | FStar_Parser_AST.TyconAbstract uu____616 -> true
-                       | uu____627 -> false))
+                    (fun uu___2 ->
+                       match uu___2 with
+                       | FStar_Parser_AST.TyconAbstract uu___3 -> true
+                       | uu___3 -> false))
                ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_AbstractTypeDeclarationInInterface,
                    "Interface contains an abstract 'type' declaration; use 'val' instead")
                  hd.FStar_Parser_AST.drange
            | FStar_Parser_AST.Val (x, t) ->
-               let uu____630 = FStar_Util.for_some (is_definition_of x) tl in
-               if uu____630
+               let uu___ = FStar_Util.for_some (is_definition_of x) tl in
+               if uu___
                then
-                 let uu____631 =
-                   let uu____636 =
-                     let uu____637 = FStar_Ident.string_of_id x in
-                     let uu____638 = FStar_Ident.string_of_id x in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = FStar_Ident.string_of_id x in
+                     let uu___4 = FStar_Ident.string_of_id x in
                      FStar_Util.format2
                        "'val %s' and 'let %s' cannot both be provided in an interface"
-                       uu____637 uu____638 in
-                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu____636) in
-                 FStar_Errors.raise_error uu____631
-                   hd.FStar_Parser_AST.drange
+                       uu___3 uu___4 in
+                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu___2) in
+                 FStar_Errors.raise_error uu___1 hd.FStar_Parser_AST.drange
                else
-                 (let uu____640 =
+                 (let uu___2 =
                     FStar_All.pipe_right hd.FStar_Parser_AST.quals
                       (FStar_List.contains FStar_Parser_AST.Assumption) in
-                  if uu____640
+                  if uu___2
                   then
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_AssumeValInInterface,
                         "Interfaces cannot use `assume val x : t`; just write `val x : t` instead")
                       hd.FStar_Parser_AST.drange
                   else ())
-           | uu____644 -> ()) in
+           | uu___ -> ()) in
     aux iface;
     FStar_All.pipe_right iface
       (FStar_List.filter
          (fun d ->
             match d.FStar_Parser_AST.d with
-            | FStar_Parser_AST.TopLevelModule uu____653 -> false
-            | uu____654 -> true))
+            | FStar_Parser_AST.TopLevelModule uu___1 -> false
+            | uu___1 -> true))
 let (ml_mode_prefix_with_iface_decls :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
@@ -246,23 +237,23 @@ let (ml_mode_prefix_with_iface_decls :
   fun iface ->
     fun impl ->
       match impl.FStar_Parser_AST.d with
-      | FStar_Parser_AST.TopLevelLet (uu____685, defs) ->
+      | FStar_Parser_AST.TopLevelLet (uu___, defs) ->
           let xs = FStar_Parser_AST.lids_of_let defs in
-          let uu____702 =
+          let uu___1 =
             FStar_List.partition
               (fun d ->
                  FStar_All.pipe_right xs
                    (FStar_Util.for_some
                       (fun x ->
-                         let uu____718 = FStar_Ident.ident_of_lid x in
-                         is_val uu____718 d))) iface in
-          (match uu____702 with
+                         let uu___2 = FStar_Ident.ident_of_lid x in
+                         is_val uu___2 d))) iface in
+          (match uu___1 with
            | (val_xs, rest_iface) ->
                (rest_iface, (FStar_List.append val_xs [impl])))
-      | uu____741 -> (iface, [impl])
+      | uu___ -> (iface, [impl])
 let ml_mode_check_initial_interface :
-  'uuuuuu752 .
-    'uuuuuu752 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list
   =
   fun mname ->
@@ -271,8 +262,8 @@ let ml_mode_check_initial_interface :
         (FStar_List.filter
            (fun d ->
               match d.FStar_Parser_AST.d with
-              | FStar_Parser_AST.Val uu____776 -> true
-              | uu____781 -> false))
+              | FStar_Parser_AST.Val uu___ -> true
+              | uu___ -> false))
 let (ulib_modules : Prims.string Prims.list) =
   ["FStar.TSet";
   "FStar.Seq.Base";
@@ -290,15 +281,15 @@ let (ulib_modules : Prims.string Prims.list) =
 let (apply_ml_mode_optimizations : FStar_Ident.lident -> Prims.bool) =
   fun mname ->
     ((FStar_Options.ml_ish ()) &&
-       (let uu____790 =
-          let uu____791 = FStar_Ident.string_of_lid mname in
-          FStar_List.contains uu____791 FStar_Parser_Dep.core_modules in
-        Prims.op_Negation uu____790))
+       (let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid mname in
+          FStar_List.contains uu___1 FStar_Parser_Dep.core_modules in
+        Prims.op_Negation uu___))
       &&
-      (let uu____793 =
-         let uu____794 = FStar_Ident.string_of_lid mname in
-         FStar_List.contains uu____794 ulib_modules in
-       Prims.op_Negation uu____793)
+      (let uu___ =
+         let uu___1 = FStar_Ident.string_of_lid mname in
+         FStar_List.contains uu___1 ulib_modules in
+       Prims.op_Negation uu___)
 let (prefix_one_decl :
   FStar_Ident.lident ->
     FStar_Parser_AST.decl Prims.list ->
@@ -309,10 +300,10 @@ let (prefix_one_decl :
     fun iface ->
       fun impl ->
         match impl.FStar_Parser_AST.d with
-        | FStar_Parser_AST.TopLevelModule uu____830 -> (iface, [impl])
-        | uu____835 ->
-            let uu____836 = apply_ml_mode_optimizations mname in
-            if uu____836
+        | FStar_Parser_AST.TopLevelModule uu___ -> (iface, [impl])
+        | uu___ ->
+            let uu___1 = apply_ml_mode_optimizations mname in
+            if uu___1
             then ml_mode_prefix_with_iface_decls iface impl
             else prefix_with_iface_decls iface impl
 let (initialize_interface :
@@ -323,25 +314,24 @@ let (initialize_interface :
     fun l ->
       fun env ->
         let decls =
-          let uu____870 = apply_ml_mode_optimizations mname in
-          if uu____870
+          let uu___ = apply_ml_mode_optimizations mname in
+          if uu___
           then ml_mode_check_initial_interface mname l
           else check_initial_interface l in
-        let uu____874 = FStar_Syntax_DsEnv.iface_decls env mname in
-        match uu____874 with
-        | FStar_Pervasives_Native.Some uu____883 ->
-            let uu____888 =
-              let uu____893 =
-                let uu____894 = FStar_Ident.string_of_lid mname in
+        let uu___ = FStar_Syntax_DsEnv.iface_decls env mname in
+        match uu___ with
+        | FStar_Pervasives_Native.Some uu___1 ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Ident.string_of_lid mname in
                 FStar_Util.format1 "Interface %s has already been processed"
-                  uu____894 in
-              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu____893) in
-            let uu____895 = FStar_Ident.range_of_lid mname in
-            FStar_Errors.raise_error uu____888 uu____895
+                  uu___4 in
+              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu___3) in
+            let uu___3 = FStar_Ident.range_of_lid mname in
+            FStar_Errors.raise_error uu___2 uu___3
         | FStar_Pervasives_Native.None ->
-            let uu____902 =
-              FStar_Syntax_DsEnv.set_iface_decls env mname decls in
-            ((), uu____902)
+            let uu___1 = FStar_Syntax_DsEnv.set_iface_decls env mname decls in
+            ((), uu___1)
 let (prefix_with_interface_decls :
   FStar_Ident.lident ->
     FStar_Parser_AST.decl ->
@@ -350,18 +340,18 @@ let (prefix_with_interface_decls :
   fun mname ->
     fun impl ->
       fun env ->
-        let uu____924 =
-          let uu____929 = FStar_Syntax_DsEnv.current_module env in
-          FStar_Syntax_DsEnv.iface_decls env uu____929 in
-        match uu____924 with
+        let uu___ =
+          let uu___1 = FStar_Syntax_DsEnv.current_module env in
+          FStar_Syntax_DsEnv.iface_decls env uu___1 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> ([impl], env)
         | FStar_Pervasives_Native.Some iface ->
-            let uu____945 = prefix_one_decl mname iface impl in
-            (match uu____945 with
+            let uu___1 = prefix_one_decl mname iface impl in
+            (match uu___1 with
              | (iface1, impl1) ->
                  let env1 =
-                   let uu____971 = FStar_Syntax_DsEnv.current_module env in
-                   FStar_Syntax_DsEnv.set_iface_decls env uu____971 iface1 in
+                   let uu___2 = FStar_Syntax_DsEnv.current_module env in
+                   FStar_Syntax_DsEnv.set_iface_decls env uu___2 iface1 in
                  (impl1, env1))
 let (interleave_module :
   FStar_Parser_AST.modul ->
@@ -371,74 +361,70 @@ let (interleave_module :
     fun expect_complete_modul ->
       fun env ->
         match a with
-        | FStar_Parser_AST.Interface uu____995 -> (a, env)
+        | FStar_Parser_AST.Interface uu___ -> (a, env)
         | FStar_Parser_AST.Module (l, impls) ->
-            let uu____1010 = FStar_Syntax_DsEnv.iface_decls env l in
-            (match uu____1010 with
+            let uu___ = FStar_Syntax_DsEnv.iface_decls env l in
+            (match uu___ with
              | FStar_Pervasives_Native.None -> (a, env)
              | FStar_Pervasives_Native.Some iface ->
-                 let uu____1026 =
+                 let uu___1 =
                    FStar_List.fold_left
-                     (fun uu____1050 ->
+                     (fun uu___2 ->
                         fun impl ->
-                          match uu____1050 with
+                          match uu___2 with
                           | (iface1, impls1) ->
-                              let uu____1078 = prefix_one_decl l iface1 impl in
-                              (match uu____1078 with
+                              let uu___3 = prefix_one_decl l iface1 impl in
+                              (match uu___3 with
                                | (iface2, impls') ->
                                    (iface2,
                                      (FStar_List.append impls1 impls'))))
                      (iface, []) impls in
-                 (match uu____1026 with
+                 (match uu___1 with
                   | (iface1, impls1) ->
-                      let uu____1127 =
-                        let uu____1136 =
+                      let uu___2 =
+                        let uu___3 =
                           FStar_Util.prefix_until
-                            (fun uu___3_1154 ->
-                               match uu___3_1154 with
+                            (fun uu___4 ->
+                               match uu___4 with
                                | {
                                    FStar_Parser_AST.d = FStar_Parser_AST.Val
-                                     uu____1155;
-                                   FStar_Parser_AST.drange = uu____1156;
-                                   FStar_Parser_AST.quals = uu____1157;
-                                   FStar_Parser_AST.attrs = uu____1158;_} ->
-                                   true
-                               | uu____1163 -> false) iface1 in
-                        match uu____1136 with
+                                     uu___5;
+                                   FStar_Parser_AST.drange = uu___6;
+                                   FStar_Parser_AST.quals = uu___7;
+                                   FStar_Parser_AST.attrs = uu___8;_} -> true
+                               | uu___5 -> false) iface1 in
+                        match uu___3 with
                         | FStar_Pervasives_Native.None -> (iface1, [])
                         | FStar_Pervasives_Native.Some (lets, one_val, rest)
                             -> (lets, (one_val :: rest)) in
-                      (match uu____1127 with
+                      (match uu___2 with
                        | (iface_lets, remaining_iface_vals) ->
                            let impls2 = FStar_List.append impls1 iface_lets in
                            let env1 =
-                             let uu____1229 = FStar_Options.interactive () in
-                             if uu____1229
+                             let uu___3 = FStar_Options.interactive () in
+                             if uu___3
                              then
                                FStar_Syntax_DsEnv.set_iface_decls env l
                                  remaining_iface_vals
                              else env in
                            let a1 = FStar_Parser_AST.Module (l, impls2) in
                            (match remaining_iface_vals with
-                            | uu____1238::uu____1239 when
-                                expect_complete_modul ->
+                            | uu___3::uu___4 when expect_complete_modul ->
                                 let err =
-                                  let uu____1243 =
+                                  let uu___5 =
                                     FStar_List.map
                                       FStar_Parser_AST.decl_to_string
                                       remaining_iface_vals in
-                                  FStar_All.pipe_right uu____1243
+                                  FStar_All.pipe_right uu___5
                                     (FStar_String.concat "\n\t") in
-                                let uu____1248 =
-                                  let uu____1253 =
-                                    let uu____1254 =
-                                      FStar_Ident.string_of_lid l in
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 = FStar_Ident.string_of_lid l in
                                     FStar_Util.format2
                                       "Some interface elements were not implemented by module %s:\n\t%s"
-                                      uu____1254 err in
+                                      uu___7 err in
                                   (FStar_Errors.Fatal_InterfaceNotImplementedByModule,
-                                    uu____1253) in
-                                let uu____1255 = FStar_Ident.range_of_lid l in
-                                FStar_Errors.raise_error uu____1248
-                                  uu____1255
-                            | uu____1260 -> (a1, env1)))))
+                                    uu___6) in
+                                let uu___6 = FStar_Ident.range_of_lid l in
+                                FStar_Errors.raise_error uu___5 uu___6
+                            | uu___3 -> (a1, env1)))))

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -1,11 +1,11 @@
 open Prims
 let (tun_r : FStar_Range.range -> FStar_Syntax_Syntax.term) =
   fun r ->
-    let uu___28_5 = FStar_Syntax_Syntax.tun in
+    let uu___ = FStar_Syntax_Syntax.tun in
     {
-      FStar_Syntax_Syntax.n = (uu___28_5.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = r;
-      FStar_Syntax_Syntax.vars = (uu___28_5.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
     }
 type annotated_pat =
   (FStar_Syntax_Syntax.pat * (FStar_Syntax_Syntax.bv *
@@ -23,31 +23,31 @@ let (desugar_disjunctive_pattern :
       fun branch ->
         FStar_All.pipe_right annotated_pats
           (FStar_List.map
-             (fun uu____109 ->
-                match uu____109 with
+             (fun uu___ ->
+                match uu___ with
                 | (pat, annots) ->
                     let branch1 =
                       FStar_List.fold_left
                         (fun br ->
-                           fun uu____164 ->
-                             match uu____164 with
+                           fun uu___1 ->
+                             match uu___1 with
                              | (bv, ty) ->
                                  let lb =
-                                   let uu____182 =
+                                   let uu___2 =
                                      FStar_Syntax_Syntax.bv_to_name bv in
                                    FStar_Syntax_Util.mk_letbinding
                                      (FStar_Util.Inl bv) [] ty
-                                     FStar_Parser_Const.effect_Tot_lid
-                                     uu____182 [] br.FStar_Syntax_Syntax.pos in
-                                 let branch1 =
-                                   let uu____188 =
-                                     let uu____189 =
+                                     FStar_Parser_Const.effect_Tot_lid uu___2
+                                     [] br.FStar_Syntax_Syntax.pos in
+                                 let branch2 =
+                                   let uu___2 =
+                                     let uu___3 =
                                        FStar_Syntax_Syntax.mk_binder bv in
-                                     [uu____189] in
-                                   FStar_Syntax_Subst.close uu____188 branch in
+                                     [uu___3] in
+                                   FStar_Syntax_Subst.close uu___2 branch in
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
-                                      ((false, [lb]), branch1))
+                                      ((false, [lb]), branch2))
                                    br.FStar_Syntax_Syntax.pos) branch annots in
                     FStar_Syntax_Util.branch (pat, when_opt, branch1)))
 let (trans_qual :
@@ -57,8 +57,8 @@ let (trans_qual :
   =
   fun r ->
     fun maybe_effect_id ->
-      fun uu___0_242 ->
-        match uu___0_242 with
+      fun uu___ ->
+        match uu___ with
         | FStar_Parser_AST.Private -> FStar_Syntax_Syntax.Private
         | FStar_Parser_AST.Assumption -> FStar_Syntax_Syntax.Assumption
         | FStar_Parser_AST.Unfold_for_unification_and_vcgen ->
@@ -101,8 +101,8 @@ let (trans_qual :
               (FStar_Errors.Fatal_UnsupportedQualifier,
                 "Unsupported qualifier") r
 let (trans_pragma : FStar_Parser_AST.pragma -> FStar_Syntax_Syntax.pragma) =
-  fun uu___1_251 ->
-    match uu___1_251 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.SetOptions s -> FStar_Syntax_Syntax.SetOptions s
     | FStar_Parser_AST.ResetOptions sopt ->
         FStar_Syntax_Syntax.ResetOptions sopt
@@ -115,23 +115,23 @@ let (as_imp :
   FStar_Parser_AST.imp ->
     FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option)
   =
-  fun uu___2_265 ->
-    match uu___2_265 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Parser_AST.Hash ->
         FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
-    | uu____268 -> FStar_Pervasives_Native.None
+    | uu___1 -> FStar_Pervasives_Native.None
 let arg_withimp_e :
-  'uuuuuu275 .
+  'uuuuu .
     FStar_Parser_AST.imp ->
-      'uuuuuu275 ->
-        ('uuuuuu275 * FStar_Syntax_Syntax.arg_qualifier
+      'uuuuu ->
+        ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option)
   = fun imp -> fun t -> (t, (as_imp imp))
 let arg_withimp_t :
-  'uuuuuu300 .
+  'uuuuu .
     FStar_Parser_AST.imp ->
-      'uuuuuu300 ->
-        ('uuuuuu300 * FStar_Syntax_Syntax.arg_qualifier
+      'uuuuu ->
+        ('uuuuu * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option)
   =
   fun imp ->
@@ -139,52 +139,49 @@ let arg_withimp_t :
       match imp with
       | FStar_Parser_AST.Hash ->
           (t, (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag))
-      | uu____319 -> (t, FStar_Pervasives_Native.None)
+      | uu___ -> (t, FStar_Pervasives_Native.None)
 let (contains_binder : FStar_Parser_AST.binder Prims.list -> Prims.bool) =
   fun binders ->
     FStar_All.pipe_right binders
       (FStar_Util.for_some
          (fun b ->
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated uu____336 -> true
-            | uu____341 -> false))
+            | FStar_Parser_AST.Annotated uu___ -> true
+            | uu___ -> false))
 let rec (unparen : FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun t ->
     match t.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Paren t1 -> unparen t1
-    | uu____348 -> t
+    | uu___ -> t
 let (tm_type_z : FStar_Range.range -> FStar_Parser_AST.term) =
   fun r ->
-    let uu____354 =
-      let uu____355 = FStar_Ident.lid_of_path ["Type0"] r in
-      FStar_Parser_AST.Name uu____355 in
-    FStar_Parser_AST.mk_term uu____354 r FStar_Parser_AST.Kind
+    let uu___ =
+      let uu___1 = FStar_Ident.lid_of_path ["Type0"] r in
+      FStar_Parser_AST.Name uu___1 in
+    FStar_Parser_AST.mk_term uu___ r FStar_Parser_AST.Kind
 let (tm_type : FStar_Range.range -> FStar_Parser_AST.term) =
   fun r ->
-    let uu____361 =
-      let uu____362 = FStar_Ident.lid_of_path ["Type"] r in
-      FStar_Parser_AST.Name uu____362 in
-    FStar_Parser_AST.mk_term uu____361 r FStar_Parser_AST.Kind
+    let uu___ =
+      let uu___1 = FStar_Ident.lid_of_path ["Type"] r in
+      FStar_Parser_AST.Name uu___1 in
+    FStar_Parser_AST.mk_term uu___ r FStar_Parser_AST.Kind
 let rec (is_comp_type :
   FStar_Syntax_DsEnv.env -> FStar_Parser_AST.term -> Prims.bool) =
   fun env ->
     fun t ->
-      let uu____373 =
-        let uu____374 = unparen t in uu____374.FStar_Parser_AST.tm in
-      match uu____373 with
+      let uu___ = let uu___1 = unparen t in uu___1.FStar_Parser_AST.tm in
+      match uu___ with
       | FStar_Parser_AST.Name l ->
-          let uu____376 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
-          FStar_All.pipe_right uu____376 FStar_Option.isSome
-      | FStar_Parser_AST.Construct (l, uu____382) ->
-          let uu____395 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
-          FStar_All.pipe_right uu____395 FStar_Option.isSome
-      | FStar_Parser_AST.App (head, uu____401, uu____402) ->
-          is_comp_type env head
+          let uu___1 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
+          FStar_All.pipe_right uu___1 FStar_Option.isSome
+      | FStar_Parser_AST.Construct (l, uu___1) ->
+          let uu___2 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
+          FStar_All.pipe_right uu___2 FStar_Option.isSome
+      | FStar_Parser_AST.App (head, uu___1, uu___2) -> is_comp_type env head
       | FStar_Parser_AST.Paren t1 -> failwith "impossible"
-      | FStar_Parser_AST.Ascribed (t1, uu____405, uu____406) ->
-          is_comp_type env t1
-      | FStar_Parser_AST.LetOpen (uu____411, t1) -> is_comp_type env t1
-      | uu____413 -> false
+      | FStar_Parser_AST.Ascribed (t1, uu___1, uu___2) -> is_comp_type env t1
+      | FStar_Parser_AST.LetOpen (uu___1, t1) -> is_comp_type env t1
+      | uu___1 -> false
 let (unit_ty : FStar_Range.range -> FStar_Parser_AST.term) =
   fun rng ->
     FStar_Parser_AST.mk_term
@@ -214,8 +211,8 @@ let (desugar_name' :
           | FStar_Pervasives_Native.Some (tm, attrs) ->
               let tm1 = setpos tm in FStar_Pervasives_Native.Some tm1
 let desugar_name :
-  'uuuuuu501 .
-    'uuuuuu501 ->
+  'uuuuu .
+    'uuuuu ->
       (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
         env_t -> Prims.bool -> FStar_Ident.lident -> FStar_Syntax_Syntax.term
   =
@@ -231,14 +228,13 @@ let (compile_op_lid :
   fun n ->
     fun s ->
       fun r ->
-        let uu____547 =
-          let uu____548 =
-            let uu____549 =
-              let uu____554 = FStar_Parser_AST.compile_op n s r in
-              (uu____554, r) in
-            FStar_Ident.mk_ident uu____549 in
-          [uu____548] in
-        FStar_All.pipe_right uu____547 FStar_Ident.lid_of_ids
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Parser_AST.compile_op n s r in (uu___3, r) in
+            FStar_Ident.mk_ident uu___2 in
+          [uu___1] in
+        FStar_All.pipe_right uu___ FStar_Ident.lid_of_ids
 let (op_as_term :
   env_t ->
     Prims.int ->
@@ -249,18 +245,18 @@ let (op_as_term :
     fun arity ->
       fun op ->
         let r l dd =
-          let uu____587 =
-            let uu____588 =
-              let uu____589 =
-                let uu____590 = FStar_Ident.range_of_id op in
-                FStar_Ident.set_lid_range l uu____590 in
-              FStar_Syntax_Syntax.lid_as_fv uu____589 dd
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Ident.range_of_id op in
+                FStar_Ident.set_lid_range l uu___3 in
+              FStar_Syntax_Syntax.lid_as_fv uu___2 dd
                 FStar_Pervasives_Native.None in
-            FStar_All.pipe_right uu____588 FStar_Syntax_Syntax.fv_to_tm in
-          FStar_Pervasives_Native.Some uu____587 in
-        let fallback uu____598 =
-          let uu____599 = FStar_Ident.string_of_id op in
-          match uu____599 with
+            FStar_All.pipe_right uu___1 FStar_Syntax_Syntax.fv_to_tm in
+          FStar_Pervasives_Native.Some uu___ in
+        let fallback uu___ =
+          let uu___1 = FStar_Ident.string_of_id op in
+          match uu___1 with
           | "=" ->
               r FStar_Parser_Const.op_Eq FStar_Syntax_Syntax.delta_equational
           | ":=" ->
@@ -300,8 +296,8 @@ let (op_as_term :
               r FStar_Parser_Const.read_lid
                 FStar_Syntax_Syntax.delta_equational
           | "@" ->
-              let uu____602 = FStar_Options.ml_ish () in
-              if uu____602
+              let uu___2 = FStar_Options.ml_ish () in
+              if uu___2
               then
                 r FStar_Parser_Const.list_append_lid
                   (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -343,42 +339,40 @@ let (op_as_term :
               r FStar_Parser_Const.iff_lid
                 (FStar_Syntax_Syntax.Delta_constant_at_level
                    (Prims.of_int (2)))
-          | uu____606 -> FStar_Pervasives_Native.None in
-        let uu____607 =
-          let uu____610 =
-            let uu____611 = FStar_Ident.string_of_id op in
-            let uu____612 = FStar_Ident.range_of_id op in
-            compile_op_lid arity uu____611 uu____612 in
+          | uu___2 -> FStar_Pervasives_Native.None in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_id op in
+            let uu___3 = FStar_Ident.range_of_id op in
+            compile_op_lid arity uu___2 uu___3 in
           desugar_name'
             (fun t ->
-               let uu___178_620 = t in
-               let uu____621 = FStar_Ident.range_of_id op in
+               let uu___2 = t in
+               let uu___3 = FStar_Ident.range_of_id op in
                {
-                 FStar_Syntax_Syntax.n = (uu___178_620.FStar_Syntax_Syntax.n);
-                 FStar_Syntax_Syntax.pos = uu____621;
-                 FStar_Syntax_Syntax.vars =
-                   (uu___178_620.FStar_Syntax_Syntax.vars)
-               }) env true uu____610 in
-        match uu____607 with
+                 FStar_Syntax_Syntax.n = (uu___2.FStar_Syntax_Syntax.n);
+                 FStar_Syntax_Syntax.pos = uu___3;
+                 FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars)
+               }) env true uu___1 in
+        match uu___ with
         | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
-        | uu____625 -> fallback ()
+        | uu___1 -> fallback ()
 let (sort_ftv : FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list)
   =
   fun ftv ->
-    let uu____639 =
+    let uu___ =
       FStar_Util.remove_dups
         (fun x ->
            fun y ->
-             let uu____648 = FStar_Ident.string_of_id x in
-             let uu____649 = FStar_Ident.string_of_id y in
-             uu____648 = uu____649) ftv in
+             let uu___1 = FStar_Ident.string_of_id x in
+             let uu___2 = FStar_Ident.string_of_id y in uu___1 = uu___2) ftv in
     FStar_All.pipe_left
       (FStar_Util.sort_with
          (fun x ->
             fun y ->
-              let uu____660 = FStar_Ident.string_of_id x in
-              let uu____661 = FStar_Ident.string_of_id y in
-              FStar_String.compare uu____660 uu____661)) uu____639
+              let uu___1 = FStar_Ident.string_of_id x in
+              let uu___2 = FStar_Ident.string_of_id y in
+              FStar_String.compare uu___1 uu___2)) uu___
 let rec (free_type_vars_b :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.binder ->
@@ -387,43 +381,42 @@ let rec (free_type_vars_b :
   fun env ->
     fun binder ->
       match binder.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Variable uu____694 -> (env, [])
+      | FStar_Parser_AST.Variable uu___ -> (env, [])
       | FStar_Parser_AST.TVariable x ->
-          let uu____698 = FStar_Syntax_DsEnv.push_bv env x in
-          (match uu____698 with | (env1, uu____710) -> (env1, [x]))
-      | FStar_Parser_AST.Annotated (uu____713, term) ->
-          let uu____715 = free_type_vars env term in (env, uu____715)
-      | FStar_Parser_AST.TAnnotated (id, uu____721) ->
-          let uu____722 = FStar_Syntax_DsEnv.push_bv env id in
-          (match uu____722 with | (env1, uu____734) -> (env1, []))
+          let uu___ = FStar_Syntax_DsEnv.push_bv env x in
+          (match uu___ with | (env1, uu___1) -> (env1, [x]))
+      | FStar_Parser_AST.Annotated (uu___, term) ->
+          let uu___1 = free_type_vars env term in (env, uu___1)
+      | FStar_Parser_AST.TAnnotated (id, uu___) ->
+          let uu___1 = FStar_Syntax_DsEnv.push_bv env id in
+          (match uu___1 with | (env1, uu___2) -> (env1, []))
       | FStar_Parser_AST.NoName t ->
-          let uu____738 = free_type_vars env t in (env, uu____738)
+          let uu___ = free_type_vars env t in (env, uu___)
 and (free_type_vars :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.term -> FStar_Ident.ident Prims.list)
   =
   fun env ->
     fun t ->
-      let uu____745 =
-        let uu____746 = unparen t in uu____746.FStar_Parser_AST.tm in
-      match uu____745 with
-      | FStar_Parser_AST.Labeled uu____749 ->
+      let uu___ = let uu___1 = unparen t in uu___1.FStar_Parser_AST.tm in
+      match uu___ with
+      | FStar_Parser_AST.Labeled uu___1 ->
           failwith "Impossible --- labeled source term"
       | FStar_Parser_AST.Tvar a ->
-          let uu____759 = FStar_Syntax_DsEnv.try_lookup_id env a in
-          (match uu____759 with
+          let uu___1 = FStar_Syntax_DsEnv.try_lookup_id env a in
+          (match uu___1 with
            | FStar_Pervasives_Native.None -> [a]
-           | uu____764 -> [])
+           | uu___2 -> [])
       | FStar_Parser_AST.Wild -> []
-      | FStar_Parser_AST.Const uu____767 -> []
-      | FStar_Parser_AST.Uvar uu____768 -> []
-      | FStar_Parser_AST.Var uu____769 -> []
-      | FStar_Parser_AST.Projector uu____770 -> []
-      | FStar_Parser_AST.Discrim uu____775 -> []
-      | FStar_Parser_AST.Name uu____776 -> []
-      | FStar_Parser_AST.Requires (t1, uu____778) -> free_type_vars env t1
-      | FStar_Parser_AST.Ensures (t1, uu____784) -> free_type_vars env t1
-      | FStar_Parser_AST.NamedTyp (uu____789, t1) -> free_type_vars env t1
+      | FStar_Parser_AST.Const uu___1 -> []
+      | FStar_Parser_AST.Uvar uu___1 -> []
+      | FStar_Parser_AST.Var uu___1 -> []
+      | FStar_Parser_AST.Projector uu___1 -> []
+      | FStar_Parser_AST.Discrim uu___1 -> []
+      | FStar_Parser_AST.Name uu___1 -> []
+      | FStar_Parser_AST.Requires (t1, uu___1) -> free_type_vars env t1
+      | FStar_Parser_AST.Ensures (t1, uu___1) -> free_type_vars env t1
+      | FStar_Parser_AST.NamedTyp (uu___1, t1) -> free_type_vars env t1
       | FStar_Parser_AST.Paren t1 -> failwith "impossible"
       | FStar_Parser_AST.Ascribed (t1, t', tacopt) ->
           let ts = t1 :: t' ::
@@ -431,93 +424,92 @@ and (free_type_vars :
              | FStar_Pervasives_Native.None -> []
              | FStar_Pervasives_Native.Some t2 -> [t2]) in
           FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.Construct (uu____807, ts) ->
+      | FStar_Parser_AST.Construct (uu___1, ts) ->
           FStar_List.collect
-            (fun uu____828 ->
-               match uu____828 with
-               | (t1, uu____836) -> free_type_vars env t1) ts
-      | FStar_Parser_AST.Op (uu____837, ts) ->
+            (fun uu___2 ->
+               match uu___2 with | (t1, uu___3) -> free_type_vars env t1) ts
+      | FStar_Parser_AST.Op (uu___1, ts) ->
           FStar_List.collect (free_type_vars env) ts
-      | FStar_Parser_AST.App (t1, t2, uu____845) ->
-          let uu____846 = free_type_vars env t1 in
-          let uu____849 = free_type_vars env t2 in
-          FStar_List.append uu____846 uu____849
+      | FStar_Parser_AST.App (t1, t2, uu___1) ->
+          let uu___2 = free_type_vars env t1 in
+          let uu___3 = free_type_vars env t2 in
+          FStar_List.append uu___2 uu___3
       | FStar_Parser_AST.Refine (b, t1) ->
-          let uu____854 = free_type_vars_b env b in
-          (match uu____854 with
+          let uu___1 = free_type_vars_b env b in
+          (match uu___1 with
            | (env1, f) ->
-               let uu____869 = free_type_vars env1 t1 in
-               FStar_List.append f uu____869)
+               let uu___2 = free_type_vars env1 t1 in
+               FStar_List.append f uu___2)
       | FStar_Parser_AST.Sum (binders, body) ->
-          let uu____886 =
+          let uu___1 =
             FStar_List.fold_left
-              (fun uu____910 ->
+              (fun uu___2 ->
                  fun bt ->
-                   match uu____910 with
+                   match uu___2 with
                    | (env1, free) ->
-                       let uu____934 =
+                       let uu___3 =
                          match bt with
                          | FStar_Util.Inl binder ->
                              free_type_vars_b env1 binder
                          | FStar_Util.Inr t1 ->
-                             let uu____949 = free_type_vars env1 body in
-                             (env1, uu____949) in
-                       (match uu____934 with
+                             let uu___4 = free_type_vars env1 body in
+                             (env1, uu___4) in
+                       (match uu___3 with
                         | (env2, f) -> (env2, (FStar_List.append f free))))
               (env, []) binders in
-          (match uu____886 with
+          (match uu___1 with
            | (env1, free) ->
-               let uu____978 = free_type_vars env1 body in
-               FStar_List.append free uu____978)
+               let uu___2 = free_type_vars env1 body in
+               FStar_List.append free uu___2)
       | FStar_Parser_AST.Product (binders, body) ->
-          let uu____987 =
+          let uu___1 =
             FStar_List.fold_left
-              (fun uu____1007 ->
+              (fun uu___2 ->
                  fun binder ->
-                   match uu____1007 with
+                   match uu___2 with
                    | (env1, free) ->
-                       let uu____1027 = free_type_vars_b env1 binder in
-                       (match uu____1027 with
+                       let uu___3 = free_type_vars_b env1 binder in
+                       (match uu___3 with
                         | (env2, f) -> (env2, (FStar_List.append f free))))
               (env, []) binders in
-          (match uu____987 with
+          (match uu___1 with
            | (env1, free) ->
-               let uu____1058 = free_type_vars env1 body in
-               FStar_List.append free uu____1058)
-      | FStar_Parser_AST.Project (t1, uu____1062) -> free_type_vars env t1
+               let uu___2 = free_type_vars env1 body in
+               FStar_List.append free uu___2)
+      | FStar_Parser_AST.Project (t1, uu___1) -> free_type_vars env t1
       | FStar_Parser_AST.Attributes cattributes ->
           FStar_List.collect (free_type_vars env) cattributes
       | FStar_Parser_AST.CalcProof (rel, init, steps) ->
-          let uu____1073 = free_type_vars env rel in
-          let uu____1076 =
-            let uu____1079 = free_type_vars env init in
-            let uu____1082 =
+          let uu___1 = free_type_vars env rel in
+          let uu___2 =
+            let uu___3 = free_type_vars env init in
+            let uu___4 =
               FStar_List.collect
-                (fun uu____1091 ->
-                   match uu____1091 with
+                (fun uu___5 ->
+                   match uu___5 with
                    | FStar_Parser_AST.CalcStep (rel1, just, next) ->
-                       let uu____1097 = free_type_vars env rel1 in
-                       let uu____1100 =
-                         let uu____1103 = free_type_vars env just in
-                         let uu____1106 = free_type_vars env next in
-                         FStar_List.append uu____1103 uu____1106 in
-                       FStar_List.append uu____1097 uu____1100) steps in
-            FStar_List.append uu____1079 uu____1082 in
-          FStar_List.append uu____1073 uu____1076
-      | FStar_Parser_AST.Abs uu____1109 -> []
-      | FStar_Parser_AST.Let uu____1116 -> []
-      | FStar_Parser_AST.LetOpen uu____1137 -> []
-      | FStar_Parser_AST.If uu____1142 -> []
-      | FStar_Parser_AST.QForall uu____1149 -> []
-      | FStar_Parser_AST.QExists uu____1168 -> []
-      | FStar_Parser_AST.Record uu____1187 -> []
-      | FStar_Parser_AST.Match uu____1200 -> []
-      | FStar_Parser_AST.TryWith uu____1215 -> []
-      | FStar_Parser_AST.Bind uu____1230 -> []
-      | FStar_Parser_AST.Quote uu____1237 -> []
-      | FStar_Parser_AST.VQuote uu____1242 -> []
-      | FStar_Parser_AST.Antiquote uu____1243 -> []
-      | FStar_Parser_AST.Seq uu____1244 -> []
+                       let uu___6 = free_type_vars env rel1 in
+                       let uu___7 =
+                         let uu___8 = free_type_vars env just in
+                         let uu___9 = free_type_vars env next in
+                         FStar_List.append uu___8 uu___9 in
+                       FStar_List.append uu___6 uu___7) steps in
+            FStar_List.append uu___3 uu___4 in
+          FStar_List.append uu___1 uu___2
+      | FStar_Parser_AST.Abs uu___1 -> []
+      | FStar_Parser_AST.Let uu___1 -> []
+      | FStar_Parser_AST.LetOpen uu___1 -> []
+      | FStar_Parser_AST.If uu___1 -> []
+      | FStar_Parser_AST.QForall uu___1 -> []
+      | FStar_Parser_AST.QExists uu___1 -> []
+      | FStar_Parser_AST.Record uu___1 -> []
+      | FStar_Parser_AST.Match uu___1 -> []
+      | FStar_Parser_AST.TryWith uu___1 -> []
+      | FStar_Parser_AST.Bind uu___1 -> []
+      | FStar_Parser_AST.Quote uu___1 -> []
+      | FStar_Parser_AST.VQuote uu___1 -> []
+      | FStar_Parser_AST.Antiquote uu___1 -> []
+      | FStar_Parser_AST.Seq uu___1 -> []
 let (head_and_args :
   FStar_Parser_AST.term ->
     (FStar_Parser_AST.term * (FStar_Parser_AST.term * FStar_Parser_AST.imp)
@@ -525,9 +517,8 @@ let (head_and_args :
   =
   fun t ->
     let rec aux args t1 =
-      let uu____1297 =
-        let uu____1298 = unparen t1 in uu____1298.FStar_Parser_AST.tm in
-      match uu____1297 with
+      let uu___ = let uu___1 = unparen t1 in uu___1.FStar_Parser_AST.tm in
+      match uu___ with
       | FStar_Parser_AST.App (t2, arg, imp) -> aux ((arg, imp) :: args) t2
       | FStar_Parser_AST.Construct (l, args') ->
           ({
@@ -535,15 +526,15 @@ let (head_and_args :
              FStar_Parser_AST.range = (t1.FStar_Parser_AST.range);
              FStar_Parser_AST.level = (t1.FStar_Parser_AST.level)
            }, (FStar_List.append args' args))
-      | uu____1340 -> (t1, args) in
+      | uu___1 -> (t1, args) in
     aux [] t
 let (close :
   FStar_Syntax_DsEnv.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun env ->
     fun t ->
       let ftv =
-        let uu____1364 = free_type_vars env t in
-        FStar_All.pipe_left sort_ftv uu____1364 in
+        let uu___ = free_type_vars env t in
+        FStar_All.pipe_left sort_ftv uu___ in
       if (FStar_List.length ftv) = Prims.int_zero
       then t
       else
@@ -551,15 +542,15 @@ let (close :
            FStar_All.pipe_right ftv
              (FStar_List.map
                 (fun x ->
-                   let uu____1383 =
-                     let uu____1384 =
-                       let uu____1389 =
-                         let uu____1390 = FStar_Ident.range_of_id x in
-                         tm_type uu____1390 in
-                       (x, uu____1389) in
-                     FStar_Parser_AST.TAnnotated uu____1384 in
-                   let uu____1391 = FStar_Ident.range_of_id x in
-                   FStar_Parser_AST.mk_binder uu____1383 uu____1391
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = FStar_Ident.range_of_id x in
+                         tm_type uu___4 in
+                       (x, uu___3) in
+                     FStar_Parser_AST.TAnnotated uu___2 in
+                   let uu___2 = FStar_Ident.range_of_id x in
+                   FStar_Parser_AST.mk_binder uu___1 uu___2
                      FStar_Parser_AST.Type_level
                      (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
          let result =
@@ -571,8 +562,8 @@ let (close_fun :
   fun env ->
     fun t ->
       let ftv =
-        let uu____1408 = free_type_vars env t in
-        FStar_All.pipe_left sort_ftv uu____1408 in
+        let uu___ = free_type_vars env t in
+        FStar_All.pipe_left sort_ftv uu___ in
       if (FStar_List.length ftv) = Prims.int_zero
       then t
       else
@@ -580,23 +571,22 @@ let (close_fun :
            FStar_All.pipe_right ftv
              (FStar_List.map
                 (fun x ->
-                   let uu____1427 =
-                     let uu____1428 =
-                       let uu____1433 =
-                         let uu____1434 = FStar_Ident.range_of_id x in
-                         tm_type uu____1434 in
-                       (x, uu____1433) in
-                     FStar_Parser_AST.TAnnotated uu____1428 in
-                   let uu____1435 = FStar_Ident.range_of_id x in
-                   FStar_Parser_AST.mk_binder uu____1427 uu____1435
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = FStar_Ident.range_of_id x in
+                         tm_type uu___4 in
+                       (x, uu___3) in
+                     FStar_Parser_AST.TAnnotated uu___2 in
+                   let uu___2 = FStar_Ident.range_of_id x in
+                   FStar_Parser_AST.mk_binder uu___1 uu___2
                      FStar_Parser_AST.Type_level
                      (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
          let t1 =
-           let uu____1437 =
-             let uu____1438 = unparen t in uu____1438.FStar_Parser_AST.tm in
-           match uu____1437 with
-           | FStar_Parser_AST.Product uu____1439 -> t
-           | uu____1446 ->
+           let uu___1 = let uu___2 = unparen t in uu___2.FStar_Parser_AST.tm in
+           match uu___1 with
+           | FStar_Parser_AST.Product uu___2 -> t
+           | uu___2 ->
                FStar_Parser_AST.mk_term
                  (FStar_Parser_AST.App
                     ((FStar_Parser_AST.mk_term
@@ -619,25 +609,25 @@ let rec (uncurry :
       match t.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (binders, t1) ->
           uncurry (FStar_List.append bs binders) t1
-      | uu____1482 -> (bs, t)
+      | uu___ -> (bs, t)
 let rec (is_var_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
   fun p ->
     match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatWild uu____1490 -> true
-    | FStar_Parser_AST.PatTvar (uu____1493, uu____1494) -> true
-    | FStar_Parser_AST.PatVar (uu____1499, uu____1500) -> true
-    | FStar_Parser_AST.PatAscribed (p1, uu____1506) -> is_var_pattern p1
-    | uu____1519 -> false
+    | FStar_Parser_AST.PatWild uu___ -> true
+    | FStar_Parser_AST.PatTvar (uu___, uu___1) -> true
+    | FStar_Parser_AST.PatVar (uu___, uu___1) -> true
+    | FStar_Parser_AST.PatAscribed (p1, uu___) -> is_var_pattern p1
+    | uu___ -> false
 let rec (is_app_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
   fun p ->
     match p.FStar_Parser_AST.pat with
-    | FStar_Parser_AST.PatAscribed (p1, uu____1526) -> is_app_pattern p1
+    | FStar_Parser_AST.PatAscribed (p1, uu___) -> is_app_pattern p1
     | FStar_Parser_AST.PatApp
-        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu____1539;
-           FStar_Parser_AST.prange = uu____1540;_},
-         uu____1541)
+        ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu___;
+           FStar_Parser_AST.prange = uu___1;_},
+         uu___2)
         -> true
-    | uu____1552 -> false
+    | uu___ -> false
 let (replace_unit_pattern :
   FStar_Parser_AST.pattern -> FStar_Parser_AST.pattern) =
   fun p ->
@@ -650,7 +640,7 @@ let (replace_unit_pattern :
                  p.FStar_Parser_AST.prange),
                ((unit_ty p.FStar_Parser_AST.prange),
                  FStar_Pervasives_Native.None))) p.FStar_Parser_AST.prange
-    | uu____1566 -> p
+    | uu___ -> p
 let rec (destruct_app_pattern :
   env_t ->
     Prims.bool ->
@@ -665,29 +655,25 @@ let rec (destruct_app_pattern :
       fun p ->
         match p.FStar_Parser_AST.pat with
         | FStar_Parser_AST.PatAscribed (p1, t) ->
-            let uu____1636 = destruct_app_pattern env is_top_level p1 in
-            (match uu____1636 with
-             | (name, args, uu____1679) ->
+            let uu___ = destruct_app_pattern env is_top_level p1 in
+            (match uu___ with
+             | (name, args, uu___1) ->
                  (name, args, (FStar_Pervasives_Native.Some t)))
         | FStar_Parser_AST.PatApp
-            ({
-               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                 (id, uu____1729);
-               FStar_Parser_AST.prange = uu____1730;_},
+            ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id, uu___);
+               FStar_Parser_AST.prange = uu___1;_},
              args)
             when is_top_level ->
-            let uu____1740 =
-              let uu____1745 = FStar_Syntax_DsEnv.qualify env id in
-              FStar_Util.Inr uu____1745 in
-            (uu____1740, args, FStar_Pervasives_Native.None)
+            let uu___2 =
+              let uu___3 = FStar_Syntax_DsEnv.qualify env id in
+              FStar_Util.Inr uu___3 in
+            (uu___2, args, FStar_Pervasives_Native.None)
         | FStar_Parser_AST.PatApp
-            ({
-               FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                 (id, uu____1767);
-               FStar_Parser_AST.prange = uu____1768;_},
+            ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (id, uu___);
+               FStar_Parser_AST.prange = uu___1;_},
              args)
             -> ((FStar_Util.Inl id), args, FStar_Pervasives_Native.None)
-        | uu____1798 -> failwith "Not an app pattern"
+        | uu___ -> failwith "Not an app pattern"
 let rec (gather_pattern_bound_vars_maybe_top :
   FStar_Ident.ident FStar_Util.set ->
     FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set)
@@ -697,25 +683,24 @@ let rec (gather_pattern_bound_vars_maybe_top :
       let gather_pattern_bound_vars_from_list =
         FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc in
       match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatWild uu____1848 -> acc
-      | FStar_Parser_AST.PatConst uu____1851 -> acc
-      | FStar_Parser_AST.PatName uu____1852 -> acc
-      | FStar_Parser_AST.PatOp uu____1853 -> acc
+      | FStar_Parser_AST.PatWild uu___ -> acc
+      | FStar_Parser_AST.PatConst uu___ -> acc
+      | FStar_Parser_AST.PatName uu___ -> acc
+      | FStar_Parser_AST.PatOp uu___ -> acc
       | FStar_Parser_AST.PatApp (phead, pats) ->
           gather_pattern_bound_vars_from_list (phead :: pats)
-      | FStar_Parser_AST.PatTvar (x, uu____1861) -> FStar_Util.set_add x acc
-      | FStar_Parser_AST.PatVar (x, uu____1867) -> FStar_Util.set_add x acc
+      | FStar_Parser_AST.PatTvar (x, uu___) -> FStar_Util.set_add x acc
+      | FStar_Parser_AST.PatVar (x, uu___) -> FStar_Util.set_add x acc
       | FStar_Parser_AST.PatList pats ->
           gather_pattern_bound_vars_from_list pats
-      | FStar_Parser_AST.PatTuple (pats, uu____1876) ->
+      | FStar_Parser_AST.PatTuple (pats, uu___) ->
           gather_pattern_bound_vars_from_list pats
       | FStar_Parser_AST.PatOr pats ->
           gather_pattern_bound_vars_from_list pats
       | FStar_Parser_AST.PatRecord guarded_pats ->
-          let uu____1891 =
-            FStar_List.map FStar_Pervasives_Native.snd guarded_pats in
-          gather_pattern_bound_vars_from_list uu____1891
-      | FStar_Parser_AST.PatAscribed (pat, uu____1899) ->
+          let uu___ = FStar_List.map FStar_Pervasives_Native.snd guarded_pats in
+          gather_pattern_bound_vars_from_list uu___
+      | FStar_Parser_AST.PatAscribed (pat, uu___) ->
           gather_pattern_bound_vars_maybe_top acc pat
 let (gather_pattern_bound_vars :
   FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set) =
@@ -723,11 +708,10 @@ let (gather_pattern_bound_vars :
     FStar_Util.new_set
       (fun id1 ->
          fun id2 ->
-           let uu____1926 =
-             let uu____1927 = FStar_Ident.string_of_id id1 in
-             let uu____1928 = FStar_Ident.string_of_id id2 in
-             uu____1927 = uu____1928 in
-           if uu____1926 then Prims.int_zero else Prims.int_one) in
+           let uu___ =
+             let uu___1 = FStar_Ident.string_of_id id1 in
+             let uu___2 = FStar_Ident.string_of_id id2 in uu___1 = uu___2 in
+           if uu___ then Prims.int_zero else Prims.int_one) in
   fun p -> gather_pattern_bound_vars_maybe_top acc p
 type bnd =
   | LocalBinder of (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual) 
@@ -735,13 +719,13 @@ type bnd =
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)) 
 let (uu___is_LocalBinder : bnd -> Prims.bool) =
   fun projectee ->
-    match projectee with | LocalBinder _0 -> true | uu____1965 -> false
+    match projectee with | LocalBinder _0 -> true | uu___ -> false
 let (__proj__LocalBinder__item___0 :
   bnd -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)) =
   fun projectee -> match projectee with | LocalBinder _0 -> _0
 let (uu___is_LetBinder : bnd -> Prims.bool) =
   fun projectee ->
-    match projectee with | LetBinder _0 -> true | uu____2000 -> false
+    match projectee with | LetBinder _0 -> true | uu___ -> false
 let (__proj__LetBinder__item___0 :
   bnd ->
     (FStar_Ident.lident * (FStar_Syntax_Syntax.term *
@@ -751,16 +735,16 @@ let (is_implicit : bnd -> Prims.bool) =
   fun b ->
     match b with
     | LocalBinder
-        (uu____2042, FStar_Pervasives_Native.Some
-         (FStar_Syntax_Syntax.Implicit uu____2043))
+        (uu___, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
+         uu___1))
         -> true
-    | uu____2044 -> false
+    | uu___ -> false
 let (binder_of_bnd :
   bnd -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.aqual)) =
-  fun uu___3_2053 ->
-    match uu___3_2053 with
+  fun uu___ ->
+    match uu___ with
     | LocalBinder (a, aq) -> (a, aq)
-    | uu____2060 -> failwith "Impossible"
+    | uu___1 -> failwith "Impossible"
 let (mk_lb :
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list *
     (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either *
@@ -768,8 +752,8 @@ let (mk_lb :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax * FStar_Range.range)
     -> FStar_Syntax_Syntax.letbinding)
   =
-  fun uu____2091 ->
-    match uu____2091 with
+  fun uu___ ->
+    match uu___ with
     | (attrs, n, t, e, pos) ->
         {
           FStar_Syntax_Syntax.lbname = n;
@@ -792,19 +776,19 @@ let (mk_ref_read :
   =
   fun tm ->
     let tm' =
-      let uu____2171 =
-        let uu____2188 =
-          let uu____2191 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.sread_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-          FStar_Syntax_Syntax.fv_to_tm uu____2191 in
-        let uu____2192 =
-          let uu____2203 =
-            let uu____2212 = FStar_Syntax_Syntax.as_implicit false in
-            (tm, uu____2212) in
-          [uu____2203] in
-        (uu____2188, uu____2192) in
-      FStar_Syntax_Syntax.Tm_app uu____2171 in
+          FStar_Syntax_Syntax.fv_to_tm uu___2 in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Syntax.as_implicit false in
+            (tm, uu___4) in
+          [uu___3] in
+        (uu___1, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___ in
     FStar_Syntax_Syntax.mk tm' tm.FStar_Syntax_Syntax.pos
 let (mk_ref_alloc :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -812,19 +796,19 @@ let (mk_ref_alloc :
   =
   fun tm ->
     let tm' =
-      let uu____2259 =
-        let uu____2276 =
-          let uu____2279 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.salloc_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-          FStar_Syntax_Syntax.fv_to_tm uu____2279 in
-        let uu____2280 =
-          let uu____2291 =
-            let uu____2300 = FStar_Syntax_Syntax.as_implicit false in
-            (tm, uu____2300) in
-          [uu____2291] in
-        (uu____2276, uu____2280) in
-      FStar_Syntax_Syntax.Tm_app uu____2259 in
+          FStar_Syntax_Syntax.fv_to_tm uu___2 in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Syntax.as_implicit false in
+            (tm, uu___4) in
+          [uu___3] in
+        (uu___1, uu___2) in
+      FStar_Syntax_Syntax.Tm_app uu___ in
     FStar_Syntax_Syntax.mk tm' tm.FStar_Syntax_Syntax.pos
 let (mk_ref_assign :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -836,342 +820,308 @@ let (mk_ref_assign :
     fun t2 ->
       fun pos ->
         let tm =
-          let uu____2361 =
-            let uu____2378 =
-              let uu____2381 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
                 FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.swrite_lid
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
-              FStar_Syntax_Syntax.fv_to_tm uu____2381 in
-            let uu____2382 =
-              let uu____2393 =
-                let uu____2402 = FStar_Syntax_Syntax.as_implicit false in
-                (t1, uu____2402) in
-              let uu____2409 =
-                let uu____2420 =
-                  let uu____2429 = FStar_Syntax_Syntax.as_implicit false in
-                  (t2, uu____2429) in
-                [uu____2420] in
-              uu____2393 :: uu____2409 in
-            (uu____2378, uu____2382) in
-          FStar_Syntax_Syntax.Tm_app uu____2361 in
+              FStar_Syntax_Syntax.fv_to_tm uu___2 in
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Syntax.as_implicit false in
+                (t1, uu___4) in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 = FStar_Syntax_Syntax.as_implicit false in
+                  (t2, uu___6) in
+                [uu___5] in
+              uu___3 :: uu___4 in
+            (uu___1, uu___2) in
+          FStar_Syntax_Syntax.Tm_app uu___ in
         FStar_Syntax_Syntax.mk tm pos
 let rec (generalize_annotated_univs :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
   fun s ->
     let bs_univnames bs =
-      let uu____2487 =
-        let uu____2502 =
-          FStar_Util.new_set FStar_Syntax_Syntax.order_univ_name in
+      let uu___ =
+        let uu___1 = FStar_Util.new_set FStar_Syntax_Syntax.order_univ_name in
         FStar_List.fold_left
           (fun uvs ->
-             fun uu____2521 ->
-               match uu____2521 with
-               | ({ FStar_Syntax_Syntax.ppname = uu____2532;
-                    FStar_Syntax_Syntax.index = uu____2533;
+             fun uu___2 ->
+               match uu___2 with
+               | ({ FStar_Syntax_Syntax.ppname = uu___3;
+                    FStar_Syntax_Syntax.index = uu___4;
                     FStar_Syntax_Syntax.sort = t;_},
-                  uu____2535) ->
-                   let uu____2542 = FStar_Syntax_Free.univnames t in
-                   FStar_Util.set_union uvs uu____2542) uu____2502 in
-      FStar_All.pipe_right bs uu____2487 in
+                  uu___5) ->
+                   let uu___6 = FStar_Syntax_Free.univnames t in
+                   FStar_Util.set_union uvs uu___6) uu___1 in
+      FStar_All.pipe_right bs uu___ in
     let empty_set = FStar_Util.new_set FStar_Syntax_Syntax.order_univ_name in
     match s.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_inductive_typ uu____2558 ->
+    | FStar_Syntax_Syntax.Sig_inductive_typ uu___ ->
         failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
-    | FStar_Syntax_Syntax.Sig_datacon uu____2575 ->
+    | FStar_Syntax_Syntax.Sig_datacon uu___ ->
         failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
     | FStar_Syntax_Syntax.Sig_bundle (sigs, lids) ->
         let uvs =
-          let uu____2601 =
+          let uu___ =
             FStar_All.pipe_right sigs
               (FStar_List.fold_left
-                 (fun uvs ->
+                 (fun uvs1 ->
                     fun se ->
                       let se_univs =
                         match se.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_inductive_typ
-                            (uu____2622, uu____2623, bs, t, uu____2626,
-                             uu____2627)
-                            ->
-                            let uu____2636 = bs_univnames bs in
-                            let uu____2639 = FStar_Syntax_Free.univnames t in
-                            FStar_Util.set_union uu____2636 uu____2639
+                            (uu___1, uu___2, bs, t, uu___3, uu___4) ->
+                            let uu___5 = bs_univnames bs in
+                            let uu___6 = FStar_Syntax_Free.univnames t in
+                            FStar_Util.set_union uu___5 uu___6
                         | FStar_Syntax_Syntax.Sig_datacon
-                            (uu____2642, uu____2643, t, uu____2645,
-                             uu____2646, uu____2647)
-                            -> FStar_Syntax_Free.univnames t
-                        | uu____2652 ->
+                            (uu___1, uu___2, t, uu___3, uu___4, uu___5) ->
+                            FStar_Syntax_Free.univnames t
+                        | uu___1 ->
                             failwith
                               "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt" in
-                      FStar_Util.set_union uvs se_univs) empty_set) in
-          FStar_All.pipe_right uu____2601 FStar_Util.set_elements in
+                      FStar_Util.set_union uvs1 se_univs) empty_set) in
+          FStar_All.pipe_right uu___ FStar_Util.set_elements in
         let usubst = FStar_Syntax_Subst.univ_var_closing uvs in
-        let uu___565_2660 = s in
-        let uu____2661 =
-          let uu____2662 =
-            let uu____2671 =
+        let uu___ = s in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
               FStar_All.pipe_right sigs
                 (FStar_List.map
                    (fun se ->
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_inductive_typ
-                          (lid, uu____2689, bs, t, lids1, lids2) ->
-                          let uu___576_2702 = se in
-                          let uu____2703 =
-                            let uu____2704 =
-                              let uu____2721 =
+                          (lid, uu___4, bs, t, lids1, lids2) ->
+                          let uu___5 = se in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_Syntax_Subst.subst_binders usubst bs in
-                              let uu____2722 =
-                                let uu____2723 =
+                              let uu___9 =
+                                let uu___10 =
                                   FStar_Syntax_Subst.shift_subst
                                     (FStar_List.length bs) usubst in
-                                FStar_Syntax_Subst.subst uu____2723 t in
-                              (lid, uvs, uu____2721, uu____2722, lids1,
-                                lids2) in
-                            FStar_Syntax_Syntax.Sig_inductive_typ uu____2704 in
+                                FStar_Syntax_Subst.subst uu___10 t in
+                              (lid, uvs, uu___8, uu___9, lids1, lids2) in
+                            FStar_Syntax_Syntax.Sig_inductive_typ uu___7 in
                           {
-                            FStar_Syntax_Syntax.sigel = uu____2703;
+                            FStar_Syntax_Syntax.sigel = uu___6;
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___576_2702.FStar_Syntax_Syntax.sigrng);
+                              (uu___5.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
-                              (uu___576_2702.FStar_Syntax_Syntax.sigquals);
+                              (uu___5.FStar_Syntax_Syntax.sigquals);
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___576_2702.FStar_Syntax_Syntax.sigmeta);
+                              (uu___5.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___576_2702.FStar_Syntax_Syntax.sigattrs);
+                              (uu___5.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___576_2702.FStar_Syntax_Syntax.sigopts)
+                              (uu___5.FStar_Syntax_Syntax.sigopts)
                           }
                       | FStar_Syntax_Syntax.Sig_datacon
-                          (lid, uu____2737, t, tlid, n, lids1) ->
-                          let uu___586_2746 = se in
-                          let uu____2747 =
-                            let uu____2748 =
-                              let uu____2763 =
-                                FStar_Syntax_Subst.subst usubst t in
-                              (lid, uvs, uu____2763, tlid, n, lids1) in
-                            FStar_Syntax_Syntax.Sig_datacon uu____2748 in
+                          (lid, uu___4, t, tlid, n, lids1) ->
+                          let uu___5 = se in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 = FStar_Syntax_Subst.subst usubst t in
+                              (lid, uvs, uu___8, tlid, n, lids1) in
+                            FStar_Syntax_Syntax.Sig_datacon uu___7 in
                           {
-                            FStar_Syntax_Syntax.sigel = uu____2747;
+                            FStar_Syntax_Syntax.sigel = uu___6;
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___586_2746.FStar_Syntax_Syntax.sigrng);
+                              (uu___5.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
-                              (uu___586_2746.FStar_Syntax_Syntax.sigquals);
+                              (uu___5.FStar_Syntax_Syntax.sigquals);
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___586_2746.FStar_Syntax_Syntax.sigmeta);
+                              (uu___5.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___586_2746.FStar_Syntax_Syntax.sigattrs);
+                              (uu___5.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___586_2746.FStar_Syntax_Syntax.sigopts)
+                              (uu___5.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____2766 ->
+                      | uu___4 ->
                           failwith
                             "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt")) in
-            (uu____2671, lids) in
-          FStar_Syntax_Syntax.Sig_bundle uu____2662 in
+            (uu___3, lids) in
+          FStar_Syntax_Syntax.Sig_bundle uu___2 in
         {
-          FStar_Syntax_Syntax.sigel = uu____2661;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___565_2660.FStar_Syntax_Syntax.sigrng);
-          FStar_Syntax_Syntax.sigquals =
-            (uu___565_2660.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___565_2660.FStar_Syntax_Syntax.sigmeta);
-          FStar_Syntax_Syntax.sigattrs =
-            (uu___565_2660.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___565_2660.FStar_Syntax_Syntax.sigopts)
+          FStar_Syntax_Syntax.sigel = uu___1;
+          FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigquals = (uu___.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
+          FStar_Syntax_Syntax.sigattrs = (uu___.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____2772, t) ->
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___, t) ->
         let uvs =
-          let uu____2775 = FStar_Syntax_Free.univnames t in
-          FStar_All.pipe_right uu____2775 FStar_Util.set_elements in
-        let uu___595_2780 = s in
-        let uu____2781 =
-          let uu____2782 =
-            let uu____2789 = FStar_Syntax_Subst.close_univ_vars uvs t in
-            (lid, uvs, uu____2789) in
-          FStar_Syntax_Syntax.Sig_declare_typ uu____2782 in
+          let uu___1 = FStar_Syntax_Free.univnames t in
+          FStar_All.pipe_right uu___1 FStar_Util.set_elements in
+        let uu___1 = s in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Subst.close_univ_vars uvs t in
+            (lid, uvs, uu___4) in
+          FStar_Syntax_Syntax.Sig_declare_typ uu___3 in
         {
-          FStar_Syntax_Syntax.sigel = uu____2781;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___595_2780.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigel = uu___2;
+          FStar_Syntax_Syntax.sigrng = (uu___1.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___595_2780.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___595_2780.FStar_Syntax_Syntax.sigmeta);
+            (uu___1.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___1.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___595_2780.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___595_2780.FStar_Syntax_Syntax.sigopts)
+            (uu___1.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___1.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_let ((b, lbs), lids) ->
         let lb_univnames lb =
-          let uu____2811 =
+          let uu___ =
             FStar_Syntax_Free.univnames lb.FStar_Syntax_Syntax.lbtyp in
-          let uu____2814 =
+          let uu___1 =
             match (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_abs (bs, e, uu____2821) ->
+            | FStar_Syntax_Syntax.Tm_abs (bs, e, uu___2) ->
                 let uvs1 = bs_univnames bs in
                 let uvs2 =
                   match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_ascribed
-                      (uu____2854, (FStar_Util.Inl t, uu____2856),
-                       uu____2857)
-                      -> FStar_Syntax_Free.univnames t
+                      (uu___3, (FStar_Util.Inl t, uu___4), uu___5) ->
+                      FStar_Syntax_Free.univnames t
                   | FStar_Syntax_Syntax.Tm_ascribed
-                      (uu____2904, (FStar_Util.Inr c, uu____2906),
-                       uu____2907)
-                      -> FStar_Syntax_Free.univnames_comp c
-                  | uu____2954 -> empty_set in
+                      (uu___3, (FStar_Util.Inr c, uu___4), uu___5) ->
+                      FStar_Syntax_Free.univnames_comp c
+                  | uu___3 -> empty_set in
                 FStar_Util.set_union uvs1 uvs2
-            | FStar_Syntax_Syntax.Tm_arrow (bs, uu____2956) ->
-                bs_univnames bs
+            | FStar_Syntax_Syntax.Tm_arrow (bs, uu___2) -> bs_univnames bs
             | FStar_Syntax_Syntax.Tm_ascribed
-                (uu____2977, (FStar_Util.Inl t, uu____2979), uu____2980) ->
+                (uu___2, (FStar_Util.Inl t, uu___3), uu___4) ->
                 FStar_Syntax_Free.univnames t
             | FStar_Syntax_Syntax.Tm_ascribed
-                (uu____3027, (FStar_Util.Inr c, uu____3029), uu____3030) ->
+                (uu___2, (FStar_Util.Inr c, uu___3), uu___4) ->
                 FStar_Syntax_Free.univnames_comp c
-            | uu____3077 -> empty_set in
-          FStar_Util.set_union uu____2811 uu____2814 in
+            | uu___2 -> empty_set in
+          FStar_Util.set_union uu___ uu___1 in
         let all_lb_univs =
-          let uu____3081 =
+          let uu___ =
             FStar_All.pipe_right lbs
               (FStar_List.fold_left
                  (fun uvs ->
                     fun lb ->
-                      let uu____3097 = lb_univnames lb in
-                      FStar_Util.set_union uvs uu____3097) empty_set) in
-          FStar_All.pipe_right uu____3081 FStar_Util.set_elements in
+                      let uu___1 = lb_univnames lb in
+                      FStar_Util.set_union uvs uu___1) empty_set) in
+          FStar_All.pipe_right uu___ FStar_Util.set_elements in
         let usubst = FStar_Syntax_Subst.univ_var_closing all_lb_univs in
-        let uu___654_3107 = s in
-        let uu____3108 =
-          let uu____3109 =
-            let uu____3116 =
-              let uu____3117 =
+        let uu___ = s in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
                 FStar_All.pipe_right lbs
                   (FStar_List.map
                      (fun lb ->
-                        let uu___657_3129 = lb in
-                        let uu____3130 =
+                        let uu___5 = lb in
+                        let uu___6 =
                           FStar_Syntax_Subst.subst usubst
                             lb.FStar_Syntax_Syntax.lbtyp in
-                        let uu____3133 =
+                        let uu___7 =
                           FStar_Syntax_Subst.subst usubst
                             lb.FStar_Syntax_Syntax.lbdef in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___657_3129.FStar_Syntax_Syntax.lbname);
+                            (uu___5.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = all_lb_univs;
-                          FStar_Syntax_Syntax.lbtyp = uu____3130;
+                          FStar_Syntax_Syntax.lbtyp = uu___6;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___657_3129.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____3133;
+                            (uu___5.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu___7;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___657_3129.FStar_Syntax_Syntax.lbattrs);
+                            (uu___5.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___657_3129.FStar_Syntax_Syntax.lbpos)
+                            (uu___5.FStar_Syntax_Syntax.lbpos)
                         })) in
-              (b, uu____3117) in
-            (uu____3116, lids) in
-          FStar_Syntax_Syntax.Sig_let uu____3109 in
+              (b, uu___4) in
+            (uu___3, lids) in
+          FStar_Syntax_Syntax.Sig_let uu___2 in
         {
-          FStar_Syntax_Syntax.sigel = uu____3108;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___654_3107.FStar_Syntax_Syntax.sigrng);
-          FStar_Syntax_Syntax.sigquals =
-            (uu___654_3107.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___654_3107.FStar_Syntax_Syntax.sigmeta);
-          FStar_Syntax_Syntax.sigattrs =
-            (uu___654_3107.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___654_3107.FStar_Syntax_Syntax.sigopts)
+          FStar_Syntax_Syntax.sigel = uu___1;
+          FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigquals = (uu___.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
+          FStar_Syntax_Syntax.sigattrs = (uu___.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_assume (lid, uu____3141, fml) ->
+    | FStar_Syntax_Syntax.Sig_assume (lid, uu___, fml) ->
         let uvs =
-          let uu____3144 = FStar_Syntax_Free.univnames fml in
-          FStar_All.pipe_right uu____3144 FStar_Util.set_elements in
-        let uu___665_3149 = s in
-        let uu____3150 =
-          let uu____3151 =
-            let uu____3158 = FStar_Syntax_Subst.close_univ_vars uvs fml in
-            (lid, uvs, uu____3158) in
-          FStar_Syntax_Syntax.Sig_assume uu____3151 in
+          let uu___1 = FStar_Syntax_Free.univnames fml in
+          FStar_All.pipe_right uu___1 FStar_Util.set_elements in
+        let uu___1 = s in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Subst.close_univ_vars uvs fml in
+            (lid, uvs, uu___4) in
+          FStar_Syntax_Syntax.Sig_assume uu___3 in
         {
-          FStar_Syntax_Syntax.sigel = uu____3150;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___665_3149.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigel = uu___2;
+          FStar_Syntax_Syntax.sigrng = (uu___1.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___665_3149.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___665_3149.FStar_Syntax_Syntax.sigmeta);
+            (uu___1.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___1.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___665_3149.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___665_3149.FStar_Syntax_Syntax.sigopts)
+            (uu___1.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___1.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uu____3160, bs, c, flags)
-        ->
+    | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uu___, bs, c, flags) ->
         let uvs =
-          let uu____3169 =
-            let uu____3172 = bs_univnames bs in
-            let uu____3175 = FStar_Syntax_Free.univnames_comp c in
-            FStar_Util.set_union uu____3172 uu____3175 in
-          FStar_All.pipe_right uu____3169 FStar_Util.set_elements in
+          let uu___1 =
+            let uu___2 = bs_univnames bs in
+            let uu___3 = FStar_Syntax_Free.univnames_comp c in
+            FStar_Util.set_union uu___2 uu___3 in
+          FStar_All.pipe_right uu___1 FStar_Util.set_elements in
         let usubst = FStar_Syntax_Subst.univ_var_closing uvs in
-        let uu___676_3183 = s in
-        let uu____3184 =
-          let uu____3185 =
-            let uu____3198 = FStar_Syntax_Subst.subst_binders usubst bs in
-            let uu____3199 = FStar_Syntax_Subst.subst_comp usubst c in
-            (lid, uvs, uu____3198, uu____3199, flags) in
-          FStar_Syntax_Syntax.Sig_effect_abbrev uu____3185 in
+        let uu___1 = s in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Syntax_Subst.subst_binders usubst bs in
+            let uu___5 = FStar_Syntax_Subst.subst_comp usubst c in
+            (lid, uvs, uu___4, uu___5, flags) in
+          FStar_Syntax_Syntax.Sig_effect_abbrev uu___3 in
         {
-          FStar_Syntax_Syntax.sigel = uu____3184;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___676_3183.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigel = uu___2;
+          FStar_Syntax_Syntax.sigrng = (uu___1.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals =
-            (uu___676_3183.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___676_3183.FStar_Syntax_Syntax.sigmeta);
+            (uu___1.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___1.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs =
-            (uu___676_3183.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___676_3183.FStar_Syntax_Syntax.sigopts)
+            (uu___1.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___1.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_fail (errs, lax, ses) ->
-        let uu___683_3213 = s in
-        let uu____3214 =
-          let uu____3215 =
-            let uu____3226 = FStar_List.map generalize_annotated_univs ses in
-            (errs, lax, uu____3226) in
-          FStar_Syntax_Syntax.Sig_fail uu____3215 in
+        let uu___ = s in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_List.map generalize_annotated_univs ses in
+            (errs, lax, uu___3) in
+          FStar_Syntax_Syntax.Sig_fail uu___2 in
         {
-          FStar_Syntax_Syntax.sigel = uu____3214;
-          FStar_Syntax_Syntax.sigrng =
-            (uu___683_3213.FStar_Syntax_Syntax.sigrng);
-          FStar_Syntax_Syntax.sigquals =
-            (uu___683_3213.FStar_Syntax_Syntax.sigquals);
-          FStar_Syntax_Syntax.sigmeta =
-            (uu___683_3213.FStar_Syntax_Syntax.sigmeta);
-          FStar_Syntax_Syntax.sigattrs =
-            (uu___683_3213.FStar_Syntax_Syntax.sigattrs);
-          FStar_Syntax_Syntax.sigopts =
-            (uu___683_3213.FStar_Syntax_Syntax.sigopts)
+          FStar_Syntax_Syntax.sigel = uu___1;
+          FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
+          FStar_Syntax_Syntax.sigquals = (uu___.FStar_Syntax_Syntax.sigquals);
+          FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
+          FStar_Syntax_Syntax.sigattrs = (uu___.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
         }
-    | FStar_Syntax_Syntax.Sig_new_effect uu____3233 -> s
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____3234 -> s
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3235 -> s
-    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____3246 -> s
-    | FStar_Syntax_Syntax.Sig_splice uu____3255 -> s
-    | FStar_Syntax_Syntax.Sig_pragma uu____3262 -> s
+    | FStar_Syntax_Syntax.Sig_new_effect uu___ -> s
+    | FStar_Syntax_Syntax.Sig_sub_effect uu___ -> s
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___ -> s
+    | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___ -> s
+    | FStar_Syntax_Syntax.Sig_splice uu___ -> s
+    | FStar_Syntax_Syntax.Sig_pragma uu___ -> s
 let (is_special_effect_combinator : Prims.string -> Prims.bool) =
-  fun uu___4_3267 ->
-    match uu___4_3267 with
+  fun uu___ ->
+    match uu___ with
     | "lift1" -> true
     | "lift2" -> true
     | "pure" -> true
@@ -1195,7 +1145,7 @@ let (is_special_effect_combinator : Prims.string -> Prims.bool) =
     | "post" -> true
     | "pre" -> true
     | "wp" -> true
-    | uu____3268 -> false
+    | uu___1 -> false
 let rec (sum_to_universe :
   FStar_Syntax_Syntax.universe -> Prims.int -> FStar_Syntax_Syntax.universe)
   =
@@ -1204,8 +1154,8 @@ let rec (sum_to_universe :
       if n = Prims.int_zero
       then u
       else
-        (let uu____3280 = sum_to_universe u (n - Prims.int_one) in
-         FStar_Syntax_Syntax.U_succ uu____3280)
+        (let uu___1 = sum_to_universe u (n - Prims.int_one) in
+         FStar_Syntax_Syntax.U_succ uu___1)
 let (int_to_universe : Prims.int -> FStar_Syntax_Syntax.universe) =
   fun n -> sum_to_universe FStar_Syntax_Syntax.U_zero n
 let rec (desugar_maybe_non_constant_universe :
@@ -1213,13 +1163,12 @@ let rec (desugar_maybe_non_constant_universe :
     (Prims.int, FStar_Syntax_Syntax.universe) FStar_Util.either)
   =
   fun t ->
-    let uu____3299 =
-      let uu____3300 = unparen t in uu____3300.FStar_Parser_AST.tm in
-    match uu____3299 with
+    let uu___ = let uu___1 = unparen t in uu___1.FStar_Parser_AST.tm in
+    match uu___ with
     | FStar_Parser_AST.Wild -> FStar_Util.Inr FStar_Syntax_Syntax.U_unknown
     | FStar_Parser_AST.Uvar u ->
         FStar_Util.Inr (FStar_Syntax_Syntax.U_name u)
-    | FStar_Parser_AST.Const (FStar_Const.Const_int (repr, uu____3307)) ->
+    | FStar_Parser_AST.Const (FStar_Const.Const_int (repr, uu___1)) ->
         let n = FStar_Util.int_of_string repr in
         (if n < Prims.int_zero
          then
@@ -1236,78 +1185,75 @@ let rec (desugar_maybe_non_constant_universe :
         (match (u1, u2) with
          | (FStar_Util.Inl n1, FStar_Util.Inl n2) -> FStar_Util.Inl (n1 + n2)
          | (FStar_Util.Inl n, FStar_Util.Inr u) ->
-             let uu____3372 = sum_to_universe u n in
-             FStar_Util.Inr uu____3372
+             let uu___2 = sum_to_universe u n in FStar_Util.Inr uu___2
          | (FStar_Util.Inr u, FStar_Util.Inl n) ->
-             let uu____3383 = sum_to_universe u n in
-             FStar_Util.Inr uu____3383
+             let uu___2 = sum_to_universe u n in FStar_Util.Inr uu___2
          | (FStar_Util.Inr u11, FStar_Util.Inr u21) ->
-             let uu____3394 =
-               let uu____3399 =
-                 let uu____3400 = FStar_Parser_AST.term_to_string t in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Parser_AST.term_to_string t in
                  Prims.op_Hat
                    "This universe might contain a sum of two universe variables "
-                   uu____3400 in
+                   uu___4 in
                (FStar_Errors.Fatal_UniverseMightContainSumOfTwoUnivVars,
-                 uu____3399) in
-             FStar_Errors.raise_error uu____3394 t.FStar_Parser_AST.range)
-    | FStar_Parser_AST.App uu____3405 ->
+                 uu___3) in
+             FStar_Errors.raise_error uu___2 t.FStar_Parser_AST.range)
+    | FStar_Parser_AST.App uu___1 ->
         let rec aux t1 univargs =
-          let uu____3439 =
-            let uu____3440 = unparen t1 in uu____3440.FStar_Parser_AST.tm in
-          match uu____3439 with
-          | FStar_Parser_AST.App (t2, targ, uu____3447) ->
+          let uu___2 = let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
+          match uu___2 with
+          | FStar_Parser_AST.App (t2, targ, uu___3) ->
               let uarg = desugar_maybe_non_constant_universe targ in
               aux t2 (uarg :: univargs)
           | FStar_Parser_AST.Var max_lid ->
               if
                 FStar_List.existsb
-                  (fun uu___5_3470 ->
-                     match uu___5_3470 with
-                     | FStar_Util.Inr uu____3475 -> true
-                     | uu____3476 -> false) univargs
+                  (fun uu___4 ->
+                     match uu___4 with
+                     | FStar_Util.Inr uu___5 -> true
+                     | uu___5 -> false) univargs
               then
-                let uu____3481 =
-                  let uu____3482 =
+                let uu___4 =
+                  let uu___5 =
                     FStar_List.map
-                      (fun uu___6_3491 ->
-                         match uu___6_3491 with
+                      (fun uu___6 ->
+                         match uu___6 with
                          | FStar_Util.Inl n -> int_to_universe n
                          | FStar_Util.Inr u -> u) univargs in
-                  FStar_Syntax_Syntax.U_max uu____3482 in
-                FStar_Util.Inr uu____3481
+                  FStar_Syntax_Syntax.U_max uu___5 in
+                FStar_Util.Inr uu___4
               else
                 (let nargs =
                    FStar_List.map
-                     (fun uu___7_3508 ->
-                        match uu___7_3508 with
+                     (fun uu___5 ->
+                        match uu___5 with
                         | FStar_Util.Inl n -> n
-                        | FStar_Util.Inr uu____3514 -> failwith "impossible")
+                        | FStar_Util.Inr uu___6 -> failwith "impossible")
                      univargs in
-                 let uu____3515 =
+                 let uu___5 =
                    FStar_List.fold_left
                      (fun m -> fun n -> if m > n then m else n)
                      Prims.int_zero nargs in
-                 FStar_Util.Inl uu____3515)
-          | uu____3521 ->
-              let uu____3522 =
-                let uu____3527 =
-                  let uu____3528 =
-                    let uu____3529 = FStar_Parser_AST.term_to_string t1 in
-                    Prims.op_Hat uu____3529 " in universe context" in
-                  Prims.op_Hat "Unexpected term " uu____3528 in
-                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____3527) in
-              FStar_Errors.raise_error uu____3522 t1.FStar_Parser_AST.range in
+                 FStar_Util.Inl uu___5)
+          | uu___3 ->
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 = FStar_Parser_AST.term_to_string t1 in
+                    Prims.op_Hat uu___7 " in universe context" in
+                  Prims.op_Hat "Unexpected term " uu___6 in
+                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu___5) in
+              FStar_Errors.raise_error uu___4 t1.FStar_Parser_AST.range in
         aux t []
-    | uu____3538 ->
-        let uu____3539 =
-          let uu____3544 =
-            let uu____3545 =
-              let uu____3546 = FStar_Parser_AST.term_to_string t in
-              Prims.op_Hat uu____3546 " in universe context" in
-            Prims.op_Hat "Unexpected term " uu____3545 in
-          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____3544) in
-        FStar_Errors.raise_error uu____3539 t.FStar_Parser_AST.range
+    | uu___1 ->
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = FStar_Parser_AST.term_to_string t in
+              Prims.op_Hat uu___5 " in universe context" in
+            Prims.op_Hat "Unexpected term " uu___4 in
+          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu___3) in
+        FStar_Errors.raise_error uu___2 t.FStar_Parser_AST.range
 let (desugar_universe :
   FStar_Parser_AST.term -> FStar_Syntax_Syntax.universe) =
   fun t ->
@@ -1324,60 +1270,60 @@ let (check_no_aq : FStar_Syntax_Syntax.antiquotations -> unit) =
          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_quoted
            (e,
             { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
-              FStar_Syntax_Syntax.antiquotes = uu____3576;_});
-         FStar_Syntax_Syntax.pos = uu____3577;
-         FStar_Syntax_Syntax.vars = uu____3578;_})::uu____3579
+              FStar_Syntax_Syntax.antiquotes = uu___;_});
+         FStar_Syntax_Syntax.pos = uu___1;
+         FStar_Syntax_Syntax.vars = uu___2;_})::uu___3
         ->
-        let uu____3610 =
-          let uu____3615 =
-            let uu____3616 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "Unexpected antiquotation: `@(%s)" uu____3616 in
-          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____3615) in
-        FStar_Errors.raise_error uu____3610 e.FStar_Syntax_Syntax.pos
-    | (bv, e)::uu____3619 ->
-        let uu____3638 =
-          let uu____3643 =
-            let uu____3644 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "Unexpected antiquotation: `#(%s)" uu____3644 in
-          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu____3643) in
-        FStar_Errors.raise_error uu____3638 e.FStar_Syntax_Syntax.pos
+        let uu___4 =
+          let uu___5 =
+            let uu___6 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "Unexpected antiquotation: `@(%s)" uu___6 in
+          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu___5) in
+        FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
+    | (bv, e)::uu___ ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "Unexpected antiquotation: `#(%s)" uu___3 in
+          (FStar_Errors.Fatal_UnexpectedAntiquotation, uu___2) in
+        FStar_Errors.raise_error uu___1 e.FStar_Syntax_Syntax.pos
 let check_fields :
-  'uuuuuu3653 .
+  'uuuuu .
     FStar_Syntax_DsEnv.env ->
-      (FStar_Ident.lident * 'uuuuuu3653) Prims.list ->
+      (FStar_Ident.lident * 'uuuuu) Prims.list ->
         FStar_Range.range -> FStar_Syntax_DsEnv.record_or_dc
   =
   fun env ->
     fun fields ->
       fun rg ->
-        let uu____3681 = FStar_List.hd fields in
-        match uu____3681 with
-        | (f, uu____3691) ->
+        let uu___ = FStar_List.hd fields in
+        match uu___ with
+        | (f, uu___1) ->
             let record =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_record_by_field_name env) f in
-            let check_field uu____3702 =
-              match uu____3702 with
-              | (f', uu____3708) ->
-                  let uu____3709 =
+            let check_field uu___2 =
+              match uu___2 with
+              | (f', uu___3) ->
+                  let uu___4 =
                     FStar_Syntax_DsEnv.belongs_to_record env f' record in
-                  if uu____3709
+                  if uu___4
                   then ()
                   else
                     (let msg =
-                       let uu____3712 = FStar_Ident.string_of_lid f in
-                       let uu____3713 =
+                       let uu___6 = FStar_Ident.string_of_lid f in
+                       let uu___7 =
                          FStar_Ident.string_of_lid
                            record.FStar_Syntax_DsEnv.typename in
-                       let uu____3714 = FStar_Ident.string_of_lid f' in
+                       let uu___8 = FStar_Ident.string_of_lid f' in
                        FStar_Util.format3
                          "Field %s belongs to record type %s, whereas field %s does not"
-                         uu____3712 uu____3713 uu____3714 in
+                         uu___6 uu___7 uu___8 in
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FieldsNotBelongToSameRecordType,
                          msg) rg) in
-            ((let uu____3716 = FStar_List.tl fields in
-              FStar_List.iter check_field uu____3716);
+            ((let uu___3 = FStar_List.tl fields in
+              FStar_List.iter check_field uu___3);
              (match () with | () -> record))
 let (check_linear_pattern_variables :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t Prims.list ->
@@ -1387,72 +1333,70 @@ let (check_linear_pattern_variables :
     fun r ->
       let rec pat_vars p =
         match p.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_dot_term uu____3763 ->
+        | FStar_Syntax_Syntax.Pat_dot_term uu___ ->
             FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_wild uu____3770 ->
-            FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_constant uu____3771 ->
+        | FStar_Syntax_Syntax.Pat_wild uu___ -> FStar_Syntax_Syntax.no_names
+        | FStar_Syntax_Syntax.Pat_constant uu___ ->
             FStar_Syntax_Syntax.no_names
         | FStar_Syntax_Syntax.Pat_var x ->
             FStar_Util.set_add x FStar_Syntax_Syntax.no_names
-        | FStar_Syntax_Syntax.Pat_cons (uu____3773, pats1) ->
-            let aux out uu____3811 =
-              match uu____3811 with
-              | (p1, uu____3823) ->
+        | FStar_Syntax_Syntax.Pat_cons (uu___, pats1) ->
+            let aux out uu___1 =
+              match uu___1 with
+              | (p1, uu___2) ->
                   let intersection =
-                    let uu____3831 = pat_vars p1 in
-                    FStar_Util.set_intersect uu____3831 out in
-                  let uu____3834 = FStar_Util.set_is_empty intersection in
-                  if uu____3834
+                    let uu___3 = pat_vars p1 in
+                    FStar_Util.set_intersect uu___3 out in
+                  let uu___3 = FStar_Util.set_is_empty intersection in
+                  if uu___3
                   then
-                    let uu____3837 = pat_vars p1 in
-                    FStar_Util.set_union out uu____3837
+                    let uu___4 = pat_vars p1 in
+                    FStar_Util.set_union out uu___4
                   else
                     (let duplicate_bv =
-                       let uu____3842 = FStar_Util.set_elements intersection in
-                       FStar_List.hd uu____3842 in
-                     let uu____3845 =
-                       let uu____3850 =
-                         let uu____3851 =
+                       let uu___5 = FStar_Util.set_elements intersection in
+                       FStar_List.hd uu___5 in
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_Ident.string_of_id
                              duplicate_bv.FStar_Syntax_Syntax.ppname in
                          FStar_Util.format1
                            "Non-linear patterns are not permitted: `%s` appears more than once in this pattern."
-                           uu____3851 in
+                           uu___7 in
                        (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
-                         uu____3850) in
-                     FStar_Errors.raise_error uu____3845 r) in
+                         uu___6) in
+                     FStar_Errors.raise_error uu___5 r) in
             FStar_List.fold_left aux FStar_Syntax_Syntax.no_names pats1 in
       match pats with
       | [] -> ()
       | p::[] ->
-          let uu____3871 = pat_vars p in
-          FStar_All.pipe_right uu____3871 (fun uu____3876 -> ())
+          let uu___ = pat_vars p in
+          FStar_All.pipe_right uu___ (fun uu___1 -> ())
       | p::ps ->
           let pvars = pat_vars p in
           let aux p1 =
-            let uu____3900 =
-              let uu____3901 = pat_vars p1 in
-              FStar_Util.set_eq pvars uu____3901 in
-            if uu____3900
+            let uu___ =
+              let uu___1 = pat_vars p1 in FStar_Util.set_eq pvars uu___1 in
+            if uu___
             then ()
             else
               (let nonlinear_vars =
-                 let uu____3908 = pat_vars p1 in
-                 FStar_Util.set_symmetric_difference pvars uu____3908 in
+                 let uu___2 = pat_vars p1 in
+                 FStar_Util.set_symmetric_difference pvars uu___2 in
                let first_nonlinear_var =
-                 let uu____3912 = FStar_Util.set_elements nonlinear_vars in
-                 FStar_List.hd uu____3912 in
-               let uu____3915 =
-                 let uu____3920 =
-                   let uu____3921 =
+                 let uu___2 = FStar_Util.set_elements nonlinear_vars in
+                 FStar_List.hd uu___2 in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
                      FStar_Ident.string_of_id
                        first_nonlinear_var.FStar_Syntax_Syntax.ppname in
                    FStar_Util.format1
                      "Patterns in this match are incoherent, variable %s is bound in some but not all patterns."
-                     uu____3921 in
-                 (FStar_Errors.Fatal_IncoherentPatterns, uu____3920) in
-               FStar_Errors.raise_error uu____3915 r) in
+                     uu___4 in
+                 (FStar_Errors.Fatal_IncoherentPatterns, uu___3) in
+               FStar_Errors.raise_error uu___2 r) in
           FStar_List.iter aux ps
 let (smt_pat_lid : FStar_Range.range -> FStar_Ident.lident) =
   fun r -> FStar_Ident.set_lid_range FStar_Parser_Const.smtpat_lid r
@@ -1467,83 +1411,79 @@ let rec (desugar_data_pat :
     fun env ->
       fun p ->
         let resolvex l e x =
-          let uu____4235 =
+          let uu___ =
             FStar_Util.find_opt
               (fun y ->
-                 let uu____4242 =
+                 let uu___1 =
                    FStar_Ident.string_of_id y.FStar_Syntax_Syntax.ppname in
-                 let uu____4243 = FStar_Ident.string_of_id x in
-                 uu____4242 = uu____4243) l in
-          match uu____4235 with
+                 let uu___2 = FStar_Ident.string_of_id x in uu___1 = uu___2)
+              l in
+          match uu___ with
           | FStar_Pervasives_Native.Some y -> (l, e, y)
-          | uu____4255 ->
-              let uu____4258 = FStar_Syntax_DsEnv.push_bv e x in
-              (match uu____4258 with | (e1, xbv) -> ((xbv :: l), e1, xbv)) in
+          | uu___1 ->
+              let uu___2 = FStar_Syntax_DsEnv.push_bv e x in
+              (match uu___2 with | (e1, xbv) -> ((xbv :: l), e1, xbv)) in
         let rec aux' top loc env1 p1 =
           let pos q =
             FStar_Syntax_Syntax.withinfo q p1.FStar_Parser_AST.prange in
           let pos_r r q = FStar_Syntax_Syntax.withinfo q r in
           let orig = p1 in
           match p1.FStar_Parser_AST.pat with
-          | FStar_Parser_AST.PatOr uu____4397 ->
+          | FStar_Parser_AST.PatOr uu___ ->
               failwith "impossible: PatOr handled below"
           | FStar_Parser_AST.PatOp op ->
               let id_op =
-                let uu____4418 =
-                  let uu____4423 =
-                    let uu____4424 = FStar_Ident.string_of_id op in
-                    let uu____4425 = FStar_Ident.range_of_id op in
-                    FStar_Parser_AST.compile_op Prims.int_zero uu____4424
-                      uu____4425 in
-                  let uu____4426 = FStar_Ident.range_of_id op in
-                  (uu____4423, uu____4426) in
-                FStar_Ident.mk_ident uu____4418 in
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 = FStar_Ident.string_of_id op in
+                    let uu___3 = FStar_Ident.range_of_id op in
+                    FStar_Parser_AST.compile_op Prims.int_zero uu___2 uu___3 in
+                  let uu___2 = FStar_Ident.range_of_id op in (uu___1, uu___2) in
+                FStar_Ident.mk_ident uu___ in
               let p2 =
-                let uu___910_4428 = p1 in
+                let uu___ = p1 in
                 {
                   FStar_Parser_AST.pat =
                     (FStar_Parser_AST.PatVar
                        (id_op, FStar_Pervasives_Native.None));
-                  FStar_Parser_AST.prange =
-                    (uu___910_4428.FStar_Parser_AST.prange)
+                  FStar_Parser_AST.prange = (uu___.FStar_Parser_AST.prange)
                 } in
               aux loc env1 p2
           | FStar_Parser_AST.PatAscribed (p2, (t, tacopt)) ->
               ((match tacopt with
                 | FStar_Pervasives_Native.None -> ()
-                | FStar_Pervasives_Native.Some uu____4445 ->
+                | FStar_Pervasives_Native.Some uu___1 ->
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_TypeWithinPatternsAllowedOnVariablesOnly,
                         "Type ascriptions within patterns cannot be associated with a tactic")
                       orig.FStar_Parser_AST.prange);
-               (let uu____4446 = aux loc env1 p2 in
-                match uu____4446 with
+               (let uu___1 = aux loc env1 p2 in
+                match uu___1 with
                 | (loc1, env', binder, p3, annots) ->
-                    let uu____4502 =
+                    let uu___2 =
                       match binder with
-                      | LetBinder uu____4523 -> failwith "impossible"
+                      | LetBinder uu___3 -> failwith "impossible"
                       | LocalBinder (x, aq) ->
                           let t1 =
-                            let uu____4547 = close_fun env1 t in
-                            desugar_term env1 uu____4547 in
+                            let uu___3 = close_fun env1 t in
+                            desugar_term env1 uu___3 in
                           let x1 =
-                            let uu___936_4549 = x in
+                            let uu___3 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___936_4549.FStar_Syntax_Syntax.ppname);
+                                (uu___3.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___936_4549.FStar_Syntax_Syntax.index);
+                                (uu___3.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             } in
                           ([(x1, t1)], (LocalBinder (x1, aq))) in
-                    (match uu____4502 with
+                    (match uu___2 with
                      | (annots', binder1) ->
                          ((match p3.FStar_Syntax_Syntax.v with
-                           | FStar_Syntax_Syntax.Pat_var uu____4595 -> ()
-                           | FStar_Syntax_Syntax.Pat_wild uu____4596 -> ()
-                           | uu____4597 when top && top_level_ascr_allowed ->
-                               ()
-                           | uu____4598 ->
+                           | FStar_Syntax_Syntax.Pat_var uu___4 -> ()
+                           | FStar_Syntax_Syntax.Pat_wild uu___4 -> ()
+                           | uu___4 when top && top_level_ascr_allowed -> ()
+                           | uu___4 ->
                                FStar_Errors.raise_error
                                  (FStar_Errors.Fatal_TypeWithinPatternsAllowedOnVariablesOnly,
                                    "Type ascriptions within patterns are only allowed on variables")
@@ -1553,124 +1493,124 @@ let rec (desugar_data_pat :
           | FStar_Parser_AST.PatWild aq ->
               let aq1 = trans_aqual env1 aq in
               let x =
-                let uu____4614 = tun_r p1.FStar_Parser_AST.prange in
+                let uu___ = tun_r p1.FStar_Parser_AST.prange in
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                  uu____4614 in
-              let uu____4615 =
+                  uu___ in
+              let uu___ =
                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild x) in
-              (loc, env1, (LocalBinder (x, aq1)), uu____4615, [])
+              (loc, env1, (LocalBinder (x, aq1)), uu___, [])
           | FStar_Parser_AST.PatConst c ->
               let x =
-                let uu____4628 = tun_r p1.FStar_Parser_AST.prange in
+                let uu___ = tun_r p1.FStar_Parser_AST.prange in
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                  uu____4628 in
-              let uu____4629 =
+                  uu___ in
+              let uu___ =
                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant c) in
               (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
-                uu____4629, [])
+                uu___, [])
           | FStar_Parser_AST.PatTvar (x, aq) ->
               let aq1 = trans_aqual env1 aq in
-              let uu____4647 = resolvex loc env1 x in
-              (match uu____4647 with
+              let uu___ = resolvex loc env1 x in
+              (match uu___ with
                | (loc1, env2, xbv) ->
-                   let uu____4679 =
+                   let uu___1 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_var xbv) in
-                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____4679, []))
+                   (loc1, env2, (LocalBinder (xbv, aq1)), uu___1, []))
           | FStar_Parser_AST.PatVar (x, aq) ->
               let aq1 = trans_aqual env1 aq in
-              let uu____4697 = resolvex loc env1 x in
-              (match uu____4697 with
+              let uu___ = resolvex loc env1 x in
+              (match uu___ with
                | (loc1, env2, xbv) ->
-                   let uu____4729 =
+                   let uu___1 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_var xbv) in
-                   (loc1, env2, (LocalBinder (xbv, aq1)), uu____4729, []))
+                   (loc1, env2, (LocalBinder (xbv, aq1)), uu___1, []))
           | FStar_Parser_AST.PatName l ->
               let l1 =
                 FStar_Syntax_DsEnv.fail_or env1
                   (FStar_Syntax_DsEnv.try_lookup_datacon env1) l in
               let x =
-                let uu____4743 = tun_r p1.FStar_Parser_AST.prange in
+                let uu___ = tun_r p1.FStar_Parser_AST.prange in
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                  uu____4743 in
-              let uu____4744 =
+                  uu___ in
+              let uu___ =
                 FStar_All.pipe_left pos
                   (FStar_Syntax_Syntax.Pat_cons (l1, [])) in
               (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
-                uu____4744, [])
+                uu___, [])
           | FStar_Parser_AST.PatApp
               ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName l;
-                 FStar_Parser_AST.prange = uu____4770;_},
+                 FStar_Parser_AST.prange = uu___;_},
                args)
               ->
-              let uu____4776 =
+              let uu___1 =
                 FStar_List.fold_right
                   (fun arg ->
-                     fun uu____4835 ->
-                       match uu____4835 with
+                     fun uu___2 ->
+                       match uu___2 with
                        | (loc1, env2, annots, args1) ->
-                           let uu____4912 = aux loc1 env2 arg in
-                           (match uu____4912 with
+                           let uu___3 = aux loc1 env2 arg in
+                           (match uu___3 with
                             | (loc2, env3, b, arg1, ans) ->
                                 let imp = is_implicit b in
                                 (loc2, env3, (FStar_List.append ans annots),
                                   ((arg1, imp) :: args1)))) args
                   (loc, env1, [], []) in
-              (match uu____4776 with
+              (match uu___1 with
                | (loc1, env2, annots, args1) ->
                    let l1 =
                      FStar_Syntax_DsEnv.fail_or env2
                        (FStar_Syntax_DsEnv.try_lookup_datacon env2) l in
                    let x =
-                     let uu____5075 = tun_r p1.FStar_Parser_AST.prange in
+                     let uu___2 = tun_r p1.FStar_Parser_AST.prange in
                      FStar_Syntax_Syntax.new_bv
                        (FStar_Pervasives_Native.Some
-                          (p1.FStar_Parser_AST.prange)) uu____5075 in
-                   let uu____5076 =
+                          (p1.FStar_Parser_AST.prange)) uu___2 in
+                   let uu___2 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_cons (l1, args1)) in
                    (loc1, env2,
-                     (LocalBinder (x, FStar_Pervasives_Native.None)),
-                     uu____5076, annots))
-          | FStar_Parser_AST.PatApp uu____5091 ->
+                     (LocalBinder (x, FStar_Pervasives_Native.None)), uu___2,
+                     annots))
+          | FStar_Parser_AST.PatApp uu___ ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern, "Unexpected pattern")
                 p1.FStar_Parser_AST.prange
           | FStar_Parser_AST.PatList pats ->
-              let uu____5117 =
+              let uu___ =
                 FStar_List.fold_right
                   (fun pat ->
-                     fun uu____5167 ->
-                       match uu____5167 with
+                     fun uu___1 ->
+                       match uu___1 with
                        | (loc1, env2, annots, pats1) ->
-                           let uu____5228 = aux loc1 env2 pat in
-                           (match uu____5228 with
-                            | (loc2, env3, uu____5267, pat1, ans) ->
+                           let uu___2 = aux loc1 env2 pat in
+                           (match uu___2 with
+                            | (loc2, env3, uu___3, pat1, ans) ->
                                 (loc2, env3, (FStar_List.append ans annots),
                                   (pat1 :: pats1)))) pats (loc, env1, [], []) in
-              (match uu____5117 with
+              (match uu___ with
                | (loc1, env2, annots, pats1) ->
                    let pat =
-                     let uu____5361 =
-                       let uu____5364 =
-                         let uu____5371 =
+                     let uu___1 =
+                       let uu___2 =
+                         let uu___3 =
                            FStar_Range.end_range p1.FStar_Parser_AST.prange in
-                         pos_r uu____5371 in
-                       let uu____5372 =
-                         let uu____5373 =
-                           let uu____5386 =
+                         pos_r uu___3 in
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 =
                              FStar_Syntax_Syntax.lid_as_fv
                                FStar_Parser_Const.nil_lid
                                FStar_Syntax_Syntax.delta_constant
                                (FStar_Pervasives_Native.Some
                                   FStar_Syntax_Syntax.Data_ctor) in
-                           (uu____5386, []) in
-                         FStar_Syntax_Syntax.Pat_cons uu____5373 in
-                       FStar_All.pipe_left uu____5364 uu____5372 in
+                           (uu___5, []) in
+                         FStar_Syntax_Syntax.Pat_cons uu___4 in
+                       FStar_All.pipe_left uu___2 uu___3 in
                      FStar_List.fold_right
                        (fun hd ->
                           fun tl ->
@@ -1678,40 +1618,40 @@ let rec (desugar_data_pat :
                               FStar_Range.union_ranges
                                 hd.FStar_Syntax_Syntax.p
                                 tl.FStar_Syntax_Syntax.p in
-                            let uu____5418 =
-                              let uu____5419 =
-                                let uu____5432 =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
                                   FStar_Syntax_Syntax.lid_as_fv
                                     FStar_Parser_Const.cons_lid
                                     FStar_Syntax_Syntax.delta_constant
                                     (FStar_Pervasives_Native.Some
                                        FStar_Syntax_Syntax.Data_ctor) in
-                                (uu____5432, [(hd, false); (tl, false)]) in
-                              FStar_Syntax_Syntax.Pat_cons uu____5419 in
-                            FStar_All.pipe_left (pos_r r) uu____5418) pats1
-                       uu____5361 in
+                                (uu___4, [(hd, false); (tl, false)]) in
+                              FStar_Syntax_Syntax.Pat_cons uu___3 in
+                            FStar_All.pipe_left (pos_r r) uu___2) pats1
+                       uu___1 in
                    let x =
-                     let uu____5466 = tun_r p1.FStar_Parser_AST.prange in
+                     let uu___1 = tun_r p1.FStar_Parser_AST.prange in
                      FStar_Syntax_Syntax.new_bv
                        (FStar_Pervasives_Native.Some
-                          (p1.FStar_Parser_AST.prange)) uu____5466 in
+                          (p1.FStar_Parser_AST.prange)) uu___1 in
                    (loc1, env2,
                      (LocalBinder (x, FStar_Pervasives_Native.None)), pat,
                      annots))
           | FStar_Parser_AST.PatTuple (args, dep) ->
-              let uu____5479 =
+              let uu___ =
                 FStar_List.fold_left
-                  (fun uu____5536 ->
+                  (fun uu___1 ->
                      fun p2 ->
-                       match uu____5536 with
+                       match uu___1 with
                        | (loc1, env2, annots, pats) ->
-                           let uu____5614 = aux loc1 env2 p2 in
-                           (match uu____5614 with
-                            | (loc2, env3, uu____5657, pat, ans) ->
+                           let uu___2 = aux loc1 env2 p2 in
+                           (match uu___2 with
+                            | (loc2, env3, uu___3, pat, ans) ->
                                 (loc2, env3, (FStar_List.append ans annots),
                                   ((pat, false) :: pats))))
                   (loc, env1, [], []) args in
-              (match uu____5479 with
+              (match uu___ with
                | (loc1, env2, annots, args1) ->
                    let args2 = FStar_List.rev args1 in
                    let l =
@@ -1728,18 +1668,18 @@ let rec (desugar_data_pat :
                    let l1 =
                      match constr.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                     | uu____5806 -> failwith "impossible" in
+                     | uu___1 -> failwith "impossible" in
                    let x =
-                     let uu____5808 = tun_r p1.FStar_Parser_AST.prange in
+                     let uu___1 = tun_r p1.FStar_Parser_AST.prange in
                      FStar_Syntax_Syntax.new_bv
                        (FStar_Pervasives_Native.Some
-                          (p1.FStar_Parser_AST.prange)) uu____5808 in
-                   let uu____5809 =
+                          (p1.FStar_Parser_AST.prange)) uu___1 in
+                   let uu___1 =
                      FStar_All.pipe_left pos
                        (FStar_Syntax_Syntax.Pat_cons (l1, args2)) in
                    (loc1, env2,
-                     (LocalBinder (x, FStar_Pervasives_Native.None)),
-                     uu____5809, annots))
+                     (LocalBinder (x, FStar_Pervasives_Native.None)), uu___1,
+                     annots))
           | FStar_Parser_AST.PatRecord [] ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern, "Unexpected pattern")
@@ -1750,89 +1690,88 @@ let rec (desugar_data_pat :
               let fields1 =
                 FStar_All.pipe_right fields
                   (FStar_List.map
-                     (fun uu____5883 ->
-                        match uu____5883 with
+                     (fun uu___ ->
+                        match uu___ with
                         | (f, p2) ->
-                            let uu____5894 = FStar_Ident.ident_of_lid f in
-                            (uu____5894, p2))) in
+                            let uu___1 = FStar_Ident.ident_of_lid f in
+                            (uu___1, p2))) in
               let args =
                 FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                   (FStar_List.map
-                     (fun uu____5914 ->
-                        match uu____5914 with
-                        | (f, uu____5920) ->
-                            let uu____5921 =
+                     (fun uu___ ->
+                        match uu___ with
+                        | (f, uu___1) ->
+                            let uu___2 =
                               FStar_All.pipe_right fields1
                                 (FStar_List.tryFind
-                                   (fun uu____5949 ->
-                                      match uu____5949 with
-                                      | (g, uu____5955) ->
-                                          let uu____5956 =
+                                   (fun uu___3 ->
+                                      match uu___3 with
+                                      | (g, uu___4) ->
+                                          let uu___5 =
                                             FStar_Ident.string_of_id f in
-                                          let uu____5957 =
+                                          let uu___6 =
                                             FStar_Ident.string_of_id g in
-                                          uu____5956 = uu____5957)) in
-                            (match uu____5921 with
+                                          uu___5 = uu___6)) in
+                            (match uu___2 with
                              | FStar_Pervasives_Native.None ->
                                  FStar_Parser_AST.mk_pattern
                                    (FStar_Parser_AST.PatWild
                                       FStar_Pervasives_Native.None)
                                    p1.FStar_Parser_AST.prange
-                             | FStar_Pervasives_Native.Some (uu____5962, p2)
-                                 -> p2))) in
+                             | FStar_Pervasives_Native.Some (uu___3, p2) ->
+                                 p2))) in
               let app =
-                let uu____5969 =
-                  let uu____5970 =
-                    let uu____5977 =
-                      let uu____5978 =
-                        let uu____5979 =
-                          let uu____5980 =
-                            let uu____5981 =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_Ident.ns_of_lid
                                 record.FStar_Syntax_DsEnv.typename in
-                            FStar_List.append uu____5981
+                            FStar_List.append uu___6
                               [record.FStar_Syntax_DsEnv.constrname] in
-                          FStar_Ident.lid_of_ids uu____5980 in
-                        FStar_Parser_AST.PatName uu____5979 in
-                      FStar_Parser_AST.mk_pattern uu____5978
+                          FStar_Ident.lid_of_ids uu___5 in
+                        FStar_Parser_AST.PatName uu___4 in
+                      FStar_Parser_AST.mk_pattern uu___3
                         p1.FStar_Parser_AST.prange in
-                    (uu____5977, args) in
-                  FStar_Parser_AST.PatApp uu____5970 in
-                FStar_Parser_AST.mk_pattern uu____5969
-                  p1.FStar_Parser_AST.prange in
-              let uu____5986 = aux loc env1 app in
-              (match uu____5986 with
+                    (uu___2, args) in
+                  FStar_Parser_AST.PatApp uu___1 in
+                FStar_Parser_AST.mk_pattern uu___ p1.FStar_Parser_AST.prange in
+              let uu___ = aux loc env1 app in
+              (match uu___ with
                | (env2, e, b, p2, annots) ->
                    let p3 =
                      match p2.FStar_Syntax_Syntax.v with
                      | FStar_Syntax_Syntax.Pat_cons (fv, args1) ->
-                         let uu____6061 =
-                           let uu____6062 =
-                             let uu____6075 =
-                               let uu___1086_6076 = fv in
-                               let uu____6077 =
-                                 let uu____6080 =
-                                   let uu____6081 =
-                                     let uu____6088 =
+                         let uu___1 =
+                           let uu___2 =
+                             let uu___3 =
+                               let uu___4 = fv in
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
+                                     let uu___8 =
                                        FStar_All.pipe_right
                                          record.FStar_Syntax_DsEnv.fields
                                          (FStar_List.map
                                             FStar_Pervasives_Native.fst) in
                                      ((record.FStar_Syntax_DsEnv.typename),
-                                       uu____6088) in
-                                   FStar_Syntax_Syntax.Record_ctor uu____6081 in
-                                 FStar_Pervasives_Native.Some uu____6080 in
+                                       uu___8) in
+                                   FStar_Syntax_Syntax.Record_ctor uu___7 in
+                                 FStar_Pervasives_Native.Some uu___6 in
                                {
                                  FStar_Syntax_Syntax.fv_name =
-                                   (uu___1086_6076.FStar_Syntax_Syntax.fv_name);
+                                   (uu___4.FStar_Syntax_Syntax.fv_name);
                                  FStar_Syntax_Syntax.fv_delta =
-                                   (uu___1086_6076.FStar_Syntax_Syntax.fv_delta);
-                                 FStar_Syntax_Syntax.fv_qual = uu____6077
+                                   (uu___4.FStar_Syntax_Syntax.fv_delta);
+                                 FStar_Syntax_Syntax.fv_qual = uu___5
                                } in
-                             (uu____6075, args1) in
-                           FStar_Syntax_Syntax.Pat_cons uu____6062 in
-                         FStar_All.pipe_left pos uu____6061
-                     | uu____6113 -> p2 in
+                             (uu___3, args1) in
+                           FStar_Syntax_Syntax.Pat_cons uu___2 in
+                         FStar_All.pipe_left pos uu___1
+                     | uu___1 -> p2 in
                    (env2, e, b, p3, annots))
         and aux loc env1 p1 = aux' false loc env1 p1 in
         let aux_maybe_or env1 p1 =
@@ -1840,35 +1779,33 @@ let rec (desugar_data_pat :
           match p1.FStar_Parser_AST.pat with
           | FStar_Parser_AST.PatOr [] -> failwith "impossible"
           | FStar_Parser_AST.PatOr (p2::ps) ->
-              let uu____6195 = aux' true loc env1 p2 in
-              (match uu____6195 with
+              let uu___ = aux' true loc env1 p2 in
+              (match uu___ with
                | (loc1, env2, var, p3, ans) ->
-                   let uu____6247 =
+                   let uu___1 =
                      FStar_List.fold_left
-                       (fun uu____6295 ->
+                       (fun uu___2 ->
                           fun p4 ->
-                            match uu____6295 with
+                            match uu___2 with
                             | (loc2, env3, ps1) ->
-                                let uu____6360 = aux' true loc2 env3 p4 in
-                                (match uu____6360 with
-                                 | (loc3, env4, uu____6397, p5, ans1) ->
+                                let uu___3 = aux' true loc2 env3 p4 in
+                                (match uu___3 with
+                                 | (loc3, env4, uu___4, p5, ans1) ->
                                      (loc3, env4, ((p5, ans1) :: ps1))))
                        (loc1, env2, []) ps in
-                   (match uu____6247 with
+                   (match uu___1 with
                     | (loc2, env3, ps1) ->
                         let pats = (p3, ans) :: (FStar_List.rev ps1) in
                         (env3, var, pats)))
-          | uu____6558 ->
-              let uu____6559 = aux' true loc env1 p1 in
-              (match uu____6559 with
+          | uu___ ->
+              let uu___1 = aux' true loc env1 p1 in
+              (match uu___1 with
                | (loc1, env2, var, pat, ans) -> (env2, var, [(pat, ans)])) in
-        let uu____6649 = aux_maybe_or env p in
-        match uu____6649 with
+        let uu___ = aux_maybe_or env p in
+        match uu___ with
         | (env1, b, pats) ->
-            ((let uu____6704 =
-                FStar_List.map FStar_Pervasives_Native.fst pats in
-              check_linear_pattern_variables uu____6704
-                p.FStar_Parser_AST.prange);
+            ((let uu___2 = FStar_List.map FStar_Pervasives_Native.fst pats in
+              check_linear_pattern_variables uu___2 p.FStar_Parser_AST.prange);
              (env1, b, pats))
 and (desugar_binding_pat_maybe_top :
   Prims.bool ->
@@ -1881,75 +1818,67 @@ and (desugar_binding_pat_maybe_top :
         if top
         then
           let mklet x ty tacopt =
-            let uu____6776 =
-              let uu____6777 =
-                let uu____6788 = FStar_Syntax_DsEnv.qualify env x in
-                (uu____6788, (ty, tacopt)) in
-              LetBinder uu____6777 in
-            (env, uu____6776, []) in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_DsEnv.qualify env x in
+                (uu___2, (ty, tacopt)) in
+              LetBinder uu___1 in
+            (env, uu___, []) in
           let op_to_ident x =
-            let uu____6805 =
-              let uu____6810 =
-                let uu____6811 = FStar_Ident.string_of_id x in
-                let uu____6812 = FStar_Ident.range_of_id x in
-                FStar_Parser_AST.compile_op Prims.int_zero uu____6811
-                  uu____6812 in
-              let uu____6813 = FStar_Ident.range_of_id x in
-              (uu____6810, uu____6813) in
-            FStar_Ident.mk_ident uu____6805 in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Ident.string_of_id x in
+                let uu___3 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.compile_op Prims.int_zero uu___2 uu___3 in
+              let uu___2 = FStar_Ident.range_of_id x in (uu___1, uu___2) in
+            FStar_Ident.mk_ident uu___ in
           match p.FStar_Parser_AST.pat with
           | FStar_Parser_AST.PatOp x ->
-              let uu____6823 = op_to_ident x in
-              let uu____6824 =
-                let uu____6825 = FStar_Ident.range_of_id x in
-                tun_r uu____6825 in
-              mklet uu____6823 uu____6824 FStar_Pervasives_Native.None
-          | FStar_Parser_AST.PatVar (x, uu____6827) ->
-              let uu____6832 =
-                let uu____6833 = FStar_Ident.range_of_id x in
-                tun_r uu____6833 in
-              mklet x uu____6832 FStar_Pervasives_Native.None
+              let uu___ = op_to_ident x in
+              let uu___1 =
+                let uu___2 = FStar_Ident.range_of_id x in tun_r uu___2 in
+              mklet uu___ uu___1 FStar_Pervasives_Native.None
+          | FStar_Parser_AST.PatVar (x, uu___) ->
+              let uu___1 =
+                let uu___2 = FStar_Ident.range_of_id x in tun_r uu___2 in
+              mklet x uu___1 FStar_Pervasives_Native.None
           | FStar_Parser_AST.PatAscribed
               ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatOp x;
-                 FStar_Parser_AST.prange = uu____6835;_},
+                 FStar_Parser_AST.prange = uu___;_},
                (t, tacopt))
               ->
               let tacopt1 = FStar_Util.map_opt tacopt (desugar_term env) in
-              let uu____6851 = op_to_ident x in
-              let uu____6852 = desugar_term env t in
-              mklet uu____6851 uu____6852 tacopt1
+              let uu___1 = op_to_ident x in
+              let uu___2 = desugar_term env t in mklet uu___1 uu___2 tacopt1
           | FStar_Parser_AST.PatAscribed
-              ({
-                 FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                   (x, uu____6854);
-                 FStar_Parser_AST.prange = uu____6855;_},
+              ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x, uu___);
+                 FStar_Parser_AST.prange = uu___1;_},
                (t, tacopt))
               ->
               let tacopt1 = FStar_Util.map_opt tacopt (desugar_term env) in
-              let uu____6875 = desugar_term env t in
-              mklet x uu____6875 tacopt1
-          | uu____6876 ->
+              let uu___2 = desugar_term env t in mklet x uu___2 tacopt1
+          | uu___ ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedPattern,
                   "Unexpected pattern at the top-level")
                 p.FStar_Parser_AST.prange
         else
-          (let uu____6886 = desugar_data_pat true env p in
-           match uu____6886 with
+          (let uu___1 = desugar_data_pat true env p in
+           match uu___1 with
            | (env1, binder, p1) ->
                let p2 =
                  match p1 with
                  | ({
                       FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_var
-                        uu____6915;
-                      FStar_Syntax_Syntax.p = uu____6916;_},
-                    uu____6917)::[] -> []
+                        uu___2;
+                      FStar_Syntax_Syntax.p = uu___3;_},
+                    uu___4)::[] -> []
                  | ({
                       FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild
-                        uu____6930;
-                      FStar_Syntax_Syntax.p = uu____6931;_},
-                    uu____6932)::[] -> []
-                 | uu____6945 -> p1 in
+                        uu___2;
+                      FStar_Syntax_Syntax.p = uu___3;_},
+                    uu___4)::[] -> []
+                 | uu___2 -> p1 in
                (env1, binder, p2))
 and (desugar_binding_pat :
   FStar_Syntax_DsEnv.env ->
@@ -1959,11 +1888,11 @@ and (desugar_match_pat_maybe_top :
   Prims.bool ->
     env_t -> FStar_Parser_AST.pattern -> (env_t * annotated_pat Prims.list))
   =
-  fun uu____6952 ->
+  fun uu___ ->
     fun env ->
       fun pat ->
-        let uu____6955 = desugar_data_pat false env pat in
-        match uu____6955 with | (env1, uu____6971, pat1) -> (env1, pat1)
+        let uu___1 = desugar_data_pat false env pat in
+        match uu___1 with | (env1, uu___2, pat1) -> (env1, pat1)
 and (desugar_match_pat :
   env_t -> FStar_Parser_AST.pattern -> (env_t * annotated_pat Prims.list)) =
   fun env -> fun p -> desugar_match_pat_maybe_top false env p
@@ -1981,8 +1910,8 @@ and (desugar_term :
   =
   fun env ->
     fun e ->
-      let uu____6990 = desugar_term_aq env e in
-      match uu____6990 with | (t, aq) -> (check_no_aq aq; t)
+      let uu___ = desugar_term_aq env e in
+      match uu___ with | (t, aq) -> (check_no_aq aq; t)
 and (desugar_typ_aq :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.term ->
@@ -1997,8 +1926,8 @@ and (desugar_typ :
   =
   fun env ->
     fun e ->
-      let uu____7007 = desugar_typ_aq env e in
-      match uu____7007 with | (t, aq) -> (check_no_aq aq; t)
+      let uu___ = desugar_typ_aq env e in
+      match uu___ with | (t, aq) -> (check_no_aq aq; t)
 and (desugar_machine_integer :
   FStar_Syntax_DsEnv.env ->
     Prims.string ->
@@ -2007,9 +1936,9 @@ and (desugar_machine_integer :
   =
   fun env ->
     fun repr ->
-      fun uu____7017 ->
+      fun uu___ ->
         fun range ->
-          match uu____7017 with
+          match uu___ with
           | (signedness, width) ->
               let tnm =
                 Prims.op_Hat "FStar."
@@ -2023,18 +1952,18 @@ and (desugar_machine_integer :
                          | FStar_Const.Int16 -> "16"
                          | FStar_Const.Int32 -> "32"
                          | FStar_Const.Int64 -> "64"))) in
-              ((let uu____7027 =
-                  let uu____7028 =
+              ((let uu___2 =
+                  let uu___3 =
                     FStar_Const.within_bounds repr signedness width in
-                  Prims.op_Negation uu____7028 in
-                if uu____7027
+                  Prims.op_Negation uu___3 in
+                if uu___2
                 then
-                  let uu____7029 =
-                    let uu____7034 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_Util.format2
                         "%s is not in the expected range for %s" repr tnm in
-                    (FStar_Errors.Error_OutOfRange, uu____7034) in
-                  FStar_Errors.log_issue range uu____7029
+                    (FStar_Errors.Error_OutOfRange, uu___4) in
+                  FStar_Errors.log_issue range uu___3
                 else ());
                (let private_intro_nm =
                   Prims.op_Hat tnm
@@ -2051,62 +1980,60 @@ and (desugar_machine_integer :
                            | FStar_Const.Unsigned -> "u"
                            | FStar_Const.Signed -> "") "int_to_t")) in
                 let lid =
-                  let uu____7039 = FStar_Ident.path_of_text intro_nm in
-                  FStar_Ident.lid_of_path uu____7039 range in
+                  let uu___2 = FStar_Ident.path_of_text intro_nm in
+                  FStar_Ident.lid_of_path uu___2 range in
                 let lid1 =
-                  let uu____7043 = FStar_Syntax_DsEnv.try_lookup_lid env lid in
-                  match uu____7043 with
+                  let uu___2 = FStar_Syntax_DsEnv.try_lookup_lid env lid in
+                  match uu___2 with
                   | FStar_Pervasives_Native.Some intro_term ->
                       (match intro_term.FStar_Syntax_Syntax.n with
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                            let private_lid =
-                             let uu____7053 =
+                             let uu___3 =
                                FStar_Ident.path_of_text private_intro_nm in
-                             FStar_Ident.lid_of_path uu____7053 range in
+                             FStar_Ident.lid_of_path uu___3 range in
                            let private_fv =
-                             let uu____7055 =
+                             let uu___3 =
                                FStar_Syntax_Util.incr_delta_depth
                                  fv.FStar_Syntax_Syntax.fv_delta in
-                             FStar_Syntax_Syntax.lid_as_fv private_lid
-                               uu____7055 fv.FStar_Syntax_Syntax.fv_qual in
-                           let uu___1253_7056 = intro_term in
+                             FStar_Syntax_Syntax.lid_as_fv private_lid uu___3
+                               fv.FStar_Syntax_Syntax.fv_qual in
+                           let uu___3 = intro_term in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_fvar private_fv);
                              FStar_Syntax_Syntax.pos =
-                               (uu___1253_7056.FStar_Syntax_Syntax.pos);
+                               (uu___3.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1253_7056.FStar_Syntax_Syntax.vars)
+                               (uu___3.FStar_Syntax_Syntax.vars)
                            }
-                       | uu____7057 ->
+                       | uu___3 ->
                            failwith
                              (Prims.op_Hat "Unexpected non-fvar for "
                                 intro_nm))
                   | FStar_Pervasives_Native.None ->
-                      let uu____7060 =
-                        let uu____7065 =
+                      let uu___3 =
+                        let uu___4 =
                           FStar_Util.format1
                             "Unexpected numeric literal.  Restart F* to load %s."
                             tnm in
-                        (FStar_Errors.Fatal_UnexpectedNumericLiteral,
-                          uu____7065) in
-                      FStar_Errors.raise_error uu____7060 range in
+                        (FStar_Errors.Fatal_UnexpectedNumericLiteral, uu___4) in
+                      FStar_Errors.raise_error uu___3 range in
                 let repr1 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_constant
                        (FStar_Const.Const_int
                           (repr, FStar_Pervasives_Native.None))) range in
-                let uu____7081 =
-                  let uu____7082 =
-                    let uu____7099 =
-                      let uu____7110 =
-                        let uu____7119 =
-                          FStar_Syntax_Syntax.as_implicit false in
-                        (repr1, uu____7119) in
-                      [uu____7110] in
-                    (lid1, uu____7099) in
-                  FStar_Syntax_Syntax.Tm_app uu____7082 in
-                FStar_Syntax_Syntax.mk uu____7081 range))
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Syntax.as_implicit false in
+                        (repr1, uu___6) in
+                      [uu___5] in
+                    (lid1, uu___4) in
+                  FStar_Syntax_Syntax.Tm_app uu___3 in
+                FStar_Syntax_Syntax.mk uu___2 range))
 and (desugar_term_maybe_top :
   Prims.bool ->
     env_t ->
@@ -2120,371 +2047,340 @@ and (desugar_term_maybe_top :
         let noaqs = [] in
         let join_aqs aqs = FStar_List.flatten aqs in
         let setpos e =
-          let uu___1269_7236 = e in
+          let uu___ = e in
           {
-            FStar_Syntax_Syntax.n = (uu___1269_7236.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
-            FStar_Syntax_Syntax.vars =
-              (uu___1269_7236.FStar_Syntax_Syntax.vars)
+            FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
           } in
-        let uu____7239 =
-          let uu____7240 = unparen top in uu____7240.FStar_Parser_AST.tm in
-        match uu____7239 with
+        let uu___ = let uu___1 = unparen top in uu___1.FStar_Parser_AST.tm in
+        match uu___ with
         | FStar_Parser_AST.Wild -> ((setpos FStar_Syntax_Syntax.tun), noaqs)
-        | FStar_Parser_AST.Labeled uu____7245 ->
-            let uu____7252 = desugar_formula env top in (uu____7252, noaqs)
+        | FStar_Parser_AST.Labeled uu___1 ->
+            let uu___2 = desugar_formula env top in (uu___2, noaqs)
         | FStar_Parser_AST.Requires (t, lopt) ->
-            let uu____7259 = desugar_formula env t in (uu____7259, noaqs)
+            let uu___1 = desugar_formula env t in (uu___1, noaqs)
         | FStar_Parser_AST.Ensures (t, lopt) ->
-            let uu____7266 = desugar_formula env t in (uu____7266, noaqs)
+            let uu___1 = desugar_formula env t in (uu___1, noaqs)
         | FStar_Parser_AST.Attributes ts ->
             failwith
               "Attributes should not be desugared by desugar_term_maybe_top"
         | FStar_Parser_AST.Const (FStar_Const.Const_int
             (i, FStar_Pervasives_Native.Some size)) ->
-            let uu____7290 =
+            let uu___1 =
               desugar_machine_integer env i size top.FStar_Parser_AST.range in
-            (uu____7290, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Const c ->
-            let uu____7292 = mk (FStar_Syntax_Syntax.Tm_constant c) in
-            (uu____7292, noaqs)
+            let uu___1 = mk (FStar_Syntax_Syntax.Tm_constant c) in
+            (uu___1, noaqs)
         | FStar_Parser_AST.Op (id, args) when
-            let uu____7299 = FStar_Ident.string_of_id id in
-            uu____7299 = "=!=" ->
+            let uu___1 = FStar_Ident.string_of_id id in uu___1 = "=!=" ->
             let r = FStar_Ident.range_of_id id in
             let e =
-              let uu____7302 =
-                let uu____7303 =
-                  let uu____7310 = FStar_Ident.mk_ident ("==", r) in
-                  (uu____7310, args) in
-                FStar_Parser_AST.Op uu____7303 in
-              FStar_Parser_AST.mk_term uu____7302 top.FStar_Parser_AST.range
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Ident.mk_ident ("==", r) in
+                  (uu___3, args) in
+                FStar_Parser_AST.Op uu___2 in
+              FStar_Parser_AST.mk_term uu___1 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level in
-            let uu____7313 =
-              let uu____7314 =
-                let uu____7315 =
-                  let uu____7322 = FStar_Ident.mk_ident ("~", r) in
-                  (uu____7322, [e]) in
-                FStar_Parser_AST.Op uu____7315 in
-              FStar_Parser_AST.mk_term uu____7314 top.FStar_Parser_AST.range
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Ident.mk_ident ("~", r) in (uu___4, [e]) in
+                FStar_Parser_AST.Op uu___3 in
+              FStar_Parser_AST.mk_term uu___2 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level in
-            desugar_term_aq env uu____7313
+            desugar_term_aq env uu___1
         | FStar_Parser_AST.Op (op_star, lhs::rhs::[]) when
-            (let uu____7332 = FStar_Ident.string_of_id op_star in
-             uu____7332 = "*") &&
-              (let uu____7334 = op_as_term env (Prims.of_int (2)) op_star in
-               FStar_All.pipe_right uu____7334 FStar_Option.isNone)
+            (let uu___1 = FStar_Ident.string_of_id op_star in uu___1 = "*")
+              &&
+              (let uu___1 = op_as_term env (Prims.of_int (2)) op_star in
+               FStar_All.pipe_right uu___1 FStar_Option.isNone)
             ->
             let rec flatten t =
               match t.FStar_Parser_AST.tm with
               | FStar_Parser_AST.Op (id, t1::t2::[]) when
-                  (let uu____7356 = FStar_Ident.string_of_id id in
-                   uu____7356 = "*") &&
-                    (let uu____7358 =
-                       op_as_term env (Prims.of_int (2)) op_star in
-                     FStar_All.pipe_right uu____7358 FStar_Option.isNone)
-                  ->
-                  let uu____7363 = flatten t1 in
-                  FStar_List.append uu____7363 [t2]
-              | uu____7366 -> [t] in
+                  (let uu___1 = FStar_Ident.string_of_id id in uu___1 = "*")
+                    &&
+                    (let uu___1 = op_as_term env (Prims.of_int (2)) op_star in
+                     FStar_All.pipe_right uu___1 FStar_Option.isNone)
+                  -> let uu___1 = flatten t1 in FStar_List.append uu___1 [t2]
+              | uu___1 -> [t] in
             let terms = flatten lhs in
             let t =
-              let uu___1314_7371 = top in
-              let uu____7372 =
-                let uu____7373 =
-                  let uu____7384 =
-                    FStar_List.map
-                      (fun uu____7395 -> FStar_Util.Inr uu____7395) terms in
-                  (uu____7384, rhs) in
-                FStar_Parser_AST.Sum uu____7373 in
+              let uu___1 = top in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    FStar_List.map (fun uu___5 -> FStar_Util.Inr uu___5)
+                      terms in
+                  (uu___4, rhs) in
+                FStar_Parser_AST.Sum uu___3 in
               {
-                FStar_Parser_AST.tm = uu____7372;
-                FStar_Parser_AST.range =
-                  (uu___1314_7371.FStar_Parser_AST.range);
-                FStar_Parser_AST.level =
-                  (uu___1314_7371.FStar_Parser_AST.level)
+                FStar_Parser_AST.tm = uu___2;
+                FStar_Parser_AST.range = (uu___1.FStar_Parser_AST.range);
+                FStar_Parser_AST.level = (uu___1.FStar_Parser_AST.level)
               } in
             desugar_term_maybe_top top_level env t
         | FStar_Parser_AST.Tvar a ->
-            let uu____7403 =
-              let uu____7404 =
+            let uu___1 =
+              let uu___2 =
                 FStar_Syntax_DsEnv.fail_or2
                   (FStar_Syntax_DsEnv.try_lookup_id env) a in
-              FStar_All.pipe_left setpos uu____7404 in
-            (uu____7403, noaqs)
+              FStar_All.pipe_left setpos uu___2 in
+            (uu___1, noaqs)
         | FStar_Parser_AST.Uvar u ->
-            let uu____7410 =
-              let uu____7415 =
-                let uu____7416 =
-                  let uu____7417 = FStar_Ident.string_of_id u in
-                  Prims.op_Hat uu____7417 " in non-universe context" in
-                Prims.op_Hat "Unexpected universe variable " uu____7416 in
-              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu____7415) in
-            FStar_Errors.raise_error uu____7410 top.FStar_Parser_AST.range
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Ident.string_of_id u in
+                  Prims.op_Hat uu___4 " in non-universe context" in
+                Prims.op_Hat "Unexpected universe variable " uu___3 in
+              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu___2) in
+            FStar_Errors.raise_error uu___1 top.FStar_Parser_AST.range
         | FStar_Parser_AST.Op (s, args) ->
-            let uu____7428 = op_as_term env (FStar_List.length args) s in
-            (match uu____7428 with
+            let uu___1 = op_as_term env (FStar_List.length args) s in
+            (match uu___1 with
              | FStar_Pervasives_Native.None ->
-                 let uu____7435 =
-                   let uu____7440 =
-                     let uu____7441 = FStar_Ident.string_of_id s in
-                     Prims.op_Hat "Unexpected or unbound operator: "
-                       uu____7441 in
-                   (FStar_Errors.Fatal_UnepxectedOrUnboundOperator,
-                     uu____7440) in
-                 FStar_Errors.raise_error uu____7435
-                   top.FStar_Parser_AST.range
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_id s in
+                     Prims.op_Hat "Unexpected or unbound operator: " uu___4 in
+                   (FStar_Errors.Fatal_UnepxectedOrUnboundOperator, uu___3) in
+                 FStar_Errors.raise_error uu___2 top.FStar_Parser_AST.range
              | FStar_Pervasives_Native.Some op ->
                  if (FStar_List.length args) > Prims.int_zero
                  then
-                   let uu____7451 =
-                     let uu____7476 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_All.pipe_right args
                          (FStar_List.map
                             (fun t ->
-                               let uu____7538 = desugar_term_aq env t in
-                               match uu____7538 with
+                               let uu___4 = desugar_term_aq env t in
+                               match uu___4 with
                                | (t', s1) ->
                                    ((t', FStar_Pervasives_Native.None), s1))) in
-                     FStar_All.pipe_right uu____7476 FStar_List.unzip in
-                   (match uu____7451 with
+                     FStar_All.pipe_right uu___3 FStar_List.unzip in
+                   (match uu___2 with
                     | (args1, aqs) ->
-                        let uu____7671 =
+                        let uu___3 =
                           mk (FStar_Syntax_Syntax.Tm_app (op, args1)) in
-                        (uu____7671, (join_aqs aqs)))
+                        (uu___3, (join_aqs aqs)))
                  else (op, noaqs))
-        | FStar_Parser_AST.Construct (n, (a, uu____7687)::[]) when
-            let uu____7702 = FStar_Ident.string_of_lid n in
-            uu____7702 = "SMTPat" ->
-            let uu____7703 =
-              let uu___1343_7704 = top in
-              let uu____7705 =
-                let uu____7706 =
-                  let uu____7713 =
-                    let uu___1345_7714 = top in
-                    let uu____7715 =
-                      let uu____7716 = smt_pat_lid top.FStar_Parser_AST.range in
-                      FStar_Parser_AST.Var uu____7716 in
+        | FStar_Parser_AST.Construct (n, (a, uu___1)::[]) when
+            let uu___2 = FStar_Ident.string_of_lid n in uu___2 = "SMTPat" ->
+            let uu___2 =
+              let uu___3 = top in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 = top in
+                    let uu___8 =
+                      let uu___9 = smt_pat_lid top.FStar_Parser_AST.range in
+                      FStar_Parser_AST.Var uu___9 in
                     {
-                      FStar_Parser_AST.tm = uu____7715;
+                      FStar_Parser_AST.tm = uu___8;
                       FStar_Parser_AST.range =
-                        (uu___1345_7714.FStar_Parser_AST.range);
+                        (uu___7.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1345_7714.FStar_Parser_AST.level)
+                        (uu___7.FStar_Parser_AST.level)
                     } in
-                  (uu____7713, a, FStar_Parser_AST.Nothing) in
-                FStar_Parser_AST.App uu____7706 in
+                  (uu___6, a, FStar_Parser_AST.Nothing) in
+                FStar_Parser_AST.App uu___5 in
               {
-                FStar_Parser_AST.tm = uu____7705;
-                FStar_Parser_AST.range =
-                  (uu___1343_7704.FStar_Parser_AST.range);
-                FStar_Parser_AST.level =
-                  (uu___1343_7704.FStar_Parser_AST.level)
+                FStar_Parser_AST.tm = uu___4;
+                FStar_Parser_AST.range = (uu___3.FStar_Parser_AST.range);
+                FStar_Parser_AST.level = (uu___3.FStar_Parser_AST.level)
               } in
-            desugar_term_maybe_top top_level env uu____7703
-        | FStar_Parser_AST.Construct (n, (a, uu____7719)::[]) when
-            let uu____7734 = FStar_Ident.string_of_lid n in
-            uu____7734 = "SMTPatT" ->
+            desugar_term_maybe_top top_level env uu___2
+        | FStar_Parser_AST.Construct (n, (a, uu___1)::[]) when
+            let uu___2 = FStar_Ident.string_of_lid n in uu___2 = "SMTPatT" ->
             (FStar_Errors.log_issue top.FStar_Parser_AST.range
                (FStar_Errors.Warning_SMTPatTDeprecated,
                  "SMTPatT is deprecated; please just use SMTPat");
-             (let uu____7736 =
-                let uu___1355_7737 = top in
-                let uu____7738 =
-                  let uu____7739 =
-                    let uu____7746 =
-                      let uu___1357_7747 = top in
-                      let uu____7748 =
-                        let uu____7749 =
-                          smt_pat_lid top.FStar_Parser_AST.range in
-                        FStar_Parser_AST.Var uu____7749 in
+             (let uu___3 =
+                let uu___4 = top in
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = top in
+                      let uu___9 =
+                        let uu___10 = smt_pat_lid top.FStar_Parser_AST.range in
+                        FStar_Parser_AST.Var uu___10 in
                       {
-                        FStar_Parser_AST.tm = uu____7748;
+                        FStar_Parser_AST.tm = uu___9;
                         FStar_Parser_AST.range =
-                          (uu___1357_7747.FStar_Parser_AST.range);
+                          (uu___8.FStar_Parser_AST.range);
                         FStar_Parser_AST.level =
-                          (uu___1357_7747.FStar_Parser_AST.level)
+                          (uu___8.FStar_Parser_AST.level)
                       } in
-                    (uu____7746, a, FStar_Parser_AST.Nothing) in
-                  FStar_Parser_AST.App uu____7739 in
+                    (uu___7, a, FStar_Parser_AST.Nothing) in
+                  FStar_Parser_AST.App uu___6 in
                 {
-                  FStar_Parser_AST.tm = uu____7738;
-                  FStar_Parser_AST.range =
-                    (uu___1355_7737.FStar_Parser_AST.range);
-                  FStar_Parser_AST.level =
-                    (uu___1355_7737.FStar_Parser_AST.level)
+                  FStar_Parser_AST.tm = uu___5;
+                  FStar_Parser_AST.range = (uu___4.FStar_Parser_AST.range);
+                  FStar_Parser_AST.level = (uu___4.FStar_Parser_AST.level)
                 } in
-              desugar_term_maybe_top top_level env uu____7736))
-        | FStar_Parser_AST.Construct (n, (a, uu____7752)::[]) when
-            let uu____7767 = FStar_Ident.string_of_lid n in
-            uu____7767 = "SMTPatOr" ->
-            let uu____7768 =
-              let uu___1366_7769 = top in
-              let uu____7770 =
-                let uu____7771 =
-                  let uu____7778 =
-                    let uu___1368_7779 = top in
-                    let uu____7780 =
-                      let uu____7781 =
-                        smt_pat_or_lid top.FStar_Parser_AST.range in
-                      FStar_Parser_AST.Var uu____7781 in
+              desugar_term_maybe_top top_level env uu___3))
+        | FStar_Parser_AST.Construct (n, (a, uu___1)::[]) when
+            let uu___2 = FStar_Ident.string_of_lid n in uu___2 = "SMTPatOr"
+            ->
+            let uu___2 =
+              let uu___3 = top in
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 = top in
+                    let uu___8 =
+                      let uu___9 = smt_pat_or_lid top.FStar_Parser_AST.range in
+                      FStar_Parser_AST.Var uu___9 in
                     {
-                      FStar_Parser_AST.tm = uu____7780;
+                      FStar_Parser_AST.tm = uu___8;
                       FStar_Parser_AST.range =
-                        (uu___1368_7779.FStar_Parser_AST.range);
+                        (uu___7.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1368_7779.FStar_Parser_AST.level)
+                        (uu___7.FStar_Parser_AST.level)
                     } in
-                  (uu____7778, a, FStar_Parser_AST.Nothing) in
-                FStar_Parser_AST.App uu____7771 in
+                  (uu___6, a, FStar_Parser_AST.Nothing) in
+                FStar_Parser_AST.App uu___5 in
               {
-                FStar_Parser_AST.tm = uu____7770;
-                FStar_Parser_AST.range =
-                  (uu___1366_7769.FStar_Parser_AST.range);
-                FStar_Parser_AST.level =
-                  (uu___1366_7769.FStar_Parser_AST.level)
+                FStar_Parser_AST.tm = uu___4;
+                FStar_Parser_AST.range = (uu___3.FStar_Parser_AST.range);
+                FStar_Parser_AST.level = (uu___3.FStar_Parser_AST.level)
               } in
-            desugar_term_maybe_top top_level env uu____7768
+            desugar_term_maybe_top top_level env uu___2
         | FStar_Parser_AST.Name lid when
-            let uu____7783 = FStar_Ident.string_of_lid lid in
-            uu____7783 = "Type0" ->
-            let uu____7784 =
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "Type0" ->
+            let uu___1 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero) in
-            (uu____7784, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____7786 = FStar_Ident.string_of_lid lid in
-            uu____7786 = "Type" ->
-            let uu____7787 =
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "Type" ->
+            let uu___1 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown) in
-            (uu____7787, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Construct (lid, (t, FStar_Parser_AST.UnivApp)::[])
             when
-            let uu____7804 = FStar_Ident.string_of_lid lid in
-            uu____7804 = "Type" ->
-            let uu____7805 =
-              let uu____7806 =
-                let uu____7807 = desugar_universe t in
-                FStar_Syntax_Syntax.Tm_type uu____7807 in
-              mk uu____7806 in
-            (uu____7805, noaqs)
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "Type" ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = desugar_universe t in
+                FStar_Syntax_Syntax.Tm_type uu___3 in
+              mk uu___2 in
+            (uu___1, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____7809 = FStar_Ident.string_of_lid lid in
-            uu____7809 = "Effect" ->
-            let uu____7810 =
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "Effect"
+            ->
+            let uu___1 =
               mk (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_effect) in
-            (uu____7810, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____7812 = FStar_Ident.string_of_lid lid in
-            uu____7812 = "True" ->
-            let uu____7813 =
-              let uu____7814 =
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "True" ->
+            let uu___1 =
+              let uu___2 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.true_lid
                   top.FStar_Parser_AST.range in
-              FStar_Syntax_Syntax.fvar uu____7814
+              FStar_Syntax_Syntax.fvar uu___2
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
-            (uu____7813, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____7816 = FStar_Ident.string_of_lid lid in
-            uu____7816 = "False" ->
-            let uu____7817 =
-              let uu____7818 =
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "False" ->
+            let uu___1 =
+              let uu___2 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.false_lid
                   top.FStar_Parser_AST.range in
-              FStar_Syntax_Syntax.fvar uu____7818
+              FStar_Syntax_Syntax.fvar uu___2
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
-            (uu____7817, noaqs)
+            (uu___1, noaqs)
         | FStar_Parser_AST.Projector (eff_name, id) when
-            (let uu____7823 = FStar_Ident.string_of_id id in
-             is_special_effect_combinator uu____7823) &&
+            (let uu___1 = FStar_Ident.string_of_id id in
+             is_special_effect_combinator uu___1) &&
               (FStar_Syntax_DsEnv.is_effect_name env eff_name)
             ->
             let txt = FStar_Ident.string_of_id id in
-            let uu____7825 =
+            let uu___1 =
               FStar_Syntax_DsEnv.try_lookup_effect_defn env eff_name in
-            (match uu____7825 with
+            (match uu___1 with
              | FStar_Pervasives_Native.Some ed ->
                  let lid = FStar_Syntax_Util.dm4f_lid ed txt in
-                 let uu____7834 =
+                 let uu___2 =
                    FStar_Syntax_Syntax.fvar lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None in
-                 (uu____7834, noaqs)
+                 (uu___2, noaqs)
              | FStar_Pervasives_Native.None ->
-                 let uu____7835 =
-                   let uu____7836 = FStar_Ident.string_of_lid eff_name in
+                 let uu___2 =
+                   let uu___3 = FStar_Ident.string_of_lid eff_name in
                    FStar_Util.format2
                      "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
-                     uu____7836 txt in
-                 failwith uu____7835)
+                     uu___3 txt in
+                 failwith uu___2)
         | FStar_Parser_AST.Var l ->
-            let uu____7842 = desugar_name mk setpos env true l in
-            (uu____7842, noaqs)
+            let uu___1 = desugar_name mk setpos env true l in (uu___1, noaqs)
         | FStar_Parser_AST.Name l ->
-            let uu____7849 = desugar_name mk setpos env true l in
-            (uu____7849, noaqs)
+            let uu___1 = desugar_name mk setpos env true l in (uu___1, noaqs)
         | FStar_Parser_AST.Projector (l, i) ->
             let name =
-              let uu____7864 = FStar_Syntax_DsEnv.try_lookup_datacon env l in
-              match uu____7864 with
-              | FStar_Pervasives_Native.Some uu____7873 ->
+              let uu___1 = FStar_Syntax_DsEnv.try_lookup_datacon env l in
+              match uu___1 with
+              | FStar_Pervasives_Native.Some uu___2 ->
                   FStar_Pervasives_Native.Some (true, l)
               | FStar_Pervasives_Native.None ->
-                  let uu____7878 =
+                  let uu___2 =
                     FStar_Syntax_DsEnv.try_lookup_root_effect_name env l in
-                  (match uu____7878 with
+                  (match uu___2 with
                    | FStar_Pervasives_Native.Some new_name ->
                        FStar_Pervasives_Native.Some (false, new_name)
-                   | uu____7892 -> FStar_Pervasives_Native.None) in
+                   | uu___3 -> FStar_Pervasives_Native.None) in
             (match name with
              | FStar_Pervasives_Native.Some (resolve, new_name) ->
-                 let uu____7909 =
-                   let uu____7910 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_Syntax_Util.mk_field_projector_name_from_ident
                        new_name i in
-                   desugar_name mk setpos env resolve uu____7910 in
-                 (uu____7909, noaqs)
-             | uu____7916 ->
-                 let uu____7923 =
-                   let uu____7928 =
-                     let uu____7929 = FStar_Ident.string_of_lid l in
+                   desugar_name mk setpos env resolve uu___2 in
+                 (uu___1, noaqs)
+             | uu___1 ->
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_lid l in
                      FStar_Util.format1
-                       "Data constructor or effect %s not found" uu____7929 in
-                   (FStar_Errors.Fatal_EffectNotFound, uu____7928) in
-                 FStar_Errors.raise_error uu____7923
-                   top.FStar_Parser_AST.range)
+                       "Data constructor or effect %s not found" uu___4 in
+                   (FStar_Errors.Fatal_EffectNotFound, uu___3) in
+                 FStar_Errors.raise_error uu___2 top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Discrim lid ->
-            let uu____7935 = FStar_Syntax_DsEnv.try_lookup_datacon env lid in
-            (match uu____7935 with
+            let uu___1 = FStar_Syntax_DsEnv.try_lookup_datacon env lid in
+            (match uu___1 with
              | FStar_Pervasives_Native.None ->
-                 let uu____7942 =
-                   let uu____7947 =
-                     let uu____7948 = FStar_Ident.string_of_lid lid in
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_lid lid in
                      FStar_Util.format1 "Data constructor %s not found"
-                       uu____7948 in
-                   (FStar_Errors.Fatal_DataContructorNotFound, uu____7947) in
-                 FStar_Errors.raise_error uu____7942
-                   top.FStar_Parser_AST.range
-             | uu____7953 ->
+                       uu___4 in
+                   (FStar_Errors.Fatal_DataContructorNotFound, uu___3) in
+                 FStar_Errors.raise_error uu___2 top.FStar_Parser_AST.range
+             | uu___2 ->
                  let lid' = FStar_Syntax_Util.mk_discriminator lid in
-                 let uu____7957 = desugar_name mk setpos env true lid' in
-                 (uu____7957, noaqs))
+                 let uu___3 = desugar_name mk setpos env true lid' in
+                 (uu___3, noaqs))
         | FStar_Parser_AST.Construct (l, args) ->
-            let uu____7977 = FStar_Syntax_DsEnv.try_lookup_datacon env l in
-            (match uu____7977 with
+            let uu___1 = FStar_Syntax_DsEnv.try_lookup_datacon env l in
+            (match uu___1 with
              | FStar_Pervasives_Native.Some head ->
                  let head1 = mk (FStar_Syntax_Syntax.Tm_fvar head) in
                  (match args with
                   | [] -> (head1, noaqs)
-                  | uu____7996 ->
-                      let uu____8003 =
+                  | uu___2 ->
+                      let uu___3 =
                         FStar_Util.take
-                          (fun uu____8027 ->
-                             match uu____8027 with
-                             | (uu____8032, imp) ->
+                          (fun uu___4 ->
+                             match uu___4 with
+                             | (uu___5, imp) ->
                                  imp = FStar_Parser_AST.UnivApp) args in
-                      (match uu____8003 with
+                      (match uu___3 with
                        | (universes, args1) ->
                            let universes1 =
                              FStar_List.map
@@ -2492,20 +2388,19 @@ and (desugar_term_maybe_top :
                                   desugar_universe
                                     (FStar_Pervasives_Native.fst x))
                                universes in
-                           let uu____8077 =
-                             let uu____8102 =
+                           let uu___4 =
+                             let uu___5 =
                                FStar_List.map
-                                 (fun uu____8145 ->
-                                    match uu____8145 with
+                                 (fun uu___6 ->
+                                    match uu___6 with
                                     | (t, imp) ->
-                                        let uu____8162 =
-                                          desugar_term_aq env t in
-                                        (match uu____8162 with
+                                        let uu___7 = desugar_term_aq env t in
+                                        (match uu___7 with
                                          | (te, aq) ->
                                              ((arg_withimp_e imp te), aq)))
                                  args1 in
-                             FStar_All.pipe_right uu____8102 FStar_List.unzip in
-                           (match uu____8077 with
+                             FStar_All.pipe_right uu___5 FStar_List.unzip in
+                           (match uu___4 with
                             | (args2, aqs) ->
                                 let head2 =
                                   if universes1 = []
@@ -2514,176 +2409,171 @@ and (desugar_term_maybe_top :
                                     mk
                                       (FStar_Syntax_Syntax.Tm_uinst
                                          (head1, universes1)) in
-                                let uu____8303 =
+                                let uu___5 =
                                   mk
                                     (FStar_Syntax_Syntax.Tm_app
                                        (head2, args2)) in
-                                (uu____8303, (join_aqs aqs)))))
+                                (uu___5, (join_aqs aqs)))))
              | FStar_Pervasives_Native.None ->
                  let err =
-                   let uu____8321 =
+                   let uu___2 =
                      FStar_Syntax_DsEnv.try_lookup_effect_name env l in
-                   match uu____8321 with
+                   match uu___2 with
                    | FStar_Pervasives_Native.None ->
-                       let uu____8328 =
-                         let uu____8329 =
-                           let uu____8330 = FStar_Ident.string_of_lid l in
-                           Prims.op_Hat uu____8330 " not found" in
-                         Prims.op_Hat "Constructor " uu____8329 in
-                       (FStar_Errors.Fatal_ConstructorNotFound, uu____8328)
-                   | FStar_Pervasives_Native.Some uu____8331 ->
-                       let uu____8332 =
-                         let uu____8333 =
-                           let uu____8334 = FStar_Ident.string_of_lid l in
-                           Prims.op_Hat uu____8334
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Ident.string_of_lid l in
+                           Prims.op_Hat uu___5 " not found" in
+                         Prims.op_Hat "Constructor " uu___4 in
+                       (FStar_Errors.Fatal_ConstructorNotFound, uu___3)
+                   | FStar_Pervasives_Native.Some uu___3 ->
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 = FStar_Ident.string_of_lid l in
+                           Prims.op_Hat uu___6
                              " used at an unexpected position" in
-                         Prims.op_Hat "Effect " uu____8333 in
-                       (FStar_Errors.Fatal_UnexpectedEffect, uu____8332) in
+                         Prims.op_Hat "Effect " uu___5 in
+                       (FStar_Errors.Fatal_UnexpectedEffect, uu___4) in
                  FStar_Errors.raise_error err top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Sum (binders, t) when
             FStar_Util.for_all
-              (fun uu___8_8359 ->
-                 match uu___8_8359 with
-                 | FStar_Util.Inr uu____8364 -> true
-                 | uu____8365 -> false) binders
+              (fun uu___1 ->
+                 match uu___1 with
+                 | FStar_Util.Inr uu___2 -> true
+                 | uu___2 -> false) binders
             ->
             let terms =
-              let uu____8373 =
+              let uu___1 =
                 FStar_All.pipe_right binders
                   (FStar_List.map
-                     (fun uu___9_8390 ->
-                        match uu___9_8390 with
+                     (fun uu___2 ->
+                        match uu___2 with
                         | FStar_Util.Inr x -> x
-                        | FStar_Util.Inl uu____8396 -> failwith "Impossible")) in
-              FStar_List.append uu____8373 [t] in
-            let uu____8397 =
-              let uu____8422 =
+                        | FStar_Util.Inl uu___3 -> failwith "Impossible")) in
+              FStar_List.append uu___1 [t] in
+            let uu___1 =
+              let uu___2 =
                 FStar_All.pipe_right terms
                   (FStar_List.map
                      (fun t1 ->
-                        let uu____8479 = desugar_typ_aq env t1 in
-                        match uu____8479 with
+                        let uu___3 = desugar_typ_aq env t1 in
+                        match uu___3 with
                         | (t', aq) ->
-                            let uu____8490 = FStar_Syntax_Syntax.as_arg t' in
-                            (uu____8490, aq))) in
-              FStar_All.pipe_right uu____8422 FStar_List.unzip in
-            (match uu____8397 with
+                            let uu___4 = FStar_Syntax_Syntax.as_arg t' in
+                            (uu___4, aq))) in
+              FStar_All.pipe_right uu___2 FStar_List.unzip in
+            (match uu___1 with
              | (targs, aqs) ->
                  let tup =
-                   let uu____8600 =
+                   let uu___2 =
                      FStar_Parser_Const.mk_tuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range in
                    FStar_Syntax_DsEnv.fail_or env
-                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu____8600 in
-                 let uu____8609 =
-                   mk (FStar_Syntax_Syntax.Tm_app (tup, targs)) in
-                 (uu____8609, (join_aqs aqs)))
+                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu___2 in
+                 let uu___2 = mk (FStar_Syntax_Syntax.Tm_app (tup, targs)) in
+                 (uu___2, (join_aqs aqs)))
         | FStar_Parser_AST.Sum (binders, t) ->
-            let uu____8636 =
-              let uu____8653 =
-                let uu____8660 =
-                  let uu____8667 =
-                    FStar_All.pipe_left
-                      (fun uu____8676 -> FStar_Util.Inl uu____8676)
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    FStar_All.pipe_left (fun uu___5 -> FStar_Util.Inl uu___5)
                       (FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
                          t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
                          FStar_Pervasives_Native.None) in
-                  [uu____8667] in
-                FStar_List.append binders uu____8660 in
+                  [uu___4] in
+                FStar_List.append binders uu___3 in
               FStar_List.fold_left
-                (fun uu____8721 ->
+                (fun uu___3 ->
                    fun b ->
-                     match uu____8721 with
+                     match uu___3 with
                      | (env1, tparams, typs) ->
-                         let uu____8782 =
+                         let uu___4 =
                            match b with
                            | FStar_Util.Inl b1 -> desugar_binder env1 b1
                            | FStar_Util.Inr t1 ->
-                               let uu____8797 = desugar_typ env1 t1 in
-                               (FStar_Pervasives_Native.None, uu____8797) in
-                         (match uu____8782 with
+                               let uu___5 = desugar_typ env1 t1 in
+                               (FStar_Pervasives_Native.None, uu___5) in
+                         (match uu___4 with
                           | (xopt, t1) ->
-                              let uu____8822 =
+                              let uu___5 =
                                 match xopt with
                                 | FStar_Pervasives_Native.None ->
-                                    let uu____8831 =
+                                    let uu___6 =
                                       FStar_Syntax_Syntax.new_bv
                                         (FStar_Pervasives_Native.Some
                                            (top.FStar_Parser_AST.range))
                                         (setpos FStar_Syntax_Syntax.tun) in
-                                    (env1, uu____8831)
+                                    (env1, uu___6)
                                 | FStar_Pervasives_Native.Some x ->
                                     FStar_Syntax_DsEnv.push_bv env1 x in
-                              (match uu____8822 with
+                              (match uu___5 with
                                | (env2, x) ->
-                                   let uu____8851 =
-                                     let uu____8854 =
-                                       let uu____8857 =
-                                         let uu____8858 =
-                                           no_annot_abs tparams t1 in
+                                   let uu___6 =
+                                     let uu___7 =
+                                       let uu___8 =
+                                         let uu___9 = no_annot_abs tparams t1 in
                                          FStar_All.pipe_left
-                                           FStar_Syntax_Syntax.as_arg
-                                           uu____8858 in
-                                       [uu____8857] in
-                                     FStar_List.append typs uu____8854 in
+                                           FStar_Syntax_Syntax.as_arg uu___9 in
+                                       [uu___8] in
+                                     FStar_List.append typs uu___7 in
                                    (env2,
                                      (FStar_List.append tparams
-                                        [(((let uu___1497_8884 = x in
+                                        [(((let uu___7 = x in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___1497_8884.FStar_Syntax_Syntax.ppname);
+                                                (uu___7.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___1497_8884.FStar_Syntax_Syntax.index);
+                                                (uu___7.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort = t1
                                             })),
                                            FStar_Pervasives_Native.None)]),
-                                     uu____8851)))) (env, [], []) uu____8653 in
-            (match uu____8636 with
-             | (env1, uu____8912, targs) ->
+                                     uu___6)))) (env, [], []) uu___2 in
+            (match uu___1 with
+             | (env1, uu___2, targs) ->
                  let tup =
-                   let uu____8935 =
+                   let uu___3 =
                      FStar_Parser_Const.mk_dtuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range in
                    FStar_Syntax_DsEnv.fail_or env1
-                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu____8935 in
-                 let uu____8936 =
+                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu___3 in
+                 let uu___3 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_app (tup, targs)) in
-                 (uu____8936, noaqs))
+                 (uu___3, noaqs))
         | FStar_Parser_AST.Product (binders, t) ->
-            let uu____8955 = uncurry binders t in
-            (match uu____8955 with
+            let uu___1 = uncurry binders t in
+            (match uu___1 with
              | (bs, t1) ->
-                 let rec aux env1 bs1 uu___10_8999 =
-                   match uu___10_8999 with
+                 let rec aux env1 bs1 uu___2 =
+                   match uu___2 with
                    | [] ->
                        let cod =
                          desugar_comp top.FStar_Parser_AST.range true env1 t1 in
-                       let uu____9015 =
+                       let uu___3 =
                          FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod in
-                       FStar_All.pipe_left setpos uu____9015
+                       FStar_All.pipe_left setpos uu___3
                    | hd::tl ->
                        let bb = desugar_binder env1 hd in
-                       let uu____9039 =
+                       let uu___3 =
                          as_binder env1 hd.FStar_Parser_AST.aqual bb in
-                       (match uu____9039 with
+                       (match uu___3 with
                         | (b, env2) -> aux env2 (b :: bs1) tl) in
-                 let uu____9072 = aux env [] bs in (uu____9072, noaqs))
+                 let uu___2 = aux env [] bs in (uu___2, noaqs))
         | FStar_Parser_AST.Refine (b, f) ->
-            let uu____9081 = desugar_binder env b in
-            (match uu____9081 with
-             | (FStar_Pervasives_Native.None, uu____9092) ->
+            let uu___1 = desugar_binder env b in
+            (match uu___1 with
+             | (FStar_Pervasives_Native.None, uu___2) ->
                  failwith "Missing binder in refinement"
              | b1 ->
-                 let uu____9106 =
-                   as_binder env FStar_Pervasives_Native.None b1 in
-                 (match uu____9106 with
-                  | ((x, uu____9122), env1) ->
+                 let uu___2 = as_binder env FStar_Pervasives_Native.None b1 in
+                 (match uu___2 with
+                  | ((x, uu___3), env1) ->
                       let f1 = desugar_formula env1 f in
-                      let uu____9135 =
-                        let uu____9136 = FStar_Syntax_Util.refine x f1 in
-                        FStar_All.pipe_left setpos uu____9136 in
-                      (uu____9135, noaqs)))
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Util.refine x f1 in
+                        FStar_All.pipe_left setpos uu___5 in
+                      (uu___4, noaqs)))
         | FStar_Parser_AST.Abs (binders, body) ->
             let bvss = FStar_List.map gather_pattern_bound_vars binders in
             let check_disjoint sets =
@@ -2692,67 +2582,65 @@ and (desugar_term_maybe_top :
                 | [] -> FStar_Pervasives_Native.None
                 | set::sets2 ->
                     let i = FStar_Util.set_intersect acc set in
-                    let uu____9214 = FStar_Util.set_is_empty i in
-                    if uu____9214
+                    let uu___1 = FStar_Util.set_is_empty i in
+                    if uu___1
                     then
-                      let uu____9217 = FStar_Util.set_union acc set in
-                      aux uu____9217 sets2
+                      let uu___2 = FStar_Util.set_union acc set in
+                      aux uu___2 sets2
                     else
-                      (let uu____9221 =
-                         let uu____9222 = FStar_Util.set_elements i in
-                         FStar_List.hd uu____9222 in
-                       FStar_Pervasives_Native.Some uu____9221) in
-              let uu____9225 = FStar_Syntax_Syntax.new_id_set () in
-              aux uu____9225 sets in
-            ((let uu____9229 = check_disjoint bvss in
-              match uu____9229 with
+                      (let uu___3 =
+                         let uu___4 = FStar_Util.set_elements i in
+                         FStar_List.hd uu___4 in
+                       FStar_Pervasives_Native.Some uu___3) in
+              let uu___1 = FStar_Syntax_Syntax.new_id_set () in
+              aux uu___1 sets in
+            ((let uu___2 = check_disjoint bvss in
+              match uu___2 with
               | FStar_Pervasives_Native.None -> ()
               | FStar_Pervasives_Native.Some id ->
-                  let uu____9233 =
-                    let uu____9238 =
-                      let uu____9239 = FStar_Ident.string_of_id id in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = FStar_Ident.string_of_id id in
                       FStar_Util.format1
                         "Non-linear patterns are not permitted: `%s` appears more than once in this function definition."
-                        uu____9239 in
-                    (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
-                      uu____9238) in
-                  let uu____9240 = FStar_Ident.range_of_id id in
-                  FStar_Errors.raise_error uu____9233 uu____9240);
+                        uu___5 in
+                    (FStar_Errors.Fatal_NonLinearPatternNotPermitted, uu___4) in
+                  let uu___4 = FStar_Ident.range_of_id id in
+                  FStar_Errors.raise_error uu___3 uu___4);
              (let binders1 =
                 FStar_All.pipe_right binders
                   (FStar_List.map replace_unit_pattern) in
-              let uu____9248 =
+              let uu___2 =
                 FStar_List.fold_left
-                  (fun uu____9268 ->
+                  (fun uu___3 ->
                      fun pat ->
-                       match uu____9268 with
+                       match uu___3 with
                        | (env1, ftvs) ->
                            (match pat.FStar_Parser_AST.pat with
                             | FStar_Parser_AST.PatAscribed
-                                (uu____9294,
-                                 (t, FStar_Pervasives_Native.None))
+                                (uu___4, (t, FStar_Pervasives_Native.None))
                                 ->
-                                let uu____9304 =
-                                  let uu____9307 = free_type_vars env1 t in
-                                  FStar_List.append uu____9307 ftvs in
-                                (env1, uu____9304)
+                                let uu___5 =
+                                  let uu___6 = free_type_vars env1 t in
+                                  FStar_List.append uu___6 ftvs in
+                                (env1, uu___5)
                             | FStar_Parser_AST.PatAscribed
-                                (uu____9312,
+                                (uu___4,
                                  (t, FStar_Pervasives_Native.Some tac))
                                 ->
-                                let uu____9323 =
-                                  let uu____9326 = free_type_vars env1 t in
-                                  let uu____9329 =
-                                    let uu____9332 = free_type_vars env1 tac in
-                                    FStar_List.append uu____9332 ftvs in
-                                  FStar_List.append uu____9326 uu____9329 in
-                                (env1, uu____9323)
-                            | uu____9337 -> (env1, ftvs))) (env, []) binders1 in
-              match uu____9248 with
-              | (uu____9346, ftv) ->
+                                let uu___5 =
+                                  let uu___6 = free_type_vars env1 t in
+                                  let uu___7 =
+                                    let uu___8 = free_type_vars env1 tac in
+                                    FStar_List.append uu___8 ftvs in
+                                  FStar_List.append uu___6 uu___7 in
+                                (env1, uu___5)
+                            | uu___4 -> (env1, ftvs))) (env, []) binders1 in
+              match uu___2 with
+              | (uu___3, ftv) ->
                   let ftv1 = sort_ftv ftv in
                   let binders2 =
-                    let uu____9358 =
+                    let uu___4 =
                       FStar_All.pipe_right ftv1
                         (FStar_List.map
                            (fun a ->
@@ -2762,69 +2650,66 @@ and (desugar_term_maybe_top :
                                      (FStar_Pervasives_Native.Some
                                         FStar_Parser_AST.Implicit)))
                                 top.FStar_Parser_AST.range)) in
-                    FStar_List.append uu____9358 binders1 in
+                    FStar_List.append uu___4 binders1 in
                   let rec aux env1 bs sc_pat_opt pats =
                     match pats with
                     | [] ->
-                        let uu____9438 = desugar_term_aq env1 body in
-                        (match uu____9438 with
+                        let uu___4 = desugar_term_aq env1 body in
+                        (match uu___4 with
                          | (body1, aq) ->
                              let body2 =
                                match sc_pat_opt with
                                | FStar_Pervasives_Native.Some (sc, pat) ->
-                                   let body2 =
-                                     let uu____9473 =
-                                       let uu____9474 =
+                                   let body3 =
+                                     let uu___5 =
+                                       let uu___6 =
                                          FStar_Syntax_Syntax.pat_bvs pat in
-                                       FStar_All.pipe_right uu____9474
+                                       FStar_All.pipe_right uu___6
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.mk_binder) in
-                                     FStar_Syntax_Subst.close uu____9473
-                                       body1 in
+                                     FStar_Syntax_Subst.close uu___5 body1 in
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_match
                                         (sc,
                                           [(pat,
                                              FStar_Pervasives_Native.None,
-                                             body2)]))
-                                     body2.FStar_Syntax_Syntax.pos
+                                             body3)]))
+                                     body3.FStar_Syntax_Syntax.pos
                                | FStar_Pervasives_Native.None -> body1 in
-                             let uu____9543 =
-                               let uu____9544 =
+                             let uu___5 =
+                               let uu___6 =
                                  no_annot_abs (FStar_List.rev bs) body2 in
-                               setpos uu____9544 in
-                             (uu____9543, aq))
+                               setpos uu___6 in
+                             (uu___5, aq))
                     | p::rest ->
-                        let uu____9557 = desugar_binding_pat env1 p in
-                        (match uu____9557 with
+                        let uu___4 = desugar_binding_pat env1 p in
+                        (match uu___4 with
                          | (env2, b, pat) ->
                              let pat1 =
                                match pat with
                                | [] -> FStar_Pervasives_Native.None
-                               | (p1, uu____9589)::[] ->
+                               | (p1, uu___5)::[] ->
                                    FStar_Pervasives_Native.Some p1
-                               | uu____9604 ->
+                               | uu___5 ->
                                    FStar_Errors.raise_error
                                      (FStar_Errors.Fatal_UnsupportedDisjuctivePatterns,
                                        "Disjunctive patterns are not supported in abstractions")
                                      p.FStar_Parser_AST.prange in
-                             let uu____9611 =
+                             let uu___5 =
                                match b with
-                               | LetBinder uu____9652 ->
-                                   failwith "Impossible"
+                               | LetBinder uu___6 -> failwith "Impossible"
                                | LocalBinder (x, aq) ->
                                    let sc_pat_opt1 =
                                      match (pat1, sc_pat_opt) with
-                                     | (FStar_Pervasives_Native.None,
-                                        uu____9720) -> sc_pat_opt
+                                     | (FStar_Pervasives_Native.None, uu___6)
+                                         -> sc_pat_opt
                                      | (FStar_Pervasives_Native.Some p1,
                                         FStar_Pervasives_Native.None) ->
-                                         let uu____9774 =
-                                           let uu____9783 =
+                                         let uu___6 =
+                                           let uu___7 =
                                              FStar_Syntax_Syntax.bv_to_name x in
-                                           (uu____9783, p1) in
-                                         FStar_Pervasives_Native.Some
-                                           uu____9774
+                                           (uu___7, p1) in
+                                         FStar_Pervasives_Native.Some uu___6
                                      | (FStar_Pervasives_Native.Some p1,
                                         FStar_Pervasives_Native.Some
                                         (sc, p')) ->
@@ -2832,47 +2717,45 @@ and (desugar_term_maybe_top :
                                                   (p'.FStar_Syntax_Syntax.v))
                                           with
                                           | (FStar_Syntax_Syntax.Tm_name
-                                             uu____9845, uu____9846) ->
+                                             uu___6, uu___7) ->
                                               let tup2 =
-                                                let uu____9848 =
+                                                let uu___8 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.of_int (2))
                                                     top.FStar_Parser_AST.range in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____9848
+                                                  uu___8
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor) in
                                               let sc1 =
-                                                let uu____9852 =
-                                                  let uu____9853 =
-                                                    let uu____9870 =
+                                                let uu___8 =
+                                                  let uu___9 =
+                                                    let uu___10 =
                                                       mk
                                                         (FStar_Syntax_Syntax.Tm_fvar
                                                            tup2) in
-                                                    let uu____9873 =
-                                                      let uu____9884 =
+                                                    let uu___11 =
+                                                      let uu___12 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           sc in
-                                                      let uu____9893 =
-                                                        let uu____9904 =
-                                                          let uu____9913 =
+                                                      let uu___13 =
+                                                        let uu___14 =
+                                                          let uu___15 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
                                                           FStar_All.pipe_left
                                                             FStar_Syntax_Syntax.as_arg
-                                                            uu____9913 in
-                                                        [uu____9904] in
-                                                      uu____9884 ::
-                                                        uu____9893 in
-                                                    (uu____9870, uu____9873) in
+                                                            uu___15 in
+                                                        [uu___14] in
+                                                      uu___12 :: uu___13 in
+                                                    (uu___10, uu___11) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____9853 in
-                                                FStar_Syntax_Syntax.mk
-                                                  uu____9852
+                                                    uu___9 in
+                                                FStar_Syntax_Syntax.mk uu___8
                                                   top.FStar_Parser_AST.range in
                                               let p2 =
-                                                let uu____9961 =
+                                                let uu___8 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p in
@@ -2880,52 +2763,50 @@ and (desugar_term_maybe_top :
                                                   (FStar_Syntax_Syntax.Pat_cons
                                                      (tup2,
                                                        [(p', false);
-                                                       (p1, false)]))
-                                                  uu____9961 in
+                                                       (p1, false)])) uu___8 in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
                                           | (FStar_Syntax_Syntax.Tm_app
-                                             (uu____10004, args),
+                                             (uu___6, args),
                                              FStar_Syntax_Syntax.Pat_cons
-                                             (uu____10006, pats1)) ->
+                                             (uu___7, pats1)) ->
                                               let tupn =
-                                                let uu____10049 =
+                                                let uu___8 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.int_one +
                                                        (FStar_List.length
                                                           args))
                                                     top.FStar_Parser_AST.range in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____10049
+                                                  uu___8
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor) in
                                               let sc1 =
-                                                let uu____10061 =
-                                                  let uu____10062 =
-                                                    let uu____10079 =
+                                                let uu___8 =
+                                                  let uu___9 =
+                                                    let uu___10 =
                                                       mk
                                                         (FStar_Syntax_Syntax.Tm_fvar
                                                            tupn) in
-                                                    let uu____10082 =
-                                                      let uu____10093 =
-                                                        let uu____10104 =
-                                                          let uu____10113 =
+                                                    let uu___11 =
+                                                      let uu___12 =
+                                                        let uu___13 =
+                                                          let uu___14 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
                                                           FStar_All.pipe_left
                                                             FStar_Syntax_Syntax.as_arg
-                                                            uu____10113 in
-                                                        [uu____10104] in
+                                                            uu___14 in
+                                                        [uu___13] in
                                                       FStar_List.append args
-                                                        uu____10093 in
-                                                    (uu____10079,
-                                                      uu____10082) in
+                                                        uu___12 in
+                                                    (uu___10, uu___11) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____10062 in
-                                                mk uu____10061 in
+                                                    uu___9 in
+                                                mk uu___8 in
                                               let p2 =
-                                                let uu____10161 =
+                                                let uu___8 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p in
@@ -2934,76 +2815,72 @@ and (desugar_term_maybe_top :
                                                      (tupn,
                                                        (FStar_List.append
                                                           pats1 [(p1, false)])))
-                                                  uu____10161 in
+                                                  uu___8 in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
-                                          | uu____10202 ->
-                                              failwith "Impossible") in
+                                          | uu___6 -> failwith "Impossible") in
                                    ((x, aq), sc_pat_opt1) in
-                             (match uu____9611 with
+                             (match uu___5 with
                               | (b1, sc_pat_opt1) ->
                                   aux env2 (b1 :: bs) sc_pat_opt1 rest)) in
                   aux env [] FStar_Pervasives_Native.None binders2))
-        | FStar_Parser_AST.App
-            (uu____10293, uu____10294, FStar_Parser_AST.UnivApp) ->
+        | FStar_Parser_AST.App (uu___1, uu___2, FStar_Parser_AST.UnivApp) ->
             let rec aux universes e =
-              let uu____10316 =
-                let uu____10317 = unparen e in
-                uu____10317.FStar_Parser_AST.tm in
-              match uu____10316 with
+              let uu___3 =
+                let uu___4 = unparen e in uu___4.FStar_Parser_AST.tm in
+              match uu___3 with
               | FStar_Parser_AST.App (e1, t, FStar_Parser_AST.UnivApp) ->
                   let univ_arg = desugar_universe t in
                   aux (univ_arg :: universes) e1
-              | uu____10327 ->
-                  let uu____10328 = desugar_term_aq env e in
-                  (match uu____10328 with
+              | uu___4 ->
+                  let uu___5 = desugar_term_aq env e in
+                  (match uu___5 with
                    | (head, aq) ->
-                       let uu____10341 =
+                       let uu___6 =
                          mk (FStar_Syntax_Syntax.Tm_uinst (head, universes)) in
-                       (uu____10341, aq)) in
+                       (uu___6, aq)) in
             aux [] top
-        | FStar_Parser_AST.App uu____10348 ->
+        | FStar_Parser_AST.App uu___1 ->
             let rec aux args aqs e =
-              let uu____10423 =
-                let uu____10424 = unparen e in
-                uu____10424.FStar_Parser_AST.tm in
-              match uu____10423 with
+              let uu___2 =
+                let uu___3 = unparen e in uu___3.FStar_Parser_AST.tm in
+              match uu___2 with
               | FStar_Parser_AST.App (e1, t, imp) when
                   imp <> FStar_Parser_AST.UnivApp ->
-                  let uu____10440 = desugar_term_aq env t in
-                  (match uu____10440 with
+                  let uu___3 = desugar_term_aq env t in
+                  (match uu___3 with
                    | (t1, aq) ->
                        let arg = arg_withimp_e imp t1 in
                        aux (arg :: args) (aq :: aqs) e1)
-              | uu____10486 ->
-                  let uu____10487 = desugar_term_aq env e in
-                  (match uu____10487 with
+              | uu___3 ->
+                  let uu___4 = desugar_term_aq env e in
+                  (match uu___4 with
                    | (head, aq) ->
-                       let uu____10506 =
+                       let uu___5 =
                          FStar_Syntax_Syntax.extend_app_n head args
                            top.FStar_Parser_AST.range in
-                       (uu____10506, (join_aqs (aq :: aqs)))) in
+                       (uu___5, (join_aqs (aq :: aqs)))) in
             aux [] [] top
         | FStar_Parser_AST.Bind (x, t1, t2) ->
             let xpat =
-              let uu____10543 = FStar_Ident.range_of_id x in
+              let uu___1 = FStar_Ident.range_of_id x in
               FStar_Parser_AST.mk_pattern
                 (FStar_Parser_AST.PatVar (x, FStar_Pervasives_Native.None))
-                uu____10543 in
+                uu___1 in
             let k =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Abs ([xpat], t2))
                 t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level in
             let bind_lid =
-              let uu____10550 = FStar_Ident.range_of_id x in
-              FStar_Ident.lid_of_path ["bind"] uu____10550 in
+              let uu___1 = FStar_Ident.range_of_id x in
+              FStar_Ident.lid_of_path ["bind"] uu___1 in
             let bind =
-              let uu____10552 = FStar_Ident.range_of_id x in
-              FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid)
-                uu____10552 FStar_Parser_AST.Expr in
-            let uu____10553 =
+              let uu___1 = FStar_Ident.range_of_id x in
+              FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid) uu___1
+                FStar_Parser_AST.Expr in
+            let uu___1 =
               FStar_Parser_AST.mkExplicitApp bind [t1; k]
                 top.FStar_Parser_AST.range in
-            desugar_term_aq env uu____10553
+            desugar_term_aq env uu___1
         | FStar_Parser_AST.Seq (t1, t2) ->
             let t =
               FStar_Parser_AST.mk_term
@@ -3015,141 +2892,136 @@ and (desugar_term_maybe_top :
                                FStar_Pervasives_Native.None)
                             t1.FStar_Parser_AST.range), t1))], t2))
                 top.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-            let uu____10605 = desugar_term_aq env t in
-            (match uu____10605 with
+            let uu___1 = desugar_term_aq env t in
+            (match uu___1 with
              | (tm, s) ->
-                 let uu____10616 =
+                 let uu___2 =
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (tm,
                           (FStar_Syntax_Syntax.Meta_desugared
                              FStar_Syntax_Syntax.Sequence))) in
-                 (uu____10616, s))
+                 (uu___2, s))
         | FStar_Parser_AST.LetOpen (lid, e) ->
             let env1 = FStar_Syntax_DsEnv.push_namespace env lid in
-            let uu____10622 =
-              let uu____10635 = FStar_Syntax_DsEnv.expect_typ env1 in
-              if uu____10635 then desugar_typ_aq else desugar_term_aq in
-            uu____10622 env1 e
+            let uu___1 =
+              let uu___2 = FStar_Syntax_DsEnv.expect_typ env1 in
+              if uu___2 then desugar_typ_aq else desugar_term_aq in
+            uu___1 env1 e
         | FStar_Parser_AST.Let (qual, lbs, body) ->
             let is_rec = qual = FStar_Parser_AST.Rec in
-            let ds_let_rec_or_app uu____10698 =
+            let ds_let_rec_or_app uu___1 =
               let bindings = lbs in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
-                     (fun uu____10841 ->
-                        match uu____10841 with
+                     (fun uu___2 ->
+                        match uu___2 with
                         | (attr_opt, (p, def)) ->
-                            let uu____10899 = is_app_pattern p in
-                            if uu____10899
+                            let uu___3 = is_app_pattern p in
+                            if uu___3
                             then
-                              let uu____10930 =
+                              let uu___4 =
                                 destruct_app_pattern env top_level p in
-                              (attr_opt, uu____10930, def)
+                              (attr_opt, uu___4, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1, def1) ->
-                                   let uu____11012 =
+                                   let uu___5 =
                                      destruct_app_pattern env top_level p1 in
-                                   (attr_opt, uu____11012, def1)
-                               | uu____11057 ->
+                                   (attr_opt, uu___5, def1)
+                               | uu___5 ->
                                    (match p.FStar_Parser_AST.pat with
                                     | FStar_Parser_AST.PatAscribed
                                         ({
                                            FStar_Parser_AST.pat =
                                              FStar_Parser_AST.PatVar
-                                             (id, uu____11095);
-                                           FStar_Parser_AST.prange =
-                                             uu____11096;_},
+                                             (id, uu___6);
+                                           FStar_Parser_AST.prange = uu___7;_},
                                          t)
                                         ->
                                         if top_level
                                         then
-                                          let uu____11144 =
-                                            let uu____11165 =
-                                              let uu____11170 =
+                                          let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id in
-                                              FStar_Util.Inr uu____11170 in
-                                            (uu____11165, [],
+                                              FStar_Util.Inr uu___10 in
+                                            (uu___9, [],
                                               (FStar_Pervasives_Native.Some t)) in
-                                          (attr_opt, uu____11144, def)
+                                          (attr_opt, uu___8, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               (FStar_Pervasives_Native.Some t)),
                                             def)
-                                    | FStar_Parser_AST.PatVar
-                                        (id, uu____11261) ->
+                                    | FStar_Parser_AST.PatVar (id, uu___6) ->
                                         if top_level
                                         then
-                                          let uu____11296 =
-                                            let uu____11317 =
-                                              let uu____11322 =
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id in
-                                              FStar_Util.Inr uu____11322 in
-                                            (uu____11317, [],
+                                              FStar_Util.Inr uu___9 in
+                                            (uu___8, [],
                                               FStar_Pervasives_Native.None) in
-                                          (attr_opt, uu____11296, def)
+                                          (attr_opt, uu___7, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               FStar_Pervasives_Native.None),
                                             def)
-                                    | uu____11412 ->
+                                    | uu___6 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
                                           p.FStar_Parser_AST.prange)))) in
-              let uu____11443 =
+              let uu___2 =
                 FStar_List.fold_left
-                  (fun uu____11530 ->
-                     fun uu____11531 ->
-                       match (uu____11530, uu____11531) with
+                  (fun uu___3 ->
+                     fun uu___4 ->
+                       match (uu___3, uu___4) with
                        | ((env1, fnames, rec_bindings, used_markers),
-                          (_attr_opt, (f, uu____11658, uu____11659),
-                           uu____11660)) ->
-                           let uu____11791 =
+                          (_attr_opt, (f, uu___5, uu___6), uu___7)) ->
+                           let uu___8 =
                              match f with
                              | FStar_Util.Inl x ->
-                                 let uu____11829 =
+                                 let uu___9 =
                                    FStar_Syntax_DsEnv.push_bv' env1 x in
-                                 (match uu____11829 with
+                                 (match uu___9 with
                                   | (env2, xx, used_marker) ->
                                       let dummy_ref = FStar_Util.mk_ref true in
-                                      let uu____11860 =
-                                        let uu____11863 =
+                                      let uu___10 =
+                                        let uu___11 =
                                           FStar_Syntax_Syntax.mk_binder xx in
-                                        uu____11863 :: rec_bindings in
-                                      (env2, (FStar_Util.Inl xx),
-                                        uu____11860, (used_marker ::
-                                        used_markers)))
+                                        uu___11 :: rec_bindings in
+                                      (env2, (FStar_Util.Inl xx), uu___10,
+                                        (used_marker :: used_markers)))
                              | FStar_Util.Inr l ->
-                                 let uu____11877 =
-                                   let uu____11884 =
-                                     FStar_Ident.ident_of_lid l in
+                                 let uu___9 =
+                                   let uu___10 = FStar_Ident.ident_of_lid l in
                                    FStar_Syntax_DsEnv.push_top_level_rec_binding
-                                     env1 uu____11884
+                                     env1 uu___10
                                      FStar_Syntax_Syntax.delta_equational in
-                                 (match uu____11877 with
+                                 (match uu___9 with
                                   | (env2, used_marker) ->
                                       (env2, (FStar_Util.Inr l),
                                         rec_bindings, (used_marker ::
                                         used_markers))) in
-                           (match uu____11791 with
+                           (match uu___8 with
                             | (env2, lbname, rec_bindings1, used_markers1) ->
                                 (env2, (lbname :: fnames), rec_bindings1,
                                   used_markers1))) (env, [], [], []) funs in
-              match uu____11443 with
+              match uu___2 with
               | (env', fnames, rec_bindings, used_markers) ->
                   let fnames1 = FStar_List.rev fnames in
                   let rec_bindings1 = FStar_List.rev rec_bindings in
                   let used_markers1 = FStar_List.rev used_markers in
-                  let desugar_one_def env1 lbname uu____12115 =
-                    match uu____12115 with
-                    | (attrs_opt, (uu____12155, args, result_t), def) ->
+                  let desugar_one_def env1 lbname uu___3 =
+                    match uu___3 with
+                    | (attrs_opt, (uu___4, args, result_t), def) ->
                         let args1 =
                           FStar_All.pipe_right args
                             (FStar_List.map replace_unit_pattern) in
@@ -3159,17 +3031,16 @@ and (desugar_term_maybe_top :
                           | FStar_Pervasives_Native.None -> def
                           | FStar_Pervasives_Native.Some (t, tacopt) ->
                               let t1 =
-                                let uu____12247 = is_comp_type env1 t in
-                                if uu____12247
+                                let uu___5 = is_comp_type env1 t in
+                                if uu___5
                                 then
-                                  ((let uu____12249 =
+                                  ((let uu___7 =
                                       FStar_All.pipe_right args1
                                         (FStar_List.tryFind
                                            (fun x ->
-                                              let uu____12259 =
-                                                is_var_pattern x in
-                                              Prims.op_Negation uu____12259)) in
-                                    match uu____12249 with
+                                              let uu___8 = is_var_pattern x in
+                                              Prims.op_Negation uu___8)) in
+                                    match uu___7 with
                                     | FStar_Pervasives_Native.None -> ()
                                     | FStar_Pervasives_Native.Some p ->
                                         FStar_Errors.raise_error
@@ -3178,18 +3049,18 @@ and (desugar_term_maybe_top :
                                           p.FStar_Parser_AST.prange);
                                    t)
                                 else
-                                  (let uu____12262 =
+                                  (let uu___7 =
                                      ((FStar_Options.ml_ish ()) &&
-                                        (let uu____12264 =
+                                        (let uu___8 =
                                            FStar_Syntax_DsEnv.try_lookup_effect_name
                                              env1
                                              FStar_Parser_Const.effect_ML_lid in
-                                         FStar_Option.isSome uu____12264))
+                                         FStar_Option.isSome uu___8))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
                                              Prims.int_zero)) in
-                                   if uu____12262
+                                   if uu___7
                                    then FStar_Parser_AST.ml_comp t
                                    else FStar_Parser_AST.tot_comp t) in
                               FStar_Parser_AST.mk_term
@@ -3199,26 +3070,25 @@ and (desugar_term_maybe_top :
                         let def2 =
                           match args1 with
                           | [] -> def1
-                          | uu____12271 ->
+                          | uu___5 ->
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
                                 top.FStar_Parser_AST.level in
-                        let uu____12274 = desugar_term_aq env1 def2 in
-                        (match uu____12274 with
+                        let uu___5 = desugar_term_aq env1 def2 in
+                        (match uu___5 with
                          | (body1, aq) ->
                              let lbname1 =
                                match lbname with
                                | FStar_Util.Inl x -> FStar_Util.Inl x
                                | FStar_Util.Inr l ->
-                                   let uu____12296 =
-                                     let uu____12297 =
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_Syntax_Util.incr_delta_qualifier
                                          body1 in
-                                     FStar_Syntax_Syntax.lid_as_fv l
-                                       uu____12297
+                                     FStar_Syntax_Syntax.lid_as_fv l uu___7
                                        FStar_Pervasives_Native.None in
-                                   FStar_Util.Inr uu____12296 in
+                                   FStar_Util.Inr uu___6 in
                              let body2 =
                                if is_rec
                                then
@@ -3233,74 +3103,72 @@ and (desugar_term_maybe_top :
                                  (attrs, lbname1,
                                    (setpos FStar_Syntax_Syntax.tun), body2,
                                    pos)), aq)) in
-                  let uu____12336 =
-                    let uu____12353 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_List.map2
                         (desugar_one_def (if is_rec then env' else env))
                         fnames1 funs in
-                    FStar_All.pipe_right uu____12353 FStar_List.unzip in
-                  (match uu____12336 with
+                    FStar_All.pipe_right uu___4 FStar_List.unzip in
+                  (match uu___3 with
                    | (lbs1, aqss) ->
-                       let uu____12493 = desugar_term_aq env' body in
-                       (match uu____12493 with
+                       let uu___4 = desugar_term_aq env' body in
+                       (match uu___4 with
                         | (body1, aq) ->
                             (if is_rec
                              then
                                FStar_List.iter2
-                                 (fun uu____12570 ->
+                                 (fun uu___6 ->
                                     fun used_marker ->
-                                      match uu____12570 with
-                                      | (_attr_opt,
-                                         (f, uu____12616, uu____12617),
-                                         uu____12618) ->
-                                          let uu____12675 =
-                                            let uu____12676 =
+                                      match uu___6 with
+                                      | (_attr_opt, (f, uu___7, uu___8),
+                                         uu___9) ->
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_ST.op_Bang used_marker in
-                                            Prims.op_Negation uu____12676 in
-                                          if uu____12675
+                                            Prims.op_Negation uu___11 in
+                                          if uu___10
                                           then
-                                            let uu____12683 =
+                                            let uu___11 =
                                               match f with
                                               | FStar_Util.Inl x ->
-                                                  let uu____12697 =
+                                                  let uu___12 =
                                                     FStar_Ident.string_of_id
                                                       x in
-                                                  let uu____12698 =
+                                                  let uu___13 =
                                                     FStar_Ident.range_of_id x in
-                                                  (uu____12697, "Local",
-                                                    uu____12698)
+                                                  (uu___12, "Local", uu___13)
                                               | FStar_Util.Inr l ->
-                                                  let uu____12700 =
+                                                  let uu___12 =
                                                     FStar_Ident.string_of_lid
                                                       l in
-                                                  let uu____12701 =
+                                                  let uu___13 =
                                                     FStar_Ident.range_of_lid
                                                       l in
-                                                  (uu____12700, "Global",
-                                                    uu____12701) in
-                                            (match uu____12683 with
+                                                  (uu___12, "Global",
+                                                    uu___13) in
+                                            (match uu___11 with
                                              | (nm, gl, rng) ->
-                                                 let uu____12705 =
-                                                   let uu____12710 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_Util.format2
                                                        "%s binding %s is recursive but not used in its body"
                                                        gl nm in
                                                    (FStar_Errors.Warning_UnusedLetRec,
-                                                     uu____12710) in
+                                                     uu___13) in
                                                  FStar_Errors.log_issue rng
-                                                   uu____12705)
+                                                   uu___12)
                                           else ()) funs used_markers1
                              else ();
-                             (let uu____12713 =
-                                let uu____12716 =
-                                  let uu____12717 =
-                                    let uu____12730 =
+                             (let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
                                       FStar_Syntax_Subst.close rec_bindings1
                                         body1 in
-                                    ((is_rec, lbs1), uu____12730) in
-                                  FStar_Syntax_Syntax.Tm_let uu____12717 in
-                                FStar_All.pipe_left mk uu____12716 in
-                              (uu____12713,
+                                    ((is_rec, lbs1), uu___9) in
+                                  FStar_Syntax_Syntax.Tm_let uu___8 in
+                                FStar_All.pipe_left mk uu___7 in
+                              (uu___6,
                                 (FStar_List.append aq
                                    (FStar_List.flatten aqss))))))) in
             let ds_non_rec attrs_opt pat t1 t2 =
@@ -3309,27 +3177,26 @@ and (desugar_term_maybe_top :
                 | FStar_Pervasives_Native.None -> []
                 | FStar_Pervasives_Native.Some l ->
                     FStar_List.map (desugar_term env) l in
-              let uu____12830 = desugar_term_aq env t1 in
-              match uu____12830 with
+              let uu___1 = desugar_term_aq env t1 in
+              match uu___1 with
               | (t11, aq0) ->
-                  let uu____12851 =
+                  let uu___2 =
                     desugar_binding_pat_maybe_top top_level env pat in
-                  (match uu____12851 with
+                  (match uu___2 with
                    | (env1, binder, pat1) ->
-                       let uu____12881 =
+                       let uu___3 =
                          match binder with
                          | LetBinder (l, (t, _tacopt)) ->
-                             let uu____12923 = desugar_term_aq env1 t2 in
-                             (match uu____12923 with
+                             let uu___4 = desugar_term_aq env1 t2 in
+                             (match uu___4 with
                               | (body1, aq) ->
                                   let fv =
-                                    let uu____12945 =
+                                    let uu___5 =
                                       FStar_Syntax_Util.incr_delta_qualifier
                                         t11 in
-                                    FStar_Syntax_Syntax.lid_as_fv l
-                                      uu____12945
+                                    FStar_Syntax_Syntax.lid_as_fv l uu___5
                                       FStar_Pervasives_Native.None in
-                                  let uu____12946 =
+                                  let uu___5 =
                                     FStar_All.pipe_left mk
                                       (FStar_Syntax_Syntax.Tm_let
                                          ((false,
@@ -3338,10 +3205,10 @@ and (desugar_term_maybe_top :
                                                  t, t11,
                                                  (t11.FStar_Syntax_Syntax.pos))]),
                                            body1)) in
-                                  (uu____12946, aq))
-                         | LocalBinder (x, uu____12984) ->
-                             let uu____12985 = desugar_term_aq env1 t2 in
-                             (match uu____12985 with
+                                  (uu___5, aq))
+                         | LocalBinder (x, uu___4) ->
+                             let uu___5 = desugar_term_aq env1 t2 in
+                             (match uu___5 with
                               | (body1, aq) ->
                                   let body2 =
                                     match pat1 with
@@ -3349,103 +3216,102 @@ and (desugar_term_maybe_top :
                                     | ({
                                          FStar_Syntax_Syntax.v =
                                            FStar_Syntax_Syntax.Pat_wild
-                                           uu____13007;
-                                         FStar_Syntax_Syntax.p = uu____13008;_},
-                                       uu____13009)::[] -> body1
-                                    | uu____13022 ->
-                                        let uu____13025 =
-                                          let uu____13026 =
-                                            let uu____13049 =
+                                           uu___6;
+                                         FStar_Syntax_Syntax.p = uu___7;_},
+                                       uu___8)::[] -> body1
+                                    | uu___6 ->
+                                        let uu___7 =
+                                          let uu___8 =
+                                            let uu___9 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 x in
-                                            let uu____13052 =
+                                            let uu___10 =
                                               desugar_disjunctive_pattern
                                                 pat1
                                                 FStar_Pervasives_Native.None
                                                 body1 in
-                                            (uu____13049, uu____13052) in
-                                          FStar_Syntax_Syntax.Tm_match
-                                            uu____13026 in
-                                        FStar_Syntax_Syntax.mk uu____13025
+                                            (uu___9, uu___10) in
+                                          FStar_Syntax_Syntax.Tm_match uu___8 in
+                                        FStar_Syntax_Syntax.mk uu___7
                                           top.FStar_Parser_AST.range in
-                                  let uu____13089 =
-                                    let uu____13092 =
-                                      let uu____13093 =
-                                        let uu____13106 =
-                                          let uu____13109 =
-                                            let uu____13110 =
+                                  let uu___6 =
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_Syntax_Syntax.mk_binder x in
-                                            [uu____13110] in
-                                          FStar_Syntax_Subst.close
-                                            uu____13109 body2 in
+                                            [uu___11] in
+                                          FStar_Syntax_Subst.close uu___10
+                                            body2 in
                                         ((false,
                                            [mk_lb
                                               (attrs, (FStar_Util.Inl x),
                                                 (x.FStar_Syntax_Syntax.sort),
                                                 t11,
                                                 (t11.FStar_Syntax_Syntax.pos))]),
-                                          uu____13106) in
-                                      FStar_Syntax_Syntax.Tm_let uu____13093 in
-                                    FStar_All.pipe_left mk uu____13092 in
-                                  (uu____13089, aq)) in
-                       (match uu____12881 with
+                                          uu___9) in
+                                      FStar_Syntax_Syntax.Tm_let uu___8 in
+                                    FStar_All.pipe_left mk uu___7 in
+                                  (uu___6, aq)) in
+                       (match uu___3 with
                         | (tm, aq1) -> (tm, (FStar_List.append aq0 aq1)))) in
-            let uu____13215 = FStar_List.hd lbs in
-            (match uu____13215 with
+            let uu___1 = FStar_List.hd lbs in
+            (match uu___1 with
              | (attrs, (head_pat, defn)) ->
-                 let uu____13259 = is_rec || (is_app_pattern head_pat) in
-                 if uu____13259
+                 let uu___2 = is_rec || (is_app_pattern head_pat) in
+                 if uu___2
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
         | FStar_Parser_AST.If (t1, t2, t3) ->
             let x =
-              let uu____13269 = tun_r t3.FStar_Parser_AST.range in
+              let uu___1 = tun_r t3.FStar_Parser_AST.range in
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (t3.FStar_Parser_AST.range))
-                uu____13269 in
+                uu___1 in
             let t_bool =
-              let uu____13273 =
-                let uu____13274 =
+              let uu___1 =
+                let uu___2 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None in
-                FStar_Syntax_Syntax.Tm_fvar uu____13274 in
-              mk uu____13273 in
-            let uu____13275 = desugar_term_aq env t1 in
-            (match uu____13275 with
+                FStar_Syntax_Syntax.Tm_fvar uu___2 in
+              mk uu___1 in
+            let uu___1 = desugar_term_aq env t1 in
+            (match uu___1 with
              | (t1', aq1) ->
-                 let uu____13286 = desugar_term_aq env t2 in
-                 (match uu____13286 with
+                 let uu___2 = desugar_term_aq env t2 in
+                 (match uu___2 with
                   | (t2', aq2) ->
-                      let uu____13297 = desugar_term_aq env t3 in
-                      (match uu____13297 with
+                      let uu___3 = desugar_term_aq env t3 in
+                      (match uu___3 with
                        | (t3', aq3) ->
-                           let uu____13308 =
-                             let uu____13309 =
-                               let uu____13310 =
-                                 let uu____13333 =
-                                   let uu____13350 =
-                                     let uu____13365 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Syntax_Syntax.withinfo
                                          (FStar_Syntax_Syntax.Pat_constant
                                             (FStar_Const.Const_bool true))
                                          t1.FStar_Parser_AST.range in
-                                     (uu____13365,
-                                       FStar_Pervasives_Native.None, t2') in
-                                   let uu____13378 =
-                                     let uu____13395 =
-                                       let uu____13410 =
+                                     (uu___9, FStar_Pervasives_Native.None,
+                                       t2') in
+                                   let uu___9 =
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_Syntax_Syntax.withinfo
                                            (FStar_Syntax_Syntax.Pat_wild x)
                                            t1.FStar_Parser_AST.range in
-                                       (uu____13410,
+                                       (uu___11,
                                          FStar_Pervasives_Native.None, t3') in
-                                     [uu____13395] in
-                                   uu____13350 :: uu____13378 in
-                                 (t1', uu____13333) in
-                               FStar_Syntax_Syntax.Tm_match uu____13310 in
-                             mk uu____13309 in
-                           (uu____13308, (join_aqs [aq1; aq2; aq3])))))
+                                     [uu___10] in
+                                   uu___8 :: uu___9 in
+                                 (t1', uu___7) in
+                               FStar_Syntax_Syntax.Tm_match uu___6 in
+                             mk uu___5 in
+                           (uu___4, (join_aqs [aq1; aq2; aq3])))))
         | FStar_Parser_AST.TryWith (e, branches) ->
             let r = top.FStar_Parser_AST.range in
             let handler = FStar_Parser_AST.mk_function branches r r in
@@ -3469,105 +3335,102 @@ and (desugar_term_maybe_top :
                 r top.FStar_Parser_AST.level in
             desugar_term_aq env a2
         | FStar_Parser_AST.Match (e, branches) ->
-            let desugar_branch uu____13603 =
-              match uu____13603 with
+            let desugar_branch uu___1 =
+              match uu___1 with
               | (pat, wopt, b) ->
-                  let uu____13625 = desugar_match_pat env pat in
-                  (match uu____13625 with
+                  let uu___2 = desugar_match_pat env pat in
+                  (match uu___2 with
                    | (env1, pat1) ->
                        let wopt1 =
                          match wopt with
                          | FStar_Pervasives_Native.None ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____13656 = desugar_term env1 e1 in
-                             FStar_Pervasives_Native.Some uu____13656 in
-                       let uu____13661 = desugar_term_aq env1 b in
-                       (match uu____13661 with
+                             let uu___3 = desugar_term env1 e1 in
+                             FStar_Pervasives_Native.Some uu___3 in
+                       let uu___3 = desugar_term_aq env1 b in
+                       (match uu___3 with
                         | (b1, aq) ->
-                            let uu____13674 =
+                            let uu___4 =
                               desugar_disjunctive_pattern pat1 wopt1 b1 in
-                            (uu____13674, aq))) in
-            let uu____13679 = desugar_term_aq env e in
-            (match uu____13679 with
+                            (uu___4, aq))) in
+            let uu___1 = desugar_term_aq env e in
+            (match uu___1 with
              | (e1, aq) ->
-                 let uu____13690 =
-                   let uu____13721 =
-                     let uu____13754 = FStar_List.map desugar_branch branches in
-                     FStar_All.pipe_right uu____13754 FStar_List.unzip in
-                   FStar_All.pipe_right uu____13721
-                     (fun uu____13972 ->
-                        match uu____13972 with
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_List.map desugar_branch branches in
+                     FStar_All.pipe_right uu___4 FStar_List.unzip in
+                   FStar_All.pipe_right uu___3
+                     (fun uu___4 ->
+                        match uu___4 with
                         | (x, y) -> ((FStar_List.flatten x), y)) in
-                 (match uu____13690 with
+                 (match uu___2 with
                   | (brs, aqs) ->
-                      let uu____14191 =
+                      let uu___3 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_match (e1, brs)) in
-                      (uu____14191, (join_aqs (aq :: aqs)))))
+                      (uu___3, (join_aqs (aq :: aqs)))))
         | FStar_Parser_AST.Ascribed (e, t, tac_opt) ->
-            let uu____14225 =
-              let uu____14246 = is_comp_type env t in
-              if uu____14246
+            let uu___1 =
+              let uu___2 = is_comp_type env t in
+              if uu___2
               then
                 let comp = desugar_comp t.FStar_Parser_AST.range true env t in
                 ((FStar_Util.Inr comp), [])
               else
-                (let uu____14297 = desugar_term_aq env t in
-                 match uu____14297 with
-                 | (tm, aq) -> ((FStar_Util.Inl tm), aq)) in
-            (match uu____14225 with
+                (let uu___4 = desugar_term_aq env t in
+                 match uu___4 with | (tm, aq) -> ((FStar_Util.Inl tm), aq)) in
+            (match uu___1 with
              | (annot, aq0) ->
                  let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env) in
-                 let uu____14389 = desugar_term_aq env e in
-                 (match uu____14389 with
+                 let uu___2 = desugar_term_aq env e in
+                 (match uu___2 with
                   | (e1, aq) ->
-                      let uu____14400 =
+                      let uu___3 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_ascribed
                              (e1, (annot, tac_opt1),
                                FStar_Pervasives_Native.None)) in
-                      (uu____14400, (FStar_List.append aq0 aq))))
-        | FStar_Parser_AST.Record (uu____14439, []) ->
+                      (uu___3, (FStar_List.append aq0 aq))))
+        | FStar_Parser_AST.Record (uu___1, []) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
         | FStar_Parser_AST.Record (eopt, fields) ->
             let record = check_fields env fields top.FStar_Parser_AST.range in
             let user_ns =
-              let uu____14480 = FStar_List.hd fields in
-              match uu____14480 with
-              | (f, uu____14492) -> FStar_Ident.ns_of_lid f in
+              let uu___1 = FStar_List.hd fields in
+              match uu___1 with | (f, uu___2) -> FStar_Ident.ns_of_lid f in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
                   (FStar_Util.find_opt
-                     (fun uu____14540 ->
-                        match uu____14540 with
-                        | (g, uu____14546) ->
-                            let uu____14547 = FStar_Ident.string_of_id f in
-                            let uu____14548 =
-                              let uu____14549 = FStar_Ident.ident_of_lid g in
-                              FStar_Ident.string_of_id uu____14549 in
-                            uu____14547 = uu____14548)) in
+                     (fun uu___1 ->
+                        match uu___1 with
+                        | (g, uu___2) ->
+                            let uu___3 = FStar_Ident.string_of_id f in
+                            let uu___4 =
+                              let uu___5 = FStar_Ident.ident_of_lid g in
+                              FStar_Ident.string_of_id uu___5 in
+                            uu___3 = uu___4)) in
               let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f]) in
               match found with
-              | FStar_Pervasives_Native.Some (uu____14555, e) -> (fn, e)
+              | FStar_Pervasives_Native.Some (uu___1, e) -> (fn, e)
               | FStar_Pervasives_Native.None ->
                   (match xopt with
                    | FStar_Pervasives_Native.None ->
-                       let uu____14569 =
-                         let uu____14574 =
-                           let uu____14575 = FStar_Ident.string_of_id f in
-                           let uu____14576 =
+                       let uu___1 =
+                         let uu___2 =
+                           let uu___3 = FStar_Ident.string_of_id f in
+                           let uu___4 =
                              FStar_Ident.string_of_lid
                                record.FStar_Syntax_DsEnv.typename in
                            FStar_Util.format2
-                             "Field %s of record type %s is missing"
-                             uu____14575 uu____14576 in
-                         (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____14574) in
-                       FStar_Errors.raise_error uu____14569
+                             "Field %s of record type %s is missing" uu___3
+                             uu___4 in
+                         (FStar_Errors.Fatal_MissingFieldInRecord, uu___2) in
+                       FStar_Errors.raise_error uu___1
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
@@ -3581,184 +3444,179 @@ and (desugar_term_maybe_top :
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None ->
-                  let uu____14584 =
-                    let uu____14595 =
+                  let uu___1 =
+                    let uu___2 =
                       FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                         (FStar_List.map
-                           (fun uu____14626 ->
-                              match uu____14626 with
-                              | (f, uu____14636) ->
-                                  let uu____14637 =
-                                    let uu____14638 =
+                           (fun uu___3 ->
+                              match uu___3 with
+                              | (f, uu___4) ->
+                                  let uu___5 =
+                                    let uu___6 =
                                       get_field FStar_Pervasives_Native.None
                                         f in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____14638 in
-                                  (uu____14637, FStar_Parser_AST.Nothing))) in
-                    (user_constrname, uu____14595) in
-                  FStar_Parser_AST.Construct uu____14584
+                                      FStar_Pervasives_Native.snd uu___6 in
+                                  (uu___5, FStar_Parser_AST.Nothing))) in
+                    (user_constrname, uu___2) in
+                  FStar_Parser_AST.Construct uu___1
               | FStar_Pervasives_Native.Some e ->
                   let x = FStar_Ident.gen e.FStar_Parser_AST.range in
                   let xterm =
-                    let uu____14656 =
-                      let uu____14657 = FStar_Ident.lid_of_ids [x] in
-                      FStar_Parser_AST.Var uu____14657 in
-                    let uu____14658 = FStar_Ident.range_of_id x in
-                    FStar_Parser_AST.mk_term uu____14656 uu____14658
+                    let uu___1 =
+                      let uu___2 = FStar_Ident.lid_of_ids [x] in
+                      FStar_Parser_AST.Var uu___2 in
+                    let uu___2 = FStar_Ident.range_of_id x in
+                    FStar_Parser_AST.mk_term uu___1 uu___2
                       FStar_Parser_AST.Expr in
                   let record1 =
-                    let uu____14660 =
-                      let uu____14673 =
+                    let uu___1 =
+                      let uu___2 =
                         FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                           (FStar_List.map
-                             (fun uu____14703 ->
-                                match uu____14703 with
-                                | (f, uu____14713) ->
+                             (fun uu___3 ->
+                                match uu___3 with
+                                | (f, uu___4) ->
                                     get_field
                                       (FStar_Pervasives_Native.Some xterm) f)) in
-                      (FStar_Pervasives_Native.None, uu____14673) in
-                    FStar_Parser_AST.Record uu____14660 in
-                  let uu____14722 =
-                    let uu____14743 =
-                      let uu____14758 =
-                        let uu____14771 =
-                          let uu____14776 =
-                            let uu____14777 = FStar_Ident.range_of_id x in
+                      (FStar_Pervasives_Native.None, uu___2) in
+                    FStar_Parser_AST.Record uu___1 in
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Ident.range_of_id x in
                             FStar_Parser_AST.mk_pattern
                               (FStar_Parser_AST.PatVar
-                                 (x, FStar_Pervasives_Native.None))
-                              uu____14777 in
-                          (uu____14776, e) in
-                        (FStar_Pervasives_Native.None, uu____14771) in
-                      [uu____14758] in
-                    (FStar_Parser_AST.NoLetQualifier, uu____14743,
+                                 (x, FStar_Pervasives_Native.None)) uu___6 in
+                          (uu___5, e) in
+                        (FStar_Pervasives_Native.None, uu___4) in
+                      [uu___3] in
+                    (FStar_Parser_AST.NoLetQualifier, uu___2,
                       (FStar_Parser_AST.mk_term record1
                          top.FStar_Parser_AST.range
                          top.FStar_Parser_AST.level)) in
-                  FStar_Parser_AST.Let uu____14722 in
+                  FStar_Parser_AST.Let uu___1 in
             let recterm1 =
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level in
-            let uu____14829 = desugar_term_aq env recterm1 in
-            (match uu____14829 with
+            let uu___1 = desugar_term_aq env recterm1 in
+            (match uu___1 with
              | (e, s) ->
                  (match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____14845;
-                         FStar_Syntax_Syntax.vars = uu____14846;_},
+                         FStar_Syntax_Syntax.pos = uu___2;
+                         FStar_Syntax_Syntax.vars = uu___3;_},
                        args)
                       ->
-                      let uu____14872 =
-                        let uu____14873 =
-                          let uu____14874 =
-                            let uu____14891 =
-                              let uu____14894 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_Ident.set_lid_range
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   e.FStar_Syntax_Syntax.pos in
-                              let uu____14895 =
-                                let uu____14898 =
-                                  let uu____14899 =
-                                    let uu____14906 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_All.pipe_right
                                         record.FStar_Syntax_DsEnv.fields
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst) in
                                     ((record.FStar_Syntax_DsEnv.typename),
-                                      uu____14906) in
-                                  FStar_Syntax_Syntax.Record_ctor uu____14899 in
-                                FStar_Pervasives_Native.Some uu____14898 in
-                              FStar_Syntax_Syntax.fvar uu____14894
-                                FStar_Syntax_Syntax.delta_constant
-                                uu____14895 in
-                            (uu____14891, args) in
-                          FStar_Syntax_Syntax.Tm_app uu____14874 in
-                        FStar_All.pipe_left mk uu____14873 in
-                      (uu____14872, s)
-                  | uu____14935 -> (e, s)))
+                                      uu___12) in
+                                  FStar_Syntax_Syntax.Record_ctor uu___11 in
+                                FStar_Pervasives_Native.Some uu___10 in
+                              FStar_Syntax_Syntax.fvar uu___8
+                                FStar_Syntax_Syntax.delta_constant uu___9 in
+                            (uu___7, args) in
+                          FStar_Syntax_Syntax.Tm_app uu___6 in
+                        FStar_All.pipe_left mk uu___5 in
+                      (uu___4, s)
+                  | uu___2 -> (e, s)))
         | FStar_Parser_AST.Project (e, f) ->
-            let uu____14938 =
+            let uu___1 =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env) f in
-            (match uu____14938 with
+            (match uu___1 with
              | (constrname, is_rec) ->
-                 let uu____14953 = desugar_term_aq env e in
-                 (match uu____14953 with
+                 let uu___2 = desugar_term_aq env e in
+                 (match uu___2 with
                   | (e1, s) ->
                       let projname =
-                        let uu____14965 = FStar_Ident.ident_of_lid f in
+                        let uu___3 = FStar_Ident.ident_of_lid f in
                         FStar_Syntax_Util.mk_field_projector_name_from_ident
-                          constrname uu____14965 in
+                          constrname uu___3 in
                       let qual =
                         if is_rec
                         then
-                          let uu____14971 =
-                            let uu____14972 =
-                              let uu____14977 = FStar_Ident.ident_of_lid f in
-                              (constrname, uu____14977) in
-                            FStar_Syntax_Syntax.Record_projector uu____14972 in
-                          FStar_Pervasives_Native.Some uu____14971
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 = FStar_Ident.ident_of_lid f in
+                              (constrname, uu___5) in
+                            FStar_Syntax_Syntax.Record_projector uu___4 in
+                          FStar_Pervasives_Native.Some uu___3
                         else FStar_Pervasives_Native.None in
-                      let uu____14979 =
-                        let uu____14980 =
-                          let uu____14981 =
-                            let uu____14998 =
-                              let uu____15001 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
                                 FStar_Ident.set_lid_range projname
                                   top.FStar_Parser_AST.range in
-                              FStar_Syntax_Syntax.fvar uu____15001
+                              FStar_Syntax_Syntax.fvar uu___7
                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one) qual in
-                            let uu____15002 =
-                              let uu____15013 = FStar_Syntax_Syntax.as_arg e1 in
-                              [uu____15013] in
-                            (uu____14998, uu____15002) in
-                          FStar_Syntax_Syntax.Tm_app uu____14981 in
-                        FStar_All.pipe_left mk uu____14980 in
-                      (uu____14979, s)))
+                            let uu___7 =
+                              let uu___8 = FStar_Syntax_Syntax.as_arg e1 in
+                              [uu___8] in
+                            (uu___6, uu___7) in
+                          FStar_Syntax_Syntax.Tm_app uu___5 in
+                        FStar_All.pipe_left mk uu___4 in
+                      (uu___3, s)))
         | FStar_Parser_AST.NamedTyp (n, e) ->
-            ((let uu____15053 = FStar_Ident.range_of_id n in
-              FStar_Errors.log_issue uu____15053
+            ((let uu___2 = FStar_Ident.range_of_id n in
+              FStar_Errors.log_issue uu___2
                 (FStar_Errors.Warning_IgnoredBinding,
                   "This name is being ignored"));
              desugar_term_aq env e)
         | FStar_Parser_AST.Paren e -> failwith "impossible"
         | FStar_Parser_AST.VQuote e ->
             let tm = desugar_term env e in
-            let uu____15061 =
-              let uu____15062 = FStar_Syntax_Subst.compress tm in
-              uu____15062.FStar_Syntax_Syntax.n in
-            (match uu____15061 with
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Subst.compress tm in
+              uu___2.FStar_Syntax_Syntax.n in
+            (match uu___1 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____15070 =
-                   let uu___2065_15071 =
-                     let uu____15072 =
-                       let uu____15073 = FStar_Syntax_Syntax.lid_of_fv fv in
-                       FStar_Ident.string_of_lid uu____15073 in
-                     FStar_Syntax_Util.exp_string uu____15072 in
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Syntax.lid_of_fv fv in
+                       FStar_Ident.string_of_lid uu___5 in
+                     FStar_Syntax_Util.exp_string uu___4 in
                    {
-                     FStar_Syntax_Syntax.n =
-                       (uu___2065_15071.FStar_Syntax_Syntax.n);
+                     FStar_Syntax_Syntax.n = (uu___3.FStar_Syntax_Syntax.n);
                      FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
                      FStar_Syntax_Syntax.vars =
-                       (uu___2065_15071.FStar_Syntax_Syntax.vars)
+                       (uu___3.FStar_Syntax_Syntax.vars)
                    } in
-                 (uu____15070, noaqs)
-             | uu____15074 ->
-                 let uu____15075 =
-                   let uu____15080 =
-                     let uu____15081 = FStar_Syntax_Print.term_to_string tm in
-                     Prims.op_Hat "VQuote, expected an fvar, got: "
-                       uu____15081 in
-                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____15080) in
-                 FStar_Errors.raise_error uu____15075
-                   top.FStar_Parser_AST.range)
+                 (uu___2, noaqs)
+             | uu___2 ->
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Print.term_to_string tm in
+                     Prims.op_Hat "VQuote, expected an fvar, got: " uu___5 in
+                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu___4) in
+                 FStar_Errors.raise_error uu___3 top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Quote (e, FStar_Parser_AST.Static) ->
-            let uu____15087 = desugar_term_aq env e in
-            (match uu____15087 with
+            let uu___1 = desugar_term_aq env e in
+            (match uu___1 with
              | (tm, vts) ->
                  let qi =
                    {
@@ -3766,34 +3624,32 @@ and (desugar_term_maybe_top :
                        FStar_Syntax_Syntax.Quote_static;
                      FStar_Syntax_Syntax.antiquotes = vts
                    } in
-                 let uu____15099 =
+                 let uu___2 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_quoted (tm, qi)) in
-                 (uu____15099, noaqs))
+                 (uu___2, noaqs))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (e.FStar_Parser_AST.range))
                 FStar_Syntax_Syntax.tun in
-            let uu____15104 = FStar_Syntax_Syntax.bv_to_name bv in
-            let uu____15105 =
-              let uu____15106 =
-                let uu____15113 = desugar_term env e in (bv, uu____15113) in
-              [uu____15106] in
-            (uu____15104, uu____15105)
+            let uu___1 = FStar_Syntax_Syntax.bv_to_name bv in
+            let uu___2 =
+              let uu___3 = let uu___4 = desugar_term env e in (bv, uu___4) in
+              [uu___3] in
+            (uu___1, uu___2)
         | FStar_Parser_AST.Quote (e, FStar_Parser_AST.Dynamic) ->
             let qi =
               {
                 FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
                 FStar_Syntax_Syntax.antiquotes = []
               } in
-            let uu____15138 =
-              let uu____15139 =
-                let uu____15140 =
-                  let uu____15147 = desugar_term env e in (uu____15147, qi) in
-                FStar_Syntax_Syntax.Tm_quoted uu____15140 in
-              FStar_All.pipe_left mk uu____15139 in
-            (uu____15138, noaqs)
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = let uu___4 = desugar_term env e in (uu___4, qi) in
+                FStar_Syntax_Syntax.Tm_quoted uu___3 in
+              FStar_All.pipe_left mk uu___2 in
+            (uu___1, noaqs)
         | FStar_Parser_AST.CalcProof (rel, init_expr, steps) ->
             let is_impl rel1 =
               let is_impl_t t =
@@ -3801,27 +3657,26 @@ and (desugar_term_maybe_top :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.imp_lid
-                | uu____15172 -> false in
-              let uu____15173 =
-                let uu____15174 = unparen rel1 in
-                uu____15174.FStar_Parser_AST.tm in
-              match uu____15173 with
-              | FStar_Parser_AST.Op (id, uu____15176) ->
-                  let uu____15181 = op_as_term env (Prims.of_int (2)) id in
-                  (match uu____15181 with
+                | uu___1 -> false in
+              let uu___1 =
+                let uu___2 = unparen rel1 in uu___2.FStar_Parser_AST.tm in
+              match uu___1 with
+              | FStar_Parser_AST.Op (id, uu___2) ->
+                  let uu___3 = op_as_term env (Prims.of_int (2)) id in
+                  (match uu___3 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
               | FStar_Parser_AST.Var lid ->
-                  let uu____15186 = desugar_name' (fun x -> x) env true lid in
-                  (match uu____15186 with
+                  let uu___2 = desugar_name' (fun x -> x) env true lid in
+                  (match uu___2 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
               | FStar_Parser_AST.Tvar id ->
-                  let uu____15194 = FStar_Syntax_DsEnv.try_lookup_id env id in
-                  (match uu____15194 with
+                  let uu___2 = FStar_Syntax_DsEnv.try_lookup_id env id in
+                  (match uu___2 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
-              | uu____15198 -> false in
+              | uu___2 -> false in
             let eta_and_annot rel1 =
               let x = FStar_Ident.gen' "x" rel1.FStar_Parser_AST.range in
               let y = FStar_Ident.gen' "y" rel1.FStar_Parser_AST.range in
@@ -3838,31 +3693,30 @@ and (desugar_term_maybe_top :
                 FStar_Parser_AST.mk_pattern
                   (FStar_Parser_AST.PatVar (y, FStar_Pervasives_Native.None))
                   rel1.FStar_Parser_AST.range] in
-              let uu____15216 =
-                let uu____15217 =
-                  let uu____15224 =
-                    let uu____15225 =
-                      let uu____15226 =
-                        let uu____15235 =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
                           FStar_Parser_AST.mkApp rel1
                             [(xt, FStar_Parser_AST.Nothing);
                             (yt, FStar_Parser_AST.Nothing)]
                             rel1.FStar_Parser_AST.range in
-                        let uu____15248 =
-                          let uu____15249 =
-                            let uu____15250 = FStar_Ident.lid_of_str "Type0" in
-                            FStar_Parser_AST.Name uu____15250 in
-                          FStar_Parser_AST.mk_term uu____15249
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 = FStar_Ident.lid_of_str "Type0" in
+                            FStar_Parser_AST.Name uu___9 in
+                          FStar_Parser_AST.mk_term uu___8
                             rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-                        (uu____15235, uu____15248,
-                          FStar_Pervasives_Native.None) in
-                      FStar_Parser_AST.Ascribed uu____15226 in
-                    FStar_Parser_AST.mk_term uu____15225
+                        (uu___6, uu___7, FStar_Pervasives_Native.None) in
+                      FStar_Parser_AST.Ascribed uu___5 in
+                    FStar_Parser_AST.mk_term uu___4
                       rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-                  (pats, uu____15224) in
-                FStar_Parser_AST.Abs uu____15217 in
-              FStar_Parser_AST.mk_term uu____15216
-                rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
+                  (pats, uu___3) in
+                FStar_Parser_AST.Abs uu___2 in
+              FStar_Parser_AST.mk_term uu___1 rel1.FStar_Parser_AST.range
+                FStar_Parser_AST.Expr in
             let rel1 = eta_and_annot rel in
             let wild r =
               FStar_Parser_AST.mk_term FStar_Parser_AST.Wild r
@@ -3876,10 +3730,10 @@ and (desugar_term_maybe_top :
                 (FStar_Parser_AST.Var FStar_Parser_Const.calc_push_impl_lid)
                 r FStar_Parser_AST.Expr in
             let last_expr =
-              let uu____15270 = FStar_List.last steps in
-              match uu____15270 with
+              let uu___1 = FStar_List.last steps in
+              match uu___1 with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.CalcStep
-                  (uu____15273, uu____15274, last_expr)) -> last_expr
+                  (uu___2, uu___3, last_expr1)) -> last_expr1
               | FStar_Pervasives_Native.None -> init_expr in
             let step r =
               FStar_Parser_AST.mk_term
@@ -3895,87 +3749,83 @@ and (desugar_term_maybe_top :
               FStar_Parser_AST.mkApp init
                 [(init_expr, FStar_Parser_AST.Nothing)]
                 init_expr.FStar_Parser_AST.range in
-            let uu____15300 =
+            let uu___1 =
               FStar_List.fold_left
-                (fun uu____15318 ->
-                   fun uu____15319 ->
-                     match (uu____15318, uu____15319) with
+                (fun uu___2 ->
+                   fun uu___3 ->
+                     match (uu___2, uu___3) with
                      | ((e1, prev), FStar_Parser_AST.CalcStep
                         (rel2, just, next_expr)) ->
                          let just1 =
-                           let uu____15342 = is_impl rel2 in
-                           if uu____15342
+                           let uu___4 = is_impl rel2 in
+                           if uu___4
                            then
-                             let uu____15343 =
-                               let uu____15350 =
-                                 let uu____15355 =
-                                   FStar_Parser_AST.thunk just in
-                                 (uu____15355, FStar_Parser_AST.Nothing) in
-                               [uu____15350] in
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 = FStar_Parser_AST.thunk just in
+                                 (uu___7, FStar_Parser_AST.Nothing) in
+                               [uu___6] in
                              FStar_Parser_AST.mkApp
-                               (push_impl just.FStar_Parser_AST.range)
-                               uu____15343 just.FStar_Parser_AST.range
+                               (push_impl just.FStar_Parser_AST.range) uu___5
+                               just.FStar_Parser_AST.range
                            else just in
                          let pf =
-                           let uu____15366 =
-                             let uu____15373 =
-                               let uu____15380 =
-                                 let uu____15387 =
-                                   let uu____15394 =
-                                     let uu____15399 = eta_and_annot rel2 in
-                                     (uu____15399, FStar_Parser_AST.Nothing) in
-                                   let uu____15400 =
-                                     let uu____15407 =
-                                       let uu____15414 =
-                                         let uu____15419 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 = eta_and_annot rel2 in
+                                     (uu___9, FStar_Parser_AST.Nothing) in
+                                   let uu___9 =
+                                     let uu___10 =
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_Parser_AST.thunk e1 in
-                                         (uu____15419,
-                                           FStar_Parser_AST.Nothing) in
-                                       let uu____15420 =
-                                         let uu____15427 =
-                                           let uu____15432 =
+                                         (uu___12, FStar_Parser_AST.Nothing) in
+                                       let uu___12 =
+                                         let uu___13 =
+                                           let uu___14 =
                                              FStar_Parser_AST.thunk just1 in
-                                           (uu____15432,
+                                           (uu___14,
                                              FStar_Parser_AST.Nothing) in
-                                         [uu____15427] in
-                                       uu____15414 :: uu____15420 in
+                                         [uu___13] in
+                                       uu___11 :: uu___12 in
                                      (next_expr, FStar_Parser_AST.Nothing) ::
-                                       uu____15407 in
-                                   uu____15394 :: uu____15400 in
-                                 (prev, FStar_Parser_AST.Hash) :: uu____15387 in
-                               (init_expr, FStar_Parser_AST.Hash) ::
-                                 uu____15380 in
+                                       uu___10 in
+                                   uu___8 :: uu___9 in
+                                 (prev, FStar_Parser_AST.Hash) :: uu___7 in
+                               (init_expr, FStar_Parser_AST.Hash) :: uu___6 in
                              ((wild rel2.FStar_Parser_AST.range),
-                               FStar_Parser_AST.Hash) :: uu____15373 in
+                               FStar_Parser_AST.Hash) :: uu___5 in
                            FStar_Parser_AST.mkApp
-                             (step rel2.FStar_Parser_AST.range) uu____15366
+                             (step rel2.FStar_Parser_AST.range) uu___4
                              FStar_Range.dummyRange in
                          (pf, next_expr)) (e, init_expr) steps in
-            (match uu____15300 with
-             | (e1, uu____15470) ->
+            (match uu___1 with
+             | (e1, uu___2) ->
                  let e2 =
-                   let uu____15472 =
-                     let uu____15479 =
-                       let uu____15486 =
-                         let uu____15493 =
-                           let uu____15498 = FStar_Parser_AST.thunk e1 in
-                           (uu____15498, FStar_Parser_AST.Nothing) in
-                         [uu____15493] in
-                       (last_expr, FStar_Parser_AST.Hash) :: uu____15486 in
-                     (init_expr, FStar_Parser_AST.Hash) :: uu____15479 in
-                   FStar_Parser_AST.mkApp finish uu____15472
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 = FStar_Parser_AST.thunk e1 in
+                           (uu___7, FStar_Parser_AST.Nothing) in
+                         [uu___6] in
+                       (last_expr, FStar_Parser_AST.Hash) :: uu___5 in
+                     (init_expr, FStar_Parser_AST.Hash) :: uu___4 in
+                   FStar_Parser_AST.mkApp finish uu___3
                      top.FStar_Parser_AST.range in
                  desugar_term_maybe_top top_level env e2)
-        | uu____15515 when
-            top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            let uu____15516 = desugar_formula env top in (uu____15516, noaqs)
-        | uu____15517 ->
-            let uu____15518 =
-              let uu____15523 =
-                let uu____15524 = FStar_Parser_AST.term_to_string top in
-                Prims.op_Hat "Unexpected term: " uu____15524 in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____15523) in
-            FStar_Errors.raise_error uu____15518 top.FStar_Parser_AST.range
+        | uu___1 when top.FStar_Parser_AST.level = FStar_Parser_AST.Formula
+            -> let uu___2 = desugar_formula env top in (uu___2, noaqs)
+        | uu___1 ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Parser_AST.term_to_string top in
+                Prims.op_Hat "Unexpected term: " uu___4 in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu___3) in
+            FStar_Errors.raise_error uu___2 top.FStar_Parser_AST.range
 and (desugar_args :
   FStar_Syntax_DsEnv.env ->
     (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list ->
@@ -3986,11 +3836,10 @@ and (desugar_args :
     fun args ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____15565 ->
-              match uu____15565 with
+           (fun uu___ ->
+              match uu___ with
               | (a, imp) ->
-                  let uu____15578 = desugar_term env a in
-                  arg_withimp_e imp uu____15578))
+                  let uu___1 = desugar_term env a in arg_withimp_e imp uu___1))
 and (desugar_comp :
   FStar_Range.range ->
     Prims.bool ->
@@ -4003,92 +3852,85 @@ and (desugar_comp :
       fun env ->
         fun t ->
           let fail err = FStar_Errors.raise_error err r in
-          let is_requires uu____15611 =
-            match uu____15611 with
-            | (t1, uu____15617) ->
-                let uu____15618 =
-                  let uu____15619 = unparen t1 in
-                  uu____15619.FStar_Parser_AST.tm in
-                (match uu____15618 with
-                 | FStar_Parser_AST.Requires uu____15620 -> true
-                 | uu____15627 -> false) in
-          let is_ensures uu____15637 =
-            match uu____15637 with
-            | (t1, uu____15643) ->
-                let uu____15644 =
-                  let uu____15645 = unparen t1 in
-                  uu____15645.FStar_Parser_AST.tm in
-                (match uu____15644 with
-                 | FStar_Parser_AST.Ensures uu____15646 -> true
-                 | uu____15653 -> false) in
-          let is_app head uu____15668 =
-            match uu____15668 with
-            | (t1, uu____15674) ->
-                let uu____15675 =
-                  let uu____15676 = unparen t1 in
-                  uu____15676.FStar_Parser_AST.tm in
-                (match uu____15675 with
+          let is_requires uu___ =
+            match uu___ with
+            | (t1, uu___1) ->
+                let uu___2 =
+                  let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
+                (match uu___2 with
+                 | FStar_Parser_AST.Requires uu___3 -> true
+                 | uu___3 -> false) in
+          let is_ensures uu___ =
+            match uu___ with
+            | (t1, uu___1) ->
+                let uu___2 =
+                  let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
+                (match uu___2 with
+                 | FStar_Parser_AST.Ensures uu___3 -> true
+                 | uu___3 -> false) in
+          let is_app head uu___ =
+            match uu___ with
+            | (t1, uu___1) ->
+                let uu___2 =
+                  let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
+                (match uu___2 with
                  | FStar_Parser_AST.App
                      ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                        FStar_Parser_AST.range = uu____15678;
-                        FStar_Parser_AST.level = uu____15679;_},
-                      uu____15680, uu____15681)
+                        FStar_Parser_AST.range = uu___3;
+                        FStar_Parser_AST.level = uu___4;_},
+                      uu___5, uu___6)
                      ->
-                     let uu____15682 =
-                       let uu____15683 = FStar_Ident.ident_of_lid d in
-                       FStar_Ident.string_of_id uu____15683 in
-                     uu____15682 = head
-                 | uu____15684 -> false) in
-          let is_smt_pat uu____15694 =
-            match uu____15694 with
-            | (t1, uu____15700) ->
-                let uu____15701 =
-                  let uu____15702 = unparen t1 in
-                  uu____15702.FStar_Parser_AST.tm in
-                (match uu____15701 with
+                     let uu___7 =
+                       let uu___8 = FStar_Ident.ident_of_lid d in
+                       FStar_Ident.string_of_id uu___8 in
+                     uu___7 = head
+                 | uu___3 -> false) in
+          let is_smt_pat uu___ =
+            match uu___ with
+            | (t1, uu___1) ->
+                let uu___2 =
+                  let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
+                (match uu___2 with
                  | FStar_Parser_AST.Construct
                      (cons,
                       ({
                          FStar_Parser_AST.tm = FStar_Parser_AST.Construct
-                           (smtpat, uu____15705);
-                         FStar_Parser_AST.range = uu____15706;
-                         FStar_Parser_AST.level = uu____15707;_},
-                       uu____15708)::uu____15709::[])
+                           (smtpat, uu___3);
+                         FStar_Parser_AST.range = uu___4;
+                         FStar_Parser_AST.level = uu___5;_},
+                       uu___6)::uu___7::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s ->
-                             let uu____15747 =
-                               FStar_Ident.string_of_lid smtpat in
-                             uu____15747 = s)
-                          ["SMTPat"; "SMTPatT"; "SMTPatOr"])
+                             let uu___8 = FStar_Ident.string_of_lid smtpat in
+                             uu___8 = s) ["SMTPat"; "SMTPatT"; "SMTPatOr"])
                  | FStar_Parser_AST.Construct
                      (cons,
                       ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var smtpat;
-                         FStar_Parser_AST.range = uu____15750;
-                         FStar_Parser_AST.level = uu____15751;_},
-                       uu____15752)::uu____15753::[])
+                         FStar_Parser_AST.range = uu___3;
+                         FStar_Parser_AST.level = uu___4;_},
+                       uu___5)::uu___6::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s ->
-                             let uu____15779 =
-                               FStar_Ident.string_of_lid smtpat in
-                             uu____15779 = s) ["smt_pat"; "smt_pat_or"])
-                 | uu____15780 -> false) in
+                             let uu___7 = FStar_Ident.string_of_lid smtpat in
+                             uu___7 = s) ["smt_pat"; "smt_pat_or"])
+                 | uu___3 -> false) in
           let is_decreases = is_app "decreases" in
           let pre_process_comp_typ t1 =
-            let uu____15812 = head_and_args t1 in
-            match uu____15812 with
+            let uu___ = head_and_args t1 in
+            match uu___ with
             | (head, args) ->
                 (match head.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Name lemma when
-                     let uu____15870 =
-                       let uu____15871 = FStar_Ident.ident_of_lid lemma in
-                       FStar_Ident.string_of_id uu____15871 in
-                     uu____15870 = "Lemma" ->
+                     let uu___1 =
+                       let uu___2 = FStar_Ident.ident_of_lid lemma in
+                       FStar_Ident.string_of_id uu___2 in
+                     uu___1 = "Lemma" ->
                      let unit_tm =
                        ((FStar_Parser_AST.mk_term
                            (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
@@ -4113,12 +3955,12 @@ and (desugar_comp :
                            t1.FStar_Parser_AST.range
                            FStar_Parser_AST.Type_level),
                          FStar_Parser_AST.Nothing) in
-                     let thunk_ens uu____15903 =
-                       match uu____15903 with
+                     let thunk_ens uu___1 =
+                       match uu___1 with
                        | (e, i) ->
-                           let uu____15914 = FStar_Parser_AST.thunk e in
-                           (uu____15914, i) in
-                     let fail_lemma uu____15926 =
+                           let uu___2 = FStar_Parser_AST.thunk e in
+                           (uu___2, i) in
+                     let fail_lemma uu___1 =
                        let expected_one_of =
                          ["Lemma post";
                          "Lemma (ensures post)";
@@ -4143,85 +3985,83 @@ and (desugar_comp :
                        | smtpat::[] when is_smt_pat smtpat -> fail_lemma ()
                        | dec::[] when is_decreases dec -> fail_lemma ()
                        | ens::[] ->
-                           let uu____16006 =
-                             let uu____16013 =
-                               let uu____16020 = thunk_ens ens in
-                               [uu____16020; nil_pat] in
-                             req_true :: uu____16013 in
-                           unit_tm :: uu____16006
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; nil_pat] in
+                             req_true :: uu___2 in
+                           unit_tm :: uu___1
                        | req::ens::[] when
                            (is_requires req) && (is_ensures ens) ->
-                           let uu____16067 =
-                             let uu____16074 =
-                               let uu____16081 = thunk_ens ens in
-                               [uu____16081; nil_pat] in
-                             req :: uu____16074 in
-                           unit_tm :: uu____16067
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; nil_pat] in
+                             req :: uu___2 in
+                           unit_tm :: uu___1
                        | ens::smtpat::[] when
-                           (((let uu____16130 = is_requires ens in
-                              Prims.op_Negation uu____16130) &&
-                               (let uu____16132 = is_smt_pat ens in
-                                Prims.op_Negation uu____16132))
+                           (((let uu___1 = is_requires ens in
+                              Prims.op_Negation uu___1) &&
+                               (let uu___1 = is_smt_pat ens in
+                                Prims.op_Negation uu___1))
                               &&
-                              (let uu____16134 = is_decreases ens in
-                               Prims.op_Negation uu____16134))
+                              (let uu___1 = is_decreases ens in
+                               Prims.op_Negation uu___1))
                              && (is_smt_pat smtpat)
                            ->
-                           let uu____16135 =
-                             let uu____16142 =
-                               let uu____16149 = thunk_ens ens in
-                               [uu____16149; smtpat] in
-                             req_true :: uu____16142 in
-                           unit_tm :: uu____16135
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in [uu___3; smtpat] in
+                             req_true :: uu___2 in
+                           unit_tm :: uu___1
                        | ens::dec::[] when
                            (is_ensures ens) && (is_decreases dec) ->
-                           let uu____16196 =
-                             let uu____16203 =
-                               let uu____16210 = thunk_ens ens in
-                               [uu____16210; nil_pat; dec] in
-                             req_true :: uu____16203 in
-                           unit_tm :: uu____16196
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; nil_pat; dec] in
+                             req_true :: uu___2 in
+                           unit_tm :: uu___1
                        | ens::dec::smtpat::[] when
                            ((is_ensures ens) && (is_decreases dec)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16270 =
-                             let uu____16277 =
-                               let uu____16284 = thunk_ens ens in
-                               [uu____16284; smtpat; dec] in
-                             req_true :: uu____16277 in
-                           unit_tm :: uu____16270
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; smtpat; dec] in
+                             req_true :: uu___2 in
+                           unit_tm :: uu___1
                        | req::ens::dec::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_decreases dec)
                            ->
-                           let uu____16344 =
-                             let uu____16351 =
-                               let uu____16358 = thunk_ens ens in
-                               [uu____16358; nil_pat; dec] in
-                             req :: uu____16351 in
-                           unit_tm :: uu____16344
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; nil_pat; dec] in
+                             req :: uu___2 in
+                           unit_tm :: uu___1
                        | req::ens::smtpat::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16418 =
-                             let uu____16425 =
-                               let uu____16432 = thunk_ens ens in
-                               [uu____16432; smtpat] in
-                             req :: uu____16425 in
-                           unit_tm :: uu____16418
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in [uu___3; smtpat] in
+                             req :: uu___2 in
+                           unit_tm :: uu___1
                        | req::ens::dec::smtpat::[] when
                            (((is_requires req) && (is_ensures ens)) &&
                               (is_smt_pat smtpat))
                              && (is_decreases dec)
                            ->
-                           let uu____16497 =
-                             let uu____16504 =
-                               let uu____16511 = thunk_ens ens in
-                               [uu____16511; dec; smtpat] in
-                             req :: uu____16504 in
-                           unit_tm :: uu____16497
+                           let uu___1 =
+                             let uu___2 =
+                               let uu___3 = thunk_ens ens in
+                               [uu___3; dec; smtpat] in
+                             req :: uu___2 in
+                           unit_tm :: uu___1
                        | _other -> fail_lemma () in
                      let head_and_attributes =
                        FStar_Syntax_DsEnv.fail_or env
@@ -4230,76 +4070,75 @@ and (desugar_comp :
                      (head_and_attributes, args1)
                  | FStar_Parser_AST.Name l when
                      FStar_Syntax_DsEnv.is_effect_name env l ->
-                     let uu____16573 =
+                     let uu___1 =
                        FStar_Syntax_DsEnv.fail_or env
                          (FStar_Syntax_DsEnv.try_lookup_effect_name_and_attributes
                             env) l in
-                     (uu____16573, args)
+                     (uu___1, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16601 = FStar_Syntax_DsEnv.current_module env in
-                      FStar_Ident.lid_equals uu____16601
+                     (let uu___1 = FStar_Syntax_DsEnv.current_module env in
+                      FStar_Ident.lid_equals uu___1
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____16603 =
-                          let uu____16604 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16604 in
-                        uu____16603 = "Tot")
+                       (let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu___2 in
+                        uu___1 = "Tot")
                      ->
-                     let uu____16605 =
-                       let uu____16612 =
+                     let uu___1 =
+                       let uu___2 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16612, []) in
-                     (uu____16605, args)
+                       (uu___2, []) in
+                     (uu___1, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16630 = FStar_Syntax_DsEnv.current_module env in
-                      FStar_Ident.lid_equals uu____16630
+                     (let uu___1 = FStar_Syntax_DsEnv.current_module env in
+                      FStar_Ident.lid_equals uu___1
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____16632 =
-                          let uu____16633 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16633 in
-                        uu____16632 = "GTot")
+                       (let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu___2 in
+                        uu___1 = "GTot")
                      ->
-                     let uu____16634 =
-                       let uu____16641 =
+                     let uu___1 =
+                       let uu___2 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_GTot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16641, []) in
-                     (uu____16634, args)
+                       (uu___2, []) in
+                     (uu___1, args)
                  | FStar_Parser_AST.Name l when
-                     ((let uu____16659 =
-                         let uu____16660 = FStar_Ident.ident_of_lid l in
-                         FStar_Ident.string_of_id uu____16660 in
-                       uu____16659 = "Type") ||
-                        (let uu____16662 =
-                           let uu____16663 = FStar_Ident.ident_of_lid l in
-                           FStar_Ident.string_of_id uu____16663 in
-                         uu____16662 = "Type0"))
+                     ((let uu___1 =
+                         let uu___2 = FStar_Ident.ident_of_lid l in
+                         FStar_Ident.string_of_id uu___2 in
+                       uu___1 = "Type") ||
+                        (let uu___1 =
+                           let uu___2 = FStar_Ident.ident_of_lid l in
+                           FStar_Ident.string_of_id uu___2 in
+                         uu___1 = "Type0"))
                        ||
-                       (let uu____16665 =
-                          let uu____16666 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16666 in
-                        uu____16665 = "Effect")
+                       (let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu___2 in
+                        uu___1 = "Effect")
                      ->
-                     let uu____16667 =
-                       let uu____16674 =
+                     let uu___1 =
+                       let uu___2 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16674, []) in
-                     (uu____16667, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____16697 when allow_type_promotion ->
+                       (uu___2, []) in
+                     (uu___1, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu___1 when allow_type_promotion ->
                      let default_effect =
-                       let uu____16699 = FStar_Options.ml_ish () in
-                       if uu____16699
+                       let uu___2 = FStar_Options.ml_ish () in
+                       if uu___2
                        then FStar_Parser_Const.effect_ML_lid
                        else
-                         ((let uu____16702 =
-                             FStar_Options.warn_default_effects () in
-                           if uu____16702
+                         ((let uu___5 = FStar_Options.warn_default_effects () in
+                           if uu___5
                            then
                              FStar_Errors.log_issue
                                head.FStar_Parser_AST.range
@@ -4307,147 +4146,140 @@ and (desugar_comp :
                                  "Using default effect Tot")
                            else ());
                           FStar_Parser_Const.effect_Tot_lid) in
-                     let uu____16704 =
-                       let uu____16711 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_Ident.set_lid_range default_effect
                            head.FStar_Parser_AST.range in
-                       (uu____16711, []) in
-                     (uu____16704, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____16734 ->
+                       (uu___3, []) in
+                     (uu___2, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu___1 ->
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_EffectNotFound,
                          "Expected an effect constructor")
                        t1.FStar_Parser_AST.range) in
-          let uu____16751 = pre_process_comp_typ t in
-          match uu____16751 with
+          let uu___ = pre_process_comp_typ t in
+          match uu___ with
           | ((eff, cattributes), args) ->
               (if (FStar_List.length args) = Prims.int_zero
                then
-                 (let uu____16800 =
-                    let uu____16805 =
-                      let uu____16806 = FStar_Syntax_Print.lid_to_string eff in
+                 (let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Print.lid_to_string eff in
                       FStar_Util.format1 "Not enough args to effect %s"
-                        uu____16806 in
-                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____16805) in
-                  fail uu____16800)
+                        uu___4 in
+                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu___3) in
+                  fail uu___2)
                else ();
-               (let is_universe uu____16817 =
-                  match uu____16817 with
-                  | (uu____16822, imp) -> imp = FStar_Parser_AST.UnivApp in
-                let uu____16824 = FStar_Util.take is_universe args in
-                match uu____16824 with
+               (let is_universe uu___2 =
+                  match uu___2 with
+                  | (uu___3, imp) -> imp = FStar_Parser_AST.UnivApp in
+                let uu___2 = FStar_Util.take is_universe args in
+                match uu___2 with
                 | (universes, args1) ->
                     let universes1 =
                       FStar_List.map
-                        (fun uu____16883 ->
-                           match uu____16883 with
-                           | (u, imp) -> desugar_universe u) universes in
-                    let uu____16890 =
-                      let uu____16905 = FStar_List.hd args1 in
-                      let uu____16914 = FStar_List.tl args1 in
-                      (uu____16905, uu____16914) in
-                    (match uu____16890 with
+                        (fun uu___3 ->
+                           match uu___3 with | (u, imp) -> desugar_universe u)
+                        universes in
+                    let uu___3 =
+                      let uu___4 = FStar_List.hd args1 in
+                      let uu___5 = FStar_List.tl args1 in (uu___4, uu___5) in
+                    (match uu___3 with
                      | (result_arg, rest) ->
                          let result_typ =
                            desugar_typ env
                              (FStar_Pervasives_Native.fst result_arg) in
                          let rest1 = desugar_args env rest in
-                         let uu____16969 =
-                           let is_decrease uu____17007 =
-                             match uu____17007 with
-                             | (t1, uu____17017) ->
+                         let uu___4 =
+                           let is_decrease uu___5 =
+                             match uu___5 with
+                             | (t1, uu___6) ->
                                  (match t1.FStar_Syntax_Syntax.n with
                                   | FStar_Syntax_Syntax.Tm_app
                                       ({
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
-                                         FStar_Syntax_Syntax.pos =
-                                           uu____17027;
-                                         FStar_Syntax_Syntax.vars =
-                                           uu____17028;_},
-                                       uu____17029::[])
+                                         FStar_Syntax_Syntax.pos = uu___7;
+                                         FStar_Syntax_Syntax.vars = uu___8;_},
+                                       uu___9::[])
                                       ->
                                       FStar_Syntax_Syntax.fv_eq_lid fv
                                         FStar_Parser_Const.decreases_lid
-                                  | uu____17068 -> false) in
+                                  | uu___7 -> false) in
                            FStar_All.pipe_right rest1
                              (FStar_List.partition is_decrease) in
-                         (match uu____16969 with
+                         (match uu___4 with
                           | (dec, rest2) ->
                               let decreases_clause =
                                 FStar_All.pipe_right dec
                                   (FStar_List.map
-                                     (fun uu____17184 ->
-                                        match uu____17184 with
-                                        | (t1, uu____17194) ->
+                                     (fun uu___5 ->
+                                        match uu___5 with
+                                        | (t1, uu___6) ->
                                             (match t1.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_app
-                                                 (uu____17203,
-                                                  (arg, uu____17205)::[])
+                                                 (uu___7, (arg, uu___8)::[])
                                                  ->
                                                  FStar_Syntax_Syntax.DECREASES
                                                    arg
-                                             | uu____17244 ->
-                                                 failwith "impos"))) in
+                                             | uu___7 -> failwith "impos"))) in
                               let no_additional_args =
                                 let is_empty l =
-                                  match l with
-                                  | [] -> true
-                                  | uu____17261 -> false in
+                                  match l with | [] -> true | uu___5 -> false in
                                 (((is_empty decreases_clause) &&
                                     (is_empty rest2))
                                    && (is_empty cattributes))
                                   && (is_empty universes1) in
-                              let uu____17272 =
+                              let uu___5 =
                                 no_additional_args &&
                                   (FStar_Ident.lid_equals eff
                                      FStar_Parser_Const.effect_Tot_lid) in
-                              if uu____17272
+                              if uu___5
                               then FStar_Syntax_Syntax.mk_Total result_typ
                               else
-                                (let uu____17276 =
+                                (let uu___7 =
                                    no_additional_args &&
                                      (FStar_Ident.lid_equals eff
                                         FStar_Parser_Const.effect_GTot_lid) in
-                                 if uu____17276
+                                 if uu___7
                                  then
                                    FStar_Syntax_Syntax.mk_GTotal result_typ
                                  else
                                    (let flags =
-                                      let uu____17283 =
+                                      let uu___9 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid in
-                                      if uu____17283
+                                      if uu___9
                                       then [FStar_Syntax_Syntax.LEMMA]
                                       else
-                                        (let uu____17287 =
+                                        (let uu___11 =
                                            FStar_Ident.lid_equals eff
                                              FStar_Parser_Const.effect_Tot_lid in
-                                         if uu____17287
+                                         if uu___11
                                          then [FStar_Syntax_Syntax.TOTAL]
                                          else
-                                           (let uu____17291 =
+                                           (let uu___13 =
                                               FStar_Ident.lid_equals eff
                                                 FStar_Parser_Const.effect_ML_lid in
-                                            if uu____17291
+                                            if uu___13
                                             then
                                               [FStar_Syntax_Syntax.MLEFFECT]
                                             else
-                                              (let uu____17295 =
+                                              (let uu___15 =
                                                  FStar_Ident.lid_equals eff
                                                    FStar_Parser_Const.effect_GTot_lid in
-                                               if uu____17295
+                                               if uu___15
                                                then
                                                  [FStar_Syntax_Syntax.SOMETRIVIAL]
                                                else []))) in
                                     let flags1 =
                                       FStar_List.append flags cattributes in
                                     let rest3 =
-                                      let uu____17313 =
+                                      let uu___9 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid in
-                                      if uu____17313
+                                      if uu___9
                                       then
                                         match rest2 with
                                         | req::ens::(pat, aq)::[] ->
@@ -4465,12 +4297,12 @@ and (desugar_comp :
                                                       pat
                                                       [FStar_Syntax_Syntax.U_zero] in
                                                   let pattern =
-                                                    let uu____17402 =
+                                                    let uu___10 =
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos in
                                                     FStar_Syntax_Syntax.fvar
-                                                      uu____17402
+                                                      uu___10
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None in
                                                   FStar_Syntax_Syntax.mk_Tm_app
@@ -4479,22 +4311,22 @@ and (desugar_comp :
                                                        (FStar_Pervasives_Native.Some
                                                           FStar_Syntax_Syntax.imp_tag))]
                                                     pat.FStar_Syntax_Syntax.pos
-                                              | uu____17423 -> pat in
-                                            let uu____17424 =
-                                              let uu____17435 =
-                                                let uu____17446 =
-                                                  let uu____17455 =
+                                              | uu___10 -> pat in
+                                            let uu___10 =
+                                              let uu___11 =
+                                                let uu___12 =
+                                                  let uu___13 =
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
                                                          (pat1,
                                                            (FStar_Syntax_Syntax.Meta_desugared
                                                               FStar_Syntax_Syntax.Meta_smt_pat)))
                                                       pat1.FStar_Syntax_Syntax.pos in
-                                                  (uu____17455, aq) in
-                                                [uu____17446] in
-                                              ens :: uu____17435 in
-                                            req :: uu____17424
-                                        | uu____17496 -> rest2
+                                                  (uu___13, aq) in
+                                                [uu___12] in
+                                              ens :: uu___11 in
+                                            req :: uu___10
+                                        | uu___10 -> rest2
                                       else rest2 in
                                     FStar_Syntax_Syntax.mk_Comp
                                       {
@@ -4516,48 +4348,45 @@ and (desugar_formula :
     fun f ->
       let mk t = FStar_Syntax_Syntax.mk t f.FStar_Parser_AST.range in
       let setpos t =
-        let uu___2390_17530 = t in
+        let uu___ = t in
         {
-          FStar_Syntax_Syntax.n = (uu___2390_17530.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
-          FStar_Syntax_Syntax.vars =
-            (uu___2390_17530.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
         } in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___2397_17584 = b in
+            (let uu___ = b in
              {
-               FStar_Parser_AST.b = (uu___2397_17584.FStar_Parser_AST.b);
-               FStar_Parser_AST.brange =
-                 (uu___2397_17584.FStar_Parser_AST.brange);
+               FStar_Parser_AST.b = (uu___.FStar_Parser_AST.b);
+               FStar_Parser_AST.brange = (uu___.FStar_Parser_AST.brange);
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
-               FStar_Parser_AST.aqual =
-                 (uu___2397_17584.FStar_Parser_AST.aqual)
+               FStar_Parser_AST.aqual = (uu___.FStar_Parser_AST.aqual)
              }) in
-        let with_pats env1 uu____17613 body1 =
-          match uu____17613 with
+        let with_pats env1 uu___ body1 =
+          match uu___ with
           | (names, pats1) ->
               (match (names, pats1) with
                | ([], []) -> body1
-               | ([], uu____17659::uu____17660) ->
+               | ([], uu___1::uu___2) ->
                    failwith
                      "Impossible: Annotated pattern without binders in scope"
-               | uu____17677 ->
+               | uu___1 ->
                    let names1 =
                      FStar_All.pipe_right names
                        (FStar_List.map
                           (fun i ->
-                             let uu___2416_17705 =
+                             let uu___2 =
                                FStar_Syntax_DsEnv.fail_or2
                                  (FStar_Syntax_DsEnv.try_lookup_id env1) i in
-                             let uu____17706 = FStar_Ident.range_of_id i in
+                             let uu___3 = FStar_Ident.range_of_id i in
                              {
                                FStar_Syntax_Syntax.n =
-                                 (uu___2416_17705.FStar_Syntax_Syntax.n);
-                               FStar_Syntax_Syntax.pos = uu____17706;
+                                 (uu___2.FStar_Syntax_Syntax.n);
+                               FStar_Syntax_Syntax.pos = uu___3;
                                FStar_Syntax_Syntax.vars =
-                                 (uu___2416_17705.FStar_Syntax_Syntax.vars)
+                                 (uu___2.FStar_Syntax_Syntax.vars)
                              })) in
                    let pats2 =
                      FStar_All.pipe_right pats1
@@ -4566,72 +4395,69 @@ and (desugar_formula :
                              FStar_All.pipe_right es
                                (FStar_List.map
                                   (fun e ->
-                                     let uu____17769 = desugar_term env1 e in
+                                     let uu___2 = desugar_term env1 e in
                                      FStar_All.pipe_left
                                        (arg_withimp_t
-                                          FStar_Parser_AST.Nothing)
-                                       uu____17769)))) in
+                                          FStar_Parser_AST.Nothing) uu___2)))) in
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (body1,
                           (FStar_Syntax_Syntax.Meta_pattern (names1, pats2))))) in
         match tk with
         | (FStar_Pervasives_Native.Some a, k) ->
-            let uu____17800 = FStar_Syntax_DsEnv.push_bv env a in
-            (match uu____17800 with
+            let uu___ = FStar_Syntax_DsEnv.push_bv env a in
+            (match uu___ with
              | (env1, a1) ->
                  let a2 =
-                   let uu___2429_17810 = a1 in
+                   let uu___1 = a1 in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2429_17810.FStar_Syntax_Syntax.ppname);
+                       (uu___1.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2429_17810.FStar_Syntax_Syntax.index);
+                       (uu___1.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
                    } in
                  let body1 = desugar_formula env1 body in
                  let body2 = with_pats env1 pats body1 in
                  let body3 =
-                   let uu____17816 =
-                     let uu____17819 =
-                       let uu____17820 = FStar_Syntax_Syntax.mk_binder a2 in
-                       [uu____17820] in
-                     no_annot_abs uu____17819 body2 in
-                   FStar_All.pipe_left setpos uu____17816 in
-                 let uu____17841 =
-                   let uu____17842 =
-                     let uu____17859 =
-                       let uu____17862 =
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Syntax.mk_binder a2 in
+                       [uu___3] in
+                     no_annot_abs uu___2 body2 in
+                   FStar_All.pipe_left setpos uu___1 in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange in
-                       FStar_Syntax_Syntax.fvar uu____17862
+                       FStar_Syntax_Syntax.fvar uu___4
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None in
-                     let uu____17863 =
-                       let uu____17874 = FStar_Syntax_Syntax.as_arg body3 in
-                       [uu____17874] in
-                     (uu____17859, uu____17863) in
-                   FStar_Syntax_Syntax.Tm_app uu____17842 in
-                 FStar_All.pipe_left mk uu____17841)
-        | uu____17913 -> failwith "impossible" in
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Syntax.as_arg body3 in
+                       [uu___5] in
+                     (uu___3, uu___4) in
+                   FStar_Syntax_Syntax.Tm_app uu___2 in
+                 FStar_All.pipe_left mk uu___1)
+        | uu___ -> failwith "impossible" in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
             let rest = b' :: _rest in
             let body1 =
-              let uu____17977 = q (rest, pats, body) in
-              let uu____17980 =
+              let uu___ = q (rest, pats, body) in
+              let uu___1 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
                   body.FStar_Parser_AST.range in
-              FStar_Parser_AST.mk_term uu____17977 uu____17980
-                FStar_Parser_AST.Formula in
-            let uu____17981 = q ([b], ([], []), body1) in
-            FStar_Parser_AST.mk_term uu____17981 f.FStar_Parser_AST.range
+              FStar_Parser_AST.mk_term uu___ uu___1 FStar_Parser_AST.Formula in
+            let uu___ = q ([b], ([], []), body1) in
+            FStar_Parser_AST.mk_term uu___ f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____17992 -> failwith "impossible" in
-      let uu____17995 =
-        let uu____17996 = unparen f in uu____17996.FStar_Parser_AST.tm in
-      match uu____17995 with
+        | uu___ -> failwith "impossible" in
+      let uu___ = let uu___1 = unparen f in uu___1.FStar_Parser_AST.tm in
+      match uu___ with
       | FStar_Parser_AST.Labeled (f1, l, p) ->
           let f2 = desugar_formula env f1 in
           FStar_All.pipe_left mk
@@ -4639,28 +4465,28 @@ and (desugar_formula :
                (f2,
                  (FStar_Syntax_Syntax.Meta_labeled
                     (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([], uu____18003, uu____18004) ->
+      | FStar_Parser_AST.QForall ([], uu___1, uu___2) ->
           failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QExists ([], uu____18027, uu____18028) ->
+      | FStar_Parser_AST.QExists ([], uu___1, uu___2) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3, pats, body) ->
           let binders = _1 :: _2 :: _3 in
-          let uu____18083 =
+          let uu___1 =
             push_quant (fun x -> FStar_Parser_AST.QForall x) binders pats
               body in
-          desugar_formula env uu____18083
+          desugar_formula env uu___1
       | FStar_Parser_AST.QExists (_1::_2::_3, pats, body) ->
           let binders = _1 :: _2 :: _3 in
-          let uu____18127 =
+          let uu___1 =
             push_quant (fun x -> FStar_Parser_AST.QExists x) binders pats
               body in
-          desugar_formula env uu____18127
+          desugar_formula env uu___1
       | FStar_Parser_AST.QForall (b::[], pats, body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
       | FStar_Parser_AST.QExists (b::[], pats, body) ->
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
-      | uu____18190 -> desugar_term env f
+      | uu___1 -> desugar_term env f
 and (desugar_binder :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.binder ->
@@ -4671,25 +4497,24 @@ and (desugar_binder :
     fun b ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x, t) ->
-          let uu____18201 = desugar_typ env t in
-          ((FStar_Pervasives_Native.Some x), uu____18201)
+          let uu___ = desugar_typ env t in
+          ((FStar_Pervasives_Native.Some x), uu___)
       | FStar_Parser_AST.Annotated (x, t) ->
-          let uu____18206 = desugar_typ env t in
-          ((FStar_Pervasives_Native.Some x), uu____18206)
+          let uu___ = desugar_typ env t in
+          ((FStar_Pervasives_Native.Some x), uu___)
       | FStar_Parser_AST.TVariable x ->
-          let uu____18210 =
-            let uu____18211 = FStar_Ident.range_of_id x in
+          let uu___ =
+            let uu___1 = FStar_Ident.range_of_id x in
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-              uu____18211 in
-          ((FStar_Pervasives_Native.Some x), uu____18210)
+              uu___1 in
+          ((FStar_Pervasives_Native.Some x), uu___)
       | FStar_Parser_AST.NoName t ->
-          let uu____18215 = desugar_typ env t in
-          (FStar_Pervasives_Native.None, uu____18215)
+          let uu___ = desugar_typ env t in
+          (FStar_Pervasives_Native.None, uu___)
       | FStar_Parser_AST.Variable x ->
-          let uu____18219 =
-            let uu____18220 = FStar_Ident.range_of_id x in tun_r uu____18220 in
-          ((FStar_Pervasives_Native.Some x), uu____18219)
+          let uu___ = let uu___1 = FStar_Ident.range_of_id x in tun_r uu___1 in
+          ((FStar_Pervasives_Native.Some x), uu___)
 and (as_binder :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
@@ -4700,46 +4525,45 @@ and (as_binder :
   =
   fun env ->
     fun imp ->
-      fun uu___11_18225 ->
-        match uu___11_18225 with
+      fun uu___ ->
+        match uu___ with
         | (FStar_Pervasives_Native.None, k) ->
-            let uu____18247 = FStar_Syntax_Syntax.null_binder k in
-            (uu____18247, env)
+            let uu___1 = FStar_Syntax_Syntax.null_binder k in (uu___1, env)
         | (FStar_Pervasives_Native.Some a, k) ->
-            let uu____18264 = FStar_Syntax_DsEnv.push_bv env a in
-            (match uu____18264 with
+            let uu___1 = FStar_Syntax_DsEnv.push_bv env a in
+            (match uu___1 with
              | (env1, a1) ->
-                 let uu____18281 =
-                   let uu____18288 = trans_aqual env1 imp in
-                   ((let uu___2529_18294 = a1 in
+                 let uu___2 =
+                   let uu___3 = trans_aqual env1 imp in
+                   ((let uu___4 = a1 in
                      {
                        FStar_Syntax_Syntax.ppname =
-                         (uu___2529_18294.FStar_Syntax_Syntax.ppname);
+                         (uu___4.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
-                         (uu___2529_18294.FStar_Syntax_Syntax.index);
+                         (uu___4.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = k
-                     }), uu____18288) in
-                 (uu____18281, env1))
+                     }), uu___3) in
+                 (uu___2, env1))
 and (trans_aqual :
   env_t ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.aqual)
   =
   fun env ->
-    fun uu___12_18302 ->
-      match uu___12_18302 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
           (FStar_Parser_AST.Arg_qualifier_meta_tac t)) ->
-          let uu____18306 =
-            let uu____18307 =
-              let uu____18308 = desugar_term env t in
-              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____18308 in
-            FStar_Syntax_Syntax.Meta uu____18307 in
-          FStar_Pervasives_Native.Some uu____18306
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = desugar_term env t in
+              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu___3 in
+            FStar_Syntax_Syntax.Meta uu___2 in
+          FStar_Pervasives_Native.Some uu___1
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
           (FStar_Parser_AST.Arg_qualifier_meta_attr t)) ->
           let t1 = desugar_term env t in
@@ -4758,52 +4582,50 @@ let (typars_of_binders :
   =
   fun env ->
     fun bs ->
-      let uu____18338 =
+      let uu___ =
         FStar_List.fold_left
-          (fun uu____18371 ->
+          (fun uu___1 ->
              fun b ->
-               match uu____18371 with
+               match uu___1 with
                | (env1, out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___2554_18415 = b in
+                       (let uu___2 = b in
                         {
-                          FStar_Parser_AST.b =
-                            (uu___2554_18415.FStar_Parser_AST.b);
+                          FStar_Parser_AST.b = (uu___2.FStar_Parser_AST.b);
                           FStar_Parser_AST.brange =
-                            (uu___2554_18415.FStar_Parser_AST.brange);
+                            (uu___2.FStar_Parser_AST.brange);
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
-                            (uu___2554_18415.FStar_Parser_AST.aqual)
+                            (uu___2.FStar_Parser_AST.aqual)
                         }) in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a, k) ->
-                        let uu____18430 = FStar_Syntax_DsEnv.push_bv env1 a in
-                        (match uu____18430 with
+                        let uu___2 = FStar_Syntax_DsEnv.push_bv env1 a in
+                        (match uu___2 with
                          | (env2, a1) ->
                              let a2 =
-                               let uu___2564_18448 = a1 in
+                               let uu___3 = a1 in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2564_18448.FStar_Syntax_Syntax.ppname);
+                                   (uu___3.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2564_18448.FStar_Syntax_Syntax.index);
+                                   (uu___3.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
                                } in
-                             let uu____18449 =
-                               let uu____18456 =
-                                 let uu____18461 =
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 =
                                    trans_aqual env2 b.FStar_Parser_AST.aqual in
-                                 (a2, uu____18461) in
-                               uu____18456 :: out in
-                             (env2, uu____18449))
-                    | uu____18472 ->
+                                 (a2, uu___5) in
+                               uu___4 :: out in
+                             (env2, uu___3))
+                    | uu___2 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
           (env, []) bs in
-      match uu____18338 with
-      | (env1, tpars) -> (env1, (FStar_List.rev tpars))
+      match uu___ with | (env1, tpars) -> (env1, (FStar_List.rev tpars))
 let (desugar_attributes :
   env_t ->
     FStar_Parser_AST.term Prims.list -> FStar_Syntax_Syntax.cflag Prims.list)
@@ -4811,39 +4633,36 @@ let (desugar_attributes :
   fun env ->
     fun cattributes ->
       let desugar_attribute t =
-        let uu____18557 =
-          let uu____18558 = unparen t in uu____18558.FStar_Parser_AST.tm in
-        match uu____18557 with
+        let uu___ = let uu___1 = unparen t in uu___1.FStar_Parser_AST.tm in
+        match uu___ with
         | FStar_Parser_AST.Var lid when
-            let uu____18560 = FStar_Ident.string_of_lid lid in
-            uu____18560 = "cps" -> FStar_Syntax_Syntax.CPS
-        | uu____18561 ->
-            let uu____18562 =
-              let uu____18567 =
-                let uu____18568 = FStar_Parser_AST.term_to_string t in
-                Prims.op_Hat "Unknown attribute " uu____18568 in
-              (FStar_Errors.Fatal_UnknownAttribute, uu____18567) in
-            FStar_Errors.raise_error uu____18562 t.FStar_Parser_AST.range in
+            let uu___1 = FStar_Ident.string_of_lid lid in uu___1 = "cps" ->
+            FStar_Syntax_Syntax.CPS
+        | uu___1 ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Parser_AST.term_to_string t in
+                Prims.op_Hat "Unknown attribute " uu___4 in
+              (FStar_Errors.Fatal_UnknownAttribute, uu___3) in
+            FStar_Errors.raise_error uu___2 t.FStar_Parser_AST.range in
       FStar_List.map desugar_attribute cattributes
 let (binder_ident :
   FStar_Parser_AST.binder -> FStar_Ident.ident FStar_Pervasives_Native.option)
   =
   fun b ->
     match b.FStar_Parser_AST.b with
-    | FStar_Parser_AST.TAnnotated (x, uu____18581) ->
+    | FStar_Parser_AST.TAnnotated (x, uu___) ->
         FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.Annotated (x, uu____18583) ->
-        FStar_Pervasives_Native.Some x
+    | FStar_Parser_AST.Annotated (x, uu___) -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.TVariable x -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.Variable x -> FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.NoName uu____18586 -> FStar_Pervasives_Native.None
+    | FStar_Parser_AST.NoName uu___ -> FStar_Pervasives_Native.None
 let (binder_idents :
   FStar_Parser_AST.binder Prims.list -> FStar_Ident.ident Prims.list) =
   fun bs ->
     FStar_List.collect
       (fun b ->
-         let uu____18603 = binder_ident b in
-         FStar_Common.list_of_option uu____18603) bs
+         let uu___ = binder_ident b in FStar_Common.list_of_option uu___) bs
 let (mk_data_discriminators :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_DsEnv.env ->
@@ -4855,25 +4674,25 @@ let (mk_data_discriminators :
         let quals1 =
           FStar_All.pipe_right quals
             (FStar_List.filter
-               (fun uu___13_18639 ->
-                  match uu___13_18639 with
+               (fun uu___ ->
+                  match uu___ with
                   | FStar_Syntax_Syntax.NoExtract -> true
                   | FStar_Syntax_Syntax.Private -> true
-                  | uu____18640 -> false)) in
+                  | uu___1 -> false)) in
         let quals2 q =
-          let uu____18653 =
-            (let uu____18656 = FStar_Syntax_DsEnv.iface env in
-             Prims.op_Negation uu____18656) ||
+          let uu___ =
+            (let uu___1 = FStar_Syntax_DsEnv.iface env in
+             Prims.op_Negation uu___1) ||
               (FStar_Syntax_DsEnv.admitted_iface env) in
-          if uu____18653
+          if uu___
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
           else FStar_List.append q quals1 in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d ->
                 let disc_name = FStar_Syntax_Util.mk_discriminator d in
-                let uu____18670 = FStar_Ident.range_of_lid disc_name in
-                let uu____18671 =
+                let uu___ = FStar_Ident.range_of_lid disc_name in
+                let uu___1 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
                     FStar_Syntax_Syntax.Discriminator d] in
@@ -4881,8 +4700,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
                        (disc_name, [], FStar_Syntax_Syntax.tun));
-                  FStar_Syntax_Syntax.sigrng = uu____18670;
-                  FStar_Syntax_Syntax.sigquals = uu____18671;
+                  FStar_Syntax_Syntax.sigrng = uu___;
+                  FStar_Syntax_Syntax.sigquals = uu___1;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = [];
@@ -4902,29 +4721,28 @@ let (mk_indexed_projector_names :
         fun lid ->
           fun fields ->
             let p = FStar_Ident.range_of_lid lid in
-            let uu____18710 =
+            let uu___ =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
                    (fun i ->
-                      fun uu____18746 ->
-                        match uu____18746 with
-                        | (x, uu____18756) ->
+                      fun uu___1 ->
+                        match uu___1 with
+                        | (x, uu___2) ->
                             let field_name =
                               FStar_Syntax_Util.mk_field_projector_name lid x
                                 i in
                             let only_decl =
-                              ((let uu____18765 =
+                              ((let uu___3 =
                                   FStar_Syntax_DsEnv.current_module env in
                                 FStar_Ident.lid_equals
-                                  FStar_Parser_Const.prims_lid uu____18765)
+                                  FStar_Parser_Const.prims_lid uu___3)
                                  || (fvq <> FStar_Syntax_Syntax.Data_ctor))
                                 ||
-                                (let uu____18767 =
-                                   let uu____18768 =
+                                (let uu___3 =
+                                   let uu___4 =
                                      FStar_Syntax_DsEnv.current_module env in
-                                   FStar_Ident.string_of_lid uu____18768 in
-                                 FStar_Options.dont_gen_projectors
-                                   uu____18767) in
+                                   FStar_Ident.string_of_lid uu___4 in
+                                 FStar_Options.dont_gen_projectors uu___3) in
                             let no_decl =
                               FStar_Syntax_Syntax.is_type
                                 x.FStar_Syntax_Syntax.sort in
@@ -4936,25 +4754,25 @@ let (mk_indexed_projector_names :
                               let iquals1 =
                                 FStar_All.pipe_right iquals
                                   (FStar_List.filter
-                                     (fun uu___14_18796 ->
-                                        match uu___14_18796 with
+                                     (fun uu___3 ->
+                                        match uu___3 with
                                         | FStar_Syntax_Syntax.NoExtract ->
                                             true
                                         | FStar_Syntax_Syntax.Private -> true
-                                        | uu____18797 -> false)) in
+                                        | uu___4 -> false)) in
                               quals (FStar_Syntax_Syntax.OnlyName ::
                                 (FStar_Syntax_Syntax.Projector
                                    (lid, (x.FStar_Syntax_Syntax.ppname))) ::
                                 iquals1) in
                             let decl =
-                              let uu____18799 =
+                              let uu___3 =
                                 FStar_Ident.range_of_lid field_name in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                      (field_name, [],
                                        FStar_Syntax_Syntax.tun));
-                                FStar_Syntax_Syntax.sigrng = uu____18799;
+                                FStar_Syntax_Syntax.sigrng = uu___3;
                                 FStar_Syntax_Syntax.sigquals = quals1;
                                 FStar_Syntax_Syntax.sigmeta =
                                   FStar_Syntax_Syntax.default_sigmeta;
@@ -4969,13 +4787,13 @@ let (mk_indexed_projector_names :
                                  FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one in
                                let lb =
-                                 let uu____18805 =
-                                   let uu____18810 =
+                                 let uu___4 =
+                                   let uu___5 =
                                      FStar_Syntax_Syntax.lid_as_fv field_name
                                        dd FStar_Pervasives_Native.None in
-                                   FStar_Util.Inr uu____18810 in
+                                   FStar_Util.Inr uu___5 in
                                  {
-                                   FStar_Syntax_Syntax.lbname = uu____18805;
+                                   FStar_Syntax_Syntax.lbname = uu___4;
                                    FStar_Syntax_Syntax.lbunivs = [];
                                    FStar_Syntax_Syntax.lbtyp =
                                      FStar_Syntax_Syntax.tun;
@@ -4988,22 +4806,22 @@ let (mk_indexed_projector_names :
                                      FStar_Range.dummyRange
                                  } in
                                let impl =
-                                 let uu____18814 =
-                                   let uu____18815 =
-                                     let uu____18822 =
-                                       let uu____18825 =
-                                         let uu____18826 =
+                                 let uu___4 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
+                                         let uu___8 =
                                            FStar_All.pipe_right
                                              lb.FStar_Syntax_Syntax.lbname
                                              FStar_Util.right in
-                                         FStar_All.pipe_right uu____18826
+                                         FStar_All.pipe_right uu___8
                                            (fun fv ->
                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                       [uu____18825] in
-                                     ((false, [lb]), uu____18822) in
-                                   FStar_Syntax_Syntax.Sig_let uu____18815 in
+                                       [uu___7] in
+                                     ((false, [lb]), uu___6) in
+                                   FStar_Syntax_Syntax.Sig_let uu___5 in
                                  {
-                                   FStar_Syntax_Syntax.sigel = uu____18814;
+                                   FStar_Syntax_Syntax.sigel = uu___4;
                                    FStar_Syntax_Syntax.sigrng = p;
                                    FStar_Syntax_Syntax.sigquals = quals1;
                                    FStar_Syntax_Syntax.sigmeta =
@@ -5013,7 +4831,7 @@ let (mk_indexed_projector_names :
                                      FStar_Pervasives_Native.None
                                  } in
                                if no_decl then [impl] else [decl; impl]))) in
-            FStar_All.pipe_right uu____18710 FStar_List.flatten
+            FStar_All.pipe_right uu___ FStar_List.flatten
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_DsEnv.env ->
@@ -5023,38 +4841,38 @@ let (mk_data_projector_names :
     fun env ->
       fun se ->
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_datacon
-            (lid, uu____18870, t, uu____18872, n, uu____18874) when
-            let uu____18879 =
+        | FStar_Syntax_Syntax.Sig_datacon (lid, uu___, t, uu___1, n, uu___2)
+            when
+            let uu___3 =
               FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid in
-            Prims.op_Negation uu____18879 ->
-            let uu____18880 = FStar_Syntax_Util.arrow_formals t in
-            (match uu____18880 with
-             | (formals, uu____18890) ->
+            Prims.op_Negation uu___3 ->
+            let uu___3 = FStar_Syntax_Util.arrow_formals t in
+            (match uu___3 with
+             | (formals, uu___4) ->
                  (match formals with
                   | [] -> []
-                  | uu____18903 ->
-                      let filter_records uu___15_18911 =
-                        match uu___15_18911 with
-                        | FStar_Syntax_Syntax.RecordConstructor
-                            (uu____18914, fns) ->
+                  | uu___5 ->
+                      let filter_records uu___6 =
+                        match uu___6 with
+                        | FStar_Syntax_Syntax.RecordConstructor (uu___7, fns)
+                            ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____18926 -> FStar_Pervasives_Native.None in
+                        | uu___7 -> FStar_Pervasives_Native.None in
                       let fv_qual =
-                        let uu____18928 =
+                        let uu___6 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
                             filter_records in
-                        match uu____18928 with
+                        match uu___6 with
                         | FStar_Pervasives_Native.None ->
                             FStar_Syntax_Syntax.Data_ctor
                         | FStar_Pervasives_Native.Some q -> q in
-                      let uu____18932 = FStar_Util.first_N n formals in
-                      (match uu____18932 with
-                       | (uu____18961, rest) ->
+                      let uu___6 = FStar_Util.first_N n formals in
+                      (match uu___6 with
+                       | (uu___7, rest) ->
                            mk_indexed_projector_names iquals fv_qual env lid
                              rest)))
-        | uu____18995 -> []
+        | uu___ -> []
 let (mk_typ_abbrev :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.decl ->
@@ -5082,35 +4900,35 @@ let (mk_typ_abbrev :
                         FStar_List.map (desugar_term env)
                           d.FStar_Parser_AST.attrs in
                       let val_attrs =
-                        let uu____19088 =
+                        let uu___ =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env lid in
-                        FStar_All.pipe_right uu____19088
+                        FStar_All.pipe_right uu___
                           FStar_Pervasives_Native.snd in
                       let dd = FStar_Syntax_Util.incr_delta_qualifier t in
                       let lb =
-                        let uu____19113 =
-                          let uu____19118 =
+                        let uu___ =
+                          let uu___1 =
                             FStar_Syntax_Syntax.lid_as_fv lid dd
                               FStar_Pervasives_Native.None in
-                          FStar_Util.Inr uu____19118 in
-                        let uu____19119 =
+                          FStar_Util.Inr uu___1 in
+                        let uu___1 =
                           if FStar_Util.is_some kopt
                           then
-                            let uu____19124 =
-                              let uu____19127 =
+                            let uu___2 =
+                              let uu___3 =
                                 FStar_All.pipe_right kopt FStar_Util.must in
-                              FStar_Syntax_Syntax.mk_Total uu____19127 in
-                            FStar_Syntax_Util.arrow typars uu____19124
+                              FStar_Syntax_Syntax.mk_Total uu___3 in
+                            FStar_Syntax_Util.arrow typars uu___2
                           else FStar_Syntax_Syntax.tun in
-                        let uu____19131 = no_annot_abs typars t in
+                        let uu___2 = no_annot_abs typars t in
                         {
-                          FStar_Syntax_Syntax.lbname = uu____19113;
+                          FStar_Syntax_Syntax.lbname = uu___;
                           FStar_Syntax_Syntax.lbunivs = uvs;
-                          FStar_Syntax_Syntax.lbtyp = uu____19119;
+                          FStar_Syntax_Syntax.lbtyp = uu___1;
                           FStar_Syntax_Syntax.lbeff =
                             FStar_Parser_Const.effect_Tot_lid;
-                          FStar_Syntax_Syntax.lbdef = uu____19131;
+                          FStar_Syntax_Syntax.lbdef = uu___2;
                           FStar_Syntax_Syntax.lbattrs = [];
                           FStar_Syntax_Syntax.lbpos = rng
                         } in
@@ -5138,40 +4956,35 @@ let rec (desugar_tycon :
       fun quals ->
         fun tcs ->
           let rng = d.FStar_Parser_AST.drange in
-          let tycon_id uu___16_19182 =
-            match uu___16_19182 with
-            | FStar_Parser_AST.TyconAbstract (id, uu____19184, uu____19185)
-                -> id
-            | FStar_Parser_AST.TyconAbbrev
-                (id, uu____19195, uu____19196, uu____19197) -> id
-            | FStar_Parser_AST.TyconRecord
-                (id, uu____19207, uu____19208, uu____19209) -> id
-            | FStar_Parser_AST.TyconVariant
-                (id, uu____19231, uu____19232, uu____19233) -> id in
+          let tycon_id uu___ =
+            match uu___ with
+            | FStar_Parser_AST.TyconAbstract (id, uu___1, uu___2) -> id
+            | FStar_Parser_AST.TyconAbbrev (id, uu___1, uu___2, uu___3) -> id
+            | FStar_Parser_AST.TyconRecord (id, uu___1, uu___2, uu___3) -> id
+            | FStar_Parser_AST.TyconVariant (id, uu___1, uu___2, uu___3) ->
+                id in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x, uu____19269) ->
-                let uu____19270 =
-                  let uu____19271 = FStar_Ident.lid_of_ids [x] in
-                  FStar_Parser_AST.Var uu____19271 in
-                let uu____19272 = FStar_Ident.range_of_id x in
-                FStar_Parser_AST.mk_term uu____19270 uu____19272
-                  FStar_Parser_AST.Expr
+            | FStar_Parser_AST.Annotated (x, uu___) ->
+                let uu___1 =
+                  let uu___2 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu___2 in
+                let uu___2 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_term uu___1 uu___2 FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
-                let uu____19274 =
-                  let uu____19275 = FStar_Ident.lid_of_ids [x] in
-                  FStar_Parser_AST.Var uu____19275 in
-                let uu____19276 = FStar_Ident.range_of_id x in
-                FStar_Parser_AST.mk_term uu____19274 uu____19276
-                  FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a, uu____19278) ->
-                let uu____19279 = FStar_Ident.range_of_id a in
-                FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____19279 FStar_Parser_AST.Type_level
+                let uu___ =
+                  let uu___1 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu___1 in
+                let uu___1 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_term uu___ uu___1 FStar_Parser_AST.Expr
+            | FStar_Parser_AST.TAnnotated (a, uu___) ->
+                let uu___1 = FStar_Ident.range_of_id a in
+                FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a) uu___1
+                  FStar_Parser_AST.Type_level
             | FStar_Parser_AST.TVariable a ->
-                let uu____19281 = FStar_Ident.range_of_id a in
-                FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____19281 FStar_Parser_AST.Type_level
+                let uu___ = FStar_Ident.range_of_id a in
+                FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a) uu___
+                  FStar_Parser_AST.Type_level
             | FStar_Parser_AST.NoName t -> t in
           let tot =
             FStar_Parser_AST.mk_term
@@ -5186,105 +4999,103 @@ let rec (desugar_tycon :
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit) ->
                   FStar_Parser_AST.Hash
-              | uu____19311 -> FStar_Parser_AST.Nothing in
+              | uu___ -> FStar_Parser_AST.Nothing in
             FStar_List.fold_left
               (fun out ->
                  fun b ->
-                   let uu____19319 =
-                     let uu____19320 =
-                       let uu____19327 = binder_to_term b in
-                       (out, uu____19327, (imp_of_aqual b)) in
-                     FStar_Parser_AST.App uu____19320 in
-                   FStar_Parser_AST.mk_term uu____19319
-                     out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
-              binders in
-          let tycon_record_as_variant uu___17_19339 =
-            match uu___17_19339 with
+                   let uu___ =
+                     let uu___1 =
+                       let uu___2 = binder_to_term b in
+                       (out, uu___2, (imp_of_aqual b)) in
+                     FStar_Parser_AST.App uu___1 in
+                   FStar_Parser_AST.mk_term uu___ out.FStar_Parser_AST.range
+                     out.FStar_Parser_AST.level) t binders in
+          let tycon_record_as_variant uu___ =
+            match uu___ with
             | FStar_Parser_AST.TyconRecord (id, parms, kopt, fields) ->
                 let constrName =
-                  let uu____19371 =
-                    let uu____19376 =
-                      let uu____19377 = FStar_Ident.string_of_id id in
-                      Prims.op_Hat "Mk" uu____19377 in
-                    let uu____19378 = FStar_Ident.range_of_id id in
-                    (uu____19376, uu____19378) in
-                  FStar_Ident.mk_ident uu____19371 in
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = FStar_Ident.string_of_id id in
+                      Prims.op_Hat "Mk" uu___3 in
+                    let uu___3 = FStar_Ident.range_of_id id in
+                    (uu___2, uu___3) in
+                  FStar_Ident.mk_ident uu___1 in
                 let mfields =
                   FStar_List.map
-                    (fun uu____19390 ->
-                       match uu____19390 with
+                    (fun uu___1 ->
+                       match uu___1 with
                        | (x, t) ->
-                           let uu____19397 = FStar_Ident.range_of_id x in
+                           let uu___2 = FStar_Ident.range_of_id x in
                            FStar_Parser_AST.mk_binder
-                             (FStar_Parser_AST.Annotated (x, t)) uu____19397
+                             (FStar_Parser_AST.Annotated (x, t)) uu___2
                              FStar_Parser_AST.Expr
                              FStar_Pervasives_Native.None) fields in
                 let result =
-                  let uu____19399 =
-                    let uu____19400 =
-                      let uu____19401 = FStar_Ident.lid_of_ids [id] in
-                      FStar_Parser_AST.Var uu____19401 in
-                    let uu____19402 = FStar_Ident.range_of_id id in
-                    FStar_Parser_AST.mk_term uu____19400 uu____19402
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = FStar_Ident.lid_of_ids [id] in
+                      FStar_Parser_AST.Var uu___3 in
+                    let uu___3 = FStar_Ident.range_of_id id in
+                    FStar_Parser_AST.mk_term uu___2 uu___3
                       FStar_Parser_AST.Type_level in
-                  apply_binders uu____19399 parms in
+                  apply_binders uu___1 parms in
                 let constrTyp =
-                  let uu____19404 = FStar_Ident.range_of_id id in
+                  let uu___1 = FStar_Ident.range_of_id id in
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
-                       (mfields, (with_constructor_effect result)))
-                    uu____19404 FStar_Parser_AST.Type_level in
-                let names =
-                  let uu____19410 = binder_idents parms in id :: uu____19410 in
+                       (mfields, (with_constructor_effect result))) uu___1
+                    FStar_Parser_AST.Type_level in
+                let names = let uu___1 = binder_idents parms in id :: uu___1 in
                 (FStar_List.iter
-                   (fun uu____19424 ->
-                      match uu____19424 with
-                      | (f, uu____19430) ->
-                          let uu____19431 =
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (f, uu___3) ->
+                          let uu___4 =
                             FStar_Util.for_some
                               (fun i -> FStar_Ident.ident_equals f i) names in
-                          if uu____19431
+                          if uu___4
                           then
-                            let uu____19434 =
-                              let uu____19439 =
-                                let uu____19440 = FStar_Ident.string_of_id f in
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Ident.string_of_id f in
                                 FStar_Util.format1
                                   "Field %s shadows the record's name or a parameter of it, please rename it"
-                                  uu____19440 in
-                              (FStar_Errors.Error_FieldShadow, uu____19439) in
-                            let uu____19441 = FStar_Ident.range_of_id f in
-                            FStar_Errors.raise_error uu____19434 uu____19441
+                                  uu___7 in
+                              (FStar_Errors.Error_FieldShadow, uu___6) in
+                            let uu___6 = FStar_Ident.range_of_id f in
+                            FStar_Errors.raise_error uu___5 uu___6
                           else ()) fields;
-                 (let uu____19443 =
+                 (let uu___2 =
                     FStar_All.pipe_right fields
                       (FStar_List.map FStar_Pervasives_Native.fst) in
                   ((FStar_Parser_AST.TyconVariant
                       (id, parms, kopt,
                         [(constrName,
                            (FStar_Pervasives_Native.Some constrTyp), false)])),
-                    uu____19443)))
-            | uu____19492 -> failwith "impossible" in
-          let desugar_abstract_tc quals1 _env mutuals uu___18_19531 =
-            match uu___18_19531 with
+                    uu___2)))
+            | uu___1 -> failwith "impossible" in
+          let desugar_abstract_tc quals1 _env mutuals uu___ =
+            match uu___ with
             | FStar_Parser_AST.TyconAbstract (id, binders, kopt) ->
-                let uu____19555 = typars_of_binders _env binders in
-                (match uu____19555 with
+                let uu___1 = typars_of_binders _env binders in
+                (match uu___1 with
                  | (_env', typars) ->
                      let k =
                        match kopt with
                        | FStar_Pervasives_Native.None ->
                            FStar_Syntax_Util.ktype
-                       | FStar_Pervasives_Native.Some k ->
-                           desugar_term _env' k in
+                       | FStar_Pervasives_Native.Some k1 ->
+                           desugar_term _env' k1 in
                      let tconstr =
-                       let uu____19591 =
-                         let uu____19592 =
-                           let uu____19593 = FStar_Ident.lid_of_ids [id] in
-                           FStar_Parser_AST.Var uu____19593 in
-                         let uu____19594 = FStar_Ident.range_of_id id in
-                         FStar_Parser_AST.mk_term uu____19592 uu____19594
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 = FStar_Ident.lid_of_ids [id] in
+                           FStar_Parser_AST.Var uu___4 in
+                         let uu___4 = FStar_Ident.range_of_id id in
+                         FStar_Parser_AST.mk_term uu___3 uu___4
                            FStar_Parser_AST.Type_level in
-                       apply_binders uu____19591 binders in
+                       apply_binders uu___2 binders in
                      let qlid = FStar_Syntax_DsEnv.qualify _env id in
                      let typars1 = FStar_Syntax_Subst.close_binders typars in
                      let k1 = FStar_Syntax_Subst.close typars1 k in
@@ -5301,51 +5112,49 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     let uu____19603 =
+                     let uu___2 =
                        FStar_Syntax_DsEnv.push_top_level_rec_binding _env id
                          FStar_Syntax_Syntax.delta_constant in
-                     (match uu____19603 with
-                      | (_env1, uu____19619) ->
-                          let uu____19624 =
+                     (match uu___2 with
+                      | (_env1, uu___3) ->
+                          let uu___4 =
                             FStar_Syntax_DsEnv.push_top_level_rec_binding
                               _env' id FStar_Syntax_Syntax.delta_constant in
-                          (match uu____19624 with
-                           | (_env2, uu____19640) ->
-                               (_env1, _env2, se, tconstr))))
-            | uu____19645 -> failwith "Unexpected tycon" in
+                          (match uu___4 with
+                           | (_env2, uu___5) -> (_env1, _env2, se, tconstr))))
+            | uu___1 -> failwith "Unexpected tycon" in
           let push_tparams env1 bs =
-            let uu____19687 =
+            let uu___ =
               FStar_List.fold_left
-                (fun uu____19721 ->
-                   fun uu____19722 ->
-                     match (uu____19721, uu____19722) with
+                (fun uu___1 ->
+                   fun uu___2 ->
+                     match (uu___1, uu___2) with
                      | ((env2, tps), (x, imp)) ->
-                         let uu____19791 =
+                         let uu___3 =
                            FStar_Syntax_DsEnv.push_bv env2
                              x.FStar_Syntax_Syntax.ppname in
-                         (match uu____19791 with
+                         (match uu___3 with
                           | (env3, y) -> (env3, ((y, imp) :: tps))))
                 (env1, []) bs in
-            match uu____19687 with
-            | (env2, bs1) -> (env2, (FStar_List.rev bs1)) in
+            match uu___ with | (env2, bs1) -> (env2, (FStar_List.rev bs1)) in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id, bs, kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None ->
-                    let uu____19882 =
-                      let uu____19883 = FStar_Ident.range_of_id id in
-                      tm_type_z uu____19883 in
-                    FStar_Pervasives_Native.Some uu____19882
-                | uu____19884 -> kopt in
+                    let uu___ =
+                      let uu___1 = FStar_Ident.range_of_id id in
+                      tm_type_z uu___1 in
+                    FStar_Pervasives_Native.Some uu___
+                | uu___ -> kopt in
               let tc = FStar_Parser_AST.TyconAbstract (id, bs, kopt1) in
-              let uu____19892 = desugar_abstract_tc quals env [] tc in
-              (match uu____19892 with
-               | (uu____19905, uu____19906, se, uu____19908) ->
+              let uu___ = desugar_abstract_tc quals env [] tc in
+              (match uu___ with
+               | (uu___1, uu___2, se, uu___3) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l, uu____19911, typars, k, [], []) ->
+                         (l, uu___4, typars, k, [], []) ->
                          let quals1 = se.FStar_Syntax_Syntax.sigquals in
                          let quals2 =
                            if
@@ -5353,22 +5162,22 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.Assumption quals1
                            then quals1
                            else
-                             ((let uu____19928 =
-                                 let uu____19929 = FStar_Options.ml_ish () in
-                                 Prims.op_Negation uu____19929 in
-                               if uu____19928
+                             ((let uu___7 =
+                                 let uu___8 = FStar_Options.ml_ish () in
+                                 Prims.op_Negation uu___8 in
+                               if uu___7
                                then
-                                 let uu____19930 =
-                                   let uu____19935 =
-                                     let uu____19936 =
+                                 let uu___8 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_Syntax_Print.lid_to_string l in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____19936 in
+                                       uu___10 in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____19935) in
+                                     uu___9) in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____19930
+                                   se.FStar_Syntax_Syntax.sigrng uu___8
                                else ());
                               FStar_Syntax_Syntax.Assumption
                               ::
@@ -5378,63 +5187,63 @@ let rec (desugar_tycon :
                          let t =
                            match typars with
                            | [] -> k
-                           | uu____19945 ->
-                               let uu____19946 =
-                                 let uu____19947 =
-                                   let uu____19962 =
+                           | uu___5 ->
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_Syntax_Syntax.mk_Total k in
-                                   (typars, uu____19962) in
-                                 FStar_Syntax_Syntax.Tm_arrow uu____19947 in
-                               FStar_Syntax_Syntax.mk uu____19946
+                                   (typars, uu___8) in
+                                 FStar_Syntax_Syntax.Tm_arrow uu___7 in
+                               FStar_Syntax_Syntax.mk uu___6
                                  se.FStar_Syntax_Syntax.sigrng in
-                         let uu___2832_19975 = se in
+                         let uu___5 = se in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___2832_19975.FStar_Syntax_Syntax.sigrng);
+                             (uu___5.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___2832_19975.FStar_Syntax_Syntax.sigmeta);
+                             (uu___5.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2832_19975.FStar_Syntax_Syntax.sigattrs);
+                             (uu___5.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___2832_19975.FStar_Syntax_Syntax.sigopts)
+                             (uu___5.FStar_Syntax_Syntax.sigopts)
                          }
-                     | uu____19976 -> failwith "Impossible" in
+                     | uu___4 -> failwith "Impossible" in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1 in
                    (env1, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t))::[] ->
-              let uu____19990 = typars_of_binders env binders in
-              (match uu____19990 with
+              let uu___ = typars_of_binders env binders in
+              (match uu___ with
                | (env', typars) ->
                    let kopt1 =
                      match kopt with
                      | FStar_Pervasives_Native.None ->
-                         let uu____20024 =
+                         let uu___1 =
                            FStar_Util.for_some
-                             (fun uu___19_20026 ->
-                                match uu___19_20026 with
+                             (fun uu___2 ->
+                                match uu___2 with
                                 | FStar_Syntax_Syntax.Effect -> true
-                                | uu____20027 -> false) quals in
-                         if uu____20024
+                                | uu___3 -> false) quals in
+                         if uu___1
                          then
                            FStar_Pervasives_Native.Some
                              FStar_Syntax_Syntax.teff
                          else FStar_Pervasives_Native.None
                      | FStar_Pervasives_Native.Some k ->
-                         let uu____20032 = desugar_term env' k in
-                         FStar_Pervasives_Native.Some uu____20032 in
+                         let uu___1 = desugar_term env' k in
+                         FStar_Pervasives_Native.Some uu___1 in
                    let t0 = t in
                    let quals1 =
-                     let uu____20037 =
+                     let uu___1 =
                        FStar_All.pipe_right quals
                          (FStar_Util.for_some
-                            (fun uu___20_20041 ->
-                               match uu___20_20041 with
+                            (fun uu___2 ->
+                               match uu___2 with
                                | FStar_Syntax_Syntax.Logic -> true
-                               | uu____20042 -> false)) in
-                     if uu____20037
+                               | uu___3 -> false)) in
+                     if uu___1
                      then quals
                      else
                        if
@@ -5443,39 +5252,39 @@ let rec (desugar_tycon :
                        else quals in
                    let qlid = FStar_Syntax_DsEnv.qualify env id in
                    let se =
-                     let uu____20051 =
+                     let uu___1 =
                        FStar_All.pipe_right quals1
                          (FStar_List.contains FStar_Syntax_Syntax.Effect) in
-                     if uu____20051
+                     if uu___1
                      then
-                       let uu____20054 =
-                         let uu____20061 =
-                           let uu____20062 = unparen t in
-                           uu____20062.FStar_Parser_AST.tm in
-                         match uu____20061 with
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 = unparen t in
+                           uu___4.FStar_Parser_AST.tm in
+                         match uu___3 with
                          | FStar_Parser_AST.Construct (head, args) ->
-                             let uu____20083 =
+                             let uu___4 =
                                match FStar_List.rev args with
-                               | (last_arg, uu____20113)::args_rev ->
-                                   let uu____20125 =
-                                     let uu____20126 = unparen last_arg in
-                                     uu____20126.FStar_Parser_AST.tm in
-                                   (match uu____20125 with
+                               | (last_arg, uu___5)::args_rev ->
+                                   let uu___6 =
+                                     let uu___7 = unparen last_arg in
+                                     uu___7.FStar_Parser_AST.tm in
+                                   (match uu___6 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
-                                    | uu____20154 -> ([], args))
-                               | uu____20163 -> ([], args) in
-                             (match uu____20083 with
+                                    | uu___7 -> ([], args))
+                               | uu___5 -> ([], args) in
+                             (match uu___4 with
                               | (cattributes, args1) ->
-                                  let uu____20202 =
+                                  let uu___5 =
                                     desugar_attributes env cattributes in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head, args1))
                                       t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____20202))
-                         | uu____20213 -> (t, []) in
-                       match uu____20054 with
+                                      t.FStar_Parser_AST.level), uu___5))
+                         | uu___4 -> (t, []) in
+                       match uu___2 with
                        | (t1, cattributes) ->
                            let c =
                              desugar_comp t1.FStar_Parser_AST.range false
@@ -5486,10 +5295,10 @@ let rec (desugar_tycon :
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
-                                  (fun uu___21_20235 ->
-                                     match uu___21_20235 with
+                                  (fun uu___3 ->
+                                     match uu___3 with
                                      | FStar_Syntax_Syntax.Effect -> false
-                                     | uu____20236 -> true)) in
+                                     | uu___4 -> true)) in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -5510,23 +5319,22 @@ let rec (desugar_tycon :
                           quals1 rng) in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se in
                    (env1, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____20242)::[] ->
+          | (FStar_Parser_AST.TyconRecord uu___)::[] ->
               let trec = FStar_List.hd tcs in
-              let uu____20262 = tycon_record_as_variant trec in
-              (match uu____20262 with
+              let uu___1 = tycon_record_as_variant trec in
+              (match uu___1 with
                | (t, fs) ->
-                   let uu____20279 =
-                     let uu____20282 =
-                       let uu____20283 =
-                         let uu____20292 =
-                           let uu____20295 =
-                             FStar_Syntax_DsEnv.current_module env in
-                           FStar_Ident.ids_of_lid uu____20295 in
-                         (uu____20292, fs) in
-                       FStar_Syntax_Syntax.RecordType uu____20283 in
-                     uu____20282 :: quals in
-                   desugar_tycon env d uu____20279 [t])
-          | uu____20300::uu____20301 ->
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 = FStar_Syntax_DsEnv.current_module env in
+                           FStar_Ident.ids_of_lid uu___6 in
+                         (uu___5, fs) in
+                       FStar_Syntax_Syntax.RecordType uu___4 in
+                     uu___3 :: quals in
+                   desugar_tycon env d uu___2 [t])
+          | uu___::uu___1 ->
               let env0 = env in
               let mutuals =
                 FStar_List.map
@@ -5534,114 +5342,109 @@ let rec (desugar_tycon :
                      FStar_All.pipe_left (FStar_Syntax_DsEnv.qualify env)
                        (tycon_id x)) tcs in
               let rec collect_tcs quals1 et tc =
-                let uu____20456 = et in
-                match uu____20456 with
+                let uu___2 = et in
+                match uu___2 with
                 | (env1, tcs1) ->
                     (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____20661 ->
+                     | FStar_Parser_AST.TyconRecord uu___3 ->
                          let trec = tc in
-                         let uu____20681 = tycon_record_as_variant trec in
-                         (match uu____20681 with
+                         let uu___4 = tycon_record_as_variant trec in
+                         (match uu___4 with
                           | (t, fs) ->
-                              let uu____20736 =
-                                let uu____20739 =
-                                  let uu____20740 =
-                                    let uu____20749 =
-                                      let uu____20752 =
+                              let uu___5 =
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Syntax_DsEnv.current_module
                                           env1 in
-                                      FStar_Ident.ids_of_lid uu____20752 in
-                                    (uu____20749, fs) in
-                                  FStar_Syntax_Syntax.RecordType uu____20740 in
-                                uu____20739 :: quals1 in
-                              collect_tcs uu____20736 (env1, tcs1) t)
+                                      FStar_Ident.ids_of_lid uu___9 in
+                                    (uu___8, fs) in
+                                  FStar_Syntax_Syntax.RecordType uu___7 in
+                                uu___6 :: quals1 in
+                              collect_tcs uu___5 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id, binders, kopt, constructors) ->
-                         let uu____20827 =
+                         let uu___3 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt)) in
-                         (match uu____20827 with
-                          | (env2, uu____20883, se, tconstr) ->
+                         (match uu___3 with
+                          | (env2, uu___4, se, tconstr) ->
                               (env2,
                                 ((FStar_Util.Inl
                                     (se, constructors, tconstr, quals1)) ::
                                 tcs1)))
                      | FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t) ->
-                         let uu____21016 =
+                         let uu___3 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt)) in
-                         (match uu____21016 with
-                          | (env2, uu____21072, se, tconstr) ->
+                         (match uu___3 with
+                          | (env2, uu___4, se, tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
-                     | uu____21185 ->
+                     | uu___3 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                              "Mutually defined type contains a non-inductive element")
                            rng) in
-              let uu____21228 =
+              let uu___2 =
                 FStar_List.fold_left (collect_tcs quals) (env, []) tcs in
-              (match uu____21228 with
+              (match uu___2 with
                | (env1, tcs1) ->
                    let tcs2 = FStar_List.rev tcs1 in
                    let tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___23_21670 ->
-                             match uu___23_21670 with
+                          (fun uu___3 ->
+                             match uu___3 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id, uvs, tpars, k, uu____21723,
-                                       uu____21724);
-                                    FStar_Syntax_Syntax.sigrng = uu____21725;
-                                    FStar_Syntax_Syntax.sigquals =
-                                      uu____21726;
-                                    FStar_Syntax_Syntax.sigmeta = uu____21727;
-                                    FStar_Syntax_Syntax.sigattrs =
-                                      uu____21728;
-                                    FStar_Syntax_Syntax.sigopts = uu____21729;_},
+                                      (id, uvs, tpars, k, uu___4, uu___5);
+                                    FStar_Syntax_Syntax.sigrng = uu___6;
+                                    FStar_Syntax_Syntax.sigquals = uu___7;
+                                    FStar_Syntax_Syntax.sigmeta = uu___8;
+                                    FStar_Syntax_Syntax.sigattrs = uu___9;
+                                    FStar_Syntax_Syntax.sigopts = uu___10;_},
                                   binders, t, quals1)
                                  ->
                                  let t1 =
-                                   let uu____21790 =
+                                   let uu___11 =
                                      typars_of_binders env1 binders in
-                                   match uu____21790 with
+                                   match uu___11 with
                                    | (env2, tpars1) ->
-                                       let uu____21817 =
-                                         push_tparams env2 tpars1 in
-                                       (match uu____21817 with
+                                       let uu___12 = push_tparams env2 tpars1 in
+                                       (match uu___12 with
                                         | (env_tps, tpars2) ->
-                                            let t1 = desugar_typ env_tps t in
+                                            let t2 = desugar_typ env_tps t in
                                             let tpars3 =
                                               FStar_Syntax_Subst.close_binders
                                                 tpars2 in
                                             FStar_Syntax_Subst.close tpars3
-                                              t1) in
-                                 let uu____21846 =
-                                   let uu____21857 =
+                                              t2) in
+                                 let uu___11 =
+                                   let uu___12 =
                                      mk_typ_abbrev env1 d id uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id] quals1 rng in
-                                   ([], uu____21857) in
-                                 [uu____21846]
+                                   ([], uu___12) in
+                                 [uu___11]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
                                       (tname, univs, tpars, k, mutuals1,
-                                       uu____21893);
-                                    FStar_Syntax_Syntax.sigrng = uu____21894;
+                                       uu___4);
+                                    FStar_Syntax_Syntax.sigrng = uu___5;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____21896;
-                                    FStar_Syntax_Syntax.sigattrs =
-                                      uu____21897;
-                                    FStar_Syntax_Syntax.sigopts = uu____21898;_},
+                                    FStar_Syntax_Syntax.sigmeta = uu___6;
+                                    FStar_Syntax_Syntax.sigattrs = uu___7;
+                                    FStar_Syntax_Syntax.sigopts = uu___8;_},
                                   constrs, tconstr, quals1)
                                  ->
                                  let mk_tot t =
@@ -5657,14 +5460,14 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.range
                                      t.FStar_Parser_AST.level in
                                  let tycon = (tname, tpars, k) in
-                                 let uu____21986 = push_tparams env1 tpars in
-                                 (match uu____21986 with
+                                 let uu___9 = push_tparams env1 tpars in
+                                 (match uu___9 with
                                   | (env_tps, tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____22045 ->
-                                             match uu____22045 with
-                                             | (x, uu____22057) ->
+                                          (fun uu___10 ->
+                                             match uu___10 with
+                                             | (x, uu___11) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
@@ -5674,17 +5477,17 @@ let rec (desugar_tycon :
                                         FStar_List.map (desugar_term env1)
                                           d.FStar_Parser_AST.attrs in
                                       let val_attrs =
-                                        let uu____22067 =
+                                        let uu___10 =
                                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                             env1 tname in
-                                        FStar_All.pipe_right uu____22067
+                                        FStar_All.pipe_right uu___10
                                           FStar_Pervasives_Native.snd in
-                                      let uu____22090 =
-                                        let uu____22109 =
+                                      let uu___10 =
+                                        let uu___11 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____22184 ->
-                                                  match uu____22184 with
+                                               (fun uu___12 ->
+                                                  match uu___12 with
                                                   | (id, topt, of_notation)
                                                       ->
                                                       let t =
@@ -5692,19 +5495,19 @@ let rec (desugar_tycon :
                                                         then
                                                           match topt with
                                                           | FStar_Pervasives_Native.Some
-                                                              t ->
+                                                              t1 ->
                                                               FStar_Parser_AST.mk_term
                                                                 (FStar_Parser_AST.Product
                                                                    ([
                                                                     FStar_Parser_AST.mk_binder
                                                                     (FStar_Parser_AST.NoName
-                                                                    t)
-                                                                    t.FStar_Parser_AST.range
-                                                                    t.FStar_Parser_AST.level
+                                                                    t1)
+                                                                    t1.FStar_Parser_AST.range
+                                                                    t1.FStar_Parser_AST.level
                                                                     FStar_Pervasives_Native.None],
                                                                     tot_tconstr))
-                                                                t.FStar_Parser_AST.range
-                                                                t.FStar_Parser_AST.level
+                                                                t1.FStar_Parser_AST.range
+                                                                t1.FStar_Parser_AST.level
                                                           | FStar_Pervasives_Native.None
                                                               -> tconstr
                                                         else
@@ -5714,12 +5517,12 @@ let rec (desugar_tycon :
                                                                failwith
                                                                  "Impossible"
                                                            | FStar_Pervasives_Native.Some
-                                                               t -> t) in
+                                                               t1 -> t1) in
                                                       let t1 =
-                                                        let uu____22221 =
+                                                        let uu___13 =
                                                           close env_tps t in
                                                         desugar_term env_tps
-                                                          uu____22221 in
+                                                          uu___13 in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env1 id in
@@ -5727,48 +5530,44 @@ let rec (desugar_tycon :
                                                         FStar_All.pipe_right
                                                           tname_quals
                                                           (FStar_List.collect
-                                                             (fun
-                                                                uu___22_22232
-                                                                ->
-                                                                match uu___22_22232
+                                                             (fun uu___13 ->
+                                                                match uu___13
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____22244
-                                                                    -> [])) in
+                                                                | uu___14 ->
+                                                                    [])) in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars in
-                                                      let uu____22252 =
-                                                        let uu____22263 =
-                                                          let uu____22264 =
-                                                            let uu____22265 =
-                                                              let uu____22280
-                                                                =
-                                                                let uu____22281
-                                                                  =
-                                                                  let uu____22284
+                                                      let uu___13 =
+                                                        let uu___14 =
+                                                          let uu___15 =
+                                                            let uu___16 =
+                                                              let uu___17 =
+                                                                let uu___18 =
+                                                                  let uu___19
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____22284 in
+                                                                    uu___19 in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____22281 in
+                                                                  uu___18 in
                                                               (name, univs,
-                                                                uu____22280,
+                                                                uu___17,
                                                                 tname, ntps,
                                                                 mutuals1) in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____22265 in
+                                                              uu___16 in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____22264;
+                                                              = uu___15;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -5785,11 +5584,11 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Pervasives_Native.None
                                                           } in
-                                                        (tps, uu____22263) in
-                                                      (name, uu____22252))) in
+                                                        (tps, uu___14) in
+                                                      (name, uu___13))) in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____22109 in
-                                      (match uu____22090 with
+                                          uu___11 in
+                                      (match uu___10 with
                                        | (constrNames, constrs1) ->
                                            ([],
                                              {
@@ -5810,19 +5609,19 @@ let rec (desugar_tycon :
                                                  FStar_Pervasives_Native.None
                                              })
                                            :: constrs1))
-                             | uu____22415 -> failwith "impossible")) in
+                             | uu___4 -> failwith "impossible")) in
                    let sigelts =
                      FStar_All.pipe_right tps_sigelts
                        (FStar_List.map
-                          (fun uu____22494 ->
-                             match uu____22494 with | (uu____22505, se) -> se)) in
-                   let uu____22519 =
-                     let uu____22526 =
+                          (fun uu___3 ->
+                             match uu___3 with | (uu___4, se) -> se)) in
+                   let uu___3 =
+                     let uu___4 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____22526 rng in
-                   (match uu____22519 with
+                       sigelts quals uu___4 rng in
+                   (match uu___3 with
                     | (bundle, abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle in
                         let env3 =
@@ -5831,8 +5630,8 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right tps_sigelts
                             (FStar_List.collect
-                               (fun uu____22571 ->
-                                  match uu____22571 with
+                               (fun uu___4 ->
+                                  match uu___4 with
                                   | (tps, se) ->
                                       mk_data_projector_names quals env3 se)) in
                         let discs =
@@ -5841,18 +5640,18 @@ let rec (desugar_tycon :
                                (fun se ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname, uu____22618, tps, k,
-                                       uu____22621, constrs)
+                                      (tname, uu___4, tps, k, uu___5,
+                                       constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals in
-                                      let uu____22634 =
+                                      let uu___6 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____22649 =
+                                                    let uu___7 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -5861,37 +5660,33 @@ let rec (desugar_tycon :
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
                                                                   (name,
-                                                                   uu____22665,
-                                                                   uu____22666,
-                                                                   uu____22667,
-                                                                   uu____22668,
-                                                                   uu____22669)
+                                                                   uu___8,
+                                                                   uu___9,
+                                                                   uu___10,
+                                                                   uu___11,
+                                                                   uu___12)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____22674
-                                                                  -> false)) in
+                                                              | uu___8 ->
+                                                                  false)) in
                                                     FStar_All.pipe_right
-                                                      uu____22649
-                                                      FStar_Util.must in
+                                                      uu___7 FStar_Util.must in
                                                   data_se.FStar_Syntax_Syntax.sigquals in
-                                                let uu____22677 =
+                                                let uu___7 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___24_22682 ->
-                                                          match uu___24_22682
-                                                          with
+                                                       (fun uu___8 ->
+                                                          match uu___8 with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____22683 ->
-                                                              true
-                                                          | uu____22692 ->
-                                                              false)) in
-                                                Prims.op_Negation uu____22677)) in
+                                                              uu___9 -> true
+                                                          | uu___9 -> false)) in
+                                                Prims.op_Negation uu___7)) in
                                       mk_data_discriminators quals1 env3
-                                        uu____22634
-                                  | uu____22693 -> [])) in
+                                        uu___6
+                                  | uu___4 -> [])) in
                         let ops = FStar_List.append discs data_ops in
                         let env4 =
                           FStar_List.fold_left FStar_Syntax_DsEnv.push_sigelt
@@ -5909,26 +5704,26 @@ let (desugar_binders :
   =
   fun env ->
     fun binders ->
-      let uu____22728 =
+      let uu___ =
         FStar_List.fold_left
-          (fun uu____22763 ->
+          (fun uu___1 ->
              fun b ->
-               match uu____22763 with
+               match uu___1 with
                | (env1, binders1) ->
-                   let uu____22807 = desugar_binder env1 b in
-                   (match uu____22807 with
+                   let uu___2 = desugar_binder env1 b in
+                   (match uu___2 with
                     | (FStar_Pervasives_Native.Some a, k) ->
-                        let uu____22830 =
+                        let uu___3 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k) in
-                        (match uu____22830 with
+                        (match uu___3 with
                          | (binder, env2) -> (env2, (binder :: binders1)))
-                    | uu____22883 ->
+                    | uu___3 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders in
-      match uu____22728 with
+      match uu___ with
       | (env1, binders1) -> (env1, (FStar_List.rev binders1))
 let (push_reflect_effect :
   FStar_Syntax_DsEnv.env ->
@@ -5939,21 +5734,21 @@ let (push_reflect_effect :
     fun quals ->
       fun effect_name ->
         fun range ->
-          let uu____22984 =
+          let uu___ =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___25_22989 ->
-                    match uu___25_22989 with
-                    | FStar_Syntax_Syntax.Reflectable uu____22990 -> true
-                    | uu____22991 -> false)) in
-          if uu____22984
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | FStar_Syntax_Syntax.Reflectable uu___2 -> true
+                    | uu___2 -> false)) in
+          if uu___
           then
             let monad_env =
-              let uu____22993 = FStar_Ident.ident_of_lid effect_name in
-              FStar_Syntax_DsEnv.enter_monad_scope env uu____22993 in
+              let uu___1 = FStar_Ident.ident_of_lid effect_name in
+              FStar_Syntax_DsEnv.enter_monad_scope env uu___1 in
             let reflect_lid =
-              let uu____22995 = FStar_Ident.id_of_text "reflect" in
-              FStar_All.pipe_right uu____22995
+              let uu___1 = FStar_Ident.id_of_text "reflect" in
+              FStar_All.pipe_right uu___1
                 (FStar_Syntax_DsEnv.qualify monad_env) in
             let quals1 =
               [FStar_Syntax_Syntax.Assumption;
@@ -5981,49 +5776,49 @@ let (parse_attr_with_list :
   fun warn ->
     fun at ->
       fun head ->
-        let warn1 uu____23037 =
+        let warn1 uu___ =
           if warn
           then
-            let uu____23038 =
-              let uu____23043 =
-                let uu____23044 = FStar_Ident.string_of_lid head in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Ident.string_of_lid head in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____23044 in
-              (FStar_Errors.Warning_UnappliedFail, uu____23043) in
-            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____23038
+                  uu___3 in
+              (FStar_Errors.Warning_UnappliedFail, uu___2) in
+            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu___1
           else () in
-        let uu____23046 = FStar_Syntax_Util.head_and_args at in
-        match uu____23046 with
+        let uu___ = FStar_Syntax_Util.head_and_args at in
+        match uu___ with
         | (hd, args) ->
-            let uu____23097 =
-              let uu____23098 = FStar_Syntax_Subst.compress hd in
-              uu____23098.FStar_Syntax_Syntax.n in
-            (match uu____23097 with
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Subst.compress hd in
+              uu___2.FStar_Syntax_Syntax.n in
+            (match uu___1 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1, uu____23133)::[] ->
-                      let uu____23158 =
-                        let uu____23163 =
-                          let uu____23172 =
+                  | (a1, uu___2)::[] ->
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int in
-                          FStar_Syntax_Embeddings.unembed uu____23172 a1 in
-                        uu____23163 true FStar_Syntax_Embeddings.id_norm_cb in
-                      (match uu____23158 with
+                          FStar_Syntax_Embeddings.unembed uu___5 a1 in
+                        uu___4 true FStar_Syntax_Embeddings.id_norm_cb in
+                      (match uu___3 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____23192 =
-                             let uu____23197 =
+                           let uu___4 =
+                             let uu___5 =
                                FStar_List.map FStar_BigInt.to_int_fs es in
-                             FStar_Pervasives_Native.Some uu____23197 in
-                           (uu____23192, true)
-                       | uu____23206 ->
+                             FStar_Pervasives_Native.Some uu___5 in
+                           (uu___4, true)
+                       | uu___4 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____23218 ->
+                  | uu___2 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____23236 -> (FStar_Pervasives_Native.None, false))
+             | uu___2 -> (FStar_Pervasives_Native.None, false))
 let (get_fail_attr1 :
   Prims.bool ->
     FStar_Syntax_Syntax.term ->
@@ -6036,16 +5831,15 @@ let (get_fail_attr1 :
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b) in
-      let uu____23325 =
-        parse_attr_with_list warn at FStar_Parser_Const.fail_attr in
-      match uu____23325 with
+      let uu___ = parse_attr_with_list warn at FStar_Parser_Const.fail_attr in
+      match uu___ with
       | (res, matched) ->
           if matched
           then rebind res false
           else
-            (let uu____23361 =
+            (let uu___2 =
                parse_attr_with_list warn at FStar_Parser_Const.fail_lax_attr in
-             match uu____23361 with | (res1, uu____23379) -> rebind res1 true)
+             match uu___2 with | (res1, uu___3) -> rebind res1 true)
 let (get_fail_attr :
   Prims.bool ->
     FStar_Syntax_Syntax.term Prims.list ->
@@ -6063,11 +5857,10 @@ let (get_fail_attr :
             -> FStar_Pervasives_Native.Some (e, l)
         | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some (e, l))
             -> FStar_Pervasives_Native.Some (e, l)
-        | uu____23625 -> FStar_Pervasives_Native.None in
+        | uu___ -> FStar_Pervasives_Native.None in
       FStar_List.fold_right
         (fun at ->
-           fun acc ->
-             let uu____23673 = get_fail_attr1 warn at in comb uu____23673 acc)
+           fun acc -> let uu___ = get_fail_attr1 warn at in comb uu___ acc)
         ats FStar_Pervasives_Native.None
 let (lookup_effect_lid :
   FStar_Syntax_DsEnv.env ->
@@ -6076,17 +5869,17 @@ let (lookup_effect_lid :
   fun env ->
     fun l ->
       fun r ->
-        let uu____23703 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l in
-        match uu____23703 with
+        let uu___ = FStar_Syntax_DsEnv.try_lookup_effect_defn env l in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
-            let uu____23706 =
-              let uu____23711 =
-                let uu____23712 =
-                  let uu____23713 = FStar_Syntax_Print.lid_to_string l in
-                  Prims.op_Hat uu____23713 " not found" in
-                Prims.op_Hat "Effect name " uu____23712 in
-              (FStar_Errors.Fatal_EffectNotFound, uu____23711) in
-            FStar_Errors.raise_error uu____23706 r
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Print.lid_to_string l in
+                  Prims.op_Hat uu___4 " not found" in
+                Prims.op_Hat "Effect name " uu___3 in
+              (FStar_Errors.Fatal_EffectNotFound, uu___2) in
+            FStar_Errors.raise_error uu___1 r
         | FStar_Pervasives_Native.Some l1 -> l1
 let rec (desugar_effect :
   FStar_Syntax_DsEnv.env ->
@@ -6113,29 +5906,29 @@ let rec (desugar_effect :
                     let env0 = env in
                     let monad_env =
                       FStar_Syntax_DsEnv.enter_monad_scope env eff_name in
-                    let uu____23862 = desugar_binders monad_env eff_binders in
-                    match uu____23862 with
+                    let uu___ = desugar_binders monad_env eff_binders in
+                    match uu___ with
                     | (env1, binders) ->
                         let eff_t = desugar_term env1 eff_typ in
                         let num_indices =
-                          let uu____23901 =
-                            let uu____23910 =
+                          let uu___1 =
+                            let uu___2 =
                               FStar_Syntax_Util.arrow_formals eff_t in
-                            FStar_Pervasives_Native.fst uu____23910 in
-                          FStar_List.length uu____23901 in
+                            FStar_Pervasives_Native.fst uu___2 in
+                          FStar_List.length uu___1 in
                         (if is_layered && (num_indices <= Prims.int_one)
                          then
-                           (let uu____23926 =
-                              let uu____23931 =
-                                let uu____23932 =
-                                  let uu____23933 =
+                           (let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_Ident.string_of_id eff_name in
-                                  Prims.op_Hat uu____23933
+                                  Prims.op_Hat uu___5
                                     "is defined as a layered effect but has no indices" in
-                                Prims.op_Hat "Effect " uu____23932 in
+                                Prims.op_Hat "Effect " uu___4 in
                               (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                                uu____23931) in
-                            FStar_Errors.raise_error uu____23926
+                                uu___3) in
+                            FStar_Errors.raise_error uu___2
                               d.FStar_Parser_AST.drange)
                          else ();
                          (let for_free = num_indices = Prims.int_one in
@@ -6160,40 +5953,39 @@ let rec (desugar_effect :
                           let name_of_eff_decl decl =
                             match decl.FStar_Parser_AST.d with
                             | FStar_Parser_AST.Tycon
-                                (uu____23954, uu____23955,
+                                (uu___2, uu___3,
                                  (FStar_Parser_AST.TyconAbbrev
-                                 (name, uu____23957, uu____23958,
-                                  uu____23959))::[])
+                                 (name, uu___4, uu___5, uu___6))::[])
                                 -> FStar_Ident.string_of_id name
-                            | uu____23970 ->
+                            | uu___2 ->
                                 failwith
                                   "Malformed effect member declaration." in
-                          let uu____23971 =
+                          let uu___2 =
                             FStar_List.partition
                               (fun decl ->
-                                 let uu____23983 = name_of_eff_decl decl in
-                                 FStar_List.mem uu____23983 mandatory_members)
+                                 let uu___3 = name_of_eff_decl decl in
+                                 FStar_List.mem uu___3 mandatory_members)
                               eff_decls in
-                          match uu____23971 with
+                          match uu___2 with
                           | (mandatory_members_decls, actions) ->
-                              let uu____24000 =
+                              let uu___3 =
                                 FStar_All.pipe_right mandatory_members_decls
                                   (FStar_List.fold_left
-                                     (fun uu____24029 ->
+                                     (fun uu___4 ->
                                         fun decl ->
-                                          match uu____24029 with
+                                          match uu___4 with
                                           | (env2, out) ->
-                                              let uu____24049 =
+                                              let uu___5 =
                                                 desugar_decl env2 decl in
-                                              (match uu____24049 with
+                                              (match uu___5 with
                                                | (env3, ses) ->
-                                                   let uu____24062 =
-                                                     let uu____24065 =
+                                                   let uu___6 =
+                                                     let uu___7 =
                                                        FStar_List.hd ses in
-                                                     uu____24065 :: out in
-                                                   (env3, uu____24062)))
+                                                     uu___7 :: out in
+                                                   (env3, uu___6)))
                                      (env1, [])) in
-                              (match uu____24000 with
+                              (match uu___3 with
                                | (env2, decls) ->
                                    let binders1 =
                                      FStar_Syntax_Subst.close_binders binders in
@@ -6203,56 +5995,55 @@ let rec (desugar_effect :
                                           (fun d1 ->
                                              match d1.FStar_Parser_AST.d with
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____24111, uu____24112,
+                                                 (uu___4, uu___5,
                                                   (FStar_Parser_AST.TyconAbbrev
                                                   (name, action_params,
-                                                   uu____24115,
+                                                   uu___6,
                                                    {
                                                      FStar_Parser_AST.tm =
                                                        FStar_Parser_AST.Construct
-                                                       (uu____24116,
-                                                        (def, uu____24118)::
-                                                        (cps_type,
-                                                         uu____24120)::[]);
+                                                       (uu___7,
+                                                        (def, uu___8)::
+                                                        (cps_type, uu___9)::[]);
                                                      FStar_Parser_AST.range =
-                                                       uu____24121;
+                                                       uu___10;
                                                      FStar_Parser_AST.level =
-                                                       uu____24122;_}))::[])
+                                                       uu___11;_}))::[])
                                                  when
                                                  Prims.op_Negation for_free
                                                  ->
-                                                 let uu____24151 =
+                                                 let uu___12 =
                                                    desugar_binders env2
                                                      action_params in
-                                                 (match uu____24151 with
+                                                 (match uu___12 with
                                                   | (env3, action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1 in
-                                                      let uu____24183 =
+                                                      let uu___13 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name in
-                                                      let uu____24184 =
-                                                        let uu____24185 =
+                                                      let uu___14 =
+                                                        let uu___15 =
                                                           desugar_term env3
                                                             def in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24185 in
-                                                      let uu____24192 =
-                                                        let uu____24193 =
+                                                          uu___15 in
+                                                      let uu___15 =
+                                                        let uu___16 =
                                                           desugar_typ env3
                                                             cps_type in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24193 in
+                                                          uu___16 in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____24183;
+                                                          = uu___13;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6260,40 +6051,40 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____24184;
+                                                          = uu___14;
                                                         FStar_Syntax_Syntax.action_typ
-                                                          = uu____24192
+                                                          = uu___15
                                                       })
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____24200, uu____24201,
+                                                 (uu___4, uu___5,
                                                   (FStar_Parser_AST.TyconAbbrev
                                                   (name, action_params,
-                                                   uu____24204, defn))::[])
+                                                   uu___6, defn))::[])
                                                  when for_free || is_layered
                                                  ->
-                                                 let uu____24216 =
+                                                 let uu___7 =
                                                    desugar_binders env2
                                                      action_params in
-                                                 (match uu____24216 with
+                                                 (match uu___7 with
                                                   | (env3, action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1 in
-                                                      let uu____24248 =
+                                                      let uu___8 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name in
-                                                      let uu____24249 =
-                                                        let uu____24250 =
+                                                      let uu___9 =
+                                                        let uu___10 =
                                                           desugar_term env3
                                                             defn in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24250 in
+                                                          uu___10 in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____24248;
+                                                          = uu___8;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6301,12 +6092,12 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____24249;
+                                                          = uu___9;
                                                         FStar_Syntax_Syntax.action_typ
                                                           =
                                                           FStar_Syntax_Syntax.tun
                                                       })
-                                             | uu____24257 ->
+                                             | uu___4 ->
                                                  FStar_Errors.raise_error
                                                    (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                      "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6315,20 +6106,19 @@ let rec (desugar_effect :
                                      FStar_Syntax_Subst.close binders1 eff_t in
                                    let lookup s =
                                      let l =
-                                       let uu____24272 =
+                                       let uu___4 =
                                          FStar_Ident.mk_ident
                                            (s, (d.FStar_Parser_AST.drange)) in
-                                       FStar_Syntax_DsEnv.qualify env2
-                                         uu____24272 in
-                                     let uu____24273 =
-                                       let uu____24274 =
+                                       FStar_Syntax_DsEnv.qualify env2 uu___4 in
+                                     let uu___4 =
+                                       let uu___5 =
                                          FStar_Syntax_DsEnv.fail_or env2
                                            (FStar_Syntax_DsEnv.try_lookup_definition
                                               env2) l in
                                        FStar_All.pipe_left
                                          (FStar_Syntax_Subst.close binders1)
-                                         uu____24274 in
-                                     ([], uu____24273) in
+                                         uu___5 in
+                                     ([], uu___4) in
                                    let mname =
                                      FStar_Syntax_DsEnv.qualify env0 eff_name in
                                    let qualifiers =
@@ -6341,19 +6131,19 @@ let rec (desugar_effect :
                                    let combinators =
                                      if for_free
                                      then
-                                       let uu____24295 =
-                                         let uu____24296 =
-                                           let uu____24299 = lookup "repr" in
+                                       let uu___4 =
+                                         let uu___5 =
+                                           let uu___6 = lookup "repr" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24299 in
-                                         let uu____24300 =
-                                           let uu____24303 = lookup "return" in
+                                             uu___6 in
+                                         let uu___6 =
+                                           let uu___7 = lookup "return" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24303 in
-                                         let uu____24304 =
-                                           let uu____24307 = lookup "bind" in
+                                             uu___7 in
+                                         let uu___7 =
+                                           let uu___8 = lookup "bind" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24307 in
+                                             uu___8 in
                                          {
                                            FStar_Syntax_Syntax.ret_wp =
                                              dummy_tscheme;
@@ -6369,163 +6159,152 @@ let rec (desugar_effect :
                                              dummy_tscheme;
                                            FStar_Syntax_Syntax.trivial =
                                              dummy_tscheme;
-                                           FStar_Syntax_Syntax.repr =
-                                             uu____24296;
+                                           FStar_Syntax_Syntax.repr = uu___5;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____24300;
+                                             uu___6;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____24304
+                                             uu___7
                                          } in
-                                       FStar_Syntax_Syntax.DM4F_eff
-                                         uu____24295
+                                       FStar_Syntax_Syntax.DM4F_eff uu___4
                                      else
                                        if is_layered
                                        then
                                          (let has_subcomp =
                                             FStar_List.existsb
                                               (fun decl ->
-                                                 let uu____24313 =
+                                                 let uu___5 =
                                                    name_of_eff_decl decl in
-                                                 uu____24313 = "subcomp")
+                                                 uu___5 = "subcomp")
                                               eff_decls in
                                           let has_if_then_else =
                                             FStar_List.existsb
                                               (fun decl ->
-                                                 let uu____24318 =
+                                                 let uu___5 =
                                                    name_of_eff_decl decl in
-                                                 uu____24318 = "if_then_else")
+                                                 uu___5 = "if_then_else")
                                               eff_decls in
-                                          let to_comb uu____24348 =
-                                            match uu____24348 with
+                                          let to_comb uu___5 =
+                                            match uu___5 with
                                             | (us, t) ->
                                                 ((us, t), dummy_tscheme) in
-                                          let uu____24395 =
-                                            let uu____24396 =
-                                              let uu____24401 = lookup "repr" in
-                                              FStar_All.pipe_right
-                                                uu____24401 to_comb in
-                                            let uu____24418 =
-                                              let uu____24423 =
-                                                lookup "return" in
-                                              FStar_All.pipe_right
-                                                uu____24423 to_comb in
-                                            let uu____24440 =
-                                              let uu____24445 = lookup "bind" in
-                                              FStar_All.pipe_right
-                                                uu____24445 to_comb in
-                                            let uu____24462 =
+                                          let uu___5 =
+                                            let uu___6 =
+                                              let uu___7 = lookup "repr" in
+                                              FStar_All.pipe_right uu___7
+                                                to_comb in
+                                            let uu___7 =
+                                              let uu___8 = lookup "return" in
+                                              FStar_All.pipe_right uu___8
+                                                to_comb in
+                                            let uu___8 =
+                                              let uu___9 = lookup "bind" in
+                                              FStar_All.pipe_right uu___9
+                                                to_comb in
+                                            let uu___9 =
                                               if has_subcomp
                                               then
-                                                let uu____24471 =
+                                                let uu___10 =
                                                   lookup "subcomp" in
-                                                FStar_All.pipe_right
-                                                  uu____24471 to_comb
+                                                FStar_All.pipe_right uu___10
+                                                  to_comb
                                               else
                                                 (dummy_tscheme,
                                                   dummy_tscheme) in
-                                            let uu____24489 =
+                                            let uu___10 =
                                               if has_if_then_else
                                               then
-                                                let uu____24498 =
+                                                let uu___11 =
                                                   lookup "if_then_else" in
-                                                FStar_All.pipe_right
-                                                  uu____24498 to_comb
+                                                FStar_All.pipe_right uu___11
+                                                  to_comb
                                               else
                                                 (dummy_tscheme,
                                                   dummy_tscheme) in
                                             {
                                               FStar_Syntax_Syntax.l_repr =
-                                                uu____24396;
+                                                uu___6;
                                               FStar_Syntax_Syntax.l_return =
-                                                uu____24418;
+                                                uu___7;
                                               FStar_Syntax_Syntax.l_bind =
-                                                uu____24440;
+                                                uu___8;
                                               FStar_Syntax_Syntax.l_subcomp =
-                                                uu____24462;
+                                                uu___9;
                                               FStar_Syntax_Syntax.l_if_then_else
-                                                = uu____24489
+                                                = uu___10
                                             } in
                                           FStar_Syntax_Syntax.Layered_eff
-                                            uu____24395)
+                                            uu___5)
                                        else
                                          (let rr =
                                             FStar_Util.for_some
-                                              (fun uu___26_24519 ->
-                                                 match uu___26_24519 with
+                                              (fun uu___6 ->
+                                                 match uu___6 with
                                                  | FStar_Syntax_Syntax.Reifiable
                                                      -> true
                                                  | FStar_Syntax_Syntax.Reflectable
-                                                     uu____24520 -> true
-                                                 | uu____24521 -> false)
+                                                     uu___7 -> true
+                                                 | uu___7 -> false)
                                               qualifiers in
-                                          let uu____24522 =
-                                            let uu____24523 =
-                                              lookup "return_wp" in
-                                            let uu____24524 =
-                                              lookup "bind_wp" in
-                                            let uu____24525 =
-                                              lookup "stronger" in
-                                            let uu____24526 =
+                                          let uu___6 =
+                                            let uu___7 = lookup "return_wp" in
+                                            let uu___8 = lookup "bind_wp" in
+                                            let uu___9 = lookup "stronger" in
+                                            let uu___10 =
                                               lookup "if_then_else" in
-                                            let uu____24527 = lookup "ite_wp" in
-                                            let uu____24528 =
-                                              lookup "close_wp" in
-                                            let uu____24529 =
-                                              lookup "trivial" in
-                                            let uu____24530 =
+                                            let uu___11 = lookup "ite_wp" in
+                                            let uu___12 = lookup "close_wp" in
+                                            let uu___13 = lookup "trivial" in
+                                            let uu___14 =
                                               if rr
                                               then
-                                                let uu____24535 =
-                                                  lookup "repr" in
+                                                let uu___15 = lookup "repr" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24535
+                                                  uu___15
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____24537 =
+                                            let uu___15 =
                                               if rr
                                               then
-                                                let uu____24542 =
-                                                  lookup "return" in
+                                                let uu___16 = lookup "return" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24542
+                                                  uu___16
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____24544 =
+                                            let uu___16 =
                                               if rr
                                               then
-                                                let uu____24549 =
-                                                  lookup "bind" in
+                                                let uu___17 = lookup "bind" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24549
+                                                  uu___17
                                               else
                                                 FStar_Pervasives_Native.None in
                                             {
                                               FStar_Syntax_Syntax.ret_wp =
-                                                uu____24523;
+                                                uu___7;
                                               FStar_Syntax_Syntax.bind_wp =
-                                                uu____24524;
+                                                uu___8;
                                               FStar_Syntax_Syntax.stronger =
-                                                uu____24525;
+                                                uu___9;
                                               FStar_Syntax_Syntax.if_then_else
-                                                = uu____24526;
+                                                = uu___10;
                                               FStar_Syntax_Syntax.ite_wp =
-                                                uu____24527;
+                                                uu___11;
                                               FStar_Syntax_Syntax.close_wp =
-                                                uu____24528;
+                                                uu___12;
                                               FStar_Syntax_Syntax.trivial =
-                                                uu____24529;
+                                                uu___13;
                                               FStar_Syntax_Syntax.repr =
-                                                uu____24530;
+                                                uu___14;
                                               FStar_Syntax_Syntax.return_repr
-                                                = uu____24537;
+                                                = uu___15;
                                               FStar_Syntax_Syntax.bind_repr =
-                                                uu____24544
+                                                uu___16
                                             } in
                                           FStar_Syntax_Syntax.Primitive_eff
-                                            uu____24522) in
+                                            uu___6) in
                                    let sigel =
-                                     let uu____24552 =
-                                       let uu____24553 =
+                                     let uu___4 =
+                                       let uu___5 =
                                          FStar_List.map (desugar_term env2)
                                            attrs in
                                        {
@@ -6541,10 +6320,10 @@ let rec (desugar_effect :
                                          FStar_Syntax_Syntax.actions =
                                            actions1;
                                          FStar_Syntax_Syntax.eff_attrs =
-                                           uu____24553
+                                           uu___5
                                        } in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____24552 in
+                                       uu___4 in
                                    let se =
                                      {
                                        FStar_Syntax_Syntax.sigel = sigel;
@@ -6563,14 +6342,14 @@ let rec (desugar_effect :
                                    let env4 =
                                      FStar_All.pipe_right actions1
                                        (FStar_List.fold_left
-                                          (fun env4 ->
+                                          (fun env5 ->
                                              fun a ->
-                                               let uu____24570 =
+                                               let uu___4 =
                                                  FStar_Syntax_Util.action_as_lb
                                                    mname a
                                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                                FStar_Syntax_DsEnv.push_sigelt
-                                                 env4 uu____24570) env3) in
+                                                 env5 uu___4) env3) in
                                    let env5 =
                                      push_reflect_effect env4 qualifiers
                                        mname d.FStar_Parser_AST.drange in
@@ -6597,50 +6376,49 @@ and (desugar_redefine_effect :
               fun defn ->
                 let env0 = env in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name in
-                let uu____24593 = desugar_binders env1 eff_binders in
-                match uu____24593 with
+                let uu___ = desugar_binders env1 eff_binders in
+                match uu___ with
                 | (env2, binders) ->
-                    let uu____24630 =
-                      let uu____24641 = head_and_args defn in
-                      match uu____24641 with
+                    let uu___1 =
+                      let uu___2 = head_and_args defn in
+                      match uu___2 with
                       | (head, args) ->
                           let lid =
                             match head.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____24678 ->
-                                let uu____24679 =
-                                  let uu____24684 =
-                                    let uu____24685 =
-                                      let uu____24686 =
+                            | uu___3 ->
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 =
                                         FStar_Parser_AST.term_to_string head in
-                                      Prims.op_Hat uu____24686 " not found" in
-                                    Prims.op_Hat "Effect " uu____24685 in
-                                  (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____24684) in
-                                FStar_Errors.raise_error uu____24679
+                                      Prims.op_Hat uu___7 " not found" in
+                                    Prims.op_Hat "Effect " uu___6 in
+                                  (FStar_Errors.Fatal_EffectNotFound, uu___5) in
+                                FStar_Errors.raise_error uu___4
                                   d.FStar_Parser_AST.drange in
                           let ed =
                             FStar_Syntax_DsEnv.fail_or env2
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid in
-                          let uu____24688 =
+                          let uu___3 =
                             match FStar_List.rev args with
-                            | (last_arg, uu____24718)::args_rev ->
-                                let uu____24730 =
-                                  let uu____24731 = unparen last_arg in
-                                  uu____24731.FStar_Parser_AST.tm in
-                                (match uu____24730 with
+                            | (last_arg, uu___4)::args_rev ->
+                                let uu___5 =
+                                  let uu___6 = unparen last_arg in
+                                  uu___6.FStar_Parser_AST.tm in
+                                (match uu___5 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____24759 -> ([], args))
-                            | uu____24768 -> ([], args) in
-                          (match uu____24688 with
+                                 | uu___6 -> ([], args))
+                            | uu___4 -> ([], args) in
+                          (match uu___3 with
                            | (cattributes, args1) ->
-                               let uu____24811 = desugar_args env2 args1 in
-                               let uu____24812 =
+                               let uu___4 = desugar_args env2 args1 in
+                               let uu___5 =
                                  desugar_attributes env2 cattributes in
-                               (lid, ed, uu____24811, uu____24812)) in
-                    (match uu____24630 with
+                               (lid, ed, uu___4, uu___5)) in
+                    (match uu___1 with
                      | (ed_lid, ed, args, cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders in
@@ -6654,65 +6432,63 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____24848 =
+                          (let uu___3 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit in
-                           match uu____24848 with
-                           | (ed_binders, uu____24862, ed_binders_opening) ->
-                               let sub' shift_n uu____24880 =
-                                 match uu____24880 with
+                           match uu___3 with
+                           | (ed_binders, uu___4, ed_binders_opening) ->
+                               let sub' shift_n uu___5 =
+                                 match uu___5 with
                                  | (us, x) ->
                                      let x1 =
-                                       let uu____24894 =
+                                       let uu___6 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening in
-                                       FStar_Syntax_Subst.subst uu____24894 x in
+                                       FStar_Syntax_Subst.subst uu___6 x in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args in
-                                     let uu____24898 =
-                                       let uu____24899 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_Syntax_Subst.subst s x1 in
-                                       (us, uu____24899) in
+                                       (us, uu___7) in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____24898 in
+                                       binders1 uu___6 in
                                let sub = sub' Prims.int_zero in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name in
                                let ed1 =
-                                 let uu____24919 =
+                                 let uu___5 =
                                    sub ed.FStar_Syntax_Syntax.signature in
-                                 let uu____24920 =
+                                 let uu___6 =
                                    FStar_Syntax_Util.apply_eff_combinators
                                      sub ed.FStar_Syntax_Syntax.combinators in
-                                 let uu____24921 =
+                                 let uu___7 =
                                    FStar_List.map
                                      (fun action ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params in
-                                        let uu____24937 =
+                                        let uu___8 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name in
-                                        let uu____24938 =
-                                          let uu____24939 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn)) in
-                                          FStar_Pervasives_Native.snd
-                                            uu____24939 in
-                                        let uu____24954 =
-                                          let uu____24955 =
+                                          FStar_Pervasives_Native.snd uu___10 in
+                                        let uu___10 =
+                                          let uu___11 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ)) in
-                                          FStar_Pervasives_Native.snd
-                                            uu____24955 in
+                                          FStar_Pervasives_Native.snd uu___11 in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____24937;
+                                            uu___8;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -6721,9 +6497,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____24938;
+                                            uu___9;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____24954
+                                            uu___10
                                         }) ed.FStar_Syntax_Syntax.actions in
                                  {
                                    FStar_Syntax_Syntax.mname = mname;
@@ -6732,26 +6508,24 @@ and (desugar_redefine_effect :
                                    FStar_Syntax_Syntax.univs =
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
-                                   FStar_Syntax_Syntax.signature =
-                                     uu____24919;
-                                   FStar_Syntax_Syntax.combinators =
-                                     uu____24920;
-                                   FStar_Syntax_Syntax.actions = uu____24921;
+                                   FStar_Syntax_Syntax.signature = uu___5;
+                                   FStar_Syntax_Syntax.combinators = uu___6;
+                                   FStar_Syntax_Syntax.actions = uu___7;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  } in
                                let se =
-                                 let uu____24971 =
-                                   let uu____24974 =
+                                 let uu___5 =
+                                   let uu___6 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname) in
-                                   FStar_List.map uu____24974 quals in
+                                   FStar_List.map uu___6 quals in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____24971;
+                                   FStar_Syntax_Syntax.sigquals = uu___5;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = [];
@@ -6765,25 +6539,25 @@ and (desugar_redefine_effect :
                                  FStar_All.pipe_right
                                    ed1.FStar_Syntax_Syntax.actions
                                    (FStar_List.fold_left
-                                      (fun env4 ->
+                                      (fun env5 ->
                                          fun a ->
-                                           let uu____24989 =
+                                           let uu___5 =
                                              FStar_Syntax_Util.action_as_lb
                                                mname a
                                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                            FStar_Syntax_DsEnv.push_sigelt
-                                             env4 uu____24989) env3) in
+                                             env5 uu___5) env3) in
                                let env5 =
-                                 let uu____24991 =
+                                 let uu___5 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable) in
-                                 if uu____24991
+                                 if uu___5
                                  then
                                    let reflect_lid =
-                                     let uu____24995 =
+                                     let uu___6 =
                                        FStar_Ident.id_of_text "reflect" in
-                                     FStar_All.pipe_right uu____24995
+                                     FStar_All.pipe_right uu___6
                                        (FStar_Syntax_DsEnv.qualify monad_env) in
                                    let quals1 =
                                      [FStar_Syntax_Syntax.Assumption;
@@ -6816,52 +6590,50 @@ and (desugar_decl_aux :
       let no_fail_attrs ats =
         FStar_List.filter
           (fun at ->
-             let uu____25026 = get_fail_attr1 false at in
-             FStar_Option.isNone uu____25026) ats in
+             let uu___ = get_fail_attr1 false at in FStar_Option.isNone uu___)
+          ats in
       let env0 =
-        let uu____25042 = FStar_Syntax_DsEnv.snapshot env in
-        FStar_All.pipe_right uu____25042 FStar_Pervasives_Native.snd in
+        let uu___ = FStar_Syntax_DsEnv.snapshot env in
+        FStar_All.pipe_right uu___ FStar_Pervasives_Native.snd in
       let attrs = FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
-      let uu____25054 =
-        let uu____25061 = get_fail_attr false attrs in
-        match uu____25061 with
+      let uu___ =
+        let uu___1 = get_fail_attr false attrs in
+        match uu___1 with
         | FStar_Pervasives_Native.Some (expected_errs, lax) ->
             let d1 =
-              let uu___3391_25089 = d in
+              let uu___2 = d in
               {
-                FStar_Parser_AST.d = (uu___3391_25089.FStar_Parser_AST.d);
-                FStar_Parser_AST.drange =
-                  (uu___3391_25089.FStar_Parser_AST.drange);
-                FStar_Parser_AST.quals =
-                  (uu___3391_25089.FStar_Parser_AST.quals);
+                FStar_Parser_AST.d = (uu___2.FStar_Parser_AST.d);
+                FStar_Parser_AST.drange = (uu___2.FStar_Parser_AST.drange);
+                FStar_Parser_AST.quals = (uu___2.FStar_Parser_AST.quals);
                 FStar_Parser_AST.attrs = []
               } in
-            let uu____25090 =
+            let uu___2 =
               FStar_Errors.catch_errors
-                (fun uu____25108 ->
+                (fun uu___3 ->
                    FStar_Options.with_saved_options
-                     (fun uu____25114 -> desugar_decl_noattrs env d1)) in
-            (match uu____25090 with
+                     (fun uu___4 -> desugar_decl_noattrs env d1)) in
+            (match uu___2 with
              | (errs, r) ->
                  (match (errs, r) with
                   | ([], FStar_Pervasives_Native.Some (env1, ses)) ->
                       let ses1 =
                         FStar_List.map
                           (fun se ->
-                             let uu___3406_25174 = se in
-                             let uu____25175 = no_fail_attrs attrs in
+                             let uu___3 = se in
+                             let uu___4 = no_fail_attrs attrs in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___3406_25174.FStar_Syntax_Syntax.sigel);
+                                 (uu___3.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___3406_25174.FStar_Syntax_Syntax.sigrng);
+                                 (uu___3.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___3406_25174.FStar_Syntax_Syntax.sigquals);
+                                 (uu___3.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___3406_25174.FStar_Syntax_Syntax.sigmeta);
-                               FStar_Syntax_Syntax.sigattrs = uu____25175;
+                                 (uu___3.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs = uu___4;
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___3406_25174.FStar_Syntax_Syntax.sigopts)
+                                 (uu___3.FStar_Syntax_Syntax.sigopts)
                              }) ses in
                       let se =
                         {
@@ -6887,118 +6659,113 @@ and (desugar_decl_aux :
                       if expected_errs = []
                       then (env0, [])
                       else
-                        (let uu____25219 =
+                        (let uu___4 =
                            FStar_Errors.find_multiset_discrepancy
                              expected_errs errnos in
-                         match uu____25219 with
+                         match uu___4 with
                          | FStar_Pervasives_Native.None -> (env0, [])
                          | FStar_Pervasives_Native.Some (e, n1, n2) ->
                              (FStar_List.iter FStar_Errors.print_issue errs1;
-                              (let uu____25253 =
-                                 let uu____25258 =
-                                   let uu____25259 =
+                              (let uu___7 =
+                                 let uu___8 =
+                                   let uu___9 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int expected_errs in
-                                   let uu____25260 =
+                                   let uu___10 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int errnos in
-                                   let uu____25261 =
-                                     FStar_Util.string_of_int e in
-                                   let uu____25262 =
-                                     FStar_Util.string_of_int n2 in
-                                   let uu____25263 =
-                                     FStar_Util.string_of_int n1 in
+                                   let uu___11 = FStar_Util.string_of_int e in
+                                   let uu___12 = FStar_Util.string_of_int n2 in
+                                   let uu___13 = FStar_Util.string_of_int n1 in
                                    FStar_Util.format5
                                      "This top-level definition was expected to raise error codes %s, but it raised %s (at desugaring time). Error #%s was raised %s times, instead of %s."
-                                     uu____25259 uu____25260 uu____25261
-                                     uu____25262 uu____25263 in
-                                 (FStar_Errors.Error_DidNotFail, uu____25258) in
+                                     uu___9 uu___10 uu___11 uu___12 uu___13 in
+                                 (FStar_Errors.Error_DidNotFail, uu___8) in
                                FStar_Errors.log_issue
-                                 d1.FStar_Parser_AST.drange uu____25253);
+                                 d1.FStar_Parser_AST.drange uu___7);
                               (env0, [])))))
         | FStar_Pervasives_Native.None -> desugar_decl_noattrs env d in
-      match uu____25054 with
+      match uu___ with
       | (env1, sigelts) ->
           let rec val_attrs ses =
             match ses with
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                  uu____25296;
-                FStar_Syntax_Syntax.sigrng = uu____25297;
-                FStar_Syntax_Syntax.sigquals = uu____25298;
-                FStar_Syntax_Syntax.sigmeta = uu____25299;
-                FStar_Syntax_Syntax.sigattrs = uu____25300;
-                FStar_Syntax_Syntax.sigopts = uu____25301;_}::[] ->
-                let uu____25314 =
-                  let uu____25317 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____25317 in
-                FStar_All.pipe_right uu____25314
+                  uu___1;
+                FStar_Syntax_Syntax.sigrng = uu___2;
+                FStar_Syntax_Syntax.sigquals = uu___3;
+                FStar_Syntax_Syntax.sigmeta = uu___4;
+                FStar_Syntax_Syntax.sigattrs = uu___5;
+                FStar_Syntax_Syntax.sigopts = uu___6;_}::[] ->
+                let uu___7 =
+                  let uu___8 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu___8 in
+                FStar_All.pipe_right uu___7
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____25325 =
+                        let uu___8 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____25325))
+                        FStar_Pervasives_Native.snd uu___8))
             | {
                 FStar_Syntax_Syntax.sigel =
-                  FStar_Syntax_Syntax.Sig_inductive_typ uu____25338;
-                FStar_Syntax_Syntax.sigrng = uu____25339;
-                FStar_Syntax_Syntax.sigquals = uu____25340;
-                FStar_Syntax_Syntax.sigmeta = uu____25341;
-                FStar_Syntax_Syntax.sigattrs = uu____25342;
-                FStar_Syntax_Syntax.sigopts = uu____25343;_}::uu____25344 ->
-                let uu____25369 =
-                  let uu____25372 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____25372 in
-                FStar_All.pipe_right uu____25369
+                  FStar_Syntax_Syntax.Sig_inductive_typ uu___1;
+                FStar_Syntax_Syntax.sigrng = uu___2;
+                FStar_Syntax_Syntax.sigquals = uu___3;
+                FStar_Syntax_Syntax.sigmeta = uu___4;
+                FStar_Syntax_Syntax.sigattrs = uu___5;
+                FStar_Syntax_Syntax.sigopts = uu___6;_}::uu___7 ->
+                let uu___8 =
+                  let uu___9 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu___9 in
+                FStar_All.pipe_right uu___8
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____25380 =
+                        let uu___9 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____25380))
+                        FStar_Pervasives_Native.snd uu___9))
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_fail
                   (_errs, _lax, ses1);
-                FStar_Syntax_Syntax.sigrng = uu____25396;
-                FStar_Syntax_Syntax.sigquals = uu____25397;
-                FStar_Syntax_Syntax.sigmeta = uu____25398;
-                FStar_Syntax_Syntax.sigattrs = uu____25399;
-                FStar_Syntax_Syntax.sigopts = uu____25400;_}::[] ->
+                FStar_Syntax_Syntax.sigrng = uu___1;
+                FStar_Syntax_Syntax.sigquals = uu___2;
+                FStar_Syntax_Syntax.sigmeta = uu___3;
+                FStar_Syntax_Syntax.sigattrs = uu___4;
+                FStar_Syntax_Syntax.sigopts = uu___5;_}::[] ->
                 FStar_List.collect (fun se -> val_attrs [se]) ses1
-            | uu____25417 -> [] in
+            | uu___1 -> [] in
           let attrs1 =
-            let uu____25423 = val_attrs sigelts in
-            FStar_List.append attrs uu____25423 in
-          let uu____25426 =
+            let uu___1 = val_attrs sigelts in FStar_List.append attrs uu___1 in
+          let uu___1 =
             FStar_List.map
               (fun sigelt ->
-                 let uu___3466_25430 = sigelt in
+                 let uu___2 = sigelt in
                  {
                    FStar_Syntax_Syntax.sigel =
-                     (uu___3466_25430.FStar_Syntax_Syntax.sigel);
+                     (uu___2.FStar_Syntax_Syntax.sigel);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___3466_25430.FStar_Syntax_Syntax.sigrng);
+                     (uu___2.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___3466_25430.FStar_Syntax_Syntax.sigquals);
+                     (uu___2.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___3466_25430.FStar_Syntax_Syntax.sigmeta);
+                     (uu___2.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___3466_25430.FStar_Syntax_Syntax.sigopts)
+                     (uu___2.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in
-          (env1, uu____25426)
+          (env1, uu___1)
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env ->
     fun d ->
-      let uu____25437 = desugar_decl_aux env d in
-      match uu____25437 with
+      let uu___ = desugar_decl_aux env d in
+      match uu___ with
       | (env1, ses) ->
-          let uu____25448 =
+          let uu___1 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs) in
-          (env1, uu____25448)
+          (env1, uu___1)
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts))
@@ -7026,47 +6793,45 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____25480 = FStar_Syntax_DsEnv.iface env in
-          if uu____25480
+          let uu___ = FStar_Syntax_DsEnv.iface env in
+          if uu___
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____25490 =
-               let uu____25491 =
-                 let uu____25492 = FStar_Syntax_DsEnv.dep_graph env in
-                 let uu____25493 = FStar_Syntax_DsEnv.current_module env in
-                 FStar_Parser_Dep.module_has_interface uu____25492
-                   uu____25493 in
-               Prims.op_Negation uu____25491 in
-             if uu____25490
+            (let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_DsEnv.dep_graph env in
+                 let uu___5 = FStar_Syntax_DsEnv.current_module env in
+                 FStar_Parser_Dep.module_has_interface uu___4 uu___5 in
+               Prims.op_Negation uu___3 in
+             if uu___2
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____25503 =
-                  let uu____25504 =
-                    let uu____25505 = FStar_Syntax_DsEnv.dep_graph env in
-                    FStar_Parser_Dep.module_has_interface uu____25505 lid in
-                  Prims.op_Negation uu____25504 in
-                if uu____25503
+               (let uu___4 =
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_DsEnv.dep_graph env in
+                    FStar_Parser_Dep.module_has_interface uu___6 lid in
+                  Prims.op_Negation uu___5 in
+                if uu___4
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____25515 =
-                     let uu____25516 =
-                       let uu____25517 = FStar_Syntax_DsEnv.dep_graph env in
-                       FStar_Parser_Dep.deps_has_implementation uu____25517
-                         lid in
-                     Prims.op_Negation uu____25516 in
-                   if uu____25515
+                  (let uu___6 =
+                     let uu___7 =
+                       let uu___8 = FStar_Syntax_DsEnv.dep_graph env in
+                       FStar_Parser_Dep.deps_has_implementation uu___8 lid in
+                     Prims.op_Negation uu___7 in
+                   if uu___6
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7076,8 +6841,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x, l) ->
-          let uu____25531 = FStar_Syntax_DsEnv.push_module_abbrev env x l in
-          (uu____25531, [])
+          let uu___ = FStar_Syntax_DsEnv.push_module_abbrev env x l in
+          (uu___, [])
       | FStar_Parser_AST.Tycon (is_effect, typeclass, tcs) ->
           let quals = d.FStar_Parser_AST.quals in
           let quals1 =
@@ -7088,75 +6853,71 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____25553)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu___)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____25572 ->
+              | uu___ ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
                     d.FStar_Parser_AST.drange
             else quals1 in
-          let uu____25578 =
-            let uu____25583 =
+          let uu___ =
+            let uu___1 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2 in
-            desugar_tycon env d uu____25583 tcs in
-          (match uu____25578 with
+            desugar_tycon env d uu___1 tcs in
+          (match uu___ with
            | (env1, ses) ->
                let mkclass lid =
                  let r = FStar_Ident.range_of_lid lid in
-                 let uu____25601 =
-                   let uu____25602 =
-                     let uu____25609 =
-                       let uu____25610 = tun_r r in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = tun_r r in
                        FStar_Syntax_Syntax.new_bv
-                         (FStar_Pervasives_Native.Some r) uu____25610 in
-                     FStar_Syntax_Syntax.mk_binder uu____25609 in
-                   [uu____25602] in
-                 let uu____25623 =
-                   let uu____25626 =
+                         (FStar_Pervasives_Native.Some r) uu___4 in
+                     FStar_Syntax_Syntax.mk_binder uu___3 in
+                   [uu___2] in
+                 let uu___2 =
+                   let uu___3 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid in
-                   let uu____25629 =
-                     let uu____25640 =
-                       let uu____25649 =
-                         let uu____25650 = FStar_Ident.string_of_lid lid in
-                         FStar_Syntax_Util.exp_string uu____25650 in
-                       FStar_Syntax_Syntax.as_arg uu____25649 in
-                     [uu____25640] in
-                   FStar_Syntax_Util.mk_app uu____25626 uu____25629 in
-                 FStar_Syntax_Util.abs uu____25601 uu____25623
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 = FStar_Ident.string_of_lid lid in
+                         FStar_Syntax_Util.exp_string uu___7 in
+                       FStar_Syntax_Syntax.as_arg uu___6 in
+                     [uu___5] in
+                   FStar_Syntax_Util.mk_app uu___3 uu___4 in
+                 FStar_Syntax_Util.abs uu___1 uu___2
                    FStar_Pervasives_Native.None in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
-                   | (FStar_Syntax_Syntax.Projector
-                       (uu____25689, id))::uu____25691 ->
+                   | (FStar_Syntax_Syntax.Projector (uu___1, id))::uu___2 ->
                        FStar_Pervasives_Native.Some id
-                   | uu____25694::quals4 -> get_fname quals4
+                   | uu___1::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None in
-                 let uu____25698 = get_fname se.FStar_Syntax_Syntax.sigquals in
-                 match uu____25698 with
+                 let uu___1 = get_fname se.FStar_Syntax_Syntax.sigquals in
+                 match uu___1 with
                  | FStar_Pervasives_Native.None -> []
                  | FStar_Pervasives_Native.Some id ->
-                     let uu____25704 = FStar_Syntax_DsEnv.qualify env1 id in
-                     [uu____25704] in
+                     let uu___2 = FStar_Syntax_DsEnv.qualify env1 id in
+                     [uu___2] in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu____25725) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu___1) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid, uu____25735, uu____25736, uu____25737,
-                      uu____25738, uu____25739)
-                     ->
-                     let uu____25748 =
-                       let uu____25749 =
-                         let uu____25750 =
-                           let uu____25757 = mkclass lid in
-                           (meths, uu____25757) in
-                         FStar_Syntax_Syntax.Sig_splice uu____25750 in
+                     (lid, uu___1, uu___2, uu___3, uu___4, uu___5) ->
+                     let uu___6 =
+                       let uu___7 =
+                         let uu___8 =
+                           let uu___9 = mkclass lid in (meths, uu___9) in
+                         FStar_Syntax_Syntax.Sig_splice uu___8 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____25749;
+                         FStar_Syntax_Syntax.sigel = uu___7;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7166,8 +6927,8 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     [uu____25748]
-                 | uu____25760 -> [] in
+                     [uu___6]
+                 | uu___1 -> [] in
                let extra =
                  if typeclass
                  then
@@ -7183,37 +6944,30 @@ and (desugar_decl_noattrs :
           let expand_toplevel_pattern =
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
+               | ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu___;
+                    FStar_Parser_AST.prange = uu___1;_},
+                  uu___2)::[] -> false
+               | ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu___;
+                    FStar_Parser_AST.prange = uu___1;_},
+                  uu___2)::[] -> false
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____25790;
-                    FStar_Parser_AST.prange = uu____25791;_},
-                  uu____25792)::[] -> false
-               | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____25801;
-                    FStar_Parser_AST.prange = uu____25802;_},
-                  uu____25803)::[] -> false
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
+                      ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu___;
+                         FStar_Parser_AST.prange = uu___1;_},
+                       uu___2);
+                    FStar_Parser_AST.prange = uu___3;_},
+                  uu___4)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
-                         FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____25818;
-                         FStar_Parser_AST.prange = uu____25819;_},
-                       uu____25820);
-                    FStar_Parser_AST.prange = uu____25821;_},
-                  uu____25822)::[] -> false
-               | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
-                      ({
-                         FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____25843;
-                         FStar_Parser_AST.prange = uu____25844;_},
-                       uu____25845);
-                    FStar_Parser_AST.prange = uu____25846;_},
-                  uu____25847)::[] -> false
-               | (p, uu____25875)::[] ->
-                   let uu____25884 = is_app_pattern p in
-                   Prims.op_Negation uu____25884
-               | uu____25885 -> false) in
+                         FStar_Parser_AST.pat = FStar_Parser_AST.PatVar uu___;
+                         FStar_Parser_AST.prange = uu___1;_},
+                       uu___2);
+                    FStar_Parser_AST.prange = uu___3;_},
+                  uu___4)::[] -> false
+               | (p, uu___)::[] ->
+                   let uu___1 = is_app_pattern p in Prims.op_Negation uu___1
+               | uu___ -> false) in
           if Prims.op_Negation expand_toplevel_pattern
           then
             let lets1 =
@@ -7227,17 +6981,17 @@ and (desugar_decl_noattrs :
                         (FStar_Parser_AST.Const FStar_Const.Const_unit)
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
-            let uu____25958 = desugar_term_maybe_top true env as_inner_let in
-            (match uu____25958 with
+            let uu___ = desugar_term_maybe_top true env as_inner_let in
+            (match uu___ with
              | (ds_lets, aq) ->
                  (check_no_aq aq;
-                  (let uu____25970 =
-                     let uu____25971 =
+                  (let uu___2 =
+                     let uu___3 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets in
-                     uu____25971.FStar_Syntax_Syntax.n in
-                   match uu____25970 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs, uu____25981) ->
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs, uu___3) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7245,40 +6999,40 @@ and (desugar_decl_noattrs :
                               (fun lb ->
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname)) in
-                       let uu____26009 =
+                       let uu___4 =
                          FStar_List.fold_right
                            (fun fv ->
-                              fun uu____26034 ->
-                                match uu____26034 with
+                              fun uu___5 ->
+                                match uu___5 with
                                 | (qs, ats) ->
-                                    let uu____26061 =
+                                    let uu___6 =
                                       FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                         env
                                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                    (match uu____26061 with
+                                    (match uu___6 with
                                      | (qs', ats') ->
                                          ((FStar_List.append qs' qs),
                                            (FStar_List.append ats' ats))))
                            fvs ([], []) in
-                       (match uu____26009 with
+                       (match uu___4 with
                         | (val_quals, val_attrs) ->
                             let quals1 =
                               match quals with
-                              | uu____26115::uu____26116 ->
+                              | uu___5::uu___6 ->
                                   FStar_List.map
                                     (trans_qual1 FStar_Pervasives_Native.None)
                                     quals
-                              | uu____26119 -> val_quals in
+                              | uu___5 -> val_quals in
                             let quals2 =
-                              let uu____26123 =
+                              let uu___5 =
                                 FStar_All.pipe_right lets1
                                   (FStar_Util.for_some
-                                     (fun uu____26154 ->
-                                        match uu____26154 with
-                                        | (uu____26167, (uu____26168, t)) ->
+                                     (fun uu___6 ->
+                                        match uu___6 with
+                                        | (uu___7, (uu___8, t)) ->
                                             t.FStar_Parser_AST.level =
                                               FStar_Parser_AST.Formula)) in
-                              if uu____26123
+                              if uu___5
                               then FStar_Syntax_Syntax.Logic :: quals1
                               else quals1 in
                             let names =
@@ -7305,16 +7059,16 @@ and (desugar_decl_noattrs :
                               } in
                             let env1 = FStar_Syntax_DsEnv.push_sigelt env s in
                             (env1, [s]))
-                   | uu____26201 ->
+                   | uu___3 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____26207 =
+            (let uu___1 =
                match lets with
                | (pat, body)::[] -> (pat, body)
-               | uu____26226 ->
+               | uu___2 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets" in
-             match uu____26207 with
+             match uu___1 with
              | (pat, body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange in
@@ -7326,14 +7080,14 @@ and (desugar_decl_noattrs :
                        FStar_Range.dummyRange in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1, ty) ->
-                       let uu___3661_26262 = pat1 in
+                       let uu___2 = pat1 in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3661_26262.FStar_Parser_AST.prange)
+                           (uu___2.FStar_Parser_AST.prange)
                        }
-                   | uu____26269 -> var_pat in
+                   | uu___2 -> var_pat in
                  let main_let =
                    let quals1 =
                      if
@@ -7343,42 +7097,42 @@ and (desugar_decl_noattrs :
                      else FStar_Parser_AST.Private ::
                        (d.FStar_Parser_AST.quals) in
                    desugar_decl env
-                     (let uu___3667_26278 = d in
+                     (let uu___2 = d in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3667_26278.FStar_Parser_AST.drange);
+                          (uu___2.FStar_Parser_AST.drange);
                         FStar_Parser_AST.quals = quals1;
                         FStar_Parser_AST.attrs =
-                          (uu___3667_26278.FStar_Parser_AST.attrs)
+                          (uu___2.FStar_Parser_AST.attrs)
                       }) in
                  let main =
-                   let uu____26294 =
-                     let uu____26295 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_Ident.lid_of_ids [fresh_toplevel_name] in
-                     FStar_Parser_AST.Var uu____26295 in
-                   FStar_Parser_AST.mk_term uu____26294
+                     FStar_Parser_AST.Var uu___3 in
+                   FStar_Parser_AST.mk_term uu___2
                      pat.FStar_Parser_AST.prange FStar_Parser_AST.Expr in
-                 let build_generic_projection uu____26319 id_opt =
-                   match uu____26319 with
+                 let build_generic_projection uu___2 id_opt =
+                   match uu___2 with
                    | (env1, ses) ->
-                       let uu____26341 =
+                       let uu___3 =
                          match id_opt with
                          | FStar_Pervasives_Native.Some id ->
                              let lid = FStar_Ident.lid_of_ids [id] in
                              let branch =
-                               let uu____26353 = FStar_Ident.range_of_lid lid in
+                               let uu___4 = FStar_Ident.range_of_lid lid in
                                FStar_Parser_AST.mk_term
-                                 (FStar_Parser_AST.Var lid) uu____26353
+                                 (FStar_Parser_AST.Var lid) uu___4
                                  FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____26355 = FStar_Ident.range_of_id id in
+                               let uu___4 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____26355 in
+                                 uu___4 in
                              (bv_pat, branch)
                          | FStar_Pervasives_Native.None ->
                              let id = FStar_Ident.gen FStar_Range.dummyRange in
@@ -7388,28 +7142,26 @@ and (desugar_decl_noattrs :
                                     FStar_Const.Const_unit)
                                  FStar_Range.dummyRange FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____26361 = FStar_Ident.range_of_id id in
+                               let uu___4 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____26361 in
+                                 uu___4 in
                              let bv_pat1 =
-                               let uu____26365 =
-                                 let uu____26366 =
-                                   let uu____26377 =
-                                     let uu____26384 =
-                                       let uu____26385 =
+                               let uu___4 =
+                                 let uu___5 =
+                                   let uu___6 =
+                                     let uu___7 =
+                                       let uu___8 =
                                          FStar_Ident.range_of_id id in
-                                       unit_ty uu____26385 in
-                                     (uu____26384,
-                                       FStar_Pervasives_Native.None) in
-                                   (bv_pat, uu____26377) in
-                                 FStar_Parser_AST.PatAscribed uu____26366 in
-                               let uu____26394 = FStar_Ident.range_of_id id in
-                               FStar_Parser_AST.mk_pattern uu____26365
-                                 uu____26394 in
+                                       unit_ty uu___8 in
+                                     (uu___7, FStar_Pervasives_Native.None) in
+                                   (bv_pat, uu___6) in
+                                 FStar_Parser_AST.PatAscribed uu___5 in
+                               let uu___5 = FStar_Ident.range_of_id id in
+                               FStar_Parser_AST.mk_pattern uu___4 uu___5 in
                              (bv_pat1, branch) in
-                       (match uu____26341 with
+                       (match uu___3 with
                         | (bv_pat, branch) ->
                             let body1 =
                               FStar_Parser_AST.mk_term
@@ -7426,39 +7178,39 @@ and (desugar_decl_noattrs :
                                      [(bv_pat, body1)]))
                                 FStar_Range.dummyRange [] in
                             let id_decl1 =
-                              let uu___3691_26448 = id_decl in
+                              let uu___4 = id_decl in
                               {
                                 FStar_Parser_AST.d =
-                                  (uu___3691_26448.FStar_Parser_AST.d);
+                                  (uu___4.FStar_Parser_AST.d);
                                 FStar_Parser_AST.drange =
-                                  (uu___3691_26448.FStar_Parser_AST.drange);
+                                  (uu___4.FStar_Parser_AST.drange);
                                 FStar_Parser_AST.quals =
                                   (d.FStar_Parser_AST.quals);
                                 FStar_Parser_AST.attrs =
-                                  (uu___3691_26448.FStar_Parser_AST.attrs)
+                                  (uu___4.FStar_Parser_AST.attrs)
                               } in
-                            let uu____26449 = desugar_decl env1 id_decl1 in
-                            (match uu____26449 with
+                            let uu___4 = desugar_decl env1 id_decl1 in
+                            (match uu___4 with
                              | (env2, ses') ->
                                  (env2, (FStar_List.append ses ses')))) in
-                 let build_projection uu____26485 id =
-                   match uu____26485 with
+                 let build_projection uu___2 id =
+                   match uu___2 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          (FStar_Pervasives_Native.Some id) in
-                 let build_coverage_check uu____26524 =
-                   match uu____26524 with
+                 let build_coverage_check uu___2 =
+                   match uu___2 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          FStar_Pervasives_Native.None in
                  let bvs =
-                   let uu____26548 = gather_pattern_bound_vars pat in
-                   FStar_All.pipe_right uu____26548 FStar_Util.set_elements in
-                 let uu____26555 =
+                   let uu___2 = gather_pattern_bound_vars pat in
+                   FStar_All.pipe_right uu___2 FStar_Util.set_elements in
+                 let uu___2 =
                    (FStar_List.isEmpty bvs) &&
-                     (let uu____26557 = is_var_pattern pat in
-                      Prims.op_Negation uu____26557) in
-                 if uu____26555
+                     (let uu___3 = is_var_pattern pat in
+                      Prims.op_Negation uu___3) in
+                 if uu___2
                  then build_coverage_check main_let
                  else FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Assume (id, t) ->
@@ -7478,27 +7230,24 @@ and (desugar_decl_noattrs :
              }])
       | FStar_Parser_AST.Val (id, t) ->
           let quals = d.FStar_Parser_AST.quals in
-          let t1 =
-            let uu____26575 = close_fun env t in desugar_term env uu____26575 in
+          let t1 = let uu___ = close_fun env t in desugar_term env uu___ in
           let quals1 =
-            let uu____26579 =
+            let uu___ =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env) in
-            if uu____26579
-            then FStar_Parser_AST.Assumption :: quals
-            else quals in
+            if uu___ then FStar_Parser_AST.Assumption :: quals else quals in
           let lid = FStar_Syntax_DsEnv.qualify env id in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
           let se =
-            let uu____26588 =
+            let uu___ =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1 in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____26588;
+              FStar_Syntax_Syntax.sigquals = uu___;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs;
@@ -7513,18 +7262,16 @@ and (desugar_decl_noattrs :
                   (FStar_Syntax_DsEnv.try_lookup_lid env)
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
-                let t = desugar_term env term in
-                let uu____26601 =
-                  let uu____26610 = FStar_Syntax_Syntax.null_binder t in
-                  [uu____26610] in
-                let uu____26629 =
-                  let uu____26632 =
+                let t1 = desugar_term env term in
+                let uu___ =
+                  let uu___1 = FStar_Syntax_Syntax.null_binder t1 in [uu___1] in
+                let uu___1 =
+                  let uu___2 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid in
-                  FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____26632 in
-                FStar_Syntax_Util.arrow uu____26601 uu____26629 in
+                  FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu___2 in
+                FStar_Syntax_Util.arrow uu___ uu___1 in
           let l = FStar_Syntax_DsEnv.qualify env id in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
           let se =
@@ -7576,7 +7323,7 @@ and (desugar_decl_noattrs :
           desugar_effect env d quals true eff_name eff_binders eff_typ
             eff_decls attrs
       | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
-          uu____26691) ->
+          uu___) ->
           failwith
             "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
       | FStar_Parser_AST.SubEffect l ->
@@ -7586,42 +7333,38 @@ and (desugar_decl_noattrs :
           let dst_ed =
             lookup_effect_lid env l.FStar_Parser_AST.mdest
               d.FStar_Parser_AST.drange in
-          let uu____26707 =
-            let uu____26708 =
+          let uu___ =
+            let uu___1 =
               (FStar_Syntax_Util.is_layered src_ed) ||
                 (FStar_Syntax_Util.is_layered dst_ed) in
-            Prims.op_Negation uu____26708 in
-          if uu____26707
+            Prims.op_Negation uu___1 in
+          if uu___
           then
-            let uu____26713 =
+            let uu___1 =
               match l.FStar_Parser_AST.lift_op with
               | FStar_Parser_AST.NonReifiableLift t ->
-                  let uu____26731 =
-                    let uu____26734 =
-                      let uu____26735 = desugar_term env t in
-                      ([], uu____26735) in
-                    FStar_Pervasives_Native.Some uu____26734 in
-                  (uu____26731, FStar_Pervasives_Native.None)
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = desugar_term env t in ([], uu___4) in
+                    FStar_Pervasives_Native.Some uu___3 in
+                  (uu___2, FStar_Pervasives_Native.None)
               | FStar_Parser_AST.ReifiableLift (wp, t) ->
-                  let uu____26748 =
-                    let uu____26751 =
-                      let uu____26752 = desugar_term env wp in
-                      ([], uu____26752) in
-                    FStar_Pervasives_Native.Some uu____26751 in
-                  let uu____26759 =
-                    let uu____26762 =
-                      let uu____26763 = desugar_term env t in
-                      ([], uu____26763) in
-                    FStar_Pervasives_Native.Some uu____26762 in
-                  (uu____26748, uu____26759)
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = desugar_term env wp in ([], uu___4) in
+                    FStar_Pervasives_Native.Some uu___3 in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = desugar_term env t in ([], uu___5) in
+                    FStar_Pervasives_Native.Some uu___4 in
+                  (uu___2, uu___3)
               | FStar_Parser_AST.LiftForFree t ->
-                  let uu____26775 =
-                    let uu____26778 =
-                      let uu____26779 = desugar_term env t in
-                      ([], uu____26779) in
-                    FStar_Pervasives_Native.Some uu____26778 in
-                  (FStar_Pervasives_Native.None, uu____26775) in
-            (match uu____26713 with
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = desugar_term env t in ([], uu___4) in
+                    FStar_Pervasives_Native.Some uu___3 in
+                  (FStar_Pervasives_Native.None, uu___2) in
+            (match uu___1 with
              | (lift_wp, lift) ->
                  let se =
                    {
@@ -7648,11 +7391,10 @@ and (desugar_decl_noattrs :
             (match l.FStar_Parser_AST.lift_op with
              | FStar_Parser_AST.NonReifiableLift t ->
                  let sub_eff =
-                   let uu____26812 =
-                     let uu____26815 =
-                       let uu____26816 = desugar_term env t in
-                       ([], uu____26816) in
-                     FStar_Pervasives_Native.Some uu____26815 in
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = desugar_term env t in ([], uu___4) in
+                     FStar_Pervasives_Native.Some uu___3 in
                    {
                      FStar_Syntax_Syntax.source =
                        (src_ed.FStar_Syntax_Syntax.mname);
@@ -7660,7 +7402,7 @@ and (desugar_decl_noattrs :
                        (dst_ed.FStar_Syntax_Syntax.mname);
                      FStar_Syntax_Syntax.lift_wp =
                        FStar_Pervasives_Native.None;
-                     FStar_Syntax_Syntax.lift = uu____26812
+                     FStar_Syntax_Syntax.lift = uu___2
                    } in
                  (env,
                    [{
@@ -7675,27 +7417,26 @@ and (desugar_decl_noattrs :
                       FStar_Syntax_Syntax.sigopts =
                         FStar_Pervasives_Native.None
                     }])
-             | uu____26823 ->
+             | uu___2 ->
                  failwith
                    "Impossible! unexpected lift_op for lift to a layered effect")
       | FStar_Parser_AST.Polymonadic_bind (m_eff, n_eff, p_eff, bind) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange in
           let p = lookup_effect_lid env p_eff d.FStar_Parser_AST.drange in
-          let uu____26835 =
-            let uu____26836 =
-              let uu____26837 =
-                let uu____26838 =
-                  let uu____26849 =
-                    let uu____26850 = desugar_term env bind in
-                    ([], uu____26850) in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = desugar_term env bind in ([], uu___5) in
                   ((m.FStar_Syntax_Syntax.mname),
                     (n.FStar_Syntax_Syntax.mname),
-                    (p.FStar_Syntax_Syntax.mname), uu____26849,
+                    (p.FStar_Syntax_Syntax.mname), uu___4,
                     ([], FStar_Syntax_Syntax.tun)) in
-                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____26838 in
+                FStar_Syntax_Syntax.Sig_polymonadic_bind uu___3 in
               {
-                FStar_Syntax_Syntax.sigel = uu____26837;
+                FStar_Syntax_Syntax.sigel = uu___2;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -7703,24 +7444,23 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
-            [uu____26836] in
-          (env, uu____26835)
+            [uu___1] in
+          (env, uu___)
       | FStar_Parser_AST.Polymonadic_subcomp (m_eff, n_eff, subcomp) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange in
-          let uu____26866 =
-            let uu____26867 =
-              let uu____26868 =
-                let uu____26869 =
-                  let uu____26878 =
-                    let uu____26879 = desugar_term env subcomp in
-                    ([], uu____26879) in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = desugar_term env subcomp in ([], uu___5) in
                   ((m.FStar_Syntax_Syntax.mname),
-                    (n.FStar_Syntax_Syntax.mname), uu____26878,
+                    (n.FStar_Syntax_Syntax.mname), uu___4,
                     ([], FStar_Syntax_Syntax.tun)) in
-                FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____26869 in
+                FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___3 in
               {
-                FStar_Syntax_Syntax.sigel = uu____26868;
+                FStar_Syntax_Syntax.sigel = uu___2;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -7728,19 +7468,19 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
-            [uu____26867] in
-          (env, uu____26866)
+            [uu___1] in
+          (env, uu___)
       | FStar_Parser_AST.Splice (ids, t) ->
           let t1 = desugar_term env t in
           let se =
-            let uu____26898 =
-              let uu____26899 =
-                let uu____26906 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids in
-                (uu____26906, t1) in
-              FStar_Syntax_Syntax.Sig_splice uu____26899 in
+                (uu___2, t1) in
+              FStar_Syntax_Syntax.Sig_splice uu___1 in
             {
-              FStar_Syntax_Syntax.sigel = uu____26898;
+              FStar_Syntax_Syntax.sigel = uu___;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -7756,17 +7496,17 @@ let (desugar_decls :
   =
   fun env ->
     fun decls ->
-      let uu____26932 =
+      let uu___ =
         FStar_List.fold_left
-          (fun uu____26952 ->
+          (fun uu___1 ->
              fun d ->
-               match uu____26952 with
+               match uu___1 with
                | (env1, sigelts) ->
-                   let uu____26972 = desugar_decl env1 d in
-                   (match uu____26972 with
+                   let uu___2 = desugar_decl env1 d in
+                   (match uu___2 with
                     | (env2, se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls in
-      match uu____26932 with | (env1, sigelts) -> (env1, sigelts)
+      match uu___ with | (env1, sigelts) -> (env1, sigelts)
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
     Prims.list)
@@ -7787,35 +7527,35 @@ let (desugar_modul_common :
       fun m ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None, uu____27059) -> env
+          | (FStar_Pervasives_Native.None, uu___) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____27063;
-               FStar_Syntax_Syntax.is_interface = uu____27064;_},
-             FStar_Parser_AST.Module (current_lid, uu____27066)) when
+               FStar_Syntax_Syntax.declarations = uu___;
+               FStar_Syntax_Syntax.is_interface = uu___1;_},
+             FStar_Parser_AST.Module (current_lid, uu___2)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod, uu____27074) ->
-              let uu____27077 =
+          | (FStar_Pervasives_Native.Some prev_mod, uu___) ->
+              let uu___1 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod in
-              FStar_Pervasives_Native.fst uu____27077 in
-        let uu____27082 =
+              FStar_Pervasives_Native.fst uu___1 in
+        let uu___ =
           match m with
           | FStar_Parser_AST.Interface (mname, decls, admitted) ->
-              let uu____27118 =
+              let uu___1 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____27118, mname, decls, true)
+              (uu___1, mname, decls, true)
           | FStar_Parser_AST.Module (mname, decls) ->
-              let uu____27135 =
+              let uu___1 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____27135, mname, decls, false) in
-        match uu____27082 with
+              (uu___1, mname, decls, false) in
+        match uu___ with
         | ((env2, pop_when_done), mname, decls, intf) ->
-            let uu____27165 = desugar_decls env2 decls in
-            (match uu____27165 with
+            let uu___1 = desugar_decls env2 decls in
+            (match uu___1 with
              | (env3, sigelts) ->
                  let modul =
                    {
@@ -7838,22 +7578,20 @@ let (desugar_partial_modul :
     fun env ->
       fun m ->
         let m1 =
-          let uu____27227 =
+          let uu___ =
             (FStar_Options.interactive ()) &&
-              (let uu____27229 =
-                 let uu____27230 =
-                   let uu____27231 = FStar_Options.file_list () in
-                   FStar_List.hd uu____27231 in
-                 FStar_Util.get_file_extension uu____27230 in
-               FStar_List.mem uu____27229 ["fsti"; "fsi"]) in
-          if uu____27227 then as_interface m else m in
-        let uu____27235 = desugar_modul_common curmod env m1 in
-        match uu____27235 with
+              (let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Options.file_list () in
+                   FStar_List.hd uu___3 in
+                 FStar_Util.get_file_extension uu___2 in
+               FStar_List.mem uu___1 ["fsti"; "fsi"]) in
+          if uu___ then as_interface m else m in
+        let uu___ = desugar_modul_common curmod env m1 in
+        match uu___ with
         | (env1, modul, pop_when_done) ->
             if pop_when_done
-            then
-              let uu____27253 = FStar_Syntax_DsEnv.pop () in
-              (uu____27253, modul)
+            then let uu___1 = FStar_Syntax_DsEnv.pop () in (uu___1, modul)
             else (env1, modul)
 let (desugar_modul :
   FStar_Syntax_DsEnv.env ->
@@ -7861,33 +7599,30 @@ let (desugar_modul :
   =
   fun env ->
     fun m ->
-      let uu____27273 =
-        desugar_modul_common FStar_Pervasives_Native.None env m in
-      match uu____27273 with
+      let uu___ = desugar_modul_common FStar_Pervasives_Native.None env m in
+      match uu___ with
       | (env1, modul, pop_when_done) ->
-          let uu____27287 =
+          let uu___1 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul in
-          (match uu____27287 with
+          (match uu___1 with
            | (env2, modul1) ->
-               ((let uu____27299 =
-                   let uu____27300 =
+               ((let uu___3 =
+                   let uu___4 =
                      FStar_Ident.string_of_lid
                        modul1.FStar_Syntax_Syntax.name in
-                   FStar_Options.dump_module uu____27300 in
-                 if uu____27299
+                   FStar_Options.dump_module uu___4 in
+                 if uu___3
                  then
-                   let uu____27301 =
-                     FStar_Syntax_Print.modul_to_string modul1 in
-                   FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____27301
+                   let uu___4 = FStar_Syntax_Print.modul_to_string modul1 in
+                   FStar_Util.print1 "Module after desugaring:\n%s\n" uu___4
                  else ());
-                (let uu____27303 =
+                (let uu___3 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2 in
-                 (uu____27303, modul1))))
+                 (uu___3, modul1))))
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f ->
     FStar_Options.push ();
@@ -7903,9 +7638,9 @@ let (ast_modul_to_modul :
   fun modul ->
     fun env ->
       with_options
-        (fun uu____27346 ->
-           let uu____27347 = desugar_modul env modul in
-           match uu____27347 with | (e, m) -> (m, e))
+        (fun uu___ ->
+           let uu___1 = desugar_modul env modul in
+           match uu___1 with | (e, m) -> (m, e))
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Syntax_Syntax.sigelts FStar_Syntax_DsEnv.withenv)
@@ -7913,9 +7648,9 @@ let (decls_to_sigelts :
   fun decls ->
     fun env ->
       with_options
-        (fun uu____27384 ->
-           let uu____27385 = desugar_decls env decls in
-           match uu____27385 with | (env1, sigelts) -> (sigelts, env1))
+        (fun uu___ ->
+           let uu___1 = desugar_decls env decls in
+           match uu___1 with | (env1, sigelts) -> (sigelts, env1))
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Parser_AST.modul ->
@@ -7925,9 +7660,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul ->
       fun env ->
         with_options
-          (fun uu____27435 ->
-             let uu____27436 = desugar_partial_modul modul env a_modul in
-             match uu____27436 with | (env1, modul1) -> (modul1, env1))
+          (fun uu___ ->
+             let uu___1 = desugar_partial_modul modul env a_modul in
+             match uu___1 with | (env1, modul1) -> (modul1, env1))
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
     FStar_Syntax_DsEnv.module_inclusion_info ->
@@ -7942,46 +7677,43 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____27530 ->
+              | uu___ ->
                   let t =
-                    let uu____27540 =
+                    let uu___1 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Range.dummyRange in
-                    erase_univs uu____27540 in
-                  let uu____27553 =
-                    let uu____27554 = FStar_Syntax_Subst.compress t in
-                    uu____27554.FStar_Syntax_Syntax.n in
-                  (match uu____27553 with
-                   | FStar_Syntax_Syntax.Tm_abs
-                       (bs1, uu____27566, uu____27567) -> bs1
-                   | uu____27592 -> failwith "Impossible") in
-            let uu____27601 =
-              let uu____27608 = erase_binders ed.FStar_Syntax_Syntax.binders in
-              FStar_Syntax_Subst.open_term' uu____27608
-                FStar_Syntax_Syntax.t_unit in
-            match uu____27601 with
-            | (binders, uu____27610, binders_opening) ->
+                    erase_univs uu___1 in
+                  let uu___1 =
+                    let uu___2 = FStar_Syntax_Subst.compress t in
+                    uu___2.FStar_Syntax_Syntax.n in
+                  (match uu___1 with
+                   | FStar_Syntax_Syntax.Tm_abs (bs1, uu___2, uu___3) -> bs1
+                   | uu___2 -> failwith "Impossible") in
+            let uu___ =
+              let uu___1 = erase_binders ed.FStar_Syntax_Syntax.binders in
+              FStar_Syntax_Subst.open_term' uu___1 FStar_Syntax_Syntax.t_unit in
+            match uu___ with
+            | (binders, uu___1, binders_opening) ->
                 let erase_term t =
-                  let uu____27618 =
-                    let uu____27619 =
-                      FStar_Syntax_Subst.subst binders_opening t in
-                    erase_univs uu____27619 in
-                  FStar_Syntax_Subst.close binders uu____27618 in
-                let erase_tscheme uu____27637 =
-                  match uu____27637 with
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Subst.subst binders_opening t in
+                    erase_univs uu___3 in
+                  FStar_Syntax_Subst.close binders uu___2 in
+                let erase_tscheme uu___2 =
+                  match uu___2 with
                   | (us, t) ->
                       let t1 =
-                        let uu____27657 =
+                        let uu___3 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening in
-                        FStar_Syntax_Subst.subst uu____27657 t in
-                      let uu____27660 =
-                        let uu____27661 = erase_univs t1 in
-                        FStar_Syntax_Subst.close binders uu____27661 in
-                      ([], uu____27660) in
+                        FStar_Syntax_Subst.subst uu___3 t in
+                      let uu___3 =
+                        let uu___4 = erase_univs t1 in
+                        FStar_Syntax_Subst.close binders uu___4 in
+                      ([], uu___3) in
                 let erase_action action =
                   let opening =
                     FStar_Syntax_Subst.shift_subst
@@ -7991,111 +7723,109 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____27684 ->
+                    | uu___2 ->
                         let bs =
-                          let uu____27694 =
+                          let uu___3 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params in
-                          FStar_All.pipe_left erase_binders uu____27694 in
+                          FStar_All.pipe_left erase_binders uu___3 in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
                                (bs, FStar_Syntax_Syntax.t_unit,
                                  FStar_Pervasives_Native.None))
                             FStar_Range.dummyRange in
-                        let uu____27734 =
-                          let uu____27735 =
-                            let uu____27738 =
-                              FStar_Syntax_Subst.close binders t in
-                            FStar_Syntax_Subst.compress uu____27738 in
-                          uu____27735.FStar_Syntax_Syntax.n in
-                        (match uu____27734 with
-                         | FStar_Syntax_Syntax.Tm_abs
-                             (bs1, uu____27740, uu____27741) -> bs1
-                         | uu____27766 -> failwith "Impossible") in
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 = FStar_Syntax_Subst.close binders t in
+                            FStar_Syntax_Subst.compress uu___5 in
+                          uu___4.FStar_Syntax_Syntax.n in
+                        (match uu___3 with
+                         | FStar_Syntax_Syntax.Tm_abs (bs1, uu___4, uu___5)
+                             -> bs1
+                         | uu___4 -> failwith "Impossible") in
                   let erase_term1 t =
-                    let uu____27773 =
-                      let uu____27774 = FStar_Syntax_Subst.subst opening t in
-                      erase_univs uu____27774 in
-                    FStar_Syntax_Subst.close binders uu____27773 in
-                  let uu___3968_27775 = action in
-                  let uu____27776 =
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Subst.subst opening t in
+                      erase_univs uu___3 in
+                    FStar_Syntax_Subst.close binders uu___2 in
+                  let uu___2 = action in
+                  let uu___3 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn in
-                  let uu____27777 =
+                  let uu___4 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3968_27775.FStar_Syntax_Syntax.action_name);
+                      (uu___2.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3968_27775.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___2.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____27776;
-                    FStar_Syntax_Syntax.action_typ = uu____27777
+                    FStar_Syntax_Syntax.action_defn = uu___3;
+                    FStar_Syntax_Syntax.action_typ = uu___4
                   } in
-                let uu___3970_27778 = ed in
-                let uu____27779 = FStar_Syntax_Subst.close_binders binders in
-                let uu____27780 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.signature in
-                let uu____27781 =
+                let uu___2 = ed in
+                let uu___3 = FStar_Syntax_Subst.close_binders binders in
+                let uu___4 = erase_tscheme ed.FStar_Syntax_Syntax.signature in
+                let uu___5 =
                   FStar_Syntax_Util.apply_eff_combinators erase_tscheme
                     ed.FStar_Syntax_Syntax.combinators in
-                let uu____27782 =
+                let uu___6 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions in
                 {
                   FStar_Syntax_Syntax.mname =
-                    (uu___3970_27778.FStar_Syntax_Syntax.mname);
+                    (uu___2.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3970_27778.FStar_Syntax_Syntax.cattributes);
+                    (uu___2.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____27779;
-                  FStar_Syntax_Syntax.signature = uu____27780;
-                  FStar_Syntax_Syntax.combinators = uu____27781;
-                  FStar_Syntax_Syntax.actions = uu____27782;
+                  FStar_Syntax_Syntax.binders = uu___3;
+                  FStar_Syntax_Syntax.signature = uu___4;
+                  FStar_Syntax_Syntax.combinators = uu___5;
+                  FStar_Syntax_Syntax.actions = uu___6;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3970_27778.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___2.FStar_Syntax_Syntax.eff_attrs)
                 } in
           let push_sigelt env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3977_27798 = se in
-                  let uu____27799 =
-                    let uu____27800 = erase_univs_ed ed in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____27800 in
+                  let uu___ = se in
+                  let uu___1 =
+                    let uu___2 = erase_univs_ed ed in
+                    FStar_Syntax_Syntax.Sig_new_effect uu___2 in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____27799;
+                    FStar_Syntax_Syntax.sigel = uu___1;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3977_27798.FStar_Syntax_Syntax.sigrng);
+                      (uu___.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3977_27798.FStar_Syntax_Syntax.sigquals);
+                      (uu___.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3977_27798.FStar_Syntax_Syntax.sigmeta);
+                      (uu___.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3977_27798.FStar_Syntax_Syntax.sigattrs);
+                      (uu___.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___3977_27798.FStar_Syntax_Syntax.sigopts)
+                      (uu___.FStar_Syntax_Syntax.sigopts)
                   } in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se' in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____27802 -> FStar_Syntax_DsEnv.push_sigelt env se in
-          let uu____27803 =
+            | uu___ -> FStar_Syntax_DsEnv.push_sigelt env se in
+          let uu___ =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii in
-          match uu____27803 with
+          match uu___ with
           | (en1, pop_when_done) ->
               let en2 =
-                let uu____27815 =
+                let uu___1 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name in
-                FStar_List.fold_left push_sigelt uu____27815
+                FStar_List.fold_left push_sigelt uu___1
                   m.FStar_Syntax_Syntax.declarations in
               let env = FStar_Syntax_DsEnv.finish en2 m in
-              let uu____27817 =
+              let uu___1 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env in
-              ((), uu____27817)
+              ((), uu___1)

--- a/src/ocaml-output/FStar_TypeChecker_Cfg.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Cfg.ml
@@ -313,148 +313,146 @@ let (steps_to_string : fsteps -> Prims.string) =
       match o with
       | FStar_Pervasives_Native.None -> "None"
       | FStar_Pervasives_Native.Some x ->
-          let uu____1508 =
-            let uu____1509 = f1 x in FStar_String.op_Hat uu____1509 ")" in
-          FStar_String.op_Hat "Some (" uu____1508 in
+          let uu___ = let uu___1 = f1 x in FStar_String.op_Hat uu___1 ")" in
+          FStar_String.op_Hat "Some (" uu___ in
     let b = FStar_Util.string_of_bool in
-    let uu____1515 =
-      let uu____1518 = FStar_All.pipe_right f.beta b in
-      let uu____1519 =
-        let uu____1522 = FStar_All.pipe_right f.iota b in
-        let uu____1523 =
-          let uu____1526 = FStar_All.pipe_right f.zeta b in
-          let uu____1527 =
-            let uu____1530 = FStar_All.pipe_right f.zeta_full b in
-            let uu____1531 =
-              let uu____1534 = FStar_All.pipe_right f.weak b in
-              let uu____1535 =
-                let uu____1538 = FStar_All.pipe_right f.hnf b in
-                let uu____1539 =
-                  let uu____1542 = FStar_All.pipe_right f.primops b in
-                  let uu____1543 =
-                    let uu____1546 =
+    let uu___ =
+      let uu___1 = FStar_All.pipe_right f.beta b in
+      let uu___2 =
+        let uu___3 = FStar_All.pipe_right f.iota b in
+        let uu___4 =
+          let uu___5 = FStar_All.pipe_right f.zeta b in
+          let uu___6 =
+            let uu___7 = FStar_All.pipe_right f.zeta_full b in
+            let uu___8 =
+              let uu___9 = FStar_All.pipe_right f.weak b in
+              let uu___10 =
+                let uu___11 = FStar_All.pipe_right f.hnf b in
+                let uu___12 =
+                  let uu___13 = FStar_All.pipe_right f.primops b in
+                  let uu___14 =
+                    let uu___15 =
                       FStar_All.pipe_right f.do_not_unfold_pure_lets b in
-                    let uu____1547 =
-                      let uu____1550 =
+                    let uu___16 =
+                      let uu___17 =
                         FStar_All.pipe_right f.unfold_until
                           (format_opt
                              FStar_Syntax_Print.delta_depth_to_string) in
-                      let uu____1553 =
-                        let uu____1556 =
+                      let uu___18 =
+                        let uu___19 =
                           FStar_All.pipe_right f.unfold_only
                             (format_opt
                                (fun x ->
-                                  let uu____1568 =
+                                  let uu___20 =
                                     FStar_List.map FStar_Ident.string_of_lid
                                       x in
-                                  FStar_All.pipe_right uu____1568
+                                  FStar_All.pipe_right uu___20
                                     (FStar_String.concat ", "))) in
-                        let uu____1573 =
-                          let uu____1576 =
+                        let uu___20 =
+                          let uu___21 =
                             FStar_All.pipe_right f.unfold_fully
                               (format_opt
                                  (fun x ->
-                                    let uu____1588 =
+                                    let uu___22 =
                                       FStar_List.map
                                         FStar_Ident.string_of_lid x in
-                                    FStar_All.pipe_right uu____1588
+                                    FStar_All.pipe_right uu___22
                                       (FStar_String.concat ", "))) in
-                          let uu____1593 =
-                            let uu____1596 =
+                          let uu___22 =
+                            let uu___23 =
                               FStar_All.pipe_right f.unfold_attr
                                 (format_opt
                                    (fun x ->
-                                      let uu____1608 =
+                                      let uu___24 =
                                         FStar_List.map
                                           FStar_Ident.string_of_lid x in
-                                      FStar_All.pipe_right uu____1608
+                                      FStar_All.pipe_right uu___24
                                         (FStar_String.concat ", "))) in
-                            let uu____1613 =
-                              let uu____1616 =
+                            let uu___24 =
+                              let uu___25 =
                                 FStar_All.pipe_right f.unfold_tac b in
-                              let uu____1617 =
-                                let uu____1620 =
+                              let uu___26 =
+                                let uu___27 =
                                   FStar_All.pipe_right
                                     f.pure_subterms_within_computations b in
-                                let uu____1621 =
-                                  let uu____1624 =
+                                let uu___28 =
+                                  let uu___29 =
                                     FStar_All.pipe_right f.simplify b in
-                                  let uu____1625 =
-                                    let uu____1628 =
+                                  let uu___30 =
+                                    let uu___31 =
                                       FStar_All.pipe_right f.erase_universes
                                         b in
-                                    let uu____1629 =
-                                      let uu____1632 =
+                                    let uu___32 =
+                                      let uu___33 =
                                         FStar_All.pipe_right
                                           f.allow_unbound_universes b in
-                                      let uu____1633 =
-                                        let uu____1636 =
+                                      let uu___34 =
+                                        let uu___35 =
                                           FStar_All.pipe_right f.reify_ b in
-                                        let uu____1637 =
-                                          let uu____1640 =
+                                        let uu___36 =
+                                          let uu___37 =
                                             FStar_All.pipe_right
                                               f.compress_uvars b in
-                                          let uu____1641 =
-                                            let uu____1644 =
+                                          let uu___38 =
+                                            let uu___39 =
                                               FStar_All.pipe_right
                                                 f.no_full_norm b in
-                                            let uu____1645 =
-                                              let uu____1648 =
+                                            let uu___40 =
+                                              let uu___41 =
                                                 FStar_All.pipe_right
                                                   f.check_no_uvars b in
-                                              let uu____1649 =
-                                                let uu____1652 =
+                                              let uu___42 =
+                                                let uu___43 =
                                                   FStar_All.pipe_right
                                                     f.unmeta b in
-                                                let uu____1653 =
-                                                  let uu____1656 =
+                                                let uu___44 =
+                                                  let uu___45 =
                                                     FStar_All.pipe_right
                                                       f.unascribe b in
-                                                  let uu____1657 =
-                                                    let uu____1660 =
+                                                  let uu___46 =
+                                                    let uu___47 =
                                                       FStar_All.pipe_right
                                                         f.in_full_norm_request
                                                         b in
-                                                    let uu____1661 =
-                                                      let uu____1664 =
+                                                    let uu___48 =
+                                                      let uu___49 =
                                                         FStar_All.pipe_right
                                                           f.weakly_reduce_scrutinee
                                                           b in
-                                                      let uu____1665 =
-                                                        let uu____1668 =
+                                                      let uu___50 =
+                                                        let uu___51 =
                                                           FStar_All.pipe_right
                                                             f.for_extraction
                                                             b in
-                                                        [uu____1668] in
-                                                      uu____1664 ::
-                                                        uu____1665 in
-                                                    uu____1660 :: uu____1661 in
-                                                  uu____1656 :: uu____1657 in
-                                                uu____1652 :: uu____1653 in
-                                              uu____1648 :: uu____1649 in
-                                            uu____1644 :: uu____1645 in
-                                          uu____1640 :: uu____1641 in
-                                        uu____1636 :: uu____1637 in
-                                      uu____1632 :: uu____1633 in
-                                    uu____1628 :: uu____1629 in
-                                  uu____1624 :: uu____1625 in
-                                uu____1620 :: uu____1621 in
-                              uu____1616 :: uu____1617 in
-                            uu____1596 :: uu____1613 in
-                          uu____1576 :: uu____1593 in
-                        uu____1556 :: uu____1573 in
-                      uu____1550 :: uu____1553 in
-                    uu____1546 :: uu____1547 in
-                  uu____1542 :: uu____1543 in
-                uu____1538 :: uu____1539 in
-              uu____1534 :: uu____1535 in
-            uu____1530 :: uu____1531 in
-          uu____1526 :: uu____1527 in
-        uu____1522 :: uu____1523 in
-      uu____1518 :: uu____1519 in
+                                                        [uu___51] in
+                                                      uu___49 :: uu___50 in
+                                                    uu___47 :: uu___48 in
+                                                  uu___45 :: uu___46 in
+                                                uu___43 :: uu___44 in
+                                              uu___41 :: uu___42 in
+                                            uu___39 :: uu___40 in
+                                          uu___37 :: uu___38 in
+                                        uu___35 :: uu___36 in
+                                      uu___33 :: uu___34 in
+                                    uu___31 :: uu___32 in
+                                  uu___29 :: uu___30 in
+                                uu___27 :: uu___28 in
+                              uu___25 :: uu___26 in
+                            uu___23 :: uu___24 in
+                          uu___21 :: uu___22 in
+                        uu___19 :: uu___20 in
+                      uu___17 :: uu___18 in
+                    uu___15 :: uu___16 in
+                  uu___13 :: uu___14 in
+                uu___11 :: uu___12 in
+              uu___9 :: uu___10 in
+            uu___7 :: uu___8 in
+          uu___5 :: uu___6 in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     FStar_Util.format
       "{\nbeta = %s;\niota = %s;\nzeta = %s;\nzeta_full = %s;\nweak = %s;\nhnf  = %s;\nprimops = %s;\ndo_not_unfold_pure_lets = %s;\nunfold_until = %s;\nunfold_only = %s;\nunfold_fully = %s;\nunfold_attr = %s;\nunfold_tac = %s;\npure_subterms_within_computations = %s;\nsimplify = %s;\nerase_universes = %s;\nallow_unbound_universes = %s;\nreify_ = %s;\ncompress_uvars = %s;\nno_full_norm = %s;\ncheck_no_uvars = %s;\nunmeta = %s;\nunascribe = %s;\nin_full_norm_request = %s;\nweakly_reduce_scrutinee = %s;\nfor_extraction = %s;\n}"
-      uu____1515
+      uu___
 let (default_steps : fsteps) =
   {
     beta = true;
@@ -490,901 +488,901 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
     fun fs ->
       match s with
       | FStar_TypeChecker_Env.Beta ->
-          let uu___97_1685 = fs in
+          let uu___ = fs in
           {
             beta = true;
-            iota = (uu___97_1685.iota);
-            zeta = (uu___97_1685.zeta);
-            zeta_full = (uu___97_1685.zeta_full);
-            weak = (uu___97_1685.weak);
-            hnf = (uu___97_1685.hnf);
-            primops = (uu___97_1685.primops);
-            do_not_unfold_pure_lets = (uu___97_1685.do_not_unfold_pure_lets);
-            unfold_until = (uu___97_1685.unfold_until);
-            unfold_only = (uu___97_1685.unfold_only);
-            unfold_fully = (uu___97_1685.unfold_fully);
-            unfold_attr = (uu___97_1685.unfold_attr);
-            unfold_tac = (uu___97_1685.unfold_tac);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___97_1685.pure_subterms_within_computations);
-            simplify = (uu___97_1685.simplify);
-            erase_universes = (uu___97_1685.erase_universes);
-            allow_unbound_universes = (uu___97_1685.allow_unbound_universes);
-            reify_ = (uu___97_1685.reify_);
-            compress_uvars = (uu___97_1685.compress_uvars);
-            no_full_norm = (uu___97_1685.no_full_norm);
-            check_no_uvars = (uu___97_1685.check_no_uvars);
-            unmeta = (uu___97_1685.unmeta);
-            unascribe = (uu___97_1685.unascribe);
-            in_full_norm_request = (uu___97_1685.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___97_1685.weakly_reduce_scrutinee);
-            nbe_step = (uu___97_1685.nbe_step);
-            for_extraction = (uu___97_1685.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Iota ->
-          let uu___100_1686 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___100_1686.beta);
+            beta = (uu___.beta);
             iota = true;
-            zeta = (uu___100_1686.zeta);
-            zeta_full = (uu___100_1686.zeta_full);
-            weak = (uu___100_1686.weak);
-            hnf = (uu___100_1686.hnf);
-            primops = (uu___100_1686.primops);
-            do_not_unfold_pure_lets = (uu___100_1686.do_not_unfold_pure_lets);
-            unfold_until = (uu___100_1686.unfold_until);
-            unfold_only = (uu___100_1686.unfold_only);
-            unfold_fully = (uu___100_1686.unfold_fully);
-            unfold_attr = (uu___100_1686.unfold_attr);
-            unfold_tac = (uu___100_1686.unfold_tac);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___100_1686.pure_subterms_within_computations);
-            simplify = (uu___100_1686.simplify);
-            erase_universes = (uu___100_1686.erase_universes);
-            allow_unbound_universes = (uu___100_1686.allow_unbound_universes);
-            reify_ = (uu___100_1686.reify_);
-            compress_uvars = (uu___100_1686.compress_uvars);
-            no_full_norm = (uu___100_1686.no_full_norm);
-            check_no_uvars = (uu___100_1686.check_no_uvars);
-            unmeta = (uu___100_1686.unmeta);
-            unascribe = (uu___100_1686.unascribe);
-            in_full_norm_request = (uu___100_1686.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___100_1686.weakly_reduce_scrutinee);
-            nbe_step = (uu___100_1686.nbe_step);
-            for_extraction = (uu___100_1686.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Zeta ->
-          let uu___103_1687 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___103_1687.beta);
-            iota = (uu___103_1687.iota);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
             zeta = true;
-            zeta_full = (uu___103_1687.zeta_full);
-            weak = (uu___103_1687.weak);
-            hnf = (uu___103_1687.hnf);
-            primops = (uu___103_1687.primops);
-            do_not_unfold_pure_lets = (uu___103_1687.do_not_unfold_pure_lets);
-            unfold_until = (uu___103_1687.unfold_until);
-            unfold_only = (uu___103_1687.unfold_only);
-            unfold_fully = (uu___103_1687.unfold_fully);
-            unfold_attr = (uu___103_1687.unfold_attr);
-            unfold_tac = (uu___103_1687.unfold_tac);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___103_1687.pure_subterms_within_computations);
-            simplify = (uu___103_1687.simplify);
-            erase_universes = (uu___103_1687.erase_universes);
-            allow_unbound_universes = (uu___103_1687.allow_unbound_universes);
-            reify_ = (uu___103_1687.reify_);
-            compress_uvars = (uu___103_1687.compress_uvars);
-            no_full_norm = (uu___103_1687.no_full_norm);
-            check_no_uvars = (uu___103_1687.check_no_uvars);
-            unmeta = (uu___103_1687.unmeta);
-            unascribe = (uu___103_1687.unascribe);
-            in_full_norm_request = (uu___103_1687.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___103_1687.weakly_reduce_scrutinee);
-            nbe_step = (uu___103_1687.nbe_step);
-            for_extraction = (uu___103_1687.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.ZetaFull ->
-          let uu___106_1688 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___106_1688.beta);
-            iota = (uu___106_1688.iota);
-            zeta = (uu___106_1688.zeta);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
             zeta_full = true;
-            weak = (uu___106_1688.weak);
-            hnf = (uu___106_1688.hnf);
-            primops = (uu___106_1688.primops);
-            do_not_unfold_pure_lets = (uu___106_1688.do_not_unfold_pure_lets);
-            unfold_until = (uu___106_1688.unfold_until);
-            unfold_only = (uu___106_1688.unfold_only);
-            unfold_fully = (uu___106_1688.unfold_fully);
-            unfold_attr = (uu___106_1688.unfold_attr);
-            unfold_tac = (uu___106_1688.unfold_tac);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___106_1688.pure_subterms_within_computations);
-            simplify = (uu___106_1688.simplify);
-            erase_universes = (uu___106_1688.erase_universes);
-            allow_unbound_universes = (uu___106_1688.allow_unbound_universes);
-            reify_ = (uu___106_1688.reify_);
-            compress_uvars = (uu___106_1688.compress_uvars);
-            no_full_norm = (uu___106_1688.no_full_norm);
-            check_no_uvars = (uu___106_1688.check_no_uvars);
-            unmeta = (uu___106_1688.unmeta);
-            unascribe = (uu___106_1688.unascribe);
-            in_full_norm_request = (uu___106_1688.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___106_1688.weakly_reduce_scrutinee);
-            nbe_step = (uu___106_1688.nbe_step);
-            for_extraction = (uu___106_1688.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Beta) ->
-          let uu___110_1689 = fs in
+          let uu___ = fs in
           {
             beta = false;
-            iota = (uu___110_1689.iota);
-            zeta = (uu___110_1689.zeta);
-            zeta_full = (uu___110_1689.zeta_full);
-            weak = (uu___110_1689.weak);
-            hnf = (uu___110_1689.hnf);
-            primops = (uu___110_1689.primops);
-            do_not_unfold_pure_lets = (uu___110_1689.do_not_unfold_pure_lets);
-            unfold_until = (uu___110_1689.unfold_until);
-            unfold_only = (uu___110_1689.unfold_only);
-            unfold_fully = (uu___110_1689.unfold_fully);
-            unfold_attr = (uu___110_1689.unfold_attr);
-            unfold_tac = (uu___110_1689.unfold_tac);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___110_1689.pure_subterms_within_computations);
-            simplify = (uu___110_1689.simplify);
-            erase_universes = (uu___110_1689.erase_universes);
-            allow_unbound_universes = (uu___110_1689.allow_unbound_universes);
-            reify_ = (uu___110_1689.reify_);
-            compress_uvars = (uu___110_1689.compress_uvars);
-            no_full_norm = (uu___110_1689.no_full_norm);
-            check_no_uvars = (uu___110_1689.check_no_uvars);
-            unmeta = (uu___110_1689.unmeta);
-            unascribe = (uu___110_1689.unascribe);
-            in_full_norm_request = (uu___110_1689.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___110_1689.weakly_reduce_scrutinee);
-            nbe_step = (uu___110_1689.nbe_step);
-            for_extraction = (uu___110_1689.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Iota) ->
-          let uu___114_1690 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___114_1690.beta);
+            beta = (uu___.beta);
             iota = false;
-            zeta = (uu___114_1690.zeta);
-            zeta_full = (uu___114_1690.zeta_full);
-            weak = (uu___114_1690.weak);
-            hnf = (uu___114_1690.hnf);
-            primops = (uu___114_1690.primops);
-            do_not_unfold_pure_lets = (uu___114_1690.do_not_unfold_pure_lets);
-            unfold_until = (uu___114_1690.unfold_until);
-            unfold_only = (uu___114_1690.unfold_only);
-            unfold_fully = (uu___114_1690.unfold_fully);
-            unfold_attr = (uu___114_1690.unfold_attr);
-            unfold_tac = (uu___114_1690.unfold_tac);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___114_1690.pure_subterms_within_computations);
-            simplify = (uu___114_1690.simplify);
-            erase_universes = (uu___114_1690.erase_universes);
-            allow_unbound_universes = (uu___114_1690.allow_unbound_universes);
-            reify_ = (uu___114_1690.reify_);
-            compress_uvars = (uu___114_1690.compress_uvars);
-            no_full_norm = (uu___114_1690.no_full_norm);
-            check_no_uvars = (uu___114_1690.check_no_uvars);
-            unmeta = (uu___114_1690.unmeta);
-            unascribe = (uu___114_1690.unascribe);
-            in_full_norm_request = (uu___114_1690.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___114_1690.weakly_reduce_scrutinee);
-            nbe_step = (uu___114_1690.nbe_step);
-            for_extraction = (uu___114_1690.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Zeta) ->
-          let uu___118_1691 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___118_1691.beta);
-            iota = (uu___118_1691.iota);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
             zeta = false;
-            zeta_full = (uu___118_1691.zeta_full);
-            weak = (uu___118_1691.weak);
-            hnf = (uu___118_1691.hnf);
-            primops = (uu___118_1691.primops);
-            do_not_unfold_pure_lets = (uu___118_1691.do_not_unfold_pure_lets);
-            unfold_until = (uu___118_1691.unfold_until);
-            unfold_only = (uu___118_1691.unfold_only);
-            unfold_fully = (uu___118_1691.unfold_fully);
-            unfold_attr = (uu___118_1691.unfold_attr);
-            unfold_tac = (uu___118_1691.unfold_tac);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___118_1691.pure_subterms_within_computations);
-            simplify = (uu___118_1691.simplify);
-            erase_universes = (uu___118_1691.erase_universes);
-            allow_unbound_universes = (uu___118_1691.allow_unbound_universes);
-            reify_ = (uu___118_1691.reify_);
-            compress_uvars = (uu___118_1691.compress_uvars);
-            no_full_norm = (uu___118_1691.no_full_norm);
-            check_no_uvars = (uu___118_1691.check_no_uvars);
-            unmeta = (uu___118_1691.unmeta);
-            unascribe = (uu___118_1691.unascribe);
-            in_full_norm_request = (uu___118_1691.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___118_1691.weakly_reduce_scrutinee);
-            nbe_step = (uu___118_1691.nbe_step);
-            for_extraction = (uu___118_1691.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
-      | FStar_TypeChecker_Env.Exclude uu____1692 -> failwith "Bad exclude"
+      | FStar_TypeChecker_Env.Exclude uu___ -> failwith "Bad exclude"
       | FStar_TypeChecker_Env.Weak ->
-          let uu___123_1693 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___123_1693.beta);
-            iota = (uu___123_1693.iota);
-            zeta = (uu___123_1693.zeta);
-            zeta_full = (uu___123_1693.zeta_full);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
             weak = true;
-            hnf = (uu___123_1693.hnf);
-            primops = (uu___123_1693.primops);
-            do_not_unfold_pure_lets = (uu___123_1693.do_not_unfold_pure_lets);
-            unfold_until = (uu___123_1693.unfold_until);
-            unfold_only = (uu___123_1693.unfold_only);
-            unfold_fully = (uu___123_1693.unfold_fully);
-            unfold_attr = (uu___123_1693.unfold_attr);
-            unfold_tac = (uu___123_1693.unfold_tac);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___123_1693.pure_subterms_within_computations);
-            simplify = (uu___123_1693.simplify);
-            erase_universes = (uu___123_1693.erase_universes);
-            allow_unbound_universes = (uu___123_1693.allow_unbound_universes);
-            reify_ = (uu___123_1693.reify_);
-            compress_uvars = (uu___123_1693.compress_uvars);
-            no_full_norm = (uu___123_1693.no_full_norm);
-            check_no_uvars = (uu___123_1693.check_no_uvars);
-            unmeta = (uu___123_1693.unmeta);
-            unascribe = (uu___123_1693.unascribe);
-            in_full_norm_request = (uu___123_1693.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___123_1693.weakly_reduce_scrutinee);
-            nbe_step = (uu___123_1693.nbe_step);
-            for_extraction = (uu___123_1693.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.HNF ->
-          let uu___126_1694 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___126_1694.beta);
-            iota = (uu___126_1694.iota);
-            zeta = (uu___126_1694.zeta);
-            zeta_full = (uu___126_1694.zeta_full);
-            weak = (uu___126_1694.weak);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
             hnf = true;
-            primops = (uu___126_1694.primops);
-            do_not_unfold_pure_lets = (uu___126_1694.do_not_unfold_pure_lets);
-            unfold_until = (uu___126_1694.unfold_until);
-            unfold_only = (uu___126_1694.unfold_only);
-            unfold_fully = (uu___126_1694.unfold_fully);
-            unfold_attr = (uu___126_1694.unfold_attr);
-            unfold_tac = (uu___126_1694.unfold_tac);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___126_1694.pure_subterms_within_computations);
-            simplify = (uu___126_1694.simplify);
-            erase_universes = (uu___126_1694.erase_universes);
-            allow_unbound_universes = (uu___126_1694.allow_unbound_universes);
-            reify_ = (uu___126_1694.reify_);
-            compress_uvars = (uu___126_1694.compress_uvars);
-            no_full_norm = (uu___126_1694.no_full_norm);
-            check_no_uvars = (uu___126_1694.check_no_uvars);
-            unmeta = (uu___126_1694.unmeta);
-            unascribe = (uu___126_1694.unascribe);
-            in_full_norm_request = (uu___126_1694.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___126_1694.weakly_reduce_scrutinee);
-            nbe_step = (uu___126_1694.nbe_step);
-            for_extraction = (uu___126_1694.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Primops ->
-          let uu___129_1695 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___129_1695.beta);
-            iota = (uu___129_1695.iota);
-            zeta = (uu___129_1695.zeta);
-            zeta_full = (uu___129_1695.zeta_full);
-            weak = (uu___129_1695.weak);
-            hnf = (uu___129_1695.hnf);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
             primops = true;
-            do_not_unfold_pure_lets = (uu___129_1695.do_not_unfold_pure_lets);
-            unfold_until = (uu___129_1695.unfold_until);
-            unfold_only = (uu___129_1695.unfold_only);
-            unfold_fully = (uu___129_1695.unfold_fully);
-            unfold_attr = (uu___129_1695.unfold_attr);
-            unfold_tac = (uu___129_1695.unfold_tac);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___129_1695.pure_subterms_within_computations);
-            simplify = (uu___129_1695.simplify);
-            erase_universes = (uu___129_1695.erase_universes);
-            allow_unbound_universes = (uu___129_1695.allow_unbound_universes);
-            reify_ = (uu___129_1695.reify_);
-            compress_uvars = (uu___129_1695.compress_uvars);
-            no_full_norm = (uu___129_1695.no_full_norm);
-            check_no_uvars = (uu___129_1695.check_no_uvars);
-            unmeta = (uu___129_1695.unmeta);
-            unascribe = (uu___129_1695.unascribe);
-            in_full_norm_request = (uu___129_1695.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___129_1695.weakly_reduce_scrutinee);
-            nbe_step = (uu___129_1695.nbe_step);
-            for_extraction = (uu___129_1695.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Eager_unfolding -> fs
       | FStar_TypeChecker_Env.Inlining -> fs
       | FStar_TypeChecker_Env.DoNotUnfoldPureLets ->
-          let uu___134_1696 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___134_1696.beta);
-            iota = (uu___134_1696.iota);
-            zeta = (uu___134_1696.zeta);
-            zeta_full = (uu___134_1696.zeta_full);
-            weak = (uu___134_1696.weak);
-            hnf = (uu___134_1696.hnf);
-            primops = (uu___134_1696.primops);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
             do_not_unfold_pure_lets = true;
-            unfold_until = (uu___134_1696.unfold_until);
-            unfold_only = (uu___134_1696.unfold_only);
-            unfold_fully = (uu___134_1696.unfold_fully);
-            unfold_attr = (uu___134_1696.unfold_attr);
-            unfold_tac = (uu___134_1696.unfold_tac);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___134_1696.pure_subterms_within_computations);
-            simplify = (uu___134_1696.simplify);
-            erase_universes = (uu___134_1696.erase_universes);
-            allow_unbound_universes = (uu___134_1696.allow_unbound_universes);
-            reify_ = (uu___134_1696.reify_);
-            compress_uvars = (uu___134_1696.compress_uvars);
-            no_full_norm = (uu___134_1696.no_full_norm);
-            check_no_uvars = (uu___134_1696.check_no_uvars);
-            unmeta = (uu___134_1696.unmeta);
-            unascribe = (uu___134_1696.unascribe);
-            in_full_norm_request = (uu___134_1696.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___134_1696.weakly_reduce_scrutinee);
-            nbe_step = (uu___134_1696.nbe_step);
-            for_extraction = (uu___134_1696.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.UnfoldUntil d ->
-          let uu___138_1698 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___138_1698.beta);
-            iota = (uu___138_1698.iota);
-            zeta = (uu___138_1698.zeta);
-            zeta_full = (uu___138_1698.zeta_full);
-            weak = (uu___138_1698.weak);
-            hnf = (uu___138_1698.hnf);
-            primops = (uu___138_1698.primops);
-            do_not_unfold_pure_lets = (uu___138_1698.do_not_unfold_pure_lets);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
             unfold_until = (FStar_Pervasives_Native.Some d);
-            unfold_only = (uu___138_1698.unfold_only);
-            unfold_fully = (uu___138_1698.unfold_fully);
-            unfold_attr = (uu___138_1698.unfold_attr);
-            unfold_tac = (uu___138_1698.unfold_tac);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___138_1698.pure_subterms_within_computations);
-            simplify = (uu___138_1698.simplify);
-            erase_universes = (uu___138_1698.erase_universes);
-            allow_unbound_universes = (uu___138_1698.allow_unbound_universes);
-            reify_ = (uu___138_1698.reify_);
-            compress_uvars = (uu___138_1698.compress_uvars);
-            no_full_norm = (uu___138_1698.no_full_norm);
-            check_no_uvars = (uu___138_1698.check_no_uvars);
-            unmeta = (uu___138_1698.unmeta);
-            unascribe = (uu___138_1698.unascribe);
-            in_full_norm_request = (uu___138_1698.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___138_1698.weakly_reduce_scrutinee);
-            nbe_step = (uu___138_1698.nbe_step);
-            for_extraction = (uu___138_1698.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.UnfoldOnly lids ->
-          let uu___142_1702 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___142_1702.beta);
-            iota = (uu___142_1702.iota);
-            zeta = (uu___142_1702.zeta);
-            zeta_full = (uu___142_1702.zeta_full);
-            weak = (uu___142_1702.weak);
-            hnf = (uu___142_1702.hnf);
-            primops = (uu___142_1702.primops);
-            do_not_unfold_pure_lets = (uu___142_1702.do_not_unfold_pure_lets);
-            unfold_until = (uu___142_1702.unfold_until);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
             unfold_only = (FStar_Pervasives_Native.Some lids);
-            unfold_fully = (uu___142_1702.unfold_fully);
-            unfold_attr = (uu___142_1702.unfold_attr);
-            unfold_tac = (uu___142_1702.unfold_tac);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___142_1702.pure_subterms_within_computations);
-            simplify = (uu___142_1702.simplify);
-            erase_universes = (uu___142_1702.erase_universes);
-            allow_unbound_universes = (uu___142_1702.allow_unbound_universes);
-            reify_ = (uu___142_1702.reify_);
-            compress_uvars = (uu___142_1702.compress_uvars);
-            no_full_norm = (uu___142_1702.no_full_norm);
-            check_no_uvars = (uu___142_1702.check_no_uvars);
-            unmeta = (uu___142_1702.unmeta);
-            unascribe = (uu___142_1702.unascribe);
-            in_full_norm_request = (uu___142_1702.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___142_1702.weakly_reduce_scrutinee);
-            nbe_step = (uu___142_1702.nbe_step);
-            for_extraction = (uu___142_1702.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.UnfoldFully lids ->
-          let uu___146_1708 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___146_1708.beta);
-            iota = (uu___146_1708.iota);
-            zeta = (uu___146_1708.zeta);
-            zeta_full = (uu___146_1708.zeta_full);
-            weak = (uu___146_1708.weak);
-            hnf = (uu___146_1708.hnf);
-            primops = (uu___146_1708.primops);
-            do_not_unfold_pure_lets = (uu___146_1708.do_not_unfold_pure_lets);
-            unfold_until = (uu___146_1708.unfold_until);
-            unfold_only = (uu___146_1708.unfold_only);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
             unfold_fully = (FStar_Pervasives_Native.Some lids);
-            unfold_attr = (uu___146_1708.unfold_attr);
-            unfold_tac = (uu___146_1708.unfold_tac);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___146_1708.pure_subterms_within_computations);
-            simplify = (uu___146_1708.simplify);
-            erase_universes = (uu___146_1708.erase_universes);
-            allow_unbound_universes = (uu___146_1708.allow_unbound_universes);
-            reify_ = (uu___146_1708.reify_);
-            compress_uvars = (uu___146_1708.compress_uvars);
-            no_full_norm = (uu___146_1708.no_full_norm);
-            check_no_uvars = (uu___146_1708.check_no_uvars);
-            unmeta = (uu___146_1708.unmeta);
-            unascribe = (uu___146_1708.unascribe);
-            in_full_norm_request = (uu___146_1708.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___146_1708.weakly_reduce_scrutinee);
-            nbe_step = (uu___146_1708.nbe_step);
-            for_extraction = (uu___146_1708.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.UnfoldAttr lids ->
-          let uu___150_1714 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___150_1714.beta);
-            iota = (uu___150_1714.iota);
-            zeta = (uu___150_1714.zeta);
-            zeta_full = (uu___150_1714.zeta_full);
-            weak = (uu___150_1714.weak);
-            hnf = (uu___150_1714.hnf);
-            primops = (uu___150_1714.primops);
-            do_not_unfold_pure_lets = (uu___150_1714.do_not_unfold_pure_lets);
-            unfold_until = (uu___150_1714.unfold_until);
-            unfold_only = (uu___150_1714.unfold_only);
-            unfold_fully = (uu___150_1714.unfold_fully);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
             unfold_attr = (FStar_Pervasives_Native.Some lids);
-            unfold_tac = (uu___150_1714.unfold_tac);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___150_1714.pure_subterms_within_computations);
-            simplify = (uu___150_1714.simplify);
-            erase_universes = (uu___150_1714.erase_universes);
-            allow_unbound_universes = (uu___150_1714.allow_unbound_universes);
-            reify_ = (uu___150_1714.reify_);
-            compress_uvars = (uu___150_1714.compress_uvars);
-            no_full_norm = (uu___150_1714.no_full_norm);
-            check_no_uvars = (uu___150_1714.check_no_uvars);
-            unmeta = (uu___150_1714.unmeta);
-            unascribe = (uu___150_1714.unascribe);
-            in_full_norm_request = (uu___150_1714.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___150_1714.weakly_reduce_scrutinee);
-            nbe_step = (uu___150_1714.nbe_step);
-            for_extraction = (uu___150_1714.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.UnfoldTac ->
-          let uu___153_1717 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___153_1717.beta);
-            iota = (uu___153_1717.iota);
-            zeta = (uu___153_1717.zeta);
-            zeta_full = (uu___153_1717.zeta_full);
-            weak = (uu___153_1717.weak);
-            hnf = (uu___153_1717.hnf);
-            primops = (uu___153_1717.primops);
-            do_not_unfold_pure_lets = (uu___153_1717.do_not_unfold_pure_lets);
-            unfold_until = (uu___153_1717.unfold_until);
-            unfold_only = (uu___153_1717.unfold_only);
-            unfold_fully = (uu___153_1717.unfold_fully);
-            unfold_attr = (uu___153_1717.unfold_attr);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
             unfold_tac = true;
             pure_subterms_within_computations =
-              (uu___153_1717.pure_subterms_within_computations);
-            simplify = (uu___153_1717.simplify);
-            erase_universes = (uu___153_1717.erase_universes);
-            allow_unbound_universes = (uu___153_1717.allow_unbound_universes);
-            reify_ = (uu___153_1717.reify_);
-            compress_uvars = (uu___153_1717.compress_uvars);
-            no_full_norm = (uu___153_1717.no_full_norm);
-            check_no_uvars = (uu___153_1717.check_no_uvars);
-            unmeta = (uu___153_1717.unmeta);
-            unascribe = (uu___153_1717.unascribe);
-            in_full_norm_request = (uu___153_1717.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___153_1717.weakly_reduce_scrutinee);
-            nbe_step = (uu___153_1717.nbe_step);
-            for_extraction = (uu___153_1717.for_extraction)
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.PureSubtermsWithinComputations ->
-          let uu___156_1718 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___156_1718.beta);
-            iota = (uu___156_1718.iota);
-            zeta = (uu___156_1718.zeta);
-            zeta_full = (uu___156_1718.zeta_full);
-            weak = (uu___156_1718.weak);
-            hnf = (uu___156_1718.hnf);
-            primops = (uu___156_1718.primops);
-            do_not_unfold_pure_lets = (uu___156_1718.do_not_unfold_pure_lets);
-            unfold_until = (uu___156_1718.unfold_until);
-            unfold_only = (uu___156_1718.unfold_only);
-            unfold_fully = (uu___156_1718.unfold_fully);
-            unfold_attr = (uu___156_1718.unfold_attr);
-            unfold_tac = (uu___156_1718.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations = true;
-            simplify = (uu___156_1718.simplify);
-            erase_universes = (uu___156_1718.erase_universes);
-            allow_unbound_universes = (uu___156_1718.allow_unbound_universes);
-            reify_ = (uu___156_1718.reify_);
-            compress_uvars = (uu___156_1718.compress_uvars);
-            no_full_norm = (uu___156_1718.no_full_norm);
-            check_no_uvars = (uu___156_1718.check_no_uvars);
-            unmeta = (uu___156_1718.unmeta);
-            unascribe = (uu___156_1718.unascribe);
-            in_full_norm_request = (uu___156_1718.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___156_1718.weakly_reduce_scrutinee);
-            nbe_step = (uu___156_1718.nbe_step);
-            for_extraction = (uu___156_1718.for_extraction)
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Simplify ->
-          let uu___159_1719 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___159_1719.beta);
-            iota = (uu___159_1719.iota);
-            zeta = (uu___159_1719.zeta);
-            zeta_full = (uu___159_1719.zeta_full);
-            weak = (uu___159_1719.weak);
-            hnf = (uu___159_1719.hnf);
-            primops = (uu___159_1719.primops);
-            do_not_unfold_pure_lets = (uu___159_1719.do_not_unfold_pure_lets);
-            unfold_until = (uu___159_1719.unfold_until);
-            unfold_only = (uu___159_1719.unfold_only);
-            unfold_fully = (uu___159_1719.unfold_fully);
-            unfold_attr = (uu___159_1719.unfold_attr);
-            unfold_tac = (uu___159_1719.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___159_1719.pure_subterms_within_computations);
+              (uu___.pure_subterms_within_computations);
             simplify = true;
-            erase_universes = (uu___159_1719.erase_universes);
-            allow_unbound_universes = (uu___159_1719.allow_unbound_universes);
-            reify_ = (uu___159_1719.reify_);
-            compress_uvars = (uu___159_1719.compress_uvars);
-            no_full_norm = (uu___159_1719.no_full_norm);
-            check_no_uvars = (uu___159_1719.check_no_uvars);
-            unmeta = (uu___159_1719.unmeta);
-            unascribe = (uu___159_1719.unascribe);
-            in_full_norm_request = (uu___159_1719.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___159_1719.weakly_reduce_scrutinee);
-            nbe_step = (uu___159_1719.nbe_step);
-            for_extraction = (uu___159_1719.for_extraction)
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.EraseUniverses ->
-          let uu___162_1720 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___162_1720.beta);
-            iota = (uu___162_1720.iota);
-            zeta = (uu___162_1720.zeta);
-            zeta_full = (uu___162_1720.zeta_full);
-            weak = (uu___162_1720.weak);
-            hnf = (uu___162_1720.hnf);
-            primops = (uu___162_1720.primops);
-            do_not_unfold_pure_lets = (uu___162_1720.do_not_unfold_pure_lets);
-            unfold_until = (uu___162_1720.unfold_until);
-            unfold_only = (uu___162_1720.unfold_only);
-            unfold_fully = (uu___162_1720.unfold_fully);
-            unfold_attr = (uu___162_1720.unfold_attr);
-            unfold_tac = (uu___162_1720.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___162_1720.pure_subterms_within_computations);
-            simplify = (uu___162_1720.simplify);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
             erase_universes = true;
-            allow_unbound_universes = (uu___162_1720.allow_unbound_universes);
-            reify_ = (uu___162_1720.reify_);
-            compress_uvars = (uu___162_1720.compress_uvars);
-            no_full_norm = (uu___162_1720.no_full_norm);
-            check_no_uvars = (uu___162_1720.check_no_uvars);
-            unmeta = (uu___162_1720.unmeta);
-            unascribe = (uu___162_1720.unascribe);
-            in_full_norm_request = (uu___162_1720.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___162_1720.weakly_reduce_scrutinee);
-            nbe_step = (uu___162_1720.nbe_step);
-            for_extraction = (uu___162_1720.for_extraction)
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.AllowUnboundUniverses ->
-          let uu___165_1721 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___165_1721.beta);
-            iota = (uu___165_1721.iota);
-            zeta = (uu___165_1721.zeta);
-            zeta_full = (uu___165_1721.zeta_full);
-            weak = (uu___165_1721.weak);
-            hnf = (uu___165_1721.hnf);
-            primops = (uu___165_1721.primops);
-            do_not_unfold_pure_lets = (uu___165_1721.do_not_unfold_pure_lets);
-            unfold_until = (uu___165_1721.unfold_until);
-            unfold_only = (uu___165_1721.unfold_only);
-            unfold_fully = (uu___165_1721.unfold_fully);
-            unfold_attr = (uu___165_1721.unfold_attr);
-            unfold_tac = (uu___165_1721.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___165_1721.pure_subterms_within_computations);
-            simplify = (uu___165_1721.simplify);
-            erase_universes = (uu___165_1721.erase_universes);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
             allow_unbound_universes = true;
-            reify_ = (uu___165_1721.reify_);
-            compress_uvars = (uu___165_1721.compress_uvars);
-            no_full_norm = (uu___165_1721.no_full_norm);
-            check_no_uvars = (uu___165_1721.check_no_uvars);
-            unmeta = (uu___165_1721.unmeta);
-            unascribe = (uu___165_1721.unascribe);
-            in_full_norm_request = (uu___165_1721.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___165_1721.weakly_reduce_scrutinee);
-            nbe_step = (uu___165_1721.nbe_step);
-            for_extraction = (uu___165_1721.for_extraction)
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Reify ->
-          let uu___168_1722 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___168_1722.beta);
-            iota = (uu___168_1722.iota);
-            zeta = (uu___168_1722.zeta);
-            zeta_full = (uu___168_1722.zeta_full);
-            weak = (uu___168_1722.weak);
-            hnf = (uu___168_1722.hnf);
-            primops = (uu___168_1722.primops);
-            do_not_unfold_pure_lets = (uu___168_1722.do_not_unfold_pure_lets);
-            unfold_until = (uu___168_1722.unfold_until);
-            unfold_only = (uu___168_1722.unfold_only);
-            unfold_fully = (uu___168_1722.unfold_fully);
-            unfold_attr = (uu___168_1722.unfold_attr);
-            unfold_tac = (uu___168_1722.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___168_1722.pure_subterms_within_computations);
-            simplify = (uu___168_1722.simplify);
-            erase_universes = (uu___168_1722.erase_universes);
-            allow_unbound_universes = (uu___168_1722.allow_unbound_universes);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
             reify_ = true;
-            compress_uvars = (uu___168_1722.compress_uvars);
-            no_full_norm = (uu___168_1722.no_full_norm);
-            check_no_uvars = (uu___168_1722.check_no_uvars);
-            unmeta = (uu___168_1722.unmeta);
-            unascribe = (uu___168_1722.unascribe);
-            in_full_norm_request = (uu___168_1722.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___168_1722.weakly_reduce_scrutinee);
-            nbe_step = (uu___168_1722.nbe_step);
-            for_extraction = (uu___168_1722.for_extraction)
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.CompressUvars ->
-          let uu___171_1723 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___171_1723.beta);
-            iota = (uu___171_1723.iota);
-            zeta = (uu___171_1723.zeta);
-            zeta_full = (uu___171_1723.zeta_full);
-            weak = (uu___171_1723.weak);
-            hnf = (uu___171_1723.hnf);
-            primops = (uu___171_1723.primops);
-            do_not_unfold_pure_lets = (uu___171_1723.do_not_unfold_pure_lets);
-            unfold_until = (uu___171_1723.unfold_until);
-            unfold_only = (uu___171_1723.unfold_only);
-            unfold_fully = (uu___171_1723.unfold_fully);
-            unfold_attr = (uu___171_1723.unfold_attr);
-            unfold_tac = (uu___171_1723.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___171_1723.pure_subterms_within_computations);
-            simplify = (uu___171_1723.simplify);
-            erase_universes = (uu___171_1723.erase_universes);
-            allow_unbound_universes = (uu___171_1723.allow_unbound_universes);
-            reify_ = (uu___171_1723.reify_);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
             compress_uvars = true;
-            no_full_norm = (uu___171_1723.no_full_norm);
-            check_no_uvars = (uu___171_1723.check_no_uvars);
-            unmeta = (uu___171_1723.unmeta);
-            unascribe = (uu___171_1723.unascribe);
-            in_full_norm_request = (uu___171_1723.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___171_1723.weakly_reduce_scrutinee);
-            nbe_step = (uu___171_1723.nbe_step);
-            for_extraction = (uu___171_1723.for_extraction)
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.NoFullNorm ->
-          let uu___174_1724 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___174_1724.beta);
-            iota = (uu___174_1724.iota);
-            zeta = (uu___174_1724.zeta);
-            zeta_full = (uu___174_1724.zeta_full);
-            weak = (uu___174_1724.weak);
-            hnf = (uu___174_1724.hnf);
-            primops = (uu___174_1724.primops);
-            do_not_unfold_pure_lets = (uu___174_1724.do_not_unfold_pure_lets);
-            unfold_until = (uu___174_1724.unfold_until);
-            unfold_only = (uu___174_1724.unfold_only);
-            unfold_fully = (uu___174_1724.unfold_fully);
-            unfold_attr = (uu___174_1724.unfold_attr);
-            unfold_tac = (uu___174_1724.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___174_1724.pure_subterms_within_computations);
-            simplify = (uu___174_1724.simplify);
-            erase_universes = (uu___174_1724.erase_universes);
-            allow_unbound_universes = (uu___174_1724.allow_unbound_universes);
-            reify_ = (uu___174_1724.reify_);
-            compress_uvars = (uu___174_1724.compress_uvars);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
             no_full_norm = true;
-            check_no_uvars = (uu___174_1724.check_no_uvars);
-            unmeta = (uu___174_1724.unmeta);
-            unascribe = (uu___174_1724.unascribe);
-            in_full_norm_request = (uu___174_1724.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___174_1724.weakly_reduce_scrutinee);
-            nbe_step = (uu___174_1724.nbe_step);
-            for_extraction = (uu___174_1724.for_extraction)
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.CheckNoUvars ->
-          let uu___177_1725 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___177_1725.beta);
-            iota = (uu___177_1725.iota);
-            zeta = (uu___177_1725.zeta);
-            zeta_full = (uu___177_1725.zeta_full);
-            weak = (uu___177_1725.weak);
-            hnf = (uu___177_1725.hnf);
-            primops = (uu___177_1725.primops);
-            do_not_unfold_pure_lets = (uu___177_1725.do_not_unfold_pure_lets);
-            unfold_until = (uu___177_1725.unfold_until);
-            unfold_only = (uu___177_1725.unfold_only);
-            unfold_fully = (uu___177_1725.unfold_fully);
-            unfold_attr = (uu___177_1725.unfold_attr);
-            unfold_tac = (uu___177_1725.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___177_1725.pure_subterms_within_computations);
-            simplify = (uu___177_1725.simplify);
-            erase_universes = (uu___177_1725.erase_universes);
-            allow_unbound_universes = (uu___177_1725.allow_unbound_universes);
-            reify_ = (uu___177_1725.reify_);
-            compress_uvars = (uu___177_1725.compress_uvars);
-            no_full_norm = (uu___177_1725.no_full_norm);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
             check_no_uvars = true;
-            unmeta = (uu___177_1725.unmeta);
-            unascribe = (uu___177_1725.unascribe);
-            in_full_norm_request = (uu___177_1725.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___177_1725.weakly_reduce_scrutinee);
-            nbe_step = (uu___177_1725.nbe_step);
-            for_extraction = (uu___177_1725.for_extraction)
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Unmeta ->
-          let uu___180_1726 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___180_1726.beta);
-            iota = (uu___180_1726.iota);
-            zeta = (uu___180_1726.zeta);
-            zeta_full = (uu___180_1726.zeta_full);
-            weak = (uu___180_1726.weak);
-            hnf = (uu___180_1726.hnf);
-            primops = (uu___180_1726.primops);
-            do_not_unfold_pure_lets = (uu___180_1726.do_not_unfold_pure_lets);
-            unfold_until = (uu___180_1726.unfold_until);
-            unfold_only = (uu___180_1726.unfold_only);
-            unfold_fully = (uu___180_1726.unfold_fully);
-            unfold_attr = (uu___180_1726.unfold_attr);
-            unfold_tac = (uu___180_1726.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___180_1726.pure_subterms_within_computations);
-            simplify = (uu___180_1726.simplify);
-            erase_universes = (uu___180_1726.erase_universes);
-            allow_unbound_universes = (uu___180_1726.allow_unbound_universes);
-            reify_ = (uu___180_1726.reify_);
-            compress_uvars = (uu___180_1726.compress_uvars);
-            no_full_norm = (uu___180_1726.no_full_norm);
-            check_no_uvars = (uu___180_1726.check_no_uvars);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
             unmeta = true;
-            unascribe = (uu___180_1726.unascribe);
-            in_full_norm_request = (uu___180_1726.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___180_1726.weakly_reduce_scrutinee);
-            nbe_step = (uu___180_1726.nbe_step);
-            for_extraction = (uu___180_1726.for_extraction)
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.Unascribe ->
-          let uu___183_1727 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___183_1727.beta);
-            iota = (uu___183_1727.iota);
-            zeta = (uu___183_1727.zeta);
-            zeta_full = (uu___183_1727.zeta_full);
-            weak = (uu___183_1727.weak);
-            hnf = (uu___183_1727.hnf);
-            primops = (uu___183_1727.primops);
-            do_not_unfold_pure_lets = (uu___183_1727.do_not_unfold_pure_lets);
-            unfold_until = (uu___183_1727.unfold_until);
-            unfold_only = (uu___183_1727.unfold_only);
-            unfold_fully = (uu___183_1727.unfold_fully);
-            unfold_attr = (uu___183_1727.unfold_attr);
-            unfold_tac = (uu___183_1727.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___183_1727.pure_subterms_within_computations);
-            simplify = (uu___183_1727.simplify);
-            erase_universes = (uu___183_1727.erase_universes);
-            allow_unbound_universes = (uu___183_1727.allow_unbound_universes);
-            reify_ = (uu___183_1727.reify_);
-            compress_uvars = (uu___183_1727.compress_uvars);
-            no_full_norm = (uu___183_1727.no_full_norm);
-            check_no_uvars = (uu___183_1727.check_no_uvars);
-            unmeta = (uu___183_1727.unmeta);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
             unascribe = true;
-            in_full_norm_request = (uu___183_1727.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___183_1727.weakly_reduce_scrutinee);
-            nbe_step = (uu___183_1727.nbe_step);
-            for_extraction = (uu___183_1727.for_extraction)
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.NBE ->
-          let uu___186_1728 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___186_1728.beta);
-            iota = (uu___186_1728.iota);
-            zeta = (uu___186_1728.zeta);
-            zeta_full = (uu___186_1728.zeta_full);
-            weak = (uu___186_1728.weak);
-            hnf = (uu___186_1728.hnf);
-            primops = (uu___186_1728.primops);
-            do_not_unfold_pure_lets = (uu___186_1728.do_not_unfold_pure_lets);
-            unfold_until = (uu___186_1728.unfold_until);
-            unfold_only = (uu___186_1728.unfold_only);
-            unfold_fully = (uu___186_1728.unfold_fully);
-            unfold_attr = (uu___186_1728.unfold_attr);
-            unfold_tac = (uu___186_1728.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___186_1728.pure_subterms_within_computations);
-            simplify = (uu___186_1728.simplify);
-            erase_universes = (uu___186_1728.erase_universes);
-            allow_unbound_universes = (uu___186_1728.allow_unbound_universes);
-            reify_ = (uu___186_1728.reify_);
-            compress_uvars = (uu___186_1728.compress_uvars);
-            no_full_norm = (uu___186_1728.no_full_norm);
-            check_no_uvars = (uu___186_1728.check_no_uvars);
-            unmeta = (uu___186_1728.unmeta);
-            unascribe = (uu___186_1728.unascribe);
-            in_full_norm_request = (uu___186_1728.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___186_1728.weakly_reduce_scrutinee);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
             nbe_step = true;
-            for_extraction = (uu___186_1728.for_extraction)
+            for_extraction = (uu___.for_extraction)
           }
       | FStar_TypeChecker_Env.ForExtraction ->
-          let uu___189_1729 = fs in
+          let uu___ = fs in
           {
-            beta = (uu___189_1729.beta);
-            iota = (uu___189_1729.iota);
-            zeta = (uu___189_1729.zeta);
-            zeta_full = (uu___189_1729.zeta_full);
-            weak = (uu___189_1729.weak);
-            hnf = (uu___189_1729.hnf);
-            primops = (uu___189_1729.primops);
-            do_not_unfold_pure_lets = (uu___189_1729.do_not_unfold_pure_lets);
-            unfold_until = (uu___189_1729.unfold_until);
-            unfold_only = (uu___189_1729.unfold_only);
-            unfold_fully = (uu___189_1729.unfold_fully);
-            unfold_attr = (uu___189_1729.unfold_attr);
-            unfold_tac = (uu___189_1729.unfold_tac);
+            beta = (uu___.beta);
+            iota = (uu___.iota);
+            zeta = (uu___.zeta);
+            zeta_full = (uu___.zeta_full);
+            weak = (uu___.weak);
+            hnf = (uu___.hnf);
+            primops = (uu___.primops);
+            do_not_unfold_pure_lets = (uu___.do_not_unfold_pure_lets);
+            unfold_until = (uu___.unfold_until);
+            unfold_only = (uu___.unfold_only);
+            unfold_fully = (uu___.unfold_fully);
+            unfold_attr = (uu___.unfold_attr);
+            unfold_tac = (uu___.unfold_tac);
             pure_subterms_within_computations =
-              (uu___189_1729.pure_subterms_within_computations);
-            simplify = (uu___189_1729.simplify);
-            erase_universes = (uu___189_1729.erase_universes);
-            allow_unbound_universes = (uu___189_1729.allow_unbound_universes);
-            reify_ = (uu___189_1729.reify_);
-            compress_uvars = (uu___189_1729.compress_uvars);
-            no_full_norm = (uu___189_1729.no_full_norm);
-            check_no_uvars = (uu___189_1729.check_no_uvars);
-            unmeta = (uu___189_1729.unmeta);
-            unascribe = (uu___189_1729.unascribe);
-            in_full_norm_request = (uu___189_1729.in_full_norm_request);
-            weakly_reduce_scrutinee = (uu___189_1729.weakly_reduce_scrutinee);
-            nbe_step = (uu___189_1729.nbe_step);
+              (uu___.pure_subterms_within_computations);
+            simplify = (uu___.simplify);
+            erase_universes = (uu___.erase_universes);
+            allow_unbound_universes = (uu___.allow_unbound_universes);
+            reify_ = (uu___.reify_);
+            compress_uvars = (uu___.compress_uvars);
+            no_full_norm = (uu___.no_full_norm);
+            check_no_uvars = (uu___.check_no_uvars);
+            unmeta = (uu___.unmeta);
+            unascribe = (uu___.unascribe);
+            in_full_norm_request = (uu___.in_full_norm_request);
+            weakly_reduce_scrutinee = (uu___.weakly_reduce_scrutinee);
+            nbe_step = (uu___.nbe_step);
             for_extraction = true
           }
 let (to_fsteps : FStar_TypeChecker_Env.step Prims.list -> fsteps) =
@@ -1401,7 +1399,7 @@ let (__proj__Mkpsc__item__psc_subst :
   fun projectee ->
     match projectee with | { psc_range; psc_subst;_} -> psc_subst
 let (null_psc : psc) =
-  { psc_range = FStar_Range.dummyRange; psc_subst = (fun uu____1782 -> []) }
+  { psc_range = FStar_Range.dummyRange; psc_subst = (fun uu___ -> []) }
 let (psc_range : psc -> FStar_Range.range) = fun psc1 -> psc1.psc_range
 let (psc_subst : psc -> FStar_Syntax_Syntax.subst_t) =
   fun psc1 -> psc1.psc_subst ()
@@ -1569,19 +1567,19 @@ let (__proj__Mkprimitive_step__item__interpretation_nbe :
         -> interpretation_nbe
 type prim_step_set = primitive_step FStar_Util.psmap
 let (empty_prim_steps : unit -> prim_step_set) =
-  fun uu____2401 -> FStar_Util.psmap_empty ()
+  fun uu___ -> FStar_Util.psmap_empty ()
 let (add_step :
   primitive_step -> prim_step_set -> primitive_step FStar_Util.psmap) =
   fun s ->
     fun ss ->
-      let uu____2414 = FStar_Ident.string_of_lid s.name in
-      FStar_Util.psmap_add ss uu____2414 s
+      let uu___ = FStar_Ident.string_of_lid s.name in
+      FStar_Util.psmap_add ss uu___ s
 let (merge_steps : prim_step_set -> prim_step_set -> prim_step_set) =
   fun s1 -> fun s2 -> FStar_Util.psmap_merge s1 s2
 let (add_steps : prim_step_set -> primitive_step Prims.list -> prim_step_set)
   = fun m -> fun l -> FStar_List.fold_right add_step l m
 let (prim_from_list : primitive_step Prims.list -> prim_step_set) =
-  fun l -> let uu____2448 = empty_prim_steps () in add_steps uu____2448 l
+  fun l -> let uu___ = empty_prim_steps () in add_steps uu___ l
 type cfg =
   {
   steps: fsteps ;
@@ -1641,14 +1639,14 @@ let (__proj__Mkcfg__item__reifying : cfg -> Prims.bool) =
         memoize_lazy; normalize_pure_lets; reifying;_} -> reifying
 let (cfg_to_string : cfg -> Prims.string) =
   fun cfg1 ->
-    let uu____2649 =
-      let uu____2652 =
-        let uu____2655 =
-          let uu____2656 = steps_to_string cfg1.steps in
-          FStar_Util.format1 "  steps = %s" uu____2656 in
-        [uu____2655; "}"] in
-      "{" :: uu____2652 in
-    FStar_String.concat "\n" uu____2649
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = steps_to_string cfg1.steps in
+          FStar_Util.format1 "  steps = %s" uu___3 in
+        [uu___2; "}"] in
+      "{" :: uu___1 in
+    FStar_String.concat "\n" uu___
 let (cfg_env : cfg -> FStar_TypeChecker_Env.env) = fun cfg1 -> cfg1.tcenv
 let (find_prim_step :
   cfg ->
@@ -1656,19 +1654,19 @@ let (find_prim_step :
   =
   fun cfg1 ->
     fun fv ->
-      let uu____2674 =
+      let uu___ =
         FStar_Ident.string_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      FStar_Util.psmap_try_find cfg1.primitive_steps uu____2674
+      FStar_Util.psmap_try_find cfg1.primitive_steps uu___
 let (is_prim_step : cfg -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun cfg1 ->
     fun fv ->
-      let uu____2685 =
-        let uu____2688 =
+      let uu___ =
+        let uu___1 =
           FStar_Ident.string_of_lid
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        FStar_Util.psmap_try_find cfg1.primitive_steps uu____2688 in
-      FStar_Util.is_some uu____2685
+        FStar_Util.psmap_try_find cfg1.primitive_steps uu___1 in
+      FStar_Util.is_some uu___
 let (log : cfg -> (unit -> unit) -> unit) =
   fun cfg1 -> fun f -> if (cfg1.debug).gen then f () else ()
 let (log_top : cfg -> (unit -> unit) -> unit) =
@@ -1689,8 +1687,8 @@ let embed_simple :
   fun emb ->
     fun r ->
       fun x ->
-        let uu____2813 = FStar_Syntax_Embeddings.embed emb x in
-        uu____2813 r FStar_Pervasives_Native.None
+        let uu___ = FStar_Syntax_Embeddings.embed emb x in
+        uu___ r FStar_Pervasives_Native.None
           FStar_Syntax_Embeddings.id_norm_cb
 let try_unembed_simple :
   'a .
@@ -1699,8 +1697,8 @@ let try_unembed_simple :
   =
   fun emb ->
     fun x ->
-      let uu____2845 = FStar_Syntax_Embeddings.unembed emb x in
-      uu____2845 false FStar_Syntax_Embeddings.id_norm_cb
+      let uu___ = FStar_Syntax_Embeddings.unembed emb x in
+      uu___ false FStar_Syntax_Embeddings.id_norm_cb
 let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
   let arg_as_int a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
@@ -1715,60 +1713,59 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
       (try_unembed_simple FStar_Syntax_Embeddings.e_string) in
   let arg_as_list e a1 =
-    let uu____2948 =
-      let uu____2957 = FStar_Syntax_Embeddings.e_list e in
-      try_unembed_simple uu____2957 in
-    FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____2948 in
-  let arg_as_bounded_int uu____2987 =
-    match uu____2987 with
-    | (a, uu____3001) ->
-        let uu____3012 = FStar_Syntax_Util.head_and_args' a in
-        (match uu____3012 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Embeddings.e_list e in
+      try_unembed_simple uu___1 in
+    FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu___ in
+  let arg_as_bounded_int uu___ =
+    match uu___ with
+    | (a, uu___1) ->
+        let uu___2 = FStar_Syntax_Util.head_and_args' a in
+        (match uu___2 with
          | (hd, args) ->
              let a1 = FStar_Syntax_Util.unlazy_emb a in
-             let uu____3056 =
-               let uu____3071 =
-                 let uu____3072 = FStar_Syntax_Subst.compress hd in
-                 uu____3072.FStar_Syntax_Syntax.n in
-               (uu____3071, args) in
-             (match uu____3056 with
-              | (FStar_Syntax_Syntax.Tm_fvar fv1, (arg, uu____3093)::[]) when
-                  let uu____3128 =
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 = FStar_Syntax_Subst.compress hd in
+                 uu___5.FStar_Syntax_Syntax.n in
+               (uu___4, args) in
+             (match uu___3 with
+              | (FStar_Syntax_Syntax.Tm_fvar fv1, (arg, uu___4)::[]) when
+                  let uu___5 =
                     FStar_Ident.string_of_lid
                       (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  FStar_Util.ends_with uu____3128 "int_to_t" ->
+                  FStar_Util.ends_with uu___5 "int_to_t" ->
                   let arg1 = FStar_Syntax_Util.unlazy_emb arg in
-                  let uu____3130 =
-                    let uu____3131 = FStar_Syntax_Subst.compress arg1 in
-                    uu____3131.FStar_Syntax_Syntax.n in
-                  (match uu____3130 with
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Subst.compress arg1 in
+                    uu___6.FStar_Syntax_Syntax.n in
+                  (match uu___5 with
                    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
                        (i, FStar_Pervasives_Native.None)) ->
-                       let uu____3151 =
-                         let uu____3156 = FStar_BigInt.big_int_of_string i in
-                         (fv1, uu____3156) in
-                       FStar_Pervasives_Native.Some uu____3151
-                   | uu____3161 -> FStar_Pervasives_Native.None)
-              | uu____3166 -> FStar_Pervasives_Native.None)) in
+                       let uu___6 =
+                         let uu___7 = FStar_BigInt.big_int_of_string i in
+                         (fv1, uu___7) in
+                       FStar_Pervasives_Native.Some uu___6
+                   | uu___6 -> FStar_Pervasives_Native.None)
+              | uu___4 -> FStar_Pervasives_Native.None)) in
   let lift_unary f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a1)::[] ->
-        let uu____3228 = f a1 in FStar_Pervasives_Native.Some uu____3228
-    | uu____3229 -> FStar_Pervasives_Native.None in
+        let uu___ = f a1 in FStar_Pervasives_Native.Some uu___
+    | uu___ -> FStar_Pervasives_Native.None in
   let lift_binary f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a0)::(FStar_Pervasives_Native.Some
-        a1)::[] ->
-        let uu____3285 = f a0 a1 in FStar_Pervasives_Native.Some uu____3285
-    | uu____3286 -> FStar_Pervasives_Native.None in
+        a1)::[] -> let uu___ = f a0 a1 in FStar_Pervasives_Native.Some uu___
+    | uu___ -> FStar_Pervasives_Native.None in
   let unary_op as_a f res norm_cb args =
-    let uu____3353 = FStar_List.map as_a args in
-    lift_unary (f res.psc_range) uu____3353 in
+    let uu___ = FStar_List.map as_a args in
+    lift_unary (f res.psc_range) uu___ in
   let binary_op as_a f res n args =
-    let uu____3435 = FStar_List.map as_a args in
-    lift_binary (f res.psc_range) uu____3435 in
-  let as_primitive_step is_strong uu____3487 =
-    match uu____3487 with
+    let uu___ = FStar_List.map as_a args in
+    lift_binary (f res.psc_range) uu___ in
+  let as_primitive_step is_strong uu___ =
+    match uu___ with
     | (l, arity, u_arity, f, f_nbe) ->
         {
           name = l;
@@ -1784,138 +1781,136 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
     unary_op arg_as_int
       (fun r ->
          fun x ->
-           let uu____3586 = f x in
-           embed_simple FStar_Syntax_Embeddings.e_int r uu____3586) in
+           let uu___ = f x in
+           embed_simple FStar_Syntax_Embeddings.e_int r uu___) in
   let binary_int_op f =
     binary_op arg_as_int
       (fun r ->
          fun x ->
            fun y ->
-             let uu____3628 = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_int r uu____3628) in
+             let uu___ = f x y in
+             embed_simple FStar_Syntax_Embeddings.e_int r uu___) in
   let unary_bool_op f =
     unary_op arg_as_bool
       (fun r ->
          fun x ->
-           let uu____3663 = f x in
-           embed_simple FStar_Syntax_Embeddings.e_bool r uu____3663) in
+           let uu___ = f x in
+           embed_simple FStar_Syntax_Embeddings.e_bool r uu___) in
   let binary_bool_op f =
     binary_op arg_as_bool
       (fun r ->
          fun x ->
            fun y ->
-             let uu____3705 = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_bool r uu____3705) in
+             let uu___ = f x y in
+             embed_simple FStar_Syntax_Embeddings.e_bool r uu___) in
   let binary_string_op f =
     binary_op arg_as_string
       (fun r ->
          fun x ->
            fun y ->
-             let uu____3747 = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_string r uu____3747) in
+             let uu___ = f x y in
+             embed_simple FStar_Syntax_Embeddings.e_string r uu___) in
   let mixed_binary_op as_a as_b embed_c f res _norm_cb args =
     match args with
     | a1::b1::[] ->
-        let uu____3898 =
-          let uu____3907 = as_a a1 in
-          let uu____3910 = as_b b1 in (uu____3907, uu____3910) in
-        (match uu____3898 with
+        let uu___ =
+          let uu___1 = as_a a1 in let uu___2 = as_b b1 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some a2, FStar_Pervasives_Native.Some b2)
              ->
-             let uu____3925 =
-               let uu____3926 = f res.psc_range a2 b2 in
-               embed_c res.psc_range uu____3926 in
-             FStar_Pervasives_Native.Some uu____3925
-         | uu____3927 -> FStar_Pervasives_Native.None)
-    | uu____3936 -> FStar_Pervasives_Native.None in
+             let uu___1 =
+               let uu___2 = f res.psc_range a2 b2 in
+               embed_c res.psc_range uu___2 in
+             FStar_Pervasives_Native.Some uu___1
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let list_of_string' rng s =
     let name l =
-      let uu____3956 =
-        let uu____3957 =
+      let uu___ =
+        let uu___1 =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             FStar_Pervasives_Native.None in
-        FStar_Syntax_Syntax.Tm_fvar uu____3957 in
-      FStar_Syntax_Syntax.mk uu____3956 rng in
+        FStar_Syntax_Syntax.Tm_fvar uu___1 in
+      FStar_Syntax_Syntax.mk uu___ rng in
     let char_t = name FStar_Parser_Const.char_lid in
     let charterm c =
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng in
-    let uu____3969 =
-      let uu____3972 = FStar_String.list_of_string s in
-      FStar_List.map charterm uu____3972 in
-    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu____3969 in
+    let uu___ =
+      let uu___1 = FStar_String.list_of_string s in
+      FStar_List.map charterm uu___1 in
+    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu___ in
   let string_of_list' rng l =
     let s = FStar_String.string_of_list l in FStar_Syntax_Util.exp_string s in
   let string_compare' rng s1 s2 =
     let r = FStar_String.compare s1 s2 in
-    let uu____4010 =
-      let uu____4011 = FStar_Util.string_of_int r in
-      FStar_BigInt.big_int_of_string uu____4011 in
-    embed_simple FStar_Syntax_Embeddings.e_int rng uu____4010 in
+    let uu___ =
+      let uu___1 = FStar_Util.string_of_int r in
+      FStar_BigInt.big_int_of_string uu___1 in
+    embed_simple FStar_Syntax_Embeddings.e_int rng uu___ in
   let string_concat' psc1 _n args =
     match args with
     | a1::a2::[] ->
-        let uu____4096 = arg_as_string a1 in
-        (match uu____4096 with
+        let uu___ = arg_as_string a1 in
+        (match uu___ with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____4102 = arg_as_list FStar_Syntax_Embeddings.e_string a2 in
-             (match uu____4102 with
+             let uu___1 = arg_as_list FStar_Syntax_Embeddings.e_string a2 in
+             (match uu___1 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.concat s1 s2 in
-                  let uu____4115 =
+                  let uu___2 =
                     embed_simple FStar_Syntax_Embeddings.e_string
                       psc1.psc_range r in
-                  FStar_Pervasives_Native.Some uu____4115
-              | uu____4116 -> FStar_Pervasives_Native.None)
-         | uu____4121 -> FStar_Pervasives_Native.None)
-    | uu____4124 -> FStar_Pervasives_Native.None in
+                  FStar_Pervasives_Native.Some uu___2
+              | uu___2 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let string_split' psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____4205 = arg_as_list FStar_Syntax_Embeddings.e_char a1 in
-        (match uu____4205 with
+        let uu___ = arg_as_list FStar_Syntax_Embeddings.e_char a1 in
+        (match uu___ with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____4217 = arg_as_string a2 in
-             (match uu____4217 with
+             let uu___1 = arg_as_string a2 in
+             (match uu___1 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.split s1 s2 in
-                  let uu____4226 =
-                    let uu____4227 =
+                  let uu___2 =
+                    let uu___3 =
                       FStar_Syntax_Embeddings.e_list
                         FStar_Syntax_Embeddings.e_string in
-                    embed_simple uu____4227 psc1.psc_range r in
-                  FStar_Pervasives_Native.Some uu____4226
-              | uu____4234 -> FStar_Pervasives_Native.None)
-         | uu____4237 -> FStar_Pervasives_Native.None)
-    | uu____4242 -> FStar_Pervasives_Native.None in
+                    embed_simple uu___3 psc1.psc_range r in
+                  FStar_Pervasives_Native.Some uu___2
+              | uu___2 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let string_substring' psc1 _norm_cb args =
     match args with
     | a1::a2::a3::[] ->
-        let uu____4280 =
-          let uu____4293 = arg_as_string a1 in
-          let uu____4296 = arg_as_int a2 in
-          let uu____4299 = arg_as_int a3 in
-          (uu____4293, uu____4296, uu____4299) in
-        (match uu____4280 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_int a2 in
+          let uu___3 = arg_as_int a3 in (uu___1, uu___2, uu___3) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s1, FStar_Pervasives_Native.Some n1,
             FStar_Pervasives_Native.Some n2) ->
              let n11 = FStar_BigInt.to_int_fs n1 in
              let n21 = FStar_BigInt.to_int_fs n2 in
              (try
-                (fun uu___510_4326 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.substring s1 n11 n21 in
-                       let uu____4330 =
+                       let uu___2 =
                          embed_simple FStar_Syntax_Embeddings.e_string
                            psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu____4330) ()
-              with | uu___509_4332 -> FStar_Pervasives_Native.None)
-         | uu____4335 -> FStar_Pervasives_Native.None)
-    | uu____4348 -> FStar_Pervasives_Native.None in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let string_of_int rng i =
-    let uu____4362 = FStar_BigInt.string_of_big_int i in
-    embed_simple FStar_Syntax_Embeddings.e_string rng uu____4362 in
+    let uu___ = FStar_BigInt.string_of_big_int i in
+    embed_simple FStar_Syntax_Embeddings.e_string rng uu___ in
   let string_of_bool rng b =
     embed_simple FStar_Syntax_Embeddings.e_string rng
       (if b then "true" else "false") in
@@ -1928,75 +1923,75 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
   let string_index psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____4425 =
-          let uu____4434 = arg_as_string a1 in
-          let uu____4437 = arg_as_int a2 in (uu____4434, uu____4437) in
-        (match uu____4425 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some i)
              ->
              (try
-                (fun uu___544_4457 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.index s i in
-                       let uu____4461 =
+                       let uu___2 =
                          embed_simple FStar_Syntax_Embeddings.e_char
                            psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu____4461) ()
-              with | uu___543_4463 -> FStar_Pervasives_Native.None)
-         | uu____4466 -> FStar_Pervasives_Native.None)
-    | uu____4475 -> FStar_Pervasives_Native.None in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let string_index_of psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____4506 =
-          let uu____4515 = arg_as_string a1 in
-          let uu____4518 = arg_as_char a2 in (uu____4515, uu____4518) in
-        (match uu____4506 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_char a2 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some c)
              ->
              (try
-                (fun uu___565_4538 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.index_of s c in
-                       let uu____4542 =
+                       let uu___2 =
                          embed_simple FStar_Syntax_Embeddings.e_int
                            psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu____4542) ()
-              with | uu___564_4544 -> FStar_Pervasives_Native.None)
-         | uu____4547 -> FStar_Pervasives_Native.None)
-    | uu____4556 -> FStar_Pervasives_Native.None in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let mk_range psc1 _norm_cb args =
     match args with
     | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu____4590 =
-          let uu____4611 = arg_as_string fn in
-          let uu____4614 = arg_as_int from_line in
-          let uu____4617 = arg_as_int from_col in
-          let uu____4620 = arg_as_int to_line in
-          let uu____4623 = arg_as_int to_col in
-          (uu____4611, uu____4614, uu____4617, uu____4620, uu____4623) in
-        (match uu____4590 with
+        let uu___ =
+          let uu___1 = arg_as_string fn in
+          let uu___2 = arg_as_int from_line in
+          let uu___3 = arg_as_int from_col in
+          let uu___4 = arg_as_int to_line in
+          let uu___5 = arg_as_int to_col in
+          (uu___1, uu___2, uu___3, uu___4, uu___5) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some fn1, FStar_Pervasives_Native.Some
             from_l, FStar_Pervasives_Native.Some from_c,
             FStar_Pervasives_Native.Some to_l, FStar_Pervasives_Native.Some
             to_c) ->
              let r =
-               let uu____4654 =
-                 let uu____4655 = FStar_BigInt.to_int_fs from_l in
-                 let uu____4656 = FStar_BigInt.to_int_fs from_c in
-                 FStar_Range.mk_pos uu____4655 uu____4656 in
-               let uu____4657 =
-                 let uu____4658 = FStar_BigInt.to_int_fs to_l in
-                 let uu____4659 = FStar_BigInt.to_int_fs to_c in
-                 FStar_Range.mk_pos uu____4658 uu____4659 in
-               FStar_Range.mk_range fn1 uu____4654 uu____4657 in
-             let uu____4660 =
+               let uu___1 =
+                 let uu___2 = FStar_BigInt.to_int_fs from_l in
+                 let uu___3 = FStar_BigInt.to_int_fs from_c in
+                 FStar_Range.mk_pos uu___2 uu___3 in
+               let uu___2 =
+                 let uu___3 = FStar_BigInt.to_int_fs to_l in
+                 let uu___4 = FStar_BigInt.to_int_fs to_c in
+                 FStar_Range.mk_pos uu___3 uu___4 in
+               FStar_Range.mk_range fn1 uu___1 uu___2 in
+             let uu___1 =
                embed_simple FStar_Syntax_Embeddings.e_range psc1.psc_range r in
-             FStar_Pervasives_Native.Some uu____4660
-         | uu____4661 -> FStar_Pervasives_Native.None)
-    | uu____4682 -> FStar_Pervasives_Native.None in
+             FStar_Pervasives_Native.Some uu___1
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None in
   let decidable_eq neg psc1 _norm_cb args =
     let r = psc1.psc_range in
     let tru =
@@ -2006,245 +2001,239 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r in
     match args with
-    | (_typ, uu____4722)::(a1, uu____4724)::(a2, uu____4726)::[] ->
-        let uu____4783 = FStar_Syntax_Util.eq_tm a1 a2 in
-        (match uu____4783 with
+    | (_typ, uu___)::(a1, uu___1)::(a2, uu___2)::[] ->
+        let uu___3 = FStar_Syntax_Util.eq_tm a1 a2 in
+        (match uu___3 with
          | FStar_Syntax_Util.Equal ->
              FStar_Pervasives_Native.Some (if neg then fal else tru)
          | FStar_Syntax_Util.NotEqual ->
              FStar_Pervasives_Native.Some (if neg then tru else fal)
-         | uu____4788 -> FStar_Pervasives_Native.None)
-    | uu____4789 -> failwith "Unexpected number of arguments" in
+         | uu___4 -> FStar_Pervasives_Native.None)
+    | uu___ -> failwith "Unexpected number of arguments" in
   let prims_to_fstar_range_step psc1 _norm_cb args =
     match args with
-    | (a1, uu____4831)::[] ->
-        let uu____4848 =
-          try_unembed_simple FStar_Syntax_Embeddings.e_range a1 in
-        (match uu____4848 with
+    | (a1, uu___)::[] ->
+        let uu___1 = try_unembed_simple FStar_Syntax_Embeddings.e_range a1 in
+        (match uu___1 with
          | FStar_Pervasives_Native.Some r ->
-             let uu____4854 =
+             let uu___2 =
                embed_simple FStar_Syntax_Embeddings.e_range psc1.psc_range r in
-             FStar_Pervasives_Native.Some uu____4854
+             FStar_Pervasives_Native.Some uu___2
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
-    | uu____4855 -> failwith "Unexpected number of arguments" in
+    | uu___ -> failwith "Unexpected number of arguments" in
   let division_op psc1 _norm_cb args =
     match args with
     | (a1, FStar_Pervasives_Native.None)::(a2, FStar_Pervasives_Native.None)::[]
         ->
-        let uu____4926 =
-          let uu____4935 =
-            try_unembed_simple FStar_Syntax_Embeddings.e_int a1 in
-          let uu____4938 =
-            try_unembed_simple FStar_Syntax_Embeddings.e_int a2 in
-          (uu____4935, uu____4938) in
-        (match uu____4926 with
+        let uu___ =
+          let uu___1 = try_unembed_simple FStar_Syntax_Embeddings.e_int a1 in
+          let uu___2 = try_unembed_simple FStar_Syntax_Embeddings.e_int a2 in
+          (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some m, FStar_Pervasives_Native.Some n)
              ->
-             let uu____4953 =
-               let uu____4954 = FStar_BigInt.to_int_fs n in
-               uu____4954 <> Prims.int_zero in
-             if uu____4953
+             let uu___1 =
+               let uu___2 = FStar_BigInt.to_int_fs n in
+               uu___2 <> Prims.int_zero in
+             if uu___1
              then
-               let uu____4957 =
-                 let uu____4958 = FStar_BigInt.div_big_int m n in
+               let uu___2 =
+                 let uu___3 = FStar_BigInt.div_big_int m n in
                  embed_simple FStar_Syntax_Embeddings.e_int psc1.psc_range
-                   uu____4958 in
-               FStar_Pervasives_Native.Some uu____4957
+                   uu___3 in
+               FStar_Pervasives_Native.Some uu___2
              else FStar_Pervasives_Native.None
-         | uu____4960 -> FStar_Pervasives_Native.None)
-    | uu____4969 -> failwith "Unexpected number of arguments" in
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> failwith "Unexpected number of arguments" in
   let bogus_cbs =
     {
       FStar_TypeChecker_NBETerm.iapp = (fun h -> fun _args -> h);
       FStar_TypeChecker_NBETerm.translate =
-        (fun uu____4980 -> failwith "bogus_cbs translate")
+        (fun uu___ -> failwith "bogus_cbs translate")
     } in
   let basic_ops =
-    let uu____5011 =
-      let uu____5039 =
+    let uu___ =
+      let uu___1 =
         FStar_TypeChecker_NBETerm.unary_int_op
           (fun x -> FStar_BigInt.minus_big_int x) in
       (FStar_Parser_Const.op_Minus, Prims.int_one, Prims.int_zero,
-        (unary_int_op (fun x -> FStar_BigInt.minus_big_int x)), uu____5039) in
-    let uu____5069 =
-      let uu____5099 =
-        let uu____5127 =
+        (unary_int_op (fun x -> FStar_BigInt.minus_big_int x)), uu___1) in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
           FStar_TypeChecker_NBETerm.binary_int_op
             (fun x -> fun y -> FStar_BigInt.add_big_int x y) in
         (FStar_Parser_Const.op_Addition, (Prims.of_int (2)), Prims.int_zero,
           (binary_int_op (fun x -> fun y -> FStar_BigInt.add_big_int x y)),
-          uu____5127) in
-      let uu____5163 =
-        let uu____5193 =
-          let uu____5221 =
+          uu___3) in
+      let uu___3 =
+        let uu___4 =
+          let uu___5 =
             FStar_TypeChecker_NBETerm.binary_int_op
               (fun x -> fun y -> FStar_BigInt.sub_big_int x y) in
           (FStar_Parser_Const.op_Subtraction, (Prims.of_int (2)),
             Prims.int_zero,
             (binary_int_op (fun x -> fun y -> FStar_BigInt.sub_big_int x y)),
-            uu____5221) in
-        let uu____5257 =
-          let uu____5287 =
-            let uu____5315 =
+            uu___5) in
+        let uu___5 =
+          let uu___6 =
+            let uu___7 =
               FStar_TypeChecker_NBETerm.binary_int_op
                 (fun x -> fun y -> FStar_BigInt.mult_big_int x y) in
             (FStar_Parser_Const.op_Multiply, (Prims.of_int (2)),
               Prims.int_zero,
               (binary_int_op
-                 (fun x -> fun y -> FStar_BigInt.mult_big_int x y)),
-              uu____5315) in
-          let uu____5351 =
-            let uu____5381 =
-              let uu____5411 =
-                let uu____5439 =
+                 (fun x -> fun y -> FStar_BigInt.mult_big_int x y)), uu___7) in
+          let uu___7 =
+            let uu___8 =
+              let uu___9 =
+                let uu___10 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_int
                     (fun x ->
                        fun y ->
-                         let uu____5451 = FStar_BigInt.lt_big_int x y in
+                         let uu___11 = FStar_BigInt.lt_big_int x y in
                          FStar_TypeChecker_NBETerm.embed
-                           FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                           uu____5451) in
+                           FStar_TypeChecker_NBETerm.e_bool bogus_cbs uu___11) in
                 (FStar_Parser_Const.op_LT, (Prims.of_int (2)),
                   Prims.int_zero,
                   (binary_op arg_as_int
                      (fun r ->
                         fun x ->
                           fun y ->
-                            let uu____5476 = FStar_BigInt.lt_big_int x y in
+                            let uu___11 = FStar_BigInt.lt_big_int x y in
                             embed_simple FStar_Syntax_Embeddings.e_bool r
-                              uu____5476)), uu____5439) in
-              let uu____5477 =
-                let uu____5507 =
-                  let uu____5535 =
+                              uu___11)), uu___10) in
+              let uu___10 =
+                let uu___11 =
+                  let uu___12 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_int
                       (fun x ->
                          fun y ->
-                           let uu____5547 = FStar_BigInt.le_big_int x y in
+                           let uu___13 = FStar_BigInt.le_big_int x y in
                            FStar_TypeChecker_NBETerm.embed
                              FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                             uu____5547) in
+                             uu___13) in
                   (FStar_Parser_Const.op_LTE, (Prims.of_int (2)),
                     Prims.int_zero,
                     (binary_op arg_as_int
                        (fun r ->
                           fun x ->
                             fun y ->
-                              let uu____5572 = FStar_BigInt.le_big_int x y in
+                              let uu___13 = FStar_BigInt.le_big_int x y in
                               embed_simple FStar_Syntax_Embeddings.e_bool r
-                                uu____5572)), uu____5535) in
-                let uu____5573 =
-                  let uu____5603 =
-                    let uu____5631 =
+                                uu___13)), uu___12) in
+                let uu___12 =
+                  let uu___13 =
+                    let uu___14 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_int
                         (fun x ->
                            fun y ->
-                             let uu____5643 = FStar_BigInt.gt_big_int x y in
+                             let uu___15 = FStar_BigInt.gt_big_int x y in
                              FStar_TypeChecker_NBETerm.embed
                                FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                               uu____5643) in
+                               uu___15) in
                     (FStar_Parser_Const.op_GT, (Prims.of_int (2)),
                       Prims.int_zero,
                       (binary_op arg_as_int
                          (fun r ->
                             fun x ->
                               fun y ->
-                                let uu____5668 = FStar_BigInt.gt_big_int x y in
+                                let uu___15 = FStar_BigInt.gt_big_int x y in
                                 embed_simple FStar_Syntax_Embeddings.e_bool r
-                                  uu____5668)), uu____5631) in
-                  let uu____5669 =
-                    let uu____5699 =
-                      let uu____5727 =
+                                  uu___15)), uu___14) in
+                  let uu___14 =
+                    let uu___15 =
+                      let uu___16 =
                         FStar_TypeChecker_NBETerm.binary_op
                           FStar_TypeChecker_NBETerm.arg_as_int
                           (fun x ->
                              fun y ->
-                               let uu____5739 = FStar_BigInt.ge_big_int x y in
+                               let uu___17 = FStar_BigInt.ge_big_int x y in
                                FStar_TypeChecker_NBETerm.embed
                                  FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                                 uu____5739) in
+                                 uu___17) in
                       (FStar_Parser_Const.op_GTE, (Prims.of_int (2)),
                         Prims.int_zero,
                         (binary_op arg_as_int
                            (fun r ->
                               fun x ->
                                 fun y ->
-                                  let uu____5764 =
-                                    FStar_BigInt.ge_big_int x y in
+                                  let uu___17 = FStar_BigInt.ge_big_int x y in
                                   embed_simple FStar_Syntax_Embeddings.e_bool
-                                    r uu____5764)), uu____5727) in
-                    let uu____5765 =
-                      let uu____5795 =
-                        let uu____5823 =
+                                    r uu___17)), uu___16) in
+                    let uu___16 =
+                      let uu___17 =
+                        let uu___18 =
                           FStar_TypeChecker_NBETerm.binary_int_op
                             (fun x -> fun y -> FStar_BigInt.mod_big_int x y) in
                         (FStar_Parser_Const.op_Modulus, (Prims.of_int (2)),
                           Prims.int_zero,
                           (binary_int_op
                              (fun x -> fun y -> FStar_BigInt.mod_big_int x y)),
-                          uu____5823) in
-                      let uu____5859 =
-                        let uu____5889 =
-                          let uu____5917 =
+                          uu___18) in
+                      let uu___18 =
+                        let uu___19 =
+                          let uu___20 =
                             FStar_TypeChecker_NBETerm.unary_bool_op
                               (fun x -> Prims.op_Negation x) in
                           (FStar_Parser_Const.op_Negation, Prims.int_one,
                             Prims.int_zero,
                             (unary_bool_op (fun x -> Prims.op_Negation x)),
-                            uu____5917) in
-                        let uu____5947 =
-                          let uu____5977 =
-                            let uu____6005 =
+                            uu___20) in
+                        let uu___20 =
+                          let uu___21 =
+                            let uu___22 =
                               FStar_TypeChecker_NBETerm.binary_bool_op
                                 (fun x -> fun y -> x && y) in
                             (FStar_Parser_Const.op_And, (Prims.of_int (2)),
                               Prims.int_zero,
                               (binary_bool_op (fun x -> fun y -> x && y)),
-                              uu____6005) in
-                          let uu____6041 =
-                            let uu____6071 =
-                              let uu____6099 =
+                              uu___22) in
+                          let uu___22 =
+                            let uu___23 =
+                              let uu___24 =
                                 FStar_TypeChecker_NBETerm.binary_bool_op
                                   (fun x -> fun y -> x || y) in
                               (FStar_Parser_Const.op_Or, (Prims.of_int (2)),
                                 Prims.int_zero,
                                 (binary_bool_op (fun x -> fun y -> x || y)),
-                                uu____6099) in
-                            let uu____6135 =
-                              let uu____6165 =
-                                let uu____6193 =
+                                uu___24) in
+                            let uu___24 =
+                              let uu___25 =
+                                let uu___26 =
                                   FStar_TypeChecker_NBETerm.unary_op
                                     FStar_TypeChecker_NBETerm.arg_as_int
                                     FStar_TypeChecker_NBETerm.string_of_int in
                                 (FStar_Parser_Const.string_of_int_lid,
                                   Prims.int_one, Prims.int_zero,
                                   (unary_op arg_as_int string_of_int),
-                                  uu____6193) in
-                              let uu____6217 =
-                                let uu____6247 =
-                                  let uu____6275 =
+                                  uu___26) in
+                              let uu___26 =
+                                let uu___27 =
+                                  let uu___28 =
                                     FStar_TypeChecker_NBETerm.unary_op
                                       FStar_TypeChecker_NBETerm.arg_as_bool
                                       FStar_TypeChecker_NBETerm.string_of_bool in
                                   (FStar_Parser_Const.string_of_bool_lid,
                                     Prims.int_one, Prims.int_zero,
                                     (unary_op arg_as_bool string_of_bool),
-                                    uu____6275) in
-                                let uu____6299 =
-                                  let uu____6329 =
-                                    let uu____6357 =
+                                    uu___28) in
+                                let uu___28 =
+                                  let uu___29 =
+                                    let uu___30 =
                                       FStar_TypeChecker_NBETerm.unary_op
                                         FStar_TypeChecker_NBETerm.arg_as_string
                                         FStar_TypeChecker_NBETerm.list_of_string' in
                                     (FStar_Parser_Const.string_list_of_string_lid,
                                       Prims.int_one, Prims.int_zero,
                                       (unary_op arg_as_string list_of_string'),
-                                      uu____6357) in
-                                  let uu____6381 =
-                                    let uu____6411 =
-                                      let uu____6439 =
+                                      uu___30) in
+                                  let uu___30 =
+                                    let uu___31 =
+                                      let uu___32 =
                                         FStar_TypeChecker_NBETerm.unary_op
                                           (FStar_TypeChecker_NBETerm.arg_as_list
                                              FStar_TypeChecker_NBETerm.e_char)
@@ -2254,12 +2243,12 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                         (unary_op
                                            (arg_as_list
                                               FStar_Syntax_Embeddings.e_char)
-                                           string_of_list'), uu____6439) in
-                                    let uu____6467 =
-                                      let uu____6497 =
-                                        let uu____6527 =
-                                          let uu____6557 =
-                                            let uu____6585 =
+                                           string_of_list'), uu___32) in
+                                    let uu___32 =
+                                      let uu___33 =
+                                        let uu___34 =
+                                          let uu___35 =
+                                            let uu___36 =
                                               FStar_TypeChecker_NBETerm.binary_string_op
                                                 (fun x ->
                                                    fun y ->
@@ -2271,11 +2260,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                  (fun x ->
                                                     fun y ->
                                                       FStar_String.op_Hat x y)),
-                                              uu____6585) in
-                                          let uu____6621 =
-                                            let uu____6651 =
-                                              let uu____6681 =
-                                                let uu____6709 =
+                                              uu___36) in
+                                          let uu___36 =
+                                            let uu___37 =
+                                              let uu___38 =
+                                                let uu___39 =
                                                   FStar_TypeChecker_NBETerm.binary_op
                                                     FStar_TypeChecker_NBETerm.arg_as_string
                                                     FStar_TypeChecker_NBETerm.string_compare' in
@@ -2284,10 +2273,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                   Prims.int_zero,
                                                   (binary_op arg_as_string
                                                      string_compare'),
-                                                  uu____6709) in
-                                              let uu____6733 =
-                                                let uu____6763 =
-                                                  let uu____6791 =
+                                                  uu___39) in
+                                              let uu___39 =
+                                                let uu___40 =
+                                                  let uu___41 =
                                                     FStar_TypeChecker_NBETerm.unary_op
                                                       FStar_TypeChecker_NBETerm.arg_as_string
                                                       FStar_TypeChecker_NBETerm.string_lowercase in
@@ -2295,11 +2284,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                     Prims.int_one,
                                                     Prims.int_zero,
                                                     (unary_op arg_as_string
-                                                       lowercase),
-                                                    uu____6791) in
-                                                let uu____6815 =
-                                                  let uu____6845 =
-                                                    let uu____6873 =
+                                                       lowercase), uu___41) in
+                                                let uu___41 =
+                                                  let uu___42 =
+                                                    let uu___43 =
                                                       FStar_TypeChecker_NBETerm.unary_op
                                                         FStar_TypeChecker_NBETerm.arg_as_string
                                                         FStar_TypeChecker_NBETerm.string_uppercase in
@@ -2307,44 +2295,39 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                       Prims.int_one,
                                                       Prims.int_zero,
                                                       (unary_op arg_as_string
-                                                         uppercase),
-                                                      uu____6873) in
-                                                  let uu____6897 =
-                                                    let uu____6927 =
-                                                      let uu____6957 =
-                                                        let uu____6987 =
-                                                          let uu____7017 =
-                                                            let uu____7047 =
-                                                              let uu____7077
-                                                                =
-                                                                let uu____7105
-                                                                  =
+                                                         uppercase), uu___43) in
+                                                  let uu___43 =
+                                                    let uu___44 =
+                                                      let uu___45 =
+                                                        let uu___46 =
+                                                          let uu___47 =
+                                                            let uu___48 =
+                                                              let uu___49 =
+                                                                let uu___50 =
                                                                   FStar_Parser_Const.p2l
                                                                     ["Prims";
                                                                     "mk_range"] in
-                                                                (uu____7105,
+                                                                (uu___50,
                                                                   (Prims.of_int (5)),
                                                                   Prims.int_zero,
                                                                   mk_range,
                                                                   FStar_TypeChecker_NBETerm.mk_range) in
-                                                              let uu____7123
-                                                                =
-                                                                let uu____7153
-                                                                  =
-                                                                  let uu____7181
+                                                              let uu___50 =
+                                                                let uu___51 =
+                                                                  let uu___52
                                                                     =
                                                                     FStar_Parser_Const.p2l
                                                                     ["FStar";
                                                                     "Range";
                                                                     "prims_to_fstar_range"] in
-                                                                  (uu____7181,
+                                                                  (uu___52,
                                                                     Prims.int_one,
                                                                     Prims.int_zero,
                                                                     prims_to_fstar_range_step,
                                                                     FStar_TypeChecker_NBETerm.prims_to_fstar_range_step) in
-                                                                [uu____7153] in
-                                                              uu____7077 ::
-                                                                uu____7123 in
+                                                                [uu___51] in
+                                                              uu___49 ::
+                                                                uu___50 in
                                                             (FStar_Parser_Const.op_notEq,
                                                               (Prims.of_int (3)),
                                                               Prims.int_zero,
@@ -2352,7 +2335,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                                  true),
                                                               (FStar_TypeChecker_NBETerm.decidable_eq
                                                                  true))
-                                                              :: uu____7047 in
+                                                              :: uu___48 in
                                                           (FStar_Parser_Const.op_Eq,
                                                             (Prims.of_int (3)),
                                                             Prims.int_zero,
@@ -2360,39 +2343,39 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                                false),
                                                             (FStar_TypeChecker_NBETerm.decidable_eq
                                                                false))
-                                                            :: uu____7017 in
+                                                            :: uu___47 in
                                                         (FStar_Parser_Const.string_sub_lid,
                                                           (Prims.of_int (3)),
                                                           Prims.int_zero,
                                                           string_substring',
                                                           FStar_TypeChecker_NBETerm.string_substring')
-                                                          :: uu____6987 in
+                                                          :: uu___46 in
                                                       (FStar_Parser_Const.string_index_of_lid,
                                                         (Prims.of_int (2)),
                                                         Prims.int_zero,
                                                         string_index_of,
                                                         FStar_TypeChecker_NBETerm.string_index_of)
-                                                        :: uu____6957 in
+                                                        :: uu___45 in
                                                     (FStar_Parser_Const.string_index_lid,
                                                       (Prims.of_int (2)),
                                                       Prims.int_zero,
                                                       string_index,
                                                       FStar_TypeChecker_NBETerm.string_index)
-                                                      :: uu____6927 in
-                                                  uu____6845 :: uu____6897 in
-                                                uu____6763 :: uu____6815 in
-                                              uu____6681 :: uu____6733 in
+                                                      :: uu___44 in
+                                                  uu___42 :: uu___43 in
+                                                uu___40 :: uu___41 in
+                                              uu___38 :: uu___39 in
                                             (FStar_Parser_Const.string_concat_lid,
                                               (Prims.of_int (2)),
                                               Prims.int_zero, string_concat',
                                               FStar_TypeChecker_NBETerm.string_concat')
-                                              :: uu____6651 in
-                                          uu____6557 :: uu____6621 in
+                                              :: uu___37 in
+                                          uu___35 :: uu___36 in
                                         (FStar_Parser_Const.string_split_lid,
                                           (Prims.of_int (2)), Prims.int_zero,
                                           string_split',
                                           FStar_TypeChecker_NBETerm.string_split')
-                                          :: uu____6527 in
+                                          :: uu___34 in
                                       (FStar_Parser_Const.string_make_lid,
                                         (Prims.of_int (2)), Prims.int_zero,
                                         (mixed_binary_op arg_as_int
@@ -2402,10 +2385,9 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                            (fun r ->
                                               fun x ->
                                                 fun y ->
-                                                  let uu____7747 =
+                                                  let uu___34 =
                                                     FStar_BigInt.to_int_fs x in
-                                                  FStar_String.make
-                                                    uu____7747 y)),
+                                                  FStar_String.make uu___34 y)),
                                         (FStar_TypeChecker_NBETerm.mixed_binary_op
                                            FStar_TypeChecker_NBETerm.arg_as_int
                                            FStar_TypeChecker_NBETerm.arg_as_char
@@ -2414,30 +2396,29 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                               bogus_cbs)
                                            (fun x ->
                                               fun y ->
-                                                let uu____7753 =
+                                                let uu___34 =
                                                   FStar_BigInt.to_int_fs x in
-                                                FStar_String.make uu____7753
-                                                  y)))
-                                        :: uu____6497 in
-                                    uu____6411 :: uu____6467 in
-                                  uu____6329 :: uu____6381 in
-                                uu____6247 :: uu____6299 in
-                              uu____6165 :: uu____6217 in
-                            uu____6071 :: uu____6135 in
-                          uu____5977 :: uu____6041 in
-                        uu____5889 :: uu____5947 in
-                      uu____5795 :: uu____5859 in
-                    uu____5699 :: uu____5765 in
-                  uu____5603 :: uu____5669 in
-                uu____5507 :: uu____5573 in
-              uu____5411 :: uu____5477 in
+                                                FStar_String.make uu___34 y)))
+                                        :: uu___33 in
+                                    uu___31 :: uu___32 in
+                                  uu___29 :: uu___30 in
+                                uu___27 :: uu___28 in
+                              uu___25 :: uu___26 in
+                            uu___23 :: uu___24 in
+                          uu___21 :: uu___22 in
+                        uu___19 :: uu___20 in
+                      uu___17 :: uu___18 in
+                    uu___15 :: uu___16 in
+                  uu___13 :: uu___14 in
+                uu___11 :: uu___12 in
+              uu___9 :: uu___10 in
             (FStar_Parser_Const.op_Division, (Prims.of_int (2)),
               Prims.int_zero, division_op,
-              FStar_TypeChecker_NBETerm.division_op) :: uu____5381 in
-          uu____5287 :: uu____5351 in
-        uu____5193 :: uu____5257 in
-      uu____5099 :: uu____5163 in
-    uu____5011 :: uu____5069 in
+              FStar_TypeChecker_NBETerm.division_op) :: uu___8 in
+          uu___6 :: uu___7 in
+        uu___4 :: uu___5 in
+      uu___2 :: uu___3 in
+    uu___ :: uu___1 in
   let weak_ops = [] in
   let bounded_arith_ops =
     let bounded_signed_int_types = ["Int8"; "Int16"; "Int32"; "Int64"] in
@@ -2446,165 +2427,155 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
     let int_as_bounded r int_to_t n =
       let c = embed_simple FStar_Syntax_Embeddings.e_int r n in
       let int_to_t1 = FStar_Syntax_Syntax.fv_to_tm int_to_t in
-      let uu____8341 =
-        let uu____8342 = FStar_Syntax_Syntax.as_arg c in [uu____8342] in
-      FStar_Syntax_Syntax.mk_Tm_app int_to_t1 uu____8341 r in
+      let uu___ = let uu___1 = FStar_Syntax_Syntax.as_arg c in [uu___1] in
+      FStar_Syntax_Syntax.mk_Tm_app int_to_t1 uu___ r in
     let add_sub_mul_v =
       FStar_All.pipe_right
         (FStar_List.append bounded_signed_int_types
            bounded_unsigned_int_types)
         (FStar_List.collect
            (fun m ->
-              let uu____8459 =
-                let uu____8487 = FStar_Parser_Const.p2l ["FStar"; m; "add"] in
-                let uu____8488 =
+              let uu___ =
+                let uu___1 = FStar_Parser_Const.p2l ["FStar"; m; "add"] in
+                let uu___2 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____8506 ->
-                       fun uu____8507 ->
-                         match (uu____8506, uu____8507) with
-                         | ((int_to_t, x), (uu____8526, y)) ->
-                             let uu____8536 = FStar_BigInt.add_big_int x y in
+                    (fun uu___3 ->
+                       fun uu___4 ->
+                         match (uu___3, uu___4) with
+                         | ((int_to_t, x), (uu___5, y)) ->
+                             let uu___6 = FStar_BigInt.add_big_int x y in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____8536) in
-                (uu____8487, (Prims.of_int (2)), Prims.int_zero,
+                               int_to_t uu___6) in
+                (uu___1, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r ->
-                        fun uu____8567 ->
-                          fun uu____8568 ->
-                            match (uu____8567, uu____8568) with
-                            | ((int_to_t, x), (uu____8587, y)) ->
-                                let uu____8597 = FStar_BigInt.add_big_int x y in
-                                int_as_bounded r int_to_t uu____8597)),
-                  uu____8488) in
-              let uu____8598 =
-                let uu____8628 =
-                  let uu____8656 = FStar_Parser_Const.p2l ["FStar"; m; "sub"] in
-                  let uu____8657 =
+                        fun uu___3 ->
+                          fun uu___4 ->
+                            match (uu___3, uu___4) with
+                            | ((int_to_t, x), (uu___5, y)) ->
+                                let uu___6 = FStar_BigInt.add_big_int x y in
+                                int_as_bounded r int_to_t uu___6)), uu___2) in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "sub"] in
+                  let uu___4 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____8675 ->
-                         fun uu____8676 ->
-                           match (uu____8675, uu____8676) with
-                           | ((int_to_t, x), (uu____8695, y)) ->
-                               let uu____8705 = FStar_BigInt.sub_big_int x y in
+                      (fun uu___5 ->
+                         fun uu___6 ->
+                           match (uu___5, uu___6) with
+                           | ((int_to_t, x), (uu___7, y)) ->
+                               let uu___8 = FStar_BigInt.sub_big_int x y in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____8705) in
-                  (uu____8656, (Prims.of_int (2)), Prims.int_zero,
+                                 int_to_t uu___8) in
+                  (uu___3, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r ->
-                          fun uu____8736 ->
-                            fun uu____8737 ->
-                              match (uu____8736, uu____8737) with
-                              | ((int_to_t, x), (uu____8756, y)) ->
-                                  let uu____8766 =
-                                    FStar_BigInt.sub_big_int x y in
-                                  int_as_bounded r int_to_t uu____8766)),
-                    uu____8657) in
-                let uu____8767 =
-                  let uu____8797 =
-                    let uu____8825 =
-                      FStar_Parser_Const.p2l ["FStar"; m; "mul"] in
-                    let uu____8826 =
+                          fun uu___5 ->
+                            fun uu___6 ->
+                              match (uu___5, uu___6) with
+                              | ((int_to_t, x), (uu___7, y)) ->
+                                  let uu___8 = FStar_BigInt.sub_big_int x y in
+                                  int_as_bounded r int_to_t uu___8)), uu___4) in
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = FStar_Parser_Const.p2l ["FStar"; m; "mul"] in
+                    let uu___6 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu____8844 ->
-                           fun uu____8845 ->
-                             match (uu____8844, uu____8845) with
-                             | ((int_to_t, x), (uu____8864, y)) ->
-                                 let uu____8874 =
-                                   FStar_BigInt.mult_big_int x y in
+                        (fun uu___7 ->
+                           fun uu___8 ->
+                             match (uu___7, uu___8) with
+                             | ((int_to_t, x), (uu___9, y)) ->
+                                 let uu___10 = FStar_BigInt.mult_big_int x y in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____8874) in
-                    (uu____8825, (Prims.of_int (2)), Prims.int_zero,
+                                   int_to_t uu___10) in
+                    (uu___5, (Prims.of_int (2)), Prims.int_zero,
                       (binary_op arg_as_bounded_int
                          (fun r ->
-                            fun uu____8905 ->
-                              fun uu____8906 ->
-                                match (uu____8905, uu____8906) with
-                                | ((int_to_t, x), (uu____8925, y)) ->
-                                    let uu____8935 =
+                            fun uu___7 ->
+                              fun uu___8 ->
+                                match (uu___7, uu___8) with
+                                | ((int_to_t, x), (uu___9, y)) ->
+                                    let uu___10 =
                                       FStar_BigInt.mult_big_int x y in
-                                    int_as_bounded r int_to_t uu____8935)),
-                      uu____8826) in
-                  let uu____8936 =
-                    let uu____8966 =
-                      let uu____8994 =
-                        FStar_Parser_Const.p2l ["FStar"; m; "v"] in
-                      let uu____8995 =
+                                    int_as_bounded r int_to_t uu___10)),
+                      uu___6) in
+                  let uu___5 =
+                    let uu___6 =
+                      let uu___7 = FStar_Parser_Const.p2l ["FStar"; m; "v"] in
+                      let uu___8 =
                         FStar_TypeChecker_NBETerm.unary_op
                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu____9009 ->
-                             match uu____9009 with
+                          (fun uu___9 ->
+                             match uu___9 with
                              | (int_to_t, x) ->
                                  FStar_TypeChecker_NBETerm.embed
                                    FStar_TypeChecker_NBETerm.e_int bogus_cbs
                                    x) in
-                      (uu____8994, Prims.int_one, Prims.int_zero,
+                      (uu___7, Prims.int_one, Prims.int_zero,
                         (unary_op arg_as_bounded_int
                            (fun r ->
-                              fun uu____9042 ->
-                                match uu____9042 with
+                              fun uu___9 ->
+                                match uu___9 with
                                 | (int_to_t, x) ->
                                     embed_simple
                                       FStar_Syntax_Embeddings.e_int r x)),
-                        uu____8995) in
-                    [uu____8966] in
-                  uu____8797 :: uu____8936 in
-                uu____8628 :: uu____8767 in
-              uu____8459 :: uu____8598)) in
+                        uu___8) in
+                    [uu___6] in
+                  uu___4 :: uu___5 in
+                uu___2 :: uu___3 in
+              uu___ :: uu___1)) in
     let div_mod_unsigned =
       FStar_All.pipe_right bounded_unsigned_int_types
         (FStar_List.collect
            (fun m ->
-              let uu____9276 =
-                let uu____9304 = FStar_Parser_Const.p2l ["FStar"; m; "div"] in
-                let uu____9305 =
+              let uu___ =
+                let uu___1 = FStar_Parser_Const.p2l ["FStar"; m; "div"] in
+                let uu___2 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____9323 ->
-                       fun uu____9324 ->
-                         match (uu____9323, uu____9324) with
-                         | ((int_to_t, x), (uu____9343, y)) ->
-                             let uu____9353 = FStar_BigInt.div_big_int x y in
+                    (fun uu___3 ->
+                       fun uu___4 ->
+                         match (uu___3, uu___4) with
+                         | ((int_to_t, x), (uu___5, y)) ->
+                             let uu___6 = FStar_BigInt.div_big_int x y in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____9353) in
-                (uu____9304, (Prims.of_int (2)), Prims.int_zero,
+                               int_to_t uu___6) in
+                (uu___1, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r ->
-                        fun uu____9384 ->
-                          fun uu____9385 ->
-                            match (uu____9384, uu____9385) with
-                            | ((int_to_t, x), (uu____9404, y)) ->
-                                let uu____9414 = FStar_BigInt.div_big_int x y in
-                                int_as_bounded r int_to_t uu____9414)),
-                  uu____9305) in
-              let uu____9415 =
-                let uu____9445 =
-                  let uu____9473 = FStar_Parser_Const.p2l ["FStar"; m; "rem"] in
-                  let uu____9474 =
+                        fun uu___3 ->
+                          fun uu___4 ->
+                            match (uu___3, uu___4) with
+                            | ((int_to_t, x), (uu___5, y)) ->
+                                let uu___6 = FStar_BigInt.div_big_int x y in
+                                int_as_bounded r int_to_t uu___6)), uu___2) in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "rem"] in
+                  let uu___4 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____9492 ->
-                         fun uu____9493 ->
-                           match (uu____9492, uu____9493) with
-                           | ((int_to_t, x), (uu____9512, y)) ->
-                               let uu____9522 = FStar_BigInt.mod_big_int x y in
+                      (fun uu___5 ->
+                         fun uu___6 ->
+                           match (uu___5, uu___6) with
+                           | ((int_to_t, x), (uu___7, y)) ->
+                               let uu___8 = FStar_BigInt.mod_big_int x y in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____9522) in
-                  (uu____9473, (Prims.of_int (2)), Prims.int_zero,
+                                 int_to_t uu___8) in
+                  (uu___3, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r ->
-                          fun uu____9553 ->
-                            fun uu____9554 ->
-                              match (uu____9553, uu____9554) with
-                              | ((int_to_t, x), (uu____9573, y)) ->
-                                  let uu____9583 =
-                                    FStar_BigInt.mod_big_int x y in
-                                  int_as_bounded r int_to_t uu____9583)),
-                    uu____9474) in
-                [uu____9445] in
-              uu____9276 :: uu____9415)) in
+                          fun uu___5 ->
+                            fun uu___6 ->
+                              match (uu___5, uu___6) with
+                              | ((int_to_t, x), (uu___7, y)) ->
+                                  let uu___8 = FStar_BigInt.mod_big_int x y in
+                                  int_as_bounded r int_to_t uu___8)), uu___4) in
+                [uu___2] in
+              uu___ :: uu___1)) in
     let mask m =
       match m with
       | "UInt8" -> FStar_BigInt.of_hex "ff"
@@ -2612,190 +2583,185 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
       | "UInt32" -> FStar_BigInt.of_hex "ffffffff"
       | "UInt64" -> FStar_BigInt.of_hex "ffffffffffffffff"
       | "UInt128" -> FStar_BigInt.of_hex "ffffffffffffffffffffffffffffffff"
-      | uu____9671 ->
-          let uu____9672 =
+      | uu___ ->
+          let uu___1 =
             FStar_Util.format1 "Impossible: bad string on mask: %s\n" m in
-          failwith uu____9672 in
+          failwith uu___1 in
     let bitwise =
       FStar_All.pipe_right bounded_unsigned_int_types
         (FStar_List.collect
            (fun m ->
-              let uu____9765 =
-                let uu____9793 = FStar_Parser_Const.p2l ["FStar"; m; "logor"] in
-                let uu____9794 =
+              let uu___ =
+                let uu___1 = FStar_Parser_Const.p2l ["FStar"; m; "logor"] in
+                let uu___2 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____9812 ->
-                       fun uu____9813 ->
-                         match (uu____9812, uu____9813) with
-                         | ((int_to_t, x), (uu____9832, y)) ->
-                             let uu____9842 = FStar_BigInt.logor_big_int x y in
+                    (fun uu___3 ->
+                       fun uu___4 ->
+                         match (uu___3, uu___4) with
+                         | ((int_to_t, x), (uu___5, y)) ->
+                             let uu___6 = FStar_BigInt.logor_big_int x y in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____9842) in
-                (uu____9793, (Prims.of_int (2)), Prims.int_zero,
+                               int_to_t uu___6) in
+                (uu___1, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r ->
-                        fun uu____9873 ->
-                          fun uu____9874 ->
-                            match (uu____9873, uu____9874) with
-                            | ((int_to_t, x), (uu____9893, y)) ->
-                                let uu____9903 =
-                                  FStar_BigInt.logor_big_int x y in
-                                int_as_bounded r int_to_t uu____9903)),
-                  uu____9794) in
-              let uu____9904 =
-                let uu____9934 =
-                  let uu____9962 =
-                    FStar_Parser_Const.p2l ["FStar"; m; "logand"] in
-                  let uu____9963 =
+                        fun uu___3 ->
+                          fun uu___4 ->
+                            match (uu___3, uu___4) with
+                            | ((int_to_t, x), (uu___5, y)) ->
+                                let uu___6 = FStar_BigInt.logor_big_int x y in
+                                int_as_bounded r int_to_t uu___6)), uu___2) in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "logand"] in
+                  let uu___4 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____9981 ->
-                         fun uu____9982 ->
-                           match (uu____9981, uu____9982) with
-                           | ((int_to_t, x), (uu____10001, y)) ->
-                               let uu____10011 =
-                                 FStar_BigInt.logand_big_int x y in
+                      (fun uu___5 ->
+                         fun uu___6 ->
+                           match (uu___5, uu___6) with
+                           | ((int_to_t, x), (uu___7, y)) ->
+                               let uu___8 = FStar_BigInt.logand_big_int x y in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____10011) in
-                  (uu____9962, (Prims.of_int (2)), Prims.int_zero,
+                                 int_to_t uu___8) in
+                  (uu___3, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r ->
-                          fun uu____10042 ->
-                            fun uu____10043 ->
-                              match (uu____10042, uu____10043) with
-                              | ((int_to_t, x), (uu____10062, y)) ->
-                                  let uu____10072 =
+                          fun uu___5 ->
+                            fun uu___6 ->
+                              match (uu___5, uu___6) with
+                              | ((int_to_t, x), (uu___7, y)) ->
+                                  let uu___8 =
                                     FStar_BigInt.logand_big_int x y in
-                                  int_as_bounded r int_to_t uu____10072)),
-                    uu____9963) in
-                let uu____10073 =
-                  let uu____10103 =
-                    let uu____10131 =
+                                  int_as_bounded r int_to_t uu___8)), uu___4) in
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 =
                       FStar_Parser_Const.p2l ["FStar"; m; "logxor"] in
-                    let uu____10132 =
+                    let uu___6 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu____10150 ->
-                           fun uu____10151 ->
-                             match (uu____10150, uu____10151) with
-                             | ((int_to_t, x), (uu____10170, y)) ->
-                                 let uu____10180 =
+                        (fun uu___7 ->
+                           fun uu___8 ->
+                             match (uu___7, uu___8) with
+                             | ((int_to_t, x), (uu___9, y)) ->
+                                 let uu___10 =
                                    FStar_BigInt.logxor_big_int x y in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____10180) in
-                    (uu____10131, (Prims.of_int (2)), Prims.int_zero,
+                                   int_to_t uu___10) in
+                    (uu___5, (Prims.of_int (2)), Prims.int_zero,
                       (binary_op arg_as_bounded_int
                          (fun r ->
-                            fun uu____10211 ->
-                              fun uu____10212 ->
-                                match (uu____10211, uu____10212) with
-                                | ((int_to_t, x), (uu____10231, y)) ->
-                                    let uu____10241 =
+                            fun uu___7 ->
+                              fun uu___8 ->
+                                match (uu___7, uu___8) with
+                                | ((int_to_t, x), (uu___9, y)) ->
+                                    let uu___10 =
                                       FStar_BigInt.logxor_big_int x y in
-                                    int_as_bounded r int_to_t uu____10241)),
-                      uu____10132) in
-                  let uu____10242 =
-                    let uu____10272 =
-                      let uu____10300 =
+                                    int_as_bounded r int_to_t uu___10)),
+                      uu___6) in
+                  let uu___5 =
+                    let uu___6 =
+                      let uu___7 =
                         FStar_Parser_Const.p2l ["FStar"; m; "lognot"] in
-                      let uu____10301 =
+                      let uu___8 =
                         FStar_TypeChecker_NBETerm.unary_op
                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu____10316 ->
-                             match uu____10316 with
+                          (fun uu___9 ->
+                             match uu___9 with
                              | (int_to_t, x) ->
-                                 let uu____10323 =
-                                   let uu____10324 =
+                                 let uu___10 =
+                                   let uu___11 =
                                      FStar_BigInt.lognot_big_int x in
-                                   let uu____10325 = mask m in
-                                   FStar_BigInt.logand_big_int uu____10324
-                                     uu____10325 in
+                                   let uu___12 = mask m in
+                                   FStar_BigInt.logand_big_int uu___11
+                                     uu___12 in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____10323) in
-                      (uu____10300, Prims.int_one, Prims.int_zero,
+                                   int_to_t uu___10) in
+                      (uu___7, Prims.int_one, Prims.int_zero,
                         (unary_op arg_as_bounded_int
                            (fun r ->
-                              fun uu____10353 ->
-                                match uu____10353 with
+                              fun uu___9 ->
+                                match uu___9 with
                                 | (int_to_t, x) ->
-                                    let uu____10360 =
-                                      let uu____10361 =
+                                    let uu___10 =
+                                      let uu___11 =
                                         FStar_BigInt.lognot_big_int x in
-                                      let uu____10362 = mask m in
-                                      FStar_BigInt.logand_big_int uu____10361
-                                        uu____10362 in
-                                    int_as_bounded r int_to_t uu____10360)),
-                        uu____10301) in
-                    let uu____10363 =
-                      let uu____10393 =
-                        let uu____10421 =
+                                      let uu___12 = mask m in
+                                      FStar_BigInt.logand_big_int uu___11
+                                        uu___12 in
+                                    int_as_bounded r int_to_t uu___10)),
+                        uu___8) in
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
                           FStar_Parser_Const.p2l ["FStar"; m; "shift_left"] in
-                        let uu____10422 =
+                        let uu___10 =
                           FStar_TypeChecker_NBETerm.binary_op
                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                            (fun uu____10440 ->
-                               fun uu____10441 ->
-                                 match (uu____10440, uu____10441) with
-                                 | ((int_to_t, x), (uu____10460, y)) ->
-                                     let uu____10470 =
-                                       let uu____10471 =
+                            (fun uu___11 ->
+                               fun uu___12 ->
+                                 match (uu___11, uu___12) with
+                                 | ((int_to_t, x), (uu___13, y)) ->
+                                     let uu___14 =
+                                       let uu___15 =
                                          FStar_BigInt.shift_left_big_int x y in
-                                       let uu____10472 = mask m in
-                                       FStar_BigInt.logand_big_int
-                                         uu____10471 uu____10472 in
+                                       let uu___16 = mask m in
+                                       FStar_BigInt.logand_big_int uu___15
+                                         uu___16 in
                                      FStar_TypeChecker_NBETerm.int_as_bounded
-                                       int_to_t uu____10470) in
-                        (uu____10421, (Prims.of_int (2)), Prims.int_zero,
+                                       int_to_t uu___14) in
+                        (uu___9, (Prims.of_int (2)), Prims.int_zero,
                           (binary_op arg_as_bounded_int
                              (fun r ->
-                                fun uu____10503 ->
-                                  fun uu____10504 ->
-                                    match (uu____10503, uu____10504) with
-                                    | ((int_to_t, x), (uu____10523, y)) ->
-                                        let uu____10533 =
-                                          let uu____10534 =
+                                fun uu___11 ->
+                                  fun uu___12 ->
+                                    match (uu___11, uu___12) with
+                                    | ((int_to_t, x), (uu___13, y)) ->
+                                        let uu___14 =
+                                          let uu___15 =
                                             FStar_BigInt.shift_left_big_int x
                                               y in
-                                          let uu____10535 = mask m in
-                                          FStar_BigInt.logand_big_int
-                                            uu____10534 uu____10535 in
-                                        int_as_bounded r int_to_t uu____10533)),
-                          uu____10422) in
-                      let uu____10536 =
-                        let uu____10566 =
-                          let uu____10594 =
+                                          let uu___16 = mask m in
+                                          FStar_BigInt.logand_big_int uu___15
+                                            uu___16 in
+                                        int_as_bounded r int_to_t uu___14)),
+                          uu___10) in
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
                             FStar_Parser_Const.p2l
                               ["FStar"; m; "shift_right"] in
-                          let uu____10595 =
+                          let uu___12 =
                             FStar_TypeChecker_NBETerm.binary_op
                               FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                              (fun uu____10613 ->
-                                 fun uu____10614 ->
-                                   match (uu____10613, uu____10614) with
-                                   | ((int_to_t, x), (uu____10633, y)) ->
-                                       let uu____10643 =
+                              (fun uu___13 ->
+                                 fun uu___14 ->
+                                   match (uu___13, uu___14) with
+                                   | ((int_to_t, x), (uu___15, y)) ->
+                                       let uu___16 =
                                          FStar_BigInt.shift_right_big_int x y in
                                        FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu____10643) in
-                          (uu____10594, (Prims.of_int (2)), Prims.int_zero,
+                                         int_to_t uu___16) in
+                          (uu___11, (Prims.of_int (2)), Prims.int_zero,
                             (binary_op arg_as_bounded_int
                                (fun r ->
-                                  fun uu____10674 ->
-                                    fun uu____10675 ->
-                                      match (uu____10674, uu____10675) with
-                                      | ((int_to_t, x), (uu____10694, y)) ->
-                                          let uu____10704 =
+                                  fun uu___13 ->
+                                    fun uu___14 ->
+                                      match (uu___13, uu___14) with
+                                      | ((int_to_t, x), (uu___15, y)) ->
+                                          let uu___16 =
                                             FStar_BigInt.shift_right_big_int
                                               x y in
-                                          int_as_bounded r int_to_t
-                                            uu____10704)), uu____10595) in
-                        [uu____10566] in
-                      uu____10393 :: uu____10536 in
-                    uu____10272 :: uu____10363 in
-                  uu____10103 :: uu____10242 in
-                uu____9934 :: uu____10073 in
-              uu____9765 :: uu____9904)) in
+                                          int_as_bounded r int_to_t uu___16)),
+                            uu___12) in
+                        [uu___10] in
+                      uu___8 :: uu___9 in
+                    uu___6 :: uu___7 in
+                  uu___4 :: uu___5 in
+                uu___2 :: uu___3 in
+              uu___ :: uu___1)) in
     FStar_List.append add_sub_mul_v
       (FStar_List.append div_mod_unsigned bitwise) in
   let strong_steps =
@@ -2808,64 +2774,58 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
   let interp_prop_eq2 psc1 _norm_cb args =
     let r = psc1.psc_range in
     match args with
-    | (_typ, uu____11065)::(a1, uu____11067)::(a2, uu____11069)::[] ->
-        let uu____11126 = FStar_Syntax_Util.eq_tm a1 a2 in
-        (match uu____11126 with
+    | (_typ, uu___)::(a1, uu___1)::(a2, uu___2)::[] ->
+        let uu___3 = FStar_Syntax_Util.eq_tm a1 a2 in
+        (match uu___3 with
          | FStar_Syntax_Util.Equal ->
              FStar_Pervasives_Native.Some
-               (let uu___900_11130 = FStar_Syntax_Util.t_true in
+               (let uu___4 = FStar_Syntax_Util.t_true in
                 {
-                  FStar_Syntax_Syntax.n =
-                    (uu___900_11130.FStar_Syntax_Syntax.n);
+                  FStar_Syntax_Syntax.n = (uu___4.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___900_11130.FStar_Syntax_Syntax.vars)
+                    (uu___4.FStar_Syntax_Syntax.vars)
                 })
          | FStar_Syntax_Util.NotEqual ->
              FStar_Pervasives_Native.Some
-               (let uu___903_11132 = FStar_Syntax_Util.t_false in
+               (let uu___4 = FStar_Syntax_Util.t_false in
                 {
-                  FStar_Syntax_Syntax.n =
-                    (uu___903_11132.FStar_Syntax_Syntax.n);
+                  FStar_Syntax_Syntax.n = (uu___4.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___903_11132.FStar_Syntax_Syntax.vars)
+                    (uu___4.FStar_Syntax_Syntax.vars)
                 })
-         | uu____11133 -> FStar_Pervasives_Native.None)
-    | uu____11134 -> failwith "Unexpected number of arguments" in
+         | uu___4 -> FStar_Pervasives_Native.None)
+    | uu___ -> failwith "Unexpected number of arguments" in
   let interp_prop_eq3 psc1 _norm_cb args =
     let r = psc1.psc_range in
     match args with
-    | (t1, uu____11163)::(t2, uu____11165)::(a1, uu____11167)::(a2,
-                                                                uu____11169)::[]
-        ->
-        let uu____11242 =
-          let uu____11243 = FStar_Syntax_Util.eq_tm t1 t2 in
-          let uu____11244 = FStar_Syntax_Util.eq_tm a1 a2 in
-          FStar_Syntax_Util.eq_inj uu____11243 uu____11244 in
-        (match uu____11242 with
+    | (t1, uu___)::(t2, uu___1)::(a1, uu___2)::(a2, uu___3)::[] ->
+        let uu___4 =
+          let uu___5 = FStar_Syntax_Util.eq_tm t1 t2 in
+          let uu___6 = FStar_Syntax_Util.eq_tm a1 a2 in
+          FStar_Syntax_Util.eq_inj uu___5 uu___6 in
+        (match uu___4 with
          | FStar_Syntax_Util.Equal ->
              FStar_Pervasives_Native.Some
-               (let uu___926_11248 = FStar_Syntax_Util.t_true in
+               (let uu___5 = FStar_Syntax_Util.t_true in
                 {
-                  FStar_Syntax_Syntax.n =
-                    (uu___926_11248.FStar_Syntax_Syntax.n);
+                  FStar_Syntax_Syntax.n = (uu___5.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___926_11248.FStar_Syntax_Syntax.vars)
+                    (uu___5.FStar_Syntax_Syntax.vars)
                 })
          | FStar_Syntax_Util.NotEqual ->
              FStar_Pervasives_Native.Some
-               (let uu___929_11250 = FStar_Syntax_Util.t_false in
+               (let uu___5 = FStar_Syntax_Util.t_false in
                 {
-                  FStar_Syntax_Syntax.n =
-                    (uu___929_11250.FStar_Syntax_Syntax.n);
+                  FStar_Syntax_Syntax.n = (uu___5.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___929_11250.FStar_Syntax_Syntax.vars)
+                    (uu___5.FStar_Syntax_Syntax.vars)
                 })
-         | uu____11251 -> FStar_Pervasives_Native.None)
-    | uu____11252 -> failwith "Unexpected number of arguments" in
+         | uu___5 -> FStar_Pervasives_Native.None)
+    | uu___ -> failwith "Unexpected number of arguments" in
   let propositional_equality =
     {
       name = FStar_Parser_Const.eq2_lid;
@@ -2894,12 +2854,12 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
 let (primop_time_map : Prims.int FStar_Util.smap) =
   FStar_Util.smap_create (Prims.of_int (50))
 let (primop_time_reset : unit -> unit) =
-  fun uu____11267 -> FStar_Util.smap_clear primop_time_map
+  fun uu___ -> FStar_Util.smap_clear primop_time_map
 let (primop_time_count : Prims.string -> Prims.int -> unit) =
   fun nm ->
     fun ms ->
-      let uu____11278 = FStar_Util.smap_try_find primop_time_map nm in
-      match uu____11278 with
+      let uu___ = FStar_Util.smap_try_find primop_time_map nm in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
           FStar_Util.smap_add primop_time_map nm ms
       | FStar_Pervasives_Native.Some ms0 ->
@@ -2909,46 +2869,44 @@ let (fixto : Prims.int -> Prims.string -> Prims.string) =
     fun s ->
       if (FStar_String.length s) < n
       then
-        let uu____11292 = FStar_String.make (n - (FStar_String.length s)) 32 in
-        FStar_String.op_Hat uu____11292 s
+        let uu___ = FStar_String.make (n - (FStar_String.length s)) 32 in
+        FStar_String.op_Hat uu___ s
       else s
 let (primop_time_report : unit -> Prims.string) =
-  fun uu____11298 ->
+  fun uu___ ->
     let pairs =
       FStar_Util.smap_fold primop_time_map
         (fun nm -> fun ms -> fun rest -> (nm, ms) :: rest) [] in
     let pairs1 =
       FStar_Util.sort_with
-        (fun uu____11349 ->
-           fun uu____11350 ->
-             match (uu____11349, uu____11350) with
-             | ((uu____11367, t1), (uu____11369, t2)) -> t1 - t2) pairs in
+        (fun uu___1 ->
+           fun uu___2 ->
+             match (uu___1, uu___2) with
+             | ((uu___3, t1), (uu___4, t2)) -> t1 - t2) pairs in
     FStar_List.fold_right
-      (fun uu____11388 ->
+      (fun uu___1 ->
          fun rest ->
-           match uu____11388 with
+           match uu___1 with
            | (nm, ms) ->
-               let uu____11396 =
-                 let uu____11397 =
-                   let uu____11398 = FStar_Util.string_of_int ms in
-                   fixto (Prims.of_int (10)) uu____11398 in
-                 FStar_Util.format2 "%sms --- %s\n" uu____11397 nm in
-               FStar_String.op_Hat uu____11396 rest) pairs1 ""
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Util.string_of_int ms in
+                   fixto (Prims.of_int (10)) uu___4 in
+                 FStar_Util.format2 "%sms --- %s\n" uu___3 nm in
+               FStar_String.op_Hat uu___2 rest) pairs1 ""
 let (extendable_primops_dirty : Prims.bool FStar_ST.ref) =
   FStar_Util.mk_ref true
 type register_prim_step_t = primitive_step -> unit
 type retrieve_prim_step_t = unit -> prim_step_set
 let (mk_extendable_primop_set :
   unit -> (register_prim_step_t * retrieve_prim_step_t)) =
-  fun uu____11417 ->
-    let steps =
-      let uu____11427 = empty_prim_steps () in FStar_Util.mk_ref uu____11427 in
+  fun uu___ ->
+    let steps = let uu___1 = empty_prim_steps () in FStar_Util.mk_ref uu___1 in
     let register p =
       FStar_ST.op_Colon_Equals extendable_primops_dirty true;
-      (let uu____11441 =
-         let uu____11442 = FStar_ST.op_Bang steps in add_step p uu____11442 in
-       FStar_ST.op_Colon_Equals steps uu____11441) in
-    let retrieve uu____11460 = FStar_ST.op_Bang steps in (register, retrieve)
+      (let uu___2 = let uu___3 = FStar_ST.op_Bang steps in add_step p uu___3 in
+       FStar_ST.op_Colon_Equals steps uu___2) in
+    let retrieve uu___1 = FStar_ST.op_Bang steps in (register, retrieve)
 let (plugins : (register_prim_step_t * retrieve_prim_step_t)) =
   mk_extendable_primop_set ()
 let (extra_steps : (register_prim_step_t * retrieve_prim_step_t)) =
@@ -2956,67 +2914,65 @@ let (extra_steps : (register_prim_step_t * retrieve_prim_step_t)) =
 let (register_plugin : primitive_step -> unit) =
   fun p -> FStar_Pervasives_Native.fst plugins p
 let (retrieve_plugins : unit -> prim_step_set) =
-  fun uu____11492 ->
-    let uu____11493 = FStar_Options.no_plugins () in
-    if uu____11493
+  fun uu___ ->
+    let uu___1 = FStar_Options.no_plugins () in
+    if uu___1
     then empty_prim_steps ()
     else FStar_Pervasives_Native.snd plugins ()
 let (register_extra_step : primitive_step -> unit) =
   fun p -> FStar_Pervasives_Native.fst extra_steps p
 let (retrieve_extra_steps : unit -> prim_step_set) =
-  fun uu____11508 -> FStar_Pervasives_Native.snd extra_steps ()
+  fun uu___ -> FStar_Pervasives_Native.snd extra_steps ()
 let (cached_steps : unit -> prim_step_set) =
-  let memo =
-    let uu____11518 = empty_prim_steps () in FStar_Util.mk_ref uu____11518 in
-  fun uu____11519 ->
-    let uu____11520 = FStar_ST.op_Bang extendable_primops_dirty in
-    if uu____11520
+  let memo = let uu___ = empty_prim_steps () in FStar_Util.mk_ref uu___ in
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang extendable_primops_dirty in
+    if uu___1
     then
       let steps =
-        let uu____11528 =
-          let uu____11529 = retrieve_plugins () in
-          let uu____11530 = retrieve_extra_steps () in
-          merge_steps uu____11529 uu____11530 in
-        merge_steps built_in_primitive_steps uu____11528 in
+        let uu___2 =
+          let uu___3 = retrieve_plugins () in
+          let uu___4 = retrieve_extra_steps () in merge_steps uu___3 uu___4 in
+        merge_steps built_in_primitive_steps uu___2 in
       (FStar_ST.op_Colon_Equals memo steps;
        FStar_ST.op_Colon_Equals extendable_primops_dirty false;
        steps)
     else FStar_ST.op_Bang memo
 let (add_nbe : fsteps -> fsteps) =
   fun s ->
-    let uu____11557 = FStar_Options.use_nbe () in
-    if uu____11557
+    let uu___ = FStar_Options.use_nbe () in
+    if uu___
     then
-      let uu___982_11558 = s in
+      let uu___1 = s in
       {
-        beta = (uu___982_11558.beta);
-        iota = (uu___982_11558.iota);
-        zeta = (uu___982_11558.zeta);
-        zeta_full = (uu___982_11558.zeta_full);
-        weak = (uu___982_11558.weak);
-        hnf = (uu___982_11558.hnf);
-        primops = (uu___982_11558.primops);
-        do_not_unfold_pure_lets = (uu___982_11558.do_not_unfold_pure_lets);
-        unfold_until = (uu___982_11558.unfold_until);
-        unfold_only = (uu___982_11558.unfold_only);
-        unfold_fully = (uu___982_11558.unfold_fully);
-        unfold_attr = (uu___982_11558.unfold_attr);
-        unfold_tac = (uu___982_11558.unfold_tac);
+        beta = (uu___1.beta);
+        iota = (uu___1.iota);
+        zeta = (uu___1.zeta);
+        zeta_full = (uu___1.zeta_full);
+        weak = (uu___1.weak);
+        hnf = (uu___1.hnf);
+        primops = (uu___1.primops);
+        do_not_unfold_pure_lets = (uu___1.do_not_unfold_pure_lets);
+        unfold_until = (uu___1.unfold_until);
+        unfold_only = (uu___1.unfold_only);
+        unfold_fully = (uu___1.unfold_fully);
+        unfold_attr = (uu___1.unfold_attr);
+        unfold_tac = (uu___1.unfold_tac);
         pure_subterms_within_computations =
-          (uu___982_11558.pure_subterms_within_computations);
-        simplify = (uu___982_11558.simplify);
-        erase_universes = (uu___982_11558.erase_universes);
-        allow_unbound_universes = (uu___982_11558.allow_unbound_universes);
-        reify_ = (uu___982_11558.reify_);
-        compress_uvars = (uu___982_11558.compress_uvars);
-        no_full_norm = (uu___982_11558.no_full_norm);
-        check_no_uvars = (uu___982_11558.check_no_uvars);
-        unmeta = (uu___982_11558.unmeta);
-        unascribe = (uu___982_11558.unascribe);
-        in_full_norm_request = (uu___982_11558.in_full_norm_request);
-        weakly_reduce_scrutinee = (uu___982_11558.weakly_reduce_scrutinee);
+          (uu___1.pure_subterms_within_computations);
+        simplify = (uu___1.simplify);
+        erase_universes = (uu___1.erase_universes);
+        allow_unbound_universes = (uu___1.allow_unbound_universes);
+        reify_ = (uu___1.reify_);
+        compress_uvars = (uu___1.compress_uvars);
+        no_full_norm = (uu___1.no_full_norm);
+        check_no_uvars = (uu___1.check_no_uvars);
+        unmeta = (uu___1.unmeta);
+        unascribe = (uu___1.unascribe);
+        in_full_norm_request = (uu___1.in_full_norm_request);
+        weakly_reduce_scrutinee = (uu___1.weakly_reduce_scrutinee);
         nbe_step = true;
-        for_extraction = (uu___982_11558.for_extraction)
+        for_extraction = (uu___1.for_extraction)
       }
     else s
 let (config' :
@@ -3029,75 +2985,71 @@ let (config' :
         let d =
           FStar_All.pipe_right s
             (FStar_List.collect
-               (fun uu___0_11592 ->
-                  match uu___0_11592 with
+               (fun uu___ ->
+                  match uu___ with
                   | FStar_TypeChecker_Env.UnfoldUntil k ->
                       [FStar_TypeChecker_Env.Unfold k]
                   | FStar_TypeChecker_Env.Eager_unfolding ->
                       [FStar_TypeChecker_Env.Eager_unfolding_only]
                   | FStar_TypeChecker_Env.Inlining ->
                       [FStar_TypeChecker_Env.InliningDelta]
-                  | uu____11596 -> [])) in
+                  | uu___1 -> [])) in
         let d1 =
-          match d with
-          | [] -> [FStar_TypeChecker_Env.NoDelta]
-          | uu____11602 -> d in
+          match d with | [] -> [FStar_TypeChecker_Env.NoDelta] | uu___ -> d in
         let steps =
-          let uu____11606 = to_fsteps s in
-          FStar_All.pipe_right uu____11606 add_nbe in
-        let psteps1 =
-          let uu____11608 = cached_steps () in add_steps uu____11608 psteps in
-        let uu____11609 =
-          let uu____11610 = FStar_Options.debug_any () in
-          if uu____11610
+          let uu___ = to_fsteps s in FStar_All.pipe_right uu___ add_nbe in
+        let psteps1 = let uu___ = cached_steps () in add_steps uu___ psteps in
+        let uu___ =
+          let uu___1 = FStar_Options.debug_any () in
+          if uu___1
           then
-            let uu____11611 =
+            let uu___2 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Norm") in
-            let uu____11612 =
+            let uu___3 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormTop") in
-            let uu____11613 =
+            let uu___4 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormCfg") in
-            let uu____11614 =
+            let uu___5 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Primops") in
-            let uu____11615 =
+            let uu___6 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Unfolding") in
-            let uu____11616 =
+            let uu___7 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "380") in
-            let uu____11617 =
+            let uu___8 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "WPE") in
-            let uu____11618 =
+            let uu___9 =
               FStar_TypeChecker_Env.debug e
                 (FStar_Options.Other "NormDelayed") in
-            let uu____11619 =
+            let uu___10 =
               FStar_TypeChecker_Env.debug e
                 (FStar_Options.Other "print_normalized_terms") in
-            let uu____11620 =
+            let uu___11 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NBE") in
             {
-              gen = uu____11611;
-              top = uu____11612;
-              cfg = uu____11613;
-              primop = uu____11614;
-              unfolding = uu____11615;
-              b380 = uu____11616;
-              wpe = uu____11617;
-              norm_delayed = uu____11618;
-              print_normalized = uu____11619;
-              debug_nbe = uu____11620
+              gen = uu___2;
+              top = uu___3;
+              cfg = uu___4;
+              primop = uu___5;
+              unfolding = uu___6;
+              b380 = uu___7;
+              wpe = uu___8;
+              norm_delayed = uu___9;
+              print_normalized = uu___10;
+              debug_nbe = uu___11
             }
           else no_debug_switches in
-        let uu____11622 =
+        let uu___1 =
           (Prims.op_Negation steps.pure_subterms_within_computations) ||
             (FStar_Options.normalize_pure_terms_for_extraction ()) in
         {
           steps;
           tcenv = e;
-          debug = uu____11609;
+          debug = uu___;
           delta_level = d1;
           primitive_steps = psteps1;
           strong = false;
           memoize_lazy = true;
-          normalize_pure_lets = uu____11622;
+          normalize_pure_lets = uu___1;
           reifying = false
         }
 let (config :
@@ -3110,23 +3062,23 @@ let (should_reduce_local_let :
       if (cfg1.steps).do_not_unfold_pure_lets
       then false
       else
-        (let uu____11648 =
+        (let uu___1 =
            (cfg1.steps).pure_subterms_within_computations &&
              (FStar_Syntax_Util.has_attribute lb.FStar_Syntax_Syntax.lbattrs
                 FStar_Parser_Const.inline_let_attr) in
-         if uu____11648
+         if uu___1
          then true
          else
            (let n =
               FStar_TypeChecker_Env.norm_eff_name cfg1.tcenv
                 lb.FStar_Syntax_Syntax.lbeff in
-            let uu____11651 =
+            let uu___3 =
               (FStar_Syntax_Util.is_pure_effect n) &&
                 (cfg1.normalize_pure_lets ||
                    (FStar_Syntax_Util.has_attribute
                       lb.FStar_Syntax_Syntax.lbattrs
                       FStar_Parser_Const.inline_let_attr)) in
-            if uu____11651
+            if uu___3
             then true
             else
               (FStar_Syntax_Util.is_ghost_effect n) &&

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -4,11 +4,11 @@ type rel =
   | SUB 
   | SUBINV 
 let (uu___is_EQ : rel -> Prims.bool) =
-  fun projectee -> match projectee with | EQ -> true | uu____35 -> false
+  fun projectee -> match projectee with | EQ -> true | uu___ -> false
 let (uu___is_SUB : rel -> Prims.bool) =
-  fun projectee -> match projectee with | SUB -> true | uu____41 -> false
+  fun projectee -> match projectee with | SUB -> true | uu___ -> false
 let (uu___is_SUBINV : rel -> Prims.bool) =
-  fun projectee -> match projectee with | SUBINV -> true | uu____47 -> false
+  fun projectee -> match projectee with | SUBINV -> true | uu___ -> false
 type rank_t =
   | Rigid_rigid 
   | Flex_rigid_eq 
@@ -18,22 +18,19 @@ type rank_t =
   | Flex_flex 
 let (uu___is_Rigid_rigid : rank_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Rigid_rigid -> true | uu____53 -> false
+    match projectee with | Rigid_rigid -> true | uu___ -> false
 let (uu___is_Flex_rigid_eq : rank_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Flex_rigid_eq -> true | uu____59 -> false
+    match projectee with | Flex_rigid_eq -> true | uu___ -> false
 let (uu___is_Flex_flex_pattern_eq : rank_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Flex_flex_pattern_eq -> true | uu____65 -> false
+    match projectee with | Flex_flex_pattern_eq -> true | uu___ -> false
 let (uu___is_Flex_rigid : rank_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Flex_rigid -> true | uu____71 -> false
+  fun projectee -> match projectee with | Flex_rigid -> true | uu___ -> false
 let (uu___is_Rigid_flex : rank_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Rigid_flex -> true | uu____77 -> false
+  fun projectee -> match projectee with | Rigid_flex -> true | uu___ -> false
 let (uu___is_Flex_flex : rank_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Flex_flex -> true | uu____83 -> false
+  fun projectee -> match projectee with | Flex_flex -> true | uu___ -> false
 type 'a problem =
   {
   pid: Prims.int ;
@@ -105,30 +102,25 @@ type prob =
   | TProb of FStar_Syntax_Syntax.typ problem 
   | CProb of FStar_Syntax_Syntax.comp problem 
 let (uu___is_TProb : prob -> Prims.bool) =
-  fun projectee ->
-    match projectee with | TProb _0 -> true | uu____472 -> false
+  fun projectee -> match projectee with | TProb _0 -> true | uu___ -> false
 let (__proj__TProb__item___0 : prob -> FStar_Syntax_Syntax.typ problem) =
   fun projectee -> match projectee with | TProb _0 -> _0
 let (uu___is_CProb : prob -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CProb _0 -> true | uu____493 -> false
+  fun projectee -> match projectee with | CProb _0 -> true | uu___ -> false
 let (__proj__CProb__item___0 : prob -> FStar_Syntax_Syntax.comp problem) =
   fun projectee -> match projectee with | CProb _0 -> _0
 let (as_tprob : prob -> FStar_Syntax_Syntax.typ problem) =
-  fun uu___0_512 ->
-    match uu___0_512 with
-    | TProb p -> p
-    | uu____518 -> failwith "Expected a TProb"
+  fun uu___ ->
+    match uu___ with | TProb p -> p | uu___1 -> failwith "Expected a TProb"
 type probs = prob Prims.list
 type guard_formula =
   | Trivial 
   | NonTrivial of FStar_Syntax_Syntax.formula 
 let (uu___is_Trivial : guard_formula -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Trivial -> true | uu____533 -> false
+  fun projectee -> match projectee with | Trivial -> true | uu___ -> false
 let (uu___is_NonTrivial : guard_formula -> Prims.bool) =
   fun projectee ->
-    match projectee with | NonTrivial _0 -> true | uu____540 -> false
+    match projectee with | NonTrivial _0 -> true | uu___ -> false
 let (__proj__NonTrivial__item___0 :
   guard_formula -> FStar_Syntax_Syntax.formula) =
   fun projectee -> match projectee with | NonTrivial _0 -> _0
@@ -142,17 +134,14 @@ let (mk_by_tactic :
   fun tac ->
     fun f ->
       let t_by_tactic =
-        let uu____568 =
+        let uu___ =
           FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.by_tactic_lid in
-        FStar_Syntax_Syntax.mk_Tm_uinst uu____568
-          [FStar_Syntax_Syntax.U_zero] in
-      let uu____569 =
-        let uu____570 = FStar_Syntax_Syntax.as_arg tac in
-        let uu____579 =
-          let uu____590 = FStar_Syntax_Syntax.as_arg f in [uu____590] in
-        uu____570 :: uu____579 in
-      FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____569
-        FStar_Range.dummyRange
+        FStar_Syntax_Syntax.mk_Tm_uinst uu___ [FStar_Syntax_Syntax.U_zero] in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Syntax.as_arg tac in
+        let uu___2 = let uu___3 = FStar_Syntax_Syntax.as_arg f in [uu___3] in
+        uu___1 :: uu___2 in
+      FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu___ FStar_Range.dummyRange
 let rec (delta_depth_greater_than :
   FStar_Syntax_Syntax.delta_depth ->
     FStar_Syntax_Syntax.delta_depth -> Prims.bool)
@@ -164,24 +153,23 @@ let rec (delta_depth_greater_than :
          FStar_Syntax_Syntax.Delta_equational_at_level j) -> i > j
       | (FStar_Syntax_Syntax.Delta_constant_at_level i,
          FStar_Syntax_Syntax.Delta_constant_at_level j) -> i > j
-      | (FStar_Syntax_Syntax.Delta_abstract d, uu____638) ->
+      | (FStar_Syntax_Syntax.Delta_abstract d, uu___) ->
           delta_depth_greater_than d m
-      | (uu____639, FStar_Syntax_Syntax.Delta_abstract d) ->
+      | (uu___, FStar_Syntax_Syntax.Delta_abstract d) ->
           delta_depth_greater_than l d
-      | (FStar_Syntax_Syntax.Delta_equational_at_level uu____641, uu____642)
-          -> true
-      | (uu____643, FStar_Syntax_Syntax.Delta_equational_at_level uu____644)
-          -> false
+      | (FStar_Syntax_Syntax.Delta_equational_at_level uu___, uu___1) -> true
+      | (uu___, FStar_Syntax_Syntax.Delta_equational_at_level uu___1) ->
+          false
 let rec (decr_delta_depth :
   FStar_Syntax_Syntax.delta_depth ->
     FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
   =
-  fun uu___1_651 ->
-    match uu___1_651 with
-    | FStar_Syntax_Syntax.Delta_constant_at_level uu____654 when
-        uu____654 = Prims.int_zero -> FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Delta_equational_at_level uu____655 when
-        uu____655 = Prims.int_zero -> FStar_Pervasives_Native.None
+  fun uu___ ->
+    match uu___ with
+    | FStar_Syntax_Syntax.Delta_constant_at_level uu___1 when
+        uu___1 = Prims.int_zero -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Delta_equational_at_level uu___1 when
+        uu___1 = Prims.int_zero -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Delta_constant_at_level i ->
         FStar_Pervasives_Native.Some
           (FStar_Syntax_Syntax.Delta_constant_at_level (i - Prims.int_one))
@@ -228,9 +216,8 @@ let (insert_col_info :
               if col < c
               then (aux, ((col, info) :: rest))
               else __insert ((c, i) :: aux) rest' in
-        let uu____896 = __insert [] col_infos in
-        match uu____896 with
-        | (l, r) -> FStar_List.append (FStar_List.rev l) r
+        let uu___ = __insert [] col_infos in
+        match uu___ with | (l, r) -> FStar_List.append (FStar_List.rev l) r
 let (find_nearest_preceding_col_info :
   Prims.int ->
     (Prims.int * identifier_info) Prims.list ->
@@ -238,8 +225,8 @@ let (find_nearest_preceding_col_info :
   =
   fun col ->
     fun col_infos ->
-      let rec aux out uu___2_1001 =
-        match uu___2_1001 with
+      let rec aux out uu___ =
+        match uu___ with
         | [] -> out
         | (c, i)::rest ->
             if c > col
@@ -270,8 +257,8 @@ let (__proj__Mkid_info_table__item__id_info_buffer :
     match projectee with
     | { id_info_enabled; id_info_db; id_info_buffer;_} -> id_info_buffer
 let (id_info_table_empty : id_info_table) =
-  let uu____1093 = FStar_Util.psmap_empty () in
-  { id_info_enabled = false; id_info_db = uu____1093; id_info_buffer = [] }
+  let uu___ = FStar_Util.psmap_empty () in
+  { id_info_enabled = false; id_info_db = uu___; id_info_buffer = [] }
 let (id_info__insert :
   (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) ->
     (Prims.int * identifier_info) Prims.list FStar_Util.pimap
@@ -285,32 +272,31 @@ let (id_info__insert :
       fun info ->
         let range = info.identifier_range in
         let use_range =
-          let uu____1146 = FStar_Range.use_range range in
-          FStar_Range.set_def_range range uu____1146 in
+          let uu___ = FStar_Range.use_range range in
+          FStar_Range.set_def_range range uu___ in
         let info1 =
-          let uu___143_1148 = info in
-          let uu____1149 = ty_map info.identifier_ty in
+          let uu___ = info in
+          let uu___1 = ty_map info.identifier_ty in
           {
-            identifier = (uu___143_1148.identifier);
-            identifier_ty = uu____1149;
+            identifier = (uu___.identifier);
+            identifier_ty = uu___1;
             identifier_range = use_range
           } in
         let fn = FStar_Range.file_of_range use_range in
         let start = FStar_Range.start_of_range use_range in
-        let uu____1152 =
-          let uu____1157 = FStar_Range.line_of_pos start in
-          let uu____1158 = FStar_Range.col_of_pos start in
-          (uu____1157, uu____1158) in
-        match uu____1152 with
+        let uu___ =
+          let uu___1 = FStar_Range.line_of_pos start in
+          let uu___2 = FStar_Range.col_of_pos start in (uu___1, uu___2) in
+        match uu___ with
         | (row, col) ->
             let rows =
-              let uu____1180 = FStar_Util.pimap_empty () in
-              FStar_Util.psmap_find_default db fn uu____1180 in
+              let uu___1 = FStar_Util.pimap_empty () in
+              FStar_Util.psmap_find_default db fn uu___1 in
             let cols = FStar_Util.pimap_find_default rows row [] in
-            let uu____1220 =
-              let uu____1229 = insert_col_info col info1 cols in
-              FStar_All.pipe_right uu____1229 (FStar_Util.pimap_add rows row) in
-            FStar_All.pipe_right uu____1220 (FStar_Util.psmap_add db fn)
+            let uu___1 =
+              let uu___2 = insert_col_info col info1 cols in
+              FStar_All.pipe_right uu___2 (FStar_Util.pimap_add rows row) in
+            FStar_All.pipe_right uu___1 (FStar_Util.psmap_add db fn)
 let (id_info_insert :
   id_info_table ->
     (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Util.either ->
@@ -322,10 +308,10 @@ let (id_info_insert :
         fun range ->
           let info =
             { identifier = id; identifier_ty = ty; identifier_range = range } in
-          let uu___158_1311 = table in
+          let uu___ = table in
           {
-            id_info_enabled = (uu___158_1311.id_info_enabled);
-            id_info_db = (uu___158_1311.id_info_db);
+            id_info_enabled = (uu___.id_info_enabled);
+            id_info_db = (uu___.id_info_db);
             id_info_buffer = (info :: (table.id_info_buffer))
           }
 let (id_info_insert_bv :
@@ -337,8 +323,8 @@ let (id_info_insert_bv :
       fun ty ->
         if table.id_info_enabled
         then
-          let uu____1327 = FStar_Syntax_Syntax.range_of_bv bv in
-          id_info_insert table (FStar_Util.Inl bv) ty uu____1327
+          let uu___ = FStar_Syntax_Syntax.range_of_bv bv in
+          id_info_insert table (FStar_Util.Inl bv) ty uu___
         else table
 let (id_info_insert_fv :
   id_info_table ->
@@ -349,17 +335,17 @@ let (id_info_insert_fv :
       fun ty ->
         if table.id_info_enabled
         then
-          let uu____1344 = FStar_Syntax_Syntax.range_of_fv fv in
-          id_info_insert table (FStar_Util.Inr fv) ty uu____1344
+          let uu___ = FStar_Syntax_Syntax.range_of_fv fv in
+          id_info_insert table (FStar_Util.Inr fv) ty uu___
         else table
 let (id_info_toggle : id_info_table -> Prims.bool -> id_info_table) =
   fun table ->
     fun enabled ->
-      let uu___170_1356 = table in
+      let uu___ = table in
       {
         id_info_enabled = enabled;
-        id_info_db = (uu___170_1356.id_info_db);
-        id_info_buffer = (uu___170_1356.id_info_buffer)
+        id_info_db = (uu___.id_info_db);
+        id_info_buffer = (uu___.id_info_buffer)
       }
 let (id_info_promote :
   id_info_table ->
@@ -367,13 +353,13 @@ let (id_info_promote :
   =
   fun table ->
     fun ty_map ->
-      let uu___174_1372 = table in
-      let uu____1373 =
+      let uu___ = table in
+      let uu___1 =
         FStar_List.fold_left (id_info__insert ty_map) table.id_info_db
           table.id_info_buffer in
       {
-        id_info_enabled = (uu___174_1372.id_info_enabled);
-        id_info_db = uu____1373;
+        id_info_enabled = (uu___.id_info_enabled);
+        id_info_db = uu___1;
         id_info_buffer = []
       }
 let (id_info_at_pos :
@@ -387,17 +373,16 @@ let (id_info_at_pos :
       fun row ->
         fun col ->
           let rows =
-            let uu____1409 = FStar_Util.pimap_empty () in
-            FStar_Util.psmap_find_default table.id_info_db fn uu____1409 in
+            let uu___ = FStar_Util.pimap_empty () in
+            FStar_Util.psmap_find_default table.id_info_db fn uu___ in
           let cols = FStar_Util.pimap_find_default rows row [] in
-          let uu____1415 = find_nearest_preceding_col_info col cols in
-          match uu____1415 with
+          let uu___ = find_nearest_preceding_col_info col cols in
+          match uu___ with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some info ->
               let last_col =
-                let uu____1422 =
-                  FStar_Range.end_of_range info.identifier_range in
-                FStar_Range.col_of_pos uu____1422 in
+                let uu___1 = FStar_Range.end_of_range info.identifier_range in
+                FStar_Range.col_of_pos uu___1 in
               if col <= last_col
               then FStar_Pervasives_Native.Some info
               else FStar_Pervasives_Native.None
@@ -413,56 +398,54 @@ let (check_uvar_ctx_invariant :
         fun g ->
           fun bs ->
             let print_gamma gamma =
-              let uu____1461 =
+              let uu___ =
                 FStar_All.pipe_right gamma
                   (FStar_List.map
-                     (fun uu___3_1471 ->
-                        match uu___3_1471 with
+                     (fun uu___1 ->
+                        match uu___1 with
                         | FStar_Syntax_Syntax.Binding_var x ->
-                            let uu____1473 =
-                              FStar_Syntax_Print.bv_to_string x in
-                            Prims.op_Hat "Binding_var " uu____1473
+                            let uu___2 = FStar_Syntax_Print.bv_to_string x in
+                            Prims.op_Hat "Binding_var " uu___2
                         | FStar_Syntax_Syntax.Binding_univ u ->
-                            let uu____1475 = FStar_Ident.string_of_id u in
-                            Prims.op_Hat "Binding_univ " uu____1475
-                        | FStar_Syntax_Syntax.Binding_lid (l, uu____1477) ->
-                            let uu____1490 = FStar_Ident.string_of_lid l in
-                            Prims.op_Hat "Binding_lid " uu____1490)) in
-              FStar_All.pipe_right uu____1461 (FStar_String.concat "::\n") in
-            let fail uu____1498 =
-              let uu____1499 =
-                let uu____1500 = FStar_Range.string_of_range r in
-                let uu____1501 = print_gamma g in
-                let uu____1502 = FStar_Syntax_Print.binders_to_string ", " bs in
+                            let uu___2 = FStar_Ident.string_of_id u in
+                            Prims.op_Hat "Binding_univ " uu___2
+                        | FStar_Syntax_Syntax.Binding_lid (l, uu___2) ->
+                            let uu___3 = FStar_Ident.string_of_lid l in
+                            Prims.op_Hat "Binding_lid " uu___3)) in
+              FStar_All.pipe_right uu___ (FStar_String.concat "::\n") in
+            let fail uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Range.string_of_range r in
+                let uu___3 = print_gamma g in
+                let uu___4 = FStar_Syntax_Print.binders_to_string ", " bs in
                 FStar_Util.format5
                   "Invariant violation: gamma and binders are out of sync\n\treason=%s, range=%s, should_check=%s\n\t\n                               gamma=%s\n\tbinders=%s\n"
-                  reason uu____1500
-                  (if should_check then "true" else "false") uu____1501
-                  uu____1502 in
-              failwith uu____1499 in
+                  reason uu___2 (if should_check then "true" else "false")
+                  uu___3 uu___4 in
+              failwith uu___1 in
             if Prims.op_Negation should_check
             then ()
             else
-              (let uu____1505 =
-                 let uu____1530 =
+              (let uu___1 =
+                 let uu___2 =
                    FStar_Util.prefix_until
-                     (fun uu___4_1545 ->
-                        match uu___4_1545 with
-                        | FStar_Syntax_Syntax.Binding_var uu____1546 -> true
-                        | uu____1547 -> false) g in
-                 (uu____1530, bs) in
-               match uu____1505 with
+                     (fun uu___3 ->
+                        match uu___3 with
+                        | FStar_Syntax_Syntax.Binding_var uu___4 -> true
+                        | uu___4 -> false) g in
+                 (uu___2, bs) in
+               match uu___1 with
                | (FStar_Pervasives_Native.None, []) -> ()
-               | (FStar_Pervasives_Native.Some (uu____1604, hd, gamma_tail),
-                  uu____1607::uu____1608) ->
-                   let uu____1667 = FStar_Util.prefix bs in
-                   (match uu____1667 with
-                    | (uu____1692, (x, uu____1694)) ->
+               | (FStar_Pervasives_Native.Some (uu___2, hd, gamma_tail),
+                  uu___3::uu___4) ->
+                   let uu___5 = FStar_Util.prefix bs in
+                   (match uu___5 with
+                    | (uu___6, (x, uu___7)) ->
                         (match hd with
                          | FStar_Syntax_Syntax.Binding_var x' when
                              FStar_Syntax_Syntax.bv_eq x x' -> ()
-                         | uu____1722 -> fail ()))
-               | uu____1723 -> fail ())
+                         | uu___8 -> fail ()))
+               | uu___2 -> fail ())
 type implicit =
   {
   imp_reason: Prims.string ;
@@ -544,18 +527,16 @@ let (conj_guard_f : guard_formula -> guard_formula -> guard_formula) =
       | (Trivial, g) -> g
       | (g, Trivial) -> g
       | (NonTrivial f1, NonTrivial f2) ->
-          let uu____1982 = FStar_Syntax_Util.mk_conj f1 f2 in
-          NonTrivial uu____1982
+          let uu___ = FStar_Syntax_Util.mk_conj f1 f2 in NonTrivial uu___
 let (check_trivial : FStar_Syntax_Syntax.term -> guard_formula) =
   fun t ->
-    let uu____1988 =
-      let uu____1989 = FStar_Syntax_Util.unmeta t in
-      uu____1989.FStar_Syntax_Syntax.n in
-    match uu____1988 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Util.unmeta t in uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         Trivial
-    | uu____1993 -> NonTrivial t
+    | uu___1 -> NonTrivial t
 let (imp_guard_f : guard_formula -> guard_formula -> guard_formula) =
   fun g1 ->
     fun g2 ->
@@ -571,9 +552,9 @@ let (binop_guard :
   fun f ->
     fun g1 ->
       fun g2 ->
-        let uu____2034 = f g1.guard_f g2.guard_f in
+        let uu___ = f g1.guard_f g2.guard_f in
         {
-          guard_f = uu____2034;
+          guard_f = uu___;
           deferred_to_tac =
             (FStar_List.append g1.deferred_to_tac g2.deferred_to_tac);
           deferred = (FStar_List.append g1.deferred g2.deferred);
@@ -596,16 +577,16 @@ let (weaken_guard_formula : guard_t -> FStar_Syntax_Syntax.typ -> guard_t) =
       match g.guard_f with
       | Trivial -> g
       | NonTrivial f ->
-          let uu___305_2103 = g in
-          let uu____2104 =
-            let uu____2105 = FStar_Syntax_Util.mk_imp fml f in
-            check_trivial uu____2105 in
+          let uu___ = g in
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Util.mk_imp fml f in
+            check_trivial uu___2 in
           {
-            guard_f = uu____2104;
-            deferred_to_tac = (uu___305_2103.deferred_to_tac);
-            deferred = (uu___305_2103.deferred);
-            univ_ineqs = (uu___305_2103.univ_ineqs);
-            implicits = (uu___305_2103.implicits)
+            guard_f = uu___1;
+            deferred_to_tac = (uu___.deferred_to_tac);
+            deferred = (uu___.deferred);
+            univ_ineqs = (uu___.univ_ineqs);
+            implicits = (uu___.implicits)
           }
 type lcomp =
   {
@@ -647,15 +628,15 @@ let (mk_lcomp :
     fun res_typ ->
       fun cflags ->
         fun comp_thunk ->
-          let uu____2309 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk) in
-          { eff_name; res_typ; cflags; comp_thunk = uu____2309 }
+          let uu___ = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk) in
+          { eff_name; res_typ; cflags; comp_thunk = uu___ }
 let (lcomp_comp : lcomp -> (FStar_Syntax_Syntax.comp * guard_t)) =
   fun lc ->
-    let uu____2350 = FStar_ST.op_Bang lc.comp_thunk in
-    match uu____2350 with
+    let uu___ = FStar_ST.op_Bang lc.comp_thunk in
+    match uu___ with
     | FStar_Util.Inl thunk ->
-        let uu____2409 = thunk () in
-        (match uu____2409 with
+        let uu___1 = thunk () in
+        (match uu___1 with
          | (c, g) ->
              (FStar_ST.op_Colon_Equals lc.comp_thunk (FStar_Util.Inr c);
               (c, g)))
@@ -668,71 +649,68 @@ let (apply_lcomp :
     fun fg ->
       fun lc ->
         mk_lcomp lc.eff_name lc.res_typ lc.cflags
-          (fun uu____2495 ->
-             let uu____2496 = lcomp_comp lc in
-             match uu____2496 with
+          (fun uu___ ->
+             let uu___1 = lcomp_comp lc in
+             match uu___1 with
              | (c, g) ->
-                 let uu____2507 = fc c in
-                 let uu____2508 = fg g in (uu____2507, uu____2508))
+                 let uu___2 = fc c in let uu___3 = fg g in (uu___2, uu___3))
 let (lcomp_to_string : lcomp -> Prims.string) =
   fun lc ->
-    let uu____2514 = FStar_Options.print_effect_args () in
-    if uu____2514
+    let uu___ = FStar_Options.print_effect_args () in
+    if uu___
     then
-      let uu____2515 =
-        let uu____2516 = FStar_All.pipe_right lc lcomp_comp in
-        FStar_All.pipe_right uu____2516 FStar_Pervasives_Native.fst in
-      FStar_Syntax_Print.comp_to_string uu____2515
+      let uu___1 =
+        let uu___2 = FStar_All.pipe_right lc lcomp_comp in
+        FStar_All.pipe_right uu___2 FStar_Pervasives_Native.fst in
+      FStar_Syntax_Print.comp_to_string uu___1
     else
-      (let uu____2530 = FStar_Syntax_Print.lid_to_string lc.eff_name in
-       let uu____2531 = FStar_Syntax_Print.term_to_string lc.res_typ in
-       FStar_Util.format2 "%s %s" uu____2530 uu____2531)
+      (let uu___2 = FStar_Syntax_Print.lid_to_string lc.eff_name in
+       let uu___3 = FStar_Syntax_Print.term_to_string lc.res_typ in
+       FStar_Util.format2 "%s %s" uu___2 uu___3)
 let (lcomp_set_flags :
   lcomp -> FStar_Syntax_Syntax.cflag Prims.list -> lcomp) =
   fun lc ->
     fun fs ->
       let comp_typ_set_flags c =
         match c.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total uu____2556 -> c
-        | FStar_Syntax_Syntax.GTotal uu____2565 -> c
+        | FStar_Syntax_Syntax.Total uu___ -> c
+        | FStar_Syntax_Syntax.GTotal uu___ -> c
         | FStar_Syntax_Syntax.Comp ct ->
             let ct1 =
-              let uu___355_2576 = ct in
+              let uu___ = ct in
               {
                 FStar_Syntax_Syntax.comp_univs =
-                  (uu___355_2576.FStar_Syntax_Syntax.comp_univs);
+                  (uu___.FStar_Syntax_Syntax.comp_univs);
                 FStar_Syntax_Syntax.effect_name =
-                  (uu___355_2576.FStar_Syntax_Syntax.effect_name);
+                  (uu___.FStar_Syntax_Syntax.effect_name);
                 FStar_Syntax_Syntax.result_typ =
-                  (uu___355_2576.FStar_Syntax_Syntax.result_typ);
+                  (uu___.FStar_Syntax_Syntax.result_typ);
                 FStar_Syntax_Syntax.effect_args =
-                  (uu___355_2576.FStar_Syntax_Syntax.effect_args);
+                  (uu___.FStar_Syntax_Syntax.effect_args);
                 FStar_Syntax_Syntax.flags = fs
               } in
-            let uu___358_2577 = c in
+            let uu___ = c in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-              FStar_Syntax_Syntax.pos =
-                (uu___358_2577.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___358_2577.FStar_Syntax_Syntax.vars)
+              FStar_Syntax_Syntax.pos = (uu___.FStar_Syntax_Syntax.pos);
+              FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
             } in
       mk_lcomp lc.eff_name lc.res_typ fs
-        (fun uu____2580 ->
-           let uu____2581 = FStar_All.pipe_right lc lcomp_comp in
-           FStar_All.pipe_right uu____2581
-             (fun uu____2603 ->
-                match uu____2603 with | (c, g) -> ((comp_typ_set_flags c), g)))
+        (fun uu___ ->
+           let uu___1 = FStar_All.pipe_right lc lcomp_comp in
+           FStar_All.pipe_right uu___1
+             (fun uu___2 ->
+                match uu___2 with | (c, g) -> ((comp_typ_set_flags c), g)))
 let (is_total_lcomp : lcomp -> Prims.bool) =
   fun c ->
     (FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___5_2626 ->
-               match uu___5_2626 with
+            (fun uu___ ->
+               match uu___ with
                | FStar_Syntax_Syntax.TOTAL -> true
                | FStar_Syntax_Syntax.RETURN -> true
-               | uu____2627 -> false)))
+               | uu___1 -> false)))
 let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
   fun c ->
     ((FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
@@ -740,30 +718,30 @@ let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
       ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___6_2636 ->
-               match uu___6_2636 with
+            (fun uu___ ->
+               match uu___ with
                | FStar_Syntax_Syntax.TOTAL -> true
                | FStar_Syntax_Syntax.RETURN -> true
-               | uu____2637 -> false)))
+               | uu___1 -> false)))
 let (is_lcomp_partial_return : lcomp -> Prims.bool) =
   fun c ->
     FStar_All.pipe_right c.cflags
       (FStar_Util.for_some
-         (fun uu___7_2646 ->
-            match uu___7_2646 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.RETURN -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
-            | uu____2647 -> false))
+            | uu___1 -> false))
 let (is_pure_lcomp : lcomp -> Prims.bool) =
   fun lc ->
     ((is_total_lcomp lc) || (FStar_Syntax_Util.is_pure_effect lc.eff_name))
       ||
       (FStar_All.pipe_right lc.cflags
          (FStar_Util.for_some
-            (fun uu___8_2656 ->
-               match uu___8_2656 with
+            (fun uu___ ->
+               match uu___ with
                | FStar_Syntax_Syntax.LEMMA -> true
-               | uu____2657 -> false)))
+               | uu___1 -> false)))
 let (is_pure_or_ghost_lcomp : lcomp -> Prims.bool) =
   fun lc ->
     (is_pure_lcomp lc) || (FStar_Syntax_Util.is_ghost_effect lc.eff_name)
@@ -771,14 +749,14 @@ let (set_result_typ_lc : lcomp -> FStar_Syntax_Syntax.typ -> lcomp) =
   fun lc ->
     fun t ->
       mk_lcomp lc.eff_name t lc.cflags
-        (fun uu____2675 ->
-           let uu____2676 = FStar_All.pipe_right lc lcomp_comp in
-           FStar_All.pipe_right uu____2676
-             (fun uu____2703 ->
-                match uu____2703 with
+        (fun uu___ ->
+           let uu___1 = FStar_All.pipe_right lc lcomp_comp in
+           FStar_All.pipe_right uu___1
+             (fun uu___2 ->
+                match uu___2 with
                 | (c, g) ->
-                    let uu____2720 = FStar_Syntax_Util.set_result_typ c t in
-                    (uu____2720, g)))
+                    let uu___3 = FStar_Syntax_Util.set_result_typ c t in
+                    (uu___3, g)))
 let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   fun lc ->
     {
@@ -790,20 +768,20 @@ let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
 let (lcomp_of_comp_guard : FStar_Syntax_Syntax.comp -> guard_t -> lcomp) =
   fun c0 ->
     fun g ->
-      let uu____2738 =
+      let uu___ =
         match c0.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total uu____2751 ->
+        | FStar_Syntax_Syntax.Total uu___1 ->
             (FStar_Parser_Const.effect_Tot_lid, [FStar_Syntax_Syntax.TOTAL])
-        | FStar_Syntax_Syntax.GTotal uu____2762 ->
+        | FStar_Syntax_Syntax.GTotal uu___1 ->
             (FStar_Parser_Const.effect_GTot_lid,
               [FStar_Syntax_Syntax.SOMETRIVIAL])
         | FStar_Syntax_Syntax.Comp c ->
             ((c.FStar_Syntax_Syntax.effect_name),
               (c.FStar_Syntax_Syntax.flags)) in
-      match uu____2738 with
+      match uu___ with
       | (eff_name, flags) ->
           mk_lcomp eff_name (FStar_Syntax_Util.comp_result c0) flags
-            (fun uu____2783 -> (c0, g))
+            (fun uu___1 -> (c0, g))
 let (lcomp_of_comp : FStar_Syntax_Syntax.comp -> lcomp) =
   fun c0 -> lcomp_of_comp_guard c0 trivial_guard
 let (simplify :
@@ -811,137 +789,135 @@ let (simplify :
   fun debug ->
     fun tm ->
       let w t =
-        let uu___409_2811 = t in
+        let uu___ = t in
         {
-          FStar_Syntax_Syntax.n = (uu___409_2811.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (tm.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (uu___409_2811.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
         } in
       let simp_t t =
-        let uu____2822 =
-          let uu____2823 = FStar_Syntax_Util.unmeta t in
-          uu____2823.FStar_Syntax_Syntax.n in
-        match uu____2822 with
+        let uu___ =
+          let uu___1 = FStar_Syntax_Util.unmeta t in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid ->
             FStar_Pervasives_Native.Some true
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid ->
             FStar_Pervasives_Native.Some false
-        | uu____2830 -> FStar_Pervasives_Native.None in
+        | uu___1 -> FStar_Pervasives_Native.None in
       let rec args_are_binders args bs =
         match (args, bs) with
-        | ((t, uu____2891)::args1, (bv, uu____2894)::bs1) ->
-            let uu____2948 =
-              let uu____2949 = FStar_Syntax_Subst.compress t in
-              uu____2949.FStar_Syntax_Syntax.n in
-            (match uu____2948 with
+        | ((t, uu___)::args1, (bv, uu___1)::bs1) ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.compress t in
+              uu___3.FStar_Syntax_Syntax.n in
+            (match uu___2 with
              | FStar_Syntax_Syntax.Tm_name bv' ->
                  (FStar_Syntax_Syntax.bv_eq bv bv') &&
                    (args_are_binders args1 bs1)
-             | uu____2953 -> false)
+             | uu___3 -> false)
         | ([], []) -> true
-        | (uu____2982, uu____2983) -> false in
+        | (uu___, uu___1) -> false in
       let is_applied bs t =
         if debug
         then
-          (let uu____3032 = FStar_Syntax_Print.term_to_string t in
-           let uu____3033 = FStar_Syntax_Print.tag_of_term t in
-           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____3032
-             uu____3033)
+          (let uu___1 = FStar_Syntax_Print.term_to_string t in
+           let uu___2 = FStar_Syntax_Print.tag_of_term t in
+           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu___1 uu___2)
         else ();
-        (let uu____3035 = FStar_Syntax_Util.head_and_args' t in
-         match uu____3035 with
+        (let uu___1 = FStar_Syntax_Util.head_and_args' t in
+         match uu___1 with
          | (hd, args) ->
-             let uu____3074 =
-               let uu____3075 = FStar_Syntax_Subst.compress hd in
-               uu____3075.FStar_Syntax_Syntax.n in
-             (match uu____3074 with
+             let uu___2 =
+               let uu___3 = FStar_Syntax_Subst.compress hd in
+               uu___3.FStar_Syntax_Syntax.n in
+             (match uu___2 with
               | FStar_Syntax_Syntax.Tm_name bv when args_are_binders args bs
                   ->
                   (if debug
                    then
-                     (let uu____3082 = FStar_Syntax_Print.term_to_string t in
-                      let uu____3083 = FStar_Syntax_Print.bv_to_string bv in
-                      let uu____3084 = FStar_Syntax_Print.term_to_string hd in
+                     (let uu___4 = FStar_Syntax_Print.term_to_string t in
+                      let uu___5 = FStar_Syntax_Print.bv_to_string bv in
+                      let uu___6 = FStar_Syntax_Print.term_to_string hd in
                       FStar_Util.print3
                         "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                        uu____3082 uu____3083 uu____3084)
+                        uu___4 uu___5 uu___6)
                    else ();
                    FStar_Pervasives_Native.Some bv)
-              | uu____3086 -> FStar_Pervasives_Native.None)) in
+              | uu___3 -> FStar_Pervasives_Native.None)) in
       let is_applied_maybe_squashed bs t =
         if debug
         then
-          (let uu____3103 = FStar_Syntax_Print.term_to_string t in
-           let uu____3104 = FStar_Syntax_Print.tag_of_term t in
+          (let uu___1 = FStar_Syntax_Print.term_to_string t in
+           let uu___2 = FStar_Syntax_Print.tag_of_term t in
            FStar_Util.print2 "WPE> is_applied_maybe_squashed %s -- %s\n"
-             uu____3103 uu____3104)
+             uu___1 uu___2)
         else ();
-        (let uu____3106 = FStar_Syntax_Util.is_squash t in
-         match uu____3106 with
-         | FStar_Pervasives_Native.Some (uu____3117, t') -> is_applied bs t'
-         | uu____3129 ->
-             let uu____3138 = FStar_Syntax_Util.is_auto_squash t in
-             (match uu____3138 with
-              | FStar_Pervasives_Native.Some (uu____3149, t') ->
-                  is_applied bs t'
-              | uu____3161 -> is_applied bs t)) in
+        (let uu___1 = FStar_Syntax_Util.is_squash t in
+         match uu___1 with
+         | FStar_Pervasives_Native.Some (uu___2, t') -> is_applied bs t'
+         | uu___2 ->
+             let uu___3 = FStar_Syntax_Util.is_auto_squash t in
+             (match uu___3 with
+              | FStar_Pervasives_Native.Some (uu___4, t') -> is_applied bs t'
+              | uu___4 -> is_applied bs t)) in
       let is_const_match phi =
-        let uu____3180 =
-          let uu____3181 = FStar_Syntax_Subst.compress phi in
-          uu____3181.FStar_Syntax_Syntax.n in
-        match uu____3180 with
-        | FStar_Syntax_Syntax.Tm_match (uu____3186, br::brs) ->
-            let uu____3253 = br in
-            (match uu____3253 with
-             | (uu____3270, uu____3271, e) ->
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress phi in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_match (uu___1, br::brs) ->
+            let uu___2 = br in
+            (match uu___2 with
+             | (uu___3, uu___4, e) ->
                  let r =
-                   let uu____3292 = simp_t e in
-                   match uu____3292 with
+                   let uu___5 = simp_t e in
+                   match uu___5 with
                    | FStar_Pervasives_Native.None ->
                        FStar_Pervasives_Native.None
                    | FStar_Pervasives_Native.Some b ->
-                       let uu____3298 =
+                       let uu___6 =
                          FStar_List.for_all
-                           (fun uu____3316 ->
-                              match uu____3316 with
-                              | (uu____3329, uu____3330, e') ->
-                                  let uu____3344 = simp_t e' in
-                                  uu____3344 =
-                                    (FStar_Pervasives_Native.Some b)) brs in
-                       if uu____3298
+                           (fun uu___7 ->
+                              match uu___7 with
+                              | (uu___8, uu___9, e') ->
+                                  let uu___10 = simp_t e' in
+                                  uu___10 = (FStar_Pervasives_Native.Some b))
+                           brs in
+                       if uu___6
                        then FStar_Pervasives_Native.Some b
                        else FStar_Pervasives_Native.None in
                  r)
-        | uu____3352 -> FStar_Pervasives_Native.None in
+        | uu___1 -> FStar_Pervasives_Native.None in
       let maybe_auto_squash t =
-        let uu____3361 = FStar_Syntax_Util.is_sub_singleton t in
-        if uu____3361
+        let uu___ = FStar_Syntax_Util.is_sub_singleton t in
+        if uu___
         then t
         else FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero t in
       let squashed_head_un_auto_squash_args t =
-        let maybe_un_auto_squash_arg uu____3394 =
-          match uu____3394 with
+        let maybe_un_auto_squash_arg uu___ =
+          match uu___ with
           | (t1, q) ->
-              let uu____3415 = FStar_Syntax_Util.is_auto_squash t1 in
-              (match uu____3415 with
+              let uu___1 = FStar_Syntax_Util.is_auto_squash t1 in
+              (match uu___1 with
                | FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.U_zero, t2) -> (t2, q)
-               | uu____3447 -> (t1, q)) in
-        let uu____3460 = FStar_Syntax_Util.head_and_args t in
-        match uu____3460 with
+               | uu___2 -> (t1, q)) in
+        let uu___ = FStar_Syntax_Util.head_and_args t in
+        match uu___ with
         | (head, args) ->
             let args1 = FStar_List.map maybe_un_auto_squash_arg args in
             FStar_Syntax_Syntax.mk_Tm_app head args1
               t.FStar_Syntax_Syntax.pos in
       let rec clearly_inhabited ty =
-        let uu____3536 =
-          let uu____3537 = FStar_Syntax_Util.unmeta ty in
-          uu____3537.FStar_Syntax_Syntax.n in
-        match uu____3536 with
-        | FStar_Syntax_Syntax.Tm_uinst (t, uu____3541) -> clearly_inhabited t
-        | FStar_Syntax_Syntax.Tm_arrow (uu____3546, c) ->
+        let uu___ =
+          let uu___1 = FStar_Syntax_Util.unmeta ty in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_uinst (t, uu___1) -> clearly_inhabited t
+        | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
             clearly_inhabited (FStar_Syntax_Util.comp_result c)
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             let l = FStar_Syntax_Syntax.lid_of_fv fv in
@@ -949,259 +925,252 @@ let (simplify :
                 (FStar_Ident.lid_equals l FStar_Parser_Const.bool_lid))
                || (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
               || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-        | uu____3570 -> false in
-      let simplify arg =
-        let uu____3601 = simp_t (FStar_Pervasives_Native.fst arg) in
-        (uu____3601, arg) in
-      let uu____3614 =
-        let uu____3615 = FStar_Syntax_Subst.compress tm in
-        uu____3615.FStar_Syntax_Syntax.n in
-      match uu____3614 with
+        | uu___1 -> false in
+      let simplify1 arg =
+        let uu___ = simp_t (FStar_Pervasives_Native.fst arg) in (uu___, arg) in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress tm in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____3619;
-                  FStar_Syntax_Syntax.vars = uu____3620;_},
-                uu____3621);
-             FStar_Syntax_Syntax.pos = uu____3622;
-             FStar_Syntax_Syntax.vars = uu____3623;_},
+                  FStar_Syntax_Syntax.pos = uu___1;
+                  FStar_Syntax_Syntax.vars = uu___2;_},
+                uu___3);
+             FStar_Syntax_Syntax.pos = uu___4;
+             FStar_Syntax_Syntax.vars = uu___5;_},
            args)
           ->
-          let uu____3653 =
+          let uu___6 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
-          if uu____3653
+          if uu___6
           then
-            let uu____3654 =
-              FStar_All.pipe_right args (FStar_List.map simplify) in
-            (match uu____3654 with
-             | (FStar_Pervasives_Native.Some (true), uu____3709)::(uu____3710,
-                                                                   (arg,
-                                                                    uu____3712))::[]
+            let uu___7 = FStar_All.pipe_right args (FStar_List.map simplify1) in
+            (match uu___7 with
+             | (FStar_Pervasives_Native.Some (true), uu___8)::(uu___9,
+                                                               (arg, uu___10))::[]
                  -> maybe_auto_squash arg
-             | (uu____3777, (arg, uu____3779))::(FStar_Pervasives_Native.Some
-                                                 (true), uu____3780)::[]
+             | (uu___8, (arg, uu___9))::(FStar_Pervasives_Native.Some (true),
+                                         uu___10)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false), uu____3845)::uu____3846::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu____3909::(FStar_Pervasives_Native.Some (false), uu____3910)::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu____3973 -> squashed_head_un_auto_squash_args tm)
+             | (FStar_Pervasives_Native.Some (false), uu___8)::uu___9::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___8::(FStar_Pervasives_Native.Some (false), uu___9)::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___8 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____3989 =
+            (let uu___8 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
-             if uu____3989
+             if uu___8
              then
-               let uu____3990 =
-                 FStar_All.pipe_right args (FStar_List.map simplify) in
-               match uu____3990 with
-               | (FStar_Pervasives_Native.Some (true), uu____4045)::uu____4046::[]
+               let uu___9 =
+                 FStar_All.pipe_right args (FStar_List.map simplify1) in
+               match uu___9 with
+               | (FStar_Pervasives_Native.Some (true), uu___10)::uu___11::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu____4109::(FStar_Pervasives_Native.Some (true),
-                              uu____4110)::[]
+               | uu___10::(FStar_Pervasives_Native.Some (true), uu___11)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false), uu____4173)::
-                   (uu____4174, (arg, uu____4176))::[] ->
-                   maybe_auto_squash arg
-               | (uu____4241, (arg, uu____4243))::(FStar_Pervasives_Native.Some
-                                                   (false), uu____4244)::[]
+               | (FStar_Pervasives_Native.Some (false), uu___10)::(uu___11,
+                                                                   (arg,
+                                                                    uu___12))::[]
                    -> maybe_auto_squash arg
-               | uu____4309 -> squashed_head_un_auto_squash_args tm
+               | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
+                                             (false), uu___12)::[]
+                   -> maybe_auto_squash arg
+               | uu___10 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____4325 =
+               (let uu___10 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
-                if uu____4325
+                if uu___10
                 then
-                  let uu____4326 =
-                    FStar_All.pipe_right args (FStar_List.map simplify) in
-                  match uu____4326 with
-                  | uu____4381::(FStar_Pervasives_Native.Some (true),
-                                 uu____4382)::[]
+                  let uu___11 =
+                    FStar_All.pipe_right args (FStar_List.map simplify1) in
+                  match uu___11 with
+                  | uu___12::(FStar_Pervasives_Native.Some (true), uu___13)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false), uu____4445)::uu____4446::[]
+                  | (FStar_Pervasives_Native.Some (false), uu___12)::uu___13::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true), uu____4509)::
-                      (uu____4510, (arg, uu____4512))::[] ->
-                      maybe_auto_squash arg
-                  | (uu____4577, (p, uu____4579))::(uu____4580,
-                                                    (q, uu____4582))::[]
-                      ->
-                      let uu____4647 = FStar_Syntax_Util.term_eq p q in
-                      (if uu____4647
+                  | (FStar_Pervasives_Native.Some (true), uu___12)::(uu___13,
+                                                                    (arg,
+                                                                    uu___14))::[]
+                      -> maybe_auto_squash arg
+                  | (uu___12, (p, uu___13))::(uu___14, (q, uu___15))::[] ->
+                      let uu___16 = FStar_Syntax_Util.term_eq p q in
+                      (if uu___16
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____4649 -> squashed_head_un_auto_squash_args tm
+                  | uu___12 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____4665 =
+                  (let uu___12 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid in
-                   if uu____4665
+                   if uu___12
                    then
-                     let uu____4666 =
-                       FStar_All.pipe_right args (FStar_List.map simplify) in
-                     match uu____4666 with
-                     | (FStar_Pervasives_Native.Some (true), uu____4721)::
-                         (FStar_Pervasives_Native.Some (true), uu____4722)::[]
+                     let uu___13 =
+                       FStar_All.pipe_right args (FStar_List.map simplify1) in
+                     match uu___13 with
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (FStar_Pervasives_Native.Some (true), uu___15)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false), uu____4787)::
-                         (FStar_Pervasives_Native.Some (false), uu____4788)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (FStar_Pervasives_Native.Some (false), uu___15)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true), uu____4853)::
-                         (FStar_Pervasives_Native.Some (false), uu____4854)::[]
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (FStar_Pervasives_Native.Some (false), uu___15)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false), uu____4919)::
-                         (FStar_Pervasives_Native.Some (true), uu____4920)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (FStar_Pervasives_Native.Some (true), uu___15)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____4985, (arg, uu____4987))::(FStar_Pervasives_Native.Some
-                                                         (true), uu____4988)::[]
+                     | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                   (true), uu___16)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true), uu____5053)::
-                         (uu____5054, (arg, uu____5056))::[] ->
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (uu___15, (arg, uu___16))::[] ->
                          maybe_auto_squash arg
-                     | (uu____5121, (arg, uu____5123))::(FStar_Pervasives_Native.Some
-                                                         (false), uu____5124)::[]
+                     | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                   (false), uu___16)::[]
                          ->
-                         let uu____5189 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu____5189
-                     | (FStar_Pervasives_Native.Some (false), uu____5190)::
-                         (uu____5191, (arg, uu____5193))::[] ->
-                         let uu____5258 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu____5258
-                     | (uu____5259, (p, uu____5261))::(uu____5262,
-                                                       (q, uu____5264))::[]
+                         let uu___17 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___17
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (uu___15, (arg, uu___16))::[] ->
+                         let uu___17 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___17
+                     | (uu___14, (p, uu___15))::(uu___16, (q, uu___17))::[]
                          ->
-                         let uu____5329 = FStar_Syntax_Util.term_eq p q in
-                         (if uu____5329
+                         let uu___18 = FStar_Syntax_Util.term_eq p q in
+                         (if uu___18
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____5331 -> squashed_head_un_auto_squash_args tm
+                     | uu___14 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____5347 =
+                     (let uu___14 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid in
-                      if uu____5347
+                      if uu___14
                       then
-                        let uu____5348 =
-                          FStar_All.pipe_right args (FStar_List.map simplify) in
-                        match uu____5348 with
-                        | (FStar_Pervasives_Native.Some (true), uu____5403)::[]
+                        let uu___15 =
+                          FStar_All.pipe_right args
+                            (FStar_List.map simplify1) in
+                        match uu___15 with
+                        | (FStar_Pervasives_Native.Some (true), uu___16)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false), uu____5442)::[]
+                        | (FStar_Pervasives_Native.Some (false), uu___16)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____5481 -> squashed_head_un_auto_squash_args tm
+                        | uu___16 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____5497 =
+                        (let uu___16 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid in
-                         if uu____5497
+                         if uu___16
                          then
                            match args with
-                           | (t, uu____5499)::[] ->
-                               let uu____5524 =
-                                 let uu____5525 =
-                                   FStar_Syntax_Subst.compress t in
-                                 uu____5525.FStar_Syntax_Syntax.n in
-                               (match uu____5524 with
+                           | (t, uu___17)::[] ->
+                               let uu___18 =
+                                 let uu___19 = FStar_Syntax_Subst.compress t in
+                                 uu___19.FStar_Syntax_Syntax.n in
+                               (match uu___18 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____5528::[], body, uu____5530) ->
-                                    let uu____5565 = simp_t body in
-                                    (match uu____5565 with
+                                    (uu___19::[], body, uu___20) ->
+                                    let uu___21 = simp_t body in
+                                    (match uu___21 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
-                                     | uu____5568 -> tm)
-                                | uu____5571 -> tm)
+                                     | uu___22 -> tm)
+                                | uu___19 -> tm)
                            | (ty, FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____5573))::
-                               (t, uu____5575)::[] ->
-                               let uu____5614 =
-                                 let uu____5615 =
-                                   FStar_Syntax_Subst.compress t in
-                                 uu____5615.FStar_Syntax_Syntax.n in
-                               (match uu____5614 with
+                              (FStar_Syntax_Syntax.Implicit uu___17))::
+                               (t, uu___18)::[] ->
+                               let uu___19 =
+                                 let uu___20 = FStar_Syntax_Subst.compress t in
+                                 uu___20.FStar_Syntax_Syntax.n in
+                               (match uu___19 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____5618::[], body, uu____5620) ->
-                                    let uu____5655 = simp_t body in
-                                    (match uu____5655 with
+                                    (uu___20::[], body, uu___21) ->
+                                    let uu___22 = simp_t body in
+                                    (match uu___22 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false)
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____5658 -> tm)
-                                | uu____5661 -> tm)
-                           | uu____5662 -> tm
+                                     | uu___23 -> tm)
+                                | uu___20 -> tm)
+                           | uu___17 -> tm
                          else
-                           (let uu____5674 =
+                           (let uu___18 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid in
-                            if uu____5674
+                            if uu___18
                             then
                               match args with
-                              | (t, uu____5676)::[] ->
-                                  let uu____5701 =
-                                    let uu____5702 =
+                              | (t, uu___19)::[] ->
+                                  let uu___20 =
+                                    let uu___21 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu____5702.FStar_Syntax_Syntax.n in
-                                  (match uu____5701 with
+                                    uu___21.FStar_Syntax_Syntax.n in
+                                  (match uu___20 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____5705::[], body, uu____5707) ->
-                                       let uu____5742 = simp_t body in
-                                       (match uu____5742 with
+                                       (uu___21::[], body, uu___22) ->
+                                       let uu___23 = simp_t body in
+                                       (match uu___23 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
-                                        | uu____5745 -> tm)
-                                   | uu____5748 -> tm)
+                                        | uu___24 -> tm)
+                                   | uu___21 -> tm)
                               | (ty, FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____5750))::
-                                  (t, uu____5752)::[] ->
-                                  let uu____5791 =
-                                    let uu____5792 =
+                                 (FStar_Syntax_Syntax.Implicit uu___19))::
+                                  (t, uu___20)::[] ->
+                                  let uu___21 =
+                                    let uu___22 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu____5792.FStar_Syntax_Syntax.n in
-                                  (match uu____5791 with
+                                    uu___22.FStar_Syntax_Syntax.n in
+                                  (match uu___21 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____5795::[], body, uu____5797) ->
-                                       let uu____5832 = simp_t body in
-                                       (match uu____5832 with
+                                       (uu___22::[], body, uu___23) ->
+                                       let uu___24 = simp_t body in
+                                       (match uu___24 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true)
                                             when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____5835 -> tm)
-                                   | uu____5838 -> tm)
-                              | uu____5839 -> tm
+                                        | uu___25 -> tm)
+                                   | uu___22 -> tm)
+                              | uu___19 -> tm
                             else
-                              (let uu____5851 =
+                              (let uu___20 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid in
-                               if uu____5851
+                               if uu___20
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true));
-                                      FStar_Syntax_Syntax.pos = uu____5852;
-                                      FStar_Syntax_Syntax.vars = uu____5853;_},
-                                    uu____5854)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___21;
+                                      FStar_Syntax_Syntax.vars = uu___22;_},
+                                    uu___23)::[] ->
                                      w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false));
-                                      FStar_Syntax_Syntax.pos = uu____5879;
-                                      FStar_Syntax_Syntax.vars = uu____5880;_},
-                                    uu____5881)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___21;
+                                      FStar_Syntax_Syntax.vars = uu___22;_},
+                                    uu___23)::[] ->
                                      w FStar_Syntax_Util.t_false
-                                 | uu____5906 -> tm
+                                 | uu___21 -> tm
                                else
-                                 (let uu____5918 =
+                                 (let uu___22 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid in
-                                  if uu____5918
+                                  if uu___22
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1209,11 +1178,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid] in
-                                      let uu____5928 =
-                                        let uu____5929 =
+                                      let uu___23 =
+                                        let uu___24 =
                                           FStar_Syntax_Subst.compress t in
-                                        uu____5929.FStar_Syntax_Syntax.n in
-                                      match uu____5928 with
+                                        uu___24.FStar_Syntax_Syntax.n in
+                                      match uu___23 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1221,114 +1190,111 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____5937 -> false in
+                                      | uu___24 -> false in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____5947 =
+                                         let uu___23 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd in
-                                         FStar_All.pipe_right uu____5947
+                                         FStar_All.pipe_right uu___23
                                            FStar_Pervasives_Native.fst in
-                                       let uu____5986 =
+                                       let uu___23 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure in
-                                       (if uu____5986
+                                       (if uu___23
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____5988 =
-                                             let uu____5989 =
+                                          (let uu___25 =
+                                             let uu___26 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____5989.FStar_Syntax_Syntax.n in
-                                           match uu____5988 with
+                                             uu___26.FStar_Syntax_Syntax.n in
+                                           match uu___25 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____5992 ->
+                                               uu___26 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
-                                               let uu____6000 =
+                                               let uu___27 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure in
-                                               if uu____6000
+                                               if uu___27
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____6005 =
-                                                      let uu____6006 =
+                                                    let uu___29 =
+                                                      let uu___30 =
                                                         FStar_Syntax_Subst.compress
                                                           tm in
-                                                      uu____6006.FStar_Syntax_Syntax.n in
-                                                    match uu____6005 with
+                                                      uu___30.FStar_Syntax_Syntax.n in
+                                                    match uu___29 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd, uu____6012) ->
-                                                        hd
-                                                    | uu____6037 ->
+                                                        (hd, uu___30) -> hd
+                                                    | uu___30 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app" in
-                                                  let uu____6040 =
-                                                    let uu____6051 =
+                                                  let uu___29 =
+                                                    let uu___30 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    [uu____6051] in
+                                                    [uu___30] in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____6040)
-                                           | uu____6084 -> tm))
+                                                    haseq_tm uu___29)
+                                           | uu___26 -> tm))
                                      else tm)
                                   else
-                                    (let uu____6087 =
+                                    (let uu___24 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid in
-                                     if uu____6087
+                                     if uu___24
                                      then
                                        match args with
-                                       | (_typ, uu____6089)::(a1, uu____6091)::
-                                           (a2, uu____6093)::[] ->
-                                           let uu____6150 =
+                                       | (_typ, uu___25)::(a1, uu___26)::
+                                           (a2, uu___27)::[] ->
+                                           let uu___28 =
                                              FStar_Syntax_Util.eq_tm a1 a2 in
-                                           (match uu____6150 with
+                                           (match uu___28 with
                                             | FStar_Syntax_Util.Equal ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____6151 -> tm)
-                                       | uu____6152 -> tm
+                                            | uu___29 -> tm)
+                                       | uu___25 -> tm
                                      else
-                                       (let uu____6164 =
+                                       (let uu___26 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid in
-                                        if uu____6164
+                                        if uu___26
                                         then
                                           match args with
-                                          | (t1, uu____6166)::(t2,
-                                                               uu____6168)::
-                                              (a1, uu____6170)::(a2,
-                                                                 uu____6172)::[]
+                                          | (t1, uu___27)::(t2, uu___28)::
+                                              (a1, uu___29)::(a2, uu___30)::[]
                                               ->
-                                              let uu____6245 =
-                                                let uu____6246 =
+                                              let uu___31 =
+                                                let uu___32 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2 in
-                                                let uu____6247 =
+                                                let uu___33 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2 in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____6246 uu____6247 in
-                                              (match uu____6245 with
+                                                  uu___32 uu___33 in
+                                              (match uu___31 with
                                                | FStar_Syntax_Util.Equal ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____6248 -> tm)
-                                          | uu____6249 -> tm
+                                               | uu___32 -> tm)
+                                          | uu___27 -> tm
                                         else
-                                          (let uu____6261 =
+                                          (let uu___28 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm in
-                                           match uu____6261 with
+                                           match uu___28 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero,
                                                 t)
@@ -1336,247 +1302,241 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____6281 -> tm)))))))))))
+                                           | uu___29 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____6291;
-             FStar_Syntax_Syntax.vars = uu____6292;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            args)
           ->
-          let uu____6318 =
+          let uu___3 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
-          if uu____6318
+          if uu___3
           then
-            let uu____6319 =
-              FStar_All.pipe_right args (FStar_List.map simplify) in
-            (match uu____6319 with
-             | (FStar_Pervasives_Native.Some (true), uu____6374)::(uu____6375,
-                                                                   (arg,
-                                                                    uu____6377))::[]
+            let uu___4 = FStar_All.pipe_right args (FStar_List.map simplify1) in
+            (match uu___4 with
+             | (FStar_Pervasives_Native.Some (true), uu___5)::(uu___6,
+                                                               (arg, uu___7))::[]
                  -> maybe_auto_squash arg
-             | (uu____6442, (arg, uu____6444))::(FStar_Pervasives_Native.Some
-                                                 (true), uu____6445)::[]
+             | (uu___5, (arg, uu___6))::(FStar_Pervasives_Native.Some (true),
+                                         uu___7)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false), uu____6510)::uu____6511::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu____6574::(FStar_Pervasives_Native.Some (false), uu____6575)::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu____6638 -> squashed_head_un_auto_squash_args tm)
+             | (FStar_Pervasives_Native.Some (false), uu___5)::uu___6::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___5::(FStar_Pervasives_Native.Some (false), uu___6)::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___5 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____6654 =
+            (let uu___5 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
-             if uu____6654
+             if uu___5
              then
-               let uu____6655 =
-                 FStar_All.pipe_right args (FStar_List.map simplify) in
-               match uu____6655 with
-               | (FStar_Pervasives_Native.Some (true), uu____6710)::uu____6711::[]
-                   -> w FStar_Syntax_Util.t_true
-               | uu____6774::(FStar_Pervasives_Native.Some (true),
-                              uu____6775)::[]
-                   -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false), uu____6838)::
-                   (uu____6839, (arg, uu____6841))::[] ->
-                   maybe_auto_squash arg
-               | (uu____6906, (arg, uu____6908))::(FStar_Pervasives_Native.Some
-                                                   (false), uu____6909)::[]
+               let uu___6 =
+                 FStar_All.pipe_right args (FStar_List.map simplify1) in
+               match uu___6 with
+               | (FStar_Pervasives_Native.Some (true), uu___7)::uu___8::[] ->
+                   w FStar_Syntax_Util.t_true
+               | uu___7::(FStar_Pervasives_Native.Some (true), uu___8)::[] ->
+                   w FStar_Syntax_Util.t_true
+               | (FStar_Pervasives_Native.Some (false), uu___7)::(uu___8,
+                                                                  (arg,
+                                                                   uu___9))::[]
                    -> maybe_auto_squash arg
-               | uu____6974 -> squashed_head_un_auto_squash_args tm
+               | (uu___7, (arg, uu___8))::(FStar_Pervasives_Native.Some
+                                           (false), uu___9)::[]
+                   -> maybe_auto_squash arg
+               | uu___7 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____6990 =
+               (let uu___7 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
-                if uu____6990
+                if uu___7
                 then
-                  let uu____6991 =
-                    FStar_All.pipe_right args (FStar_List.map simplify) in
-                  match uu____6991 with
-                  | uu____7046::(FStar_Pervasives_Native.Some (true),
-                                 uu____7047)::[]
+                  let uu___8 =
+                    FStar_All.pipe_right args (FStar_List.map simplify1) in
+                  match uu___8 with
+                  | uu___9::(FStar_Pervasives_Native.Some (true), uu___10)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false), uu____7110)::uu____7111::[]
+                  | (FStar_Pervasives_Native.Some (false), uu___9)::uu___10::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true), uu____7174)::
-                      (uu____7175, (arg, uu____7177))::[] ->
-                      maybe_auto_squash arg
-                  | (uu____7242, (p, uu____7244))::(uu____7245,
-                                                    (q, uu____7247))::[]
-                      ->
-                      let uu____7312 = FStar_Syntax_Util.term_eq p q in
-                      (if uu____7312
+                  | (FStar_Pervasives_Native.Some (true), uu___9)::(uu___10,
+                                                                    (arg,
+                                                                    uu___11))::[]
+                      -> maybe_auto_squash arg
+                  | (uu___9, (p, uu___10))::(uu___11, (q, uu___12))::[] ->
+                      let uu___13 = FStar_Syntax_Util.term_eq p q in
+                      (if uu___13
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____7314 -> squashed_head_un_auto_squash_args tm
+                  | uu___9 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____7330 =
+                  (let uu___9 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid in
-                   if uu____7330
+                   if uu___9
                    then
-                     let uu____7331 =
-                       FStar_All.pipe_right args (FStar_List.map simplify) in
-                     match uu____7331 with
-                     | (FStar_Pervasives_Native.Some (true), uu____7386)::
-                         (FStar_Pervasives_Native.Some (true), uu____7387)::[]
+                     let uu___10 =
+                       FStar_All.pipe_right args (FStar_List.map simplify1) in
+                     match uu___10 with
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (FStar_Pervasives_Native.Some (true), uu___12)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false), uu____7452)::
-                         (FStar_Pervasives_Native.Some (false), uu____7453)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (FStar_Pervasives_Native.Some (false), uu___12)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true), uu____7518)::
-                         (FStar_Pervasives_Native.Some (false), uu____7519)::[]
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (FStar_Pervasives_Native.Some (false), uu___12)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false), uu____7584)::
-                         (FStar_Pervasives_Native.Some (true), uu____7585)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (FStar_Pervasives_Native.Some (true), uu___12)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____7650, (arg, uu____7652))::(FStar_Pervasives_Native.Some
-                                                         (true), uu____7653)::[]
+                     | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                   (true), uu___13)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true), uu____7718)::
-                         (uu____7719, (arg, uu____7721))::[] ->
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (uu___12, (arg, uu___13))::[] ->
                          maybe_auto_squash arg
-                     | (uu____7786, (arg, uu____7788))::(FStar_Pervasives_Native.Some
-                                                         (false), uu____7789)::[]
+                     | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                   (false), uu___13)::[]
                          ->
-                         let uu____7854 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu____7854
-                     | (FStar_Pervasives_Native.Some (false), uu____7855)::
-                         (uu____7856, (arg, uu____7858))::[] ->
-                         let uu____7923 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu____7923
-                     | (uu____7924, (p, uu____7926))::(uu____7927,
-                                                       (q, uu____7929))::[]
+                         let uu___14 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___14
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (uu___12, (arg, uu___13))::[] ->
+                         let uu___14 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___14
+                     | (uu___11, (p, uu___12))::(uu___13, (q, uu___14))::[]
                          ->
-                         let uu____7994 = FStar_Syntax_Util.term_eq p q in
-                         (if uu____7994
+                         let uu___15 = FStar_Syntax_Util.term_eq p q in
+                         (if uu___15
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____7996 -> squashed_head_un_auto_squash_args tm
+                     | uu___11 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____8012 =
+                     (let uu___11 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid in
-                      if uu____8012
+                      if uu___11
                       then
-                        let uu____8013 =
-                          FStar_All.pipe_right args (FStar_List.map simplify) in
-                        match uu____8013 with
-                        | (FStar_Pervasives_Native.Some (true), uu____8068)::[]
+                        let uu___12 =
+                          FStar_All.pipe_right args
+                            (FStar_List.map simplify1) in
+                        match uu___12 with
+                        | (FStar_Pervasives_Native.Some (true), uu___13)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false), uu____8107)::[]
+                        | (FStar_Pervasives_Native.Some (false), uu___13)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____8146 -> squashed_head_un_auto_squash_args tm
+                        | uu___13 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____8162 =
+                        (let uu___13 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid in
-                         if uu____8162
+                         if uu___13
                          then
                            match args with
-                           | (t, uu____8164)::[] ->
-                               let uu____8189 =
-                                 let uu____8190 =
-                                   FStar_Syntax_Subst.compress t in
-                                 uu____8190.FStar_Syntax_Syntax.n in
-                               (match uu____8189 with
+                           | (t, uu___14)::[] ->
+                               let uu___15 =
+                                 let uu___16 = FStar_Syntax_Subst.compress t in
+                                 uu___16.FStar_Syntax_Syntax.n in
+                               (match uu___15 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____8193::[], body, uu____8195) ->
-                                    let uu____8230 = simp_t body in
-                                    (match uu____8230 with
+                                    (uu___16::[], body, uu___17) ->
+                                    let uu___18 = simp_t body in
+                                    (match uu___18 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
-                                     | uu____8233 -> tm)
-                                | uu____8236 -> tm)
+                                     | uu___19 -> tm)
+                                | uu___16 -> tm)
                            | (ty, FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____8238))::
-                               (t, uu____8240)::[] ->
-                               let uu____8279 =
-                                 let uu____8280 =
-                                   FStar_Syntax_Subst.compress t in
-                                 uu____8280.FStar_Syntax_Syntax.n in
-                               (match uu____8279 with
+                              (FStar_Syntax_Syntax.Implicit uu___14))::
+                               (t, uu___15)::[] ->
+                               let uu___16 =
+                                 let uu___17 = FStar_Syntax_Subst.compress t in
+                                 uu___17.FStar_Syntax_Syntax.n in
+                               (match uu___16 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____8283::[], body, uu____8285) ->
-                                    let uu____8320 = simp_t body in
-                                    (match uu____8320 with
+                                    (uu___17::[], body, uu___18) ->
+                                    let uu___19 = simp_t body in
+                                    (match uu___19 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false)
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____8323 -> tm)
-                                | uu____8326 -> tm)
-                           | uu____8327 -> tm
+                                     | uu___20 -> tm)
+                                | uu___17 -> tm)
+                           | uu___14 -> tm
                          else
-                           (let uu____8339 =
+                           (let uu___15 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid in
-                            if uu____8339
+                            if uu___15
                             then
                               match args with
-                              | (t, uu____8341)::[] ->
-                                  let uu____8366 =
-                                    let uu____8367 =
+                              | (t, uu___16)::[] ->
+                                  let uu___17 =
+                                    let uu___18 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu____8367.FStar_Syntax_Syntax.n in
-                                  (match uu____8366 with
+                                    uu___18.FStar_Syntax_Syntax.n in
+                                  (match uu___17 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____8370::[], body, uu____8372) ->
-                                       let uu____8407 = simp_t body in
-                                       (match uu____8407 with
+                                       (uu___18::[], body, uu___19) ->
+                                       let uu___20 = simp_t body in
+                                       (match uu___20 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
-                                        | uu____8410 -> tm)
-                                   | uu____8413 -> tm)
+                                        | uu___21 -> tm)
+                                   | uu___18 -> tm)
                               | (ty, FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____8415))::
-                                  (t, uu____8417)::[] ->
-                                  let uu____8456 =
-                                    let uu____8457 =
+                                 (FStar_Syntax_Syntax.Implicit uu___16))::
+                                  (t, uu___17)::[] ->
+                                  let uu___18 =
+                                    let uu___19 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu____8457.FStar_Syntax_Syntax.n in
-                                  (match uu____8456 with
+                                    uu___19.FStar_Syntax_Syntax.n in
+                                  (match uu___18 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____8460::[], body, uu____8462) ->
-                                       let uu____8497 = simp_t body in
-                                       (match uu____8497 with
+                                       (uu___19::[], body, uu___20) ->
+                                       let uu___21 = simp_t body in
+                                       (match uu___21 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true)
                                             when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____8500 -> tm)
-                                   | uu____8503 -> tm)
-                              | uu____8504 -> tm
+                                        | uu___22 -> tm)
+                                   | uu___19 -> tm)
+                              | uu___16 -> tm
                             else
-                              (let uu____8516 =
+                              (let uu___17 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid in
-                               if uu____8516
+                               if uu___17
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true));
-                                      FStar_Syntax_Syntax.pos = uu____8517;
-                                      FStar_Syntax_Syntax.vars = uu____8518;_},
-                                    uu____8519)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___18;
+                                      FStar_Syntax_Syntax.vars = uu___19;_},
+                                    uu___20)::[] ->
                                      w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false));
-                                      FStar_Syntax_Syntax.pos = uu____8544;
-                                      FStar_Syntax_Syntax.vars = uu____8545;_},
-                                    uu____8546)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___18;
+                                      FStar_Syntax_Syntax.vars = uu___19;_},
+                                    uu___20)::[] ->
                                      w FStar_Syntax_Util.t_false
-                                 | uu____8571 -> tm
+                                 | uu___18 -> tm
                                else
-                                 (let uu____8583 =
+                                 (let uu___19 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid in
-                                  if uu____8583
+                                  if uu___19
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1584,11 +1544,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid] in
-                                      let uu____8593 =
-                                        let uu____8594 =
+                                      let uu___20 =
+                                        let uu___21 =
                                           FStar_Syntax_Subst.compress t in
-                                        uu____8594.FStar_Syntax_Syntax.n in
-                                      match uu____8593 with
+                                        uu___21.FStar_Syntax_Syntax.n in
+                                      match uu___20 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1596,114 +1556,111 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____8602 -> false in
+                                      | uu___21 -> false in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____8612 =
+                                         let uu___20 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd in
-                                         FStar_All.pipe_right uu____8612
+                                         FStar_All.pipe_right uu___20
                                            FStar_Pervasives_Native.fst in
-                                       let uu____8647 =
+                                       let uu___20 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure in
-                                       (if uu____8647
+                                       (if uu___20
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____8649 =
-                                             let uu____8650 =
+                                          (let uu___22 =
+                                             let uu___23 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____8650.FStar_Syntax_Syntax.n in
-                                           match uu____8649 with
+                                             uu___23.FStar_Syntax_Syntax.n in
+                                           match uu___22 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____8653 ->
+                                               uu___23 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
-                                               let uu____8661 =
+                                               let uu___24 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure in
-                                               if uu____8661
+                                               if uu___24
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____8666 =
-                                                      let uu____8667 =
+                                                    let uu___26 =
+                                                      let uu___27 =
                                                         FStar_Syntax_Subst.compress
                                                           tm in
-                                                      uu____8667.FStar_Syntax_Syntax.n in
-                                                    match uu____8666 with
+                                                      uu___27.FStar_Syntax_Syntax.n in
+                                                    match uu___26 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd, uu____8673) ->
-                                                        hd
-                                                    | uu____8698 ->
+                                                        (hd, uu___27) -> hd
+                                                    | uu___27 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app" in
-                                                  let uu____8701 =
-                                                    let uu____8712 =
+                                                  let uu___26 =
+                                                    let uu___27 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    [uu____8712] in
+                                                    [uu___27] in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____8701)
-                                           | uu____8745 -> tm))
+                                                    haseq_tm uu___26)
+                                           | uu___23 -> tm))
                                      else tm)
                                   else
-                                    (let uu____8748 =
+                                    (let uu___21 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid in
-                                     if uu____8748
+                                     if uu___21
                                      then
                                        match args with
-                                       | (_typ, uu____8750)::(a1, uu____8752)::
-                                           (a2, uu____8754)::[] ->
-                                           let uu____8811 =
+                                       | (_typ, uu___22)::(a1, uu___23)::
+                                           (a2, uu___24)::[] ->
+                                           let uu___25 =
                                              FStar_Syntax_Util.eq_tm a1 a2 in
-                                           (match uu____8811 with
+                                           (match uu___25 with
                                             | FStar_Syntax_Util.Equal ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____8812 -> tm)
-                                       | uu____8813 -> tm
+                                            | uu___26 -> tm)
+                                       | uu___22 -> tm
                                      else
-                                       (let uu____8825 =
+                                       (let uu___23 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid in
-                                        if uu____8825
+                                        if uu___23
                                         then
                                           match args with
-                                          | (t1, uu____8827)::(t2,
-                                                               uu____8829)::
-                                              (a1, uu____8831)::(a2,
-                                                                 uu____8833)::[]
+                                          | (t1, uu___24)::(t2, uu___25)::
+                                              (a1, uu___26)::(a2, uu___27)::[]
                                               ->
-                                              let uu____8906 =
-                                                let uu____8907 =
+                                              let uu___28 =
+                                                let uu___29 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2 in
-                                                let uu____8908 =
+                                                let uu___30 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2 in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____8907 uu____8908 in
-                                              (match uu____8906 with
+                                                  uu___29 uu___30 in
+                                              (match uu___28 with
                                                | FStar_Syntax_Util.Equal ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____8909 -> tm)
-                                          | uu____8910 -> tm
+                                               | uu___29 -> tm)
+                                          | uu___24 -> tm
                                         else
-                                          (let uu____8922 =
+                                          (let uu___25 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm in
-                                           match uu____8922 with
+                                           match uu___25 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero,
                                                 t)
@@ -1711,20 +1668,20 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____8942 -> tm)))))))))))
+                                           | uu___26 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_refine (bv, t) ->
-          let uu____8957 = simp_t t in
-          (match uu____8957 with
+          let uu___1 = simp_t t in
+          (match uu___1 with
            | FStar_Pervasives_Native.Some (true) ->
                bv.FStar_Syntax_Syntax.sort
            | FStar_Pervasives_Native.Some (false) -> tm
            | FStar_Pervasives_Native.None -> tm)
-      | FStar_Syntax_Syntax.Tm_match uu____8960 ->
-          let uu____8983 = is_const_match tm in
-          (match uu____8983 with
+      | FStar_Syntax_Syntax.Tm_match uu___1 ->
+          let uu___2 = is_const_match tm in
+          (match uu___2 with
            | FStar_Pervasives_Native.Some (true) ->
                w FStar_Syntax_Util.t_true
            | FStar_Pervasives_Native.Some (false) ->
                w FStar_Syntax_Util.t_false
            | FStar_Pervasives_Native.None -> tm)
-      | uu____8986 -> tm
+      | uu___1 -> tm

--- a/src/ocaml-output/FStar_TypeChecker_DMFF.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DMFF.ml
@@ -37,200 +37,196 @@ let (gen_wps_for_free :
                 [FStar_TypeChecker_Env.Beta;
                 FStar_TypeChecker_Env.EraseUniverses] env1 wp_a in
             let a1 =
-              let uu___28_125 = a in
-              let uu____126 =
+              let uu___ = a in
+              let uu___1 =
                 FStar_TypeChecker_Normalize.normalize
                   [FStar_TypeChecker_Env.EraseUniverses] env1
                   a.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___28_125.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___28_125.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____126
+                  (uu___.FStar_Syntax_Syntax.ppname);
+                FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu___1
               } in
             let d s = FStar_Util.print1 "\027[01;36m%s\027[00m\n" s in
-            (let uu____136 =
+            (let uu___1 =
                FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
-             if uu____136
+             if uu___1
              then
                (d "Elaborating extra WP combinators";
-                (let uu____138 = FStar_Syntax_Print.term_to_string wp_a1 in
-                 FStar_Util.print1 "wp_a is: %s\n" uu____138))
+                (let uu___3 = FStar_Syntax_Print.term_to_string wp_a1 in
+                 FStar_Util.print1 "wp_a is: %s\n" uu___3))
              else ());
             (let rec collect_binders t =
                let t1 = FStar_Syntax_Util.unascribe t in
-               let uu____155 =
-                 let uu____156 = FStar_Syntax_Subst.compress t1 in
-                 uu____156.FStar_Syntax_Syntax.n in
-               match uu____155 with
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress t1 in
+                 uu___2.FStar_Syntax_Syntax.n in
+               match uu___1 with
                | FStar_Syntax_Syntax.Tm_arrow (bs, comp) ->
                    let rest =
                      match comp.FStar_Syntax_Syntax.n with
-                     | FStar_Syntax_Syntax.Total (t2, uu____191) -> t2
-                     | uu____200 ->
-                         let uu____201 =
-                           let uu____206 =
-                             let uu____207 =
+                     | FStar_Syntax_Syntax.Total (t2, uu___2) -> t2
+                     | uu___2 ->
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 =
                                FStar_Syntax_Print.comp_to_string comp in
                              FStar_Util.format1
-                               "wp_a contains non-Tot arrow: %s" uu____207 in
-                           (FStar_Errors.Error_UnexpectedDM4FType, uu____206) in
-                         FStar_Errors.raise_error uu____201
+                               "wp_a contains non-Tot arrow: %s" uu___5 in
+                           (FStar_Errors.Error_UnexpectedDM4FType, uu___4) in
+                         FStar_Errors.raise_error uu___3
                            comp.FStar_Syntax_Syntax.pos in
-                   let uu____208 = collect_binders rest in
-                   FStar_List.append bs uu____208
-               | FStar_Syntax_Syntax.Tm_type uu____223 -> []
-               | uu____230 ->
-                   let uu____231 =
-                     let uu____236 =
-                       let uu____237 = FStar_Syntax_Print.term_to_string t1 in
+                   let uu___2 = collect_binders rest in
+                   FStar_List.append bs uu___2
+               | FStar_Syntax_Syntax.Tm_type uu___2 -> []
+               | uu___2 ->
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Print.term_to_string t1 in
                        FStar_Util.format1
-                         "wp_a doesn't end in Type0, but rather in %s"
-                         uu____237 in
-                     (FStar_Errors.Error_UnexpectedDM4FType, uu____236) in
-                   FStar_Errors.raise_error uu____231
-                     t1.FStar_Syntax_Syntax.pos in
+                         "wp_a doesn't end in Type0, but rather in %s" uu___5 in
+                     (FStar_Errors.Error_UnexpectedDM4FType, uu___4) in
+                   FStar_Errors.raise_error uu___3 t1.FStar_Syntax_Syntax.pos in
              let mk_lid name = FStar_Syntax_Util.dm4f_lid ed name in
              let gamma =
-               let uu____261 = collect_binders wp_a1 in
-               FStar_All.pipe_right uu____261 FStar_Syntax_Util.name_binders in
-             (let uu____287 =
+               let uu___1 = collect_binders wp_a1 in
+               FStar_All.pipe_right uu___1 FStar_Syntax_Util.name_binders in
+             (let uu___2 =
                 FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
-              if uu____287
+              if uu___2
               then
-                let uu____288 =
-                  let uu____289 =
+                let uu___3 =
+                  let uu___4 =
                     FStar_Syntax_Print.binders_to_string ", " gamma in
-                  FStar_Util.format1 "Gamma is %s\n" uu____289 in
-                d uu____288
+                  FStar_Util.format1 "Gamma is %s\n" uu___4 in
+                d uu___3
               else ());
              (let unknown = FStar_Syntax_Syntax.tun in
               let mk x = FStar_Syntax_Syntax.mk x FStar_Range.dummyRange in
               let sigelts = FStar_Util.mk_ref [] in
               let register env2 lident def =
-                let uu____323 =
+                let uu___2 =
                   FStar_TypeChecker_Util.mk_toplevel_definition env2 lident
                     def in
-                match uu____323 with
+                match uu___2 with
                 | (sigelt, fv) ->
-                    ((let uu____331 =
-                        let uu____334 = FStar_ST.op_Bang sigelts in sigelt ::
-                          uu____334 in
-                      FStar_ST.op_Colon_Equals sigelts uu____331);
+                    ((let uu___4 =
+                        let uu___5 = FStar_ST.op_Bang sigelts in sigelt ::
+                          uu___5 in
+                      FStar_ST.op_Colon_Equals sigelts uu___4);
                      fv) in
               let binders_of_list =
                 FStar_List.map
-                  (fun uu____386 ->
-                     match uu____386 with
+                  (fun uu___2 ->
+                     match uu___2 with
                      | (t, b) ->
-                         let uu____397 = FStar_Syntax_Syntax.as_implicit b in
-                         (t, uu____397)) in
+                         let uu___3 = FStar_Syntax_Syntax.as_implicit b in
+                         (t, uu___3)) in
               let mk_all_implicit =
                 FStar_List.map
                   (fun t ->
-                     let uu____436 = FStar_Syntax_Syntax.as_implicit true in
-                     ((FStar_Pervasives_Native.fst t), uu____436)) in
+                     let uu___2 = FStar_Syntax_Syntax.as_implicit true in
+                     ((FStar_Pervasives_Native.fst t), uu___2)) in
               let args_of_binders =
                 FStar_List.map
                   (fun bv ->
-                     let uu____469 =
+                     let uu___2 =
                        FStar_Syntax_Syntax.bv_to_name
                          (FStar_Pervasives_Native.fst bv) in
-                     FStar_Syntax_Syntax.as_arg uu____469) in
-              let uu____472 =
-                let uu____489 =
+                     FStar_Syntax_Syntax.as_arg uu___2) in
+              let uu___2 =
+                let uu___3 =
                   let mk1 f =
                     let t =
                       FStar_Syntax_Syntax.gen_bv "t"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let body =
-                      let uu____513 =
-                        let uu____516 = FStar_Syntax_Syntax.bv_to_name t in
-                        f uu____516 in
-                      FStar_Syntax_Util.arrow gamma uu____513 in
-                    let uu____517 =
-                      let uu____518 =
-                        let uu____527 = FStar_Syntax_Syntax.mk_binder a1 in
-                        let uu____534 =
-                          let uu____543 = FStar_Syntax_Syntax.mk_binder t in
-                          [uu____543] in
-                        uu____527 :: uu____534 in
-                      FStar_List.append binders uu____518 in
-                    FStar_Syntax_Util.abs uu____517 body
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.bv_to_name t in
+                        f uu___5 in
+                      FStar_Syntax_Util.arrow gamma uu___4 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Syntax.mk_binder a1 in
+                        let uu___7 =
+                          let uu___8 = FStar_Syntax_Syntax.mk_binder t in
+                          [uu___8] in
+                        uu___6 :: uu___7 in
+                      FStar_List.append binders uu___5 in
+                    FStar_Syntax_Util.abs uu___4 body
                       FStar_Pervasives_Native.None in
-                  let uu____574 = mk1 FStar_Syntax_Syntax.mk_Total in
-                  let uu____575 = mk1 FStar_Syntax_Syntax.mk_GTotal in
-                  (uu____574, uu____575) in
-                match uu____489 with
+                  let uu___4 = mk1 FStar_Syntax_Syntax.mk_Total in
+                  let uu___5 = mk1 FStar_Syntax_Syntax.mk_GTotal in
+                  (uu___4, uu___5) in
+                match uu___3 with
                 | (ctx_def, gctx_def) ->
                     let ctx_lid = mk_lid "ctx" in
                     let ctx_fv = register env1 ctx_lid ctx_def in
                     let gctx_lid = mk_lid "gctx" in
                     let gctx_fv = register env1 gctx_lid gctx_def in
                     let mk_app fv t =
-                      let uu____615 =
-                        let uu____616 =
-                          let uu____633 =
-                            let uu____644 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_List.map
-                                (fun uu____666 ->
-                                   match uu____666 with
-                                   | (bv, uu____678) ->
-                                       let uu____683 =
+                                (fun uu___8 ->
+                                   match uu___8 with
+                                   | (bv, uu___9) ->
+                                       let uu___10 =
                                          FStar_Syntax_Syntax.bv_to_name bv in
-                                       let uu____684 =
+                                       let uu___11 =
                                          FStar_Syntax_Syntax.as_implicit
                                            false in
-                                       (uu____683, uu____684)) binders in
-                            let uu____685 =
-                              let uu____692 =
-                                let uu____697 =
+                                       (uu___10, uu___11)) binders in
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
                                   FStar_Syntax_Syntax.bv_to_name a1 in
-                                let uu____698 =
+                                let uu___11 =
                                   FStar_Syntax_Syntax.as_implicit false in
-                                (uu____697, uu____698) in
-                              let uu____699 =
-                                let uu____706 =
-                                  let uu____711 =
+                                (uu___10, uu___11) in
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_Syntax_Syntax.as_implicit false in
-                                  (t, uu____711) in
-                                [uu____706] in
-                              uu____692 :: uu____699 in
-                            FStar_List.append uu____644 uu____685 in
-                          (fv, uu____633) in
-                        FStar_Syntax_Syntax.Tm_app uu____616 in
-                      mk uu____615 in
+                                  (t, uu___12) in
+                                [uu___11] in
+                              uu___9 :: uu___10 in
+                            FStar_List.append uu___7 uu___8 in
+                          (fv, uu___6) in
+                        FStar_Syntax_Syntax.Tm_app uu___5 in
+                      mk uu___4 in
                     (env1, (mk_app ctx_fv), (mk_app gctx_fv)) in
-              match uu____472 with
+              match uu___2 with
               | (env2, mk_ctx, mk_gctx) ->
                   let c_pure =
                     let t =
                       FStar_Syntax_Syntax.gen_bv "t"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let x =
-                      let uu____782 = FStar_Syntax_Syntax.bv_to_name t in
+                      let uu___3 = FStar_Syntax_Syntax.bv_to_name t in
                       FStar_Syntax_Syntax.gen_bv "x"
-                        FStar_Pervasives_Native.None uu____782 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let ret =
-                      let uu____786 =
-                        let uu____787 =
-                          let uu____790 = FStar_Syntax_Syntax.bv_to_name t in
-                          mk_ctx uu____790 in
-                        FStar_Syntax_Util.residual_tot uu____787 in
-                      FStar_Pervasives_Native.Some uu____786 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t in
+                          mk_ctx uu___5 in
+                        FStar_Syntax_Util.residual_tot uu___4 in
+                      FStar_Pervasives_Native.Some uu___3 in
                     let body =
-                      let uu____794 = FStar_Syntax_Syntax.bv_to_name x in
-                      FStar_Syntax_Util.abs gamma uu____794 ret in
-                    let uu____797 =
-                      let uu____798 = mk_all_implicit binders in
-                      let uu____805 =
+                      let uu___3 = FStar_Syntax_Syntax.bv_to_name x in
+                      FStar_Syntax_Util.abs gamma uu___3 ret in
+                    let uu___3 =
+                      let uu___4 = mk_all_implicit binders in
+                      let uu___5 =
                         binders_of_list [(a1, true); (t, true); (x, false)] in
-                      FStar_List.append uu____798 uu____805 in
-                    FStar_Syntax_Util.abs uu____797 body ret in
+                      FStar_List.append uu___4 uu___5 in
+                    FStar_Syntax_Util.abs uu___3 body ret in
                   let c_pure1 =
-                    let uu____833 = mk_lid "pure" in
-                    register env2 uu____833 c_pure in
+                    let uu___3 = mk_lid "pure" in register env2 uu___3 c_pure in
                   let c_app =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
@@ -239,68 +235,65 @@ let (gen_wps_for_free :
                       FStar_Syntax_Syntax.gen_bv "t2"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let l =
-                      let uu____840 =
-                        let uu____841 =
-                          let uu____842 =
-                            let uu____851 =
-                              let uu____858 =
-                                let uu____859 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_Syntax_Syntax.bv_to_name t1 in
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None uu____859 in
-                              FStar_Syntax_Syntax.mk_binder uu____858 in
-                            [uu____851] in
-                          let uu____872 =
-                            let uu____875 = FStar_Syntax_Syntax.bv_to_name t2 in
-                            FStar_Syntax_Syntax.mk_GTotal uu____875 in
-                          FStar_Syntax_Util.arrow uu____842 uu____872 in
-                        mk_gctx uu____841 in
+                                  FStar_Pervasives_Native.None uu___8 in
+                              FStar_Syntax_Syntax.mk_binder uu___7 in
+                            [uu___6] in
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Syntax.bv_to_name t2 in
+                            FStar_Syntax_Syntax.mk_GTotal uu___7 in
+                          FStar_Syntax_Util.arrow uu___5 uu___6 in
+                        mk_gctx uu___4 in
                       FStar_Syntax_Syntax.gen_bv "l"
-                        FStar_Pervasives_Native.None uu____840 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let r =
-                      let uu____877 =
-                        let uu____878 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____878 in
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu___4 in
                       FStar_Syntax_Syntax.gen_bv "r"
-                        FStar_Pervasives_Native.None uu____877 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let ret =
-                      let uu____882 =
-                        let uu____883 =
-                          let uu____886 = FStar_Syntax_Syntax.bv_to_name t2 in
-                          mk_gctx uu____886 in
-                        FStar_Syntax_Util.residual_tot uu____883 in
-                      FStar_Pervasives_Native.Some uu____882 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu___5 in
+                        FStar_Syntax_Util.residual_tot uu___4 in
+                      FStar_Pervasives_Native.Some uu___3 in
                     let outer_body =
                       let gamma_as_args = args_of_binders gamma in
                       let inner_body =
-                        let uu____896 = FStar_Syntax_Syntax.bv_to_name l in
-                        let uu____899 =
-                          let uu____910 =
-                            let uu____913 =
-                              let uu____914 =
-                                let uu____915 =
-                                  FStar_Syntax_Syntax.bv_to_name r in
-                                FStar_Syntax_Util.mk_app uu____915
-                                  gamma_as_args in
-                              FStar_Syntax_Syntax.as_arg uu____914 in
-                            [uu____913] in
-                          FStar_List.append gamma_as_args uu____910 in
-                        FStar_Syntax_Util.mk_app uu____896 uu____899 in
+                        let uu___3 = FStar_Syntax_Syntax.bv_to_name l in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Syntax_Syntax.bv_to_name r in
+                                FStar_Syntax_Util.mk_app uu___8 gamma_as_args in
+                              FStar_Syntax_Syntax.as_arg uu___7 in
+                            [uu___6] in
+                          FStar_List.append gamma_as_args uu___5 in
+                        FStar_Syntax_Util.mk_app uu___3 uu___4 in
                       FStar_Syntax_Util.abs gamma inner_body ret in
-                    let uu____918 =
-                      let uu____919 = mk_all_implicit binders in
-                      let uu____926 =
+                    let uu___3 =
+                      let uu___4 = mk_all_implicit binders in
+                      let uu___5 =
                         binders_of_list
                           [(a1, true);
                           (t1, true);
                           (t2, true);
                           (l, false);
                           (r, false)] in
-                      FStar_List.append uu____919 uu____926 in
-                    FStar_Syntax_Util.abs uu____918 outer_body ret in
+                      FStar_List.append uu___4 uu___5 in
+                    FStar_Syntax_Util.abs uu___3 outer_body ret in
                   let c_app1 =
-                    let uu____962 = mk_lid "app" in
-                    register env2 uu____962 c_app in
+                    let uu___3 = mk_lid "app" in register env2 uu___3 c_app in
                   let c_lift1 =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
@@ -309,64 +302,63 @@ let (gen_wps_for_free :
                       FStar_Syntax_Syntax.gen_bv "t2"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
-                      let uu____971 =
-                        let uu____980 =
-                          let uu____987 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____987 in
-                        [uu____980] in
-                      let uu____1000 =
-                        let uu____1003 = FStar_Syntax_Syntax.bv_to_name t2 in
-                        FStar_Syntax_Syntax.mk_GTotal uu____1003 in
-                      FStar_Syntax_Util.arrow uu____971 uu____1000 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu___5 in
+                        [uu___4] in
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.bv_to_name t2 in
+                        FStar_Syntax_Syntax.mk_GTotal uu___5 in
+                      FStar_Syntax_Util.arrow uu___3 uu___4 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
                         FStar_Pervasives_Native.None t_f in
                     let a11 =
-                      let uu____1006 =
-                        let uu____1007 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____1007 in
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu___4 in
                       FStar_Syntax_Syntax.gen_bv "a1"
-                        FStar_Pervasives_Native.None uu____1006 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let ret =
-                      let uu____1011 =
-                        let uu____1012 =
-                          let uu____1015 = FStar_Syntax_Syntax.bv_to_name t2 in
-                          mk_gctx uu____1015 in
-                        FStar_Syntax_Util.residual_tot uu____1012 in
-                      FStar_Pervasives_Native.Some uu____1011 in
-                    let uu____1016 =
-                      let uu____1017 = mk_all_implicit binders in
-                      let uu____1024 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu___5 in
+                        FStar_Syntax_Util.residual_tot uu___4 in
+                      FStar_Pervasives_Native.Some uu___3 in
+                    let uu___3 =
+                      let uu___4 = mk_all_implicit binders in
+                      let uu___5 =
                         binders_of_list
                           [(a1, true);
                           (t1, true);
                           (t2, true);
                           (f, false);
                           (a11, false)] in
-                      FStar_List.append uu____1017 uu____1024 in
-                    let uu____1059 =
-                      let uu____1062 =
-                        let uu____1073 =
-                          let uu____1076 =
-                            let uu____1077 =
-                              let uu____1088 =
-                                let uu____1091 =
+                      FStar_List.append uu___4 uu___5 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
                                   FStar_Syntax_Syntax.bv_to_name f in
-                                [uu____1091] in
+                                [uu___10] in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1088 in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1077 in
-                          let uu____1100 =
-                            let uu____1103 =
-                              FStar_Syntax_Syntax.bv_to_name a11 in
-                            [uu____1103] in
-                          uu____1076 :: uu____1100 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1073 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1062 in
-                    FStar_Syntax_Util.abs uu____1016 uu____1059 ret in
+                                uu___9 in
+                            FStar_Syntax_Util.mk_app c_pure1 uu___8 in
+                          let uu___8 =
+                            let uu___9 = FStar_Syntax_Syntax.bv_to_name a11 in
+                            [uu___9] in
+                          uu___7 :: uu___8 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu___6 in
+                      FStar_Syntax_Util.mk_app c_app1 uu___5 in
+                    FStar_Syntax_Util.abs uu___3 uu___4 ret in
                   let c_lift11 =
-                    let uu____1113 = mk_lid "lift1" in
-                    register env2 uu____1113 c_lift1 in
+                    let uu___3 = mk_lid "lift1" in
+                    register env2 uu___3 c_lift1 in
                   let c_lift2 =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
@@ -378,46 +370,45 @@ let (gen_wps_for_free :
                       FStar_Syntax_Syntax.gen_bv "t3"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
-                      let uu____1123 =
-                        let uu____1132 =
-                          let uu____1139 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____1139 in
-                        let uu____1140 =
-                          let uu____1149 =
-                            let uu____1156 =
-                              FStar_Syntax_Syntax.bv_to_name t2 in
-                            FStar_Syntax_Syntax.null_binder uu____1156 in
-                          [uu____1149] in
-                        uu____1132 :: uu____1140 in
-                      let uu____1175 =
-                        let uu____1178 = FStar_Syntax_Syntax.bv_to_name t3 in
-                        FStar_Syntax_Syntax.mk_GTotal uu____1178 in
-                      FStar_Syntax_Util.arrow uu____1123 uu____1175 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu___5 in
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Syntax.bv_to_name t2 in
+                            FStar_Syntax_Syntax.null_binder uu___7 in
+                          [uu___6] in
+                        uu___4 :: uu___5 in
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.bv_to_name t3 in
+                        FStar_Syntax_Syntax.mk_GTotal uu___5 in
+                      FStar_Syntax_Util.arrow uu___3 uu___4 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
                         FStar_Pervasives_Native.None t_f in
                     let a11 =
-                      let uu____1181 =
-                        let uu____1182 = FStar_Syntax_Syntax.bv_to_name t1 in
-                        mk_gctx uu____1182 in
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu___4 in
                       FStar_Syntax_Syntax.gen_bv "a1"
-                        FStar_Pervasives_Native.None uu____1181 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let a2 =
-                      let uu____1184 =
-                        let uu____1185 = FStar_Syntax_Syntax.bv_to_name t2 in
-                        mk_gctx uu____1185 in
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.bv_to_name t2 in
+                        mk_gctx uu___4 in
                       FStar_Syntax_Syntax.gen_bv "a2"
-                        FStar_Pervasives_Native.None uu____1184 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let ret =
-                      let uu____1189 =
-                        let uu____1190 =
-                          let uu____1193 = FStar_Syntax_Syntax.bv_to_name t3 in
-                          mk_gctx uu____1193 in
-                        FStar_Syntax_Util.residual_tot uu____1190 in
-                      FStar_Pervasives_Native.Some uu____1189 in
-                    let uu____1194 =
-                      let uu____1195 = mk_all_implicit binders in
-                      let uu____1202 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t3 in
+                          mk_gctx uu___5 in
+                        FStar_Syntax_Util.residual_tot uu___4 in
+                      FStar_Pervasives_Native.Some uu___3 in
+                    let uu___3 =
+                      let uu___4 = mk_all_implicit binders in
+                      let uu___5 =
                         binders_of_list
                           [(a1, true);
                           (t1, true);
@@ -426,41 +417,40 @@ let (gen_wps_for_free :
                           (f, false);
                           (a11, false);
                           (a2, false)] in
-                      FStar_List.append uu____1195 uu____1202 in
-                    let uu____1245 =
-                      let uu____1248 =
-                        let uu____1259 =
-                          let uu____1262 =
-                            let uu____1263 =
-                              let uu____1274 =
-                                let uu____1277 =
-                                  let uu____1278 =
-                                    let uu____1289 =
-                                      let uu____1292 =
+                      FStar_List.append uu___4 uu___5 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_Syntax_Syntax.bv_to_name f in
-                                      [uu____1292] in
+                                      [uu___13] in
                                     FStar_List.map FStar_Syntax_Syntax.as_arg
-                                      uu____1289 in
-                                  FStar_Syntax_Util.mk_app c_pure1 uu____1278 in
-                                let uu____1301 =
-                                  let uu____1304 =
+                                      uu___12 in
+                                  FStar_Syntax_Util.mk_app c_pure1 uu___11 in
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_Syntax_Syntax.bv_to_name a11 in
-                                  [uu____1304] in
-                                uu____1277 :: uu____1301 in
+                                  [uu___12] in
+                                uu___10 :: uu___11 in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1274 in
-                            FStar_Syntax_Util.mk_app c_app1 uu____1263 in
-                          let uu____1313 =
-                            let uu____1316 =
-                              FStar_Syntax_Syntax.bv_to_name a2 in
-                            [uu____1316] in
-                          uu____1262 :: uu____1313 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1259 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1248 in
-                    FStar_Syntax_Util.abs uu____1194 uu____1245 ret in
+                                uu___9 in
+                            FStar_Syntax_Util.mk_app c_app1 uu___8 in
+                          let uu___8 =
+                            let uu___9 = FStar_Syntax_Syntax.bv_to_name a2 in
+                            [uu___9] in
+                          uu___7 :: uu___8 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu___6 in
+                      FStar_Syntax_Util.mk_app c_app1 uu___5 in
+                    FStar_Syntax_Util.abs uu___3 uu___4 ret in
                   let c_lift21 =
-                    let uu____1326 = mk_lid "lift2" in
-                    register env2 uu____1326 c_lift2 in
+                    let uu___3 = mk_lid "lift2" in
+                    register env2 uu___3 c_lift2 in
                   let c_push =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
@@ -469,238 +459,229 @@ let (gen_wps_for_free :
                       FStar_Syntax_Syntax.gen_bv "t2"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
-                      let uu____1335 =
-                        let uu____1344 =
-                          let uu____1351 = FStar_Syntax_Syntax.bv_to_name t1 in
-                          FStar_Syntax_Syntax.null_binder uu____1351 in
-                        [uu____1344] in
-                      let uu____1364 =
-                        let uu____1367 =
-                          let uu____1368 = FStar_Syntax_Syntax.bv_to_name t2 in
-                          mk_gctx uu____1368 in
-                        FStar_Syntax_Syntax.mk_Total uu____1367 in
-                      FStar_Syntax_Util.arrow uu____1335 uu____1364 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu___5 in
+                        [uu___4] in
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu___6 in
+                        FStar_Syntax_Syntax.mk_Total uu___5 in
+                      FStar_Syntax_Util.arrow uu___3 uu___4 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
                         FStar_Pervasives_Native.None t_f in
                     let ret =
-                      let uu____1373 =
-                        let uu____1374 =
-                          let uu____1377 =
-                            let uu____1378 =
-                              let uu____1387 =
-                                let uu____1394 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_Syntax_Syntax.bv_to_name t1 in
-                                FStar_Syntax_Syntax.null_binder uu____1394 in
-                              [uu____1387] in
-                            let uu____1407 =
-                              let uu____1410 =
-                                FStar_Syntax_Syntax.bv_to_name t2 in
-                              FStar_Syntax_Syntax.mk_GTotal uu____1410 in
-                            FStar_Syntax_Util.arrow uu____1378 uu____1407 in
-                          mk_ctx uu____1377 in
-                        FStar_Syntax_Util.residual_tot uu____1374 in
-                      FStar_Pervasives_Native.Some uu____1373 in
+                                FStar_Syntax_Syntax.null_binder uu___8 in
+                              [uu___7] in
+                            let uu___7 =
+                              let uu___8 = FStar_Syntax_Syntax.bv_to_name t2 in
+                              FStar_Syntax_Syntax.mk_GTotal uu___8 in
+                            FStar_Syntax_Util.arrow uu___6 uu___7 in
+                          mk_ctx uu___5 in
+                        FStar_Syntax_Util.residual_tot uu___4 in
+                      FStar_Pervasives_Native.Some uu___3 in
                     let e1 =
-                      let uu____1412 = FStar_Syntax_Syntax.bv_to_name t1 in
+                      let uu___3 = FStar_Syntax_Syntax.bv_to_name t1 in
                       FStar_Syntax_Syntax.gen_bv "e1"
-                        FStar_Pervasives_Native.None uu____1412 in
+                        FStar_Pervasives_Native.None uu___3 in
                     let body =
-                      let uu____1416 =
-                        let uu____1417 =
-                          let uu____1426 = FStar_Syntax_Syntax.mk_binder e1 in
-                          [uu____1426] in
-                        FStar_List.append gamma uu____1417 in
-                      let uu____1451 =
-                        let uu____1454 = FStar_Syntax_Syntax.bv_to_name f in
-                        let uu____1457 =
-                          let uu____1468 =
-                            let uu____1469 =
-                              FStar_Syntax_Syntax.bv_to_name e1 in
-                            FStar_Syntax_Syntax.as_arg uu____1469 in
-                          let uu____1470 = args_of_binders gamma in
-                          uu____1468 :: uu____1470 in
-                        FStar_Syntax_Util.mk_app uu____1454 uu____1457 in
-                      FStar_Syntax_Util.abs uu____1416 uu____1451 ret in
-                    let uu____1473 =
-                      let uu____1474 = mk_all_implicit binders in
-                      let uu____1481 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.mk_binder e1 in
+                          [uu___5] in
+                        FStar_List.append gamma uu___4 in
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.bv_to_name f in
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 = FStar_Syntax_Syntax.bv_to_name e1 in
+                            FStar_Syntax_Syntax.as_arg uu___8 in
+                          let uu___8 = args_of_binders gamma in uu___7 ::
+                            uu___8 in
+                        FStar_Syntax_Util.mk_app uu___5 uu___6 in
+                      FStar_Syntax_Util.abs uu___3 uu___4 ret in
+                    let uu___3 =
+                      let uu___4 = mk_all_implicit binders in
+                      let uu___5 =
                         binders_of_list
                           [(a1, true); (t1, true); (t2, true); (f, false)] in
-                      FStar_List.append uu____1474 uu____1481 in
-                    FStar_Syntax_Util.abs uu____1473 body ret in
+                      FStar_List.append uu___4 uu___5 in
+                    FStar_Syntax_Util.abs uu___3 body ret in
                   let c_push1 =
-                    let uu____1513 = mk_lid "push" in
-                    register env2 uu____1513 c_push in
+                    let uu___3 = mk_lid "push" in register env2 uu___3 c_push in
                   let ret_tot_wp_a =
                     FStar_Pervasives_Native.Some
                       (FStar_Syntax_Util.residual_tot wp_a1) in
                   let mk_generic_app c =
                     if (FStar_List.length binders) > Prims.int_zero
                     then
-                      let uu____1537 =
-                        let uu____1538 =
-                          let uu____1555 = args_of_binders binders in
-                          (c, uu____1555) in
-                        FStar_Syntax_Syntax.Tm_app uu____1538 in
-                      mk uu____1537
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = args_of_binders binders in (c, uu___5) in
+                        FStar_Syntax_Syntax.Tm_app uu___4 in
+                      mk uu___3
                     else c in
                   let wp_if_then_else =
                     let result_comp =
-                      let uu____1583 =
-                        let uu____1584 =
-                          let uu____1593 =
-                            FStar_Syntax_Syntax.null_binder wp_a1 in
-                          let uu____1600 =
-                            let uu____1609 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.null_binder wp_a1 in
+                          let uu___6 =
+                            let uu___7 =
                               FStar_Syntax_Syntax.null_binder wp_a1 in
-                            [uu____1609] in
-                          uu____1593 :: uu____1600 in
-                        let uu____1634 = FStar_Syntax_Syntax.mk_Total wp_a1 in
-                        FStar_Syntax_Util.arrow uu____1584 uu____1634 in
-                      FStar_Syntax_Syntax.mk_Total uu____1583 in
+                            [uu___7] in
+                          uu___5 :: uu___6 in
+                        let uu___5 = FStar_Syntax_Syntax.mk_Total wp_a1 in
+                        FStar_Syntax_Util.arrow uu___4 uu___5 in
+                      FStar_Syntax_Syntax.mk_Total uu___3 in
                     let c =
                       FStar_Syntax_Syntax.gen_bv "c"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
-                    let uu____1638 =
-                      let uu____1639 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Syntax.binders_of_list [a1; c] in
-                      FStar_List.append binders uu____1639 in
-                    let uu____1654 =
+                      FStar_List.append binders uu___4 in
+                    let uu___4 =
                       let l_ite =
                         FStar_Syntax_Syntax.fvar FStar_Parser_Const.ite_lid
                           (FStar_Syntax_Syntax.Delta_constant_at_level
                              (Prims.of_int (2))) FStar_Pervasives_Native.None in
-                      let uu____1658 =
-                        let uu____1661 =
-                          let uu____1672 =
-                            let uu____1675 =
-                              let uu____1676 =
-                                let uu____1687 =
-                                  let uu____1696 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_Syntax_Syntax.bv_to_name c in
-                                  FStar_Syntax_Syntax.as_arg uu____1696 in
-                                [uu____1687] in
-                              FStar_Syntax_Util.mk_app l_ite uu____1676 in
-                            [uu____1675] in
-                          FStar_List.map FStar_Syntax_Syntax.as_arg
-                            uu____1672 in
-                        FStar_Syntax_Util.mk_app c_lift21 uu____1661 in
-                      FStar_Syntax_Util.ascribe uu____1658
+                                  FStar_Syntax_Syntax.as_arg uu___11 in
+                                [uu___10] in
+                              FStar_Syntax_Util.mk_app l_ite uu___9 in
+                            [uu___8] in
+                          FStar_List.map FStar_Syntax_Syntax.as_arg uu___7 in
+                        FStar_Syntax_Util.mk_app c_lift21 uu___6 in
+                      FStar_Syntax_Util.ascribe uu___5
                         ((FStar_Util.Inr result_comp),
                           FStar_Pervasives_Native.None) in
-                    FStar_Syntax_Util.abs uu____1638 uu____1654
+                    FStar_Syntax_Util.abs uu___3 uu___4
                       (FStar_Pervasives_Native.Some
                          (FStar_Syntax_Util.residual_comp_of_comp result_comp)) in
                   let wp_if_then_else1 =
-                    let uu____1740 = mk_lid "wp_if_then_else" in
-                    register env2 uu____1740 wp_if_then_else in
+                    let uu___3 = mk_lid "wp_if_then_else" in
+                    register env2 uu___3 wp_if_then_else in
                   let wp_if_then_else2 = mk_generic_app wp_if_then_else1 in
                   let wp_close =
                     let b =
                       FStar_Syntax_Syntax.gen_bv "b"
                         FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
-                      let uu____1751 =
-                        let uu____1760 =
-                          let uu____1767 = FStar_Syntax_Syntax.bv_to_name b in
-                          FStar_Syntax_Syntax.null_binder uu____1767 in
-                        [uu____1760] in
-                      let uu____1780 = FStar_Syntax_Syntax.mk_Total wp_a1 in
-                      FStar_Syntax_Util.arrow uu____1751 uu____1780 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name b in
+                          FStar_Syntax_Syntax.null_binder uu___5 in
+                        [uu___4] in
+                      let uu___4 = FStar_Syntax_Syntax.mk_Total wp_a1 in
+                      FStar_Syntax_Util.arrow uu___3 uu___4 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
                         FStar_Pervasives_Native.None t_f in
                     let body =
-                      let uu____1787 =
-                        let uu____1798 =
-                          let uu____1801 =
-                            let uu____1802 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_List.map FStar_Syntax_Syntax.as_arg
                                 [FStar_Syntax_Util.tforall] in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1802 in
-                          let uu____1821 =
-                            let uu____1824 =
-                              let uu____1825 =
-                                let uu____1836 =
-                                  let uu____1839 =
+                            FStar_Syntax_Util.mk_app c_pure1 uu___6 in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_Syntax_Syntax.bv_to_name f in
-                                  [uu____1839] in
+                                  [uu___10] in
                                 FStar_List.map FStar_Syntax_Syntax.as_arg
-                                  uu____1836 in
-                              FStar_Syntax_Util.mk_app c_push1 uu____1825 in
-                            [uu____1824] in
-                          uu____1801 :: uu____1821 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1798 in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1787 in
-                    let uu____1856 =
-                      let uu____1857 =
+                                  uu___9 in
+                              FStar_Syntax_Util.mk_app c_push1 uu___8 in
+                            [uu___7] in
+                          uu___5 :: uu___6 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu___4 in
+                      FStar_Syntax_Util.mk_app c_app1 uu___3 in
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Syntax.binders_of_list [a1; b; f] in
-                      FStar_List.append binders uu____1857 in
-                    FStar_Syntax_Util.abs uu____1856 body ret_tot_wp_a in
+                      FStar_List.append binders uu___4 in
+                    FStar_Syntax_Util.abs uu___3 body ret_tot_wp_a in
                   let wp_close1 =
-                    let uu____1873 = mk_lid "wp_close" in
-                    register env2 uu____1873 wp_close in
+                    let uu___3 = mk_lid "wp_close" in
+                    register env2 uu___3 wp_close in
                   let wp_close2 = mk_generic_app wp_close1 in
                   let ret_tot_type =
                     FStar_Pervasives_Native.Some
                       (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype) in
                   let ret_gtot_type =
-                    let uu____1883 =
-                      let uu____1884 =
-                        let uu____1885 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Syntax_Syntax.mk_GTotal
                             FStar_Syntax_Util.ktype in
                         FStar_All.pipe_left
-                          FStar_TypeChecker_Common.lcomp_of_comp uu____1885 in
-                      FStar_TypeChecker_Common.residual_comp_of_lcomp
-                        uu____1884 in
-                    FStar_Pervasives_Native.Some uu____1883 in
+                          FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                      FStar_TypeChecker_Common.residual_comp_of_lcomp uu___4 in
+                    FStar_Pervasives_Native.Some uu___3 in
                   let mk_forall x body =
-                    let uu____1897 =
-                      let uu____1898 =
-                        let uu____1915 =
-                          let uu____1926 =
-                            let uu____1935 =
-                              let uu____1936 =
-                                let uu____1937 =
-                                  FStar_Syntax_Syntax.mk_binder x in
-                                [uu____1937] in
-                              FStar_Syntax_Util.abs uu____1936 body
-                                ret_tot_type in
-                            FStar_Syntax_Syntax.as_arg uu____1935 in
-                          [uu____1926] in
-                        (FStar_Syntax_Util.tforall, uu____1915) in
-                      FStar_Syntax_Syntax.Tm_app uu____1898 in
-                    FStar_Syntax_Syntax.mk uu____1897 FStar_Range.dummyRange in
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 = FStar_Syntax_Syntax.mk_binder x in
+                                [uu___9] in
+                              FStar_Syntax_Util.abs uu___8 body ret_tot_type in
+                            FStar_Syntax_Syntax.as_arg uu___7 in
+                          [uu___6] in
+                        (FStar_Syntax_Util.tforall, uu___5) in
+                      FStar_Syntax_Syntax.Tm_app uu___4 in
+                    FStar_Syntax_Syntax.mk uu___3 FStar_Range.dummyRange in
                   let rec is_discrete t =
-                    let uu____1994 =
-                      let uu____1995 = FStar_Syntax_Subst.compress t in
-                      uu____1995.FStar_Syntax_Syntax.n in
-                    match uu____1994 with
-                    | FStar_Syntax_Syntax.Tm_type uu____1998 -> false
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Subst.compress t in
+                      uu___4.FStar_Syntax_Syntax.n in
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Tm_type uu___4 -> false
                     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                         (FStar_List.for_all
-                           (fun uu____2030 ->
-                              match uu____2030 with
-                              | (b, uu____2038) ->
+                           (fun uu___4 ->
+                              match uu___4 with
+                              | (b, uu___5) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_discrete (FStar_Syntax_Util.comp_result c))
-                    | uu____2043 -> true in
+                    | uu___4 -> true in
                   let rec is_monotonic t =
-                    let uu____2054 =
-                      let uu____2055 = FStar_Syntax_Subst.compress t in
-                      uu____2055.FStar_Syntax_Syntax.n in
-                    match uu____2054 with
-                    | FStar_Syntax_Syntax.Tm_type uu____2058 -> true
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Subst.compress t in
+                      uu___4.FStar_Syntax_Syntax.n in
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Tm_type uu___4 -> true
                     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                         (FStar_List.for_all
-                           (fun uu____2090 ->
-                              match uu____2090 with
-                              | (b, uu____2098) ->
+                           (fun uu___4 ->
+                              match uu___4 with
+                              | (b, uu___5) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_monotonic (FStar_Syntax_Util.comp_result c))
-                    | uu____2103 -> is_discrete t in
+                    | uu___4 -> is_discrete t in
                   let rec mk_rel rel t x y =
                     let mk_rel1 = mk_rel rel in
                     let t1 =
@@ -709,46 +690,45 @@ let (gen_wps_for_free :
                         FStar_TypeChecker_Env.Eager_unfolding;
                         FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant] env2 t in
-                    let uu____2177 =
-                      let uu____2178 = FStar_Syntax_Subst.compress t1 in
-                      uu____2178.FStar_Syntax_Syntax.n in
-                    match uu____2177 with
-                    | FStar_Syntax_Syntax.Tm_type uu____2183 -> rel x y
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Subst.compress t1 in
+                      uu___4.FStar_Syntax_Syntax.n in
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Tm_type uu___4 -> rel x y
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],
                          {
                            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal
-                             (b, uu____2186);
-                           FStar_Syntax_Syntax.pos = uu____2187;
-                           FStar_Syntax_Syntax.vars = uu____2188;_})
+                             (b, uu___4);
+                           FStar_Syntax_Syntax.pos = uu___5;
+                           FStar_Syntax_Syntax.vars = uu___6;_})
                         ->
                         let a2 =
                           (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort in
-                        let uu____2232 =
-                          (is_monotonic a2) || (is_monotonic b) in
-                        if uu____2232
+                        let uu___7 = (is_monotonic a2) || (is_monotonic b) in
+                        if uu___7
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2 in
                           let body =
-                            let uu____2239 =
-                              let uu____2242 =
-                                let uu____2253 =
-                                  let uu____2262 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____2262 in
-                                [uu____2253] in
-                              FStar_Syntax_Util.mk_app x uu____2242 in
-                            let uu____2279 =
-                              let uu____2282 =
-                                let uu____2293 =
-                                  let uu____2302 =
+                                  FStar_Syntax_Syntax.as_arg uu___11 in
+                                [uu___10] in
+                              FStar_Syntax_Util.mk_app x uu___9 in
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____2302 in
-                                [uu____2293] in
-                              FStar_Syntax_Util.mk_app y uu____2282 in
-                            mk_rel1 b uu____2239 uu____2279 in
+                                  FStar_Syntax_Syntax.as_arg uu___12 in
+                                [uu___11] in
+                              FStar_Syntax_Util.mk_app y uu___10 in
+                            mk_rel1 b uu___8 uu___9 in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -758,68 +738,67 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.gen_bv "a2"
                                FStar_Pervasives_Native.None a2 in
                            let body =
-                             let uu____2323 =
-                               let uu____2326 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Syntax.bv_to_name a11 in
-                               let uu____2329 =
+                               let uu___11 =
                                  FStar_Syntax_Syntax.bv_to_name a21 in
-                               mk_rel1 a2 uu____2326 uu____2329 in
-                             let uu____2332 =
-                               let uu____2335 =
-                                 let uu____2338 =
-                                   let uu____2349 =
-                                     let uu____2358 =
+                               mk_rel1 a2 uu___10 uu___11 in
+                             let uu___10 =
+                               let uu___11 =
+                                 let uu___12 =
+                                   let uu___13 =
+                                     let uu___14 =
                                        FStar_Syntax_Syntax.bv_to_name a11 in
-                                     FStar_Syntax_Syntax.as_arg uu____2358 in
-                                   [uu____2349] in
-                                 FStar_Syntax_Util.mk_app x uu____2338 in
-                               let uu____2375 =
-                                 let uu____2378 =
-                                   let uu____2389 =
-                                     let uu____2398 =
+                                     FStar_Syntax_Syntax.as_arg uu___14 in
+                                   [uu___13] in
+                                 FStar_Syntax_Util.mk_app x uu___12 in
+                               let uu___12 =
+                                 let uu___13 =
+                                   let uu___14 =
+                                     let uu___15 =
                                        FStar_Syntax_Syntax.bv_to_name a21 in
-                                     FStar_Syntax_Syntax.as_arg uu____2398 in
-                                   [uu____2389] in
-                                 FStar_Syntax_Util.mk_app y uu____2378 in
-                               mk_rel1 b uu____2335 uu____2375 in
-                             FStar_Syntax_Util.mk_imp uu____2323 uu____2332 in
-                           let uu____2415 = mk_forall a21 body in
-                           mk_forall a11 uu____2415)
+                                     FStar_Syntax_Syntax.as_arg uu___15 in
+                                   [uu___14] in
+                                 FStar_Syntax_Util.mk_app y uu___13 in
+                               mk_rel1 b uu___11 uu___12 in
+                             FStar_Syntax_Util.mk_imp uu___9 uu___10 in
+                           let uu___9 = mk_forall a21 body in
+                           mk_forall a11 uu___9)
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],
                          {
                            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total
-                             (b, uu____2418);
-                           FStar_Syntax_Syntax.pos = uu____2419;
-                           FStar_Syntax_Syntax.vars = uu____2420;_})
+                             (b, uu___4);
+                           FStar_Syntax_Syntax.pos = uu___5;
+                           FStar_Syntax_Syntax.vars = uu___6;_})
                         ->
                         let a2 =
                           (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort in
-                        let uu____2464 =
-                          (is_monotonic a2) || (is_monotonic b) in
-                        if uu____2464
+                        let uu___7 = (is_monotonic a2) || (is_monotonic b) in
+                        if uu___7
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2 in
                           let body =
-                            let uu____2471 =
-                              let uu____2474 =
-                                let uu____2485 =
-                                  let uu____2494 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____2494 in
-                                [uu____2485] in
-                              FStar_Syntax_Util.mk_app x uu____2474 in
-                            let uu____2511 =
-                              let uu____2514 =
-                                let uu____2525 =
-                                  let uu____2534 =
+                                  FStar_Syntax_Syntax.as_arg uu___11 in
+                                [uu___10] in
+                              FStar_Syntax_Util.mk_app x uu___9 in
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu____2534 in
-                                [uu____2525] in
-                              FStar_Syntax_Util.mk_app y uu____2514 in
-                            mk_rel1 b uu____2471 uu____2511 in
+                                  FStar_Syntax_Syntax.as_arg uu___12 in
+                                [uu___11] in
+                              FStar_Syntax_Util.mk_app y uu___10 in
+                            mk_rel1 b uu___8 uu___9 in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -829,56 +808,56 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.gen_bv "a2"
                                FStar_Pervasives_Native.None a2 in
                            let body =
-                             let uu____2555 =
-                               let uu____2558 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Syntax.bv_to_name a11 in
-                               let uu____2561 =
+                               let uu___11 =
                                  FStar_Syntax_Syntax.bv_to_name a21 in
-                               mk_rel1 a2 uu____2558 uu____2561 in
-                             let uu____2564 =
-                               let uu____2567 =
-                                 let uu____2570 =
-                                   let uu____2581 =
-                                     let uu____2590 =
+                               mk_rel1 a2 uu___10 uu___11 in
+                             let uu___10 =
+                               let uu___11 =
+                                 let uu___12 =
+                                   let uu___13 =
+                                     let uu___14 =
                                        FStar_Syntax_Syntax.bv_to_name a11 in
-                                     FStar_Syntax_Syntax.as_arg uu____2590 in
-                                   [uu____2581] in
-                                 FStar_Syntax_Util.mk_app x uu____2570 in
-                               let uu____2607 =
-                                 let uu____2610 =
-                                   let uu____2621 =
-                                     let uu____2630 =
+                                     FStar_Syntax_Syntax.as_arg uu___14 in
+                                   [uu___13] in
+                                 FStar_Syntax_Util.mk_app x uu___12 in
+                               let uu___12 =
+                                 let uu___13 =
+                                   let uu___14 =
+                                     let uu___15 =
                                        FStar_Syntax_Syntax.bv_to_name a21 in
-                                     FStar_Syntax_Syntax.as_arg uu____2630 in
-                                   [uu____2621] in
-                                 FStar_Syntax_Util.mk_app y uu____2610 in
-                               mk_rel1 b uu____2567 uu____2607 in
-                             FStar_Syntax_Util.mk_imp uu____2555 uu____2564 in
-                           let uu____2647 = mk_forall a21 body in
-                           mk_forall a11 uu____2647)
+                                     FStar_Syntax_Syntax.as_arg uu___15 in
+                                   [uu___14] in
+                                 FStar_Syntax_Util.mk_app y uu___13 in
+                               mk_rel1 b uu___11 uu___12 in
+                             FStar_Syntax_Util.mk_imp uu___9 uu___10 in
+                           let uu___9 = mk_forall a21 body in
+                           mk_forall a11 uu___9)
                     | FStar_Syntax_Syntax.Tm_arrow (binder::binders1, comp)
                         ->
                         let t2 =
-                          let uu___229_2686 = t1 in
-                          let uu____2687 =
-                            let uu____2688 =
-                              let uu____2703 =
-                                let uu____2706 =
+                          let uu___4 = t1 in
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_Syntax_Util.arrow binders1 comp in
-                                FStar_Syntax_Syntax.mk_Total uu____2706 in
-                              ([binder], uu____2703) in
-                            FStar_Syntax_Syntax.Tm_arrow uu____2688 in
+                                FStar_Syntax_Syntax.mk_Total uu___8 in
+                              ([binder], uu___7) in
+                            FStar_Syntax_Syntax.Tm_arrow uu___6 in
                           {
-                            FStar_Syntax_Syntax.n = uu____2687;
+                            FStar_Syntax_Syntax.n = uu___5;
                             FStar_Syntax_Syntax.pos =
-                              (uu___229_2686.FStar_Syntax_Syntax.pos);
+                              (uu___4.FStar_Syntax_Syntax.pos);
                             FStar_Syntax_Syntax.vars =
-                              (uu___229_2686.FStar_Syntax_Syntax.vars)
+                              (uu___4.FStar_Syntax_Syntax.vars)
                           } in
                         mk_rel1 t2 x y
-                    | FStar_Syntax_Syntax.Tm_arrow ([], uu____2729) ->
+                    | FStar_Syntax_Syntax.Tm_arrow ([], uu___4) ->
                         failwith "impossible: arrow with empty binders"
-                    | uu____2750 -> FStar_Syntax_Util.mk_untyped_eq2 x y in
+                    | uu___4 -> FStar_Syntax_Util.mk_untyped_eq2 x y in
                   let stronger =
                     let wp1 =
                       FStar_Syntax_Syntax.gen_bv "wp1"
@@ -893,48 +872,46 @@ let (gen_wps_for_free :
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.UnfoldUntil
                             FStar_Syntax_Syntax.delta_constant] env2 t in
-                      let uu____2785 =
-                        let uu____2786 = FStar_Syntax_Subst.compress t1 in
-                        uu____2786.FStar_Syntax_Syntax.n in
-                      match uu____2785 with
-                      | FStar_Syntax_Syntax.Tm_type uu____2789 ->
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Subst.compress t1 in
+                        uu___4.FStar_Syntax_Syntax.n in
+                      match uu___3 with
+                      | FStar_Syntax_Syntax.Tm_type uu___4 ->
                           FStar_Syntax_Util.mk_imp x y
                       | FStar_Syntax_Syntax.Tm_app (head, args) when
-                          let uu____2816 = FStar_Syntax_Subst.compress head in
-                          FStar_Syntax_Util.is_tuple_constructor uu____2816
-                          ->
+                          let uu___4 = FStar_Syntax_Subst.compress head in
+                          FStar_Syntax_Util.is_tuple_constructor uu___4 ->
                           let project i tuple =
                             let projector =
-                              let uu____2835 =
-                                let uu____2836 =
+                              let uu___4 =
+                                let uu___5 =
                                   FStar_Parser_Const.mk_tuple_data_lid
                                     (FStar_List.length args)
                                     FStar_Range.dummyRange in
                                 FStar_TypeChecker_Env.lookup_projector env2
-                                  uu____2836 i in
-                              FStar_Syntax_Syntax.fvar uu____2835
+                                  uu___5 i in
+                              FStar_Syntax_Syntax.fvar uu___4
                                 (FStar_Syntax_Syntax.Delta_constant_at_level
                                    Prims.int_one)
                                 FStar_Pervasives_Native.None in
                             FStar_Syntax_Util.mk_app projector
                               [(tuple, FStar_Pervasives_Native.None)] in
-                          let uu____2865 =
-                            let uu____2876 =
+                          let uu___4 =
+                            let uu___5 =
                               FStar_List.mapi
                                 (fun i ->
-                                   fun uu____2894 ->
-                                     match uu____2894 with
+                                   fun uu___6 ->
+                                     match uu___6 with
                                      | (t2, q) ->
-                                         let uu____2913 = project i x in
-                                         let uu____2916 = project i y in
-                                         mk_stronger t2 uu____2913 uu____2916)
-                                args in
-                            match uu____2876 with
+                                         let uu___7 = project i x in
+                                         let uu___8 = project i y in
+                                         mk_stronger t2 uu___7 uu___8) args in
+                            match uu___5 with
                             | [] ->
                                 failwith
                                   "Impossible: empty application when creating stronger relation in DM4F"
                             | rel0::rels -> (rel0, rels) in
-                          (match uu____2865 with
+                          (match uu___4 with
                            | (rel0, rels) ->
                                FStar_List.fold_left FStar_Syntax_Util.mk_conj
                                  rel0 rels)
@@ -942,34 +919,34 @@ let (gen_wps_for_free :
                           (binders1,
                            {
                              FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.GTotal (b, uu____2969);
-                             FStar_Syntax_Syntax.pos = uu____2970;
-                             FStar_Syntax_Syntax.vars = uu____2971;_})
+                               FStar_Syntax_Syntax.GTotal (b, uu___4);
+                             FStar_Syntax_Syntax.pos = uu___5;
+                             FStar_Syntax_Syntax.vars = uu___6;_})
                           ->
                           let bvs =
                             FStar_List.mapi
                               (fun i ->
-                                 fun uu____3015 ->
-                                   match uu____3015 with
+                                 fun uu___7 ->
+                                   match uu___7 with
                                    | (bv, q) ->
-                                       let uu____3028 =
-                                         let uu____3029 =
+                                       let uu___8 =
+                                         let uu___9 =
                                            FStar_Util.string_of_int i in
-                                         Prims.op_Hat "a" uu____3029 in
-                                       FStar_Syntax_Syntax.gen_bv uu____3028
+                                         Prims.op_Hat "a" uu___9 in
+                                       FStar_Syntax_Syntax.gen_bv uu___8
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1 in
                           let args =
                             FStar_List.map
                               (fun ai ->
-                                 let uu____3036 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.bv_to_name ai in
-                                 FStar_Syntax_Syntax.as_arg uu____3036) bvs in
+                                 FStar_Syntax_Syntax.as_arg uu___7) bvs in
                           let body =
-                            let uu____3038 = FStar_Syntax_Util.mk_app x args in
-                            let uu____3041 = FStar_Syntax_Util.mk_app y args in
-                            mk_stronger b uu____3038 uu____3041 in
+                            let uu___7 = FStar_Syntax_Util.mk_app x args in
+                            let uu___8 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu___7 uu___8 in
                           FStar_List.fold_right
                             (fun bv -> fun body1 -> mk_forall bv body1) bvs
                             body
@@ -977,59 +954,59 @@ let (gen_wps_for_free :
                           (binders1,
                            {
                              FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.Total (b, uu____3050);
-                             FStar_Syntax_Syntax.pos = uu____3051;
-                             FStar_Syntax_Syntax.vars = uu____3052;_})
+                               FStar_Syntax_Syntax.Total (b, uu___4);
+                             FStar_Syntax_Syntax.pos = uu___5;
+                             FStar_Syntax_Syntax.vars = uu___6;_})
                           ->
                           let bvs =
                             FStar_List.mapi
                               (fun i ->
-                                 fun uu____3096 ->
-                                   match uu____3096 with
+                                 fun uu___7 ->
+                                   match uu___7 with
                                    | (bv, q) ->
-                                       let uu____3109 =
-                                         let uu____3110 =
+                                       let uu___8 =
+                                         let uu___9 =
                                            FStar_Util.string_of_int i in
-                                         Prims.op_Hat "a" uu____3110 in
-                                       FStar_Syntax_Syntax.gen_bv uu____3109
+                                         Prims.op_Hat "a" uu___9 in
+                                       FStar_Syntax_Syntax.gen_bv uu___8
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1 in
                           let args =
                             FStar_List.map
                               (fun ai ->
-                                 let uu____3117 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.bv_to_name ai in
-                                 FStar_Syntax_Syntax.as_arg uu____3117) bvs in
+                                 FStar_Syntax_Syntax.as_arg uu___7) bvs in
                           let body =
-                            let uu____3119 = FStar_Syntax_Util.mk_app x args in
-                            let uu____3122 = FStar_Syntax_Util.mk_app y args in
-                            mk_stronger b uu____3119 uu____3122 in
+                            let uu___7 = FStar_Syntax_Util.mk_app x args in
+                            let uu___8 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu___7 uu___8 in
                           FStar_List.fold_right
                             (fun bv -> fun body1 -> mk_forall bv body1) bvs
                             body
-                      | uu____3129 -> failwith "Not a DM elaborated type" in
+                      | uu___4 -> failwith "Not a DM elaborated type" in
                     let body =
-                      let uu____3131 = FStar_Syntax_Util.unascribe wp_a1 in
-                      let uu____3134 = FStar_Syntax_Syntax.bv_to_name wp1 in
-                      let uu____3137 = FStar_Syntax_Syntax.bv_to_name wp2 in
-                      mk_stronger uu____3131 uu____3134 uu____3137 in
-                    let uu____3140 =
-                      let uu____3141 =
+                      let uu___3 = FStar_Syntax_Util.unascribe wp_a1 in
+                      let uu___4 = FStar_Syntax_Syntax.bv_to_name wp1 in
+                      let uu___5 = FStar_Syntax_Syntax.bv_to_name wp2 in
+                      mk_stronger uu___3 uu___4 uu___5 in
+                    let uu___3 =
+                      let uu___4 =
                         binders_of_list
                           [(a1, false); (wp1, false); (wp2, false)] in
-                      FStar_List.append binders uu____3141 in
-                    FStar_Syntax_Util.abs uu____3140 body ret_tot_type in
+                      FStar_List.append binders uu___4 in
+                    FStar_Syntax_Util.abs uu___3 body ret_tot_type in
                   let stronger1 =
-                    let uu____3173 = mk_lid "stronger" in
-                    register env2 uu____3173 stronger in
+                    let uu___3 = mk_lid "stronger" in
+                    register env2 uu___3 stronger in
                   let stronger2 = mk_generic_app stronger1 in
                   let ite_wp =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
                         FStar_Pervasives_Native.None wp_a1 in
-                    let uu____3179 = FStar_Util.prefix gamma in
-                    match uu____3179 with
+                    let uu___3 = FStar_Util.prefix gamma in
+                    match uu___3 with
                     | (wp_args, post) ->
                         let k =
                           FStar_Syntax_Syntax.gen_bv "k"
@@ -1038,248 +1015,232 @@ let (gen_wps_for_free :
                         let equiv =
                           let k_tm = FStar_Syntax_Syntax.bv_to_name k in
                           let eq =
-                            let uu____3244 =
+                            let uu___4 =
                               FStar_Syntax_Syntax.bv_to_name
                                 (FStar_Pervasives_Native.fst post) in
                             mk_rel FStar_Syntax_Util.mk_iff
-                              k.FStar_Syntax_Syntax.sort k_tm uu____3244 in
-                          let uu____3249 =
+                              k.FStar_Syntax_Syntax.sort k_tm uu___4 in
+                          let uu___4 =
                             FStar_Syntax_Util.destruct_typ_as_formula eq in
-                          match uu____3249 with
+                          match uu___4 with
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.QAll (binders1, [], body))
                               ->
                               let k_app =
-                                let uu____3259 = args_of_binders binders1 in
-                                FStar_Syntax_Util.mk_app k_tm uu____3259 in
+                                let uu___5 = args_of_binders binders1 in
+                                FStar_Syntax_Util.mk_app k_tm uu___5 in
                               let guard_free =
-                                let uu____3271 =
+                                let uu___5 =
                                   FStar_Syntax_Syntax.lid_as_fv
                                     FStar_Parser_Const.guard_free
                                     FStar_Syntax_Syntax.delta_constant
                                     FStar_Pervasives_Native.None in
-                                FStar_Syntax_Syntax.fv_to_tm uu____3271 in
+                                FStar_Syntax_Syntax.fv_to_tm uu___5 in
                               let pat =
-                                let uu____3275 =
-                                  let uu____3286 =
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Syntax_Syntax.as_arg k_app in
-                                  [uu____3286] in
-                                FStar_Syntax_Util.mk_app guard_free
-                                  uu____3275 in
+                                  [uu___6] in
+                                FStar_Syntax_Util.mk_app guard_free uu___5 in
                               let pattern_guarded_body =
-                                let uu____3314 =
-                                  let uu____3315 =
-                                    let uu____3322 =
-                                      let uu____3323 =
-                                        let uu____3344 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_Syntax_Syntax.binders_to_names
                                             binders1 in
-                                        let uu____3349 =
-                                          let uu____3362 =
-                                            let uu____3373 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_Syntax_Syntax.as_arg pat in
-                                            [uu____3373] in
-                                          [uu____3362] in
-                                        (uu____3344, uu____3349) in
-                                      FStar_Syntax_Syntax.Meta_pattern
-                                        uu____3323 in
-                                    (body, uu____3322) in
-                                  FStar_Syntax_Syntax.Tm_meta uu____3315 in
-                                mk uu____3314 in
+                                            [uu___12] in
+                                          [uu___11] in
+                                        (uu___9, uu___10) in
+                                      FStar_Syntax_Syntax.Meta_pattern uu___8 in
+                                    (body, uu___7) in
+                                  FStar_Syntax_Syntax.Tm_meta uu___6 in
+                                mk uu___5 in
                               FStar_Syntax_Util.close_forall_no_univs
                                 binders1 pattern_guarded_body
-                          | uu____3436 ->
+                          | uu___5 ->
                               failwith
                                 "Impossible: Expected the equivalence to be a quantified formula" in
                         let body =
-                          let uu____3444 =
-                            let uu____3447 =
-                              let uu____3448 =
-                                let uu____3451 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Syntax.bv_to_name wp in
-                                let uu____3454 =
-                                  let uu____3465 = args_of_binders wp_args in
-                                  let uu____3468 =
-                                    let uu____3471 =
-                                      let uu____3472 =
+                                let uu___8 =
+                                  let uu___9 = args_of_binders wp_args in
+                                  let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.bv_to_name k in
-                                      FStar_Syntax_Syntax.as_arg uu____3472 in
-                                    [uu____3471] in
-                                  FStar_List.append uu____3465 uu____3468 in
-                                FStar_Syntax_Util.mk_app uu____3451
-                                  uu____3454 in
-                              FStar_Syntax_Util.mk_imp equiv uu____3448 in
-                            FStar_Syntax_Util.mk_forall_no_univ k uu____3447 in
-                          FStar_Syntax_Util.abs gamma uu____3444
-                            ret_gtot_type in
-                        let uu____3473 =
-                          let uu____3474 =
+                                      FStar_Syntax_Syntax.as_arg uu___12 in
+                                    [uu___11] in
+                                  FStar_List.append uu___9 uu___10 in
+                                FStar_Syntax_Util.mk_app uu___7 uu___8 in
+                              FStar_Syntax_Util.mk_imp equiv uu___6 in
+                            FStar_Syntax_Util.mk_forall_no_univ k uu___5 in
+                          FStar_Syntax_Util.abs gamma uu___4 ret_gtot_type in
+                        let uu___4 =
+                          let uu___5 =
                             FStar_Syntax_Syntax.binders_of_list [a1; wp] in
-                          FStar_List.append binders uu____3474 in
-                        FStar_Syntax_Util.abs uu____3473 body ret_gtot_type in
+                          FStar_List.append binders uu___5 in
+                        FStar_Syntax_Util.abs uu___4 body ret_gtot_type in
                   let ite_wp1 =
-                    let uu____3490 = mk_lid "ite_wp" in
-                    register env2 uu____3490 ite_wp in
+                    let uu___3 = mk_lid "ite_wp" in
+                    register env2 uu___3 ite_wp in
                   let ite_wp2 = mk_generic_app ite_wp1 in
                   let null_wp =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
                         FStar_Pervasives_Native.None wp_a1 in
-                    let uu____3496 = FStar_Util.prefix gamma in
-                    match uu____3496 with
+                    let uu___3 = FStar_Util.prefix gamma in
+                    match uu___3 with
                     | (wp_args, post) ->
                         let x =
                           FStar_Syntax_Syntax.gen_bv "x"
                             FStar_Pervasives_Native.None
                             FStar_Syntax_Syntax.tun in
                         let body =
-                          let uu____3553 =
-                            let uu____3554 =
+                          let uu___4 =
+                            let uu___5 =
                               FStar_All.pipe_left
                                 FStar_Syntax_Syntax.bv_to_name
                                 (FStar_Pervasives_Native.fst post) in
-                            let uu____3561 =
-                              let uu____3572 =
-                                let uu____3581 =
-                                  FStar_Syntax_Syntax.bv_to_name x in
-                                FStar_Syntax_Syntax.as_arg uu____3581 in
-                              [uu____3572] in
-                            FStar_Syntax_Util.mk_app uu____3554 uu____3561 in
-                          FStar_Syntax_Util.mk_forall_no_univ x uu____3553 in
-                        let uu____3598 =
-                          let uu____3599 =
-                            let uu____3608 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Syntax_Syntax.bv_to_name x in
+                                FStar_Syntax_Syntax.as_arg uu___8 in
+                              [uu___7] in
+                            FStar_Syntax_Util.mk_app uu___5 uu___6 in
+                          FStar_Syntax_Util.mk_forall_no_univ x uu___4 in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_Syntax_Syntax.binders_of_list [a1] in
-                            FStar_List.append uu____3608 gamma in
-                          FStar_List.append binders uu____3599 in
-                        FStar_Syntax_Util.abs uu____3598 body ret_gtot_type in
+                            FStar_List.append uu___6 gamma in
+                          FStar_List.append binders uu___5 in
+                        FStar_Syntax_Util.abs uu___4 body ret_gtot_type in
                   let null_wp1 =
-                    let uu____3630 = mk_lid "null_wp" in
-                    register env2 uu____3630 null_wp in
+                    let uu___3 = mk_lid "null_wp" in
+                    register env2 uu___3 null_wp in
                   let null_wp2 = mk_generic_app null_wp1 in
                   let wp_trivial =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
                         FStar_Pervasives_Native.None wp_a1 in
                     let body =
-                      let uu____3641 =
-                        let uu____3652 =
-                          let uu____3655 = FStar_Syntax_Syntax.bv_to_name a1 in
-                          let uu____3656 =
-                            let uu____3659 =
-                              let uu____3660 =
-                                let uu____3671 =
-                                  let uu____3680 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.bv_to_name a1 in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_Syntax_Syntax.bv_to_name a1 in
-                                  FStar_Syntax_Syntax.as_arg uu____3680 in
-                                [uu____3671] in
-                              FStar_Syntax_Util.mk_app null_wp2 uu____3660 in
-                            let uu____3697 =
-                              let uu____3700 =
-                                FStar_Syntax_Syntax.bv_to_name wp in
-                              [uu____3700] in
-                            uu____3659 :: uu____3697 in
-                          uu____3655 :: uu____3656 in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____3652 in
-                      FStar_Syntax_Util.mk_app stronger2 uu____3641 in
-                    let uu____3709 =
-                      let uu____3710 =
+                                  FStar_Syntax_Syntax.as_arg uu___10 in
+                                [uu___9] in
+                              FStar_Syntax_Util.mk_app null_wp2 uu___8 in
+                            let uu___8 =
+                              let uu___9 = FStar_Syntax_Syntax.bv_to_name wp in
+                              [uu___9] in
+                            uu___7 :: uu___8 in
+                          uu___5 :: uu___6 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu___4 in
+                      FStar_Syntax_Util.mk_app stronger2 uu___3 in
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Syntax.binders_of_list [a1; wp] in
-                      FStar_List.append binders uu____3710 in
-                    FStar_Syntax_Util.abs uu____3709 body ret_tot_type in
+                      FStar_List.append binders uu___4 in
+                    FStar_Syntax_Util.abs uu___3 body ret_tot_type in
                   let wp_trivial1 =
-                    let uu____3726 = mk_lid "wp_trivial" in
-                    register env2 uu____3726 wp_trivial in
+                    let uu___3 = mk_lid "wp_trivial" in
+                    register env2 uu___3 wp_trivial in
                   let wp_trivial2 = mk_generic_app wp_trivial1 in
-                  ((let uu____3731 =
+                  ((let uu___4 =
                       FStar_TypeChecker_Env.debug env2
                         (FStar_Options.Other "ED") in
-                    if uu____3731
-                    then d "End Dijkstra monads for free"
-                    else ());
+                    if uu___4 then d "End Dijkstra monads for free" else ());
                    (let c = FStar_Syntax_Subst.close binders in
                     let ed_combs =
                       match ed.FStar_Syntax_Syntax.combinators with
                       | FStar_Syntax_Syntax.DM4F_eff combs ->
-                          let uu____3740 =
-                            let uu___340_3741 = combs in
-                            let uu____3742 =
-                              let uu____3743 = c stronger2 in
-                              ([], uu____3743) in
-                            let uu____3750 =
-                              let uu____3751 = c wp_if_then_else2 in
-                              ([], uu____3751) in
-                            let uu____3758 =
-                              let uu____3759 = c ite_wp2 in ([], uu____3759) in
-                            let uu____3766 =
-                              let uu____3767 = c wp_close2 in
-                              ([], uu____3767) in
-                            let uu____3774 =
-                              let uu____3775 = c wp_trivial2 in
-                              ([], uu____3775) in
+                          let uu___4 =
+                            let uu___5 = combs in
+                            let uu___6 =
+                              let uu___7 = c stronger2 in ([], uu___7) in
+                            let uu___7 =
+                              let uu___8 = c wp_if_then_else2 in ([], uu___8) in
+                            let uu___8 =
+                              let uu___9 = c ite_wp2 in ([], uu___9) in
+                            let uu___9 =
+                              let uu___10 = c wp_close2 in ([], uu___10) in
+                            let uu___10 =
+                              let uu___11 = c wp_trivial2 in ([], uu___11) in
                             {
                               FStar_Syntax_Syntax.ret_wp =
-                                (uu___340_3741.FStar_Syntax_Syntax.ret_wp);
+                                (uu___5.FStar_Syntax_Syntax.ret_wp);
                               FStar_Syntax_Syntax.bind_wp =
-                                (uu___340_3741.FStar_Syntax_Syntax.bind_wp);
-                              FStar_Syntax_Syntax.stronger = uu____3742;
-                              FStar_Syntax_Syntax.if_then_else = uu____3750;
-                              FStar_Syntax_Syntax.ite_wp = uu____3758;
-                              FStar_Syntax_Syntax.close_wp = uu____3766;
-                              FStar_Syntax_Syntax.trivial = uu____3774;
+                                (uu___5.FStar_Syntax_Syntax.bind_wp);
+                              FStar_Syntax_Syntax.stronger = uu___6;
+                              FStar_Syntax_Syntax.if_then_else = uu___7;
+                              FStar_Syntax_Syntax.ite_wp = uu___8;
+                              FStar_Syntax_Syntax.close_wp = uu___9;
+                              FStar_Syntax_Syntax.trivial = uu___10;
                               FStar_Syntax_Syntax.repr =
-                                (uu___340_3741.FStar_Syntax_Syntax.repr);
+                                (uu___5.FStar_Syntax_Syntax.repr);
                               FStar_Syntax_Syntax.return_repr =
-                                (uu___340_3741.FStar_Syntax_Syntax.return_repr);
+                                (uu___5.FStar_Syntax_Syntax.return_repr);
                               FStar_Syntax_Syntax.bind_repr =
-                                (uu___340_3741.FStar_Syntax_Syntax.bind_repr)
+                                (uu___5.FStar_Syntax_Syntax.bind_repr)
                             } in
-                          FStar_Syntax_Syntax.DM4F_eff uu____3740
-                      | uu____3782 ->
+                          FStar_Syntax_Syntax.DM4F_eff uu___4
+                      | uu___4 ->
                           failwith
                             "Impossible! For a DM4F effect combinators must be in DM4f_eff" in
-                    let uu____3783 =
-                      let uu____3784 = FStar_ST.op_Bang sigelts in
-                      FStar_List.rev uu____3784 in
-                    (uu____3783,
-                      (let uu___344_3798 = ed in
+                    let uu___4 =
+                      let uu___5 = FStar_ST.op_Bang sigelts in
+                      FStar_List.rev uu___5 in
+                    (uu___4,
+                      (let uu___5 = ed in
                        {
                          FStar_Syntax_Syntax.mname =
-                           (uu___344_3798.FStar_Syntax_Syntax.mname);
+                           (uu___5.FStar_Syntax_Syntax.mname);
                          FStar_Syntax_Syntax.cattributes =
-                           (uu___344_3798.FStar_Syntax_Syntax.cattributes);
+                           (uu___5.FStar_Syntax_Syntax.cattributes);
                          FStar_Syntax_Syntax.univs =
-                           (uu___344_3798.FStar_Syntax_Syntax.univs);
+                           (uu___5.FStar_Syntax_Syntax.univs);
                          FStar_Syntax_Syntax.binders =
-                           (uu___344_3798.FStar_Syntax_Syntax.binders);
+                           (uu___5.FStar_Syntax_Syntax.binders);
                          FStar_Syntax_Syntax.signature =
-                           (uu___344_3798.FStar_Syntax_Syntax.signature);
+                           (uu___5.FStar_Syntax_Syntax.signature);
                          FStar_Syntax_Syntax.combinators = ed_combs;
                          FStar_Syntax_Syntax.actions =
-                           (uu___344_3798.FStar_Syntax_Syntax.actions);
+                           (uu___5.FStar_Syntax_Syntax.actions);
                          FStar_Syntax_Syntax.eff_attrs =
-                           (uu___344_3798.FStar_Syntax_Syntax.eff_attrs)
+                           (uu___5.FStar_Syntax_Syntax.eff_attrs)
                        }))))))
 type env_ = env
 let (get_env : env -> FStar_TypeChecker_Env.env) = fun env1 -> env1.tcenv
 let (set_env : env -> FStar_TypeChecker_Env.env -> env) =
   fun dmff_env ->
     fun env' ->
-      let uu___349_3814 = dmff_env in
-      {
-        tcenv = env';
-        subst = (uu___349_3814.subst);
-        tc_const = (uu___349_3814.tc_const)
-      }
+      let uu___ = dmff_env in
+      { tcenv = env'; subst = (uu___.subst); tc_const = (uu___.tc_const) }
 type nm =
   | N of FStar_Syntax_Syntax.typ 
   | M of FStar_Syntax_Syntax.typ 
 let (uu___is_N : nm -> Prims.bool) =
-  fun projectee -> match projectee with | N _0 -> true | uu____3831 -> false
+  fun projectee -> match projectee with | N _0 -> true | uu___ -> false
 let (__proj__N__item___0 : nm -> FStar_Syntax_Syntax.typ) =
   fun projectee -> match projectee with | N _0 -> _0
 let (uu___is_M : nm -> Prims.bool) =
-  fun projectee -> match projectee with | M _0 -> true | uu____3844 -> false
+  fun projectee -> match projectee with | M _0 -> true | uu___ -> false
 let (__proj__M__item___0 : nm -> FStar_Syntax_Syntax.typ) =
   fun projectee -> match projectee with | M _0 -> _0
 type nm_ = nm
@@ -1287,59 +1248,58 @@ let (nm_of_comp : FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> nm)
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t, uu____3861) -> N t
+    | FStar_Syntax_Syntax.Total (t, uu___) -> N t
     | FStar_Syntax_Syntax.Comp c1 when
         FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
           (FStar_Util.for_some
-             (fun uu___0_3874 ->
-                match uu___0_3874 with
+             (fun uu___ ->
+                match uu___ with
                 | FStar_Syntax_Syntax.CPS -> true
-                | uu____3875 -> false))
+                | uu___1 -> false))
         -> M (c1.FStar_Syntax_Syntax.result_typ)
-    | uu____3876 ->
-        let uu____3877 =
-          let uu____3882 =
-            let uu____3883 = FStar_Syntax_Print.comp_to_string c in
+    | uu___ ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.comp_to_string c in
             FStar_Util.format1 "[nm_of_comp]: unexpected computation type %s"
-              uu____3883 in
-          (FStar_Errors.Error_UnexpectedDM4FType, uu____3882) in
-        FStar_Errors.raise_error uu____3877 c.FStar_Syntax_Syntax.pos
+              uu___3 in
+          (FStar_Errors.Error_UnexpectedDM4FType, uu___2) in
+        FStar_Errors.raise_error uu___1 c.FStar_Syntax_Syntax.pos
 let (string_of_nm : nm -> Prims.string) =
-  fun uu___1_3888 ->
-    match uu___1_3888 with
+  fun uu___ ->
+    match uu___ with
     | N t ->
-        let uu____3890 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "N[%s]" uu____3890
+        let uu___1 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format1 "N[%s]" uu___1
     | M t ->
-        let uu____3892 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "M[%s]" uu____3892
+        let uu___1 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format1 "M[%s]" uu___1
 let (is_monadic_arrow : FStar_Syntax_Syntax.term' -> nm) =
   fun n ->
     match n with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____3898, c) -> nm_of_comp c
-    | uu____3920 -> failwith "unexpected_argument: [is_monadic_arrow]"
+    | FStar_Syntax_Syntax.Tm_arrow (uu___, c) -> nm_of_comp c
+    | uu___ -> failwith "unexpected_argument: [is_monadic_arrow]"
 let (is_monadic_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
-    let uu____3930 = nm_of_comp c in
-    match uu____3930 with | M uu____3931 -> true | N uu____3932 -> false
+    let uu___ = nm_of_comp c in
+    match uu___ with | M uu___1 -> true | N uu___1 -> false
 exception Not_found 
 let (uu___is_Not_found : Prims.exn -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Not_found -> true | uu____3938 -> false
+  fun projectee -> match projectee with | Not_found -> true | uu___ -> false
 let (double_star : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
   fun typ ->
     let star_once typ1 =
-      let uu____3952 =
-        let uu____3961 =
-          let uu____3968 =
+      let uu___ =
+        let uu___1 =
+          let uu___2 =
             FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None typ1 in
-          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____3968 in
-        [uu____3961] in
-      let uu____3987 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-      FStar_Syntax_Util.arrow uu____3952 uu____3987 in
-    let uu____3990 = FStar_All.pipe_right typ star_once in
-    FStar_All.pipe_left star_once uu____3990
+          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu___2 in
+        [uu___1] in
+      let uu___1 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+      FStar_Syntax_Util.arrow uu___ uu___1 in
+    let uu___ = FStar_All.pipe_right typ star_once in
+    FStar_All.pipe_left star_once uu___
 let rec (mk_star_to_type :
   (FStar_Syntax_Syntax.term' ->
      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -1351,21 +1311,21 @@ let rec (mk_star_to_type :
   fun mk ->
     fun env1 ->
       fun a ->
-        let uu____4031 =
-          let uu____4032 =
-            let uu____4047 =
-              let uu____4056 =
-                let uu____4063 =
-                  let uu____4064 = star_type' env1 a in
-                  FStar_Syntax_Syntax.null_bv uu____4064 in
-                let uu____4065 = FStar_Syntax_Syntax.as_implicit false in
-                (uu____4063, uu____4065) in
-              [uu____4056] in
-            let uu____4082 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = star_type' env1 a in
+                  FStar_Syntax_Syntax.null_bv uu___5 in
+                let uu___5 = FStar_Syntax_Syntax.as_implicit false in
+                (uu___4, uu___5) in
+              [uu___3] in
+            let uu___3 =
               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-            (uu____4047, uu____4082) in
-          FStar_Syntax_Syntax.Tm_arrow uu____4032 in
-        mk uu____4031
+            (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_arrow uu___1 in
+        mk uu___
 and (star_type' :
   env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -1377,73 +1337,73 @@ and (star_type' :
       let mk_star_to_type1 = mk_star_to_type mk in
       let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_arrow (binders, uu____4122) ->
+      | FStar_Syntax_Syntax.Tm_arrow (binders, uu___) ->
           let binders1 =
             FStar_List.map
-              (fun uu____4168 ->
-                 match uu____4168 with
+              (fun uu___1 ->
+                 match uu___1 with
                  | (bv, aqual) ->
-                     let uu____4187 =
-                       let uu___399_4188 = bv in
-                       let uu____4189 =
+                     let uu___2 =
+                       let uu___3 = bv in
+                       let uu___4 =
                          star_type' env1 bv.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___399_4188.FStar_Syntax_Syntax.ppname);
+                           (uu___3.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___399_4188.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____4189
+                           (uu___3.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu___4
                        } in
-                     (uu____4187, aqual)) binders in
+                     (uu___2, aqual)) binders in
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_arrow
-               (uu____4194,
+               (uu___1,
                 {
                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal
-                    (hn, uu____4196);
-                  FStar_Syntax_Syntax.pos = uu____4197;
-                  FStar_Syntax_Syntax.vars = uu____4198;_})
+                    (hn, uu___2);
+                  FStar_Syntax_Syntax.pos = uu___3;
+                  FStar_Syntax_Syntax.vars = uu___4;_})
                ->
-               let uu____4227 =
-                 let uu____4228 =
-                   let uu____4243 =
-                     let uu____4246 = star_type' env1 hn in
-                     FStar_Syntax_Syntax.mk_GTotal uu____4246 in
-                   (binders1, uu____4243) in
-                 FStar_Syntax_Syntax.Tm_arrow uu____4228 in
-               mk uu____4227
-           | uu____4257 ->
-               let uu____4258 = is_monadic_arrow t1.FStar_Syntax_Syntax.n in
-               (match uu____4258 with
+               let uu___5 =
+                 let uu___6 =
+                   let uu___7 =
+                     let uu___8 = star_type' env1 hn in
+                     FStar_Syntax_Syntax.mk_GTotal uu___8 in
+                   (binders1, uu___7) in
+                 FStar_Syntax_Syntax.Tm_arrow uu___6 in
+               mk uu___5
+           | uu___1 ->
+               let uu___2 = is_monadic_arrow t1.FStar_Syntax_Syntax.n in
+               (match uu___2 with
                 | N hn ->
-                    let uu____4260 =
-                      let uu____4261 =
-                        let uu____4276 =
-                          let uu____4279 = star_type' env1 hn in
-                          FStar_Syntax_Syntax.mk_Total uu____4279 in
-                        (binders1, uu____4276) in
-                      FStar_Syntax_Syntax.Tm_arrow uu____4261 in
-                    mk uu____4260
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = star_type' env1 hn in
+                          FStar_Syntax_Syntax.mk_Total uu___6 in
+                        (binders1, uu___5) in
+                      FStar_Syntax_Syntax.Tm_arrow uu___4 in
+                    mk uu___3
                 | M a ->
-                    let uu____4291 =
-                      let uu____4292 =
-                        let uu____4307 =
-                          let uu____4316 =
-                            let uu____4325 =
-                              let uu____4332 =
-                                let uu____4333 = mk_star_to_type1 env1 a in
-                                FStar_Syntax_Syntax.null_bv uu____4333 in
-                              let uu____4334 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 = mk_star_to_type1 env1 a in
+                                FStar_Syntax_Syntax.null_bv uu___9 in
+                              let uu___9 =
                                 FStar_Syntax_Syntax.as_implicit false in
-                              (uu____4332, uu____4334) in
-                            [uu____4325] in
-                          FStar_List.append binders1 uu____4316 in
-                        let uu____4357 =
+                              (uu___8, uu___9) in
+                            [uu___7] in
+                          FStar_List.append binders1 uu___6 in
+                        let uu___6 =
                           FStar_Syntax_Syntax.mk_Total
                             FStar_Syntax_Util.ktype0 in
-                        (uu____4307, uu____4357) in
-                      FStar_Syntax_Syntax.Tm_arrow uu____4292 in
-                    mk uu____4291))
+                        (uu___5, uu___6) in
+                      FStar_Syntax_Syntax.Tm_arrow uu___4 in
+                    mk uu___3))
       | FStar_Syntax_Syntax.Tm_app (head, args) ->
           let debug t2 s =
             let string_of_set f s1 =
@@ -1453,66 +1413,63 @@ and (star_type' :
               | x::xs ->
                   let strb = FStar_Util.new_string_builder () in
                   (FStar_Util.string_builder_append strb "{";
-                   (let uu____4445 = f x in
-                    FStar_Util.string_builder_append strb uu____4445);
+                   (let uu___2 = f x in
+                    FStar_Util.string_builder_append strb uu___2);
                    FStar_List.iter
                      (fun x1 ->
                         FStar_Util.string_builder_append strb ", ";
-                        (let uu____4452 = f x1 in
-                         FStar_Util.string_builder_append strb uu____4452))
-                     xs;
+                        (let uu___4 = f x1 in
+                         FStar_Util.string_builder_append strb uu___4)) xs;
                    FStar_Util.string_builder_append strb "}";
                    FStar_Util.string_of_string_builder strb) in
-            let uu____4454 =
-              let uu____4459 =
-                let uu____4460 = FStar_Syntax_Print.term_to_string t2 in
-                let uu____4461 =
-                  string_of_set FStar_Syntax_Print.bv_to_string s in
-                FStar_Util.format2 "Dependency found in term %s : %s"
-                  uu____4460 uu____4461 in
-              (FStar_Errors.Warning_DependencyFound, uu____4459) in
-            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu____4454 in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t2 in
+                let uu___3 = string_of_set FStar_Syntax_Print.bv_to_string s in
+                FStar_Util.format2 "Dependency found in term %s : %s" uu___2
+                  uu___3 in
+              (FStar_Errors.Warning_DependencyFound, uu___1) in
+            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu___ in
           let rec is_non_dependent_arrow ty n =
-            let uu____4477 =
-              let uu____4478 = FStar_Syntax_Subst.compress ty in
-              uu____4478.FStar_Syntax_Syntax.n in
-            match uu____4477 with
+            let uu___ =
+              let uu___1 = FStar_Syntax_Subst.compress ty in
+              uu___1.FStar_Syntax_Syntax.n in
+            match uu___ with
             | FStar_Syntax_Syntax.Tm_arrow (binders, c) ->
-                let uu____4503 =
-                  let uu____4504 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                  Prims.op_Negation uu____4504 in
-                if uu____4503
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
+                  Prims.op_Negation uu___2 in
+                if uu___1
                 then false
                 else
                   (try
-                     (fun uu___448_4515 ->
+                     (fun uu___3 ->
                         match () with
                         | () ->
                             let non_dependent_or_raise s ty1 =
                               let sinter =
-                                let uu____4538 = FStar_Syntax_Free.names ty1 in
-                                FStar_Util.set_intersect uu____4538 s in
-                              let uu____4541 =
-                                let uu____4542 =
-                                  FStar_Util.set_is_empty sinter in
-                                Prims.op_Negation uu____4542 in
-                              if uu____4541
+                                let uu___4 = FStar_Syntax_Free.names ty1 in
+                                FStar_Util.set_intersect uu___4 s in
+                              let uu___4 =
+                                let uu___5 = FStar_Util.set_is_empty sinter in
+                                Prims.op_Negation uu___5 in
+                              if uu___4
                               then
                                 (debug ty1 sinter; FStar_Exn.raise Not_found)
                               else () in
-                            let uu____4545 =
+                            let uu___4 =
                               FStar_Syntax_Subst.open_comp binders c in
-                            (match uu____4545 with
+                            (match uu___4 with
                              | (binders1, c1) ->
                                  let s =
                                    FStar_List.fold_left
-                                     (fun s ->
-                                        fun uu____4569 ->
-                                          match uu____4569 with
-                                          | (bv, uu____4581) ->
-                                              (non_dependent_or_raise s
+                                     (fun s1 ->
+                                        fun uu___5 ->
+                                          match uu___5 with
+                                          | (bv, uu___6) ->
+                                              (non_dependent_or_raise s1
                                                  bv.FStar_Syntax_Syntax.sort;
-                                               FStar_Util.set_add bv s))
+                                               FStar_Util.set_add bv s1))
                                      FStar_Syntax_Syntax.no_names binders1 in
                                  let ct = FStar_Syntax_Util.comp_result c1 in
                                  (non_dependent_or_raise s ct;
@@ -1521,21 +1478,19 @@ and (star_type' :
                                    then is_non_dependent_arrow ct k
                                    else true)))) ()
                    with | Not_found -> false)
-            | uu____4601 ->
-                ((let uu____4603 =
-                    let uu____4608 =
-                      let uu____4609 = FStar_Syntax_Print.term_to_string ty in
-                      FStar_Util.format1 "Not a dependent arrow : %s"
-                        uu____4609 in
-                    (FStar_Errors.Warning_NotDependentArrow, uu____4608) in
-                  FStar_Errors.log_issue ty.FStar_Syntax_Syntax.pos
-                    uu____4603);
+            | uu___1 ->
+                ((let uu___3 =
+                    let uu___4 =
+                      let uu___5 = FStar_Syntax_Print.term_to_string ty in
+                      FStar_Util.format1 "Not a dependent arrow : %s" uu___5 in
+                    (FStar_Errors.Warning_NotDependentArrow, uu___4) in
+                  FStar_Errors.log_issue ty.FStar_Syntax_Syntax.pos uu___3);
                  false) in
           let rec is_valid_application head1 =
-            let uu____4620 =
-              let uu____4621 = FStar_Syntax_Subst.compress head1 in
-              uu____4621.FStar_Syntax_Syntax.n in
-            match uu____4620 with
+            let uu___ =
+              let uu___1 = FStar_Syntax_Subst.compress head1 in
+              uu___1.FStar_Syntax_Syntax.n in
+            match uu___ with
             | FStar_Syntax_Syntax.Tm_fvar fv when
                 (((FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.option_lid)
@@ -1546,18 +1501,18 @@ and (star_type' :
                    (FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.eq2_lid))
                   ||
-                  (let uu____4626 = FStar_Syntax_Subst.compress head1 in
-                   FStar_Syntax_Util.is_tuple_constructor uu____4626)
+                  (let uu___1 = FStar_Syntax_Subst.compress head1 in
+                   FStar_Syntax_Util.is_tuple_constructor uu___1)
                 -> true
             | FStar_Syntax_Syntax.Tm_fvar fv ->
-                let uu____4628 =
+                let uu___1 =
                   FStar_TypeChecker_Env.lookup_lid env1.tcenv
                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                (match uu____4628 with
-                 | ((uu____4637, ty), uu____4639) ->
-                     let uu____4644 =
+                (match uu___1 with
+                 | ((uu___2, ty), uu___3) ->
+                     let uu___4 =
                        is_non_dependent_arrow ty (FStar_List.length args) in
-                     if uu____4644
+                     if uu___4
                      then
                        let res =
                          FStar_TypeChecker_Normalize.normalize
@@ -1566,70 +1521,70 @@ and (star_type' :
                            FStar_TypeChecker_Env.UnfoldUntil
                              FStar_Syntax_Syntax.delta_constant] env1.tcenv
                            t1 in
-                       let uu____4654 =
-                         let uu____4655 = FStar_Syntax_Subst.compress res in
-                         uu____4655.FStar_Syntax_Syntax.n in
-                       (match uu____4654 with
-                        | FStar_Syntax_Syntax.Tm_app uu____4658 -> true
-                        | uu____4675 ->
-                            ((let uu____4677 =
-                                let uu____4682 =
-                                  let uu____4683 =
+                       let uu___5 =
+                         let uu___6 = FStar_Syntax_Subst.compress res in
+                         uu___6.FStar_Syntax_Syntax.n in
+                       (match uu___5 with
+                        | FStar_Syntax_Syntax.Tm_app uu___6 -> true
+                        | uu___6 ->
+                            ((let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_Syntax_Print.term_to_string head1 in
                                   FStar_Util.format1
                                     "Got a term which might be a non-dependent user-defined data-type %s\n"
-                                    uu____4683 in
+                                    uu___10 in
                                 (FStar_Errors.Warning_NondependentUserDefinedDataType,
-                                  uu____4682) in
+                                  uu___9) in
                               FStar_Errors.log_issue
-                                head1.FStar_Syntax_Syntax.pos uu____4677);
+                                head1.FStar_Syntax_Syntax.pos uu___8);
                              false))
                      else false)
-            | FStar_Syntax_Syntax.Tm_bvar uu____4685 -> true
-            | FStar_Syntax_Syntax.Tm_name uu____4686 -> true
-            | FStar_Syntax_Syntax.Tm_uinst (t2, uu____4688) ->
+            | FStar_Syntax_Syntax.Tm_bvar uu___1 -> true
+            | FStar_Syntax_Syntax.Tm_name uu___1 -> true
+            | FStar_Syntax_Syntax.Tm_uinst (t2, uu___1) ->
                 is_valid_application t2
-            | uu____4693 -> false in
-          let uu____4694 = is_valid_application head in
-          if uu____4694
+            | uu___1 -> false in
+          let uu___ = is_valid_application head in
+          if uu___
           then
-            let uu____4695 =
-              let uu____4696 =
-                let uu____4713 =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
                   FStar_List.map
-                    (fun uu____4742 ->
-                       match uu____4742 with
+                    (fun uu___4 ->
+                       match uu___4 with
                        | (t2, qual) ->
-                           let uu____4767 = star_type' env1 t2 in
-                           (uu____4767, qual)) args in
-                (head, uu____4713) in
-              FStar_Syntax_Syntax.Tm_app uu____4696 in
-            mk uu____4695
+                           let uu___5 = star_type' env1 t2 in (uu___5, qual))
+                    args in
+                (head, uu___3) in
+              FStar_Syntax_Syntax.Tm_app uu___2 in
+            mk uu___1
           else
-            (let uu____4783 =
-               let uu____4788 =
-                 let uu____4789 = FStar_Syntax_Print.term_to_string t1 in
+            (let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Print.term_to_string t1 in
                  FStar_Util.format1
                    "For now, only [either], [option] and [eq2] are supported in the definition language (got: %s)"
-                   uu____4789 in
-               (FStar_Errors.Fatal_WrongTerm, uu____4788) in
-             FStar_Errors.raise_err uu____4783)
-      | FStar_Syntax_Syntax.Tm_bvar uu____4790 -> t1
-      | FStar_Syntax_Syntax.Tm_name uu____4791 -> t1
-      | FStar_Syntax_Syntax.Tm_type uu____4792 -> t1
-      | FStar_Syntax_Syntax.Tm_fvar uu____4793 -> t1
+                   uu___4 in
+               (FStar_Errors.Fatal_WrongTerm, uu___3) in
+             FStar_Errors.raise_err uu___2)
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_name uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_type uu___ -> t1
+      | FStar_Syntax_Syntax.Tm_fvar uu___ -> t1
       | FStar_Syntax_Syntax.Tm_abs (binders, repr, something) ->
-          let uu____4821 = FStar_Syntax_Subst.open_term binders repr in
-          (match uu____4821 with
+          let uu___ = FStar_Syntax_Subst.open_term binders repr in
+          (match uu___ with
            | (binders1, repr1) ->
                let env2 =
-                 let uu___520_4829 = env1 in
-                 let uu____4830 =
+                 let uu___1 = env1 in
+                 let uu___2 =
                    FStar_TypeChecker_Env.push_binders env1.tcenv binders1 in
                  {
-                   tcenv = uu____4830;
-                   subst = (uu___520_4829.subst);
-                   tc_const = (uu___520_4829.tc_const)
+                   tcenv = uu___2;
+                   subst = (uu___1.subst);
+                   tc_const = (uu___1.tc_const)
                  } in
                let repr2 = star_type' env2 repr1 in
                FStar_Syntax_Util.abs binders1 repr2 something)
@@ -1643,222 +1598,210 @@ and (star_type' :
           let t5 = FStar_Syntax_Subst.subst subst1 t4 in
           mk
             (FStar_Syntax_Syntax.Tm_refine
-               ((let uu___535_4852 = x1 in
+               ((let uu___ = x1 in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___535_4852.FStar_Syntax_Syntax.ppname);
+                     (uu___.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___535_4852.FStar_Syntax_Syntax.index);
+                     (uu___.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = sort
                  }), t5))
       | FStar_Syntax_Syntax.Tm_meta (t2, m) ->
-          let uu____4859 =
-            let uu____4860 =
-              let uu____4867 = star_type' env1 t2 in (uu____4867, m) in
-            FStar_Syntax_Syntax.Tm_meta uu____4860 in
-          mk uu____4859
+          let uu___ =
+            let uu___1 = let uu___2 = star_type' env1 t2 in (uu___2, m) in
+            FStar_Syntax_Syntax.Tm_meta uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_ascribed
           (e, (FStar_Util.Inl t2, FStar_Pervasives_Native.None), something)
           ->
-          let uu____4919 =
-            let uu____4920 =
-              let uu____4947 = star_type' env1 e in
-              let uu____4950 =
-                let uu____4967 =
-                  let uu____4976 = star_type' env1 t2 in
-                  FStar_Util.Inl uu____4976 in
-                (uu____4967, FStar_Pervasives_Native.None) in
-              (uu____4947, uu____4950, something) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____4920 in
-          mk uu____4919
+          let uu___ =
+            let uu___1 =
+              let uu___2 = star_type' env1 e in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = star_type' env1 t2 in FStar_Util.Inl uu___5 in
+                (uu___4, FStar_Pervasives_Native.None) in
+              (uu___2, uu___3, something) in
+            FStar_Syntax_Syntax.Tm_ascribed uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_ascribed
           (e, (FStar_Util.Inr c, FStar_Pervasives_Native.None), something) ->
-          let uu____5064 =
-            let uu____5065 =
-              let uu____5092 = star_type' env1 e in
-              let uu____5095 =
-                let uu____5112 =
-                  let uu____5121 =
+          let uu___ =
+            let uu___1 =
+              let uu___2 = star_type' env1 e in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
                     star_type' env1 (FStar_Syntax_Util.comp_result c) in
-                  FStar_Util.Inl uu____5121 in
-                (uu____5112, FStar_Pervasives_Native.None) in
-              (uu____5092, uu____5095, something) in
-            FStar_Syntax_Syntax.Tm_ascribed uu____5065 in
-          mk uu____5064
+                  FStar_Util.Inl uu___5 in
+                (uu___4, FStar_Pervasives_Native.None) in
+              (uu___2, uu___3, something) in
+            FStar_Syntax_Syntax.Tm_ascribed uu___1 in
+          mk uu___
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____5162, (uu____5163, FStar_Pervasives_Native.Some uu____5164),
-           uu____5165)
-          ->
-          let uu____5214 =
-            let uu____5219 =
-              let uu____5220 = FStar_Syntax_Print.term_to_string t1 in
+          (uu___, (uu___1, FStar_Pervasives_Native.Some uu___2), uu___3) ->
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Ascriptions with tactics are outside of the definition language: %s"
-                uu____5220 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5219) in
-          FStar_Errors.raise_err uu____5214
-      | FStar_Syntax_Syntax.Tm_refine uu____5221 ->
-          let uu____5228 =
-            let uu____5233 =
-              let uu____5234 = FStar_Syntax_Print.term_to_string t1 in
+                uu___6 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___5) in
+          FStar_Errors.raise_err uu___4
+      | FStar_Syntax_Syntax.Tm_refine uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_refine is outside of the definition language: %s"
-                uu____5234 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5233) in
-          FStar_Errors.raise_err uu____5228
-      | FStar_Syntax_Syntax.Tm_uinst uu____5235 ->
-          let uu____5242 =
-            let uu____5247 =
-              let uu____5248 = FStar_Syntax_Print.term_to_string t1 in
+                "Tm_refine is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_uinst uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_uinst is outside of the definition language: %s"
-                uu____5248 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5247) in
-          FStar_Errors.raise_err uu____5242
-      | FStar_Syntax_Syntax.Tm_quoted uu____5249 ->
-          let uu____5256 =
-            let uu____5261 =
-              let uu____5262 = FStar_Syntax_Print.term_to_string t1 in
+                "Tm_uinst is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_quoted uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_quoted is outside of the definition language: %s"
-                uu____5262 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5261) in
-          FStar_Errors.raise_err uu____5256
-      | FStar_Syntax_Syntax.Tm_constant uu____5263 ->
-          let uu____5264 =
-            let uu____5269 =
-              let uu____5270 = FStar_Syntax_Print.term_to_string t1 in
+                "Tm_quoted is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_constant uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_constant is outside of the definition language: %s"
-                uu____5270 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5269) in
-          FStar_Errors.raise_err uu____5264
-      | FStar_Syntax_Syntax.Tm_match uu____5271 ->
-          let uu____5294 =
-            let uu____5299 =
-              let uu____5300 = FStar_Syntax_Print.term_to_string t1 in
+                uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_match uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_match is outside of the definition language: %s"
-                uu____5300 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5299) in
-          FStar_Errors.raise_err uu____5294
-      | FStar_Syntax_Syntax.Tm_let uu____5301 ->
-          let uu____5314 =
-            let uu____5319 =
-              let uu____5320 = FStar_Syntax_Print.term_to_string t1 in
+                "Tm_match is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_let uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_let is outside of the definition language: %s" uu____5320 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5319) in
-          FStar_Errors.raise_err uu____5314
-      | FStar_Syntax_Syntax.Tm_uvar uu____5321 ->
-          let uu____5334 =
-            let uu____5339 =
-              let uu____5340 = FStar_Syntax_Print.term_to_string t1 in
+                "Tm_let is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
+      | FStar_Syntax_Syntax.Tm_uvar uu___ ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_uvar is outside of the definition language: %s"
-                uu____5340 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5339) in
-          FStar_Errors.raise_err uu____5334
+                "Tm_uvar is outside of the definition language: %s" uu___3 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___2) in
+          FStar_Errors.raise_err uu___1
       | FStar_Syntax_Syntax.Tm_unknown ->
-          let uu____5341 =
-            let uu____5346 =
-              let uu____5347 = FStar_Syntax_Print.term_to_string t1 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_unknown is outside of the definition language: %s"
-                uu____5347 in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5346) in
-          FStar_Errors.raise_err uu____5341
+                "Tm_unknown is outside of the definition language: %s" uu___2 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu___1) in
+          FStar_Errors.raise_err uu___
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____5349 = FStar_Syntax_Util.unfold_lazy i in
-          star_type' env1 uu____5349
-      | FStar_Syntax_Syntax.Tm_delayed uu____5352 -> failwith "impossible"
+          let uu___ = FStar_Syntax_Util.unfold_lazy i in
+          star_type' env1 uu___
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "impossible"
 let (is_monadic :
   FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
     Prims.bool)
   =
-  fun uu___3_5373 ->
-    match uu___3_5373 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.None -> failwith "un-annotated lambda?!"
     | FStar_Pervasives_Native.Some rc ->
         FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
           (FStar_Util.for_some
-             (fun uu___2_5380 ->
-                match uu___2_5380 with
+             (fun uu___1 ->
+                match uu___1 with
                 | FStar_Syntax_Syntax.CPS -> true
-                | uu____5381 -> false))
+                | uu___2 -> false))
 let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t ->
-    let uu____5387 =
-      let uu____5388 = FStar_Syntax_Subst.compress t in
-      uu____5388.FStar_Syntax_Syntax.n in
-    match uu____5387 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_app (head, args) when
         FStar_Syntax_Util.is_tuple_constructor head ->
         let r =
-          let uu____5418 =
-            let uu____5419 = FStar_List.hd args in
-            FStar_Pervasives_Native.fst uu____5419 in
-          is_C uu____5418 in
+          let uu___1 =
+            let uu___2 = FStar_List.hd args in
+            FStar_Pervasives_Native.fst uu___2 in
+          is_C uu___1 in
         if r
         then
-          ((let uu____5441 =
-              let uu____5442 =
+          ((let uu___2 =
+              let uu___3 =
                 FStar_List.for_all
-                  (fun uu____5452 ->
-                     match uu____5452 with | (h, uu____5460) -> is_C h) args in
-              Prims.op_Negation uu____5442 in
-            if uu____5441
+                  (fun uu___4 -> match uu___4 with | (h, uu___5) -> is_C h)
+                  args in
+              Prims.op_Negation uu___3 in
+            if uu___2
             then
-              let uu____5465 =
-                let uu____5470 =
-                  let uu____5471 = FStar_Syntax_Print.term_to_string t in
-                  FStar_Util.format1 "Not a C-type (A * C): %s" uu____5471 in
-                (FStar_Errors.Error_UnexpectedDM4FType, uu____5470) in
-              FStar_Errors.raise_error uu____5465 t.FStar_Syntax_Syntax.pos
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Print.term_to_string t in
+                  FStar_Util.format1 "Not a C-type (A * C): %s" uu___5 in
+                (FStar_Errors.Error_UnexpectedDM4FType, uu___4) in
+              FStar_Errors.raise_error uu___3 t.FStar_Syntax_Syntax.pos
             else ());
            true)
         else
-          ((let uu____5475 =
-              let uu____5476 =
+          ((let uu___3 =
+              let uu___4 =
                 FStar_List.for_all
-                  (fun uu____5487 ->
-                     match uu____5487 with
-                     | (h, uu____5495) ->
-                         let uu____5500 = is_C h in
-                         Prims.op_Negation uu____5500) args in
-              Prims.op_Negation uu____5476 in
-            if uu____5475
+                  (fun uu___5 ->
+                     match uu___5 with
+                     | (h, uu___6) ->
+                         let uu___7 = is_C h in Prims.op_Negation uu___7)
+                  args in
+              Prims.op_Negation uu___4 in
+            if uu___3
             then
-              let uu____5501 =
-                let uu____5506 =
-                  let uu____5507 = FStar_Syntax_Print.term_to_string t in
-                  FStar_Util.format1 "Not a C-type (C * A): %s" uu____5507 in
-                (FStar_Errors.Error_UnexpectedDM4FType, uu____5506) in
-              FStar_Errors.raise_error uu____5501 t.FStar_Syntax_Syntax.pos
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 = FStar_Syntax_Print.term_to_string t in
+                  FStar_Util.format1 "Not a C-type (C * A): %s" uu___6 in
+                (FStar_Errors.Error_UnexpectedDM4FType, uu___5) in
+              FStar_Errors.raise_error uu___4 t.FStar_Syntax_Syntax.pos
             else ());
            false)
     | FStar_Syntax_Syntax.Tm_arrow (binders, comp) ->
-        let uu____5531 = nm_of_comp comp in
-        (match uu____5531 with
+        let uu___1 = nm_of_comp comp in
+        (match uu___1 with
          | M t1 ->
-             ((let uu____5534 = is_C t1 in
-               if uu____5534
+             ((let uu___3 = is_C t1 in
+               if uu___3
                then
-                 let uu____5535 =
-                   let uu____5540 =
-                     let uu____5541 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.format1 "Not a C-type (C -> C): %s"
-                       uu____5541 in
-                   (FStar_Errors.Error_UnexpectedDM4FType, uu____5540) in
-                 FStar_Errors.raise_error uu____5535
-                   t1.FStar_Syntax_Syntax.pos
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.format1 "Not a C-type (C -> C): %s" uu___6 in
+                   (FStar_Errors.Error_UnexpectedDM4FType, uu___5) in
+                 FStar_Errors.raise_error uu___4 t1.FStar_Syntax_Syntax.pos
                else ());
               true)
          | N t1 -> is_C t1)
-    | FStar_Syntax_Syntax.Tm_meta (t1, uu____5545) -> is_C t1
-    | FStar_Syntax_Syntax.Tm_uinst (t1, uu____5551) -> is_C t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu____5557, uu____5558) -> is_C t1
-    | uu____5599 -> false
+    | FStar_Syntax_Syntax.Tm_meta (t1, uu___1) -> is_C t1
+    | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> is_C t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu___1, uu___2) -> is_C t1
+    | uu___1 -> false
 let (mk_return :
   env ->
     FStar_Syntax_Syntax.typ ->
@@ -1873,27 +1816,26 @@ let (mk_return :
         let p =
           FStar_Syntax_Syntax.gen_bv "p'" FStar_Pervasives_Native.None p_type in
         let body =
-          let uu____5632 =
-            let uu____5633 =
-              let uu____5650 = FStar_Syntax_Syntax.bv_to_name p in
-              let uu____5653 =
-                let uu____5664 =
-                  let uu____5673 = FStar_Syntax_Syntax.as_implicit false in
-                  (e, uu____5673) in
-                [uu____5664] in
-              (uu____5650, uu____5653) in
-            FStar_Syntax_Syntax.Tm_app uu____5633 in
-          mk uu____5632 in
-        let uu____5708 =
-          let uu____5709 = FStar_Syntax_Syntax.mk_binder p in [uu____5709] in
-        FStar_Syntax_Util.abs uu____5708 body
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Syntax.bv_to_name p in
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Syntax.as_implicit false in
+                  (e, uu___5) in
+                [uu___4] in
+              (uu___2, uu___3) in
+            FStar_Syntax_Syntax.Tm_app uu___1 in
+          mk uu___ in
+        let uu___ = let uu___1 = FStar_Syntax_Syntax.mk_binder p in [uu___1] in
+        FStar_Syntax_Util.abs uu___ body
           (FStar_Pervasives_Native.Some
              (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
 let (is_unknown : FStar_Syntax_Syntax.term' -> Prims.bool) =
-  fun uu___4_5732 ->
-    match uu___4_5732 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_unknown -> true
-    | uu____5733 -> false
+    | uu___1 -> false
 let rec (check :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -1902,126 +1844,126 @@ let rec (check :
   fun env1 ->
     fun e ->
       fun context_nm ->
-        let return_if uu____5968 =
-          match uu____5968 with
+        let return_if uu___ =
+          match uu___ with
           | (rec_nm, s_e, u_e) ->
               let check1 t1 t2 =
-                let uu____6005 =
+                let uu___1 =
                   (Prims.op_Negation (is_unknown t2.FStar_Syntax_Syntax.n))
                     &&
-                    (let uu____6007 =
-                       let uu____6008 =
+                    (let uu___2 =
+                       let uu___3 =
                          FStar_TypeChecker_Rel.teq env1.tcenv t1 t2 in
-                       FStar_TypeChecker_Env.is_trivial uu____6008 in
-                     Prims.op_Negation uu____6007) in
-                if uu____6005
+                       FStar_TypeChecker_Env.is_trivial uu___3 in
+                     Prims.op_Negation uu___2) in
+                if uu___1
                 then
-                  let uu____6009 =
-                    let uu____6014 =
-                      let uu____6015 = FStar_Syntax_Print.term_to_string e in
-                      let uu____6016 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____6017 = FStar_Syntax_Print.term_to_string t2 in
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Print.term_to_string e in
+                      let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu___6 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format3
                         "[check]: the expression [%s] has type [%s] but should have type [%s]"
-                        uu____6015 uu____6016 uu____6017 in
-                    (FStar_Errors.Fatal_TypeMismatch, uu____6014) in
-                  FStar_Errors.raise_err uu____6009
+                        uu___4 uu___5 uu___6 in
+                    (FStar_Errors.Fatal_TypeMismatch, uu___3) in
+                  FStar_Errors.raise_err uu___2
                 else () in
               (match (rec_nm, context_nm) with
                | (N t1, N t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (M t1, M t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (N t1, M t2) ->
                    (check1 t1 t2;
-                    (let uu____6038 = mk_return env1 t1 s_e in
-                     ((M t1), uu____6038, u_e)))
+                    (let uu___2 = mk_return env1 t1 s_e in
+                     ((M t1), uu___2, u_e)))
                | (M t1, N t2) ->
-                   let uu____6045 =
-                     let uu____6050 =
-                       let uu____6051 = FStar_Syntax_Print.term_to_string e in
-                       let uu____6052 = FStar_Syntax_Print.term_to_string t1 in
-                       let uu____6053 = FStar_Syntax_Print.term_to_string t2 in
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Print.term_to_string e in
+                       let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu___5 = FStar_Syntax_Print.term_to_string t2 in
                        FStar_Util.format3
                          "[check %s]: got an effectful computation [%s] in lieu of a pure computation [%s]"
-                         uu____6051 uu____6052 uu____6053 in
+                         uu___3 uu___4 uu___5 in
                      (FStar_Errors.Fatal_EffectfulAndPureComputationMismatch,
-                       uu____6050) in
-                   FStar_Errors.raise_err uu____6045) in
+                       uu___2) in
+                   FStar_Errors.raise_err uu___1) in
         let ensure_m env2 e2 =
-          let strip_m uu___5_6102 =
-            match uu___5_6102 with
+          let strip_m uu___ =
+            match uu___ with
             | (M t, s_e, u_e) -> (t, s_e, u_e)
-            | uu____6118 -> failwith "impossible" in
+            | uu___1 -> failwith "impossible" in
           match context_nm with
           | N t ->
-              let uu____6138 =
-                let uu____6143 =
-                  let uu____6144 = FStar_Syntax_Print.term_to_string t in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Print.term_to_string t in
                   Prims.op_Hat
                     "let-bound monadic body has a non-monadic continuation or a branch of a match is monadic and the others aren't : "
-                    uu____6144 in
-                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu____6143) in
-              FStar_Errors.raise_error uu____6138 e2.FStar_Syntax_Syntax.pos
-          | M uu____6151 ->
-              let uu____6152 = check env2 e2 context_nm in strip_m uu____6152 in
-        let uu____6159 =
-          let uu____6160 = FStar_Syntax_Subst.compress e in
-          uu____6160.FStar_Syntax_Syntax.n in
-        match uu____6159 with
-        | FStar_Syntax_Syntax.Tm_bvar uu____6169 ->
-            let uu____6170 = infer env1 e in return_if uu____6170
-        | FStar_Syntax_Syntax.Tm_name uu____6177 ->
-            let uu____6178 = infer env1 e in return_if uu____6178
-        | FStar_Syntax_Syntax.Tm_fvar uu____6185 ->
-            let uu____6186 = infer env1 e in return_if uu____6186
-        | FStar_Syntax_Syntax.Tm_abs uu____6193 ->
-            let uu____6212 = infer env1 e in return_if uu____6212
-        | FStar_Syntax_Syntax.Tm_constant uu____6219 ->
-            let uu____6220 = infer env1 e in return_if uu____6220
-        | FStar_Syntax_Syntax.Tm_quoted uu____6227 ->
-            let uu____6234 = infer env1 e in return_if uu____6234
-        | FStar_Syntax_Syntax.Tm_app uu____6241 ->
-            let uu____6258 = infer env1 e in return_if uu____6258
+                    uu___2 in
+                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu___1) in
+              FStar_Errors.raise_error uu___ e2.FStar_Syntax_Syntax.pos
+          | M uu___ ->
+              let uu___1 = check env2 e2 context_nm in strip_m uu___1 in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress e in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_name uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_abs uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_constant uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_quoted uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
+        | FStar_Syntax_Syntax.Tm_app uu___1 ->
+            let uu___2 = infer env1 e in return_if uu___2
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____6266 = FStar_Syntax_Util.unfold_lazy i in
-            check env1 uu____6266 context_nm
+            let uu___1 = FStar_Syntax_Util.unfold_lazy i in
+            check env1 uu___1 context_nm
         | FStar_Syntax_Syntax.Tm_let ((false, binding::[]), e2) ->
             mk_let env1 binding e2
               (fun env2 -> fun e21 -> check env2 e21 context_nm) ensure_m
         | FStar_Syntax_Syntax.Tm_match (e0, branches) ->
             mk_match env1 e0 branches
               (fun env2 -> fun body -> check env2 body context_nm)
-        | FStar_Syntax_Syntax.Tm_meta (e1, uu____6328) ->
+        | FStar_Syntax_Syntax.Tm_meta (e1, uu___1) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_uinst (e1, uu____6334) ->
+        | FStar_Syntax_Syntax.Tm_uinst (e1, uu___1) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_ascribed (e1, uu____6340, uu____6341) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (e1, uu___1, uu___2) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_let uu____6382 ->
-            let uu____6395 =
-              let uu____6396 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_let %s" uu____6396 in
-            failwith uu____6395
-        | FStar_Syntax_Syntax.Tm_type uu____6403 ->
+        | FStar_Syntax_Syntax.Tm_let uu___1 ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_let %s" uu___3 in
+            failwith uu___2
+        | FStar_Syntax_Syntax.Tm_type uu___1 ->
             failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_arrow uu____6410 ->
+        | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
             failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_refine uu____6431 ->
-            let uu____6438 =
-              let uu____6439 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_refine %s" uu____6439 in
-            failwith uu____6438
-        | FStar_Syntax_Syntax.Tm_uvar uu____6446 ->
-            let uu____6459 =
-              let uu____6460 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_uvar %s" uu____6460 in
-            failwith uu____6459
-        | FStar_Syntax_Syntax.Tm_delayed uu____6467 ->
+        | FStar_Syntax_Syntax.Tm_refine uu___1 ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_refine %s" uu___3 in
+            failwith uu___2
+        | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_uvar %s" uu___3 in
+            failwith uu___2
+        | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
             failwith "impossible (compressed)"
         | FStar_Syntax_Syntax.Tm_unknown ->
-            let uu____6488 =
-              let uu____6489 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "[check]: Tm_unknown %s" uu____6489 in
-            failwith uu____6488
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_unknown %s" uu___2 in
+            failwith uu___1
 and (infer :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -2037,159 +1979,156 @@ and (infer :
           FStar_TypeChecker_Env.UnfoldUntil
             FStar_Syntax_Syntax.delta_constant;
           FStar_TypeChecker_Env.EraseUniverses] env1.tcenv in
-      let uu____6517 =
-        let uu____6518 = FStar_Syntax_Subst.compress e in
-        uu____6518.FStar_Syntax_Syntax.n in
-      match uu____6517 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress e in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_bvar bv ->
           failwith "I failed to open a binder... boo"
       | FStar_Syntax_Syntax.Tm_name bv ->
           ((N (bv.FStar_Syntax_Syntax.sort)), e, e)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____6536 = FStar_Syntax_Util.unfold_lazy i in
-          infer env1 uu____6536
+          let uu___1 = FStar_Syntax_Util.unfold_lazy i in infer env1 uu___1
       | FStar_Syntax_Syntax.Tm_abs (binders, body, rc_opt) ->
           let subst_rc_opt subst rc_opt1 =
             match rc_opt1 with
             | FStar_Pervasives_Native.Some
-                { FStar_Syntax_Syntax.residual_effect = uu____6587;
+                { FStar_Syntax_Syntax.residual_effect = uu___1;
                   FStar_Syntax_Syntax.residual_typ =
                     FStar_Pervasives_Native.None;
-                  FStar_Syntax_Syntax.residual_flags = uu____6588;_}
+                  FStar_Syntax_Syntax.residual_flags = uu___2;_}
                 -> rc_opt1
             | FStar_Pervasives_Native.None -> rc_opt1
             | FStar_Pervasives_Native.Some rc ->
-                let uu____6594 =
-                  let uu___770_6595 = rc in
-                  let uu____6596 =
-                    let uu____6601 =
-                      let uu____6604 =
+                let uu___1 =
+                  let uu___2 = rc in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
                         FStar_Util.must rc.FStar_Syntax_Syntax.residual_typ in
-                      FStar_Syntax_Subst.subst subst uu____6604 in
-                    FStar_Pervasives_Native.Some uu____6601 in
+                      FStar_Syntax_Subst.subst subst uu___5 in
+                    FStar_Pervasives_Native.Some uu___4 in
                   {
                     FStar_Syntax_Syntax.residual_effect =
-                      (uu___770_6595.FStar_Syntax_Syntax.residual_effect);
-                    FStar_Syntax_Syntax.residual_typ = uu____6596;
+                      (uu___2.FStar_Syntax_Syntax.residual_effect);
+                    FStar_Syntax_Syntax.residual_typ = uu___3;
                     FStar_Syntax_Syntax.residual_flags =
-                      (uu___770_6595.FStar_Syntax_Syntax.residual_flags)
+                      (uu___2.FStar_Syntax_Syntax.residual_flags)
                   } in
-                FStar_Pervasives_Native.Some uu____6594 in
+                FStar_Pervasives_Native.Some uu___1 in
           let binders1 = FStar_Syntax_Subst.open_binders binders in
           let subst = FStar_Syntax_Subst.opening_of_binders binders1 in
           let body1 = FStar_Syntax_Subst.subst subst body in
           let rc_opt1 = subst_rc_opt subst rc_opt in
           let env2 =
-            let uu___776_6616 = env1 in
-            let uu____6617 =
+            let uu___1 = env1 in
+            let uu___2 =
               FStar_TypeChecker_Env.push_binders env1.tcenv binders1 in
             {
-              tcenv = uu____6617;
-              subst = (uu___776_6616.subst);
-              tc_const = (uu___776_6616.tc_const)
+              tcenv = uu___2;
+              subst = (uu___1.subst);
+              tc_const = (uu___1.tc_const)
             } in
           let s_binders =
             FStar_List.map
-              (fun uu____6643 ->
-                 match uu____6643 with
+              (fun uu___1 ->
+                 match uu___1 with
                  | (bv, qual) ->
                      let sort = star_type' env2 bv.FStar_Syntax_Syntax.sort in
-                     ((let uu___783_6666 = bv in
+                     ((let uu___2 = bv in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___783_6666.FStar_Syntax_Syntax.ppname);
+                           (uu___2.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___783_6666.FStar_Syntax_Syntax.index);
+                           (uu___2.FStar_Syntax_Syntax.index);
                          FStar_Syntax_Syntax.sort = sort
                        }), qual)) binders1 in
-          let uu____6667 =
+          let uu___1 =
             FStar_List.fold_left
-              (fun uu____6698 ->
-                 fun uu____6699 ->
-                   match (uu____6698, uu____6699) with
+              (fun uu___2 ->
+                 fun uu___3 ->
+                   match (uu___2, uu___3) with
                    | ((env3, acc), (bv, qual)) ->
                        let c = bv.FStar_Syntax_Syntax.sort in
-                       let uu____6757 = is_C c in
-                       if uu____6757
+                       let uu___4 = is_C c in
+                       if uu___4
                        then
                          let xw =
-                           let uu____6765 =
-                             let uu____6766 =
+                           let uu___5 =
+                             let uu___6 =
                                FStar_Ident.string_of_id
                                  bv.FStar_Syntax_Syntax.ppname in
-                             Prims.op_Hat uu____6766 "__w" in
-                           let uu____6767 = star_type' env3 c in
-                           FStar_Syntax_Syntax.gen_bv uu____6765
-                             FStar_Pervasives_Native.None uu____6767 in
+                             Prims.op_Hat uu___6 "__w" in
+                           let uu___6 = star_type' env3 c in
+                           FStar_Syntax_Syntax.gen_bv uu___5
+                             FStar_Pervasives_Native.None uu___6 in
                          let x =
-                           let uu___795_6769 = bv in
-                           let uu____6770 =
-                             let uu____6773 =
-                               FStar_Syntax_Syntax.bv_to_name xw in
-                             trans_F_ env3 c uu____6773 in
+                           let uu___5 = bv in
+                           let uu___6 =
+                             let uu___7 = FStar_Syntax_Syntax.bv_to_name xw in
+                             trans_F_ env3 c uu___7 in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___795_6769.FStar_Syntax_Syntax.ppname);
+                               (uu___5.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___795_6769.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____6770
+                               (uu___5.FStar_Syntax_Syntax.index);
+                             FStar_Syntax_Syntax.sort = uu___6
                            } in
                          let env4 =
-                           let uu___798_6775 = env3 in
-                           let uu____6776 =
-                             let uu____6779 =
-                               let uu____6780 =
-                                 let uu____6787 =
+                           let uu___5 = env3 in
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_Syntax_Syntax.bv_to_name xw in
-                                 (bv, uu____6787) in
-                               FStar_Syntax_Syntax.NT uu____6780 in
-                             uu____6779 :: (env3.subst) in
+                                 (bv, uu___9) in
+                               FStar_Syntax_Syntax.NT uu___8 in
+                             uu___7 :: (env3.subst) in
                            {
-                             tcenv = (uu___798_6775.tcenv);
-                             subst = uu____6776;
-                             tc_const = (uu___798_6775.tc_const)
+                             tcenv = (uu___5.tcenv);
+                             subst = uu___6;
+                             tc_const = (uu___5.tc_const)
                            } in
-                         let uu____6792 =
-                           let uu____6795 = FStar_Syntax_Syntax.mk_binder x in
-                           let uu____6796 =
-                             let uu____6799 =
-                               FStar_Syntax_Syntax.mk_binder xw in
-                             uu____6799 :: acc in
-                           uu____6795 :: uu____6796 in
-                         (env4, uu____6792)
+                         let uu___5 =
+                           let uu___6 = FStar_Syntax_Syntax.mk_binder x in
+                           let uu___7 =
+                             let uu___8 = FStar_Syntax_Syntax.mk_binder xw in
+                             uu___8 :: acc in
+                           uu___6 :: uu___7 in
+                         (env4, uu___5)
                        else
                          (let x =
-                            let uu___801_6804 = bv in
-                            let uu____6805 =
+                            let uu___6 = bv in
+                            let uu___7 =
                               star_type' env3 bv.FStar_Syntax_Syntax.sort in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___801_6804.FStar_Syntax_Syntax.ppname);
+                                (uu___6.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___801_6804.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = uu____6805
+                                (uu___6.FStar_Syntax_Syntax.index);
+                              FStar_Syntax_Syntax.sort = uu___7
                             } in
-                          let uu____6808 =
-                            let uu____6811 = FStar_Syntax_Syntax.mk_binder x in
-                            uu____6811 :: acc in
-                          (env3, uu____6808))) (env2, []) binders1 in
-          (match uu____6667 with
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Syntax.mk_binder x in
+                            uu___7 :: acc in
+                          (env3, uu___6))) (env2, []) binders1 in
+          (match uu___1 with
            | (env3, u_binders) ->
                let u_binders1 = FStar_List.rev u_binders in
-               let uu____6831 =
+               let uu___2 =
                  let check_what =
-                   let uu____6857 = is_monadic rc_opt1 in
-                   if uu____6857 then check_m else check_n in
-                 let uu____6871 = check_what env3 body1 in
-                 match uu____6871 with
+                   let uu___3 = is_monadic rc_opt1 in
+                   if uu___3 then check_m else check_n in
+                 let uu___3 = check_what env3 body1 in
+                 match uu___3 with
                  | (t, s_body, u_body) ->
-                     let uu____6891 =
-                       let uu____6894 =
-                         let uu____6895 = is_monadic rc_opt1 in
-                         if uu____6895 then M t else N t in
-                       comp_of_nm uu____6894 in
-                     (uu____6891, s_body, u_body) in
-               (match uu____6831 with
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 = is_monadic rc_opt1 in
+                         if uu___6 then M t else N t in
+                       comp_of_nm uu___5 in
+                     (uu___4, s_body, u_body) in
+               (match uu___2 with
                 | (comp, s_body, u_body) ->
                     let t = FStar_Syntax_Util.arrow binders1 comp in
                     let s_rc_opt =
@@ -2200,143 +2139,143 @@ and (infer :
                           (match rc.FStar_Syntax_Syntax.residual_typ with
                            | FStar_Pervasives_Native.None ->
                                let rc1 =
-                                 let uu____6932 =
+                                 let uu___3 =
                                    FStar_All.pipe_right
                                      rc.FStar_Syntax_Syntax.residual_flags
                                      (FStar_Util.for_some
-                                        (fun uu___6_6936 ->
-                                           match uu___6_6936 with
+                                        (fun uu___4 ->
+                                           match uu___4 with
                                            | FStar_Syntax_Syntax.CPS -> true
-                                           | uu____6937 -> false)) in
-                                 if uu____6932
+                                           | uu___5 -> false)) in
+                                 if uu___3
                                  then
-                                   let uu____6938 =
+                                   let uu___4 =
                                      FStar_List.filter
-                                       (fun uu___7_6942 ->
-                                          match uu___7_6942 with
+                                       (fun uu___5 ->
+                                          match uu___5 with
                                           | FStar_Syntax_Syntax.CPS -> false
-                                          | uu____6943 -> true)
+                                          | uu___6 -> true)
                                        rc.FStar_Syntax_Syntax.residual_flags in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     FStar_Pervasives_Native.None uu____6938
+                                     FStar_Pervasives_Native.None uu___4
                                  else rc in
                                FStar_Pervasives_Native.Some rc1
                            | FStar_Pervasives_Native.Some rt ->
-                               let uu____6952 =
+                               let uu___3 =
                                  FStar_All.pipe_right
                                    rc.FStar_Syntax_Syntax.residual_flags
                                    (FStar_Util.for_some
-                                      (fun uu___8_6956 ->
-                                         match uu___8_6956 with
+                                      (fun uu___4 ->
+                                         match uu___4 with
                                          | FStar_Syntax_Syntax.CPS -> true
-                                         | uu____6957 -> false)) in
-                               if uu____6952
+                                         | uu___5 -> false)) in
+                               if uu___3
                                then
                                  let flags =
                                    FStar_List.filter
-                                     (fun uu___9_6964 ->
-                                        match uu___9_6964 with
+                                     (fun uu___4 ->
+                                        match uu___4 with
                                         | FStar_Syntax_Syntax.CPS -> false
-                                        | uu____6965 -> true)
+                                        | uu___5 -> true)
                                      rc.FStar_Syntax_Syntax.residual_flags in
-                                 let uu____6966 =
-                                   let uu____6967 =
-                                     let uu____6972 = double_star rt in
-                                     FStar_Pervasives_Native.Some uu____6972 in
+                                 let uu___4 =
+                                   let uu___5 =
+                                     let uu___6 = double_star rt in
+                                     FStar_Pervasives_Native.Some uu___6 in
                                    FStar_Syntax_Util.mk_residual_comp
-                                     FStar_Parser_Const.effect_Tot_lid
-                                     uu____6967 flags in
-                                 FStar_Pervasives_Native.Some uu____6966
+                                     FStar_Parser_Const.effect_Tot_lid uu___5
+                                     flags in
+                                 FStar_Pervasives_Native.Some uu___4
                                else
-                                 (let uu____6978 =
-                                    let uu___842_6979 = rc in
-                                    let uu____6980 =
-                                      let uu____6985 = star_type' env3 rt in
-                                      FStar_Pervasives_Native.Some uu____6985 in
+                                 (let uu___5 =
+                                    let uu___6 = rc in
+                                    let uu___7 =
+                                      let uu___8 = star_type' env3 rt in
+                                      FStar_Pervasives_Native.Some uu___8 in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___842_6979.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ =
-                                        uu____6980;
+                                        uu___7;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___842_6979.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     } in
-                                  FStar_Pervasives_Native.Some uu____6978)) in
-                    let uu____6990 =
+                                  FStar_Pervasives_Native.Some uu___5)) in
+                    let uu___3 =
                       let comp1 =
-                        let uu____6998 = is_monadic rc_opt1 in
-                        let uu____6999 =
+                        let uu___4 = is_monadic rc_opt1 in
+                        let uu___5 =
                           FStar_Syntax_Subst.subst env3.subst s_body in
                         trans_G env3 (FStar_Syntax_Util.comp_result comp)
-                          uu____6998 uu____6999 in
-                      let uu____7000 =
+                          uu___4 uu___5 in
+                      let uu___4 =
                         FStar_Syntax_Util.ascribe u_body
                           ((FStar_Util.Inr comp1),
                             FStar_Pervasives_Native.None) in
-                      (uu____7000,
+                      (uu___4,
                         (FStar_Pervasives_Native.Some
                            (FStar_Syntax_Util.residual_comp_of_comp comp1))) in
-                    (match uu____6990 with
+                    (match uu___3 with
                      | (u_body1, u_rc_opt) ->
                          let s_body1 =
                            FStar_Syntax_Subst.close s_binders s_body in
                          let s_binders1 =
                            FStar_Syntax_Subst.close_binders s_binders in
                          let s_term =
-                           let uu____7038 =
-                             let uu____7039 =
-                               let uu____7058 =
-                                 let uu____7061 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      s_binders1 in
-                                 subst_rc_opt uu____7061 s_rc_opt in
-                               (s_binders1, s_body1, uu____7058) in
-                             FStar_Syntax_Syntax.Tm_abs uu____7039 in
-                           mk uu____7038 in
+                                 subst_rc_opt uu___7 s_rc_opt in
+                               (s_binders1, s_body1, uu___6) in
+                             FStar_Syntax_Syntax.Tm_abs uu___5 in
+                           mk uu___4 in
                          let u_body2 =
                            FStar_Syntax_Subst.close u_binders1 u_body1 in
                          let u_binders2 =
                            FStar_Syntax_Subst.close_binders u_binders1 in
                          let u_term =
-                           let uu____7081 =
-                             let uu____7082 =
-                               let uu____7101 =
-                                 let uu____7104 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      u_binders2 in
-                                 subst_rc_opt uu____7104 u_rc_opt in
-                               (u_binders2, u_body2, uu____7101) in
-                             FStar_Syntax_Syntax.Tm_abs uu____7082 in
-                           mk uu____7081 in
+                                 subst_rc_opt uu___7 u_rc_opt in
+                               (u_binders2, u_body2, uu___6) in
+                             FStar_Syntax_Syntax.Tm_abs uu___5 in
+                           mk uu___4 in
                          ((N t), s_term, u_term))))
       | FStar_Syntax_Syntax.Tm_fvar
           {
             FStar_Syntax_Syntax.fv_name =
               { FStar_Syntax_Syntax.v = lid;
-                FStar_Syntax_Syntax.p = uu____7120;_};
-            FStar_Syntax_Syntax.fv_delta = uu____7121;
-            FStar_Syntax_Syntax.fv_qual = uu____7122;_}
+                FStar_Syntax_Syntax.p = uu___1;_};
+            FStar_Syntax_Syntax.fv_delta = uu___2;
+            FStar_Syntax_Syntax.fv_qual = uu___3;_}
           ->
-          let uu____7125 =
-            let uu____7130 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7130 in
-          (match uu____7125 with
-           | (uu____7161, t) ->
-               let uu____7163 = let uu____7164 = normalize t in N uu____7164 in
-               (uu____7163, e, e))
+          let uu___4 =
+            let uu___5 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid in
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu___5 in
+          (match uu___4 with
+           | (uu___5, t) ->
+               let uu___6 = let uu___7 = normalize t in N uu___7 in
+               (uu___6, e, e))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____7165;
-             FStar_Syntax_Syntax.vars = uu____7166;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            a::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____7245 = FStar_Syntax_Util.head_and_args e in
-          (match uu____7245 with
-           | (unary_op, uu____7269) ->
+          let uu___3 = FStar_Syntax_Util.head_and_args e in
+          (match uu___3 with
+           | (unary_op, uu___4) ->
                let head = mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1)) in
                infer env1 t)
@@ -2344,14 +2283,14 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____7340;
-             FStar_Syntax_Syntax.vars = uu____7341;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____7437 = FStar_Syntax_Util.head_and_args e in
-          (match uu____7437 with
-           | (unary_op, uu____7461) ->
+          let uu___3 = FStar_Syntax_Util.head_and_args e in
+          (match uu___3 with
+           | (unary_op, uu___4) ->
                let head =
                  mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1)) in
@@ -2360,313 +2299,306 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____7540;
-             FStar_Syntax_Syntax.vars = uu____7541;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            (a, FStar_Pervasives_Native.None)::[])
           ->
-          let uu____7579 = infer env1 a in
-          (match uu____7579 with
+          let uu___3 = infer env1 a in
+          (match uu___3 with
            | (t, s, u) ->
-               let uu____7595 = FStar_Syntax_Util.head_and_args e in
-               (match uu____7595 with
-                | (head, uu____7619) ->
-                    let uu____7644 =
-                      let uu____7645 =
+               let uu___4 = FStar_Syntax_Util.head_and_args e in
+               (match uu___4 with
+                | (head, uu___5) ->
+                    let uu___6 =
+                      let uu___7 =
                         FStar_Syntax_Syntax.tabbrev
                           FStar_Parser_Const.range_lid in
-                      N uu____7645 in
-                    let uu____7646 =
-                      let uu____7647 =
-                        let uu____7648 =
-                          let uu____7665 =
-                            let uu____7676 = FStar_Syntax_Syntax.as_arg s in
-                            [uu____7676] in
-                          (head, uu____7665) in
-                        FStar_Syntax_Syntax.Tm_app uu____7648 in
-                      mk uu____7647 in
-                    let uu____7713 =
-                      let uu____7714 =
-                        let uu____7715 =
-                          let uu____7732 =
-                            let uu____7743 = FStar_Syntax_Syntax.as_arg u in
-                            [uu____7743] in
-                          (head, uu____7732) in
-                        FStar_Syntax_Syntax.Tm_app uu____7715 in
-                      mk uu____7714 in
-                    (uu____7644, uu____7646, uu____7713)))
+                      N uu___7 in
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 = FStar_Syntax_Syntax.as_arg s in
+                            [uu___11] in
+                          (head, uu___10) in
+                        FStar_Syntax_Syntax.Tm_app uu___9 in
+                      mk uu___8 in
+                    let uu___8 =
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
+                            let uu___12 = FStar_Syntax_Syntax.as_arg u in
+                            [uu___12] in
+                          (head, uu___11) in
+                        FStar_Syntax_Syntax.Tm_app uu___10 in
+                      mk uu___9 in
+                    (uu___6, uu___7, uu___8)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____7780;
-             FStar_Syntax_Syntax.vars = uu____7781;_},
-           (a1, uu____7783)::a2::[])
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
+           (a1, uu___3)::a2::[])
           ->
-          let uu____7839 = infer env1 a1 in
-          (match uu____7839 with
+          let uu___4 = infer env1 a1 in
+          (match uu___4 with
            | (t, s, u) ->
-               let uu____7855 = FStar_Syntax_Util.head_and_args e in
-               (match uu____7855 with
-                | (head, uu____7879) ->
-                    let uu____7904 =
-                      let uu____7905 =
-                        let uu____7906 =
-                          let uu____7923 =
-                            let uu____7934 = FStar_Syntax_Syntax.as_arg s in
-                            [uu____7934; a2] in
-                          (head, uu____7923) in
-                        FStar_Syntax_Syntax.Tm_app uu____7906 in
-                      mk uu____7905 in
-                    let uu____7979 =
-                      let uu____7980 =
-                        let uu____7981 =
-                          let uu____7998 =
-                            let uu____8009 = FStar_Syntax_Syntax.as_arg u in
-                            [uu____8009; a2] in
-                          (head, uu____7998) in
-                        FStar_Syntax_Syntax.Tm_app uu____7981 in
-                      mk uu____7980 in
-                    (t, uu____7904, uu____7979)))
+               let uu___5 = FStar_Syntax_Util.head_and_args e in
+               (match uu___5 with
+                | (head, uu___6) ->
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 = FStar_Syntax_Syntax.as_arg s in
+                            [uu___11; a2] in
+                          (head, uu___10) in
+                        FStar_Syntax_Syntax.Tm_app uu___9 in
+                      mk uu___8 in
+                    let uu___8 =
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
+                            let uu___12 = FStar_Syntax_Syntax.as_arg u in
+                            [uu___12; a2] in
+                          (head, uu___11) in
+                        FStar_Syntax_Syntax.Tm_app uu___10 in
+                      mk uu___9 in
+                    (t, uu___7, uu___8)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____8054;
-             FStar_Syntax_Syntax.vars = uu____8055;_},
-           uu____8056)
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
+           uu___3)
           ->
-          let uu____8081 =
-            let uu____8086 =
-              let uu____8087 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8087 in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8086) in
-          FStar_Errors.raise_error uu____8081 e.FStar_Syntax_Syntax.pos
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu___6 in
+            (FStar_Errors.Fatal_IllAppliedConstant, uu___5) in
+          FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____8094;
-             FStar_Syntax_Syntax.vars = uu____8095;_},
-           uu____8096)
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
+           uu___3)
           ->
-          let uu____8121 =
-            let uu____8126 =
-              let uu____8127 = FStar_Syntax_Print.term_to_string e in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8127 in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8126) in
-          FStar_Errors.raise_error uu____8121 e.FStar_Syntax_Syntax.pos
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu___6 in
+            (FStar_Errors.Fatal_IllAppliedConstant, uu___5) in
+          FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (head, args) ->
-          let uu____8160 = check_n env1 head in
-          (match uu____8160 with
+          let uu___1 = check_n env1 head in
+          (match uu___1 with
            | (t_head, s_head, u_head) ->
                let is_arrow t =
-                 let uu____8182 =
-                   let uu____8183 = FStar_Syntax_Subst.compress t in
-                   uu____8183.FStar_Syntax_Syntax.n in
-                 match uu____8182 with
-                 | FStar_Syntax_Syntax.Tm_arrow uu____8186 -> true
-                 | uu____8201 -> false in
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
+                 | FStar_Syntax_Syntax.Tm_arrow uu___3 -> true
+                 | uu___3 -> false in
                let rec flatten t =
-                 let uu____8222 =
-                   let uu____8223 = FStar_Syntax_Subst.compress t in
-                   uu____8223.FStar_Syntax_Syntax.n in
-                 match uu____8222 with
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
                  | FStar_Syntax_Syntax.Tm_arrow
                      (binders,
                       {
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total
-                          (t1, uu____8242);
-                        FStar_Syntax_Syntax.pos = uu____8243;
-                        FStar_Syntax_Syntax.vars = uu____8244;_})
+                          (t1, uu___3);
+                        FStar_Syntax_Syntax.pos = uu___4;
+                        FStar_Syntax_Syntax.vars = uu___5;_})
                      when is_arrow t1 ->
-                     let uu____8273 = flatten t1 in
-                     (match uu____8273 with
+                     let uu___6 = flatten t1 in
+                     (match uu___6 with
                       | (binders', comp) ->
                           ((FStar_List.append binders binders'), comp))
                  | FStar_Syntax_Syntax.Tm_arrow (binders, comp) ->
                      (binders, comp)
-                 | FStar_Syntax_Syntax.Tm_ascribed
-                     (e1, uu____8373, uu____8374) -> flatten e1
-                 | uu____8415 ->
-                     let uu____8416 =
-                       let uu____8421 =
-                         let uu____8422 =
+                 | FStar_Syntax_Syntax.Tm_ascribed (e1, uu___3, uu___4) ->
+                     flatten e1
+                 | uu___3 ->
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_Syntax_Print.term_to_string t_head in
-                         FStar_Util.format1 "%s: not a function type"
-                           uu____8422 in
-                       (FStar_Errors.Fatal_NotFunctionType, uu____8421) in
-                     FStar_Errors.raise_err uu____8416 in
-               let uu____8437 = flatten t_head in
-               (match uu____8437 with
+                         FStar_Util.format1 "%s: not a function type" uu___6 in
+                       (FStar_Errors.Fatal_NotFunctionType, uu___5) in
+                     FStar_Errors.raise_err uu___4 in
+               let uu___2 = flatten t_head in
+               (match uu___2 with
                 | (binders, comp) ->
                     let n = FStar_List.length binders in
                     let n' = FStar_List.length args in
                     (if
                        (FStar_List.length binders) < (FStar_List.length args)
                      then
-                       (let uu____8511 =
-                          let uu____8516 =
-                            let uu____8517 = FStar_Util.string_of_int n in
-                            let uu____8518 =
-                              FStar_Util.string_of_int (n' - n) in
-                            let uu____8519 = FStar_Util.string_of_int n in
+                       (let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Util.string_of_int n in
+                            let uu___7 = FStar_Util.string_of_int (n' - n) in
+                            let uu___8 = FStar_Util.string_of_int n in
                             FStar_Util.format3
                               "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments."
-                              uu____8517 uu____8518 uu____8519 in
+                              uu___6 uu___7 uu___8 in
                           (FStar_Errors.Fatal_BinderAndArgsLengthMismatch,
-                            uu____8516) in
-                        FStar_Errors.raise_err uu____8511)
+                            uu___5) in
+                        FStar_Errors.raise_err uu___4)
                      else ();
-                     (let uu____8521 =
-                        FStar_Syntax_Subst.open_comp binders comp in
-                      match uu____8521 with
+                     (let uu___4 = FStar_Syntax_Subst.open_comp binders comp in
+                      match uu___4 with
                       | (binders1, comp1) ->
-                          let rec final_type subst uu____8574 args1 =
-                            match uu____8574 with
+                          let rec final_type subst uu___5 args1 =
+                            match uu___5 with
                             | (binders2, comp2) ->
                                 (match (binders2, args1) with
                                  | ([], []) ->
-                                     let uu____8674 =
+                                     let uu___6 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          comp2 in
-                                     nm_of_comp uu____8674
+                                     nm_of_comp uu___6
                                  | (binders3, []) ->
-                                     let uu____8712 =
-                                       let uu____8713 =
-                                         let uu____8716 =
-                                           let uu____8717 =
+                                     let uu___6 =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           let uu___9 =
                                              mk
                                                (FStar_Syntax_Syntax.Tm_arrow
                                                   (binders3, comp2)) in
                                            FStar_Syntax_Subst.subst subst
-                                             uu____8717 in
-                                         FStar_Syntax_Subst.compress
-                                           uu____8716 in
-                                       uu____8713.FStar_Syntax_Syntax.n in
-                                     (match uu____8712 with
+                                             uu___9 in
+                                         FStar_Syntax_Subst.compress uu___8 in
+                                       uu___7.FStar_Syntax_Syntax.n in
+                                     (match uu___6 with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (binders4, comp3) ->
-                                          let uu____8750 =
-                                            let uu____8751 =
-                                              let uu____8752 =
-                                                let uu____8767 =
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
+                                                let uu___10 =
                                                   FStar_Syntax_Subst.close_comp
                                                     binders4 comp3 in
-                                                (binders4, uu____8767) in
+                                                (binders4, uu___10) in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____8752 in
-                                            mk uu____8751 in
-                                          N uu____8750
-                                      | uu____8780 -> failwith "wat?")
-                                 | ([], uu____8781::uu____8782) ->
+                                                uu___9 in
+                                            mk uu___8 in
+                                          N uu___7
+                                      | uu___7 -> failwith "wat?")
+                                 | ([], uu___6::uu___7) ->
                                      failwith "just checked that?!"
-                                 | ((bv, uu____8834)::binders3,
-                                    (arg, uu____8837)::args2) ->
+                                 | ((bv, uu___6)::binders3,
+                                    (arg, uu___7)::args2) ->
                                      final_type
                                        ((FStar_Syntax_Syntax.NT (bv, arg)) ::
                                        subst) (binders3, comp2) args2) in
                           let final_type1 =
                             final_type [] (binders1, comp1) args in
-                          let uu____8924 = FStar_List.splitAt n' binders1 in
-                          (match uu____8924 with
-                           | (binders2, uu____8958) ->
-                               let uu____8991 =
-                                 let uu____9014 =
+                          let uu___5 = FStar_List.splitAt n' binders1 in
+                          (match uu___5 with
+                           | (binders2, uu___6) ->
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_List.map2
-                                     (fun uu____9076 ->
-                                        fun uu____9077 ->
-                                          match (uu____9076, uu____9077) with
-                                          | ((bv, uu____9125), (arg, q)) ->
-                                              let uu____9154 =
-                                                let uu____9155 =
+                                     (fun uu___9 ->
+                                        fun uu___10 ->
+                                          match (uu___9, uu___10) with
+                                          | ((bv, uu___11), (arg, q)) ->
+                                              let uu___12 =
+                                                let uu___13 =
                                                   FStar_Syntax_Subst.compress
                                                     bv.FStar_Syntax_Syntax.sort in
-                                                uu____9155.FStar_Syntax_Syntax.n in
-                                              (match uu____9154 with
+                                                uu___13.FStar_Syntax_Syntax.n in
+                                              (match uu___12 with
                                                | FStar_Syntax_Syntax.Tm_type
-                                                   uu____9176 ->
-                                                   let uu____9177 =
-                                                     let uu____9184 =
+                                                   uu___13 ->
+                                                   let uu___14 =
+                                                     let uu___15 =
                                                        star_type' env1 arg in
-                                                     (uu____9184, q) in
-                                                   (uu____9177, [(arg, q)])
-                                               | uu____9221 ->
-                                                   let uu____9222 =
+                                                     (uu___15, q) in
+                                                   (uu___14, [(arg, q)])
+                                               | uu___13 ->
+                                                   let uu___14 =
                                                      check_n env1 arg in
-                                                   (match uu____9222 with
-                                                    | (uu____9247, s_arg,
-                                                       u_arg) ->
-                                                        let uu____9250 =
-                                                          let uu____9259 =
+                                                   (match uu___14 with
+                                                    | (uu___15, s_arg, u_arg)
+                                                        ->
+                                                        let uu___16 =
+                                                          let uu___17 =
                                                             is_C
                                                               bv.FStar_Syntax_Syntax.sort in
-                                                          if uu____9259
+                                                          if uu___17
                                                           then
-                                                            let uu____9268 =
-                                                              let uu____9275
-                                                                =
+                                                            let uu___18 =
+                                                              let uu___19 =
                                                                 FStar_Syntax_Subst.subst
                                                                   env1.subst
                                                                   s_arg in
-                                                              (uu____9275, q) in
-                                                            [uu____9268;
+                                                              (uu___19, q) in
+                                                            [uu___18;
                                                             (u_arg, q)]
                                                           else [(u_arg, q)] in
-                                                        ((s_arg, q),
-                                                          uu____9250))))
+                                                        ((s_arg, q), uu___16))))
                                      binders2 args in
-                                 FStar_List.split uu____9014 in
-                               (match uu____8991 with
+                                 FStar_List.split uu___8 in
+                               (match uu___7 with
                                 | (s_args, u_args) ->
                                     let u_args1 = FStar_List.flatten u_args in
-                                    let uu____9402 =
+                                    let uu___8 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (s_head, s_args)) in
-                                    let uu____9415 =
+                                    let uu___9 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (u_head, u_args1)) in
-                                    (final_type1, uu____9402, uu____9415)))))))
+                                    (final_type1, uu___8, uu___9)))))))
       | FStar_Syntax_Syntax.Tm_let ((false, binding::[]), e2) ->
           mk_let env1 binding e2 infer check_m
       | FStar_Syntax_Syntax.Tm_match (e0, branches) ->
           mk_match env1 e0 branches infer
-      | FStar_Syntax_Syntax.Tm_uinst (e1, uu____9481) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_meta (e1, uu____9487) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_ascribed (e1, uu____9493, uu____9494) ->
-          infer env1 e1
+      | FStar_Syntax_Syntax.Tm_uinst (e1, uu___1) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_meta (e1, uu___1) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_ascribed (e1, uu___1, uu___2) -> infer env1 e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____9536 = let uu____9537 = env1.tc_const c in N uu____9537 in
-          (uu____9536, e, e)
+          let uu___1 = let uu___2 = env1.tc_const c in N uu___2 in
+          (uu___1, e, e)
       | FStar_Syntax_Syntax.Tm_quoted (tm, qt) ->
           ((N FStar_Syntax_Syntax.t_term), e, e)
-      | FStar_Syntax_Syntax.Tm_let uu____9544 ->
-          let uu____9557 =
-            let uu____9558 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_let %s" uu____9558 in
-          failwith uu____9557
-      | FStar_Syntax_Syntax.Tm_type uu____9565 ->
+      | FStar_Syntax_Syntax.Tm_let uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_let %s" uu___3 in
+          failwith uu___2
+      | FStar_Syntax_Syntax.Tm_type uu___1 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_arrow uu____9572 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_refine uu____9593 ->
-          let uu____9600 =
-            let uu____9601 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_refine %s" uu____9601 in
-          failwith uu____9600
-      | FStar_Syntax_Syntax.Tm_uvar uu____9608 ->
-          let uu____9621 =
-            let uu____9622 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____9622 in
-          failwith uu____9621
-      | FStar_Syntax_Syntax.Tm_delayed uu____9629 ->
+      | FStar_Syntax_Syntax.Tm_refine uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_refine %s" uu___3 in
+          failwith uu___2
+      | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_uvar %s" uu___3 in
+          failwith uu___2
+      | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
           failwith "impossible (compressed)"
       | FStar_Syntax_Syntax.Tm_unknown ->
-          let uu____9650 =
-            let uu____9651 = FStar_Syntax_Print.term_to_string e in
-            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____9651 in
-          failwith uu____9650
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_unknown %s" uu___2 in
+          failwith uu___1
 and (mk_match :
   env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2684,58 +2616,57 @@ and (mk_match :
       fun branches ->
         fun f ->
           let mk x = FStar_Syntax_Syntax.mk x e0.FStar_Syntax_Syntax.pos in
-          let uu____9698 = check_n env1 e0 in
-          match uu____9698 with
-          | (uu____9711, s_e0, u_e0) ->
-              let uu____9714 =
-                let uu____9743 =
+          let uu___ = check_n env1 e0 in
+          match uu___ with
+          | (uu___1, s_e0, u_e0) ->
+              let uu___2 =
+                let uu___3 =
                   FStar_List.map
                     (fun b ->
-                       let uu____9804 = FStar_Syntax_Subst.open_branch b in
-                       match uu____9804 with
+                       let uu___4 = FStar_Syntax_Subst.open_branch b in
+                       match uu___4 with
                        | (pat, FStar_Pervasives_Native.None, body) ->
                            let env2 =
-                             let uu___1117_9846 = env1 in
-                             let uu____9847 =
-                               let uu____9848 =
-                                 FStar_Syntax_Syntax.pat_bvs pat in
+                             let uu___5 = env1 in
+                             let uu___6 =
+                               let uu___7 = FStar_Syntax_Syntax.pat_bvs pat in
                                FStar_List.fold_left
                                  FStar_TypeChecker_Env.push_bv env1.tcenv
-                                 uu____9848 in
+                                 uu___7 in
                              {
-                               tcenv = uu____9847;
-                               subst = (uu___1117_9846.subst);
-                               tc_const = (uu___1117_9846.tc_const)
+                               tcenv = uu___6;
+                               subst = (uu___5.subst);
+                               tc_const = (uu___5.tc_const)
                              } in
-                           let uu____9851 = f env2 body in
-                           (match uu____9851 with
+                           let uu___5 = f env2 body in
+                           (match uu___5 with
                             | (nm1, s_body, u_body) ->
                                 (nm1,
                                   (pat, FStar_Pervasives_Native.None,
                                     (s_body, u_body, body))))
-                       | uu____9923 ->
+                       | uu___5 ->
                            FStar_Errors.raise_err
                              (FStar_Errors.Fatal_WhenClauseNotSupported,
                                "No when clauses in the definition language"))
                     branches in
-                FStar_List.split uu____9743 in
-              (match uu____9714 with
+                FStar_List.split uu___3 in
+              (match uu___2 with
                | (nms, branches1) ->
                    let t1 =
-                     let uu____10027 = FStar_List.hd nms in
-                     match uu____10027 with | M t1 -> t1 | N t1 -> t1 in
+                     let uu___3 = FStar_List.hd nms in
+                     match uu___3 with | M t11 -> t11 | N t11 -> t11 in
                    let has_m =
                      FStar_List.existsb
-                       (fun uu___10_10035 ->
-                          match uu___10_10035 with
-                          | M uu____10036 -> true
-                          | uu____10037 -> false) nms in
-                   let uu____10038 =
-                     let uu____10075 =
+                       (fun uu___3 ->
+                          match uu___3 with
+                          | M uu___4 -> true
+                          | uu___4 -> false) nms in
+                   let uu___3 =
+                     let uu___4 =
                        FStar_List.map2
                          (fun nm1 ->
-                            fun uu____10165 ->
-                              match uu____10165 with
+                            fun uu___5 ->
+                              match uu___5 with
                               | (pat, guard, (s_body, u_body, original_body))
                                   ->
                                   (match (nm1, has_m) with
@@ -2746,16 +2677,16 @@ and (mk_match :
                                        (nm1, (pat, guard, s_body),
                                          (pat, guard, u_body))
                                    | (N t2, true) ->
-                                       let uu____10342 =
+                                       let uu___6 =
                                          check env1 original_body (M t2) in
-                                       (match uu____10342 with
-                                        | (uu____10379, s_body1, u_body1) ->
+                                       (match uu___6 with
+                                        | (uu___7, s_body1, u_body1) ->
                                             ((M t2), (pat, guard, s_body1),
                                               (pat, guard, u_body1)))
-                                   | (M uu____10418, false) ->
+                                   | (M uu___6, false) ->
                                        failwith "impossible")) nms branches1 in
-                     FStar_List.unzip3 uu____10075 in
-                   (match uu____10038 with
+                     FStar_List.unzip3 uu___4 in
+                   (match uu___3 with
                     | (nms1, s_branches, u_branches) ->
                         if has_m
                         then
@@ -2765,26 +2696,25 @@ and (mk_match :
                               FStar_Pervasives_Native.None p_type in
                           let s_branches1 =
                             FStar_List.map
-                              (fun uu____10602 ->
-                                 match uu____10602 with
+                              (fun uu___4 ->
+                                 match uu___4 with
                                  | (pat, guard, s_body) ->
                                      let s_body1 =
-                                       let uu____10653 =
-                                         let uu____10654 =
-                                           let uu____10671 =
-                                             let uu____10682 =
-                                               let uu____10691 =
+                                       let uu___5 =
+                                         let uu___6 =
+                                           let uu___7 =
+                                             let uu___8 =
+                                               let uu___9 =
                                                  FStar_Syntax_Syntax.bv_to_name
                                                    p in
-                                               let uu____10694 =
+                                               let uu___10 =
                                                  FStar_Syntax_Syntax.as_implicit
                                                    false in
-                                               (uu____10691, uu____10694) in
-                                             [uu____10682] in
-                                           (s_body, uu____10671) in
-                                         FStar_Syntax_Syntax.Tm_app
-                                           uu____10654 in
-                                       mk uu____10653 in
+                                               (uu___9, uu___10) in
+                                             [uu___8] in
+                                           (s_body, uu___7) in
+                                         FStar_Syntax_Syntax.Tm_app uu___6 in
+                                       mk uu___5 in
                                      (pat, guard, s_body1)) s_branches in
                           let s_branches2 =
                             FStar_List.map FStar_Syntax_Subst.close_branch
@@ -2793,43 +2723,42 @@ and (mk_match :
                             FStar_List.map FStar_Syntax_Subst.close_branch
                               u_branches in
                           let s_e =
-                            let uu____10828 =
-                              let uu____10829 =
-                                FStar_Syntax_Syntax.mk_binder p in
-                              [uu____10829] in
-                            let uu____10848 =
+                            let uu___4 =
+                              let uu___5 = FStar_Syntax_Syntax.mk_binder p in
+                              [uu___5] in
+                            let uu___5 =
                               mk
                                 (FStar_Syntax_Syntax.Tm_match
                                    (s_e0, s_branches2)) in
-                            FStar_Syntax_Util.abs uu____10828 uu____10848
+                            FStar_Syntax_Util.abs uu___4 uu___5
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0)) in
                           let t1_star =
-                            let uu____10872 =
-                              let uu____10881 =
-                                let uu____10888 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
                                   FStar_Syntax_Syntax.new_bv
                                     FStar_Pervasives_Native.None p_type in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.mk_binder uu____10888 in
-                              [uu____10881] in
-                            let uu____10907 =
+                                  FStar_Syntax_Syntax.mk_binder uu___6 in
+                              [uu___5] in
+                            let uu___5 =
                               FStar_Syntax_Syntax.mk_Total
                                 FStar_Syntax_Util.ktype0 in
-                            FStar_Syntax_Util.arrow uu____10872 uu____10907 in
-                          let uu____10910 =
+                            FStar_Syntax_Util.arrow uu___4 uu___5 in
+                          let uu___4 =
                             mk
                               (FStar_Syntax_Syntax.Tm_ascribed
                                  (s_e,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None)) in
-                          let uu____10949 =
+                          let uu___5 =
                             mk
                               (FStar_Syntax_Syntax.Tm_match
                                  (u_e0, u_branches1)) in
-                          ((M t1), uu____10910, uu____10949)
+                          ((M t1), uu___4, uu___5)
                         else
                           (let s_branches1 =
                              FStar_List.map FStar_Syntax_Subst.close_branch
@@ -2838,24 +2767,24 @@ and (mk_match :
                              FStar_List.map FStar_Syntax_Subst.close_branch
                                u_branches in
                            let t1_star = t1 in
-                           let uu____11058 =
-                             let uu____11059 =
-                               let uu____11060 =
-                                 let uu____11087 =
+                           let uu___5 =
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
                                    mk
                                      (FStar_Syntax_Syntax.Tm_match
                                         (s_e0, s_branches1)) in
-                                 (uu____11087,
+                                 (uu___8,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11060 in
-                             mk uu____11059 in
-                           let uu____11146 =
+                               FStar_Syntax_Syntax.Tm_ascribed uu___7 in
+                             mk uu___6 in
+                           let uu___6 =
                              mk
                                (FStar_Syntax_Syntax.Tm_match
                                   (u_e0, u_branches1)) in
-                           ((N t1), uu____11058, uu____11146))))
+                           ((N t1), uu___5, uu___6))))
 and (mk_let :
   env_ ->
     FStar_Syntax_Syntax.letbinding ->
@@ -2879,235 +2808,233 @@ and (mk_let :
             let e1 = binding.FStar_Syntax_Syntax.lbdef in
             let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname in
             let x_binders =
-              let uu____11211 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____11211] in
-            let uu____11230 = FStar_Syntax_Subst.open_term x_binders e2 in
-            match uu____11230 with
+              let uu___ = FStar_Syntax_Syntax.mk_binder x in [uu___] in
+            let uu___ = FStar_Syntax_Subst.open_term x_binders e2 in
+            match uu___ with
             | (x_binders1, e21) ->
-                let uu____11243 = infer env1 e1 in
-                (match uu____11243 with
+                let uu___1 = infer env1 e1 in
+                (match uu___1 with
                  | (N t1, s_e1, u_e1) ->
                      let u_binding =
-                       let uu____11260 = is_C t1 in
-                       if uu____11260
+                       let uu___2 = is_C t1 in
+                       if uu___2
                        then
-                         let uu___1203_11261 = binding in
-                         let uu____11262 =
-                           let uu____11265 =
+                         let uu___3 = binding in
+                         let uu___4 =
+                           let uu___5 =
                              FStar_Syntax_Subst.subst env1.subst s_e1 in
-                           trans_F_ env1 t1 uu____11265 in
+                           trans_F_ env1 t1 uu___5 in
                          {
                            FStar_Syntax_Syntax.lbname =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbname);
+                             (uu___3.FStar_Syntax_Syntax.lbname);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbunivs);
-                           FStar_Syntax_Syntax.lbtyp = uu____11262;
+                             (uu___3.FStar_Syntax_Syntax.lbunivs);
+                           FStar_Syntax_Syntax.lbtyp = uu___4;
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbeff);
+                             (uu___3.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbdef);
+                             (uu___3.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbattrs);
+                             (uu___3.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___1203_11261.FStar_Syntax_Syntax.lbpos)
+                             (uu___3.FStar_Syntax_Syntax.lbpos)
                          }
                        else binding in
                      let env2 =
-                       let uu___1206_11268 = env1 in
-                       let uu____11269 =
+                       let uu___2 = env1 in
+                       let uu___3 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1208_11271 = x in
+                           (let uu___4 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1208_11271.FStar_Syntax_Syntax.ppname);
+                                (uu___4.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1208_11271.FStar_Syntax_Syntax.index);
+                                (uu___4.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             }) in
                        {
-                         tcenv = uu____11269;
-                         subst = (uu___1206_11268.subst);
-                         tc_const = (uu___1206_11268.tc_const)
+                         tcenv = uu___3;
+                         subst = (uu___2.subst);
+                         tc_const = (uu___2.tc_const)
                        } in
-                     let uu____11272 = proceed env2 e21 in
-                     (match uu____11272 with
+                     let uu___2 = proceed env2 e21 in
+                     (match uu___2 with
                       | (nm_rec, s_e2, u_e2) ->
                           let s_binding =
-                            let uu___1215_11289 = binding in
-                            let uu____11290 =
+                            let uu___3 = binding in
+                            let uu___4 =
                               star_type' env2
                                 binding.FStar_Syntax_Syntax.lbtyp in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbname);
+                                (uu___3.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbunivs);
-                              FStar_Syntax_Syntax.lbtyp = uu____11290;
+                                (uu___3.FStar_Syntax_Syntax.lbunivs);
+                              FStar_Syntax_Syntax.lbtyp = uu___4;
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbeff);
+                                (uu___3.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbdef);
+                                (uu___3.FStar_Syntax_Syntax.lbdef);
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbattrs);
+                                (uu___3.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1215_11289.FStar_Syntax_Syntax.lbpos)
+                                (uu___3.FStar_Syntax_Syntax.lbpos)
                             } in
-                          let uu____11293 =
-                            let uu____11294 =
-                              let uu____11295 =
-                                let uu____11308 =
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
                                   FStar_Syntax_Subst.close x_binders1 s_e2 in
                                 ((false,
-                                   [(let uu___1218_11322 = s_binding in
+                                   [(let uu___7 = s_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbname);
+                                         (uu___7.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___7.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___7.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbeff);
+                                         (uu___7.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = s_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___7.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1218_11322.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11308) in
-                              FStar_Syntax_Syntax.Tm_let uu____11295 in
-                            mk uu____11294 in
-                          let uu____11323 =
-                            let uu____11324 =
-                              let uu____11325 =
-                                let uu____11338 =
+                                         (uu___7.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu___6) in
+                              FStar_Syntax_Syntax.Tm_let uu___5 in
+                            mk uu___4 in
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2 in
                                 ((false,
-                                   [(let uu___1220_11352 = u_binding in
+                                   [(let uu___8 = u_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbname);
+                                         (uu___8.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___8.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___8.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbeff);
+                                         (uu___8.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___8.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1220_11352.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11338) in
-                              FStar_Syntax_Syntax.Tm_let uu____11325 in
-                            mk uu____11324 in
-                          (nm_rec, uu____11293, uu____11323))
+                                         (uu___8.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu___7) in
+                              FStar_Syntax_Syntax.Tm_let uu___6 in
+                            mk uu___5 in
+                          (nm_rec, uu___3, uu___4))
                  | (M t1, s_e1, u_e1) ->
                      let u_binding =
-                       let uu___1227_11357 = binding in
+                       let uu___2 = binding in
                        {
                          FStar_Syntax_Syntax.lbname =
-                           (uu___1227_11357.FStar_Syntax_Syntax.lbname);
+                           (uu___2.FStar_Syntax_Syntax.lbname);
                          FStar_Syntax_Syntax.lbunivs =
-                           (uu___1227_11357.FStar_Syntax_Syntax.lbunivs);
+                           (uu___2.FStar_Syntax_Syntax.lbunivs);
                          FStar_Syntax_Syntax.lbtyp = t1;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_PURE_lid;
                          FStar_Syntax_Syntax.lbdef =
-                           (uu___1227_11357.FStar_Syntax_Syntax.lbdef);
+                           (uu___2.FStar_Syntax_Syntax.lbdef);
                          FStar_Syntax_Syntax.lbattrs =
-                           (uu___1227_11357.FStar_Syntax_Syntax.lbattrs);
+                           (uu___2.FStar_Syntax_Syntax.lbattrs);
                          FStar_Syntax_Syntax.lbpos =
-                           (uu___1227_11357.FStar_Syntax_Syntax.lbpos)
+                           (uu___2.FStar_Syntax_Syntax.lbpos)
                        } in
                      let env2 =
-                       let uu___1230_11359 = env1 in
-                       let uu____11360 =
+                       let uu___2 = env1 in
+                       let uu___3 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1232_11362 = x in
+                           (let uu___4 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1232_11362.FStar_Syntax_Syntax.ppname);
+                                (uu___4.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1232_11362.FStar_Syntax_Syntax.index);
+                                (uu___4.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             }) in
                        {
-                         tcenv = uu____11360;
-                         subst = (uu___1230_11359.subst);
-                         tc_const = (uu___1230_11359.tc_const)
+                         tcenv = uu___3;
+                         subst = (uu___2.subst);
+                         tc_const = (uu___2.tc_const)
                        } in
-                     let uu____11363 = ensure_m env2 e21 in
-                     (match uu____11363 with
+                     let uu___2 = ensure_m env2 e21 in
+                     (match uu___2 with
                       | (t2, s_e2, u_e2) ->
                           let p_type = mk_star_to_type mk env2 t2 in
                           let p =
                             FStar_Syntax_Syntax.gen_bv "p''"
                               FStar_Pervasives_Native.None p_type in
                           let s_e21 =
-                            let uu____11386 =
-                              let uu____11387 =
-                                let uu____11404 =
-                                  let uu____11415 =
-                                    let uu____11424 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_Syntax_Syntax.bv_to_name p in
-                                    let uu____11427 =
+                                    let uu___8 =
                                       FStar_Syntax_Syntax.as_implicit false in
-                                    (uu____11424, uu____11427) in
-                                  [uu____11415] in
-                                (s_e2, uu____11404) in
-                              FStar_Syntax_Syntax.Tm_app uu____11387 in
-                            mk uu____11386 in
+                                    (uu___7, uu___8) in
+                                  [uu___6] in
+                                (s_e2, uu___5) in
+                              FStar_Syntax_Syntax.Tm_app uu___4 in
+                            mk uu___3 in
                           let s_e22 =
                             FStar_Syntax_Util.abs x_binders1 s_e21
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0)) in
                           let body =
-                            let uu____11468 =
-                              let uu____11469 =
-                                let uu____11486 =
-                                  let uu____11497 =
-                                    let uu____11506 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_Syntax_Syntax.as_implicit false in
-                                    (s_e22, uu____11506) in
-                                  [uu____11497] in
-                                (s_e1, uu____11486) in
-                              FStar_Syntax_Syntax.Tm_app uu____11469 in
-                            mk uu____11468 in
-                          let uu____11541 =
-                            let uu____11542 =
-                              let uu____11543 =
-                                FStar_Syntax_Syntax.mk_binder p in
-                              [uu____11543] in
-                            FStar_Syntax_Util.abs uu____11542 body
+                                    (s_e22, uu___7) in
+                                  [uu___6] in
+                                (s_e1, uu___5) in
+                              FStar_Syntax_Syntax.Tm_app uu___4 in
+                            mk uu___3 in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 = FStar_Syntax_Syntax.mk_binder p in
+                              [uu___5] in
+                            FStar_Syntax_Util.abs uu___4 body
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0)) in
-                          let uu____11562 =
-                            let uu____11563 =
-                              let uu____11564 =
-                                let uu____11577 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2 in
                                 ((false,
-                                   [(let uu___1244_11591 = u_binding in
+                                   [(let uu___8 = u_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbname);
+                                         (uu___8.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___8.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___8.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbeff);
+                                         (uu___8.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___8.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1244_11591.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11577) in
-                              FStar_Syntax_Syntax.Tm_let uu____11564 in
-                            mk uu____11563 in
-                          ((M t2), uu____11541, uu____11562)))
+                                         (uu___8.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu___7) in
+                              FStar_Syntax_Syntax.Tm_let uu___6 in
+                            mk uu___5 in
+                          ((M t2), uu___3, uu___4)))
 and (check_n :
   env_ ->
     FStar_Syntax_Syntax.term ->
@@ -3117,14 +3044,14 @@ and (check_n :
   fun env1 ->
     fun e ->
       let mn =
-        let uu____11601 =
+        let uu___ =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             e.FStar_Syntax_Syntax.pos in
-        N uu____11601 in
-      let uu____11602 = check env1 e mn in
-      match uu____11602 with
+        N uu___ in
+      let uu___ = check env1 e mn in
+      match uu___ with
       | (N t, s_e, u_e) -> (t, s_e, u_e)
-      | uu____11618 -> failwith "[check_n]: impossible"
+      | uu___1 -> failwith "[check_n]: impossible"
 and (check_m :
   env_ ->
     FStar_Syntax_Syntax.term ->
@@ -3134,14 +3061,14 @@ and (check_m :
   fun env1 ->
     fun e ->
       let mn =
-        let uu____11640 =
+        let uu___ =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             e.FStar_Syntax_Syntax.pos in
-        M uu____11640 in
-      let uu____11641 = check env1 e mn in
-      match uu____11641 with
+        M uu___ in
+      let uu___ = check env1 e mn in
+      match uu___ with
       | (M t, s_e, u_e) -> (t, s_e, u_e)
-      | uu____11657 -> failwith "[check_m]: impossible"
+      | uu___1 -> failwith "[check_m]: impossible"
 and (comp_of_nm : nm_ -> FStar_Syntax_Syntax.comp) =
   fun nm1 ->
     match nm1 with | N t -> FStar_Syntax_Syntax.mk_Total t | M t -> mk_M t
@@ -3168,166 +3095,158 @@ and (trans_F_ :
   fun env1 ->
     fun c ->
       fun wp ->
-        (let uu____11689 =
-           let uu____11690 = is_C c in Prims.op_Negation uu____11690 in
-         if uu____11689
+        (let uu___1 = let uu___2 = is_C c in Prims.op_Negation uu___2 in
+         if uu___1
          then
-           let uu____11691 =
-             let uu____11696 =
-               let uu____11697 = FStar_Syntax_Print.term_to_string c in
-               FStar_Util.format1 "Not a DM4F C-type: %s" uu____11697 in
-             (FStar_Errors.Error_UnexpectedDM4FType, uu____11696) in
-           FStar_Errors.raise_error uu____11691 c.FStar_Syntax_Syntax.pos
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Syntax_Print.term_to_string c in
+               FStar_Util.format1 "Not a DM4F C-type: %s" uu___4 in
+             (FStar_Errors.Error_UnexpectedDM4FType, uu___3) in
+           FStar_Errors.raise_error uu___2 c.FStar_Syntax_Syntax.pos
          else ());
         (let mk x = FStar_Syntax_Syntax.mk x c.FStar_Syntax_Syntax.pos in
-         let uu____11707 =
-           let uu____11708 = FStar_Syntax_Subst.compress c in
-           uu____11708.FStar_Syntax_Syntax.n in
-         match uu____11707 with
+         let uu___1 =
+           let uu___2 = FStar_Syntax_Subst.compress c in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
          | FStar_Syntax_Syntax.Tm_app (head, args) ->
-             let uu____11737 = FStar_Syntax_Util.head_and_args wp in
-             (match uu____11737 with
+             let uu___2 = FStar_Syntax_Util.head_and_args wp in
+             (match uu___2 with
               | (wp_head, wp_args) ->
-                  ((let uu____11781 =
+                  ((let uu___4 =
                       (Prims.op_Negation
                          ((FStar_List.length wp_args) =
                             (FStar_List.length args)))
                         ||
-                        (let uu____11799 =
-                           let uu____11800 =
+                        (let uu___5 =
+                           let uu___6 =
                              FStar_Parser_Const.mk_tuple_data_lid
                                (FStar_List.length wp_args)
                                FStar_Range.dummyRange in
-                           FStar_Syntax_Util.is_constructor wp_head
-                             uu____11800 in
-                         Prims.op_Negation uu____11799) in
-                    if uu____11781 then failwith "mismatch" else ());
-                   (let uu____11810 =
-                      let uu____11811 =
-                        let uu____11828 =
+                           FStar_Syntax_Util.is_constructor wp_head uu___6 in
+                         Prims.op_Negation uu___5) in
+                    if uu___4 then failwith "mismatch" else ());
+                   (let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
                           FStar_List.map2
-                            (fun uu____11866 ->
-                               fun uu____11867 ->
-                                 match (uu____11866, uu____11867) with
+                            (fun uu___7 ->
+                               fun uu___8 ->
+                                 match (uu___7, uu___8) with
                                  | ((arg, q), (wp_arg, q')) ->
                                      let print_implicit q1 =
-                                       let uu____11928 =
+                                       let uu___9 =
                                          FStar_Syntax_Syntax.is_implicit q1 in
-                                       if uu____11928
+                                       if uu___9
                                        then "implicit"
                                        else "explicit" in
-                                     ((let uu____11931 =
-                                         let uu____11932 =
+                                     ((let uu___10 =
+                                         let uu___11 =
                                            FStar_Syntax_Util.eq_aqual q q' in
-                                         uu____11932 <>
-                                           FStar_Syntax_Util.Equal in
-                                       if uu____11931
+                                         uu___11 <> FStar_Syntax_Util.Equal in
+                                       if uu___10
                                        then
-                                         let uu____11933 =
-                                           let uu____11938 =
-                                             let uu____11939 =
-                                               print_implicit q in
-                                             let uu____11940 =
-                                               print_implicit q' in
+                                         let uu___11 =
+                                           let uu___12 =
+                                             let uu___13 = print_implicit q in
+                                             let uu___14 = print_implicit q' in
                                              FStar_Util.format2
                                                "Incoherent implicit qualifiers %s %s\n"
-                                               uu____11939 uu____11940 in
+                                               uu___13 uu___14 in
                                            (FStar_Errors.Warning_IncoherentImplicitQualifier,
-                                             uu____11938) in
+                                             uu___12) in
                                          FStar_Errors.log_issue
                                            head.FStar_Syntax_Syntax.pos
-                                           uu____11933
+                                           uu___11
                                        else ());
-                                      (let uu____11942 =
-                                         trans_F_ env1 arg wp_arg in
-                                       (uu____11942, q)))) args wp_args in
-                        (head, uu____11828) in
-                      FStar_Syntax_Syntax.Tm_app uu____11811 in
-                    mk uu____11810)))
+                                      (let uu___10 = trans_F_ env1 arg wp_arg in
+                                       (uu___10, q)))) args wp_args in
+                        (head, uu___6) in
+                      FStar_Syntax_Syntax.Tm_app uu___5 in
+                    mk uu___4)))
          | FStar_Syntax_Syntax.Tm_arrow (binders, comp) ->
              let binders1 = FStar_Syntax_Util.name_binders binders in
-             let uu____11988 = FStar_Syntax_Subst.open_comp binders1 comp in
-             (match uu____11988 with
+             let uu___2 = FStar_Syntax_Subst.open_comp binders1 comp in
+             (match uu___2 with
               | (binders_orig, comp1) ->
-                  let uu____11995 =
-                    let uu____12012 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_List.map
-                        (fun uu____12052 ->
-                           match uu____12052 with
+                        (fun uu___5 ->
+                           match uu___5 with
                            | (bv, q) ->
                                let h = bv.FStar_Syntax_Syntax.sort in
-                               let uu____12080 = is_C h in
-                               if uu____12080
+                               let uu___6 = is_C h in
+                               if uu___6
                                then
                                  let w' =
-                                   let uu____12094 =
-                                     let uu____12095 =
+                                   let uu___7 =
+                                     let uu___8 =
                                        FStar_Ident.string_of_id
                                          bv.FStar_Syntax_Syntax.ppname in
-                                     Prims.op_Hat uu____12095 "__w'" in
-                                   let uu____12096 = star_type' env1 h in
-                                   FStar_Syntax_Syntax.gen_bv uu____12094
-                                     FStar_Pervasives_Native.None uu____12096 in
-                                 let uu____12097 =
-                                   let uu____12106 =
-                                     let uu____12115 =
-                                       let uu____12122 =
-                                         let uu____12123 =
-                                           let uu____12124 =
+                                     Prims.op_Hat uu___8 "__w'" in
+                                   let uu___8 = star_type' env1 h in
+                                   FStar_Syntax_Syntax.gen_bv uu___7
+                                     FStar_Pervasives_Native.None uu___8 in
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 =
+                                         let uu___11 =
+                                           let uu___12 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                w' in
-                                           trans_F_ env1 h uu____12124 in
-                                         FStar_Syntax_Syntax.null_bv
-                                           uu____12123 in
-                                       (uu____12122, q) in
-                                     [uu____12115] in
-                                   (w', q) :: uu____12106 in
-                                 (w', uu____12097)
+                                           trans_F_ env1 h uu___12 in
+                                         FStar_Syntax_Syntax.null_bv uu___11 in
+                                       (uu___10, q) in
+                                     [uu___9] in
+                                   (w', q) :: uu___8 in
+                                 (w', uu___7)
                                else
                                  (let x =
-                                    let uu____12157 =
-                                      let uu____12158 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Ident.string_of_id
                                           bv.FStar_Syntax_Syntax.ppname in
-                                      Prims.op_Hat uu____12158 "__x" in
-                                    let uu____12159 = star_type' env1 h in
-                                    FStar_Syntax_Syntax.gen_bv uu____12157
-                                      FStar_Pervasives_Native.None
-                                      uu____12159 in
+                                      Prims.op_Hat uu___9 "__x" in
+                                    let uu___9 = star_type' env1 h in
+                                    FStar_Syntax_Syntax.gen_bv uu___8
+                                      FStar_Pervasives_Native.None uu___9 in
                                   (x, [(x, q)]))) binders_orig in
-                    FStar_List.split uu____12012 in
-                  (match uu____11995 with
+                    FStar_List.split uu___4 in
+                  (match uu___3 with
                    | (bvs, binders2) ->
                        let binders3 = FStar_List.flatten binders2 in
                        let comp2 =
-                         let uu____12232 =
-                           let uu____12235 =
+                         let uu___4 =
+                           let uu___5 =
                              FStar_Syntax_Syntax.binders_of_list bvs in
                            FStar_Syntax_Util.rename_binders binders_orig
-                             uu____12235 in
-                         FStar_Syntax_Subst.subst_comp uu____12232 comp1 in
+                             uu___5 in
+                         FStar_Syntax_Subst.subst_comp uu___4 comp1 in
                        let app =
-                         let uu____12239 =
-                           let uu____12240 =
-                             let uu____12257 =
+                         let uu___4 =
+                           let uu___5 =
+                             let uu___6 =
                                FStar_List.map
                                  (fun bv ->
-                                    let uu____12276 =
+                                    let uu___7 =
                                       FStar_Syntax_Syntax.bv_to_name bv in
-                                    let uu____12277 =
+                                    let uu___8 =
                                       FStar_Syntax_Syntax.as_implicit false in
-                                    (uu____12276, uu____12277)) bvs in
-                             (wp, uu____12257) in
-                           FStar_Syntax_Syntax.Tm_app uu____12240 in
-                         mk uu____12239 in
+                                    (uu___7, uu___8)) bvs in
+                             (wp, uu___6) in
+                           FStar_Syntax_Syntax.Tm_app uu___5 in
+                         mk uu___4 in
                        let comp3 =
-                         let uu____12291 = type_of_comp comp2 in
-                         let uu____12292 = is_monadic_comp comp2 in
-                         trans_G env1 uu____12291 uu____12292 app in
+                         let uu___4 = type_of_comp comp2 in
+                         let uu___5 = is_monadic_comp comp2 in
+                         trans_G env1 uu___4 uu___5 app in
                        FStar_Syntax_Util.arrow binders3 comp3))
-         | FStar_Syntax_Syntax.Tm_ascribed (e, uu____12294, uu____12295) ->
+         | FStar_Syntax_Syntax.Tm_ascribed (e, uu___2, uu___3) ->
              trans_F_ env1 e wp
-         | uu____12336 -> failwith "impossible trans_F_")
+         | uu___2 -> failwith "impossible trans_F_")
 and (trans_G :
   env_ ->
     FStar_Syntax_Syntax.typ ->
@@ -3339,26 +3258,26 @@ and (trans_G :
         fun wp ->
           if is_monadic1
           then
-            let uu____12341 =
-              let uu____12342 = star_type' env1 h in
-              let uu____12345 =
-                let uu____12356 =
-                  let uu____12365 = FStar_Syntax_Syntax.as_implicit false in
-                  (wp, uu____12365) in
-                [uu____12356] in
+            let uu___ =
+              let uu___1 = star_type' env1 h in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Syntax.as_implicit false in
+                  (wp, uu___4) in
+                [uu___3] in
               {
                 FStar_Syntax_Syntax.comp_univs =
                   [FStar_Syntax_Syntax.U_unknown];
                 FStar_Syntax_Syntax.effect_name =
                   FStar_Parser_Const.effect_PURE_lid;
-                FStar_Syntax_Syntax.result_typ = uu____12342;
-                FStar_Syntax_Syntax.effect_args = uu____12345;
+                FStar_Syntax_Syntax.result_typ = uu___1;
+                FStar_Syntax_Syntax.effect_args = uu___2;
                 FStar_Syntax_Syntax.flags = []
               } in
-            FStar_Syntax_Syntax.mk_Comp uu____12341
+            FStar_Syntax_Syntax.mk_Comp uu___
           else
-            (let uu____12389 = trans_F_ env1 h wp in
-             FStar_Syntax_Syntax.mk_Total uu____12389)
+            (let uu___1 = trans_F_ env1 h wp in
+             FStar_Syntax_Syntax.mk_Total uu___1)
 let (n :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -3370,16 +3289,13 @@ let (n :
     FStar_TypeChecker_Env.Eager_unfolding;
     FStar_TypeChecker_Env.EraseUniverses]
 let (star_type : env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
-  fun env1 ->
-    fun t -> let uu____12408 = n env1.tcenv t in star_type' env1 uu____12408
+  fun env1 -> fun t -> let uu___ = n env1.tcenv t in star_type' env1 uu___
 let (star_expr :
   env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.term *
         FStar_Syntax_Syntax.term))
-  =
-  fun env1 ->
-    fun t -> let uu____12427 = n env1.tcenv t in check_n env1 uu____12427
+  = fun env1 -> fun t -> let uu___ = n env1.tcenv t in check_n env1 uu___
 let (trans_F :
   env ->
     FStar_Syntax_Syntax.typ ->
@@ -3388,9 +3304,8 @@ let (trans_F :
   fun env1 ->
     fun c ->
       fun wp ->
-        let uu____12443 = n env1.tcenv c in
-        let uu____12444 = n env1.tcenv wp in
-        trans_F_ env1 uu____12443 uu____12444
+        let uu___ = n env1.tcenv c in
+        let uu___1 = n env1.tcenv wp in trans_F_ env1 uu___ uu___1
 let (recheck_debug :
   Prims.string ->
     FStar_TypeChecker_Env.env ->
@@ -3399,25 +3314,24 @@ let (recheck_debug :
   fun s ->
     fun env1 ->
       fun t ->
-        (let uu____12461 =
+        (let uu___1 =
            FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
-         if uu____12461
+         if uu___1
          then
-           let uu____12462 = FStar_Syntax_Print.term_to_string t in
+           let uu___2 = FStar_Syntax_Print.term_to_string t in
            FStar_Util.print2
-             "Term has been %s-transformed to:\n%s\n----------\n" s
-             uu____12462
+             "Term has been %s-transformed to:\n%s\n----------\n" s uu___2
          else ());
-        (let uu____12464 = FStar_TypeChecker_TcTerm.tc_term env1 t in
-         match uu____12464 with
-         | (t', uu____12472, uu____12473) ->
-             ((let uu____12475 =
+        (let uu___1 = FStar_TypeChecker_TcTerm.tc_term env1 t in
+         match uu___1 with
+         | (t', uu___2, uu___3) ->
+             ((let uu___5 =
                  FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
-               if uu____12475
+               if uu___5
                then
-                 let uu____12476 = FStar_Syntax_Print.term_to_string t' in
+                 let uu___6 = FStar_Syntax_Print.term_to_string t' in
                  FStar_Util.print1 "Re-checked; got:\n%s\n----------\n"
-                   uu____12476
+                   uu___6
                else ());
               t'))
 let (cps_and_elaborate :
@@ -3428,67 +3342,65 @@ let (cps_and_elaborate :
   =
   fun env1 ->
     fun ed ->
-      let uu____12508 =
+      let uu___ =
         FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
           (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature) in
-      match uu____12508 with
+      match uu___ with
       | (effect_binders_un, signature_un) ->
-          let uu____12529 =
+          let uu___1 =
             FStar_TypeChecker_TcTerm.tc_tparams env1 effect_binders_un in
-          (match uu____12529 with
-           | (effect_binders, env2, uu____12548) ->
-               let uu____12549 =
+          (match uu___1 with
+           | (effect_binders, env2, uu___2) ->
+               let uu___3 =
                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 signature_un in
-               (match uu____12549 with
-                | (signature, uu____12565) ->
-                    let raise_error uu____12580 =
-                      match uu____12580 with
+               (match uu___3 with
+                | (signature, uu___4) ->
+                    let raise_error uu___5 =
+                      match uu___5 with
                       | (e, err_msg) ->
                           FStar_Errors.raise_error (e, err_msg)
                             signature.FStar_Syntax_Syntax.pos in
                     let effect_binders1 =
                       FStar_List.map
-                        (fun uu____12612 ->
-                           match uu____12612 with
+                        (fun uu___5 ->
+                           match uu___5 with
                            | (bv, qual) ->
-                               let uu____12631 =
-                                 let uu___1370_12632 = bv in
-                                 let uu____12633 =
+                               let uu___6 =
+                                 let uu___7 = bv in
+                                 let uu___8 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Env.EraseUniverses]
                                      env2 bv.FStar_Syntax_Syntax.sort in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1370_12632.FStar_Syntax_Syntax.ppname);
+                                     (uu___7.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1370_12632.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort = uu____12633
+                                     (uu___7.FStar_Syntax_Syntax.index);
+                                   FStar_Syntax_Syntax.sort = uu___8
                                  } in
-                               (uu____12631, qual)) effect_binders in
-                    let uu____12638 =
-                      let uu____12645 =
-                        let uu____12646 =
-                          FStar_Syntax_Subst.compress signature_un in
-                        uu____12646.FStar_Syntax_Syntax.n in
-                      match uu____12645 with
+                               (uu___6, qual)) effect_binders in
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 = FStar_Syntax_Subst.compress signature_un in
+                        uu___7.FStar_Syntax_Syntax.n in
+                      match uu___6 with
                       | FStar_Syntax_Syntax.Tm_arrow
-                          ((a, uu____12656)::[], effect_marker) ->
+                          ((a, uu___7)::[], effect_marker) ->
                           (a, effect_marker)
-                      | uu____12688 ->
+                      | uu___7 ->
                           raise_error
                             (FStar_Errors.Fatal_BadSignatureShape,
                               "bad shape for effect-for-free signature") in
-                    (match uu____12638 with
+                    (match uu___5 with
                      | (a, effect_marker) ->
                          let a1 =
-                           let uu____12712 = FStar_Syntax_Syntax.is_null_bv a in
-                           if uu____12712
+                           let uu___6 = FStar_Syntax_Syntax.is_null_bv a in
+                           if uu___6
                            then
-                             let uu____12713 =
-                               let uu____12716 =
-                                 FStar_Syntax_Syntax.range_of_bv a in
-                               FStar_Pervasives_Native.Some uu____12716 in
-                             FStar_Syntax_Syntax.gen_bv "a" uu____12713
+                             let uu___7 =
+                               let uu___8 = FStar_Syntax_Syntax.range_of_bv a in
+                               FStar_Pervasives_Native.Some uu___8 in
+                             FStar_Syntax_Syntax.gen_bv "a" uu___7
                                a.FStar_Syntax_Syntax.sort
                            else a in
                          let open_and_check env3 other_binders t =
@@ -3497,35 +3409,34 @@ let (cps_and_elaborate :
                                (FStar_List.append effect_binders1
                                   other_binders) in
                            let t1 = FStar_Syntax_Subst.subst subst t in
-                           let uu____12762 =
+                           let uu___6 =
                              FStar_TypeChecker_TcTerm.tc_term env3 t1 in
-                           match uu____12762 with
-                           | (t2, comp, uu____12775) -> (t2, comp) in
+                           match uu___6 with
+                           | (t2, comp, uu___7) -> (t2, comp) in
                          let mk x =
                            FStar_Syntax_Syntax.mk x
                              signature.FStar_Syntax_Syntax.pos in
-                         let uu____12784 =
-                           let uu____12789 =
-                             let uu____12790 =
-                               let uu____12799 =
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr in
-                               FStar_All.pipe_right uu____12799
-                                 FStar_Util.must in
-                             FStar_All.pipe_right uu____12790
+                               FStar_All.pipe_right uu___9 FStar_Util.must in
+                             FStar_All.pipe_right uu___8
                                FStar_Pervasives_Native.snd in
-                           open_and_check env2 [] uu____12789 in
-                         (match uu____12784 with
+                           open_and_check env2 [] uu___7 in
+                         (match uu___6 with
                           | (repr, _comp) ->
-                              ((let uu____12845 =
+                              ((let uu___8 =
                                   FStar_TypeChecker_Env.debug env2
                                     (FStar_Options.Other "ED") in
-                                if uu____12845
+                                if uu___8
                                 then
-                                  let uu____12846 =
+                                  let uu___9 =
                                     FStar_Syntax_Print.term_to_string repr in
                                   FStar_Util.print1 "Representation is: %s\n"
-                                    uu____12846
+                                    uu___9
                                 else ());
                                (let ed_range =
                                   FStar_TypeChecker_Env.get_range env2 in
@@ -3534,50 +3445,48 @@ let (cps_and_elaborate :
                                     (FStar_TypeChecker_TcTerm.tc_constant
                                        env2 FStar_Range.dummyRange) in
                                 let wp_type = star_type dmff_env repr in
-                                let uu____12851 =
-                                  recheck_debug "*" env2 wp_type in
+                                let uu___8 = recheck_debug "*" env2 wp_type in
                                 let wp_a =
-                                  let uu____12853 =
-                                    let uu____12854 =
-                                      let uu____12855 =
-                                        let uu____12872 =
-                                          let uu____12883 =
-                                            let uu____12892 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          let uu___13 =
+                                            let uu___14 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a1 in
-                                            let uu____12895 =
+                                            let uu___15 =
                                               FStar_Syntax_Syntax.as_implicit
                                                 false in
-                                            (uu____12892, uu____12895) in
-                                          [uu____12883] in
-                                        (wp_type, uu____12872) in
-                                      FStar_Syntax_Syntax.Tm_app uu____12855 in
-                                    mk uu____12854 in
+                                            (uu___14, uu___15) in
+                                          [uu___13] in
+                                        (wp_type, uu___12) in
+                                      FStar_Syntax_Syntax.Tm_app uu___11 in
+                                    mk uu___10 in
                                   FStar_TypeChecker_Normalize.normalize
-                                    [FStar_TypeChecker_Env.Beta] env2
-                                    uu____12853 in
+                                    [FStar_TypeChecker_Env.Beta] env2 uu___9 in
                                 let effect_signature =
                                   let binders =
-                                    let uu____12942 =
-                                      let uu____12949 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_Syntax_Syntax.as_implicit false in
-                                      (a1, uu____12949) in
-                                    let uu____12954 =
-                                      let uu____12963 =
-                                        let uu____12970 =
+                                      (a1, uu___10) in
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
                                           FStar_Syntax_Syntax.gen_bv
                                             "dijkstra_wp"
                                             FStar_Pervasives_Native.None wp_a in
-                                        FStar_All.pipe_right uu____12970
+                                        FStar_All.pipe_right uu___12
                                           FStar_Syntax_Syntax.mk_binder in
-                                      [uu____12963] in
-                                    uu____12942 :: uu____12954 in
+                                      [uu___11] in
+                                    uu___9 :: uu___10 in
                                   let binders1 =
                                     FStar_Syntax_Subst.close_binders binders in
                                   mk
                                     (FStar_Syntax_Syntax.Tm_arrow
                                        (binders1, effect_marker)) in
-                                let uu____13006 =
+                                let uu___9 =
                                   recheck_debug
                                     "turned into the effect signature" env2
                                     effect_signature in
@@ -3587,72 +3496,69 @@ let (cps_and_elaborate :
                                 let elaborate_and_star dmff_env1
                                   other_binders item =
                                   let env3 = get_env dmff_env1 in
-                                  let uu____13069 = item in
-                                  match uu____13069 with
+                                  let uu___10 = item in
+                                  match uu___10 with
                                   | (u_item, item1) ->
-                                      let uu____13084 =
+                                      let uu___11 =
                                         open_and_check env3 other_binders
                                           item1 in
-                                      (match uu____13084 with
+                                      (match uu___11 with
                                        | (item2, item_comp) ->
-                                           ((let uu____13100 =
-                                               let uu____13101 =
+                                           ((let uu___13 =
+                                               let uu___14 =
                                                  FStar_TypeChecker_Common.is_total_lcomp
                                                    item_comp in
-                                               Prims.op_Negation uu____13101 in
-                                             if uu____13100
+                                               Prims.op_Negation uu___14 in
+                                             if uu___13
                                              then
-                                               let uu____13102 =
-                                                 let uu____13107 =
-                                                   let uu____13108 =
+                                               let uu___14 =
+                                                 let uu___15 =
+                                                   let uu___16 =
                                                      FStar_Syntax_Print.term_to_string
                                                        item2 in
-                                                   let uu____13109 =
+                                                   let uu___17 =
                                                      FStar_TypeChecker_Common.lcomp_to_string
                                                        item_comp in
                                                    FStar_Util.format2
                                                      "Computation for [%s] is not total : %s !"
-                                                     uu____13108 uu____13109 in
+                                                     uu___16 uu___17 in
                                                  (FStar_Errors.Fatal_ComputationNotTotal,
-                                                   uu____13107) in
-                                               FStar_Errors.raise_err
-                                                 uu____13102
+                                                   uu___15) in
+                                               FStar_Errors.raise_err uu___14
                                              else ());
-                                            (let uu____13111 =
+                                            (let uu___13 =
                                                star_expr dmff_env1 item2 in
-                                             match uu____13111 with
+                                             match uu___13 with
                                              | (item_t, item_wp, item_elab)
                                                  ->
-                                                 let uu____13129 =
+                                                 let uu___14 =
                                                    recheck_debug "*" env3
                                                      item_wp in
-                                                 let uu____13130 =
+                                                 let uu___15 =
                                                    recheck_debug "_" env3
                                                      item_elab in
                                                  (dmff_env1, item_t, item_wp,
                                                    item_elab)))) in
-                                let uu____13131 =
-                                  let uu____13140 =
-                                    let uu____13145 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr in
-                                    FStar_All.pipe_right uu____13145
+                                    FStar_All.pipe_right uu___12
                                       FStar_Util.must in
-                                  elaborate_and_star dmff_env [] uu____13140 in
-                                match uu____13131 with
-                                | (dmff_env1, uu____13173, bind_wp,
-                                   bind_elab) ->
-                                    let uu____13176 =
-                                      let uu____13185 =
-                                        let uu____13190 =
+                                  elaborate_and_star dmff_env [] uu___11 in
+                                match uu___10 with
+                                | (dmff_env1, uu___11, bind_wp, bind_elab) ->
+                                    let uu___12 =
+                                      let uu___13 =
+                                        let uu___14 =
                                           FStar_All.pipe_right ed
                                             FStar_Syntax_Util.get_return_repr in
-                                        FStar_All.pipe_right uu____13190
+                                        FStar_All.pipe_right uu___14
                                           FStar_Util.must in
-                                      elaborate_and_star dmff_env1 []
-                                        uu____13185 in
-                                    (match uu____13176 with
-                                     | (dmff_env2, uu____13218, return_wp,
+                                      elaborate_and_star dmff_env1 [] uu___13 in
+                                    (match uu___12 with
+                                     | (dmff_env2, uu___13, return_wp,
                                         return_elab) ->
                                          let rc_gtot =
                                            {
@@ -3665,86 +3571,78 @@ let (cps_and_elaborate :
                                                = []
                                            } in
                                          let lift_from_pure_wp =
-                                           let uu____13227 =
-                                             let uu____13228 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp in
-                                             uu____13228.FStar_Syntax_Syntax.n in
-                                           match uu____13227 with
+                                             uu___15.FStar_Syntax_Syntax.n in
+                                           match uu___14 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs, body, what) ->
-                                               let uu____13286 =
-                                                 let uu____13305 =
-                                                   let uu____13310 =
+                                               let uu___15 =
+                                                 let uu___16 =
+                                                   let uu___17 =
                                                      FStar_Syntax_Util.abs bs
                                                        body
                                                        FStar_Pervasives_Native.None in
                                                    FStar_Syntax_Subst.open_term
-                                                     [b1; b2] uu____13310 in
-                                                 match uu____13305 with
+                                                     [b1; b2] uu___17 in
+                                                 match uu___16 with
                                                  | (b11::b21::[], body1) ->
                                                      (b11, b21, body1)
-                                                 | uu____13392 ->
+                                                 | uu___17 ->
                                                      failwith
                                                        "Impossible : open_term not preserving binders arity" in
-                                               (match uu____13286 with
+                                               (match uu___15 with
                                                 | (b11, b21, body1) ->
                                                     let env0 =
-                                                      let uu____13445 =
+                                                      let uu___16 =
                                                         get_env dmff_env2 in
                                                       FStar_TypeChecker_Env.push_binders
-                                                        uu____13445
-                                                        [b11; b21] in
+                                                        uu___16 [b11; b21] in
                                                     let wp_b1 =
                                                       let raw_wp_b1 =
-                                                        let uu____13468 =
-                                                          let uu____13469 =
-                                                            let uu____13486 =
-                                                              let uu____13497
-                                                                =
-                                                                let uu____13506
-                                                                  =
+                                                        let uu___16 =
+                                                          let uu___17 =
+                                                            let uu___18 =
+                                                              let uu___19 =
+                                                                let uu___20 =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     (
                                                                     FStar_Pervasives_Native.fst
                                                                     b11) in
-                                                                let uu____13511
-                                                                  =
+                                                                let uu___21 =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false in
-                                                                (uu____13506,
-                                                                  uu____13511) in
-                                                              [uu____13497] in
+                                                                (uu___20,
+                                                                  uu___21) in
+                                                              [uu___19] in
                                                             (wp_type,
-                                                              uu____13486) in
+                                                              uu___18) in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____13469 in
-                                                        mk uu____13468 in
+                                                            uu___17 in
+                                                        mk uu___16 in
                                                       FStar_TypeChecker_Normalize.normalize
                                                         [FStar_TypeChecker_Env.Beta]
                                                         env0 raw_wp_b1 in
-                                                    let uu____13546 =
-                                                      let uu____13555 =
-                                                        let uu____13556 =
+                                                    let uu___16 =
+                                                      let uu___17 =
+                                                        let uu___18 =
                                                           FStar_Syntax_Util.unascribe
                                                             wp_b1 in
                                                         FStar_TypeChecker_Normalize.eta_expand_with_type
-                                                          env0 body1
-                                                          uu____13556 in
+                                                          env0 body1 uu___18 in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Util.abs_formals
-                                                        uu____13555 in
-                                                    (match uu____13546 with
+                                                        uu___17 in
+                                                    (match uu___16 with
                                                      | (bs1, body2, what') ->
-                                                         let fail uu____13579
-                                                           =
+                                                         let fail uu___17 =
                                                            let error_msg =
-                                                             let uu____13581
-                                                               =
+                                                             let uu___18 =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body2 in
-                                                             let uu____13582
-                                                               =
+                                                             let uu___19 =
                                                                match what'
                                                                with
                                                                | FStar_Pervasives_Native.None
@@ -3755,8 +3653,8 @@ let (cps_and_elaborate :
                                                                     rc.FStar_Syntax_Syntax.residual_effect in
                                                              FStar_Util.format2
                                                                "The body of return_wp (%s) should be of type Type0 but is of type %s"
-                                                               uu____13581
-                                                               uu____13582 in
+                                                               uu___18
+                                                               uu___19 in
                                                            raise_error
                                                              (FStar_Errors.Fatal_WrongBodyTypeForReturnWP,
                                                                error_msg) in
@@ -3765,19 +3663,18 @@ let (cps_and_elaborate :
                                                                -> fail ()
                                                            | FStar_Pervasives_Native.Some
                                                                rc ->
-                                                               ((let uu____13587
+                                                               ((let uu___19
                                                                    =
-                                                                   let uu____13588
+                                                                   let uu___20
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_effect
                                                                     rc.FStar_Syntax_Syntax.residual_effect in
                                                                    Prims.op_Negation
-                                                                    uu____13588 in
-                                                                 if
-                                                                   uu____13587
+                                                                    uu___20 in
+                                                                 if uu___19
                                                                  then fail ()
                                                                  else ());
-                                                                (let uu____13590
+                                                                (let uu___19
                                                                    =
                                                                    FStar_Util.map_opt
                                                                     rc.FStar_Syntax_Syntax.residual_typ
@@ -3801,9 +3698,9 @@ let (cps_and_elaborate :
                                                                     ->
                                                                     fail ()) in
                                                                  FStar_All.pipe_right
-                                                                   uu____13590
+                                                                   uu___19
                                                                    (fun
-                                                                    uu____13607
+                                                                    uu___20
                                                                     -> ()))));
                                                           (let wp =
                                                              let t2 =
@@ -3817,76 +3714,69 @@ let (cps_and_elaborate :
                                                                FStar_Pervasives_Native.None
                                                                pure_wp_type in
                                                            let body3 =
-                                                             let uu____13616
-                                                               =
+                                                             let uu___18 =
                                                                FStar_Syntax_Syntax.bv_to_name
                                                                  wp in
-                                                             let uu____13617
-                                                               =
-                                                               let uu____13618
-                                                                 =
-                                                                 let uu____13627
+                                                             let uu___19 =
+                                                               let uu___20 =
+                                                                 let uu___21
                                                                    =
                                                                    FStar_Syntax_Util.abs
                                                                     [b21]
                                                                     body2
                                                                     what' in
-                                                                 (uu____13627,
+                                                                 (uu___21,
                                                                    FStar_Pervasives_Native.None) in
-                                                               [uu____13618] in
+                                                               [uu___20] in
                                                              FStar_Syntax_Syntax.mk_Tm_app
-                                                               uu____13616
-                                                               uu____13617
+                                                               uu___18
+                                                               uu___19
                                                                ed_range in
-                                                           let uu____13662 =
-                                                             let uu____13663
-                                                               =
-                                                               let uu____13672
-                                                                 =
+                                                           let uu___18 =
+                                                             let uu___19 =
+                                                               let uu___20 =
                                                                  FStar_Syntax_Syntax.mk_binder
                                                                    wp in
-                                                               [uu____13672] in
-                                                             b11 ::
-                                                               uu____13663 in
-                                                           let uu____13697 =
+                                                               [uu___20] in
+                                                             b11 :: uu___19 in
+                                                           let uu___19 =
                                                              FStar_Syntax_Util.abs
                                                                bs1 body3 what in
                                                            FStar_Syntax_Util.abs
-                                                             uu____13662
-                                                             uu____13697
+                                                             uu___18 uu___19
                                                              (FStar_Pervasives_Native.Some
                                                                 rc_gtot)))))
-                                           | uu____13700 ->
+                                           | uu___15 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return") in
                                          let return_wp1 =
-                                           let uu____13706 =
-                                             let uu____13707 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp in
-                                             uu____13707.FStar_Syntax_Syntax.n in
-                                           match uu____13706 with
+                                             uu___15.FStar_Syntax_Syntax.n in
+                                           match uu___14 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs, body, what) ->
-                                               let uu____13765 =
+                                               let uu___15 =
                                                  FStar_Syntax_Util.abs bs
                                                    body what in
                                                FStar_Syntax_Util.abs 
-                                                 [b1; b2] uu____13765
+                                                 [b1; b2] uu___15
                                                  (FStar_Pervasives_Native.Some
                                                     rc_gtot)
-                                           | uu____13786 ->
+                                           | uu___15 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return") in
                                          let bind_wp1 =
-                                           let uu____13792 =
-                                             let uu____13793 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                FStar_Syntax_Subst.compress
                                                  bind_wp in
-                                             uu____13793.FStar_Syntax_Syntax.n in
-                                           match uu____13792 with
+                                             uu___15.FStar_Syntax_Syntax.n in
+                                           match uu___14 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (binders, body, what) ->
                                                let r =
@@ -3895,21 +3785,21 @@ let (cps_and_elaborate :
                                                    (FStar_Syntax_Syntax.Delta_constant_at_level
                                                       Prims.int_one)
                                                    FStar_Pervasives_Native.None in
-                                               let uu____13826 =
-                                                 let uu____13827 =
-                                                   let uu____13836 =
-                                                     let uu____13843 =
+                                               let uu___15 =
+                                                 let uu___16 =
+                                                   let uu___17 =
+                                                     let uu___18 =
                                                        mk
                                                          (FStar_Syntax_Syntax.Tm_fvar
                                                             r) in
                                                      FStar_Syntax_Syntax.null_binder
-                                                       uu____13843 in
-                                                   [uu____13836] in
-                                                 FStar_List.append
-                                                   uu____13827 binders in
-                                               FStar_Syntax_Util.abs
-                                                 uu____13826 body what
-                                           | uu____13862 ->
+                                                       uu___18 in
+                                                   [uu___17] in
+                                                 FStar_List.append uu___16
+                                                   binders in
+                                               FStar_Syntax_Util.abs uu___15
+                                                 body what
+                                           | uu___15 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedBindShape,
                                                    "unexpected shape for bind") in
@@ -3920,33 +3810,32 @@ let (cps_and_elaborate :
                                                = Prims.int_zero
                                            then t
                                            else
-                                             (let uu____13886 =
-                                                let uu____13887 =
-                                                  let uu____13888 =
-                                                    let uu____13905 =
-                                                      let uu____13916 =
+                                             (let uu___15 =
+                                                let uu___16 =
+                                                  let uu___17 =
+                                                    let uu___18 =
+                                                      let uu___19 =
                                                         FStar_Syntax_Util.args_of_binders
                                                           effect_binders1 in
                                                       FStar_Pervasives_Native.snd
-                                                        uu____13916 in
-                                                    (t, uu____13905) in
+                                                        uu___19 in
+                                                    (t, uu___18) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____13888 in
-                                                mk uu____13887 in
+                                                    uu___17 in
+                                                mk uu___16 in
                                               FStar_Syntax_Subst.close
-                                                effect_binders1 uu____13886) in
+                                                effect_binders1 uu___15) in
                                          let rec apply_last f l =
                                            match l with
                                            | [] ->
                                                failwith
                                                  "impossible: empty path.."
                                            | a2::[] ->
-                                               let uu____13960 = f a2 in
-                                               [uu____13960]
+                                               let uu___14 = f a2 in
+                                               [uu___14]
                                            | x::xs ->
-                                               let uu____13965 =
-                                                 apply_last f xs in
-                                               x :: uu____13965 in
+                                               let uu___14 = apply_last f xs in
+                                               x :: uu___14 in
                                          let register maybe_admit name item =
                                            let p =
                                              FStar_Ident.path_of_lid
@@ -3962,89 +3851,84 @@ let (cps_and_elaborate :
                                            let l' =
                                              FStar_Ident.lid_of_path p'
                                                ed_range in
-                                           let uu____13996 =
+                                           let uu___14 =
                                              FStar_TypeChecker_Env.try_lookup_lid
                                                env2 l' in
-                                           match uu____13996 with
+                                           match uu___14 with
                                            | FStar_Pervasives_Native.Some
                                                (_us, _t) ->
-                                               ((let uu____14026 =
+                                               ((let uu___16 =
                                                    FStar_Options.debug_any () in
-                                                 if uu____14026
+                                                 if uu___16
                                                  then
-                                                   let uu____14027 =
+                                                   let uu___17 =
                                                      FStar_Ident.string_of_lid
                                                        l' in
                                                    FStar_Util.print1
                                                      "DM4F: Applying override %s\n"
-                                                     uu____14027
+                                                     uu___17
                                                  else ());
-                                                (let uu____14029 =
+                                                (let uu___16 =
                                                    FStar_Syntax_Syntax.lid_as_fv
                                                      l'
                                                      FStar_Syntax_Syntax.delta_equational
                                                      FStar_Pervasives_Native.None in
                                                  FStar_Syntax_Syntax.fv_to_tm
-                                                   uu____14029))
+                                                   uu___16))
                                            | FStar_Pervasives_Native.None ->
-                                               let uu____14038 =
-                                                 let uu____14043 =
-                                                   mk_lid name in
-                                                 let uu____14044 =
+                                               let uu___15 =
+                                                 let uu___16 = mk_lid name in
+                                                 let uu___17 =
                                                    FStar_Syntax_Util.abs
                                                      effect_binders1 item
                                                      FStar_Pervasives_Native.None in
                                                  FStar_TypeChecker_Util.mk_toplevel_definition
-                                                   env2 uu____14043
-                                                   uu____14044 in
-                                               (match uu____14038 with
+                                                   env2 uu___16 uu___17 in
+                                               (match uu___15 with
                                                 | (sigelt, fv) ->
                                                     let sigelt1 =
                                                       if maybe_admit
                                                       then
-                                                        let uu___1544_14048 =
-                                                          sigelt in
+                                                        let uu___16 = sigelt in
                                                         {
                                                           FStar_Syntax_Syntax.sigel
                                                             =
-                                                            (uu___1544_14048.FStar_Syntax_Syntax.sigel);
+                                                            (uu___16.FStar_Syntax_Syntax.sigel);
                                                           FStar_Syntax_Syntax.sigrng
                                                             =
-                                                            (uu___1544_14048.FStar_Syntax_Syntax.sigrng);
+                                                            (uu___16.FStar_Syntax_Syntax.sigrng);
                                                           FStar_Syntax_Syntax.sigquals
                                                             =
-                                                            (uu___1544_14048.FStar_Syntax_Syntax.sigquals);
+                                                            (uu___16.FStar_Syntax_Syntax.sigquals);
                                                           FStar_Syntax_Syntax.sigmeta
                                                             =
-                                                            (let uu___1546_14050
-                                                               =
+                                                            (let uu___17 =
                                                                sigelt.FStar_Syntax_Syntax.sigmeta in
                                                              {
                                                                FStar_Syntax_Syntax.sigmeta_active
                                                                  =
-                                                                 (uu___1546_14050.FStar_Syntax_Syntax.sigmeta_active);
+                                                                 (uu___17.FStar_Syntax_Syntax.sigmeta_active);
                                                                FStar_Syntax_Syntax.sigmeta_fact_db_ids
                                                                  =
-                                                                 (uu___1546_14050.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
+                                                                 (uu___17.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
                                                                FStar_Syntax_Syntax.sigmeta_admit
                                                                  = true
                                                              });
                                                           FStar_Syntax_Syntax.sigattrs
                                                             =
-                                                            (uu___1544_14048.FStar_Syntax_Syntax.sigattrs);
+                                                            (uu___16.FStar_Syntax_Syntax.sigattrs);
                                                           FStar_Syntax_Syntax.sigopts
                                                             =
-                                                            (uu___1544_14048.FStar_Syntax_Syntax.sigopts)
+                                                            (uu___16.FStar_Syntax_Syntax.sigopts)
                                                         }
                                                       else sigelt in
-                                                    ((let uu____14053 =
-                                                        let uu____14056 =
+                                                    ((let uu___17 =
+                                                        let uu___18 =
                                                           FStar_ST.op_Bang
                                                             sigelts in
-                                                        sigelt1 ::
-                                                          uu____14056 in
+                                                        sigelt1 :: uu___18 in
                                                       FStar_ST.op_Colon_Equals
-                                                        sigelts uu____14053);
+                                                        sigelts uu___17);
                                                      fv)) in
                                          let register_admit = register true in
                                          let register1 = register false in
@@ -4052,115 +3936,113 @@ let (cps_and_elaborate :
                                            register1 "lift_from_pure"
                                              lift_from_pure_wp in
                                          let mk_sigelt se =
-                                           let uu___1555_14108 =
+                                           let uu___14 =
                                              FStar_Syntax_Syntax.mk_sigelt se in
                                            {
                                              FStar_Syntax_Syntax.sigel =
-                                               (uu___1555_14108.FStar_Syntax_Syntax.sigel);
+                                               (uu___14.FStar_Syntax_Syntax.sigel);
                                              FStar_Syntax_Syntax.sigrng =
                                                ed_range;
                                              FStar_Syntax_Syntax.sigquals =
-                                               (uu___1555_14108.FStar_Syntax_Syntax.sigquals);
+                                               (uu___14.FStar_Syntax_Syntax.sigquals);
                                              FStar_Syntax_Syntax.sigmeta =
-                                               (uu___1555_14108.FStar_Syntax_Syntax.sigmeta);
+                                               (uu___14.FStar_Syntax_Syntax.sigmeta);
                                              FStar_Syntax_Syntax.sigattrs =
-                                               (uu___1555_14108.FStar_Syntax_Syntax.sigattrs);
+                                               (uu___14.FStar_Syntax_Syntax.sigattrs);
                                              FStar_Syntax_Syntax.sigopts =
-                                               (uu___1555_14108.FStar_Syntax_Syntax.sigopts)
+                                               (uu___14.FStar_Syntax_Syntax.sigopts)
                                            } in
                                          let return_wp2 =
                                            register1 "return_wp" return_wp1 in
-                                         ((let uu____14111 =
-                                             let uu____14114 =
+                                         ((let uu___15 =
+                                             let uu___16 =
                                                mk_sigelt
                                                  (FStar_Syntax_Syntax.Sig_pragma
                                                     (FStar_Syntax_Syntax.PushOptions
                                                        FStar_Pervasives_Native.None)) in
-                                             let uu____14115 =
+                                             let uu___17 =
                                                FStar_ST.op_Bang sigelts in
-                                             uu____14114 :: uu____14115 in
+                                             uu___16 :: uu___17 in
                                            FStar_ST.op_Colon_Equals sigelts
-                                             uu____14111);
+                                             uu___15);
                                           (let return_elab1 =
                                              register_admit "return_elab"
                                                return_elab in
-                                           (let uu____14140 =
-                                              let uu____14143 =
+                                           (let uu___16 =
+                                              let uu___17 =
                                                 mk_sigelt
                                                   (FStar_Syntax_Syntax.Sig_pragma
                                                      FStar_Syntax_Syntax.PopOptions) in
-                                              let uu____14144 =
+                                              let uu___18 =
                                                 FStar_ST.op_Bang sigelts in
-                                              uu____14143 :: uu____14144 in
+                                              uu___17 :: uu___18 in
                                             FStar_ST.op_Colon_Equals sigelts
-                                              uu____14140);
+                                              uu___16);
                                            (let bind_wp2 =
                                               register1 "bind_wp" bind_wp1 in
-                                            (let uu____14169 =
-                                               let uu____14172 =
+                                            (let uu___17 =
+                                               let uu___18 =
                                                  mk_sigelt
                                                    (FStar_Syntax_Syntax.Sig_pragma
                                                       (FStar_Syntax_Syntax.PushOptions
                                                          FStar_Pervasives_Native.None)) in
-                                               let uu____14173 =
+                                               let uu___19 =
                                                  FStar_ST.op_Bang sigelts in
-                                               uu____14172 :: uu____14173 in
+                                               uu___18 :: uu___19 in
                                              FStar_ST.op_Colon_Equals sigelts
-                                               uu____14169);
+                                               uu___17);
                                             (let bind_elab1 =
                                                register_admit "bind_elab"
                                                  bind_elab in
-                                             (let uu____14198 =
-                                                let uu____14201 =
+                                             (let uu___18 =
+                                                let uu___19 =
                                                   mk_sigelt
                                                     (FStar_Syntax_Syntax.Sig_pragma
                                                        FStar_Syntax_Syntax.PopOptions) in
-                                                let uu____14202 =
+                                                let uu___20 =
                                                   FStar_ST.op_Bang sigelts in
-                                                uu____14201 :: uu____14202 in
+                                                uu___19 :: uu___20 in
                                               FStar_ST.op_Colon_Equals
-                                                sigelts uu____14198);
-                                             (let uu____14225 =
+                                                sigelts uu___18);
+                                             (let uu___18 =
                                                 FStar_List.fold_left
-                                                  (fun uu____14265 ->
+                                                  (fun uu___19 ->
                                                      fun action ->
-                                                       match uu____14265 with
+                                                       match uu___19 with
                                                        | (dmff_env3, actions)
                                                            ->
                                                            let params_un =
                                                              FStar_Syntax_Subst.open_binders
                                                                action.FStar_Syntax_Syntax.action_params in
-                                                           let uu____14286 =
-                                                             let uu____14293
-                                                               =
+                                                           let uu___20 =
+                                                             let uu___21 =
                                                                get_env
                                                                  dmff_env3 in
                                                              FStar_TypeChecker_TcTerm.tc_tparams
-                                                               uu____14293
+                                                               uu___21
                                                                params_un in
-                                                           (match uu____14286
+                                                           (match uu___20
                                                             with
                                                             | (action_params,
-                                                               env',
-                                                               uu____14302)
+                                                               env', uu___21)
                                                                 ->
                                                                 let action_params1
                                                                   =
                                                                   FStar_List.map
                                                                     (
                                                                     fun
-                                                                    uu____14328
+                                                                    uu___22
                                                                     ->
-                                                                    match uu____14328
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     (bv,
                                                                     qual) ->
-                                                                    let uu____14347
+                                                                    let uu___23
                                                                     =
-                                                                    let uu___1577_14348
+                                                                    let uu___24
                                                                     = bv in
-                                                                    let uu____14349
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.EraseUniverses]
@@ -4169,15 +4051,14 @@ let (cps_and_elaborate :
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     =
-                                                                    (uu___1577_14348.FStar_Syntax_Syntax.ppname);
+                                                                    (uu___24.FStar_Syntax_Syntax.ppname);
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1577_14348.FStar_Syntax_Syntax.index);
+                                                                    (uu___24.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
-                                                                    =
-                                                                    uu____14349
+                                                                    = uu___25
                                                                     } in
-                                                                    (uu____14347,
+                                                                    (uu___23,
                                                                     qual))
                                                                     action_params in
                                                                 let dmff_env'
@@ -4185,14 +4066,13 @@ let (cps_and_elaborate :
                                                                   set_env
                                                                     dmff_env3
                                                                     env' in
-                                                                let uu____14355
-                                                                  =
+                                                                let uu___22 =
                                                                   elaborate_and_star
                                                                     dmff_env'
                                                                     action_params1
                                                                     ((action.FStar_Syntax_Syntax.action_univs),
                                                                     (action.FStar_Syntax_Syntax.action_defn)) in
-                                                                (match uu____14355
+                                                                (match uu___22
                                                                  with
                                                                  | (dmff_env4,
                                                                     action_t,
@@ -4201,12 +4081,12 @@ let (cps_and_elaborate :
                                                                     ->
                                                                     let name
                                                                     =
-                                                                    let uu____14375
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Ident.ident_of_lid
                                                                     action.FStar_Syntax_Syntax.action_name in
                                                                     FStar_Ident.string_of_id
-                                                                    uu____14375 in
+                                                                    uu___23 in
                                                                     let action_typ_with_wp
                                                                     =
                                                                     trans_F
@@ -4241,17 +4121,17 @@ let (cps_and_elaborate :
                                                                     [] ->
                                                                     action_typ_with_wp1
                                                                     | 
-                                                                    uu____14394
+                                                                    uu___23
                                                                     ->
-                                                                    let uu____14395
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     action_typ_with_wp1 in
                                                                     FStar_Syntax_Util.flat_arrow
                                                                     action_params2
-                                                                    uu____14395 in
+                                                                    uu___24 in
                                                                     ((
-                                                                    let uu____14399
+                                                                    let uu___24
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -4259,32 +4139,32 @@ let (cps_and_elaborate :
                                                                     (FStar_Options.Other
                                                                     "ED") in
                                                                     if
-                                                                    uu____14399
+                                                                    uu___24
                                                                     then
-                                                                    let uu____14400
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     params_un in
-                                                                    let uu____14401
+                                                                    let uu___26
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     action_params2 in
-                                                                    let uu____14402
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_typ_with_wp2 in
-                                                                    let uu____14403
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_elab2 in
                                                                     FStar_Util.print4
                                                                     "original action_params %s, end action_params %s, type %s, term %s\n"
-                                                                    uu____14400
-                                                                    uu____14401
-                                                                    uu____14402
-                                                                    uu____14403
+                                                                    uu___25
+                                                                    uu___26
+                                                                    uu___27
+                                                                    uu___28
                                                                     else ());
                                                                     (let action_elab3
                                                                     =
@@ -4300,47 +4180,45 @@ let (cps_and_elaborate :
                                                                     name
                                                                     "_complete_type")
                                                                     action_typ_with_wp2 in
-                                                                    let uu____14407
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____14410
+                                                                    let uu___25
                                                                     =
-                                                                    let uu___1599_14411
+                                                                    let uu___26
                                                                     = action in
-                                                                    let uu____14412
+                                                                    let uu___27
                                                                     =
                                                                     apply_close
                                                                     action_elab3 in
-                                                                    let uu____14413
+                                                                    let uu___28
                                                                     =
                                                                     apply_close
                                                                     action_typ_with_wp3 in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___1599_14411.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___26.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___1599_14411.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___26.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     =
-                                                                    (uu___1599_14411.FStar_Syntax_Syntax.action_univs);
+                                                                    (uu___26.FStar_Syntax_Syntax.action_univs);
                                                                     FStar_Syntax_Syntax.action_params
                                                                     = [];
                                                                     FStar_Syntax_Syntax.action_defn
-                                                                    =
-                                                                    uu____14412;
+                                                                    = uu___27;
                                                                     FStar_Syntax_Syntax.action_typ
-                                                                    =
-                                                                    uu____14413
+                                                                    = uu___28
                                                                     } in
-                                                                    uu____14410
+                                                                    uu___25
                                                                     ::
                                                                     actions in
                                                                     (dmff_env4,
-                                                                    uu____14407))))))
+                                                                    uu___24))))))
                                                   (dmff_env2, [])
                                                   ed.FStar_Syntax_Syntax.actions in
-                                              match uu____14225 with
+                                              match uu___18 with
                                               | (dmff_env3, actions) ->
                                                   let actions1 =
                                                     FStar_List.rev actions in
@@ -4351,142 +4229,132 @@ let (cps_and_elaborate :
                                                         FStar_Pervasives_Native.None
                                                         wp_a in
                                                     let binders =
-                                                      let uu____14456 =
+                                                      let uu___19 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           a1 in
-                                                      let uu____14463 =
-                                                        let uu____14472 =
+                                                      let uu___20 =
+                                                        let uu___21 =
                                                           FStar_Syntax_Syntax.mk_binder
                                                             wp in
-                                                        [uu____14472] in
-                                                      uu____14456 ::
-                                                        uu____14463 in
-                                                    let uu____14497 =
-                                                      let uu____14500 =
-                                                        let uu____14501 =
-                                                          let uu____14502 =
-                                                            let uu____14519 =
-                                                              let uu____14530
-                                                                =
-                                                                let uu____14539
-                                                                  =
+                                                        [uu___21] in
+                                                      uu___19 :: uu___20 in
+                                                    let uu___19 =
+                                                      let uu___20 =
+                                                        let uu___21 =
+                                                          let uu___22 =
+                                                            let uu___23 =
+                                                              let uu___24 =
+                                                                let uu___25 =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a1 in
-                                                                let uu____14542
-                                                                  =
+                                                                let uu___26 =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false in
-                                                                (uu____14539,
-                                                                  uu____14542) in
-                                                              [uu____14530] in
-                                                            (repr,
-                                                              uu____14519) in
+                                                                (uu___25,
+                                                                  uu___26) in
+                                                              [uu___24] in
+                                                            (repr, uu___23) in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____14502 in
-                                                        mk uu____14501 in
-                                                      let uu____14577 =
+                                                            uu___22 in
+                                                        mk uu___21 in
+                                                      let uu___21 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           wp in
                                                       trans_F dmff_env3
-                                                        uu____14500
-                                                        uu____14577 in
+                                                        uu___20 uu___21 in
                                                     FStar_Syntax_Util.abs
-                                                      binders uu____14497
+                                                      binders uu___19
                                                       FStar_Pervasives_Native.None in
-                                                  let uu____14578 =
+                                                  let uu___19 =
                                                     recheck_debug "FC" env2
                                                       repr1 in
                                                   let repr2 =
                                                     register1 "repr" repr1 in
-                                                  let uu____14580 =
-                                                    let uu____14589 =
-                                                      let uu____14590 =
-                                                        let uu____14593 =
+                                                  let uu___20 =
+                                                    let uu___21 =
+                                                      let uu___22 =
+                                                        let uu___23 =
                                                           FStar_Syntax_Subst.compress
                                                             wp_type in
                                                         FStar_All.pipe_left
                                                           FStar_Syntax_Util.unascribe
-                                                          uu____14593 in
-                                                      uu____14590.FStar_Syntax_Syntax.n in
-                                                    match uu____14589 with
+                                                          uu___23 in
+                                                      uu___22.FStar_Syntax_Syntax.n in
+                                                    match uu___21 with
                                                     | FStar_Syntax_Syntax.Tm_abs
                                                         (type_param::effect_param,
-                                                         arrow, uu____14607)
+                                                         arrow, uu___22)
                                                         ->
-                                                        let uu____14644 =
-                                                          let uu____14665 =
+                                                        let uu___23 =
+                                                          let uu___24 =
                                                             FStar_Syntax_Subst.open_term
                                                               (type_param ::
                                                               effect_param)
                                                               arrow in
-                                                          match uu____14665
-                                                          with
+                                                          match uu___24 with
                                                           | (b::bs, body) ->
                                                               (b, bs, body)
-                                                          | uu____14733 ->
+                                                          | uu___25 ->
                                                               failwith
                                                                 "Impossible : open_term nt preserving binders arity" in
-                                                        (match uu____14644
-                                                         with
+                                                        (match uu___23 with
                                                          | (type_param1,
                                                             effect_param1,
                                                             arrow1) ->
-                                                             let uu____14797
-                                                               =
-                                                               let uu____14798
-                                                                 =
-                                                                 let uu____14801
+                                                             let uu___24 =
+                                                               let uu___25 =
+                                                                 let uu___26
                                                                    =
                                                                    FStar_Syntax_Subst.compress
                                                                     arrow1 in
                                                                  FStar_All.pipe_left
                                                                    FStar_Syntax_Util.unascribe
-                                                                   uu____14801 in
-                                                               uu____14798.FStar_Syntax_Syntax.n in
-                                                             (match uu____14797
+                                                                   uu___26 in
+                                                               uu___25.FStar_Syntax_Syntax.n in
+                                                             (match uu___24
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_arrow
                                                                   (wp_binders,
                                                                    c)
                                                                   ->
-                                                                  let uu____14834
+                                                                  let uu___25
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     wp_binders
                                                                     c in
-                                                                  (match uu____14834
+                                                                  (match uu___25
                                                                    with
                                                                    | 
                                                                    (wp_binders1,
                                                                     c1) ->
-                                                                    let uu____14849
+                                                                    let uu___26
                                                                     =
                                                                     FStar_List.partition
                                                                     (fun
-                                                                    uu____14880
+                                                                    uu___27
                                                                     ->
-                                                                    match uu____14880
+                                                                    match uu___27
                                                                     with
                                                                     | 
                                                                     (bv,
-                                                                    uu____14888)
+                                                                    uu___28)
                                                                     ->
-                                                                    let uu____14893
+                                                                    let uu___29
                                                                     =
-                                                                    let uu____14894
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Free.names
                                                                     bv.FStar_Syntax_Syntax.sort in
                                                                     FStar_All.pipe_right
-                                                                    uu____14894
+                                                                    uu___30
                                                                     (FStar_Util.set_mem
                                                                     (FStar_Pervasives_Native.fst
                                                                     type_param1)) in
                                                                     FStar_All.pipe_right
-                                                                    uu____14893
+                                                                    uu___29
                                                                     Prims.op_Negation)
                                                                     wp_binders1 in
-                                                                    (match uu____14849
+                                                                    (match uu___26
                                                                     with
                                                                     | 
                                                                     (pre_args,
@@ -4497,43 +4365,43 @@ let (cps_and_elaborate :
                                                                     match post_args
                                                                     with
                                                                     | 
-                                                                    post::[]
-                                                                    -> post
+                                                                    post1::[]
+                                                                    -> post1
                                                                     | 
                                                                     [] ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____14982
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1 in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: no post candidate %s (Type variable does not appear)"
-                                                                    uu____14982 in
+                                                                    uu___27 in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
                                                                     | 
-                                                                    uu____14989
+                                                                    uu___27
                                                                     ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____14999
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1 in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: multiple post candidates %s"
-                                                                    uu____14999 in
+                                                                    uu___28 in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg) in
-                                                                    let uu____15006
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Util.arrow
                                                                     pre_args
                                                                     c1 in
-                                                                    let uu____15009
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Util.abs
                                                                     (type_param1
@@ -4542,49 +4410,47 @@ let (cps_and_elaborate :
                                                                     (FStar_Pervasives_Native.fst
                                                                     post).FStar_Syntax_Syntax.sort
                                                                     FStar_Pervasives_Native.None in
-                                                                    (uu____15006,
-                                                                    uu____15009)))
-                                                              | uu____15024
-                                                                  ->
-                                                                  let uu____15025
+                                                                    (uu___27,
+                                                                    uu___28)))
+                                                              | uu___25 ->
+                                                                  let uu___26
                                                                     =
-                                                                    let uu____15030
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____15031
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1 in
                                                                     FStar_Util.format1
                                                                     "Impossible: pre/post arrow %s"
-                                                                    uu____15031 in
+                                                                    uu___28 in
                                                                     (FStar_Errors.Fatal_ImpossiblePrePostArrow,
-                                                                    uu____15030) in
+                                                                    uu___27) in
                                                                   raise_error
-                                                                    uu____15025))
-                                                    | uu____15040 ->
-                                                        let uu____15041 =
-                                                          let uu____15046 =
-                                                            let uu____15047 =
+                                                                    uu___26))
+                                                    | uu___22 ->
+                                                        let uu___23 =
+                                                          let uu___24 =
+                                                            let uu___25 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 wp_type in
                                                             FStar_Util.format1
                                                               "Impossible: pre/post abs %s"
-                                                              uu____15047 in
+                                                              uu___25 in
                                                           (FStar_Errors.Fatal_ImpossiblePrePostAbs,
-                                                            uu____15046) in
-                                                        raise_error
-                                                          uu____15041 in
-                                                  (match uu____14580 with
+                                                            uu___24) in
+                                                        raise_error uu___23 in
+                                                  (match uu___20 with
                                                    | (pre, post) ->
-                                                       ((let uu____15077 =
+                                                       ((let uu___22 =
                                                            register1 "pre"
                                                              pre in
                                                          ());
-                                                        (let uu____15079 =
+                                                        (let uu___23 =
                                                            register1 "post"
                                                              post in
                                                          ());
-                                                        (let uu____15081 =
+                                                        (let uu___24 =
                                                            register1 "wp"
                                                              wp_type in
                                                          ());
@@ -4593,157 +4459,146 @@ let (cps_and_elaborate :
                                                            with
                                                            | FStar_Syntax_Syntax.DM4F_eff
                                                                combs ->
-                                                               let uu____15084
-                                                                 =
-                                                                 let uu___1657_15085
+                                                               let uu___24 =
+                                                                 let uu___25
                                                                    = combs in
-                                                                 let uu____15086
+                                                                 let uu___26
                                                                    =
-                                                                   let uu____15087
+                                                                   let uu___27
                                                                     =
                                                                     apply_close
                                                                     return_wp2 in
                                                                    ([],
-                                                                    uu____15087) in
-                                                                 let uu____15094
+                                                                    uu___27) in
+                                                                 let uu___27
                                                                    =
-                                                                   let uu____15095
+                                                                   let uu___28
                                                                     =
                                                                     apply_close
                                                                     bind_wp2 in
                                                                    ([],
-                                                                    uu____15095) in
-                                                                 let uu____15102
+                                                                    uu___28) in
+                                                                 let uu___28
                                                                    =
-                                                                   let uu____15105
+                                                                   let uu___29
                                                                     =
-                                                                    let uu____15106
+                                                                    let uu___30
                                                                     =
                                                                     apply_close
                                                                     repr2 in
                                                                     ([],
-                                                                    uu____15106) in
+                                                                    uu___30) in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____15105 in
-                                                                 let uu____15113
+                                                                    uu___29 in
+                                                                 let uu___29
                                                                    =
-                                                                   let uu____15116
+                                                                   let uu___30
                                                                     =
-                                                                    let uu____15117
+                                                                    let uu___31
                                                                     =
                                                                     apply_close
                                                                     return_elab1 in
                                                                     ([],
-                                                                    uu____15117) in
+                                                                    uu___31) in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____15116 in
-                                                                 let uu____15124
+                                                                    uu___30 in
+                                                                 let uu___30
                                                                    =
-                                                                   let uu____15127
+                                                                   let uu___31
                                                                     =
-                                                                    let uu____15128
+                                                                    let uu___32
                                                                     =
                                                                     apply_close
                                                                     bind_elab1 in
                                                                     ([],
-                                                                    uu____15128) in
+                                                                    uu___32) in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____15127 in
+                                                                    uu___31 in
                                                                  {
                                                                    FStar_Syntax_Syntax.ret_wp
-                                                                    =
-                                                                    uu____15086;
+                                                                    = uu___26;
                                                                    FStar_Syntax_Syntax.bind_wp
-                                                                    =
-                                                                    uu____15094;
+                                                                    = uu___27;
                                                                    FStar_Syntax_Syntax.stronger
                                                                     =
-                                                                    (uu___1657_15085.FStar_Syntax_Syntax.stronger);
+                                                                    (uu___25.FStar_Syntax_Syntax.stronger);
                                                                    FStar_Syntax_Syntax.if_then_else
                                                                     =
-                                                                    (uu___1657_15085.FStar_Syntax_Syntax.if_then_else);
+                                                                    (uu___25.FStar_Syntax_Syntax.if_then_else);
                                                                    FStar_Syntax_Syntax.ite_wp
                                                                     =
-                                                                    (uu___1657_15085.FStar_Syntax_Syntax.ite_wp);
+                                                                    (uu___25.FStar_Syntax_Syntax.ite_wp);
                                                                    FStar_Syntax_Syntax.close_wp
                                                                     =
-                                                                    (uu___1657_15085.FStar_Syntax_Syntax.close_wp);
+                                                                    (uu___25.FStar_Syntax_Syntax.close_wp);
                                                                    FStar_Syntax_Syntax.trivial
                                                                     =
-                                                                    (uu___1657_15085.FStar_Syntax_Syntax.trivial);
+                                                                    (uu___25.FStar_Syntax_Syntax.trivial);
                                                                    FStar_Syntax_Syntax.repr
-                                                                    =
-                                                                    uu____15102;
+                                                                    = uu___28;
                                                                    FStar_Syntax_Syntax.return_repr
-                                                                    =
-                                                                    uu____15113;
+                                                                    = uu___29;
                                                                    FStar_Syntax_Syntax.bind_repr
-                                                                    =
-                                                                    uu____15124
+                                                                    = uu___30
                                                                  } in
                                                                FStar_Syntax_Syntax.DM4F_eff
-                                                                 uu____15084
-                                                           | uu____15135 ->
+                                                                 uu___24
+                                                           | uu___24 ->
                                                                failwith
                                                                  "Impossible! For a DM4F effect combinators must be in DM4f_eff" in
                                                          let ed1 =
-                                                           let uu___1661_15137
-                                                             = ed in
-                                                           let uu____15138 =
+                                                           let uu___24 = ed in
+                                                           let uu___25 =
                                                              FStar_Syntax_Subst.close_binders
                                                                effect_binders1 in
-                                                           let uu____15139 =
-                                                             let uu____15140
-                                                               =
+                                                           let uu___26 =
+                                                             let uu___27 =
                                                                FStar_Syntax_Subst.close
                                                                  effect_binders1
                                                                  effect_signature in
-                                                             ([],
-                                                               uu____15140) in
+                                                             ([], uu___27) in
                                                            {
                                                              FStar_Syntax_Syntax.mname
                                                                =
-                                                               (uu___1661_15137.FStar_Syntax_Syntax.mname);
+                                                               (uu___24.FStar_Syntax_Syntax.mname);
                                                              FStar_Syntax_Syntax.cattributes
                                                                =
-                                                               (uu___1661_15137.FStar_Syntax_Syntax.cattributes);
+                                                               (uu___24.FStar_Syntax_Syntax.cattributes);
                                                              FStar_Syntax_Syntax.univs
                                                                =
-                                                               (uu___1661_15137.FStar_Syntax_Syntax.univs);
+                                                               (uu___24.FStar_Syntax_Syntax.univs);
                                                              FStar_Syntax_Syntax.binders
-                                                               = uu____15138;
+                                                               = uu___25;
                                                              FStar_Syntax_Syntax.signature
-                                                               = uu____15139;
+                                                               = uu___26;
                                                              FStar_Syntax_Syntax.combinators
                                                                = ed_combs;
                                                              FStar_Syntax_Syntax.actions
                                                                = actions1;
                                                              FStar_Syntax_Syntax.eff_attrs
                                                                =
-                                                               (uu___1661_15137.FStar_Syntax_Syntax.eff_attrs)
+                                                               (uu___24.FStar_Syntax_Syntax.eff_attrs)
                                                            } in
-                                                         let uu____15147 =
+                                                         let uu___24 =
                                                            gen_wps_for_free
                                                              env2
                                                              effect_binders1
                                                              a1 wp_a ed1 in
-                                                         match uu____15147
-                                                         with
+                                                         match uu___24 with
                                                          | (sigelts', ed2) ->
-                                                             ((let uu____15165
-                                                                 =
+                                                             ((let uu___26 =
                                                                  FStar_TypeChecker_Env.debug
                                                                    env2
                                                                    (FStar_Options.Other
                                                                     "ED") in
-                                                               if uu____15165
+                                                               if uu___26
                                                                then
-                                                                 let uu____15166
+                                                                 let uu___27
                                                                    =
                                                                    FStar_Syntax_Print.eff_decl_to_string
                                                                     true ed2 in
                                                                  FStar_Util.print_string
-                                                                   uu____15166
+                                                                   uu___27
                                                                else ());
                                                               (let lift_from_pure_opt
                                                                  =
@@ -4755,18 +4610,18 @@ let (cps_and_elaborate :
                                                                  then
                                                                    let lift_from_pure
                                                                     =
-                                                                    let uu____15180
+                                                                    let uu___26
                                                                     =
-                                                                    let uu____15183
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____15184
+                                                                    let uu___28
                                                                     =
                                                                     apply_close
                                                                     lift_from_pure_wp1 in
                                                                     ([],
-                                                                    uu____15184) in
+                                                                    uu___28) in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____15183 in
+                                                                    uu___27 in
                                                                     {
                                                                     FStar_Syntax_Syntax.source
                                                                     =
@@ -4775,34 +4630,31 @@ let (cps_and_elaborate :
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
                                                                     FStar_Syntax_Syntax.lift_wp
-                                                                    =
-                                                                    uu____15180;
+                                                                    = uu___26;
                                                                     FStar_Syntax_Syntax.lift
                                                                     =
                                                                     FStar_Pervasives_Native.None
                                                                     } in
-                                                                   let uu____15191
+                                                                   let uu___26
                                                                     =
                                                                     mk_sigelt
                                                                     (FStar_Syntax_Syntax.Sig_sub_effect
                                                                     lift_from_pure) in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____15191
+                                                                    uu___26
                                                                  else
                                                                    FStar_Pervasives_Native.None in
-                                                               let uu____15193
-                                                                 =
-                                                                 let uu____15196
+                                                               let uu___26 =
+                                                                 let uu___27
                                                                    =
-                                                                   let uu____15199
+                                                                   let uu___28
                                                                     =
                                                                     FStar_ST.op_Bang
                                                                     sigelts in
                                                                    FStar_List.rev
-                                                                    uu____15199 in
+                                                                    uu___28 in
                                                                  FStar_List.append
-                                                                   uu____15196
+                                                                   uu___27
                                                                    sigelts' in
-                                                               (uu____15193,
-                                                                 ed2,
+                                                               (uu___26, ed2,
                                                                  lift_from_pure_opt))))))))))))))))))

--- a/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
@@ -1,27 +1,27 @@
 open Prims
 let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____12 = FStar_Syntax_Util.head_and_args t in
-    match uu____12 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, _args) ->
-        let uu____55 =
-          let uu____56 = FStar_Syntax_Subst.compress head in
-          uu____56.FStar_Syntax_Syntax.n in
-        (match uu____55 with
-         | FStar_Syntax_Syntax.Tm_uvar uu____59 -> true
-         | uu____72 -> false)
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress head in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
+         | FStar_Syntax_Syntax.Tm_uvar uu___2 -> true
+         | uu___2 -> false)
 let (flex_uvar_head :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar) =
   fun t ->
-    let uu____78 = FStar_Syntax_Util.head_and_args t in
-    match uu____78 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, _args) ->
-        let uu____121 =
-          let uu____122 = FStar_Syntax_Subst.compress head in
-          uu____122.FStar_Syntax_Syntax.n in
-        (match uu____121 with
-         | FStar_Syntax_Syntax.Tm_uvar (u, uu____126) -> u
-         | uu____143 -> failwith "Not a flex-uvar")
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress head in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
+         | FStar_Syntax_Syntax.Tm_uvar (u, uu___2) -> u
+         | uu___2 -> failwith "Not a flex-uvar")
 type goal_type =
   | FlexRigid of (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.term) 
   | FlexFlex of (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.ctx_uvar)
@@ -31,26 +31,26 @@ type goal_type =
   | Imp of FStar_Syntax_Syntax.ctx_uvar 
 let (uu___is_FlexRigid : goal_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | FlexRigid _0 -> true | uu____188 -> false
+    match projectee with | FlexRigid _0 -> true | uu___ -> false
 let (__proj__FlexRigid__item___0 :
   goal_type -> (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.term)) =
   fun projectee -> match projectee with | FlexRigid _0 -> _0
 let (uu___is_FlexFlex : goal_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | FlexFlex _0 -> true | uu____217 -> false
+    match projectee with | FlexFlex _0 -> true | uu___ -> false
 let (__proj__FlexFlex__item___0 :
   goal_type -> (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.ctx_uvar))
   = fun projectee -> match projectee with | FlexFlex _0 -> _0
 let (uu___is_Can_be_split_into : goal_type -> Prims.bool) =
   fun projectee ->
-    match projectee with | Can_be_split_into _0 -> true | uu____248 -> false
+    match projectee with | Can_be_split_into _0 -> true | uu___ -> false
 let (__proj__Can_be_split_into__item___0 :
   goal_type ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term *
       FStar_Syntax_Syntax.ctx_uvar))
   = fun projectee -> match projectee with | Can_be_split_into _0 -> _0
 let (uu___is_Imp : goal_type -> Prims.bool) =
-  fun projectee -> match projectee with | Imp _0 -> true | uu____279 -> false
+  fun projectee -> match projectee with | Imp _0 -> true | uu___ -> false
 let (__proj__Imp__item___0 : goal_type -> FStar_Syntax_Syntax.ctx_uvar) =
   fun projectee -> match projectee with | Imp _0 -> _0
 type goal_dep =
@@ -106,33 +106,33 @@ type goal_deps = goal_dep Prims.list
 let (print_uvar_set :
   FStar_Syntax_Syntax.ctx_uvar FStar_Util.set -> Prims.string) =
   fun s ->
-    let uu____520 =
-      let uu____523 = FStar_Util.set_elements s in
-      FStar_All.pipe_right uu____523
+    let uu___ =
+      let uu___1 = FStar_Util.set_elements s in
+      FStar_All.pipe_right uu___1
         (FStar_List.map
            (fun u ->
-              let uu____533 =
-                let uu____534 =
+              let uu___2 =
+                let uu___3 =
                   FStar_Syntax_Unionfind.uvar_id
                     u.FStar_Syntax_Syntax.ctx_uvar_head in
-                FStar_All.pipe_left FStar_Util.string_of_int uu____534 in
-              Prims.op_Hat "?" uu____533)) in
-    FStar_All.pipe_right uu____520 (FStar_String.concat "; ")
+                FStar_All.pipe_left FStar_Util.string_of_int uu___3 in
+              Prims.op_Hat "?" uu___2)) in
+    FStar_All.pipe_right uu___ (FStar_String.concat "; ")
 let (print_goal_dep : goal_dep -> Prims.string) =
   fun gd ->
-    let uu____542 = FStar_Util.string_of_int gd.goal_dep_id in
-    let uu____543 = print_uvar_set gd.assignees in
-    let uu____544 =
-      let uu____545 =
-        let uu____548 = FStar_ST.op_Bang gd.dependences in
+    let uu___ = FStar_Util.string_of_int gd.goal_dep_id in
+    let uu___1 = print_uvar_set gd.assignees in
+    let uu___2 =
+      let uu___3 =
+        let uu___4 = FStar_ST.op_Bang gd.dependences in
         FStar_List.map (fun gd1 -> FStar_Util.string_of_int gd1.goal_dep_id)
-          uu____548 in
-      FStar_All.pipe_right uu____545 (FStar_String.concat "; ") in
-    let uu____565 =
+          uu___4 in
+      FStar_All.pipe_right uu___3 (FStar_String.concat "; ") in
+    let uu___3 =
       FStar_Syntax_Print.ctx_uvar_to_string
         (gd.goal_imp).FStar_TypeChecker_Common.imp_uvar in
-    FStar_Util.format4 "%s:{assignees=[%s], dependences=[%s]}\n\t%s\n"
-      uu____542 uu____543 uu____544 uu____565
+    FStar_Util.format4 "%s:{assignees=[%s], dependences=[%s]}\n\t%s\n" uu___
+      uu___1 uu___2 uu___3
 let (find_user_tac_for_uvar :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.ctx_uvar ->
@@ -151,7 +151,7 @@ let (find_user_tac_for_uvar :
                (fun hook ->
                   FStar_All.pipe_right hook.FStar_Syntax_Syntax.sigattrs
                     (FStar_Util.for_some (FStar_Syntax_Util.attr_eq a))))
-      | uu____594 -> FStar_Pervasives_Native.None
+      | uu___ -> FStar_Pervasives_Native.None
 let (should_defer_uvar_to_user_tac :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.ctx_uvar -> Prims.bool) =
   fun env ->
@@ -159,12 +159,12 @@ let (should_defer_uvar_to_user_tac :
       if Prims.op_Negation env.FStar_TypeChecker_Env.enable_defer_to_tac
       then false
       else
-        (let uu____608 = find_user_tac_for_uvar env u in
-         FStar_Option.isSome uu____608)
+        (let uu___1 = find_user_tac_for_uvar env u in
+         FStar_Option.isSome uu___1)
 let solve_goals_with_tac :
-  'uuuuuu621 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      'uuuuuu621 ->
+      'uuuuu ->
         FStar_TypeChecker_Common.implicits ->
           FStar_Syntax_Syntax.sigelt -> unit
   =
@@ -174,120 +174,118 @@ let solve_goals_with_tac :
         fun tac ->
           let resolve_tac =
             match tac.FStar_Syntax_Syntax.sigel with
-            | FStar_Syntax_Syntax.Sig_let (uu____643, lid::[]) ->
+            | FStar_Syntax_Syntax.Sig_let (uu___, lid::[]) ->
                 let qn = FStar_TypeChecker_Env.lookup_qname env lid in
                 let fv =
                   FStar_Syntax_Syntax.lid_as_fv lid
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero) FStar_Pervasives_Native.None in
                 let dd =
-                  let uu____650 =
+                  let uu___1 =
                     FStar_TypeChecker_Env.delta_depth_of_qninfo fv qn in
-                  match uu____650 with
-                  | FStar_Pervasives_Native.Some dd -> dd
+                  match uu___1 with
+                  | FStar_Pervasives_Native.Some dd1 -> dd1
                   | FStar_Pervasives_Native.None -> failwith "Expected a dd" in
                 let term =
-                  let uu____655 =
+                  let uu___1 =
                     FStar_Syntax_Syntax.lid_as_fv lid dd
                       FStar_Pervasives_Native.None in
-                  FStar_Syntax_Syntax.fv_to_tm uu____655 in
+                  FStar_Syntax_Syntax.fv_to_tm uu___1 in
                 term
-            | uu____656 -> failwith "Resolve_tac not found" in
+            | uu___ -> failwith "Resolve_tac not found" in
           let env1 =
-            let uu___74_658 = env in
+            let uu___ = env in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___74_658.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___74_658.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___74_658.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___74_658.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___74_658.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___74_658.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___74_658.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___74_658.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___74_658.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___74_658.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___74_658.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___74_658.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___74_658.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___74_658.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___74_658.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___74_658.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___74_658.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___74_658.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___74_658.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___74_658.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___74_658.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___74_658.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___74_658.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___74_658.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___74_658.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___74_658.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___74_658.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___74_658.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___74_658.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___74_658.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___74_658.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___74_658.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___74_658.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___74_658.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___74_658.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___74_658.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___74_658.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___74_658.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___74_658.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___74_658.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___74_658.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___74_658.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___74_658.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___74_658.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___74_658.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___74_658.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac = false
             } in
           env1.FStar_TypeChecker_Env.try_solve_implicits_hook env1
@@ -302,273 +300,271 @@ let (solve_deferred_to_tactic_goals :
       then g
       else
         (let deferred = g.FStar_TypeChecker_Common.deferred_to_tac in
-         let prob_as_implicit uu____684 =
-           match uu____684 with
+         let prob_as_implicit uu___1 =
+           match uu___1 with
            | (reason, prob) ->
                (match prob with
                 | FStar_TypeChecker_Common.TProb tp when
                     tp.FStar_TypeChecker_Common.relation =
                       FStar_TypeChecker_Common.EQ
                     ->
-                    let uu____702 =
-                      FStar_TypeChecker_Env.clear_expected_typ env in
-                    (match uu____702 with
-                     | (env1, uu____714) ->
+                    let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env in
+                    (match uu___2 with
+                     | (env1, uu___3) ->
                          let env2 =
-                           let uu___90_720 = env1 in
+                           let uu___4 = env1 in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___90_720.FStar_TypeChecker_Env.solver);
+                               (uu___4.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___90_720.FStar_TypeChecker_Env.range);
+                               (uu___4.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___90_720.FStar_TypeChecker_Env.curmodule);
+                               (uu___4.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
                                ((tp.FStar_TypeChecker_Common.logical_guard_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___90_720.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___4.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___90_720.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___4.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___90_720.FStar_TypeChecker_Env.modules);
+                               (uu___4.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___90_720.FStar_TypeChecker_Env.expected_typ);
+                               (uu___4.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___90_720.FStar_TypeChecker_Env.sigtab);
+                               (uu___4.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___90_720.FStar_TypeChecker_Env.attrtab);
+                               (uu___4.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___90_720.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___90_720.FStar_TypeChecker_Env.effects);
+                               (uu___4.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___90_720.FStar_TypeChecker_Env.generalize);
+                               (uu___4.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___90_720.FStar_TypeChecker_Env.letrecs);
+                               (uu___4.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___90_720.FStar_TypeChecker_Env.top_level);
+                               (uu___4.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___90_720.FStar_TypeChecker_Env.check_uvars);
+                               (uu___4.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___90_720.FStar_TypeChecker_Env.use_eq);
+                               (uu___4.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___90_720.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___90_720.FStar_TypeChecker_Env.is_iface);
+                               (uu___4.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___90_720.FStar_TypeChecker_Env.admit);
+                               (uu___4.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___90_720.FStar_TypeChecker_Env.lax);
+                               (uu___4.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___90_720.FStar_TypeChecker_Env.lax_universes);
+                               (uu___4.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___90_720.FStar_TypeChecker_Env.phase1);
+                               (uu___4.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___90_720.FStar_TypeChecker_Env.failhard);
+                               (uu___4.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___90_720.FStar_TypeChecker_Env.nosynth);
+                               (uu___4.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___90_720.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___90_720.FStar_TypeChecker_Env.tc_term);
+                               (uu___4.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___90_720.FStar_TypeChecker_Env.type_of);
+                               (uu___4.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___90_720.FStar_TypeChecker_Env.universe_of);
+                               (uu___4.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___90_720.FStar_TypeChecker_Env.check_type_of);
+                               (uu___4.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___90_720.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___90_720.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___90_720.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___90_720.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___90_720.FStar_TypeChecker_Env.proof_ns);
+                               (uu___4.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___90_720.FStar_TypeChecker_Env.synth_hook);
+                               (uu___4.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___90_720.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___90_720.FStar_TypeChecker_Env.splice);
+                               (uu___4.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___90_720.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___4.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___90_720.FStar_TypeChecker_Env.postprocess);
+                               (uu___4.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___90_720.FStar_TypeChecker_Env.identifier_info);
+                               (uu___4.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___90_720.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___4.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___90_720.FStar_TypeChecker_Env.dsenv);
+                               (uu___4.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___90_720.FStar_TypeChecker_Env.nbe);
+                               (uu___4.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___90_720.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___90_720.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___90_720.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let env_lax =
-                           let uu___93_722 = env2 in
+                           let uu___4 = env2 in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___93_722.FStar_TypeChecker_Env.solver);
+                               (uu___4.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___93_722.FStar_TypeChecker_Env.range);
+                               (uu___4.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___93_722.FStar_TypeChecker_Env.curmodule);
+                               (uu___4.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___93_722.FStar_TypeChecker_Env.gamma);
+                               (uu___4.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___93_722.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___4.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___93_722.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___4.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___93_722.FStar_TypeChecker_Env.modules);
+                               (uu___4.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___93_722.FStar_TypeChecker_Env.expected_typ);
+                               (uu___4.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___93_722.FStar_TypeChecker_Env.sigtab);
+                               (uu___4.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___93_722.FStar_TypeChecker_Env.attrtab);
+                               (uu___4.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___93_722.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___93_722.FStar_TypeChecker_Env.effects);
+                               (uu___4.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___93_722.FStar_TypeChecker_Env.generalize);
+                               (uu___4.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___93_722.FStar_TypeChecker_Env.letrecs);
+                               (uu___4.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___93_722.FStar_TypeChecker_Env.top_level);
+                               (uu___4.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___93_722.FStar_TypeChecker_Env.check_uvars);
+                               (uu___4.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___93_722.FStar_TypeChecker_Env.use_eq);
+                               (uu___4.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___93_722.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___93_722.FStar_TypeChecker_Env.is_iface);
+                               (uu___4.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___93_722.FStar_TypeChecker_Env.admit);
+                               (uu___4.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___93_722.FStar_TypeChecker_Env.lax_universes);
+                               (uu___4.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___93_722.FStar_TypeChecker_Env.phase1);
+                               (uu___4.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___93_722.FStar_TypeChecker_Env.failhard);
+                               (uu___4.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___93_722.FStar_TypeChecker_Env.nosynth);
+                               (uu___4.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___93_722.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___93_722.FStar_TypeChecker_Env.tc_term);
+                               (uu___4.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___93_722.FStar_TypeChecker_Env.type_of);
+                               (uu___4.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___93_722.FStar_TypeChecker_Env.universe_of);
+                               (uu___4.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___93_722.FStar_TypeChecker_Env.check_type_of);
+                               (uu___4.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts = true;
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___93_722.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___93_722.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___93_722.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___93_722.FStar_TypeChecker_Env.proof_ns);
+                               (uu___4.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___93_722.FStar_TypeChecker_Env.synth_hook);
+                               (uu___4.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___93_722.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___93_722.FStar_TypeChecker_Env.splice);
+                               (uu___4.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___93_722.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___4.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___93_722.FStar_TypeChecker_Env.postprocess);
+                               (uu___4.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___93_722.FStar_TypeChecker_Env.identifier_info);
+                               (uu___4.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___93_722.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___4.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___93_722.FStar_TypeChecker_Env.dsenv);
+                               (uu___4.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___93_722.FStar_TypeChecker_Env.nbe);
+                               (uu___4.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___93_722.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___93_722.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___93_722.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
-                         let uu____723 =
-                           let uu____730 =
+                         let uu___4 =
+                           let uu___5 =
                              is_flex tp.FStar_TypeChecker_Common.lhs in
-                           if uu____730
+                           if uu___5
                            then
                              env2.FStar_TypeChecker_Env.type_of env_lax
                                tp.FStar_TypeChecker_Common.lhs
                            else
                              env2.FStar_TypeChecker_Env.type_of env_lax
                                tp.FStar_TypeChecker_Common.rhs in
-                         (match uu____723 with
-                          | (uu____742, t_eq, uu____744) ->
+                         (match uu___4 with
+                          | (uu___5, t_eq, uu___6) ->
                               let goal_ty =
-                                let uu____746 =
+                                let uu___7 =
                                   env2.FStar_TypeChecker_Env.universe_of
                                     env_lax t_eq in
-                                FStar_Syntax_Util.mk_eq2 uu____746 t_eq
+                                FStar_Syntax_Util.mk_eq2 uu___7 t_eq
                                   tp.FStar_TypeChecker_Common.lhs
                                   tp.FStar_TypeChecker_Common.rhs in
-                              let uu____747 =
+                              let uu___7 =
                                 FStar_TypeChecker_Env.new_implicit_var_aux
                                   reason
                                   (tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos
                                   env2 goal_ty FStar_Syntax_Syntax.Strict
                                   FStar_Pervasives_Native.None in
-                              (match uu____747 with
-                               | (goal, ctx_uvar, uu____766) ->
+                              (match uu___7 with
+                               | (goal, ctx_uvar, uu___8) ->
                                    let imp =
-                                     let uu____780 =
-                                       let uu____781 = FStar_List.hd ctx_uvar in
-                                       FStar_Pervasives_Native.fst uu____781 in
+                                     let uu___9 =
+                                       let uu___10 = FStar_List.hd ctx_uvar in
+                                       FStar_Pervasives_Native.fst uu___10 in
                                      {
                                        FStar_TypeChecker_Common.imp_reason =
                                          "";
                                        FStar_TypeChecker_Common.imp_uvar =
-                                         uu____780;
+                                         uu___9;
                                        FStar_TypeChecker_Common.imp_tm = goal;
                                        FStar_TypeChecker_Common.imp_range =
                                          ((tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos)
                                      } in
                                    let sigelt =
-                                     let uu____793 =
+                                     let uu___9 =
                                        is_flex
                                          tp.FStar_TypeChecker_Common.lhs in
-                                     if uu____793
+                                     if uu___9
                                      then
-                                       let uu____796 =
+                                       let uu___10 =
                                          flex_uvar_head
                                            tp.FStar_TypeChecker_Common.lhs in
-                                       find_user_tac_for_uvar env2 uu____796
+                                       find_user_tac_for_uvar env2 uu___10
                                      else
-                                       (let uu____798 =
+                                       (let uu___11 =
                                           is_flex
                                             tp.FStar_TypeChecker_Common.rhs in
-                                        if uu____798
+                                        if uu___11
                                         then
-                                          let uu____801 =
+                                          let uu___12 =
                                             flex_uvar_head
                                               tp.FStar_TypeChecker_Common.rhs in
-                                          find_user_tac_for_uvar env2
-                                            uu____801
+                                          find_user_tac_for_uvar env2 uu___12
                                         else FStar_Pervasives_Native.None) in
                                    (match sigelt with
                                     | FStar_Pervasives_Native.None ->
@@ -576,22 +572,21 @@ let (solve_deferred_to_tactic_goals :
                                           "Impossible: No tactic associated with deferred problem"
                                     | FStar_Pervasives_Native.Some se ->
                                         (imp, se)))))
-                | uu____812 ->
-                    failwith "Unexpected problem deferred to tactic") in
+                | uu___2 -> failwith "Unexpected problem deferred to tactic") in
          let eqs =
            FStar_List.map prob_as_implicit
              g.FStar_TypeChecker_Common.deferred_to_tac in
-         let uu____832 =
+         let uu___1 =
            FStar_List.fold_right
              (fun imp ->
-                fun uu____864 ->
-                  match uu____864 with
+                fun uu___2 ->
+                  match uu___2 with
                   | (more, imps) ->
-                      let uu____907 =
+                      let uu___3 =
                         FStar_Syntax_Unionfind.find
                           (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                      (match uu____907 with
-                       | FStar_Pervasives_Native.Some uu____922 ->
+                      (match uu___3 with
+                       | FStar_Pervasives_Native.Some uu___4 ->
                            (more, (imp :: imps))
                        | FStar_Pervasives_Native.None ->
                            let se =
@@ -603,23 +598,22 @@ let (solve_deferred_to_tactic_goals :
                             | FStar_Pervasives_Native.Some se1 ->
                                 (((imp, se1) :: more), imps))))
              g.FStar_TypeChecker_Common.implicits ([], []) in
-         match uu____832 with
+         match uu___1 with
          | (more, imps) ->
              let bucketize is =
                let map = FStar_Util.smap_create (Prims.of_int (17)) in
                FStar_List.iter
-                 (fun uu____1047 ->
-                    match uu____1047 with
+                 (fun uu___3 ->
+                    match uu___3 with
                     | (i, s) ->
-                        let uu____1054 = FStar_Syntax_Util.lid_of_sigelt s in
-                        (match uu____1054 with
+                        let uu___4 = FStar_Syntax_Util.lid_of_sigelt s in
+                        (match uu___4 with
                          | FStar_Pervasives_Native.None ->
                              failwith "Unexpected: tactic without a name"
                          | FStar_Pervasives_Native.Some l ->
                              let lstr = FStar_Ident.string_of_lid l in
-                             let uu____1059 =
-                               FStar_Util.smap_try_find map lstr in
-                             (match uu____1059 with
+                             let uu___5 = FStar_Util.smap_try_find map lstr in
+                             (match uu___5 with
                               | FStar_Pervasives_Native.None ->
                                   FStar_Util.smap_add map lstr ([i], s)
                               | FStar_Pervasives_Native.Some (is1, s1) ->
@@ -627,21 +621,21 @@ let (solve_deferred_to_tactic_goals :
                                    FStar_Util.smap_add map lstr
                                      ((i :: is1), s1))))) is;
                FStar_Util.smap_fold map
-                 (fun uu____1106 -> fun is1 -> fun out -> is1 :: out) [] in
+                 (fun uu___3 -> fun is1 -> fun out -> is1 :: out) [] in
              let buckets = bucketize (FStar_List.append eqs more) in
              (FStar_List.iter
-                (fun uu____1146 ->
-                   match uu____1146 with
+                (fun uu___3 ->
+                   match uu___3 with
                    | (imps1, sigel) -> solve_goals_with_tac env g imps1 sigel)
                 buckets;
-              (let uu___154_1153 = g in
+              (let uu___3 = g in
                {
                  FStar_TypeChecker_Common.guard_f =
-                   (uu___154_1153.FStar_TypeChecker_Common.guard_f);
+                   (uu___3.FStar_TypeChecker_Common.guard_f);
                  FStar_TypeChecker_Common.deferred_to_tac = [];
                  FStar_TypeChecker_Common.deferred =
-                   (uu___154_1153.FStar_TypeChecker_Common.deferred);
+                   (uu___3.FStar_TypeChecker_Common.deferred);
                  FStar_TypeChecker_Common.univ_ineqs =
-                   (uu___154_1153.FStar_TypeChecker_Common.univ_ineqs);
+                   (uu___3.FStar_TypeChecker_Common.univ_ineqs);
                  FStar_TypeChecker_Common.implicits = imps
                })))

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -29,93 +29,85 @@ type step =
   | NBE 
   | ForExtraction 
 let (uu___is_Beta : step -> Prims.bool) =
-  fun projectee -> match projectee with | Beta -> true | uu____104 -> false
+  fun projectee -> match projectee with | Beta -> true | uu___ -> false
 let (uu___is_Iota : step -> Prims.bool) =
-  fun projectee -> match projectee with | Iota -> true | uu____110 -> false
+  fun projectee -> match projectee with | Iota -> true | uu___ -> false
 let (uu___is_Zeta : step -> Prims.bool) =
-  fun projectee -> match projectee with | Zeta -> true | uu____116 -> false
+  fun projectee -> match projectee with | Zeta -> true | uu___ -> false
 let (uu___is_ZetaFull : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | ZetaFull -> true | uu____122 -> false
+  fun projectee -> match projectee with | ZetaFull -> true | uu___ -> false
 let (uu___is_Exclude : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Exclude _0 -> true | uu____129 -> false
+  fun projectee -> match projectee with | Exclude _0 -> true | uu___ -> false
 let (__proj__Exclude__item___0 : step -> step) =
   fun projectee -> match projectee with | Exclude _0 -> _0
 let (uu___is_Weak : step -> Prims.bool) =
-  fun projectee -> match projectee with | Weak -> true | uu____141 -> false
+  fun projectee -> match projectee with | Weak -> true | uu___ -> false
 let (uu___is_HNF : step -> Prims.bool) =
-  fun projectee -> match projectee with | HNF -> true | uu____147 -> false
+  fun projectee -> match projectee with | HNF -> true | uu___ -> false
 let (uu___is_Primops : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Primops -> true | uu____153 -> false
+  fun projectee -> match projectee with | Primops -> true | uu___ -> false
 let (uu___is_Eager_unfolding : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | Eager_unfolding -> true | uu____159 -> false
+    match projectee with | Eager_unfolding -> true | uu___ -> false
 let (uu___is_Inlining : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Inlining -> true | uu____165 -> false
+  fun projectee -> match projectee with | Inlining -> true | uu___ -> false
 let (uu___is_DoNotUnfoldPureLets : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | DoNotUnfoldPureLets -> true | uu____171 -> false
+    match projectee with | DoNotUnfoldPureLets -> true | uu___ -> false
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldUntil _0 -> true | uu____178 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu___ -> false
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee -> match projectee with | UnfoldUntil _0 -> _0
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldOnly _0 -> true | uu____193 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu___ -> false
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee -> match projectee with | UnfoldOnly _0 -> _0
 let (uu___is_UnfoldFully : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldFully _0 -> true | uu____214 -> false
+    match projectee with | UnfoldFully _0 -> true | uu___ -> false
 let (__proj__UnfoldFully__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee -> match projectee with | UnfoldFully _0 -> _0
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldAttr _0 -> true | uu____235 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu___ -> false
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee -> match projectee with | UnfoldAttr _0 -> _0
 let (uu___is_UnfoldTac : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UnfoldTac -> true | uu____253 -> false
+  fun projectee -> match projectee with | UnfoldTac -> true | uu___ -> false
 let (uu___is_PureSubtermsWithinComputations : step -> Prims.bool) =
   fun projectee ->
     match projectee with
     | PureSubtermsWithinComputations -> true
-    | uu____259 -> false
+    | uu___ -> false
 let (uu___is_Simplify : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Simplify -> true | uu____265 -> false
+  fun projectee -> match projectee with | Simplify -> true | uu___ -> false
 let (uu___is_EraseUniverses : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | EraseUniverses -> true | uu____271 -> false
+    match projectee with | EraseUniverses -> true | uu___ -> false
 let (uu___is_AllowUnboundUniverses : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | AllowUnboundUniverses -> true | uu____277 -> false
+    match projectee with | AllowUnboundUniverses -> true | uu___ -> false
 let (uu___is_Reify : step -> Prims.bool) =
-  fun projectee -> match projectee with | Reify -> true | uu____283 -> false
+  fun projectee -> match projectee with | Reify -> true | uu___ -> false
 let (uu___is_CompressUvars : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | CompressUvars -> true | uu____289 -> false
+    match projectee with | CompressUvars -> true | uu___ -> false
 let (uu___is_NoFullNorm : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoFullNorm -> true | uu____295 -> false
+  fun projectee -> match projectee with | NoFullNorm -> true | uu___ -> false
 let (uu___is_CheckNoUvars : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | CheckNoUvars -> true | uu____301 -> false
+    match projectee with | CheckNoUvars -> true | uu___ -> false
 let (uu___is_Unmeta : step -> Prims.bool) =
-  fun projectee -> match projectee with | Unmeta -> true | uu____307 -> false
+  fun projectee -> match projectee with | Unmeta -> true | uu___ -> false
 let (uu___is_Unascribe : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unascribe -> true | uu____313 -> false
+  fun projectee -> match projectee with | Unascribe -> true | uu___ -> false
 let (uu___is_NBE : step -> Prims.bool) =
-  fun projectee -> match projectee with | NBE -> true | uu____319 -> false
+  fun projectee -> match projectee with | NBE -> true | uu___ -> false
 let (uu___is_ForExtraction : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | ForExtraction -> true | uu____325 -> false
+    match projectee with | ForExtraction -> true | uu___ -> false
 type steps = step Prims.list
 let rec (eq_step : step -> step -> Prims.bool) =
   fun s1 ->
@@ -155,7 +147,7 @@ let rec (eq_step : step -> step -> Prims.bool) =
       | (UnfoldAttr lids1, UnfoldAttr lids2) ->
           ((FStar_List.length lids1) = (FStar_List.length lids2)) &&
             (FStar_List.forall2 FStar_Ident.lid_equals lids1 lids2)
-      | uu____360 -> false
+      | uu___ -> false
 type sig_binding =
   (FStar_Ident.lident Prims.list * FStar_Syntax_Syntax.sigelt)
 type delta_level =
@@ -164,17 +156,15 @@ type delta_level =
   | Eager_unfolding_only 
   | Unfold of FStar_Syntax_Syntax.delta_depth 
 let (uu___is_NoDelta : delta_level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | NoDelta -> true | uu____381 -> false
+  fun projectee -> match projectee with | NoDelta -> true | uu___ -> false
 let (uu___is_InliningDelta : delta_level -> Prims.bool) =
   fun projectee ->
-    match projectee with | InliningDelta -> true | uu____387 -> false
+    match projectee with | InliningDelta -> true | uu___ -> false
 let (uu___is_Eager_unfolding_only : delta_level -> Prims.bool) =
   fun projectee ->
-    match projectee with | Eager_unfolding_only -> true | uu____393 -> false
+    match projectee with | Eager_unfolding_only -> true | uu___ -> false
 let (uu___is_Unfold : delta_level -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unfold _0 -> true | uu____400 -> false
+  fun projectee -> match projectee with | Unfold _0 -> true | uu___ -> false
 let (__proj__Unfold__item___0 :
   delta_level -> FStar_Syntax_Syntax.delta_depth) =
   fun projectee -> match projectee with | Unfold _0 -> _0
@@ -1213,195 +1203,195 @@ let (rename_gamma :
     fun gamma ->
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___0_13123 ->
-              match uu___0_13123 with
+           (fun uu___ ->
+              match uu___ with
               | FStar_Syntax_Syntax.Binding_var x ->
                   let y =
-                    let uu____13126 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Subst.subst subst uu____13126 in
-                  let uu____13127 =
-                    let uu____13128 = FStar_Syntax_Subst.compress y in
-                    uu____13128.FStar_Syntax_Syntax.n in
-                  (match uu____13127 with
+                    let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
+                    FStar_Syntax_Subst.subst subst uu___1 in
+                  let uu___1 =
+                    let uu___2 = FStar_Syntax_Subst.compress y in
+                    uu___2.FStar_Syntax_Syntax.n in
+                  (match uu___1 with
                    | FStar_Syntax_Syntax.Tm_name y1 ->
-                       let uu____13132 =
-                         let uu___330_13133 = y1 in
-                         let uu____13134 =
+                       let uu___2 =
+                         let uu___3 = y1 in
+                         let uu___4 =
                            FStar_Syntax_Subst.subst subst
                              x.FStar_Syntax_Syntax.sort in
                          {
                            FStar_Syntax_Syntax.ppname =
-                             (uu___330_13133.FStar_Syntax_Syntax.ppname);
+                             (uu___3.FStar_Syntax_Syntax.ppname);
                            FStar_Syntax_Syntax.index =
-                             (uu___330_13133.FStar_Syntax_Syntax.index);
-                           FStar_Syntax_Syntax.sort = uu____13134
+                             (uu___3.FStar_Syntax_Syntax.index);
+                           FStar_Syntax_Syntax.sort = uu___4
                          } in
-                       FStar_Syntax_Syntax.Binding_var uu____13132
-                   | uu____13137 -> failwith "Not a renaming")
+                       FStar_Syntax_Syntax.Binding_var uu___2
+                   | uu___2 -> failwith "Not a renaming")
               | b -> b))
 let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
   fun subst ->
     fun env1 ->
-      let uu___336_13149 = env1 in
-      let uu____13150 = rename_gamma subst env1.gamma in
+      let uu___ = env1 in
+      let uu___1 = rename_gamma subst env1.gamma in
       {
-        solver = (uu___336_13149.solver);
-        range = (uu___336_13149.range);
-        curmodule = (uu___336_13149.curmodule);
-        gamma = uu____13150;
-        gamma_sig = (uu___336_13149.gamma_sig);
-        gamma_cache = (uu___336_13149.gamma_cache);
-        modules = (uu___336_13149.modules);
-        expected_typ = (uu___336_13149.expected_typ);
-        sigtab = (uu___336_13149.sigtab);
-        attrtab = (uu___336_13149.attrtab);
-        instantiate_imp = (uu___336_13149.instantiate_imp);
-        effects = (uu___336_13149.effects);
-        generalize = (uu___336_13149.generalize);
-        letrecs = (uu___336_13149.letrecs);
-        top_level = (uu___336_13149.top_level);
-        check_uvars = (uu___336_13149.check_uvars);
-        use_eq = (uu___336_13149.use_eq);
-        use_eq_strict = (uu___336_13149.use_eq_strict);
-        is_iface = (uu___336_13149.is_iface);
-        admit = (uu___336_13149.admit);
-        lax = (uu___336_13149.lax);
-        lax_universes = (uu___336_13149.lax_universes);
-        phase1 = (uu___336_13149.phase1);
-        failhard = (uu___336_13149.failhard);
-        nosynth = (uu___336_13149.nosynth);
-        uvar_subtyping = (uu___336_13149.uvar_subtyping);
-        tc_term = (uu___336_13149.tc_term);
-        type_of = (uu___336_13149.type_of);
-        universe_of = (uu___336_13149.universe_of);
-        check_type_of = (uu___336_13149.check_type_of);
-        use_bv_sorts = (uu___336_13149.use_bv_sorts);
-        qtbl_name_and_index = (uu___336_13149.qtbl_name_and_index);
-        normalized_eff_names = (uu___336_13149.normalized_eff_names);
-        fv_delta_depths = (uu___336_13149.fv_delta_depths);
-        proof_ns = (uu___336_13149.proof_ns);
-        synth_hook = (uu___336_13149.synth_hook);
-        try_solve_implicits_hook = (uu___336_13149.try_solve_implicits_hook);
-        splice = (uu___336_13149.splice);
-        mpreprocess = (uu___336_13149.mpreprocess);
-        postprocess = (uu___336_13149.postprocess);
-        identifier_info = (uu___336_13149.identifier_info);
-        tc_hooks = (uu___336_13149.tc_hooks);
-        dsenv = (uu___336_13149.dsenv);
-        nbe = (uu___336_13149.nbe);
-        strict_args_tab = (uu___336_13149.strict_args_tab);
-        erasable_types_tab = (uu___336_13149.erasable_types_tab);
-        enable_defer_to_tac = (uu___336_13149.enable_defer_to_tac)
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
+        gamma = uu___1;
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (default_tc_hooks : tcenv_hooks) =
-  { tc_push_in_gamma_hook = (fun uu____13157 -> fun uu____13158 -> ()) }
+  { tc_push_in_gamma_hook = (fun uu___ -> fun uu___1 -> ()) }
 let (tc_hooks : env -> tcenv_hooks) = fun env1 -> env1.tc_hooks
 let (set_tc_hooks : env -> tcenv_hooks -> env) =
   fun env1 ->
     fun hooks ->
-      let uu___343_13178 = env1 in
+      let uu___ = env1 in
       {
-        solver = (uu___343_13178.solver);
-        range = (uu___343_13178.range);
-        curmodule = (uu___343_13178.curmodule);
-        gamma = (uu___343_13178.gamma);
-        gamma_sig = (uu___343_13178.gamma_sig);
-        gamma_cache = (uu___343_13178.gamma_cache);
-        modules = (uu___343_13178.modules);
-        expected_typ = (uu___343_13178.expected_typ);
-        sigtab = (uu___343_13178.sigtab);
-        attrtab = (uu___343_13178.attrtab);
-        instantiate_imp = (uu___343_13178.instantiate_imp);
-        effects = (uu___343_13178.effects);
-        generalize = (uu___343_13178.generalize);
-        letrecs = (uu___343_13178.letrecs);
-        top_level = (uu___343_13178.top_level);
-        check_uvars = (uu___343_13178.check_uvars);
-        use_eq = (uu___343_13178.use_eq);
-        use_eq_strict = (uu___343_13178.use_eq_strict);
-        is_iface = (uu___343_13178.is_iface);
-        admit = (uu___343_13178.admit);
-        lax = (uu___343_13178.lax);
-        lax_universes = (uu___343_13178.lax_universes);
-        phase1 = (uu___343_13178.phase1);
-        failhard = (uu___343_13178.failhard);
-        nosynth = (uu___343_13178.nosynth);
-        uvar_subtyping = (uu___343_13178.uvar_subtyping);
-        tc_term = (uu___343_13178.tc_term);
-        type_of = (uu___343_13178.type_of);
-        universe_of = (uu___343_13178.universe_of);
-        check_type_of = (uu___343_13178.check_type_of);
-        use_bv_sorts = (uu___343_13178.use_bv_sorts);
-        qtbl_name_and_index = (uu___343_13178.qtbl_name_and_index);
-        normalized_eff_names = (uu___343_13178.normalized_eff_names);
-        fv_delta_depths = (uu___343_13178.fv_delta_depths);
-        proof_ns = (uu___343_13178.proof_ns);
-        synth_hook = (uu___343_13178.synth_hook);
-        try_solve_implicits_hook = (uu___343_13178.try_solve_implicits_hook);
-        splice = (uu___343_13178.splice);
-        mpreprocess = (uu___343_13178.mpreprocess);
-        postprocess = (uu___343_13178.postprocess);
-        identifier_info = (uu___343_13178.identifier_info);
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
+        gamma = (uu___.gamma);
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
         tc_hooks = hooks;
-        dsenv = (uu___343_13178.dsenv);
-        nbe = (uu___343_13178.nbe);
-        strict_args_tab = (uu___343_13178.strict_args_tab);
-        erasable_types_tab = (uu___343_13178.erasable_types_tab);
-        enable_defer_to_tac = (uu___343_13178.enable_defer_to_tac)
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
   fun e ->
     fun g ->
-      let uu___347_13189 = e in
-      let uu____13190 = FStar_Syntax_DsEnv.set_dep_graph e.dsenv g in
+      let uu___ = e in
+      let uu___1 = FStar_Syntax_DsEnv.set_dep_graph e.dsenv g in
       {
-        solver = (uu___347_13189.solver);
-        range = (uu___347_13189.range);
-        curmodule = (uu___347_13189.curmodule);
-        gamma = (uu___347_13189.gamma);
-        gamma_sig = (uu___347_13189.gamma_sig);
-        gamma_cache = (uu___347_13189.gamma_cache);
-        modules = (uu___347_13189.modules);
-        expected_typ = (uu___347_13189.expected_typ);
-        sigtab = (uu___347_13189.sigtab);
-        attrtab = (uu___347_13189.attrtab);
-        instantiate_imp = (uu___347_13189.instantiate_imp);
-        effects = (uu___347_13189.effects);
-        generalize = (uu___347_13189.generalize);
-        letrecs = (uu___347_13189.letrecs);
-        top_level = (uu___347_13189.top_level);
-        check_uvars = (uu___347_13189.check_uvars);
-        use_eq = (uu___347_13189.use_eq);
-        use_eq_strict = (uu___347_13189.use_eq_strict);
-        is_iface = (uu___347_13189.is_iface);
-        admit = (uu___347_13189.admit);
-        lax = (uu___347_13189.lax);
-        lax_universes = (uu___347_13189.lax_universes);
-        phase1 = (uu___347_13189.phase1);
-        failhard = (uu___347_13189.failhard);
-        nosynth = (uu___347_13189.nosynth);
-        uvar_subtyping = (uu___347_13189.uvar_subtyping);
-        tc_term = (uu___347_13189.tc_term);
-        type_of = (uu___347_13189.type_of);
-        universe_of = (uu___347_13189.universe_of);
-        check_type_of = (uu___347_13189.check_type_of);
-        use_bv_sorts = (uu___347_13189.use_bv_sorts);
-        qtbl_name_and_index = (uu___347_13189.qtbl_name_and_index);
-        normalized_eff_names = (uu___347_13189.normalized_eff_names);
-        fv_delta_depths = (uu___347_13189.fv_delta_depths);
-        proof_ns = (uu___347_13189.proof_ns);
-        synth_hook = (uu___347_13189.synth_hook);
-        try_solve_implicits_hook = (uu___347_13189.try_solve_implicits_hook);
-        splice = (uu___347_13189.splice);
-        mpreprocess = (uu___347_13189.mpreprocess);
-        postprocess = (uu___347_13189.postprocess);
-        identifier_info = (uu___347_13189.identifier_info);
-        tc_hooks = (uu___347_13189.tc_hooks);
-        dsenv = uu____13190;
-        nbe = (uu___347_13189.nbe);
-        strict_args_tab = (uu___347_13189.strict_args_tab);
-        erasable_types_tab = (uu___347_13189.erasable_types_tab);
-        enable_defer_to_tac = (uu___347_13189.enable_defer_to_tac)
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
+        gamma = (uu___.gamma);
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = uu___1;
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (dep_graph : env -> FStar_Parser_Dep.deps) =
   fun e -> FStar_Syntax_DsEnv.dep_graph e.dsenv
@@ -1410,26 +1400,26 @@ type sigtable = FStar_Syntax_Syntax.sigelt FStar_Util.smap
 let (should_verify : env -> Prims.bool) =
   fun env1 ->
     ((Prims.op_Negation env1.lax) && (Prims.op_Negation env1.admit)) &&
-      (let uu____13204 = FStar_Ident.string_of_lid env1.curmodule in
-       FStar_Options.should_verify uu____13204)
+      (let uu___ = FStar_Ident.string_of_lid env1.curmodule in
+       FStar_Options.should_verify uu___)
 let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
   =
   fun d ->
     fun q ->
       match (d, q) with
-      | (NoDelta, uu____13215) -> true
+      | (NoDelta, uu___) -> true
       | (Eager_unfolding_only,
          FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen) -> true
-      | (Unfold uu____13216,
-         FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen) -> true
-      | (Unfold uu____13217, FStar_Syntax_Syntax.Visible_default) -> true
+      | (Unfold uu___, FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)
+          -> true
+      | (Unfold uu___, FStar_Syntax_Syntax.Visible_default) -> true
       | (InliningDelta, FStar_Syntax_Syntax.Inline_for_extraction) -> true
-      | uu____13218 -> false
+      | uu___ -> false
 let (default_table_size : Prims.int) = (Prims.of_int (200))
-let new_sigtab : 'uuuuuu13227 . unit -> 'uuuuuu13227 FStar_Util.smap =
-  fun uu____13234 -> FStar_Util.smap_create default_table_size
-let new_gamma_cache : 'uuuuuu13239 . unit -> 'uuuuuu13239 FStar_Util.smap =
-  fun uu____13246 -> FStar_Util.smap_create (Prims.of_int (100))
+let new_sigtab : 'uuuuu . unit -> 'uuuuu FStar_Util.smap =
+  fun uu___ -> FStar_Util.smap_create default_table_size
+let new_gamma_cache : 'uuuuu . unit -> 'uuuuu FStar_Util.smap =
+  fun uu___ -> FStar_Util.smap_create (Prims.of_int (100))
 let (initial_env :
   FStar_Parser_Dep.deps ->
     (env ->
@@ -1461,37 +1451,32 @@ let (initial_env :
             fun solver ->
               fun module_lid ->
                 fun nbe ->
-                  let uu____13380 = new_gamma_cache () in
-                  let uu____13383 = new_sigtab () in
-                  let uu____13386 = new_sigtab () in
-                  let uu____13393 =
-                    let uu____13406 =
-                      FStar_Util.smap_create (Prims.of_int (10)) in
-                    (uu____13406, FStar_Pervasives_Native.None) in
-                  let uu____13421 =
-                    FStar_Util.smap_create (Prims.of_int (20)) in
-                  let uu____13424 =
-                    FStar_Util.smap_create (Prims.of_int (50)) in
-                  let uu____13427 = FStar_Options.using_facts_from () in
-                  let uu____13428 =
+                  let uu___ = new_gamma_cache () in
+                  let uu___1 = new_sigtab () in
+                  let uu___2 = new_sigtab () in
+                  let uu___3 =
+                    let uu___4 = FStar_Util.smap_create (Prims.of_int (10)) in
+                    (uu___4, FStar_Pervasives_Native.None) in
+                  let uu___4 = FStar_Util.smap_create (Prims.of_int (20)) in
+                  let uu___5 = FStar_Util.smap_create (Prims.of_int (50)) in
+                  let uu___6 = FStar_Options.using_facts_from () in
+                  let uu___7 =
                     FStar_Util.mk_ref
                       FStar_TypeChecker_Common.id_info_table_empty in
-                  let uu____13431 = FStar_Syntax_DsEnv.empty_env deps in
-                  let uu____13432 =
-                    FStar_Util.smap_create (Prims.of_int (20)) in
-                  let uu____13443 =
-                    FStar_Util.smap_create (Prims.of_int (20)) in
+                  let uu___8 = FStar_Syntax_DsEnv.empty_env deps in
+                  let uu___9 = FStar_Util.smap_create (Prims.of_int (20)) in
+                  let uu___10 = FStar_Util.smap_create (Prims.of_int (20)) in
                   {
                     solver;
                     range = FStar_Range.dummyRange;
                     curmodule = module_lid;
                     gamma = [];
                     gamma_sig = [];
-                    gamma_cache = uu____13380;
+                    gamma_cache = uu___;
                     modules = [];
                     expected_typ = FStar_Pervasives_Native.None;
-                    sigtab = uu____13383;
-                    attrtab = uu____13386;
+                    sigtab = uu___1;
+                    attrtab = uu___2;
                     instantiate_imp = true;
                     effects =
                       {
@@ -1520,10 +1505,10 @@ let (initial_env :
                     universe_of;
                     check_type_of;
                     use_bv_sorts = false;
-                    qtbl_name_and_index = uu____13393;
-                    normalized_eff_names = uu____13421;
-                    fv_delta_depths = uu____13424;
-                    proof_ns = uu____13427;
+                    qtbl_name_and_index = uu___3;
+                    normalized_eff_names = uu___4;
+                    fv_delta_depths = uu___5;
+                    proof_ns = uu___6;
                     synth_hook =
                       (fun e ->
                          fun g ->
@@ -1545,12 +1530,12 @@ let (initial_env :
                          fun tau ->
                            fun typ ->
                              fun tm -> failwith "no postprocessor available");
-                    identifier_info = uu____13428;
+                    identifier_info = uu___7;
                     tc_hooks = default_tc_hooks;
-                    dsenv = uu____13431;
+                    dsenv = uu___8;
                     nbe;
-                    strict_args_tab = uu____13432;
-                    erasable_types_tab = uu____13443;
+                    strict_args_tab = uu___9;
+                    erasable_types_tab = uu___10;
                     enable_defer_to_tac = true
                   }
 let (dsenv : env -> FStar_Syntax_DsEnv.env) = fun env1 -> env1.dsenv
@@ -1564,126 +1549,122 @@ let (query_indices :
   (FStar_Ident.lident * Prims.int) Prims.list Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [[]]
 let (push_query_indices : unit -> unit) =
-  fun uu____13610 ->
-    let uu____13611 = FStar_ST.op_Bang query_indices in
-    match uu____13611 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang query_indices in
+    match uu___1 with
     | [] -> failwith "Empty query indices!"
-    | uu____13648 ->
-        let uu____13657 =
-          let uu____13666 =
-            let uu____13673 = FStar_ST.op_Bang query_indices in
-            FStar_List.hd uu____13673 in
-          let uu____13710 = FStar_ST.op_Bang query_indices in uu____13666 ::
-            uu____13710 in
-        FStar_ST.op_Colon_Equals query_indices uu____13657
+    | uu___2 ->
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = FStar_ST.op_Bang query_indices in
+            FStar_List.hd uu___5 in
+          let uu___5 = FStar_ST.op_Bang query_indices in uu___4 :: uu___5 in
+        FStar_ST.op_Colon_Equals query_indices uu___3
 let (pop_query_indices : unit -> unit) =
-  fun uu____13773 ->
-    let uu____13774 = FStar_ST.op_Bang query_indices in
-    match uu____13774 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang query_indices in
+    match uu___1 with
     | [] -> failwith "Empty query indices!"
     | hd::tl -> FStar_ST.op_Colon_Equals query_indices tl
 let (snapshot_query_indices : unit -> (Prims.int * unit)) =
-  fun uu____13863 ->
-    FStar_Common.snapshot push_query_indices query_indices ()
+  fun uu___ -> FStar_Common.snapshot push_query_indices query_indices ()
 let (rollback_query_indices :
   Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth -> FStar_Common.rollback pop_query_indices query_indices depth
 let (add_query_index : (FStar_Ident.lident * Prims.int) -> unit) =
-  fun uu____13893 ->
-    match uu____13893 with
+  fun uu___ ->
+    match uu___ with
     | (l, n) ->
-        let uu____13900 = FStar_ST.op_Bang query_indices in
-        (match uu____13900 with
+        let uu___1 = FStar_ST.op_Bang query_indices in
+        (match uu___1 with
          | hd::tl ->
              FStar_ST.op_Colon_Equals query_indices (((l, n) :: hd) :: tl)
-         | uu____13985 -> failwith "Empty query indices")
+         | uu___2 -> failwith "Empty query indices")
 let (peek_query_indices :
   unit -> (FStar_Ident.lident * Prims.int) Prims.list) =
-  fun uu____14004 ->
-    let uu____14005 = FStar_ST.op_Bang query_indices in
-    FStar_List.hd uu____14005
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang query_indices in FStar_List.hd uu___1
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref []
 let (push_stack : env -> env) =
   fun env1 ->
-    (let uu____14054 =
-       let uu____14057 = FStar_ST.op_Bang stack in env1 :: uu____14057 in
-     FStar_ST.op_Colon_Equals stack uu____14054);
-    (let uu___421_14080 = env1 in
-     let uu____14081 = FStar_Util.smap_copy (gamma_cache env1) in
-     let uu____14084 = FStar_Util.smap_copy (sigtab env1) in
-     let uu____14087 = FStar_Util.smap_copy (attrtab env1) in
-     let uu____14094 =
-       let uu____14107 =
-         let uu____14110 =
+    (let uu___1 = let uu___2 = FStar_ST.op_Bang stack in env1 :: uu___2 in
+     FStar_ST.op_Colon_Equals stack uu___1);
+    (let uu___1 = env1 in
+     let uu___2 = FStar_Util.smap_copy (gamma_cache env1) in
+     let uu___3 = FStar_Util.smap_copy (sigtab env1) in
+     let uu___4 = FStar_Util.smap_copy (attrtab env1) in
+     let uu___5 =
+       let uu___6 =
+         let uu___7 =
            FStar_All.pipe_right env1.qtbl_name_and_index
              FStar_Pervasives_Native.fst in
-         FStar_Util.smap_copy uu____14110 in
-       let uu____14135 =
+         FStar_Util.smap_copy uu___7 in
+       let uu___7 =
          FStar_All.pipe_right env1.qtbl_name_and_index
            FStar_Pervasives_Native.snd in
-       (uu____14107, uu____14135) in
-     let uu____14176 = FStar_Util.smap_copy env1.normalized_eff_names in
-     let uu____14179 = FStar_Util.smap_copy env1.fv_delta_depths in
-     let uu____14182 =
-       let uu____14185 = FStar_ST.op_Bang env1.identifier_info in
-       FStar_Util.mk_ref uu____14185 in
-     let uu____14192 = FStar_Util.smap_copy env1.strict_args_tab in
-     let uu____14203 = FStar_Util.smap_copy env1.erasable_types_tab in
+       (uu___6, uu___7) in
+     let uu___6 = FStar_Util.smap_copy env1.normalized_eff_names in
+     let uu___7 = FStar_Util.smap_copy env1.fv_delta_depths in
+     let uu___8 =
+       let uu___9 = FStar_ST.op_Bang env1.identifier_info in
+       FStar_Util.mk_ref uu___9 in
+     let uu___9 = FStar_Util.smap_copy env1.strict_args_tab in
+     let uu___10 = FStar_Util.smap_copy env1.erasable_types_tab in
      {
-       solver = (uu___421_14080.solver);
-       range = (uu___421_14080.range);
-       curmodule = (uu___421_14080.curmodule);
-       gamma = (uu___421_14080.gamma);
-       gamma_sig = (uu___421_14080.gamma_sig);
-       gamma_cache = uu____14081;
-       modules = (uu___421_14080.modules);
-       expected_typ = (uu___421_14080.expected_typ);
-       sigtab = uu____14084;
-       attrtab = uu____14087;
-       instantiate_imp = (uu___421_14080.instantiate_imp);
-       effects = (uu___421_14080.effects);
-       generalize = (uu___421_14080.generalize);
-       letrecs = (uu___421_14080.letrecs);
-       top_level = (uu___421_14080.top_level);
-       check_uvars = (uu___421_14080.check_uvars);
-       use_eq = (uu___421_14080.use_eq);
-       use_eq_strict = (uu___421_14080.use_eq_strict);
-       is_iface = (uu___421_14080.is_iface);
-       admit = (uu___421_14080.admit);
-       lax = (uu___421_14080.lax);
-       lax_universes = (uu___421_14080.lax_universes);
-       phase1 = (uu___421_14080.phase1);
-       failhard = (uu___421_14080.failhard);
-       nosynth = (uu___421_14080.nosynth);
-       uvar_subtyping = (uu___421_14080.uvar_subtyping);
-       tc_term = (uu___421_14080.tc_term);
-       type_of = (uu___421_14080.type_of);
-       universe_of = (uu___421_14080.universe_of);
-       check_type_of = (uu___421_14080.check_type_of);
-       use_bv_sorts = (uu___421_14080.use_bv_sorts);
-       qtbl_name_and_index = uu____14094;
-       normalized_eff_names = uu____14176;
-       fv_delta_depths = uu____14179;
-       proof_ns = (uu___421_14080.proof_ns);
-       synth_hook = (uu___421_14080.synth_hook);
-       try_solve_implicits_hook = (uu___421_14080.try_solve_implicits_hook);
-       splice = (uu___421_14080.splice);
-       mpreprocess = (uu___421_14080.mpreprocess);
-       postprocess = (uu___421_14080.postprocess);
-       identifier_info = uu____14182;
-       tc_hooks = (uu___421_14080.tc_hooks);
-       dsenv = (uu___421_14080.dsenv);
-       nbe = (uu___421_14080.nbe);
-       strict_args_tab = uu____14192;
-       erasable_types_tab = uu____14203;
-       enable_defer_to_tac = (uu___421_14080.enable_defer_to_tac)
+       solver = (uu___1.solver);
+       range = (uu___1.range);
+       curmodule = (uu___1.curmodule);
+       gamma = (uu___1.gamma);
+       gamma_sig = (uu___1.gamma_sig);
+       gamma_cache = uu___2;
+       modules = (uu___1.modules);
+       expected_typ = (uu___1.expected_typ);
+       sigtab = uu___3;
+       attrtab = uu___4;
+       instantiate_imp = (uu___1.instantiate_imp);
+       effects = (uu___1.effects);
+       generalize = (uu___1.generalize);
+       letrecs = (uu___1.letrecs);
+       top_level = (uu___1.top_level);
+       check_uvars = (uu___1.check_uvars);
+       use_eq = (uu___1.use_eq);
+       use_eq_strict = (uu___1.use_eq_strict);
+       is_iface = (uu___1.is_iface);
+       admit = (uu___1.admit);
+       lax = (uu___1.lax);
+       lax_universes = (uu___1.lax_universes);
+       phase1 = (uu___1.phase1);
+       failhard = (uu___1.failhard);
+       nosynth = (uu___1.nosynth);
+       uvar_subtyping = (uu___1.uvar_subtyping);
+       tc_term = (uu___1.tc_term);
+       type_of = (uu___1.type_of);
+       universe_of = (uu___1.universe_of);
+       check_type_of = (uu___1.check_type_of);
+       use_bv_sorts = (uu___1.use_bv_sorts);
+       qtbl_name_and_index = uu___5;
+       normalized_eff_names = uu___6;
+       fv_delta_depths = uu___7;
+       proof_ns = (uu___1.proof_ns);
+       synth_hook = (uu___1.synth_hook);
+       try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+       splice = (uu___1.splice);
+       mpreprocess = (uu___1.mpreprocess);
+       postprocess = (uu___1.postprocess);
+       identifier_info = uu___8;
+       tc_hooks = (uu___1.tc_hooks);
+       dsenv = (uu___1.dsenv);
+       nbe = (uu___1.nbe);
+       strict_args_tab = uu___9;
+       erasable_types_tab = uu___10;
+       enable_defer_to_tac = (uu___1.enable_defer_to_tac)
      })
 let (pop_stack : unit -> env) =
-  fun uu____14210 ->
-    let uu____14211 = FStar_ST.op_Bang stack in
-    match uu____14211 with
+  fun uu___ ->
+    let uu___1 = FStar_ST.op_Bang stack in
+    match uu___1 with
     | env1::tl -> (FStar_ST.op_Colon_Equals stack tl; env1)
-    | uu____14239 -> failwith "Impossible: Too many pops"
+    | uu___2 -> failwith "Impossible: Too many pops"
 let (snapshot_stack : env -> (Prims.int * env)) =
   fun env1 -> FStar_Common.snapshot push_stack stack env1
 let (rollback_stack : Prims.int FStar_Pervasives_Native.option -> env) =
@@ -1693,86 +1674,75 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
   fun env1 ->
     fun msg ->
       FStar_Util.atomically
-        (fun uu____14311 ->
-           let uu____14312 = snapshot_stack env1 in
-           match uu____14312 with
+        (fun uu___ ->
+           let uu___1 = snapshot_stack env1 in
+           match uu___1 with
            | (stack_depth, env2) ->
-               let uu____14337 = snapshot_query_indices () in
-               (match uu____14337 with
+               let uu___2 = snapshot_query_indices () in
+               (match uu___2 with
                 | (query_indices_depth, ()) ->
-                    let uu____14361 = (env2.solver).snapshot msg in
-                    (match uu____14361 with
+                    let uu___3 = (env2.solver).snapshot msg in
+                    (match uu___3 with
                      | (solver_depth, ()) ->
-                         let uu____14403 =
-                           FStar_Syntax_DsEnv.snapshot env2.dsenv in
-                         (match uu____14403 with
+                         let uu___4 = FStar_Syntax_DsEnv.snapshot env2.dsenv in
+                         (match uu___4 with
                           | (dsenv_depth, dsenv1) ->
                               ((stack_depth, query_indices_depth,
                                  solver_depth, dsenv_depth),
-                                (let uu___446_14449 = env2 in
+                                (let uu___5 = env2 in
                                  {
-                                   solver = (uu___446_14449.solver);
-                                   range = (uu___446_14449.range);
-                                   curmodule = (uu___446_14449.curmodule);
-                                   gamma = (uu___446_14449.gamma);
-                                   gamma_sig = (uu___446_14449.gamma_sig);
-                                   gamma_cache = (uu___446_14449.gamma_cache);
-                                   modules = (uu___446_14449.modules);
-                                   expected_typ =
-                                     (uu___446_14449.expected_typ);
-                                   sigtab = (uu___446_14449.sigtab);
-                                   attrtab = (uu___446_14449.attrtab);
-                                   instantiate_imp =
-                                     (uu___446_14449.instantiate_imp);
-                                   effects = (uu___446_14449.effects);
-                                   generalize = (uu___446_14449.generalize);
-                                   letrecs = (uu___446_14449.letrecs);
-                                   top_level = (uu___446_14449.top_level);
-                                   check_uvars = (uu___446_14449.check_uvars);
-                                   use_eq = (uu___446_14449.use_eq);
-                                   use_eq_strict =
-                                     (uu___446_14449.use_eq_strict);
-                                   is_iface = (uu___446_14449.is_iface);
-                                   admit = (uu___446_14449.admit);
-                                   lax = (uu___446_14449.lax);
-                                   lax_universes =
-                                     (uu___446_14449.lax_universes);
-                                   phase1 = (uu___446_14449.phase1);
-                                   failhard = (uu___446_14449.failhard);
-                                   nosynth = (uu___446_14449.nosynth);
-                                   uvar_subtyping =
-                                     (uu___446_14449.uvar_subtyping);
-                                   tc_term = (uu___446_14449.tc_term);
-                                   type_of = (uu___446_14449.type_of);
-                                   universe_of = (uu___446_14449.universe_of);
-                                   check_type_of =
-                                     (uu___446_14449.check_type_of);
-                                   use_bv_sorts =
-                                     (uu___446_14449.use_bv_sorts);
+                                   solver = (uu___5.solver);
+                                   range = (uu___5.range);
+                                   curmodule = (uu___5.curmodule);
+                                   gamma = (uu___5.gamma);
+                                   gamma_sig = (uu___5.gamma_sig);
+                                   gamma_cache = (uu___5.gamma_cache);
+                                   modules = (uu___5.modules);
+                                   expected_typ = (uu___5.expected_typ);
+                                   sigtab = (uu___5.sigtab);
+                                   attrtab = (uu___5.attrtab);
+                                   instantiate_imp = (uu___5.instantiate_imp);
+                                   effects = (uu___5.effects);
+                                   generalize = (uu___5.generalize);
+                                   letrecs = (uu___5.letrecs);
+                                   top_level = (uu___5.top_level);
+                                   check_uvars = (uu___5.check_uvars);
+                                   use_eq = (uu___5.use_eq);
+                                   use_eq_strict = (uu___5.use_eq_strict);
+                                   is_iface = (uu___5.is_iface);
+                                   admit = (uu___5.admit);
+                                   lax = (uu___5.lax);
+                                   lax_universes = (uu___5.lax_universes);
+                                   phase1 = (uu___5.phase1);
+                                   failhard = (uu___5.failhard);
+                                   nosynth = (uu___5.nosynth);
+                                   uvar_subtyping = (uu___5.uvar_subtyping);
+                                   tc_term = (uu___5.tc_term);
+                                   type_of = (uu___5.type_of);
+                                   universe_of = (uu___5.universe_of);
+                                   check_type_of = (uu___5.check_type_of);
+                                   use_bv_sorts = (uu___5.use_bv_sorts);
                                    qtbl_name_and_index =
-                                     (uu___446_14449.qtbl_name_and_index);
+                                     (uu___5.qtbl_name_and_index);
                                    normalized_eff_names =
-                                     (uu___446_14449.normalized_eff_names);
-                                   fv_delta_depths =
-                                     (uu___446_14449.fv_delta_depths);
-                                   proof_ns = (uu___446_14449.proof_ns);
-                                   synth_hook = (uu___446_14449.synth_hook);
+                                     (uu___5.normalized_eff_names);
+                                   fv_delta_depths = (uu___5.fv_delta_depths);
+                                   proof_ns = (uu___5.proof_ns);
+                                   synth_hook = (uu___5.synth_hook);
                                    try_solve_implicits_hook =
-                                     (uu___446_14449.try_solve_implicits_hook);
-                                   splice = (uu___446_14449.splice);
-                                   mpreprocess = (uu___446_14449.mpreprocess);
-                                   postprocess = (uu___446_14449.postprocess);
-                                   identifier_info =
-                                     (uu___446_14449.identifier_info);
-                                   tc_hooks = (uu___446_14449.tc_hooks);
+                                     (uu___5.try_solve_implicits_hook);
+                                   splice = (uu___5.splice);
+                                   mpreprocess = (uu___5.mpreprocess);
+                                   postprocess = (uu___5.postprocess);
+                                   identifier_info = (uu___5.identifier_info);
+                                   tc_hooks = (uu___5.tc_hooks);
                                    dsenv = dsenv1;
-                                   nbe = (uu___446_14449.nbe);
-                                   strict_args_tab =
-                                     (uu___446_14449.strict_args_tab);
+                                   nbe = (uu___5.nbe);
+                                   strict_args_tab = (uu___5.strict_args_tab);
                                    erasable_types_tab =
-                                     (uu___446_14449.erasable_types_tab);
+                                     (uu___5.erasable_types_tab);
                                    enable_defer_to_tac =
-                                     (uu___446_14449.enable_defer_to_tac)
+                                     (uu___5.enable_defer_to_tac)
                                  }))))))
 let (rollback :
   solver_t ->
@@ -1782,8 +1752,8 @@ let (rollback :
     fun msg ->
       fun depth ->
         FStar_Util.atomically
-          (fun uu____14480 ->
-             let uu____14481 =
+          (fun uu___ ->
+             let uu___1 =
                match depth with
                | FStar_Pervasives_Native.Some (s1, s2, s3, s4) ->
                    ((FStar_Pervasives_Native.Some s1),
@@ -1795,7 +1765,7 @@ let (rollback :
                      FStar_Pervasives_Native.None,
                      FStar_Pervasives_Native.None,
                      FStar_Pervasives_Native.None) in
-             match uu____14481 with
+             match uu___1 with
              | (stack_depth, query_indices_depth, solver_depth, dsenv_depth)
                  ->
                  (solver.rollback msg solver_depth;
@@ -1807,17 +1777,16 @@ let (rollback :
                              let tcenv = rollback_stack stack_depth in
                              let dsenv1 =
                                FStar_Syntax_DsEnv.rollback dsenv_depth in
-                             ((let uu____14607 =
+                             ((let uu___5 =
                                  FStar_Util.physical_equality tcenv.dsenv
                                    dsenv1 in
-                               FStar_Common.runtime_assert uu____14607
+                               FStar_Common.runtime_assert uu___5
                                  "Inconsistent stack state");
                               tcenv))))))
 let (push : env -> Prims.string -> env) =
   fun env1 ->
     fun msg ->
-      let uu____14618 = snapshot env1 msg in
-      FStar_Pervasives_Native.snd uu____14618
+      let uu___ = snapshot env1 msg in FStar_Pervasives_Native.snd uu___
 let (pop : env -> Prims.string -> env) =
   fun env1 ->
     fun msg -> rollback env1.solver msg FStar_Pervasives_Native.None
@@ -1825,280 +1794,277 @@ let (incr_query_index : env -> env) =
   fun env1 ->
     let qix = peek_query_indices () in
     match env1.qtbl_name_and_index with
-    | (uu____14645, FStar_Pervasives_Native.None) -> env1
+    | (uu___, FStar_Pervasives_Native.None) -> env1
     | (tbl, FStar_Pervasives_Native.Some (l, n)) ->
-        let uu____14677 =
+        let uu___ =
           FStar_All.pipe_right qix
             (FStar_List.tryFind
-               (fun uu____14703 ->
-                  match uu____14703 with
-                  | (m, uu____14709) -> FStar_Ident.lid_equals l m)) in
-        (match uu____14677 with
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (m, uu___2) -> FStar_Ident.lid_equals l m)) in
+        (match uu___ with
          | FStar_Pervasives_Native.None ->
              let next = n + Prims.int_one in
              (add_query_index (l, next);
-              (let uu____14717 = FStar_Ident.string_of_lid l in
-               FStar_Util.smap_add tbl uu____14717 next);
-              (let uu___491_14718 = env1 in
+              (let uu___3 = FStar_Ident.string_of_lid l in
+               FStar_Util.smap_add tbl uu___3 next);
+              (let uu___3 = env1 in
                {
-                 solver = (uu___491_14718.solver);
-                 range = (uu___491_14718.range);
-                 curmodule = (uu___491_14718.curmodule);
-                 gamma = (uu___491_14718.gamma);
-                 gamma_sig = (uu___491_14718.gamma_sig);
-                 gamma_cache = (uu___491_14718.gamma_cache);
-                 modules = (uu___491_14718.modules);
-                 expected_typ = (uu___491_14718.expected_typ);
-                 sigtab = (uu___491_14718.sigtab);
-                 attrtab = (uu___491_14718.attrtab);
-                 instantiate_imp = (uu___491_14718.instantiate_imp);
-                 effects = (uu___491_14718.effects);
-                 generalize = (uu___491_14718.generalize);
-                 letrecs = (uu___491_14718.letrecs);
-                 top_level = (uu___491_14718.top_level);
-                 check_uvars = (uu___491_14718.check_uvars);
-                 use_eq = (uu___491_14718.use_eq);
-                 use_eq_strict = (uu___491_14718.use_eq_strict);
-                 is_iface = (uu___491_14718.is_iface);
-                 admit = (uu___491_14718.admit);
-                 lax = (uu___491_14718.lax);
-                 lax_universes = (uu___491_14718.lax_universes);
-                 phase1 = (uu___491_14718.phase1);
-                 failhard = (uu___491_14718.failhard);
-                 nosynth = (uu___491_14718.nosynth);
-                 uvar_subtyping = (uu___491_14718.uvar_subtyping);
-                 tc_term = (uu___491_14718.tc_term);
-                 type_of = (uu___491_14718.type_of);
-                 universe_of = (uu___491_14718.universe_of);
-                 check_type_of = (uu___491_14718.check_type_of);
-                 use_bv_sorts = (uu___491_14718.use_bv_sorts);
+                 solver = (uu___3.solver);
+                 range = (uu___3.range);
+                 curmodule = (uu___3.curmodule);
+                 gamma = (uu___3.gamma);
+                 gamma_sig = (uu___3.gamma_sig);
+                 gamma_cache = (uu___3.gamma_cache);
+                 modules = (uu___3.modules);
+                 expected_typ = (uu___3.expected_typ);
+                 sigtab = (uu___3.sigtab);
+                 attrtab = (uu___3.attrtab);
+                 instantiate_imp = (uu___3.instantiate_imp);
+                 effects = (uu___3.effects);
+                 generalize = (uu___3.generalize);
+                 letrecs = (uu___3.letrecs);
+                 top_level = (uu___3.top_level);
+                 check_uvars = (uu___3.check_uvars);
+                 use_eq = (uu___3.use_eq);
+                 use_eq_strict = (uu___3.use_eq_strict);
+                 is_iface = (uu___3.is_iface);
+                 admit = (uu___3.admit);
+                 lax = (uu___3.lax);
+                 lax_universes = (uu___3.lax_universes);
+                 phase1 = (uu___3.phase1);
+                 failhard = (uu___3.failhard);
+                 nosynth = (uu___3.nosynth);
+                 uvar_subtyping = (uu___3.uvar_subtyping);
+                 tc_term = (uu___3.tc_term);
+                 type_of = (uu___3.type_of);
+                 universe_of = (uu___3.universe_of);
+                 check_type_of = (uu___3.check_type_of);
+                 use_bv_sorts = (uu___3.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___491_14718.normalized_eff_names);
-                 fv_delta_depths = (uu___491_14718.fv_delta_depths);
-                 proof_ns = (uu___491_14718.proof_ns);
-                 synth_hook = (uu___491_14718.synth_hook);
-                 try_solve_implicits_hook =
-                   (uu___491_14718.try_solve_implicits_hook);
-                 splice = (uu___491_14718.splice);
-                 mpreprocess = (uu___491_14718.mpreprocess);
-                 postprocess = (uu___491_14718.postprocess);
-                 identifier_info = (uu___491_14718.identifier_info);
-                 tc_hooks = (uu___491_14718.tc_hooks);
-                 dsenv = (uu___491_14718.dsenv);
-                 nbe = (uu___491_14718.nbe);
-                 strict_args_tab = (uu___491_14718.strict_args_tab);
-                 erasable_types_tab = (uu___491_14718.erasable_types_tab);
-                 enable_defer_to_tac = (uu___491_14718.enable_defer_to_tac)
+                 normalized_eff_names = (uu___3.normalized_eff_names);
+                 fv_delta_depths = (uu___3.fv_delta_depths);
+                 proof_ns = (uu___3.proof_ns);
+                 synth_hook = (uu___3.synth_hook);
+                 try_solve_implicits_hook = (uu___3.try_solve_implicits_hook);
+                 splice = (uu___3.splice);
+                 mpreprocess = (uu___3.mpreprocess);
+                 postprocess = (uu___3.postprocess);
+                 identifier_info = (uu___3.identifier_info);
+                 tc_hooks = (uu___3.tc_hooks);
+                 dsenv = (uu___3.dsenv);
+                 nbe = (uu___3.nbe);
+                 strict_args_tab = (uu___3.strict_args_tab);
+                 erasable_types_tab = (uu___3.erasable_types_tab);
+                 enable_defer_to_tac = (uu___3.enable_defer_to_tac)
                }))
-         | FStar_Pervasives_Native.Some (uu____14731, m) ->
+         | FStar_Pervasives_Native.Some (uu___1, m) ->
              let next = m + Prims.int_one in
              (add_query_index (l, next);
-              (let uu____14740 = FStar_Ident.string_of_lid l in
-               FStar_Util.smap_add tbl uu____14740 next);
-              (let uu___500_14741 = env1 in
+              (let uu___4 = FStar_Ident.string_of_lid l in
+               FStar_Util.smap_add tbl uu___4 next);
+              (let uu___4 = env1 in
                {
-                 solver = (uu___500_14741.solver);
-                 range = (uu___500_14741.range);
-                 curmodule = (uu___500_14741.curmodule);
-                 gamma = (uu___500_14741.gamma);
-                 gamma_sig = (uu___500_14741.gamma_sig);
-                 gamma_cache = (uu___500_14741.gamma_cache);
-                 modules = (uu___500_14741.modules);
-                 expected_typ = (uu___500_14741.expected_typ);
-                 sigtab = (uu___500_14741.sigtab);
-                 attrtab = (uu___500_14741.attrtab);
-                 instantiate_imp = (uu___500_14741.instantiate_imp);
-                 effects = (uu___500_14741.effects);
-                 generalize = (uu___500_14741.generalize);
-                 letrecs = (uu___500_14741.letrecs);
-                 top_level = (uu___500_14741.top_level);
-                 check_uvars = (uu___500_14741.check_uvars);
-                 use_eq = (uu___500_14741.use_eq);
-                 use_eq_strict = (uu___500_14741.use_eq_strict);
-                 is_iface = (uu___500_14741.is_iface);
-                 admit = (uu___500_14741.admit);
-                 lax = (uu___500_14741.lax);
-                 lax_universes = (uu___500_14741.lax_universes);
-                 phase1 = (uu___500_14741.phase1);
-                 failhard = (uu___500_14741.failhard);
-                 nosynth = (uu___500_14741.nosynth);
-                 uvar_subtyping = (uu___500_14741.uvar_subtyping);
-                 tc_term = (uu___500_14741.tc_term);
-                 type_of = (uu___500_14741.type_of);
-                 universe_of = (uu___500_14741.universe_of);
-                 check_type_of = (uu___500_14741.check_type_of);
-                 use_bv_sorts = (uu___500_14741.use_bv_sorts);
+                 solver = (uu___4.solver);
+                 range = (uu___4.range);
+                 curmodule = (uu___4.curmodule);
+                 gamma = (uu___4.gamma);
+                 gamma_sig = (uu___4.gamma_sig);
+                 gamma_cache = (uu___4.gamma_cache);
+                 modules = (uu___4.modules);
+                 expected_typ = (uu___4.expected_typ);
+                 sigtab = (uu___4.sigtab);
+                 attrtab = (uu___4.attrtab);
+                 instantiate_imp = (uu___4.instantiate_imp);
+                 effects = (uu___4.effects);
+                 generalize = (uu___4.generalize);
+                 letrecs = (uu___4.letrecs);
+                 top_level = (uu___4.top_level);
+                 check_uvars = (uu___4.check_uvars);
+                 use_eq = (uu___4.use_eq);
+                 use_eq_strict = (uu___4.use_eq_strict);
+                 is_iface = (uu___4.is_iface);
+                 admit = (uu___4.admit);
+                 lax = (uu___4.lax);
+                 lax_universes = (uu___4.lax_universes);
+                 phase1 = (uu___4.phase1);
+                 failhard = (uu___4.failhard);
+                 nosynth = (uu___4.nosynth);
+                 uvar_subtyping = (uu___4.uvar_subtyping);
+                 tc_term = (uu___4.tc_term);
+                 type_of = (uu___4.type_of);
+                 universe_of = (uu___4.universe_of);
+                 check_type_of = (uu___4.check_type_of);
+                 use_bv_sorts = (uu___4.use_bv_sorts);
                  qtbl_name_and_index =
                    (tbl, (FStar_Pervasives_Native.Some (l, next)));
-                 normalized_eff_names = (uu___500_14741.normalized_eff_names);
-                 fv_delta_depths = (uu___500_14741.fv_delta_depths);
-                 proof_ns = (uu___500_14741.proof_ns);
-                 synth_hook = (uu___500_14741.synth_hook);
-                 try_solve_implicits_hook =
-                   (uu___500_14741.try_solve_implicits_hook);
-                 splice = (uu___500_14741.splice);
-                 mpreprocess = (uu___500_14741.mpreprocess);
-                 postprocess = (uu___500_14741.postprocess);
-                 identifier_info = (uu___500_14741.identifier_info);
-                 tc_hooks = (uu___500_14741.tc_hooks);
-                 dsenv = (uu___500_14741.dsenv);
-                 nbe = (uu___500_14741.nbe);
-                 strict_args_tab = (uu___500_14741.strict_args_tab);
-                 erasable_types_tab = (uu___500_14741.erasable_types_tab);
-                 enable_defer_to_tac = (uu___500_14741.enable_defer_to_tac)
+                 normalized_eff_names = (uu___4.normalized_eff_names);
+                 fv_delta_depths = (uu___4.fv_delta_depths);
+                 proof_ns = (uu___4.proof_ns);
+                 synth_hook = (uu___4.synth_hook);
+                 try_solve_implicits_hook = (uu___4.try_solve_implicits_hook);
+                 splice = (uu___4.splice);
+                 mpreprocess = (uu___4.mpreprocess);
+                 postprocess = (uu___4.postprocess);
+                 identifier_info = (uu___4.identifier_info);
+                 tc_hooks = (uu___4.tc_hooks);
+                 dsenv = (uu___4.dsenv);
+                 nbe = (uu___4.nbe);
+                 strict_args_tab = (uu___4.strict_args_tab);
+                 erasable_types_tab = (uu___4.erasable_types_tab);
+                 enable_defer_to_tac = (uu___4.enable_defer_to_tac)
                })))
 let (debug : env -> FStar_Options.debug_level_t -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu____14764 = FStar_Ident.string_of_lid env1.curmodule in
-      FStar_Options.debug_at_level uu____14764 l
+      let uu___ = FStar_Ident.string_of_lid env1.curmodule in
+      FStar_Options.debug_at_level uu___ l
 let (set_range : env -> FStar_Range.range -> env) =
   fun e ->
     fun r ->
       if r = FStar_Range.dummyRange
       then e
       else
-        (let uu___507_14776 = e in
+        (let uu___1 = e in
          {
-           solver = (uu___507_14776.solver);
+           solver = (uu___1.solver);
            range = r;
-           curmodule = (uu___507_14776.curmodule);
-           gamma = (uu___507_14776.gamma);
-           gamma_sig = (uu___507_14776.gamma_sig);
-           gamma_cache = (uu___507_14776.gamma_cache);
-           modules = (uu___507_14776.modules);
-           expected_typ = (uu___507_14776.expected_typ);
-           sigtab = (uu___507_14776.sigtab);
-           attrtab = (uu___507_14776.attrtab);
-           instantiate_imp = (uu___507_14776.instantiate_imp);
-           effects = (uu___507_14776.effects);
-           generalize = (uu___507_14776.generalize);
-           letrecs = (uu___507_14776.letrecs);
-           top_level = (uu___507_14776.top_level);
-           check_uvars = (uu___507_14776.check_uvars);
-           use_eq = (uu___507_14776.use_eq);
-           use_eq_strict = (uu___507_14776.use_eq_strict);
-           is_iface = (uu___507_14776.is_iface);
-           admit = (uu___507_14776.admit);
-           lax = (uu___507_14776.lax);
-           lax_universes = (uu___507_14776.lax_universes);
-           phase1 = (uu___507_14776.phase1);
-           failhard = (uu___507_14776.failhard);
-           nosynth = (uu___507_14776.nosynth);
-           uvar_subtyping = (uu___507_14776.uvar_subtyping);
-           tc_term = (uu___507_14776.tc_term);
-           type_of = (uu___507_14776.type_of);
-           universe_of = (uu___507_14776.universe_of);
-           check_type_of = (uu___507_14776.check_type_of);
-           use_bv_sorts = (uu___507_14776.use_bv_sorts);
-           qtbl_name_and_index = (uu___507_14776.qtbl_name_and_index);
-           normalized_eff_names = (uu___507_14776.normalized_eff_names);
-           fv_delta_depths = (uu___507_14776.fv_delta_depths);
-           proof_ns = (uu___507_14776.proof_ns);
-           synth_hook = (uu___507_14776.synth_hook);
-           try_solve_implicits_hook =
-             (uu___507_14776.try_solve_implicits_hook);
-           splice = (uu___507_14776.splice);
-           mpreprocess = (uu___507_14776.mpreprocess);
-           postprocess = (uu___507_14776.postprocess);
-           identifier_info = (uu___507_14776.identifier_info);
-           tc_hooks = (uu___507_14776.tc_hooks);
-           dsenv = (uu___507_14776.dsenv);
-           nbe = (uu___507_14776.nbe);
-           strict_args_tab = (uu___507_14776.strict_args_tab);
-           erasable_types_tab = (uu___507_14776.erasable_types_tab);
-           enable_defer_to_tac = (uu___507_14776.enable_defer_to_tac)
+           curmodule = (uu___1.curmodule);
+           gamma = (uu___1.gamma);
+           gamma_sig = (uu___1.gamma_sig);
+           gamma_cache = (uu___1.gamma_cache);
+           modules = (uu___1.modules);
+           expected_typ = (uu___1.expected_typ);
+           sigtab = (uu___1.sigtab);
+           attrtab = (uu___1.attrtab);
+           instantiate_imp = (uu___1.instantiate_imp);
+           effects = (uu___1.effects);
+           generalize = (uu___1.generalize);
+           letrecs = (uu___1.letrecs);
+           top_level = (uu___1.top_level);
+           check_uvars = (uu___1.check_uvars);
+           use_eq = (uu___1.use_eq);
+           use_eq_strict = (uu___1.use_eq_strict);
+           is_iface = (uu___1.is_iface);
+           admit = (uu___1.admit);
+           lax = (uu___1.lax);
+           lax_universes = (uu___1.lax_universes);
+           phase1 = (uu___1.phase1);
+           failhard = (uu___1.failhard);
+           nosynth = (uu___1.nosynth);
+           uvar_subtyping = (uu___1.uvar_subtyping);
+           tc_term = (uu___1.tc_term);
+           type_of = (uu___1.type_of);
+           universe_of = (uu___1.universe_of);
+           check_type_of = (uu___1.check_type_of);
+           use_bv_sorts = (uu___1.use_bv_sorts);
+           qtbl_name_and_index = (uu___1.qtbl_name_and_index);
+           normalized_eff_names = (uu___1.normalized_eff_names);
+           fv_delta_depths = (uu___1.fv_delta_depths);
+           proof_ns = (uu___1.proof_ns);
+           synth_hook = (uu___1.synth_hook);
+           try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+           splice = (uu___1.splice);
+           mpreprocess = (uu___1.mpreprocess);
+           postprocess = (uu___1.postprocess);
+           identifier_info = (uu___1.identifier_info);
+           tc_hooks = (uu___1.tc_hooks);
+           dsenv = (uu___1.dsenv);
+           nbe = (uu___1.nbe);
+           strict_args_tab = (uu___1.strict_args_tab);
+           erasable_types_tab = (uu___1.erasable_types_tab);
+           enable_defer_to_tac = (uu___1.enable_defer_to_tac)
          })
 let (get_range : env -> FStar_Range.range) = fun e -> e.range
 let (toggle_id_info : env -> Prims.bool -> unit) =
   fun env1 ->
     fun enabled ->
-      let uu____14792 =
-        let uu____14793 = FStar_ST.op_Bang env1.identifier_info in
-        FStar_TypeChecker_Common.id_info_toggle uu____14793 enabled in
-      FStar_ST.op_Colon_Equals env1.identifier_info uu____14792
+      let uu___ =
+        let uu___1 = FStar_ST.op_Bang env1.identifier_info in
+        FStar_TypeChecker_Common.id_info_toggle uu___1 enabled in
+      FStar_ST.op_Colon_Equals env1.identifier_info uu___
 let (insert_bv_info :
   env -> FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env1 ->
     fun bv ->
       fun ty ->
-        let uu____14821 =
-          let uu____14822 = FStar_ST.op_Bang env1.identifier_info in
-          FStar_TypeChecker_Common.id_info_insert_bv uu____14822 bv ty in
-        FStar_ST.op_Colon_Equals env1.identifier_info uu____14821
+        let uu___ =
+          let uu___1 = FStar_ST.op_Bang env1.identifier_info in
+          FStar_TypeChecker_Common.id_info_insert_bv uu___1 bv ty in
+        FStar_ST.op_Colon_Equals env1.identifier_info uu___
 let (insert_fv_info :
   env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> unit) =
   fun env1 ->
     fun fv ->
       fun ty ->
-        let uu____14850 =
-          let uu____14851 = FStar_ST.op_Bang env1.identifier_info in
-          FStar_TypeChecker_Common.id_info_insert_fv uu____14851 fv ty in
-        FStar_ST.op_Colon_Equals env1.identifier_info uu____14850
+        let uu___ =
+          let uu___1 = FStar_ST.op_Bang env1.identifier_info in
+          FStar_TypeChecker_Common.id_info_insert_fv uu___1 fv ty in
+        FStar_ST.op_Colon_Equals env1.identifier_info uu___
 let (promote_id_info :
   env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> unit) =
   fun env1 ->
     fun ty_map ->
-      let uu____14879 =
-        let uu____14880 = FStar_ST.op_Bang env1.identifier_info in
-        FStar_TypeChecker_Common.id_info_promote uu____14880 ty_map in
-      FStar_ST.op_Colon_Equals env1.identifier_info uu____14879
+      let uu___ =
+        let uu___1 = FStar_ST.op_Bang env1.identifier_info in
+        FStar_TypeChecker_Common.id_info_promote uu___1 ty_map in
+      FStar_ST.op_Colon_Equals env1.identifier_info uu___
 let (modules : env -> FStar_Syntax_Syntax.modul Prims.list) =
   fun env1 -> env1.modules
 let (current_module : env -> FStar_Ident.lident) = fun env1 -> env1.curmodule
 let (set_current_module : env -> FStar_Ident.lident -> env) =
   fun env1 ->
     fun lid ->
-      let uu___524_14915 = env1 in
+      let uu___ = env1 in
       {
-        solver = (uu___524_14915.solver);
-        range = (uu___524_14915.range);
+        solver = (uu___.solver);
+        range = (uu___.range);
         curmodule = lid;
-        gamma = (uu___524_14915.gamma);
-        gamma_sig = (uu___524_14915.gamma_sig);
-        gamma_cache = (uu___524_14915.gamma_cache);
-        modules = (uu___524_14915.modules);
-        expected_typ = (uu___524_14915.expected_typ);
-        sigtab = (uu___524_14915.sigtab);
-        attrtab = (uu___524_14915.attrtab);
-        instantiate_imp = (uu___524_14915.instantiate_imp);
-        effects = (uu___524_14915.effects);
-        generalize = (uu___524_14915.generalize);
-        letrecs = (uu___524_14915.letrecs);
-        top_level = (uu___524_14915.top_level);
-        check_uvars = (uu___524_14915.check_uvars);
-        use_eq = (uu___524_14915.use_eq);
-        use_eq_strict = (uu___524_14915.use_eq_strict);
-        is_iface = (uu___524_14915.is_iface);
-        admit = (uu___524_14915.admit);
-        lax = (uu___524_14915.lax);
-        lax_universes = (uu___524_14915.lax_universes);
-        phase1 = (uu___524_14915.phase1);
-        failhard = (uu___524_14915.failhard);
-        nosynth = (uu___524_14915.nosynth);
-        uvar_subtyping = (uu___524_14915.uvar_subtyping);
-        tc_term = (uu___524_14915.tc_term);
-        type_of = (uu___524_14915.type_of);
-        universe_of = (uu___524_14915.universe_of);
-        check_type_of = (uu___524_14915.check_type_of);
-        use_bv_sorts = (uu___524_14915.use_bv_sorts);
-        qtbl_name_and_index = (uu___524_14915.qtbl_name_and_index);
-        normalized_eff_names = (uu___524_14915.normalized_eff_names);
-        fv_delta_depths = (uu___524_14915.fv_delta_depths);
-        proof_ns = (uu___524_14915.proof_ns);
-        synth_hook = (uu___524_14915.synth_hook);
-        try_solve_implicits_hook = (uu___524_14915.try_solve_implicits_hook);
-        splice = (uu___524_14915.splice);
-        mpreprocess = (uu___524_14915.mpreprocess);
-        postprocess = (uu___524_14915.postprocess);
-        identifier_info = (uu___524_14915.identifier_info);
-        tc_hooks = (uu___524_14915.tc_hooks);
-        dsenv = (uu___524_14915.dsenv);
-        nbe = (uu___524_14915.nbe);
-        strict_args_tab = (uu___524_14915.strict_args_tab);
-        erasable_types_tab = (uu___524_14915.erasable_types_tab);
-        enable_defer_to_tac = (uu___524_14915.enable_defer_to_tac)
+        gamma = (uu___.gamma);
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
@@ -2115,27 +2081,26 @@ let (find_in_sigtab :
   =
   fun env1 ->
     fun lid ->
-      let uu____14942 = FStar_Ident.string_of_lid lid in
-      FStar_Util.smap_try_find (sigtab env1) uu____14942
+      let uu___ = FStar_Ident.string_of_lid lid in
+      FStar_Util.smap_try_find (sigtab env1) uu___
 let (name_not_found :
   FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)) =
   fun l ->
-    let uu____14952 =
-      let uu____14953 = FStar_Ident.string_of_lid l in
-      FStar_Util.format1 "Name \"%s\" not found" uu____14953 in
-    (FStar_Errors.Fatal_NameNotFound, uu____14952)
+    let uu___ =
+      let uu___1 = FStar_Ident.string_of_lid l in
+      FStar_Util.format1 "Name \"%s\" not found" uu___1 in
+    (FStar_Errors.Fatal_NameNotFound, uu___)
 let (variable_not_found :
   FStar_Syntax_Syntax.bv -> (FStar_Errors.raw_error * Prims.string)) =
   fun v ->
-    let uu____14963 =
-      let uu____14964 = FStar_Syntax_Print.bv_to_string v in
-      FStar_Util.format1 "Variable \"%s\" not found" uu____14964 in
-    (FStar_Errors.Fatal_VariableNotFound, uu____14963)
+    let uu___ =
+      let uu___1 = FStar_Syntax_Print.bv_to_string v in
+      FStar_Util.format1 "Variable \"%s\" not found" uu___1 in
+    (FStar_Errors.Fatal_VariableNotFound, uu___)
 let (new_u_univ : unit -> FStar_Syntax_Syntax.universe) =
-  fun uu____14969 ->
-    let uu____14970 =
-      FStar_Syntax_Unionfind.univ_fresh FStar_Range.dummyRange in
-    FStar_Syntax_Syntax.U_unif uu____14970
+  fun uu___ ->
+    let uu___1 = FStar_Syntax_Unionfind.univ_fresh FStar_Range.dummyRange in
+    FStar_Syntax_Syntax.U_unif uu___1
 let (mk_univ_subst :
   FStar_Syntax_Syntax.univ_name Prims.list ->
     FStar_Syntax_Syntax.universes -> FStar_Syntax_Syntax.subst_elt Prims.list)
@@ -2155,21 +2120,20 @@ let (inst_tscheme_with :
     fun us ->
       match (ts, us) with
       | (([], t), []) -> ([], t)
-      | ((formals, t), uu____15066) ->
+      | ((formals, t), uu___) ->
           let vs = mk_univ_subst formals us in
-          let uu____15090 = FStar_Syntax_Subst.subst vs t in
-          (us, uu____15090)
+          let uu___1 = FStar_Syntax_Subst.subst vs t in (us, uu___1)
 let (inst_tscheme :
   FStar_Syntax_Syntax.tscheme ->
     (FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.term))
   =
-  fun uu___1_15106 ->
-    match uu___1_15106 with
+  fun uu___ ->
+    match uu___ with
     | ([], t) -> ([], t)
     | (us, t) ->
         let us' =
           FStar_All.pipe_right us
-            (FStar_List.map (fun uu____15132 -> new_u_univ ())) in
+            (FStar_List.map (fun uu___1 -> new_u_univ ())) in
         inst_tscheme_with (us, t) us'
 let (inst_tscheme_with_range :
   FStar_Range.range ->
@@ -2178,11 +2142,10 @@ let (inst_tscheme_with_range :
   =
   fun r ->
     fun t ->
-      let uu____15151 = inst_tscheme t in
-      match uu____15151 with
+      let uu___ = inst_tscheme t in
+      match uu___ with
       | (us, t1) ->
-          let uu____15162 = FStar_Syntax_Subst.set_use_range r t1 in
-          (us, uu____15162)
+          let uu___1 = FStar_Syntax_Subst.set_use_range r t1 in (us, uu___1)
 let (check_effect_is_not_a_template :
   FStar_Syntax_Syntax.eff_decl -> FStar_Range.range -> unit) =
   fun ed ->
@@ -2194,14 +2157,14 @@ let (check_effect_is_not_a_template :
              Prims.int_zero)
       then
         let msg =
-          let uu____15180 =
+          let uu___ =
             FStar_Syntax_Print.lid_to_string ed.FStar_Syntax_Syntax.mname in
-          let uu____15181 =
+          let uu___1 =
             FStar_Syntax_Print.binders_to_string ", "
               ed.FStar_Syntax_Syntax.binders in
           FStar_Util.format2
             "Effect template %s should be applied to arguments for its binders (%s) before it can be used at an effect position"
-            uu____15180 uu____15181 in
+            uu___ uu___1 in
         FStar_Errors.raise_error
           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect, msg) rng
       else ()
@@ -2214,78 +2177,74 @@ let (inst_effect_fun_with :
   fun insts ->
     fun env1 ->
       fun ed ->
-        fun uu____15202 ->
-          match uu____15202 with
+        fun uu___ ->
+          match uu___ with
           | (us, t) ->
               (check_effect_is_not_a_template ed env1.range;
                if (FStar_List.length insts) <> (FStar_List.length us)
                then
-                 (let uu____15215 =
-                    let uu____15216 =
+                 (let uu___3 =
+                    let uu___4 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length us) in
-                    let uu____15217 =
+                    let uu___5 =
                       FStar_All.pipe_left FStar_Util.string_of_int
                         (FStar_List.length insts) in
-                    let uu____15218 =
+                    let uu___6 =
                       FStar_Syntax_Print.lid_to_string
                         ed.FStar_Syntax_Syntax.mname in
-                    let uu____15219 = FStar_Syntax_Print.term_to_string t in
+                    let uu___7 = FStar_Syntax_Print.term_to_string t in
                     FStar_Util.format4
                       "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
-                      uu____15216 uu____15217 uu____15218 uu____15219 in
-                  failwith uu____15215)
+                      uu___4 uu___5 uu___6 uu___7 in
+                  failwith uu___3)
                else ();
-               (let uu____15221 = inst_tscheme_with (us, t) insts in
-                FStar_Pervasives_Native.snd uu____15221))
+               (let uu___3 = inst_tscheme_with (us, t) insts in
+                FStar_Pervasives_Native.snd uu___3))
 type tri =
   | Yes 
   | No 
   | Maybe 
 let (uu___is_Yes : tri -> Prims.bool) =
-  fun projectee -> match projectee with | Yes -> true | uu____15235 -> false
+  fun projectee -> match projectee with | Yes -> true | uu___ -> false
 let (uu___is_No : tri -> Prims.bool) =
-  fun projectee -> match projectee with | No -> true | uu____15241 -> false
+  fun projectee -> match projectee with | No -> true | uu___ -> false
 let (uu___is_Maybe : tri -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Maybe -> true | uu____15247 -> false
+  fun projectee -> match projectee with | Maybe -> true | uu___ -> false
 let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
   fun env1 ->
     fun l ->
       let cur = current_module env1 in
-      let uu____15259 =
-        let uu____15260 = FStar_Ident.nsstr l in
-        let uu____15261 = FStar_Ident.string_of_lid cur in
-        uu____15260 = uu____15261 in
-      if uu____15259
+      let uu___ =
+        let uu___1 = FStar_Ident.nsstr l in
+        let uu___2 = FStar_Ident.string_of_lid cur in uu___1 = uu___2 in
+      if uu___
       then Yes
       else
-        (let uu____15263 =
-           let uu____15264 = FStar_Ident.nsstr l in
-           let uu____15265 = FStar_Ident.string_of_lid cur in
-           FStar_Util.starts_with uu____15264 uu____15265 in
-         if uu____15263
+        (let uu___2 =
+           let uu___3 = FStar_Ident.nsstr l in
+           let uu___4 = FStar_Ident.string_of_lid cur in
+           FStar_Util.starts_with uu___3 uu___4 in
+         if uu___2
          then
            let lns =
-             let uu____15269 = FStar_Ident.ns_of_lid l in
-             let uu____15272 =
-               let uu____15275 = FStar_Ident.ident_of_lid l in [uu____15275] in
-             FStar_List.append uu____15269 uu____15272 in
+             let uu___3 = FStar_Ident.ns_of_lid l in
+             let uu___4 = let uu___5 = FStar_Ident.ident_of_lid l in [uu___5] in
+             FStar_List.append uu___3 uu___4 in
            let cur1 =
-             let uu____15279 = FStar_Ident.ns_of_lid cur in
-             let uu____15282 =
-               let uu____15285 = FStar_Ident.ident_of_lid cur in
-               [uu____15285] in
-             FStar_List.append uu____15279 uu____15282 in
+             let uu___3 = FStar_Ident.ns_of_lid cur in
+             let uu___4 =
+               let uu___5 = FStar_Ident.ident_of_lid cur in [uu___5] in
+             FStar_List.append uu___3 uu___4 in
            let rec aux c l1 =
              match (c, l1) with
-             | ([], uu____15309) -> Maybe
-             | (uu____15316, []) -> No
+             | ([], uu___3) -> Maybe
+             | (uu___3, []) -> No
              | (hd::tl, hd'::tl') when
-                 let uu____15335 = FStar_Ident.string_of_id hd in
-                 let uu____15336 = FStar_Ident.string_of_id hd' in
-                 uu____15335 = uu____15336 -> aux tl tl'
-             | uu____15337 -> No in
+                 let uu___3 = FStar_Ident.string_of_id hd in
+                 let uu___4 = FStar_Ident.string_of_id hd' in uu___3 = uu___4
+                 -> aux tl tl'
+             | uu___3 -> No in
            aux cur1 lns
          else No)
 type qninfo =
@@ -2298,57 +2257,55 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
     fun lid ->
       let cur_mod = in_cur_mod env1 lid in
       let cache t =
-        (let uu____15387 = FStar_Ident.string_of_lid lid in
-         FStar_Util.smap_add (gamma_cache env1) uu____15387 t);
+        (let uu___1 = FStar_Ident.string_of_lid lid in
+         FStar_Util.smap_add (gamma_cache env1) uu___1 t);
         FStar_Pervasives_Native.Some t in
       let found =
         if cur_mod <> No
         then
-          let uu____15429 =
-            let uu____15432 = FStar_Ident.string_of_lid lid in
-            FStar_Util.smap_try_find (gamma_cache env1) uu____15432 in
-          match uu____15429 with
+          let uu___ =
+            let uu___1 = FStar_Ident.string_of_lid lid in
+            FStar_Util.smap_try_find (gamma_cache env1) uu___1 in
+          match uu___ with
           | FStar_Pervasives_Native.None ->
-              let uu____15453 =
+              let uu___1 =
                 FStar_Util.find_map env1.gamma
-                  (fun uu___2_15506 ->
-                     match uu___2_15506 with
+                  (fun uu___2 ->
+                     match uu___2 with
                      | FStar_Syntax_Syntax.Binding_lid (l, (us_names, t))
                          when FStar_Ident.lid_equals lid l ->
                          let us =
                            FStar_List.map
-                             (fun uu____15547 ->
-                                FStar_Syntax_Syntax.U_name uu____15547)
+                             (fun uu___3 -> FStar_Syntax_Syntax.U_name uu___3)
                              us_names in
-                         let uu____15548 =
-                           let uu____15571 = FStar_Ident.range_of_lid l in
-                           ((FStar_Util.Inl (us, t)), uu____15571) in
-                         FStar_Pervasives_Native.Some uu____15548
-                     | uu____15630 -> FStar_Pervasives_Native.None) in
-              FStar_Util.catch_opt uu____15453
-                (fun uu____15676 ->
+                         let uu___3 =
+                           let uu___4 = FStar_Ident.range_of_lid l in
+                           ((FStar_Util.Inl (us, t)), uu___4) in
+                         FStar_Pervasives_Native.Some uu___3
+                     | uu___3 -> FStar_Pervasives_Native.None) in
+              FStar_Util.catch_opt uu___1
+                (fun uu___2 ->
                    FStar_Util.find_map env1.gamma_sig
-                     (fun uu___3_15686 ->
-                        match uu___3_15686 with
-                        | (uu____15689,
+                     (fun uu___3 ->
+                        match uu___3 with
+                        | (uu___4,
                            {
                              FStar_Syntax_Syntax.sigel =
-                               FStar_Syntax_Syntax.Sig_bundle
-                               (ses, uu____15691);
-                             FStar_Syntax_Syntax.sigrng = uu____15692;
-                             FStar_Syntax_Syntax.sigquals = uu____15693;
-                             FStar_Syntax_Syntax.sigmeta = uu____15694;
-                             FStar_Syntax_Syntax.sigattrs = uu____15695;
-                             FStar_Syntax_Syntax.sigopts = uu____15696;_})
+                               FStar_Syntax_Syntax.Sig_bundle (ses, uu___5);
+                             FStar_Syntax_Syntax.sigrng = uu___6;
+                             FStar_Syntax_Syntax.sigquals = uu___7;
+                             FStar_Syntax_Syntax.sigmeta = uu___8;
+                             FStar_Syntax_Syntax.sigattrs = uu___9;
+                             FStar_Syntax_Syntax.sigopts = uu___10;_})
                             ->
                             FStar_Util.find_map ses
                               (fun se ->
-                                 let uu____15718 =
+                                 let uu___11 =
                                    FStar_All.pipe_right
                                      (FStar_Syntax_Util.lids_of_sigelt se)
                                      (FStar_Util.for_some
                                         (FStar_Ident.lid_equals lid)) in
-                                 if uu____15718
+                                 if uu___11
                                  then
                                    cache
                                      ((FStar_Util.Inr
@@ -2358,31 +2315,29 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                         | (lids, s) ->
                             let maybe_cache t =
                               match s.FStar_Syntax_Syntax.sigel with
-                              | FStar_Syntax_Syntax.Sig_declare_typ
-                                  uu____15766 ->
+                              | FStar_Syntax_Syntax.Sig_declare_typ uu___4 ->
                                   FStar_Pervasives_Native.Some t
-                              | uu____15773 -> cache t in
-                            let uu____15774 =
+                              | uu___4 -> cache t in
+                            let uu___4 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids in
-                            (match uu____15774 with
+                            (match uu___4 with
                              | FStar_Pervasives_Native.None ->
                                  FStar_Pervasives_Native.None
                              | FStar_Pervasives_Native.Some l ->
-                                 let uu____15780 =
-                                   let uu____15781 =
-                                     FStar_Ident.range_of_lid l in
+                                 let uu___5 =
+                                   let uu___6 = FStar_Ident.range_of_lid l in
                                    ((FStar_Util.Inr
                                        (s, FStar_Pervasives_Native.None)),
-                                     uu____15781) in
-                                 maybe_cache uu____15780)))
+                                     uu___6) in
+                                 maybe_cache uu___5)))
           | se -> se
         else FStar_Pervasives_Native.None in
       if FStar_Util.is_some found
       then found
       else
-        (let uu____15849 = find_in_sigtab env1 lid in
-         match uu____15849 with
+        (let uu___1 = find_in_sigtab env1 lid in
+         match uu___1 with
          | FStar_Pervasives_Native.Some se ->
              FStar_Pervasives_Native.Some
                ((FStar_Util.Inr (se, FStar_Pervasives_Native.None)),
@@ -2395,10 +2350,10 @@ let (lookup_sigelt :
   =
   fun env1 ->
     fun lid ->
-      let uu____15929 = lookup_qname env1 lid in
-      match uu____15929 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____15950, rng) ->
+      | FStar_Pervasives_Native.Some (FStar_Util.Inl uu___1, rng) ->
           FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, us), rng) ->
           FStar_Pervasives_Native.Some se
@@ -2406,41 +2361,39 @@ let (lookup_attr :
   env -> Prims.string -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun env1 ->
     fun attr ->
-      let uu____16061 = FStar_Util.smap_try_find (attrtab env1) attr in
-      match uu____16061 with
+      let uu___ = FStar_Util.smap_try_find (attrtab env1) attr in
+      match uu___ with
       | FStar_Pervasives_Native.Some ses -> ses
       | FStar_Pervasives_Native.None -> []
 let (add_se_to_attrtab : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env1 ->
     fun se ->
       let add_one env2 se1 attr =
-        let uu____16103 =
-          let uu____16106 = lookup_attr env2 attr in se1 :: uu____16106 in
-        FStar_Util.smap_add (attrtab env2) attr uu____16103 in
+        let uu___ = let uu___1 = lookup_attr env2 attr in se1 :: uu___1 in
+        FStar_Util.smap_add (attrtab env2) attr uu___ in
       FStar_List.iter
         (fun attr ->
-           let uu____16116 =
-             let uu____16117 = FStar_Syntax_Subst.compress attr in
-             uu____16117.FStar_Syntax_Syntax.n in
-           match uu____16116 with
+           let uu___ =
+             let uu___1 = FStar_Syntax_Subst.compress attr in
+             uu___1.FStar_Syntax_Syntax.n in
+           match uu___ with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____16121 =
-                 let uu____16122 = FStar_Syntax_Syntax.lid_of_fv fv in
-                 FStar_Ident.string_of_lid uu____16122 in
-               add_one env1 se uu____16121
-           | uu____16123 -> ()) se.FStar_Syntax_Syntax.sigattrs
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
+                 FStar_Ident.string_of_lid uu___2 in
+               add_one env1 se uu___1
+           | uu___1 -> ()) se.FStar_Syntax_Syntax.sigattrs
 let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env1 ->
     fun se ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle (ses, uu____16145) ->
-          add_sigelts env1 ses
-      | uu____16154 ->
+      | FStar_Syntax_Syntax.Sig_bundle (ses, uu___) -> add_sigelts env1 ses
+      | uu___ ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se in
           (FStar_List.iter
              (fun l ->
-                let uu____16162 = FStar_Ident.string_of_lid l in
-                FStar_Util.smap_add (sigtab env1) uu____16162 se) lids;
+                let uu___2 = FStar_Ident.string_of_lid l in
+                FStar_Util.smap_add (sigtab env1) uu___2 se) lids;
            add_se_to_attrtab env1 se)
 and (add_sigelts : env -> FStar_Syntax_Syntax.sigelt Prims.list -> unit) =
   fun env1 ->
@@ -2454,16 +2407,16 @@ let (try_lookup_bv :
   fun env1 ->
     fun bv ->
       FStar_Util.find_map env1.gamma
-        (fun uu___4_16194 ->
-           match uu___4_16194 with
+        (fun uu___ ->
+           match uu___ with
            | FStar_Syntax_Syntax.Binding_var id when
                FStar_Syntax_Syntax.bv_eq id bv ->
-               let uu____16204 =
-                 let uu____16211 =
+               let uu___1 =
+                 let uu___2 =
                    FStar_Ident.range_of_id id.FStar_Syntax_Syntax.ppname in
-                 ((id.FStar_Syntax_Syntax.sort), uu____16211) in
-               FStar_Pervasives_Native.Some uu____16204
-           | uu____16220 -> FStar_Pervasives_Native.None)
+                 ((id.FStar_Syntax_Syntax.sort), uu___2) in
+               FStar_Pervasives_Native.Some uu___1
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (lookup_type_of_let :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.sigelt ->
@@ -2479,36 +2432,36 @@ let (lookup_type_of_let :
           | FStar_Pervasives_Native.None -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_let ((uu____16281, lb::[]), uu____16283) ->
-            let uu____16290 =
-              let uu____16299 =
+        | FStar_Syntax_Syntax.Sig_let ((uu___, lb::[]), uu___1) ->
+            let uu___2 =
+              let uu___3 =
                 inst_tscheme1
                   ((lb.FStar_Syntax_Syntax.lbunivs),
                     (lb.FStar_Syntax_Syntax.lbtyp)) in
-              let uu____16308 =
+              let uu___4 =
                 FStar_Syntax_Syntax.range_of_lbname
                   lb.FStar_Syntax_Syntax.lbname in
-              (uu____16299, uu____16308) in
-            FStar_Pervasives_Native.Some uu____16290
-        | FStar_Syntax_Syntax.Sig_let ((uu____16321, lbs), uu____16323) ->
+              (uu___3, uu___4) in
+            FStar_Pervasives_Native.Some uu___2
+        | FStar_Syntax_Syntax.Sig_let ((uu___, lbs), uu___1) ->
             FStar_Util.find_map lbs
               (fun lb ->
                  match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Util.Inl uu____16353 -> failwith "impossible"
+                 | FStar_Util.Inl uu___2 -> failwith "impossible"
                  | FStar_Util.Inr fv ->
-                     let uu____16365 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
-                     if uu____16365
+                     let uu___2 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
+                     if uu___2
                      then
-                       let uu____16376 =
-                         let uu____16385 =
+                       let uu___3 =
+                         let uu___4 =
                            inst_tscheme1
                              ((lb.FStar_Syntax_Syntax.lbunivs),
                                (lb.FStar_Syntax_Syntax.lbtyp)) in
-                         let uu____16394 = FStar_Syntax_Syntax.range_of_fv fv in
-                         (uu____16385, uu____16394) in
-                       FStar_Pervasives_Native.Some uu____16376
+                         let uu___5 = FStar_Syntax_Syntax.range_of_fv fv in
+                         (uu___4, uu___5) in
+                       FStar_Pervasives_Native.Some uu___3
                      else FStar_Pervasives_Native.None)
-        | uu____16416 -> FStar_Pervasives_Native.None
+        | uu___ -> FStar_Pervasives_Native.None
 let (effect_signature :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.sigelt ->
@@ -2535,50 +2488,49 @@ let (effect_signature :
                          (FStar_Pervasives_Native.fst
                             ne.FStar_Syntax_Syntax.signature))
                   then
-                    let uu____16506 =
-                      let uu____16507 =
-                        let uu____16508 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
                           FStar_Ident.string_of_lid
                             ne.FStar_Syntax_Syntax.mname in
-                        let uu____16509 =
-                          let uu____16510 =
-                            let uu____16511 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_Util.string_of_int
                                 (FStar_List.length
                                    (FStar_Pervasives_Native.fst
                                       ne.FStar_Syntax_Syntax.signature)) in
-                            let uu____16516 =
-                              let uu____16517 =
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_Util.string_of_int
                                   (FStar_List.length us) in
-                              Prims.op_Hat ", got " uu____16517 in
-                            Prims.op_Hat uu____16511 uu____16516 in
-                          Prims.op_Hat ", expected " uu____16510 in
-                        Prims.op_Hat uu____16508 uu____16509 in
+                              Prims.op_Hat ", got " uu___9 in
+                            Prims.op_Hat uu___7 uu___8 in
+                          Prims.op_Hat ", expected " uu___6 in
+                        Prims.op_Hat uu___4 uu___5 in
                       Prims.op_Hat
                         "effect_signature: incorrect number of universes for the signature of "
-                        uu____16507 in
-                    failwith uu____16506
+                        uu___3 in
+                    failwith uu___2
                   else ());
-             (let uu____16519 =
-                let uu____16528 =
-                  inst_ts us_opt ne.FStar_Syntax_Syntax.signature in
-                (uu____16528, (se.FStar_Syntax_Syntax.sigrng)) in
-              FStar_Pervasives_Native.Some uu____16519))
+             (let uu___2 =
+                let uu___3 = inst_ts us_opt ne.FStar_Syntax_Syntax.signature in
+                (uu___3, (se.FStar_Syntax_Syntax.sigrng)) in
+              FStar_Pervasives_Native.Some uu___2))
         | FStar_Syntax_Syntax.Sig_effect_abbrev
-            (lid, us, binders, uu____16548, uu____16549) ->
-            let uu____16554 =
-              let uu____16563 =
-                let uu____16568 =
-                  let uu____16569 =
-                    let uu____16572 =
+            (lid, us, binders, uu___, uu___1) ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 =
                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff in
-                    FStar_Syntax_Util.arrow binders uu____16572 in
-                  (us, uu____16569) in
-                inst_ts us_opt uu____16568 in
-              (uu____16563, (se.FStar_Syntax_Syntax.sigrng)) in
-            FStar_Pervasives_Native.Some uu____16554
-        | uu____16591 -> FStar_Pervasives_Native.None
+                    FStar_Syntax_Util.arrow binders uu___6 in
+                  (us, uu___5) in
+                inst_ts us_opt uu___4 in
+              (uu___3, (se.FStar_Syntax_Syntax.sigrng)) in
+            FStar_Pervasives_Native.Some uu___2
+        | uu___ -> FStar_Pervasives_Native.None
 let (try_lookup_lid_aux :
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     env ->
@@ -2594,8 +2546,8 @@ let (try_lookup_lid_aux :
           match us_opt with
           | FStar_Pervasives_Native.None -> inst_tscheme ts
           | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us in
-        let mapper uu____16679 =
-          match uu____16679 with
+        let mapper uu___ =
+          match uu___ with
           | (lr, rng) ->
               (match lr with
                | FStar_Util.Inl t -> FStar_Pervasives_Native.Some (t, rng)
@@ -2603,160 +2555,153 @@ let (try_lookup_lid_aux :
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_datacon
-                        (uu____16775, uvs, t, uu____16778, uu____16779,
-                         uu____16780);
-                      FStar_Syntax_Syntax.sigrng = uu____16781;
-                      FStar_Syntax_Syntax.sigquals = uu____16782;
-                      FStar_Syntax_Syntax.sigmeta = uu____16783;
-                      FStar_Syntax_Syntax.sigattrs = uu____16784;
-                      FStar_Syntax_Syntax.sigopts = uu____16785;_},
+                        (uu___1, uvs, t, uu___2, uu___3, uu___4);
+                      FStar_Syntax_Syntax.sigrng = uu___5;
+                      FStar_Syntax_Syntax.sigquals = uu___6;
+                      FStar_Syntax_Syntax.sigmeta = uu___7;
+                      FStar_Syntax_Syntax.sigattrs = uu___8;
+                      FStar_Syntax_Syntax.sigopts = uu___9;_},
                     FStar_Pervasives_Native.None)
                    ->
-                   let uu____16808 =
-                     let uu____16817 = inst_tscheme1 (uvs, t) in
-                     (uu____16817, rng) in
-                   FStar_Pervasives_Native.Some uu____16808
+                   let uu___10 =
+                     let uu___11 = inst_tscheme1 (uvs, t) in (uu___11, rng) in
+                   FStar_Pervasives_Native.Some uu___10
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_declare_typ (l, uvs, t);
-                      FStar_Syntax_Syntax.sigrng = uu____16841;
+                      FStar_Syntax_Syntax.sigrng = uu___1;
                       FStar_Syntax_Syntax.sigquals = qs;
-                      FStar_Syntax_Syntax.sigmeta = uu____16843;
-                      FStar_Syntax_Syntax.sigattrs = uu____16844;
-                      FStar_Syntax_Syntax.sigopts = uu____16845;_},
+                      FStar_Syntax_Syntax.sigmeta = uu___2;
+                      FStar_Syntax_Syntax.sigattrs = uu___3;
+                      FStar_Syntax_Syntax.sigopts = uu___4;_},
                     FStar_Pervasives_Native.None)
                    ->
-                   let uu____16864 =
-                     let uu____16865 = in_cur_mod env1 l in uu____16865 = Yes in
-                   if uu____16864
+                   let uu___5 =
+                     let uu___6 = in_cur_mod env1 l in uu___6 = Yes in
+                   if uu___5
                    then
-                     let uu____16876 =
+                     let uu___6 =
                        (FStar_All.pipe_right qs
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                          || env1.is_iface in
-                     (if uu____16876
+                     (if uu___6
                       then
-                        let uu____16889 =
-                          let uu____16898 = inst_tscheme1 (uvs, t) in
-                          (uu____16898, rng) in
-                        FStar_Pervasives_Native.Some uu____16889
+                        let uu___7 =
+                          let uu___8 = inst_tscheme1 (uvs, t) in
+                          (uu___8, rng) in
+                        FStar_Pervasives_Native.Some uu___7
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu____16929 =
-                        let uu____16938 = inst_tscheme1 (uvs, t) in
-                        (uu____16938, rng) in
-                      FStar_Pervasives_Native.Some uu____16929)
+                     (let uu___7 =
+                        let uu___8 = inst_tscheme1 (uvs, t) in (uu___8, rng) in
+                      FStar_Pervasives_Native.Some uu___7)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1, uvs, tps, k, uu____16963, uu____16964);
-                      FStar_Syntax_Syntax.sigrng = uu____16965;
-                      FStar_Syntax_Syntax.sigquals = uu____16966;
-                      FStar_Syntax_Syntax.sigmeta = uu____16967;
-                      FStar_Syntax_Syntax.sigattrs = uu____16968;
-                      FStar_Syntax_Syntax.sigopts = uu____16969;_},
+                        (lid1, uvs, tps, k, uu___1, uu___2);
+                      FStar_Syntax_Syntax.sigrng = uu___3;
+                      FStar_Syntax_Syntax.sigquals = uu___4;
+                      FStar_Syntax_Syntax.sigmeta = uu___5;
+                      FStar_Syntax_Syntax.sigattrs = uu___6;
+                      FStar_Syntax_Syntax.sigopts = uu___7;_},
                     FStar_Pervasives_Native.None)
                    ->
                    (match tps with
                     | [] ->
-                        let uu____17012 =
-                          let uu____17021 = inst_tscheme1 (uvs, k) in
-                          (uu____17021, rng) in
-                        FStar_Pervasives_Native.Some uu____17012
-                    | uu____17042 ->
-                        let uu____17043 =
-                          let uu____17052 =
-                            let uu____17057 =
-                              let uu____17058 =
-                                let uu____17061 =
-                                  FStar_Syntax_Syntax.mk_Total k in
-                                FStar_Syntax_Util.flat_arrow tps uu____17061 in
-                              (uvs, uu____17058) in
-                            inst_tscheme1 uu____17057 in
-                          (uu____17052, rng) in
-                        FStar_Pervasives_Native.Some uu____17043)
+                        let uu___8 =
+                          let uu___9 = inst_tscheme1 (uvs, k) in
+                          (uu___9, rng) in
+                        FStar_Pervasives_Native.Some uu___8
+                    | uu___8 ->
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 =
+                              let uu___12 =
+                                let uu___13 = FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu___13 in
+                              (uvs, uu___12) in
+                            inst_tscheme1 uu___11 in
+                          (uu___10, rng) in
+                        FStar_Pervasives_Native.Some uu___9)
                | FStar_Util.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
                         FStar_Syntax_Syntax.Sig_inductive_typ
-                        (lid1, uvs, tps, k, uu____17084, uu____17085);
-                      FStar_Syntax_Syntax.sigrng = uu____17086;
-                      FStar_Syntax_Syntax.sigquals = uu____17087;
-                      FStar_Syntax_Syntax.sigmeta = uu____17088;
-                      FStar_Syntax_Syntax.sigattrs = uu____17089;
-                      FStar_Syntax_Syntax.sigopts = uu____17090;_},
+                        (lid1, uvs, tps, k, uu___1, uu___2);
+                      FStar_Syntax_Syntax.sigrng = uu___3;
+                      FStar_Syntax_Syntax.sigquals = uu___4;
+                      FStar_Syntax_Syntax.sigmeta = uu___5;
+                      FStar_Syntax_Syntax.sigattrs = uu___6;
+                      FStar_Syntax_Syntax.sigopts = uu___7;_},
                     FStar_Pervasives_Native.Some us)
                    ->
                    (match tps with
                     | [] ->
-                        let uu____17134 =
-                          let uu____17143 = inst_tscheme_with (uvs, k) us in
-                          (uu____17143, rng) in
-                        FStar_Pervasives_Native.Some uu____17134
-                    | uu____17164 ->
-                        let uu____17165 =
-                          let uu____17174 =
-                            let uu____17179 =
-                              let uu____17180 =
-                                let uu____17183 =
-                                  FStar_Syntax_Syntax.mk_Total k in
-                                FStar_Syntax_Util.flat_arrow tps uu____17183 in
-                              (uvs, uu____17180) in
-                            inst_tscheme_with uu____17179 us in
-                          (uu____17174, rng) in
-                        FStar_Pervasives_Native.Some uu____17165)
+                        let uu___8 =
+                          let uu___9 = inst_tscheme_with (uvs, k) us in
+                          (uu___9, rng) in
+                        FStar_Pervasives_Native.Some uu___8
+                    | uu___8 ->
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 =
+                              let uu___12 =
+                                let uu___13 = FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu___13 in
+                              (uvs, uu___12) in
+                            inst_tscheme_with uu___11 us in
+                          (uu___10, rng) in
+                        FStar_Pervasives_Native.Some uu___9)
                | FStar_Util.Inr se ->
-                   let uu____17219 =
+                   let uu___1 =
                      match se with
                      | ({
                           FStar_Syntax_Syntax.sigel =
-                            FStar_Syntax_Syntax.Sig_let uu____17240;
-                          FStar_Syntax_Syntax.sigrng = uu____17241;
-                          FStar_Syntax_Syntax.sigquals = uu____17242;
-                          FStar_Syntax_Syntax.sigmeta = uu____17243;
-                          FStar_Syntax_Syntax.sigattrs = uu____17244;
-                          FStar_Syntax_Syntax.sigopts = uu____17245;_},
+                            FStar_Syntax_Syntax.Sig_let uu___2;
+                          FStar_Syntax_Syntax.sigrng = uu___3;
+                          FStar_Syntax_Syntax.sigquals = uu___4;
+                          FStar_Syntax_Syntax.sigmeta = uu___5;
+                          FStar_Syntax_Syntax.sigattrs = uu___6;
+                          FStar_Syntax_Syntax.sigopts = uu___7;_},
                         FStar_Pervasives_Native.None) ->
                          lookup_type_of_let us_opt
                            (FStar_Pervasives_Native.fst se) lid
-                     | uu____17262 ->
+                     | uu___2 ->
                          effect_signature us_opt
                            (FStar_Pervasives_Native.fst se) env1.range in
-                   FStar_All.pipe_right uu____17219
+                   FStar_All.pipe_right uu___1
                      (FStar_Util.map_option
-                        (fun uu____17310 ->
-                           match uu____17310 with
-                           | (us_t, rng1) -> (us_t, rng1)))) in
-        let uu____17341 =
-          let uu____17352 = lookup_qname env1 lid in
-          FStar_Util.bind_opt uu____17352 mapper in
-        match uu____17341 with
+                        (fun uu___2 ->
+                           match uu___2 with | (us_t, rng1) -> (us_t, rng1)))) in
+        let uu___ =
+          let uu___1 = lookup_qname env1 lid in
+          FStar_Util.bind_opt uu___1 mapper in
+        match uu___ with
         | FStar_Pervasives_Native.Some ((us, t), r) ->
-            let uu____17426 =
-              let uu____17437 =
-                let uu____17444 =
-                  let uu___863_17447 = t in
-                  let uu____17448 = FStar_Ident.range_of_lid lid in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = t in
+                  let uu___5 = FStar_Ident.range_of_lid lid in
                   {
-                    FStar_Syntax_Syntax.n =
-                      (uu___863_17447.FStar_Syntax_Syntax.n);
-                    FStar_Syntax_Syntax.pos = uu____17448;
+                    FStar_Syntax_Syntax.n = (uu___4.FStar_Syntax_Syntax.n);
+                    FStar_Syntax_Syntax.pos = uu___5;
                     FStar_Syntax_Syntax.vars =
-                      (uu___863_17447.FStar_Syntax_Syntax.vars)
+                      (uu___4.FStar_Syntax_Syntax.vars)
                   } in
-                (us, uu____17444) in
-              (uu____17437, r) in
-            FStar_Pervasives_Native.Some uu____17426
+                (us, uu___3) in
+              (uu___2, r) in
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let (lid_exists : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu____17495 = lookup_qname env1 l in
-      match uu____17495 with
+      let uu___ = lookup_qname env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.None -> false
-      | FStar_Pervasives_Native.Some uu____17514 -> true
+      | FStar_Pervasives_Native.Some uu___1 -> true
 let (lookup_bv :
   env ->
     FStar_Syntax_Syntax.bv -> (FStar_Syntax_Syntax.typ * FStar_Range.range))
@@ -2764,17 +2709,17 @@ let (lookup_bv :
   fun env1 ->
     fun bv ->
       let bvr = FStar_Syntax_Syntax.range_of_bv bv in
-      let uu____17566 = try_lookup_bv env1 bv in
-      match uu____17566 with
+      let uu___ = try_lookup_bv env1 bv in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____17581 = variable_not_found bv in
-          FStar_Errors.raise_error uu____17581 bvr
+          let uu___1 = variable_not_found bv in
+          FStar_Errors.raise_error uu___1 bvr
       | FStar_Pervasives_Native.Some (t, r) ->
-          let uu____17596 = FStar_Syntax_Subst.set_use_range bvr t in
-          let uu____17597 =
-            let uu____17598 = FStar_Range.use_range bvr in
-            FStar_Range.set_use_range r uu____17598 in
-          (uu____17596, uu____17597)
+          let uu___1 = FStar_Syntax_Subst.set_use_range bvr t in
+          let uu___2 =
+            let uu___3 = FStar_Range.use_range bvr in
+            FStar_Range.set_use_range r uu___3 in
+          (uu___1, uu___2)
 let (try_lookup_lid :
   env ->
     FStar_Ident.lident ->
@@ -2783,21 +2728,20 @@ let (try_lookup_lid :
   =
   fun env1 ->
     fun l ->
-      let uu____17619 =
-        try_lookup_lid_aux FStar_Pervasives_Native.None env1 l in
-      match uu____17619 with
+      let uu___ = try_lookup_lid_aux FStar_Pervasives_Native.None env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some ((us, t), r) ->
           let use_range = FStar_Ident.range_of_lid l in
           let r1 =
-            let uu____17685 = FStar_Range.use_range use_range in
-            FStar_Range.set_use_range r uu____17685 in
-          let uu____17686 =
-            let uu____17695 =
-              let uu____17700 = FStar_Syntax_Subst.set_use_range use_range t in
-              (us, uu____17700) in
-            (uu____17695, r1) in
-          FStar_Pervasives_Native.Some uu____17686
+            let uu___1 = FStar_Range.use_range use_range in
+            FStar_Range.set_use_range r uu___1 in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.set_use_range use_range t in
+              (us, uu___3) in
+            (uu___2, r1) in
+          FStar_Pervasives_Native.Some uu___1
 let (try_lookup_and_inst_lid :
   env ->
     FStar_Syntax_Syntax.universes ->
@@ -2808,19 +2752,19 @@ let (try_lookup_and_inst_lid :
   fun env1 ->
     fun us ->
       fun l ->
-        let uu____17734 =
+        let uu___ =
           try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env1 l in
-        match uu____17734 with
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some ((uu____17767, t), r) ->
+        | FStar_Pervasives_Native.Some ((uu___1, t), r) ->
             let use_range = FStar_Ident.range_of_lid l in
             let r1 =
-              let uu____17792 = FStar_Range.use_range use_range in
-              FStar_Range.set_use_range r uu____17792 in
-            let uu____17793 =
-              let uu____17798 = FStar_Syntax_Subst.set_use_range use_range t in
-              (uu____17798, r1) in
-            FStar_Pervasives_Native.Some uu____17793
+              let uu___2 = FStar_Range.use_range use_range in
+              FStar_Range.set_use_range r uu___2 in
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.set_use_range use_range t in
+              (uu___3, r1) in
+            FStar_Pervasives_Native.Some uu___2
 let (lookup_lid :
   env ->
     FStar_Ident.lident ->
@@ -2829,25 +2773,24 @@ let (lookup_lid :
   =
   fun env1 ->
     fun l ->
-      let uu____17821 = try_lookup_lid env1 l in
-      match uu____17821 with
+      let uu___ = try_lookup_lid env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____17848 = name_not_found l in
-          let uu____17853 = FStar_Ident.range_of_lid l in
-          FStar_Errors.raise_error uu____17848 uu____17853
+          let uu___1 = name_not_found l in
+          let uu___2 = FStar_Ident.range_of_lid l in
+          FStar_Errors.raise_error uu___1 uu___2
       | FStar_Pervasives_Native.Some v -> v
 let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
   fun env1 ->
     fun x ->
       FStar_All.pipe_right
         (FStar_List.find
-           (fun uu___5_17895 ->
-              match uu___5_17895 with
+           (fun uu___ ->
+              match uu___ with
               | FStar_Syntax_Syntax.Binding_univ y ->
-                  let uu____17897 = FStar_Ident.string_of_id x in
-                  let uu____17898 = FStar_Ident.string_of_id y in
-                  uu____17897 = uu____17898
-              | uu____17899 -> false) env1.gamma) FStar_Option.isSome
+                  let uu___1 = FStar_Ident.string_of_id x in
+                  let uu___2 = FStar_Ident.string_of_id y in uu___1 = uu___2
+              | uu___1 -> false) env1.gamma) FStar_Option.isSome
 let (try_lookup_val_decl :
   env ->
     FStar_Ident.lident ->
@@ -2856,30 +2799,30 @@ let (try_lookup_val_decl :
   =
   fun env1 ->
     fun lid ->
-      let uu____17918 = lookup_qname env1 lid in
-      match uu____17918 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____17927, uvs, t);
-              FStar_Syntax_Syntax.sigrng = uu____17930;
+                (uu___1, uvs, t);
+              FStar_Syntax_Syntax.sigrng = uu___2;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____17932;
-              FStar_Syntax_Syntax.sigattrs = uu____17933;
-              FStar_Syntax_Syntax.sigopts = uu____17934;_},
+              FStar_Syntax_Syntax.sigmeta = uu___3;
+              FStar_Syntax_Syntax.sigattrs = uu___4;
+              FStar_Syntax_Syntax.sigopts = uu___5;_},
             FStar_Pervasives_Native.None),
-           uu____17935)
+           uu___6)
           ->
-          let uu____17986 =
-            let uu____17993 =
-              let uu____17994 =
-                let uu____17997 = FStar_Ident.range_of_lid lid in
-                FStar_Syntax_Subst.set_use_range uu____17997 t in
-              (uvs, uu____17994) in
-            (uu____17993, q) in
-          FStar_Pervasives_Native.Some uu____17986
-      | uu____18010 -> FStar_Pervasives_Native.None
+          let uu___7 =
+            let uu___8 =
+              let uu___9 =
+                let uu___10 = FStar_Ident.range_of_lid lid in
+                FStar_Syntax_Subst.set_use_range uu___10 t in
+              (uvs, uu___9) in
+            (uu___8, q) in
+          FStar_Pervasives_Native.Some uu___7
+      | uu___1 -> FStar_Pervasives_Native.None
 let (lookup_val_decl :
   env ->
     FStar_Ident.lident ->
@@ -2887,27 +2830,27 @@ let (lookup_val_decl :
   =
   fun env1 ->
     fun lid ->
-      let uu____18031 = lookup_qname env1 lid in
-      match uu____18031 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____18036, uvs, t);
-              FStar_Syntax_Syntax.sigrng = uu____18039;
-              FStar_Syntax_Syntax.sigquals = uu____18040;
-              FStar_Syntax_Syntax.sigmeta = uu____18041;
-              FStar_Syntax_Syntax.sigattrs = uu____18042;
-              FStar_Syntax_Syntax.sigopts = uu____18043;_},
+                (uu___1, uvs, t);
+              FStar_Syntax_Syntax.sigrng = uu___2;
+              FStar_Syntax_Syntax.sigquals = uu___3;
+              FStar_Syntax_Syntax.sigmeta = uu___4;
+              FStar_Syntax_Syntax.sigattrs = uu___5;
+              FStar_Syntax_Syntax.sigopts = uu___6;_},
             FStar_Pervasives_Native.None),
-           uu____18044)
+           uu___7)
           ->
-          let uu____18095 = FStar_Ident.range_of_lid lid in
-          inst_tscheme_with_range uu____18095 (uvs, t)
-      | uu____18100 ->
-          let uu____18101 = name_not_found lid in
-          let uu____18106 = FStar_Ident.range_of_lid lid in
-          FStar_Errors.raise_error uu____18101 uu____18106
+          let uu___8 = FStar_Ident.range_of_lid lid in
+          inst_tscheme_with_range uu___8 (uvs, t)
+      | uu___1 ->
+          let uu___2 = name_not_found lid in
+          let uu___3 = FStar_Ident.range_of_lid lid in
+          FStar_Errors.raise_error uu___2 uu___3
 let (lookup_datacon :
   env ->
     FStar_Ident.lident ->
@@ -2915,74 +2858,72 @@ let (lookup_datacon :
   =
   fun env1 ->
     fun lid ->
-      let uu____18125 = lookup_qname env1 lid in
-      match uu____18125 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18130, uvs, t, uu____18133, uu____18134, uu____18135);
-              FStar_Syntax_Syntax.sigrng = uu____18136;
-              FStar_Syntax_Syntax.sigquals = uu____18137;
-              FStar_Syntax_Syntax.sigmeta = uu____18138;
-              FStar_Syntax_Syntax.sigattrs = uu____18139;
-              FStar_Syntax_Syntax.sigopts = uu____18140;_},
+                (uu___1, uvs, t, uu___2, uu___3, uu___4);
+              FStar_Syntax_Syntax.sigrng = uu___5;
+              FStar_Syntax_Syntax.sigquals = uu___6;
+              FStar_Syntax_Syntax.sigmeta = uu___7;
+              FStar_Syntax_Syntax.sigattrs = uu___8;
+              FStar_Syntax_Syntax.sigopts = uu___9;_},
             FStar_Pervasives_Native.None),
-           uu____18141)
+           uu___10)
           ->
-          let uu____18196 = FStar_Ident.range_of_lid lid in
-          inst_tscheme_with_range uu____18196 (uvs, t)
-      | uu____18201 ->
-          let uu____18202 = name_not_found lid in
-          let uu____18207 = FStar_Ident.range_of_lid lid in
-          FStar_Errors.raise_error uu____18202 uu____18207
+          let uu___11 = FStar_Ident.range_of_lid lid in
+          inst_tscheme_with_range uu___11 (uvs, t)
+      | uu___1 ->
+          let uu___2 = name_not_found lid in
+          let uu___3 = FStar_Ident.range_of_lid lid in
+          FStar_Errors.raise_error uu___2 uu___3
 let (datacons_of_typ :
   env -> FStar_Ident.lident -> (Prims.bool * FStar_Ident.lident Prims.list))
   =
   fun env1 ->
     fun lid ->
-      let uu____18228 = lookup_qname env1 lid in
-      match uu____18228 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____18235, uu____18236, uu____18237, uu____18238,
-                 uu____18239, dcs);
-              FStar_Syntax_Syntax.sigrng = uu____18241;
-              FStar_Syntax_Syntax.sigquals = uu____18242;
-              FStar_Syntax_Syntax.sigmeta = uu____18243;
-              FStar_Syntax_Syntax.sigattrs = uu____18244;
-              FStar_Syntax_Syntax.sigopts = uu____18245;_},
-            uu____18246),
-           uu____18247)
+                (uu___1, uu___2, uu___3, uu___4, uu___5, dcs);
+              FStar_Syntax_Syntax.sigrng = uu___6;
+              FStar_Syntax_Syntax.sigquals = uu___7;
+              FStar_Syntax_Syntax.sigmeta = uu___8;
+              FStar_Syntax_Syntax.sigattrs = uu___9;
+              FStar_Syntax_Syntax.sigopts = uu___10;_},
+            uu___11),
+           uu___12)
           -> (true, dcs)
-      | uu____18310 -> (false, [])
+      | uu___1 -> (false, [])
 let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1 ->
     fun lid ->
-      let uu____18323 = lookup_qname env1 lid in
-      match uu____18323 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____18324, uu____18325, uu____18326, l, uu____18328,
-                 uu____18329);
-              FStar_Syntax_Syntax.sigrng = uu____18330;
-              FStar_Syntax_Syntax.sigquals = uu____18331;
-              FStar_Syntax_Syntax.sigmeta = uu____18332;
-              FStar_Syntax_Syntax.sigattrs = uu____18333;
-              FStar_Syntax_Syntax.sigopts = uu____18334;_},
-            uu____18335),
-           uu____18336)
+                (uu___1, uu___2, uu___3, l, uu___4, uu___5);
+              FStar_Syntax_Syntax.sigrng = uu___6;
+              FStar_Syntax_Syntax.sigquals = uu___7;
+              FStar_Syntax_Syntax.sigmeta = uu___8;
+              FStar_Syntax_Syntax.sigattrs = uu___9;
+              FStar_Syntax_Syntax.sigopts = uu___10;_},
+            uu___11),
+           uu___12)
           -> l
-      | uu____18393 ->
-          let uu____18394 =
-            let uu____18395 = FStar_Syntax_Print.lid_to_string lid in
-            FStar_Util.format1 "Not a datacon: %s" uu____18395 in
-          failwith uu____18394
+      | uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.lid_to_string lid in
+            FStar_Util.format1 "Not a datacon: %s" uu___3 in
+          failwith uu___2
 let (lookup_definition_qninfo_aux :
   Prims.bool ->
     delta_level Prims.list ->
@@ -3004,12 +2945,9 @@ let (lookup_definition_qninfo_aux :
                       (FStar_Util.for_some (visible_at dl)))) in
           match qninfo1 with
           | FStar_Pervasives_Native.Some
-              (FStar_Util.Inr (se, FStar_Pervasives_Native.None),
-               uu____18457)
-              ->
+              (FStar_Util.Inr (se, FStar_Pervasives_Native.None), uu___) ->
               (match se.FStar_Syntax_Syntax.sigel with
-               | FStar_Syntax_Syntax.Sig_let ((is_rec, lbs), uu____18514)
-                   when
+               | FStar_Syntax_Syntax.Sig_let ((is_rec, lbs), uu___1) when
                    (visible se.FStar_Syntax_Syntax.sigquals) &&
                      ((Prims.op_Negation is_rec) || rec_ok)
                    ->
@@ -3017,16 +2955,15 @@ let (lookup_definition_qninfo_aux :
                      (fun lb ->
                         let fv =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                        let uu____18536 =
-                          FStar_Syntax_Syntax.fv_eq_lid fv lid in
-                        if uu____18536
+                        let uu___2 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
+                        if uu___2
                         then
                           FStar_Pervasives_Native.Some
                             ((lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbdef))
                         else FStar_Pervasives_Native.None)
-               | uu____18568 -> FStar_Pervasives_Native.None)
-          | uu____18577 -> FStar_Pervasives_Native.None
+               | uu___1 -> FStar_Pervasives_Native.None)
+          | uu___ -> FStar_Pervasives_Native.None
 let (lookup_definition_qninfo :
   delta_level Prims.list ->
     FStar_Ident.lident ->
@@ -3048,9 +2985,8 @@ let (lookup_definition :
   fun delta_levels ->
     fun env1 ->
       fun lid ->
-        let uu____18636 = lookup_qname env1 lid in
-        FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid)
-          uu____18636
+        let uu___ = lookup_qname env1 lid in
+        FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid) uu___
 let (lookup_nonrec_definition :
   delta_level Prims.list ->
     env ->
@@ -3061,9 +2997,9 @@ let (lookup_nonrec_definition :
   fun delta_levels ->
     fun env1 ->
       fun lid ->
-        let uu____18668 = lookup_qname env1 lid in
+        let uu___ = lookup_qname env1 lid in
         FStar_All.pipe_left
-          (lookup_definition_qninfo_aux false delta_levels lid) uu____18668
+          (lookup_definition_qninfo_aux false delta_levels lid) uu___
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
     qninfo -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
@@ -3071,118 +3007,113 @@ let (delta_depth_of_qninfo :
   fun fv ->
     fun qn ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu____18690 =
-        let uu____18691 = FStar_Ident.nsstr lid in uu____18691 = "Prims" in
-      if uu____18690
+      let uu___ = let uu___1 = FStar_Ident.nsstr lid in uu___1 = "Prims" in
+      if uu___
       then FStar_Pervasives_Native.Some (fv.FStar_Syntax_Syntax.fv_delta)
       else
         (match qn with
          | FStar_Pervasives_Native.None ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
-         | FStar_Pervasives_Native.Some
-             (FStar_Util.Inl uu____18715, uu____18716) ->
+         | FStar_Pervasives_Native.Some (FStar_Util.Inl uu___2, uu___3) ->
              FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
-         | FStar_Pervasives_Native.Some
-             (FStar_Util.Inr (se, uu____18764), uu____18765) ->
+         | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, uu___2), uu___3)
+             ->
              (match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_inductive_typ uu____18814 ->
+              | FStar_Syntax_Syntax.Sig_inductive_typ uu___4 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_bundle uu____18831 ->
+              | FStar_Syntax_Syntax.Sig_bundle uu___4 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_datacon uu____18840 ->
+              | FStar_Syntax_Syntax.Sig_datacon uu___4 ->
                   FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Delta_constant_at_level
                        Prims.int_zero)
-              | FStar_Syntax_Syntax.Sig_declare_typ uu____18855 ->
-                  let uu____18862 =
+              | FStar_Syntax_Syntax.Sig_declare_typ uu___4 ->
+                  let uu___5 =
                     FStar_Syntax_DsEnv.delta_depth_of_declaration lid
                       se.FStar_Syntax_Syntax.sigquals in
-                  FStar_Pervasives_Native.Some uu____18862
-              | FStar_Syntax_Syntax.Sig_let ((uu____18863, lbs), uu____18865)
-                  ->
+                  FStar_Pervasives_Native.Some uu___5
+              | FStar_Syntax_Syntax.Sig_let ((uu___4, lbs), uu___5) ->
                   FStar_Util.find_map lbs
                     (fun lb ->
                        let fv1 =
                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                       let uu____18879 =
-                         FStar_Syntax_Syntax.fv_eq_lid fv1 lid in
-                       if uu____18879
+                       let uu___6 = FStar_Syntax_Syntax.fv_eq_lid fv1 lid in
+                       if uu___6
                        then
                          FStar_Pervasives_Native.Some
                            (fv1.FStar_Syntax_Syntax.fv_delta)
                        else FStar_Pervasives_Native.None)
-              | FStar_Syntax_Syntax.Sig_fail uu____18883 ->
+              | FStar_Syntax_Syntax.Sig_fail uu___4 ->
                   failwith "impossible: delta_depth_of_qninfo"
-              | FStar_Syntax_Syntax.Sig_splice uu____18896 ->
+              | FStar_Syntax_Syntax.Sig_splice uu___4 ->
                   failwith "impossible: delta_depth_of_qninfo"
-              | FStar_Syntax_Syntax.Sig_assume uu____18905 ->
+              | FStar_Syntax_Syntax.Sig_assume uu___4 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_new_effect uu____18912 ->
+              | FStar_Syntax_Syntax.Sig_new_effect uu___4 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_sub_effect uu____18913 ->
+              | FStar_Syntax_Syntax.Sig_sub_effect uu___4 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18914 ->
+              | FStar_Syntax_Syntax.Sig_effect_abbrev uu___4 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_pragma uu____18927 ->
+              | FStar_Syntax_Syntax.Sig_pragma uu___4 ->
                   FStar_Pervasives_Native.None
-              | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____18928 ->
+              | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___4 ->
                   FStar_Pervasives_Native.None))
 let (delta_depth_of_fv :
   env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth) =
   fun env1 ->
     fun fv ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu____18950 =
-        let uu____18951 = FStar_Ident.nsstr lid in uu____18951 = "Prims" in
-      if uu____18950
+      let uu___ = let uu___1 = FStar_Ident.nsstr lid in uu___1 = "Prims" in
+      if uu___
       then fv.FStar_Syntax_Syntax.fv_delta
       else
-        (let uu____18953 =
-           let uu____18956 = FStar_Ident.string_of_lid lid in
-           FStar_All.pipe_right uu____18956
+        (let uu___2 =
+           let uu___3 = FStar_Ident.string_of_lid lid in
+           FStar_All.pipe_right uu___3
              (FStar_Util.smap_try_find env1.fv_delta_depths) in
-         FStar_All.pipe_right uu____18953
+         FStar_All.pipe_right uu___2
            (fun d_opt ->
-              let uu____18966 = FStar_All.pipe_right d_opt FStar_Util.is_some in
-              if uu____18966
+              let uu___3 = FStar_All.pipe_right d_opt FStar_Util.is_some in
+              if uu___3
               then FStar_All.pipe_right d_opt FStar_Util.must
               else
-                (let uu____18972 =
-                   let uu____18975 =
+                (let uu___5 =
+                   let uu___6 =
                      lookup_qname env1
                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                   delta_depth_of_qninfo fv uu____18975 in
-                 match uu____18972 with
+                   delta_depth_of_qninfo fv uu___6 in
+                 match uu___5 with
                  | FStar_Pervasives_Native.None ->
-                     let uu____18976 =
-                       let uu____18977 = FStar_Syntax_Print.fv_to_string fv in
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Print.fv_to_string fv in
                        FStar_Util.format1 "Delta depth not found for %s"
-                         uu____18977 in
-                     failwith uu____18976
+                         uu___7 in
+                     failwith uu___6
                  | FStar_Pervasives_Native.Some d ->
-                     ((let uu____18980 =
+                     ((let uu___7 =
                          (d <> fv.FStar_Syntax_Syntax.fv_delta) &&
                            (FStar_Options.debug_any ()) in
-                       if uu____18980
+                       if uu___7
                        then
-                         let uu____18981 = FStar_Syntax_Print.fv_to_string fv in
-                         let uu____18982 =
+                         let uu___8 = FStar_Syntax_Print.fv_to_string fv in
+                         let uu___9 =
                            FStar_Syntax_Print.delta_depth_to_string
                              fv.FStar_Syntax_Syntax.fv_delta in
-                         let uu____18983 =
+                         let uu___10 =
                            FStar_Syntax_Print.delta_depth_to_string d in
                          FStar_Util.print3
                            "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
-                           uu____18981 uu____18982 uu____18983
+                           uu___8 uu___9 uu___10
                        else ());
-                      (let uu____18986 = FStar_Ident.string_of_lid lid in
-                       FStar_Util.smap_add env1.fv_delta_depths uu____18986 d);
+                      (let uu___8 = FStar_Ident.string_of_lid lid in
+                       FStar_Util.smap_add env1.fv_delta_depths uu___8 d);
                       d))))
 let (quals_of_qninfo :
   qninfo ->
@@ -3190,20 +3121,18 @@ let (quals_of_qninfo :
   =
   fun qninfo1 ->
     match qninfo1 with
-    | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se, uu____19005), uu____19006) ->
+    | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, uu___), uu___1) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigquals)
-    | uu____19055 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (attrs_of_qninfo :
   qninfo ->
     FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option)
   =
   fun qninfo1 ->
     match qninfo1 with
-    | FStar_Pervasives_Native.Some
-        (FStar_Util.Inr (se, uu____19076), uu____19077) ->
+    | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, uu___), uu___1) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigattrs)
-    | uu____19126 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (lookup_attrs_of_lid :
   env ->
     FStar_Ident.lid ->
@@ -3211,37 +3140,37 @@ let (lookup_attrs_of_lid :
   =
   fun env1 ->
     fun lid ->
-      let uu____19147 = lookup_qname env1 lid in
-      FStar_All.pipe_left attrs_of_qninfo uu____19147
+      let uu___ = lookup_qname env1 lid in
+      FStar_All.pipe_left attrs_of_qninfo uu___
 let (fv_exists_and_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lident -> (Prims.bool * Prims.bool))
   =
   fun env1 ->
     fun fv_lid ->
       fun attr_lid ->
-        let uu____19175 = lookup_attrs_of_lid env1 fv_lid in
-        match uu____19175 with
+        let uu___ = lookup_attrs_of_lid env1 fv_lid in
+        match uu___ with
         | FStar_Pervasives_Native.None -> (false, false)
         | FStar_Pervasives_Native.Some attrs ->
-            let uu____19191 =
+            let uu___1 =
               FStar_All.pipe_right attrs
                 (FStar_Util.for_some
                    (fun tm ->
-                      let uu____19198 =
-                        let uu____19199 = FStar_Syntax_Util.un_uinst tm in
-                        uu____19199.FStar_Syntax_Syntax.n in
-                      match uu____19198 with
+                      let uu___2 =
+                        let uu___3 = FStar_Syntax_Util.un_uinst tm in
+                        uu___3.FStar_Syntax_Syntax.n in
+                      match uu___2 with
                       | FStar_Syntax_Syntax.Tm_fvar fv ->
                           FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
-                      | uu____19203 -> false)) in
-            (true, uu____19191)
+                      | uu___3 -> false)) in
+            (true, uu___1)
 let (fv_with_lid_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lid -> Prims.bool) =
   fun env1 ->
     fun fv_lid ->
       fun attr_lid ->
-        let uu____19219 = fv_exists_and_has_attr env1 fv_lid attr_lid in
-        FStar_Pervasives_Native.snd uu____19219
+        let uu___ = fv_exists_and_has_attr env1 fv_lid attr_lid in
+        FStar_Pervasives_Native.snd uu___
 let (fv_has_attr :
   env -> FStar_Syntax_Syntax.fv -> FStar_Ident.lid -> Prims.bool) =
   fun env1 ->
@@ -3258,13 +3187,13 @@ let cache_in_fv_tab :
     fun fv ->
       fun f ->
         let s =
-          let uu____19281 = FStar_Syntax_Syntax.lid_of_fv fv in
-          FStar_Ident.string_of_lid uu____19281 in
-        let uu____19282 = FStar_Util.smap_try_find tab s in
-        match uu____19282 with
+          let uu___ = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu___ in
+        let uu___ = FStar_Util.smap_try_find tab s in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
-            let uu____19285 = f () in
-            (match uu____19285 with
+            let uu___1 = f () in
+            (match uu___1 with
              | (should_cache, res) ->
                  (if should_cache then FStar_Util.smap_add tab s res else ();
                   res))
@@ -3272,35 +3201,34 @@ let cache_in_fv_tab :
 let (type_is_erasable : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun env1 ->
     fun fv ->
-      let f uu____19314 =
-        let uu____19315 =
+      let f uu___ =
+        let uu___1 =
           fv_exists_and_has_attr env1
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             FStar_Parser_Const.erasable_attr in
-        match uu____19315 with | (ex, erasable) -> (ex, erasable) in
+        match uu___1 with | (ex, erasable) -> (ex, erasable) in
       cache_in_fv_tab env1.erasable_types_tab fv f
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env1 ->
     fun t ->
-      let uu____19336 =
-        let uu____19337 = FStar_Syntax_Util.unrefine t in
-        uu____19337.FStar_Syntax_Syntax.n in
-      match uu____19336 with
-      | FStar_Syntax_Syntax.Tm_type uu____19340 -> true
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.unrefine t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_type uu___1 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
               (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
              ||
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid))
             || (type_is_erasable env1 fv)
-      | FStar_Syntax_Syntax.Tm_app (head, uu____19343) ->
+      | FStar_Syntax_Syntax.Tm_app (head, uu___1) ->
           non_informative env1 head
-      | FStar_Syntax_Syntax.Tm_uinst (t1, uu____19369) ->
-          non_informative env1 t1
-      | FStar_Syntax_Syntax.Tm_arrow (uu____19374, c) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> non_informative env1 t1
+      | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
           (FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
             (non_informative env1 (FStar_Syntax_Util.comp_result c))
-      | uu____19396 -> false
+      | uu___1 -> false
 let (fv_has_strict_args :
   env ->
     FStar_Syntax_Syntax.fv ->
@@ -3308,10 +3236,10 @@ let (fv_has_strict_args :
   =
   fun env1 ->
     fun fv ->
-      let f uu____19424 =
+      let f uu___ =
         let attrs =
-          let uu____19430 = FStar_Syntax_Syntax.lid_of_fv fv in
-          lookup_attrs_of_lid env1 uu____19430 in
+          let uu___1 = FStar_Syntax_Syntax.lid_of_fv fv in
+          lookup_attrs_of_lid env1 uu___1 in
         match attrs with
         | FStar_Pervasives_Native.None ->
             (false, FStar_Pervasives_Native.None)
@@ -3319,10 +3247,10 @@ let (fv_has_strict_args :
             let res =
               FStar_Util.find_map attrs1
                 (fun x ->
-                   let uu____19462 =
+                   let uu___1 =
                      FStar_ToSyntax_ToSyntax.parse_attr_with_list false x
                        FStar_Parser_Const.strict_on_arguments_attr in
-                   FStar_Pervasives_Native.fst uu____19462) in
+                   FStar_Pervasives_Native.fst uu___1) in
             (true, res) in
       cache_in_fv_tab env1.strict_args_tab fv f
 let (try_lookup_effect_lid :
@@ -3332,30 +3260,30 @@ let (try_lookup_effect_lid :
   =
   fun env1 ->
     fun ftv ->
-      let uu____19497 = lookup_qname env1 ftv in
-      match uu____19497 with
+      let uu___ = lookup_qname env1 ftv in
+      match uu___ with
       | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se, FStar_Pervasives_Native.None), uu____19501) ->
-          let uu____19546 =
+          (FStar_Util.Inr (se, FStar_Pervasives_Native.None), uu___1) ->
+          let uu___2 =
             effect_signature FStar_Pervasives_Native.None se env1.range in
-          (match uu____19546 with
+          (match uu___2 with
            | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-           | FStar_Pervasives_Native.Some ((uu____19567, t), r) ->
-               let uu____19582 =
-                 let uu____19583 = FStar_Ident.range_of_lid ftv in
-                 FStar_Syntax_Subst.set_use_range uu____19583 t in
-               FStar_Pervasives_Native.Some uu____19582)
-      | uu____19584 -> FStar_Pervasives_Native.None
+           | FStar_Pervasives_Native.Some ((uu___3, t), r) ->
+               let uu___4 =
+                 let uu___5 = FStar_Ident.range_of_lid ftv in
+                 FStar_Syntax_Subst.set_use_range uu___5 t in
+               FStar_Pervasives_Native.Some uu___4)
+      | uu___1 -> FStar_Pervasives_Native.None
 let (lookup_effect_lid :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun env1 ->
     fun ftv ->
-      let uu____19595 = try_lookup_effect_lid env1 ftv in
-      match uu____19595 with
+      let uu___ = try_lookup_effect_lid env1 ftv in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____19598 = name_not_found ftv in
-          let uu____19603 = FStar_Ident.range_of_lid ftv in
-          FStar_Errors.raise_error uu____19598 uu____19603
+          let uu___1 = name_not_found ftv in
+          let uu___2 = FStar_Ident.range_of_lid ftv in
+          FStar_Errors.raise_error uu___1 uu___2
       | FStar_Pervasives_Native.Some k -> k
 let (lookup_effect_abbrev :
   env ->
@@ -3367,38 +3295,38 @@ let (lookup_effect_abbrev :
   fun env1 ->
     fun univ_insts ->
       fun lid0 ->
-        let uu____19626 = lookup_qname env1 lid0 in
-        match uu____19626 with
+        let uu___ = lookup_qname env1 lid0 in
+        match uu___ with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
              ({
                 FStar_Syntax_Syntax.sigel =
                   FStar_Syntax_Syntax.Sig_effect_abbrev
-                  (lid, univs, binders, c, uu____19637);
-                FStar_Syntax_Syntax.sigrng = uu____19638;
+                  (lid, univs, binders, c, uu___1);
+                FStar_Syntax_Syntax.sigrng = uu___2;
                 FStar_Syntax_Syntax.sigquals = quals;
-                FStar_Syntax_Syntax.sigmeta = uu____19640;
-                FStar_Syntax_Syntax.sigattrs = uu____19641;
-                FStar_Syntax_Syntax.sigopts = uu____19642;_},
+                FStar_Syntax_Syntax.sigmeta = uu___3;
+                FStar_Syntax_Syntax.sigattrs = uu___4;
+                FStar_Syntax_Syntax.sigopts = uu___5;_},
               FStar_Pervasives_Native.None),
-             uu____19643)
+             uu___6)
             ->
             let lid1 =
-              let uu____19699 =
-                let uu____19700 = FStar_Ident.range_of_lid lid in
-                let uu____19701 =
-                  let uu____19702 = FStar_Ident.range_of_lid lid0 in
-                  FStar_Range.use_range uu____19702 in
-                FStar_Range.set_use_range uu____19700 uu____19701 in
-              FStar_Ident.set_lid_range lid uu____19699 in
-            let uu____19703 =
+              let uu___7 =
+                let uu___8 = FStar_Ident.range_of_lid lid in
+                let uu___9 =
+                  let uu___10 = FStar_Ident.range_of_lid lid0 in
+                  FStar_Range.use_range uu___10 in
+                FStar_Range.set_use_range uu___8 uu___9 in
+              FStar_Ident.set_lid_range lid uu___7 in
+            let uu___7 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
-                   (fun uu___6_19707 ->
-                      match uu___6_19707 with
+                   (fun uu___8 ->
+                      match uu___8 with
                       | FStar_Syntax_Syntax.Irreducible -> true
-                      | uu____19708 -> false)) in
-            if uu____19703
+                      | uu___9 -> false)) in
+            if uu___7
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3406,147 +3334,145 @@ let (lookup_effect_abbrev :
                    (FStar_List.length univ_insts) = (FStar_List.length univs)
                  then univ_insts
                  else
-                   (let uu____19722 =
-                      let uu____19723 =
-                        let uu____19724 = get_range env1 in
-                        FStar_Range.string_of_range uu____19724 in
-                      let uu____19725 = FStar_Syntax_Print.lid_to_string lid1 in
-                      let uu____19726 =
+                   (let uu___10 =
+                      let uu___11 =
+                        let uu___12 = get_range env1 in
+                        FStar_Range.string_of_range uu___12 in
+                      let uu___12 = FStar_Syntax_Print.lid_to_string lid1 in
+                      let uu___13 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
                           FStar_Util.string_of_int in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____19723 uu____19725 uu____19726 in
-                    failwith uu____19722) in
+                        uu___11 uu___12 uu___13 in
+                    failwith uu___10) in
                match (binders, univs) with
-               | ([], uu____19743) ->
+               | ([], uu___9) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu____19768, uu____19769::uu____19770::uu____19771) ->
-                   let uu____19792 =
-                     let uu____19793 = FStar_Syntax_Print.lid_to_string lid1 in
-                     let uu____19794 =
+               | (uu___9, uu___10::uu___11::uu___12) ->
+                   let uu___13 =
+                     let uu___14 = FStar_Syntax_Print.lid_to_string lid1 in
+                     let uu___15 =
                        FStar_All.pipe_left FStar_Util.string_of_int
                          (FStar_List.length univs) in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____19793 uu____19794 in
-                   failwith uu____19792
-               | uu____19801 ->
-                   let uu____19816 =
-                     let uu____19821 =
-                       let uu____19822 = FStar_Syntax_Util.arrow binders c in
-                       (univs, uu____19822) in
-                     inst_tscheme_with uu____19821 insts in
-                   (match uu____19816 with
-                    | (uu____19835, t) ->
+                       uu___14 uu___15 in
+                   failwith uu___13
+               | uu___9 ->
+                   let uu___10 =
+                     let uu___11 =
+                       let uu___12 = FStar_Syntax_Util.arrow binders c in
+                       (univs, uu___12) in
+                     inst_tscheme_with uu___11 insts in
+                   (match uu___10 with
+                    | (uu___11, t) ->
                         let t1 =
-                          let uu____19838 = FStar_Ident.range_of_lid lid1 in
-                          FStar_Syntax_Subst.set_use_range uu____19838 t in
-                        let uu____19839 =
-                          let uu____19840 = FStar_Syntax_Subst.compress t1 in
-                          uu____19840.FStar_Syntax_Syntax.n in
-                        (match uu____19839 with
+                          let uu___12 = FStar_Ident.range_of_lid lid1 in
+                          FStar_Syntax_Subst.set_use_range uu___12 t in
+                        let uu___12 =
+                          let uu___13 = FStar_Syntax_Subst.compress t1 in
+                          uu___13.FStar_Syntax_Syntax.n in
+                        (match uu___12 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1, c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu____19875 -> failwith "Impossible")))
-        | uu____19882 -> FStar_Pervasives_Native.None
+                         | uu___13 -> failwith "Impossible")))
+        | uu___1 -> FStar_Pervasives_Native.None
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1 ->
     fun l ->
       let rec find l1 =
-        let uu____19905 =
+        let uu___ =
           lookup_effect_abbrev env1 [FStar_Syntax_Syntax.U_unknown] l1 in
-        match uu____19905 with
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (uu____19918, c) ->
+        | FStar_Pervasives_Native.Some (uu___1, c) ->
             let l2 = FStar_Syntax_Util.comp_effect_name c in
-            let uu____19925 = find l2 in
-            (match uu____19925 with
+            let uu___2 = find l2 in
+            (match uu___2 with
              | FStar_Pervasives_Native.None ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
                  FStar_Pervasives_Native.Some l') in
       let res =
-        let uu____19932 =
-          let uu____19935 = FStar_Ident.string_of_lid l in
-          FStar_Util.smap_try_find env1.normalized_eff_names uu____19935 in
-        match uu____19932 with
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid l in
+          FStar_Util.smap_try_find env1.normalized_eff_names uu___1 in
+        match uu___ with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None ->
-            let uu____19937 = find l in
-            (match uu____19937 with
+            let uu___1 = find l in
+            (match uu___1 with
              | FStar_Pervasives_Native.None -> l
              | FStar_Pervasives_Native.Some m ->
-                 ((let uu____19942 = FStar_Ident.string_of_lid l in
-                   FStar_Util.smap_add env1.normalized_eff_names uu____19942
-                     m);
+                 ((let uu___3 = FStar_Ident.string_of_lid l in
+                   FStar_Util.smap_add env1.normalized_eff_names uu___3 m);
                   m)) in
-      let uu____19943 = FStar_Ident.range_of_lid l in
-      FStar_Ident.set_lid_range res uu____19943
+      let uu___ = FStar_Ident.range_of_lid l in
+      FStar_Ident.set_lid_range res uu___
 let (num_effect_indices :
   env -> FStar_Ident.lident -> FStar_Range.range -> Prims.int) =
   fun env1 ->
     fun name ->
       fun r ->
         let sig_t =
-          let uu____19962 =
-            FStar_All.pipe_right name (lookup_effect_lid env1) in
-          FStar_All.pipe_right uu____19962 FStar_Syntax_Subst.compress in
+          let uu___ = FStar_All.pipe_right name (lookup_effect_lid env1) in
+          FStar_All.pipe_right uu___ FStar_Syntax_Subst.compress in
         match sig_t.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_arrow (_a::bs, uu____19967) ->
+        | FStar_Syntax_Syntax.Tm_arrow (_a::bs, uu___) ->
             FStar_List.length bs
-        | uu____20006 ->
-            let uu____20007 =
-              let uu____20012 =
-                let uu____20013 = FStar_Ident.string_of_lid name in
-                let uu____20014 = FStar_Syntax_Print.term_to_string sig_t in
+        | uu___ ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Ident.string_of_lid name in
+                let uu___4 = FStar_Syntax_Print.term_to_string sig_t in
                 FStar_Util.format2 "Signature for %s not an arrow (%s)"
-                  uu____20013 uu____20014 in
-              (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____20012) in
-            FStar_Errors.raise_error uu____20007 r
+                  uu___3 uu___4 in
+              (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu___2) in
+            FStar_Errors.raise_error uu___1 r
 let (lookup_effect_quals :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
   fun env1 ->
     fun l ->
       let l1 = norm_eff_name env1 l in
-      let uu____20028 = lookup_qname env1 l1 in
-      match uu____20028 with
+      let uu___ = lookup_qname env1 l1 in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_new_effect
-                uu____20031;
-              FStar_Syntax_Syntax.sigrng = uu____20032;
+                uu___1;
+              FStar_Syntax_Syntax.sigrng = uu___2;
               FStar_Syntax_Syntax.sigquals = q;
-              FStar_Syntax_Syntax.sigmeta = uu____20034;
-              FStar_Syntax_Syntax.sigattrs = uu____20035;
-              FStar_Syntax_Syntax.sigopts = uu____20036;_},
-            uu____20037),
-           uu____20038)
+              FStar_Syntax_Syntax.sigmeta = uu___3;
+              FStar_Syntax_Syntax.sigattrs = uu___4;
+              FStar_Syntax_Syntax.sigopts = uu___5;_},
+            uu___6),
+           uu___7)
           -> q
-      | uu____20091 -> []
+      | uu___1 -> []
 let (lookup_projector :
   env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
   fun env1 ->
     fun lid ->
       fun i ->
-        let fail uu____20112 =
-          let uu____20113 =
-            let uu____20114 = FStar_Util.string_of_int i in
-            let uu____20115 = FStar_Syntax_Print.lid_to_string lid in
+        let fail uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Util.string_of_int i in
+            let uu___3 = FStar_Syntax_Print.lid_to_string lid in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____20114 uu____20115 in
-          failwith uu____20113 in
-        let uu____20116 = lookup_datacon env1 lid in
-        match uu____20116 with
-        | (uu____20121, t) ->
-            let uu____20123 =
-              let uu____20124 = FStar_Syntax_Subst.compress t in
-              uu____20124.FStar_Syntax_Syntax.n in
-            (match uu____20123 with
-             | FStar_Syntax_Syntax.Tm_arrow (binders, uu____20128) ->
+              uu___2 uu___3 in
+          failwith uu___1 in
+        let uu___ = lookup_datacon env1 lid in
+        match uu___ with
+        | (uu___1, t) ->
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.compress t in
+              uu___3.FStar_Syntax_Syntax.n in
+            (match uu___2 with
+             | FStar_Syntax_Syntax.Tm_arrow (binders, uu___3) ->
                  if
                    (i < Prims.int_zero) || (i >= (FStar_List.length binders))
                  then fail ()
@@ -3554,78 +3480,76 @@ let (lookup_projector :
                    (let b = FStar_List.nth binders i in
                     FStar_Syntax_Util.mk_field_projector_name lid
                       (FStar_Pervasives_Native.fst b) i)
-             | uu____20171 -> fail ())
+             | uu___3 -> fail ())
 let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu____20182 = lookup_qname env1 l in
-      match uu____20182 with
+      let uu___ = lookup_qname env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_declare_typ
-                (uu____20183, uu____20184, uu____20185);
-              FStar_Syntax_Syntax.sigrng = uu____20186;
+                (uu___1, uu___2, uu___3);
+              FStar_Syntax_Syntax.sigrng = uu___4;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20188;
-              FStar_Syntax_Syntax.sigattrs = uu____20189;
-              FStar_Syntax_Syntax.sigopts = uu____20190;_},
-            uu____20191),
-           uu____20192)
+              FStar_Syntax_Syntax.sigmeta = uu___5;
+              FStar_Syntax_Syntax.sigattrs = uu___6;
+              FStar_Syntax_Syntax.sigopts = uu___7;_},
+            uu___8),
+           uu___9)
           ->
           FStar_Util.for_some
-            (fun uu___7_20247 ->
-               match uu___7_20247 with
-               | FStar_Syntax_Syntax.Projector uu____20248 -> true
-               | uu____20253 -> false) quals
-      | uu____20254 -> false
+            (fun uu___10 ->
+               match uu___10 with
+               | FStar_Syntax_Syntax.Projector uu___11 -> true
+               | uu___11 -> false) quals
+      | uu___1 -> false
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
-      let uu____20265 = lookup_qname env1 lid in
-      match uu____20265 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                (uu____20266, uu____20267, uu____20268, uu____20269,
-                 uu____20270, uu____20271);
-              FStar_Syntax_Syntax.sigrng = uu____20272;
-              FStar_Syntax_Syntax.sigquals = uu____20273;
-              FStar_Syntax_Syntax.sigmeta = uu____20274;
-              FStar_Syntax_Syntax.sigattrs = uu____20275;
-              FStar_Syntax_Syntax.sigopts = uu____20276;_},
-            uu____20277),
-           uu____20278)
+                (uu___1, uu___2, uu___3, uu___4, uu___5, uu___6);
+              FStar_Syntax_Syntax.sigrng = uu___7;
+              FStar_Syntax_Syntax.sigquals = uu___8;
+              FStar_Syntax_Syntax.sigmeta = uu___9;
+              FStar_Syntax_Syntax.sigattrs = uu___10;
+              FStar_Syntax_Syntax.sigopts = uu___11;_},
+            uu___12),
+           uu___13)
           -> true
-      | uu____20335 -> false
+      | uu___1 -> false
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
-      let uu____20346 = lookup_qname env1 lid in
-      match uu____20346 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20347, uu____20348, uu____20349, uu____20350,
-                 uu____20351, uu____20352);
-              FStar_Syntax_Syntax.sigrng = uu____20353;
+                (uu___1, uu___2, uu___3, uu___4, uu___5, uu___6);
+              FStar_Syntax_Syntax.sigrng = uu___7;
               FStar_Syntax_Syntax.sigquals = quals;
-              FStar_Syntax_Syntax.sigmeta = uu____20355;
-              FStar_Syntax_Syntax.sigattrs = uu____20356;
-              FStar_Syntax_Syntax.sigopts = uu____20357;_},
-            uu____20358),
-           uu____20359)
+              FStar_Syntax_Syntax.sigmeta = uu___8;
+              FStar_Syntax_Syntax.sigattrs = uu___9;
+              FStar_Syntax_Syntax.sigopts = uu___10;_},
+            uu___11),
+           uu___12)
           ->
           FStar_Util.for_some
-            (fun uu___8_20422 ->
-               match uu___8_20422 with
-               | FStar_Syntax_Syntax.RecordType uu____20423 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu____20432 -> true
-               | uu____20441 -> false) quals
-      | uu____20442 -> false
+            (fun uu___13 ->
+               match uu___13 with
+               | FStar_Syntax_Syntax.RecordType uu___14 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu___14 -> true
+               | uu___14 -> false) quals
+      | uu___1 -> false
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo1 ->
     match qninfo1 with
@@ -3633,26 +3557,26 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-              (uu____20448, uu____20449);
-            FStar_Syntax_Syntax.sigrng = uu____20450;
+              (uu___, uu___1);
+            FStar_Syntax_Syntax.sigrng = uu___2;
             FStar_Syntax_Syntax.sigquals = quals;
-            FStar_Syntax_Syntax.sigmeta = uu____20452;
-            FStar_Syntax_Syntax.sigattrs = uu____20453;
-            FStar_Syntax_Syntax.sigopts = uu____20454;_},
-          uu____20455),
-         uu____20456)
+            FStar_Syntax_Syntax.sigmeta = uu___3;
+            FStar_Syntax_Syntax.sigattrs = uu___4;
+            FStar_Syntax_Syntax.sigopts = uu___5;_},
+          uu___6),
+         uu___7)
         ->
         FStar_Util.for_some
-          (fun uu___9_20515 ->
-             match uu___9_20515 with
-             | FStar_Syntax_Syntax.Action uu____20516 -> true
-             | uu____20517 -> false) quals
-    | uu____20518 -> false
+          (fun uu___8 ->
+             match uu___8 with
+             | FStar_Syntax_Syntax.Action uu___9 -> true
+             | uu___9 -> false) quals
+    | uu___ -> false
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
-      let uu____20529 = lookup_qname env1 lid in
-      FStar_All.pipe_left qninfo_is_action uu____20529
+      let uu___ = lookup_qname env1 lid in
+      FStar_All.pipe_left qninfo_is_action uu___
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
     [FStar_Parser_Const.op_Eq;
@@ -3672,72 +3596,69 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Negation] in
   fun env1 ->
     fun head ->
-      let uu____20543 =
-        let uu____20544 = FStar_Syntax_Util.un_uinst head in
-        uu____20544.FStar_Syntax_Syntax.n in
-      match uu____20543 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.un_uinst head in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu____20548 ->
-               true
-           | uu____20549 -> false)
-      | uu____20550 -> false
+           | FStar_Syntax_Syntax.Delta_equational_at_level uu___1 -> true
+           | uu___1 -> false)
+      | uu___1 -> false
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu____20561 = lookup_qname env1 l in
-      match uu____20561 with
-      | FStar_Pervasives_Native.Some
-          (FStar_Util.Inr (se, uu____20563), uu____20564) ->
+      let uu___ = lookup_qname env1 l in
+      match uu___ with
+      | FStar_Pervasives_Native.Some (FStar_Util.Inr (se, uu___1), uu___2) ->
           FStar_Util.for_some
-            (fun uu___10_20612 ->
-               match uu___10_20612 with
+            (fun uu___3 ->
+               match uu___3 with
                | FStar_Syntax_Syntax.Irreducible -> true
-               | uu____20613 -> false) se.FStar_Syntax_Syntax.sigquals
-      | uu____20614 -> false
+               | uu___4 -> false) se.FStar_Syntax_Syntax.sigquals
+      | uu___1 -> false
 let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
       let mapper x =
         match FStar_Pervasives_Native.fst x with
-        | FStar_Util.Inl uu____20685 -> FStar_Pervasives_Native.Some false
-        | FStar_Util.Inr (se, uu____20701) ->
+        | FStar_Util.Inl uu___ -> FStar_Pervasives_Native.Some false
+        | FStar_Util.Inr (se, uu___) ->
             (match se.FStar_Syntax_Syntax.sigel with
-             | FStar_Syntax_Syntax.Sig_declare_typ uu____20718 ->
+             | FStar_Syntax_Syntax.Sig_declare_typ uu___1 ->
                  FStar_Pervasives_Native.Some
                    (FStar_List.contains FStar_Syntax_Syntax.New
                       se.FStar_Syntax_Syntax.sigquals)
-             | FStar_Syntax_Syntax.Sig_inductive_typ uu____20725 ->
+             | FStar_Syntax_Syntax.Sig_inductive_typ uu___1 ->
                  FStar_Pervasives_Native.Some true
-             | uu____20742 -> FStar_Pervasives_Native.Some false) in
-      let uu____20743 =
-        let uu____20746 = lookup_qname env1 lid in
-        FStar_Util.bind_opt uu____20746 mapper in
-      match uu____20743 with
+             | uu___1 -> FStar_Pervasives_Native.Some false) in
+      let uu___ =
+        let uu___1 = lookup_qname env1 lid in
+        FStar_Util.bind_opt uu___1 mapper in
+      match uu___ with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None -> false
 let (num_inductive_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env1 ->
     fun lid ->
-      let uu____20798 = lookup_qname env1 lid in
-      match uu____20798 with
+      let uu___ = lookup_qname env1 lid in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
            ({
               FStar_Syntax_Syntax.sigel =
                 FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____20801, uu____20802, tps, uu____20804, uu____20805,
-                 uu____20806);
-              FStar_Syntax_Syntax.sigrng = uu____20807;
-              FStar_Syntax_Syntax.sigquals = uu____20808;
-              FStar_Syntax_Syntax.sigmeta = uu____20809;
-              FStar_Syntax_Syntax.sigattrs = uu____20810;
-              FStar_Syntax_Syntax.sigopts = uu____20811;_},
-            uu____20812),
-           uu____20813)
+                (uu___1, uu___2, tps, uu___3, uu___4, uu___5);
+              FStar_Syntax_Syntax.sigrng = uu___6;
+              FStar_Syntax_Syntax.sigquals = uu___7;
+              FStar_Syntax_Syntax.sigmeta = uu___8;
+              FStar_Syntax_Syntax.sigattrs = uu___9;
+              FStar_Syntax_Syntax.sigopts = uu___10;_},
+            uu___11),
+           uu___12)
           -> FStar_Pervasives_Native.Some (FStar_List.length tps)
-      | uu____20880 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (effect_decl_opt :
   env ->
     FStar_Ident.lident ->
@@ -3748,35 +3669,33 @@ let (effect_decl_opt :
     fun l ->
       FStar_All.pipe_right (env1.effects).decls
         (FStar_Util.find_opt
-           (fun uu____20924 ->
-              match uu____20924 with
-              | (d, uu____20932) ->
+           (fun uu___ ->
+              match uu___ with
+              | (d, uu___1) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env1 ->
     fun l ->
-      let uu____20947 = effect_decl_opt env1 l in
-      match uu____20947 with
+      let uu___ = effect_decl_opt env1 l in
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____20962 = name_not_found l in
-          let uu____20967 = FStar_Ident.range_of_lid l in
-          FStar_Errors.raise_error uu____20962 uu____20967
+          let uu___1 = name_not_found l in
+          let uu___2 = FStar_Ident.range_of_lid l in
+          FStar_Errors.raise_error uu___1 uu___2
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
 let (is_layered_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu____20993 = FStar_All.pipe_right l (get_effect_decl env1) in
-      FStar_All.pipe_right uu____20993 FStar_Syntax_Util.is_layered
+      let uu___ = FStar_All.pipe_right l (get_effect_decl env1) in
+      FStar_All.pipe_right uu___ FStar_Syntax_Util.is_layered
 let (identity_mlift : mlift) =
   {
     mlift_wp =
-      (fun uu____20998 ->
-         fun c -> (c, FStar_TypeChecker_Common.trivial_guard));
+      (fun uu___ -> fun c -> (c, FStar_TypeChecker_Common.trivial_guard));
     mlift_term =
       (FStar_Pervasives_Native.Some
-         (fun uu____21012 ->
-            fun uu____21013 -> fun e -> FStar_Util.return_all e))
+         (fun uu___ -> fun uu___1 -> fun e -> FStar_Util.return_all e))
   }
 let (join_opt :
   env ->
@@ -3787,12 +3706,12 @@ let (join_opt :
   fun env1 ->
     fun l1 ->
       fun l2 ->
-        let uu____21046 = FStar_Ident.lid_equals l1 l2 in
-        if uu____21046
+        let uu___ = FStar_Ident.lid_equals l1 l2 in
+        if uu___
         then
           FStar_Pervasives_Native.Some (l1, identity_mlift, identity_mlift)
         else
-          (let uu____21062 =
+          (let uu___2 =
              ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GTot_lid)
                 &&
                 (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_Tot_lid))
@@ -3801,24 +3720,23 @@ let (join_opt :
                   &&
                   (FStar_Ident.lid_equals l1
                      FStar_Parser_Const.effect_Tot_lid)) in
-           if uu____21062
+           if uu___2
            then
              FStar_Pervasives_Native.Some
                (FStar_Parser_Const.effect_GTot_lid, identity_mlift,
                  identity_mlift)
            else
-             (let uu____21078 =
+             (let uu___4 =
                 FStar_All.pipe_right (env1.effects).joins
                   (FStar_Util.find_opt
-                     (fun uu____21131 ->
-                        match uu____21131 with
-                        | (m1, m2, uu____21144, uu____21145, uu____21146) ->
+                     (fun uu___5 ->
+                        match uu___5 with
+                        | (m1, m2, uu___6, uu___7, uu___8) ->
                             (FStar_Ident.lid_equals l1 m1) &&
                               (FStar_Ident.lid_equals l2 m2))) in
-              match uu____21078 with
+              match uu___4 with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-              | FStar_Pervasives_Native.Some
-                  (uu____21171, uu____21172, m3, j1, j2) ->
+              | FStar_Pervasives_Native.Some (uu___5, uu___6, m3, j1, j2) ->
                   FStar_Pervasives_Native.Some (m3, j1, j2)))
 let (join :
   env ->
@@ -3828,17 +3746,17 @@ let (join :
   fun env1 ->
     fun l1 ->
       fun l2 ->
-        let uu____21219 = join_opt env1 l1 l2 in
-        match uu____21219 with
+        let uu___ = join_opt env1 l1 l2 in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
-            let uu____21240 =
-              let uu____21245 =
-                let uu____21246 = FStar_Syntax_Print.lid_to_string l1 in
-                let uu____21247 = FStar_Syntax_Print.lid_to_string l2 in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.lid_to_string l1 in
+                let uu___4 = FStar_Syntax_Print.lid_to_string l2 in
                 FStar_Util.format2 "Effects %s and %s cannot be composed"
-                  uu____21246 uu____21247 in
-              (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____21245) in
-            FStar_Errors.raise_error uu____21240 env1.range
+                  uu___3 uu___4 in
+              (FStar_Errors.Fatal_EffectsCannotBeComposed, uu___2) in
+            FStar_Errors.raise_error uu___1 env1.range
         | FStar_Pervasives_Native.Some t -> t
 let (monad_leq :
   env ->
@@ -3848,11 +3766,11 @@ let (monad_leq :
   fun env1 ->
     fun l1 ->
       fun l2 ->
-        let uu____21286 =
+        let uu___ =
           (FStar_Ident.lid_equals l1 l2) ||
             ((FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_Tot_lid) &&
                (FStar_Ident.lid_equals l2 FStar_Parser_Const.effect_GTot_lid)) in
-        if uu____21286
+        if uu___
         then
           FStar_Pervasives_Native.Some
             { msource = l1; mtarget = l2; mlift = identity_mlift }
@@ -3863,42 +3781,42 @@ let (monad_leq :
                   (FStar_Ident.lid_equals l1 e.msource) &&
                     (FStar_Ident.lid_equals l2 e.mtarget)))
 let wp_sig_aux :
-  'uuuuuu21302 .
-    (FStar_Syntax_Syntax.eff_decl * 'uuuuuu21302) Prims.list ->
+  'uuuuu .
+    (FStar_Syntax_Syntax.eff_decl * 'uuuuu) Prims.list ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
           FStar_Syntax_Syntax.syntax)
   =
   fun decls ->
     fun m ->
-      let uu____21331 =
+      let uu___ =
         FStar_All.pipe_right decls
           (FStar_Util.find_opt
-             (fun uu____21357 ->
-                match uu____21357 with
-                | (d, uu____21363) ->
+             (fun uu___1 ->
+                match uu___1 with
+                | (d, uu___2) ->
                     FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m)) in
-      match uu____21331 with
+      match uu___ with
       | FStar_Pervasives_Native.None ->
-          let uu____21374 =
-            let uu____21375 = FStar_Ident.string_of_lid m in
+          let uu___1 =
+            let uu___2 = FStar_Ident.string_of_lid m in
             FStar_Util.format1
-              "Impossible: declaration for monad %s not found" uu____21375 in
-          failwith uu____21374
+              "Impossible: declaration for monad %s not found" uu___2 in
+          failwith uu___1
       | FStar_Pervasives_Native.Some (md, _q) ->
-          let uu____21388 = inst_tscheme md.FStar_Syntax_Syntax.signature in
-          (match uu____21388 with
-           | (uu____21399, s) ->
+          let uu___1 = inst_tscheme md.FStar_Syntax_Syntax.signature in
+          (match uu___1 with
+           | (uu___2, s) ->
                let s1 = FStar_Syntax_Subst.compress s in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
                 | ([], FStar_Syntax_Syntax.Tm_arrow
-                   ((a, uu____21417)::(wp, uu____21419)::[], c)) when
+                   ((a, uu___3)::(wp, uu___4)::[], c)) when
                     FStar_Syntax_Syntax.is_teff
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
-                | uu____21475 -> failwith "Impossible"))
+                | uu___3 -> failwith "Impossible"))
 let (wp_signature :
   env ->
     FStar_Ident.lident -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
@@ -3915,83 +3833,81 @@ let (comp_to_comp_typ :
         | FStar_Syntax_Syntax.GTotal (t, FStar_Pervasives_Native.None) ->
             let u = env1.universe_of env1 t in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____21537 -> c in
+        | uu___ -> c in
       FStar_Syntax_Util.comp_to_comp_typ c1
 let rec (unfold_effect_abbrev :
   env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
   fun env1 ->
     fun comp ->
       let c = comp_to_comp_typ env1 comp in
-      let uu____21549 =
+      let uu___ =
         lookup_effect_abbrev env1 c.FStar_Syntax_Syntax.comp_univs
           c.FStar_Syntax_Syntax.effect_name in
-      match uu____21549 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> c
       | FStar_Pervasives_Native.Some (binders, cdef) ->
-          let uu____21566 = FStar_Syntax_Subst.open_comp binders cdef in
-          (match uu____21566 with
+          let uu___1 = FStar_Syntax_Subst.open_comp binders cdef in
+          (match uu___1 with
            | (binders1, cdef1) ->
                (if
                   (FStar_List.length binders1) <>
                     ((FStar_List.length c.FStar_Syntax_Syntax.effect_args) +
                        Prims.int_one)
                 then
-                  (let uu____21588 =
-                     let uu____21593 =
-                       let uu____21594 =
+                  (let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Util.string_of_int
                            (FStar_List.length binders1) in
-                       let uu____21601 =
+                       let uu___6 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
                               + Prims.int_one) in
-                       let uu____21610 =
-                         let uu____21611 = FStar_Syntax_Syntax.mk_Comp c in
-                         FStar_Syntax_Print.comp_to_string uu____21611 in
+                       let uu___7 =
+                         let uu___8 = FStar_Syntax_Syntax.mk_Comp c in
+                         FStar_Syntax_Print.comp_to_string uu___8 in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____21594 uu____21601 uu____21610 in
+                         uu___5 uu___6 uu___7 in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____21593) in
-                   FStar_Errors.raise_error uu____21588
+                       uu___4) in
+                   FStar_Errors.raise_error uu___3
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
                 (let inst =
-                   let uu____21616 =
-                     let uu____21627 =
+                   let uu___3 =
+                     let uu___4 =
                        FStar_Syntax_Syntax.as_arg
                          c.FStar_Syntax_Syntax.result_typ in
-                     uu____21627 :: (c.FStar_Syntax_Syntax.effect_args) in
+                     uu___4 :: (c.FStar_Syntax_Syntax.effect_args) in
                    FStar_List.map2
-                     (fun uu____21664 ->
-                        fun uu____21665 ->
-                          match (uu____21664, uu____21665) with
-                          | ((x, uu____21695), (t, uu____21697)) ->
-                              FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____21616 in
+                     (fun uu___4 ->
+                        fun uu___5 ->
+                          match (uu___4, uu___5) with
+                          | ((x, uu___6), (t, uu___7)) ->
+                              FStar_Syntax_Syntax.NT (x, t)) binders1 uu___3 in
                  let c1 = FStar_Syntax_Subst.subst_comp inst cdef1 in
                  let c2 =
-                   let uu____21728 =
-                     let uu___1617_21729 = comp_to_comp_typ env1 c1 in
+                   let uu___3 =
+                     let uu___4 = comp_to_comp_typ env1 c1 in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___1617_21729.FStar_Syntax_Syntax.comp_univs);
+                         (uu___4.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___1617_21729.FStar_Syntax_Syntax.effect_name);
+                         (uu___4.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___1617_21729.FStar_Syntax_Syntax.result_typ);
+                         (uu___4.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___1617_21729.FStar_Syntax_Syntax.effect_args);
+                         (uu___4.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
                      } in
-                   FStar_All.pipe_right uu____21728
-                     FStar_Syntax_Syntax.mk_Comp in
+                   FStar_All.pipe_right uu___3 FStar_Syntax_Syntax.mk_Comp in
                  unfold_effect_abbrev env1 c2)))
 let effect_repr_aux :
-  'uuuuuu21740 .
-    'uuuuuu21740 ->
+  'uuuuu .
+    'uuuuu ->
       env ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.universe ->
@@ -4004,33 +3920,33 @@ let effect_repr_aux :
         fun u_res ->
           let check_partial_application eff_name args =
             let r = get_range env1 in
-            let uu____21781 =
-              let uu____21786 = num_effect_indices env1 eff_name r in
-              ((FStar_List.length args), uu____21786) in
-            match uu____21781 with
+            let uu___ =
+              let uu___1 = num_effect_indices env1 eff_name r in
+              ((FStar_List.length args), uu___1) in
+            match uu___ with
             | (given, expected) ->
                 if given = expected
                 then ()
                 else
                   (let message =
-                     let uu____21799 = FStar_Ident.string_of_lid eff_name in
-                     let uu____21800 = FStar_Util.string_of_int given in
-                     let uu____21801 = FStar_Util.string_of_int expected in
+                     let uu___2 = FStar_Ident.string_of_lid eff_name in
+                     let uu___3 = FStar_Util.string_of_int given in
+                     let uu___4 = FStar_Util.string_of_int expected in
                      FStar_Util.format3
                        "Not enough arguments for effect %s, This usually happens when you use a partially applied DM4F effect, like [TAC int] instead of [Tac int] (given:%s, expected:%s)."
-                       uu____21799 uu____21800 uu____21801 in
+                       uu___2 uu___3 uu___4 in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                        message) r) in
           let effect_name =
             norm_eff_name env1 (FStar_Syntax_Util.comp_effect_name c) in
-          let uu____21803 = effect_decl_opt env1 effect_name in
-          match uu____21803 with
+          let uu___ = effect_decl_opt env1 effect_name in
+          match uu___ with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-          | FStar_Pervasives_Native.Some (ed, uu____21825) ->
-              let uu____21836 =
+          | FStar_Pervasives_Native.Some (ed, uu___1) ->
+              let uu___2 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
-              (match uu____21836 with
+              (match uu___2 with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some ts ->
                    let c1 = unfold_effect_abbrev env1 c in
@@ -4038,20 +3954,19 @@ let effect_repr_aux :
                    let repr = inst_effect_fun_with [u_res] env1 ed ts in
                    (check_partial_application effect_name
                       c1.FStar_Syntax_Syntax.effect_args;
-                    (let uu____21854 =
-                       let uu____21857 =
-                         let uu____21858 =
-                           let uu____21875 =
-                             let uu____21886 =
+                    (let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
                                FStar_All.pipe_right res_typ
                                  FStar_Syntax_Syntax.as_arg in
-                             uu____21886 ::
-                               (c1.FStar_Syntax_Syntax.effect_args) in
-                           (repr, uu____21875) in
-                         FStar_Syntax_Syntax.Tm_app uu____21858 in
-                       let uu____21923 = get_range env1 in
-                       FStar_Syntax_Syntax.mk uu____21857 uu____21923 in
-                     FStar_Pervasives_Native.Some uu____21854)))
+                             uu___8 :: (c1.FStar_Syntax_Syntax.effect_args) in
+                           (repr, uu___7) in
+                         FStar_Syntax_Syntax.Tm_app uu___6 in
+                       let uu___6 = get_range env1 in
+                       FStar_Syntax_Syntax.mk uu___5 uu___6 in
+                     FStar_Pervasives_Native.Some uu___4)))
 let (effect_repr :
   env ->
     FStar_Syntax_Syntax.comp ->
@@ -4071,10 +3986,10 @@ let (is_user_reflectable_effect : env -> FStar_Ident.lident -> Prims.bool) =
       let quals = lookup_effect_quals env1 effect_lid1 in
       FStar_All.pipe_right quals
         (FStar_List.existsb
-           (fun uu___11_21977 ->
-              match uu___11_21977 with
-              | FStar_Syntax_Syntax.Reflectable uu____21978 -> true
-              | uu____21979 -> false))
+           (fun uu___ ->
+              match uu___ with
+              | FStar_Syntax_Syntax.Reflectable uu___1 -> true
+              | uu___1 -> false))
 let (is_total_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun effect_lid ->
@@ -4097,17 +4012,16 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env1 ct.FStar_Syntax_Syntax.effect_name
-      | uu____22026 -> false
+      | uu___ -> false
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env1 ->
     fun t ->
-      let uu____22037 =
-        let uu____22038 = FStar_Syntax_Subst.compress t in
-        uu____22038.FStar_Syntax_Syntax.n in
-      match uu____22037 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____22041, c) ->
-          is_reifiable_comp env1 c
-      | uu____22063 -> false
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress t in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) -> is_reifiable_comp env1 c
+      | uu___1 -> false
 let (reify_comp :
   env ->
     FStar_Syntax_Syntax.comp ->
@@ -4117,21 +4031,21 @@ let (reify_comp :
     fun c ->
       fun u_c ->
         let l = FStar_Syntax_Util.comp_effect_name c in
-        (let uu____22081 =
-           let uu____22082 = is_reifiable_effect env1 l in
-           Prims.op_Negation uu____22082 in
-         if uu____22081
+        (let uu___1 =
+           let uu___2 = is_reifiable_effect env1 l in
+           Prims.op_Negation uu___2 in
+         if uu___1
          then
-           let uu____22083 =
-             let uu____22088 =
-               let uu____22089 = FStar_Ident.string_of_lid l in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____22089 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____22088) in
-           let uu____22090 = get_range env1 in
-           FStar_Errors.raise_error uu____22083 uu____22090
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Ident.string_of_lid l in
+               FStar_Util.format1 "Effect %s cannot be reified" uu___4 in
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu___3) in
+           let uu___3 = get_range env1 in
+           FStar_Errors.raise_error uu___2 uu___3
          else ());
-        (let uu____22092 = effect_repr_aux true env1 c u_c in
-         match uu____22092 with
+        (let uu___1 = effect_repr_aux true env1 c u_c in
+         match uu___1 with
          | FStar_Pervasives_Native.None ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4140,56 +4054,55 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s) in
       let env2 =
-        let uu___1694_22124 = env1 in
+        let uu___ = env1 in
         {
-          solver = (uu___1694_22124.solver);
-          range = (uu___1694_22124.range);
-          curmodule = (uu___1694_22124.curmodule);
-          gamma = (uu___1694_22124.gamma);
+          solver = (uu___.solver);
+          range = (uu___.range);
+          curmodule = (uu___.curmodule);
+          gamma = (uu___.gamma);
           gamma_sig = (sb :: (env1.gamma_sig));
-          gamma_cache = (uu___1694_22124.gamma_cache);
-          modules = (uu___1694_22124.modules);
-          expected_typ = (uu___1694_22124.expected_typ);
-          sigtab = (uu___1694_22124.sigtab);
-          attrtab = (uu___1694_22124.attrtab);
-          instantiate_imp = (uu___1694_22124.instantiate_imp);
-          effects = (uu___1694_22124.effects);
-          generalize = (uu___1694_22124.generalize);
-          letrecs = (uu___1694_22124.letrecs);
-          top_level = (uu___1694_22124.top_level);
-          check_uvars = (uu___1694_22124.check_uvars);
-          use_eq = (uu___1694_22124.use_eq);
-          use_eq_strict = (uu___1694_22124.use_eq_strict);
-          is_iface = (uu___1694_22124.is_iface);
-          admit = (uu___1694_22124.admit);
-          lax = (uu___1694_22124.lax);
-          lax_universes = (uu___1694_22124.lax_universes);
-          phase1 = (uu___1694_22124.phase1);
-          failhard = (uu___1694_22124.failhard);
-          nosynth = (uu___1694_22124.nosynth);
-          uvar_subtyping = (uu___1694_22124.uvar_subtyping);
-          tc_term = (uu___1694_22124.tc_term);
-          type_of = (uu___1694_22124.type_of);
-          universe_of = (uu___1694_22124.universe_of);
-          check_type_of = (uu___1694_22124.check_type_of);
-          use_bv_sorts = (uu___1694_22124.use_bv_sorts);
-          qtbl_name_and_index = (uu___1694_22124.qtbl_name_and_index);
-          normalized_eff_names = (uu___1694_22124.normalized_eff_names);
-          fv_delta_depths = (uu___1694_22124.fv_delta_depths);
-          proof_ns = (uu___1694_22124.proof_ns);
-          synth_hook = (uu___1694_22124.synth_hook);
-          try_solve_implicits_hook =
-            (uu___1694_22124.try_solve_implicits_hook);
-          splice = (uu___1694_22124.splice);
-          mpreprocess = (uu___1694_22124.mpreprocess);
-          postprocess = (uu___1694_22124.postprocess);
-          identifier_info = (uu___1694_22124.identifier_info);
-          tc_hooks = (uu___1694_22124.tc_hooks);
-          dsenv = (uu___1694_22124.dsenv);
-          nbe = (uu___1694_22124.nbe);
-          strict_args_tab = (uu___1694_22124.strict_args_tab);
-          erasable_types_tab = (uu___1694_22124.erasable_types_tab);
-          enable_defer_to_tac = (uu___1694_22124.enable_defer_to_tac)
+          gamma_cache = (uu___.gamma_cache);
+          modules = (uu___.modules);
+          expected_typ = (uu___.expected_typ);
+          sigtab = (uu___.sigtab);
+          attrtab = (uu___.attrtab);
+          instantiate_imp = (uu___.instantiate_imp);
+          effects = (uu___.effects);
+          generalize = (uu___.generalize);
+          letrecs = (uu___.letrecs);
+          top_level = (uu___.top_level);
+          check_uvars = (uu___.check_uvars);
+          use_eq = (uu___.use_eq);
+          use_eq_strict = (uu___.use_eq_strict);
+          is_iface = (uu___.is_iface);
+          admit = (uu___.admit);
+          lax = (uu___.lax);
+          lax_universes = (uu___.lax_universes);
+          phase1 = (uu___.phase1);
+          failhard = (uu___.failhard);
+          nosynth = (uu___.nosynth);
+          uvar_subtyping = (uu___.uvar_subtyping);
+          tc_term = (uu___.tc_term);
+          type_of = (uu___.type_of);
+          universe_of = (uu___.universe_of);
+          check_type_of = (uu___.check_type_of);
+          use_bv_sorts = (uu___.use_bv_sorts);
+          qtbl_name_and_index = (uu___.qtbl_name_and_index);
+          normalized_eff_names = (uu___.normalized_eff_names);
+          fv_delta_depths = (uu___.fv_delta_depths);
+          proof_ns = (uu___.proof_ns);
+          synth_hook = (uu___.synth_hook);
+          try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+          splice = (uu___.splice);
+          mpreprocess = (uu___.mpreprocess);
+          postprocess = (uu___.postprocess);
+          identifier_info = (uu___.identifier_info);
+          tc_hooks = (uu___.tc_hooks);
+          dsenv = (uu___.dsenv);
+          nbe = (uu___.nbe);
+          strict_args_tab = (uu___.strict_args_tab);
+          erasable_types_tab = (uu___.erasable_types_tab);
+          enable_defer_to_tac = (uu___.enable_defer_to_tac)
         } in
       add_sigelt env2 s;
       (env2.tc_hooks).tc_push_in_gamma_hook env2 (FStar_Util.Inr sb);
@@ -4200,68 +4113,67 @@ let (push_new_effect :
       -> env)
   =
   fun env1 ->
-    fun uu____22142 ->
-      match uu____22142 with
+    fun uu___ ->
+      match uu___ with
       | (ed, quals) ->
           let effects1 =
-            let uu___1703_22156 = env1.effects in
+            let uu___1 = env1.effects in
             {
               decls = (FStar_List.append (env1.effects).decls [(ed, quals)]);
-              order = (uu___1703_22156.order);
-              joins = (uu___1703_22156.joins);
-              polymonadic_binds = (uu___1703_22156.polymonadic_binds);
-              polymonadic_subcomps = (uu___1703_22156.polymonadic_subcomps)
+              order = (uu___1.order);
+              joins = (uu___1.joins);
+              polymonadic_binds = (uu___1.polymonadic_binds);
+              polymonadic_subcomps = (uu___1.polymonadic_subcomps)
             } in
-          let uu___1706_22177 = env1 in
+          let uu___1 = env1 in
           {
-            solver = (uu___1706_22177.solver);
-            range = (uu___1706_22177.range);
-            curmodule = (uu___1706_22177.curmodule);
-            gamma = (uu___1706_22177.gamma);
-            gamma_sig = (uu___1706_22177.gamma_sig);
-            gamma_cache = (uu___1706_22177.gamma_cache);
-            modules = (uu___1706_22177.modules);
-            expected_typ = (uu___1706_22177.expected_typ);
-            sigtab = (uu___1706_22177.sigtab);
-            attrtab = (uu___1706_22177.attrtab);
-            instantiate_imp = (uu___1706_22177.instantiate_imp);
+            solver = (uu___1.solver);
+            range = (uu___1.range);
+            curmodule = (uu___1.curmodule);
+            gamma = (uu___1.gamma);
+            gamma_sig = (uu___1.gamma_sig);
+            gamma_cache = (uu___1.gamma_cache);
+            modules = (uu___1.modules);
+            expected_typ = (uu___1.expected_typ);
+            sigtab = (uu___1.sigtab);
+            attrtab = (uu___1.attrtab);
+            instantiate_imp = (uu___1.instantiate_imp);
             effects = effects1;
-            generalize = (uu___1706_22177.generalize);
-            letrecs = (uu___1706_22177.letrecs);
-            top_level = (uu___1706_22177.top_level);
-            check_uvars = (uu___1706_22177.check_uvars);
-            use_eq = (uu___1706_22177.use_eq);
-            use_eq_strict = (uu___1706_22177.use_eq_strict);
-            is_iface = (uu___1706_22177.is_iface);
-            admit = (uu___1706_22177.admit);
-            lax = (uu___1706_22177.lax);
-            lax_universes = (uu___1706_22177.lax_universes);
-            phase1 = (uu___1706_22177.phase1);
-            failhard = (uu___1706_22177.failhard);
-            nosynth = (uu___1706_22177.nosynth);
-            uvar_subtyping = (uu___1706_22177.uvar_subtyping);
-            tc_term = (uu___1706_22177.tc_term);
-            type_of = (uu___1706_22177.type_of);
-            universe_of = (uu___1706_22177.universe_of);
-            check_type_of = (uu___1706_22177.check_type_of);
-            use_bv_sorts = (uu___1706_22177.use_bv_sorts);
-            qtbl_name_and_index = (uu___1706_22177.qtbl_name_and_index);
-            normalized_eff_names = (uu___1706_22177.normalized_eff_names);
-            fv_delta_depths = (uu___1706_22177.fv_delta_depths);
-            proof_ns = (uu___1706_22177.proof_ns);
-            synth_hook = (uu___1706_22177.synth_hook);
-            try_solve_implicits_hook =
-              (uu___1706_22177.try_solve_implicits_hook);
-            splice = (uu___1706_22177.splice);
-            mpreprocess = (uu___1706_22177.mpreprocess);
-            postprocess = (uu___1706_22177.postprocess);
-            identifier_info = (uu___1706_22177.identifier_info);
-            tc_hooks = (uu___1706_22177.tc_hooks);
-            dsenv = (uu___1706_22177.dsenv);
-            nbe = (uu___1706_22177.nbe);
-            strict_args_tab = (uu___1706_22177.strict_args_tab);
-            erasable_types_tab = (uu___1706_22177.erasable_types_tab);
-            enable_defer_to_tac = (uu___1706_22177.enable_defer_to_tac)
+            generalize = (uu___1.generalize);
+            letrecs = (uu___1.letrecs);
+            top_level = (uu___1.top_level);
+            check_uvars = (uu___1.check_uvars);
+            use_eq = (uu___1.use_eq);
+            use_eq_strict = (uu___1.use_eq_strict);
+            is_iface = (uu___1.is_iface);
+            admit = (uu___1.admit);
+            lax = (uu___1.lax);
+            lax_universes = (uu___1.lax_universes);
+            phase1 = (uu___1.phase1);
+            failhard = (uu___1.failhard);
+            nosynth = (uu___1.nosynth);
+            uvar_subtyping = (uu___1.uvar_subtyping);
+            tc_term = (uu___1.tc_term);
+            type_of = (uu___1.type_of);
+            universe_of = (uu___1.universe_of);
+            check_type_of = (uu___1.check_type_of);
+            use_bv_sorts = (uu___1.use_bv_sorts);
+            qtbl_name_and_index = (uu___1.qtbl_name_and_index);
+            normalized_eff_names = (uu___1.normalized_eff_names);
+            fv_delta_depths = (uu___1.fv_delta_depths);
+            proof_ns = (uu___1.proof_ns);
+            synth_hook = (uu___1.synth_hook);
+            try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+            splice = (uu___1.splice);
+            mpreprocess = (uu___1.mpreprocess);
+            postprocess = (uu___1.postprocess);
+            identifier_info = (uu___1.identifier_info);
+            tc_hooks = (uu___1.tc_hooks);
+            dsenv = (uu___1.dsenv);
+            nbe = (uu___1.nbe);
+            strict_args_tab = (uu___1.strict_args_tab);
+            erasable_types_tab = (uu___1.erasable_types_tab);
+            enable_defer_to_tac = (uu___1.enable_defer_to_tac)
           }
 let (exists_polymonadic_bind :
   env ->
@@ -4273,18 +4185,18 @@ let (exists_polymonadic_bind :
   fun env1 ->
     fun m ->
       fun n ->
-        let uu____22205 =
+        let uu___ =
           FStar_All.pipe_right (env1.effects).polymonadic_binds
             (FStar_Util.find_opt
-               (fun uu____22273 ->
-                  match uu____22273 with
-                  | (m1, n1, uu____22290, uu____22291) ->
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (m1, n1, uu___2, uu___3) ->
                       (FStar_Ident.lid_equals m m1) &&
                         (FStar_Ident.lid_equals n n1))) in
-        match uu____22205 with
-        | FStar_Pervasives_Native.Some (uu____22316, uu____22317, p, t) ->
+        match uu___ with
+        | FStar_Pervasives_Native.Some (uu___1, uu___2, p, t) ->
             FStar_Pervasives_Native.Some (p, t)
-        | uu____22362 -> FStar_Pervasives_Native.None
+        | uu___1 -> FStar_Pervasives_Native.None
 let (exists_polymonadic_subcomp :
   env ->
     FStar_Ident.lident ->
@@ -4294,18 +4206,18 @@ let (exists_polymonadic_subcomp :
   fun env1 ->
     fun m ->
       fun n ->
-        let uu____22406 =
+        let uu___ =
           FStar_All.pipe_right (env1.effects).polymonadic_subcomps
             (FStar_Util.find_opt
-               (fun uu____22441 ->
-                  match uu____22441 with
-                  | (m1, n1, uu____22450) ->
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (m1, n1, uu___2) ->
                       (FStar_Ident.lid_equals m m1) &&
                         (FStar_Ident.lid_equals n n1))) in
-        match uu____22406 with
-        | FStar_Pervasives_Native.Some (uu____22453, uu____22454, ts) ->
+        match uu___ with
+        | FStar_Pervasives_Native.Some (uu___1, uu___2, ts) ->
             FStar_Pervasives_Native.Some ts
-        | uu____22462 -> FStar_Pervasives_Native.None
+        | uu___1 -> FStar_Pervasives_Native.None
 let (update_effect_lattice :
   env -> FStar_Ident.lident -> FStar_Ident.lident -> mlift -> env) =
   fun env1 ->
@@ -4315,21 +4227,20 @@ let (update_effect_lattice :
           let compose_edges e1 e2 =
             let composed_lift =
               let mlift_wp env2 c =
-                let uu____22518 =
-                  FStar_All.pipe_right c ((e1.mlift).mlift_wp env2) in
-                FStar_All.pipe_right uu____22518
-                  (fun uu____22539 ->
-                     match uu____22539 with
+                let uu___ = FStar_All.pipe_right c ((e1.mlift).mlift_wp env2) in
+                FStar_All.pipe_right uu___
+                  (fun uu___1 ->
+                     match uu___1 with
                      | (c1, g1) ->
-                         let uu____22550 =
+                         let uu___2 =
                            FStar_All.pipe_right c1 ((e2.mlift).mlift_wp env2) in
-                         FStar_All.pipe_right uu____22550
-                           (fun uu____22571 ->
-                              match uu____22571 with
+                         FStar_All.pipe_right uu___2
+                           (fun uu___3 ->
+                              match uu___3 with
                               | (c2, g2) ->
-                                  let uu____22582 =
+                                  let uu___4 =
                                     FStar_TypeChecker_Common.conj_guard g1 g2 in
-                                  (c2, uu____22582))) in
+                                  (c2, uu___4))) in
               let mlift_term =
                 match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
                 | (FStar_Pervasives_Native.Some l1,
@@ -4337,10 +4248,8 @@ let (update_effect_lattice :
                     FStar_Pervasives_Native.Some
                       ((fun u ->
                           fun t ->
-                            fun e ->
-                              let uu____22704 = l1 u t e in
-                              l2 u t uu____22704))
-                | uu____22705 -> FStar_Pervasives_Native.None in
+                            fun e -> let uu___ = l1 u t e in l2 u t uu___))
+                | uu___ -> FStar_Pervasives_Native.None in
               { mlift_wp; mlift_term } in
             {
               msource = (e1.msource);
@@ -4350,15 +4259,14 @@ let (update_effect_lattice :
           let edge1 = { msource = src; mtarget = tgt; mlift = st_mlift } in
           let id_edge l =
             { msource = src; mtarget = tgt; mlift = identity_mlift } in
-          let find_edge order uu____22766 =
-            match uu____22766 with
+          let find_edge order uu___ =
+            match uu___ with
             | (i, j) ->
-                let uu____22777 = FStar_Ident.lid_equals i j in
-                if uu____22777
+                let uu___1 = FStar_Ident.lid_equals i j in
+                if uu___1
                 then
                   FStar_All.pipe_right (id_edge i)
-                    (fun uu____22782 ->
-                       FStar_Pervasives_Native.Some uu____22782)
+                    (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
                 else
                   FStar_All.pipe_right order
                     (FStar_Util.find_opt
@@ -4368,17 +4276,17 @@ let (update_effect_lattice :
           let ms =
             FStar_All.pipe_right (env1.effects).decls
               (FStar_List.map
-                 (fun uu____22812 ->
-                    match uu____22812 with
-                    | (e, uu____22820) -> e.FStar_Syntax_Syntax.mname)) in
+                 (fun uu___ ->
+                    match uu___ with
+                    | (e, uu___1) -> e.FStar_Syntax_Syntax.mname)) in
           let all_i_src =
             FStar_All.pipe_right ms
               (FStar_List.fold_left
                  (fun edges ->
                     fun i ->
-                      let uu____22842 =
+                      let uu___ =
                         find_edge (env1.effects).order (i, (edge1.msource)) in
-                      match uu____22842 with
+                      match uu___ with
                       | FStar_Pervasives_Native.Some e -> e :: edges
                       | FStar_Pervasives_Native.None -> edges) []) in
           let all_tgt_j =
@@ -4386,9 +4294,9 @@ let (update_effect_lattice :
               (FStar_List.fold_left
                  (fun edges ->
                     fun j ->
-                      let uu____22865 =
+                      let uu___ =
                         find_edge (env1.effects).order ((edge1.mtarget), j) in
-                      match uu____22865 with
+                      match uu___ with
                       | FStar_Pervasives_Native.Some e -> e :: edges
                       | FStar_Pervasives_Native.None -> edges) []) in
           let new_edges =
@@ -4400,95 +4308,88 @@ let (update_effect_lattice :
                         fun tgt_j ->
                           let src1 = i_src.msource in
                           let tgt1 = tgt_j.mtarget in
-                          (let uu____22897 = FStar_Ident.lid_equals src1 tgt1 in
-                           if uu____22897
+                          (let uu___1 = FStar_Ident.lid_equals src1 tgt1 in
+                           if uu___1
                            then
-                             let uu____22898 =
-                               let uu____22903 =
-                                 let uu____22904 =
+                             let uu___2 =
+                               let uu___3 =
+                                 let uu___4 =
                                    FStar_Ident.string_of_lid edge1.msource in
-                                 let uu____22905 =
+                                 let uu___5 =
                                    FStar_Ident.string_of_lid edge1.mtarget in
-                                 let uu____22906 =
-                                   FStar_Ident.string_of_lid src1 in
+                                 let uu___6 = FStar_Ident.string_of_lid src1 in
                                  FStar_Util.format3
                                    "Adding an edge %s~>%s induces a cycle %s"
-                                   uu____22904 uu____22905 uu____22906 in
+                                   uu___4 uu___5 uu___6 in
                                (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                                 uu____22903) in
-                             FStar_Errors.raise_error uu____22898 env1.range
+                                 uu___3) in
+                             FStar_Errors.raise_error uu___2 env1.range
                            else ());
-                          (let uu____22908 =
-                             let uu____22909 =
+                          (let uu___1 =
+                             let uu___2 =
                                find_edge (env1.effects).order (src1, tgt1) in
-                             FStar_All.pipe_right uu____22909
-                               FStar_Util.is_some in
-                           if uu____22908
+                             FStar_All.pipe_right uu___2 FStar_Util.is_some in
+                           if uu___1
                            then edges1
                            else
-                             (let uu____22917 =
-                                (let uu____22920 =
+                             (let uu___3 =
+                                (let uu___4 =
                                    exists_polymonadic_subcomp env1 src1 tgt1 in
-                                 FStar_All.pipe_right uu____22920
+                                 FStar_All.pipe_right uu___4
                                    FStar_Util.is_some)
                                   ||
-                                  (let uu____22926 =
+                                  (let uu___4 =
                                      exists_polymonadic_subcomp env1 tgt1
                                        src1 in
-                                   FStar_All.pipe_right uu____22926
+                                   FStar_All.pipe_right uu___4
                                      FStar_Util.is_some) in
-                              if uu____22917
+                              if uu___3
                               then
-                                let uu____22933 =
-                                  let uu____22938 =
-                                    let uu____22939 =
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       FStar_Ident.string_of_lid edge1.msource in
-                                    let uu____22940 =
+                                    let uu___7 =
                                       FStar_Ident.string_of_lid edge1.mtarget in
-                                    let uu____22941 =
+                                    let uu___8 =
                                       FStar_Ident.string_of_lid src1 in
-                                    let uu____22942 =
+                                    let uu___9 =
                                       FStar_Ident.string_of_lid tgt1 in
                                     FStar_Util.format4
                                       "Adding an edge %s~>%s induces an edge %s~>%s that conflicts with an existing polymonadic subcomp between them"
-                                      uu____22939 uu____22940 uu____22941
-                                      uu____22942 in
+                                      uu___6 uu___7 uu___8 uu___9 in
                                   (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                                    uu____22938) in
-                                FStar_Errors.raise_error uu____22933
-                                  env1.range
+                                    uu___5) in
+                                FStar_Errors.raise_error uu___4 env1.range
                               else
-                                (let uu____22946 =
-                                   let uu____22947 =
-                                     compose_edges i_src edge1 in
-                                   compose_edges uu____22947 tgt_j in
-                                 uu____22946 :: edges1)))) edges all_tgt_j)
-              [] all_i_src in
+                                (let uu___5 =
+                                   let uu___6 = compose_edges i_src edge1 in
+                                   compose_edges uu___6 tgt_j in
+                                 uu___5 :: edges1)))) edges all_tgt_j) []
+              all_i_src in
           let order = FStar_List.append new_edges (env1.effects).order in
           FStar_All.pipe_right order
             (FStar_List.iter
                (fun edge2 ->
-                  let uu____22959 =
+                  let uu___1 =
                     (FStar_Ident.lid_equals edge2.msource
                        FStar_Parser_Const.effect_DIV_lid)
                       &&
-                      (let uu____22961 =
-                         lookup_effect_quals env1 edge2.mtarget in
-                       FStar_All.pipe_right uu____22961
+                      (let uu___2 = lookup_effect_quals env1 edge2.mtarget in
+                       FStar_All.pipe_right uu___2
                          (FStar_List.contains FStar_Syntax_Syntax.TotalEffect)) in
-                  if uu____22959
+                  if uu___1
                   then
-                    let uu____22966 =
-                      let uu____22971 =
-                        let uu____22972 =
-                          FStar_Ident.string_of_lid edge2.mtarget in
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = FStar_Ident.string_of_lid edge2.mtarget in
                         FStar_Util.format1
                           "Divergent computations cannot be included in an effect %s marked 'total'"
-                          uu____22972 in
+                          uu___4 in
                       (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____22971) in
-                    let uu____22973 = get_range env1 in
-                    FStar_Errors.raise_error uu____22966 uu____22973
+                        uu___3) in
+                    let uu___3 = get_range env1 in
+                    FStar_Errors.raise_error uu___2 uu___3
                   else ()));
           (let joins =
              FStar_All.pipe_right ms
@@ -4498,8 +4399,8 @@ let (update_effect_lattice :
                        (FStar_List.collect
                           (fun j ->
                              let k_opt =
-                               let uu____23050 = FStar_Ident.lid_equals i j in
-                               if uu____23050
+                               let uu___1 = FStar_Ident.lid_equals i j in
+                               if uu___1
                                then
                                  FStar_Pervasives_Native.Some
                                    (i, (id_edge i), (id_edge i))
@@ -4508,13 +4409,13 @@ let (update_effect_lattice :
                                    (FStar_List.fold_left
                                       (fun bopt ->
                                          fun k ->
-                                           let uu____23099 =
-                                             let uu____23108 =
+                                           let uu___3 =
+                                             let uu___4 =
                                                find_edge order (i, k) in
-                                             let uu____23111 =
+                                             let uu___5 =
                                                find_edge order (j, k) in
-                                             (uu____23108, uu____23111) in
-                                           match uu____23099 with
+                                             (uu___4, uu___5) in
+                                           match uu___3 with
                                            | (FStar_Pervasives_Native.Some
                                               ik,
                                               FStar_Pervasives_Native.Some
@@ -4525,30 +4426,27 @@ let (update_effect_lattice :
                                                     FStar_Pervasives_Native.Some
                                                       (k, ik, jk)
                                                 | FStar_Pervasives_Native.Some
-                                                    (ub, uu____23153,
-                                                     uu____23154)
-                                                    ->
-                                                    let uu____23161 =
-                                                      let uu____23166 =
-                                                        let uu____23167 =
+                                                    (ub, uu___4, uu___5) ->
+                                                    let uu___6 =
+                                                      let uu___7 =
+                                                        let uu___8 =
                                                           find_edge order
                                                             (k, ub) in
                                                         FStar_Util.is_some
-                                                          uu____23167 in
-                                                      let uu____23170 =
-                                                        let uu____23171 =
+                                                          uu___8 in
+                                                      let uu___8 =
+                                                        let uu___9 =
                                                           find_edge order
                                                             (ub, k) in
                                                         FStar_Util.is_some
-                                                          uu____23171 in
-                                                      (uu____23166,
-                                                        uu____23170) in
-                                                    (match uu____23161 with
+                                                          uu___9 in
+                                                      (uu___7, uu___8) in
+                                                    (match uu___6 with
                                                      | (true, true) ->
-                                                         let uu____23182 =
+                                                         let uu___7 =
                                                            FStar_Ident.lid_equals
                                                              k ub in
-                                                         if uu____23182
+                                                         if uu___7
                                                          then
                                                            (FStar_Errors.log_issue
                                                               FStar_Range.dummyRange
@@ -4559,191 +4457,178 @@ let (update_effect_lattice :
                                                            failwith
                                                              "Found a cycle in the lattice"
                                                      | (false, false) ->
-                                                         let uu____23201 =
-                                                           let uu____23206 =
-                                                             let uu____23207
-                                                               =
+                                                         let uu___7 =
+                                                           let uu___8 =
+                                                             let uu___9 =
                                                                FStar_Ident.string_of_lid
                                                                  i in
-                                                             let uu____23208
-                                                               =
+                                                             let uu___10 =
                                                                FStar_Ident.string_of_lid
                                                                  j in
-                                                             let uu____23209
-                                                               =
+                                                             let uu___11 =
                                                                FStar_Ident.string_of_lid
                                                                  k in
-                                                             let uu____23210
-                                                               =
+                                                             let uu___12 =
                                                                FStar_Ident.string_of_lid
                                                                  ub in
                                                              FStar_Util.format4
                                                                "Uncomparable upper bounds! i=%s, j=%s, k=%s, ub=%s\n"
-                                                               uu____23207
-                                                               uu____23208
-                                                               uu____23209
-                                                               uu____23210 in
+                                                               uu___9 uu___10
+                                                               uu___11
+                                                               uu___12 in
                                                            (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                                                             uu____23206) in
+                                                             uu___8) in
                                                          FStar_Errors.raise_error
-                                                           uu____23201
-                                                           env1.range
+                                                           uu___7 env1.range
                                                      | (true, false) ->
                                                          FStar_Pervasives_Native.Some
                                                            (k, ik, jk)
                                                      | (false, true) -> bopt))
-                                           | uu____23225 -> bopt)
+                                           | uu___4 -> bopt)
                                       FStar_Pervasives_Native.None) in
                              match k_opt with
                              | FStar_Pervasives_Native.None -> []
                              | FStar_Pervasives_Native.Some (k, e1, e2) ->
-                                 let uu____23277 =
-                                   (let uu____23280 =
+                                 let uu___1 =
+                                   (let uu___2 =
                                       exists_polymonadic_bind env1 i j in
-                                    FStar_All.pipe_right uu____23280
+                                    FStar_All.pipe_right uu___2
                                       FStar_Util.is_some)
                                      ||
-                                     (let uu____23316 =
+                                     (let uu___2 =
                                         exists_polymonadic_bind env1 j i in
-                                      FStar_All.pipe_right uu____23316
+                                      FStar_All.pipe_right uu___2
                                         FStar_Util.is_some) in
-                                 if uu____23277
+                                 if uu___1
                                  then
-                                   let uu____23363 =
-                                     let uu____23368 =
-                                       let uu____23369 =
+                                   let uu___2 =
+                                     let uu___3 =
+                                       let uu___4 =
                                          FStar_Ident.string_of_lid src in
-                                       let uu____23370 =
+                                       let uu___5 =
                                          FStar_Ident.string_of_lid tgt in
-                                       let uu____23371 =
+                                       let uu___6 =
                                          FStar_Ident.string_of_lid i in
-                                       let uu____23372 =
+                                       let uu___7 =
                                          FStar_Ident.string_of_lid j in
-                                       let uu____23373 =
+                                       let uu___8 =
                                          FStar_Ident.string_of_lid k in
                                        FStar_Util.format5
                                          "Updating effect lattice with a lift between %s and %s induces a least upper bound %s of %s and %s, and this conflicts with a polymonadic bind between them"
-                                         uu____23369 uu____23370 uu____23371
-                                         uu____23372 uu____23373 in
+                                         uu___4 uu___5 uu___6 uu___7 uu___8 in
                                      (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                                       uu____23368) in
-                                   FStar_Errors.raise_error uu____23363
-                                     env1.range
+                                       uu___3) in
+                                   FStar_Errors.raise_error uu___2 env1.range
                                  else
                                    (let j_opt = join_opt env1 i j in
-                                    let uu____23396 =
+                                    let uu___3 =
                                       (FStar_All.pipe_right j_opt
                                          FStar_Util.is_some)
                                         &&
-                                        (let uu____23412 =
-                                           let uu____23413 =
-                                             let uu____23414 =
+                                        (let uu___4 =
+                                           let uu___5 =
+                                             let uu___6 =
                                                FStar_All.pipe_right j_opt
                                                  FStar_Util.must in
-                                             FStar_All.pipe_right uu____23414
-                                               (fun uu____23451 ->
-                                                  match uu____23451 with
-                                                  | (l, uu____23459,
-                                                     uu____23460) -> l) in
-                                           FStar_Ident.lid_equals k
-                                             uu____23413 in
-                                         Prims.op_Negation uu____23412) in
-                                    if uu____23396
+                                             FStar_All.pipe_right uu___6
+                                               (fun uu___7 ->
+                                                  match uu___7 with
+                                                  | (l, uu___8, uu___9) -> l) in
+                                           FStar_Ident.lid_equals k uu___5 in
+                                         Prims.op_Negation uu___4) in
+                                    if uu___3
                                     then
-                                      let uu____23473 =
-                                        let uu____23478 =
-                                          let uu____23479 =
+                                      let uu___4 =
+                                        let uu___5 =
+                                          let uu___6 =
                                             FStar_Ident.string_of_lid src in
-                                          let uu____23480 =
+                                          let uu___7 =
                                             FStar_Ident.string_of_lid tgt in
-                                          let uu____23481 =
+                                          let uu___8 =
                                             FStar_Ident.string_of_lid i in
-                                          let uu____23482 =
+                                          let uu___9 =
                                             FStar_Ident.string_of_lid j in
-                                          let uu____23483 =
+                                          let uu___10 =
                                             FStar_Ident.string_of_lid k in
-                                          let uu____23484 =
-                                            let uu____23485 =
-                                              let uu____23486 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              let uu___13 =
                                                 FStar_All.pipe_right j_opt
                                                   FStar_Util.must in
-                                              FStar_All.pipe_right
-                                                uu____23486
-                                                (fun uu____23523 ->
-                                                   match uu____23523 with
-                                                   | (l, uu____23531,
-                                                      uu____23532) -> l) in
-                                            FStar_All.pipe_right uu____23485
+                                              FStar_All.pipe_right uu___13
+                                                (fun uu___14 ->
+                                                   match uu___14 with
+                                                   | (l, uu___15, uu___16) ->
+                                                       l) in
+                                            FStar_All.pipe_right uu___12
                                               FStar_Ident.string_of_lid in
                                           FStar_Util.format6
                                             "Updating effect lattice with %s ~> %s makes the least upper bound of %s and %s as %s, whereas earlier it was %s"
-                                            uu____23479 uu____23480
-                                            uu____23481 uu____23482
-                                            uu____23483 uu____23484 in
+                                            uu___6 uu___7 uu___8 uu___9
+                                            uu___10 uu___11 in
                                         (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                                          uu____23478) in
-                                      FStar_Errors.raise_error uu____23473
+                                          uu___5) in
+                                      FStar_Errors.raise_error uu___4
                                         env1.range
                                     else [(i, j, k, (e1.mlift), (e2.mlift))]))))) in
            let effects1 =
-             let uu___1856_23567 = env1.effects in
+             let uu___1 = env1.effects in
              {
-               decls = (uu___1856_23567.decls);
+               decls = (uu___1.decls);
                order;
                joins;
-               polymonadic_binds = (uu___1856_23567.polymonadic_binds);
-               polymonadic_subcomps = (uu___1856_23567.polymonadic_subcomps)
+               polymonadic_binds = (uu___1.polymonadic_binds);
+               polymonadic_subcomps = (uu___1.polymonadic_subcomps)
              } in
-           let uu___1859_23568 = env1 in
+           let uu___1 = env1 in
            {
-             solver = (uu___1859_23568.solver);
-             range = (uu___1859_23568.range);
-             curmodule = (uu___1859_23568.curmodule);
-             gamma = (uu___1859_23568.gamma);
-             gamma_sig = (uu___1859_23568.gamma_sig);
-             gamma_cache = (uu___1859_23568.gamma_cache);
-             modules = (uu___1859_23568.modules);
-             expected_typ = (uu___1859_23568.expected_typ);
-             sigtab = (uu___1859_23568.sigtab);
-             attrtab = (uu___1859_23568.attrtab);
-             instantiate_imp = (uu___1859_23568.instantiate_imp);
+             solver = (uu___1.solver);
+             range = (uu___1.range);
+             curmodule = (uu___1.curmodule);
+             gamma = (uu___1.gamma);
+             gamma_sig = (uu___1.gamma_sig);
+             gamma_cache = (uu___1.gamma_cache);
+             modules = (uu___1.modules);
+             expected_typ = (uu___1.expected_typ);
+             sigtab = (uu___1.sigtab);
+             attrtab = (uu___1.attrtab);
+             instantiate_imp = (uu___1.instantiate_imp);
              effects = effects1;
-             generalize = (uu___1859_23568.generalize);
-             letrecs = (uu___1859_23568.letrecs);
-             top_level = (uu___1859_23568.top_level);
-             check_uvars = (uu___1859_23568.check_uvars);
-             use_eq = (uu___1859_23568.use_eq);
-             use_eq_strict = (uu___1859_23568.use_eq_strict);
-             is_iface = (uu___1859_23568.is_iface);
-             admit = (uu___1859_23568.admit);
-             lax = (uu___1859_23568.lax);
-             lax_universes = (uu___1859_23568.lax_universes);
-             phase1 = (uu___1859_23568.phase1);
-             failhard = (uu___1859_23568.failhard);
-             nosynth = (uu___1859_23568.nosynth);
-             uvar_subtyping = (uu___1859_23568.uvar_subtyping);
-             tc_term = (uu___1859_23568.tc_term);
-             type_of = (uu___1859_23568.type_of);
-             universe_of = (uu___1859_23568.universe_of);
-             check_type_of = (uu___1859_23568.check_type_of);
-             use_bv_sorts = (uu___1859_23568.use_bv_sorts);
-             qtbl_name_and_index = (uu___1859_23568.qtbl_name_and_index);
-             normalized_eff_names = (uu___1859_23568.normalized_eff_names);
-             fv_delta_depths = (uu___1859_23568.fv_delta_depths);
-             proof_ns = (uu___1859_23568.proof_ns);
-             synth_hook = (uu___1859_23568.synth_hook);
-             try_solve_implicits_hook =
-               (uu___1859_23568.try_solve_implicits_hook);
-             splice = (uu___1859_23568.splice);
-             mpreprocess = (uu___1859_23568.mpreprocess);
-             postprocess = (uu___1859_23568.postprocess);
-             identifier_info = (uu___1859_23568.identifier_info);
-             tc_hooks = (uu___1859_23568.tc_hooks);
-             dsenv = (uu___1859_23568.dsenv);
-             nbe = (uu___1859_23568.nbe);
-             strict_args_tab = (uu___1859_23568.strict_args_tab);
-             erasable_types_tab = (uu___1859_23568.erasable_types_tab);
-             enable_defer_to_tac = (uu___1859_23568.enable_defer_to_tac)
+             generalize = (uu___1.generalize);
+             letrecs = (uu___1.letrecs);
+             top_level = (uu___1.top_level);
+             check_uvars = (uu___1.check_uvars);
+             use_eq = (uu___1.use_eq);
+             use_eq_strict = (uu___1.use_eq_strict);
+             is_iface = (uu___1.is_iface);
+             admit = (uu___1.admit);
+             lax = (uu___1.lax);
+             lax_universes = (uu___1.lax_universes);
+             phase1 = (uu___1.phase1);
+             failhard = (uu___1.failhard);
+             nosynth = (uu___1.nosynth);
+             uvar_subtyping = (uu___1.uvar_subtyping);
+             tc_term = (uu___1.tc_term);
+             type_of = (uu___1.type_of);
+             universe_of = (uu___1.universe_of);
+             check_type_of = (uu___1.check_type_of);
+             use_bv_sorts = (uu___1.use_bv_sorts);
+             qtbl_name_and_index = (uu___1.qtbl_name_and_index);
+             normalized_eff_names = (uu___1.normalized_eff_names);
+             fv_delta_depths = (uu___1.fv_delta_depths);
+             proof_ns = (uu___1.proof_ns);
+             synth_hook = (uu___1.synth_hook);
+             try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+             splice = (uu___1.splice);
+             mpreprocess = (uu___1.mpreprocess);
+             postprocess = (uu___1.postprocess);
+             identifier_info = (uu___1.identifier_info);
+             tc_hooks = (uu___1.tc_hooks);
+             dsenv = (uu___1.dsenv);
+             nbe = (uu___1.nbe);
+             strict_args_tab = (uu___1.strict_args_tab);
+             erasable_types_tab = (uu___1.erasable_types_tab);
+             enable_defer_to_tac = (uu___1.enable_defer_to_tac)
            })
 let (add_polymonadic_bind :
   env ->
@@ -4756,101 +4641,96 @@ let (add_polymonadic_bind :
         fun p ->
           fun ty ->
             let err_msg poly =
-              let uu____23612 = FStar_Ident.string_of_lid m in
-              let uu____23613 = FStar_Ident.string_of_lid n in
-              let uu____23614 = FStar_Ident.string_of_lid p in
+              let uu___ = FStar_Ident.string_of_lid m in
+              let uu___1 = FStar_Ident.string_of_lid n in
+              let uu___2 = FStar_Ident.string_of_lid p in
               FStar_Util.format4
                 "Polymonadic bind ((%s, %s) |> %s) conflicts with an already existing %s"
-                uu____23612 uu____23613 uu____23614
+                uu___ uu___1 uu___2
                 (if poly
                  then "polymonadic bind"
                  else "path in the effect lattice") in
-            let uu____23616 =
-              let uu____23617 = exists_polymonadic_bind env1 m n in
-              FStar_All.pipe_right uu____23617 FStar_Util.is_some in
-            if uu____23616
+            let uu___ =
+              let uu___1 = exists_polymonadic_bind env1 m n in
+              FStar_All.pipe_right uu___1 FStar_Util.is_some in
+            if uu___
             then
-              let uu____23652 =
-                let uu____23657 = err_msg true in
-                (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu____23657) in
-              FStar_Errors.raise_error uu____23652 env1.range
+              let uu___1 =
+                let uu___2 = err_msg true in
+                (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu___2) in
+              FStar_Errors.raise_error uu___1 env1.range
             else
-              (let uu____23659 =
-                 (let uu____23662 = join_opt env1 m n in
-                  FStar_All.pipe_right uu____23662 FStar_Util.is_some) &&
-                   (let uu____23686 = FStar_Ident.lid_equals m n in
-                    Prims.op_Negation uu____23686) in
-               if uu____23659
+              (let uu___2 =
+                 (let uu___3 = join_opt env1 m n in
+                  FStar_All.pipe_right uu___3 FStar_Util.is_some) &&
+                   (let uu___3 = FStar_Ident.lid_equals m n in
+                    Prims.op_Negation uu___3) in
+               if uu___2
                then
-                 let uu____23687 =
-                   let uu____23692 = err_msg false in
-                   (FStar_Errors.Fatal_Effects_Ordering_Coherence,
-                     uu____23692) in
-                 FStar_Errors.raise_error uu____23687 env1.range
+                 let uu___3 =
+                   let uu___4 = err_msg false in
+                   (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu___4) in
+                 FStar_Errors.raise_error uu___3 env1.range
                else
-                 (let uu___1874_23694 = env1 in
+                 (let uu___4 = env1 in
                   {
-                    solver = (uu___1874_23694.solver);
-                    range = (uu___1874_23694.range);
-                    curmodule = (uu___1874_23694.curmodule);
-                    gamma = (uu___1874_23694.gamma);
-                    gamma_sig = (uu___1874_23694.gamma_sig);
-                    gamma_cache = (uu___1874_23694.gamma_cache);
-                    modules = (uu___1874_23694.modules);
-                    expected_typ = (uu___1874_23694.expected_typ);
-                    sigtab = (uu___1874_23694.sigtab);
-                    attrtab = (uu___1874_23694.attrtab);
-                    instantiate_imp = (uu___1874_23694.instantiate_imp);
+                    solver = (uu___4.solver);
+                    range = (uu___4.range);
+                    curmodule = (uu___4.curmodule);
+                    gamma = (uu___4.gamma);
+                    gamma_sig = (uu___4.gamma_sig);
+                    gamma_cache = (uu___4.gamma_cache);
+                    modules = (uu___4.modules);
+                    expected_typ = (uu___4.expected_typ);
+                    sigtab = (uu___4.sigtab);
+                    attrtab = (uu___4.attrtab);
+                    instantiate_imp = (uu___4.instantiate_imp);
                     effects =
-                      (let uu___1876_23696 = env1.effects in
+                      (let uu___5 = env1.effects in
                        {
-                         decls = (uu___1876_23696.decls);
-                         order = (uu___1876_23696.order);
-                         joins = (uu___1876_23696.joins);
+                         decls = (uu___5.decls);
+                         order = (uu___5.order);
+                         joins = (uu___5.joins);
                          polymonadic_binds = ((m, n, p, ty) ::
                            ((env1.effects).polymonadic_binds));
-                         polymonadic_subcomps =
-                           (uu___1876_23696.polymonadic_subcomps)
+                         polymonadic_subcomps = (uu___5.polymonadic_subcomps)
                        });
-                    generalize = (uu___1874_23694.generalize);
-                    letrecs = (uu___1874_23694.letrecs);
-                    top_level = (uu___1874_23694.top_level);
-                    check_uvars = (uu___1874_23694.check_uvars);
-                    use_eq = (uu___1874_23694.use_eq);
-                    use_eq_strict = (uu___1874_23694.use_eq_strict);
-                    is_iface = (uu___1874_23694.is_iface);
-                    admit = (uu___1874_23694.admit);
-                    lax = (uu___1874_23694.lax);
-                    lax_universes = (uu___1874_23694.lax_universes);
-                    phase1 = (uu___1874_23694.phase1);
-                    failhard = (uu___1874_23694.failhard);
-                    nosynth = (uu___1874_23694.nosynth);
-                    uvar_subtyping = (uu___1874_23694.uvar_subtyping);
-                    tc_term = (uu___1874_23694.tc_term);
-                    type_of = (uu___1874_23694.type_of);
-                    universe_of = (uu___1874_23694.universe_of);
-                    check_type_of = (uu___1874_23694.check_type_of);
-                    use_bv_sorts = (uu___1874_23694.use_bv_sorts);
-                    qtbl_name_and_index =
-                      (uu___1874_23694.qtbl_name_and_index);
-                    normalized_eff_names =
-                      (uu___1874_23694.normalized_eff_names);
-                    fv_delta_depths = (uu___1874_23694.fv_delta_depths);
-                    proof_ns = (uu___1874_23694.proof_ns);
-                    synth_hook = (uu___1874_23694.synth_hook);
+                    generalize = (uu___4.generalize);
+                    letrecs = (uu___4.letrecs);
+                    top_level = (uu___4.top_level);
+                    check_uvars = (uu___4.check_uvars);
+                    use_eq = (uu___4.use_eq);
+                    use_eq_strict = (uu___4.use_eq_strict);
+                    is_iface = (uu___4.is_iface);
+                    admit = (uu___4.admit);
+                    lax = (uu___4.lax);
+                    lax_universes = (uu___4.lax_universes);
+                    phase1 = (uu___4.phase1);
+                    failhard = (uu___4.failhard);
+                    nosynth = (uu___4.nosynth);
+                    uvar_subtyping = (uu___4.uvar_subtyping);
+                    tc_term = (uu___4.tc_term);
+                    type_of = (uu___4.type_of);
+                    universe_of = (uu___4.universe_of);
+                    check_type_of = (uu___4.check_type_of);
+                    use_bv_sorts = (uu___4.use_bv_sorts);
+                    qtbl_name_and_index = (uu___4.qtbl_name_and_index);
+                    normalized_eff_names = (uu___4.normalized_eff_names);
+                    fv_delta_depths = (uu___4.fv_delta_depths);
+                    proof_ns = (uu___4.proof_ns);
+                    synth_hook = (uu___4.synth_hook);
                     try_solve_implicits_hook =
-                      (uu___1874_23694.try_solve_implicits_hook);
-                    splice = (uu___1874_23694.splice);
-                    mpreprocess = (uu___1874_23694.mpreprocess);
-                    postprocess = (uu___1874_23694.postprocess);
-                    identifier_info = (uu___1874_23694.identifier_info);
-                    tc_hooks = (uu___1874_23694.tc_hooks);
-                    dsenv = (uu___1874_23694.dsenv);
-                    nbe = (uu___1874_23694.nbe);
-                    strict_args_tab = (uu___1874_23694.strict_args_tab);
-                    erasable_types_tab = (uu___1874_23694.erasable_types_tab);
-                    enable_defer_to_tac =
-                      (uu___1874_23694.enable_defer_to_tac)
+                      (uu___4.try_solve_implicits_hook);
+                    splice = (uu___4.splice);
+                    mpreprocess = (uu___4.mpreprocess);
+                    postprocess = (uu___4.postprocess);
+                    identifier_info = (uu___4.identifier_info);
+                    tc_hooks = (uu___4.tc_hooks);
+                    dsenv = (uu___4.dsenv);
+                    nbe = (uu___4.nbe);
+                    strict_args_tab = (uu___4.strict_args_tab);
+                    erasable_types_tab = (uu___4.erasable_types_tab);
+                    enable_defer_to_tac = (uu___4.enable_defer_to_tac)
                   }))
 let (add_polymonadic_subcomp :
   env ->
@@ -4862,152 +4742,150 @@ let (add_polymonadic_subcomp :
       fun n ->
         fun ts ->
           let err_msg poly =
-            let uu____23783 = FStar_Ident.string_of_lid m in
-            let uu____23784 = FStar_Ident.string_of_lid n in
+            let uu___ = FStar_Ident.string_of_lid m in
+            let uu___1 = FStar_Ident.string_of_lid n in
             FStar_Util.format3
               "Polymonadic subcomp %s <: %s conflicts with an already existing %s"
-              uu____23783 uu____23784
+              uu___ uu___1
               (if poly
                then "polymonadic subcomp"
                else "path in the effect lattice") in
-          let uu____23786 =
-            (let uu____23789 = exists_polymonadic_subcomp env1 m n in
-             FStar_All.pipe_right uu____23789 FStar_Util.is_some) ||
-              (let uu____23795 = exists_polymonadic_subcomp env1 n m in
-               FStar_All.pipe_right uu____23795 FStar_Util.is_some) in
-          if uu____23786
+          let uu___ =
+            (let uu___1 = exists_polymonadic_subcomp env1 m n in
+             FStar_All.pipe_right uu___1 FStar_Util.is_some) ||
+              (let uu___1 = exists_polymonadic_subcomp env1 n m in
+               FStar_All.pipe_right uu___1 FStar_Util.is_some) in
+          if uu___
           then
-            let uu____23800 =
-              let uu____23805 = err_msg true in
-              (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu____23805) in
-            FStar_Errors.raise_error uu____23800 env1.range
+            let uu___1 =
+              let uu___2 = err_msg true in
+              (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu___2) in
+            FStar_Errors.raise_error uu___1 env1.range
           else
-            (let uu____23807 =
-               (let uu____23810 = monad_leq env1 m n in
-                FStar_All.pipe_right uu____23810 FStar_Util.is_some) ||
-                 (let uu____23816 = monad_leq env1 n m in
-                  FStar_All.pipe_right uu____23816 FStar_Util.is_some) in
-             if uu____23807
+            (let uu___2 =
+               (let uu___3 = monad_leq env1 m n in
+                FStar_All.pipe_right uu___3 FStar_Util.is_some) ||
+                 (let uu___3 = monad_leq env1 n m in
+                  FStar_All.pipe_right uu___3 FStar_Util.is_some) in
+             if uu___2
              then
-               let uu____23821 =
-                 let uu____23826 = err_msg false in
-                 (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu____23826) in
-               FStar_Errors.raise_error uu____23821 env1.range
+               let uu___3 =
+                 let uu___4 = err_msg false in
+                 (FStar_Errors.Fatal_Effects_Ordering_Coherence, uu___4) in
+               FStar_Errors.raise_error uu___3 env1.range
              else
-               (let uu___1889_23828 = env1 in
+               (let uu___4 = env1 in
                 {
-                  solver = (uu___1889_23828.solver);
-                  range = (uu___1889_23828.range);
-                  curmodule = (uu___1889_23828.curmodule);
-                  gamma = (uu___1889_23828.gamma);
-                  gamma_sig = (uu___1889_23828.gamma_sig);
-                  gamma_cache = (uu___1889_23828.gamma_cache);
-                  modules = (uu___1889_23828.modules);
-                  expected_typ = (uu___1889_23828.expected_typ);
-                  sigtab = (uu___1889_23828.sigtab);
-                  attrtab = (uu___1889_23828.attrtab);
-                  instantiate_imp = (uu___1889_23828.instantiate_imp);
+                  solver = (uu___4.solver);
+                  range = (uu___4.range);
+                  curmodule = (uu___4.curmodule);
+                  gamma = (uu___4.gamma);
+                  gamma_sig = (uu___4.gamma_sig);
+                  gamma_cache = (uu___4.gamma_cache);
+                  modules = (uu___4.modules);
+                  expected_typ = (uu___4.expected_typ);
+                  sigtab = (uu___4.sigtab);
+                  attrtab = (uu___4.attrtab);
+                  instantiate_imp = (uu___4.instantiate_imp);
                   effects =
-                    (let uu___1891_23830 = env1.effects in
+                    (let uu___5 = env1.effects in
                      {
-                       decls = (uu___1891_23830.decls);
-                       order = (uu___1891_23830.order);
-                       joins = (uu___1891_23830.joins);
-                       polymonadic_binds =
-                         (uu___1891_23830.polymonadic_binds);
+                       decls = (uu___5.decls);
+                       order = (uu___5.order);
+                       joins = (uu___5.joins);
+                       polymonadic_binds = (uu___5.polymonadic_binds);
                        polymonadic_subcomps = ((m, n, ts) ::
                          ((env1.effects).polymonadic_subcomps))
                      });
-                  generalize = (uu___1889_23828.generalize);
-                  letrecs = (uu___1889_23828.letrecs);
-                  top_level = (uu___1889_23828.top_level);
-                  check_uvars = (uu___1889_23828.check_uvars);
-                  use_eq = (uu___1889_23828.use_eq);
-                  use_eq_strict = (uu___1889_23828.use_eq_strict);
-                  is_iface = (uu___1889_23828.is_iface);
-                  admit = (uu___1889_23828.admit);
-                  lax = (uu___1889_23828.lax);
-                  lax_universes = (uu___1889_23828.lax_universes);
-                  phase1 = (uu___1889_23828.phase1);
-                  failhard = (uu___1889_23828.failhard);
-                  nosynth = (uu___1889_23828.nosynth);
-                  uvar_subtyping = (uu___1889_23828.uvar_subtyping);
-                  tc_term = (uu___1889_23828.tc_term);
-                  type_of = (uu___1889_23828.type_of);
-                  universe_of = (uu___1889_23828.universe_of);
-                  check_type_of = (uu___1889_23828.check_type_of);
-                  use_bv_sorts = (uu___1889_23828.use_bv_sorts);
-                  qtbl_name_and_index = (uu___1889_23828.qtbl_name_and_index);
-                  normalized_eff_names =
-                    (uu___1889_23828.normalized_eff_names);
-                  fv_delta_depths = (uu___1889_23828.fv_delta_depths);
-                  proof_ns = (uu___1889_23828.proof_ns);
-                  synth_hook = (uu___1889_23828.synth_hook);
+                  generalize = (uu___4.generalize);
+                  letrecs = (uu___4.letrecs);
+                  top_level = (uu___4.top_level);
+                  check_uvars = (uu___4.check_uvars);
+                  use_eq = (uu___4.use_eq);
+                  use_eq_strict = (uu___4.use_eq_strict);
+                  is_iface = (uu___4.is_iface);
+                  admit = (uu___4.admit);
+                  lax = (uu___4.lax);
+                  lax_universes = (uu___4.lax_universes);
+                  phase1 = (uu___4.phase1);
+                  failhard = (uu___4.failhard);
+                  nosynth = (uu___4.nosynth);
+                  uvar_subtyping = (uu___4.uvar_subtyping);
+                  tc_term = (uu___4.tc_term);
+                  type_of = (uu___4.type_of);
+                  universe_of = (uu___4.universe_of);
+                  check_type_of = (uu___4.check_type_of);
+                  use_bv_sorts = (uu___4.use_bv_sorts);
+                  qtbl_name_and_index = (uu___4.qtbl_name_and_index);
+                  normalized_eff_names = (uu___4.normalized_eff_names);
+                  fv_delta_depths = (uu___4.fv_delta_depths);
+                  proof_ns = (uu___4.proof_ns);
+                  synth_hook = (uu___4.synth_hook);
                   try_solve_implicits_hook =
-                    (uu___1889_23828.try_solve_implicits_hook);
-                  splice = (uu___1889_23828.splice);
-                  mpreprocess = (uu___1889_23828.mpreprocess);
-                  postprocess = (uu___1889_23828.postprocess);
-                  identifier_info = (uu___1889_23828.identifier_info);
-                  tc_hooks = (uu___1889_23828.tc_hooks);
-                  dsenv = (uu___1889_23828.dsenv);
-                  nbe = (uu___1889_23828.nbe);
-                  strict_args_tab = (uu___1889_23828.strict_args_tab);
-                  erasable_types_tab = (uu___1889_23828.erasable_types_tab);
-                  enable_defer_to_tac = (uu___1889_23828.enable_defer_to_tac)
+                    (uu___4.try_solve_implicits_hook);
+                  splice = (uu___4.splice);
+                  mpreprocess = (uu___4.mpreprocess);
+                  postprocess = (uu___4.postprocess);
+                  identifier_info = (uu___4.identifier_info);
+                  tc_hooks = (uu___4.tc_hooks);
+                  dsenv = (uu___4.dsenv);
+                  nbe = (uu___4.nbe);
+                  strict_args_tab = (uu___4.strict_args_tab);
+                  erasable_types_tab = (uu___4.erasable_types_tab);
+                  enable_defer_to_tac = (uu___4.enable_defer_to_tac)
                 }))
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env1 ->
     fun b ->
-      let uu___1895_23847 = env1 in
+      let uu___ = env1 in
       {
-        solver = (uu___1895_23847.solver);
-        range = (uu___1895_23847.range);
-        curmodule = (uu___1895_23847.curmodule);
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
         gamma = (b :: (env1.gamma));
-        gamma_sig = (uu___1895_23847.gamma_sig);
-        gamma_cache = (uu___1895_23847.gamma_cache);
-        modules = (uu___1895_23847.modules);
-        expected_typ = (uu___1895_23847.expected_typ);
-        sigtab = (uu___1895_23847.sigtab);
-        attrtab = (uu___1895_23847.attrtab);
-        instantiate_imp = (uu___1895_23847.instantiate_imp);
-        effects = (uu___1895_23847.effects);
-        generalize = (uu___1895_23847.generalize);
-        letrecs = (uu___1895_23847.letrecs);
-        top_level = (uu___1895_23847.top_level);
-        check_uvars = (uu___1895_23847.check_uvars);
-        use_eq = (uu___1895_23847.use_eq);
-        use_eq_strict = (uu___1895_23847.use_eq_strict);
-        is_iface = (uu___1895_23847.is_iface);
-        admit = (uu___1895_23847.admit);
-        lax = (uu___1895_23847.lax);
-        lax_universes = (uu___1895_23847.lax_universes);
-        phase1 = (uu___1895_23847.phase1);
-        failhard = (uu___1895_23847.failhard);
-        nosynth = (uu___1895_23847.nosynth);
-        uvar_subtyping = (uu___1895_23847.uvar_subtyping);
-        tc_term = (uu___1895_23847.tc_term);
-        type_of = (uu___1895_23847.type_of);
-        universe_of = (uu___1895_23847.universe_of);
-        check_type_of = (uu___1895_23847.check_type_of);
-        use_bv_sorts = (uu___1895_23847.use_bv_sorts);
-        qtbl_name_and_index = (uu___1895_23847.qtbl_name_and_index);
-        normalized_eff_names = (uu___1895_23847.normalized_eff_names);
-        fv_delta_depths = (uu___1895_23847.fv_delta_depths);
-        proof_ns = (uu___1895_23847.proof_ns);
-        synth_hook = (uu___1895_23847.synth_hook);
-        try_solve_implicits_hook = (uu___1895_23847.try_solve_implicits_hook);
-        splice = (uu___1895_23847.splice);
-        mpreprocess = (uu___1895_23847.mpreprocess);
-        postprocess = (uu___1895_23847.postprocess);
-        identifier_info = (uu___1895_23847.identifier_info);
-        tc_hooks = (uu___1895_23847.tc_hooks);
-        dsenv = (uu___1895_23847.dsenv);
-        nbe = (uu___1895_23847.nbe);
-        strict_args_tab = (uu___1895_23847.strict_args_tab);
-        erasable_types_tab = (uu___1895_23847.erasable_types_tab);
-        enable_defer_to_tac = (uu___1895_23847.enable_defer_to_tac)
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
   fun env1 ->
@@ -5023,65 +4901,63 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1908_23902 = env1 in
+            (let uu___ = env1 in
              {
-               solver = (uu___1908_23902.solver);
-               range = (uu___1908_23902.range);
-               curmodule = (uu___1908_23902.curmodule);
+               solver = (uu___.solver);
+               range = (uu___.range);
+               curmodule = (uu___.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1908_23902.gamma_sig);
-               gamma_cache = (uu___1908_23902.gamma_cache);
-               modules = (uu___1908_23902.modules);
-               expected_typ = (uu___1908_23902.expected_typ);
-               sigtab = (uu___1908_23902.sigtab);
-               attrtab = (uu___1908_23902.attrtab);
-               instantiate_imp = (uu___1908_23902.instantiate_imp);
-               effects = (uu___1908_23902.effects);
-               generalize = (uu___1908_23902.generalize);
-               letrecs = (uu___1908_23902.letrecs);
-               top_level = (uu___1908_23902.top_level);
-               check_uvars = (uu___1908_23902.check_uvars);
-               use_eq = (uu___1908_23902.use_eq);
-               use_eq_strict = (uu___1908_23902.use_eq_strict);
-               is_iface = (uu___1908_23902.is_iface);
-               admit = (uu___1908_23902.admit);
-               lax = (uu___1908_23902.lax);
-               lax_universes = (uu___1908_23902.lax_universes);
-               phase1 = (uu___1908_23902.phase1);
-               failhard = (uu___1908_23902.failhard);
-               nosynth = (uu___1908_23902.nosynth);
-               uvar_subtyping = (uu___1908_23902.uvar_subtyping);
-               tc_term = (uu___1908_23902.tc_term);
-               type_of = (uu___1908_23902.type_of);
-               universe_of = (uu___1908_23902.universe_of);
-               check_type_of = (uu___1908_23902.check_type_of);
-               use_bv_sorts = (uu___1908_23902.use_bv_sorts);
-               qtbl_name_and_index = (uu___1908_23902.qtbl_name_and_index);
-               normalized_eff_names = (uu___1908_23902.normalized_eff_names);
-               fv_delta_depths = (uu___1908_23902.fv_delta_depths);
-               proof_ns = (uu___1908_23902.proof_ns);
-               synth_hook = (uu___1908_23902.synth_hook);
-               try_solve_implicits_hook =
-                 (uu___1908_23902.try_solve_implicits_hook);
-               splice = (uu___1908_23902.splice);
-               mpreprocess = (uu___1908_23902.mpreprocess);
-               postprocess = (uu___1908_23902.postprocess);
-               identifier_info = (uu___1908_23902.identifier_info);
-               tc_hooks = (uu___1908_23902.tc_hooks);
-               dsenv = (uu___1908_23902.dsenv);
-               nbe = (uu___1908_23902.nbe);
-               strict_args_tab = (uu___1908_23902.strict_args_tab);
-               erasable_types_tab = (uu___1908_23902.erasable_types_tab);
-               enable_defer_to_tac = (uu___1908_23902.enable_defer_to_tac)
+               gamma_sig = (uu___.gamma_sig);
+               gamma_cache = (uu___.gamma_cache);
+               modules = (uu___.modules);
+               expected_typ = (uu___.expected_typ);
+               sigtab = (uu___.sigtab);
+               attrtab = (uu___.attrtab);
+               instantiate_imp = (uu___.instantiate_imp);
+               effects = (uu___.effects);
+               generalize = (uu___.generalize);
+               letrecs = (uu___.letrecs);
+               top_level = (uu___.top_level);
+               check_uvars = (uu___.check_uvars);
+               use_eq = (uu___.use_eq);
+               use_eq_strict = (uu___.use_eq_strict);
+               is_iface = (uu___.is_iface);
+               admit = (uu___.admit);
+               lax = (uu___.lax);
+               lax_universes = (uu___.lax_universes);
+               phase1 = (uu___.phase1);
+               failhard = (uu___.failhard);
+               nosynth = (uu___.nosynth);
+               uvar_subtyping = (uu___.uvar_subtyping);
+               tc_term = (uu___.tc_term);
+               type_of = (uu___.type_of);
+               universe_of = (uu___.universe_of);
+               check_type_of = (uu___.check_type_of);
+               use_bv_sorts = (uu___.use_bv_sorts);
+               qtbl_name_and_index = (uu___.qtbl_name_and_index);
+               normalized_eff_names = (uu___.normalized_eff_names);
+               fv_delta_depths = (uu___.fv_delta_depths);
+               proof_ns = (uu___.proof_ns);
+               synth_hook = (uu___.synth_hook);
+               try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+               splice = (uu___.splice);
+               mpreprocess = (uu___.mpreprocess);
+               postprocess = (uu___.postprocess);
+               identifier_info = (uu___.identifier_info);
+               tc_hooks = (uu___.tc_hooks);
+               dsenv = (uu___.dsenv);
+               nbe = (uu___.nbe);
+               strict_args_tab = (uu___.strict_args_tab);
+               erasable_types_tab = (uu___.erasable_types_tab);
+               enable_defer_to_tac = (uu___.enable_defer_to_tac)
              }))
-    | uu____23903 -> FStar_Pervasives_Native.None
+    | uu___ -> FStar_Pervasives_Native.None
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env1 ->
     fun bs ->
       FStar_List.fold_left
         (fun env2 ->
-           fun uu____23931 ->
-             match uu____23931 with | (x, uu____23939) -> push_bv env2 x)
+           fun uu___ -> match uu___ with | (x, uu___1) -> push_bv env2 x)
         env1 bs
 let (binding_of_lb :
   FStar_Syntax_Syntax.lbname ->
@@ -5093,12 +4969,11 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1922_23969 = x1 in
+            let uu___1 = x1 in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1922_23969.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index =
-                (uu___1922_23969.FStar_Syntax_Syntax.index);
+                (uu___1.FStar_Syntax_Syntax.ppname);
+              FStar_Syntax_Syntax.index = (uu___1.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             } in
           FStar_Syntax_Syntax.Binding_var x2
@@ -5127,65 +5002,65 @@ let (open_universes_in :
   fun env1 ->
     fun uvs ->
       fun terms ->
-        let uu____24035 = FStar_Syntax_Subst.univ_var_opening uvs in
-        match uu____24035 with
+        let uu___ = FStar_Syntax_Subst.univ_var_opening uvs in
+        match uu___ with
         | (univ_subst, univ_vars) ->
             let env' = push_univ_vars env1 univ_vars in
-            let uu____24063 =
+            let uu___1 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms in
-            (env', univ_vars, uu____24063)
+            (env', univ_vars, uu___1)
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env1 ->
     fun t ->
-      let uu___1943_24078 = env1 in
+      let uu___ = env1 in
       {
-        solver = (uu___1943_24078.solver);
-        range = (uu___1943_24078.range);
-        curmodule = (uu___1943_24078.curmodule);
-        gamma = (uu___1943_24078.gamma);
-        gamma_sig = (uu___1943_24078.gamma_sig);
-        gamma_cache = (uu___1943_24078.gamma_cache);
-        modules = (uu___1943_24078.modules);
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
+        gamma = (uu___.gamma);
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1943_24078.sigtab);
-        attrtab = (uu___1943_24078.attrtab);
-        instantiate_imp = (uu___1943_24078.instantiate_imp);
-        effects = (uu___1943_24078.effects);
-        generalize = (uu___1943_24078.generalize);
-        letrecs = (uu___1943_24078.letrecs);
-        top_level = (uu___1943_24078.top_level);
-        check_uvars = (uu___1943_24078.check_uvars);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1943_24078.use_eq_strict);
-        is_iface = (uu___1943_24078.is_iface);
-        admit = (uu___1943_24078.admit);
-        lax = (uu___1943_24078.lax);
-        lax_universes = (uu___1943_24078.lax_universes);
-        phase1 = (uu___1943_24078.phase1);
-        failhard = (uu___1943_24078.failhard);
-        nosynth = (uu___1943_24078.nosynth);
-        uvar_subtyping = (uu___1943_24078.uvar_subtyping);
-        tc_term = (uu___1943_24078.tc_term);
-        type_of = (uu___1943_24078.type_of);
-        universe_of = (uu___1943_24078.universe_of);
-        check_type_of = (uu___1943_24078.check_type_of);
-        use_bv_sorts = (uu___1943_24078.use_bv_sorts);
-        qtbl_name_and_index = (uu___1943_24078.qtbl_name_and_index);
-        normalized_eff_names = (uu___1943_24078.normalized_eff_names);
-        fv_delta_depths = (uu___1943_24078.fv_delta_depths);
-        proof_ns = (uu___1943_24078.proof_ns);
-        synth_hook = (uu___1943_24078.synth_hook);
-        try_solve_implicits_hook = (uu___1943_24078.try_solve_implicits_hook);
-        splice = (uu___1943_24078.splice);
-        mpreprocess = (uu___1943_24078.mpreprocess);
-        postprocess = (uu___1943_24078.postprocess);
-        identifier_info = (uu___1943_24078.identifier_info);
-        tc_hooks = (uu___1943_24078.tc_hooks);
-        dsenv = (uu___1943_24078.dsenv);
-        nbe = (uu___1943_24078.nbe);
-        strict_args_tab = (uu___1943_24078.strict_args_tab);
-        erasable_types_tab = (uu___1943_24078.erasable_types_tab);
-        enable_defer_to_tac = (uu___1943_24078.enable_defer_to_tac)
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
+        proof_ns = (uu___.proof_ns);
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (expected_typ :
   env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option) =
@@ -5196,126 +5071,124 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_ ->
-    let uu____24106 = expected_typ env_ in
-    ((let uu___1950_24112 = env_ in
+    let uu___ = expected_typ env_ in
+    ((let uu___1 = env_ in
       {
-        solver = (uu___1950_24112.solver);
-        range = (uu___1950_24112.range);
-        curmodule = (uu___1950_24112.curmodule);
-        gamma = (uu___1950_24112.gamma);
-        gamma_sig = (uu___1950_24112.gamma_sig);
-        gamma_cache = (uu___1950_24112.gamma_cache);
-        modules = (uu___1950_24112.modules);
+        solver = (uu___1.solver);
+        range = (uu___1.range);
+        curmodule = (uu___1.curmodule);
+        gamma = (uu___1.gamma);
+        gamma_sig = (uu___1.gamma_sig);
+        gamma_cache = (uu___1.gamma_cache);
+        modules = (uu___1.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1950_24112.sigtab);
-        attrtab = (uu___1950_24112.attrtab);
-        instantiate_imp = (uu___1950_24112.instantiate_imp);
-        effects = (uu___1950_24112.effects);
-        generalize = (uu___1950_24112.generalize);
-        letrecs = (uu___1950_24112.letrecs);
-        top_level = (uu___1950_24112.top_level);
-        check_uvars = (uu___1950_24112.check_uvars);
+        sigtab = (uu___1.sigtab);
+        attrtab = (uu___1.attrtab);
+        instantiate_imp = (uu___1.instantiate_imp);
+        effects = (uu___1.effects);
+        generalize = (uu___1.generalize);
+        letrecs = (uu___1.letrecs);
+        top_level = (uu___1.top_level);
+        check_uvars = (uu___1.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1950_24112.use_eq_strict);
-        is_iface = (uu___1950_24112.is_iface);
-        admit = (uu___1950_24112.admit);
-        lax = (uu___1950_24112.lax);
-        lax_universes = (uu___1950_24112.lax_universes);
-        phase1 = (uu___1950_24112.phase1);
-        failhard = (uu___1950_24112.failhard);
-        nosynth = (uu___1950_24112.nosynth);
-        uvar_subtyping = (uu___1950_24112.uvar_subtyping);
-        tc_term = (uu___1950_24112.tc_term);
-        type_of = (uu___1950_24112.type_of);
-        universe_of = (uu___1950_24112.universe_of);
-        check_type_of = (uu___1950_24112.check_type_of);
-        use_bv_sorts = (uu___1950_24112.use_bv_sorts);
-        qtbl_name_and_index = (uu___1950_24112.qtbl_name_and_index);
-        normalized_eff_names = (uu___1950_24112.normalized_eff_names);
-        fv_delta_depths = (uu___1950_24112.fv_delta_depths);
-        proof_ns = (uu___1950_24112.proof_ns);
-        synth_hook = (uu___1950_24112.synth_hook);
-        try_solve_implicits_hook = (uu___1950_24112.try_solve_implicits_hook);
-        splice = (uu___1950_24112.splice);
-        mpreprocess = (uu___1950_24112.mpreprocess);
-        postprocess = (uu___1950_24112.postprocess);
-        identifier_info = (uu___1950_24112.identifier_info);
-        tc_hooks = (uu___1950_24112.tc_hooks);
-        dsenv = (uu___1950_24112.dsenv);
-        nbe = (uu___1950_24112.nbe);
-        strict_args_tab = (uu___1950_24112.strict_args_tab);
-        erasable_types_tab = (uu___1950_24112.erasable_types_tab);
-        enable_defer_to_tac = (uu___1950_24112.enable_defer_to_tac)
-      }), uu____24106)
+        use_eq_strict = (uu___1.use_eq_strict);
+        is_iface = (uu___1.is_iface);
+        admit = (uu___1.admit);
+        lax = (uu___1.lax);
+        lax_universes = (uu___1.lax_universes);
+        phase1 = (uu___1.phase1);
+        failhard = (uu___1.failhard);
+        nosynth = (uu___1.nosynth);
+        uvar_subtyping = (uu___1.uvar_subtyping);
+        tc_term = (uu___1.tc_term);
+        type_of = (uu___1.type_of);
+        universe_of = (uu___1.universe_of);
+        check_type_of = (uu___1.check_type_of);
+        use_bv_sorts = (uu___1.use_bv_sorts);
+        qtbl_name_and_index = (uu___1.qtbl_name_and_index);
+        normalized_eff_names = (uu___1.normalized_eff_names);
+        fv_delta_depths = (uu___1.fv_delta_depths);
+        proof_ns = (uu___1.proof_ns);
+        synth_hook = (uu___1.synth_hook);
+        try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+        splice = (uu___1.splice);
+        mpreprocess = (uu___1.mpreprocess);
+        postprocess = (uu___1.postprocess);
+        identifier_info = (uu___1.identifier_info);
+        tc_hooks = (uu___1.tc_hooks);
+        dsenv = (uu___1.dsenv);
+        nbe = (uu___1.nbe);
+        strict_args_tab = (uu___1.strict_args_tab);
+        erasable_types_tab = (uu___1.erasable_types_tab);
+        enable_defer_to_tac = (uu___1.enable_defer_to_tac)
+      }), uu___)
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____24122 =
-      let uu____24123 = FStar_Ident.id_of_text "" in [uu____24123] in
-    FStar_Ident.lid_of_ids uu____24122 in
+    let uu___ = let uu___1 = FStar_Ident.id_of_text "" in [uu___1] in
+    FStar_Ident.lid_of_ids uu___ in
   fun env1 ->
     fun m ->
       let sigs =
-        let uu____24129 =
+        let uu___ =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid in
-        if uu____24129
+        if uu___
         then
-          let uu____24132 =
+          let uu___1 =
             FStar_All.pipe_right env1.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd) in
-          FStar_All.pipe_right uu____24132 FStar_List.rev
+          FStar_All.pipe_right uu___1 FStar_List.rev
         else m.FStar_Syntax_Syntax.declarations in
       add_sigelts env1 sigs;
-      (let uu___1958_24159 = env1 in
+      (let uu___1 = env1 in
        {
-         solver = (uu___1958_24159.solver);
-         range = (uu___1958_24159.range);
+         solver = (uu___1.solver);
+         range = (uu___1.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1958_24159.gamma_cache);
+         gamma_cache = (uu___1.gamma_cache);
          modules = (m :: (env1.modules));
-         expected_typ = (uu___1958_24159.expected_typ);
-         sigtab = (uu___1958_24159.sigtab);
-         attrtab = (uu___1958_24159.attrtab);
-         instantiate_imp = (uu___1958_24159.instantiate_imp);
-         effects = (uu___1958_24159.effects);
-         generalize = (uu___1958_24159.generalize);
-         letrecs = (uu___1958_24159.letrecs);
-         top_level = (uu___1958_24159.top_level);
-         check_uvars = (uu___1958_24159.check_uvars);
-         use_eq = (uu___1958_24159.use_eq);
-         use_eq_strict = (uu___1958_24159.use_eq_strict);
-         is_iface = (uu___1958_24159.is_iface);
-         admit = (uu___1958_24159.admit);
-         lax = (uu___1958_24159.lax);
-         lax_universes = (uu___1958_24159.lax_universes);
-         phase1 = (uu___1958_24159.phase1);
-         failhard = (uu___1958_24159.failhard);
-         nosynth = (uu___1958_24159.nosynth);
-         uvar_subtyping = (uu___1958_24159.uvar_subtyping);
-         tc_term = (uu___1958_24159.tc_term);
-         type_of = (uu___1958_24159.type_of);
-         universe_of = (uu___1958_24159.universe_of);
-         check_type_of = (uu___1958_24159.check_type_of);
-         use_bv_sorts = (uu___1958_24159.use_bv_sorts);
-         qtbl_name_and_index = (uu___1958_24159.qtbl_name_and_index);
-         normalized_eff_names = (uu___1958_24159.normalized_eff_names);
-         fv_delta_depths = (uu___1958_24159.fv_delta_depths);
-         proof_ns = (uu___1958_24159.proof_ns);
-         synth_hook = (uu___1958_24159.synth_hook);
-         try_solve_implicits_hook =
-           (uu___1958_24159.try_solve_implicits_hook);
-         splice = (uu___1958_24159.splice);
-         mpreprocess = (uu___1958_24159.mpreprocess);
-         postprocess = (uu___1958_24159.postprocess);
-         identifier_info = (uu___1958_24159.identifier_info);
-         tc_hooks = (uu___1958_24159.tc_hooks);
-         dsenv = (uu___1958_24159.dsenv);
-         nbe = (uu___1958_24159.nbe);
-         strict_args_tab = (uu___1958_24159.strict_args_tab);
-         erasable_types_tab = (uu___1958_24159.erasable_types_tab);
-         enable_defer_to_tac = (uu___1958_24159.enable_defer_to_tac)
+         expected_typ = (uu___1.expected_typ);
+         sigtab = (uu___1.sigtab);
+         attrtab = (uu___1.attrtab);
+         instantiate_imp = (uu___1.instantiate_imp);
+         effects = (uu___1.effects);
+         generalize = (uu___1.generalize);
+         letrecs = (uu___1.letrecs);
+         top_level = (uu___1.top_level);
+         check_uvars = (uu___1.check_uvars);
+         use_eq = (uu___1.use_eq);
+         use_eq_strict = (uu___1.use_eq_strict);
+         is_iface = (uu___1.is_iface);
+         admit = (uu___1.admit);
+         lax = (uu___1.lax);
+         lax_universes = (uu___1.lax_universes);
+         phase1 = (uu___1.phase1);
+         failhard = (uu___1.failhard);
+         nosynth = (uu___1.nosynth);
+         uvar_subtyping = (uu___1.uvar_subtyping);
+         tc_term = (uu___1.tc_term);
+         type_of = (uu___1.type_of);
+         universe_of = (uu___1.universe_of);
+         check_type_of = (uu___1.check_type_of);
+         use_bv_sorts = (uu___1.use_bv_sorts);
+         qtbl_name_and_index = (uu___1.qtbl_name_and_index);
+         normalized_eff_names = (uu___1.normalized_eff_names);
+         fv_delta_depths = (uu___1.fv_delta_depths);
+         proof_ns = (uu___1.proof_ns);
+         synth_hook = (uu___1.synth_hook);
+         try_solve_implicits_hook = (uu___1.try_solve_implicits_hook);
+         splice = (uu___1.splice);
+         mpreprocess = (uu___1.mpreprocess);
+         postprocess = (uu___1.postprocess);
+         identifier_info = (uu___1.identifier_info);
+         tc_hooks = (uu___1.tc_hooks);
+         dsenv = (uu___1.dsenv);
+         nbe = (uu___1.nbe);
+         strict_args_tab = (uu___1.strict_args_tab);
+         erasable_types_tab = (uu___1.erasable_types_tab);
+         enable_defer_to_tac = (uu___1.enable_defer_to_tac)
        })
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
   fun env1 ->
@@ -5324,22 +5197,19 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24210)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24214, (uu____24215, t)))::tl
-          ->
-          let uu____24230 =
-            let uu____24233 = FStar_Syntax_Free.uvars t in
-            ext out uu____24233 in
-          aux uu____24230 tl
+      | (FStar_Syntax_Syntax.Binding_univ uu___)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu___, (uu___1, t)))::tl ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.uvars t in ext out uu___3 in
+          aux uu___2 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24236;
-            FStar_Syntax_Syntax.index = uu____24237;
+          { FStar_Syntax_Syntax.ppname = uu___;
+            FStar_Syntax_Syntax.index = uu___1;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____24244 =
-            let uu____24247 = FStar_Syntax_Free.uvars t in
-            ext out uu____24247 in
-          aux uu____24244 tl in
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.uvars t in ext out uu___3 in
+          aux uu___2 tl in
     aux no_uvs env1.gamma
 let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
   fun env1 ->
@@ -5348,22 +5218,19 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____24304)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24308, (uu____24309, t)))::tl
-          ->
-          let uu____24324 =
-            let uu____24327 = FStar_Syntax_Free.univs t in
-            ext out uu____24327 in
-          aux uu____24324 tl
+      | (FStar_Syntax_Syntax.Binding_univ uu___)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu___, (uu___1, t)))::tl ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.univs t in ext out uu___3 in
+          aux uu___2 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24330;
-            FStar_Syntax_Syntax.index = uu____24331;
+          { FStar_Syntax_Syntax.ppname = uu___;
+            FStar_Syntax_Syntax.index = uu___1;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____24338 =
-            let uu____24341 = FStar_Syntax_Free.univs t in
-            ext out uu____24341 in
-          aux uu____24338 tl in
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.univs t in ext out uu___3 in
+          aux uu___2 tl in
     aux no_univs env1.gamma
 let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
   fun env1 ->
@@ -5373,23 +5240,19 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl ->
-          let uu____24402 = FStar_Util.set_add uname out in
-          aux uu____24402 tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____24405, (uu____24406, t)))::tl
-          ->
-          let uu____24421 =
-            let uu____24424 = FStar_Syntax_Free.univnames t in
-            ext out uu____24424 in
-          aux uu____24421 tl
+          let uu___ = FStar_Util.set_add uname out in aux uu___ tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu___, (uu___1, t)))::tl ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.univnames t in ext out uu___3 in
+          aux uu___2 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____24427;
-            FStar_Syntax_Syntax.index = uu____24428;
+          { FStar_Syntax_Syntax.ppname = uu___;
+            FStar_Syntax_Syntax.index = uu___1;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____24435 =
-            let uu____24438 = FStar_Syntax_Free.univnames t in
-            ext out uu____24438 in
-          aux uu____24435 tl in
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Free.univnames t in ext out uu___3 in
+          aux uu___2 tl in
     aux no_univ_names env1.gamma
 let (bound_vars_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list)
@@ -5397,54 +5260,54 @@ let (bound_vars_of_bindings :
   fun bs ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___12_24458 ->
-            match uu___12_24458 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____24462 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____24473 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu___1 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu___1 -> []))
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs ->
-    let uu____24483 =
-      let uu____24492 = bound_vars_of_bindings bs in
-      FStar_All.pipe_right uu____24492
+    let uu___ =
+      let uu___1 = bound_vars_of_bindings bs in
+      FStar_All.pipe_right uu___1
         (FStar_List.map FStar_Syntax_Syntax.mk_binder) in
-    FStar_All.pipe_right uu____24483 FStar_List.rev
+    FStar_All.pipe_right uu___ FStar_List.rev
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env1 -> bound_vars_of_bindings env1.gamma
 let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env1 -> binders_of_bindings env1.gamma
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma ->
-    let uu____24536 =
+    let uu___ =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___13_24546 ->
-              match uu___13_24546 with
+           (fun uu___1 ->
+              match uu___1 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____24548 = FStar_Syntax_Print.bv_to_string x in
-                  Prims.op_Hat "Binding_var " uu____24548
+                  let uu___2 = FStar_Syntax_Print.bv_to_string x in
+                  Prims.op_Hat "Binding_var " uu___2
               | FStar_Syntax_Syntax.Binding_univ u ->
-                  let uu____24550 = FStar_Ident.string_of_id u in
-                  Prims.op_Hat "Binding_univ " uu____24550
-              | FStar_Syntax_Syntax.Binding_lid (l, uu____24552) ->
-                  let uu____24565 = FStar_Ident.string_of_lid l in
-                  Prims.op_Hat "Binding_lid " uu____24565)) in
-    FStar_All.pipe_right uu____24536 (FStar_String.concat "::\n")
+                  let uu___2 = FStar_Ident.string_of_id u in
+                  Prims.op_Hat "Binding_univ " uu___2
+              | FStar_Syntax_Syntax.Binding_lid (l, uu___2) ->
+                  let uu___3 = FStar_Ident.string_of_lid l in
+                  Prims.op_Hat "Binding_lid " uu___3)) in
+    FStar_All.pipe_right uu___ (FStar_String.concat "::\n")
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___14_24572 ->
-    match uu___14_24572 with
+  fun uu___ ->
+    match uu___ with
     | NoDelta -> "NoDelta"
     | InliningDelta -> "Inlining"
     | Eager_unfolding_only -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____24574 = FStar_Syntax_Print.delta_depth_to_string d in
-        Prims.op_Hat "Unfold " uu____24574
+        let uu___1 = FStar_Syntax_Print.delta_depth_to_string d in
+        Prims.op_Hat "Unfold " uu___1
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env1 ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env1.gamma_sig in
     FStar_Util.smap_fold (sigtab env1)
-      (fun uu____24594 ->
+      (fun uu___ ->
          fun v ->
            fun keys1 ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v) keys1)
@@ -5454,78 +5317,76 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([], uu____24636) -> true
+        | ([], uu___) -> true
         | (x::xs1, y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____24655, uu____24656) -> false in
-      let uu____24665 =
+        | (uu___, uu___1) -> false in
+      let uu___ =
         FStar_List.tryFind
-          (fun uu____24683 ->
-             match uu____24683 with | (p, uu____24691) -> str_i_prefix p path)
+          (fun uu___1 ->
+             match uu___1 with | (p, uu___2) -> str_i_prefix p path)
           env1.proof_ns in
-      match uu____24665 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> false
-      | FStar_Pervasives_Native.Some (uu____24702, b) -> b
+      | FStar_Pervasives_Native.Some (uu___1, b) -> b
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun lid ->
-      let uu____24724 = FStar_Ident.path_of_lid lid in
-      should_enc_path env1 uu____24724
+      let uu___ = FStar_Ident.path_of_lid lid in should_enc_path env1 uu___
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b ->
     fun e ->
       fun path ->
-        let uu___2101_24742 = e in
+        let uu___ = e in
         {
-          solver = (uu___2101_24742.solver);
-          range = (uu___2101_24742.range);
-          curmodule = (uu___2101_24742.curmodule);
-          gamma = (uu___2101_24742.gamma);
-          gamma_sig = (uu___2101_24742.gamma_sig);
-          gamma_cache = (uu___2101_24742.gamma_cache);
-          modules = (uu___2101_24742.modules);
-          expected_typ = (uu___2101_24742.expected_typ);
-          sigtab = (uu___2101_24742.sigtab);
-          attrtab = (uu___2101_24742.attrtab);
-          instantiate_imp = (uu___2101_24742.instantiate_imp);
-          effects = (uu___2101_24742.effects);
-          generalize = (uu___2101_24742.generalize);
-          letrecs = (uu___2101_24742.letrecs);
-          top_level = (uu___2101_24742.top_level);
-          check_uvars = (uu___2101_24742.check_uvars);
-          use_eq = (uu___2101_24742.use_eq);
-          use_eq_strict = (uu___2101_24742.use_eq_strict);
-          is_iface = (uu___2101_24742.is_iface);
-          admit = (uu___2101_24742.admit);
-          lax = (uu___2101_24742.lax);
-          lax_universes = (uu___2101_24742.lax_universes);
-          phase1 = (uu___2101_24742.phase1);
-          failhard = (uu___2101_24742.failhard);
-          nosynth = (uu___2101_24742.nosynth);
-          uvar_subtyping = (uu___2101_24742.uvar_subtyping);
-          tc_term = (uu___2101_24742.tc_term);
-          type_of = (uu___2101_24742.type_of);
-          universe_of = (uu___2101_24742.universe_of);
-          check_type_of = (uu___2101_24742.check_type_of);
-          use_bv_sorts = (uu___2101_24742.use_bv_sorts);
-          qtbl_name_and_index = (uu___2101_24742.qtbl_name_and_index);
-          normalized_eff_names = (uu___2101_24742.normalized_eff_names);
-          fv_delta_depths = (uu___2101_24742.fv_delta_depths);
+          solver = (uu___.solver);
+          range = (uu___.range);
+          curmodule = (uu___.curmodule);
+          gamma = (uu___.gamma);
+          gamma_sig = (uu___.gamma_sig);
+          gamma_cache = (uu___.gamma_cache);
+          modules = (uu___.modules);
+          expected_typ = (uu___.expected_typ);
+          sigtab = (uu___.sigtab);
+          attrtab = (uu___.attrtab);
+          instantiate_imp = (uu___.instantiate_imp);
+          effects = (uu___.effects);
+          generalize = (uu___.generalize);
+          letrecs = (uu___.letrecs);
+          top_level = (uu___.top_level);
+          check_uvars = (uu___.check_uvars);
+          use_eq = (uu___.use_eq);
+          use_eq_strict = (uu___.use_eq_strict);
+          is_iface = (uu___.is_iface);
+          admit = (uu___.admit);
+          lax = (uu___.lax);
+          lax_universes = (uu___.lax_universes);
+          phase1 = (uu___.phase1);
+          failhard = (uu___.failhard);
+          nosynth = (uu___.nosynth);
+          uvar_subtyping = (uu___.uvar_subtyping);
+          tc_term = (uu___.tc_term);
+          type_of = (uu___.type_of);
+          universe_of = (uu___.universe_of);
+          check_type_of = (uu___.check_type_of);
+          use_bv_sorts = (uu___.use_bv_sorts);
+          qtbl_name_and_index = (uu___.qtbl_name_and_index);
+          normalized_eff_names = (uu___.normalized_eff_names);
+          fv_delta_depths = (uu___.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___2101_24742.synth_hook);
-          try_solve_implicits_hook =
-            (uu___2101_24742.try_solve_implicits_hook);
-          splice = (uu___2101_24742.splice);
-          mpreprocess = (uu___2101_24742.mpreprocess);
-          postprocess = (uu___2101_24742.postprocess);
-          identifier_info = (uu___2101_24742.identifier_info);
-          tc_hooks = (uu___2101_24742.tc_hooks);
-          dsenv = (uu___2101_24742.dsenv);
-          nbe = (uu___2101_24742.nbe);
-          strict_args_tab = (uu___2101_24742.strict_args_tab);
-          erasable_types_tab = (uu___2101_24742.erasable_types_tab);
-          enable_defer_to_tac = (uu___2101_24742.enable_defer_to_tac)
+          synth_hook = (uu___.synth_hook);
+          try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+          splice = (uu___.splice);
+          mpreprocess = (uu___.mpreprocess);
+          postprocess = (uu___.postprocess);
+          identifier_info = (uu___.identifier_info);
+          tc_hooks = (uu___.tc_hooks);
+          dsenv = (uu___.dsenv);
+          nbe = (uu___.nbe);
+          strict_args_tab = (uu___.strict_args_tab);
+          erasable_types_tab = (uu___.erasable_types_tab);
+          enable_defer_to_tac = (uu___.enable_defer_to_tac)
         }
 let (add_proof_ns : env -> name_prefix -> env) =
   fun e -> fun path -> cons_proof_ns true e path
@@ -5535,87 +5396,84 @@ let (get_proof_ns : env -> proof_namespace) = fun e -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns ->
     fun e ->
-      let uu___2110_24782 = e in
+      let uu___ = e in
       {
-        solver = (uu___2110_24782.solver);
-        range = (uu___2110_24782.range);
-        curmodule = (uu___2110_24782.curmodule);
-        gamma = (uu___2110_24782.gamma);
-        gamma_sig = (uu___2110_24782.gamma_sig);
-        gamma_cache = (uu___2110_24782.gamma_cache);
-        modules = (uu___2110_24782.modules);
-        expected_typ = (uu___2110_24782.expected_typ);
-        sigtab = (uu___2110_24782.sigtab);
-        attrtab = (uu___2110_24782.attrtab);
-        instantiate_imp = (uu___2110_24782.instantiate_imp);
-        effects = (uu___2110_24782.effects);
-        generalize = (uu___2110_24782.generalize);
-        letrecs = (uu___2110_24782.letrecs);
-        top_level = (uu___2110_24782.top_level);
-        check_uvars = (uu___2110_24782.check_uvars);
-        use_eq = (uu___2110_24782.use_eq);
-        use_eq_strict = (uu___2110_24782.use_eq_strict);
-        is_iface = (uu___2110_24782.is_iface);
-        admit = (uu___2110_24782.admit);
-        lax = (uu___2110_24782.lax);
-        lax_universes = (uu___2110_24782.lax_universes);
-        phase1 = (uu___2110_24782.phase1);
-        failhard = (uu___2110_24782.failhard);
-        nosynth = (uu___2110_24782.nosynth);
-        uvar_subtyping = (uu___2110_24782.uvar_subtyping);
-        tc_term = (uu___2110_24782.tc_term);
-        type_of = (uu___2110_24782.type_of);
-        universe_of = (uu___2110_24782.universe_of);
-        check_type_of = (uu___2110_24782.check_type_of);
-        use_bv_sorts = (uu___2110_24782.use_bv_sorts);
-        qtbl_name_and_index = (uu___2110_24782.qtbl_name_and_index);
-        normalized_eff_names = (uu___2110_24782.normalized_eff_names);
-        fv_delta_depths = (uu___2110_24782.fv_delta_depths);
+        solver = (uu___.solver);
+        range = (uu___.range);
+        curmodule = (uu___.curmodule);
+        gamma = (uu___.gamma);
+        gamma_sig = (uu___.gamma_sig);
+        gamma_cache = (uu___.gamma_cache);
+        modules = (uu___.modules);
+        expected_typ = (uu___.expected_typ);
+        sigtab = (uu___.sigtab);
+        attrtab = (uu___.attrtab);
+        instantiate_imp = (uu___.instantiate_imp);
+        effects = (uu___.effects);
+        generalize = (uu___.generalize);
+        letrecs = (uu___.letrecs);
+        top_level = (uu___.top_level);
+        check_uvars = (uu___.check_uvars);
+        use_eq = (uu___.use_eq);
+        use_eq_strict = (uu___.use_eq_strict);
+        is_iface = (uu___.is_iface);
+        admit = (uu___.admit);
+        lax = (uu___.lax);
+        lax_universes = (uu___.lax_universes);
+        phase1 = (uu___.phase1);
+        failhard = (uu___.failhard);
+        nosynth = (uu___.nosynth);
+        uvar_subtyping = (uu___.uvar_subtyping);
+        tc_term = (uu___.tc_term);
+        type_of = (uu___.type_of);
+        universe_of = (uu___.universe_of);
+        check_type_of = (uu___.check_type_of);
+        use_bv_sorts = (uu___.use_bv_sorts);
+        qtbl_name_and_index = (uu___.qtbl_name_and_index);
+        normalized_eff_names = (uu___.normalized_eff_names);
+        fv_delta_depths = (uu___.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___2110_24782.synth_hook);
-        try_solve_implicits_hook = (uu___2110_24782.try_solve_implicits_hook);
-        splice = (uu___2110_24782.splice);
-        mpreprocess = (uu___2110_24782.mpreprocess);
-        postprocess = (uu___2110_24782.postprocess);
-        identifier_info = (uu___2110_24782.identifier_info);
-        tc_hooks = (uu___2110_24782.tc_hooks);
-        dsenv = (uu___2110_24782.dsenv);
-        nbe = (uu___2110_24782.nbe);
-        strict_args_tab = (uu___2110_24782.strict_args_tab);
-        erasable_types_tab = (uu___2110_24782.erasable_types_tab);
-        enable_defer_to_tac = (uu___2110_24782.enable_defer_to_tac)
+        synth_hook = (uu___.synth_hook);
+        try_solve_implicits_hook = (uu___.try_solve_implicits_hook);
+        splice = (uu___.splice);
+        mpreprocess = (uu___.mpreprocess);
+        postprocess = (uu___.postprocess);
+        identifier_info = (uu___.identifier_info);
+        tc_hooks = (uu___.tc_hooks);
+        dsenv = (uu___.dsenv);
+        nbe = (uu___.nbe);
+        strict_args_tab = (uu___.strict_args_tab);
+        erasable_types_tab = (uu___.erasable_types_tab);
+        enable_defer_to_tac = (uu___.enable_defer_to_tac)
       }
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e ->
     fun t ->
-      let uu____24797 = FStar_Syntax_Free.names t in
-      let uu____24800 = bound_vars e in
+      let uu___ = FStar_Syntax_Free.names t in
+      let uu___1 = bound_vars e in
       FStar_List.fold_left (fun s -> fun bv -> FStar_Util.set_remove bv s)
-        uu____24797 uu____24800
+        uu___ uu___1
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
-    fun t ->
-      let uu____24821 = unbound_vars e t in
-      FStar_Util.set_is_empty uu____24821
+    fun t -> let uu___ = unbound_vars e t in FStar_Util.set_is_empty uu___
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____24829 = FStar_Syntax_Free.names t in
-    FStar_Util.set_is_empty uu____24829
+    let uu___ = FStar_Syntax_Free.names t in FStar_Util.set_is_empty uu___
 let (string_of_proof_ns : env -> Prims.string) =
   fun env1 ->
-    let aux uu____24846 =
-      match uu____24846 with
+    let aux uu___ =
+      match uu___ with
       | (p, b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____24856 = FStar_Ident.text_of_path p in
-             Prims.op_Hat (if b then "+" else "-") uu____24856) in
-    let uu____24858 =
-      let uu____24861 = FStar_List.map aux env1.proof_ns in
-      FStar_All.pipe_right uu____24861 FStar_List.rev in
-    FStar_All.pipe_right uu____24858 (FStar_String.concat " ")
+            (let uu___2 = FStar_Ident.text_of_path p in
+             Prims.op_Hat (if b then "+" else "-") uu___2) in
+    let uu___ =
+      let uu___1 = FStar_List.map aux env1.proof_ns in
+      FStar_All.pipe_right uu___1 FStar_List.rev in
+    FStar_All.pipe_right uu___ (FStar_String.concat " ")
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
   fun g ->
@@ -5632,7 +5490,7 @@ let (is_trivial : guard_t -> Prims.bool) =
   fun g ->
     match g with
     | { FStar_TypeChecker_Common.guard_f = FStar_TypeChecker_Common.Trivial;
-        FStar_TypeChecker_Common.deferred_to_tac = uu____24901;
+        FStar_TypeChecker_Common.deferred_to_tac = uu___;
         FStar_TypeChecker_Common.deferred = [];
         FStar_TypeChecker_Common.univ_ineqs = ([], []);
         FStar_TypeChecker_Common.implicits = i;_} ->
@@ -5642,22 +5500,22 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
                    = FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____24917 =
+                  (let uu___1 =
                      FStar_Syntax_Unionfind.find
                        (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                   match uu____24917 with
-                   | FStar_Pervasives_Native.Some uu____24920 -> true
+                   match uu___1 with
+                   | FStar_Pervasives_Native.Some uu___2 -> true
                    | FStar_Pervasives_Native.None -> false)))
-    | uu____24921 -> false
+    | uu___ -> false
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g ->
     match g with
     | { FStar_TypeChecker_Common.guard_f = FStar_TypeChecker_Common.Trivial;
-        FStar_TypeChecker_Common.deferred_to_tac = uu____24927;
-        FStar_TypeChecker_Common.deferred = uu____24928;
-        FStar_TypeChecker_Common.univ_ineqs = uu____24929;
-        FStar_TypeChecker_Common.implicits = uu____24930;_} -> true
-    | uu____24939 -> false
+        FStar_TypeChecker_Common.deferred_to_tac = uu___;
+        FStar_TypeChecker_Common.deferred = uu___1;
+        FStar_TypeChecker_Common.univ_ineqs = uu___2;
+        FStar_TypeChecker_Common.implicits = uu___3;_} -> true
+    | uu___ -> false
 let (trivial_guard : guard_t) = FStar_TypeChecker_Common.trivial_guard
 let (abstract_guard_n :
   FStar_Syntax_Syntax.binder Prims.list -> guard_t -> guard_t) =
@@ -5670,18 +5528,18 @@ let (abstract_guard_n :
             FStar_Syntax_Util.abs bs f
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0)) in
-          let uu___2156_24958 = g in
+          let uu___ = g in
           {
             FStar_TypeChecker_Common.guard_f =
               (FStar_TypeChecker_Common.NonTrivial f');
             FStar_TypeChecker_Common.deferred_to_tac =
-              (uu___2156_24958.FStar_TypeChecker_Common.deferred_to_tac);
+              (uu___.FStar_TypeChecker_Common.deferred_to_tac);
             FStar_TypeChecker_Common.deferred =
-              (uu___2156_24958.FStar_TypeChecker_Common.deferred);
+              (uu___.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2156_24958.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2156_24958.FStar_TypeChecker_Common.implicits)
+              (uu___.FStar_TypeChecker_Common.implicits)
           }
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
   fun b -> fun g -> abstract_guard_n [b] g
@@ -5695,29 +5553,29 @@ let (def_check_vars_in_set :
     fun msg ->
       fun vset ->
         fun t ->
-          let uu____24993 = FStar_Options.defensive () in
-          if uu____24993
+          let uu___ = FStar_Options.defensive () in
+          if uu___
           then
             let s = FStar_Syntax_Free.names t in
-            let uu____24997 =
-              let uu____24998 =
-                let uu____24999 = FStar_Util.set_difference s vset in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____24999 in
-              Prims.op_Negation uu____24998 in
-            (if uu____24997
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Util.set_difference s vset in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu___3 in
+              Prims.op_Negation uu___2 in
+            (if uu___1
              then
-               let uu____25004 =
-                 let uu____25009 =
-                   let uu____25010 = FStar_Syntax_Print.term_to_string t in
-                   let uu____25011 =
-                     let uu____25012 = FStar_Util.set_elements s in
-                     FStar_All.pipe_right uu____25012
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Print.term_to_string t in
+                   let uu___5 =
+                     let uu___6 = FStar_Util.set_elements s in
+                     FStar_All.pipe_right uu___6
                        (FStar_Syntax_Print.bvs_to_string ",\n\t") in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____25010 uu____25011 in
-                 (FStar_Errors.Warning_Defensive, uu____25009) in
-               FStar_Errors.log_issue rng uu____25004
+                     msg uu___4 uu___5 in
+                 (FStar_Errors.Warning_Defensive, uu___3) in
+               FStar_Errors.log_issue rng uu___2
              else ())
           else ()
 let (def_check_closed_in :
@@ -5729,15 +5587,14 @@ let (def_check_closed_in :
     fun msg ->
       fun l ->
         fun t ->
-          let uu____25043 =
-            let uu____25044 = FStar_Options.defensive () in
-            Prims.op_Negation uu____25044 in
-          if uu____25043
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
           then ()
           else
-            (let uu____25046 =
-               FStar_Util.as_set l FStar_Syntax_Syntax.order_bv in
-             def_check_vars_in_set rng msg uu____25046 t)
+            (let uu___2 = FStar_Util.as_set l FStar_Syntax_Syntax.order_bv in
+             def_check_vars_in_set rng msg uu___2 t)
 let (def_check_closed_in_env :
   FStar_Range.range ->
     Prims.string -> env -> FStar_Syntax_Syntax.term -> unit)
@@ -5746,14 +5603,14 @@ let (def_check_closed_in_env :
     fun msg ->
       fun e ->
         fun t ->
-          let uu____25069 =
-            let uu____25070 = FStar_Options.defensive () in
-            Prims.op_Negation uu____25070 in
-          if uu____25069
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
           then ()
           else
-            (let uu____25072 = bound_vars e in
-             def_check_closed_in rng msg uu____25072 t)
+            (let uu___2 = bound_vars e in
+             def_check_closed_in rng msg uu___2 t)
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
   fun rng ->
@@ -5770,30 +5627,29 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2193_25107 = g in
-          let uu____25108 =
-            let uu____25109 =
-              let uu____25110 =
-                let uu____25111 =
-                  let uu____25128 =
-                    let uu____25139 = FStar_Syntax_Syntax.as_arg e in
-                    [uu____25139] in
-                  (f, uu____25128) in
-                FStar_Syntax_Syntax.Tm_app uu____25111 in
-              FStar_Syntax_Syntax.mk uu____25110 f.FStar_Syntax_Syntax.pos in
+          let uu___ = g in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 = FStar_Syntax_Syntax.as_arg e in [uu___6] in
+                  (f, uu___5) in
+                FStar_Syntax_Syntax.Tm_app uu___4 in
+              FStar_Syntax_Syntax.mk uu___3 f.FStar_Syntax_Syntax.pos in
             FStar_All.pipe_left
-              (fun uu____25176 ->
-                 FStar_TypeChecker_Common.NonTrivial uu____25176) uu____25109 in
+              (fun uu___3 -> FStar_TypeChecker_Common.NonTrivial uu___3)
+              uu___2 in
           {
-            FStar_TypeChecker_Common.guard_f = uu____25108;
+            FStar_TypeChecker_Common.guard_f = uu___1;
             FStar_TypeChecker_Common.deferred_to_tac =
-              (uu___2193_25107.FStar_TypeChecker_Common.deferred_to_tac);
+              (uu___.FStar_TypeChecker_Common.deferred_to_tac);
             FStar_TypeChecker_Common.deferred =
-              (uu___2193_25107.FStar_TypeChecker_Common.deferred);
+              (uu___.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2193_25107.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2193_25107.FStar_TypeChecker_Common.implicits)
+              (uu___.FStar_TypeChecker_Common.implicits)
           }
 let (map_guard :
   guard_t ->
@@ -5804,20 +5660,19 @@ let (map_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2200_25193 = g in
-          let uu____25194 =
-            let uu____25195 = map f in
-            FStar_TypeChecker_Common.NonTrivial uu____25195 in
+          let uu___ = g in
+          let uu___1 =
+            let uu___2 = map f in FStar_TypeChecker_Common.NonTrivial uu___2 in
           {
-            FStar_TypeChecker_Common.guard_f = uu____25194;
+            FStar_TypeChecker_Common.guard_f = uu___1;
             FStar_TypeChecker_Common.deferred_to_tac =
-              (uu___2200_25193.FStar_TypeChecker_Common.deferred_to_tac);
+              (uu___.FStar_TypeChecker_Common.deferred_to_tac);
             FStar_TypeChecker_Common.deferred =
-              (uu___2200_25193.FStar_TypeChecker_Common.deferred);
+              (uu___.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2200_25193.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2200_25193.FStar_TypeChecker_Common.implicits)
+              (uu___.FStar_TypeChecker_Common.implicits)
           }
 let (always_map_guard :
   guard_t ->
@@ -5827,43 +5682,41 @@ let (always_map_guard :
     fun map ->
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial ->
-          let uu___2205_25211 = g in
-          let uu____25212 =
-            let uu____25213 = map FStar_Syntax_Util.t_true in
-            FStar_TypeChecker_Common.NonTrivial uu____25213 in
+          let uu___ = g in
+          let uu___1 =
+            let uu___2 = map FStar_Syntax_Util.t_true in
+            FStar_TypeChecker_Common.NonTrivial uu___2 in
           {
-            FStar_TypeChecker_Common.guard_f = uu____25212;
+            FStar_TypeChecker_Common.guard_f = uu___1;
             FStar_TypeChecker_Common.deferred_to_tac =
-              (uu___2205_25211.FStar_TypeChecker_Common.deferred_to_tac);
+              (uu___.FStar_TypeChecker_Common.deferred_to_tac);
             FStar_TypeChecker_Common.deferred =
-              (uu___2205_25211.FStar_TypeChecker_Common.deferred);
+              (uu___.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2205_25211.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2205_25211.FStar_TypeChecker_Common.implicits)
+              (uu___.FStar_TypeChecker_Common.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2209_25215 = g in
-          let uu____25216 =
-            let uu____25217 = map f in
-            FStar_TypeChecker_Common.NonTrivial uu____25217 in
+          let uu___ = g in
+          let uu___1 =
+            let uu___2 = map f in FStar_TypeChecker_Common.NonTrivial uu___2 in
           {
-            FStar_TypeChecker_Common.guard_f = uu____25216;
+            FStar_TypeChecker_Common.guard_f = uu___1;
             FStar_TypeChecker_Common.deferred_to_tac =
-              (uu___2209_25215.FStar_TypeChecker_Common.deferred_to_tac);
+              (uu___.FStar_TypeChecker_Common.deferred_to_tac);
             FStar_TypeChecker_Common.deferred =
-              (uu___2209_25215.FStar_TypeChecker_Common.deferred);
+              (uu___.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2209_25215.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2209_25215.FStar_TypeChecker_Common.implicits)
+              (uu___.FStar_TypeChecker_Common.implicits)
           }
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t ->
     match t with
     | FStar_TypeChecker_Common.Trivial -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____25223 ->
-        failwith "impossible"
+    | FStar_TypeChecker_Common.NonTrivial uu___ -> failwith "impossible"
 let (check_trivial :
   FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
   fun t -> FStar_TypeChecker_Common.check_trivial t
@@ -5887,25 +5740,25 @@ let (close_guard_univs :
               FStar_List.fold_right2
                 (fun u ->
                    fun b ->
-                     fun f1 ->
-                       let uu____25294 = FStar_Syntax_Syntax.is_null_binder b in
-                       if uu____25294
-                       then f1
+                     fun f2 ->
+                       let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+                       if uu___
+                       then f2
                        else
                          FStar_Syntax_Util.mk_forall u
-                           (FStar_Pervasives_Native.fst b) f1) us bs f in
-            let uu___2232_25298 = g in
+                           (FStar_Pervasives_Native.fst b) f2) us bs f in
+            let uu___ = g in
             {
               FStar_TypeChecker_Common.guard_f =
                 (FStar_TypeChecker_Common.NonTrivial f1);
               FStar_TypeChecker_Common.deferred_to_tac =
-                (uu___2232_25298.FStar_TypeChecker_Common.deferred_to_tac);
+                (uu___.FStar_TypeChecker_Common.deferred_to_tac);
               FStar_TypeChecker_Common.deferred =
-                (uu___2232_25298.FStar_TypeChecker_Common.deferred);
+                (uu___.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2232_25298.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2232_25298.FStar_TypeChecker_Common.implicits)
+                (uu___.FStar_TypeChecker_Common.implicits)
             }
 let (close_forall :
   env ->
@@ -5918,8 +5771,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b ->
              fun f1 ->
-               let uu____25331 = FStar_Syntax_Syntax.is_null_binder b in
-               if uu____25331
+               let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+               if uu___
                then f1
                else
                  (let u =
@@ -5935,20 +5788,20 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.FStar_TypeChecker_Common.guard_f with
         | FStar_TypeChecker_Common.Trivial -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2247_25354 = g in
-            let uu____25355 =
-              let uu____25356 = close_forall env1 binders f in
-              FStar_TypeChecker_Common.NonTrivial uu____25356 in
+            let uu___ = g in
+            let uu___1 =
+              let uu___2 = close_forall env1 binders f in
+              FStar_TypeChecker_Common.NonTrivial uu___2 in
             {
-              FStar_TypeChecker_Common.guard_f = uu____25355;
+              FStar_TypeChecker_Common.guard_f = uu___1;
               FStar_TypeChecker_Common.deferred_to_tac =
-                (uu___2247_25354.FStar_TypeChecker_Common.deferred_to_tac);
+                (uu___.FStar_TypeChecker_Common.deferred_to_tac);
               FStar_TypeChecker_Common.deferred =
-                (uu___2247_25354.FStar_TypeChecker_Common.deferred);
+                (uu___.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2247_25354.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2247_25354.FStar_TypeChecker_Common.implicits)
+                (uu___.FStar_TypeChecker_Common.implicits)
             }
 let (new_implicit_var_aux :
   Prims.string ->
@@ -5967,11 +5820,10 @@ let (new_implicit_var_aux :
         fun k ->
           fun should_check ->
             fun meta ->
-              let uu____25403 =
+              let uu___ =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid in
-              match uu____25403 with
-              | FStar_Pervasives_Native.Some
-                  (uu____25428::(tm, uu____25430)::[]) ->
+              match uu___ with
+              | FStar_Pervasives_Native.Some (uu___1::(tm, uu___2)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
@@ -5979,13 +5831,13 @@ let (new_implicit_var_aux :
                             (tm.FStar_Syntax_Syntax.pos)))
                       tm.FStar_Syntax_Syntax.pos in
                   (t, [], trivial_guard)
-              | uu____25494 ->
+              | uu___1 ->
                   let binders = all_binders env1 in
                   let gamma = env1.gamma in
                   let ctx_uvar =
-                    let uu____25512 = FStar_Syntax_Unionfind.fresh r in
+                    let uu___2 = FStar_Syntax_Unionfind.fresh r in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____25512;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu___2;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -6009,27 +5861,27 @@ let (new_implicit_var_aux :
                         FStar_TypeChecker_Common.imp_tm = t;
                         FStar_TypeChecker_Common.imp_range = r
                       } in
-                    (let uu____25545 =
+                    (let uu___4 =
                        debug env1 (FStar_Options.Other "ImplicitTrace") in
-                     if uu____25545
+                     if uu___4
                      then
-                       let uu____25546 =
+                       let uu___5 =
                          FStar_Syntax_Print.uvar_to_string
                            ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
                        FStar_Util.print1
-                         "Just created uvar for implicit {%s}\n" uu____25546
+                         "Just created uvar for implicit {%s}\n" uu___5
                      else ());
                     (let g =
-                       let uu___2271_25549 = trivial_guard in
+                       let uu___4 = trivial_guard in
                        {
                          FStar_TypeChecker_Common.guard_f =
-                           (uu___2271_25549.FStar_TypeChecker_Common.guard_f);
+                           (uu___4.FStar_TypeChecker_Common.guard_f);
                          FStar_TypeChecker_Common.deferred_to_tac =
-                           (uu___2271_25549.FStar_TypeChecker_Common.deferred_to_tac);
+                           (uu___4.FStar_TypeChecker_Common.deferred_to_tac);
                          FStar_TypeChecker_Common.deferred =
-                           (uu___2271_25549.FStar_TypeChecker_Common.deferred);
+                           (uu___4.FStar_TypeChecker_Common.deferred);
                          FStar_TypeChecker_Common.univ_ineqs =
-                           (uu___2271_25549.FStar_TypeChecker_Common.univ_ineqs);
+                           (uu___4.FStar_TypeChecker_Common.univ_ineqs);
                          FStar_TypeChecker_Common.implicits = [imp]
                        } in
                      (t, [(ctx_uvar, r)], g))))
@@ -6046,32 +5898,31 @@ let (uvars_for_binders :
       fun substs ->
         fun reason ->
           fun r ->
-            let uu____25600 =
+            let uu___ =
               FStar_All.pipe_right bs
                 (FStar_List.fold_left
-                   (fun uu____25661 ->
+                   (fun uu___1 ->
                       fun b ->
-                        match uu____25661 with
+                        match uu___1 with
                         | (substs1, uvars, g) ->
                             let sort =
                               FStar_Syntax_Subst.subst substs1
                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                            let uu____25703 =
+                            let uu___2 =
                               match FStar_Pervasives_Native.snd b with
                               | FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Syntax.Meta
                                   (FStar_Syntax_Syntax.Arg_qualifier_meta_tac
                                   t)) ->
-                                  let uu____25721 =
-                                    let uu____25724 =
-                                      let uu____25725 =
-                                        let uu____25732 =
-                                          FStar_Dyn.mkdyn env1 in
-                                        (uu____25732, t) in
+                                  let uu___3 =
+                                    let uu___4 =
+                                      let uu___5 =
+                                        let uu___6 = FStar_Dyn.mkdyn env1 in
+                                        (uu___6, t) in
                                       FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                        uu____25725 in
-                                    FStar_Pervasives_Native.Some uu____25724 in
-                                  (uu____25721, false)
+                                        uu___5 in
+                                    FStar_Pervasives_Native.Some uu___4 in
+                                  (uu___3, false)
                               | FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Syntax.Meta
                                   (FStar_Syntax_Syntax.Arg_qualifier_meta_attr
@@ -6079,59 +5930,55 @@ let (uvars_for_binders :
                                   ((FStar_Pervasives_Native.Some
                                       (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
                                          t)), true)
-                              | uu____25742 ->
+                              | uu___3 ->
                                   (FStar_Pervasives_Native.None, false) in
-                            (match uu____25703 with
+                            (match uu___2 with
                              | (ctx_uvar_meta_t, strict) ->
-                                 let uu____25763 =
-                                   let uu____25776 = reason b in
-                                   new_implicit_var_aux uu____25776 r env1
-                                     sort
+                                 let uu___3 =
+                                   let uu___4 = reason b in
+                                   new_implicit_var_aux uu___4 r env1 sort
                                      (if strict
                                       then FStar_Syntax_Syntax.Strict
                                       else FStar_Syntax_Syntax.Allow_untyped)
                                      ctx_uvar_meta_t in
-                                 (match uu____25763 with
+                                 (match uu___3 with
                                   | (t, l_ctx_uvars, g_t) ->
-                                      ((let uu____25804 =
+                                      ((let uu___5 =
                                           FStar_All.pipe_left (debug env1)
                                             (FStar_Options.Other
                                                "LayeredEffectsEqns") in
-                                        if uu____25804
+                                        if uu___5
                                         then
                                           FStar_List.iter
-                                            (fun uu____25813 ->
-                                               match uu____25813 with
-                                               | (ctx_uvar, uu____25819) ->
-                                                   let uu____25820 =
+                                            (fun uu___6 ->
+                                               match uu___6 with
+                                               | (ctx_uvar, uu___7) ->
+                                                   let uu___8 =
                                                      FStar_Syntax_Print.ctx_uvar_to_string_no_reason
                                                        ctx_uvar in
                                                    FStar_Util.print1
                                                      "Layered Effect uvar : %s\n"
-                                                     uu____25820) l_ctx_uvars
+                                                     uu___8) l_ctx_uvars
                                         else ());
-                                       (let uu____25822 =
-                                          let uu____25825 =
-                                            let uu____25828 =
-                                              let uu____25829 =
-                                                let uu____25836 =
+                                       (let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
+                                              let uu___8 =
+                                                let uu___9 =
                                                   FStar_All.pipe_right b
                                                     FStar_Pervasives_Native.fst in
-                                                (uu____25836, t) in
-                                              FStar_Syntax_Syntax.NT
-                                                uu____25829 in
-                                            [uu____25828] in
-                                          FStar_List.append substs1
-                                            uu____25825 in
-                                        let uu____25847 = conj_guard g g_t in
-                                        (uu____25822,
+                                                (uu___9, t) in
+                                              FStar_Syntax_Syntax.NT uu___8 in
+                                            [uu___7] in
+                                          FStar_List.append substs1 uu___6 in
+                                        let uu___6 = conj_guard g g_t in
+                                        (uu___5,
                                           (FStar_List.append uvars [t]),
-                                          uu____25847))))))
+                                          uu___6))))))
                    (substs, [], trivial_guard)) in
-            FStar_All.pipe_right uu____25600
-              (fun uu____25876 ->
-                 match uu____25876 with
-                 | (uu____25893, uvars, g) -> (uvars, g))
+            FStar_All.pipe_right uu___
+              (fun uu___1 ->
+                 match uu___1 with | (uu___2, uvars, g) -> (uvars, g))
 let (pure_precondition_for_trivial_post :
   env ->
     FStar_Syntax_Syntax.universe ->
@@ -6146,42 +5993,40 @@ let (pure_precondition_for_trivial_post :
           fun r ->
             let trivial_post =
               let post_ts =
-                let uu____25933 =
+                let uu___ =
                   lookup_definition [NoDelta] env1
                     FStar_Parser_Const.trivial_pure_post_lid in
-                FStar_All.pipe_right uu____25933 FStar_Util.must in
-              let uu____25950 = inst_tscheme_with post_ts [u] in
-              match uu____25950 with
-              | (uu____25955, post) ->
-                  let uu____25957 =
-                    let uu____25958 =
+                FStar_All.pipe_right uu___ FStar_Util.must in
+              let uu___ = inst_tscheme_with post_ts [u] in
+              match uu___ with
+              | (uu___1, post) ->
+                  let uu___2 =
+                    let uu___3 =
                       FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg in
-                    [uu____25958] in
-                  FStar_Syntax_Syntax.mk_Tm_app post uu____25957 r in
-            let uu____25991 =
-              let uu____25992 =
+                    [uu___3] in
+                  FStar_Syntax_Syntax.mk_Tm_app post uu___2 r in
+            let uu___ =
+              let uu___1 =
                 FStar_All.pipe_right trivial_post FStar_Syntax_Syntax.as_arg in
-              [uu____25992] in
-            FStar_Syntax_Syntax.mk_Tm_app wp uu____25991 r
+              [uu___1] in
+            FStar_Syntax_Syntax.mk_Tm_app wp uu___ r
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____26027 -> ());
-    push = (fun uu____26029 -> ());
-    pop = (fun uu____26031 -> ());
+    init = (fun uu___ -> ());
+    push = (fun uu___ -> ());
+    pop = (fun uu___ -> ());
     snapshot =
-      (fun uu____26033 ->
-         ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____26042 -> fun uu____26043 -> ());
-    encode_sig = (fun uu____26054 -> fun uu____26055 -> ());
+      (fun uu___ -> ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
+    rollback = (fun uu___ -> fun uu___1 -> ());
+    encode_sig = (fun uu___ -> fun uu___1 -> ());
     preprocess =
       (fun e ->
          fun g ->
-           let uu____26061 =
-             let uu____26068 = FStar_Options.peek () in (e, g, uu____26068) in
-           [uu____26061]);
-    solve = (fun uu____26084 -> fun uu____26085 -> fun uu____26086 -> ());
-    finish = (fun uu____26092 -> ());
-    refresh = (fun uu____26094 -> ())
+           let uu___ = let uu___1 = FStar_Options.peek () in (e, g, uu___1) in
+           [uu___]);
+    solve = (fun uu___ -> fun uu___1 -> fun uu___2 -> ());
+    finish = (fun uu___ -> ());
+    refresh = (fun uu___ -> ())
   }
 let (get_letrec_arity :
   env ->
@@ -6193,16 +6038,15 @@ let (get_letrec_arity :
         match (e1, e2) with
         | (FStar_Util.Inl v1, FStar_Util.Inl v2) -> f1 v1 v2
         | (FStar_Util.Inr v1, FStar_Util.Inr v2) -> f2 v1 v2
-        | uu____26194 -> false in
-      let uu____26207 =
+        | uu___ -> false in
+      let uu___ =
         FStar_Util.find_opt
-          (fun uu____26239 ->
-             match uu____26239 with
-             | (lbname', uu____26253, uu____26254, uu____26255) ->
+          (fun uu___1 ->
+             match uu___1 with
+             | (lbname', uu___2, uu___3, uu___4) ->
                  compare_either FStar_Syntax_Syntax.bv_eq
                    FStar_Syntax_Syntax.fv_eq lbname lbname') env1.letrecs in
-      match uu____26207 with
-      | FStar_Pervasives_Native.Some
-          (uu____26266, arity, uu____26268, uu____26269) ->
+      match uu___ with
+      | FStar_Pervasives_Native.Some (uu___1, arity, uu___2, uu___3) ->
           FStar_Pervasives_Native.Some arity
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_TypeChecker_Err.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Err.ml
@@ -12,61 +12,59 @@ let (info_at_pos :
     fun file ->
       fun row ->
         fun col ->
-          let uu____32 =
-            let uu____35 =
+          let uu___ =
+            let uu___1 =
               FStar_ST.op_Bang env.FStar_TypeChecker_Env.identifier_info in
-            FStar_TypeChecker_Common.id_info_at_pos uu____35 file row col in
-          match uu____32 with
+            FStar_TypeChecker_Common.id_info_at_pos uu___1 file row col in
+          match uu___ with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some info ->
               (match info.FStar_TypeChecker_Common.identifier with
                | FStar_Util.Inl bv ->
-                   let uu____78 =
-                     let uu____89 =
-                       let uu____94 = FStar_Syntax_Print.nm_to_string bv in
-                       FStar_Util.Inl uu____94 in
-                     let uu____95 = FStar_Syntax_Syntax.range_of_bv bv in
-                     (uu____89,
-                       (info.FStar_TypeChecker_Common.identifier_ty),
-                       uu____95) in
-                   FStar_Pervasives_Native.Some uu____78
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Print.nm_to_string bv in
+                       FStar_Util.Inl uu___3 in
+                     let uu___3 = FStar_Syntax_Syntax.range_of_bv bv in
+                     (uu___2, (info.FStar_TypeChecker_Common.identifier_ty),
+                       uu___3) in
+                   FStar_Pervasives_Native.Some uu___1
                | FStar_Util.Inr fv ->
-                   let uu____111 =
-                     let uu____122 =
-                       let uu____127 = FStar_Syntax_Syntax.lid_of_fv fv in
-                       FStar_Util.Inr uu____127 in
-                     let uu____128 = FStar_Syntax_Syntax.range_of_fv fv in
-                     (uu____122,
-                       (info.FStar_TypeChecker_Common.identifier_ty),
-                       uu____128) in
-                   FStar_Pervasives_Native.Some uu____111)
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Syntax.lid_of_fv fv in
+                       FStar_Util.Inr uu___3 in
+                     let uu___3 = FStar_Syntax_Syntax.range_of_fv fv in
+                     (uu___2, (info.FStar_TypeChecker_Common.identifier_ty),
+                       uu___3) in
+                   FStar_Pervasives_Native.Some uu___1)
 let print_discrepancy :
   'a . ('a -> Prims.string) -> 'a -> 'a -> (Prims.string * Prims.string) =
   fun f ->
     fun x ->
       fun y ->
-        let print uu____187 =
+        let print uu___ =
           let xs = f x in let ys = f y in (xs, ys, (xs <> ys)) in
         let rec blist_leq l1 l2 =
           match (l1, l2) with
           | (h1::t1, h2::t2) ->
               ((Prims.op_Negation h1) || h2) && (blist_leq t1 t2)
           | ([], []) -> true
-          | uu____235 -> failwith "print_discrepancy: bad lists" in
+          | uu___ -> failwith "print_discrepancy: bad lists" in
         let rec succ l =
           match l with
           | (false)::t -> true :: t
-          | (true)::t -> let uu____264 = succ t in false :: uu____264
+          | (true)::t -> let uu___ = succ t in false :: uu___
           | [] -> failwith "" in
         let full l = FStar_List.for_all (fun b -> b) l in
         let get_bool_option s =
-          let uu____287 = FStar_Options.get_option s in
-          match uu____287 with
+          let uu___ = FStar_Options.get_option s in
+          match uu___ with
           | FStar_Options.Bool b -> b
-          | uu____289 -> failwith "print_discrepancy: impossible" in
+          | uu___1 -> failwith "print_discrepancy: impossible" in
         let set_bool_option s b =
           FStar_Options.set_option s (FStar_Options.Bool b) in
-        let get uu____308 =
+        let get uu___ =
           let pi = get_bool_option "print_implicits" in
           let pu = get_bool_option "print_universes" in
           let pea = get_bool_option "print_effect_args" in
@@ -78,30 +76,28 @@ let print_discrepancy :
                set_bool_option "print_universes" pu;
                set_bool_option "print_effect_args" pea;
                set_bool_option "print_full_names " pf)
-          | uu____332 -> failwith "impossible: print_discrepancy" in
+          | uu___ -> failwith "impossible: print_discrepancy" in
         let bas = get () in
         let rec go cur =
           match () with
           | () when full cur ->
-              let uu____356 = print () in
-              (match uu____356 with | (xs, ys, uu____369) -> (xs, ys))
-          | () when
-              let uu____370 = blist_leq bas cur in
-              Prims.op_Negation uu____370 ->
-              let uu____371 = succ cur in go uu____371
+              let uu___ = print () in
+              (match uu___ with | (xs, ys, uu___1) -> (xs, ys))
+          | () when let uu___ = blist_leq bas cur in Prims.op_Negation uu___
+              -> let uu___ = succ cur in go uu___
           | () ->
               (set cur;
-               (let uu____375 = print () in
-                match uu____375 with
+               (let uu___1 = print () in
+                match uu___1 with
                 | (xs, ys, true) -> (xs, ys)
-                | uu____388 -> let uu____395 = succ cur in go uu____395)) in
-        FStar_Options.with_saved_options (fun uu____403 -> go bas)
+                | uu___2 -> let uu___3 = succ cur in go uu___3)) in
+        FStar_Options.with_saved_options (fun uu___ -> go bas)
 let errors_smt_detail :
-  'uuuuuu412 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      ('uuuuuu412 * Prims.string * FStar_Range.range) Prims.list ->
+      ('uuuuu * Prims.string * FStar_Range.range) Prims.list ->
         (Prims.string, Prims.string) FStar_Util.either ->
-          ('uuuuuu412 * Prims.string * FStar_Range.range) Prims.list
+          ('uuuuu * Prims.string * FStar_Range.range) Prims.list
   =
   fun env ->
     fun errs ->
@@ -111,64 +107,63 @@ let errors_smt_detail :
           | FStar_Util.Inr d -> Prims.op_Hat msg (Prims.op_Hat "\n\t" d)
           | FStar_Util.Inl d when (FStar_Util.trim_string d) <> "" ->
               Prims.op_Hat msg (Prims.op_Hat "; " d)
-          | uu____468 -> msg in
+          | uu___ -> msg in
         let errs1 =
           FStar_All.pipe_right errs
             (FStar_List.map
-               (fun uu____518 ->
-                  match uu____518 with
+               (fun uu___ ->
+                  match uu___ with
                   | (e, msg, r) ->
-                      let uu____534 =
+                      let uu___1 =
                         if r = FStar_Range.dummyRange
                         then
-                          let uu____547 = FStar_TypeChecker_Env.get_range env in
-                          (e, msg, uu____547)
+                          let uu___2 = FStar_TypeChecker_Env.get_range env in
+                          (e, msg, uu___2)
                         else
                           (let r' =
-                             let uu____550 = FStar_Range.use_range r in
-                             FStar_Range.set_def_range r uu____550 in
-                           let uu____551 =
-                             let uu____552 = FStar_Range.file_of_range r' in
-                             let uu____553 =
-                               let uu____554 =
+                             let uu___3 = FStar_Range.use_range r in
+                             FStar_Range.set_def_range r uu___3 in
+                           let uu___3 =
+                             let uu___4 = FStar_Range.file_of_range r' in
+                             let uu___5 =
+                               let uu___6 =
                                  FStar_TypeChecker_Env.get_range env in
-                               FStar_Range.file_of_range uu____554 in
-                             uu____552 <> uu____553 in
-                           if uu____551
+                               FStar_Range.file_of_range uu___6 in
+                             uu___4 <> uu___5 in
+                           if uu___3
                            then
-                             let uu____561 =
-                               let uu____562 =
-                                 let uu____563 =
-                                   let uu____564 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
                                      FStar_Range.string_of_use_range r in
-                                   let uu____565 =
-                                     let uu____566 =
-                                       let uu____567 =
-                                         let uu____568 =
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 =
+                                         let uu___11 =
                                            FStar_Range.use_range r in
-                                         let uu____569 =
+                                         let uu___12 =
                                            FStar_Range.def_range r in
-                                         uu____568 <> uu____569 in
-                                       if uu____567
+                                         uu___11 <> uu___12 in
+                                       if uu___10
                                        then
-                                         let uu____570 =
-                                           let uu____571 =
+                                         let uu___11 =
+                                           let uu___12 =
                                              FStar_Range.string_of_def_range
                                                r in
-                                           Prims.op_Hat uu____571 ")" in
+                                           Prims.op_Hat uu___12 ")" in
                                          Prims.op_Hat
                                            "(Other related locations: "
-                                           uu____570
+                                           uu___11
                                        else "" in
-                                     Prims.op_Hat ")" uu____566 in
-                                   Prims.op_Hat uu____564 uu____565 in
-                                 Prims.op_Hat " (Also see: " uu____563 in
-                               Prims.op_Hat msg uu____562 in
-                             let uu____573 =
-                               FStar_TypeChecker_Env.get_range env in
-                             (e, uu____561, uu____573)
+                                     Prims.op_Hat ")" uu___9 in
+                                   Prims.op_Hat uu___7 uu___8 in
+                                 Prims.op_Hat " (Also see: " uu___6 in
+                               Prims.op_Hat msg uu___5 in
+                             let uu___5 = FStar_TypeChecker_Env.get_range env in
+                             (e, uu___4, uu___5)
                            else (e, msg, r)) in
-                      (match uu____534 with
+                      (match uu___1 with
                        | (e1, msg1, r1) ->
                            (e1, (maybe_add_smt_detail msg1), r1)))) in
         errs1
@@ -180,8 +175,8 @@ let (add_errors_smt_detail :
   fun env ->
     fun errs ->
       fun smt_detail ->
-        let uu____623 = errors_smt_detail env errs smt_detail in
-        FStar_Errors.add_errors uu____623
+        let uu___ = errors_smt_detail env errs smt_detail in
+        FStar_Errors.add_errors uu___
 let (add_errors :
   FStar_TypeChecker_Env.env ->
     (FStar_Errors.raw_error * Prims.string * FStar_Range.range) Prims.list ->
@@ -216,9 +211,9 @@ let (subtyping_failed :
   fun env ->
     fun t1 ->
       fun t2 ->
-        fun uu____723 ->
-          let uu____724 = err_msg_type_strings env t1 t2 in
-          match uu____724 with
+        fun uu___ ->
+          let uu___1 = err_msg_type_strings env t1 t2 in
+          match uu___1 with
           | (s1, s2) ->
               FStar_Util.format2
                 "Subtyping check failed; expected type %s; got type %s" s2 s1
@@ -232,13 +227,13 @@ let (unexpected_signature_for_monad :
   fun env ->
     fun m ->
       fun k ->
-        let uu____750 =
-          let uu____751 = FStar_Ident.string_of_lid m in
-          let uu____752 = FStar_TypeChecker_Normalize.term_to_string env k in
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid m in
+          let uu___2 = FStar_TypeChecker_Normalize.term_to_string env k in
           FStar_Util.format2
             "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type -> WP a -> Effect); got %s"
-            uu____751 uu____752 in
-        (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____750)
+            uu___1 uu___2 in
+        (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu___)
 let (expected_a_term_of_type_t_got_a_function :
   FStar_TypeChecker_Env.env ->
     Prims.string ->
@@ -249,13 +244,13 @@ let (expected_a_term_of_type_t_got_a_function :
     fun msg ->
       fun t ->
         fun e ->
-          let uu____777 =
-            let uu____778 = FStar_TypeChecker_Normalize.term_to_string env t in
-            let uu____779 = FStar_Syntax_Print.term_to_string e in
+          let uu___ =
+            let uu___1 = FStar_TypeChecker_Normalize.term_to_string env t in
+            let uu___2 = FStar_Syntax_Print.term_to_string e in
             FStar_Util.format3
               "Expected a term of type \"%s\"; got a function \"%s\" (%s)"
-              uu____778 uu____779 msg in
-          (FStar_Errors.Fatal_ExpectTermGotFunction, uu____777)
+              uu___1 uu___2 msg in
+          (FStar_Errors.Fatal_ExpectTermGotFunction, uu___)
 let (unexpected_implicit_argument : (FStar_Errors.raw_error * Prims.string))
   =
   (FStar_Errors.Fatal_UnexpectedImplicitArgument,
@@ -270,15 +265,15 @@ let (expected_expression_of_type :
     fun t1 ->
       fun e ->
         fun t2 ->
-          let uu____808 = err_msg_type_strings env t1 t2 in
-          match uu____808 with
+          let uu___ = err_msg_type_strings env t1 t2 in
+          match uu___ with
           | (s1, s2) ->
-              let uu____819 =
-                let uu____820 = FStar_Syntax_Print.term_to_string e in
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string e in
                 FStar_Util.format3
                   "Expected expression of type \"%s\"; got expression \"%s\" of type \"%s\""
-                  s1 uu____820 s2 in
-              (FStar_Errors.Fatal_UnexpectedExpressionType, uu____819)
+                  s1 uu___2 s2 in
+              (FStar_Errors.Fatal_UnexpectedExpressionType, uu___1)
 let (expected_pattern_of_type :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -289,15 +284,15 @@ let (expected_pattern_of_type :
     fun t1 ->
       fun e ->
         fun t2 ->
-          let uu____845 = err_msg_type_strings env t1 t2 in
-          match uu____845 with
+          let uu___ = err_msg_type_strings env t1 t2 in
+          match uu___ with
           | (s1, s2) ->
-              let uu____856 =
-                let uu____857 = FStar_Syntax_Print.term_to_string e in
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string e in
                 FStar_Util.format3
                   "Expected pattern of type \"%s\"; got pattern \"%s\" of type \"%s\""
-                  s1 uu____857 s2 in
-              (FStar_Errors.Fatal_UnexpectedPattern, uu____856)
+                  s1 uu___2 s2 in
+              (FStar_Errors.Fatal_UnexpectedPattern, uu___1)
 let (basic_type_error :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
@@ -308,8 +303,8 @@ let (basic_type_error :
     fun eopt ->
       fun t1 ->
         fun t2 ->
-          let uu____886 = err_msg_type_strings env t1 t2 in
-          match uu____886 with
+          let uu___ = err_msg_type_strings env t1 t2 in
+          match uu___ with
           | (s1, s2) ->
               let msg =
                 match eopt with
@@ -317,40 +312,40 @@ let (basic_type_error :
                     FStar_Util.format2
                       "Expected type \"%s\"; got type \"%s\"" s1 s2
                 | FStar_Pervasives_Native.Some e ->
-                    let uu____899 =
+                    let uu___1 =
                       FStar_TypeChecker_Normalize.term_to_string env e in
                     FStar_Util.format3
                       "Expected type \"%s\"; but \"%s\" has type \"%s\"" s1
-                      uu____899 s2 in
+                      uu___1 s2 in
               (FStar_Errors.Error_TypeError, msg)
 let (occurs_check : (FStar_Errors.raw_error * Prims.string)) =
   (FStar_Errors.Fatal_PossibleInfiniteTyp,
     "Possibly infinite typ (occurs check failed)")
 let constructor_fails_the_positivity_check :
-  'uuuuuu912 .
-    'uuuuuu912 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_Syntax_Syntax.term ->
         FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)
   =
   fun env ->
     fun d ->
       fun l ->
-        let uu____932 =
-          let uu____933 = FStar_Syntax_Print.term_to_string d in
-          let uu____934 = FStar_Syntax_Print.lid_to_string l in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.term_to_string d in
+          let uu___2 = FStar_Syntax_Print.lid_to_string l in
           FStar_Util.format2
             "Constructor \"%s\" fails the strict positivity check; the constructed type \"%s\" occurs to the left of a pure function type"
-            uu____933 uu____934 in
-        (FStar_Errors.Fatal_ConstructorFailedCheck, uu____932)
+            uu___1 uu___2 in
+        (FStar_Errors.Fatal_ConstructorFailedCheck, uu___)
 let (inline_type_annotation_and_val_decl :
   FStar_Ident.lid -> (FStar_Errors.raw_error * Prims.string)) =
   fun l ->
-    let uu____944 =
-      let uu____945 = FStar_Syntax_Print.lid_to_string l in
+    let uu___ =
+      let uu___1 = FStar_Syntax_Print.lid_to_string l in
       FStar_Util.format1
         "\"%s\" has a val declaration as well as an inlined type annotation; remove one"
-        uu____945 in
-    (FStar_Errors.Fatal_DuplicateTypeAnnotationAndValDecl, uu____944)
+        uu___1 in
+    (FStar_Errors.Fatal_DuplicateTypeAnnotationAndValDecl, uu___)
 let (inferred_type_causes_variable_to_escape :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -359,24 +354,24 @@ let (inferred_type_causes_variable_to_escape :
   fun env ->
     fun t ->
       fun x ->
-        let uu____965 =
-          let uu____966 = FStar_TypeChecker_Normalize.term_to_string env t in
-          let uu____967 = FStar_Syntax_Print.bv_to_string x in
+        let uu___ =
+          let uu___1 = FStar_TypeChecker_Normalize.term_to_string env t in
+          let uu___2 = FStar_Syntax_Print.bv_to_string x in
           FStar_Util.format2
             "Inferred type \"%s\" causes variable \"%s\" to escape its scope"
-            uu____966 uu____967 in
-        (FStar_Errors.Fatal_InferredTypeCauseVarEscape, uu____965)
+            uu___1 uu___2 in
+        (FStar_Errors.Fatal_InferredTypeCauseVarEscape, uu___)
 let (expected_function_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> (FStar_Errors.raw_error * Prims.string))
   =
   fun env ->
     fun t ->
-      let uu____982 =
-        let uu____983 = FStar_TypeChecker_Normalize.term_to_string env t in
+      let uu___ =
+        let uu___1 = FStar_TypeChecker_Normalize.term_to_string env t in
         FStar_Util.format1
-          "Expected a function; got an expression of type \"%s\"" uu____983 in
-      (FStar_Errors.Fatal_FunctionTypeExpected, uu____982)
+          "Expected a function; got an expression of type \"%s\"" uu___1 in
+      (FStar_Errors.Fatal_FunctionTypeExpected, uu___)
 let (expected_poly_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -387,15 +382,14 @@ let (expected_poly_typ :
     fun f ->
       fun t ->
         fun targ ->
-          let uu____1008 =
-            let uu____1009 = FStar_Syntax_Print.term_to_string f in
-            let uu____1010 = FStar_TypeChecker_Normalize.term_to_string env t in
-            let uu____1011 =
-              FStar_TypeChecker_Normalize.term_to_string env targ in
+          let uu___ =
+            let uu___1 = FStar_Syntax_Print.term_to_string f in
+            let uu___2 = FStar_TypeChecker_Normalize.term_to_string env t in
+            let uu___3 = FStar_TypeChecker_Normalize.term_to_string env targ in
             FStar_Util.format3
               "Expected a polymorphic function; got an expression \"%s\" of type \"%s\" applied to a type \"%s\""
-              uu____1009 uu____1010 uu____1011 in
-          (FStar_Errors.Fatal_PolyTypeExpected, uu____1008)
+              uu___1 uu___2 uu___3 in
+          (FStar_Errors.Fatal_PolyTypeExpected, uu___)
 let (disjunctive_pattern_vars :
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.bv Prims.list ->
@@ -404,33 +398,33 @@ let (disjunctive_pattern_vars :
   fun v1 ->
     fun v2 ->
       let vars v =
-        let uu____1044 =
+        let uu___ =
           FStar_All.pipe_right v
             (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-        FStar_All.pipe_right uu____1044 (FStar_String.concat ", ") in
-      let uu____1053 =
-        let uu____1054 = vars v1 in
-        let uu____1055 = vars v2 in
+        FStar_All.pipe_right uu___ (FStar_String.concat ", ") in
+      let uu___ =
+        let uu___1 = vars v1 in
+        let uu___2 = vars v2 in
         FStar_Util.format2
           "Every alternative of an 'or' pattern must bind the same variables; here one branch binds (\"%s\") and another (\"%s\")"
-          uu____1054 uu____1055 in
-      (FStar_Errors.Fatal_DisjuctivePatternVarsMismatch, uu____1053)
+          uu___1 uu___2 in
+      (FStar_Errors.Fatal_DisjuctivePatternVarsMismatch, uu___)
 let (name_and_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     (Prims.string * FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax))
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t, uu____1078) -> ("Tot", t)
-    | FStar_Syntax_Syntax.GTotal (t, uu____1090) -> ("GTot", t)
+    | FStar_Syntax_Syntax.Total (t, uu___) -> ("Tot", t)
+    | FStar_Syntax_Syntax.GTotal (t, uu___) -> ("GTot", t)
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____1102 =
+        let uu___ =
           FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name in
-        (uu____1102, (ct.FStar_Syntax_Syntax.result_typ))
+        (uu___, (ct.FStar_Syntax_Syntax.result_typ))
 let computed_computation_type_does_not_match_annotation :
-  'uuuuuu1115 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      'uuuuuu1115 ->
+      'uuuuu ->
         FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
           FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
             (FStar_Errors.raw_error * Prims.string)
@@ -439,25 +433,25 @@ let computed_computation_type_does_not_match_annotation :
     fun e ->
       fun c ->
         fun c' ->
-          let uu____1148 = name_and_result c in
-          match uu____1148 with
+          let uu___ = name_and_result c in
+          match uu___ with
           | (f1, r1) ->
-              let uu____1165 = name_and_result c' in
-              (match uu____1165 with
+              let uu___1 = name_and_result c' in
+              (match uu___1 with
                | (f2, r2) ->
-                   let uu____1182 = err_msg_type_strings env r1 r2 in
-                   (match uu____1182 with
+                   let uu___2 = err_msg_type_strings env r1 r2 in
+                   (match uu___2 with
                     | (s1, s2) ->
-                        let uu____1193 =
+                        let uu___3 =
                           FStar_Util.format4
                             "Computed type \"%s\" and effect \"%s\" is not compatible with the annotated type \"%s\" effect \"%s\""
                             s1 f1 s2 f2 in
                         (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation,
-                          uu____1193)))
+                          uu___3)))
 let computed_computation_type_does_not_match_annotation_eq :
-  'uuuuuu1204 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      'uuuuuu1204 ->
+      'uuuuu ->
         FStar_Syntax_Syntax.comp ->
           FStar_Syntax_Syntax.comp -> (FStar_Errors.raw_error * Prims.string)
   =
@@ -465,25 +459,25 @@ let computed_computation_type_does_not_match_annotation_eq :
     fun e ->
       fun c ->
         fun c' ->
-          let uu____1229 = err_msg_comp_strings env c c' in
-          match uu____1229 with
+          let uu___ = err_msg_comp_strings env c c' in
+          match uu___ with
           | (s1, s2) ->
-              let uu____1240 =
+              let uu___1 =
                 FStar_Util.format2
                   "Computed type \"%s\" does not match annotated type \"%s\", and no subtyping was allowed"
                   s1 s2 in
-              (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation, uu____1240)
+              (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation, uu___1)
 let (unexpected_non_trivial_precondition_on_term :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> (FStar_Errors.raw_error * Prims.string))
   =
   fun env ->
     fun f ->
-      let uu____1255 =
-        let uu____1256 = FStar_TypeChecker_Normalize.term_to_string env f in
+      let uu___ =
+        let uu___1 = FStar_TypeChecker_Normalize.term_to_string env f in
         FStar_Util.format1
-          "Term has an unexpected non-trivial pre-condition: %s" uu____1256 in
-      (FStar_Errors.Fatal_UnExpectedPreCondition, uu____1255)
+          "Term has an unexpected non-trivial pre-condition: %s" uu___1 in
+      (FStar_Errors.Fatal_UnExpectedPreCondition, uu___)
 let (expected_pure_expression :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -497,16 +491,15 @@ let (expected_pure_expression :
           if reason = ""
           then msg
           else FStar_Util.format1 (Prims.op_Hat msg " (%s)") reason in
-        let uu____1283 =
-          let uu____1284 = FStar_Syntax_Print.term_to_string e in
-          let uu____1285 =
-            let uu____1286 = name_and_result c in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1286 in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.term_to_string e in
+          let uu___2 =
+            let uu___3 = name_and_result c in
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu___3 in
           FStar_Util.format2
             (Prims.op_Hat msg1
-               "; got an expression \"%s\" with effect \"%s\"") uu____1284
-            uu____1285 in
-        (FStar_Errors.Fatal_ExpectedPureExpression, uu____1283)
+               "; got an expression \"%s\" with effect \"%s\"") uu___1 uu___2 in
+        (FStar_Errors.Fatal_ExpectedPureExpression, uu___)
 let (expected_ghost_expression :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -520,42 +513,41 @@ let (expected_ghost_expression :
           if reason = ""
           then msg
           else FStar_Util.format1 (Prims.op_Hat msg " (%s)") reason in
-        let uu____1327 =
-          let uu____1328 = FStar_Syntax_Print.term_to_string e in
-          let uu____1329 =
-            let uu____1330 = name_and_result c in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____1330 in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.term_to_string e in
+          let uu___2 =
+            let uu___3 = name_and_result c in
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu___3 in
           FStar_Util.format2
             (Prims.op_Hat msg1
-               "; got an expression \"%s\" with effect \"%s\"") uu____1328
-            uu____1329 in
-        (FStar_Errors.Fatal_ExpectedGhostExpression, uu____1327)
+               "; got an expression \"%s\" with effect \"%s\"") uu___1 uu___2 in
+        (FStar_Errors.Fatal_ExpectedGhostExpression, uu___)
 let (expected_effect_1_got_effect_2 :
   FStar_Ident.lident ->
     FStar_Ident.lident -> (FStar_Errors.raw_error * Prims.string))
   =
   fun c1 ->
     fun c2 ->
-      let uu____1359 =
-        let uu____1360 = FStar_Syntax_Print.lid_to_string c1 in
-        let uu____1361 = FStar_Syntax_Print.lid_to_string c2 in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Print.lid_to_string c1 in
+        let uu___2 = FStar_Syntax_Print.lid_to_string c2 in
         FStar_Util.format2
           "Expected a computation with effect %s; but it has effect %s"
-          uu____1360 uu____1361 in
-      (FStar_Errors.Fatal_UnexpectedEffect, uu____1359)
+          uu___1 uu___2 in
+      (FStar_Errors.Fatal_UnexpectedEffect, uu___)
 let (failed_to_prove_specification_of :
   FStar_Syntax_Syntax.lbname ->
     Prims.string Prims.list -> (FStar_Errors.raw_error * Prims.string))
   =
   fun l ->
     fun lbls ->
-      let uu____1380 =
-        let uu____1381 = FStar_Syntax_Print.lbname_to_string l in
-        let uu____1382 = FStar_All.pipe_right lbls (FStar_String.concat ", ") in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Print.lbname_to_string l in
+        let uu___2 = FStar_All.pipe_right lbls (FStar_String.concat ", ") in
         FStar_Util.format2
           "Failed to prove specification of %s; assertions at [%s] may fail"
-          uu____1381 uu____1382 in
-      (FStar_Errors.Error_TypeCheckerFailToProve, uu____1380)
+          uu___1 uu___2 in
+      (FStar_Errors.Error_TypeCheckerFailToProve, uu___)
 let (failed_to_prove_specification :
   Prims.string Prims.list -> (FStar_Errors.raw_error * Prims.string)) =
   fun lbls ->
@@ -563,11 +555,10 @@ let (failed_to_prove_specification :
       match lbls with
       | [] ->
           "An unknown assertion in the term at this location was not provable"
-      | uu____1399 ->
-          let uu____1402 =
-            FStar_All.pipe_right lbls (FStar_String.concat "\n\t") in
+      | uu___ ->
+          let uu___1 = FStar_All.pipe_right lbls (FStar_String.concat "\n\t") in
           FStar_Util.format1 "The following problems were found:\n\t%s"
-            uu____1402 in
+            uu___1 in
     (FStar_Errors.Error_TypeCheckerFailToProve, msg)
 let (top_level_effect : (FStar_Errors.raw_error * Prims.string)) =
   (FStar_Errors.Warning_TopLevelEffect,
@@ -579,11 +570,10 @@ let (cardinality_constraint_violated :
   =
   fun l ->
     fun a ->
-      let uu____1427 =
-        let uu____1428 = FStar_Syntax_Print.lid_to_string l in
-        let uu____1429 =
-          FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Print.lid_to_string l in
+        let uu___2 = FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v in
         FStar_Util.format2
           "Constructor %s violates the cardinality of Type at parameter '%s'; type arguments are not allowed"
-          uu____1428 uu____1429 in
-      (FStar_Errors.Fatal_CardinalityConstraintViolated, uu____1427)
+          uu___1 uu___2 in
+      (FStar_Errors.Fatal_CardinalityConstraintViolated, uu___)

--- a/src/ocaml-output/FStar_TypeChecker_Generalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Generalize.ml
@@ -2,14 +2,14 @@ open Prims
 let (string_of_univs :
   FStar_Syntax_Syntax.universe_uvar FStar_Util.set -> Prims.string) =
   fun univs ->
-    let uu____9 =
-      let uu____12 = FStar_Util.set_elements univs in
-      FStar_All.pipe_right uu____12
+    let uu___ =
+      let uu___1 = FStar_Util.set_elements univs in
+      FStar_All.pipe_right uu___1
         (FStar_List.map
            (fun u ->
-              let uu____22 = FStar_Syntax_Unionfind.univ_uvar_id u in
-              FStar_All.pipe_right uu____22 FStar_Util.string_of_int)) in
-    FStar_All.pipe_right uu____9 (FStar_String.concat ", ")
+              let uu___2 = FStar_Syntax_Unionfind.univ_uvar_id u in
+              FStar_All.pipe_right uu___2 FStar_Util.string_of_int)) in
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let (gen_univs :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe_uvar FStar_Util.set ->
@@ -17,51 +17,49 @@ let (gen_univs :
   =
   fun env ->
     fun x ->
-      let uu____43 = FStar_Util.set_is_empty x in
-      if uu____43
+      let uu___ = FStar_Util.set_is_empty x in
+      if uu___
       then []
       else
         (let s =
-           let uu____60 =
-             let uu____63 = FStar_TypeChecker_Env.univ_vars env in
-             FStar_Util.set_difference x uu____63 in
-           FStar_All.pipe_right uu____60 FStar_Util.set_elements in
-         (let uu____81 =
+           let uu___2 =
+             let uu___3 = FStar_TypeChecker_Env.univ_vars env in
+             FStar_Util.set_difference x uu___3 in
+           FStar_All.pipe_right uu___2 FStar_Util.set_elements in
+         (let uu___3 =
             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
               (FStar_Options.Other "Gen") in
-          if uu____81
+          if uu___3
           then
-            let uu____82 =
-              let uu____83 = FStar_TypeChecker_Env.univ_vars env in
-              string_of_univs uu____83 in
-            FStar_Util.print1 "univ_vars in env: %s\n" uu____82
+            let uu___4 =
+              let uu___5 = FStar_TypeChecker_Env.univ_vars env in
+              string_of_univs uu___5 in
+            FStar_Util.print1 "univ_vars in env: %s\n" uu___4
           else ());
          (let r =
-            let uu____90 = FStar_TypeChecker_Env.get_range env in
-            FStar_Pervasives_Native.Some uu____90 in
+            let uu___3 = FStar_TypeChecker_Env.get_range env in
+            FStar_Pervasives_Native.Some uu___3 in
           let u_names =
             FStar_All.pipe_right s
               (FStar_List.map
                  (fun u ->
                     let u_name = FStar_Syntax_Syntax.new_univ_name r in
-                    (let uu____135 =
+                    (let uu___4 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Gen") in
-                     if uu____135
+                     if uu___4
                      then
-                       let uu____136 =
-                         let uu____137 =
-                           FStar_Syntax_Unionfind.univ_uvar_id u in
-                         FStar_All.pipe_left FStar_Util.string_of_int
-                           uu____137 in
-                       let uu____138 =
+                       let uu___5 =
+                         let uu___6 = FStar_Syntax_Unionfind.univ_uvar_id u in
+                         FStar_All.pipe_left FStar_Util.string_of_int uu___6 in
+                       let uu___6 =
                          FStar_Syntax_Print.univ_to_string
                            (FStar_Syntax_Syntax.U_unif u) in
-                       let uu____139 =
+                       let uu___7 =
                          FStar_Syntax_Print.univ_to_string
                            (FStar_Syntax_Syntax.U_name u_name) in
-                       FStar_Util.print3 "Setting ?%s (%s) to %s\n" uu____136
-                         uu____138 uu____139
+                       FStar_Util.print3 "Setting ?%s (%s) to %s\n" uu___5
+                         uu___6 uu___7
                      else ());
                     FStar_Syntax_Unionfind.univ_change u
                       (FStar_Syntax_Syntax.U_name u_name);
@@ -76,8 +74,8 @@ let (gather_free_univnames :
       let ctx_univnames = FStar_TypeChecker_Env.univnames env in
       let tm_univnames = FStar_Syntax_Free.univnames t in
       let univnames =
-        let uu____165 = FStar_Util.set_difference tm_univnames ctx_univnames in
-        FStar_All.pipe_right uu____165 FStar_Util.set_elements in
+        let uu___ = FStar_Util.set_difference tm_univnames ctx_univnames in
+        FStar_All.pipe_right uu___ FStar_Util.set_elements in
       univnames
 let (check_universe_generalization :
   FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -88,17 +86,17 @@ let (check_universe_generalization :
     fun generalized_univ_names ->
       fun t ->
         match (explicit_univ_names, generalized_univ_names) with
-        | ([], uu____203) -> generalized_univ_names
-        | (uu____210, []) -> explicit_univ_names
-        | uu____217 ->
-            let uu____226 =
-              let uu____231 =
-                let uu____232 = FStar_Syntax_Print.term_to_string t in
+        | ([], uu___) -> generalized_univ_names
+        | (uu___, []) -> explicit_univ_names
+        | uu___ ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.term_to_string t in
                 Prims.op_Hat
                   "Generalized universe in a term containing explicit universe annotation : "
-                  uu____232 in
-              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu____231) in
-            FStar_Errors.raise_error uu____226 t.FStar_Syntax_Syntax.pos
+                  uu___3 in
+              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu___2) in
+            FStar_Errors.raise_error uu___1 t.FStar_Syntax_Syntax.pos
 let (generalize_universes :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.tscheme)
@@ -111,36 +109,36 @@ let (generalize_universes :
           FStar_TypeChecker_Env.Beta;
           FStar_TypeChecker_Env.DoNotUnfoldPureLets] env t0 in
       let univnames = gather_free_univnames env t in
-      (let uu____250 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Gen") in
-       if uu____250
+       if uu___1
        then
-         let uu____251 = FStar_Syntax_Print.term_to_string t in
-         let uu____252 = FStar_Syntax_Print.univ_names_to_string univnames in
+         let uu___2 = FStar_Syntax_Print.term_to_string t in
+         let uu___3 = FStar_Syntax_Print.univ_names_to_string univnames in
          FStar_Util.print2
            "generalizing universes in the term (post norm): %s with univnames: %s\n"
-           uu____251 uu____252
+           uu___2 uu___3
        else ());
       (let univs = FStar_Syntax_Free.univs t in
-       (let uu____258 =
+       (let uu___2 =
           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
             (FStar_Options.Other "Gen") in
-        if uu____258
+        if uu___2
         then
-          let uu____259 = string_of_univs univs in
-          FStar_Util.print1 "univs to gen : %s\n" uu____259
+          let uu___3 = string_of_univs univs in
+          FStar_Util.print1 "univs to gen : %s\n" uu___3
         else ());
        (let gen = gen_univs env univs in
-        (let uu____265 =
+        (let uu___3 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Gen") in
-         if uu____265
+         if uu___3
          then
-           let uu____266 = FStar_Syntax_Print.term_to_string t in
-           let uu____267 = FStar_Syntax_Print.univ_names_to_string gen in
+           let uu___4 = FStar_Syntax_Print.term_to_string t in
+           let uu___5 = FStar_Syntax_Print.univ_names_to_string gen in
            FStar_Util.print2 "After generalization, t: %s and univs: %s\n"
-             uu____266 uu____267
+             uu___4 uu___5
          else ());
         (let univs1 = check_universe_generalization univnames gen t0 in
          let t1 = FStar_TypeChecker_Normalize.reduce_uvar_solutions env t in
@@ -159,25 +157,25 @@ let (gen :
   fun env ->
     fun is_rec ->
       fun lecs ->
-        let uu____345 =
-          let uu____346 =
+        let uu___ =
+          let uu___1 =
             FStar_Util.for_all
-              (fun uu____359 ->
-                 match uu____359 with
-                 | (uu____368, uu____369, c) ->
+              (fun uu___2 ->
+                 match uu___2 with
+                 | (uu___3, uu___4, c) ->
                      FStar_Syntax_Util.is_pure_or_ghost_comp c) lecs in
-          FStar_All.pipe_left Prims.op_Negation uu____346 in
-        if uu____345
+          FStar_All.pipe_left Prims.op_Negation uu___1 in
+        if uu___
         then FStar_Pervasives_Native.None
         else
           (let norm c =
-             (let uu____417 =
+             (let uu___3 =
                 FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-              if uu____417
+              if uu___3
               then
-                let uu____418 = FStar_Syntax_Print.comp_to_string c in
+                let uu___4 = FStar_Syntax_Print.comp_to_string c in
                 FStar_Util.print1 "Normalizing before generalizing:\n\t %s\n"
-                  uu____418
+                  uu___4
               else ());
              (let c1 =
                 FStar_TypeChecker_Normalize.normalize_comp
@@ -185,137 +183,133 @@ let (gen :
                   FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                   FStar_TypeChecker_Env.NoFullNorm;
                   FStar_TypeChecker_Env.DoNotUnfoldPureLets] env c in
-              (let uu____422 =
+              (let uu___4 =
                  FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-               if uu____422
+               if uu___4
                then
-                 let uu____423 = FStar_Syntax_Print.comp_to_string c1 in
-                 FStar_Util.print1 "Normalized to:\n\t %s\n" uu____423
+                 let uu___5 = FStar_Syntax_Print.comp_to_string c1 in
+                 FStar_Util.print1 "Normalized to:\n\t %s\n" uu___5
                else ());
               c1) in
            let env_uvars = FStar_TypeChecker_Env.uvars_in_env env in
            let gen_uvars uvs =
-             let uu____438 = FStar_Util.set_difference uvs env_uvars in
-             FStar_All.pipe_right uu____438 FStar_Util.set_elements in
-           let univs_and_uvars_of_lec uu____472 =
-             match uu____472 with
+             let uu___2 = FStar_Util.set_difference uvs env_uvars in
+             FStar_All.pipe_right uu___2 FStar_Util.set_elements in
+           let univs_and_uvars_of_lec uu___2 =
+             match uu___2 with
              | (lbname, e, c) ->
                  let c1 = norm c in
                  let t = FStar_Syntax_Util.comp_result c1 in
                  let univs = FStar_Syntax_Free.univs t in
                  let uvt = FStar_Syntax_Free.uvars t in
-                 ((let uu____509 =
+                 ((let uu___4 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "Gen") in
-                   if uu____509
+                   if uu___4
                    then
-                     let uu____510 =
-                       let uu____511 =
-                         let uu____514 = FStar_Util.set_elements univs in
-                         FStar_All.pipe_right uu____514
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 = FStar_Util.set_elements univs in
+                         FStar_All.pipe_right uu___7
                            (FStar_List.map
                               (fun u ->
                                  FStar_Syntax_Print.univ_to_string
                                    (FStar_Syntax_Syntax.U_unif u))) in
-                       FStar_All.pipe_right uu____511
-                         (FStar_String.concat ", ") in
-                     let uu____565 =
-                       let uu____566 =
-                         let uu____569 = FStar_Util.set_elements uvt in
-                         FStar_All.pipe_right uu____569
+                       FStar_All.pipe_right uu___6 (FStar_String.concat ", ") in
+                     let uu___6 =
+                       let uu___7 =
+                         let uu___8 = FStar_Util.set_elements uvt in
+                         FStar_All.pipe_right uu___8
                            (FStar_List.map
                               (fun u ->
-                                 let uu____580 =
+                                 let uu___9 =
                                    FStar_Syntax_Print.uvar_to_string
                                      u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                 let uu____581 =
+                                 let uu___10 =
                                    FStar_Syntax_Print.term_to_string
                                      u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                 FStar_Util.format2 "(%s : %s)" uu____580
-                                   uu____581)) in
-                       FStar_All.pipe_right uu____566
-                         (FStar_String.concat ", ") in
+                                 FStar_Util.format2 "(%s : %s)" uu___9
+                                   uu___10)) in
+                       FStar_All.pipe_right uu___7 (FStar_String.concat ", ") in
                      FStar_Util.print2
-                       "^^^^\n\tFree univs = %s\n\tFree uvt=%s\n" uu____510
-                       uu____565
+                       "^^^^\n\tFree univs = %s\n\tFree uvt=%s\n" uu___5
+                       uu___6
                    else ());
                   (let univs1 =
-                     let uu____588 = FStar_Util.set_elements uvt in
+                     let uu___4 = FStar_Util.set_elements uvt in
                      FStar_List.fold_left
-                       (fun univs1 ->
+                       (fun univs2 ->
                           fun uv ->
-                            let uu____600 =
+                            let uu___5 =
                               FStar_Syntax_Free.univs
                                 uv.FStar_Syntax_Syntax.ctx_uvar_typ in
-                            FStar_Util.set_union univs1 uu____600) univs
-                       uu____588 in
+                            FStar_Util.set_union univs2 uu___5) univs uu___4 in
                    let uvs = gen_uvars uvt in
-                   (let uu____607 =
+                   (let uu___5 =
                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                         (FStar_Options.Other "Gen") in
-                    if uu____607
+                    if uu___5
                     then
-                      let uu____608 =
-                        let uu____609 =
-                          let uu____612 = FStar_Util.set_elements univs1 in
-                          FStar_All.pipe_right uu____612
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 = FStar_Util.set_elements univs1 in
+                          FStar_All.pipe_right uu___8
                             (FStar_List.map
                                (fun u ->
                                   FStar_Syntax_Print.univ_to_string
                                     (FStar_Syntax_Syntax.U_unif u))) in
-                        FStar_All.pipe_right uu____609
+                        FStar_All.pipe_right uu___7
                           (FStar_String.concat ", ") in
-                      let uu____663 =
-                        let uu____664 =
+                      let uu___7 =
+                        let uu___8 =
                           FStar_All.pipe_right uvs
                             (FStar_List.map
                                (fun u ->
-                                  let uu____675 =
+                                  let uu___9 =
                                     FStar_Syntax_Print.uvar_to_string
                                       u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                  let uu____676 =
+                                  let uu___10 =
                                     FStar_TypeChecker_Normalize.term_to_string
                                       env u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                  FStar_Util.format2 "(%s : %s)" uu____675
-                                    uu____676)) in
-                        FStar_All.pipe_right uu____664
+                                  FStar_Util.format2 "(%s : %s)" uu___9
+                                    uu___10)) in
+                        FStar_All.pipe_right uu___8
                           (FStar_String.concat ", ") in
                       FStar_Util.print2
-                        "^^^^\n\tFree univs = %s\n\tgen_uvars =%s" uu____608
-                        uu____663
+                        "^^^^\n\tFree univs = %s\n\tgen_uvars =%s" uu___6
+                        uu___7
                     else ());
                    (univs1, uvs, (lbname, e, c1)))) in
-           let uu____690 =
-             let uu____707 = FStar_List.hd lecs in
-             univs_and_uvars_of_lec uu____707 in
-           match uu____690 with
+           let uu___2 =
+             let uu___3 = FStar_List.hd lecs in univs_and_uvars_of_lec uu___3 in
+           match uu___2 with
            | (univs, uvs, lec_hd) ->
                let force_univs_eq lec2 u1 u2 =
-                 let uu____797 =
+                 let uu___3 =
                    (FStar_Util.set_is_subset_of u1 u2) &&
                      (FStar_Util.set_is_subset_of u2 u1) in
-                 if uu____797
+                 if uu___3
                  then ()
                  else
-                   (let uu____799 = lec_hd in
-                    match uu____799 with
-                    | (lb1, uu____807, uu____808) ->
-                        let uu____809 = lec2 in
-                        (match uu____809 with
-                         | (lb2, uu____817, uu____818) ->
+                   (let uu___5 = lec_hd in
+                    match uu___5 with
+                    | (lb1, uu___6, uu___7) ->
+                        let uu___8 = lec2 in
+                        (match uu___8 with
+                         | (lb2, uu___9, uu___10) ->
                              let msg =
-                               let uu____820 =
+                               let uu___11 =
                                  FStar_Syntax_Print.lbname_to_string lb1 in
-                               let uu____821 =
+                               let uu___12 =
                                  FStar_Syntax_Print.lbname_to_string lb2 in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible set of universes for %s and %s"
-                                 uu____820 uu____821 in
-                             let uu____822 =
+                                 uu___11 uu___12 in
+                             let uu___11 =
                                FStar_TypeChecker_Env.get_range env in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleSetOfUniverse,
-                                 msg) uu____822)) in
+                                 msg) uu___11)) in
                let force_uvars_eq lec2 u1 u2 =
                  let uvars_subseteq u11 u21 =
                    FStar_All.pipe_right u11
@@ -327,129 +321,125 @@ let (gen :
                                    FStar_Syntax_Unionfind.equiv
                                      u.FStar_Syntax_Syntax.ctx_uvar_head
                                      u'.FStar_Syntax_Syntax.ctx_uvar_head)))) in
-                 let uu____886 =
+                 let uu___3 =
                    (uvars_subseteq u1 u2) && (uvars_subseteq u2 u1) in
-                 if uu____886
+                 if uu___3
                  then ()
                  else
-                   (let uu____888 = lec_hd in
-                    match uu____888 with
-                    | (lb1, uu____896, uu____897) ->
-                        let uu____898 = lec2 in
-                        (match uu____898 with
-                         | (lb2, uu____906, uu____907) ->
+                   (let uu___5 = lec_hd in
+                    match uu___5 with
+                    | (lb1, uu___6, uu___7) ->
+                        let uu___8 = lec2 in
+                        (match uu___8 with
+                         | (lb2, uu___9, uu___10) ->
                              let msg =
-                               let uu____909 =
+                               let uu___11 =
                                  FStar_Syntax_Print.lbname_to_string lb1 in
-                               let uu____910 =
+                               let uu___12 =
                                  FStar_Syntax_Print.lbname_to_string lb2 in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible number of types for %s and %s"
-                                 uu____909 uu____910 in
-                             let uu____911 =
+                                 uu___11 uu___12 in
+                             let uu___11 =
                                FStar_TypeChecker_Env.get_range env in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleNumberOfTypes,
-                                 msg) uu____911)) in
+                                 msg) uu___11)) in
                let lecs1 =
-                 let uu____921 = FStar_List.tl lecs in
+                 let uu___3 = FStar_List.tl lecs in
                  FStar_List.fold_right
                    (fun this_lec ->
-                      fun lecs1 ->
-                        let uu____974 = univs_and_uvars_of_lec this_lec in
-                        match uu____974 with
+                      fun lecs2 ->
+                        let uu___4 = univs_and_uvars_of_lec this_lec in
+                        match uu___4 with
                         | (this_univs, this_uvs, this_lec1) ->
                             (force_univs_eq this_lec1 univs this_univs;
                              force_uvars_eq this_lec1 uvs this_uvs;
                              this_lec1
                              ::
-                             lecs1)) uu____921 [] in
+                             lecs2)) uu___3 [] in
                let lecs2 = lec_hd :: lecs1 in
                let gen_types uvs1 =
                  let fail rng k =
-                   let uu____1084 = lec_hd in
-                   match uu____1084 with
+                   let uu___3 = lec_hd in
+                   match uu___3 with
                    | (lbname, e, c) ->
-                       let uu____1094 =
-                         let uu____1099 =
-                           let uu____1100 =
-                             FStar_Syntax_Print.term_to_string k in
-                           let uu____1101 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 = FStar_Syntax_Print.term_to_string k in
+                           let uu___7 =
                              FStar_Syntax_Print.lbname_to_string lbname in
-                           let uu____1102 =
+                           let uu___8 =
                              FStar_Syntax_Print.term_to_string
                                (FStar_Syntax_Util.comp_result c) in
                            FStar_Util.format3
                              "Failed to resolve implicit argument of type '%s' in the type of %s (%s)"
-                             uu____1100 uu____1101 uu____1102 in
+                             uu___6 uu___7 uu___8 in
                          (FStar_Errors.Fatal_FailToResolveImplicitArgument,
-                           uu____1099) in
-                       FStar_Errors.raise_error uu____1094 rng in
+                           uu___5) in
+                       FStar_Errors.raise_error uu___4 rng in
                  FStar_All.pipe_right uvs1
                    (FStar_List.map
                       (fun u ->
-                         let uu____1121 =
+                         let uu___3 =
                            FStar_Syntax_Unionfind.find
                              u.FStar_Syntax_Syntax.ctx_uvar_head in
-                         match uu____1121 with
-                         | FStar_Pervasives_Native.Some uu____1130 ->
+                         match uu___3 with
+                         | FStar_Pervasives_Native.Some uu___4 ->
                              failwith
                                "Unexpected instantiation of mutually recursive uvar"
-                         | uu____1137 ->
+                         | uu___4 ->
                              let k =
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.Beta;
                                  FStar_TypeChecker_Env.Exclude
                                    FStar_TypeChecker_Env.Zeta] env
                                  u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                             let uu____1141 =
-                               FStar_Syntax_Util.arrow_formals k in
-                             (match uu____1141 with
+                             let uu___5 = FStar_Syntax_Util.arrow_formals k in
+                             (match uu___5 with
                               | (bs, kres) ->
-                                  ((let uu____1161 =
-                                      let uu____1162 =
-                                        let uu____1165 =
+                                  ((let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_TypeChecker_Normalize.unfold_whnf
                                             env kres in
-                                        FStar_Syntax_Util.unrefine uu____1165 in
-                                      uu____1162.FStar_Syntax_Syntax.n in
-                                    match uu____1161 with
-                                    | FStar_Syntax_Syntax.Tm_type uu____1166
-                                        ->
+                                        FStar_Syntax_Util.unrefine uu___9 in
+                                      uu___8.FStar_Syntax_Syntax.n in
+                                    match uu___7 with
+                                    | FStar_Syntax_Syntax.Tm_type uu___8 ->
                                         let free =
                                           FStar_Syntax_Free.names kres in
-                                        let uu____1170 =
-                                          let uu____1171 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             FStar_Util.set_is_empty free in
-                                          Prims.op_Negation uu____1171 in
-                                        if uu____1170
+                                          Prims.op_Negation uu___10 in
+                                        if uu___9
                                         then
                                           fail
                                             u.FStar_Syntax_Syntax.ctx_uvar_range
                                             kres
                                         else ()
-                                    | uu____1173 ->
+                                    | uu___8 ->
                                         fail
                                           u.FStar_Syntax_Syntax.ctx_uvar_range
                                           kres);
                                    (let a =
-                                      let uu____1175 =
-                                        let uu____1178 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_TypeChecker_Env.get_range env in
                                         FStar_All.pipe_left
-                                          (fun uu____1181 ->
+                                          (fun uu___9 ->
                                              FStar_Pervasives_Native.Some
-                                               uu____1181) uu____1178 in
-                                      FStar_Syntax_Syntax.new_bv uu____1175
-                                        kres in
+                                               uu___9) uu___8 in
+                                      FStar_Syntax_Syntax.new_bv uu___7 kres in
                                     let t =
                                       match bs with
                                       | [] ->
                                           FStar_Syntax_Syntax.bv_to_name a
-                                      | uu____1189 ->
-                                          let uu____1190 =
+                                      | uu___7 ->
+                                          let uu___8 =
                                             FStar_Syntax_Syntax.bv_to_name a in
-                                          FStar_Syntax_Util.abs bs uu____1190
+                                          FStar_Syntax_Util.abs bs uu___8
                                             (FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Util.residual_tot
                                                   kres)) in
@@ -463,15 +453,15 @@ let (gen :
                let ecs =
                  FStar_All.pipe_right lecs2
                    (FStar_List.map
-                      (fun uu____1293 ->
-                         match uu____1293 with
+                      (fun uu___3 ->
+                         match uu___3 with
                          | (lbname, e, c) ->
-                             let uu____1339 =
+                             let uu___4 =
                                match (gen_tvars, gen_univs1) with
                                | ([], []) -> (e, c, [])
-                               | uu____1400 ->
-                                   let uu____1413 = (e, c) in
-                                   (match uu____1413 with
+                               | uu___5 ->
+                                   let uu___6 = (e, c) in
+                                   (match uu___6 with
                                     | (e0, c0) ->
                                         let c1 =
                                           FStar_TypeChecker_Normalize.normalize_comp
@@ -490,23 +480,22 @@ let (gen :
                                           then
                                             let tvar_args =
                                               FStar_List.map
-                                                (fun uu____1452 ->
-                                                   match uu____1452 with
-                                                   | (x, uu____1458) ->
-                                                       let uu____1459 =
+                                                (fun uu___7 ->
+                                                   match uu___7 with
+                                                   | (x, uu___8) ->
+                                                       let uu___9 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            x in
                                                        FStar_Syntax_Syntax.iarg
-                                                         uu____1459)
-                                                gen_tvars in
+                                                         uu___9) gen_tvars in
                                             let instantiate_lbname_with_app
                                               tm fv =
-                                              let uu____1477 =
-                                                let uu____1478 =
+                                              let uu___7 =
+                                                let uu___8 =
                                                   FStar_Util.right lbname in
                                                 FStar_Syntax_Syntax.fv_eq fv
-                                                  uu____1478 in
-                                              if uu____1477
+                                                  uu___8 in
+                                              if uu___7
                                               then
                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                   tm tvar_args
@@ -516,24 +505,24 @@ let (gen :
                                               instantiate_lbname_with_app e1
                                           else e1 in
                                         let t =
-                                          let uu____1484 =
-                                            let uu____1485 =
+                                          let uu___7 =
+                                            let uu___8 =
                                               FStar_Syntax_Subst.compress
                                                 (FStar_Syntax_Util.comp_result
                                                    c1) in
-                                            uu____1485.FStar_Syntax_Syntax.n in
-                                          match uu____1484 with
+                                            uu___8.FStar_Syntax_Syntax.n in
+                                          match uu___7 with
                                           | FStar_Syntax_Syntax.Tm_arrow
                                               (bs, cod) ->
-                                              let uu____1510 =
+                                              let uu___8 =
                                                 FStar_Syntax_Subst.open_comp
                                                   bs cod in
-                                              (match uu____1510 with
+                                              (match uu___8 with
                                                | (bs1, cod1) ->
                                                    FStar_Syntax_Util.arrow
                                                      (FStar_List.append
                                                         gen_tvars bs1) cod1)
-                                          | uu____1521 ->
+                                          | uu___8 ->
                                               FStar_Syntax_Util.arrow
                                                 gen_tvars c1 in
                                         let e' =
@@ -541,10 +530,10 @@ let (gen :
                                             (FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Util.residual_comp_of_comp
                                                   c1)) in
-                                        let uu____1525 =
+                                        let uu___7 =
                                           FStar_Syntax_Syntax.mk_Total t in
-                                        (e', uu____1525, gen_tvars)) in
-                             (match uu____1339 with
+                                        (e', uu___7, gen_tvars)) in
+                             (match uu___4 with
                               | (e1, c1, gvs) ->
                                   (lbname, gen_univs1, e1, c1, gvs)))) in
                FStar_Pervasives_Native.Some ecs)
@@ -560,71 +549,69 @@ let (generalize' :
   fun env ->
     fun is_rec ->
       fun lecs ->
-        (let uu____1669 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
-         if uu____1669
+        (let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
+         if uu___2
          then
-           let uu____1670 =
-             let uu____1671 =
+           let uu___3 =
+             let uu___4 =
                FStar_List.map
-                 (fun uu____1684 ->
-                    match uu____1684 with
-                    | (lb, uu____1692, uu____1693) ->
+                 (fun uu___5 ->
+                    match uu___5 with
+                    | (lb, uu___6, uu___7) ->
                         FStar_Syntax_Print.lbname_to_string lb) lecs in
-             FStar_All.pipe_right uu____1671 (FStar_String.concat ", ") in
-           FStar_Util.print1 "Generalizing: %s\n" uu____1670
+             FStar_All.pipe_right uu___4 (FStar_String.concat ", ") in
+           FStar_Util.print1 "Generalizing: %s\n" uu___3
          else ());
         (let univnames_lecs =
            FStar_List.map
-             (fun uu____1714 ->
-                match uu____1714 with
-                | (l, t, c) -> gather_free_univnames env t) lecs in
+             (fun uu___2 ->
+                match uu___2 with | (l, t, c) -> gather_free_univnames env t)
+             lecs in
          let generalized_lecs =
-           let uu____1743 = gen env is_rec lecs in
-           match uu____1743 with
+           let uu___2 = gen env is_rec lecs in
+           match uu___2 with
            | FStar_Pervasives_Native.None ->
                FStar_All.pipe_right lecs
                  (FStar_List.map
-                    (fun uu____1842 ->
-                       match uu____1842 with | (l, t, c) -> (l, [], t, c, [])))
+                    (fun uu___3 ->
+                       match uu___3 with | (l, t, c) -> (l, [], t, c, [])))
            | FStar_Pervasives_Native.Some luecs ->
-               ((let uu____1904 =
+               ((let uu___4 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-                 if uu____1904
+                 if uu___4
                  then
                    FStar_All.pipe_right luecs
                      (FStar_List.iter
-                        (fun uu____1950 ->
-                           match uu____1950 with
+                        (fun uu___5 ->
+                           match uu___5 with
                            | (l, us, e, c, gvs) ->
-                               let uu____1984 =
+                               let uu___6 =
                                  FStar_Range.string_of_range
                                    e.FStar_Syntax_Syntax.pos in
-                               let uu____1985 =
+                               let uu___7 =
                                  FStar_Syntax_Print.lbname_to_string l in
-                               let uu____1986 =
+                               let uu___8 =
                                  FStar_Syntax_Print.term_to_string
                                    (FStar_Syntax_Util.comp_result c) in
-                               let uu____1987 =
+                               let uu___9 =
                                  FStar_Syntax_Print.term_to_string e in
-                               let uu____1988 =
+                               let uu___10 =
                                  FStar_Syntax_Print.binders_to_string ", "
                                    gvs in
                                FStar_Util.print5
                                  "(%s) Generalized %s at type %s\n%s\nVars = (%s)\n"
-                                 uu____1984 uu____1985 uu____1986 uu____1987
-                                 uu____1988))
+                                 uu___6 uu___7 uu___8 uu___9 uu___10))
                  else ());
                 luecs) in
          FStar_List.map2
            (fun univnames ->
-              fun uu____2029 ->
-                match uu____2029 with
+              fun uu___2 ->
+                match uu___2 with
                 | (l, generalized_univs, t, c, gvs) ->
-                    let uu____2073 =
+                    let uu___3 =
                       check_universe_generalization univnames
                         generalized_univs t in
-                    (l, uu____2073, t, c, gvs)) univnames_lecs
-           generalized_lecs)
+                    (l, uu___3, t, c, gvs)) univnames_lecs generalized_lecs)
 let (generalize :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
@@ -637,11 +624,10 @@ let (generalize :
   fun env ->
     fun is_rec ->
       fun lecs ->
-        let uu____2125 =
-          let uu____2128 =
-            let uu____2129 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.string_of_lid uu____2129 in
-          FStar_Pervasives_Native.Some uu____2128 in
-        FStar_Profiling.profile
-          (fun uu____2145 -> generalize' env is_rec lecs) uu____2125
-          "FStar.TypeChecker.Util.generalize"
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
+        FStar_Profiling.profile (fun uu___1 -> generalize' env is_rec lecs)
+          uu___ "FStar.TypeChecker.Util.generalize"

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -8,8 +8,7 @@ let map_rev : 'a 'b . ('a -> 'b) -> 'a Prims.list -> 'b Prims.list =
         match l1 with
         | [] -> acc
         | x::xs ->
-            let uu____71 = let uu____74 = f x in uu____74 :: acc in
-            aux xs uu____71 in
+            let uu___ = let uu___1 = f x in uu___1 :: acc in aux xs uu___ in
       aux l []
 let map_rev_append :
   'a 'b . ('a -> 'b) -> 'a Prims.list -> 'b Prims.list -> 'b Prims.list =
@@ -20,8 +19,7 @@ let map_rev_append :
           match l with
           | [] -> l2
           | x::xs ->
-              let uu____144 = let uu____147 = f x in uu____147 :: acc in
-              aux xs uu____144 in
+              let uu___ = let uu___1 = f x in uu___1 :: acc in aux xs uu___ in
         aux l1 l2
 let rec map_append :
   'a 'b . ('a -> 'b) -> 'a Prims.list -> 'b Prims.list -> 'b Prims.list =
@@ -31,15 +29,14 @@ let rec map_append :
         match l1 with
         | [] -> l2
         | x::xs ->
-            let uu____196 = f x in
-            let uu____197 = map_append f xs l2 in uu____196 :: uu____197
+            let uu___ = f x in
+            let uu___1 = map_append f xs l2 in uu___ :: uu___1
 let rec drop : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a Prims.list =
   fun p ->
     fun l ->
       match l with
       | [] -> []
-      | x::xs ->
-          let uu____233 = p x in if uu____233 then x :: xs else drop p xs
+      | x::xs -> let uu___ = p x in if uu___ then x :: xs else drop p xs
 let fmap_opt :
   'a 'b .
     ('a -> 'b) ->
@@ -48,47 +45,46 @@ let fmap_opt :
   fun f ->
     fun x ->
       FStar_Util.bind_opt x
-        (fun x1 ->
-           let uu____271 = f x1 in FStar_Pervasives_Native.Some uu____271)
+        (fun x1 -> let uu___ = f x1 in FStar_Pervasives_Native.Some uu___)
 let drop_until : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a Prims.list =
   fun f ->
     fun l ->
       let rec aux l1 =
         match l1 with
         | [] -> []
-        | x::xs -> let uu____318 = f x in if uu____318 then l1 else aux xs in
+        | x::xs -> let uu___ = f x in if uu___ then l1 else aux xs in
       aux l
 let (trim : Prims.bool Prims.list -> Prims.bool Prims.list) =
   fun l ->
-    let uu____335 = drop_until FStar_Pervasives.id (FStar_List.rev l) in
-    FStar_List.rev uu____335
+    let uu___ = drop_until FStar_Pervasives.id (FStar_List.rev l) in
+    FStar_List.rev uu___
 let (implies : Prims.bool -> Prims.bool -> Prims.bool) =
   fun b1 ->
     fun b2 ->
-      match (b1, b2) with | (false, uu____348) -> true | (true, b21) -> b21
+      match (b1, b2) with | (false, uu___) -> true | (true, b21) -> b21
 let (let_rec_arity :
   FStar_Syntax_Syntax.letbinding -> (Prims.int * Prims.bool Prims.list)) =
   fun b ->
-    let uu____367 = FStar_Syntax_Util.let_rec_arity b in
-    match uu____367 with
+    let uu___ = FStar_Syntax_Util.let_rec_arity b in
+    match uu___ with
     | (ar, maybe_lst) ->
         (match maybe_lst with
          | FStar_Pervasives_Native.None ->
-             let uu____400 = FStar_Common.tabulate ar (fun uu____404 -> true) in
-             (ar, uu____400)
+             let uu___1 = FStar_Common.tabulate ar (fun uu___2 -> true) in
+             (ar, uu___1)
          | FStar_Pervasives_Native.Some lst -> (ar, lst))
 let (debug_term : FStar_Syntax_Syntax.term -> unit) =
   fun t ->
-    let uu____419 = FStar_Syntax_Print.term_to_string t in
-    FStar_Util.print1 "%s\n" uu____419
+    let uu___ = FStar_Syntax_Print.term_to_string t in
+    FStar_Util.print1 "%s\n" uu___
 let (debug_sigmap : FStar_Syntax_Syntax.sigelt FStar_Util.smap -> unit) =
   fun m ->
     FStar_Util.smap_fold m
       (fun k ->
          fun v ->
            fun u ->
-             let uu____436 = FStar_Syntax_Print.sigelt_to_string_short v in
-             FStar_Util.print2 "%s -> %%s\n" k uu____436) ()
+             let uu___ = FStar_Syntax_Print.sigelt_to_string_short v in
+             FStar_Util.print2 "%s -> %%s\n" k uu___) ()
 type config =
   {
   core_cfg: FStar_TypeChecker_Cfg.cfg ;
@@ -101,31 +97,28 @@ let (__proj__Mkconfig__item__fv_cache :
   fun projectee -> match projectee with | { core_cfg; fv_cache;_} -> fv_cache
 let (new_config : FStar_TypeChecker_Cfg.cfg -> config) =
   fun cfg ->
-    let uu____476 = FStar_Util.smap_create (Prims.of_int (51)) in
-    { core_cfg = cfg; fv_cache = uu____476 }
+    let uu___ = FStar_Util.smap_create (Prims.of_int (51)) in
+    { core_cfg = cfg; fv_cache = uu___ }
 let (reifying_false : config -> config) =
   fun cfg ->
     if (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying
     then
       new_config
-        (let uu___92_486 = cfg.core_cfg in
+        (let uu___ = cfg.core_cfg in
          {
-           FStar_TypeChecker_Cfg.steps =
-             (uu___92_486.FStar_TypeChecker_Cfg.steps);
-           FStar_TypeChecker_Cfg.tcenv =
-             (uu___92_486.FStar_TypeChecker_Cfg.tcenv);
-           FStar_TypeChecker_Cfg.debug =
-             (uu___92_486.FStar_TypeChecker_Cfg.debug);
+           FStar_TypeChecker_Cfg.steps = (uu___.FStar_TypeChecker_Cfg.steps);
+           FStar_TypeChecker_Cfg.tcenv = (uu___.FStar_TypeChecker_Cfg.tcenv);
+           FStar_TypeChecker_Cfg.debug = (uu___.FStar_TypeChecker_Cfg.debug);
            FStar_TypeChecker_Cfg.delta_level =
-             (uu___92_486.FStar_TypeChecker_Cfg.delta_level);
+             (uu___.FStar_TypeChecker_Cfg.delta_level);
            FStar_TypeChecker_Cfg.primitive_steps =
-             (uu___92_486.FStar_TypeChecker_Cfg.primitive_steps);
+             (uu___.FStar_TypeChecker_Cfg.primitive_steps);
            FStar_TypeChecker_Cfg.strong =
-             (uu___92_486.FStar_TypeChecker_Cfg.strong);
+             (uu___.FStar_TypeChecker_Cfg.strong);
            FStar_TypeChecker_Cfg.memoize_lazy =
-             (uu___92_486.FStar_TypeChecker_Cfg.memoize_lazy);
+             (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
            FStar_TypeChecker_Cfg.normalize_pure_lets =
-             (uu___92_486.FStar_TypeChecker_Cfg.normalize_pure_lets);
+             (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
            FStar_TypeChecker_Cfg.reifying = false
          })
     else cfg
@@ -134,24 +127,21 @@ let (reifying_true : config -> config) =
     if Prims.op_Negation (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying
     then
       new_config
-        (let uu___96_495 = cfg.core_cfg in
+        (let uu___ = cfg.core_cfg in
          {
-           FStar_TypeChecker_Cfg.steps =
-             (uu___96_495.FStar_TypeChecker_Cfg.steps);
-           FStar_TypeChecker_Cfg.tcenv =
-             (uu___96_495.FStar_TypeChecker_Cfg.tcenv);
-           FStar_TypeChecker_Cfg.debug =
-             (uu___96_495.FStar_TypeChecker_Cfg.debug);
+           FStar_TypeChecker_Cfg.steps = (uu___.FStar_TypeChecker_Cfg.steps);
+           FStar_TypeChecker_Cfg.tcenv = (uu___.FStar_TypeChecker_Cfg.tcenv);
+           FStar_TypeChecker_Cfg.debug = (uu___.FStar_TypeChecker_Cfg.debug);
            FStar_TypeChecker_Cfg.delta_level =
-             (uu___96_495.FStar_TypeChecker_Cfg.delta_level);
+             (uu___.FStar_TypeChecker_Cfg.delta_level);
            FStar_TypeChecker_Cfg.primitive_steps =
-             (uu___96_495.FStar_TypeChecker_Cfg.primitive_steps);
+             (uu___.FStar_TypeChecker_Cfg.primitive_steps);
            FStar_TypeChecker_Cfg.strong =
-             (uu___96_495.FStar_TypeChecker_Cfg.strong);
+             (uu___.FStar_TypeChecker_Cfg.strong);
            FStar_TypeChecker_Cfg.memoize_lazy =
-             (uu___96_495.FStar_TypeChecker_Cfg.memoize_lazy);
+             (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
            FStar_TypeChecker_Cfg.normalize_pure_lets =
-             (uu___96_495.FStar_TypeChecker_Cfg.normalize_pure_lets);
+             (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
            FStar_TypeChecker_Cfg.reifying = true
          })
     else cfg
@@ -161,81 +151,77 @@ let (zeta_false : config -> config) =
     if (cfg_core.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
     then
       let cfg_core' =
-        let uu___101_504 = cfg_core in
+        let uu___ = cfg_core in
         {
           FStar_TypeChecker_Cfg.steps =
-            (let uu___103_507 = cfg_core.FStar_TypeChecker_Cfg.steps in
+            (let uu___1 = cfg_core.FStar_TypeChecker_Cfg.steps in
              {
                FStar_TypeChecker_Cfg.beta =
-                 (uu___103_507.FStar_TypeChecker_Cfg.beta);
+                 (uu___1.FStar_TypeChecker_Cfg.beta);
                FStar_TypeChecker_Cfg.iota =
-                 (uu___103_507.FStar_TypeChecker_Cfg.iota);
+                 (uu___1.FStar_TypeChecker_Cfg.iota);
                FStar_TypeChecker_Cfg.zeta = false;
                FStar_TypeChecker_Cfg.zeta_full =
-                 (uu___103_507.FStar_TypeChecker_Cfg.zeta_full);
+                 (uu___1.FStar_TypeChecker_Cfg.zeta_full);
                FStar_TypeChecker_Cfg.weak =
-                 (uu___103_507.FStar_TypeChecker_Cfg.weak);
-               FStar_TypeChecker_Cfg.hnf =
-                 (uu___103_507.FStar_TypeChecker_Cfg.hnf);
+                 (uu___1.FStar_TypeChecker_Cfg.weak);
+               FStar_TypeChecker_Cfg.hnf = (uu___1.FStar_TypeChecker_Cfg.hnf);
                FStar_TypeChecker_Cfg.primops =
-                 (uu___103_507.FStar_TypeChecker_Cfg.primops);
+                 (uu___1.FStar_TypeChecker_Cfg.primops);
                FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                 (uu___103_507.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                 (uu___1.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                FStar_TypeChecker_Cfg.unfold_until =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unfold_until);
+                 (uu___1.FStar_TypeChecker_Cfg.unfold_until);
                FStar_TypeChecker_Cfg.unfold_only =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unfold_only);
+                 (uu___1.FStar_TypeChecker_Cfg.unfold_only);
                FStar_TypeChecker_Cfg.unfold_fully =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unfold_fully);
+                 (uu___1.FStar_TypeChecker_Cfg.unfold_fully);
                FStar_TypeChecker_Cfg.unfold_attr =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unfold_attr);
+                 (uu___1.FStar_TypeChecker_Cfg.unfold_attr);
                FStar_TypeChecker_Cfg.unfold_tac =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unfold_tac);
+                 (uu___1.FStar_TypeChecker_Cfg.unfold_tac);
                FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                 (uu___103_507.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                 (uu___1.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                FStar_TypeChecker_Cfg.simplify =
-                 (uu___103_507.FStar_TypeChecker_Cfg.simplify);
+                 (uu___1.FStar_TypeChecker_Cfg.simplify);
                FStar_TypeChecker_Cfg.erase_universes =
-                 (uu___103_507.FStar_TypeChecker_Cfg.erase_universes);
+                 (uu___1.FStar_TypeChecker_Cfg.erase_universes);
                FStar_TypeChecker_Cfg.allow_unbound_universes =
-                 (uu___103_507.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                 (uu___1.FStar_TypeChecker_Cfg.allow_unbound_universes);
                FStar_TypeChecker_Cfg.reify_ =
-                 (uu___103_507.FStar_TypeChecker_Cfg.reify_);
+                 (uu___1.FStar_TypeChecker_Cfg.reify_);
                FStar_TypeChecker_Cfg.compress_uvars =
-                 (uu___103_507.FStar_TypeChecker_Cfg.compress_uvars);
+                 (uu___1.FStar_TypeChecker_Cfg.compress_uvars);
                FStar_TypeChecker_Cfg.no_full_norm =
-                 (uu___103_507.FStar_TypeChecker_Cfg.no_full_norm);
+                 (uu___1.FStar_TypeChecker_Cfg.no_full_norm);
                FStar_TypeChecker_Cfg.check_no_uvars =
-                 (uu___103_507.FStar_TypeChecker_Cfg.check_no_uvars);
+                 (uu___1.FStar_TypeChecker_Cfg.check_no_uvars);
                FStar_TypeChecker_Cfg.unmeta =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unmeta);
+                 (uu___1.FStar_TypeChecker_Cfg.unmeta);
                FStar_TypeChecker_Cfg.unascribe =
-                 (uu___103_507.FStar_TypeChecker_Cfg.unascribe);
+                 (uu___1.FStar_TypeChecker_Cfg.unascribe);
                FStar_TypeChecker_Cfg.in_full_norm_request =
-                 (uu___103_507.FStar_TypeChecker_Cfg.in_full_norm_request);
+                 (uu___1.FStar_TypeChecker_Cfg.in_full_norm_request);
                FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                 (uu___103_507.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                 (uu___1.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                FStar_TypeChecker_Cfg.nbe_step =
-                 (uu___103_507.FStar_TypeChecker_Cfg.nbe_step);
+                 (uu___1.FStar_TypeChecker_Cfg.nbe_step);
                FStar_TypeChecker_Cfg.for_extraction =
-                 (uu___103_507.FStar_TypeChecker_Cfg.for_extraction)
+                 (uu___1.FStar_TypeChecker_Cfg.for_extraction)
              });
-          FStar_TypeChecker_Cfg.tcenv =
-            (uu___101_504.FStar_TypeChecker_Cfg.tcenv);
-          FStar_TypeChecker_Cfg.debug =
-            (uu___101_504.FStar_TypeChecker_Cfg.debug);
+          FStar_TypeChecker_Cfg.tcenv = (uu___.FStar_TypeChecker_Cfg.tcenv);
+          FStar_TypeChecker_Cfg.debug = (uu___.FStar_TypeChecker_Cfg.debug);
           FStar_TypeChecker_Cfg.delta_level =
-            (uu___101_504.FStar_TypeChecker_Cfg.delta_level);
+            (uu___.FStar_TypeChecker_Cfg.delta_level);
           FStar_TypeChecker_Cfg.primitive_steps =
-            (uu___101_504.FStar_TypeChecker_Cfg.primitive_steps);
-          FStar_TypeChecker_Cfg.strong =
-            (uu___101_504.FStar_TypeChecker_Cfg.strong);
+            (uu___.FStar_TypeChecker_Cfg.primitive_steps);
+          FStar_TypeChecker_Cfg.strong = (uu___.FStar_TypeChecker_Cfg.strong);
           FStar_TypeChecker_Cfg.memoize_lazy =
-            (uu___101_504.FStar_TypeChecker_Cfg.memoize_lazy);
+            (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
           FStar_TypeChecker_Cfg.normalize_pure_lets =
-            (uu___101_504.FStar_TypeChecker_Cfg.normalize_pure_lets);
+            (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
           FStar_TypeChecker_Cfg.reifying =
-            (uu___101_504.FStar_TypeChecker_Cfg.reifying)
+            (uu___.FStar_TypeChecker_Cfg.reifying)
         } in
       new_config cfg_core'
     else cfg
@@ -245,8 +231,8 @@ let (cache_add :
     fun fv ->
       fun v ->
         let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        let uu____525 = FStar_Ident.string_of_lid lid in
-        FStar_Util.smap_add cfg.fv_cache uu____525 v
+        let uu___ = FStar_Ident.string_of_lid lid in
+        FStar_Util.smap_add cfg.fv_cache uu___ v
 let (try_in_cache :
   config ->
     FStar_Syntax_Syntax.fv ->
@@ -255,24 +241,24 @@ let (try_in_cache :
   fun cfg ->
     fun fv ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu____541 = FStar_Ident.string_of_lid lid in
-      FStar_Util.smap_try_find cfg.fv_cache uu____541
+      let uu___ = FStar_Ident.string_of_lid lid in
+      FStar_Util.smap_try_find cfg.fv_cache uu___
 let (debug : config -> (unit -> unit) -> unit) =
   fun cfg -> fun f -> FStar_TypeChecker_Cfg.log_nbe cfg.core_cfg f
 let rec (unlazy_unmeta :
   FStar_TypeChecker_NBETerm.t -> FStar_TypeChecker_NBETerm.t) =
   fun t ->
     match t.FStar_TypeChecker_NBETerm.nbe_t with
-    | FStar_TypeChecker_NBETerm.Lazy (uu____562, t1) ->
-        let uu____584 = FStar_Thunk.force t1 in unlazy_unmeta uu____584
+    | FStar_TypeChecker_NBETerm.Lazy (uu___, t1) ->
+        let uu___1 = FStar_Thunk.force t1 in unlazy_unmeta uu___1
     | FStar_TypeChecker_NBETerm.Meta (t0, m) ->
-        let uu____591 = FStar_Thunk.force m in
-        (match uu____591 with
-         | FStar_Syntax_Syntax.Meta_monadic (uu____592, uu____593) -> t
-         | FStar_Syntax_Syntax.Meta_monadic_lift
-             (uu____598, uu____599, uu____600) -> t
-         | uu____605 -> unlazy_unmeta t0)
-    | uu____606 -> t
+        let uu___ = FStar_Thunk.force m in
+        (match uu___ with
+         | FStar_Syntax_Syntax.Meta_monadic (uu___1, uu___2) -> t
+         | FStar_Syntax_Syntax.Meta_monadic_lift (uu___1, uu___2, uu___3) ->
+             t
+         | uu___1 -> unlazy_unmeta t0)
+    | uu___ -> t
 let (pickBranch :
   config ->
     FStar_TypeChecker_NBETerm.t ->
@@ -287,12 +273,11 @@ let (pickBranch :
         let rec pickBranch_aux scrut1 branches1 branches0 =
           let rec matches_pat scrutinee0 p =
             debug cfg
-              (fun uu____712 ->
-                 let uu____713 =
+              (fun uu___1 ->
+                 let uu___2 =
                    FStar_TypeChecker_NBETerm.t_to_string scrutinee0 in
-                 let uu____714 = FStar_Syntax_Print.pat_to_string p in
-                 FStar_Util.print2 "matches_pat (%s, %s)\n" uu____713
-                   uu____714);
+                 let uu___3 = FStar_Syntax_Print.pat_to_string p in
+                 FStar_Util.print2 "matches_pat (%s, %s)\n" uu___2 uu___3);
             (let scrutinee = unlazy_unmeta scrutinee0 in
              let r =
                match p.FStar_Syntax_Syntax.v with
@@ -300,19 +285,17 @@ let (pickBranch :
                    FStar_Util.Inl [scrutinee0]
                | FStar_Syntax_Syntax.Pat_wild bv ->
                    FStar_Util.Inl [scrutinee0]
-               | FStar_Syntax_Syntax.Pat_dot_term uu____735 ->
-                   FStar_Util.Inl []
+               | FStar_Syntax_Syntax.Pat_dot_term uu___1 -> FStar_Util.Inl []
                | FStar_Syntax_Syntax.Pat_constant s ->
                    let matches_const c s1 =
                      debug cfg
-                       (fun uu____760 ->
-                          let uu____761 =
+                       (fun uu___2 ->
+                          let uu___3 =
                             FStar_TypeChecker_NBETerm.t_to_string c in
-                          let uu____762 =
-                            FStar_Syntax_Print.const_to_string s1 in
+                          let uu___4 = FStar_Syntax_Print.const_to_string s1 in
                           FStar_Util.print2
-                            "Testing term %s against pattern %s\n" uu____761
-                            uu____762);
+                            "Testing term %s against pattern %s\n" uu___3
+                            uu___4);
                      (match c.FStar_TypeChecker_NBETerm.nbe_t with
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Unit) ->
@@ -321,82 +304,77 @@ let (pickBranch :
                           (FStar_TypeChecker_NBETerm.Bool b) ->
                           (match s1 with
                            | FStar_Const.Const_bool p1 -> b = p1
-                           | uu____765 -> false)
+                           | uu___2 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Int i) ->
                           (match s1 with
                            | FStar_Const.Const_int
                                (p1, FStar_Pervasives_Native.None) ->
-                               let uu____778 =
-                                 FStar_BigInt.big_int_of_string p1 in
-                               i = uu____778
-                           | uu____779 -> false)
+                               let uu___2 = FStar_BigInt.big_int_of_string p1 in
+                               i = uu___2
+                           | uu___2 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
-                          (FStar_TypeChecker_NBETerm.String (st, uu____781))
-                          ->
+                          (FStar_TypeChecker_NBETerm.String (st, uu___2)) ->
                           (match s1 with
-                           | FStar_Const.Const_string (p1, uu____783) ->
-                               st = p1
-                           | uu____784 -> false)
+                           | FStar_Const.Const_string (p1, uu___3) -> st = p1
+                           | uu___3 -> false)
                       | FStar_TypeChecker_NBETerm.Constant
                           (FStar_TypeChecker_NBETerm.Char c1) ->
                           (match s1 with
                            | FStar_Const.Const_char p1 -> c1 = p1
-                           | uu____787 -> false)
-                      | uu____788 -> false) in
-                   let uu____789 = matches_const scrutinee s in
-                   if uu____789
-                   then FStar_Util.Inl []
-                   else FStar_Util.Inr false
+                           | uu___2 -> false)
+                      | uu___2 -> false) in
+                   let uu___1 = matches_const scrutinee s in
+                   if uu___1 then FStar_Util.Inl [] else FStar_Util.Inr false
                | FStar_Syntax_Syntax.Pat_cons (fv, arg_pats) ->
                    let rec matches_args out a p1 =
                      match (a, p1) with
                      | ([], []) -> FStar_Util.Inl out
-                     | ((t, uu____910)::rest_a, (p2, uu____913)::rest_p) ->
-                         let uu____947 = matches_pat t p2 in
-                         (match uu____947 with
+                     | ((t, uu___1)::rest_a, (p2, uu___2)::rest_p) ->
+                         let uu___3 = matches_pat t p2 in
+                         (match uu___3 with
                           | FStar_Util.Inl s ->
                               matches_args (FStar_List.append out s) rest_a
                                 rest_p
                           | m -> m)
-                     | uu____972 -> FStar_Util.Inr false in
+                     | uu___1 -> FStar_Util.Inr false in
                    (match scrutinee.FStar_TypeChecker_NBETerm.nbe_t with
                     | FStar_TypeChecker_NBETerm.Construct
                         (fv', _us, args_rev) ->
-                        let uu____1016 = FStar_Syntax_Syntax.fv_eq fv fv' in
-                        if uu____1016
+                        let uu___1 = FStar_Syntax_Syntax.fv_eq fv fv' in
+                        if uu___1
                         then
                           matches_args [] (FStar_List.rev args_rev) arg_pats
                         else FStar_Util.Inr false
-                    | uu____1030 -> FStar_Util.Inr true) in
-             let res_to_string uu___0_1044 =
-               match uu___0_1044 with
+                    | uu___1 -> FStar_Util.Inr true) in
+             let res_to_string uu___1 =
+               match uu___1 with
                | FStar_Util.Inr b ->
-                   let uu____1054 = FStar_Util.string_of_bool b in
-                   Prims.op_Hat "Inr " uu____1054
+                   let uu___2 = FStar_Util.string_of_bool b in
+                   Prims.op_Hat "Inr " uu___2
                | FStar_Util.Inl bs ->
-                   let uu____1060 =
+                   let uu___2 =
                      FStar_Util.string_of_int (FStar_List.length bs) in
-                   Prims.op_Hat "Inl " uu____1060 in
+                   Prims.op_Hat "Inl " uu___2 in
              debug cfg
-               (fun uu____1066 ->
-                  let uu____1067 =
+               (fun uu___2 ->
+                  let uu___3 =
                     FStar_TypeChecker_NBETerm.t_to_string scrutinee in
-                  let uu____1068 = FStar_Syntax_Print.pat_to_string p in
-                  let uu____1069 = res_to_string r in
-                  FStar_Util.print3 "matches_pat (%s, %s) = %s\n" uu____1067
-                    uu____1068 uu____1069);
+                  let uu___4 = FStar_Syntax_Print.pat_to_string p in
+                  let uu___5 = res_to_string r in
+                  FStar_Util.print3 "matches_pat (%s, %s) = %s\n" uu___3
+                    uu___4 uu___5);
              r) in
           match branches1 with
           | [] -> FStar_Pervasives_Native.None
           | (p, _wopt, e)::branches2 ->
-              let uu____1106 = matches_pat scrut1 p in
-              (match uu____1106 with
+              let uu___ = matches_pat scrut1 p in
+              (match uu___ with
                | FStar_Util.Inl matches ->
                    (debug cfg
-                      (fun uu____1129 ->
-                         let uu____1130 = FStar_Syntax_Print.pat_to_string p in
-                         FStar_Util.print1 "Pattern %s matches\n" uu____1130);
+                      (fun uu___2 ->
+                         let uu___3 = FStar_Syntax_Print.pat_to_string p in
+                         FStar_Util.print1 "Pattern %s matches\n" uu___3);
                     FStar_Pervasives_Native.Some (e, matches))
                | FStar_Util.Inr (false) ->
                    pickBranch_aux scrut1 branches2 branches0
@@ -412,14 +390,14 @@ let (should_reduce_recursive_definition :
     fun formals_in_decreases ->
       let rec aux ts ar_list acc =
         match (ts, ar_list) with
-        | (uu____1263, []) -> (true, acc, ts)
-        | ([], uu____1290::uu____1291) -> (false, acc, [])
+        | (uu___, []) -> (true, acc, ts)
+        | ([], uu___::uu___1) -> (false, acc, [])
         | (t::ts1, in_decreases_clause::bs) ->
-            let uu____1350 =
+            let uu___ =
               in_decreases_clause &&
                 (FStar_TypeChecker_NBETerm.isAccu
                    (FStar_Pervasives_Native.fst t)) in
-            if uu____1350
+            if uu___
             then (false, (FStar_List.rev_append ts1 acc), [])
             else aux ts1 bs (t :: acc) in
       aux arguments formals_in_decreases []
@@ -432,37 +410,36 @@ let (find_sigelt_in_gamma :
   fun cfg ->
     fun env ->
       fun lid ->
-        let mapper uu____1442 =
-          match uu____1442 with
+        let mapper uu___ =
+          match uu___ with
           | (lr, rng) ->
               (match lr with
                | FStar_Util.Inr (elt, FStar_Pervasives_Native.None) ->
                    FStar_Pervasives_Native.Some elt
                | FStar_Util.Inr (elt, FStar_Pervasives_Native.Some us) ->
                    (debug cfg
-                      (fun uu____1525 ->
-                         let uu____1526 =
-                           FStar_Syntax_Print.univs_to_string us in
+                      (fun uu___2 ->
+                         let uu___3 = FStar_Syntax_Print.univs_to_string us in
                          FStar_Util.print1
-                           "Universes in local declaration: %s\n" uu____1526);
+                           "Universes in local declaration: %s\n" uu___3);
                     FStar_Pervasives_Native.Some elt)
-               | uu____1527 -> FStar_Pervasives_Native.None) in
-        let uu____1542 = FStar_TypeChecker_Env.lookup_qname env lid in
-        FStar_Util.bind_opt uu____1542 mapper
+               | uu___1 -> FStar_Pervasives_Native.None) in
+        let uu___ = FStar_TypeChecker_Env.lookup_qname env lid in
+        FStar_Util.bind_opt uu___ mapper
 let (is_univ : FStar_TypeChecker_NBETerm.t -> Prims.bool) =
   fun tm ->
     match tm.FStar_TypeChecker_NBETerm.nbe_t with
-    | FStar_TypeChecker_NBETerm.Univ uu____1586 -> true
-    | uu____1587 -> false
+    | FStar_TypeChecker_NBETerm.Univ uu___ -> true
+    | uu___ -> false
 let (un_univ : FStar_TypeChecker_NBETerm.t -> FStar_Syntax_Syntax.universe) =
   fun tm ->
     match tm.FStar_TypeChecker_NBETerm.nbe_t with
     | FStar_TypeChecker_NBETerm.Univ u -> u
-    | uu____1594 ->
-        let uu____1595 =
-          let uu____1596 = FStar_TypeChecker_NBETerm.t_to_string tm in
-          Prims.op_Hat "Not a universe: " uu____1596 in
-        failwith uu____1595
+    | uu___ ->
+        let uu___1 =
+          let uu___2 = FStar_TypeChecker_NBETerm.t_to_string tm in
+          Prims.op_Hat "Not a universe: " uu___2 in
+        failwith uu___1
 let (is_constr_fv : FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun fvar ->
     fvar.FStar_Syntax_Syntax.fv_qual =
@@ -474,17 +451,16 @@ let (is_constr : FStar_TypeChecker_Env.qninfo -> Prims.bool) =
         (FStar_Util.Inr
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (uu____1609, uu____1610, uu____1611, uu____1612, uu____1613,
-               uu____1614);
-            FStar_Syntax_Syntax.sigrng = uu____1615;
-            FStar_Syntax_Syntax.sigquals = uu____1616;
-            FStar_Syntax_Syntax.sigmeta = uu____1617;
-            FStar_Syntax_Syntax.sigattrs = uu____1618;
-            FStar_Syntax_Syntax.sigopts = uu____1619;_},
-          uu____1620),
-         uu____1621)
+              (uu___, uu___1, uu___2, uu___3, uu___4, uu___5);
+            FStar_Syntax_Syntax.sigrng = uu___6;
+            FStar_Syntax_Syntax.sigquals = uu___7;
+            FStar_Syntax_Syntax.sigmeta = uu___8;
+            FStar_Syntax_Syntax.sigattrs = uu___9;
+            FStar_Syntax_Syntax.sigopts = uu___10;_},
+          uu___11),
+         uu___12)
         -> true
-    | uu____1678 -> false
+    | uu___ -> false
 let (translate_univ :
   config ->
     FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -505,14 +481,13 @@ let (translate_univ :
                 then FStar_Syntax_Syntax.U_zero
                 else failwith "Universe index out of bounds"
           | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____1710 = aux u3 in
-              FStar_Syntax_Syntax.U_succ uu____1710
+              let uu___ = aux u3 in FStar_Syntax_Syntax.U_succ uu___
           | FStar_Syntax_Syntax.U_max us ->
-              let uu____1714 = FStar_List.map aux us in
-              FStar_Syntax_Syntax.U_max uu____1714
+              let uu___ = FStar_List.map aux us in
+              FStar_Syntax_Syntax.U_max uu___
           | FStar_Syntax_Syntax.U_unknown -> u2
-          | FStar_Syntax_Syntax.U_name uu____1717 -> u2
-          | FStar_Syntax_Syntax.U_unif uu____1718 -> u2
+          | FStar_Syntax_Syntax.U_name uu___ -> u2
+          | FStar_Syntax_Syntax.U_unif uu___ -> u2
           | FStar_Syntax_Syntax.U_zero -> u2 in
         aux u
 let (find_let :
@@ -525,10 +500,10 @@ let (find_let :
       FStar_Util.find_map lbs
         (fun lb ->
            match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inl uu____1750 -> failwith "find_let : impossible"
+           | FStar_Util.Inl uu___ -> failwith "find_let : impossible"
            | FStar_Util.Inr name ->
-               let uu____1754 = FStar_Syntax_Syntax.fv_eq name fvar in
-               if uu____1754
+               let uu___ = FStar_Syntax_Syntax.fv_eq name fvar in
+               if uu___
                then FStar_Pervasives_Native.Some lb
                else FStar_Pervasives_Native.None)
 let (mk_rt :
@@ -558,111 +533,107 @@ let rec (translate :
         let debug1 = debug cfg in
         let mk_t1 t = mk_rt e.FStar_Syntax_Syntax.pos t in
         debug1
-          (fun uu____2041 ->
-             let uu____2042 =
-               let uu____2043 = FStar_Syntax_Subst.compress e in
-               FStar_Syntax_Print.tag_of_term uu____2043 in
-             let uu____2044 =
-               let uu____2045 = FStar_Syntax_Subst.compress e in
-               FStar_Syntax_Print.term_to_string uu____2045 in
-             FStar_Util.print2 "Term: %s - %s\n" uu____2042 uu____2044);
-        (let uu____2046 =
-           let uu____2047 = FStar_Syntax_Subst.compress e in
-           uu____2047.FStar_Syntax_Syntax.n in
-         match uu____2046 with
-         | FStar_Syntax_Syntax.Tm_delayed (uu____2050, uu____2051) ->
+          (fun uu___1 ->
+             let uu___2 =
+               let uu___3 = FStar_Syntax_Subst.compress e in
+               FStar_Syntax_Print.tag_of_term uu___3 in
+             let uu___3 =
+               let uu___4 = FStar_Syntax_Subst.compress e in
+               FStar_Syntax_Print.term_to_string uu___4 in
+             FStar_Util.print2 "Term: %s - %s\n" uu___2 uu___3);
+        (let uu___1 =
+           let uu___2 = FStar_Syntax_Subst.compress e in
+           uu___2.FStar_Syntax_Syntax.n in
+         match uu___1 with
+         | FStar_Syntax_Syntax.Tm_delayed (uu___2, uu___3) ->
              failwith "Tm_delayed: Impossible"
          | FStar_Syntax_Syntax.Tm_unknown ->
              mk_t1 FStar_TypeChecker_NBETerm.Unknown
          | FStar_Syntax_Syntax.Tm_constant c ->
-             let uu____2073 =
-               let uu____2074 = translate_constant c in
-               FStar_TypeChecker_NBETerm.Constant uu____2074 in
-             FStar_All.pipe_left mk_t1 uu____2073
+             let uu___2 =
+               let uu___3 = translate_constant c in
+               FStar_TypeChecker_NBETerm.Constant uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_bvar db ->
              if db.FStar_Syntax_Syntax.index < (FStar_List.length bs)
              then
                let t = FStar_List.nth bs db.FStar_Syntax_Syntax.index in
                (debug1
-                  (fun uu____2084 ->
-                     let uu____2085 = FStar_TypeChecker_NBETerm.t_to_string t in
-                     let uu____2086 =
-                       let uu____2087 =
+                  (fun uu___3 ->
+                     let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
+                     let uu___5 =
+                       let uu___6 =
                          FStar_List.map FStar_TypeChecker_NBETerm.t_to_string
                            bs in
-                       FStar_All.pipe_right uu____2087
-                         (FStar_String.concat "; ") in
+                       FStar_All.pipe_right uu___6 (FStar_String.concat "; ") in
                      FStar_Util.print2
-                       "Resolved bvar to %s\n\tcontext is [%s]\n" uu____2085
-                       uu____2086);
+                       "Resolved bvar to %s\n\tcontext is [%s]\n" uu___4
+                       uu___5);
                 t)
              else failwith "de Bruijn index out of bounds"
          | FStar_Syntax_Syntax.Tm_uinst (t, us) ->
              (debug1
-                (fun uu____2106 ->
-                   let uu____2107 = FStar_Syntax_Print.term_to_string t in
-                   let uu____2108 =
-                     let uu____2109 =
+                (fun uu___3 ->
+                   let uu___4 = FStar_Syntax_Print.term_to_string t in
+                   let uu___5 =
+                     let uu___6 =
                        FStar_List.map FStar_Syntax_Print.univ_to_string us in
-                     FStar_All.pipe_right uu____2109
-                       (FStar_String.concat ", ") in
-                   FStar_Util.print2 "Uinst term : %s\nUnivs : %s\n"
-                     uu____2107 uu____2108);
-              (let uu____2114 = translate cfg bs t in
-               let uu____2115 =
+                     FStar_All.pipe_right uu___6 (FStar_String.concat ", ") in
+                   FStar_Util.print2 "Uinst term : %s\nUnivs : %s\n" uu___4
+                     uu___5);
+              (let uu___3 = translate cfg bs t in
+               let uu___4 =
                  FStar_List.map
                    (fun x ->
-                      let uu____2119 =
-                        let uu____2120 =
-                          let uu____2121 = translate_univ cfg bs x in
-                          FStar_TypeChecker_NBETerm.Univ uu____2121 in
-                        FStar_All.pipe_left mk_t1 uu____2120 in
-                      FStar_TypeChecker_NBETerm.as_arg uu____2119) us in
-               iapp cfg uu____2114 uu____2115))
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 = translate_univ cfg bs x in
+                          FStar_TypeChecker_NBETerm.Univ uu___7 in
+                        FStar_All.pipe_left mk_t1 uu___6 in
+                      FStar_TypeChecker_NBETerm.as_arg uu___5) us in
+               iapp cfg uu___3 uu___4))
          | FStar_Syntax_Syntax.Tm_type u ->
-             let uu____2123 =
-               let uu____2124 = translate_univ cfg bs u in
-               FStar_TypeChecker_NBETerm.Type_t uu____2124 in
-             FStar_All.pipe_left mk_t1 uu____2123
+             let uu___2 =
+               let uu___3 = translate_univ cfg bs u in
+               FStar_TypeChecker_NBETerm.Type_t uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_arrow (xs, c) ->
-             let norm uu____2154 =
-               let uu____2155 =
+             let norm uu___2 =
+               let uu___3 =
                  FStar_List.fold_left
-                   (fun uu____2199 ->
-                      fun uu____2200 ->
-                        match (uu____2199, uu____2200) with
+                   (fun uu___4 ->
+                      fun uu___5 ->
+                        match (uu___4, uu___5) with
                         | ((ctx, binders_rev), (x, q)) ->
                             let t =
-                              let uu____2304 =
+                              let uu___6 =
                                 translate cfg ctx x.FStar_Syntax_Syntax.sort in
-                              readback cfg uu____2304 in
+                              readback cfg uu___6 in
                             let x1 =
-                              let uu___399_2306 =
-                                FStar_Syntax_Syntax.freshen_bv x in
+                              let uu___6 = FStar_Syntax_Syntax.freshen_bv x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___399_2306.FStar_Syntax_Syntax.ppname);
+                                  (uu___6.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___399_2306.FStar_Syntax_Syntax.index);
+                                  (uu___6.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               } in
                             let ctx1 =
-                              let uu____2310 =
+                              let uu___6 =
                                 FStar_TypeChecker_NBETerm.mkAccuVar x1 in
-                              uu____2310 :: ctx in
+                              uu___6 :: ctx in
                             (ctx1, ((x1, q) :: binders_rev))) (bs, []) xs in
-               match uu____2155 with
+               match uu___3 with
                | (ctx, binders_rev) ->
                    let c1 =
-                     let uu____2370 = translate_comp cfg ctx c in
-                     readback_comp cfg uu____2370 in
+                     let uu___4 = translate_comp cfg ctx c in
+                     readback_comp cfg uu___4 in
                    FStar_Syntax_Util.arrow (FStar_List.rev binders_rev) c1 in
-             let uu____2377 =
-               let uu____2378 =
-                 let uu____2395 = FStar_Thunk.mk norm in
-                 FStar_Util.Inl uu____2395 in
-               FStar_TypeChecker_NBETerm.Arrow uu____2378 in
-             FStar_All.pipe_left mk_t1 uu____2377
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Thunk.mk norm in FStar_Util.Inl uu___4 in
+               FStar_TypeChecker_NBETerm.Arrow uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_refine (bv, tm) ->
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
@@ -671,66 +642,64 @@ let rec (translate :
                FStar_All.pipe_left mk_t1
                  (FStar_TypeChecker_NBETerm.Refinement
                     ((fun y -> translate cfg (y :: bs) tm),
-                      (fun uu____2431 ->
-                         let uu____2432 =
+                      (fun uu___3 ->
+                         let uu___4 =
                            translate cfg bs bv.FStar_Syntax_Syntax.sort in
-                         FStar_TypeChecker_NBETerm.as_arg uu____2432)))
-         | FStar_Syntax_Syntax.Tm_ascribed (t, uu____2434, uu____2435) ->
+                         FStar_TypeChecker_NBETerm.as_arg uu___4)))
+         | FStar_Syntax_Syntax.Tm_ascribed (t, uu___2, uu___3) ->
              translate cfg bs t
          | FStar_Syntax_Syntax.Tm_uvar (u, (subst, set_use_range)) ->
-             let norm_uvar uu____2502 =
-               let norm_subst_elt uu___1_2508 =
-                 match uu___1_2508 with
+             let norm_uvar uu___2 =
+               let norm_subst_elt uu___3 =
+                 match uu___3 with
                  | FStar_Syntax_Syntax.NT (x, t) ->
-                     let uu____2515 =
-                       let uu____2522 =
-                         let uu____2525 = translate cfg bs t in
-                         readback cfg uu____2525 in
-                       (x, uu____2522) in
-                     FStar_Syntax_Syntax.NT uu____2515
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 = translate cfg bs t in
+                         readback cfg uu___6 in
+                       (x, uu___5) in
+                     FStar_Syntax_Syntax.NT uu___4
                  | FStar_Syntax_Syntax.NM (x, i) ->
                      let x_i =
                        FStar_Syntax_Syntax.bv_to_tm
-                         (let uu___436_2533 = x in
+                         (let uu___4 = x in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___436_2533.FStar_Syntax_Syntax.ppname);
+                              (uu___4.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index = i;
                             FStar_Syntax_Syntax.sort =
-                              (uu___436_2533.FStar_Syntax_Syntax.sort)
+                              (uu___4.FStar_Syntax_Syntax.sort)
                           }) in
                      let t =
-                       let uu____2535 = translate cfg bs x_i in
-                       readback cfg uu____2535 in
+                       let uu___4 = translate cfg bs x_i in
+                       readback cfg uu___4 in
                      (match t.FStar_Syntax_Syntax.n with
                       | FStar_Syntax_Syntax.Tm_bvar x_j ->
                           FStar_Syntax_Syntax.NM
                             (x, (x_j.FStar_Syntax_Syntax.index))
-                      | uu____2537 -> FStar_Syntax_Syntax.NT (x, t))
-                 | uu____2540 ->
+                      | uu___4 -> FStar_Syntax_Syntax.NT (x, t))
+                 | uu___4 ->
                      failwith "Impossible: subst invariant of uvar nodes" in
                let subst1 =
                  FStar_List.map (FStar_List.map norm_subst_elt) subst in
-               let uu___446_2550 = e in
+               let uu___3 = e in
                {
                  FStar_Syntax_Syntax.n =
                    (FStar_Syntax_Syntax.Tm_uvar (u, (subst1, set_use_range)));
-                 FStar_Syntax_Syntax.pos =
-                   (uu___446_2550.FStar_Syntax_Syntax.pos);
-                 FStar_Syntax_Syntax.vars =
-                   (uu___446_2550.FStar_Syntax_Syntax.vars)
+                 FStar_Syntax_Syntax.pos = (uu___3.FStar_Syntax_Syntax.pos);
+                 FStar_Syntax_Syntax.vars = (uu___3.FStar_Syntax_Syntax.vars)
                } in
-             let uu____2563 =
-               let uu____2564 =
-                 let uu____2575 =
-                   let uu____2576 = FStar_Thunk.mk norm_uvar in
-                   FStar_TypeChecker_NBETerm.UVar uu____2576 in
-                 (uu____2575, []) in
-               FStar_TypeChecker_NBETerm.Accu uu____2564 in
-             FStar_All.pipe_left mk_t1 uu____2563
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = FStar_Thunk.mk norm_uvar in
+                   FStar_TypeChecker_NBETerm.UVar uu___5 in
+                 (uu___4, []) in
+               FStar_TypeChecker_NBETerm.Accu uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_name x ->
              FStar_TypeChecker_NBETerm.mkAccuVar x
-         | FStar_Syntax_Syntax.Tm_abs ([], uu____2590, uu____2591) ->
+         | FStar_Syntax_Syntax.Tm_abs ([], uu___2, uu___3) ->
              failwith "Impossible: abstraction with no binders"
          | FStar_Syntax_Syntax.Tm_abs (xs, body, resc) ->
              FStar_All.pipe_left mk_t1
@@ -738,56 +707,56 @@ let rec (translate :
                   ((fun ys -> translate cfg (FStar_List.append ys bs) body),
                     (FStar_Util.Inl (bs, xs, resc)), (FStar_List.length xs)))
          | FStar_Syntax_Syntax.Tm_fvar fvar ->
-             let uu____2697 = try_in_cache cfg fvar in
-             (match uu____2697 with
+             let uu___2 = try_in_cache cfg fvar in
+             (match uu___2 with
               | FStar_Pervasives_Native.Some t -> t
-              | uu____2701 ->
-                  let uu____2704 =
+              | uu___3 ->
+                  let uu___4 =
                     FStar_Syntax_Syntax.set_range_of_fv fvar
                       e.FStar_Syntax_Syntax.pos in
-                  translate_fv cfg bs uu____2704)
+                  translate_fv cfg bs uu___4)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify);
-                FStar_Syntax_Syntax.pos = uu____2705;
-                FStar_Syntax_Syntax.vars = uu____2706;_},
+                FStar_Syntax_Syntax.pos = uu___2;
+                FStar_Syntax_Syntax.vars = uu___3;_},
               arg::more::args)
              ->
-             let uu____2766 = FStar_Syntax_Util.head_and_args e in
-             (match uu____2766 with
-              | (head, uu____2784) ->
+             let uu___4 = FStar_Syntax_Util.head_and_args e in
+             (match uu___4 with
+              | (head, uu___5) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       e.FStar_Syntax_Syntax.pos in
-                  let uu____2826 =
+                  let uu___6 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       e.FStar_Syntax_Syntax.pos in
-                  translate cfg bs uu____2826)
+                  translate cfg bs uu___6)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____2835);
-                FStar_Syntax_Syntax.pos = uu____2836;
-                FStar_Syntax_Syntax.vars = uu____2837;_},
+                  (FStar_Const.Const_reflect uu___2);
+                FStar_Syntax_Syntax.pos = uu___3;
+                FStar_Syntax_Syntax.vars = uu___4;_},
               arg::more::args)
              ->
-             let uu____2897 = FStar_Syntax_Util.head_and_args e in
-             (match uu____2897 with
-              | (head, uu____2915) ->
+             let uu___5 = FStar_Syntax_Util.head_and_args e in
+             (match uu___5 with
+              | (head, uu___6) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       e.FStar_Syntax_Syntax.pos in
-                  let uu____2957 =
+                  let uu___7 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       e.FStar_Syntax_Syntax.pos in
-                  translate cfg bs uu____2957)
+                  translate cfg bs uu___7)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____2966);
-                FStar_Syntax_Syntax.pos = uu____2967;
-                FStar_Syntax_Syntax.vars = uu____2968;_},
+                  (FStar_Const.Const_reflect uu___2);
+                FStar_Syntax_Syntax.pos = uu___3;
+                FStar_Syntax_Syntax.vars = uu___4;_},
               arg::[])
              when (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              let cfg1 = reifying_false cfg in
@@ -795,22 +764,22 @@ let rec (translate :
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3013);
-                FStar_Syntax_Syntax.pos = uu____3014;
-                FStar_Syntax_Syntax.vars = uu____3015;_},
+                  (FStar_Const.Const_reflect uu___2);
+                FStar_Syntax_Syntax.pos = uu___3;
+                FStar_Syntax_Syntax.vars = uu___4;_},
               arg::[])
              ->
-             let uu____3055 =
-               let uu____3056 =
+             let uu___5 =
+               let uu___6 =
                  translate cfg bs (FStar_Pervasives_Native.fst arg) in
-               FStar_TypeChecker_NBETerm.Reflect uu____3056 in
-             FStar_All.pipe_left mk_t1 uu____3055
+               FStar_TypeChecker_NBETerm.Reflect uu___6 in
+             FStar_All.pipe_left mk_t1 uu___5
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify);
-                FStar_Syntax_Syntax.pos = uu____3061;
-                FStar_Syntax_Syntax.vars = uu____3062;_},
+                FStar_Syntax_Syntax.pos = uu___2;
+                FStar_Syntax_Syntax.vars = uu___3;_},
               arg::[])
              when
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
@@ -819,156 +788,153 @@ let rec (translate :
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app (head, args) ->
              (debug1
-                (fun uu____3141 ->
-                   let uu____3142 = FStar_Syntax_Print.term_to_string head in
-                   let uu____3143 = FStar_Syntax_Print.args_to_string args in
-                   FStar_Util.print2 "Application: %s @ %s\n" uu____3142
-                     uu____3143);
-              (let uu____3144 = translate cfg bs head in
-               let uu____3145 =
+                (fun uu___3 ->
+                   let uu___4 = FStar_Syntax_Print.term_to_string head in
+                   let uu___5 = FStar_Syntax_Print.args_to_string args in
+                   FStar_Util.print2 "Application: %s @ %s\n" uu___4 uu___5);
+              (let uu___3 = translate cfg bs head in
+               let uu___4 =
                  FStar_List.map
                    (fun x ->
-                      let uu____3167 =
+                      let uu___5 =
                         translate cfg bs (FStar_Pervasives_Native.fst x) in
-                      (uu____3167, (FStar_Pervasives_Native.snd x))) args in
-               iapp cfg uu____3144 uu____3145))
+                      (uu___5, (FStar_Pervasives_Native.snd x))) args in
+               iapp cfg uu___3 uu___4))
          | FStar_Syntax_Syntax.Tm_match (scrut, branches) ->
-             let make_branches uu____3219 =
+             let make_branches uu___2 =
                let cfg1 = zeta_false cfg in
                let rec process_pattern bs1 p =
-                 let uu____3250 =
+                 let uu___3 =
                    match p.FStar_Syntax_Syntax.v with
                    | FStar_Syntax_Syntax.Pat_constant c ->
                        (bs1, (FStar_Syntax_Syntax.Pat_constant c))
                    | FStar_Syntax_Syntax.Pat_cons (fvar, args) ->
-                       let uu____3284 =
+                       let uu___4 =
                          FStar_List.fold_left
-                           (fun uu____3322 ->
-                              fun uu____3323 ->
-                                match (uu____3322, uu____3323) with
+                           (fun uu___5 ->
+                              fun uu___6 ->
+                                match (uu___5, uu___6) with
                                 | ((bs2, args1), (arg, b)) ->
-                                    let uu____3404 = process_pattern bs2 arg in
-                                    (match uu____3404 with
+                                    let uu___7 = process_pattern bs2 arg in
+                                    (match uu___7 with
                                      | (bs', arg') ->
                                          (bs', ((arg', b) :: args1))))
                            (bs1, []) args in
-                       (match uu____3284 with
+                       (match uu___4 with
                         | (bs', args') ->
                             (bs',
                               (FStar_Syntax_Syntax.Pat_cons
                                  (fvar, (FStar_List.rev args')))))
                    | FStar_Syntax_Syntax.Pat_var bvar ->
                        let x =
-                         let uu____3493 =
-                           let uu____3494 =
+                         let uu___4 =
+                           let uu___5 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort in
-                           readback cfg1 uu____3494 in
+                           readback cfg1 uu___5 in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3493 in
-                       let uu____3495 =
-                         let uu____3498 =
-                           FStar_TypeChecker_NBETerm.mkAccuVar x in
-                         uu____3498 :: bs1 in
-                       (uu____3495, (FStar_Syntax_Syntax.Pat_var x))
+                           FStar_Pervasives_Native.None uu___4 in
+                       let uu___4 =
+                         let uu___5 = FStar_TypeChecker_NBETerm.mkAccuVar x in
+                         uu___5 :: bs1 in
+                       (uu___4, (FStar_Syntax_Syntax.Pat_var x))
                    | FStar_Syntax_Syntax.Pat_wild bvar ->
                        let x =
-                         let uu____3503 =
-                           let uu____3504 =
+                         let uu___4 =
+                           let uu___5 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort in
-                           readback cfg1 uu____3504 in
+                           readback cfg1 uu___5 in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3503 in
-                       let uu____3505 =
-                         let uu____3508 =
-                           FStar_TypeChecker_NBETerm.mkAccuVar x in
-                         uu____3508 :: bs1 in
-                       (uu____3505, (FStar_Syntax_Syntax.Pat_wild x))
+                           FStar_Pervasives_Native.None uu___4 in
+                       let uu___4 =
+                         let uu___5 = FStar_TypeChecker_NBETerm.mkAccuVar x in
+                         uu___5 :: bs1 in
+                       (uu___4, (FStar_Syntax_Syntax.Pat_wild x))
                    | FStar_Syntax_Syntax.Pat_dot_term (bvar, tm) ->
                        let x =
-                         let uu____3518 =
-                           let uu____3519 =
+                         let uu___4 =
+                           let uu___5 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort in
-                           readback cfg1 uu____3519 in
+                           readback cfg1 uu___5 in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3518 in
-                       let uu____3520 =
-                         let uu____3521 =
-                           let uu____3528 =
-                             let uu____3531 = translate cfg1 bs1 tm in
-                             readback cfg1 uu____3531 in
-                           (x, uu____3528) in
-                         FStar_Syntax_Syntax.Pat_dot_term uu____3521 in
-                       (bs1, uu____3520) in
-                 match uu____3250 with
+                           FStar_Pervasives_Native.None uu___4 in
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 = translate cfg1 bs1 tm in
+                             readback cfg1 uu___7 in
+                           (x, uu___6) in
+                         FStar_Syntax_Syntax.Pat_dot_term uu___5 in
+                       (bs1, uu___4) in
+                 match uu___3 with
                  | (bs2, p_new) ->
                      (bs2,
-                       (let uu___573_3551 = p in
+                       (let uu___4 = p in
                         {
                           FStar_Syntax_Syntax.v = p_new;
                           FStar_Syntax_Syntax.p =
-                            (uu___573_3551.FStar_Syntax_Syntax.p)
+                            (uu___4.FStar_Syntax_Syntax.p)
                         })) in
                FStar_List.map
-                 (fun uu____3570 ->
-                    match uu____3570 with
+                 (fun uu___3 ->
+                    match uu___3 with
                     | (pat, when_clause, e1) ->
-                        let uu____3592 = process_pattern bs pat in
-                        (match uu____3592 with
+                        let uu___4 = process_pattern bs pat in
+                        (match uu___4 with
                          | (bs', pat') ->
-                             let uu____3605 =
-                               let uu____3606 =
-                                 let uu____3609 = translate cfg1 bs' e1 in
-                                 readback cfg1 uu____3609 in
-                               (pat', when_clause, uu____3606) in
-                             FStar_Syntax_Util.branch uu____3605)) branches in
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 = translate cfg1 bs' e1 in
+                                 readback cfg1 uu___7 in
+                               (pat', when_clause, uu___6) in
+                             FStar_Syntax_Util.branch uu___5)) branches in
              let scrut1 = translate cfg bs scrut in
              (debug1
-                (fun uu____3626 ->
-                   let uu____3627 =
+                (fun uu___3 ->
+                   let uu___4 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                   let uu____3628 = FStar_Syntax_Print.term_to_string e in
-                   FStar_Util.print2 "%s: Translating match %s\n" uu____3627
-                     uu____3628);
+                   let uu___5 = FStar_Syntax_Print.term_to_string e in
+                   FStar_Util.print2 "%s: Translating match %s\n" uu___4
+                     uu___5);
               (let scrut2 = unlazy_unmeta scrut1 in
                match scrut2.FStar_TypeChecker_NBETerm.nbe_t with
                | FStar_TypeChecker_NBETerm.Construct (c, us, args) ->
                    (debug1
-                      (fun uu____3654 ->
-                         let uu____3655 =
-                           let uu____3656 =
+                      (fun uu___4 ->
+                         let uu___5 =
+                           let uu___6 =
                              FStar_All.pipe_right args
                                (FStar_List.map
-                                  (fun uu____3679 ->
-                                     match uu____3679 with
+                                  (fun uu___7 ->
+                                     match uu___7 with
                                      | (x, q) ->
-                                         let uu____3692 =
+                                         let uu___8 =
                                            FStar_TypeChecker_NBETerm.t_to_string
                                              x in
                                          Prims.op_Hat
                                            (if FStar_Util.is_some q
                                             then "#"
-                                            else "") uu____3692)) in
-                           FStar_All.pipe_right uu____3656
+                                            else "") uu___8)) in
+                           FStar_All.pipe_right uu___6
                              (FStar_String.concat "; ") in
-                         FStar_Util.print1 "Match args: %s\n" uu____3655);
-                    (let uu____3696 = pickBranch cfg scrut2 branches in
-                     match uu____3696 with
+                         FStar_Util.print1 "Match args: %s\n" uu___5);
+                    (let uu___4 = pickBranch cfg scrut2 branches in
+                     match uu___4 with
                      | FStar_Pervasives_Native.Some (branch, args1) ->
-                         let uu____3717 =
+                         let uu___5 =
                            FStar_List.fold_left
                              (fun bs1 -> fun x -> x :: bs1) bs args1 in
-                         translate cfg uu____3717 branch
+                         translate cfg uu___5 branch
                      | FStar_Pervasives_Native.None ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches))
                | FStar_TypeChecker_NBETerm.Constant c ->
                    (debug1
-                      (fun uu____3740 ->
-                         let uu____3741 =
+                      (fun uu___4 ->
+                         let uu___5 =
                            FStar_TypeChecker_NBETerm.t_to_string scrut2 in
-                         FStar_Util.print1 "Match constant : %s\n" uu____3741);
-                    (let uu____3742 = pickBranch cfg scrut2 branches in
-                     match uu____3742 with
+                         FStar_Util.print1 "Match constant : %s\n" uu___5);
+                    (let uu___4 = pickBranch cfg scrut2 branches in
+                     match uu___4 with
                      | FStar_Pervasives_Native.Some (branch, []) ->
                          translate cfg bs branch
                      | FStar_Pervasives_Native.Some (branch, arg::[]) ->
@@ -976,10 +942,10 @@ let rec (translate :
                      | FStar_Pervasives_Native.None ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches
-                     | FStar_Pervasives_Native.Some (uu____3776, hd::tl) ->
+                     | FStar_Pervasives_Native.Some (uu___5, hd::tl) ->
                          failwith
                            "Impossible: Matching on constants cannot bind more than one variable"))
-               | uu____3789 ->
+               | uu___3 ->
                    FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 make_branches))
          | FStar_Syntax_Syntax.Tm_meta
              (e1, FStar_Syntax_Syntax.Meta_monadic (m, t)) when
@@ -990,74 +956,69 @@ let rec (translate :
              (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              translate_monadic_lift (m, m', t) cfg bs e1
          | FStar_Syntax_Syntax.Tm_meta (e1, meta) ->
-             let norm_meta uu____3828 =
+             let norm_meta uu___2 =
                let norm t =
-                 let uu____3835 = translate cfg bs t in
-                 readback cfg uu____3835 in
+                 let uu___3 = translate cfg bs t in readback cfg uu___3 in
                match meta with
-               | FStar_Syntax_Syntax.Meta_named uu____3836 -> meta
-               | FStar_Syntax_Syntax.Meta_labeled uu____3837 -> meta
-               | FStar_Syntax_Syntax.Meta_desugared uu____3844 -> meta
+               | FStar_Syntax_Syntax.Meta_named uu___3 -> meta
+               | FStar_Syntax_Syntax.Meta_labeled uu___3 -> meta
+               | FStar_Syntax_Syntax.Meta_desugared uu___3 -> meta
                | FStar_Syntax_Syntax.Meta_pattern (ts, args) ->
-                   let uu____3879 =
-                     let uu____3900 = FStar_List.map norm ts in
-                     let uu____3909 =
+                   let uu___3 =
+                     let uu___4 = FStar_List.map norm ts in
+                     let uu___5 =
                        FStar_List.map
                          (FStar_List.map
-                            (fun uu____3958 ->
-                               match uu____3958 with
-                               | (t, a) ->
-                                   let uu____3977 = norm t in (uu____3977, a)))
+                            (fun uu___6 ->
+                               match uu___6 with
+                               | (t, a) -> let uu___7 = norm t in (uu___7, a)))
                          args in
-                     (uu____3900, uu____3909) in
-                   FStar_Syntax_Syntax.Meta_pattern uu____3879
+                     (uu___4, uu___5) in
+                   FStar_Syntax_Syntax.Meta_pattern uu___3
                | FStar_Syntax_Syntax.Meta_monadic (m, t) ->
-                   let uu____4002 =
-                     let uu____4009 = norm t in (m, uu____4009) in
-                   FStar_Syntax_Syntax.Meta_monadic uu____4002
+                   let uu___3 = let uu___4 = norm t in (m, uu___4) in
+                   FStar_Syntax_Syntax.Meta_monadic uu___3
                | FStar_Syntax_Syntax.Meta_monadic_lift (m0, m1, t) ->
-                   let uu____4021 =
-                     let uu____4030 = norm t in (m0, m1, uu____4030) in
-                   FStar_Syntax_Syntax.Meta_monadic_lift uu____4021 in
-             let uu____4035 =
-               let uu____4036 =
-                 let uu____4043 = translate cfg bs e1 in
-                 let uu____4044 = FStar_Thunk.mk norm_meta in
-                 (uu____4043, uu____4044) in
-               FStar_TypeChecker_NBETerm.Meta uu____4036 in
-             FStar_All.pipe_left mk_t1 uu____4035
+                   let uu___3 = let uu___4 = norm t in (m0, m1, uu___4) in
+                   FStar_Syntax_Syntax.Meta_monadic_lift uu___3 in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = translate cfg bs e1 in
+                 let uu___5 = FStar_Thunk.mk norm_meta in (uu___4, uu___5) in
+               FStar_TypeChecker_NBETerm.Meta uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
-             let uu____4063 =
+             let uu___2 =
                FStar_TypeChecker_Cfg.should_reduce_local_let cfg.core_cfg lb in
-             if uu____4063
+             if uu___2
              then
-               let uu____4064 =
+               let uu___3 =
                  (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                     &&
                     (FStar_Syntax_Util.is_unit lb.FStar_Syntax_Syntax.lbtyp))
                    &&
                    (FStar_Syntax_Util.is_pure_or_ghost_effect
                       lb.FStar_Syntax_Syntax.lbeff) in
-               (if uu____4064
+               (if uu___3
                 then
                   let bs1 =
-                    let uu____4068 =
-                      let uu____4069 =
+                    let uu___4 =
+                      let uu___5 =
                         FStar_Syntax_Syntax.range_of_lbname
                           lb.FStar_Syntax_Syntax.lbname in
-                      mk_rt uu____4069
+                      mk_rt uu___5
                         (FStar_TypeChecker_NBETerm.Constant
                            FStar_TypeChecker_NBETerm.Unit) in
-                    uu____4068 :: bs in
+                    uu___4 :: bs in
                   translate cfg bs1 body
                 else
                   (let bs1 =
-                     let uu____4074 = translate_letbinding cfg bs lb in
-                     uu____4074 :: bs in
+                     let uu___5 = translate_letbinding cfg bs lb in uu___5 ::
+                       bs in
                    translate cfg bs1 body))
              else
-               (let def uu____4081 =
-                  let uu____4082 =
+               (let def uu___4 =
+                  let uu___5 =
                     (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                        &&
                        (FStar_Syntax_Util.is_unit
@@ -1065,38 +1026,37 @@ let rec (translate :
                       &&
                       (FStar_Syntax_Util.is_pure_or_ghost_effect
                          lb.FStar_Syntax_Syntax.lbeff) in
-                  if uu____4082
+                  if uu___5
                   then
                     FStar_All.pipe_left mk_t1
                       (FStar_TypeChecker_NBETerm.Constant
                          FStar_TypeChecker_NBETerm.Unit)
                   else translate cfg bs lb.FStar_Syntax_Syntax.lbdef in
-                let typ uu____4089 =
+                let typ uu___4 =
                   translate cfg bs lb.FStar_Syntax_Syntax.lbtyp in
                 let name =
-                  let uu____4091 =
-                    FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                  FStar_Syntax_Syntax.freshen_bv uu____4091 in
+                  let uu___4 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                  FStar_Syntax_Syntax.freshen_bv uu___4 in
                 let bs1 =
-                  let uu____4095 =
-                    let uu____4096 = FStar_Syntax_Syntax.range_of_bv name in
-                    mk_rt uu____4096
+                  let uu___4 =
+                    let uu___5 = FStar_Syntax_Syntax.range_of_bv name in
+                    mk_rt uu___5
                       (FStar_TypeChecker_NBETerm.Accu
                          ((FStar_TypeChecker_NBETerm.Var name), [])) in
-                  uu____4095 :: bs in
-                let body1 uu____4112 = translate cfg bs1 body in
-                let uu____4113 =
-                  let uu____4114 =
-                    let uu____4125 =
-                      let uu____4126 =
-                        let uu____4143 = FStar_Thunk.mk typ in
-                        let uu____4146 = FStar_Thunk.mk def in
-                        let uu____4149 = FStar_Thunk.mk body1 in
-                        (name, uu____4143, uu____4146, uu____4149, lb) in
-                      FStar_TypeChecker_NBETerm.UnreducedLet uu____4126 in
-                    (uu____4125, []) in
-                  FStar_TypeChecker_NBETerm.Accu uu____4114 in
-                FStar_All.pipe_left mk_t1 uu____4113)
+                  uu___4 :: bs in
+                let body1 uu___4 = translate cfg bs1 body in
+                let uu___4 =
+                  let uu___5 =
+                    let uu___6 =
+                      let uu___7 =
+                        let uu___8 = FStar_Thunk.mk typ in
+                        let uu___9 = FStar_Thunk.mk def in
+                        let uu___10 = FStar_Thunk.mk body1 in
+                        (name, uu___8, uu___9, uu___10, lb) in
+                      FStar_TypeChecker_NBETerm.UnreducedLet uu___7 in
+                    (uu___6, []) in
+                  FStar_TypeChecker_NBETerm.Accu uu___5 in
+                FStar_All.pipe_left mk_t1 uu___4)
          | FStar_Syntax_Syntax.Tm_let ((_rec, lbs), body) ->
              if
                (Prims.op_Negation
@@ -1107,64 +1067,62 @@ let rec (translate :
                let vars =
                  FStar_List.map
                    (fun lb ->
-                      let uu____4191 =
+                      let uu___2 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                      FStar_Syntax_Syntax.freshen_bv uu____4191) lbs in
+                      FStar_Syntax_Syntax.freshen_bv uu___2) lbs in
                let typs =
                  FStar_List.map
                    (fun lb -> translate cfg bs lb.FStar_Syntax_Syntax.lbtyp)
                    lbs in
                let rec_bs =
-                 let uu____4200 =
+                 let uu___2 =
                    FStar_List.map
                      (fun v ->
-                        let uu____4206 =
-                          let uu____4211 = FStar_Syntax_Syntax.range_of_bv v in
-                          mk_rt uu____4211 in
-                        FStar_All.pipe_left uu____4206
+                        let uu___3 =
+                          let uu___4 = FStar_Syntax_Syntax.range_of_bv v in
+                          mk_rt uu___4 in
+                        FStar_All.pipe_left uu___3
                           (FStar_TypeChecker_NBETerm.Accu
                              ((FStar_TypeChecker_NBETerm.Var v), []))) vars in
-                 FStar_List.append uu____4200 bs in
+                 FStar_List.append uu___2 bs in
                let defs =
                  FStar_List.map
                    (fun lb ->
                       translate cfg rec_bs lb.FStar_Syntax_Syntax.lbdef) lbs in
                let body1 = translate cfg rec_bs body in
-               let uu____4228 =
-                 let uu____4229 =
-                   let uu____4240 =
-                     let uu____4241 =
-                       let uu____4258 = FStar_List.zip3 vars typs defs in
-                       (uu____4258, body1, lbs) in
-                     FStar_TypeChecker_NBETerm.UnreducedLetRec uu____4241 in
-                   (uu____4240, []) in
-                 FStar_TypeChecker_NBETerm.Accu uu____4229 in
-               FStar_All.pipe_left mk_t1 uu____4228
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_List.zip3 vars typs defs in
+                       (uu___6, body1, lbs) in
+                     FStar_TypeChecker_NBETerm.UnreducedLetRec uu___5 in
+                   (uu___4, []) in
+                 FStar_TypeChecker_NBETerm.Accu uu___3 in
+               FStar_All.pipe_left mk_t1 uu___2
              else
-               (let uu____4288 = make_rec_env lbs bs in
-                translate cfg uu____4288 body)
+               (let uu___3 = make_rec_env lbs bs in translate cfg uu___3 body)
          | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
              let close t =
                let bvs =
                  FStar_List.map
-                   (fun uu____4307 ->
+                   (fun uu___2 ->
                       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                         FStar_Syntax_Syntax.tun) bs in
                let s1 =
                  FStar_List.mapi
                    (fun i -> fun bv -> FStar_Syntax_Syntax.DB (i, bv)) bvs in
                let s2 =
-                 let uu____4318 = FStar_List.zip bvs bs in
+                 let uu___2 = FStar_List.zip bvs bs in
                  FStar_List.map
-                   (fun uu____4333 ->
-                      match uu____4333 with
+                   (fun uu___3 ->
+                      match uu___3 with
                       | (bv, t1) ->
-                          let uu____4340 =
-                            let uu____4347 = readback cfg t1 in
-                            (bv, uu____4347) in
-                          FStar_Syntax_Syntax.NT uu____4340) uu____4318 in
-               let uu____4352 = FStar_Syntax_Subst.subst s1 t in
-               FStar_Syntax_Subst.subst s2 uu____4352 in
+                          let uu___4 =
+                            let uu___5 = readback cfg t1 in (bv, uu___5) in
+                          FStar_Syntax_Syntax.NT uu___4) uu___2 in
+               let uu___2 = FStar_Syntax_Subst.subst s1 t in
+               FStar_Syntax_Subst.subst s2 uu___2 in
              (match qi.FStar_Syntax_Syntax.qkind with
               | FStar_Syntax_Syntax.Quote_dynamic ->
                   let qt1 = close qt in
@@ -1175,20 +1133,19 @@ let rec (translate :
                   FStar_All.pipe_left mk_t1
                     (FStar_TypeChecker_NBETerm.Quote (qt, qi1)))
          | FStar_Syntax_Syntax.Tm_lazy li ->
-             let f uu____4361 =
+             let f uu___2 =
                let t = FStar_Syntax_Util.unfold_lazy li in
                debug1
-                 (fun uu____4368 ->
-                    let uu____4369 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1 ">> Unfolding Tm_lazy to %s\n"
-                      uu____4369);
+                 (fun uu___4 ->
+                    let uu___5 = FStar_Syntax_Print.term_to_string t in
+                    FStar_Util.print1 ">> Unfolding Tm_lazy to %s\n" uu___5);
                translate cfg bs t in
-             let uu____4370 =
-               let uu____4371 =
-                 let uu____4386 = FStar_Thunk.mk f in
-                 ((FStar_Util.Inl li), uu____4386) in
-               FStar_TypeChecker_NBETerm.Lazy uu____4371 in
-             FStar_All.pipe_left mk_t1 uu____4370)
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Thunk.mk f in
+                 ((FStar_Util.Inl li), uu___4) in
+               FStar_TypeChecker_NBETerm.Lazy uu___3 in
+             FStar_All.pipe_left mk_t1 uu___2)
 and (translate_comp :
   config ->
     FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -1199,20 +1156,20 @@ and (translate_comp :
       fun c ->
         match c.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (typ, u) ->
-            let uu____4418 =
-              let uu____4425 = translate cfg bs typ in
-              let uu____4426 = fmap_opt (translate_univ cfg bs) u in
-              (uu____4425, uu____4426) in
-            FStar_TypeChecker_NBETerm.Tot uu____4418
+            let uu___ =
+              let uu___1 = translate cfg bs typ in
+              let uu___2 = fmap_opt (translate_univ cfg bs) u in
+              (uu___1, uu___2) in
+            FStar_TypeChecker_NBETerm.Tot uu___
         | FStar_Syntax_Syntax.GTotal (typ, u) ->
-            let uu____4441 =
-              let uu____4448 = translate cfg bs typ in
-              let uu____4449 = fmap_opt (translate_univ cfg bs) u in
-              (uu____4448, uu____4449) in
-            FStar_TypeChecker_NBETerm.GTot uu____4441
+            let uu___ =
+              let uu___1 = translate cfg bs typ in
+              let uu___2 = fmap_opt (translate_univ cfg bs) u in
+              (uu___1, uu___2) in
+            FStar_TypeChecker_NBETerm.GTot uu___
         | FStar_Syntax_Syntax.Comp ctyp ->
-            let uu____4455 = translate_comp_typ cfg bs ctyp in
-            FStar_TypeChecker_NBETerm.Comp uu____4455
+            let uu___ = translate_comp_typ cfg bs ctyp in
+            FStar_TypeChecker_NBETerm.Comp uu___
 and (iapp :
   config ->
     FStar_TypeChecker_NBETerm.t ->
@@ -1222,10 +1179,10 @@ and (iapp :
     fun f ->
       fun args ->
         let mk t = mk_rt f.FStar_TypeChecker_NBETerm.nbe_r t in
-        let uu____4465 =
-          let uu____4466 = unlazy_unmeta f in
-          uu____4466.FStar_TypeChecker_NBETerm.nbe_t in
-        match uu____4465 with
+        let uu___ =
+          let uu___1 = unlazy_unmeta f in
+          uu___1.FStar_TypeChecker_NBETerm.nbe_t in
+        match uu___ with
         | FStar_TypeChecker_NBETerm.Lam (f1, binders, n) ->
             let m = FStar_List.length args in
             if m < n
@@ -1234,13 +1191,13 @@ and (iapp :
               let binders1 =
                 match binders with
                 | FStar_Util.Inr raw_args ->
-                    let uu____4596 = FStar_List.splitAt m raw_args in
-                    (match uu____4596 with
-                     | (uu____4637, raw_args1) -> FStar_Util.Inr raw_args1)
+                    let uu___1 = FStar_List.splitAt m raw_args in
+                    (match uu___1 with
+                     | (uu___2, raw_args1) -> FStar_Util.Inr raw_args1)
                 | FStar_Util.Inl (ctx, xs, rc) ->
-                    let uu____4706 = FStar_List.splitAt m xs in
-                    (match uu____4706 with
-                     | (uu____4753, xs1) ->
+                    let uu___1 = FStar_List.splitAt m xs in
+                    (match uu___1 with
+                     | (uu___2, xs1) ->
                          let ctx1 = FStar_List.append arg_values_rev ctx in
                          FStar_Util.Inl (ctx1, xs1, rc)) in
               FStar_All.pipe_left mk
@@ -1254,14 +1211,13 @@ and (iapp :
                    map_rev FStar_Pervasives_Native.fst args in
                  f1 arg_values_rev)
               else
-                (let uu____4848 = FStar_List.splitAt n args in
-                 match uu____4848 with
+                (let uu___3 = FStar_List.splitAt n args in
+                 match uu___3 with
                  | (args1, args') ->
-                     let uu____4895 =
-                       let uu____4896 =
-                         map_rev FStar_Pervasives_Native.fst args1 in
-                       f1 uu____4896 in
-                     iapp cfg uu____4895 args')
+                     let uu___4 =
+                       let uu___5 = map_rev FStar_Pervasives_Native.fst args1 in
+                       f1 uu___5 in
+                     iapp cfg uu___4 args')
         | FStar_TypeChecker_NBETerm.Accu (a, ts) ->
             FStar_All.pipe_left mk
               (FStar_TypeChecker_NBETerm.Accu
@@ -1272,12 +1228,12 @@ and (iapp :
               | ({
                    FStar_TypeChecker_NBETerm.nbe_t =
                      FStar_TypeChecker_NBETerm.Univ u;
-                   FStar_TypeChecker_NBETerm.nbe_r = uu____5015;_},
-                 uu____5016)::args2 -> aux args2 (u :: us1) ts1
+                   FStar_TypeChecker_NBETerm.nbe_r = uu___1;_},
+                 uu___2)::args2 -> aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1) in
-            let uu____5060 = aux args us ts in
-            (match uu____5060 with
+            let uu___1 = aux args us ts in
+            (match uu___1 with
              | (us', ts') ->
                  FStar_All.pipe_left mk
                    (FStar_TypeChecker_NBETerm.Construct (i, us', ts')))
@@ -1287,12 +1243,12 @@ and (iapp :
               | ({
                    FStar_TypeChecker_NBETerm.nbe_t =
                      FStar_TypeChecker_NBETerm.Univ u;
-                   FStar_TypeChecker_NBETerm.nbe_r = uu____5187;_},
-                 uu____5188)::args2 -> aux args2 (u :: us1) ts1
+                   FStar_TypeChecker_NBETerm.nbe_r = uu___1;_},
+                 uu___2)::args2 -> aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1) in
-            let uu____5232 = aux args us ts in
-            (match uu____5232 with
+            let uu___1 = aux args us ts in
+            (match uu___1 with
              | (us', ts') ->
                  FStar_All.pipe_left mk
                    (FStar_TypeChecker_NBETerm.FV (i, us', ts')))
@@ -1301,76 +1257,75 @@ and (iapp :
             let n_args_rev = FStar_List.length args_rev1 in
             let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs in
             (debug cfg
-               (fun uu____5308 ->
-                  let uu____5309 =
+               (fun uu___2 ->
+                  let uu___3 =
                     FStar_Syntax_Print.lbname_to_string
                       lb.FStar_Syntax_Syntax.lbname in
-                  let uu____5310 = FStar_Util.string_of_int arity in
-                  let uu____5311 = FStar_Util.string_of_int n_args_rev in
+                  let uu___4 = FStar_Util.string_of_int arity in
+                  let uu___5 = FStar_Util.string_of_int n_args_rev in
                   FStar_Util.print3
                     "Reached iapp for %s with arity %s and n_args = %s\n"
-                    uu____5309 uu____5310 uu____5311);
+                    uu___3 uu___4 uu___5);
              if n_args_rev >= arity
              then
-               (let uu____5312 =
-                  let uu____5325 =
-                    let uu____5326 =
+               (let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_Syntax_Util.unascribe
                         lb.FStar_Syntax_Syntax.lbdef in
-                    uu____5326.FStar_Syntax_Syntax.n in
-                  match uu____5325 with
-                  | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____5343) ->
+                    uu___4.FStar_Syntax_Syntax.n in
+                  match uu___3 with
+                  | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___4) ->
                       (bs, body)
-                  | uu____5376 -> ([], (lb.FStar_Syntax_Syntax.lbdef)) in
-                match uu____5312 with
+                  | uu___4 -> ([], (lb.FStar_Syntax_Syntax.lbdef)) in
+                match uu___2 with
                 | (bs, body) ->
                     if (n_univs + (FStar_List.length bs)) = arity
                     then
-                      let uu____5415 =
+                      let uu___3 =
                         FStar_Util.first_N (n_args_rev - arity) args_rev1 in
-                      (match uu____5415 with
+                      (match uu___3 with
                        | (extra, args_rev2) ->
                            (debug cfg
-                              (fun uu____5467 ->
-                                 let uu____5468 =
+                              (fun uu___5 ->
+                                 let uu___6 =
                                    FStar_Syntax_Print.lbname_to_string
                                      lb.FStar_Syntax_Syntax.lbname in
-                                 let uu____5469 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.term_to_string body in
-                                 let uu____5470 =
-                                   let uu____5471 =
+                                 let uu___8 =
+                                   let uu___9 =
                                      FStar_List.map
-                                       (fun uu____5481 ->
-                                          match uu____5481 with
-                                          | (x, uu____5487) ->
+                                       (fun uu___10 ->
+                                          match uu___10 with
+                                          | (x, uu___11) ->
                                               FStar_TypeChecker_NBETerm.t_to_string
                                                 x) args_rev2 in
-                                   FStar_All.pipe_right uu____5471
+                                   FStar_All.pipe_right uu___9
                                      (FStar_String.concat ", ") in
                                  FStar_Util.print3
                                    "Reducing body of %s = %s,\n\twith args = %s\n"
-                                   uu____5468 uu____5469 uu____5470);
+                                   uu___6 uu___7 uu___8);
                             (let t =
-                               let uu____5491 =
+                               let uu___5 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    args_rev2 in
-                               translate cfg uu____5491 body in
+                               translate cfg uu___5 body in
                              match extra with
                              | [] -> t
-                             | uu____5502 ->
-                                 iapp cfg t (FStar_List.rev extra))))
+                             | uu___5 -> iapp cfg t (FStar_List.rev extra))))
                     else
-                      (let uu____5514 =
+                      (let uu___4 =
                          FStar_Util.first_N (n_args_rev - n_univs) args_rev1 in
-                       match uu____5514 with
+                       match uu___4 with
                        | (extra, univs) ->
-                           let uu____5561 =
-                             let uu____5562 =
+                           let uu___5 =
+                             let uu___6 =
                                FStar_List.map FStar_Pervasives_Native.fst
                                  univs in
-                             translate cfg uu____5562
+                             translate cfg uu___6
                                lb.FStar_Syntax_Syntax.lbdef in
-                           iapp cfg uu____5561 (FStar_List.rev extra)))
+                           iapp cfg uu___5 (FStar_List.rev extra)))
              else
                FStar_All.pipe_left mk
                  (FStar_TypeChecker_NBETerm.TopLevelLet
@@ -1380,50 +1335,49 @@ and (iapp :
             let args1 = FStar_List.append args' args in
             if (FStar_List.length args1) >= arity
             then
-              let uu____5615 =
+              let uu___1 =
                 should_reduce_recursive_definition args1 decreases_list in
-              (match uu____5615 with
-               | (should_reduce, uu____5623, uu____5624) ->
+              (match uu___1 with
+               | (should_reduce, uu___2, uu___3) ->
                    if Prims.op_Negation should_reduce
                    then
                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                      (debug cfg
-                        (fun uu____5629 ->
-                           let uu____5630 =
-                             FStar_Syntax_Print.fv_to_string fv in
+                        (fun uu___5 ->
+                           let uu___6 = FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "Decided to not unfold recursive definition %s\n"
-                             uu____5630);
-                      (let uu____5631 =
-                         let uu____5632 = FStar_Syntax_Syntax.range_of_fv fv in
-                         mk_rt uu____5632
+                             uu___6);
+                      (let uu___5 =
+                         let uu___6 = FStar_Syntax_Syntax.range_of_fv fv in
+                         mk_rt uu___6
                            (FStar_TypeChecker_NBETerm.FV (fv, [], [])) in
-                       iapp cfg uu____5631 args1))
+                       iapp cfg uu___5 args1))
                    else
                      (debug cfg
-                        (fun uu____5649 ->
-                           let uu____5650 =
-                             let uu____5651 =
+                        (fun uu___6 ->
+                           let uu___7 =
+                             let uu___8 =
                                FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-                             FStar_Syntax_Print.fv_to_string uu____5651 in
+                             FStar_Syntax_Print.fv_to_string uu___8 in
                            FStar_Util.print1
                              "Yes, Decided to unfold recursive definition %s\n"
-                             uu____5650);
-                      (let uu____5652 =
+                             uu___7);
+                      (let uu___6 =
                          FStar_Util.first_N
                            (FStar_List.length lb.FStar_Syntax_Syntax.lbunivs)
                            args1 in
-                       match uu____5652 with
+                       match uu___6 with
                        | (univs, rest) ->
-                           let uu____5699 =
-                             let uu____5700 =
-                               let uu____5703 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    univs in
-                               FStar_List.rev uu____5703 in
-                             translate cfg uu____5700
+                               FStar_List.rev uu___9 in
+                             translate cfg uu___8
                                lb.FStar_Syntax_Syntax.lbdef in
-                           iapp cfg uu____5699 rest)))
+                           iapp cfg uu___7 rest)))
             else
               FStar_All.pipe_left mk
                 (FStar_TypeChecker_NBETerm.TopLevelRec
@@ -1450,10 +1404,10 @@ and (iapp :
                         (remaining_arity - n_args), decreases_list))
                else
                  (let args1 = FStar_List.append acc_args args in
-                  let uu____5800 =
+                  let uu___3 =
                     should_reduce_recursive_definition args1 decreases_list in
-                  match uu____5800 with
-                  | (should_reduce, uu____5808, uu____5809) ->
+                  match uu___3 with
+                  | (should_reduce, uu___4, uu___5) ->
                       if Prims.op_Negation should_reduce
                       then
                         FStar_All.pipe_left mk
@@ -1463,71 +1417,70 @@ and (iapp :
                       else
                         (let env = make_rec_env mutual_lbs local_env in
                          debug cfg
-                           (fun uu____5830 ->
-                              (let uu____5832 =
-                                 let uu____5833 =
+                           (fun uu___8 ->
+                              (let uu___10 =
+                                 let uu___11 =
                                    FStar_List.map
                                      FStar_TypeChecker_NBETerm.t_to_string
                                      env in
-                                 FStar_String.concat ",\n\t " uu____5833 in
+                                 FStar_String.concat ",\n\t " uu___11 in
                                FStar_Util.print1
-                                 "LocalLetRec Env = {\n\t%s\n}\n" uu____5832);
-                              (let uu____5836 =
-                                 let uu____5837 =
+                                 "LocalLetRec Env = {\n\t%s\n}\n" uu___10);
+                              (let uu___10 =
+                                 let uu___11 =
                                    FStar_List.map
-                                     (fun uu____5847 ->
-                                        match uu____5847 with
-                                        | (t, uu____5853) ->
+                                     (fun uu___12 ->
+                                        match uu___12 with
+                                        | (t, uu___13) ->
                                             FStar_TypeChecker_NBETerm.t_to_string
                                               t) args1 in
-                                 FStar_String.concat ",\n\t " uu____5837 in
+                                 FStar_String.concat ",\n\t " uu___11 in
                                FStar_Util.print1
-                                 "LocalLetRec Args = {\n\t%s\n}\n" uu____5836));
-                         (let uu____5854 =
+                                 "LocalLetRec Args = {\n\t%s\n}\n" uu___10));
+                         (let uu___8 =
                             translate cfg env lb.FStar_Syntax_Syntax.lbdef in
-                          iapp cfg uu____5854 args1))))
+                          iapp cfg uu___8 args1))))
         | FStar_TypeChecker_NBETerm.Constant
             (FStar_TypeChecker_NBETerm.SConst (FStar_Const.Const_range_of))
             ->
             (match args with
-             | (a, uu____5856)::[] ->
+             | (a, uu___1)::[] ->
                  mk_rt a.FStar_TypeChecker_NBETerm.nbe_r
                    (FStar_TypeChecker_NBETerm.Constant
                       (FStar_TypeChecker_NBETerm.Range
                          (a.FStar_TypeChecker_NBETerm.nbe_r)))
-             | uu____5865 ->
-                 let uu____5866 =
-                   let uu____5867 = FStar_TypeChecker_NBETerm.t_to_string f in
-                   Prims.op_Hat "NBE ill-typed application: " uu____5867 in
-                 failwith uu____5866)
+             | uu___1 ->
+                 let uu___2 =
+                   let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
+                   Prims.op_Hat "NBE ill-typed application: " uu___3 in
+                 failwith uu___2)
         | FStar_TypeChecker_NBETerm.Constant
             (FStar_TypeChecker_NBETerm.SConst
             (FStar_Const.Const_set_range_of)) ->
             (match args with
-             | (t, uu____5869)::({
-                                   FStar_TypeChecker_NBETerm.nbe_t =
-                                     FStar_TypeChecker_NBETerm.Constant
-                                     (FStar_TypeChecker_NBETerm.Range r);
-                                   FStar_TypeChecker_NBETerm.nbe_r =
-                                     uu____5871;_},
-                                 uu____5872)::[]
+             | (t, uu___1)::({
+                               FStar_TypeChecker_NBETerm.nbe_t =
+                                 FStar_TypeChecker_NBETerm.Constant
+                                 (FStar_TypeChecker_NBETerm.Range r);
+                               FStar_TypeChecker_NBETerm.nbe_r = uu___2;_},
+                             uu___3)::[]
                  ->
-                 let uu___934_5885 = t in
+                 let uu___4 = t in
                  {
                    FStar_TypeChecker_NBETerm.nbe_t =
-                     (uu___934_5885.FStar_TypeChecker_NBETerm.nbe_t);
+                     (uu___4.FStar_TypeChecker_NBETerm.nbe_t);
                    FStar_TypeChecker_NBETerm.nbe_r = r
                  }
-             | uu____5886 ->
-                 let uu____5887 =
-                   let uu____5888 = FStar_TypeChecker_NBETerm.t_to_string f in
-                   Prims.op_Hat "NBE ill-typed application: " uu____5888 in
-                 failwith uu____5887)
-        | uu____5889 ->
-            let uu____5890 =
-              let uu____5891 = FStar_TypeChecker_NBETerm.t_to_string f in
-              Prims.op_Hat "NBE ill-typed application: " uu____5891 in
-            failwith uu____5890
+             | uu___1 ->
+                 let uu___2 =
+                   let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
+                   Prims.op_Hat "NBE ill-typed application: " uu___3 in
+                 failwith uu___2)
+        | uu___1 ->
+            let uu___2 =
+              let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
+              Prims.op_Hat "NBE ill-typed application: " uu___3 in
+            failwith uu___2
 and (translate_fv :
   config ->
     FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -1538,52 +1491,51 @@ and (translate_fv :
       fun fvar ->
         let debug1 = debug cfg in
         let qninfo =
-          let uu____5906 = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg in
-          let uu____5907 = FStar_Syntax_Syntax.lid_of_fv fvar in
-          FStar_TypeChecker_Env.lookup_qname uu____5906 uu____5907 in
-        let uu____5908 = (is_constr qninfo) || (is_constr_fv fvar) in
-        if uu____5908
+          let uu___ = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg in
+          let uu___1 = FStar_Syntax_Syntax.lid_of_fv fvar in
+          FStar_TypeChecker_Env.lookup_qname uu___ uu___1 in
+        let uu___ = (is_constr qninfo) || (is_constr_fv fvar) in
+        if uu___
         then FStar_TypeChecker_NBETerm.mkConstruct fvar [] []
         else
-          (let uu____5914 =
+          (let uu___2 =
              FStar_TypeChecker_Normalize.should_unfold cfg.core_cfg
-               (fun uu____5916 ->
-                  (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying) fvar qninfo in
-           match uu____5914 with
+               (fun uu___3 -> (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying)
+               fvar qninfo in
+           match uu___2 with
            | FStar_TypeChecker_Normalize.Should_unfold_fully ->
                failwith "Not yet handled"
            | FStar_TypeChecker_Normalize.Should_unfold_no ->
                (debug1
-                  (fun uu____5922 ->
-                     let uu____5923 = FStar_Syntax_Print.fv_to_string fvar in
+                  (fun uu___4 ->
+                     let uu___5 = FStar_Syntax_Print.fv_to_string fvar in
                      FStar_Util.print1 "(1) Decided to not unfold %s\n"
-                       uu____5923);
-                (let uu____5924 =
+                       uu___5);
+                (let uu___4 =
                    FStar_TypeChecker_Cfg.find_prim_step cfg.core_cfg fvar in
-                 match uu____5924 with
+                 match uu___4 with
                  | FStar_Pervasives_Native.Some prim_step when
                      prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok ->
                      let arity =
                        prim_step.FStar_TypeChecker_Cfg.arity +
                          prim_step.FStar_TypeChecker_Cfg.univ_arity in
                      (debug1
-                        (fun uu____5934 ->
-                           let uu____5935 =
-                             FStar_Syntax_Print.fv_to_string fvar in
-                           FStar_Util.print1 "Found a primop %s\n" uu____5935);
-                      (let uu____5936 =
-                         let uu____5937 =
-                           let uu____5969 =
-                             let f uu____6001 =
-                               let uu____6002 =
+                        (fun uu___6 ->
+                           let uu___7 = FStar_Syntax_Print.fv_to_string fvar in
+                           FStar_Util.print1 "Found a primop %s\n" uu___7);
+                      (let uu___6 =
+                         let uu___7 =
+                           let uu___8 =
+                             let f uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Syntax.new_bv
                                    FStar_Pervasives_Native.None
                                    FStar_Syntax_Syntax.t_unit in
-                               (uu____6002, FStar_Pervasives_Native.None) in
-                             let uu____6005 =
-                               let uu____6016 = FStar_Common.tabulate arity f in
-                               ([], uu____6016, FStar_Pervasives_Native.None) in
-                             FStar_Util.Inl uu____6005 in
+                               (uu___10, FStar_Pervasives_Native.None) in
+                             let uu___9 =
+                               let uu___10 = FStar_Common.tabulate arity f in
+                               ([], uu___10, FStar_Pervasives_Native.None) in
+                             FStar_Util.Inl uu___9 in
                            ((fun args_rev ->
                                let args' =
                                  map_rev FStar_TypeChecker_NBETerm.as_arg
@@ -1595,64 +1547,62 @@ and (translate_fv :
                                    FStar_TypeChecker_NBETerm.translate =
                                      (translate cfg bs)
                                  } in
-                               let uu____6089 =
+                               let uu___9 =
                                  prim_step.FStar_TypeChecker_Cfg.interpretation_nbe
                                    callbacks args' in
-                               match uu____6089 with
+                               match uu___9 with
                                | FStar_Pervasives_Native.Some x ->
                                    (debug1
-                                      (fun uu____6100 ->
-                                         let uu____6101 =
+                                      (fun uu___11 ->
+                                         let uu___12 =
                                            FStar_Syntax_Print.fv_to_string
                                              fvar in
-                                         let uu____6102 =
+                                         let uu___13 =
                                            FStar_TypeChecker_NBETerm.t_to_string
                                              x in
                                          FStar_Util.print2
                                            "Primitive operator %s returned %s\n"
-                                           uu____6101 uu____6102);
+                                           uu___12 uu___13);
                                     x)
                                | FStar_Pervasives_Native.None ->
                                    (debug1
-                                      (fun uu____6108 ->
-                                         let uu____6109 =
+                                      (fun uu___11 ->
+                                         let uu___12 =
                                            FStar_Syntax_Print.fv_to_string
                                              fvar in
                                          FStar_Util.print1
                                            "Primitive operator %s failed\n"
-                                           uu____6109);
-                                    (let uu____6110 =
+                                           uu___12);
+                                    (let uu___11 =
                                        FStar_TypeChecker_NBETerm.mkFV fvar []
                                          [] in
-                                     iapp cfg uu____6110 args'))),
-                             uu____5969, arity) in
-                         FStar_TypeChecker_NBETerm.Lam uu____5937 in
-                       FStar_All.pipe_left mk_t uu____5936))
-                 | FStar_Pervasives_Native.Some uu____6115 ->
+                                     iapp cfg uu___11 args'))), uu___8,
+                             arity) in
+                         FStar_TypeChecker_NBETerm.Lam uu___7 in
+                       FStar_All.pipe_left mk_t uu___6))
+                 | FStar_Pervasives_Native.Some uu___5 ->
                      (debug1
-                        (fun uu____6121 ->
-                           let uu____6122 =
-                             FStar_Syntax_Print.fv_to_string fvar in
+                        (fun uu___7 ->
+                           let uu___8 = FStar_Syntax_Print.fv_to_string fvar in
                            FStar_Util.print1 "(2) Decided to not unfold %s\n"
-                             uu____6122);
+                             uu___8);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])
-                 | uu____6127 ->
+                 | uu___5 ->
                      (debug1
-                        (fun uu____6135 ->
-                           let uu____6136 =
-                             FStar_Syntax_Print.fv_to_string fvar in
+                        (fun uu___7 ->
+                           let uu___8 = FStar_Syntax_Print.fv_to_string fvar in
                            FStar_Util.print1 "(3) Decided to not unfold %s\n"
-                             uu____6136);
+                             uu___8);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])))
            | FStar_TypeChecker_Normalize.Should_unfold_reify ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6143 =
+                   let uu___3 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo in
-                   FStar_Option.isSome uu____6143 in
+                   FStar_Option.isSome uu___3 in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1662,20 +1612,20 @@ and (translate_fv :
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let
                              ((is_rec, lbs), names);
-                           FStar_Syntax_Syntax.sigrng = uu____6157;
-                           FStar_Syntax_Syntax.sigquals = uu____6158;
-                           FStar_Syntax_Syntax.sigmeta = uu____6159;
-                           FStar_Syntax_Syntax.sigattrs = uu____6160;
-                           FStar_Syntax_Syntax.sigopts = uu____6161;_},
+                           FStar_Syntax_Syntax.sigrng = uu___3;
+                           FStar_Syntax_Syntax.sigquals = uu___4;
+                           FStar_Syntax_Syntax.sigmeta = uu___5;
+                           FStar_Syntax_Syntax.sigattrs = uu___6;
+                           FStar_Syntax_Syntax.sigopts = uu___7;_},
                          _us_opt),
                         _rng)
                        ->
                        (debug1
-                          (fun uu____6229 ->
-                             let uu____6230 =
+                          (fun uu___9 ->
+                             let uu___10 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6230);
+                               uu___10);
                         (let lbm = find_let lbs fvar in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1683,46 +1633,45 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6235 = let_rec_arity lb in
-                               (match uu____6235 with
+                               let uu___9 = let_rec_arity lb in
+                               (match uu___9 with
                                 | (ar, lst) ->
-                                    let uu____6248 =
-                                      let uu____6253 =
+                                    let uu___10 =
+                                      let uu___11 =
                                         FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu____6253 in
-                                    FStar_All.pipe_left uu____6248
+                                      mk_rt uu___11 in
+                                    FStar_All.pipe_left uu___10
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None ->
                              failwith "Could not find let binding"))
-                   | uu____6267 ->
+                   | uu___3 ->
                        (debug1
-                          (fun uu____6273 ->
-                             let uu____6274 =
+                          (fun uu___5 ->
+                             let uu___6 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6274);
+                               "(1) qninfo is None for (%s)\n" uu___6);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6285 ->
-                         let uu____6286 =
-                           FStar_Syntax_Print.fv_to_string fvar in
+                      (fun uu___5 ->
+                         let uu___6 = FStar_Syntax_Print.fv_to_string fvar in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6286);
+                           uu___6);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] []) in
                (cache_add cfg fvar t; t)
            | FStar_TypeChecker_Normalize.Should_unfold_yes ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6294 =
+                   let uu___3 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo in
-                   FStar_Option.isSome uu____6294 in
+                   FStar_Option.isSome uu___3 in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1732,20 +1681,20 @@ and (translate_fv :
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let
                              ((is_rec, lbs), names);
-                           FStar_Syntax_Syntax.sigrng = uu____6308;
-                           FStar_Syntax_Syntax.sigquals = uu____6309;
-                           FStar_Syntax_Syntax.sigmeta = uu____6310;
-                           FStar_Syntax_Syntax.sigattrs = uu____6311;
-                           FStar_Syntax_Syntax.sigopts = uu____6312;_},
+                           FStar_Syntax_Syntax.sigrng = uu___3;
+                           FStar_Syntax_Syntax.sigquals = uu___4;
+                           FStar_Syntax_Syntax.sigmeta = uu___5;
+                           FStar_Syntax_Syntax.sigattrs = uu___6;
+                           FStar_Syntax_Syntax.sigopts = uu___7;_},
                          _us_opt),
                         _rng)
                        ->
                        (debug1
-                          (fun uu____6380 ->
-                             let uu____6381 =
+                          (fun uu___9 ->
+                             let uu___10 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6381);
+                               uu___10);
                         (let lbm = find_let lbs fvar in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1753,35 +1702,34 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6386 = let_rec_arity lb in
-                               (match uu____6386 with
+                               let uu___9 = let_rec_arity lb in
+                               (match uu___9 with
                                 | (ar, lst) ->
-                                    let uu____6399 =
-                                      let uu____6404 =
+                                    let uu___10 =
+                                      let uu___11 =
                                         FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu____6404 in
-                                    FStar_All.pipe_left uu____6399
+                                      mk_rt uu___11 in
+                                    FStar_All.pipe_left uu___10
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None ->
                              failwith "Could not find let binding"))
-                   | uu____6418 ->
+                   | uu___3 ->
                        (debug1
-                          (fun uu____6424 ->
-                             let uu____6425 =
+                          (fun uu___5 ->
+                             let uu___6 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6425);
+                               "(1) qninfo is None for (%s)\n" uu___6);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6436 ->
-                         let uu____6437 =
-                           FStar_Syntax_Print.fv_to_string fvar in
+                      (fun uu___5 ->
+                         let uu___6 = FStar_Syntax_Print.fv_to_string fvar in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6437);
+                           uu___6);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] []) in
                (cache_add cfg fvar t; t))
 and (translate_letbinding :
@@ -1794,33 +1742,32 @@ and (translate_letbinding :
       fun lb ->
         let debug1 = debug cfg in
         let us = lb.FStar_Syntax_Syntax.lbunivs in
-        let uu____6459 =
+        let uu___ =
           FStar_Syntax_Util.arrow_formals lb.FStar_Syntax_Syntax.lbtyp in
-        match uu____6459 with
-        | (formals, uu____6467) ->
+        match uu___ with
+        | (formals, uu___1) ->
             let arity = (FStar_List.length us) + (FStar_List.length formals) in
             if arity = Prims.int_zero
             then translate cfg bs lb.FStar_Syntax_Syntax.lbdef
             else
-              (let uu____6480 =
-                 FStar_Util.is_right lb.FStar_Syntax_Syntax.lbname in
-               if uu____6480
+              (let uu___3 = FStar_Util.is_right lb.FStar_Syntax_Syntax.lbname in
+               if uu___3
                then
                  (debug1
-                    (fun uu____6488 ->
-                       let uu____6489 =
+                    (fun uu___5 ->
+                       let uu___6 =
                          FStar_Syntax_Print.lbname_to_string
                            lb.FStar_Syntax_Syntax.lbname in
-                       let uu____6490 = FStar_Util.string_of_int arity in
+                       let uu___7 = FStar_Util.string_of_int arity in
                        FStar_Util.print2
-                         "Making TopLevelLet for %s with arity %s\n"
-                         uu____6489 uu____6490);
-                  (let uu____6491 =
-                     let uu____6496 =
+                         "Making TopLevelLet for %s with arity %s\n" uu___6
+                         uu___7);
+                  (let uu___5 =
+                     let uu___6 =
                        FStar_Syntax_Syntax.range_of_lbname
                          lb.FStar_Syntax_Syntax.lbname in
-                     mk_rt uu____6496 in
-                   FStar_All.pipe_left uu____6491
+                     mk_rt uu___6 in
+                   FStar_All.pipe_left uu___5
                      (FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, []))))
                else translate cfg bs lb.FStar_Syntax_Syntax.lbdef)
 and (mkRec :
@@ -1833,8 +1780,8 @@ and (mkRec :
     fun b ->
       fun bs ->
         fun env ->
-          let uu____6516 = let_rec_arity b in
-          match uu____6516 with
+          let uu___ = let_rec_arity b in
+          match uu___ with
           | (ar, ar_lst) ->
               FStar_All.pipe_left mk_t
                 (FStar_TypeChecker_NBETerm.LocalLetRec
@@ -1857,13 +1804,13 @@ and (translate_constant :
     | FStar_Const.Const_unit -> FStar_TypeChecker_NBETerm.Unit
     | FStar_Const.Const_bool b -> FStar_TypeChecker_NBETerm.Bool b
     | FStar_Const.Const_int (s, FStar_Pervasives_Native.None) ->
-        let uu____6573 = FStar_BigInt.big_int_of_string s in
-        FStar_TypeChecker_NBETerm.Int uu____6573
+        let uu___ = FStar_BigInt.big_int_of_string s in
+        FStar_TypeChecker_NBETerm.Int uu___
     | FStar_Const.Const_string (s, r) ->
         FStar_TypeChecker_NBETerm.String (s, r)
     | FStar_Const.Const_char c1 -> FStar_TypeChecker_NBETerm.Char c1
     | FStar_Const.Const_range r -> FStar_TypeChecker_NBETerm.Range r
-    | uu____6578 -> FStar_TypeChecker_NBETerm.SConst c
+    | uu___ -> FStar_TypeChecker_NBETerm.SConst c
 and (readback_comp :
   config -> FStar_TypeChecker_NBETerm.comp -> FStar_Syntax_Syntax.comp) =
   fun cfg ->
@@ -1871,16 +1818,14 @@ and (readback_comp :
       let c' =
         match c with
         | FStar_TypeChecker_NBETerm.Tot (typ, u) ->
-            let uu____6588 =
-              let uu____6597 = readback cfg typ in (uu____6597, u) in
-            FStar_Syntax_Syntax.Total uu____6588
+            let uu___ = let uu___1 = readback cfg typ in (uu___1, u) in
+            FStar_Syntax_Syntax.Total uu___
         | FStar_TypeChecker_NBETerm.GTot (typ, u) ->
-            let uu____6610 =
-              let uu____6619 = readback cfg typ in (uu____6619, u) in
-            FStar_Syntax_Syntax.GTotal uu____6610
+            let uu___ = let uu___1 = readback cfg typ in (uu___1, u) in
+            FStar_Syntax_Syntax.GTotal uu___
         | FStar_TypeChecker_NBETerm.Comp ctyp ->
-            let uu____6627 = readback_comp_typ cfg ctyp in
-            FStar_Syntax_Syntax.Comp uu____6627 in
+            let uu___ = readback_comp_typ cfg ctyp in
+            FStar_Syntax_Syntax.Comp uu___ in
       FStar_Syntax_Syntax.mk c' FStar_Range.dummyRange
 and (translate_comp_typ :
   config ->
@@ -1890,29 +1835,28 @@ and (translate_comp_typ :
   fun cfg ->
     fun bs ->
       fun c ->
-        let uu____6633 = c in
-        match uu____6633 with
+        let uu___ = c in
+        match uu___ with
         | { FStar_Syntax_Syntax.comp_univs = comp_univs;
             FStar_Syntax_Syntax.effect_name = effect_name;
             FStar_Syntax_Syntax.result_typ = result_typ;
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags = flags;_} ->
-            let uu____6653 =
-              FStar_List.map (translate_univ cfg bs) comp_univs in
-            let uu____6654 = translate cfg bs result_typ in
-            let uu____6655 =
+            let uu___1 = FStar_List.map (translate_univ cfg bs) comp_univs in
+            let uu___2 = translate cfg bs result_typ in
+            let uu___3 =
               FStar_List.map
                 (fun x ->
-                   let uu____6683 =
+                   let uu___4 =
                      translate cfg bs (FStar_Pervasives_Native.fst x) in
-                   (uu____6683, (FStar_Pervasives_Native.snd x))) effect_args in
-            let uu____6690 = FStar_List.map (translate_flag cfg bs) flags in
+                   (uu___4, (FStar_Pervasives_Native.snd x))) effect_args in
+            let uu___4 = FStar_List.map (translate_flag cfg bs) flags in
             {
-              FStar_TypeChecker_NBETerm.comp_univs = uu____6653;
+              FStar_TypeChecker_NBETerm.comp_univs = uu___1;
               FStar_TypeChecker_NBETerm.effect_name = effect_name;
-              FStar_TypeChecker_NBETerm.result_typ = uu____6654;
-              FStar_TypeChecker_NBETerm.effect_args = uu____6655;
-              FStar_TypeChecker_NBETerm.flags = uu____6690
+              FStar_TypeChecker_NBETerm.result_typ = uu___2;
+              FStar_TypeChecker_NBETerm.effect_args = uu___3;
+              FStar_TypeChecker_NBETerm.flags = uu___4
             }
 and (readback_comp_typ :
   config ->
@@ -1920,23 +1864,23 @@ and (readback_comp_typ :
   =
   fun cfg ->
     fun c ->
-      let uu____6695 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ in
-      let uu____6698 =
+      let uu___ = readback cfg c.FStar_TypeChecker_NBETerm.result_typ in
+      let uu___1 =
         FStar_List.map
           (fun x ->
-             let uu____6724 = readback cfg (FStar_Pervasives_Native.fst x) in
-             (uu____6724, (FStar_Pervasives_Native.snd x)))
+             let uu___2 = readback cfg (FStar_Pervasives_Native.fst x) in
+             (uu___2, (FStar_Pervasives_Native.snd x)))
           c.FStar_TypeChecker_NBETerm.effect_args in
-      let uu____6725 =
+      let uu___2 =
         FStar_List.map (readback_flag cfg) c.FStar_TypeChecker_NBETerm.flags in
       {
         FStar_Syntax_Syntax.comp_univs =
           (c.FStar_TypeChecker_NBETerm.comp_univs);
         FStar_Syntax_Syntax.effect_name =
           (c.FStar_TypeChecker_NBETerm.effect_name);
-        FStar_Syntax_Syntax.result_typ = uu____6695;
-        FStar_Syntax_Syntax.effect_args = uu____6698;
-        FStar_Syntax_Syntax.flags = uu____6725
+        FStar_Syntax_Syntax.result_typ = uu___;
+        FStar_Syntax_Syntax.effect_args = uu___1;
+        FStar_Syntax_Syntax.flags = uu___2
       }
 and (translate_residual_comp :
   config ->
@@ -1947,22 +1891,22 @@ and (translate_residual_comp :
   fun cfg ->
     fun bs ->
       fun c ->
-        let uu____6733 = c in
-        match uu____6733 with
+        let uu___ = c in
+        match uu___ with
         | { FStar_Syntax_Syntax.residual_effect = residual_effect;
             FStar_Syntax_Syntax.residual_typ = residual_typ;
             FStar_Syntax_Syntax.residual_flags = residual_flags;_} ->
-            let uu____6743 =
+            let uu___1 =
               if
                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
               then FStar_Pervasives_Native.None
               else FStar_Util.map_opt residual_typ (translate cfg bs) in
-            let uu____6751 =
+            let uu___2 =
               FStar_List.map (translate_flag cfg bs) residual_flags in
             {
               FStar_TypeChecker_NBETerm.residual_effect = residual_effect;
-              FStar_TypeChecker_NBETerm.residual_typ = uu____6743;
-              FStar_TypeChecker_NBETerm.residual_flags = uu____6751
+              FStar_TypeChecker_NBETerm.residual_typ = uu___1;
+              FStar_TypeChecker_NBETerm.residual_flags = uu___2
             }
 and (readback_residual_comp :
   config ->
@@ -1971,23 +1915,22 @@ and (readback_residual_comp :
   =
   fun cfg ->
     fun c ->
-      let uu____6756 =
+      let uu___ =
         FStar_Util.map_opt c.FStar_TypeChecker_NBETerm.residual_typ
           (fun x ->
              debug cfg
-               (fun uu____6767 ->
-                  let uu____6768 = FStar_TypeChecker_NBETerm.t_to_string x in
-                  FStar_Util.print1 "Reading back residualtype %s\n"
-                    uu____6768);
+               (fun uu___2 ->
+                  let uu___3 = FStar_TypeChecker_NBETerm.t_to_string x in
+                  FStar_Util.print1 "Reading back residualtype %s\n" uu___3);
              readback cfg x) in
-      let uu____6769 =
+      let uu___1 =
         FStar_List.map (readback_flag cfg)
           c.FStar_TypeChecker_NBETerm.residual_flags in
       {
         FStar_Syntax_Syntax.residual_effect =
           (c.FStar_TypeChecker_NBETerm.residual_effect);
-        FStar_Syntax_Syntax.residual_typ = uu____6756;
-        FStar_Syntax_Syntax.residual_flags = uu____6769
+        FStar_Syntax_Syntax.residual_typ = uu___;
+        FStar_Syntax_Syntax.residual_flags = uu___1
       }
 and (translate_flag :
   config ->
@@ -2012,8 +1955,8 @@ and (translate_flag :
         | FStar_Syntax_Syntax.LEMMA -> FStar_TypeChecker_NBETerm.LEMMA
         | FStar_Syntax_Syntax.CPS -> FStar_TypeChecker_NBETerm.CPS
         | FStar_Syntax_Syntax.DECREASES tm ->
-            let uu____6780 = translate cfg bs tm in
-            FStar_TypeChecker_NBETerm.DECREASES uu____6780
+            let uu___ = translate cfg bs tm in
+            FStar_TypeChecker_NBETerm.DECREASES uu___
 and (readback_flag :
   config -> FStar_TypeChecker_NBETerm.cflag -> FStar_Syntax_Syntax.cflag) =
   fun cfg ->
@@ -2033,8 +1976,7 @@ and (readback_flag :
       | FStar_TypeChecker_NBETerm.LEMMA -> FStar_Syntax_Syntax.LEMMA
       | FStar_TypeChecker_NBETerm.CPS -> FStar_Syntax_Syntax.CPS
       | FStar_TypeChecker_NBETerm.DECREASES t ->
-          let uu____6784 = readback cfg t in
-          FStar_Syntax_Syntax.DECREASES uu____6784
+          let uu___ = readback cfg t in FStar_Syntax_Syntax.DECREASES uu___
 and (translate_monadic :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.term'
     FStar_Syntax_Syntax.syntax) ->
@@ -2043,28 +1985,28 @@ and (translate_monadic :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____6787 ->
+  fun uu___ ->
     fun cfg ->
       fun bs ->
         fun e ->
-          match uu____6787 with
+          match uu___ with
           | (m, ty) ->
               let e1 = FStar_Syntax_Util.unascribe e in
               (match e1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
-                   let uu____6822 =
-                     let uu____6831 =
+                   let uu___1 =
+                     let uu___2 =
                        FStar_TypeChecker_Env.norm_eff_name
                          (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv m in
                      FStar_TypeChecker_Env.effect_decl_opt
-                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____6831 in
-                   (match uu____6822 with
+                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu___2 in
+                   (match uu___1 with
                     | FStar_Pervasives_Native.None ->
-                        let uu____6838 =
-                          let uu____6839 = FStar_Ident.string_of_lid m in
+                        let uu___2 =
+                          let uu___3 = FStar_Ident.string_of_lid m in
                           FStar_Util.format1
-                            "Effect declaration not found: %s" uu____6839 in
-                        failwith uu____6838
+                            "Effect declaration not found: %s" uu___3 in
+                        failwith uu___2
                     | FStar_Pervasives_Native.Some (ed, q) ->
                         let cfg' = reifying_false cfg in
                         let body_lam =
@@ -2075,222 +2017,215 @@ and (translate_monadic :
                                 (FStar_Pervasives_Native.Some ty);
                               FStar_Syntax_Syntax.residual_flags = []
                             } in
-                          let uu____6859 =
-                            let uu____6860 =
-                              let uu____6879 =
-                                let uu____6888 =
-                                  let uu____6895 =
+                          let uu___2 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Util.left
                                       lb.FStar_Syntax_Syntax.lbname in
-                                  (uu____6895, FStar_Pervasives_Native.None) in
-                                [uu____6888] in
-                              (uu____6879, body,
+                                  (uu___6, FStar_Pervasives_Native.None) in
+                                [uu___5] in
+                              (uu___4, body,
                                 (FStar_Pervasives_Native.Some body_rc)) in
-                            FStar_Syntax_Syntax.Tm_abs uu____6860 in
-                          FStar_Syntax_Syntax.mk uu____6859
+                            FStar_Syntax_Syntax.Tm_abs uu___3 in
+                          FStar_Syntax_Syntax.mk uu___2
                             body.FStar_Syntax_Syntax.pos in
                         let maybe_range_arg =
-                          let uu____6929 =
+                          let uu___2 =
                             FStar_Util.for_some
                               (FStar_Syntax_Util.attr_eq
                                  FStar_Syntax_Util.dm4f_bind_range_attr)
                               ed.FStar_Syntax_Syntax.eff_attrs in
-                          if uu____6929
+                          if uu___2
                           then
-                            let uu____6936 =
-                              let uu____6941 =
-                                let uu____6942 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
                                   FStar_TypeChecker_Cfg.embed_simple
                                     FStar_Syntax_Embeddings.e_range
                                     lb.FStar_Syntax_Syntax.lbpos
                                     lb.FStar_Syntax_Syntax.lbpos in
-                                translate cfg [] uu____6942 in
-                              (uu____6941, FStar_Pervasives_Native.None) in
-                            let uu____6943 =
-                              let uu____6950 =
-                                let uu____6955 =
-                                  let uu____6956 =
+                                translate cfg [] uu___5 in
+                              (uu___4, FStar_Pervasives_Native.None) in
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
+                                  let uu___7 =
                                     FStar_TypeChecker_Cfg.embed_simple
                                       FStar_Syntax_Embeddings.e_range
                                       body.FStar_Syntax_Syntax.pos
                                       body.FStar_Syntax_Syntax.pos in
-                                  translate cfg [] uu____6956 in
-                                (uu____6955, FStar_Pervasives_Native.None) in
-                              [uu____6950] in
-                            uu____6936 :: uu____6943
+                                  translate cfg [] uu___7 in
+                                (uu___6, FStar_Pervasives_Native.None) in
+                              [uu___5] in
+                            uu___3 :: uu___4
                           else [] in
                         let t =
-                          let uu____6975 =
-                            let uu____6976 =
-                              let uu____6977 =
-                                let uu____6978 =
-                                  let uu____6979 =
-                                    let uu____6986 =
+                          let uu___2 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr in
-                                    FStar_All.pipe_right uu____6986
+                                    FStar_All.pipe_right uu___7
                                       FStar_Util.must in
-                                  FStar_All.pipe_right uu____6979
+                                  FStar_All.pipe_right uu___6
                                     FStar_Pervasives_Native.snd in
-                                FStar_Syntax_Util.un_uinst uu____6978 in
-                              translate cfg' [] uu____6977 in
-                            let uu____7007 =
-                              let uu____7008 =
-                                let uu____7013 =
+                                FStar_Syntax_Util.un_uinst uu___5 in
+                              translate cfg' [] uu___4 in
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
                                   FStar_All.pipe_left mk_t
                                     (FStar_TypeChecker_NBETerm.Univ
                                        FStar_Syntax_Syntax.U_unknown) in
-                                (uu____7013, FStar_Pervasives_Native.None) in
-                              let uu____7014 =
-                                let uu____7021 =
-                                  let uu____7026 =
+                                (uu___6, FStar_Pervasives_Native.None) in
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
                                     FStar_All.pipe_left mk_t
                                       (FStar_TypeChecker_NBETerm.Univ
                                          FStar_Syntax_Syntax.U_unknown) in
-                                  (uu____7026, FStar_Pervasives_Native.None) in
-                                [uu____7021] in
-                              uu____7008 :: uu____7014 in
-                            iapp cfg uu____6976 uu____7007 in
-                          let uu____7039 =
-                            let uu____7040 =
-                              let uu____7047 =
-                                let uu____7052 =
+                                  (uu___8, FStar_Pervasives_Native.None) in
+                                [uu___7] in
+                              uu___5 :: uu___6 in
+                            iapp cfg uu___3 uu___4 in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
                                   translate cfg' bs
                                     lb.FStar_Syntax_Syntax.lbtyp in
-                                (uu____7052, FStar_Pervasives_Native.None) in
-                              let uu____7053 =
-                                let uu____7060 =
-                                  let uu____7065 = translate cfg' bs ty in
-                                  (uu____7065, FStar_Pervasives_Native.None) in
-                                [uu____7060] in
-                              uu____7047 :: uu____7053 in
-                            let uu____7078 =
-                              let uu____7085 =
-                                let uu____7092 =
-                                  let uu____7099 =
-                                    let uu____7104 =
+                                (uu___6, FStar_Pervasives_Native.None) in
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 = translate cfg' bs ty in
+                                  (uu___8, FStar_Pervasives_Native.None) in
+                                [uu___7] in
+                              uu___5 :: uu___6 in
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
                                       translate cfg bs
                                         lb.FStar_Syntax_Syntax.lbdef in
-                                    (uu____7104,
-                                      FStar_Pervasives_Native.None) in
-                                  let uu____7105 =
-                                    let uu____7112 =
-                                      let uu____7119 =
-                                        let uu____7124 =
+                                    (uu___9, FStar_Pervasives_Native.None) in
+                                  let uu___9 =
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
                                           translate cfg bs body_lam in
-                                        (uu____7124,
+                                        (uu___12,
                                           FStar_Pervasives_Native.None) in
-                                      [uu____7119] in
+                                      [uu___11] in
                                     ((mk_t FStar_TypeChecker_NBETerm.Unknown),
                                       FStar_Pervasives_Native.None) ::
-                                      uu____7112 in
-                                  uu____7099 :: uu____7105 in
+                                      uu___10 in
+                                  uu___8 :: uu___9 in
                                 ((mk_t FStar_TypeChecker_NBETerm.Unknown),
-                                  FStar_Pervasives_Native.None) :: uu____7092 in
-                              FStar_List.append maybe_range_arg uu____7085 in
-                            FStar_List.append uu____7040 uu____7078 in
-                          iapp cfg uu____6975 uu____7039 in
+                                  FStar_Pervasives_Native.None) :: uu___7 in
+                              FStar_List.append maybe_range_arg uu___6 in
+                            FStar_List.append uu___4 uu___5 in
+                          iapp cfg uu___2 uu___3 in
                         (debug cfg
-                           (fun uu____7156 ->
-                              let uu____7157 =
+                           (fun uu___3 ->
+                              let uu___4 =
                                 FStar_TypeChecker_NBETerm.t_to_string t in
                               FStar_Util.print1 "translate_monadic: %s\n"
-                                uu____7157);
+                                uu___4);
                          t))
                | FStar_Syntax_Syntax.Tm_app
                    ({
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                        (FStar_Const.Const_reflect uu____7158);
-                      FStar_Syntax_Syntax.pos = uu____7159;
-                      FStar_Syntax_Syntax.vars = uu____7160;_},
-                    (e2, uu____7162)::[])
+                        (FStar_Const.Const_reflect uu___1);
+                      FStar_Syntax_Syntax.pos = uu___2;
+                      FStar_Syntax_Syntax.vars = uu___3;_},
+                    (e2, uu___4)::[])
                    ->
-                   let uu____7201 = reifying_false cfg in
-                   translate uu____7201 bs e2
+                   let uu___5 = reifying_false cfg in translate uu___5 bs e2
                | FStar_Syntax_Syntax.Tm_app (head, args) ->
                    (debug cfg
-                      (fun uu____7232 ->
-                         let uu____7233 =
-                           FStar_Syntax_Print.term_to_string head in
-                         let uu____7234 =
-                           FStar_Syntax_Print.args_to_string args in
+                      (fun uu___2 ->
+                         let uu___3 = FStar_Syntax_Print.term_to_string head in
+                         let uu___4 = FStar_Syntax_Print.args_to_string args in
                          FStar_Util.print2
-                           "translate_monadic app (%s) @ (%s)\n" uu____7233
-                           uu____7234);
-                    (let fallback1 uu____7240 = translate cfg bs e1 in
-                     let fallback2 uu____7246 =
-                       let uu____7247 = reifying_false cfg in
-                       let uu____7248 =
+                           "translate_monadic app (%s) @ (%s)\n" uu___3
+                           uu___4);
+                    (let fallback1 uu___2 = translate cfg bs e1 in
+                     let fallback2 uu___2 =
+                       let uu___3 = reifying_false cfg in
+                       let uu___4 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_meta
                               (e1,
                                 (FStar_Syntax_Syntax.Meta_monadic (m, ty))))
                            e1.FStar_Syntax_Syntax.pos in
-                       translate uu____7247 bs uu____7248 in
-                     let uu____7253 =
-                       let uu____7254 = FStar_Syntax_Util.un_uinst head in
-                       uu____7254.FStar_Syntax_Syntax.n in
-                     match uu____7253 with
+                       translate uu___3 bs uu___4 in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Util.un_uinst head in
+                       uu___3.FStar_Syntax_Syntax.n in
+                     match uu___2 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
                          let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                          let qninfo =
                            FStar_TypeChecker_Env.lookup_qname
                              (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid in
-                         let uu____7260 =
-                           let uu____7261 =
+                         let uu___3 =
+                           let uu___4 =
                              FStar_TypeChecker_Env.is_action
                                (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid in
-                           Prims.op_Negation uu____7261 in
-                         if uu____7260
+                           Prims.op_Negation uu___4 in
+                         if uu___3
                          then fallback1 ()
                          else
-                           (let uu____7263 =
-                              let uu____7264 =
+                           (let uu___5 =
+                              let uu___6 =
                                 FStar_TypeChecker_Env.lookup_definition_qninfo
                                   (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   qninfo in
-                              FStar_Option.isNone uu____7264 in
-                            if uu____7263
+                              FStar_Option.isNone uu___6 in
+                            if uu___5
                             then fallback2 ()
                             else
                               (let e2 =
-                                 let uu____7277 =
-                                   FStar_Syntax_Util.mk_reify head in
-                                 FStar_Syntax_Syntax.mk_Tm_app uu____7277
-                                   args e1.FStar_Syntax_Syntax.pos in
-                               let uu____7278 = reifying_false cfg in
-                               translate uu____7278 bs e2))
-                     | uu____7279 -> fallback1 ()))
+                                 let uu___7 = FStar_Syntax_Util.mk_reify head in
+                                 FStar_Syntax_Syntax.mk_Tm_app uu___7 args
+                                   e1.FStar_Syntax_Syntax.pos in
+                               let uu___7 = reifying_false cfg in
+                               translate uu___7 bs e2))
+                     | uu___3 -> fallback1 ()))
                | FStar_Syntax_Syntax.Tm_match (sc, branches) ->
                    let branches1 =
                      FStar_All.pipe_right branches
                        (FStar_List.map
-                          (fun uu____7400 ->
-                             match uu____7400 with
+                          (fun uu___1 ->
+                             match uu___1 with
                              | (pat, wopt, tm) ->
-                                 let uu____7448 =
-                                   FStar_Syntax_Util.mk_reify tm in
-                                 (pat, wopt, uu____7448))) in
+                                 let uu___2 = FStar_Syntax_Util.mk_reify tm in
+                                 (pat, wopt, uu___2))) in
                    let tm =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_match (sc, branches1))
                        e1.FStar_Syntax_Syntax.pos in
-                   let uu____7480 = reifying_false cfg in
-                   translate uu____7480 bs tm
+                   let uu___1 = reifying_false cfg in translate uu___1 bs tm
                | FStar_Syntax_Syntax.Tm_meta
-                   (t, FStar_Syntax_Syntax.Meta_monadic uu____7482) ->
+                   (t, FStar_Syntax_Syntax.Meta_monadic uu___1) ->
                    translate_monadic (m, ty) cfg bs e1
                | FStar_Syntax_Syntax.Tm_meta
                    (t, FStar_Syntax_Syntax.Meta_monadic_lift
                     (msrc, mtgt, ty'))
                    -> translate_monadic_lift (msrc, mtgt, ty') cfg bs e1
-               | uu____7509 ->
-                   let uu____7510 =
-                     let uu____7511 = FStar_Syntax_Print.tag_of_term e1 in
+               | uu___1 ->
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Print.tag_of_term e1 in
                      FStar_Util.format1
-                       "Unexpected case in translate_monadic: %s" uu____7511 in
-                   failwith uu____7510)
+                       "Unexpected case in translate_monadic: %s" uu___3 in
+                   failwith uu___2)
 and (translate_monadic_lift :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name *
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) ->
@@ -2299,109 +2234,108 @@ and (translate_monadic_lift :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____7512 ->
+  fun uu___ ->
     fun cfg ->
       fun bs ->
         fun e ->
-          match uu____7512 with
+          match uu___ with
           | (msrc, mtgt, ty) ->
               let e1 = FStar_Syntax_Util.unascribe e in
-              let uu____7536 =
+              let uu___1 =
                 (FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc) in
-              if uu____7536
+              if uu___1
               then
                 let ed =
-                  let uu____7538 =
+                  let uu___2 =
                     FStar_TypeChecker_Env.norm_eff_name
                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv mtgt in
                   FStar_TypeChecker_Env.get_effect_decl
-                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7538 in
+                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu___2 in
                 let ret =
-                  let uu____7540 =
-                    let uu____7541 =
-                      let uu____7544 =
-                        let uu____7545 =
-                          let uu____7552 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
                             FStar_All.pipe_right ed
                               FStar_Syntax_Util.get_return_repr in
-                          FStar_All.pipe_right uu____7552 FStar_Util.must in
-                        FStar_All.pipe_right uu____7545
+                          FStar_All.pipe_right uu___6 FStar_Util.must in
+                        FStar_All.pipe_right uu___5
                           FStar_Pervasives_Native.snd in
-                      FStar_Syntax_Subst.compress uu____7544 in
-                    uu____7541.FStar_Syntax_Syntax.n in
-                  match uu____7540 with
-                  | FStar_Syntax_Syntax.Tm_uinst (ret, uu____7598::[]) ->
+                      FStar_Syntax_Subst.compress uu___4 in
+                    uu___3.FStar_Syntax_Syntax.n in
+                  match uu___2 with
+                  | FStar_Syntax_Syntax.Tm_uinst (ret1, uu___3::[]) ->
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_uinst
-                           (ret, [FStar_Syntax_Syntax.U_unknown]))
+                           (ret1, [FStar_Syntax_Syntax.U_unknown]))
                         e1.FStar_Syntax_Syntax.pos
-                  | uu____7605 ->
+                  | uu___3 ->
                       failwith "NYI: Reification of indexed effect (NBE)" in
                 let cfg' = reifying_false cfg in
                 let t =
-                  let uu____7608 =
-                    let uu____7609 = translate cfg' [] ret in
-                    let uu____7610 =
-                      let uu____7611 =
-                        let uu____7616 =
+                  let uu___2 =
+                    let uu___3 = translate cfg' [] ret in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
                           FStar_All.pipe_left mk_t
                             (FStar_TypeChecker_NBETerm.Univ
                                FStar_Syntax_Syntax.U_unknown) in
-                        (uu____7616, FStar_Pervasives_Native.None) in
-                      [uu____7611] in
-                    iapp cfg' uu____7609 uu____7610 in
-                  let uu____7625 =
-                    let uu____7626 =
-                      let uu____7631 = translate cfg' bs ty in
-                      (uu____7631, FStar_Pervasives_Native.None) in
-                    let uu____7632 =
-                      let uu____7639 =
-                        let uu____7644 = translate cfg' bs e1 in
-                        (uu____7644, FStar_Pervasives_Native.None) in
-                      [uu____7639] in
-                    uu____7626 :: uu____7632 in
-                  iapp cfg' uu____7608 uu____7625 in
+                        (uu___6, FStar_Pervasives_Native.None) in
+                      [uu___5] in
+                    iapp cfg' uu___3 uu___4 in
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 = translate cfg' bs ty in
+                      (uu___5, FStar_Pervasives_Native.None) in
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 = translate cfg' bs e1 in
+                        (uu___7, FStar_Pervasives_Native.None) in
+                      [uu___6] in
+                    uu___4 :: uu___5 in
+                  iapp cfg' uu___2 uu___3 in
                 (debug cfg
-                   (fun uu____7660 ->
-                      let uu____7661 =
-                        FStar_TypeChecker_NBETerm.t_to_string t in
+                   (fun uu___3 ->
+                      let uu___4 = FStar_TypeChecker_NBETerm.t_to_string t in
                       FStar_Util.print1 "translate_monadic_lift(1): %s\n"
-                        uu____7661);
+                        uu___4);
                  t)
               else
-                (let uu____7663 =
+                (let uu___3 =
                    FStar_TypeChecker_Env.monad_leq
                      (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv msrc mtgt in
-                 match uu____7663 with
+                 match uu___3 with
                  | FStar_Pervasives_Native.None ->
-                     let uu____7666 =
-                       let uu____7667 = FStar_Ident.string_of_lid msrc in
-                       let uu____7668 = FStar_Ident.string_of_lid mtgt in
+                     let uu___4 =
+                       let uu___5 = FStar_Ident.string_of_lid msrc in
+                       let uu___6 = FStar_Ident.string_of_lid mtgt in
                        FStar_Util.format2
                          "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                         uu____7667 uu____7668 in
-                     failwith uu____7666
+                         uu___5 uu___6 in
+                     failwith uu___4
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7669;
-                       FStar_TypeChecker_Env.mtarget = uu____7670;
+                     { FStar_TypeChecker_Env.msource = uu___4;
+                       FStar_TypeChecker_Env.mtarget = uu___5;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7671;
+                         { FStar_TypeChecker_Env.mlift_wp = uu___6;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.None;_};_}
                      ->
-                     let uu____7691 =
-                       let uu____7692 = FStar_Ident.string_of_lid msrc in
-                       let uu____7693 = FStar_Ident.string_of_lid mtgt in
+                     let uu___7 =
+                       let uu___8 = FStar_Ident.string_of_lid msrc in
+                       let uu___9 = FStar_Ident.string_of_lid mtgt in
                        FStar_Util.format2
                          "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                         uu____7692 uu____7693 in
-                     failwith uu____7691
+                         uu___8 uu___9 in
+                     failwith uu___7
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7694;
-                       FStar_TypeChecker_Env.mtarget = uu____7695;
+                     { FStar_TypeChecker_Env.msource = uu___4;
+                       FStar_TypeChecker_Env.mtarget = uu___5;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7696;
+                         { FStar_TypeChecker_Env.mlift_wp = uu___6;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.Some lift;_};_}
                      ->
@@ -2410,27 +2344,27 @@ and (translate_monadic_lift :
                          FStar_Syntax_Syntax.new_bv
                            FStar_Pervasives_Native.None
                            FStar_Syntax_Syntax.tun in
-                       let uu____7730 =
-                         let uu____7733 = FStar_Syntax_Syntax.bv_to_name x in
-                         lift FStar_Syntax_Syntax.U_unknown ty uu____7733 in
+                       let uu___7 =
+                         let uu___8 = FStar_Syntax_Syntax.bv_to_name x in
+                         lift FStar_Syntax_Syntax.U_unknown ty uu___8 in
                        FStar_Syntax_Util.abs
-                         [(x, FStar_Pervasives_Native.None)] uu____7730
+                         [(x, FStar_Pervasives_Native.None)] uu___7
                          FStar_Pervasives_Native.None in
                      let cfg' = reifying_false cfg in
                      let t =
-                       let uu____7750 = translate cfg' [] lift_lam in
-                       let uu____7751 =
-                         let uu____7752 =
-                           let uu____7757 = translate cfg bs e1 in
-                           (uu____7757, FStar_Pervasives_Native.None) in
-                         [uu____7752] in
-                       iapp cfg uu____7750 uu____7751 in
+                       let uu___7 = translate cfg' [] lift_lam in
+                       let uu___8 =
+                         let uu___9 =
+                           let uu___10 = translate cfg bs e1 in
+                           (uu___10, FStar_Pervasives_Native.None) in
+                         [uu___9] in
+                       iapp cfg uu___7 uu___8 in
                      (debug cfg
-                        (fun uu____7769 ->
-                           let uu____7770 =
+                        (fun uu___8 ->
+                           let uu___9 =
                              FStar_TypeChecker_NBETerm.t_to_string t in
                            FStar_Util.print1
-                             "translate_monadic_lift(2): %s\n" uu____7770);
+                             "translate_monadic_lift(2): %s\n" uu___9);
                       t))
 and (readback :
   config -> FStar_TypeChecker_NBETerm.t -> FStar_Syntax_Syntax.term) =
@@ -2439,23 +2373,21 @@ and (readback :
       let debug1 = debug cfg in
       let readback_args cfg1 args =
         map_rev
-          (fun uu____7822 ->
-             match uu____7822 with
-             | (x1, q) ->
-                 let uu____7833 = readback cfg1 x1 in (uu____7833, q)) args in
+          (fun uu___ ->
+             match uu___ with
+             | (x1, q) -> let uu___1 = readback cfg1 x1 in (uu___1, q)) args in
       let with_range t =
-        let uu___1255_7846 = t in
+        let uu___ = t in
         {
-          FStar_Syntax_Syntax.n = (uu___1255_7846.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (x.FStar_TypeChecker_NBETerm.nbe_r);
-          FStar_Syntax_Syntax.vars =
-            (uu___1255_7846.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
         } in
       let mk t = FStar_Syntax_Syntax.mk t x.FStar_TypeChecker_NBETerm.nbe_r in
       debug1
-        (fun uu____7862 ->
-           let uu____7863 = FStar_TypeChecker_NBETerm.t_to_string x in
-           FStar_Util.print1 "Readback: %s\n" uu____7863);
+        (fun uu___1 ->
+           let uu___2 = FStar_TypeChecker_NBETerm.t_to_string x in
+           FStar_Util.print1 "Readback: %s\n" uu___2);
       (match x.FStar_TypeChecker_NBETerm.nbe_t with
        | FStar_TypeChecker_NBETerm.Univ u ->
            failwith "Readback of universes should not occur"
@@ -2470,10 +2402,10 @@ and (readback :
            (false)) -> with_range FStar_Syntax_Util.exp_false_bool
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Int i)
            ->
-           let uu____7866 =
-             let uu____7869 = FStar_BigInt.string_of_big_int i in
-             FStar_Syntax_Util.exp_int uu____7869 in
-           with_range uu____7866
+           let uu___1 =
+             let uu___2 = FStar_BigInt.string_of_big_int i in
+             FStar_Syntax_Util.exp_int uu___2 in
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.String
            (s, r)) ->
            mk
@@ -2481,8 +2413,7 @@ and (readback :
                 (FStar_Const.Const_string (s, r)))
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Char
            c) ->
-           let uu____7873 = FStar_Syntax_Util.exp_char c in
-           with_range uu____7873
+           let uu___1 = FStar_Syntax_Util.exp_char c in with_range uu___1
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Range
            r) ->
            FStar_TypeChecker_Cfg.embed_simple FStar_Syntax_Embeddings.e_range
@@ -2490,108 +2421,105 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.SConst
            c) -> mk (FStar_Syntax_Syntax.Tm_constant c)
        | FStar_TypeChecker_NBETerm.Meta (t, m) ->
-           let uu____7884 =
-             let uu____7885 =
-               let uu____7892 = readback cfg t in
-               let uu____7895 = FStar_Thunk.force m in
-               (uu____7892, uu____7895) in
-             FStar_Syntax_Syntax.Tm_meta uu____7885 in
-           mk uu____7884
+           let uu___1 =
+             let uu___2 =
+               let uu___3 = readback cfg t in
+               let uu___4 = FStar_Thunk.force m in (uu___3, uu___4) in
+             FStar_Syntax_Syntax.Tm_meta uu___2 in
+           mk uu___1
        | FStar_TypeChecker_NBETerm.Type_t u ->
            mk (FStar_Syntax_Syntax.Tm_type u)
        | FStar_TypeChecker_NBETerm.Lam (f, binders, arity) ->
-           let uu____7952 =
+           let uu___1 =
              match binders with
              | FStar_Util.Inl (ctx, binders1, rc) ->
-                 let uu____8000 =
+                 let uu___2 =
                    FStar_List.fold_left
-                     (fun uu____8054 ->
-                        fun uu____8055 ->
-                          match (uu____8054, uu____8055) with
+                     (fun uu___3 ->
+                        fun uu___4 ->
+                          match (uu___3, uu___4) with
                           | ((ctx1, binders_rev, accus_rev), (x1, q)) ->
                               let tnorm =
-                                let uu____8180 =
+                                let uu___5 =
                                   translate cfg ctx1
                                     x1.FStar_Syntax_Syntax.sort in
-                                readback cfg uu____8180 in
+                                readback cfg uu___5 in
                               let x2 =
-                                let uu___1313_8182 =
+                                let uu___5 =
                                   FStar_Syntax_Syntax.freshen_bv x1 in
                                 {
                                   FStar_Syntax_Syntax.ppname =
-                                    (uu___1313_8182.FStar_Syntax_Syntax.ppname);
+                                    (uu___5.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
-                                    (uu___1313_8182.FStar_Syntax_Syntax.index);
+                                    (uu___5.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = tnorm
                                 } in
                               let ax = FStar_TypeChecker_NBETerm.mkAccuVar x2 in
                               let ctx2 = ax :: ctx1 in
                               (ctx2, ((x2, q) :: binders_rev), (ax ::
                                 accus_rev))) (ctx, [], []) binders1 in
-                 (match uu____8000 with
+                 (match uu___2 with
                   | (ctx1, binders_rev, accus_rev) ->
                       let rc1 =
                         match rc with
                         | FStar_Pervasives_Native.None ->
                             FStar_Pervasives_Native.None
-                        | FStar_Pervasives_Native.Some rc1 ->
-                            let uu____8268 =
-                              let uu____8269 =
-                                translate_residual_comp cfg ctx1 rc1 in
-                              readback_residual_comp cfg uu____8269 in
-                            FStar_Pervasives_Native.Some uu____8268 in
+                        | FStar_Pervasives_Native.Some rc2 ->
+                            let uu___3 =
+                              let uu___4 =
+                                translate_residual_comp cfg ctx1 rc2 in
+                              readback_residual_comp cfg uu___4 in
+                            FStar_Pervasives_Native.Some uu___3 in
                       ((FStar_List.rev binders_rev), accus_rev, rc1))
              | FStar_Util.Inr args ->
-                 let uu____8303 =
+                 let uu___2 =
                    FStar_List.fold_right
-                     (fun uu____8344 ->
-                        fun uu____8345 ->
-                          match (uu____8344, uu____8345) with
-                          | ((t, uu____8397), (binders1, accus)) ->
+                     (fun uu___3 ->
+                        fun uu___4 ->
+                          match (uu___3, uu___4) with
+                          | ((t, uu___5), (binders1, accus)) ->
                               let x1 =
-                                let uu____8439 = readback cfg t in
+                                let uu___6 = readback cfg t in
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None uu____8439 in
-                              let uu____8440 =
-                                let uu____8443 =
+                                  FStar_Pervasives_Native.None uu___6 in
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_TypeChecker_NBETerm.mkAccuVar x1 in
-                                uu____8443 :: accus in
+                                uu___7 :: accus in
                               (((x1, FStar_Pervasives_Native.None) ::
-                                binders1), uu____8440)) args ([], []) in
-                 (match uu____8303 with
+                                binders1), uu___6)) args ([], []) in
+                 (match uu___2 with
                   | (binders1, accus) ->
                       (binders1, (FStar_List.rev accus),
                         FStar_Pervasives_Native.None)) in
-           (match uu____7952 with
+           (match uu___1 with
             | (binders1, accus_rev, rc) ->
-                let body =
-                  let uu____8526 = f accus_rev in readback cfg uu____8526 in
-                let uu____8527 = FStar_Syntax_Util.abs binders1 body rc in
-                with_range uu____8527)
+                let body = let uu___2 = f accus_rev in readback cfg uu___2 in
+                let uu___2 = FStar_Syntax_Util.abs binders1 body rc in
+                with_range uu___2)
        | FStar_TypeChecker_NBETerm.Refinement (f, targ) ->
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
            then
-             let uu____8552 =
-               let uu____8553 = targ () in
-               FStar_Pervasives_Native.fst uu____8553 in
-             readback cfg uu____8552
+             let uu___1 =
+               let uu___2 = targ () in FStar_Pervasives_Native.fst uu___2 in
+             readback cfg uu___1
            else
              (let x1 =
-                let uu____8560 =
-                  let uu____8561 =
-                    let uu____8562 = targ () in
-                    FStar_Pervasives_Native.fst uu____8562 in
-                  readback cfg uu____8561 in
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = targ () in
+                    FStar_Pervasives_Native.fst uu___4 in
+                  readback cfg uu___3 in
                 FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                  uu____8560 in
+                  uu___2 in
               let body =
-                let uu____8568 =
-                  let uu____8569 = FStar_TypeChecker_NBETerm.mkAccuVar x1 in
-                  f uu____8569 in
-                readback cfg uu____8568 in
+                let uu___2 =
+                  let uu___3 = FStar_TypeChecker_NBETerm.mkAccuVar x1 in
+                  f uu___3 in
+                readback cfg uu___2 in
               let refinement = FStar_Syntax_Util.refine x1 body in
-              let uu____8573 =
+              let uu___2 =
                 if
                   ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
                 then
@@ -2599,18 +2527,17 @@ and (readback :
                     ((cfg.core_cfg).FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     refinement
                 else refinement in
-              with_range uu____8573)
+              with_range uu___2)
        | FStar_TypeChecker_NBETerm.Reflect t ->
            let tm = readback cfg t in
-           let uu____8581 = FStar_Syntax_Util.mk_reflect tm in
-           with_range uu____8581
+           let uu___1 = FStar_Syntax_Util.mk_reflect tm in with_range uu___1
        | FStar_TypeChecker_NBETerm.Arrow (FStar_Util.Inl f) ->
-           let uu____8599 = FStar_Thunk.force f in with_range uu____8599
+           let uu___1 = FStar_Thunk.force f in with_range uu___1
        | FStar_TypeChecker_NBETerm.Arrow (FStar_Util.Inr (args, c)) ->
            let binders =
              FStar_List.map
-               (fun uu____8648 ->
-                  match uu____8648 with
+               (fun uu___1 ->
+                  match uu___1 with
                   | (t, q) ->
                       let t1 = readback cfg t in
                       let x1 =
@@ -2618,41 +2545,38 @@ and (readback :
                           FStar_Pervasives_Native.None t1 in
                       (x1, q)) args in
            let c1 = readback_comp cfg c in
-           let uu____8662 = FStar_Syntax_Util.arrow binders c1 in
-           with_range uu____8662
+           let uu___1 = FStar_Syntax_Util.arrow binders c1 in
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Construct (fv, us, args) ->
            let args1 =
              map_rev
-               (fun uu____8703 ->
-                  match uu____8703 with
-                  | (x1, q) ->
-                      let uu____8714 = readback cfg x1 in (uu____8714, q))
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (x1, q) -> let uu___2 = readback cfg x1 in (uu___2, q))
                args in
            let fv1 =
-             let uu____8718 = FStar_Syntax_Syntax.range_of_fv fv in
-             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-               uu____8718 in
+             let uu___1 = FStar_Syntax_Syntax.range_of_fv fv in
+             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv) uu___1 in
            let app =
-             let uu____8722 =
+             let uu___1 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us) in
-             FStar_Syntax_Util.mk_app uu____8722 args1 in
+             FStar_Syntax_Util.mk_app uu___1 args1 in
            with_range app
        | FStar_TypeChecker_NBETerm.FV (fv, us, args) ->
            let args1 =
              map_rev
-               (fun uu____8763 ->
-                  match uu____8763 with
-                  | (x1, q) ->
-                      let uu____8774 = readback cfg x1 in (uu____8774, q))
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (x1, q) -> let uu___2 = readback cfg x1 in (uu___2, q))
                args in
            let fv1 =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                FStar_Range.dummyRange in
            let app =
-             let uu____8781 =
+             let uu___1 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us) in
-             FStar_Syntax_Util.mk_app uu____8781 args1 in
-           let uu____8784 =
+             FStar_Syntax_Util.mk_app uu___1 args1 in
+           let uu___1 =
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
              then
@@ -2660,18 +2584,18 @@ and (readback :
                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                  app
              else app in
-           with_range uu____8784
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.Var bv, []) ->
-           let uu____8801 = FStar_Syntax_Syntax.bv_to_name bv in
-           with_range uu____8801
+           let uu___1 = FStar_Syntax_Syntax.bv_to_name bv in
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.Var bv, args) ->
            let args1 = readback_args cfg args in
            let app =
-             let uu____8828 = FStar_Syntax_Syntax.bv_to_name bv in
-             FStar_Syntax_Util.mk_app uu____8828 args1 in
-           let uu____8831 =
+             let uu___1 = FStar_Syntax_Syntax.bv_to_name bv in
+             FStar_Syntax_Util.mk_app uu___1 args1 in
+           let uu___1 =
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
              then
@@ -2679,7 +2603,7 @@ and (readback :
                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                  app
              else app in
-           with_range uu____8831
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.Match (scrut, make_branches), args) ->
            let args1 = readback_args cfg args in
@@ -2690,7 +2614,7 @@ and (readback :
                (FStar_Syntax_Syntax.Tm_match (scrut_new, branches_new))
                scrut.FStar_TypeChecker_NBETerm.nbe_r in
            let app = FStar_Syntax_Util.mk_app head args1 in
-           let uu____8897 =
+           let uu___1 =
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
              then
@@ -2698,192 +2622,184 @@ and (readback :
                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                  app
              else app in
-           with_range uu____8897
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.UnreducedLet
             (var, typ, defn, body, lb), args)
            ->
            let typ1 =
-             let uu____8934 = FStar_Thunk.force typ in
-             readback cfg uu____8934 in
+             let uu___1 = FStar_Thunk.force typ in readback cfg uu___1 in
            let defn1 =
-             let uu____8936 = FStar_Thunk.force defn in
-             readback cfg uu____8936 in
+             let uu___1 = FStar_Thunk.force defn in readback cfg uu___1 in
            let body1 =
-             let uu____8938 =
-               let uu____8939 = FStar_Thunk.force body in
-               readback cfg uu____8939 in
+             let uu___1 =
+               let uu___2 = FStar_Thunk.force body in readback cfg uu___2 in
              FStar_Syntax_Subst.close [(var, FStar_Pervasives_Native.None)]
-               uu____8938 in
+               uu___1 in
            let lbname =
-             let uu____8959 =
-               let uu___1432_8960 =
-                 FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+             let uu___1 =
+               let uu___2 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___1432_8960.FStar_Syntax_Syntax.ppname);
+                   (uu___2.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___1432_8960.FStar_Syntax_Syntax.index);
+                   (uu___2.FStar_Syntax_Syntax.index);
                  FStar_Syntax_Syntax.sort = typ1
                } in
-             FStar_Util.Inl uu____8959 in
+             FStar_Util.Inl uu___1 in
            let lb1 =
-             let uu___1435_8962 = lb in
+             let uu___1 = lb in
              {
                FStar_Syntax_Syntax.lbname = lbname;
                FStar_Syntax_Syntax.lbunivs =
-                 (uu___1435_8962.FStar_Syntax_Syntax.lbunivs);
+                 (uu___1.FStar_Syntax_Syntax.lbunivs);
                FStar_Syntax_Syntax.lbtyp = typ1;
-               FStar_Syntax_Syntax.lbeff =
-                 (uu___1435_8962.FStar_Syntax_Syntax.lbeff);
+               FStar_Syntax_Syntax.lbeff = (uu___1.FStar_Syntax_Syntax.lbeff);
                FStar_Syntax_Syntax.lbdef = defn1;
                FStar_Syntax_Syntax.lbattrs =
-                 (uu___1435_8962.FStar_Syntax_Syntax.lbattrs);
-               FStar_Syntax_Syntax.lbpos =
-                 (uu___1435_8962.FStar_Syntax_Syntax.lbpos)
+                 (uu___1.FStar_Syntax_Syntax.lbattrs);
+               FStar_Syntax_Syntax.lbpos = (uu___1.FStar_Syntax_Syntax.lbpos)
              } in
            let hd =
              FStar_Syntax_Syntax.mk
                (FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1))
                FStar_Range.dummyRange in
            let args1 = readback_args cfg args in
-           let uu____8983 = FStar_Syntax_Util.mk_app hd args1 in
-           with_range uu____8983
+           let uu___1 = FStar_Syntax_Util.mk_app hd args1 in
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.UnreducedLetRec
             (vars_typs_defns, body, lbs), args)
            ->
            let lbs1 =
              FStar_List.map2
-               (fun uu____9040 ->
+               (fun uu___1 ->
                   fun lb ->
-                    match uu____9040 with
+                    match uu___1 with
                     | (v, t, d) ->
                         let t1 = readback cfg t in
                         let def = readback cfg d in
                         let v1 =
-                          let uu___1455_9054 = v in
+                          let uu___2 = v in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1455_9054.FStar_Syntax_Syntax.ppname);
+                              (uu___2.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1455_9054.FStar_Syntax_Syntax.index);
+                              (uu___2.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t1
                           } in
-                        let uu___1458_9055 = lb in
+                        let uu___2 = lb in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl v1);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1458_9055.FStar_Syntax_Syntax.lbunivs);
+                            (uu___2.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp = t1;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1458_9055.FStar_Syntax_Syntax.lbeff);
+                            (uu___2.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = def;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___1458_9055.FStar_Syntax_Syntax.lbattrs);
+                            (uu___2.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1458_9055.FStar_Syntax_Syntax.lbpos)
+                            (uu___2.FStar_Syntax_Syntax.lbpos)
                         }) vars_typs_defns lbs in
            let body1 = readback cfg body in
-           let uu____9057 = FStar_Syntax_Subst.close_let_rec lbs1 body1 in
-           (match uu____9057 with
+           let uu___1 = FStar_Syntax_Subst.close_let_rec lbs1 body1 in
+           (match uu___1 with
             | (lbs2, body2) ->
                 let hd =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_let ((true, lbs2), body2))
                     FStar_Range.dummyRange in
                 let args1 = readback_args cfg args in
-                let uu____9090 = FStar_Syntax_Util.mk_app hd args1 in
-                with_range uu____9090)
+                let uu___2 = FStar_Syntax_Util.mk_app hd args1 in
+                with_range uu___2)
        | FStar_TypeChecker_NBETerm.Accu
            (FStar_TypeChecker_NBETerm.UVar f, args) ->
            let hd = FStar_Thunk.force f in
            let args1 = readback_args cfg args in
-           let uu____9117 = FStar_Syntax_Util.mk_app hd args1 in
-           with_range uu____9117
+           let uu___1 = FStar_Syntax_Util.mk_app hd args1 in
+           with_range uu___1
        | FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, args_rev) ->
            let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs in
            let n_args = FStar_List.length args_rev in
-           let uu____9141 = FStar_Util.first_N (n_args - n_univs) args_rev in
-           (match uu____9141 with
+           let uu___1 = FStar_Util.first_N (n_args - n_univs) args_rev in
+           (match uu___1 with
             | (args_rev1, univs) ->
-                let uu____9188 =
-                  let uu____9189 =
-                    let uu____9190 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_List.map FStar_Pervasives_Native.fst univs in
-                    translate cfg uu____9190 lb.FStar_Syntax_Syntax.lbdef in
-                  iapp cfg uu____9189 (FStar_List.rev args_rev1) in
-                readback cfg uu____9188)
-       | FStar_TypeChecker_NBETerm.TopLevelRec
-           (lb, uu____9202, uu____9203, args) ->
+                    translate cfg uu___4 lb.FStar_Syntax_Syntax.lbdef in
+                  iapp cfg uu___3 (FStar_List.rev args_rev1) in
+                readback cfg uu___2)
+       | FStar_TypeChecker_NBETerm.TopLevelRec (lb, uu___1, uu___2, args) ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
            let head =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
                FStar_Range.dummyRange in
            let args1 =
              FStar_List.map
-               (fun uu____9244 ->
-                  match uu____9244 with
-                  | (t, q) ->
-                      let uu____9255 = readback cfg t in (uu____9255, q))
+               (fun uu___3 ->
+                  match uu___3 with
+                  | (t, q) -> let uu___4 = readback cfg t in (uu___4, q))
                args in
-           let uu____9256 = FStar_Syntax_Util.mk_app head args1 in
-           with_range uu____9256
+           let uu___3 = FStar_Syntax_Util.mk_app head args1 in
+           with_range uu___3
        | FStar_TypeChecker_NBETerm.LocalLetRec
-           (i, uu____9260, lbs, bs, args, _ar, _ar_lst) ->
+           (i, uu___1, lbs, bs, args, _ar, _ar_lst) ->
            let lbnames =
              FStar_List.map
                (fun lb ->
-                  let uu____9296 =
-                    let uu____9297 =
-                      let uu____9298 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                      uu____9298.FStar_Syntax_Syntax.ppname in
-                    FStar_Ident.string_of_id uu____9297 in
-                  FStar_Syntax_Syntax.gen_bv uu____9296
+                      uu___4.FStar_Syntax_Syntax.ppname in
+                    FStar_Ident.string_of_id uu___3 in
+                  FStar_Syntax_Syntax.gen_bv uu___2
                     FStar_Pervasives_Native.None lb.FStar_Syntax_Syntax.lbtyp)
                lbs in
            let let_rec_env =
-             let uu____9302 =
+             let uu___2 =
                FStar_List.map
                  (fun x1 ->
-                    let uu____9308 = FStar_Syntax_Syntax.range_of_bv x1 in
-                    mk_rt uu____9308
+                    let uu___3 = FStar_Syntax_Syntax.range_of_bv x1 in
+                    mk_rt uu___3
                       (FStar_TypeChecker_NBETerm.Accu
                          ((FStar_TypeChecker_NBETerm.Var x1), []))) lbnames in
-             FStar_List.rev_append uu____9302 bs in
+             FStar_List.rev_append uu___2 bs in
            let lbs1 =
              FStar_List.map2
                (fun lb ->
                   fun lbname ->
                     let lbdef =
-                      let uu____9330 =
+                      let uu___2 =
                         translate cfg let_rec_env
                           lb.FStar_Syntax_Syntax.lbdef in
-                      readback cfg uu____9330 in
+                      readback cfg uu___2 in
                     let lbtyp =
-                      let uu____9332 =
+                      let uu___2 =
                         translate cfg bs lb.FStar_Syntax_Syntax.lbtyp in
-                      readback cfg uu____9332 in
-                    let uu___1513_9333 = lb in
+                      readback cfg uu___2 in
+                    let uu___2 = lb in
                     {
                       FStar_Syntax_Syntax.lbname = (FStar_Util.Inl lbname);
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___1513_9333.FStar_Syntax_Syntax.lbunivs);
+                        (uu___2.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbtyp;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___1513_9333.FStar_Syntax_Syntax.lbeff);
+                        (uu___2.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbdef;
                       FStar_Syntax_Syntax.lbattrs =
-                        (uu___1513_9333.FStar_Syntax_Syntax.lbattrs);
+                        (uu___2.FStar_Syntax_Syntax.lbattrs);
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___1513_9333.FStar_Syntax_Syntax.lbpos)
+                        (uu___2.FStar_Syntax_Syntax.lbpos)
                     }) lbs lbnames in
            let body =
-             let uu____9335 = FStar_List.nth lbnames i in
-             FStar_Syntax_Syntax.bv_to_name uu____9335 in
-           let uu____9336 = FStar_Syntax_Subst.close_let_rec lbs1 body in
-           (match uu____9336 with
+             let uu___2 = FStar_List.nth lbnames i in
+             FStar_Syntax_Syntax.bv_to_name uu___2 in
+           let uu___2 = FStar_Syntax_Subst.close_let_rec lbs1 body in
+           (match uu___2 with
             | (lbs2, body1) ->
                 let head =
                   FStar_Syntax_Syntax.mk
@@ -2891,20 +2807,18 @@ and (readback :
                     FStar_Range.dummyRange in
                 let args1 =
                   FStar_List.map
-                    (fun uu____9381 ->
-                       match uu____9381 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | (x1, q) ->
-                           let uu____9392 = readback cfg x1 in
-                           (uu____9392, q)) args in
-                let uu____9393 = FStar_Syntax_Util.mk_app head args1 in
-                with_range uu____9393)
+                           let uu___4 = readback cfg x1 in (uu___4, q)) args in
+                let uu___3 = FStar_Syntax_Util.mk_app head args1 in
+                with_range uu___3)
        | FStar_TypeChecker_NBETerm.Quote (qt, qi) ->
            mk (FStar_Syntax_Syntax.Tm_quoted (qt, qi))
-       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li, uu____9401) ->
+       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li, uu___1) ->
            mk (FStar_Syntax_Syntax.Tm_lazy li)
-       | FStar_TypeChecker_NBETerm.Lazy (uu____9418, thunk) ->
-           let uu____9440 = FStar_Thunk.force thunk in
-           readback cfg uu____9440)
+       | FStar_TypeChecker_NBETerm.Lazy (uu___1, thunk) ->
+           let uu___2 = FStar_Thunk.force thunk in readback cfg uu___2)
 type step =
   | Primops 
   | UnfoldUntil of FStar_Syntax_Syntax.delta_depth 
@@ -2913,31 +2827,29 @@ type step =
   | UnfoldTac 
   | Reify 
 let (uu___is_Primops : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Primops -> true | uu____9465 -> false
+  fun projectee -> match projectee with | Primops -> true | uu___ -> false
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldUntil _0 -> true | uu____9472 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu___ -> false
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee -> match projectee with | UnfoldUntil _0 -> _0
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldOnly _0 -> true | uu____9487 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu___ -> false
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee -> match projectee with | UnfoldOnly _0 -> _0
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnfoldAttr _0 -> true | uu____9508 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu___ -> false
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee -> match projectee with | UnfoldAttr _0 -> _0
 let (uu___is_UnfoldTac : step -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UnfoldTac -> true | uu____9526 -> false
+  fun projectee -> match projectee with | UnfoldTac -> true | uu___ -> false
 let (uu___is_Reify : step -> Prims.bool) =
-  fun projectee -> match projectee with | Reify -> true | uu____9532 -> false
+  fun projectee -> match projectee with | Reify -> true | uu___ -> false
 let (step_as_normalizer_step : step -> FStar_TypeChecker_Env.step) =
-  fun uu___2_9537 ->
-    match uu___2_9537 with
+  fun uu___ ->
+    match uu___ with
     | Primops -> FStar_TypeChecker_Env.Primops
     | UnfoldUntil d -> FStar_TypeChecker_Env.UnfoldUntil d
     | UnfoldOnly lids -> FStar_TypeChecker_Env.UnfoldOnly lids
@@ -2950,8 +2862,7 @@ let (reduce_application :
       FStar_TypeChecker_NBETerm.args -> FStar_TypeChecker_NBETerm.t)
   =
   fun cfg ->
-    fun t ->
-      fun args -> let uu____9560 = new_config cfg in iapp uu____9560 t args
+    fun t -> fun args -> let uu___ = new_config cfg in iapp uu___ t args
 let (normalize :
   FStar_TypeChecker_Cfg.primitive_step Prims.list ->
     FStar_TypeChecker_Env.step Prims.list ->
@@ -2964,102 +2875,101 @@ let (normalize :
         fun e ->
           let cfg = FStar_TypeChecker_Cfg.config' psteps steps env in
           let cfg1 =
-            let uu___1559_9591 = cfg in
+            let uu___ = cfg in
             {
               FStar_TypeChecker_Cfg.steps =
-                (let uu___1561_9594 = cfg.FStar_TypeChecker_Cfg.steps in
+                (let uu___1 = cfg.FStar_TypeChecker_Cfg.steps in
                  {
                    FStar_TypeChecker_Cfg.beta =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.beta);
+                     (uu___1.FStar_TypeChecker_Cfg.beta);
                    FStar_TypeChecker_Cfg.iota =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.iota);
+                     (uu___1.FStar_TypeChecker_Cfg.iota);
                    FStar_TypeChecker_Cfg.zeta =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.zeta);
+                     (uu___1.FStar_TypeChecker_Cfg.zeta);
                    FStar_TypeChecker_Cfg.zeta_full =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.zeta_full);
+                     (uu___1.FStar_TypeChecker_Cfg.zeta_full);
                    FStar_TypeChecker_Cfg.weak =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.weak);
+                     (uu___1.FStar_TypeChecker_Cfg.weak);
                    FStar_TypeChecker_Cfg.hnf =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.hnf);
+                     (uu___1.FStar_TypeChecker_Cfg.hnf);
                    FStar_TypeChecker_Cfg.primops =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.primops);
+                     (uu___1.FStar_TypeChecker_Cfg.primops);
                    FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                     (uu___1.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                    FStar_TypeChecker_Cfg.unfold_until =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unfold_until);
+                     (uu___1.FStar_TypeChecker_Cfg.unfold_until);
                    FStar_TypeChecker_Cfg.unfold_only =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unfold_only);
+                     (uu___1.FStar_TypeChecker_Cfg.unfold_only);
                    FStar_TypeChecker_Cfg.unfold_fully =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unfold_fully);
+                     (uu___1.FStar_TypeChecker_Cfg.unfold_fully);
                    FStar_TypeChecker_Cfg.unfold_attr =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unfold_attr);
+                     (uu___1.FStar_TypeChecker_Cfg.unfold_attr);
                    FStar_TypeChecker_Cfg.unfold_tac =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unfold_tac);
+                     (uu___1.FStar_TypeChecker_Cfg.unfold_tac);
                    FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                     (uu___1.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                    FStar_TypeChecker_Cfg.simplify =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.simplify);
+                     (uu___1.FStar_TypeChecker_Cfg.simplify);
                    FStar_TypeChecker_Cfg.erase_universes =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.erase_universes);
+                     (uu___1.FStar_TypeChecker_Cfg.erase_universes);
                    FStar_TypeChecker_Cfg.allow_unbound_universes =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                     (uu___1.FStar_TypeChecker_Cfg.allow_unbound_universes);
                    FStar_TypeChecker_Cfg.reify_ = true;
                    FStar_TypeChecker_Cfg.compress_uvars =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.compress_uvars);
+                     (uu___1.FStar_TypeChecker_Cfg.compress_uvars);
                    FStar_TypeChecker_Cfg.no_full_norm =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.no_full_norm);
+                     (uu___1.FStar_TypeChecker_Cfg.no_full_norm);
                    FStar_TypeChecker_Cfg.check_no_uvars =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.check_no_uvars);
+                     (uu___1.FStar_TypeChecker_Cfg.check_no_uvars);
                    FStar_TypeChecker_Cfg.unmeta =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unmeta);
+                     (uu___1.FStar_TypeChecker_Cfg.unmeta);
                    FStar_TypeChecker_Cfg.unascribe =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.unascribe);
+                     (uu___1.FStar_TypeChecker_Cfg.unascribe);
                    FStar_TypeChecker_Cfg.in_full_norm_request =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.in_full_norm_request);
+                     (uu___1.FStar_TypeChecker_Cfg.in_full_norm_request);
                    FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                     (uu___1.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                    FStar_TypeChecker_Cfg.nbe_step =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.nbe_step);
+                     (uu___1.FStar_TypeChecker_Cfg.nbe_step);
                    FStar_TypeChecker_Cfg.for_extraction =
-                     (uu___1561_9594.FStar_TypeChecker_Cfg.for_extraction)
+                     (uu___1.FStar_TypeChecker_Cfg.for_extraction)
                  });
               FStar_TypeChecker_Cfg.tcenv =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.tcenv);
+                (uu___.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.debug);
+                (uu___.FStar_TypeChecker_Cfg.debug);
               FStar_TypeChecker_Cfg.delta_level =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.delta_level);
+                (uu___.FStar_TypeChecker_Cfg.delta_level);
               FStar_TypeChecker_Cfg.primitive_steps =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.primitive_steps);
+                (uu___.FStar_TypeChecker_Cfg.primitive_steps);
               FStar_TypeChecker_Cfg.strong =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.strong);
+                (uu___.FStar_TypeChecker_Cfg.strong);
               FStar_TypeChecker_Cfg.memoize_lazy =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.memoize_lazy);
+                (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
               FStar_TypeChecker_Cfg.reifying =
-                (uu___1559_9591.FStar_TypeChecker_Cfg.reifying)
+                (uu___.FStar_TypeChecker_Cfg.reifying)
             } in
-          (let uu____9596 =
+          (let uu___1 =
              (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                ||
                (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE")) in
-           if uu____9596
+           if uu___1
            then
-             let uu____9597 = FStar_Syntax_Print.term_to_string e in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9597
+             let uu___2 = FStar_Syntax_Print.term_to_string e in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu___2
            else ());
           (let cfg2 = new_config cfg1 in
-           let r =
-             let uu____9601 = translate cfg2 [] e in readback cfg2 uu____9601 in
-           (let uu____9603 =
+           let r = let uu___1 = translate cfg2 [] e in readback cfg2 uu___1 in
+           (let uu___2 =
               (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                 ||
                 (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE")) in
-            if uu____9603
+            if uu___2
             then
-              let uu____9604 = FStar_Syntax_Print.term_to_string r in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9604
+              let uu___3 = FStar_Syntax_Print.term_to_string r in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu___3
             else ());
            r)
 let (normalize_for_unit_test :
@@ -3072,91 +2982,88 @@ let (normalize_for_unit_test :
       fun e ->
         let cfg = FStar_TypeChecker_Cfg.config steps env in
         let cfg1 =
-          let uu___1577_9627 = cfg in
+          let uu___ = cfg in
           {
             FStar_TypeChecker_Cfg.steps =
-              (let uu___1579_9630 = cfg.FStar_TypeChecker_Cfg.steps in
+              (let uu___1 = cfg.FStar_TypeChecker_Cfg.steps in
                {
                  FStar_TypeChecker_Cfg.beta =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.beta);
+                   (uu___1.FStar_TypeChecker_Cfg.beta);
                  FStar_TypeChecker_Cfg.iota =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.iota);
+                   (uu___1.FStar_TypeChecker_Cfg.iota);
                  FStar_TypeChecker_Cfg.zeta =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.zeta);
+                   (uu___1.FStar_TypeChecker_Cfg.zeta);
                  FStar_TypeChecker_Cfg.zeta_full =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.zeta_full);
+                   (uu___1.FStar_TypeChecker_Cfg.zeta_full);
                  FStar_TypeChecker_Cfg.weak =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.weak);
+                   (uu___1.FStar_TypeChecker_Cfg.weak);
                  FStar_TypeChecker_Cfg.hnf =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.hnf);
+                   (uu___1.FStar_TypeChecker_Cfg.hnf);
                  FStar_TypeChecker_Cfg.primops =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.primops);
+                   (uu___1.FStar_TypeChecker_Cfg.primops);
                  FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                   (uu___1.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                  FStar_TypeChecker_Cfg.unfold_until =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unfold_until);
+                   (uu___1.FStar_TypeChecker_Cfg.unfold_until);
                  FStar_TypeChecker_Cfg.unfold_only =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unfold_only);
+                   (uu___1.FStar_TypeChecker_Cfg.unfold_only);
                  FStar_TypeChecker_Cfg.unfold_fully =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unfold_fully);
+                   (uu___1.FStar_TypeChecker_Cfg.unfold_fully);
                  FStar_TypeChecker_Cfg.unfold_attr =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unfold_attr);
+                   (uu___1.FStar_TypeChecker_Cfg.unfold_attr);
                  FStar_TypeChecker_Cfg.unfold_tac =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unfold_tac);
+                   (uu___1.FStar_TypeChecker_Cfg.unfold_tac);
                  FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                   (uu___1.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                  FStar_TypeChecker_Cfg.simplify =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.simplify);
+                   (uu___1.FStar_TypeChecker_Cfg.simplify);
                  FStar_TypeChecker_Cfg.erase_universes =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.erase_universes);
+                   (uu___1.FStar_TypeChecker_Cfg.erase_universes);
                  FStar_TypeChecker_Cfg.allow_unbound_universes =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                   (uu___1.FStar_TypeChecker_Cfg.allow_unbound_universes);
                  FStar_TypeChecker_Cfg.reify_ = true;
                  FStar_TypeChecker_Cfg.compress_uvars =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.compress_uvars);
+                   (uu___1.FStar_TypeChecker_Cfg.compress_uvars);
                  FStar_TypeChecker_Cfg.no_full_norm =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.no_full_norm);
+                   (uu___1.FStar_TypeChecker_Cfg.no_full_norm);
                  FStar_TypeChecker_Cfg.check_no_uvars =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.check_no_uvars);
+                   (uu___1.FStar_TypeChecker_Cfg.check_no_uvars);
                  FStar_TypeChecker_Cfg.unmeta =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unmeta);
+                   (uu___1.FStar_TypeChecker_Cfg.unmeta);
                  FStar_TypeChecker_Cfg.unascribe =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.unascribe);
+                   (uu___1.FStar_TypeChecker_Cfg.unascribe);
                  FStar_TypeChecker_Cfg.in_full_norm_request =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.in_full_norm_request);
+                   (uu___1.FStar_TypeChecker_Cfg.in_full_norm_request);
                  FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                   (uu___1.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                  FStar_TypeChecker_Cfg.nbe_step =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.nbe_step);
+                   (uu___1.FStar_TypeChecker_Cfg.nbe_step);
                  FStar_TypeChecker_Cfg.for_extraction =
-                   (uu___1579_9630.FStar_TypeChecker_Cfg.for_extraction)
+                   (uu___1.FStar_TypeChecker_Cfg.for_extraction)
                });
-            FStar_TypeChecker_Cfg.tcenv =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.tcenv);
-            FStar_TypeChecker_Cfg.debug =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.debug);
+            FStar_TypeChecker_Cfg.tcenv = (uu___.FStar_TypeChecker_Cfg.tcenv);
+            FStar_TypeChecker_Cfg.debug = (uu___.FStar_TypeChecker_Cfg.debug);
             FStar_TypeChecker_Cfg.delta_level =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.delta_level);
+              (uu___.FStar_TypeChecker_Cfg.delta_level);
             FStar_TypeChecker_Cfg.primitive_steps =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.primitive_steps);
+              (uu___.FStar_TypeChecker_Cfg.primitive_steps);
             FStar_TypeChecker_Cfg.strong =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.strong);
+              (uu___.FStar_TypeChecker_Cfg.strong);
             FStar_TypeChecker_Cfg.memoize_lazy =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.memoize_lazy);
+              (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
             FStar_TypeChecker_Cfg.normalize_pure_lets =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.normalize_pure_lets);
+              (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
             FStar_TypeChecker_Cfg.reifying =
-              (uu___1577_9627.FStar_TypeChecker_Cfg.reifying)
+              (uu___.FStar_TypeChecker_Cfg.reifying)
           } in
         let cfg2 = new_config cfg1 in
         debug cfg2
-          (fun uu____9635 ->
-             let uu____9636 = FStar_Syntax_Print.term_to_string e in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9636);
-        (let r =
-           let uu____9638 = translate cfg2 [] e in readback cfg2 uu____9638 in
+          (fun uu___1 ->
+             let uu___2 = FStar_Syntax_Print.term_to_string e in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu___2);
+        (let r = let uu___1 = translate cfg2 [] e in readback cfg2 uu___1 in
          debug cfg2
-           (fun uu____9642 ->
-              let uu____9643 = FStar_Syntax_Print.term_to_string r in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9643);
+           (fun uu___2 ->
+              let uu___3 = FStar_Syntax_Print.term_to_string r in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu___3);
          r)

--- a/src/ocaml-output/FStar_TypeChecker_NBETerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBETerm.ml
@@ -10,34 +10,30 @@ type constant =
   | Range of FStar_Range.range 
   | SConst of FStar_Const.sconst 
 let (uu___is_Unit : constant -> Prims.bool) =
-  fun projectee -> match projectee with | Unit -> true | uu____56 -> false
+  fun projectee -> match projectee with | Unit -> true | uu___ -> false
 let (uu___is_Bool : constant -> Prims.bool) =
-  fun projectee -> match projectee with | Bool _0 -> true | uu____63 -> false
+  fun projectee -> match projectee with | Bool _0 -> true | uu___ -> false
 let (__proj__Bool__item___0 : constant -> Prims.bool) =
   fun projectee -> match projectee with | Bool _0 -> _0
 let (uu___is_Int : constant -> Prims.bool) =
-  fun projectee -> match projectee with | Int _0 -> true | uu____76 -> false
+  fun projectee -> match projectee with | Int _0 -> true | uu___ -> false
 let (__proj__Int__item___0 : constant -> FStar_BigInt.t) =
   fun projectee -> match projectee with | Int _0 -> _0
 let (uu___is_String : constant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | String _0 -> true | uu____93 -> false
+  fun projectee -> match projectee with | String _0 -> true | uu___ -> false
 let (__proj__String__item___0 :
   constant -> (Prims.string * FStar_Range.range)) =
   fun projectee -> match projectee with | String _0 -> _0
 let (uu___is_Char : constant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Char _0 -> true | uu____118 -> false
+  fun projectee -> match projectee with | Char _0 -> true | uu___ -> false
 let (__proj__Char__item___0 : constant -> FStar_Char.char) =
   fun projectee -> match projectee with | Char _0 -> _0
 let (uu___is_Range : constant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Range _0 -> true | uu____131 -> false
+  fun projectee -> match projectee with | Range _0 -> true | uu___ -> false
 let (__proj__Range__item___0 : constant -> FStar_Range.range) =
   fun projectee -> match projectee with | Range _0 -> _0
 let (uu___is_SConst : constant -> Prims.bool) =
-  fun projectee ->
-    match projectee with | SConst _0 -> true | uu____144 -> false
+  fun projectee -> match projectee with | SConst _0 -> true | uu___ -> false
 let (__proj__SConst__item___0 : constant -> FStar_Const.sconst) =
   fun projectee -> match projectee with | SConst _0 -> _0
 type atom =
@@ -112,18 +108,17 @@ and residual_comp =
   residual_typ: t FStar_Pervasives_Native.option ;
   residual_flags: cflag Prims.list }
 let (uu___is_Var : atom -> Prims.bool) =
-  fun projectee -> match projectee with | Var _0 -> true | uu____615 -> false
+  fun projectee -> match projectee with | Var _0 -> true | uu___ -> false
 let (__proj__Var__item___0 : atom -> var) =
   fun projectee -> match projectee with | Var _0 -> _0
 let (uu___is_Match : atom -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Match _0 -> true | uu____637 -> false
+  fun projectee -> match projectee with | Match _0 -> true | uu___ -> false
 let (__proj__Match__item___0 :
   atom -> (t * (unit -> FStar_Syntax_Syntax.branch Prims.list))) =
   fun projectee -> match projectee with | Match _0 -> _0
 let (uu___is_UnreducedLet : atom -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnreducedLet _0 -> true | uu____693 -> false
+    match projectee with | UnreducedLet _0 -> true | uu___ -> false
 let (__proj__UnreducedLet__item___0 :
   atom ->
     (var * t FStar_Thunk.t * t FStar_Thunk.t * t FStar_Thunk.t *
@@ -131,19 +126,18 @@ let (__proj__UnreducedLet__item___0 :
   = fun projectee -> match projectee with | UnreducedLet _0 -> _0
 let (uu___is_UnreducedLetRec : atom -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnreducedLetRec _0 -> true | uu____770 -> false
+    match projectee with | UnreducedLetRec _0 -> true | uu___ -> false
 let (__proj__UnreducedLetRec__item___0 :
   atom ->
     ((var * t * t) Prims.list * t * FStar_Syntax_Syntax.letbinding
       Prims.list))
   = fun projectee -> match projectee with | UnreducedLetRec _0 -> _0
 let (uu___is_UVar : atom -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UVar _0 -> true | uu____833 -> false
+  fun projectee -> match projectee with | UVar _0 -> true | uu___ -> false
 let (__proj__UVar__item___0 : atom -> FStar_Syntax_Syntax.term FStar_Thunk.t)
   = fun projectee -> match projectee with | UVar _0 -> _0
 let (uu___is_Lam : t' -> Prims.bool) =
-  fun projectee -> match projectee with | Lam _0 -> true | uu____883 -> false
+  fun projectee -> match projectee with | Lam _0 -> true | uu___ -> false
 let (__proj__Lam__item___0 :
   t' ->
     ((t Prims.list -> t) *
@@ -153,21 +147,20 @@ let (__proj__Lam__item___0 :
       Prims.int))
   = fun projectee -> match projectee with | Lam _0 -> _0
 let (uu___is_Accu : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Accu _0 -> true | uu____999 -> false
+  fun projectee -> match projectee with | Accu _0 -> true | uu___ -> false
 let (__proj__Accu__item___0 :
   t' -> (atom * (t * FStar_Syntax_Syntax.aqual) Prims.list)) =
   fun projectee -> match projectee with | Accu _0 -> _0
 let (uu___is_Construct : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Construct _0 -> true | uu____1056 -> false
+    match projectee with | Construct _0 -> true | uu___ -> false
 let (__proj__Construct__item___0 :
   t' ->
     (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universe Prims.list * (t *
       FStar_Syntax_Syntax.aqual) Prims.list))
   = fun projectee -> match projectee with | Construct _0 -> _0
 let (uu___is_FV : t' -> Prims.bool) =
-  fun projectee -> match projectee with | FV _0 -> true | uu____1125 -> false
+  fun projectee -> match projectee with | FV _0 -> true | uu___ -> false
 let (__proj__FV__item___0 :
   t' ->
     (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universe Prims.list * (t *
@@ -175,25 +168,21 @@ let (__proj__FV__item___0 :
   = fun projectee -> match projectee with | FV _0 -> _0
 let (uu___is_Constant : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Constant _0 -> true | uu____1180 -> false
+    match projectee with | Constant _0 -> true | uu___ -> false
 let (__proj__Constant__item___0 : t' -> constant) =
   fun projectee -> match projectee with | Constant _0 -> _0
 let (uu___is_Type_t : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Type_t _0 -> true | uu____1193 -> false
+  fun projectee -> match projectee with | Type_t _0 -> true | uu___ -> false
 let (__proj__Type_t__item___0 : t' -> FStar_Syntax_Syntax.universe) =
   fun projectee -> match projectee with | Type_t _0 -> _0
 let (uu___is_Univ : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Univ _0 -> true | uu____1206 -> false
+  fun projectee -> match projectee with | Univ _0 -> true | uu___ -> false
 let (__proj__Univ__item___0 : t' -> FStar_Syntax_Syntax.universe) =
   fun projectee -> match projectee with | Univ _0 -> _0
 let (uu___is_Unknown : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Unknown -> true | uu____1218 -> false
+  fun projectee -> match projectee with | Unknown -> true | uu___ -> false
 let (uu___is_Arrow : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Arrow _0 -> true | uu____1241 -> false
+  fun projectee -> match projectee with | Arrow _0 -> true | uu___ -> false
 let (__proj__Arrow__item___0 :
   t' ->
     (FStar_Syntax_Syntax.term FStar_Thunk.t,
@@ -201,24 +190,21 @@ let (__proj__Arrow__item___0 :
   = fun projectee -> match projectee with | Arrow _0 -> _0
 let (uu___is_Refinement : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Refinement _0 -> true | uu____1316 -> false
+    match projectee with | Refinement _0 -> true | uu___ -> false
 let (__proj__Refinement__item___0 :
   t' -> ((t -> t) * (unit -> (t * FStar_Syntax_Syntax.aqual)))) =
   fun projectee -> match projectee with | Refinement _0 -> _0
 let (uu___is_Reflect : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Reflect _0 -> true | uu____1371 -> false
+  fun projectee -> match projectee with | Reflect _0 -> true | uu___ -> false
 let (__proj__Reflect__item___0 : t' -> t) =
   fun projectee -> match projectee with | Reflect _0 -> _0
 let (uu___is_Quote : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Quote _0 -> true | uu____1388 -> false
+  fun projectee -> match projectee with | Quote _0 -> true | uu___ -> false
 let (__proj__Quote__item___0 :
   t' -> (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.quoteinfo)) =
   fun projectee -> match projectee with | Quote _0 -> _0
 let (uu___is_Lazy : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Lazy _0 -> true | uu____1427 -> false
+  fun projectee -> match projectee with | Lazy _0 -> true | uu___ -> false
 let (__proj__Lazy__item___0 :
   t' ->
     ((FStar_Syntax_Syntax.lazyinfo,
@@ -226,14 +212,13 @@ let (__proj__Lazy__item___0 :
       FStar_Thunk.t))
   = fun projectee -> match projectee with | Lazy _0 -> _0
 let (uu___is_Meta : t' -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Meta _0 -> true | uu____1488 -> false
+  fun projectee -> match projectee with | Meta _0 -> true | uu___ -> false
 let (__proj__Meta__item___0 :
   t' -> (t * FStar_Syntax_Syntax.metadata FStar_Thunk.t)) =
   fun projectee -> match projectee with | Meta _0 -> _0
 let (uu___is_TopLevelLet : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TopLevelLet _0 -> true | uu____1531 -> false
+    match projectee with | TopLevelLet _0 -> true | uu___ -> false
 let (__proj__TopLevelLet__item___0 :
   t' ->
     (FStar_Syntax_Syntax.letbinding * Prims.int * (t *
@@ -241,7 +226,7 @@ let (__proj__TopLevelLet__item___0 :
   = fun projectee -> match projectee with | TopLevelLet _0 -> _0
 let (uu___is_TopLevelRec : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | TopLevelRec _0 -> true | uu____1596 -> false
+    match projectee with | TopLevelRec _0 -> true | uu___ -> false
 let (__proj__TopLevelRec__item___0 :
   t' ->
     (FStar_Syntax_Syntax.letbinding * Prims.int * Prims.bool Prims.list * (t
@@ -249,7 +234,7 @@ let (__proj__TopLevelRec__item___0 :
   = fun projectee -> match projectee with | TopLevelRec _0 -> _0
 let (uu___is_LocalLetRec : t' -> Prims.bool) =
   fun projectee ->
-    match projectee with | LocalLetRec _0 -> true | uu____1683 -> false
+    match projectee with | LocalLetRec _0 -> true | uu___ -> false
 let (__proj__LocalLetRec__item___0 :
   t' ->
     (Prims.int * FStar_Syntax_Syntax.letbinding *
@@ -262,20 +247,17 @@ let (__proj__Mkt__item__nbe_t : t -> t') =
 let (__proj__Mkt__item__nbe_r : t -> FStar_Range.range) =
   fun projectee -> match projectee with | { nbe_t; nbe_r;_} -> nbe_r
 let (uu___is_Tot : comp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Tot _0 -> true | uu____1794 -> false
+  fun projectee -> match projectee with | Tot _0 -> true | uu___ -> false
 let (__proj__Tot__item___0 :
   comp -> (t * FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | Tot _0 -> _0
 let (uu___is_GTot : comp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | GTot _0 -> true | uu____1831 -> false
+  fun projectee -> match projectee with | GTot _0 -> true | uu___ -> false
 let (__proj__GTot__item___0 :
   comp -> (t * FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option))
   = fun projectee -> match projectee with | GTot _0 -> _0
 let (uu___is_Comp : comp -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Comp _0 -> true | uu____1862 -> false
+  fun projectee -> match projectee with | Comp _0 -> true | uu___ -> false
 let (__proj__Comp__item___0 : comp -> comp_typ) =
   fun projectee -> match projectee with | Comp _0 -> _0
 let (__proj__Mkcomp_typ__item__comp_univs :
@@ -306,34 +288,30 @@ let (__proj__Mkcomp_typ__item__flags : comp_typ -> cflag Prims.list) =
     match projectee with
     | { comp_univs; effect_name; result_typ; effect_args; flags;_} -> flags
 let (uu___is_TOTAL : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | TOTAL -> true | uu____1980 -> false
+  fun projectee -> match projectee with | TOTAL -> true | uu___ -> false
 let (uu___is_MLEFFECT : cflag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | MLEFFECT -> true | uu____1986 -> false
+  fun projectee -> match projectee with | MLEFFECT -> true | uu___ -> false
 let (uu___is_RETURN : cflag -> Prims.bool) =
-  fun projectee ->
-    match projectee with | RETURN -> true | uu____1992 -> false
+  fun projectee -> match projectee with | RETURN -> true | uu___ -> false
 let (uu___is_PARTIAL_RETURN : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | PARTIAL_RETURN -> true | uu____1998 -> false
+    match projectee with | PARTIAL_RETURN -> true | uu___ -> false
 let (uu___is_SOMETRIVIAL : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SOMETRIVIAL -> true | uu____2004 -> false
+    match projectee with | SOMETRIVIAL -> true | uu___ -> false
 let (uu___is_TRIVIAL_POSTCONDITION : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with
-    | TRIVIAL_POSTCONDITION -> true
-    | uu____2010 -> false
+    match projectee with | TRIVIAL_POSTCONDITION -> true | uu___ -> false
 let (uu___is_SHOULD_NOT_INLINE : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SHOULD_NOT_INLINE -> true | uu____2016 -> false
+    match projectee with | SHOULD_NOT_INLINE -> true | uu___ -> false
 let (uu___is_LEMMA : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | LEMMA -> true | uu____2022 -> false
+  fun projectee -> match projectee with | LEMMA -> true | uu___ -> false
 let (uu___is_CPS : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | CPS -> true | uu____2028 -> false
+  fun projectee -> match projectee with | CPS -> true | uu___ -> false
 let (uu___is_DECREASES : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | DECREASES _0 -> true | uu____2035 -> false
+    match projectee with | DECREASES _0 -> true | uu___ -> false
 let (__proj__DECREASES__item___0 : cflag -> t) =
   fun projectee -> match projectee with | DECREASES _0 -> _0
 let (__proj__Mkresidual_comp__item__residual_effect :
@@ -356,13 +334,9 @@ type args = (t * FStar_Syntax_Syntax.aqual) Prims.list
 type head = t
 type annot = t FStar_Pervasives_Native.option
 let (isAccu : t -> Prims.bool) =
-  fun trm ->
-    match trm.nbe_t with | Accu uu____2103 -> true | uu____2114 -> false
+  fun trm -> match trm.nbe_t with | Accu uu___ -> true | uu___ -> false
 let (isNotAccu : t -> Prims.bool) =
-  fun x ->
-    match x.nbe_t with
-    | Accu (uu____2120, uu____2121) -> false
-    | uu____2134 -> true
+  fun x -> match x.nbe_t with | Accu (uu___, uu___1) -> false | uu___ -> true
 let (mk_rt : FStar_Range.range -> t' -> t) =
   fun r -> fun t1 -> { nbe_t = t1; nbe_r = r }
 let (mk_t : t' -> t) = fun t1 -> mk_rt FStar_Range.dummyRange t1
@@ -380,24 +354,20 @@ let (mkFV :
   fun i ->
     fun us ->
       fun ts ->
-        let uu____2201 = FStar_Syntax_Syntax.range_of_fv i in
-        mk_rt uu____2201 (FV (i, us, ts))
+        let uu___ = FStar_Syntax_Syntax.range_of_fv i in
+        mk_rt uu___ (FV (i, us, ts))
 let (mkAccuVar : var -> t) =
   fun v ->
-    let uu____2215 = FStar_Syntax_Syntax.range_of_bv v in
-    mk_rt uu____2215 (Accu ((Var v), []))
+    let uu___ = FStar_Syntax_Syntax.range_of_bv v in
+    mk_rt uu___ (Accu ((Var v), []))
 let (mkAccuMatch : t -> (unit -> FStar_Syntax_Syntax.branch Prims.list) -> t)
   = fun s -> fun bs -> FStar_All.pipe_left mk_t (Accu ((Match (s, bs)), []))
 let (equal_if : Prims.bool -> FStar_Syntax_Util.eq_result) =
-  fun uu___0_2264 ->
-    if uu___0_2264
-    then FStar_Syntax_Util.Equal
-    else FStar_Syntax_Util.Unknown
+  fun uu___ ->
+    if uu___ then FStar_Syntax_Util.Equal else FStar_Syntax_Util.Unknown
 let (equal_iff : Prims.bool -> FStar_Syntax_Util.eq_result) =
-  fun uu___1_2270 ->
-    if uu___1_2270
-    then FStar_Syntax_Util.Equal
-    else FStar_Syntax_Util.NotEqual
+  fun uu___ ->
+    if uu___ then FStar_Syntax_Util.Equal else FStar_Syntax_Util.NotEqual
 let (eq_inj :
   FStar_Syntax_Util.eq_result ->
     FStar_Syntax_Util.eq_result -> FStar_Syntax_Util.eq_result)
@@ -407,12 +377,10 @@ let (eq_inj :
       match (r1, r2) with
       | (FStar_Syntax_Util.Equal, FStar_Syntax_Util.Equal) ->
           FStar_Syntax_Util.Equal
-      | (FStar_Syntax_Util.NotEqual, uu____2282) ->
-          FStar_Syntax_Util.NotEqual
-      | (uu____2283, FStar_Syntax_Util.NotEqual) ->
-          FStar_Syntax_Util.NotEqual
-      | (FStar_Syntax_Util.Unknown, uu____2284) -> FStar_Syntax_Util.Unknown
-      | (uu____2285, FStar_Syntax_Util.Unknown) -> FStar_Syntax_Util.Unknown
+      | (FStar_Syntax_Util.NotEqual, uu___) -> FStar_Syntax_Util.NotEqual
+      | (uu___, FStar_Syntax_Util.NotEqual) -> FStar_Syntax_Util.NotEqual
+      | (FStar_Syntax_Util.Unknown, uu___) -> FStar_Syntax_Util.Unknown
+      | (uu___, FStar_Syntax_Util.Unknown) -> FStar_Syntax_Util.Unknown
 let (eq_and :
   FStar_Syntax_Util.eq_result ->
     (unit -> FStar_Syntax_Util.eq_result) -> FStar_Syntax_Util.eq_result)
@@ -421,7 +389,7 @@ let (eq_and :
     fun g ->
       match f with
       | FStar_Syntax_Util.Equal -> g ()
-      | uu____2301 -> FStar_Syntax_Util.Unknown
+      | uu___ -> FStar_Syntax_Util.Unknown
 let (eq_constant : constant -> constant -> FStar_Syntax_Util.eq_result) =
   fun c1 ->
     fun c2 ->
@@ -429,80 +397,73 @@ let (eq_constant : constant -> constant -> FStar_Syntax_Util.eq_result) =
       | (Unit, Unit) -> FStar_Syntax_Util.Equal
       | (Bool b1, Bool b2) -> equal_iff (b1 = b2)
       | (Int i1, Int i2) -> equal_iff (i1 = i2)
-      | (String (s1, uu____2317), String (s2, uu____2319)) ->
-          equal_iff (s1 = s2)
+      | (String (s1, uu___), String (s2, uu___1)) -> equal_iff (s1 = s2)
       | (Char c11, Char c21) -> equal_iff (c11 = c21)
       | (Range r1, Range r2) -> FStar_Syntax_Util.Unknown
-      | (uu____2324, uu____2325) -> FStar_Syntax_Util.NotEqual
+      | (uu___, uu___1) -> FStar_Syntax_Util.NotEqual
 let rec (eq_t : t -> t -> FStar_Syntax_Util.eq_result) =
   fun t1 ->
     fun t2 ->
       match ((t1.nbe_t), (t2.nbe_t)) with
-      | (Lam uu____2360, Lam uu____2361) -> FStar_Syntax_Util.Unknown
+      | (Lam uu___, Lam uu___1) -> FStar_Syntax_Util.Unknown
       | (Accu (a1, as1), Accu (a2, as2)) ->
-          let uu____2452 = eq_atom a1 a2 in
-          eq_and uu____2452 (fun uu____2454 -> eq_args as1 as2)
+          let uu___ = eq_atom a1 a2 in
+          eq_and uu___ (fun uu___1 -> eq_args as1 as2)
       | (Construct (v1, us1, args1), Construct (v2, us2, args2)) ->
-          let uu____2493 = FStar_Syntax_Syntax.fv_eq v1 v2 in
-          if uu____2493
+          let uu___ = FStar_Syntax_Syntax.fv_eq v1 v2 in
+          if uu___
           then
             (if (FStar_List.length args1) <> (FStar_List.length args2)
              then failwith "eq_t, different number of args on Construct"
              else ();
-             (let uu____2504 = FStar_List.zip args1 args2 in
+             (let uu___2 = FStar_List.zip args1 args2 in
               FStar_All.pipe_left
                 (FStar_List.fold_left
                    (fun acc ->
-                      fun uu____2561 ->
-                        match uu____2561 with
-                        | ((a1, uu____2575), (a2, uu____2577)) ->
-                            let uu____2586 = eq_t a1 a2 in
-                            eq_inj acc uu____2586) FStar_Syntax_Util.Equal)
-                uu____2504))
+                      fun uu___3 ->
+                        match uu___3 with
+                        | ((a1, uu___4), (a2, uu___5)) ->
+                            let uu___6 = eq_t a1 a2 in eq_inj acc uu___6)
+                   FStar_Syntax_Util.Equal) uu___2))
           else FStar_Syntax_Util.NotEqual
       | (FV (v1, us1, args1), FV (v2, us2, args2)) ->
-          let uu____2626 = FStar_Syntax_Syntax.fv_eq v1 v2 in
-          if uu____2626
+          let uu___ = FStar_Syntax_Syntax.fv_eq v1 v2 in
+          if uu___
           then
-            let uu____2627 =
-              let uu____2628 = FStar_Syntax_Util.eq_univs_list us1 us2 in
-              equal_iff uu____2628 in
-            eq_and uu____2627 (fun uu____2630 -> eq_args args1 args2)
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Util.eq_univs_list us1 us2 in
+              equal_iff uu___2 in
+            eq_and uu___1 (fun uu___2 -> eq_args args1 args2)
           else FStar_Syntax_Util.Unknown
       | (Constant c1, Constant c2) -> eq_constant c1 c2
       | (Type_t u1, Type_t u2) ->
-          let uu____2636 = FStar_Syntax_Util.eq_univs u1 u2 in
-          equal_iff uu____2636
+          let uu___ = FStar_Syntax_Util.eq_univs u1 u2 in equal_iff uu___
       | (Univ u1, Univ u2) ->
-          let uu____2639 = FStar_Syntax_Util.eq_univs u1 u2 in
-          equal_iff uu____2639
+          let uu___ = FStar_Syntax_Util.eq_univs u1 u2 in equal_iff uu___
       | (Refinement (r1, t11), Refinement (r2, t21)) ->
           let x =
             FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
               FStar_Syntax_Syntax.t_unit in
-          let uu____2685 =
-            let uu____2686 =
-              let uu____2687 = t11 () in
-              FStar_Pervasives_Native.fst uu____2687 in
-            let uu____2692 =
-              let uu____2693 = t21 () in
-              FStar_Pervasives_Native.fst uu____2693 in
-            eq_t uu____2686 uu____2692 in
-          eq_and uu____2685
-            (fun uu____2701 ->
-               let uu____2702 = let uu____2703 = mkAccuVar x in r1 uu____2703 in
-               let uu____2704 = let uu____2705 = mkAccuVar x in r2 uu____2705 in
-               eq_t uu____2702 uu____2704)
+          let uu___ =
+            let uu___1 =
+              let uu___2 = t11 () in FStar_Pervasives_Native.fst uu___2 in
+            let uu___2 =
+              let uu___3 = t21 () in FStar_Pervasives_Native.fst uu___3 in
+            eq_t uu___1 uu___2 in
+          eq_and uu___
+            (fun uu___1 ->
+               let uu___2 = let uu___3 = mkAccuVar x in r1 uu___3 in
+               let uu___3 = let uu___4 = mkAccuVar x in r2 uu___4 in
+               eq_t uu___2 uu___3)
       | (Unknown, Unknown) -> FStar_Syntax_Util.Equal
-      | (uu____2706, uu____2707) -> FStar_Syntax_Util.Unknown
+      | (uu___, uu___1) -> FStar_Syntax_Util.Unknown
 and (eq_atom : atom -> atom -> FStar_Syntax_Util.eq_result) =
   fun a1 ->
     fun a2 ->
       match (a1, a2) with
       | (Var bv1, Var bv2) ->
-          let uu____2712 = FStar_Syntax_Syntax.bv_eq bv1 bv2 in
-          equal_if uu____2712
-      | (uu____2713, uu____2714) -> FStar_Syntax_Util.Unknown
+          let uu___ = FStar_Syntax_Syntax.bv_eq bv1 bv2 in equal_if uu___
+      | (uu___, uu___1) -> FStar_Syntax_Util.Unknown
 and (eq_arg : arg -> arg -> FStar_Syntax_Util.eq_result) =
   fun a1 ->
     fun a2 ->
@@ -513,9 +474,9 @@ and (eq_args : args -> args -> FStar_Syntax_Util.eq_result) =
       match (as1, as2) with
       | ([], []) -> FStar_Syntax_Util.Equal
       | (x::xs, y::ys) ->
-          let uu____2795 = eq_arg x y in
-          eq_and uu____2795 (fun uu____2797 -> eq_args xs ys)
-      | (uu____2798, uu____2799) -> FStar_Syntax_Util.Unknown
+          let uu___ = eq_arg x y in
+          eq_and uu___ (fun uu___1 -> eq_args xs ys)
+      | (uu___, uu___1) -> FStar_Syntax_Util.Unknown
 let (constant_to_string : constant -> Prims.string) =
   fun c ->
     match c with
@@ -523,178 +484,169 @@ let (constant_to_string : constant -> Prims.string) =
     | Bool b -> if b then "Bool true" else "Bool false"
     | Int i -> FStar_BigInt.string_of_big_int i
     | Char c1 -> FStar_Util.format1 "'%s'" (FStar_Util.string_of_char c1)
-    | String (s, uu____2834) -> FStar_Util.format1 "\"%s\"" s
+    | String (s, uu___) -> FStar_Util.format1 "\"%s\"" s
     | Range r ->
-        let uu____2836 = FStar_Range.string_of_range r in
-        FStar_Util.format1 "Range %s" uu____2836
+        let uu___ = FStar_Range.string_of_range r in
+        FStar_Util.format1 "Range %s" uu___
     | SConst s -> FStar_Syntax_Print.const_to_string s
 let rec (t_to_string : t -> Prims.string) =
   fun x ->
     match x.nbe_t with
-    | Lam (b, uu____2848, arity) ->
-        let uu____2900 = FStar_Util.string_of_int arity in
-        FStar_Util.format1 "Lam (_, %s args)" uu____2900
+    | Lam (b, uu___, arity) ->
+        let uu___1 = FStar_Util.string_of_int arity in
+        FStar_Util.format1 "Lam (_, %s args)" uu___1
     | Accu (a, l) ->
-        let uu____2915 =
-          let uu____2916 = atom_to_string a in
-          let uu____2917 =
-            let uu____2918 =
-              let uu____2919 =
-                let uu____2920 =
+        let uu___ =
+          let uu___1 = atom_to_string a in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
                   FStar_List.map
                     (fun x1 -> t_to_string (FStar_Pervasives_Native.fst x1))
                     l in
-                FStar_String.concat "; " uu____2920 in
-              FStar_String.op_Hat uu____2919 ")" in
-            FStar_String.op_Hat ") (" uu____2918 in
-          FStar_String.op_Hat uu____2916 uu____2917 in
-        FStar_String.op_Hat "Accu (" uu____2915
+                FStar_String.concat "; " uu___5 in
+              FStar_String.op_Hat uu___4 ")" in
+            FStar_String.op_Hat ") (" uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "Accu (" uu___
     | Construct (fv, us, l) ->
-        let uu____2952 =
-          let uu____2953 = FStar_Syntax_Print.fv_to_string fv in
-          let uu____2954 =
-            let uu____2955 =
-              let uu____2956 =
-                let uu____2957 =
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.fv_to_string fv in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
                   FStar_List.map FStar_Syntax_Print.univ_to_string us in
-                FStar_String.concat "; " uu____2957 in
-              let uu____2960 =
-                let uu____2961 =
-                  let uu____2962 =
-                    let uu____2963 =
+                FStar_String.concat "; " uu___5 in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 =
                       FStar_List.map
                         (fun x1 ->
                            t_to_string (FStar_Pervasives_Native.fst x1)) l in
-                    FStar_String.concat "; " uu____2963 in
-                  FStar_String.op_Hat uu____2962 "]" in
-                FStar_String.op_Hat "] [" uu____2961 in
-              FStar_String.op_Hat uu____2956 uu____2960 in
-            FStar_String.op_Hat ") [" uu____2955 in
-          FStar_String.op_Hat uu____2953 uu____2954 in
-        FStar_String.op_Hat "Construct (" uu____2952
+                    FStar_String.concat "; " uu___8 in
+                  FStar_String.op_Hat uu___7 "]" in
+                FStar_String.op_Hat "] [" uu___6 in
+              FStar_String.op_Hat uu___4 uu___5 in
+            FStar_String.op_Hat ") [" uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "Construct (" uu___
     | FV (fv, us, l) ->
-        let uu____2995 =
-          let uu____2996 = FStar_Syntax_Print.fv_to_string fv in
-          let uu____2997 =
-            let uu____2998 =
-              let uu____2999 =
-                let uu____3000 =
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.fv_to_string fv in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
                   FStar_List.map FStar_Syntax_Print.univ_to_string us in
-                FStar_String.concat "; " uu____3000 in
-              let uu____3003 =
-                let uu____3004 =
-                  let uu____3005 =
-                    let uu____3006 =
+                FStar_String.concat "; " uu___5 in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 =
                       FStar_List.map
                         (fun x1 ->
                            t_to_string (FStar_Pervasives_Native.fst x1)) l in
-                    FStar_String.concat "; " uu____3006 in
-                  FStar_String.op_Hat uu____3005 "]" in
-                FStar_String.op_Hat "] [" uu____3004 in
-              FStar_String.op_Hat uu____2999 uu____3003 in
-            FStar_String.op_Hat ") [" uu____2998 in
-          FStar_String.op_Hat uu____2996 uu____2997 in
-        FStar_String.op_Hat "FV (" uu____2995
+                    FStar_String.concat "; " uu___8 in
+                  FStar_String.op_Hat uu___7 "]" in
+                FStar_String.op_Hat "] [" uu___6 in
+              FStar_String.op_Hat uu___4 uu___5 in
+            FStar_String.op_Hat ") [" uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "FV (" uu___
     | Constant c -> constant_to_string c
     | Univ u ->
-        let uu____3021 = FStar_Syntax_Print.univ_to_string u in
-        FStar_String.op_Hat "Universe " uu____3021
+        let uu___ = FStar_Syntax_Print.univ_to_string u in
+        FStar_String.op_Hat "Universe " uu___
     | Type_t u ->
-        let uu____3023 = FStar_Syntax_Print.univ_to_string u in
-        FStar_String.op_Hat "Type_t " uu____3023
-    | Arrow uu____3024 -> "Arrow"
+        let uu___ = FStar_Syntax_Print.univ_to_string u in
+        FStar_String.op_Hat "Type_t " uu___
+    | Arrow uu___ -> "Arrow"
     | Refinement (f, t1) ->
         let x1 =
           FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
             FStar_Syntax_Syntax.t_unit in
-        let t2 =
-          let uu____3065 = t1 () in FStar_Pervasives_Native.fst uu____3065 in
-        let uu____3070 =
-          let uu____3071 = FStar_Syntax_Print.bv_to_string x1 in
-          let uu____3072 =
-            let uu____3073 =
-              let uu____3074 = t_to_string t2 in
-              let uu____3075 =
-                let uu____3076 =
-                  let uu____3077 =
-                    let uu____3078 =
-                      let uu____3079 = mkAccuVar x1 in f uu____3079 in
-                    t_to_string uu____3078 in
-                  FStar_String.op_Hat uu____3077 "}" in
-                FStar_String.op_Hat "{" uu____3076 in
-              FStar_String.op_Hat uu____3074 uu____3075 in
-            FStar_String.op_Hat ":" uu____3073 in
-          FStar_String.op_Hat uu____3071 uu____3072 in
-        FStar_String.op_Hat "Refinement " uu____3070
+        let t2 = let uu___ = t1 () in FStar_Pervasives_Native.fst uu___ in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.bv_to_string x1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = t_to_string t2 in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 = let uu___9 = mkAccuVar x1 in f uu___9 in
+                    t_to_string uu___8 in
+                  FStar_String.op_Hat uu___7 "}" in
+                FStar_String.op_Hat "{" uu___6 in
+              FStar_String.op_Hat uu___4 uu___5 in
+            FStar_String.op_Hat ":" uu___3 in
+          FStar_String.op_Hat uu___1 uu___2 in
+        FStar_String.op_Hat "Refinement " uu___
     | Unknown -> "Unknown"
     | Reflect t1 ->
-        let uu____3081 = t_to_string t1 in
-        FStar_String.op_Hat "Reflect " uu____3081
-    | Quote uu____3082 -> "Quote _"
-    | Lazy (FStar_Util.Inl li, uu____3088) ->
-        let uu____3105 =
-          let uu____3106 = FStar_Syntax_Util.unfold_lazy li in
-          FStar_Syntax_Print.term_to_string uu____3106 in
-        FStar_Util.format1 "Lazy (Inl {%s})" uu____3105
-    | Lazy (FStar_Util.Inr (uu____3107, et), uu____3109) ->
-        let uu____3126 = FStar_Syntax_Print.emb_typ_to_string et in
-        FStar_Util.format1 "Lazy (Inr (?, %s))" uu____3126
-    | LocalLetRec
-        (uu____3127, l, uu____3129, uu____3130, uu____3131, uu____3132,
-         uu____3133)
-        ->
-        let uu____3158 =
-          let uu____3159 = FStar_Syntax_Print.lbs_to_string [] (true, [l]) in
-          FStar_String.op_Hat uu____3159 ")" in
-        FStar_String.op_Hat "LocalLetRec (" uu____3158
-    | TopLevelLet (lb, uu____3163, uu____3164) ->
-        let uu____3177 =
-          let uu____3178 =
-            let uu____3179 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-            FStar_Syntax_Print.fv_to_string uu____3179 in
-          FStar_String.op_Hat uu____3178 ")" in
-        FStar_String.op_Hat "TopLevelLet (" uu____3177
-    | TopLevelRec (lb, uu____3181, uu____3182, uu____3183) ->
-        let uu____3200 =
-          let uu____3201 =
-            let uu____3202 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
-            FStar_Syntax_Print.fv_to_string uu____3202 in
-          FStar_String.op_Hat uu____3201 ")" in
-        FStar_String.op_Hat "TopLevelRec (" uu____3200
+        let uu___ = t_to_string t1 in FStar_String.op_Hat "Reflect " uu___
+    | Quote uu___ -> "Quote _"
+    | Lazy (FStar_Util.Inl li, uu___) ->
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Util.unfold_lazy li in
+          FStar_Syntax_Print.term_to_string uu___2 in
+        FStar_Util.format1 "Lazy (Inl {%s})" uu___1
+    | Lazy (FStar_Util.Inr (uu___, et), uu___1) ->
+        let uu___2 = FStar_Syntax_Print.emb_typ_to_string et in
+        FStar_Util.format1 "Lazy (Inr (?, %s))" uu___2
+    | LocalLetRec (uu___, l, uu___1, uu___2, uu___3, uu___4, uu___5) ->
+        let uu___6 =
+          let uu___7 = FStar_Syntax_Print.lbs_to_string [] (true, [l]) in
+          FStar_String.op_Hat uu___7 ")" in
+        FStar_String.op_Hat "LocalLetRec (" uu___6
+    | TopLevelLet (lb, uu___, uu___1) ->
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+            FStar_Syntax_Print.fv_to_string uu___4 in
+          FStar_String.op_Hat uu___3 ")" in
+        FStar_String.op_Hat "TopLevelLet (" uu___2
+    | TopLevelRec (lb, uu___, uu___1, uu___2) ->
+        let uu___3 =
+          let uu___4 =
+            let uu___5 = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+            FStar_Syntax_Print.fv_to_string uu___5 in
+          FStar_String.op_Hat uu___4 ")" in
+        FStar_String.op_Hat "TopLevelRec (" uu___3
 and (atom_to_string : atom -> Prims.string) =
   fun a ->
     match a with
     | Var v ->
-        let uu____3205 = FStar_Syntax_Print.bv_to_string v in
-        FStar_String.op_Hat "Var " uu____3205
-    | Match (t1, uu____3207) ->
-        let uu____3218 = t_to_string t1 in
-        FStar_String.op_Hat "Match " uu____3218
+        let uu___ = FStar_Syntax_Print.bv_to_string v in
+        FStar_String.op_Hat "Var " uu___
+    | Match (t1, uu___) ->
+        let uu___1 = t_to_string t1 in FStar_String.op_Hat "Match " uu___1
     | UnreducedLet (var1, typ, def, body, lb) ->
-        let uu____3236 =
-          let uu____3237 = FStar_Syntax_Print.lbs_to_string [] (false, [lb]) in
-          FStar_String.op_Hat uu____3237 " in ...)" in
-        FStar_String.op_Hat "UnreducedLet(" uu____3236
-    | UnreducedLetRec (uu____3240, body, lbs) ->
-        let uu____3263 =
-          let uu____3264 = FStar_Syntax_Print.lbs_to_string [] (true, lbs) in
-          let uu____3267 =
-            let uu____3268 =
-              let uu____3269 = t_to_string body in
-              FStar_String.op_Hat uu____3269 ")" in
-            FStar_String.op_Hat " in " uu____3268 in
-          FStar_String.op_Hat uu____3264 uu____3267 in
-        FStar_String.op_Hat "UnreducedLetRec(" uu____3263
-    | UVar uu____3270 -> "UVar"
+        let uu___ =
+          let uu___1 = FStar_Syntax_Print.lbs_to_string [] (false, [lb]) in
+          FStar_String.op_Hat uu___1 " in ...)" in
+        FStar_String.op_Hat "UnreducedLet(" uu___
+    | UnreducedLetRec (uu___, body, lbs) ->
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Print.lbs_to_string [] (true, lbs) in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = t_to_string body in FStar_String.op_Hat uu___5 ")" in
+            FStar_String.op_Hat " in " uu___4 in
+          FStar_String.op_Hat uu___2 uu___3 in
+        FStar_String.op_Hat "UnreducedLetRec(" uu___1
+    | UVar uu___ -> "UVar"
 let (arg_to_string : arg -> Prims.string) =
   fun a ->
-    let uu____3278 = FStar_All.pipe_right a FStar_Pervasives_Native.fst in
-    FStar_All.pipe_right uu____3278 t_to_string
+    let uu___ = FStar_All.pipe_right a FStar_Pervasives_Native.fst in
+    FStar_All.pipe_right uu___ t_to_string
 let (args_to_string : args -> Prims.string) =
   fun args1 ->
-    let uu____3288 =
-      FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
-    FStar_All.pipe_right uu____3288 (FStar_String.concat " ")
+    let uu___ = FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
+    FStar_All.pipe_right uu___ (FStar_String.concat " ")
 type nbe_cbs =
   {
   iapp: t -> args -> t ;
@@ -738,18 +690,16 @@ let mk_emb :
         t -> FStar_Syntax_Syntax.emb_typ -> 'a embedding
   = fun em -> fun un -> fun typ -> fun et -> { em; un; typ; emb_typ = et }
 let mk_emb' :
-  'uuuuuu3729 .
-    (nbe_cbs -> 'uuuuuu3729 -> t') ->
-      (nbe_cbs -> t' -> 'uuuuuu3729 FStar_Pervasives_Native.option) ->
-        t -> FStar_Syntax_Syntax.emb_typ -> 'uuuuuu3729 embedding
+  'uuuuu .
+    (nbe_cbs -> 'uuuuu -> t') ->
+      (nbe_cbs -> t' -> 'uuuuu FStar_Pervasives_Native.option) ->
+        t -> FStar_Syntax_Syntax.emb_typ -> 'uuuuu embedding
   =
   fun em ->
     fun un ->
       mk_emb
         (fun cbs ->
-           fun t1 ->
-             let uu____3779 = em cbs t1 in
-             FStar_All.pipe_left mk_t uu____3779)
+           fun t1 -> let uu___ = em cbs t1 in FStar_All.pipe_left mk_t uu___)
         (fun cbs -> fun t1 -> un cbs t1.nbe_t)
 let embed_as :
   'a 'b .
@@ -761,13 +711,10 @@ let embed_as :
     fun ab ->
       fun ba ->
         fun ot ->
-          mk_emb
-            (fun cbs ->
-               fun x -> let uu____3843 = ba x in embed ea cbs uu____3843)
+          mk_emb (fun cbs -> fun x -> let uu___ = ba x in embed ea cbs uu___)
             (fun cbs ->
                fun t1 ->
-                 let uu____3849 = unembed ea cbs t1 in
-                 FStar_Util.map_opt uu____3849 ab)
+                 let uu___ = unembed ea cbs t1 in FStar_Util.map_opt uu___ ab)
             (match ot with
              | FStar_Pervasives_Native.Some t1 -> t1
              | FStar_Pervasives_Native.None -> ea.typ) ea.emb_typ
@@ -777,20 +724,20 @@ let (lid_as_constr :
   fun l ->
     fun us ->
       fun args1 ->
-        let uu____3873 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
-        mkConstruct uu____3873 us args1
+        mkConstruct uu___ us args1
 let (lid_as_typ :
   FStar_Ident.lident -> FStar_Syntax_Syntax.universe Prims.list -> args -> t)
   =
   fun l ->
     fun us ->
       fun args1 ->
-        let uu____3893 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             FStar_Pervasives_Native.None in
-        mkFV uu____3893 us args1
+        mkFV uu___ us args1
 let (as_iarg : t -> arg) =
   fun a -> (a, (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag))
 let (as_arg : t -> arg) = fun a -> (a, FStar_Pervasives_Native.None)
@@ -804,22 +751,22 @@ let lazy_embed : 'a . FStar_Syntax_Syntax.emb_typ -> 'a -> (unit -> t) -> t =
   fun et ->
     fun x ->
       fun f ->
-        (let uu____3972 = FStar_ST.op_Bang FStar_Options.debug_embedding in
-         if uu____3972
+        (let uu___1 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+         if uu___1
          then
-           let uu____3979 = FStar_Syntax_Print.emb_typ_to_string et in
-           FStar_Util.print1 "Embedding\n\temb_typ=%s\n" uu____3979
+           let uu___2 = FStar_Syntax_Print.emb_typ_to_string et in
+           FStar_Util.print1 "Embedding\n\temb_typ=%s\n" uu___2
          else ());
-        (let uu____3981 = FStar_ST.op_Bang FStar_Options.eager_embedding in
-         if uu____3981
+        (let uu___1 = FStar_ST.op_Bang FStar_Options.eager_embedding in
+         if uu___1
          then f ()
          else
            (let thunk = FStar_Thunk.mk f in
-            let li = let uu____3997 = FStar_Dyn.mkdyn x in (uu____3997, et) in
+            let li = let uu___3 = FStar_Dyn.mkdyn x in (uu___3, et) in
             FStar_All.pipe_left mk_t (Lazy ((FStar_Util.Inr li), thunk))))
 let lazy_unembed :
-  'uuuuuu4024 'a .
-    'uuuuuu4024 ->
+  'uuuuu 'a .
+    'uuuuu ->
       FStar_Syntax_Syntax.emb_typ ->
         t ->
           (t -> 'a FStar_Pervasives_Native.option) ->
@@ -831,44 +778,40 @@ let lazy_unembed :
         fun f ->
           match x.nbe_t with
           | Lazy (FStar_Util.Inl li, thunk) ->
-              let uu____4075 = FStar_Thunk.force thunk in f uu____4075
+              let uu___ = FStar_Thunk.force thunk in f uu___
           | Lazy (FStar_Util.Inr (b, et'), thunk) ->
-              let uu____4095 =
+              let uu___ =
                 (et <> et') ||
                   (FStar_ST.op_Bang FStar_Options.eager_embedding) in
-              if uu____4095
+              if uu___
               then
-                let res =
-                  let uu____4107 = FStar_Thunk.force thunk in f uu____4107 in
-                ((let uu____4109 =
-                    FStar_ST.op_Bang FStar_Options.debug_embedding in
-                  if uu____4109
+                let res = let uu___1 = FStar_Thunk.force thunk in f uu___1 in
+                ((let uu___2 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+                  if uu___2
                   then
-                    let uu____4116 = FStar_Syntax_Print.emb_typ_to_string et in
-                    let uu____4117 = FStar_Syntax_Print.emb_typ_to_string et' in
+                    let uu___3 = FStar_Syntax_Print.emb_typ_to_string et in
+                    let uu___4 = FStar_Syntax_Print.emb_typ_to_string et' in
                     FStar_Util.print2
-                      "Unembed cancellation failed\n\t%s <> %s\n" uu____4116
-                      uu____4117
+                      "Unembed cancellation failed\n\t%s <> %s\n" uu___3
+                      uu___4
                   else ());
                  res)
               else
                 (let a1 = FStar_Dyn.undyn b in
-                 (let uu____4122 =
-                    FStar_ST.op_Bang FStar_Options.debug_embedding in
-                  if uu____4122
+                 (let uu___3 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+                  if uu___3
                   then
-                    let uu____4129 = FStar_Syntax_Print.emb_typ_to_string et in
-                    FStar_Util.print1 "Unembed cancelled for %s\n" uu____4129
+                    let uu___4 = FStar_Syntax_Print.emb_typ_to_string et in
+                    FStar_Util.print1 "Unembed cancelled for %s\n" uu___4
                   else ());
                  FStar_Pervasives_Native.Some a1)
-          | uu____4131 ->
+          | uu___ ->
               let aopt = f x in
-              ((let uu____4136 =
-                  FStar_ST.op_Bang FStar_Options.debug_embedding in
-                if uu____4136
+              ((let uu___2 = FStar_ST.op_Bang FStar_Options.debug_embedding in
+                if uu___2
                 then
-                  let uu____4143 = FStar_Syntax_Print.emb_typ_to_string et in
-                  FStar_Util.print1 "Unembedding:\n\temb_typ=%s\n" uu____4143
+                  let uu___3 = FStar_Syntax_Print.emb_typ_to_string et in
+                  FStar_Util.print1 "Unembedding:\n\temb_typ=%s\n" uu___3
                 else ());
                aopt)
 let (mk_any_emb : t -> t embedding) =
@@ -879,87 +822,84 @@ let (mk_any_emb : t -> t embedding) =
 let (e_any : t embedding) =
   let em _cb a = a in
   let un _cb t1 = FStar_Pervasives_Native.Some t1 in
-  let uu____4206 = lid_as_typ FStar_Parser_Const.term_lid [] [] in
-  mk_emb em un uu____4206 FStar_Syntax_Syntax.ET_abstract
+  let uu___ = lid_as_typ FStar_Parser_Const.term_lid [] [] in
+  mk_emb em un uu___ FStar_Syntax_Syntax.ET_abstract
 let (e_unit : unit embedding) =
   let em _cb a = Constant Unit in
   let un _cb t1 = FStar_Pervasives_Native.Some () in
-  let uu____4239 = lid_as_typ FStar_Parser_Const.unit_lid [] [] in
-  let uu____4244 =
+  let uu___ = lid_as_typ FStar_Parser_Const.unit_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit in
-  mk_emb' em un uu____4239 uu____4244
+  mk_emb' em un uu___ uu___1
 let (e_bool : Prims.bool embedding) =
   let em _cb a = Constant (Bool a) in
   let un _cb t1 =
     match t1 with
     | Constant (Bool a) -> FStar_Pervasives_Native.Some a
-    | uu____4276 -> FStar_Pervasives_Native.None in
-  let uu____4277 = lid_as_typ FStar_Parser_Const.bool_lid [] [] in
-  let uu____4282 =
+    | uu___ -> FStar_Pervasives_Native.None in
+  let uu___ = lid_as_typ FStar_Parser_Const.bool_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit in
-  mk_emb' em un uu____4277 uu____4282
+  mk_emb' em un uu___ uu___1
 let (e_char : FStar_Char.char embedding) =
   let em _cb c = Constant (Char c) in
   let un _cb c =
     match c with
     | Constant (Char a) -> FStar_Pervasives_Native.Some a
-    | uu____4314 -> FStar_Pervasives_Native.None in
-  let uu____4315 = lid_as_typ FStar_Parser_Const.char_lid [] [] in
-  let uu____4320 =
+    | uu___ -> FStar_Pervasives_Native.None in
+  let uu___ = lid_as_typ FStar_Parser_Const.char_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_char in
-  mk_emb' em un uu____4315 uu____4320
+  mk_emb' em un uu___ uu___1
 let (e_string : Prims.string embedding) =
   let em _cb s = Constant (String (s, FStar_Range.dummyRange)) in
   let un _cb s =
     match s with
-    | Constant (String (s1, uu____4352)) -> FStar_Pervasives_Native.Some s1
-    | uu____4353 -> FStar_Pervasives_Native.None in
-  let uu____4354 = lid_as_typ FStar_Parser_Const.string_lid [] [] in
-  let uu____4359 =
+    | Constant (String (s1, uu___)) -> FStar_Pervasives_Native.Some s1
+    | uu___ -> FStar_Pervasives_Native.None in
+  let uu___ = lid_as_typ FStar_Parser_Const.string_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_string in
-  mk_emb' em un uu____4354 uu____4359
+  mk_emb' em un uu___ uu___1
 let (e_int : FStar_BigInt.t embedding) =
   let em _cb c = Constant (Int c) in
   let un _cb c =
     match c with
     | Constant (Int a) -> FStar_Pervasives_Native.Some a
-    | uu____4391 -> FStar_Pervasives_Native.None in
-  let uu____4392 = lid_as_typ FStar_Parser_Const.int_lid [] [] in
-  let uu____4397 =
+    | uu___ -> FStar_Pervasives_Native.None in
+  let uu___ = lid_as_typ FStar_Parser_Const.int_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_int in
-  mk_emb' em un uu____4392 uu____4397
+  mk_emb' em un uu___ uu___1
 let e_option :
   'a . 'a embedding -> 'a FStar_Pervasives_Native.option embedding =
   fun ea ->
     let etyp =
-      let uu____4417 =
-        let uu____4424 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right FStar_Parser_Const.option_lid
             FStar_Ident.string_of_lid in
-        (uu____4424, [ea.emb_typ]) in
-      FStar_Syntax_Syntax.ET_app uu____4417 in
+        (uu___1, [ea.emb_typ]) in
+      FStar_Syntax_Syntax.ET_app uu___ in
     let em cb o =
       lazy_embed etyp o
-        (fun uu____4446 ->
+        (fun uu___ ->
            match o with
            | FStar_Pervasives_Native.None ->
-               let uu____4447 =
-                 let uu____4448 =
-                   let uu____4453 = type_of ea in as_iarg uu____4453 in
-                 [uu____4448] in
+               let uu___1 =
+                 let uu___2 = let uu___3 = type_of ea in as_iarg uu___3 in
+                 [uu___2] in
                lid_as_constr FStar_Parser_Const.none_lid
-                 [FStar_Syntax_Syntax.U_zero] uu____4447
+                 [FStar_Syntax_Syntax.U_zero] uu___1
            | FStar_Pervasives_Native.Some x ->
-               let uu____4463 =
-                 let uu____4464 =
-                   let uu____4469 = embed ea cb x in as_arg uu____4469 in
-                 let uu____4470 =
-                   let uu____4477 =
-                     let uu____4482 = type_of ea in as_iarg uu____4482 in
-                   [uu____4477] in
-                 uu____4464 :: uu____4470 in
+               let uu___1 =
+                 let uu___2 = let uu___3 = embed ea cb x in as_arg uu___3 in
+                 let uu___3 =
+                   let uu___4 = let uu___5 = type_of ea in as_iarg uu___5 in
+                   [uu___4] in
+                 uu___2 :: uu___3 in
                lid_as_constr FStar_Parser_Const.some_lid
-                 [FStar_Syntax_Syntax.U_zero] uu____4463) in
+                 [FStar_Syntax_Syntax.U_zero] uu___1) in
     let un cb trm =
       lazy_unembed cb etyp trm
         (fun trm1 ->
@@ -967,85 +907,79 @@ let e_option :
            | Construct (fvar, us, args1) when
                FStar_Syntax_Syntax.fv_eq_lid fvar FStar_Parser_Const.none_lid
                -> FStar_Pervasives_Native.Some FStar_Pervasives_Native.None
-           | Construct (fvar, us, (a1, uu____4549)::uu____4550::[]) when
+           | Construct (fvar, us, (a1, uu___)::uu___1::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fvar FStar_Parser_Const.some_lid
                ->
-               let uu____4577 = unembed ea cb a1 in
-               FStar_Util.bind_opt uu____4577
+               let uu___2 = unembed ea cb a1 in
+               FStar_Util.bind_opt uu___2
                  (fun a2 ->
                     FStar_Pervasives_Native.Some
                       (FStar_Pervasives_Native.Some a2))
-           | uu____4586 -> FStar_Pervasives_Native.None) in
-    let uu____4589 =
-      let uu____4590 =
-        let uu____4591 = let uu____4596 = type_of ea in as_arg uu____4596 in
-        [uu____4591] in
+           | uu___ -> FStar_Pervasives_Native.None) in
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = type_of ea in as_arg uu___3 in [uu___2] in
       lid_as_typ FStar_Parser_Const.option_lid [FStar_Syntax_Syntax.U_zero]
-        uu____4590 in
-    mk_emb em un uu____4589 etyp
+        uu___1 in
+    mk_emb em un uu___ etyp
 let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
   fun ea ->
     fun eb ->
       let etyp =
-        let uu____4642 =
-          let uu____4649 =
+        let uu___ =
+          let uu___1 =
             FStar_All.pipe_right FStar_Parser_Const.lid_tuple2
               FStar_Ident.string_of_lid in
-          (uu____4649, [ea.emb_typ; eb.emb_typ]) in
-        FStar_Syntax_Syntax.ET_app uu____4642 in
+          (uu___1, [ea.emb_typ; eb.emb_typ]) in
+        FStar_Syntax_Syntax.ET_app uu___ in
       let em cb x =
         lazy_embed etyp x
-          (fun uu____4677 ->
-             let uu____4678 =
-               let uu____4679 =
-                 let uu____4684 = embed eb cb (FStar_Pervasives_Native.snd x) in
-                 as_arg uu____4684 in
-               let uu____4685 =
-                 let uu____4692 =
-                   let uu____4697 =
-                     embed ea cb (FStar_Pervasives_Native.fst x) in
-                   as_arg uu____4697 in
-                 let uu____4698 =
-                   let uu____4705 =
-                     let uu____4710 = type_of eb in as_iarg uu____4710 in
-                   let uu____4711 =
-                     let uu____4718 =
-                       let uu____4723 = type_of ea in as_iarg uu____4723 in
-                     [uu____4718] in
-                   uu____4705 :: uu____4711 in
-                 uu____4692 :: uu____4698 in
-               uu____4679 :: uu____4685 in
+          (fun uu___ ->
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 = embed eb cb (FStar_Pervasives_Native.snd x) in
+                 as_arg uu___3 in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = embed ea cb (FStar_Pervasives_Native.fst x) in
+                   as_arg uu___5 in
+                 let uu___5 =
+                   let uu___6 = let uu___7 = type_of eb in as_iarg uu___7 in
+                   let uu___7 =
+                     let uu___8 = let uu___9 = type_of ea in as_iarg uu___9 in
+                     [uu___8] in
+                   uu___6 :: uu___7 in
+                 uu___4 :: uu___5 in
+               uu___2 :: uu___3 in
              lid_as_constr FStar_Parser_Const.lid_Mktuple2
                [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-               uu____4678) in
+               uu___1) in
       let un cb trm =
         lazy_unembed cb etyp trm
           (fun trm1 ->
              match trm1.nbe_t with
              | Construct
-                 (fvar, us,
-                  (b1, uu____4791)::(a1, uu____4793)::uu____4794::uu____4795::[])
+                 (fvar, us, (b1, uu___)::(a1, uu___1)::uu___2::uu___3::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.lid_Mktuple2
                  ->
-                 let uu____4834 = unembed ea cb a1 in
-                 FStar_Util.bind_opt uu____4834
+                 let uu___4 = unembed ea cb a1 in
+                 FStar_Util.bind_opt uu___4
                    (fun a2 ->
-                      let uu____4844 = unembed eb cb b1 in
-                      FStar_Util.bind_opt uu____4844
+                      let uu___5 = unembed eb cb b1 in
+                      FStar_Util.bind_opt uu___5
                         (fun b2 -> FStar_Pervasives_Native.Some (a2, b2)))
-             | uu____4857 -> FStar_Pervasives_Native.None) in
-      let uu____4862 =
-        let uu____4863 =
-          let uu____4864 = let uu____4869 = type_of eb in as_arg uu____4869 in
-          let uu____4870 =
-            let uu____4877 = let uu____4882 = type_of ea in as_arg uu____4882 in
-            [uu____4877] in
-          uu____4864 :: uu____4870 in
+             | uu___ -> FStar_Pervasives_Native.None) in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = let uu___3 = type_of eb in as_arg uu___3 in
+          let uu___3 =
+            let uu___4 = let uu___5 = type_of ea in as_arg uu___5 in [uu___4] in
+          uu___2 :: uu___3 in
         lid_as_typ FStar_Parser_Const.lid_tuple2
-          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____4863 in
-      mk_emb em un uu____4862 etyp
+          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu___1 in
+      mk_emb em un uu___ etyp
 let e_either :
   'a 'b .
     'a embedding -> 'b embedding -> ('a, 'b) FStar_Util.either embedding
@@ -1053,163 +987,150 @@ let e_either :
   fun ea ->
     fun eb ->
       let etyp =
-        let uu____4934 =
-          let uu____4941 =
+        let uu___ =
+          let uu___1 =
             FStar_All.pipe_right FStar_Parser_Const.either_lid
               FStar_Ident.string_of_lid in
-          (uu____4941, [ea.emb_typ; eb.emb_typ]) in
-        FStar_Syntax_Syntax.ET_app uu____4934 in
+          (uu___1, [ea.emb_typ; eb.emb_typ]) in
+        FStar_Syntax_Syntax.ET_app uu___ in
       let em cb s =
         lazy_embed etyp s
-          (fun uu____4970 ->
+          (fun uu___ ->
              match s with
              | FStar_Util.Inl a1 ->
-                 let uu____4972 =
-                   let uu____4973 =
-                     let uu____4978 = embed ea cb a1 in as_arg uu____4978 in
-                   let uu____4979 =
-                     let uu____4986 =
-                       let uu____4991 = type_of eb in as_iarg uu____4991 in
-                     let uu____4992 =
-                       let uu____4999 =
-                         let uu____5004 = type_of ea in as_iarg uu____5004 in
-                       [uu____4999] in
-                     uu____4986 :: uu____4992 in
-                   uu____4973 :: uu____4979 in
+                 let uu___1 =
+                   let uu___2 = let uu___3 = embed ea cb a1 in as_arg uu___3 in
+                   let uu___3 =
+                     let uu___4 = let uu___5 = type_of eb in as_iarg uu___5 in
+                     let uu___5 =
+                       let uu___6 = let uu___7 = type_of ea in as_iarg uu___7 in
+                       [uu___6] in
+                     uu___4 :: uu___5 in
+                   uu___2 :: uu___3 in
                  lid_as_constr FStar_Parser_Const.inl_lid
                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-                   uu____4972
+                   uu___1
              | FStar_Util.Inr b1 ->
-                 let uu____5022 =
-                   let uu____5023 =
-                     let uu____5028 = embed eb cb b1 in as_arg uu____5028 in
-                   let uu____5029 =
-                     let uu____5036 =
-                       let uu____5041 = type_of eb in as_iarg uu____5041 in
-                     let uu____5042 =
-                       let uu____5049 =
-                         let uu____5054 = type_of ea in as_iarg uu____5054 in
-                       [uu____5049] in
-                     uu____5036 :: uu____5042 in
-                   uu____5023 :: uu____5029 in
+                 let uu___1 =
+                   let uu___2 = let uu___3 = embed eb cb b1 in as_arg uu___3 in
+                   let uu___3 =
+                     let uu___4 = let uu___5 = type_of eb in as_iarg uu___5 in
+                     let uu___5 =
+                       let uu___6 = let uu___7 = type_of ea in as_iarg uu___7 in
+                       [uu___6] in
+                     uu___4 :: uu___5 in
+                   uu___2 :: uu___3 in
                  lid_as_constr FStar_Parser_Const.inr_lid
                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-                   uu____5022) in
+                   uu___1) in
       let un cb trm =
         lazy_unembed cb etyp trm
           (fun trm1 ->
              match trm1.nbe_t with
-             | Construct
-                 (fvar, us, (a1, uu____5116)::uu____5117::uu____5118::[])
-                 when
+             | Construct (fvar, us, (a1, uu___)::uu___1::uu___2::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.inl_lid
                  ->
-                 let uu____5153 = unembed ea cb a1 in
-                 FStar_Util.bind_opt uu____5153
+                 let uu___3 = unembed ea cb a1 in
+                 FStar_Util.bind_opt uu___3
                    (fun a2 ->
                       FStar_Pervasives_Native.Some (FStar_Util.Inl a2))
-             | Construct
-                 (fvar, us, (b1, uu____5169)::uu____5170::uu____5171::[])
-                 when
+             | Construct (fvar, us, (b1, uu___)::uu___1::uu___2::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fvar
                    FStar_Parser_Const.inr_lid
                  ->
-                 let uu____5206 = unembed eb cb b1 in
-                 FStar_Util.bind_opt uu____5206
+                 let uu___3 = unembed eb cb b1 in
+                 FStar_Util.bind_opt uu___3
                    (fun b2 ->
                       FStar_Pervasives_Native.Some (FStar_Util.Inr b2))
-             | uu____5219 -> FStar_Pervasives_Native.None) in
-      let uu____5224 =
-        let uu____5225 =
-          let uu____5226 = let uu____5231 = type_of eb in as_arg uu____5231 in
-          let uu____5232 =
-            let uu____5239 = let uu____5244 = type_of ea in as_arg uu____5244 in
-            [uu____5239] in
-          uu____5226 :: uu____5232 in
+             | uu___ -> FStar_Pervasives_Native.None) in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = let uu___3 = type_of eb in as_arg uu___3 in
+          let uu___3 =
+            let uu___4 = let uu___5 = type_of ea in as_arg uu___5 in [uu___4] in
+          uu___2 :: uu___3 in
         lid_as_typ FStar_Parser_Const.either_lid
-          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu____5225 in
-      mk_emb em un uu____5224 etyp
+          [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] uu___1 in
+      mk_emb em un uu___ etyp
 let (e_range : FStar_Range.range embedding) =
   let em cb r = Constant (Range r) in
   let un cb t1 =
     match t1 with
     | Constant (Range r) -> FStar_Pervasives_Native.Some r
-    | uu____5292 -> FStar_Pervasives_Native.None in
-  let uu____5293 = lid_as_typ FStar_Parser_Const.range_lid [] [] in
-  let uu____5298 =
+    | uu___ -> FStar_Pervasives_Native.None in
+  let uu___ = lid_as_typ FStar_Parser_Const.range_lid [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_range in
-  mk_emb' em un uu____5293 uu____5298
+  mk_emb' em un uu___ uu___1
 let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
   fun ea ->
     let etyp =
-      let uu____5318 =
-        let uu____5325 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right FStar_Parser_Const.list_lid
             FStar_Ident.string_of_lid in
-        (uu____5325, [ea.emb_typ]) in
-      FStar_Syntax_Syntax.ET_app uu____5318 in
+        (uu___1, [ea.emb_typ]) in
+      FStar_Syntax_Syntax.ET_app uu___ in
     let em cb l =
       lazy_embed etyp l
-        (fun uu____5349 ->
-           let typ = let uu____5351 = type_of ea in as_iarg uu____5351 in
+        (fun uu___ ->
+           let typ = let uu___1 = type_of ea in as_iarg uu___1 in
            let nil =
              lid_as_constr FStar_Parser_Const.nil_lid
                [FStar_Syntax_Syntax.U_zero] [typ] in
            let cons hd tl =
-             let uu____5372 =
-               let uu____5373 = as_arg tl in
-               let uu____5378 =
-                 let uu____5385 =
-                   let uu____5390 = embed ea cb hd in as_arg uu____5390 in
-                 [uu____5385; typ] in
-               uu____5373 :: uu____5378 in
+             let uu___1 =
+               let uu___2 = as_arg tl in
+               let uu___3 =
+                 let uu___4 = let uu___5 = embed ea cb hd in as_arg uu___5 in
+                 [uu___4; typ] in
+               uu___2 :: uu___3 in
              lid_as_constr FStar_Parser_Const.cons_lid
-               [FStar_Syntax_Syntax.U_zero] uu____5372 in
+               [FStar_Syntax_Syntax.U_zero] uu___1 in
            FStar_List.fold_right cons l nil) in
     let rec un cb trm =
       lazy_unembed cb etyp trm
         (fun trm1 ->
            match trm1.nbe_t with
-           | Construct (fv, uu____5438, uu____5439) when
+           | Construct (fv, uu___, uu___1) when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
                FStar_Pervasives_Native.Some []
            | Construct
-               (fv, uu____5459,
+               (fv, uu___,
                 (tl, FStar_Pervasives_Native.None)::(hd,
                                                      FStar_Pervasives_Native.None)::
-                (uu____5462, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____5463))::[])
+                (uu___1, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___2))::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                ->
-               let uu____5490 = unembed ea cb hd in
-               FStar_Util.bind_opt uu____5490
+               let uu___3 = unembed ea cb hd in
+               FStar_Util.bind_opt uu___3
                  (fun hd1 ->
-                    let uu____5498 = un cb tl in
-                    FStar_Util.bind_opt uu____5498
+                    let uu___4 = un cb tl in
+                    FStar_Util.bind_opt uu___4
                       (fun tl1 -> FStar_Pervasives_Native.Some (hd1 :: tl1)))
            | Construct
-               (fv, uu____5514,
+               (fv, uu___,
                 (tl, FStar_Pervasives_Native.None)::(hd,
                                                      FStar_Pervasives_Native.None)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                ->
-               let uu____5539 = unembed ea cb hd in
-               FStar_Util.bind_opt uu____5539
+               let uu___1 = unembed ea cb hd in
+               FStar_Util.bind_opt uu___1
                  (fun hd1 ->
-                    let uu____5547 = un cb tl in
-                    FStar_Util.bind_opt uu____5547
+                    let uu___2 = un cb tl in
+                    FStar_Util.bind_opt uu___2
                       (fun tl1 -> FStar_Pervasives_Native.Some (hd1 :: tl1)))
-           | uu____5562 -> FStar_Pervasives_Native.None) in
-    let uu____5565 =
-      let uu____5566 =
-        let uu____5567 = let uu____5572 = type_of ea in as_arg uu____5572 in
-        [uu____5567] in
+           | uu___ -> FStar_Pervasives_Native.None) in
+    let uu___ =
+      let uu___1 =
+        let uu___2 = let uu___3 = type_of ea in as_arg uu___3 in [uu___2] in
       lid_as_typ FStar_Parser_Const.list_lid [FStar_Syntax_Syntax.U_zero]
-        uu____5566 in
-    mk_emb em un uu____5565 etyp
+        uu___1 in
+    mk_emb em un uu___ etyp
 let (e_string_list : Prims.string Prims.list embedding) = e_list e_string
 let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
   fun ea ->
@@ -1217,209 +1138,200 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
       let etyp = FStar_Syntax_Syntax.ET_fun ((ea.emb_typ), (eb.emb_typ)) in
       let em cb f =
         lazy_embed etyp f
-          (fun uu____5642 ->
-             let uu____5643 =
-               let uu____5644 =
-                 let uu____5676 =
-                   let uu____5697 =
-                     let uu____5704 =
-                       let uu____5709 = type_of eb in as_arg uu____5709 in
-                     [uu____5704] in
-                   FStar_Util.Inr uu____5697 in
+          (fun uu___ ->
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = let uu___6 = type_of eb in as_arg uu___6 in
+                     [uu___5] in
+                   FStar_Util.Inr uu___4 in
                  ((fun tas ->
-                     let uu____5766 =
-                       let uu____5769 = FStar_List.hd tas in
-                       unembed ea cb uu____5769 in
-                     match uu____5766 with
+                     let uu___4 =
+                       let uu___5 = FStar_List.hd tas in unembed ea cb uu___5 in
+                     match uu___4 with
                      | FStar_Pervasives_Native.Some a1 ->
-                         let uu____5771 = f a1 in embed eb cb uu____5771
+                         let uu___5 = f a1 in embed eb cb uu___5
                      | FStar_Pervasives_Native.None ->
                          failwith "cannot unembed function argument"),
-                   uu____5676, Prims.int_one) in
-               Lam uu____5644 in
-             FStar_All.pipe_left mk_t uu____5643) in
+                   uu___3, Prims.int_one) in
+               Lam uu___2 in
+             FStar_All.pipe_left mk_t uu___1) in
       let un cb lam =
         let k lam1 =
           FStar_Pervasives_Native.Some
             (fun x ->
-               let uu____5816 =
-                 let uu____5819 =
-                   let uu____5820 =
-                     let uu____5821 =
-                       let uu____5826 = embed ea cb x in as_arg uu____5826 in
-                     [uu____5821] in
-                   cb.iapp lam1 uu____5820 in
-                 unembed eb cb uu____5819 in
-               match uu____5816 with
+               let uu___ =
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = let uu___4 = embed ea cb x in as_arg uu___4 in
+                     [uu___3] in
+                   cb.iapp lam1 uu___2 in
+                 unembed eb cb uu___1 in
+               match uu___ with
                | FStar_Pervasives_Native.Some y -> y
                | FStar_Pervasives_Native.None ->
                    failwith "cannot unembed function result") in
         lazy_unembed cb etyp lam k in
-      let uu____5839 =
-        let uu____5840 = type_of ea in
-        let uu____5841 = let uu____5842 = type_of eb in as_iarg uu____5842 in
-        make_arrow1 uu____5840 uu____5841 in
-      mk_emb em un uu____5839 etyp
+      let uu___ =
+        let uu___1 = type_of ea in
+        let uu___2 = let uu___3 = type_of eb in as_iarg uu___3 in
+        make_arrow1 uu___1 uu___2 in
+      mk_emb em un uu___ etyp
 let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
   let em cb n =
     match n with
     | FStar_Syntax_Embeddings.Simpl ->
-        let uu____5859 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_simpl
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5859 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Weak ->
-        let uu____5864 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_weak
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5864 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.HNF ->
-        let uu____5869 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_hnf
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5869 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Primops ->
-        let uu____5874 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_primops
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5874 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Delta ->
-        let uu____5879 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_delta
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5879 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Zeta ->
-        let uu____5884 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5884 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Iota ->
-        let uu____5889 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_iota
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5889 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Reify ->
-        let uu____5894 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_reify
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5894 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.NBE ->
-        let uu____5899 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_nbe
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        mkFV uu____5899 [] []
+        mkFV uu___ [] []
     | FStar_Syntax_Embeddings.UnfoldOnly l ->
-        let uu____5907 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldonly
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____5908 =
-          let uu____5909 =
-            let uu____5914 =
-              let uu____5915 = e_list e_string in embed uu____5915 cb l in
-            as_arg uu____5914 in
-          [uu____5909] in
-        mkFV uu____5907 [] uu____5908
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
+            as_arg uu___3 in
+          [uu___2] in
+        mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldFully l ->
-        let uu____5933 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldfully
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____5934 =
-          let uu____5935 =
-            let uu____5940 =
-              let uu____5941 = e_list e_string in embed uu____5941 cb l in
-            as_arg uu____5940 in
-          [uu____5935] in
-        mkFV uu____5933 [] uu____5934
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
+            as_arg uu___3 in
+          [uu___2] in
+        mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldAttr l ->
-        let uu____5959 =
+        let uu___ =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldattr
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____5960 =
-          let uu____5961 =
-            let uu____5966 =
-              let uu____5967 = e_list e_string in embed uu____5967 cb l in
-            as_arg uu____5966 in
-          [uu____5961] in
-        mkFV uu____5959 [] uu____5960 in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
+            as_arg uu___3 in
+          [uu___2] in
+        mkFV uu___ [] uu___1 in
   let un cb t0 =
     match t0.nbe_t with
-    | FV (fv, uu____5998, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_simpl ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Simpl
-    | FV (fv, uu____6014, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_weak ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Weak
-    | FV (fv, uu____6030, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_hnf ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.HNF
-    | FV (fv, uu____6046, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_primops ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Primops
-    | FV (fv, uu____6062, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_delta ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Delta
-    | FV (fv, uu____6078, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_zeta ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Zeta
-    | FV (fv, uu____6094, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_iota ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Iota
-    | FV (fv, uu____6110, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_nbe ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.NBE
-    | FV (fv, uu____6126, []) when
+    | FV (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_reify ->
         FStar_Pervasives_Native.Some FStar_Syntax_Embeddings.Reify
-    | FV (fv, uu____6142, (l, uu____6144)::[]) when
+    | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldonly
         ->
-        let uu____6163 =
-          let uu____6168 = e_list e_string in unembed uu____6168 cb l in
-        FStar_Util.bind_opt uu____6163
+        let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
+        FStar_Util.bind_opt uu___2
           (fun ss ->
              FStar_All.pipe_left
-               (fun uu____6183 -> FStar_Pervasives_Native.Some uu____6183)
+               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                (FStar_Syntax_Embeddings.UnfoldOnly ss))
-    | FV (fv, uu____6185, (l, uu____6187)::[]) when
+    | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldfully
         ->
-        let uu____6206 =
-          let uu____6211 = e_list e_string in unembed uu____6211 cb l in
-        FStar_Util.bind_opt uu____6206
+        let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
+        FStar_Util.bind_opt uu___2
           (fun ss ->
              FStar_All.pipe_left
-               (fun uu____6226 -> FStar_Pervasives_Native.Some uu____6226)
+               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                (FStar_Syntax_Embeddings.UnfoldFully ss))
-    | FV (fv, uu____6228, (l, uu____6230)::[]) when
+    | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldattr
         ->
-        let uu____6249 =
-          let uu____6254 = e_list e_string in unembed uu____6254 cb l in
-        FStar_Util.bind_opt uu____6249
+        let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
+        FStar_Util.bind_opt uu___2
           (fun ss ->
              FStar_All.pipe_left
-               (fun uu____6269 -> FStar_Pervasives_Native.Some uu____6269)
+               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                (FStar_Syntax_Embeddings.UnfoldAttr ss))
-    | uu____6270 ->
-        ((let uu____6272 =
-            let uu____6277 =
-              let uu____6278 = t_to_string t0 in
-              FStar_Util.format1 "Not an embedded norm_step: %s" uu____6278 in
-            (FStar_Errors.Warning_NotEmbedded, uu____6277) in
-          FStar_Errors.log_issue FStar_Range.dummyRange uu____6272);
+    | uu___ ->
+        ((let uu___2 =
+            let uu___3 =
+              let uu___4 = t_to_string t0 in
+              FStar_Util.format1 "Not an embedded norm_step: %s" uu___4 in
+            (FStar_Errors.Warning_NotEmbedded, uu___3) in
+          FStar_Errors.log_issue FStar_Range.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
-  let uu____6279 =
-    let uu____6280 =
+  let uu___ =
+    let uu___1 =
       FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.norm_step_lid
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-    mkFV uu____6280 [] [] in
-  let uu____6285 =
+    mkFV uu___1 [] [] in
+  let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_norm_step in
-  mk_emb em un uu____6279 uu____6285
+  mk_emb em un uu___ uu___1
 let (bogus_cbs : nbe_cbs) =
   {
     iapp = (fun h -> fun _args -> h);
-    translate = (fun uu____6293 -> failwith "bogus_cbs translate")
+    translate = (fun uu___ -> failwith "bogus_cbs translate")
   }
 let (arg_as_int : arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
   fun a ->
@@ -1441,35 +1353,33 @@ let arg_as_list :
   'a . 'a embedding -> arg -> 'a Prims.list FStar_Pervasives_Native.option =
   fun e ->
     fun a1 ->
-      let uu____6355 =
-        let uu____6364 = e_list e in unembed uu____6364 bogus_cbs in
-      FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____6355
+      let uu___ = let uu___1 = e_list e in unembed uu___1 bogus_cbs in
+      FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu___
 let (arg_as_bounded_int :
   arg ->
     (FStar_Syntax_Syntax.fv * FStar_BigInt.t) FStar_Pervasives_Native.option)
   =
-  fun uu____6385 ->
-    match uu____6385 with
-    | (a, uu____6393) ->
+  fun uu___ ->
+    match uu___ with
+    | (a, uu___1) ->
         (match a.nbe_t with
          | FV
              (fv1, [],
-              ({ nbe_t = Constant (Int i); nbe_r = uu____6408;_}, uu____6409)::[])
+              ({ nbe_t = Constant (Int i); nbe_r = uu___2;_}, uu___3)::[])
              when
-             let uu____6426 =
+             let uu___4 =
                FStar_Ident.string_of_lid
                  (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             FStar_Util.ends_with uu____6426 "int_to_t" ->
+             FStar_Util.ends_with uu___4 "int_to_t" ->
              FStar_Pervasives_Native.Some (fv1, i)
-         | uu____6431 -> FStar_Pervasives_Native.None)
+         | uu___2 -> FStar_Pervasives_Native.None)
 let (int_as_bounded : FStar_Syntax_Syntax.fv -> FStar_BigInt.t -> t) =
   fun int_to_t ->
     fun n ->
       let c = embed e_int bogus_cbs n in
       let int_to_t1 args1 =
         FStar_All.pipe_left mk_t (FV (int_to_t, [], args1)) in
-      let uu____6473 = let uu____6480 = as_arg c in [uu____6480] in
-      int_to_t1 uu____6473
+      let uu___ = let uu___1 = as_arg c in [uu___1] in int_to_t1 uu___
 let lift_unary :
   'a 'b .
     ('a -> 'b) ->
@@ -1480,8 +1390,8 @@ let lift_unary :
     fun aopts ->
       match aopts with
       | (FStar_Pervasives_Native.Some a1)::[] ->
-          let uu____6533 = f a1 in FStar_Pervasives_Native.Some uu____6533
-      | uu____6534 -> FStar_Pervasives_Native.None
+          let uu___ = f a1 in FStar_Pervasives_Native.Some uu___
+      | uu___ -> FStar_Pervasives_Native.None
 let lift_binary :
   'a 'b .
     ('a -> 'a -> 'b) ->
@@ -1493,8 +1403,8 @@ let lift_binary :
       match aopts with
       | (FStar_Pervasives_Native.Some a0)::(FStar_Pervasives_Native.Some
           a1)::[] ->
-          let uu____6587 = f a0 a1 in FStar_Pervasives_Native.Some uu____6587
-      | uu____6588 -> FStar_Pervasives_Native.None
+          let uu___ = f a0 a1 in FStar_Pervasives_Native.Some uu___
+      | uu___ -> FStar_Pervasives_Native.None
 let unary_op :
   'a .
     (arg -> 'a FStar_Pervasives_Native.option) ->
@@ -1503,7 +1413,7 @@ let unary_op :
   fun as_a ->
     fun f ->
       fun args1 ->
-        let uu____6631 = FStar_List.map as_a args1 in lift_unary f uu____6631
+        let uu___ = FStar_List.map as_a args1 in lift_unary f uu___
 let binary_op :
   'a .
     (arg -> 'a FStar_Pervasives_Native.option) ->
@@ -1512,45 +1422,40 @@ let binary_op :
   fun as_a ->
     fun f ->
       fun args1 ->
-        let uu____6685 = FStar_List.map as_a args1 in
-        lift_binary f uu____6685
+        let uu___ = FStar_List.map as_a args1 in lift_binary f uu___
 let (unary_int_op :
   (FStar_BigInt.t -> FStar_BigInt.t) ->
     args -> t FStar_Pervasives_Native.option)
   =
   fun f ->
     unary_op arg_as_int
-      (fun x -> let uu____6714 = f x in embed e_int bogus_cbs uu____6714)
+      (fun x -> let uu___ = f x in embed e_int bogus_cbs uu___)
 let (binary_int_op :
   (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
     args -> t FStar_Pervasives_Native.option)
   =
   fun f ->
     binary_op arg_as_int
-      (fun x ->
-         fun y -> let uu____6740 = f x y in embed e_int bogus_cbs uu____6740)
+      (fun x -> fun y -> let uu___ = f x y in embed e_int bogus_cbs uu___)
 let (unary_bool_op :
   (Prims.bool -> Prims.bool) -> args -> t FStar_Pervasives_Native.option) =
   fun f ->
     unary_op arg_as_bool
-      (fun x -> let uu____6759 = f x in embed e_bool bogus_cbs uu____6759)
+      (fun x -> let uu___ = f x in embed e_bool bogus_cbs uu___)
 let (binary_bool_op :
   (Prims.bool -> Prims.bool -> Prims.bool) ->
     args -> t FStar_Pervasives_Native.option)
   =
   fun f ->
     binary_op arg_as_bool
-      (fun x ->
-         fun y -> let uu____6785 = f x y in embed e_bool bogus_cbs uu____6785)
+      (fun x -> fun y -> let uu___ = f x y in embed e_bool bogus_cbs uu___)
 let (binary_string_op :
   (Prims.string -> Prims.string -> Prims.string) ->
     args -> t FStar_Pervasives_Native.option)
   =
   fun f ->
     binary_op arg_as_string
-      (fun x ->
-         fun y ->
-           let uu____6811 = f x y in embed e_string bogus_cbs uu____6811)
+      (fun x -> fun y -> let uu___ = f x y in embed e_string bogus_cbs uu___)
 let mixed_binary_op :
   'a 'b 'c .
     (arg -> 'a FStar_Pervasives_Native.option) ->
@@ -1565,22 +1470,21 @@ let mixed_binary_op :
           fun args1 ->
             match args1 with
             | a1::b1::[] ->
-                let uu____6913 =
-                  let uu____6922 = as_a a1 in
-                  let uu____6925 = as_b b1 in (uu____6922, uu____6925) in
-                (match uu____6913 with
+                let uu___ =
+                  let uu___1 = as_a a1 in
+                  let uu___2 = as_b b1 in (uu___1, uu___2) in
+                (match uu___ with
                  | (FStar_Pervasives_Native.Some a2,
                     FStar_Pervasives_Native.Some b2) ->
-                     let uu____6940 =
-                       let uu____6941 = f a2 b2 in embed_c uu____6941 in
-                     FStar_Pervasives_Native.Some uu____6940
-                 | uu____6942 -> FStar_Pervasives_Native.None)
-            | uu____6951 -> FStar_Pervasives_Native.None
+                     let uu___1 = let uu___2 = f a2 b2 in embed_c uu___2 in
+                     FStar_Pervasives_Native.Some uu___1
+                 | uu___1 -> FStar_Pervasives_Native.None)
+            | uu___ -> FStar_Pervasives_Native.None
 let (list_of_string' : Prims.string -> t) =
   fun s ->
-    let uu____6957 = e_list e_char in
-    let uu____6962 = FStar_String.list_of_string s in
-    embed uu____6957 bogus_cbs uu____6962
+    let uu___ = e_list e_char in
+    let uu___1 = FStar_String.list_of_string s in
+    embed uu___ bogus_cbs uu___1
 let (string_of_list' : FStar_Char.char Prims.list -> t) =
   fun l ->
     let s = FStar_String.string_of_list l in
@@ -1589,30 +1493,30 @@ let (string_compare' : Prims.string -> Prims.string -> t) =
   fun s1 ->
     fun s2 ->
       let r = FStar_String.compare s1 s2 in
-      let uu____6988 =
-        let uu____6989 = FStar_Util.string_of_int r in
-        FStar_BigInt.big_int_of_string uu____6989 in
-      embed e_int bogus_cbs uu____6988
+      let uu___ =
+        let uu___1 = FStar_Util.string_of_int r in
+        FStar_BigInt.big_int_of_string uu___1 in
+      embed e_int bogus_cbs uu___
 let (string_concat' : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7021 = arg_as_string a1 in
-        (match uu____7021 with
+        let uu___ = arg_as_string a1 in
+        (match uu___ with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____7027 = arg_as_list e_string a2 in
-             (match uu____7027 with
+             let uu___1 = arg_as_list e_string a2 in
+             (match uu___1 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.concat s1 s2 in
-                  let uu____7040 = embed e_string bogus_cbs r in
-                  FStar_Pervasives_Native.Some uu____7040
-              | uu____7041 -> FStar_Pervasives_Native.None)
-         | uu____7046 -> FStar_Pervasives_Native.None)
-    | uu____7049 -> FStar_Pervasives_Native.None
+                  let uu___2 = embed e_string bogus_cbs r in
+                  FStar_Pervasives_Native.Some uu___2
+              | uu___2 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (string_of_int : FStar_BigInt.t -> t) =
   fun i ->
-    let uu____7055 = FStar_BigInt.string_of_big_int i in
-    embed e_string bogus_cbs uu____7055
+    let uu___ = FStar_BigInt.string_of_big_int i in
+    embed e_string bogus_cbs uu___
 let (string_of_bool : Prims.bool -> t) =
   fun b -> embed e_string bogus_cbs (if b then "true" else "false")
 let (string_lowercase : Prims.string -> t) =
@@ -1625,202 +1529,197 @@ let (decidable_eq : Prims.bool -> args -> t FStar_Pervasives_Native.option) =
       let tru = embed e_bool bogus_cbs true in
       let fal = embed e_bool bogus_cbs false in
       match args1 with
-      | (_typ, uu____7091)::(a1, uu____7093)::(a2, uu____7095)::[] ->
-          let uu____7112 = eq_t a1 a2 in
-          (match uu____7112 with
+      | (_typ, uu___)::(a1, uu___1)::(a2, uu___2)::[] ->
+          let uu___3 = eq_t a1 a2 in
+          (match uu___3 with
            | FStar_Syntax_Util.Equal ->
                FStar_Pervasives_Native.Some (if neg then fal else tru)
            | FStar_Syntax_Util.NotEqual ->
                FStar_Pervasives_Native.Some (if neg then tru else fal)
-           | uu____7117 -> FStar_Pervasives_Native.None)
-      | uu____7118 -> failwith "Unexpected number of arguments"
+           | uu___4 -> FStar_Pervasives_Native.None)
+      | uu___ -> failwith "Unexpected number of arguments"
 let (interp_prop_eq2 : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
-    | (_u, uu____7131)::(_typ, uu____7133)::(a1, uu____7135)::(a2,
-                                                               uu____7137)::[]
-        ->
-        let uu____7158 = eq_t a1 a2 in
-        (match uu____7158 with
+    | (_u, uu___)::(_typ, uu___1)::(a1, uu___2)::(a2, uu___3)::[] ->
+        let uu___4 = eq_t a1 a2 in
+        (match uu___4 with
          | FStar_Syntax_Util.Equal ->
-             let uu____7161 = embed e_bool bogus_cbs true in
-             FStar_Pervasives_Native.Some uu____7161
+             let uu___5 = embed e_bool bogus_cbs true in
+             FStar_Pervasives_Native.Some uu___5
          | FStar_Syntax_Util.NotEqual ->
-             let uu____7162 = embed e_bool bogus_cbs false in
-             FStar_Pervasives_Native.Some uu____7162
+             let uu___5 = embed e_bool bogus_cbs false in
+             FStar_Pervasives_Native.Some uu___5
          | FStar_Syntax_Util.Unknown -> FStar_Pervasives_Native.None)
-    | uu____7163 -> failwith "Unexpected number of arguments"
+    | uu___ -> failwith "Unexpected number of arguments"
 let (interp_prop_eq3 : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
-    | (_u, uu____7176)::(_v, uu____7178)::(t1, uu____7180)::(t2, uu____7182)::
-        (a1, uu____7184)::(a2, uu____7186)::[] ->
-        let uu____7215 =
-          let uu____7216 = eq_t t1 t2 in
-          let uu____7217 = eq_t a1 a2 in
-          FStar_Syntax_Util.eq_inj uu____7216 uu____7217 in
-        (match uu____7215 with
+    | (_u, uu___)::(_v, uu___1)::(t1, uu___2)::(t2, uu___3)::(a1, uu___4)::
+        (a2, uu___5)::[] ->
+        let uu___6 =
+          let uu___7 = eq_t t1 t2 in
+          let uu___8 = eq_t a1 a2 in FStar_Syntax_Util.eq_inj uu___7 uu___8 in
+        (match uu___6 with
          | FStar_Syntax_Util.Equal ->
-             let uu____7220 = embed e_bool bogus_cbs true in
-             FStar_Pervasives_Native.Some uu____7220
+             let uu___7 = embed e_bool bogus_cbs true in
+             FStar_Pervasives_Native.Some uu___7
          | FStar_Syntax_Util.NotEqual ->
-             let uu____7221 = embed e_bool bogus_cbs false in
-             FStar_Pervasives_Native.Some uu____7221
+             let uu___7 = embed e_bool bogus_cbs false in
+             FStar_Pervasives_Native.Some uu___7
          | FStar_Syntax_Util.Unknown -> FStar_Pervasives_Native.None)
-    | uu____7222 -> failwith "Unexpected number of arguments"
+    | uu___ -> failwith "Unexpected number of arguments"
 let (dummy_interp :
   FStar_Ident.lid -> args -> t FStar_Pervasives_Native.option) =
   fun lid ->
     fun args1 ->
-      let uu____7239 =
-        let uu____7240 = FStar_Ident.string_of_lid lid in
-        FStar_String.op_Hat "No interpretation for " uu____7240 in
-      failwith uu____7239
+      let uu___ =
+        let uu___1 = FStar_Ident.string_of_lid lid in
+        FStar_String.op_Hat "No interpretation for " uu___1 in
+      failwith uu___
 let (prims_to_fstar_range_step : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
-    | (a1, uu____7253)::[] ->
-        let uu____7262 = unembed e_range bogus_cbs a1 in
-        (match uu____7262 with
+    | (a1, uu___)::[] ->
+        let uu___1 = unembed e_range bogus_cbs a1 in
+        (match uu___1 with
          | FStar_Pervasives_Native.Some r ->
-             let uu____7268 = embed e_range bogus_cbs r in
-             FStar_Pervasives_Native.Some uu____7268
+             let uu___2 = embed e_range bogus_cbs r in
+             FStar_Pervasives_Native.Some uu___2
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
-    | uu____7269 -> failwith "Unexpected number of arguments"
+    | uu___ -> failwith "Unexpected number of arguments"
 let (string_split' : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7303 = arg_as_list e_char a1 in
-        (match uu____7303 with
+        let uu___ = arg_as_list e_char a1 in
+        (match uu___ with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____7315 = arg_as_string a2 in
-             (match uu____7315 with
+             let uu___1 = arg_as_string a2 in
+             (match uu___1 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.split s1 s2 in
-                  let uu____7324 =
-                    let uu____7325 = e_list e_string in
-                    embed uu____7325 bogus_cbs r in
-                  FStar_Pervasives_Native.Some uu____7324
-              | uu____7332 -> FStar_Pervasives_Native.None)
-         | uu____7335 -> FStar_Pervasives_Native.None)
-    | uu____7340 -> FStar_Pervasives_Native.None
+                  let uu___2 =
+                    let uu___3 = e_list e_string in embed uu___3 bogus_cbs r in
+                  FStar_Pervasives_Native.Some uu___2
+              | uu___2 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (string_index : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7372 =
-          let uu____7381 = arg_as_string a1 in
-          let uu____7384 = arg_as_int a2 in (uu____7381, uu____7384) in
-        (match uu____7372 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some i)
              ->
              (try
-                (fun uu___1042_7404 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.index s i in
-                       let uu____7408 = embed e_char bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu____7408) ()
-              with | uu___1041_7410 -> FStar_Pervasives_Native.None)
-         | uu____7413 -> FStar_Pervasives_Native.None)
-    | uu____7422 -> FStar_Pervasives_Native.None
+                       let uu___2 = embed e_char bogus_cbs r in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (string_index_of : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7454 =
-          let uu____7463 = arg_as_string a1 in
-          let uu____7466 = arg_as_char a2 in (uu____7463, uu____7466) in
-        (match uu____7454 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_char a2 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some c)
              ->
              (try
-                (fun uu___1060_7486 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.index_of s c in
-                       let uu____7490 = embed e_int bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu____7490) ()
-              with | uu___1059_7492 -> FStar_Pervasives_Native.None)
-         | uu____7495 -> FStar_Pervasives_Native.None)
-    | uu____7504 -> FStar_Pervasives_Native.None
+                       let uu___2 = embed e_int bogus_cbs r in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (string_substring' : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::a3::[] ->
-        let uu____7545 =
-          let uu____7558 = arg_as_string a1 in
-          let uu____7561 = arg_as_int a2 in
-          let uu____7564 = arg_as_int a3 in
-          (uu____7558, uu____7561, uu____7564) in
-        (match uu____7545 with
+        let uu___ =
+          let uu___1 = arg_as_string a1 in
+          let uu___2 = arg_as_int a2 in
+          let uu___3 = arg_as_int a3 in (uu___1, uu___2, uu___3) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some s1, FStar_Pervasives_Native.Some n1,
             FStar_Pervasives_Native.Some n2) ->
              let n11 = FStar_BigInt.to_int_fs n1 in
              let n21 = FStar_BigInt.to_int_fs n2 in
              (try
-                (fun uu___1083_7591 ->
+                (fun uu___1 ->
                    match () with
                    | () ->
                        let r = FStar_String.substring s1 n11 n21 in
-                       let uu____7595 = embed e_string bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu____7595) ()
-              with | uu___1082_7597 -> FStar_Pervasives_Native.None)
-         | uu____7600 -> FStar_Pervasives_Native.None)
-    | uu____7613 -> FStar_Pervasives_Native.None
+                       let uu___2 = embed e_string bogus_cbs r in
+                       FStar_Pervasives_Native.Some uu___2) ()
+              with | uu___1 -> FStar_Pervasives_Native.None)
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (mk_range : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu____7672 =
-          let uu____7693 = arg_as_string fn in
-          let uu____7696 = arg_as_int from_line in
-          let uu____7699 = arg_as_int from_col in
-          let uu____7702 = arg_as_int to_line in
-          let uu____7705 = arg_as_int to_col in
-          (uu____7693, uu____7696, uu____7699, uu____7702, uu____7705) in
-        (match uu____7672 with
+        let uu___ =
+          let uu___1 = arg_as_string fn in
+          let uu___2 = arg_as_int from_line in
+          let uu___3 = arg_as_int from_col in
+          let uu___4 = arg_as_int to_line in
+          let uu___5 = arg_as_int to_col in
+          (uu___1, uu___2, uu___3, uu___4, uu___5) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some fn1, FStar_Pervasives_Native.Some
             from_l, FStar_Pervasives_Native.Some from_c,
             FStar_Pervasives_Native.Some to_l, FStar_Pervasives_Native.Some
             to_c) ->
              let r =
-               let uu____7736 =
-                 let uu____7737 = FStar_BigInt.to_int_fs from_l in
-                 let uu____7738 = FStar_BigInt.to_int_fs from_c in
-                 FStar_Range.mk_pos uu____7737 uu____7738 in
-               let uu____7739 =
-                 let uu____7740 = FStar_BigInt.to_int_fs to_l in
-                 let uu____7741 = FStar_BigInt.to_int_fs to_c in
-                 FStar_Range.mk_pos uu____7740 uu____7741 in
-               FStar_Range.mk_range fn1 uu____7736 uu____7739 in
-             let uu____7742 = embed e_range bogus_cbs r in
-             FStar_Pervasives_Native.Some uu____7742
-         | uu____7743 -> FStar_Pervasives_Native.None)
-    | uu____7764 -> FStar_Pervasives_Native.None
+               let uu___1 =
+                 let uu___2 = FStar_BigInt.to_int_fs from_l in
+                 let uu___3 = FStar_BigInt.to_int_fs from_c in
+                 FStar_Range.mk_pos uu___2 uu___3 in
+               let uu___2 =
+                 let uu___3 = FStar_BigInt.to_int_fs to_l in
+                 let uu___4 = FStar_BigInt.to_int_fs to_c in
+                 FStar_Range.mk_pos uu___3 uu___4 in
+               FStar_Range.mk_range fn1 uu___1 uu___2 in
+             let uu___1 = embed e_range bogus_cbs r in
+             FStar_Pervasives_Native.Some uu___1
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> FStar_Pervasives_Native.None
 let (division_op : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
     | a1::a2::[] ->
-        let uu____7796 =
-          let uu____7805 = arg_as_int a1 in
-          let uu____7808 = arg_as_int a2 in (uu____7805, uu____7808) in
-        (match uu____7796 with
+        let uu___ =
+          let uu___1 = arg_as_int a1 in
+          let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
+        (match uu___ with
          | (FStar_Pervasives_Native.Some m, FStar_Pervasives_Native.Some n)
              ->
-             let uu____7823 =
-               let uu____7824 = FStar_BigInt.to_int_fs n in
-               uu____7824 <> Prims.int_zero in
-             if uu____7823
+             let uu___1 =
+               let uu___2 = FStar_BigInt.to_int_fs n in
+               uu___2 <> Prims.int_zero in
+             if uu___1
              then
-               let uu____7827 =
-                 let uu____7828 = FStar_BigInt.div_big_int m n in
-                 embed e_int bogus_cbs uu____7828 in
-               FStar_Pervasives_Native.Some uu____7827
+               let uu___2 =
+                 let uu___3 = FStar_BigInt.div_big_int m n in
+                 embed e_int bogus_cbs uu___3 in
+               FStar_Pervasives_Native.Some uu___2
              else FStar_Pervasives_Native.None
-         | uu____7830 -> FStar_Pervasives_Native.None)
-    | uu____7839 -> failwith "Unexpected number of arguments"
+         | uu___1 -> FStar_Pervasives_Native.None)
+    | uu___ -> failwith "Unexpected number of arguments"
 let arrow_as_prim_step_1 :
   'a 'b .
     'a embedding ->
@@ -1837,16 +1736,15 @@ let arrow_as_prim_step_1 :
           fun _fv_lid ->
             fun cb ->
               let f_wrapped args1 =
-                let uu____7928 = FStar_List.splitAt n_tvars args1 in
-                match uu____7928 with
+                let uu___ = FStar_List.splitAt n_tvars args1 in
+                match uu___ with
                 | (_tvar_args, rest_args) ->
-                    let uu____7977 = FStar_List.hd rest_args in
-                    (match uu____7977 with
-                     | (x, uu____7989) ->
-                         let uu____7990 = unembed ea cb x in
-                         FStar_Util.map_opt uu____7990
-                           (fun x1 ->
-                              let uu____7996 = f x1 in embed eb cb uu____7996)) in
+                    let uu___1 = FStar_List.hd rest_args in
+                    (match uu___1 with
+                     | (x, uu___2) ->
+                         let uu___3 = unembed ea cb x in
+                         FStar_Util.map_opt uu___3
+                           (fun x1 -> let uu___4 = f x1 in embed eb cb uu___4)) in
               f_wrapped
 let arrow_as_prim_step_2 :
   'a 'b 'c .
@@ -1866,28 +1764,27 @@ let arrow_as_prim_step_2 :
             fun _fv_lid ->
               fun cb ->
                 let f_wrapped args1 =
-                  let uu____8102 = FStar_List.splitAt n_tvars args1 in
-                  match uu____8102 with
+                  let uu___ = FStar_List.splitAt n_tvars args1 in
+                  match uu___ with
                   | (_tvar_args, rest_args) ->
-                      let uu____8151 = FStar_List.hd rest_args in
-                      (match uu____8151 with
-                       | (x, uu____8163) ->
-                           let uu____8164 =
-                             let uu____8169 = FStar_List.tl rest_args in
-                             FStar_List.hd uu____8169 in
-                           (match uu____8164 with
-                            | (y, uu____8187) ->
-                                let uu____8188 = unembed ea cb x in
-                                FStar_Util.bind_opt uu____8188
+                      let uu___1 = FStar_List.hd rest_args in
+                      (match uu___1 with
+                       | (x, uu___2) ->
+                           let uu___3 =
+                             let uu___4 = FStar_List.tl rest_args in
+                             FStar_List.hd uu___4 in
+                           (match uu___3 with
+                            | (y, uu___4) ->
+                                let uu___5 = unembed ea cb x in
+                                FStar_Util.bind_opt uu___5
                                   (fun x1 ->
-                                     let uu____8194 = unembed eb cb y in
-                                     FStar_Util.bind_opt uu____8194
+                                     let uu___6 = unembed eb cb y in
+                                     FStar_Util.bind_opt uu___6
                                        (fun y1 ->
-                                          let uu____8200 =
-                                            let uu____8201 = f x1 y1 in
-                                            embed ec cb uu____8201 in
-                                          FStar_Pervasives_Native.Some
-                                            uu____8200)))) in
+                                          let uu___7 =
+                                            let uu___8 = f x1 y1 in
+                                            embed ec cb uu___8 in
+                                          FStar_Pervasives_Native.Some uu___7)))) in
                 f_wrapped
 let arrow_as_prim_step_3 :
   'a 'b 'c 'd .
@@ -1909,41 +1806,37 @@ let arrow_as_prim_step_3 :
               fun _fv_lid ->
                 fun cb ->
                   let f_wrapped args1 =
-                    let uu____8326 = FStar_List.splitAt n_tvars args1 in
-                    match uu____8326 with
+                    let uu___ = FStar_List.splitAt n_tvars args1 in
+                    match uu___ with
                     | (_tvar_args, rest_args) ->
-                        let uu____8375 = FStar_List.hd rest_args in
-                        (match uu____8375 with
-                         | (x, uu____8387) ->
-                             let uu____8388 =
-                               let uu____8393 = FStar_List.tl rest_args in
-                               FStar_List.hd uu____8393 in
-                             (match uu____8388 with
-                              | (y, uu____8411) ->
-                                  let uu____8412 =
-                                    let uu____8417 =
-                                      let uu____8424 =
-                                        FStar_List.tl rest_args in
-                                      FStar_List.tl uu____8424 in
-                                    FStar_List.hd uu____8417 in
-                                  (match uu____8412 with
-                                   | (z, uu____8446) ->
-                                       let uu____8447 = unembed ea cb x in
-                                       FStar_Util.bind_opt uu____8447
+                        let uu___1 = FStar_List.hd rest_args in
+                        (match uu___1 with
+                         | (x, uu___2) ->
+                             let uu___3 =
+                               let uu___4 = FStar_List.tl rest_args in
+                               FStar_List.hd uu___4 in
+                             (match uu___3 with
+                              | (y, uu___4) ->
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 = FStar_List.tl rest_args in
+                                      FStar_List.tl uu___7 in
+                                    FStar_List.hd uu___6 in
+                                  (match uu___5 with
+                                   | (z, uu___6) ->
+                                       let uu___7 = unembed ea cb x in
+                                       FStar_Util.bind_opt uu___7
                                          (fun x1 ->
-                                            let uu____8453 = unembed eb cb y in
-                                            FStar_Util.bind_opt uu____8453
+                                            let uu___8 = unembed eb cb y in
+                                            FStar_Util.bind_opt uu___8
                                               (fun y1 ->
-                                                 let uu____8459 =
-                                                   unembed ec cb z in
-                                                 FStar_Util.bind_opt
-                                                   uu____8459
+                                                 let uu___9 = unembed ec cb z in
+                                                 FStar_Util.bind_opt uu___9
                                                    (fun z1 ->
-                                                      let uu____8465 =
-                                                        let uu____8466 =
+                                                      let uu___10 =
+                                                        let uu___11 =
                                                           f x1 y1 z1 in
-                                                        embed ed cb
-                                                          uu____8466 in
+                                                        embed ed cb uu___11 in
                                                       FStar_Pervasives_Native.Some
-                                                        uu____8465)))))) in
+                                                        uu___10)))))) in
                   f_wrapped

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -1,13 +1,13 @@
 open Prims
 let cases :
-  'uuuuuu10 'uuuuuu11 .
-    ('uuuuuu10 -> 'uuuuuu11) ->
-      'uuuuuu11 -> 'uuuuuu10 FStar_Pervasives_Native.option -> 'uuuuuu11
+  'uuuuu 'uuuuu1 .
+    ('uuuuu -> 'uuuuu1) ->
+      'uuuuu1 -> 'uuuuu FStar_Pervasives_Native.option -> 'uuuuu1
   =
   fun f ->
     fun d ->
-      fun uu___0_31 ->
-        match uu___0_31 with
+      fun uu___ ->
+        match uu___ with
         | FStar_Pervasives_Native.Some x -> f x
         | FStar_Pervasives_Native.None -> d
 type closure =
@@ -19,8 +19,7 @@ type closure =
   | Univ of FStar_Syntax_Syntax.universe 
   | Dummy 
 let (uu___is_Clos : closure -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Clos _0 -> true | uu____115 -> false
+  fun projectee -> match projectee with | Clos _0 -> true | uu___ -> false
 let (__proj__Clos__item___0 :
   closure ->
     ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
@@ -29,12 +28,11 @@ let (__proj__Clos__item___0 :
       FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo * Prims.bool))
   = fun projectee -> match projectee with | Clos _0 -> _0
 let (uu___is_Univ : closure -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Univ _0 -> true | uu____218 -> false
+  fun projectee -> match projectee with | Univ _0 -> true | uu___ -> false
 let (__proj__Univ__item___0 : closure -> FStar_Syntax_Syntax.universe) =
   fun projectee -> match projectee with | Univ _0 -> _0
 let (uu___is_Dummy : closure -> Prims.bool) =
-  fun projectee -> match projectee with | Dummy -> true | uu____230 -> false
+  fun projectee -> match projectee with | Dummy -> true | uu___ -> false
 type env =
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
     Prims.list
@@ -64,31 +62,30 @@ type stack_elt =
   | Cfg of FStar_TypeChecker_Cfg.cfg 
   | Debug of (FStar_Syntax_Syntax.term * FStar_Util.time) 
 let (uu___is_Arg : stack_elt -> Prims.bool) =
-  fun projectee -> match projectee with | Arg _0 -> true | uu____398 -> false
+  fun projectee -> match projectee with | Arg _0 -> true | uu___ -> false
 let (__proj__Arg__item___0 :
   stack_elt -> (closure * FStar_Syntax_Syntax.aqual * FStar_Range.range)) =
   fun projectee -> match projectee with | Arg _0 -> _0
 let (uu___is_UnivArgs : stack_elt -> Prims.bool) =
   fun projectee ->
-    match projectee with | UnivArgs _0 -> true | uu____435 -> false
+    match projectee with | UnivArgs _0 -> true | uu___ -> false
 let (__proj__UnivArgs__item___0 :
   stack_elt -> (FStar_Syntax_Syntax.universe Prims.list * FStar_Range.range))
   = fun projectee -> match projectee with | UnivArgs _0 -> _0
 let (uu___is_MemoLazy : stack_elt -> Prims.bool) =
   fun projectee ->
-    match projectee with | MemoLazy _0 -> true | uu____472 -> false
+    match projectee with | MemoLazy _0 -> true | uu___ -> false
 let (__proj__MemoLazy__item___0 :
   stack_elt -> (env * FStar_Syntax_Syntax.term) FStar_Syntax_Syntax.memo) =
   fun projectee -> match projectee with | MemoLazy _0 -> _0
 let (uu___is_Match : stack_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Match _0 -> true | uu____511 -> false
+  fun projectee -> match projectee with | Match _0 -> true | uu___ -> false
 let (__proj__Match__item___0 :
   stack_elt ->
     (env * branches * FStar_TypeChecker_Cfg.cfg * FStar_Range.range))
   = fun projectee -> match projectee with | Match _0 -> _0
 let (uu___is_Abs : stack_elt -> Prims.bool) =
-  fun projectee -> match projectee with | Abs _0 -> true | uu____560 -> false
+  fun projectee -> match projectee with | Abs _0 -> true | uu___ -> false
 let (__proj__Abs__item___0 :
   stack_elt ->
     (env * FStar_Syntax_Syntax.binders * env *
@@ -96,48 +93,45 @@ let (__proj__Abs__item___0 :
       FStar_Range.range))
   = fun projectee -> match projectee with | Abs _0 -> _0
 let (uu___is_App : stack_elt -> Prims.bool) =
-  fun projectee -> match projectee with | App _0 -> true | uu____617 -> false
+  fun projectee -> match projectee with | App _0 -> true | uu___ -> false
 let (__proj__App__item___0 :
   stack_elt ->
     (env * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual *
       FStar_Range.range))
   = fun projectee -> match projectee with | App _0 -> _0
 let (uu___is_CBVApp : stack_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | CBVApp _0 -> true | uu____662 -> false
+  fun projectee -> match projectee with | CBVApp _0 -> true | uu___ -> false
 let (__proj__CBVApp__item___0 :
   stack_elt ->
     (env * FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual *
       FStar_Range.range))
   = fun projectee -> match projectee with | CBVApp _0 -> _0
 let (uu___is_Meta : stack_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Meta _0 -> true | uu____705 -> false
+  fun projectee -> match projectee with | Meta _0 -> true | uu___ -> false
 let (__proj__Meta__item___0 :
   stack_elt -> (env * FStar_Syntax_Syntax.metadata * FStar_Range.range)) =
   fun projectee -> match projectee with | Meta _0 -> _0
 let (uu___is_Let : stack_elt -> Prims.bool) =
-  fun projectee -> match projectee with | Let _0 -> true | uu____744 -> false
+  fun projectee -> match projectee with | Let _0 -> true | uu___ -> false
 let (__proj__Let__item___0 :
   stack_elt ->
     (env * FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.letbinding *
       FStar_Range.range))
   = fun projectee -> match projectee with | Let _0 -> _0
 let (uu___is_Cfg : stack_elt -> Prims.bool) =
-  fun projectee -> match projectee with | Cfg _0 -> true | uu____781 -> false
+  fun projectee -> match projectee with | Cfg _0 -> true | uu___ -> false
 let (__proj__Cfg__item___0 : stack_elt -> FStar_TypeChecker_Cfg.cfg) =
   fun projectee -> match projectee with | Cfg _0 -> _0
 let (uu___is_Debug : stack_elt -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Debug _0 -> true | uu____798 -> false
+  fun projectee -> match projectee with | Debug _0 -> true | uu___ -> false
 let (__proj__Debug__item___0 :
   stack_elt -> (FStar_Syntax_Syntax.term * FStar_Util.time)) =
   fun projectee -> match projectee with | Debug _0 -> _0
 type stack = stack_elt Prims.list
 let (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____824 = FStar_Syntax_Util.head_and_args' t in
-    match uu____824 with | (hd, uu____840) -> hd
+    let uu___ = FStar_Syntax_Util.head_and_args' t in
+    match uu___ with | (hd, uu___1) -> hd
 let set_memo :
   'a . FStar_TypeChecker_Cfg.cfg -> 'a FStar_Syntax_Syntax.memo -> 'a -> unit
   =
@@ -146,74 +140,73 @@ let set_memo :
       fun t ->
         if cfg.FStar_TypeChecker_Cfg.memoize_lazy
         then
-          let uu____889 = FStar_ST.op_Bang r in
-          match uu____889 with
-          | FStar_Pervasives_Native.Some uu____902 ->
+          let uu___ = FStar_ST.op_Bang r in
+          match uu___ with
+          | FStar_Pervasives_Native.Some uu___1 ->
               failwith "Unexpected set_memo: thunk already evaluated"
           | FStar_Pervasives_Native.None ->
               FStar_ST.op_Colon_Equals r (FStar_Pervasives_Native.Some t)
         else ()
 let (closure_to_string : closure -> Prims.string) =
-  fun uu___1_918 ->
-    match uu___1_918 with
-    | Clos (env1, t, uu____921, uu____922) ->
-        let uu____967 =
+  fun uu___ ->
+    match uu___ with
+    | Clos (env1, t, uu___1, uu___2) ->
+        let uu___3 =
           FStar_All.pipe_right (FStar_List.length env1)
             FStar_Util.string_of_int in
-        let uu____974 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format2 "(env=%s elts; %s)" uu____967 uu____974
-    | Univ uu____975 -> "Univ"
+        let uu___4 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format2 "(env=%s elts; %s)" uu___3 uu___4
+    | Univ uu___1 -> "Univ"
     | Dummy -> "dummy"
 let (env_to_string :
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
     Prims.list -> Prims.string)
   =
   fun env1 ->
-    let uu____997 =
+    let uu___ =
       FStar_List.map
-        (fun uu____1011 ->
-           match uu____1011 with
+        (fun uu___1 ->
+           match uu___1 with
            | (bopt, c) ->
-               let uu____1024 =
+               let uu___2 =
                  match bopt with
                  | FStar_Pervasives_Native.None -> "."
                  | FStar_Pervasives_Native.Some x ->
                      FStar_Syntax_Print.binder_to_string x in
-               let uu____1026 = closure_to_string c in
-               FStar_Util.format2 "(%s, %s)" uu____1024 uu____1026) env1 in
-    FStar_All.pipe_right uu____997 (FStar_String.concat "; ")
+               let uu___3 = closure_to_string c in
+               FStar_Util.format2 "(%s, %s)" uu___2 uu___3) env1 in
+    FStar_All.pipe_right uu___ (FStar_String.concat "; ")
 let (stack_elt_to_string : stack_elt -> Prims.string) =
-  fun uu___2_1033 ->
-    match uu___2_1033 with
-    | Arg (c, uu____1035, uu____1036) ->
-        let uu____1037 = closure_to_string c in
-        FStar_Util.format1 "Closure %s" uu____1037
-    | MemoLazy uu____1038 -> "MemoLazy"
-    | Abs (uu____1045, bs, uu____1047, uu____1048, uu____1049) ->
-        let uu____1054 =
+  fun uu___ ->
+    match uu___ with
+    | Arg (c, uu___1, uu___2) ->
+        let uu___3 = closure_to_string c in
+        FStar_Util.format1 "Closure %s" uu___3
+    | MemoLazy uu___1 -> "MemoLazy"
+    | Abs (uu___1, bs, uu___2, uu___3, uu___4) ->
+        let uu___5 =
           FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs) in
-        FStar_Util.format1 "Abs %s" uu____1054
-    | UnivArgs uu____1061 -> "UnivArgs"
-    | Match uu____1068 -> "Match"
-    | App (uu____1077, t, uu____1079, uu____1080) ->
-        let uu____1081 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "App %s" uu____1081
-    | CBVApp (uu____1082, t, uu____1084, uu____1085) ->
-        let uu____1086 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "CBVApp %s" uu____1086
-    | Meta (uu____1087, m, uu____1089) -> "Meta"
-    | Let uu____1090 -> "Let"
-    | Cfg uu____1099 -> "Cfg"
-    | Debug (t, uu____1101) ->
-        let uu____1102 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.format1 "Debug %s" uu____1102
+        FStar_Util.format1 "Abs %s" uu___5
+    | UnivArgs uu___1 -> "UnivArgs"
+    | Match uu___1 -> "Match"
+    | App (uu___1, t, uu___2, uu___3) ->
+        let uu___4 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format1 "App %s" uu___4
+    | CBVApp (uu___1, t, uu___2, uu___3) ->
+        let uu___4 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format1 "CBVApp %s" uu___4
+    | Meta (uu___1, m, uu___2) -> "Meta"
+    | Let uu___1 -> "Let"
+    | Cfg uu___1 -> "Cfg"
+    | Debug (t, uu___1) ->
+        let uu___2 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.format1 "Debug %s" uu___2
 let (stack_to_string : stack_elt Prims.list -> Prims.string) =
   fun s ->
-    let uu____1112 = FStar_List.map stack_elt_to_string s in
-    FStar_All.pipe_right uu____1112 (FStar_String.concat "; ")
-let is_empty : 'uuuuuu1121 . 'uuuuuu1121 Prims.list -> Prims.bool =
-  fun uu___3_1128 ->
-    match uu___3_1128 with | [] -> true | uu____1131 -> false
+    let uu___ = FStar_List.map stack_elt_to_string s in
+    FStar_All.pipe_right uu___ (FStar_String.concat "; ")
+let is_empty : 'uuuuu . 'uuuuu Prims.list -> Prims.bool =
+  fun uu___ -> match uu___ with | [] -> true | uu___1 -> false
 let (lookup_bvar :
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
     Prims.list -> FStar_Syntax_Syntax.bv -> closure)
@@ -221,36 +214,33 @@ let (lookup_bvar :
   fun env1 ->
     fun x ->
       try
-        (fun uu___119_1162 ->
+        (fun uu___ ->
            match () with
            | () ->
-               let uu____1163 =
-                 FStar_List.nth env1 x.FStar_Syntax_Syntax.index in
-               FStar_Pervasives_Native.snd uu____1163) ()
+               let uu___1 = FStar_List.nth env1 x.FStar_Syntax_Syntax.index in
+               FStar_Pervasives_Native.snd uu___1) ()
       with
-      | uu___118_1180 ->
-          let uu____1181 =
-            let uu____1182 = FStar_Syntax_Print.db_to_string x in
-            let uu____1183 = env_to_string env1 in
-            FStar_Util.format2 "Failed to find %s\nEnv is %s\n" uu____1182
-              uu____1183 in
-          failwith uu____1181
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.db_to_string x in
+            let uu___3 = env_to_string env1 in
+            FStar_Util.format2 "Failed to find %s\nEnv is %s\n" uu___2 uu___3 in
+          failwith uu___1
 let (downgrade_ghost_effect_name :
   FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option) =
   fun l ->
-    let uu____1191 =
-      FStar_Ident.lid_equals l FStar_Parser_Const.effect_Ghost_lid in
-    if uu____1191
+    let uu___ = FStar_Ident.lid_equals l FStar_Parser_Const.effect_Ghost_lid in
+    if uu___
     then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_Pure_lid
     else
-      (let uu____1195 =
+      (let uu___2 =
          FStar_Ident.lid_equals l FStar_Parser_Const.effect_GTot_lid in
-       if uu____1195
+       if uu___2
        then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_Tot_lid
        else
-         (let uu____1199 =
+         (let uu___4 =
             FStar_Ident.lid_equals l FStar_Parser_Const.effect_GHOST_lid in
-          if uu____1199
+          if uu___4
           then
             FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
           else FStar_Pervasives_Native.None))
@@ -263,109 +253,106 @@ let (norm_universe :
       fun u ->
         let norm_univs_for_max us =
           let us1 = FStar_Util.sort_with FStar_Syntax_Util.compare_univs us in
-          let uu____1233 =
+          let uu___ =
             FStar_List.fold_left
-              (fun uu____1259 ->
+              (fun uu___1 ->
                  fun u1 ->
-                   match uu____1259 with
+                   match uu___1 with
                    | (cur_kernel, cur_max, out) ->
-                       let uu____1284 = FStar_Syntax_Util.univ_kernel u1 in
-                       (match uu____1284 with
+                       let uu___2 = FStar_Syntax_Util.univ_kernel u1 in
+                       (match uu___2 with
                         | (k_u, n) ->
-                            let uu____1299 =
+                            let uu___3 =
                               FStar_Syntax_Util.eq_univs cur_kernel k_u in
-                            if uu____1299
+                            if uu___3
                             then (cur_kernel, u1, out)
                             else (k_u, u1, (cur_max :: out))))
               (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero, [])
               us1 in
-          match uu____1233 with
-          | (uu____1317, u1, out) -> FStar_List.rev (u1 :: out) in
+          match uu___ with | (uu___1, u1, out) -> FStar_List.rev (u1 :: out) in
         let rec aux u1 =
           let u2 = FStar_Syntax_Subst.compress_univ u1 in
           match u2 with
           | FStar_Syntax_Syntax.U_bvar x ->
               (try
-                 (fun uu___153_1344 ->
+                 (fun uu___ ->
                     match () with
                     | () ->
-                        let uu____1347 =
-                          let uu____1348 = FStar_List.nth env1 x in
-                          FStar_Pervasives_Native.snd uu____1348 in
-                        (match uu____1347 with
+                        let uu___1 =
+                          let uu___2 = FStar_List.nth env1 x in
+                          FStar_Pervasives_Native.snd uu___2 in
+                        (match uu___1 with
                          | Univ u3 ->
-                             ((let uu____1367 =
+                             ((let uu___3 =
                                  FStar_All.pipe_left
                                    (FStar_TypeChecker_Env.debug
                                       cfg.FStar_TypeChecker_Cfg.tcenv)
                                    (FStar_Options.Other "univ_norm") in
-                               if uu____1367
+                               if uu___3
                                then
-                                 let uu____1368 =
+                                 let uu___4 =
                                    FStar_Syntax_Print.univ_to_string u3 in
                                  FStar_Util.print1
-                                   "Univ (in norm_universe): %s\n" uu____1368
+                                   "Univ (in norm_universe): %s\n" uu___4
                                else ());
                               aux u3)
                          | Dummy -> [u2]
-                         | uu____1370 ->
-                             let uu____1371 =
-                               let uu____1372 = FStar_Util.string_of_int x in
+                         | uu___2 ->
+                             let uu___3 =
+                               let uu___4 = FStar_Util.string_of_int x in
                                FStar_Util.format1
                                  "Impossible: universe variable u@%s bound to a term"
-                                 uu____1372 in
-                             failwith uu____1371)) ()
+                                 uu___4 in
+                             failwith uu___3)) ()
                with
-               | uu____1380 ->
+               | uu___1 ->
                    if
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                    then [FStar_Syntax_Syntax.U_unknown]
                    else
-                     (let uu____1384 =
-                        let uu____1385 = FStar_Util.string_of_int x in
+                     (let uu___3 =
+                        let uu___4 = FStar_Util.string_of_int x in
                         FStar_String.op_Hat "Universe variable not found: u@"
-                          uu____1385 in
-                      failwith uu____1384))
-          | FStar_Syntax_Syntax.U_unif uu____1388 when
+                          uu___4 in
+                      failwith uu___3))
+          | FStar_Syntax_Syntax.U_unif uu___ when
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
               -> [FStar_Syntax_Syntax.U_zero]
           | FStar_Syntax_Syntax.U_zero -> [u2]
-          | FStar_Syntax_Syntax.U_unif uu____1399 -> [u2]
-          | FStar_Syntax_Syntax.U_name uu____1410 -> [u2]
+          | FStar_Syntax_Syntax.U_unif uu___ -> [u2]
+          | FStar_Syntax_Syntax.U_name uu___ -> [u2]
           | FStar_Syntax_Syntax.U_unknown -> [u2]
           | FStar_Syntax_Syntax.U_max [] -> [FStar_Syntax_Syntax.U_zero]
           | FStar_Syntax_Syntax.U_max us ->
               let us1 =
-                let uu____1417 = FStar_List.collect aux us in
-                FStar_All.pipe_right uu____1417 norm_univs_for_max in
+                let uu___ = FStar_List.collect aux us in
+                FStar_All.pipe_right uu___ norm_univs_for_max in
               (match us1 with
                | u_k::hd::rest ->
                    let rest1 = hd :: rest in
-                   let uu____1434 = FStar_Syntax_Util.univ_kernel u_k in
-                   (match uu____1434 with
+                   let uu___ = FStar_Syntax_Util.univ_kernel u_k in
+                   (match uu___ with
                     | (FStar_Syntax_Syntax.U_zero, n) ->
-                        let uu____1442 =
+                        let uu___1 =
                           FStar_All.pipe_right rest1
                             (FStar_List.for_all
                                (fun u3 ->
-                                  let uu____1450 =
+                                  let uu___2 =
                                     FStar_Syntax_Util.univ_kernel u3 in
-                                  match uu____1450 with
-                                  | (uu____1455, m) -> n <= m)) in
-                        if uu____1442 then rest1 else us1
-                    | uu____1460 -> us1)
-               | uu____1465 -> us1)
+                                  match uu___2 with | (uu___3, m) -> n <= m)) in
+                        if uu___1 then rest1 else us1
+                    | uu___1 -> us1)
+               | uu___ -> us1)
           | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____1469 = aux u3 in
+              let uu___ = aux u3 in
               FStar_List.map
-                (fun uu____1472 -> FStar_Syntax_Syntax.U_succ uu____1472)
-                uu____1469 in
+                (fun uu___1 -> FStar_Syntax_Syntax.U_succ uu___1) uu___ in
         if
           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
         then FStar_Syntax_Syntax.U_unknown
         else
-          (let uu____1474 = aux u in
-           match uu____1474 with
+          (let uu___1 = aux u in
+           match uu___1 with
            | [] -> FStar_Syntax_Syntax.U_zero
            | (FStar_Syntax_Syntax.U_zero)::[] -> FStar_Syntax_Syntax.U_zero
            | (FStar_Syntax_Syntax.U_zero)::u1::[] -> u1
@@ -384,31 +371,31 @@ let rec (inline_closure_env :
       fun stack1 ->
         fun t ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____1634 ->
-               let uu____1635 = FStar_Syntax_Print.tag_of_term t in
-               let uu____1636 = env_to_string env1 in
-               let uu____1637 = FStar_Syntax_Print.term_to_string t in
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.tag_of_term t in
+               let uu___3 = env_to_string env1 in
+               let uu___4 = FStar_Syntax_Print.term_to_string t in
                FStar_Util.print3 ">>> %s (env=%s)\nClosure_as_term %s\n"
-                 uu____1635 uu____1636 uu____1637);
+                 uu___2 uu___3 uu___4);
           (match env1 with
            | [] when
                FStar_All.pipe_left Prims.op_Negation
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                -> rebuild_closure cfg env1 stack1 t
-           | uu____1646 ->
+           | uu___1 ->
                (match t.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_delayed uu____1649 ->
-                    let uu____1664 = FStar_Syntax_Subst.compress t in
-                    inline_closure_env cfg env1 stack1 uu____1664
+                | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
+                    let uu___3 = FStar_Syntax_Subst.compress t in
+                    inline_closure_env cfg env1 stack1 uu___3
                 | FStar_Syntax_Syntax.Tm_unknown ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_constant uu____1665 ->
+                | FStar_Syntax_Syntax.Tm_constant uu___2 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_name uu____1666 ->
+                | FStar_Syntax_Syntax.Tm_name uu___2 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_lazy uu____1667 ->
+                | FStar_Syntax_Syntax.Tm_lazy uu___2 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_fvar uu____1668 ->
+                | FStar_Syntax_Syntax.Tm_fvar uu___2 ->
                     rebuild_closure cfg env1 stack1 t
                 | FStar_Syntax_Syntax.Tm_uvar (uv, s) ->
                     if
@@ -416,18 +403,18 @@ let rec (inline_closure_env :
                     then
                       let t1 = FStar_Syntax_Subst.compress t in
                       (match t1.FStar_Syntax_Syntax.n with
-                       | FStar_Syntax_Syntax.Tm_uvar uu____1692 ->
-                           let uu____1705 =
-                             let uu____1706 =
+                       | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
+                           let uu___3 =
+                             let uu___4 =
                                FStar_Range.string_of_range
                                  t1.FStar_Syntax_Syntax.pos in
-                             let uu____1707 =
+                             let uu___5 =
                                FStar_Syntax_Print.term_to_string t1 in
                              FStar_Util.format2
                                "(%s): CheckNoUvars: Unexpected unification variable remains: %s"
-                               uu____1706 uu____1707 in
-                           failwith uu____1705
-                       | uu____1710 -> inline_closure_env cfg env1 stack1 t1)
+                               uu___4 uu___5 in
+                           failwith uu___3
+                       | uu___2 -> inline_closure_env cfg env1 stack1 t1)
                     else
                       (let s' =
                          FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
@@ -435,29 +422,28 @@ let rec (inline_closure_env :
                               (fun s1 ->
                                  FStar_All.pipe_right s1
                                    (FStar_List.map
-                                      (fun uu___4_1745 ->
-                                         match uu___4_1745 with
+                                      (fun uu___3 ->
+                                         match uu___3 with
                                          | FStar_Syntax_Syntax.NT (x, t1) ->
-                                             let uu____1752 =
-                                               let uu____1759 =
+                                             let uu___4 =
+                                               let uu___5 =
                                                  inline_closure_env cfg env1
                                                    [] t1 in
-                                               (x, uu____1759) in
-                                             FStar_Syntax_Syntax.NT
-                                               uu____1752
+                                               (x, uu___5) in
+                                             FStar_Syntax_Syntax.NT uu___4
                                          | FStar_Syntax_Syntax.NM (x, i) ->
                                              let x_i =
                                                FStar_Syntax_Syntax.bv_to_tm
-                                                 (let uu___247_1769 = x in
+                                                 (let uu___4 = x in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___247_1769.FStar_Syntax_Syntax.ppname);
+                                                      (uu___4.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       = i;
                                                     FStar_Syntax_Syntax.sort
                                                       =
-                                                      (uu___247_1769.FStar_Syntax_Syntax.sort)
+                                                      (uu___4.FStar_Syntax_Syntax.sort)
                                                   }) in
                                              let t1 =
                                                inline_closure_env cfg env1 []
@@ -469,52 +455,50 @@ let rec (inline_closure_env :
                                                   FStar_Syntax_Syntax.NM
                                                     (x,
                                                       (x_j.FStar_Syntax_Syntax.index))
-                                              | uu____1774 ->
+                                              | uu___4 ->
                                                   FStar_Syntax_Syntax.NT
                                                     (x, t1))
-                                         | uu____1777 ->
+                                         | uu___4 ->
                                              failwith
                                                "Impossible: subst invariant of uvar nodes")))) in
                        let t1 =
-                         let uu___256_1781 = t in
+                         let uu___3 = t in
                          {
                            FStar_Syntax_Syntax.n =
                              (FStar_Syntax_Syntax.Tm_uvar
                                 (uv, (s', (FStar_Pervasives_Native.snd s))));
                            FStar_Syntax_Syntax.pos =
-                             (uu___256_1781.FStar_Syntax_Syntax.pos);
+                             (uu___3.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___256_1781.FStar_Syntax_Syntax.vars)
+                             (uu___3.FStar_Syntax_Syntax.vars)
                          } in
                        rebuild_closure cfg env1 stack1 t1)
                 | FStar_Syntax_Syntax.Tm_type u ->
                     let t1 =
-                      let uu____1802 =
-                        let uu____1803 = norm_universe cfg env1 u in
-                        FStar_Syntax_Syntax.Tm_type uu____1803 in
-                      FStar_Syntax_Syntax.mk uu____1802
-                        t.FStar_Syntax_Syntax.pos in
+                      let uu___2 =
+                        let uu___3 = norm_universe cfg env1 u in
+                        FStar_Syntax_Syntax.Tm_type uu___3 in
+                      FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos in
                     rebuild_closure cfg env1 stack1 t1
                 | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
                     let t1 =
-                      let uu____1811 =
-                        FStar_List.map (norm_universe cfg env1) us in
-                      FStar_Syntax_Syntax.mk_Tm_uinst t' uu____1811 in
+                      let uu___2 = FStar_List.map (norm_universe cfg env1) us in
+                      FStar_Syntax_Syntax.mk_Tm_uinst t' uu___2 in
                     rebuild_closure cfg env1 stack1 t1
                 | FStar_Syntax_Syntax.Tm_bvar x ->
-                    let uu____1813 = lookup_bvar env1 x in
-                    (match uu____1813 with
-                     | Univ uu____1816 ->
+                    let uu___2 = lookup_bvar env1 x in
+                    (match uu___2 with
+                     | Univ uu___3 ->
                          failwith
                            "Impossible: term variable is bound to a universe"
                      | Dummy ->
                          let x1 =
-                           let uu___272_1820 = x in
+                           let uu___3 = x in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___272_1820.FStar_Syntax_Syntax.ppname);
+                               (uu___3.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___272_1820.FStar_Syntax_Syntax.index);
+                               (uu___3.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort =
                                FStar_Syntax_Syntax.tun
                            } in
@@ -523,29 +507,29 @@ let rec (inline_closure_env :
                              (FStar_Syntax_Syntax.Tm_bvar x1)
                              t.FStar_Syntax_Syntax.pos in
                          rebuild_closure cfg env1 stack1 t1
-                     | Clos (env2, t0, uu____1826, uu____1827) ->
+                     | Clos (env2, t0, uu___3, uu___4) ->
                          inline_closure_env cfg env2 stack1 t0)
                 | FStar_Syntax_Syntax.Tm_app (head, args) ->
                     let stack2 =
                       FStar_All.pipe_right stack1
                         (FStar_List.fold_right
-                           (fun uu____1916 ->
-                              fun stack2 ->
-                                match uu____1916 with
+                           (fun uu___2 ->
+                              fun stack3 ->
+                                match uu___2 with
                                 | (a, aq) ->
-                                    let uu____1928 =
-                                      let uu____1929 =
-                                        let uu____1936 =
-                                          let uu____1937 =
-                                            let uu____1968 =
+                                    let uu___3 =
+                                      let uu___4 =
+                                        let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None in
-                                            (env1, a, uu____1968, false) in
-                                          Clos uu____1937 in
-                                        (uu____1936, aq,
+                                            (env1, a, uu___7, false) in
+                                          Clos uu___6 in
+                                        (uu___5, aq,
                                           (t.FStar_Syntax_Syntax.pos)) in
-                                      Arg uu____1929 in
-                                    uu____1928 :: stack2) args) in
+                                      Arg uu___4 in
+                                    uu___3 :: stack3) args) in
                     inline_closure_env cfg env1 stack2 head
                 | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
                     let env' =
@@ -561,8 +545,8 @@ let rec (inline_closure_env :
                       :: stack1 in
                     inline_closure_env cfg env' stack2 body
                 | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                    let uu____2134 = close_binders cfg env1 bs in
-                    (match uu____2134 with
+                    let uu___2 = close_binders cfg env1 bs in
+                    (match uu___2 with
                      | (bs1, env') ->
                          let c1 = close_comp cfg env' c in
                          let t1 =
@@ -570,30 +554,30 @@ let rec (inline_closure_env :
                              (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
                              t.FStar_Syntax_Syntax.pos in
                          rebuild_closure cfg env1 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_refine (x, uu____2184) when
+                | FStar_Syntax_Syntax.Tm_refine (x, uu___2) when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                     ->
                     inline_closure_env cfg env1 stack1
                       x.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_refine (x, phi) ->
-                    let uu____2195 =
-                      let uu____2208 =
-                        let uu____2217 = FStar_Syntax_Syntax.mk_binder x in
-                        [uu____2217] in
-                      close_binders cfg env1 uu____2208 in
-                    (match uu____2195 with
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Syntax.mk_binder x in
+                        [uu___4] in
+                      close_binders cfg env1 uu___3 in
+                    (match uu___2 with
                      | (x1, env2) ->
                          let phi1 = non_tail_inline_closure_env cfg env2 phi in
                          let t1 =
-                           let uu____2262 =
-                             let uu____2263 =
-                               let uu____2270 =
-                                 let uu____2271 = FStar_List.hd x1 in
-                                 FStar_All.pipe_right uu____2271
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 = FStar_List.hd x1 in
+                                 FStar_All.pipe_right uu___6
                                    FStar_Pervasives_Native.fst in
-                               (uu____2270, phi1) in
-                             FStar_Syntax_Syntax.Tm_refine uu____2263 in
-                           FStar_Syntax_Syntax.mk uu____2262
+                               (uu___5, phi1) in
+                             FStar_Syntax_Syntax.Tm_refine uu___4 in
+                           FStar_Syntax_Syntax.mk uu___3
                              t.FStar_Syntax_Syntax.pos in
                          rebuild_closure cfg env2 stack1 t1)
                 | FStar_Syntax_Syntax.Tm_ascribed (t1, (annot, tacopt), lopt)
@@ -601,36 +585,35 @@ let rec (inline_closure_env :
                     let annot1 =
                       match annot with
                       | FStar_Util.Inl t2 ->
-                          let uu____2370 =
+                          let uu___2 =
                             non_tail_inline_closure_env cfg env1 t2 in
-                          FStar_Util.Inl uu____2370
+                          FStar_Util.Inl uu___2
                       | FStar_Util.Inr c ->
-                          let uu____2384 = close_comp cfg env1 c in
-                          FStar_Util.Inr uu____2384 in
+                          let uu___2 = close_comp cfg env1 c in
+                          FStar_Util.Inr uu___2 in
                     let tacopt1 =
                       FStar_Util.map_opt tacopt
                         (non_tail_inline_closure_env cfg env1) in
                     let t2 =
-                      let uu____2403 =
-                        let uu____2404 =
-                          let uu____2431 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
                             non_tail_inline_closure_env cfg env1 t1 in
-                          (uu____2431, (annot1, tacopt1), lopt) in
-                        FStar_Syntax_Syntax.Tm_ascribed uu____2404 in
-                      FStar_Syntax_Syntax.mk uu____2403
-                        t.FStar_Syntax_Syntax.pos in
+                          (uu___4, (annot1, tacopt1), lopt) in
+                        FStar_Syntax_Syntax.Tm_ascribed uu___3 in
+                      FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos in
                     rebuild_closure cfg env1 stack1 t2
                 | FStar_Syntax_Syntax.Tm_quoted (t', qi) ->
                     let t1 =
                       match qi.FStar_Syntax_Syntax.qkind with
                       | FStar_Syntax_Syntax.Quote_dynamic ->
-                          let uu____2477 =
-                            let uu____2478 =
-                              let uu____2485 =
+                          let uu___2 =
+                            let uu___3 =
+                              let uu___4 =
                                 non_tail_inline_closure_env cfg env1 t' in
-                              (uu____2485, qi) in
-                            FStar_Syntax_Syntax.Tm_quoted uu____2478 in
-                          FStar_Syntax_Syntax.mk uu____2477
+                              (uu___4, qi) in
+                            FStar_Syntax_Syntax.Tm_quoted uu___3 in
+                          FStar_Syntax_Syntax.mk uu___2
                             t.FStar_Syntax_Syntax.pos
                       | FStar_Syntax_Syntax.Quote_static ->
                           let qi1 =
@@ -648,7 +631,7 @@ let rec (inline_closure_env :
                     let env0 = env1 in
                     let env2 =
                       FStar_List.fold_left
-                        (fun env2 -> fun uu____2537 -> dummy :: env2) env1
+                        (fun env3 -> fun uu___2 -> dummy :: env3) env1
                         lb.FStar_Syntax_Syntax.lbunivs in
                     let typ =
                       non_tail_inline_closure_env cfg env2
@@ -656,44 +639,44 @@ let rec (inline_closure_env :
                     let def =
                       non_tail_inline_closure_env cfg env2
                         lb.FStar_Syntax_Syntax.lbdef in
-                    let uu____2558 =
-                      let uu____2569 = FStar_Syntax_Syntax.is_top_level [lb] in
-                      if uu____2569
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Syntax.is_top_level [lb] in
+                      if uu___3
                       then ((lb.FStar_Syntax_Syntax.lbname), body)
                       else
                         (let x =
                            FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                         let uu____2588 =
+                         let uu___5 =
                            non_tail_inline_closure_env cfg (dummy :: env0)
                              body in
                          ((FStar_Util.Inl
-                             (let uu___364_2604 = x in
+                             (let uu___6 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___364_2604.FStar_Syntax_Syntax.ppname);
+                                  (uu___6.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___364_2604.FStar_Syntax_Syntax.index);
+                                  (uu___6.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = typ
-                              })), uu____2588)) in
-                    (match uu____2558 with
+                              })), uu___5)) in
+                    (match uu___2 with
                      | (nm, body1) ->
                          let attrs =
                            FStar_List.map
                              (non_tail_inline_closure_env cfg env0)
                              lb.FStar_Syntax_Syntax.lbattrs in
                          let lb1 =
-                           let uu___370_2631 = lb in
+                           let uu___3 = lb in
                            {
                              FStar_Syntax_Syntax.lbname = nm;
                              FStar_Syntax_Syntax.lbunivs =
-                               (uu___370_2631.FStar_Syntax_Syntax.lbunivs);
+                               (uu___3.FStar_Syntax_Syntax.lbunivs);
                              FStar_Syntax_Syntax.lbtyp = typ;
                              FStar_Syntax_Syntax.lbeff =
-                               (uu___370_2631.FStar_Syntax_Syntax.lbeff);
+                               (uu___3.FStar_Syntax_Syntax.lbeff);
                              FStar_Syntax_Syntax.lbdef = def;
                              FStar_Syntax_Syntax.lbattrs = attrs;
                              FStar_Syntax_Syntax.lbpos =
-                               (uu___370_2631.FStar_Syntax_Syntax.lbpos)
+                               (uu___3.FStar_Syntax_Syntax.lbpos)
                            } in
                          let t1 =
                            FStar_Syntax_Syntax.mk
@@ -701,55 +684,55 @@ let rec (inline_closure_env :
                                 ((false, [lb1]), body1))
                              t.FStar_Syntax_Syntax.pos in
                          rebuild_closure cfg env0 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_let ((uu____2645, lbs), body) ->
+                | FStar_Syntax_Syntax.Tm_let ((uu___2, lbs), body) ->
                     let norm_one_lb env2 lb =
                       let env_univs =
                         FStar_List.fold_right
-                          (fun uu____2708 -> fun env3 -> dummy :: env3)
+                          (fun uu___3 -> fun env3 -> dummy :: env3)
                           lb.FStar_Syntax_Syntax.lbunivs env2 in
                       let env3 =
-                        let uu____2725 = FStar_Syntax_Syntax.is_top_level lbs in
-                        if uu____2725
+                        let uu___3 = FStar_Syntax_Syntax.is_top_level lbs in
+                        if uu___3
                         then env_univs
                         else
                           FStar_List.fold_right
-                            (fun uu____2737 -> fun env3 -> dummy :: env3) lbs
+                            (fun uu___5 -> fun env4 -> dummy :: env4) lbs
                             env_univs in
                       let ty =
                         non_tail_inline_closure_env cfg env_univs
                           lb.FStar_Syntax_Syntax.lbtyp in
                       let nm =
-                        let uu____2761 = FStar_Syntax_Syntax.is_top_level lbs in
-                        if uu____2761
+                        let uu___3 = FStar_Syntax_Syntax.is_top_level lbs in
+                        if uu___3
                         then lb.FStar_Syntax_Syntax.lbname
                         else
                           (let x =
                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                            FStar_Util.Inl
-                             (let uu___393_2769 = x in
+                             (let uu___5 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___393_2769.FStar_Syntax_Syntax.ppname);
+                                  (uu___5.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___393_2769.FStar_Syntax_Syntax.index);
+                                  (uu___5.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = ty
                               })) in
-                      let uu___396_2770 = lb in
-                      let uu____2771 =
+                      let uu___3 = lb in
+                      let uu___4 =
                         non_tail_inline_closure_env cfg env3
                           lb.FStar_Syntax_Syntax.lbdef in
                       {
                         FStar_Syntax_Syntax.lbname = nm;
                         FStar_Syntax_Syntax.lbunivs =
-                          (uu___396_2770.FStar_Syntax_Syntax.lbunivs);
+                          (uu___3.FStar_Syntax_Syntax.lbunivs);
                         FStar_Syntax_Syntax.lbtyp = ty;
                         FStar_Syntax_Syntax.lbeff =
-                          (uu___396_2770.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu____2771;
+                          (uu___3.FStar_Syntax_Syntax.lbeff);
+                        FStar_Syntax_Syntax.lbdef = uu___4;
                         FStar_Syntax_Syntax.lbattrs =
-                          (uu___396_2770.FStar_Syntax_Syntax.lbattrs);
+                          (uu___3.FStar_Syntax_Syntax.lbattrs);
                         FStar_Syntax_Syntax.lbpos =
-                          (uu___396_2770.FStar_Syntax_Syntax.lbpos)
+                          (uu___3.FStar_Syntax_Syntax.lbpos)
                       } in
                     let lbs1 =
                       FStar_All.pipe_right lbs
@@ -757,8 +740,7 @@ let rec (inline_closure_env :
                     let body1 =
                       let body_env =
                         FStar_List.fold_right
-                          (fun uu____2803 -> fun env2 -> dummy :: env2) lbs1
-                          env1 in
+                          (fun uu___3 -> fun env2 -> dummy :: env2) lbs1 env1 in
                       non_tail_inline_closure_env cfg body_env body in
                     let t1 =
                       FStar_Syntax_Syntax.mk
@@ -789,19 +771,17 @@ and (rebuild_closure :
       fun stack1 ->
         fun t ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____2892 ->
-               let uu____2893 = FStar_Syntax_Print.tag_of_term t in
-               let uu____2894 = env_to_string env1 in
-               let uu____2895 = stack_to_string stack1 in
-               let uu____2896 = FStar_Syntax_Print.term_to_string t in
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.tag_of_term t in
+               let uu___3 = env_to_string env1 in
+               let uu___4 = stack_to_string stack1 in
+               let uu___5 = FStar_Syntax_Print.term_to_string t in
                FStar_Util.print4
                  ">>> %s (env=%s, stack=%s)\nRebuild closure_as_term %s\n"
-                 uu____2893 uu____2894 uu____2895 uu____2896);
+                 uu___2 uu___3 uu___4 uu___5);
           (match stack1 with
            | [] -> t
-           | (Arg
-               (Clos (env_arg, tm, uu____2901, uu____2902), aq, r))::stack2
-               ->
+           | (Arg (Clos (env_arg, tm, uu___1, uu___2), aq, r))::stack2 ->
                let stack3 = (App (env1, t, aq, r)) :: stack2 in
                inline_closure_env cfg env_arg stack3 tm
            | (App (env2, head, aq, r))::stack2 ->
@@ -811,177 +791,176 @@ and (rebuild_closure :
                let t1 = FStar_Syntax_Syntax.extend_app head (t, aq) r in
                rebuild_closure cfg env2 stack2 t1
            | (Abs (env', bs, env'', lopt, r))::stack2 ->
-               let uu____2991 = close_binders cfg env' bs in
-               (match uu____2991 with
-                | (bs1, uu____3007) ->
+               let uu___1 = close_binders cfg env' bs in
+               (match uu___1 with
+                | (bs1, uu___2) ->
                     let lopt1 = close_lcomp_opt cfg env'' lopt in
-                    let uu____3027 =
-                      let uu___463_3030 = FStar_Syntax_Util.abs bs1 t lopt1 in
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Util.abs bs1 t lopt1 in
                       {
                         FStar_Syntax_Syntax.n =
-                          (uu___463_3030.FStar_Syntax_Syntax.n);
+                          (uu___4.FStar_Syntax_Syntax.n);
                         FStar_Syntax_Syntax.pos = r;
                         FStar_Syntax_Syntax.vars =
-                          (uu___463_3030.FStar_Syntax_Syntax.vars)
+                          (uu___4.FStar_Syntax_Syntax.vars)
                       } in
-                    rebuild_closure cfg env1 stack2 uu____3027)
+                    rebuild_closure cfg env1 stack2 uu___3)
            | (Match (env2, branches1, cfg1, r))::stack2 ->
-               let close_one_branch env3 uu____3086 =
-                 match uu____3086 with
+               let close_one_branch env3 uu___1 =
+                 match uu___1 with
                  | (pat, w_opt, tm) ->
                      let rec norm_pat env4 p =
                        match p.FStar_Syntax_Syntax.v with
-                       | FStar_Syntax_Syntax.Pat_constant uu____3201 ->
-                           (p, env4)
+                       | FStar_Syntax_Syntax.Pat_constant uu___2 -> (p, env4)
                        | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-                           let uu____3230 =
+                           let uu___2 =
                              FStar_All.pipe_right pats
                                (FStar_List.fold_left
-                                  (fun uu____3314 ->
-                                     fun uu____3315 ->
-                                       match (uu____3314, uu____3315) with
+                                  (fun uu___3 ->
+                                     fun uu___4 ->
+                                       match (uu___3, uu___4) with
                                        | ((pats1, env5), (p1, b)) ->
-                                           let uu____3454 = norm_pat env5 p1 in
-                                           (match uu____3454 with
+                                           let uu___5 = norm_pat env5 p1 in
+                                           (match uu___5 with
                                             | (p2, env6) ->
                                                 (((p2, b) :: pats1), env6)))
                                   ([], env4)) in
-                           (match uu____3230 with
+                           (match uu___2 with
                             | (pats1, env5) ->
-                                ((let uu___500_3616 = p in
+                                ((let uu___3 = p in
                                   {
                                     FStar_Syntax_Syntax.v =
                                       (FStar_Syntax_Syntax.Pat_cons
                                          (fv, (FStar_List.rev pats1)));
                                     FStar_Syntax_Syntax.p =
-                                      (uu___500_3616.FStar_Syntax_Syntax.p)
+                                      (uu___3.FStar_Syntax_Syntax.p)
                                   }), env5))
                        | FStar_Syntax_Syntax.Pat_var x ->
                            let x1 =
-                             let uu___504_3635 = x in
-                             let uu____3636 =
+                             let uu___2 = x in
+                             let uu___3 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___504_3635.FStar_Syntax_Syntax.ppname);
+                                 (uu___2.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___504_3635.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____3636
+                                 (uu___2.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu___3
                              } in
-                           ((let uu___507_3650 = p in
+                           ((let uu___2 = p in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_var x1);
                                FStar_Syntax_Syntax.p =
-                                 (uu___507_3650.FStar_Syntax_Syntax.p)
+                                 (uu___2.FStar_Syntax_Syntax.p)
                              }), (dummy :: env4))
                        | FStar_Syntax_Syntax.Pat_wild x ->
                            let x1 =
-                             let uu___511_3661 = x in
-                             let uu____3662 =
+                             let uu___2 = x in
+                             let uu___3 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___511_3661.FStar_Syntax_Syntax.ppname);
+                                 (uu___2.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___511_3661.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____3662
+                                 (uu___2.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu___3
                              } in
-                           ((let uu___514_3676 = p in
+                           ((let uu___2 = p in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_wild x1);
                                FStar_Syntax_Syntax.p =
-                                 (uu___514_3676.FStar_Syntax_Syntax.p)
+                                 (uu___2.FStar_Syntax_Syntax.p)
                              }), (dummy :: env4))
                        | FStar_Syntax_Syntax.Pat_dot_term (x, t1) ->
                            let x1 =
-                             let uu___520_3692 = x in
-                             let uu____3693 =
+                             let uu___2 = x in
+                             let uu___3 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___520_3692.FStar_Syntax_Syntax.ppname);
+                                 (uu___2.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___520_3692.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____3693
+                                 (uu___2.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu___3
                              } in
                            let t2 = non_tail_inline_closure_env cfg1 env4 t1 in
-                           ((let uu___524_3710 = p in
+                           ((let uu___2 = p in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_dot_term (x1, t2));
                                FStar_Syntax_Syntax.p =
-                                 (uu___524_3710.FStar_Syntax_Syntax.p)
+                                 (uu___2.FStar_Syntax_Syntax.p)
                              }), env4) in
-                     let uu____3715 = norm_pat env3 pat in
-                     (match uu____3715 with
+                     let uu___2 = norm_pat env3 pat in
+                     (match uu___2 with
                       | (pat1, env4) ->
                           let w_opt1 =
                             match w_opt with
                             | FStar_Pervasives_Native.None ->
                                 FStar_Pervasives_Native.None
                             | FStar_Pervasives_Native.Some w ->
-                                let uu____3784 =
+                                let uu___3 =
                                   non_tail_inline_closure_env cfg1 env4 w in
-                                FStar_Pervasives_Native.Some uu____3784 in
+                                FStar_Pervasives_Native.Some uu___3 in
                           let tm1 = non_tail_inline_closure_env cfg1 env4 tm in
                           (pat1, w_opt1, tm1)) in
                let t1 =
-                 let uu____3803 =
-                   let uu____3804 =
-                     let uu____3827 =
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
                        FStar_All.pipe_right branches1
                          (FStar_List.map (close_one_branch env2)) in
-                     (t, uu____3827) in
-                   FStar_Syntax_Syntax.Tm_match uu____3804 in
-                 FStar_Syntax_Syntax.mk uu____3803 t.FStar_Syntax_Syntax.pos in
+                     (t, uu___3) in
+                   FStar_Syntax_Syntax.Tm_match uu___2 in
+                 FStar_Syntax_Syntax.mk uu___1 t.FStar_Syntax_Syntax.pos in
                rebuild_closure cfg1 env2 stack2 t1
            | (Meta (env_m, m, r))::stack2 ->
                let m1 =
                  match m with
                  | FStar_Syntax_Syntax.Meta_pattern (names, args) ->
-                     let uu____3963 =
-                       let uu____3984 =
+                     let uu___1 =
+                       let uu___2 =
                          FStar_All.pipe_right names
                            (FStar_List.map
                               (non_tail_inline_closure_env cfg env_m)) in
-                       let uu____4001 =
+                       let uu___3 =
                          FStar_All.pipe_right args
                            (FStar_List.map
                               (fun args1 ->
                                  FStar_All.pipe_right args1
                                    (FStar_List.map
-                                      (fun uu____4110 ->
-                                         match uu____4110 with
+                                      (fun uu___4 ->
+                                         match uu___4 with
                                          | (a, q) ->
-                                             let uu____4137 =
+                                             let uu___5 =
                                                non_tail_inline_closure_env
                                                  cfg env_m a in
-                                             (uu____4137, q))))) in
-                       (uu____3984, uu____4001) in
-                     FStar_Syntax_Syntax.Meta_pattern uu____3963
-                 | FStar_Syntax_Syntax.Meta_monadic (m1, tbody) ->
-                     let uu____4166 =
-                       let uu____4173 =
+                                             (uu___5, q))))) in
+                       (uu___2, uu___3) in
+                     FStar_Syntax_Syntax.Meta_pattern uu___1
+                 | FStar_Syntax_Syntax.Meta_monadic (m2, tbody) ->
+                     let uu___1 =
+                       let uu___2 =
                          non_tail_inline_closure_env cfg env_m tbody in
-                       (m1, uu____4173) in
-                     FStar_Syntax_Syntax.Meta_monadic uu____4166
-                 | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, tbody) ->
-                     let uu____4185 =
-                       let uu____4194 =
+                       (m2, uu___2) in
+                     FStar_Syntax_Syntax.Meta_monadic uu___1
+                 | FStar_Syntax_Syntax.Meta_monadic_lift (m11, m2, tbody) ->
+                     let uu___1 =
+                       let uu___2 =
                          non_tail_inline_closure_env cfg env_m tbody in
-                       (m1, m2, uu____4194) in
-                     FStar_Syntax_Syntax.Meta_monadic_lift uu____4185
-                 | uu____4199 -> m in
+                       (m11, m2, uu___2) in
+                     FStar_Syntax_Syntax.Meta_monadic_lift uu___1
+                 | uu___1 -> m in
                let t1 =
                  FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (t, m1))
                    r in
                rebuild_closure cfg env1 stack2 t1
-           | uu____4205 -> failwith "Impossible: unexpected stack element")
+           | uu___1 -> failwith "Impossible: unexpected stack element")
 and (close_imp :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -994,20 +973,20 @@ and (close_imp :
         match imp with
         | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
             (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-            let uu____4220 =
-              let uu____4221 =
-                let uu____4222 = inline_closure_env cfg env1 [] t in
-                FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____4222 in
-              FStar_Syntax_Syntax.Meta uu____4221 in
-            FStar_Pervasives_Native.Some uu____4220
+            let uu___ =
+              let uu___1 =
+                let uu___2 = inline_closure_env cfg env1 [] t in
+                FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu___2 in
+              FStar_Syntax_Syntax.Meta uu___1 in
+            FStar_Pervasives_Native.Some uu___
         | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
             (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-            let uu____4228 =
-              let uu____4229 =
-                let uu____4230 = inline_closure_env cfg env1 [] t in
-                FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____4230 in
-              FStar_Syntax_Syntax.Meta uu____4229 in
-            FStar_Pervasives_Native.Some uu____4228
+            let uu___ =
+              let uu___1 =
+                let uu___2 = inline_closure_env cfg env1 [] t in
+                FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu___2 in
+              FStar_Syntax_Syntax.Meta uu___1 in
+            FStar_Pervasives_Native.Some uu___
         | i -> i
 and (close_binders :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1020,29 +999,29 @@ and (close_binders :
   fun cfg ->
     fun env1 ->
       fun bs ->
-        let uu____4247 =
+        let uu___ =
           FStar_All.pipe_right bs
             (FStar_List.fold_left
-               (fun uu____4331 ->
-                  fun uu____4332 ->
-                    match (uu____4331, uu____4332) with
+               (fun uu___1 ->
+                  fun uu___2 ->
+                    match (uu___1, uu___2) with
                     | ((env2, out), (b, imp)) ->
                         let b1 =
-                          let uu___584_4472 = b in
-                          let uu____4473 =
+                          let uu___3 = b in
+                          let uu___4 =
                             inline_closure_env cfg env2 []
                               b.FStar_Syntax_Syntax.sort in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___584_4472.FStar_Syntax_Syntax.ppname);
+                              (uu___3.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___584_4472.FStar_Syntax_Syntax.index);
-                            FStar_Syntax_Syntax.sort = uu____4473
+                              (uu___3.FStar_Syntax_Syntax.index);
+                            FStar_Syntax_Syntax.sort = uu___4
                           } in
                         let imp1 = close_imp cfg env2 imp in
                         let env3 = dummy :: env2 in
                         (env3, ((b1, imp1) :: out))) (env1, [])) in
-        match uu____4247 with | (env2, bs1) -> ((FStar_List.rev bs1), env2)
+        match uu___ with | (env2, bs1) -> ((FStar_List.rev bs1), env2)
 and (close_comp :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -1057,18 +1036,16 @@ and (close_comp :
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
             -> c
-        | uu____4613 ->
+        | uu___ ->
             (match c.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Total (t, uopt) ->
-                 let uu____4626 = inline_closure_env cfg env1 [] t in
-                 let uu____4627 =
-                   FStar_Option.map (norm_universe cfg env1) uopt in
-                 FStar_Syntax_Syntax.mk_Total' uu____4626 uu____4627
+                 let uu___1 = inline_closure_env cfg env1 [] t in
+                 let uu___2 = FStar_Option.map (norm_universe cfg env1) uopt in
+                 FStar_Syntax_Syntax.mk_Total' uu___1 uu___2
              | FStar_Syntax_Syntax.GTotal (t, uopt) ->
-                 let uu____4640 = inline_closure_env cfg env1 [] t in
-                 let uu____4641 =
-                   FStar_Option.map (norm_universe cfg env1) uopt in
-                 FStar_Syntax_Syntax.mk_GTotal' uu____4640 uu____4641
+                 let uu___1 = inline_closure_env cfg env1 [] t in
+                 let uu___2 = FStar_Option.map (norm_universe cfg env1) uopt in
+                 FStar_Syntax_Syntax.mk_GTotal' uu___1 uu___2
              | FStar_Syntax_Syntax.Comp c1 ->
                  let rt =
                    inline_closure_env cfg env1 []
@@ -1076,36 +1053,34 @@ and (close_comp :
                  let args =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
                      (FStar_List.map
-                        (fun uu____4695 ->
-                           match uu____4695 with
+                        (fun uu___1 ->
+                           match uu___1 with
                            | (a, q) ->
-                               let uu____4716 =
-                                 inline_closure_env cfg env1 [] a in
-                               (uu____4716, q))) in
+                               let uu___2 = inline_closure_env cfg env1 [] a in
+                               (uu___2, q))) in
                  let flags =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                      (FStar_List.map
-                        (fun uu___5_4733 ->
-                           match uu___5_4733 with
+                        (fun uu___1 ->
+                           match uu___1 with
                            | FStar_Syntax_Syntax.DECREASES t ->
-                               let uu____4737 =
-                                 inline_closure_env cfg env1 [] t in
-                               FStar_Syntax_Syntax.DECREASES uu____4737
+                               let uu___2 = inline_closure_env cfg env1 [] t in
+                               FStar_Syntax_Syntax.DECREASES uu___2
                            | f -> f)) in
-                 let uu____4741 =
-                   let uu___617_4742 = c1 in
-                   let uu____4743 =
+                 let uu___1 =
+                   let uu___2 = c1 in
+                   let uu___3 =
                      FStar_List.map (norm_universe cfg env1)
                        c1.FStar_Syntax_Syntax.comp_univs in
                    {
-                     FStar_Syntax_Syntax.comp_univs = uu____4743;
+                     FStar_Syntax_Syntax.comp_univs = uu___3;
                      FStar_Syntax_Syntax.effect_name =
-                       (uu___617_4742.FStar_Syntax_Syntax.effect_name);
+                       (uu___2.FStar_Syntax_Syntax.effect_name);
                      FStar_Syntax_Syntax.result_typ = rt;
                      FStar_Syntax_Syntax.effect_args = args;
                      FStar_Syntax_Syntax.flags = flags
                    } in
-                 FStar_Syntax_Syntax.mk_Comp uu____4741)
+                 FStar_Syntax_Syntax.mk_Comp uu___1)
 and (close_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -1120,23 +1095,23 @@ and (close_lcomp_opt :
             let flags =
               FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                 (FStar_List.filter
-                   (fun uu___6_4761 ->
-                      match uu___6_4761 with
-                      | FStar_Syntax_Syntax.DECREASES uu____4762 -> false
-                      | uu____4765 -> true)) in
+                   (fun uu___ ->
+                      match uu___ with
+                      | FStar_Syntax_Syntax.DECREASES uu___1 -> false
+                      | uu___1 -> true)) in
             let rc1 =
-              let uu___629_4767 = rc in
-              let uu____4768 =
+              let uu___ = rc in
+              let uu___1 =
                 FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                   (inline_closure_env cfg env1 []) in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___629_4767.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____4768;
+                  (uu___.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu___1;
                 FStar_Syntax_Syntax.residual_flags = flags
               } in
             FStar_Pervasives_Native.Some rc1
-        | uu____4777 -> lopt
+        | uu___ -> lopt
 let (filter_out_lcomp_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
     FStar_Syntax_Syntax.cflag Prims.list)
@@ -1144,10 +1119,10 @@ let (filter_out_lcomp_cflags :
   fun flags ->
     FStar_All.pipe_right flags
       (FStar_List.filter
-         (fun uu___7_4797 ->
-            match uu___7_4797 with
-            | FStar_Syntax_Syntax.DECREASES uu____4798 -> false
-            | uu____4801 -> true))
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Syntax_Syntax.DECREASES uu___1 -> false
+            | uu___1 -> true))
 let (closure_as_term :
   FStar_TypeChecker_Cfg.cfg ->
     env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -1161,99 +1136,99 @@ let (unembed_binder :
     FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____4844 = FStar_ST.op_Bang unembed_binder_knot in
-    match uu____4844 with
+    let uu___ = FStar_ST.op_Bang unembed_binder_knot in
+    match uu___ with
     | FStar_Pervasives_Native.Some e ->
-        let uu____4870 = FStar_Syntax_Embeddings.unembed e t in
-        uu____4870 false FStar_Syntax_Embeddings.id_norm_cb
+        let uu___1 = FStar_Syntax_Embeddings.unembed e t in
+        uu___1 false FStar_Syntax_Embeddings.id_norm_cb
     | FStar_Pervasives_Native.None ->
         (FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
            (FStar_Errors.Warning_UnembedBinderKnot,
              "unembed_binder_knot is unset!");
          FStar_Pervasives_Native.None)
 let mk_psc_subst :
-  'uuuuuu4886 .
+  'uuuuu .
     FStar_TypeChecker_Cfg.cfg ->
-      ((FStar_Syntax_Syntax.bv * 'uuuuuu4886) FStar_Pervasives_Native.option
-        * closure) Prims.list -> FStar_Syntax_Syntax.subst_elt Prims.list
+      ((FStar_Syntax_Syntax.bv * 'uuuuu) FStar_Pervasives_Native.option *
+        closure) Prims.list -> FStar_Syntax_Syntax.subst_elt Prims.list
   =
   fun cfg ->
     fun env1 ->
       FStar_List.fold_right
-        (fun uu____4948 ->
+        (fun uu___ ->
            fun subst ->
-             match uu____4948 with
+             match uu___ with
              | (binder_opt, closure1) ->
                  (match (binder_opt, closure1) with
                   | (FStar_Pervasives_Native.Some b, Clos
-                     (env2, term, uu____4989, uu____4990)) ->
-                      let uu____5049 = b in
-                      (match uu____5049 with
-                       | (bv, uu____5057) ->
-                           let uu____5058 =
-                             let uu____5059 =
+                     (env2, term, uu___1, uu___2)) ->
+                      let uu___3 = b in
+                      (match uu___3 with
+                       | (bv, uu___4) ->
+                           let uu___5 =
+                             let uu___6 =
                                FStar_Syntax_Util.is_constructed_typ
                                  bv.FStar_Syntax_Syntax.sort
                                  FStar_Parser_Const.binder_lid in
-                             Prims.op_Negation uu____5059 in
-                           if uu____5058
+                             Prims.op_Negation uu___6 in
+                           if uu___5
                            then subst
                            else
                              (let term1 = closure_as_term cfg env2 term in
-                              let uu____5064 = unembed_binder term1 in
-                              match uu____5064 with
+                              let uu___7 = unembed_binder term1 in
+                              match uu___7 with
                               | FStar_Pervasives_Native.None -> subst
                               | FStar_Pervasives_Native.Some x ->
                                   let b1 =
-                                    let uu____5071 =
-                                      let uu___669_5072 = bv in
-                                      let uu____5073 =
+                                    let uu___8 =
+                                      let uu___9 = bv in
+                                      let uu___10 =
                                         FStar_Syntax_Subst.subst subst
                                           (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort in
                                       {
                                         FStar_Syntax_Syntax.ppname =
-                                          (uu___669_5072.FStar_Syntax_Syntax.ppname);
+                                          (uu___9.FStar_Syntax_Syntax.ppname);
                                         FStar_Syntax_Syntax.index =
-                                          (uu___669_5072.FStar_Syntax_Syntax.index);
-                                        FStar_Syntax_Syntax.sort = uu____5073
+                                          (uu___9.FStar_Syntax_Syntax.index);
+                                        FStar_Syntax_Syntax.sort = uu___10
                                       } in
-                                    FStar_Syntax_Syntax.freshen_bv uu____5071 in
+                                    FStar_Syntax_Syntax.freshen_bv uu___8 in
                                   let b_for_x =
-                                    let uu____5079 =
-                                      let uu____5086 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Syntax_Syntax.bv_to_name b1 in
                                       ((FStar_Pervasives_Native.fst x),
-                                        uu____5086) in
-                                    FStar_Syntax_Syntax.NT uu____5079 in
+                                        uu___9) in
+                                    FStar_Syntax_Syntax.NT uu___8 in
                                   let subst1 =
                                     FStar_List.filter
-                                      (fun uu___8_5102 ->
-                                         match uu___8_5102 with
+                                      (fun uu___8 ->
+                                         match uu___8 with
                                          | FStar_Syntax_Syntax.NT
-                                             (uu____5103,
+                                             (uu___9,
                                               {
                                                 FStar_Syntax_Syntax.n =
                                                   FStar_Syntax_Syntax.Tm_name
                                                   b';
                                                 FStar_Syntax_Syntax.pos =
-                                                  uu____5105;
+                                                  uu___10;
                                                 FStar_Syntax_Syntax.vars =
-                                                  uu____5106;_})
+                                                  uu___11;_})
                                              ->
-                                             let uu____5111 =
+                                             let uu___12 =
                                                FStar_Ident.ident_equals
                                                  b1.FStar_Syntax_Syntax.ppname
                                                  b'.FStar_Syntax_Syntax.ppname in
-                                             Prims.op_Negation uu____5111
-                                         | uu____5112 -> true) subst in
+                                             Prims.op_Negation uu___12
+                                         | uu___9 -> true) subst in
                                   b_for_x :: subst1))
-                  | uu____5113 -> subst)) env1 []
+                  | uu___1 -> subst)) env1 []
 let reduce_primops :
-  'uuuuuu5134 .
+  'uuuuu .
     FStar_Syntax_Embeddings.norm_cb ->
       FStar_TypeChecker_Cfg.cfg ->
-        ((FStar_Syntax_Syntax.bv * 'uuuuuu5134)
-          FStar_Pervasives_Native.option * closure) Prims.list ->
+        ((FStar_Syntax_Syntax.bv * 'uuuuu) FStar_Pervasives_Native.option *
+          closure) Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
@@ -1266,17 +1241,17 @@ let reduce_primops :
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
           then tm
           else
-            (let uu____5184 = FStar_Syntax_Util.head_and_args tm in
-             match uu____5184 with
+            (let uu___1 = FStar_Syntax_Util.head_and_args tm in
+             match uu___1 with
              | (head, args) ->
-                 let uu____5229 =
-                   let uu____5230 = FStar_Syntax_Util.un_uinst head in
-                   uu____5230.FStar_Syntax_Syntax.n in
-                 (match uu____5229 with
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Util.un_uinst head in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (match uu___2 with
                   | FStar_Syntax_Syntax.Tm_fvar fv ->
-                      let uu____5236 =
+                      let uu___3 =
                         FStar_TypeChecker_Cfg.find_prim_step cfg fv in
-                      (match uu____5236 with
+                      (match uu___3 with
                        | FStar_Pervasives_Native.Some prim_step when
                            prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok
                              ||
@@ -1287,43 +1262,42 @@ let reduce_primops :
                            if l < prim_step.FStar_TypeChecker_Cfg.arity
                            then
                              (FStar_TypeChecker_Cfg.log_primops cfg
-                                (fun uu____5258 ->
-                                   let uu____5259 =
+                                (fun uu___5 ->
+                                   let uu___6 =
                                      FStar_Syntax_Print.lid_to_string
                                        prim_step.FStar_TypeChecker_Cfg.name in
-                                   let uu____5260 =
-                                     FStar_Util.string_of_int l in
-                                   let uu____5261 =
+                                   let uu___7 = FStar_Util.string_of_int l in
+                                   let uu___8 =
                                      FStar_Util.string_of_int
                                        prim_step.FStar_TypeChecker_Cfg.arity in
                                    FStar_Util.print3
                                      "primop: found partially applied %s (%s/%s args)\n"
-                                     uu____5259 uu____5260 uu____5261);
+                                     uu___6 uu___7 uu___8);
                               tm)
                            else
-                             (let uu____5263 =
+                             (let uu___5 =
                                 if l = prim_step.FStar_TypeChecker_Cfg.arity
                                 then (args, [])
                                 else
                                   FStar_List.splitAt
                                     prim_step.FStar_TypeChecker_Cfg.arity
                                     args in
-                              match uu____5263 with
+                              match uu___5 with
                               | (args_1, args_2) ->
                                   (FStar_TypeChecker_Cfg.log_primops cfg
-                                     (fun uu____5346 ->
-                                        let uu____5347 =
+                                     (fun uu___7 ->
+                                        let uu___8 =
                                           FStar_Syntax_Print.term_to_string
                                             tm in
                                         FStar_Util.print1
                                           "primop: trying to reduce <%s>\n"
-                                          uu____5347);
+                                          uu___8);
                                    (let psc =
                                       {
                                         FStar_TypeChecker_Cfg.psc_range =
                                           (head.FStar_Syntax_Syntax.pos);
                                         FStar_TypeChecker_Cfg.psc_subst =
-                                          (fun uu____5350 ->
+                                          (fun uu___7 ->
                                              if
                                                prim_step.FStar_TypeChecker_Cfg.requires_binder_substitution
                                              then mk_psc_subst cfg env1
@@ -1336,81 +1310,79 @@ let reduce_primops :
                                     | FStar_Pervasives_Native.None ->
                                         (FStar_TypeChecker_Cfg.log_primops
                                            cfg
-                                           (fun uu____5362 ->
-                                              let uu____5363 =
+                                           (fun uu___8 ->
+                                              let uu___9 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tm in
                                               FStar_Util.print1
                                                 "primop: <%s> did not reduce\n"
-                                                uu____5363);
+                                                uu___9);
                                          tm)
                                     | FStar_Pervasives_Native.Some reduced ->
                                         (FStar_TypeChecker_Cfg.log_primops
                                            cfg
-                                           (fun uu____5369 ->
-                                              let uu____5370 =
+                                           (fun uu___8 ->
+                                              let uu___9 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tm in
-                                              let uu____5371 =
+                                              let uu___10 =
                                                 FStar_Syntax_Print.term_to_string
                                                   reduced in
                                               FStar_Util.print2
                                                 "primop: <%s> reduced to <%s>\n"
-                                                uu____5370 uu____5371);
+                                                uu___9 uu___10);
                                          FStar_Syntax_Util.mk_app reduced
                                            args_2))))
-                       | FStar_Pervasives_Native.Some uu____5372 ->
+                       | FStar_Pervasives_Native.Some uu___4 ->
                            (FStar_TypeChecker_Cfg.log_primops cfg
-                              (fun uu____5376 ->
-                                 let uu____5377 =
+                              (fun uu___6 ->
+                                 let uu___7 =
                                    FStar_Syntax_Print.term_to_string tm in
                                  FStar_Util.print1
                                    "primop: not reducing <%s> since we're doing strong reduction\n"
-                                   uu____5377);
+                                   uu___7);
                             tm)
                        | FStar_Pervasives_Native.None -> tm)
                   | FStar_Syntax_Syntax.Tm_constant
                       (FStar_Const.Const_range_of) when
                       Prims.op_Negation cfg.FStar_TypeChecker_Cfg.strong ->
                       (FStar_TypeChecker_Cfg.log_primops cfg
-                         (fun uu____5381 ->
-                            let uu____5382 =
-                              FStar_Syntax_Print.term_to_string tm in
+                         (fun uu___4 ->
+                            let uu___5 = FStar_Syntax_Print.term_to_string tm in
                             FStar_Util.print1 "primop: reducing <%s>\n"
-                              uu____5382);
+                              uu___5);
                        (match args with
-                        | (a1, uu____5386)::[] ->
+                        | (a1, uu___4)::[] ->
                             FStar_TypeChecker_Cfg.embed_simple
                               FStar_Syntax_Embeddings.e_range
                               a1.FStar_Syntax_Syntax.pos
                               tm.FStar_Syntax_Syntax.pos
-                        | uu____5411 -> tm))
+                        | uu___4 -> tm))
                   | FStar_Syntax_Syntax.Tm_constant
                       (FStar_Const.Const_set_range_of) when
                       Prims.op_Negation cfg.FStar_TypeChecker_Cfg.strong ->
                       (FStar_TypeChecker_Cfg.log_primops cfg
-                         (fun uu____5425 ->
-                            let uu____5426 =
-                              FStar_Syntax_Print.term_to_string tm in
+                         (fun uu___4 ->
+                            let uu___5 = FStar_Syntax_Print.term_to_string tm in
                             FStar_Util.print1 "primop: reducing <%s>\n"
-                              uu____5426);
+                              uu___5);
                        (match args with
-                        | (t, uu____5430)::(r, uu____5432)::[] ->
-                            let uu____5473 =
+                        | (t, uu___4)::(r, uu___5)::[] ->
+                            let uu___6 =
                               FStar_TypeChecker_Cfg.try_unembed_simple
                                 FStar_Syntax_Embeddings.e_range r in
-                            (match uu____5473 with
+                            (match uu___6 with
                              | FStar_Pervasives_Native.Some rng ->
                                  FStar_Syntax_Subst.set_use_range rng t
                              | FStar_Pervasives_Native.None -> tm)
-                        | uu____5479 -> tm))
-                  | uu____5490 -> tm))
+                        | uu___4 -> tm))
+                  | uu___3 -> tm))
 let reduce_equality :
-  'uuuuuu5500 .
+  'uuuuu .
     FStar_Syntax_Embeddings.norm_cb ->
       FStar_TypeChecker_Cfg.cfg ->
-        ((FStar_Syntax_Syntax.bv * 'uuuuuu5500)
-          FStar_Pervasives_Native.option * closure) Prims.list ->
+        ((FStar_Syntax_Syntax.bv * 'uuuuu) FStar_Pervasives_Native.option *
+          closure) Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
@@ -1418,81 +1390,81 @@ let reduce_equality :
     fun cfg ->
       fun tm ->
         reduce_primops norm_cb
-          (let uu___757_5549 = cfg in
+          (let uu___ = cfg in
            {
              FStar_TypeChecker_Cfg.steps =
-               (let uu___759_5552 = FStar_TypeChecker_Cfg.default_steps in
+               (let uu___1 = FStar_TypeChecker_Cfg.default_steps in
                 {
                   FStar_TypeChecker_Cfg.beta =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.beta);
+                    (uu___1.FStar_TypeChecker_Cfg.beta);
                   FStar_TypeChecker_Cfg.iota =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.iota);
+                    (uu___1.FStar_TypeChecker_Cfg.iota);
                   FStar_TypeChecker_Cfg.zeta =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.zeta);
+                    (uu___1.FStar_TypeChecker_Cfg.zeta);
                   FStar_TypeChecker_Cfg.zeta_full =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.zeta_full);
+                    (uu___1.FStar_TypeChecker_Cfg.zeta_full);
                   FStar_TypeChecker_Cfg.weak =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.weak);
+                    (uu___1.FStar_TypeChecker_Cfg.weak);
                   FStar_TypeChecker_Cfg.hnf =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.hnf);
+                    (uu___1.FStar_TypeChecker_Cfg.hnf);
                   FStar_TypeChecker_Cfg.primops = true;
                   FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                    (uu___1.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                   FStar_TypeChecker_Cfg.unfold_until =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unfold_until);
+                    (uu___1.FStar_TypeChecker_Cfg.unfold_until);
                   FStar_TypeChecker_Cfg.unfold_only =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unfold_only);
+                    (uu___1.FStar_TypeChecker_Cfg.unfold_only);
                   FStar_TypeChecker_Cfg.unfold_fully =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unfold_fully);
+                    (uu___1.FStar_TypeChecker_Cfg.unfold_fully);
                   FStar_TypeChecker_Cfg.unfold_attr =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unfold_attr);
+                    (uu___1.FStar_TypeChecker_Cfg.unfold_attr);
                   FStar_TypeChecker_Cfg.unfold_tac =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unfold_tac);
+                    (uu___1.FStar_TypeChecker_Cfg.unfold_tac);
                   FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                    (uu___1.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                   FStar_TypeChecker_Cfg.simplify =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.simplify);
+                    (uu___1.FStar_TypeChecker_Cfg.simplify);
                   FStar_TypeChecker_Cfg.erase_universes =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.erase_universes);
+                    (uu___1.FStar_TypeChecker_Cfg.erase_universes);
                   FStar_TypeChecker_Cfg.allow_unbound_universes =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                    (uu___1.FStar_TypeChecker_Cfg.allow_unbound_universes);
                   FStar_TypeChecker_Cfg.reify_ =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.reify_);
+                    (uu___1.FStar_TypeChecker_Cfg.reify_);
                   FStar_TypeChecker_Cfg.compress_uvars =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.compress_uvars);
+                    (uu___1.FStar_TypeChecker_Cfg.compress_uvars);
                   FStar_TypeChecker_Cfg.no_full_norm =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.no_full_norm);
+                    (uu___1.FStar_TypeChecker_Cfg.no_full_norm);
                   FStar_TypeChecker_Cfg.check_no_uvars =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.check_no_uvars);
+                    (uu___1.FStar_TypeChecker_Cfg.check_no_uvars);
                   FStar_TypeChecker_Cfg.unmeta =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unmeta);
+                    (uu___1.FStar_TypeChecker_Cfg.unmeta);
                   FStar_TypeChecker_Cfg.unascribe =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.unascribe);
+                    (uu___1.FStar_TypeChecker_Cfg.unascribe);
                   FStar_TypeChecker_Cfg.in_full_norm_request =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.in_full_norm_request);
+                    (uu___1.FStar_TypeChecker_Cfg.in_full_norm_request);
                   FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                    (uu___1.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                   FStar_TypeChecker_Cfg.nbe_step =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.nbe_step);
+                    (uu___1.FStar_TypeChecker_Cfg.nbe_step);
                   FStar_TypeChecker_Cfg.for_extraction =
-                    (uu___759_5552.FStar_TypeChecker_Cfg.for_extraction)
+                    (uu___1.FStar_TypeChecker_Cfg.for_extraction)
                 });
              FStar_TypeChecker_Cfg.tcenv =
-               (uu___757_5549.FStar_TypeChecker_Cfg.tcenv);
+               (uu___.FStar_TypeChecker_Cfg.tcenv);
              FStar_TypeChecker_Cfg.debug =
-               (uu___757_5549.FStar_TypeChecker_Cfg.debug);
+               (uu___.FStar_TypeChecker_Cfg.debug);
              FStar_TypeChecker_Cfg.delta_level =
-               (uu___757_5549.FStar_TypeChecker_Cfg.delta_level);
+               (uu___.FStar_TypeChecker_Cfg.delta_level);
              FStar_TypeChecker_Cfg.primitive_steps =
                FStar_TypeChecker_Cfg.equality_ops;
              FStar_TypeChecker_Cfg.strong =
-               (uu___757_5549.FStar_TypeChecker_Cfg.strong);
+               (uu___.FStar_TypeChecker_Cfg.strong);
              FStar_TypeChecker_Cfg.memoize_lazy =
-               (uu___757_5549.FStar_TypeChecker_Cfg.memoize_lazy);
+               (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
              FStar_TypeChecker_Cfg.normalize_pure_lets =
-               (uu___757_5549.FStar_TypeChecker_Cfg.normalize_pure_lets);
+               (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
              FStar_TypeChecker_Cfg.reifying =
-               (uu___757_5549.FStar_TypeChecker_Cfg.reifying)
+               (uu___.FStar_TypeChecker_Cfg.reifying)
            }) tm
 type norm_request_t =
   | Norm_request_none 
@@ -1500,22 +1472,22 @@ type norm_request_t =
   | Norm_request_requires_rejig 
 let (uu___is_Norm_request_none : norm_request_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Norm_request_none -> true | uu____5558 -> false
+    match projectee with | Norm_request_none -> true | uu___ -> false
 let (uu___is_Norm_request_ready : norm_request_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Norm_request_ready -> true | uu____5564 -> false
+    match projectee with | Norm_request_ready -> true | uu___ -> false
 let (uu___is_Norm_request_requires_rejig : norm_request_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Norm_request_requires_rejig -> true
-    | uu____5570 -> false
+    | uu___ -> false
 let (is_norm_request :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.args -> norm_request_t) =
   fun hd ->
     fun args ->
       let aux min_args =
-        let uu____5587 = FStar_All.pipe_right args FStar_List.length in
-        FStar_All.pipe_right uu____5587
+        let uu___ = FStar_All.pipe_right args FStar_List.length in
+        FStar_All.pipe_right uu___
           (fun n ->
              if n < min_args
              then Norm_request_none
@@ -1523,10 +1495,10 @@ let (is_norm_request :
                if n = min_args
                then Norm_request_ready
                else Norm_request_requires_rejig) in
-      let uu____5610 =
-        let uu____5611 = FStar_Syntax_Util.un_uinst hd in
-        uu____5611.FStar_Syntax_Syntax.n in
-      match uu____5610 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.un_uinst hd in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize_term
           -> aux (Prims.of_int (2))
@@ -1536,45 +1508,45 @@ let (is_norm_request :
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.norm ->
           aux (Prims.of_int (3))
-      | uu____5617 -> Norm_request_none
+      | uu___1 -> Norm_request_none
 let (should_consider_norm_requests : FStar_TypeChecker_Cfg.cfg -> Prims.bool)
   =
   fun cfg ->
     (Prims.op_Negation
        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm)
       &&
-      (let uu____5624 =
+      (let uu___ =
          FStar_Ident.lid_equals
            (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.curmodule
            FStar_Parser_Const.prims_lid in
-       Prims.op_Negation uu____5624)
+       Prims.op_Negation uu___)
 let (rejig_norm_request :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.term)
   =
   fun hd ->
     fun args ->
-      let uu____5635 =
-        let uu____5636 = FStar_Syntax_Util.un_uinst hd in
-        uu____5636.FStar_Syntax_Syntax.n in
-      match uu____5635 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.un_uinst hd in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize_term
           ->
           (match args with
            | t1::t2::rest when (FStar_List.length rest) > Prims.int_zero ->
-               let uu____5693 = FStar_Syntax_Util.mk_app hd [t1; t2] in
-               FStar_Syntax_Util.mk_app uu____5693 rest
-           | uu____5720 ->
+               let uu___1 = FStar_Syntax_Util.mk_app hd [t1; t2] in
+               FStar_Syntax_Util.mk_app uu___1 rest
+           | uu___1 ->
                failwith
                  "Impossible! invalid rejig_norm_request for normalize_term")
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize ->
           (match args with
            | t::rest when (FStar_List.length rest) > Prims.int_zero ->
-               let uu____5758 = FStar_Syntax_Util.mk_app hd [t] in
-               FStar_Syntax_Util.mk_app uu____5758 rest
-           | uu____5777 ->
+               let uu___1 = FStar_Syntax_Util.mk_app hd [t] in
+               FStar_Syntax_Util.mk_app uu___1 rest
+           | uu___1 ->
                failwith
                  "Impossible! invalid rejig_norm_request for normalize")
       | FStar_Syntax_Syntax.Tm_fvar fv when
@@ -1582,16 +1554,16 @@ let (rejig_norm_request :
           (match args with
            | t1::t2::t3::rest when (FStar_List.length rest) > Prims.int_zero
                ->
-               let uu____5849 = FStar_Syntax_Util.mk_app hd [t1; t2; t3] in
-               FStar_Syntax_Util.mk_app uu____5849 rest
-           | uu____5884 ->
+               let uu___1 = FStar_Syntax_Util.mk_app hd [t1; t2; t3] in
+               FStar_Syntax_Util.mk_app uu___1 rest
+           | uu___1 ->
                failwith "Impossible! invalid rejig_norm_request for norm")
-      | uu____5885 ->
-          let uu____5886 =
-            let uu____5887 = FStar_Syntax_Print.term_to_string hd in
+      | uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.term_to_string hd in
             FStar_String.op_Hat
-              "Impossible! invalid rejig_norm_request for: %s" uu____5887 in
-          failwith uu____5886
+              "Impossible! invalid rejig_norm_request for: %s" uu___3 in
+          failwith uu___2
 let (is_nbe_request : FStar_TypeChecker_Env.step Prims.list -> Prims.bool) =
   fun s ->
     FStar_Util.for_some
@@ -1599,8 +1571,8 @@ let (is_nbe_request : FStar_TypeChecker_Env.step Prims.list -> Prims.bool) =
 let (tr_norm_step :
   FStar_Syntax_Embeddings.norm_step -> FStar_TypeChecker_Env.step Prims.list)
   =
-  fun uu___9_5903 ->
-    match uu___9_5903 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Embeddings.Zeta -> [FStar_TypeChecker_Env.Zeta]
     | FStar_Syntax_Embeddings.ZetaFull -> [FStar_TypeChecker_Env.ZetaFull]
     | FStar_Syntax_Embeddings.Iota -> [FStar_TypeChecker_Env.Iota]
@@ -1612,29 +1584,29 @@ let (tr_norm_step :
     | FStar_Syntax_Embeddings.Primops -> [FStar_TypeChecker_Env.Primops]
     | FStar_Syntax_Embeddings.Reify -> [FStar_TypeChecker_Env.Reify]
     | FStar_Syntax_Embeddings.UnfoldOnly names ->
-        let uu____5909 =
-          let uu____5912 =
-            let uu____5913 = FStar_List.map FStar_Ident.lid_of_str names in
-            FStar_TypeChecker_Env.UnfoldOnly uu____5913 in
-          [uu____5912] in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_List.map FStar_Ident.lid_of_str names in
+            FStar_TypeChecker_Env.UnfoldOnly uu___3 in
+          [uu___2] in
         (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
-          :: uu____5909
+          :: uu___1
     | FStar_Syntax_Embeddings.UnfoldFully names ->
-        let uu____5919 =
-          let uu____5922 =
-            let uu____5923 = FStar_List.map FStar_Ident.lid_of_str names in
-            FStar_TypeChecker_Env.UnfoldFully uu____5923 in
-          [uu____5922] in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_List.map FStar_Ident.lid_of_str names in
+            FStar_TypeChecker_Env.UnfoldFully uu___3 in
+          [uu___2] in
         (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
-          :: uu____5919
+          :: uu___1
     | FStar_Syntax_Embeddings.UnfoldAttr names ->
-        let uu____5929 =
-          let uu____5932 =
-            let uu____5933 = FStar_List.map FStar_Ident.lid_of_str names in
-            FStar_TypeChecker_Env.UnfoldAttr uu____5933 in
-          [uu____5932] in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_List.map FStar_Ident.lid_of_str names in
+            FStar_TypeChecker_Env.UnfoldAttr uu___3 in
+          [uu___2] in
         (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
-          :: uu____5929
+          :: uu___1
     | FStar_Syntax_Embeddings.NBE -> [FStar_TypeChecker_Env.NBE]
 let (tr_norm_steps :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -1643,17 +1615,16 @@ let (tr_norm_steps :
   fun s ->
     let s1 = FStar_List.concatMap tr_norm_step s in
     let add_exclude s2 z =
-      let uu____5967 =
-        FStar_Util.for_some (FStar_TypeChecker_Env.eq_step z) s2 in
-      if uu____5967 then s2 else (FStar_TypeChecker_Env.Exclude z) :: s2 in
+      let uu___ = FStar_Util.for_some (FStar_TypeChecker_Env.eq_step z) s2 in
+      if uu___ then s2 else (FStar_TypeChecker_Env.Exclude z) :: s2 in
     let s2 = FStar_TypeChecker_Env.Beta :: s1 in
     let s3 = add_exclude s2 FStar_TypeChecker_Env.Zeta in
     let s4 = add_exclude s3 FStar_TypeChecker_Env.Iota in s4
 let get_norm_request :
-  'uuuuuu5988 .
+  'uuuuu .
     FStar_TypeChecker_Cfg.cfg ->
       (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu5988) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuu) Prims.list ->
           (FStar_TypeChecker_Env.step Prims.list * FStar_Syntax_Syntax.term)
             FStar_Pervasives_Native.option
   =
@@ -1661,15 +1632,15 @@ let get_norm_request :
     fun full_norm ->
       fun args ->
         let parse_steps s =
-          let uu____6039 =
-            let uu____6044 =
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Embeddings.e_list
                 FStar_Syntax_Embeddings.e_norm_step in
-            FStar_TypeChecker_Cfg.try_unembed_simple uu____6044 s in
-          match uu____6039 with
+            FStar_TypeChecker_Cfg.try_unembed_simple uu___1 s in
+          match uu___ with
           | FStar_Pervasives_Native.Some steps ->
-              let uu____6060 = tr_norm_steps steps in
-              FStar_Pervasives_Native.Some uu____6060
+              let uu___1 = tr_norm_steps steps in
+              FStar_Pervasives_Native.Some uu___1
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
         let inherited_steps =
           FStar_List.append
@@ -1687,7 +1658,7 @@ let get_norm_request :
                 then [FStar_TypeChecker_Env.NBE]
                 else [])) in
         match args with
-        | uu____6089::(tm, uu____6091)::[] ->
+        | uu___::(tm, uu___1)::[] ->
             let s =
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.Zeta;
@@ -1698,7 +1669,7 @@ let get_norm_request :
               FStar_TypeChecker_Env.Reify] in
             FStar_Pervasives_Native.Some
               ((FStar_List.append inherited_steps s), tm)
-        | (tm, uu____6120)::[] ->
+        | (tm, uu___)::[] ->
             let s =
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.Zeta;
@@ -1709,15 +1680,14 @@ let get_norm_request :
               FStar_TypeChecker_Env.Reify] in
             FStar_Pervasives_Native.Some
               ((FStar_List.append inherited_steps s), tm)
-        | (steps, uu____6141)::uu____6142::(tm, uu____6144)::[] ->
-            let uu____6165 =
-              let uu____6170 = full_norm steps in parse_steps uu____6170 in
-            (match uu____6165 with
+        | (steps, uu___)::uu___1::(tm, uu___2)::[] ->
+            let uu___3 = let uu___4 = full_norm steps in parse_steps uu___4 in
+            (match uu___3 with
              | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
              | FStar_Pervasives_Native.Some s ->
                  FStar_Pervasives_Native.Some
                    ((FStar_List.append inherited_steps s), tm))
-        | uu____6200 -> FStar_Pervasives_Native.None
+        | uu___ -> FStar_Pervasives_Native.None
 let (nbe_eval :
   FStar_TypeChecker_Cfg.cfg ->
     FStar_TypeChecker_Env.steps ->
@@ -1727,37 +1697,35 @@ let (nbe_eval :
     fun s ->
       fun tm ->
         let delta_level =
-          let uu____6231 =
+          let uu___ =
             FStar_All.pipe_right s
               (FStar_Util.for_some
-                 (fun uu___10_6236 ->
-                    match uu___10_6236 with
-                    | FStar_TypeChecker_Env.UnfoldUntil uu____6237 -> true
-                    | FStar_TypeChecker_Env.UnfoldOnly uu____6238 -> true
-                    | FStar_TypeChecker_Env.UnfoldFully uu____6241 -> true
-                    | uu____6244 -> false)) in
-          if uu____6231
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | FStar_TypeChecker_Env.UnfoldUntil uu___2 -> true
+                    | FStar_TypeChecker_Env.UnfoldOnly uu___2 -> true
+                    | FStar_TypeChecker_Env.UnfoldFully uu___2 -> true
+                    | uu___2 -> false)) in
+          if uu___
           then
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
           else [FStar_TypeChecker_Env.NoDelta] in
         FStar_TypeChecker_Cfg.log_nbe cfg
-          (fun uu____6251 ->
-             let uu____6252 = FStar_Syntax_Print.term_to_string tm in
-             FStar_Util.print1 "Invoking NBE with  %s\n" uu____6252);
+          (fun uu___1 ->
+             let uu___2 = FStar_Syntax_Print.term_to_string tm in
+             FStar_Util.print1 "Invoking NBE with  %s\n" uu___2);
         (let tm_norm =
-           let uu____6254 = FStar_TypeChecker_Cfg.cfg_env cfg in
-           uu____6254.FStar_TypeChecker_Env.nbe s
-             cfg.FStar_TypeChecker_Cfg.tcenv tm in
+           let uu___1 = FStar_TypeChecker_Cfg.cfg_env cfg in
+           uu___1.FStar_TypeChecker_Env.nbe s cfg.FStar_TypeChecker_Cfg.tcenv
+             tm in
          FStar_TypeChecker_Cfg.log_nbe cfg
-           (fun uu____6258 ->
-              let uu____6259 = FStar_Syntax_Print.term_to_string tm_norm in
-              FStar_Util.print1 "Result of NBE is  %s\n" uu____6259);
+           (fun uu___2 ->
+              let uu___3 = FStar_Syntax_Print.term_to_string tm_norm in
+              FStar_Util.print1 "Result of NBE is  %s\n" uu___3);
          tm_norm)
 let firstn :
-  'uuuuuu6266 .
-    Prims.int ->
-      'uuuuuu6266 Prims.list ->
-        ('uuuuuu6266 Prims.list * 'uuuuuu6266 Prims.list)
+  'uuuuu .
+    Prims.int -> 'uuuuu Prims.list -> ('uuuuu Prims.list * 'uuuuu Prims.list)
   =
   fun k ->
     fun l ->
@@ -1766,63 +1734,61 @@ let (should_reify :
   FStar_TypeChecker_Cfg.cfg -> stack_elt Prims.list -> Prims.bool) =
   fun cfg ->
     fun stack1 ->
-      let rec drop_irrel uu___11_6317 =
-        match uu___11_6317 with
-        | (MemoLazy uu____6322)::s -> drop_irrel s
-        | (UnivArgs uu____6332)::s -> drop_irrel s
+      let rec drop_irrel uu___ =
+        match uu___ with
+        | (MemoLazy uu___1)::s -> drop_irrel s
+        | (UnivArgs uu___1)::s -> drop_irrel s
         | s -> s in
-      let uu____6345 = drop_irrel stack1 in
-      match uu____6345 with
+      let uu___ = drop_irrel stack1 in
+      match uu___ with
       | (App
-          (uu____6348,
+          (uu___1,
            {
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify);
-             FStar_Syntax_Syntax.pos = uu____6349;
-             FStar_Syntax_Syntax.vars = uu____6350;_},
-           uu____6351, uu____6352))::uu____6353
+             FStar_Syntax_Syntax.pos = uu___2;
+             FStar_Syntax_Syntax.vars = uu___3;_},
+           uu___4, uu___5))::uu___6
           -> (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
-      | uu____6358 -> false
+      | uu___1 -> false
 let rec (maybe_weakly_reduced :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun tm ->
     let aux_comp c =
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.GTotal (t, uu____6381) -> maybe_weakly_reduced t
-      | FStar_Syntax_Syntax.Total (t, uu____6391) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.GTotal (t, uu___) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.Total (t, uu___) -> maybe_weakly_reduced t
       | FStar_Syntax_Syntax.Comp ct ->
           (maybe_weakly_reduced ct.FStar_Syntax_Syntax.result_typ) ||
             (FStar_Util.for_some
-               (fun uu____6412 ->
-                  match uu____6412 with
-                  | (a, uu____6422) -> maybe_weakly_reduced a)
+               (fun uu___ ->
+                  match uu___ with | (a, uu___1) -> maybe_weakly_reduced a)
                ct.FStar_Syntax_Syntax.effect_args) in
     let t = FStar_Syntax_Subst.compress tm in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____6432 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_name uu____6447 -> false
-    | FStar_Syntax_Syntax.Tm_uvar uu____6448 -> false
-    | FStar_Syntax_Syntax.Tm_type uu____6461 -> false
-    | FStar_Syntax_Syntax.Tm_bvar uu____6462 -> false
-    | FStar_Syntax_Syntax.Tm_fvar uu____6463 -> false
-    | FStar_Syntax_Syntax.Tm_constant uu____6464 -> false
-    | FStar_Syntax_Syntax.Tm_lazy uu____6465 -> false
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_name uu___ -> false
+    | FStar_Syntax_Syntax.Tm_uvar uu___ -> false
+    | FStar_Syntax_Syntax.Tm_type uu___ -> false
+    | FStar_Syntax_Syntax.Tm_bvar uu___ -> false
+    | FStar_Syntax_Syntax.Tm_fvar uu___ -> false
+    | FStar_Syntax_Syntax.Tm_constant uu___ -> false
+    | FStar_Syntax_Syntax.Tm_lazy uu___ -> false
     | FStar_Syntax_Syntax.Tm_unknown -> false
-    | FStar_Syntax_Syntax.Tm_uinst uu____6466 -> false
-    | FStar_Syntax_Syntax.Tm_quoted uu____6473 -> false
-    | FStar_Syntax_Syntax.Tm_let uu____6480 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____6493 -> true
-    | FStar_Syntax_Syntax.Tm_arrow uu____6512 -> true
-    | FStar_Syntax_Syntax.Tm_refine uu____6527 -> true
-    | FStar_Syntax_Syntax.Tm_match uu____6534 -> true
+    | FStar_Syntax_Syntax.Tm_uinst uu___ -> false
+    | FStar_Syntax_Syntax.Tm_quoted uu___ -> false
+    | FStar_Syntax_Syntax.Tm_let uu___ -> true
+    | FStar_Syntax_Syntax.Tm_abs uu___ -> true
+    | FStar_Syntax_Syntax.Tm_arrow uu___ -> true
+    | FStar_Syntax_Syntax.Tm_refine uu___ -> true
+    | FStar_Syntax_Syntax.Tm_match uu___ -> true
     | FStar_Syntax_Syntax.Tm_app (t1, args) ->
         (maybe_weakly_reduced t1) ||
           (FStar_All.pipe_right args
              (FStar_Util.for_some
-                (fun uu____6604 ->
-                   match uu____6604 with
-                   | (a, uu____6614) -> maybe_weakly_reduced a)))
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____6625) ->
+                (fun uu___ ->
+                   match uu___ with | (a, uu___1) -> maybe_weakly_reduced a)))
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu___) ->
         ((maybe_weakly_reduced t1) ||
            (match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> maybe_weakly_reduced t2
@@ -1834,19 +1800,19 @@ let rec (maybe_weakly_reduced :
     | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
         (maybe_weakly_reduced t1) ||
           ((match m with
-            | FStar_Syntax_Syntax.Meta_pattern (uu____6720, args) ->
+            | FStar_Syntax_Syntax.Meta_pattern (uu___, args) ->
                 FStar_Util.for_some
                   (FStar_Util.for_some
-                     (fun uu____6775 ->
-                        match uu____6775 with
-                        | (a, uu____6785) -> maybe_weakly_reduced a)) args
-            | FStar_Syntax_Syntax.Meta_monadic_lift
-                (uu____6794, uu____6795, t') -> maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_monadic (uu____6801, t') ->
+                     (fun uu___1 ->
+                        match uu___1 with
+                        | (a, uu___2) -> maybe_weakly_reduced a)) args
+            | FStar_Syntax_Syntax.Meta_monadic_lift (uu___, uu___1, t') ->
                 maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_labeled uu____6807 -> false
-            | FStar_Syntax_Syntax.Meta_desugared uu____6814 -> false
-            | FStar_Syntax_Syntax.Meta_named uu____6815 -> false))
+            | FStar_Syntax_Syntax.Meta_monadic (uu___, t') ->
+                maybe_weakly_reduced t'
+            | FStar_Syntax_Syntax.Meta_labeled uu___ -> false
+            | FStar_Syntax_Syntax.Meta_desugared uu___ -> false
+            | FStar_Syntax_Syntax.Meta_named uu___ -> false))
 type should_unfold_res =
   | Should_unfold_no 
   | Should_unfold_yes 
@@ -1854,16 +1820,16 @@ type should_unfold_res =
   | Should_unfold_reify 
 let (uu___is_Should_unfold_no : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_no -> true | uu____6821 -> false
+    match projectee with | Should_unfold_no -> true | uu___ -> false
 let (uu___is_Should_unfold_yes : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_yes -> true | uu____6827 -> false
+    match projectee with | Should_unfold_yes -> true | uu___ -> false
 let (uu___is_Should_unfold_fully : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_fully -> true | uu____6833 -> false
+    match projectee with | Should_unfold_fully -> true | uu___ -> false
 let (uu___is_Should_unfold_reify : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_reify -> true | uu____6839 -> false
+    match projectee with | Should_unfold_reify -> true | uu___ -> false
 let (should_unfold :
   FStar_TypeChecker_Cfg.cfg ->
     (FStar_TypeChecker_Cfg.cfg -> Prims.bool) ->
@@ -1875,8 +1841,8 @@ let (should_unfold :
       fun fv ->
         fun qninfo ->
           let attrs =
-            let uu____6868 = FStar_TypeChecker_Env.attrs_of_qninfo qninfo in
-            match uu____6868 with
+            let uu___ = FStar_TypeChecker_Env.attrs_of_qninfo qninfo in
+            match uu___ with
             | FStar_Pervasives_Native.None -> []
             | FStar_Pervasives_Native.Some ats -> ats in
           let yes = (true, false, false) in
@@ -1887,38 +1853,37 @@ let (should_unfold :
           let fullyno b = if b then fully else no in
           let comb_or l =
             FStar_List.fold_right
-              (fun uu____6996 ->
-                 fun uu____6997 ->
-                   match (uu____6996, uu____6997) with
+              (fun uu___ ->
+                 fun uu___1 ->
+                   match (uu___, uu___1) with
                    | ((a, b, c), (x, y, z)) -> ((a || x), (b || y), (c || z)))
               l (false, false, false) in
-          let string_of_res uu____7057 =
-            match uu____7057 with
+          let string_of_res uu___ =
+            match uu___ with
             | (x, y, z) ->
-                let uu____7067 = FStar_Util.string_of_bool x in
-                let uu____7068 = FStar_Util.string_of_bool y in
-                let uu____7069 = FStar_Util.string_of_bool z in
-                FStar_Util.format3 "(%s,%s,%s)" uu____7067 uu____7068
-                  uu____7069 in
+                let uu___1 = FStar_Util.string_of_bool x in
+                let uu___2 = FStar_Util.string_of_bool y in
+                let uu___3 = FStar_Util.string_of_bool z in
+                FStar_Util.format3 "(%s,%s,%s)" uu___1 uu___2 uu___3 in
           let res =
             if FStar_TypeChecker_Env.qninfo_is_action qninfo
             then
               let b = should_reify1 cfg in
               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                 (fun uu____7088 ->
-                    let uu____7089 = FStar_Syntax_Print.fv_to_string fv in
-                    let uu____7090 = FStar_Util.string_of_bool b in
+                 (fun uu___1 ->
+                    let uu___2 = FStar_Syntax_Print.fv_to_string fv in
+                    let uu___3 = FStar_Util.string_of_bool b in
                     FStar_Util.print2
                       "should_unfold: For DM4F action %s, should_reify = %s\n"
-                      uu____7089 uu____7090);
+                      uu___2 uu___3);
                if b then reif else no)
             else
               if
-                (let uu____7098 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
-                 FStar_Option.isSome uu____7098)
+                (let uu___ = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
+                 FStar_Option.isSome uu___)
               then
                 (FStar_TypeChecker_Cfg.log_unfolding cfg
-                   (fun uu____7103 ->
+                   (fun uu___1 ->
                       FStar_Util.print_string
                         " >> It's a primop, not unfolding\n");
                  no)
@@ -1933,24 +1898,24 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec, uu____7137), uu____7138);
-                        FStar_Syntax_Syntax.sigrng = uu____7139;
+                          ((is_rec, uu___), uu___1);
+                        FStar_Syntax_Syntax.sigrng = uu___2;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7141;
-                        FStar_Syntax_Syntax.sigattrs = uu____7142;
-                        FStar_Syntax_Syntax.sigopts = uu____7143;_},
-                      uu____7144),
-                     uu____7145),
-                    uu____7146, uu____7147, uu____7148) when
+                        FStar_Syntax_Syntax.sigmeta = uu___3;
+                        FStar_Syntax_Syntax.sigattrs = uu___4;
+                        FStar_Syntax_Syntax.sigopts = uu___5;_},
+                      uu___6),
+                     uu___7),
+                    uu___8, uu___9, uu___10) when
                      FStar_List.contains FStar_Syntax_Syntax.HasMaskedEffect
                        qs
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7255 ->
+                        (fun uu___12 ->
                            FStar_Util.print_string
                              " >> HasMaskedEffect, not unfolding\n");
                       no)
-                 | (uu____7256, uu____7257, uu____7258, uu____7259) when
+                 | (uu___, uu___1, uu___2, uu___3) when
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_tac
                        &&
                        (FStar_Util.for_some
@@ -1958,7 +1923,7 @@ let (should_unfold :
                              FStar_Syntax_Util.tac_opaque_attr) attrs)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7326 ->
+                        (fun uu___5 ->
                            FStar_Util.print_string
                              " >> tac_opaque, not unfolding\n");
                       no)
@@ -1967,15 +1932,15 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec, uu____7328), uu____7329);
-                        FStar_Syntax_Syntax.sigrng = uu____7330;
+                          ((is_rec, uu___), uu___1);
+                        FStar_Syntax_Syntax.sigrng = uu___2;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7332;
-                        FStar_Syntax_Syntax.sigattrs = uu____7333;
-                        FStar_Syntax_Syntax.sigopts = uu____7334;_},
-                      uu____7335),
-                     uu____7336),
-                    uu____7337, uu____7338, uu____7339) when
+                        FStar_Syntax_Syntax.sigmeta = uu___3;
+                        FStar_Syntax_Syntax.sigattrs = uu___4;
+                        FStar_Syntax_Syntax.sigopts = uu___5;_},
+                      uu___6),
+                     uu___7),
+                    uu___8, uu___9, uu___10) when
                      (is_rec &&
                         (Prims.op_Negation
                            (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta))
@@ -1984,214 +1949,209 @@ let (should_unfold :
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7446 ->
+                        (fun uu___12 ->
                            FStar_Util.print_string
                              " >> It's a recursive definition but we're not doing Zeta, not unfolding\n");
                       no)
-                 | (uu____7447, FStar_Pervasives_Native.Some uu____7448,
-                    uu____7449, uu____7450) ->
+                 | (uu___, FStar_Pervasives_Native.Some uu___1, uu___2,
+                    uu___3) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7518 ->
-                           let uu____7519 =
-                             FStar_Syntax_Print.fv_to_string fv in
+                        (fun uu___5 ->
+                           let uu___6 = FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7519);
-                      (let uu____7520 =
-                         let uu____7529 =
+                             uu___6);
+                      (let uu___5 =
+                         let uu___6 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7549 =
+                               let uu___7 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7549 in
-                         let uu____7556 =
-                           let uu____7565 =
+                               FStar_All.pipe_left yesno uu___7 in
+                         let uu___7 =
+                           let uu___8 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____7585 =
+                                 let uu___9 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____7585 in
-                           let uu____7596 =
-                             let uu____7605 =
+                                 FStar_All.pipe_left yesno uu___9 in
+                           let uu___9 =
+                             let uu___10 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____7625 =
+                                   let uu___11 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____7625 in
-                             [uu____7605] in
-                           uu____7565 :: uu____7596 in
-                         uu____7529 :: uu____7556 in
-                       comb_or uu____7520))
-                 | (uu____7656, uu____7657, FStar_Pervasives_Native.Some
-                    uu____7658, uu____7659) ->
+                                   FStar_All.pipe_left fullyno uu___11 in
+                             [uu___10] in
+                           uu___8 :: uu___9 in
+                         uu___6 :: uu___7 in
+                       comb_or uu___5))
+                 | (uu___, uu___1, FStar_Pervasives_Native.Some uu___2,
+                    uu___3) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7727 ->
-                           let uu____7728 =
-                             FStar_Syntax_Print.fv_to_string fv in
+                        (fun uu___5 ->
+                           let uu___6 = FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7728);
-                      (let uu____7729 =
-                         let uu____7738 =
+                             uu___6);
+                      (let uu___5 =
+                         let uu___6 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7758 =
+                               let uu___7 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7758 in
-                         let uu____7765 =
-                           let uu____7774 =
+                               FStar_All.pipe_left yesno uu___7 in
+                         let uu___7 =
+                           let uu___8 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____7794 =
+                                 let uu___9 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____7794 in
-                           let uu____7805 =
-                             let uu____7814 =
+                                 FStar_All.pipe_left yesno uu___9 in
+                           let uu___9 =
+                             let uu___10 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____7834 =
+                                   let uu___11 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____7834 in
-                             [uu____7814] in
-                           uu____7774 :: uu____7805 in
-                         uu____7738 :: uu____7765 in
-                       comb_or uu____7729))
-                 | (uu____7865, uu____7866, uu____7867,
-                    FStar_Pervasives_Native.Some uu____7868) ->
+                                   FStar_All.pipe_left fullyno uu___11 in
+                             [uu___10] in
+                           uu___8 :: uu___9 in
+                         uu___6 :: uu___7 in
+                       comb_or uu___5))
+                 | (uu___, uu___1, uu___2, FStar_Pervasives_Native.Some
+                    uu___3) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7936 ->
-                           let uu____7937 =
-                             FStar_Syntax_Print.fv_to_string fv in
+                        (fun uu___5 ->
+                           let uu___6 = FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7937);
-                      (let uu____7938 =
-                         let uu____7947 =
+                             uu___6);
+                      (let uu___5 =
+                         let uu___6 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7967 =
+                               let uu___7 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7967 in
-                         let uu____7974 =
-                           let uu____7983 =
+                               FStar_All.pipe_left yesno uu___7 in
+                         let uu___7 =
+                           let uu___8 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8003 =
+                                 let uu___9 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____8003 in
-                           let uu____8014 =
-                             let uu____8023 =
+                                 FStar_All.pipe_left yesno uu___9 in
+                           let uu___9 =
+                             let uu___10 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8043 =
+                                   let uu___11 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____8043 in
-                             [uu____8023] in
-                           uu____7983 :: uu____8014 in
-                         uu____7947 :: uu____7974 in
-                       comb_or uu____7938))
-                 | uu____8074 ->
+                                   FStar_All.pipe_left fullyno uu___11 in
+                             [uu___10] in
+                           uu___8 :: uu___9 in
+                         uu___6 :: uu___7 in
+                       comb_or uu___5))
+                 | uu___ ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8120 ->
-                           let uu____8121 =
-                             FStar_Syntax_Print.fv_to_string fv in
-                           let uu____8122 =
+                        (fun uu___2 ->
+                           let uu___3 = FStar_Syntax_Print.fv_to_string fv in
+                           let uu___4 =
                              FStar_Syntax_Print.delta_depth_to_string
                                fv.FStar_Syntax_Syntax.fv_delta in
-                           let uu____8123 =
+                           let uu___5 =
                              FStar_Common.string_of_list
                                FStar_TypeChecker_Env.string_of_delta_level
                                cfg.FStar_TypeChecker_Cfg.delta_level in
                            FStar_Util.print3
                              "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
-                             uu____8121 uu____8122 uu____8123);
-                      (let uu____8124 =
+                             uu___3 uu___4 uu___5);
+                      (let uu___2 =
                          FStar_All.pipe_right
                            cfg.FStar_TypeChecker_Cfg.delta_level
                            (FStar_Util.for_some
-                              (fun uu___12_8128 ->
-                                 match uu___12_8128 with
+                              (fun uu___3 ->
+                                 match uu___3 with
                                  | FStar_TypeChecker_Env.NoDelta -> false
                                  | FStar_TypeChecker_Env.InliningDelta ->
                                      true
                                  | FStar_TypeChecker_Env.Eager_unfolding_only
                                      -> true
                                  | FStar_TypeChecker_Env.Unfold l ->
-                                     let uu____8130 =
+                                     let uu___4 =
                                        FStar_TypeChecker_Env.delta_depth_of_fv
                                          cfg.FStar_TypeChecker_Cfg.tcenv fv in
                                      FStar_TypeChecker_Common.delta_depth_greater_than
-                                       uu____8130 l)) in
-                       FStar_All.pipe_left yesno uu____8124))) in
+                                       uu___4 l)) in
+                       FStar_All.pipe_left yesno uu___2))) in
           FStar_TypeChecker_Cfg.log_unfolding cfg
-            (fun uu____8142 ->
-               let uu____8143 = FStar_Syntax_Print.fv_to_string fv in
-               let uu____8144 =
-                 let uu____8145 = FStar_Syntax_Syntax.range_of_fv fv in
-                 FStar_Range.string_of_range uu____8145 in
-               let uu____8146 = string_of_res res in
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.fv_to_string fv in
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Syntax.range_of_fv fv in
+                 FStar_Range.string_of_range uu___4 in
+               let uu___4 = string_of_res res in
                FStar_Util.print3
-                 "should_unfold: For %s (%s), unfolding res = %s\n"
-                 uu____8143 uu____8144 uu____8146);
+                 "should_unfold: For %s (%s), unfolding res = %s\n" uu___2
+                 uu___3 uu___4);
           (match res with
-           | (false, uu____8147, uu____8148) -> Should_unfold_no
+           | (false, uu___1, uu___2) -> Should_unfold_no
            | (true, false, false) -> Should_unfold_yes
            | (true, true, false) -> Should_unfold_fully
            | (true, false, true) -> Should_unfold_reify
-           | uu____8149 ->
-               let uu____8156 =
-                 let uu____8157 = string_of_res res in
-                 FStar_Util.format1 "Unexpected unfolding result: %s"
-                   uu____8157 in
-               FStar_All.pipe_left failwith uu____8156)
+           | uu___1 ->
+               let uu___2 =
+                 let uu___3 = string_of_res res in
+                 FStar_Util.format1 "Unexpected unfolding result: %s" uu___3 in
+               FStar_All.pipe_left failwith uu___2)
 let decide_unfolding :
-  'uuuuuu8172 .
+  'uuuuu .
     FStar_TypeChecker_Cfg.cfg ->
       env ->
         stack_elt Prims.list ->
-          'uuuuuu8172 ->
+          'uuuuu ->
             FStar_Syntax_Syntax.fv ->
               FStar_TypeChecker_Env.qninfo ->
                 (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
@@ -2212,27 +2172,27 @@ let decide_unfolding :
                   FStar_Pervasives_Native.Some (cfg, stack1)
               | Should_unfold_fully ->
                   let cfg' =
-                    let uu___1168_8241 = cfg in
+                    let uu___ = cfg in
                     {
                       FStar_TypeChecker_Cfg.steps =
-                        (let uu___1170_8244 = cfg.FStar_TypeChecker_Cfg.steps in
+                        (let uu___1 = cfg.FStar_TypeChecker_Cfg.steps in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.beta);
+                             (uu___1.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.iota);
+                             (uu___1.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___1.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.weak);
+                             (uu___1.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.primops);
+                             (uu___1.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
                              (FStar_Pervasives_Native.Some
                                 FStar_Syntax_Syntax.delta_constant);
@@ -2243,75 +2203,74 @@ let decide_unfolding :
                            FStar_TypeChecker_Cfg.unfold_attr =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.in_full_norm_request);
+                             (uu___1.FStar_TypeChecker_Cfg.in_full_norm_request);
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1170_8244.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1.FStar_TypeChecker_Cfg.for_extraction)
                          });
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.debug);
+                        (uu___.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.delta_level);
+                        (uu___.FStar_TypeChecker_Cfg.delta_level);
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.strong);
+                        (uu___.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1168_8241.FStar_TypeChecker_Cfg.reifying)
+                        (uu___.FStar_TypeChecker_Cfg.reifying)
                     } in
                   let stack' =
                     match stack1 with
-                    | (UnivArgs (us, r))::stack' -> (UnivArgs (us, r)) ::
-                        (Cfg cfg) :: stack'
-                    | stack' -> (Cfg cfg) :: stack' in
+                    | (UnivArgs (us, r))::stack'1 -> (UnivArgs (us, r)) ::
+                        (Cfg cfg) :: stack'1
+                    | stack'1 -> (Cfg cfg) :: stack'1 in
                   FStar_Pervasives_Native.Some (cfg', stack')
               | Should_unfold_reify ->
                   let rec push e s =
                     match s with
                     | [] -> [e]
                     | (UnivArgs (us, r))::t ->
-                        let uu____8306 = push e t in (UnivArgs (us, r)) ::
-                          uu____8306
+                        let uu___ = push e t in (UnivArgs (us, r)) :: uu___
                     | h::t -> e :: h :: t in
                   let ref =
-                    let uu____8318 =
-                      let uu____8319 =
-                        let uu____8320 = FStar_Syntax_Syntax.lid_of_fv fv in
-                        FStar_Const.Const_reflect uu____8320 in
-                      FStar_Syntax_Syntax.Tm_constant uu____8319 in
-                    FStar_Syntax_Syntax.mk uu____8318 FStar_Range.dummyRange in
+                    let uu___ =
+                      let uu___1 =
+                        let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
+                        FStar_Const.Const_reflect uu___2 in
+                      FStar_Syntax_Syntax.Tm_constant uu___1 in
+                    FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange in
                   let stack2 =
                     push
                       (App
@@ -2332,48 +2291,48 @@ let (is_fext_on_domain :
     let is_on_dom fv =
       FStar_All.pipe_right on_domain_lids
         (FStar_List.existsb (fun l -> FStar_Syntax_Syntax.fv_eq_lid fv l)) in
-    let uu____8363 =
-      let uu____8364 = FStar_Syntax_Subst.compress t in
-      uu____8364.FStar_Syntax_Syntax.n in
-    match uu____8363 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-        let uu____8395 =
-          let uu____8396 = FStar_Syntax_Util.un_uinst hd in
-          uu____8396.FStar_Syntax_Syntax.n in
-        (match uu____8395 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Util.un_uinst hd in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              (is_on_dom fv) &&
                ((FStar_List.length args) = (Prims.of_int (3)))
              ->
              let f =
-               let uu____8411 =
-                 let uu____8418 =
-                   let uu____8429 = FStar_All.pipe_right args FStar_List.tl in
-                   FStar_All.pipe_right uu____8429 FStar_List.tl in
-                 FStar_All.pipe_right uu____8418 FStar_List.hd in
-               FStar_All.pipe_right uu____8411 FStar_Pervasives_Native.fst in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_All.pipe_right args FStar_List.tl in
+                   FStar_All.pipe_right uu___4 FStar_List.tl in
+                 FStar_All.pipe_right uu___3 FStar_List.hd in
+               FStar_All.pipe_right uu___2 FStar_Pervasives_Native.fst in
              FStar_Pervasives_Native.Some f
-         | uu____8528 -> FStar_Pervasives_Native.None)
-    | uu____8529 -> FStar_Pervasives_Native.None
+         | uu___2 -> FStar_Pervasives_Native.None)
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_partial_primop_app :
   FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun cfg ->
     fun t ->
-      let uu____8540 = FStar_Syntax_Util.head_and_args t in
-      match uu____8540 with
+      let uu___ = FStar_Syntax_Util.head_and_args t in
+      match uu___ with
       | (hd, args) ->
-          let uu____8583 =
-            let uu____8584 = FStar_Syntax_Util.un_uinst hd in
-            uu____8584.FStar_Syntax_Syntax.n in
-          (match uu____8583 with
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Util.un_uinst hd in
+            uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____8588 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
-               (match uu____8588 with
+               let uu___2 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
+               (match uu___2 with
                 | FStar_Pervasives_Native.Some prim_step ->
                     prim_step.FStar_TypeChecker_Cfg.arity >
                       (FStar_List.length args)
                 | FStar_Pervasives_Native.None -> false)
-           | uu____8600 -> false)
+           | uu___2 -> false)
 let rec (norm :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -2387,109 +2346,101 @@ let rec (norm :
               (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.norm_delayed
             then
               (match t.FStar_Syntax_Syntax.n with
-               | FStar_Syntax_Syntax.Tm_delayed uu____8877 ->
-                   let uu____8892 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print1 "NORM delayed: %s\n" uu____8892
-               | uu____8893 -> ())
+               | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
+                   let uu___2 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print1 "NORM delayed: %s\n" uu___2
+               | uu___1 -> ())
             else ();
             FStar_Syntax_Subst.compress t in
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____8902 ->
-               let uu____8903 = FStar_Syntax_Print.tag_of_term t1 in
-               let uu____8904 =
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.tag_of_term t1 in
+               let uu___3 =
                  FStar_Util.string_of_bool
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm in
-               let uu____8905 = FStar_Syntax_Print.term_to_string t1 in
-               let uu____8906 =
-                 FStar_Util.string_of_int (FStar_List.length env1) in
-               let uu____8913 =
-                 let uu____8914 =
-                   let uu____8917 = firstn (Prims.of_int (4)) stack1 in
-                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8917 in
-                 stack_to_string uu____8914 in
+               let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+               let uu___5 = FStar_Util.string_of_int (FStar_List.length env1) in
+               let uu___6 =
+                 let uu___7 =
+                   let uu___8 = firstn (Prims.of_int (4)) stack1 in
+                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu___8 in
+                 stack_to_string uu___7 in
                FStar_Util.print5
                  ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
-                 uu____8903 uu____8904 uu____8905 uu____8906 uu____8913);
+                 uu___2 uu___3 uu___4 uu___5 uu___6);
           FStar_TypeChecker_Cfg.log_cfg cfg
-            (fun uu____8943 ->
-               let uu____8944 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
-               FStar_Util.print1 ">>> cfg = %s\n" uu____8944);
+            (fun uu___2 ->
+               let uu___3 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
+               FStar_Util.print1 ">>> cfg = %s\n" uu___3);
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8948 ->
-                     let uu____8949 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8949);
+                  (fun uu___3 ->
+                     let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___4);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_constant uu____8950 ->
+           | FStar_Syntax_Syntax.Tm_constant uu___2 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8954 ->
-                     let uu____8955 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8955);
+                  (fun uu___4 ->
+                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___5);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_name uu____8956 ->
+           | FStar_Syntax_Syntax.Tm_name uu___2 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8960 ->
-                     let uu____8961 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8961);
+                  (fun uu___4 ->
+                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___5);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_lazy uu____8962 ->
+           | FStar_Syntax_Syntax.Tm_lazy uu___2 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8966 ->
-                     let uu____8967 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8967);
+                  (fun uu___4 ->
+                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___5);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____8968;
-                 FStar_Syntax_Syntax.fv_delta = uu____8969;
+               { FStar_Syntax_Syntax.fv_name = uu___2;
+                 FStar_Syntax_Syntax.fv_delta = uu___3;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Data_ctor);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8973 ->
-                     let uu____8974 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8974);
+                  (fun uu___5 ->
+                     let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___6);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____8975;
-                 FStar_Syntax_Syntax.fv_delta = uu____8976;
+               { FStar_Syntax_Syntax.fv_name = uu___2;
+                 FStar_Syntax_Syntax.fv_delta = uu___3;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                   (FStar_Syntax_Syntax.Record_ctor uu____8977);_}
+                   (FStar_Syntax_Syntax.Record_ctor uu___4);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8987 ->
-                     let uu____8988 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8988);
+                  (fun uu___6 ->
+                     let uu___7 = FStar_Syntax_Print.term_to_string t1 in
+                     FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n" uu___7);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                let qninfo =
                  FStar_TypeChecker_Env.lookup_qname
                    cfg.FStar_TypeChecker_Cfg.tcenv lid in
-               let uu____8992 =
+               let uu___2 =
                  FStar_TypeChecker_Env.delta_depth_of_qninfo fv qninfo in
-               (match uu____8992 with
+               (match uu___2 with
                 | FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Delta_constant_at_level uu____8995)
-                    when uu____8995 = Prims.int_zero ->
+                    (FStar_Syntax_Syntax.Delta_constant_at_level uu___3) when
+                    uu___3 = Prims.int_zero ->
                     (FStar_TypeChecker_Cfg.log_unfolding cfg
-                       (fun uu____8999 ->
-                          let uu____9000 =
-                            FStar_Syntax_Print.term_to_string t1 in
+                       (fun uu___5 ->
+                          let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                           FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                            uu____9000);
+                            uu___6);
                      rebuild cfg env1 stack1 t1)
-                | uu____9001 ->
-                    let uu____9004 =
+                | uu___3 ->
+                    let uu___4 =
                       decide_unfolding cfg env1 stack1
                         t1.FStar_Syntax_Syntax.pos fv qninfo in
-                    (match uu____9004 with
+                    (match uu___4 with
                      | FStar_Pervasives_Native.Some (cfg1, stack2) ->
                          do_unfold_fv cfg1 env1 stack2 t1 qninfo fv
                      | FStar_Pervasives_Native.None ->
@@ -2501,110 +2452,109 @@ let rec (norm :
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
                    t1.FStar_Syntax_Syntax.pos in
-               let uu____9043 = closure_as_term cfg env1 t2 in
-               rebuild cfg env1 stack1 uu____9043
+               let uu___2 = closure_as_term cfg env1 t2 in
+               rebuild cfg env1 stack1 uu___2
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9071 = is_norm_request hd args in
-                  uu____9071 = Norm_request_requires_rejig)
+                 (let uu___2 = is_norm_request hd args in
+                  uu___2 = Norm_request_requires_rejig)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Rejigging norm request ... \n"
                 else ();
-                (let uu____9074 = rejig_norm_request hd args in
-                 norm cfg env1 stack1 uu____9074))
+                (let uu___3 = rejig_norm_request hd args in
+                 norm cfg env1 stack1 uu___3))
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9102 = is_norm_request hd args in
-                  uu____9102 = Norm_request_ready)
+                 (let uu___2 = is_norm_request hd args in
+                  uu___2 = Norm_request_ready)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Potential norm request ... \n"
                 else ();
                 (let cfg' =
-                   let uu___1292_9106 = cfg in
+                   let uu___3 = cfg in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1294_9109 = cfg.FStar_TypeChecker_Cfg.steps in
+                       (let uu___4 = cfg.FStar_TypeChecker_Cfg.steps in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.beta);
+                            (uu___4.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.iota);
+                            (uu___4.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.zeta);
+                            (uu___4.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___4.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.weak);
+                            (uu___4.FStar_TypeChecker_Cfg.weak);
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.hnf);
+                            (uu___4.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.primops);
+                            (uu___4.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
                             false;
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___4.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_fully =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___4.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___4.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___4.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.simplify);
+                            (uu___4.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___4.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___4.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.reify_);
+                            (uu___4.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___4.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___4.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___4.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___4.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___4.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___4.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___4.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___4.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1294_9109.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___4.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___3.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.debug);
+                       (uu___3.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
                        [FStar_TypeChecker_Env.Unfold
                           FStar_Syntax_Syntax.delta_constant];
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___3.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.strong);
+                       (uu___3.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___3.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1292_9106.FStar_TypeChecker_Cfg.reifying)
+                       (uu___3.FStar_TypeChecker_Cfg.reifying)
                    } in
-                 let uu____9114 =
-                   get_norm_request cfg (norm cfg' env1 []) args in
-                 match uu____9114 with
+                 let uu___3 = get_norm_request cfg (norm cfg' env1 []) args in
+                 match uu___3 with
                  | FStar_Pervasives_Native.None ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
@@ -2613,30 +2563,30 @@ let rec (norm :
                       (let stack2 =
                          FStar_All.pipe_right stack1
                            (FStar_List.fold_right
-                              (fun uu____9147 ->
-                                 fun stack2 ->
-                                   match uu____9147 with
+                              (fun uu___5 ->
+                                 fun stack3 ->
+                                   match uu___5 with
                                    | (a, aq) ->
-                                       let uu____9159 =
-                                         let uu____9160 =
-                                           let uu____9167 =
-                                             let uu____9168 =
-                                               let uu____9199 =
+                                       let uu___6 =
+                                         let uu___7 =
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
                                                  FStar_Util.mk_ref
                                                    FStar_Pervasives_Native.None in
-                                               (env1, a, uu____9199, false) in
-                                             Clos uu____9168 in
-                                           (uu____9167, aq,
+                                               (env1, a, uu___10, false) in
+                                             Clos uu___9 in
+                                           (uu___8, aq,
                                              (t1.FStar_Syntax_Syntax.pos)) in
-                                         Arg uu____9160 in
-                                       uu____9159 :: stack2) args) in
+                                         Arg uu___7 in
+                                       uu___6 :: stack3) args) in
                        FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____9265 ->
-                            let uu____9266 =
+                         (fun uu___6 ->
+                            let uu___7 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args) in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____9266);
+                              uu___7);
                        norm cfg env1 stack2 hd))
                  | FStar_Pervasives_Native.Some (s, tm) when is_nbe_request s
                      ->
@@ -2650,154 +2600,150 @@ let rec (norm :
                         (let cfg'1 =
                            FStar_TypeChecker_Cfg.config' [] s
                              cfg.FStar_TypeChecker_Cfg.tcenv in
-                         let uu____9293 =
-                           let uu____9294 =
-                             let uu____9295 = FStar_Util.time_diff start fin in
-                             FStar_Pervasives_Native.snd uu____9295 in
-                           FStar_Util.string_of_int uu____9294 in
-                         let uu____9300 =
-                           FStar_Syntax_Print.term_to_string tm' in
-                         let uu____9301 =
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 = FStar_Util.time_diff start fin in
+                             FStar_Pervasives_Native.snd uu___7 in
+                           FStar_Util.string_of_int uu___6 in
+                         let uu___6 = FStar_Syntax_Print.term_to_string tm' in
+                         let uu___7 =
                            FStar_TypeChecker_Cfg.cfg_to_string cfg'1 in
-                         let uu____9302 =
+                         let uu___8 =
                            FStar_Syntax_Print.term_to_string tm_norm in
                          FStar_Util.print4
                            "NBE result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                           uu____9293 uu____9300 uu____9301 uu____9302)
+                           uu___5 uu___6 uu___7 uu___8)
                       else ();
                       rebuild cfg env1 stack1 tm_norm)
                  | FStar_Pervasives_Native.Some (s, tm) ->
                      let delta_level =
-                       let uu____9319 =
+                       let uu___4 =
                          FStar_All.pipe_right s
                            (FStar_Util.for_some
-                              (fun uu___13_9324 ->
-                                 match uu___13_9324 with
-                                 | FStar_TypeChecker_Env.UnfoldUntil
-                                     uu____9325 -> true
-                                 | FStar_TypeChecker_Env.UnfoldOnly
-                                     uu____9326 -> true
-                                 | FStar_TypeChecker_Env.UnfoldFully
-                                     uu____9329 -> true
-                                 | uu____9332 -> false)) in
-                       if uu____9319
+                              (fun uu___5 ->
+                                 match uu___5 with
+                                 | FStar_TypeChecker_Env.UnfoldUntil uu___6
+                                     -> true
+                                 | FStar_TypeChecker_Env.UnfoldOnly uu___6 ->
+                                     true
+                                 | FStar_TypeChecker_Env.UnfoldFully uu___6
+                                     -> true
+                                 | uu___6 -> false)) in
+                       if uu___4
                        then
                          [FStar_TypeChecker_Env.Unfold
                             FStar_Syntax_Syntax.delta_constant]
                        else [FStar_TypeChecker_Env.NoDelta] in
                      let cfg'1 =
-                       let uu___1332_9337 = cfg in
-                       let uu____9338 =
-                         let uu___1334_9339 =
-                           FStar_TypeChecker_Cfg.to_fsteps s in
+                       let uu___4 = cfg in
+                       let uu___5 =
+                         let uu___6 = FStar_TypeChecker_Cfg.to_fsteps s in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.beta);
+                             (uu___6.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.iota);
+                             (uu___6.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.zeta);
+                             (uu___6.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___6.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.weak);
+                             (uu___6.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.hnf);
+                             (uu___6.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.primops);
+                             (uu___6.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___6.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_until);
+                             (uu___6.FStar_TypeChecker_Cfg.unfold_until);
                            FStar_TypeChecker_Cfg.unfold_only =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_only);
+                             (uu___6.FStar_TypeChecker_Cfg.unfold_only);
                            FStar_TypeChecker_Cfg.unfold_fully =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_fully);
+                             (uu___6.FStar_TypeChecker_Cfg.unfold_fully);
                            FStar_TypeChecker_Cfg.unfold_attr =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_attr);
+                             (uu___6.FStar_TypeChecker_Cfg.unfold_attr);
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___6.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___6.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.simplify);
+                             (uu___6.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___6.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___6.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.reify_);
+                             (uu___6.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___6.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___6.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___6.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___6.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___6.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request = true;
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___6.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___6.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1334_9339.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___6.FStar_TypeChecker_Cfg.for_extraction)
                          } in
                        {
-                         FStar_TypeChecker_Cfg.steps = uu____9338;
+                         FStar_TypeChecker_Cfg.steps = uu___5;
                          FStar_TypeChecker_Cfg.tcenv =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.tcenv);
+                           (uu___4.FStar_TypeChecker_Cfg.tcenv);
                          FStar_TypeChecker_Cfg.debug =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.debug);
+                           (uu___4.FStar_TypeChecker_Cfg.debug);
                          FStar_TypeChecker_Cfg.delta_level = delta_level;
                          FStar_TypeChecker_Cfg.primitive_steps =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.primitive_steps);
+                           (uu___4.FStar_TypeChecker_Cfg.primitive_steps);
                          FStar_TypeChecker_Cfg.strong =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.strong);
+                           (uu___4.FStar_TypeChecker_Cfg.strong);
                          FStar_TypeChecker_Cfg.memoize_lazy =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.memoize_lazy);
+                           (uu___4.FStar_TypeChecker_Cfg.memoize_lazy);
                          FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                          FStar_TypeChecker_Cfg.reifying =
-                           (uu___1332_9337.FStar_TypeChecker_Cfg.reifying)
+                           (uu___4.FStar_TypeChecker_Cfg.reifying)
                        } in
                      let stack' =
                        let tail = (Cfg cfg) :: stack1 in
                        if
                          (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                        then
-                         let uu____9344 =
-                           let uu____9345 =
-                             let uu____9350 = FStar_Util.now () in
-                             (tm, uu____9350) in
-                           Debug uu____9345 in
-                         uu____9344 :: tail
+                         let uu___4 =
+                           let uu___5 =
+                             let uu___6 = FStar_Util.now () in (tm, uu___6) in
+                           Debug uu___5 in
+                         uu___4 :: tail
                        else tail in
                      norm cfg'1 env1 stack' tm))
            | FStar_Syntax_Syntax.Tm_type u ->
                let u1 = norm_universe cfg env1 u in
-               let uu____9354 =
+               let uu___2 =
                  FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu____9354
+               rebuild cfg env1 stack1 uu___2
            | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                then norm cfg env1 stack1 t'
                else
                  (let us1 =
-                    let uu____9363 =
-                      let uu____9370 =
-                        FStar_List.map (norm_universe cfg env1) us in
-                      (uu____9370, (t1.FStar_Syntax_Syntax.pos)) in
-                    UnivArgs uu____9363 in
+                    let uu___3 =
+                      let uu___4 = FStar_List.map (norm_universe cfg env1) us in
+                      (uu___4, (t1.FStar_Syntax_Syntax.pos)) in
+                    UnivArgs uu___3 in
                   let stack2 = us1 :: stack1 in norm cfg env1 stack2 t')
            | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____9379 = lookup_bvar env1 x in
-               (match uu____9379 with
-                | Univ uu____9380 ->
+               let uu___2 = lookup_bvar env1 x in
+               (match uu___2 with
+                | Univ uu___3 ->
                     failwith
                       "Impossible: term variable is bound to a universe"
                 | Dummy -> failwith "Term variable not found"
@@ -2808,20 +2754,20 @@ let rec (norm :
                         ||
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full
                     then
-                      let uu____9429 = FStar_ST.op_Bang r in
-                      (match uu____9429 with
+                      let uu___3 = FStar_ST.op_Bang r in
+                      (match uu___3 with
                        | FStar_Pervasives_Native.Some (env3, t') ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9512 ->
-                                 let uu____9513 =
+                              (fun uu___5 ->
+                                 let uu___6 =
                                    FStar_Syntax_Print.term_to_string t1 in
-                                 let uu____9514 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.term_to_string t' in
                                  FStar_Util.print2
-                                   "Lazy hit: %s cached to %s\n" uu____9513
-                                   uu____9514);
-                            (let uu____9515 = maybe_weakly_reduced t' in
-                             if uu____9515
+                                   "Lazy hit: %s cached to %s\n" uu___6
+                                   uu___7);
+                            (let uu___5 = maybe_weakly_reduced t' in
+                             if uu___5
                              then
                                match stack1 with
                                | [] when
@@ -2829,39 +2775,37 @@ let rec (norm :
                                      ||
                                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                                    -> rebuild cfg env3 stack1 t'
-                               | uu____9516 -> norm cfg env3 stack1 t'
+                               | uu___6 -> norm cfg env3 stack1 t'
                              else rebuild cfg env3 stack1 t'))
                        | FStar_Pervasives_Native.None ->
                            norm cfg env2 ((MemoLazy r) :: stack1) t0)
                     else norm cfg env2 stack1 t0)
            | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
                (match stack1 with
-                | (UnivArgs uu____9558)::uu____9559 ->
+                | (UnivArgs uu___2)::uu___3 ->
                     failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
-                | (Arg (c, uu____9569, uu____9570))::stack_rest ->
+                | (Arg (c, uu___2, uu___3))::stack_rest ->
                     (match c with
-                     | Univ uu____9574 ->
+                     | Univ uu___4 ->
                          norm cfg ((FStar_Pervasives_Native.None, c) :: env1)
                            stack_rest t1
-                     | uu____9583 ->
+                     | uu___4 ->
                          (match bs with
                           | [] -> failwith "Impossible"
                           | b::[] ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____9612 ->
-                                    let uu____9613 = closure_to_string c in
-                                    FStar_Util.print1 "\tShifted %s\n"
-                                      uu____9613);
+                                 (fun uu___6 ->
+                                    let uu___7 = closure_to_string c in
+                                    FStar_Util.print1 "\tShifted %s\n" uu___7);
                                norm cfg
                                  (((FStar_Pervasives_Native.Some b), c) ::
                                  env1) stack_rest body)
                           | b::tl ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____9647 ->
-                                    let uu____9648 = closure_to_string c in
-                                    FStar_Util.print1 "\tShifted %s\n"
-                                      uu____9648);
+                                 (fun uu___6 ->
+                                    let uu___7 = closure_to_string c in
+                                    FStar_Util.print1 "\tShifted %s\n" uu___7);
                                (let body1 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_abs
@@ -2874,26 +2818,25 @@ let rec (norm :
                 | (MemoLazy r)::stack2 ->
                     (set_memo cfg r (env1, t1);
                      FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____9694 ->
-                          let uu____9695 =
-                            FStar_Syntax_Print.term_to_string t1 in
-                          FStar_Util.print1 "\tSet memo %s\n" uu____9695);
+                       (fun uu___4 ->
+                          let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                          FStar_Util.print1 "\tSet memo %s\n" uu___5);
                      norm cfg env1 stack2 t1)
-                | (Match uu____9696)::uu____9697 ->
+                | (Match uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9710 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9710 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____9746 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -2904,74 +2847,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____9789 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____9789)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_9796 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_9796.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_9796.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____9797 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9803 ->
-                                 let uu____9804 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____9804);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_9815 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_9815.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Debug uu____9818)::uu____9819 ->
+                | (Debug uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9828 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9828 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____9864 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -2982,74 +2925,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____9907 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____9907)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_9914 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_9914.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_9914.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____9915 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9921 ->
-                                 let uu____9922 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____9922);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_9933 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_9933.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Meta uu____9936)::uu____9937 ->
+                | (Meta uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9948 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9948 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____9984 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3060,75 +3003,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10027 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10027)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10034 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10034.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10034.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10035 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10041 ->
-                                 let uu____10042 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10042);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10053 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10053.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Let uu____10056)::uu____10057 ->
+                | (Let uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10070 =
-                         FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10070 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____10106 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3139,75 +3081,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10149 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10149)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10156 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10156.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10156.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10157 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10163 ->
-                                 let uu____10164 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10164);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10175 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10175.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (App uu____10178)::uu____10179 ->
+                | (App uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10192 =
-                         FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10192 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____10228 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3218,75 +3159,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10271 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10271)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10278 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10278.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10278.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10279 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10285 ->
-                                 let uu____10286 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10286);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10297 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10297.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (CBVApp uu____10300)::uu____10301 ->
+                | (CBVApp uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10314 =
-                         FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10314 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____10350 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3297,75 +3237,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10393 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10393)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10400 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10400.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10400.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10401 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10407 ->
-                                 let uu____10408 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10408);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10419 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10419.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Abs uu____10422)::uu____10423 ->
+                | (Abs uu___2)::uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10440 =
-                         FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10440 with
+                      (let uu___5 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___5 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____10476 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___6 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3376,53 +3315,53 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10519 =
+                                          let uu___6 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10519)
+                                          norm cfg env' [] uu___6)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10526 = rc in
+                                   (let uu___6 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10526.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___6.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10526.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___6.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10527 -> lopt in
+                             | uu___6 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10533 ->
-                                 let uu____10534 =
+                              (fun uu___7 ->
+                                 let uu___8 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10534);
+                                   uu___8);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10545 = cfg in
+                               let uu___7 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___7.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.debug);
+                                   (uu___7.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___7.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10545.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___7.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
@@ -3436,15 +3375,14 @@ let rec (norm :
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10550 =
-                         FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10550 with
+                      (let uu___3 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu___3 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
-                                  (fun env2 ->
-                                     fun uu____10586 -> dummy :: env2) env1) in
+                                  (fun env2 -> fun uu___4 -> dummy :: env2)
+                                  env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3455,53 +3393,53 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10629 =
+                                          let uu___4 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10629)
+                                          norm cfg env' [] uu___4)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10636 = rc in
+                                   (let uu___4 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10636.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___4.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10636.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___4.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10637 -> lopt in
+                             | uu___4 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10643 ->
-                                 let uu____10644 =
+                              (fun uu___5 ->
+                                 let uu___6 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10644);
+                                   uu___6);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10655 = cfg in
+                               let uu___5 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.steps);
+                                   (uu___5.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___5.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.debug);
+                                   (uu___5.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___5.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___5.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___5.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___5.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10655.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___5.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
@@ -3510,115 +3448,114 @@ let rec (norm :
                                stack2) body1))))
            | FStar_Syntax_Syntax.Tm_app (head, args) ->
                let strict_args =
-                 let uu____10689 =
-                   let uu____10690 = FStar_Syntax_Util.un_uinst head in
-                   uu____10690.FStar_Syntax_Syntax.n in
-                 match uu____10689 with
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Util.un_uinst head in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
                      FStar_TypeChecker_Env.fv_has_strict_args
                        cfg.FStar_TypeChecker_Cfg.tcenv fv
-                 | uu____10698 -> FStar_Pervasives_Native.None in
+                 | uu___3 -> FStar_Pervasives_Native.None in
                (match strict_args with
                 | FStar_Pervasives_Native.None ->
                     let stack2 =
                       FStar_All.pipe_right stack1
                         (FStar_List.fold_right
-                           (fun uu____10717 ->
-                              fun stack2 ->
-                                match uu____10717 with
+                           (fun uu___2 ->
+                              fun stack3 ->
+                                match uu___2 with
                                 | (a, aq) ->
-                                    let uu____10729 =
-                                      let uu____10730 =
-                                        let uu____10737 =
-                                          let uu____10738 =
-                                            let uu____10769 =
+                                    let uu___3 =
+                                      let uu___4 =
+                                        let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None in
-                                            (env1, a, uu____10769, false) in
-                                          Clos uu____10738 in
-                                        (uu____10737, aq,
+                                            (env1, a, uu___7, false) in
+                                          Clos uu___6 in
+                                        (uu___5, aq,
                                           (t1.FStar_Syntax_Syntax.pos)) in
-                                      Arg uu____10730 in
-                                    uu____10729 :: stack2) args) in
+                                      Arg uu___4 in
+                                    uu___3 :: stack3) args) in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____10835 ->
-                          let uu____10836 =
+                       (fun uu___3 ->
+                          let uu___4 =
                             FStar_All.pipe_left FStar_Util.string_of_int
                               (FStar_List.length args) in
-                          FStar_Util.print1 "\tPushed %s arguments\n"
-                            uu____10836);
+                          FStar_Util.print1 "\tPushed %s arguments\n" uu___4);
                      norm cfg env1 stack2 head)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____10881 ->
-                              match uu____10881 with
+                           (fun uu___2 ->
+                              match uu___2 with
                               | (a, i) ->
-                                  let uu____10892 = norm cfg env1 [] a in
-                                  (uu____10892, i))) in
+                                  let uu___3 = norm cfg env1 [] a in
+                                  (uu___3, i))) in
                     let norm_args_len = FStar_List.length norm_args in
-                    let uu____10898 =
+                    let uu___2 =
                       FStar_All.pipe_right strict_args1
                         (FStar_List.for_all
                            (fun i ->
                               if i >= norm_args_len
                               then false
                               else
-                                (let uu____10904 = FStar_List.nth norm_args i in
-                                 match uu____10904 with
-                                 | (arg_i, uu____10914) ->
-                                     let uu____10915 =
+                                (let uu___4 = FStar_List.nth norm_args i in
+                                 match uu___4 with
+                                 | (arg_i, uu___5) ->
+                                     let uu___6 =
                                        FStar_Syntax_Util.head_and_args arg_i in
-                                     (match uu____10915 with
-                                      | (head1, uu____10933) ->
-                                          let uu____10958 =
-                                            let uu____10959 =
+                                     (match uu___6 with
+                                      | (head1, uu___7) ->
+                                          let uu___8 =
+                                            let uu___9 =
                                               FStar_Syntax_Util.un_uinst
                                                 head1 in
-                                            uu____10959.FStar_Syntax_Syntax.n in
-                                          (match uu____10958 with
+                                            uu___9.FStar_Syntax_Syntax.n in
+                                          (match uu___8 with
                                            | FStar_Syntax_Syntax.Tm_constant
-                                               uu____10962 -> true
+                                               uu___9 -> true
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
-                                               let uu____10964 =
+                                               let uu___9 =
                                                  FStar_Syntax_Syntax.lid_of_fv
                                                    fv in
                                                FStar_TypeChecker_Env.is_datacon
                                                  cfg.FStar_TypeChecker_Cfg.tcenv
-                                                 uu____10964
-                                           | uu____10965 -> false))))) in
-                    if uu____10898
+                                                 uu___9
+                                           | uu___9 -> false))))) in
+                    if uu___2
                     then
                       let stack2 =
                         FStar_All.pipe_right stack1
                           (FStar_List.fold_right
-                             (fun uu____10980 ->
-                                fun stack2 ->
-                                  match uu____10980 with
+                             (fun uu___3 ->
+                                fun stack3 ->
+                                  match uu___3 with
                                   | (a, aq) ->
-                                      let uu____10992 =
-                                        let uu____10993 =
-                                          let uu____11000 =
-                                            let uu____11001 =
-                                              let uu____11032 =
+                                      let uu___4 =
+                                        let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_Util.mk_ref
                                                   (FStar_Pervasives_Native.Some
                                                      ([], a)) in
-                                              (env1, a, uu____11032, false) in
-                                            Clos uu____11001 in
-                                          (uu____11000, aq,
+                                              (env1, a, uu___8, false) in
+                                            Clos uu___7 in
+                                          (uu___6, aq,
                                             (t1.FStar_Syntax_Syntax.pos)) in
-                                        Arg uu____10993 in
-                                      uu____10992 :: stack2) norm_args) in
+                                        Arg uu___5 in
+                                      uu___4 :: stack3) norm_args) in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____11112 ->
-                            let uu____11113 =
+                         (fun uu___4 ->
+                            let uu___5 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args) in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____11113);
+                              uu___5);
                        norm cfg env1 stack2 head)
                     else
                       (let head1 = closure_as_term cfg env1 head in
@@ -3626,7 +3563,7 @@ let rec (norm :
                          FStar_Syntax_Syntax.mk_Tm_app head1 norm_args
                            t1.FStar_Syntax_Syntax.pos in
                        rebuild cfg env1 stack1 term))
-           | FStar_Syntax_Syntax.Tm_refine (x, uu____11126) when
+           | FStar_Syntax_Syntax.Tm_refine (x, uu___2) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                -> norm cfg env1 stack1 x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x, f) ->
@@ -3639,152 +3576,148 @@ let rec (norm :
                       let t2 =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___1525_11170 = x in
+                             ((let uu___2 = x in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1525_11170.FStar_Syntax_Syntax.ppname);
+                                   (uu___2.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1525_11170.FStar_Syntax_Syntax.index);
+                                   (uu___2.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t_x
                                }), f)) t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env1 stack1 t2
-                  | uu____11171 ->
-                      let uu____11186 = closure_as_term cfg env1 t1 in
-                      rebuild cfg env1 stack1 uu____11186)
+                  | uu___2 ->
+                      let uu___3 = closure_as_term cfg env1 t1 in
+                      rebuild cfg env1 stack1 uu___3)
                else
                  (let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
-                  let uu____11189 =
+                  let uu___3 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] f in
-                  match uu____11189 with
+                  match uu___3 with
                   | (closing, f1) ->
                       let f2 = norm cfg (dummy :: env1) [] f1 in
                       let t2 =
-                        let uu____11220 =
-                          let uu____11221 =
-                            let uu____11228 =
-                              FStar_Syntax_Subst.close closing f2 in
-                            ((let uu___1534_11234 = x in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Subst.close closing f2 in
+                            ((let uu___7 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1534_11234.FStar_Syntax_Syntax.ppname);
+                                  (uu___7.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___1534_11234.FStar_Syntax_Syntax.index);
+                                  (uu___7.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
-                              }), uu____11228) in
-                          FStar_Syntax_Syntax.Tm_refine uu____11221 in
-                        FStar_Syntax_Syntax.mk uu____11220
+                              }), uu___6) in
+                          FStar_Syntax_Syntax.Tm_refine uu___5 in
+                        FStar_Syntax_Syntax.mk uu___4
                           t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
-                 let uu____11257 = closure_as_term cfg env1 t1 in
-                 rebuild cfg env1 stack1 uu____11257
+                 let uu___2 = closure_as_term cfg env1 t1 in
+                 rebuild cfg env1 stack1 uu___2
                else
-                 (let uu____11259 = FStar_Syntax_Subst.open_comp bs c in
-                  match uu____11259 with
+                 (let uu___3 = FStar_Syntax_Subst.open_comp bs c in
+                  match uu___3 with
                   | (bs1, c1) ->
                       let c2 =
-                        let uu____11267 =
+                        let uu___4 =
                           FStar_All.pipe_right bs1
                             (FStar_List.fold_left
-                               (fun env2 -> fun uu____11293 -> dummy :: env2)
-                               env1) in
-                        norm_comp cfg uu____11267 c1 in
+                               (fun env2 -> fun uu___5 -> dummy :: env2) env1) in
+                        norm_comp cfg uu___4 c1 in
                       let t2 =
-                        let uu____11317 = norm_binders cfg env1 bs1 in
-                        FStar_Syntax_Util.arrow uu____11317 c2 in
+                        let uu___4 = norm_binders cfg env1 bs1 in
+                        FStar_Syntax_Util.arrow uu___4 c2 in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11, (tc, tacopt), l) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unascribe
                -> norm cfg env1 stack1 t11
            | FStar_Syntax_Syntax.Tm_ascribed (t11, (tc, tacopt), l) ->
                (match stack1 with
-                | (Match uu____11430)::uu____11431 when
+                | (Match uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11444 ->
+                       (fun uu___5 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (Arg uu____11445)::uu____11446 when
+                | (Arg uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11457 ->
+                       (fun uu___5 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
                 | (App
-                    (uu____11458,
+                    (uu___2,
                      {
                        FStar_Syntax_Syntax.n =
                          FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_reify);
-                       FStar_Syntax_Syntax.pos = uu____11459;
-                       FStar_Syntax_Syntax.vars = uu____11460;_},
-                     uu____11461, uu____11462))::uu____11463
+                       FStar_Syntax_Syntax.pos = uu___3;
+                       FStar_Syntax_Syntax.vars = uu___4;_},
+                     uu___5, uu___6))::uu___7
                     when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11470 ->
+                       (fun uu___9 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (MemoLazy uu____11471)::uu____11472 when
+                | (MemoLazy uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11483 ->
+                       (fun uu___5 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | uu____11484 ->
+                | uu___2 ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11487 ->
+                       (fun uu___4 ->
                           FStar_Util.print_string "+++ Keeping ascription \n");
                      (let t12 = norm cfg env1 [] t11 in
                       FStar_TypeChecker_Cfg.log cfg
-                        (fun uu____11491 ->
+                        (fun uu___5 ->
                            FStar_Util.print_string
                              "+++ Normalizing ascription \n");
                       (let tc1 =
                          match tc with
                          | FStar_Util.Inl t2 ->
-                             let uu____11516 = norm cfg env1 [] t2 in
-                             FStar_Util.Inl uu____11516
+                             let uu___5 = norm cfg env1 [] t2 in
+                             FStar_Util.Inl uu___5
                          | FStar_Util.Inr c ->
-                             let uu____11530 = norm_comp cfg env1 c in
-                             FStar_Util.Inr uu____11530 in
+                             let uu___5 = norm_comp cfg env1 c in
+                             FStar_Util.Inr uu___5 in
                        let tacopt1 =
                          FStar_Util.map_opt tacopt (norm cfg env1 []) in
                        match stack1 with
                        | (Cfg cfg1)::stack2 ->
                            let t2 =
-                             let uu____11553 =
-                               let uu____11554 =
-                                 let uu____11581 =
-                                   FStar_Syntax_Util.unascribe t12 in
-                                 (uu____11581, (tc1, tacopt1), l) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11554 in
-                             FStar_Syntax_Syntax.mk uu____11553
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 = FStar_Syntax_Util.unascribe t12 in
+                                 (uu___7, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu___6 in
+                             FStar_Syntax_Syntax.mk uu___5
                                t1.FStar_Syntax_Syntax.pos in
                            norm cfg1 env1 stack2 t2
-                       | uu____11616 ->
-                           let uu____11617 =
-                             let uu____11618 =
-                               let uu____11619 =
-                                 let uu____11646 =
-                                   FStar_Syntax_Util.unascribe t12 in
-                                 (uu____11646, (tc1, tacopt1), l) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11619 in
-                             FStar_Syntax_Syntax.mk uu____11618
+                       | uu___5 ->
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = FStar_Syntax_Util.unascribe t12 in
+                                 (uu___9, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu___8 in
+                             FStar_Syntax_Syntax.mk uu___7
                                t1.FStar_Syntax_Syntax.pos in
-                           rebuild cfg env1 stack1 uu____11617))))
+                           rebuild cfg env1 stack1 uu___6))))
            | FStar_Syntax_Syntax.Tm_match (head, branches1) ->
                let stack2 =
                  (Match (env1, branches1, cfg, (t1.FStar_Syntax_Syntax.pos)))
@@ -3798,82 +3731,82 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak)
                then
                  let cfg' =
-                   let uu___1613_11723 = cfg in
+                   let uu___2 = cfg in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1615_11726 = cfg.FStar_TypeChecker_Cfg.steps in
+                       (let uu___3 = cfg.FStar_TypeChecker_Cfg.steps in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.beta);
+                            (uu___3.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.iota);
+                            (uu___3.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.zeta);
+                            (uu___3.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___3.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak = true;
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.hnf);
+                            (uu___3.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.primops);
+                            (uu___3.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                            (uu___3.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___3.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_only);
+                            (uu___3.FStar_TypeChecker_Cfg.unfold_only);
                           FStar_TypeChecker_Cfg.unfold_fully =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_fully);
+                            (uu___3.FStar_TypeChecker_Cfg.unfold_fully);
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___3.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___3.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___3.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.simplify);
+                            (uu___3.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___3.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___3.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.reify_);
+                            (uu___3.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___3.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___3.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___3.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___3.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___3.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___3.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___3.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___3.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1615_11726.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___3.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___2.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.debug);
+                       (uu___2.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.delta_level);
+                       (uu___2.FStar_TypeChecker_Cfg.delta_level);
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___2.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.strong);
+                       (uu___2.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___2.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                       (uu___2.FStar_TypeChecker_Cfg.normalize_pure_lets);
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1613_11723.FStar_TypeChecker_Cfg.reifying)
+                       (uu___2.FStar_TypeChecker_Cfg.reifying)
                    } in
                  norm cfg' env1 ((Cfg cfg) :: stack2) head
                else norm cfg env1 stack2 head
@@ -3885,124 +3818,123 @@ let rec (norm :
                  FStar_All.pipe_right lbs
                    (FStar_List.map
                       (fun lb ->
-                         let uu____11762 =
+                         let uu___2 =
                            FStar_Syntax_Subst.univ_var_opening
                              lb.FStar_Syntax_Syntax.lbunivs in
-                         match uu____11762 with
+                         match uu___2 with
                          | (openings, lbunivs) ->
                              let cfg1 =
-                               let uu___1628_11782 = cfg in
-                               let uu____11783 =
+                               let uu___3 = cfg in
+                               let uu___4 =
                                  FStar_TypeChecker_Env.push_univ_vars
                                    cfg.FStar_TypeChecker_Cfg.tcenv lbunivs in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.steps);
-                                 FStar_TypeChecker_Cfg.tcenv = uu____11783;
+                                   (uu___3.FStar_TypeChecker_Cfg.steps);
+                                 FStar_TypeChecker_Cfg.tcenv = uu___4;
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.debug);
+                                   (uu___3.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___3.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___3.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.strong);
+                                   (uu___3.FStar_TypeChecker_Cfg.strong);
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___3.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___3.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1628_11782.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___3.FStar_TypeChecker_Cfg.reifying)
                                } in
                              let norm1 t2 =
-                               let uu____11790 =
-                                 let uu____11791 =
+                               let uu___3 =
+                                 let uu___4 =
                                    FStar_Syntax_Subst.subst openings t2 in
-                                 norm cfg1 env1 [] uu____11791 in
+                                 norm cfg1 env1 [] uu___4 in
                                FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu____11790 in
+                                 uu___3 in
                              let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp in
                              let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef in
-                             let uu___1635_11794 = lb in
+                             let uu___3 = lb in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1635_11794.FStar_Syntax_Syntax.lbname);
+                                 (uu___3.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs = lbunivs;
                                FStar_Syntax_Syntax.lbtyp = lbtyp;
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1635_11794.FStar_Syntax_Syntax.lbeff);
+                                 (uu___3.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef = lbdef;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1635_11794.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___3.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1635_11794.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3.FStar_Syntax_Syntax.lbpos)
                              })) in
-               let uu____11795 =
+               let uu___2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu____11795
+               rebuild cfg env1 stack1 uu___2
            | FStar_Syntax_Syntax.Tm_let
-               ((uu____11806,
-                 { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____11807;
-                   FStar_Syntax_Syntax.lbunivs = uu____11808;
-                   FStar_Syntax_Syntax.lbtyp = uu____11809;
-                   FStar_Syntax_Syntax.lbeff = uu____11810;
-                   FStar_Syntax_Syntax.lbdef = uu____11811;
-                   FStar_Syntax_Syntax.lbattrs = uu____11812;
-                   FStar_Syntax_Syntax.lbpos = uu____11813;_}::uu____11814),
-                uu____11815)
+               ((uu___2,
+                 { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu___3;
+                   FStar_Syntax_Syntax.lbunivs = uu___4;
+                   FStar_Syntax_Syntax.lbtyp = uu___5;
+                   FStar_Syntax_Syntax.lbeff = uu___6;
+                   FStar_Syntax_Syntax.lbdef = uu___7;
+                   FStar_Syntax_Syntax.lbattrs = uu___8;
+                   FStar_Syntax_Syntax.lbpos = uu___9;_}::uu___10),
+                uu___11)
                -> rebuild cfg env1 stack1 t1
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
-               let uu____11854 =
+               let uu___2 =
                  FStar_TypeChecker_Cfg.should_reduce_local_let cfg lb in
-               if uu____11854
+               if uu___2
                then
                  let binder =
-                   let uu____11856 =
-                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                   FStar_Syntax_Syntax.mk_binder uu____11856 in
+                   let uu___3 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                   FStar_Syntax_Syntax.mk_binder uu___3 in
                  let def =
                    FStar_Syntax_Util.unmeta_lift lb.FStar_Syntax_Syntax.lbdef in
                  let env2 =
-                   let uu____11867 =
-                     let uu____11874 =
-                       let uu____11875 =
-                         let uu____11906 =
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_Util.mk_ref FStar_Pervasives_Native.None in
-                         (env1, def, uu____11906, false) in
-                       Clos uu____11875 in
-                     ((FStar_Pervasives_Native.Some binder), uu____11874) in
-                   uu____11867 :: env1 in
+                         (env1, def, uu___6, false) in
+                       Clos uu___5 in
+                     ((FStar_Pervasives_Native.Some binder), uu___4) in
+                   uu___3 :: env1 in
                  (FStar_TypeChecker_Cfg.log cfg
-                    (fun uu____11979 ->
+                    (fun uu___4 ->
                        FStar_Util.print_string "+++ Reducing Tm_let\n");
                   norm cfg env2 stack1 body)
                else
-                 (let uu____11981 =
+                 (let uu___4 =
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
                       &&
-                      (let uu____11983 =
+                      (let uu___5 =
                          FStar_TypeChecker_Env.norm_eff_name
                            cfg.FStar_TypeChecker_Cfg.tcenv
                            lb.FStar_Syntax_Syntax.lbeff in
-                       FStar_Syntax_Util.is_div_effect uu____11983) in
-                  if uu____11981
+                       FStar_Syntax_Util.is_div_effect uu___5) in
+                  if uu___4
                   then
                     let ffun =
-                      let uu____11987 =
-                        let uu____11988 =
-                          let uu____12007 =
-                            let uu____12016 =
-                              let uu____12023 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_All.pipe_right
                                   lb.FStar_Syntax_Syntax.lbname
                                   FStar_Util.left in
-                              FStar_Syntax_Syntax.mk_binder uu____12023 in
-                            [uu____12016] in
-                          (uu____12007, body, FStar_Pervasives_Native.None) in
-                        FStar_Syntax_Syntax.Tm_abs uu____11988 in
-                      FStar_Syntax_Syntax.mk uu____11987
+                              FStar_Syntax_Syntax.mk_binder uu___9 in
+                            [uu___8] in
+                          (uu___7, body, FStar_Pervasives_Native.None) in
+                        FStar_Syntax_Syntax.Tm_abs uu___6 in
+                      FStar_Syntax_Syntax.mk uu___5
                         t1.FStar_Syntax_Syntax.pos in
                     let stack2 =
                       (CBVApp
@@ -4010,7 +3942,7 @@ let rec (norm :
                            (t1.FStar_Syntax_Syntax.pos)))
                       :: stack1 in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12057 ->
+                       (fun uu___6 ->
                           FStar_Util.print_string
                             "+++ Evaluating DIV Tm_let\n");
                      norm cfg env1 stack2 lb.FStar_Syntax_Syntax.lbdef)
@@ -4019,98 +3951,97 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____12061 ->
+                         (fun uu___7 ->
                             FStar_Util.print_string
                               "+++ Not touching Tm_let\n");
-                       (let uu____12062 = closure_as_term cfg env1 t1 in
-                        rebuild cfg env1 stack1 uu____12062))
+                       (let uu___7 = closure_as_term cfg env1 t1 in
+                        rebuild cfg env1 stack1 uu___7))
                     else
-                      (let uu____12064 =
-                         let uu____12069 =
-                           let uu____12070 =
-                             let uu____12077 =
+                      (let uu___7 =
+                         let uu___8 =
+                           let uu___9 =
+                             let uu___10 =
                                FStar_All.pipe_right
                                  lb.FStar_Syntax_Syntax.lbname
                                  FStar_Util.left in
-                             FStar_All.pipe_right uu____12077
+                             FStar_All.pipe_right uu___10
                                FStar_Syntax_Syntax.mk_binder in
-                           [uu____12070] in
-                         FStar_Syntax_Subst.open_term uu____12069 body in
-                       match uu____12064 with
+                           [uu___9] in
+                         FStar_Syntax_Subst.open_term uu___8 body in
+                       match uu___7 with
                        | (bs, body1) ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____12104 ->
+                              (fun uu___9 ->
                                  FStar_Util.print_string
                                    "+++ Normalizing Tm_let -- type");
                             (let ty =
                                norm cfg env1 [] lb.FStar_Syntax_Syntax.lbtyp in
                              let lbname =
                                let x =
-                                 let uu____12112 = FStar_List.hd bs in
-                                 FStar_Pervasives_Native.fst uu____12112 in
+                                 let uu___9 = FStar_List.hd bs in
+                                 FStar_Pervasives_Native.fst uu___9 in
                                FStar_Util.Inl
-                                 (let uu___1682_12128 = x in
+                                 (let uu___9 = x in
                                   {
                                     FStar_Syntax_Syntax.ppname =
-                                      (uu___1682_12128.FStar_Syntax_Syntax.ppname);
+                                      (uu___9.FStar_Syntax_Syntax.ppname);
                                     FStar_Syntax_Syntax.index =
-                                      (uu___1682_12128.FStar_Syntax_Syntax.index);
+                                      (uu___9.FStar_Syntax_Syntax.index);
                                     FStar_Syntax_Syntax.sort = ty
                                   }) in
                              FStar_TypeChecker_Cfg.log cfg
-                               (fun uu____12131 ->
+                               (fun uu___10 ->
                                   FStar_Util.print_string
                                     "+++ Normalizing Tm_let -- definiens\n");
                              (let lb1 =
-                                let uu___1687_12133 = lb in
-                                let uu____12134 =
+                                let uu___10 = lb in
+                                let uu___11 =
                                   norm cfg env1 []
                                     lb.FStar_Syntax_Syntax.lbdef in
-                                let uu____12137 =
+                                let uu___12 =
                                   FStar_List.map (norm cfg env1 [])
                                     lb.FStar_Syntax_Syntax.lbattrs in
                                 {
                                   FStar_Syntax_Syntax.lbname = lbname;
                                   FStar_Syntax_Syntax.lbunivs =
-                                    (uu___1687_12133.FStar_Syntax_Syntax.lbunivs);
+                                    (uu___10.FStar_Syntax_Syntax.lbunivs);
                                   FStar_Syntax_Syntax.lbtyp = ty;
                                   FStar_Syntax_Syntax.lbeff =
-                                    (uu___1687_12133.FStar_Syntax_Syntax.lbeff);
-                                  FStar_Syntax_Syntax.lbdef = uu____12134;
-                                  FStar_Syntax_Syntax.lbattrs = uu____12137;
+                                    (uu___10.FStar_Syntax_Syntax.lbeff);
+                                  FStar_Syntax_Syntax.lbdef = uu___11;
+                                  FStar_Syntax_Syntax.lbattrs = uu___12;
                                   FStar_Syntax_Syntax.lbpos =
-                                    (uu___1687_12133.FStar_Syntax_Syntax.lbpos)
+                                    (uu___10.FStar_Syntax_Syntax.lbpos)
                                 } in
                               let env' =
                                 FStar_All.pipe_right bs
                                   (FStar_List.fold_left
                                      (fun env2 ->
-                                        fun uu____12172 -> dummy :: env2)
-                                     env1) in
+                                        fun uu___10 -> dummy :: env2) env1) in
                               let stack2 = (Cfg cfg) :: stack1 in
                               let cfg1 =
-                                let uu___1694_12197 = cfg in
+                                let uu___10 = cfg in
                                 {
                                   FStar_TypeChecker_Cfg.steps =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.steps);
+                                    (uu___10.FStar_TypeChecker_Cfg.steps);
                                   FStar_TypeChecker_Cfg.tcenv =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.tcenv);
+                                    (uu___10.FStar_TypeChecker_Cfg.tcenv);
                                   FStar_TypeChecker_Cfg.debug =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.debug);
+                                    (uu___10.FStar_TypeChecker_Cfg.debug);
                                   FStar_TypeChecker_Cfg.delta_level =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.delta_level);
+                                    (uu___10.FStar_TypeChecker_Cfg.delta_level);
                                   FStar_TypeChecker_Cfg.primitive_steps =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.primitive_steps);
+                                    (uu___10.FStar_TypeChecker_Cfg.primitive_steps);
                                   FStar_TypeChecker_Cfg.strong = true;
                                   FStar_TypeChecker_Cfg.memoize_lazy =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.memoize_lazy);
+                                    (uu___10.FStar_TypeChecker_Cfg.memoize_lazy);
                                   FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                    (uu___10.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                   FStar_TypeChecker_Cfg.reifying =
-                                    (uu___1694_12197.FStar_TypeChecker_Cfg.reifying)
+                                    (uu___10.FStar_TypeChecker_Cfg.reifying)
                                 } in
                               FStar_TypeChecker_Cfg.log cfg1
-                                (fun uu____12200 ->
+                                (fun uu___11 ->
                                    FStar_Util.print_string
                                      "+++ Normalizing Tm_let -- body\n");
                               norm cfg1 env'
@@ -4129,8 +4060,8 @@ let rec (norm :
                     &&
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations)
                ->
-               let uu____12217 = FStar_Syntax_Subst.open_let_rec lbs body in
-               (match uu____12217 with
+               let uu___2 = FStar_Syntax_Subst.open_let_rec lbs body in
+               (match uu___2 with
                 | (lbs1, body1) ->
                     let lbs2 =
                       FStar_List.map
@@ -4138,90 +4069,87 @@ let rec (norm :
                            let ty =
                              norm cfg env1 [] lb.FStar_Syntax_Syntax.lbtyp in
                            let lbname =
-                             let uu____12253 =
-                               let uu___1710_12254 =
+                             let uu___3 =
+                               let uu___4 =
                                  FStar_Util.left
                                    lb.FStar_Syntax_Syntax.lbname in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1710_12254.FStar_Syntax_Syntax.ppname);
+                                   (uu___4.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1710_12254.FStar_Syntax_Syntax.index);
+                                   (uu___4.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
                                } in
-                             FStar_Util.Inl uu____12253 in
-                           let uu____12255 =
+                             FStar_Util.Inl uu___3 in
+                           let uu___3 =
                              FStar_Syntax_Util.abs_formals
                                lb.FStar_Syntax_Syntax.lbdef in
-                           match uu____12255 with
+                           match uu___3 with
                            | (xs, def_body, lopt) ->
                                let xs1 = norm_binders cfg env1 xs in
                                let env2 =
-                                 let uu____12281 =
-                                   FStar_List.map (fun uu____12303 -> dummy)
-                                     xs1 in
-                                 let uu____12310 =
-                                   let uu____12319 =
-                                     FStar_List.map
-                                       (fun uu____12335 -> dummy) lbs1 in
-                                   FStar_List.append uu____12319 env1 in
-                                 FStar_List.append uu____12281 uu____12310 in
+                                 let uu___4 =
+                                   FStar_List.map (fun uu___5 -> dummy) xs1 in
+                                 let uu___5 =
+                                   let uu___6 =
+                                     FStar_List.map (fun uu___7 -> dummy)
+                                       lbs1 in
+                                   FStar_List.append uu___6 env1 in
+                                 FStar_List.append uu___4 uu___5 in
                                let def_body1 = norm cfg env2 [] def_body in
                                let lopt1 =
                                  match lopt with
                                  | FStar_Pervasives_Native.Some rc ->
-                                     let uu____12355 =
-                                       let uu___1724_12356 = rc in
-                                       let uu____12357 =
+                                     let uu___4 =
+                                       let uu___5 = rc in
+                                       let uu___6 =
                                          FStar_Util.map_opt
                                            rc.FStar_Syntax_Syntax.residual_typ
                                            (norm cfg env2 []) in
                                        {
                                          FStar_Syntax_Syntax.residual_effect
                                            =
-                                           (uu___1724_12356.FStar_Syntax_Syntax.residual_effect);
+                                           (uu___5.FStar_Syntax_Syntax.residual_effect);
                                          FStar_Syntax_Syntax.residual_typ =
-                                           uu____12357;
+                                           uu___6;
                                          FStar_Syntax_Syntax.residual_flags =
-                                           (uu___1724_12356.FStar_Syntax_Syntax.residual_flags)
+                                           (uu___5.FStar_Syntax_Syntax.residual_flags)
                                        } in
-                                     FStar_Pervasives_Native.Some uu____12355
-                                 | uu____12366 -> lopt in
+                                     FStar_Pervasives_Native.Some uu___4
+                                 | uu___4 -> lopt in
                                let def =
                                  FStar_Syntax_Util.abs xs1 def_body1 lopt1 in
-                               let uu___1729_12372 = lb in
+                               let uu___4 = lb in
                                {
                                  FStar_Syntax_Syntax.lbname = lbname;
                                  FStar_Syntax_Syntax.lbunivs =
-                                   (uu___1729_12372.FStar_Syntax_Syntax.lbunivs);
+                                   (uu___4.FStar_Syntax_Syntax.lbunivs);
                                  FStar_Syntax_Syntax.lbtyp = ty;
                                  FStar_Syntax_Syntax.lbeff =
-                                   (uu___1729_12372.FStar_Syntax_Syntax.lbeff);
+                                   (uu___4.FStar_Syntax_Syntax.lbeff);
                                  FStar_Syntax_Syntax.lbdef = def;
                                  FStar_Syntax_Syntax.lbattrs =
-                                   (uu___1729_12372.FStar_Syntax_Syntax.lbattrs);
+                                   (uu___4.FStar_Syntax_Syntax.lbattrs);
                                  FStar_Syntax_Syntax.lbpos =
-                                   (uu___1729_12372.FStar_Syntax_Syntax.lbpos)
+                                   (uu___4.FStar_Syntax_Syntax.lbpos)
                                }) lbs1 in
                     let env' =
-                      let uu____12382 =
-                        FStar_List.map (fun uu____12398 -> dummy) lbs2 in
-                      FStar_List.append uu____12382 env1 in
+                      let uu___3 = FStar_List.map (fun uu___4 -> dummy) lbs2 in
+                      FStar_List.append uu___3 env1 in
                     let body2 = norm cfg env' [] body1 in
-                    let uu____12406 =
-                      FStar_Syntax_Subst.close_let_rec lbs2 body2 in
-                    (match uu____12406 with
+                    let uu___3 = FStar_Syntax_Subst.close_let_rec lbs2 body2 in
+                    (match uu___3 with
                      | (lbs3, body3) ->
                          let t2 =
-                           let uu___1738_12422 = t1 in
+                           let uu___4 = t1 in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_let
                                   ((true, lbs3), body3));
                              FStar_Syntax_Syntax.pos =
-                               (uu___1738_12422.FStar_Syntax_Syntax.pos);
+                               (uu___4.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1738_12422.FStar_Syntax_Syntax.vars)
+                               (uu___4.FStar_Syntax_Syntax.vars)
                            } in
                          rebuild cfg env1 stack1 t2))
            | FStar_Syntax_Syntax.Tm_let (lbs, body) when
@@ -4231,24 +4159,24 @@ let rec (norm :
                  (Prims.op_Negation
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                ->
-               let uu____12451 = closure_as_term cfg env1 t1 in
-               rebuild cfg env1 stack1 uu____12451
+               let uu___2 = closure_as_term cfg env1 t1 in
+               rebuild cfg env1 stack1 uu___2
            | FStar_Syntax_Syntax.Tm_let (lbs, body) ->
-               let uu____12470 =
+               let uu___2 =
                  FStar_List.fold_right
                    (fun lb ->
-                      fun uu____12546 ->
-                        match uu____12546 with
+                      fun uu___3 ->
+                        match uu___3 with
                         | (rec_env, memos, i) ->
                             let bv =
-                              let uu___1754_12667 =
+                              let uu___4 =
                                 FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1754_12667.FStar_Syntax_Syntax.ppname);
+                                  (uu___4.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index = i;
                                 FStar_Syntax_Syntax.sort =
-                                  (uu___1754_12667.FStar_Syntax_Syntax.sort)
+                                  (uu___4.FStar_Syntax_Syntax.sort)
                               } in
                             let f_i = FStar_Syntax_Syntax.bv_to_tm bv in
                             let fix_f_i =
@@ -4264,9 +4192,9 @@ let rec (norm :
                             (rec_env1, (memo :: memos), (i + Prims.int_one)))
                    (FStar_Pervasives_Native.snd lbs)
                    (env1, [], Prims.int_zero) in
-               (match uu____12470 with
-                | (rec_env, memos, uu____12850) ->
-                    let uu____12903 =
+               (match uu___2 with
+                | (rec_env, memos, uu___3) ->
+                    let uu___4 =
                       FStar_List.map2
                         (fun lb ->
                            fun memo ->
@@ -4278,25 +4206,24 @@ let rec (norm :
                       FStar_List.fold_right
                         (fun lb ->
                            fun env2 ->
-                             let uu____13086 =
-                               let uu____13093 =
-                                 let uu____13094 =
-                                   let uu____13125 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_Util.mk_ref
                                        FStar_Pervasives_Native.None in
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                     uu____13125, false) in
-                                 Clos uu____13094 in
-                               (FStar_Pervasives_Native.None, uu____13093) in
-                             uu____13086 :: env2)
+                                     uu___8, false) in
+                                 Clos uu___7 in
+                               (FStar_Pervasives_Native.None, uu___6) in
+                             uu___5 :: env2)
                         (FStar_Pervasives_Native.snd lbs) env1 in
                     norm cfg body_env stack1 body)
            | FStar_Syntax_Syntax.Tm_meta (head, m) ->
                (FStar_TypeChecker_Cfg.log cfg
-                  (fun uu____13207 ->
-                     let uu____13208 =
-                       FStar_Syntax_Print.metadata_to_string m in
-                     FStar_Util.print1 ">> metadata = %s\n" uu____13208);
+                  (fun uu___3 ->
+                     let uu___4 = FStar_Syntax_Print.metadata_to_string m in
+                     FStar_Util.print1 ">> metadata = %s\n" uu___4);
                 (match m with
                  | FStar_Syntax_Syntax.Meta_monadic (m1, t2) ->
                      reduce_impure_comp cfg env1 stack1 head
@@ -4304,16 +4231,16 @@ let rec (norm :
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t2) ->
                      reduce_impure_comp cfg env1 stack1 head
                        (FStar_Util.Inr (m1, m')) t2
-                 | uu____13230 ->
+                 | uu___3 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta
                      then norm cfg env1 stack1 head
                      else
                        (match stack1 with
-                        | uu____13232::uu____13233 ->
+                        | uu___5::uu___6 ->
                             (match m with
                              | FStar_Syntax_Syntax.Meta_labeled
-                                 (l, r, uu____13238) ->
+                                 (l, r, uu___7) ->
                                  norm cfg env1 ((Meta (env1, m, r)) ::
                                    stack1) head
                              | FStar_Syntax_Syntax.Meta_pattern (names, args)
@@ -4329,7 +4256,7 @@ let rec (norm :
                                             (names1, args1)),
                                          (t1.FStar_Syntax_Syntax.pos))) ::
                                    stack1) head
-                             | uu____13313 -> norm cfg env1 stack1 head)
+                             | uu___7 -> norm cfg env1 stack1 head)
                         | [] ->
                             let head1 = norm cfg env1 [] head in
                             let m1 =
@@ -4339,42 +4266,40 @@ let rec (norm :
                                   let names1 =
                                     FStar_All.pipe_right names
                                       (FStar_List.map (norm cfg env1 [])) in
-                                  let uu____13361 =
-                                    let uu____13382 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       norm_pattern_args cfg env1 args in
-                                    (names1, uu____13382) in
-                                  FStar_Syntax_Syntax.Meta_pattern
-                                    uu____13361
-                              | uu____13411 -> m in
+                                    (names1, uu___6) in
+                                  FStar_Syntax_Syntax.Meta_pattern uu___5
+                              | uu___5 -> m in
                             let t2 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_meta (head1, m1))
                                 t1.FStar_Syntax_Syntax.pos in
                             rebuild cfg env1 stack1 t2)))
-           | FStar_Syntax_Syntax.Tm_delayed uu____13417 ->
+           | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
                let t2 = FStar_Syntax_Subst.compress t1 in
                norm cfg env1 stack1 t2
-           | FStar_Syntax_Syntax.Tm_uvar uu____13433 ->
+           | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
                let t2 = FStar_Syntax_Subst.compress t1 in
                (match t2.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_uvar uu____13447 ->
+                | FStar_Syntax_Syntax.Tm_uvar uu___3 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
                     then
-                      let uu____13460 =
-                        let uu____13461 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Range.string_of_range
                             t2.FStar_Syntax_Syntax.pos in
-                        let uu____13462 =
-                          FStar_Syntax_Print.term_to_string t2 in
+                        let uu___6 = FStar_Syntax_Print.term_to_string t2 in
                         FStar_Util.format2
                           "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu____13461 uu____13462 in
-                      failwith uu____13460
+                          uu___5 uu___6 in
+                      failwith uu___4
                     else
-                      (let uu____13464 = inline_closure_env cfg env1 [] t2 in
-                       rebuild cfg env1 stack1 uu____13464)
-                | uu____13465 -> norm cfg env1 stack1 t2))
+                      (let uu___5 = inline_closure_env cfg env1 [] t2 in
+                       rebuild cfg env1 stack1 uu___5)
+                | uu___3 -> norm cfg env1 stack1 t2))
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -4389,27 +4314,26 @@ and (do_unfold_fv :
         fun t0 ->
           fun qninfo ->
             fun f ->
-              let uu____13474 =
+              let uu___ =
                 FStar_TypeChecker_Env.lookup_definition_qninfo
                   cfg.FStar_TypeChecker_Cfg.delta_level
                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   qninfo in
-              match uu____13474 with
+              match uu___ with
               | FStar_Pervasives_Native.None ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____13488 ->
-                        let uu____13489 = FStar_Syntax_Print.fv_to_string f in
+                     (fun uu___2 ->
+                        let uu___3 = FStar_Syntax_Print.fv_to_string f in
                         FStar_Util.print1 " >> Tm_fvar case 2 for %s\n"
-                          uu____13489);
+                          uu___3);
                    rebuild cfg env1 stack1 t0)
               | FStar_Pervasives_Native.Some (us, t) ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____13500 ->
-                        let uu____13501 =
-                          FStar_Syntax_Print.term_to_string t0 in
-                        let uu____13502 = FStar_Syntax_Print.term_to_string t in
-                        FStar_Util.print2 " >> Unfolded %s to %s\n"
-                          uu____13501 uu____13502);
+                     (fun uu___2 ->
+                        let uu___3 = FStar_Syntax_Print.term_to_string t0 in
+                        let uu___4 = FStar_Syntax_Print.term_to_string t in
+                        FStar_Util.print2 " >> Unfolded %s to %s\n" uu___3
+                          uu___4);
                    (let t1 =
                       if
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
@@ -4424,44 +4348,44 @@ and (do_unfold_fv :
                     if n > Prims.int_zero
                     then
                       match stack1 with
-                      | (UnivArgs (us', uu____13509))::stack2 ->
-                          ((let uu____13518 =
+                      | (UnivArgs (us', uu___2))::stack2 ->
+                          ((let uu___4 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug
                                    cfg.FStar_TypeChecker_Cfg.tcenv)
                                 (FStar_Options.Other "univ_norm") in
-                            if uu____13518
+                            if uu___4
                             then
                               FStar_List.iter
                                 (fun x ->
-                                   let uu____13522 =
+                                   let uu___5 =
                                      FStar_Syntax_Print.univ_to_string x in
                                    FStar_Util.print1 "Univ (normalizer) %s\n"
-                                     uu____13522) us'
+                                     uu___5) us'
                             else ());
                            (let env2 =
                               FStar_All.pipe_right us'
                                 (FStar_List.fold_left
-                                   (fun env2 ->
+                                   (fun env3 ->
                                       fun u ->
                                         (FStar_Pervasives_Native.None,
                                           (Univ u))
-                                        :: env2) env1) in
+                                        :: env3) env1) in
                             norm cfg env2 stack2 t1))
-                      | uu____13555 when
+                      | uu___2 when
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                             ||
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                           -> norm cfg env1 stack1 t1
-                      | uu____13558 ->
-                          let uu____13561 =
-                            let uu____13562 =
+                      | uu___2 ->
+                          let uu___3 =
+                            let uu___4 =
                               FStar_Syntax_Print.lid_to_string
                                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                             FStar_Util.format1
                               "Impossible: missing universe instantiation on %s"
-                              uu____13562 in
-                          failwith uu____13561
+                              uu___4 in
+                          failwith uu___3
                     else norm cfg env1 stack1 t1))
 and (reduce_impure_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -4480,7 +4404,7 @@ and (reduce_impure_comp :
           fun m ->
             fun t ->
               let t1 = norm cfg env1 [] t in
-              let uu____13579 =
+              let uu___ =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations
                 then
@@ -4492,34 +4416,34 @@ and (reduce_impure_comp :
                     FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                     FStar_TypeChecker_Env.Inlining] in
                   let cfg' =
-                    let uu___1865_13596 = cfg in
-                    let uu____13597 =
+                    let uu___1 = cfg in
+                    let uu___2 =
                       FStar_List.fold_right
                         FStar_TypeChecker_Cfg.fstep_add_one new_steps
                         cfg.FStar_TypeChecker_Cfg.steps in
                     {
-                      FStar_TypeChecker_Cfg.steps = uu____13597;
+                      FStar_TypeChecker_Cfg.steps = uu___2;
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.debug);
+                        (uu___1.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
                         [FStar_TypeChecker_Env.InliningDelta;
                         FStar_TypeChecker_Env.Eager_unfolding_only];
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.strong);
+                        (uu___1.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1865_13596.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1.FStar_TypeChecker_Cfg.reifying)
                     } in
                   (cfg', ((Cfg cfg) :: stack1))
                 else (cfg, stack1) in
-              match uu____13579 with
+              match uu___ with
               | (cfg1, stack2) ->
                   let metadata =
                     match m with
@@ -4548,36 +4472,34 @@ and (do_reify_monadic :
               fun t ->
                 (match stack1 with
                  | (App
-                     (uu____13637,
+                     (uu___1,
                       {
                         FStar_Syntax_Syntax.n =
                           FStar_Syntax_Syntax.Tm_constant
                           (FStar_Const.Const_reify);
-                        FStar_Syntax_Syntax.pos = uu____13638;
-                        FStar_Syntax_Syntax.vars = uu____13639;_},
-                      uu____13640, uu____13641))::uu____13642
+                        FStar_Syntax_Syntax.pos = uu___2;
+                        FStar_Syntax_Syntax.vars = uu___3;_},
+                      uu___4, uu___5))::uu___6
                      -> ()
-                 | uu____13647 ->
-                     let uu____13650 =
-                       let uu____13651 = stack_to_string stack1 in
+                 | uu___1 ->
+                     let uu___2 =
+                       let uu___3 = stack_to_string stack1 in
                        FStar_Util.format1
                          "INTERNAL ERROR: do_reify_monadic: bad stack: %s"
-                         uu____13651 in
-                     failwith uu____13650);
+                         uu___3 in
+                     failwith uu___2);
                 (let top0 = top in
                  let top1 = FStar_Syntax_Util.unascribe top in
                  FStar_TypeChecker_Cfg.log cfg
-                   (fun uu____13658 ->
-                      let uu____13659 = FStar_Syntax_Print.tag_of_term top1 in
-                      let uu____13660 =
-                        FStar_Syntax_Print.term_to_string top1 in
-                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____13659
-                        uu____13660);
+                   (fun uu___2 ->
+                      let uu___3 = FStar_Syntax_Print.tag_of_term top1 in
+                      let uu___4 = FStar_Syntax_Print.term_to_string top1 in
+                      FStar_Util.print2 "Reifying: (%s) %s\n" uu___3 uu___4);
                  (let top2 = FStar_Syntax_Util.unmeta_safe top1 in
-                  let uu____13662 =
-                    let uu____13663 = FStar_Syntax_Subst.compress top2 in
-                    uu____13663.FStar_Syntax_Syntax.n in
-                  match uu____13662 with
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Subst.compress top2 in
+                    uu___3.FStar_Syntax_Syntax.n in
+                  match uu___2 with
                   | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
                       let eff_name =
                         FStar_TypeChecker_Env.norm_eff_name
@@ -4585,113 +4507,109 @@ and (do_reify_monadic :
                       let ed =
                         FStar_TypeChecker_Env.get_effect_decl
                           cfg.FStar_TypeChecker_Cfg.tcenv eff_name in
-                      let uu____13682 =
-                        let uu____13691 =
+                      let uu___3 =
+                        let uu___4 =
                           FStar_All.pipe_right ed
                             FStar_Syntax_Util.get_eff_repr in
-                        FStar_All.pipe_right uu____13691 FStar_Util.must in
-                      (match uu____13682 with
-                       | (uu____13706, repr) ->
-                           let uu____13716 =
-                             let uu____13723 =
+                        FStar_All.pipe_right uu___4 FStar_Util.must in
+                      (match uu___3 with
+                       | (uu___4, repr) ->
+                           let uu___5 =
+                             let uu___6 =
                                FStar_All.pipe_right ed
                                  FStar_Syntax_Util.get_bind_repr in
-                             FStar_All.pipe_right uu____13723 FStar_Util.must in
-                           (match uu____13716 with
-                            | (uu____13760, bind_repr) ->
+                             FStar_All.pipe_right uu___6 FStar_Util.must in
+                           (match uu___5 with
+                            | (uu___6, bind_repr) ->
                                 (match lb.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____13766 ->
+                                 | FStar_Util.Inr uu___7 ->
                                      failwith
                                        "Cannot reify a top-level let binding"
                                  | FStar_Util.Inl x ->
                                      let is_return e =
-                                       let uu____13776 =
-                                         let uu____13777 =
+                                       let uu___7 =
+                                         let uu___8 =
                                            FStar_Syntax_Subst.compress e in
-                                         uu____13777.FStar_Syntax_Syntax.n in
-                                       match uu____13776 with
+                                         uu___8.FStar_Syntax_Syntax.n in
+                                       match uu___7 with
                                        | FStar_Syntax_Syntax.Tm_meta
                                            (e1,
                                             FStar_Syntax_Syntax.Meta_monadic
-                                            (uu____13783, uu____13784))
+                                            (uu___8, uu___9))
                                            ->
-                                           let uu____13793 =
-                                             let uu____13794 =
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_Syntax_Subst.compress e1 in
-                                             uu____13794.FStar_Syntax_Syntax.n in
-                                           (match uu____13793 with
+                                             uu___11.FStar_Syntax_Syntax.n in
+                                           (match uu___10 with
                                             | FStar_Syntax_Syntax.Tm_meta
                                                 (e2,
                                                  FStar_Syntax_Syntax.Meta_monadic_lift
-                                                 (uu____13800, msrc,
-                                                  uu____13802))
+                                                 (uu___11, msrc, uu___12))
                                                 when
                                                 FStar_Syntax_Util.is_pure_effect
                                                   msrc
                                                 ->
-                                                let uu____13811 =
+                                                let uu___13 =
                                                   FStar_Syntax_Subst.compress
                                                     e2 in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____13811
-                                            | uu____13812 ->
+                                                  uu___13
+                                            | uu___11 ->
                                                 FStar_Pervasives_Native.None)
-                                       | uu____13813 ->
+                                       | uu___8 ->
                                            FStar_Pervasives_Native.None in
-                                     let uu____13814 =
+                                     let uu___7 =
                                        is_return lb.FStar_Syntax_Syntax.lbdef in
-                                     (match uu____13814 with
+                                     (match uu___7 with
                                       | FStar_Pervasives_Native.Some e ->
                                           let lb1 =
-                                            let uu___1944_13819 = lb in
+                                            let uu___8 = lb in
                                             {
                                               FStar_Syntax_Syntax.lbname =
-                                                (uu___1944_13819.FStar_Syntax_Syntax.lbname);
+                                                (uu___8.FStar_Syntax_Syntax.lbname);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___1944_13819.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___8.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___1944_13819.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___8.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.lbdef = e;
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___1944_13819.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___8.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___1944_13819.FStar_Syntax_Syntax.lbpos)
+                                                (uu___8.FStar_Syntax_Syntax.lbpos)
                                             } in
-                                          let uu____13820 =
-                                            FStar_List.tl stack1 in
-                                          let uu____13821 =
-                                            let uu____13822 =
-                                              let uu____13823 =
-                                                let uu____13836 =
+                                          let uu___8 = FStar_List.tl stack1 in
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
+                                                let uu___12 =
                                                   FStar_Syntax_Util.mk_reify
                                                     body in
-                                                ((false, [lb1]), uu____13836) in
+                                                ((false, [lb1]), uu___12) in
                                               FStar_Syntax_Syntax.Tm_let
-                                                uu____13823 in
-                                            FStar_Syntax_Syntax.mk
-                                              uu____13822
+                                                uu___11 in
+                                            FStar_Syntax_Syntax.mk uu___10
                                               top2.FStar_Syntax_Syntax.pos in
-                                          norm cfg env1 uu____13820
-                                            uu____13821
+                                          norm cfg env1 uu___8 uu___9
                                       | FStar_Pervasives_Native.None ->
-                                          let uu____13849 =
-                                            let uu____13850 = is_return body in
-                                            match uu____13850 with
+                                          let uu___8 =
+                                            let uu___9 = is_return body in
+                                            match uu___9 with
                                             | FStar_Pervasives_Native.Some
                                                 {
                                                   FStar_Syntax_Syntax.n =
                                                     FStar_Syntax_Syntax.Tm_bvar
                                                     y;
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____13854;
+                                                    uu___10;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____13855;_}
+                                                    uu___11;_}
                                                 ->
                                                 FStar_Syntax_Syntax.bv_eq x y
-                                            | uu____13858 -> false in
-                                          if uu____13849
+                                            | uu___10 -> false in
+                                          if uu___8
                                           then
                                             norm cfg env1 stack1
                                               lb.FStar_Syntax_Syntax.lbdef
@@ -4718,94 +4636,92 @@ and (do_reify_monadic :
                                                    = []
                                                } in
                                              let body2 =
-                                               let uu____13883 =
-                                                 let uu____13884 =
-                                                   let uu____13903 =
-                                                     let uu____13912 =
+                                               let uu___10 =
+                                                 let uu___11 =
+                                                   let uu___12 =
+                                                     let uu___13 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          x in
-                                                     [uu____13912] in
-                                                   (uu____13903, body1,
+                                                     [uu___13] in
+                                                   (uu___12, body1,
                                                      (FStar_Pervasives_Native.Some
                                                         body_rc)) in
                                                  FStar_Syntax_Syntax.Tm_abs
-                                                   uu____13884 in
-                                               FStar_Syntax_Syntax.mk
-                                                 uu____13883
+                                                   uu___11 in
+                                               FStar_Syntax_Syntax.mk uu___10
                                                  body1.FStar_Syntax_Syntax.pos in
                                              let close =
                                                closure_as_term cfg env1 in
                                              let bind_inst =
-                                               let uu____13951 =
-                                                 let uu____13952 =
+                                               let uu___10 =
+                                                 let uu___11 =
                                                    FStar_Syntax_Subst.compress
                                                      bind_repr in
-                                                 uu____13952.FStar_Syntax_Syntax.n in
-                                               match uu____13951 with
+                                                 uu___11.FStar_Syntax_Syntax.n in
+                                               match uu___10 with
                                                | FStar_Syntax_Syntax.Tm_uinst
                                                    (bind,
-                                                    uu____13958::uu____13959::[])
+                                                    uu___11::uu___12::[])
                                                    ->
-                                                   let uu____13964 =
-                                                     let uu____13965 =
-                                                       let uu____13972 =
-                                                         let uu____13973 =
-                                                           let uu____13974 =
+                                                   let uu___13 =
+                                                     let uu___14 =
+                                                       let uu___15 =
+                                                         let uu___16 =
+                                                           let uu___17 =
                                                              close
                                                                lb.FStar_Syntax_Syntax.lbtyp in
                                                            (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                              cfg.FStar_TypeChecker_Cfg.tcenv
-                                                             uu____13974 in
-                                                         let uu____13975 =
-                                                           let uu____13978 =
-                                                             let uu____13979
-                                                               = close t in
+                                                             uu___17 in
+                                                         let uu___17 =
+                                                           let uu___18 =
+                                                             let uu___19 =
+                                                               close t in
                                                              (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                                cfg.FStar_TypeChecker_Cfg.tcenv
-                                                               uu____13979 in
-                                                           [uu____13978] in
-                                                         uu____13973 ::
-                                                           uu____13975 in
-                                                       (bind, uu____13972) in
+                                                               uu___19 in
+                                                           [uu___18] in
+                                                         uu___16 :: uu___17 in
+                                                       (bind, uu___15) in
                                                      FStar_Syntax_Syntax.Tm_uinst
-                                                       uu____13965 in
+                                                       uu___14 in
                                                    FStar_Syntax_Syntax.mk
-                                                     uu____13964 rng
-                                               | uu____13982 ->
+                                                     uu___13 rng
+                                               | uu___11 ->
                                                    failwith
                                                      "NIY : Reification of indexed effects" in
                                              let bind_inst_args f_arg =
-                                               let uu____13993 =
+                                               let uu___10 =
                                                  FStar_Syntax_Util.is_layered
                                                    ed in
-                                               if uu____13993
+                                               if uu___10
                                                then
                                                  let unit_args =
-                                                   let uu____13999 =
-                                                     let uu____14000 =
-                                                       let uu____14003 =
-                                                         let uu____14004 =
+                                                   let uu___11 =
+                                                     let uu___12 =
+                                                       let uu___13 =
+                                                         let uu___14 =
                                                            FStar_All.pipe_right
                                                              ed
                                                              FStar_Syntax_Util.get_bind_vc_combinator in
                                                          FStar_All.pipe_right
-                                                           uu____14004
+                                                           uu___14
                                                            FStar_Pervasives_Native.snd in
                                                        FStar_All.pipe_right
-                                                         uu____14003
+                                                         uu___13
                                                          FStar_Syntax_Subst.compress in
-                                                     uu____14000.FStar_Syntax_Syntax.n in
-                                                   match uu____13999 with
+                                                     uu___12.FStar_Syntax_Syntax.n in
+                                                   match uu___11 with
                                                    | FStar_Syntax_Syntax.Tm_arrow
-                                                       (uu____14037::uu____14038::bs,
-                                                        uu____14040)
+                                                       (uu___12::uu___13::bs,
+                                                        uu___14)
                                                        when
                                                        (FStar_List.length bs)
                                                          >=
                                                          (Prims.of_int (2))
                                                        ->
-                                                       let uu____14091 =
-                                                         let uu____14100 =
+                                                       let uu___15 =
+                                                         let uu___16 =
                                                            FStar_All.pipe_right
                                                              bs
                                                              (FStar_List.splitAt
@@ -4814,136 +4730,125 @@ and (do_reify_monadic :
                                                                    -
                                                                    (Prims.of_int (2)))) in
                                                          FStar_All.pipe_right
-                                                           uu____14100
+                                                           uu___16
                                                            FStar_Pervasives_Native.fst in
                                                        FStar_All.pipe_right
-                                                         uu____14091
+                                                         uu___15
                                                          (FStar_List.map
-                                                            (fun uu____14222
-                                                               ->
+                                                            (fun uu___16 ->
                                                                FStar_Syntax_Syntax.as_arg
                                                                  FStar_Syntax_Syntax.unit_const))
-                                                   | uu____14229 ->
-                                                       let uu____14230 =
-                                                         let uu____14235 =
-                                                           let uu____14236 =
+                                                   | uu___12 ->
+                                                       let uu___13 =
+                                                         let uu___14 =
+                                                           let uu___15 =
                                                              FStar_Ident.string_of_lid
                                                                ed.FStar_Syntax_Syntax.mname in
-                                                           let uu____14237 =
-                                                             let uu____14238
-                                                               =
-                                                               let uu____14239
-                                                                 =
+                                                           let uu___16 =
+                                                             let uu___17 =
+                                                               let uu___18 =
                                                                  FStar_All.pipe_right
                                                                    ed
                                                                    FStar_Syntax_Util.get_bind_vc_combinator in
                                                                FStar_All.pipe_right
-                                                                 uu____14239
+                                                                 uu___18
                                                                  FStar_Pervasives_Native.snd in
                                                              FStar_All.pipe_right
-                                                               uu____14238
+                                                               uu___17
                                                                FStar_Syntax_Print.term_to_string in
                                                            FStar_Util.format2
                                                              "bind_wp for layered effect %s is not an arrow with >= 4 arguments (%s)"
-                                                             uu____14236
-                                                             uu____14237 in
+                                                             uu___15 uu___16 in
                                                          (FStar_Errors.Fatal_UnexpectedEffect,
-                                                           uu____14235) in
+                                                           uu___14) in
                                                        FStar_Errors.raise_error
-                                                         uu____14230 rng in
-                                                 let uu____14262 =
+                                                         uu___13 rng in
+                                                 let uu___11 =
                                                    FStar_Syntax_Syntax.as_arg
                                                      lb.FStar_Syntax_Syntax.lbtyp in
-                                                 let uu____14263 =
-                                                   let uu____14266 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        t in
-                                                   let uu____14267 =
-                                                     let uu____14270 =
-                                                       let uu____14273 =
+                                                   let uu___14 =
+                                                     let uu___15 =
+                                                       let uu___16 =
                                                          FStar_Syntax_Syntax.as_arg
                                                            f_arg in
-                                                       let uu____14274 =
-                                                         let uu____14277 =
+                                                       let uu___17 =
+                                                         let uu___18 =
                                                            FStar_Syntax_Syntax.as_arg
                                                              body2 in
-                                                         [uu____14277] in
-                                                       uu____14273 ::
-                                                         uu____14274 in
+                                                         [uu___18] in
+                                                       uu___16 :: uu___17 in
                                                      FStar_List.append
-                                                       unit_args uu____14270 in
-                                                   uu____14266 :: uu____14267 in
-                                                 uu____14262 :: uu____14263
+                                                       unit_args uu___15 in
+                                                   uu___13 :: uu___14 in
+                                                 uu___11 :: uu___12
                                                else
                                                  (let maybe_range_arg =
-                                                    let uu____14282 =
+                                                    let uu___12 =
                                                       FStar_Util.for_some
                                                         (FStar_Syntax_Util.attr_eq
                                                            FStar_Syntax_Util.dm4f_bind_range_attr)
                                                         ed.FStar_Syntax_Syntax.eff_attrs in
-                                                    if uu____14282
+                                                    if uu___12
                                                     then
-                                                      let uu____14285 =
-                                                        let uu____14286 =
+                                                      let uu___13 =
+                                                        let uu___14 =
                                                           FStar_TypeChecker_Cfg.embed_simple
                                                             FStar_Syntax_Embeddings.e_range
                                                             lb.FStar_Syntax_Syntax.lbpos
                                                             lb.FStar_Syntax_Syntax.lbpos in
                                                         FStar_Syntax_Syntax.as_arg
-                                                          uu____14286 in
-                                                      let uu____14287 =
-                                                        let uu____14290 =
-                                                          let uu____14291 =
+                                                          uu___14 in
+                                                      let uu___14 =
+                                                        let uu___15 =
+                                                          let uu___16 =
                                                             FStar_TypeChecker_Cfg.embed_simple
                                                               FStar_Syntax_Embeddings.e_range
                                                               body2.FStar_Syntax_Syntax.pos
                                                               body2.FStar_Syntax_Syntax.pos in
                                                           FStar_Syntax_Syntax.as_arg
-                                                            uu____14291 in
-                                                        [uu____14290] in
-                                                      uu____14285 ::
-                                                        uu____14287
+                                                            uu___16 in
+                                                        [uu___15] in
+                                                      uu___13 :: uu___14
                                                     else [] in
-                                                  let uu____14293 =
-                                                    let uu____14296 =
+                                                  let uu___12 =
+                                                    let uu___13 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         lb.FStar_Syntax_Syntax.lbtyp in
-                                                    let uu____14297 =
-                                                      let uu____14300 =
+                                                    let uu___14 =
+                                                      let uu___15 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           t in
-                                                      [uu____14300] in
-                                                    uu____14296 ::
-                                                      uu____14297 in
-                                                  let uu____14301 =
-                                                    let uu____14304 =
-                                                      let uu____14307 =
+                                                      [uu___15] in
+                                                    uu___13 :: uu___14 in
+                                                  let uu___13 =
+                                                    let uu___14 =
+                                                      let uu___15 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           FStar_Syntax_Syntax.tun in
-                                                      let uu____14308 =
-                                                        let uu____14311 =
+                                                      let uu___16 =
+                                                        let uu___17 =
                                                           FStar_Syntax_Syntax.as_arg
                                                             f_arg in
-                                                        let uu____14312 =
-                                                          let uu____14315 =
+                                                        let uu___18 =
+                                                          let uu___19 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               FStar_Syntax_Syntax.tun in
-                                                          let uu____14316 =
-                                                            let uu____14319 =
+                                                          let uu___20 =
+                                                            let uu___21 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 body2 in
-                                                            [uu____14319] in
-                                                          uu____14315 ::
-                                                            uu____14316 in
-                                                        uu____14311 ::
-                                                          uu____14312 in
-                                                      uu____14307 ::
-                                                        uu____14308 in
+                                                            [uu___21] in
+                                                          uu___19 :: uu___20 in
+                                                        uu___17 :: uu___18 in
+                                                      uu___15 :: uu___16 in
                                                     FStar_List.append
-                                                      maybe_range_arg
-                                                      uu____14304 in
-                                                  FStar_List.append
-                                                    uu____14293 uu____14301) in
+                                                      maybe_range_arg uu___14 in
+                                                  FStar_List.append uu___12
+                                                    uu___13) in
                                              let reified =
                                                let is_total_effect =
                                                  FStar_TypeChecker_Env.is_total_effect
@@ -4951,30 +4856,30 @@ and (do_reify_monadic :
                                                    eff_name in
                                                if is_total_effect
                                                then
-                                                 let uu____14322 =
-                                                   let uu____14323 =
-                                                     let uu____14340 =
+                                                 let uu___10 =
+                                                   let uu___11 =
+                                                     let uu___12 =
                                                        bind_inst_args head in
-                                                     (bind_inst, uu____14340) in
+                                                     (bind_inst, uu___12) in
                                                    FStar_Syntax_Syntax.Tm_app
-                                                     uu____14323 in
+                                                     uu___11 in
                                                  FStar_Syntax_Syntax.mk
-                                                   uu____14322 rng
+                                                   uu___10 rng
                                                else
-                                                 (let uu____14364 =
+                                                 (let uu___11 =
                                                     let bv =
                                                       FStar_Syntax_Syntax.new_bv
                                                         FStar_Pervasives_Native.None
                                                         x.FStar_Syntax_Syntax.sort in
                                                     let lb1 =
-                                                      let uu____14373 =
-                                                        let uu____14376 =
-                                                          let uu____14387 =
+                                                      let uu___12 =
+                                                        let uu___13 =
+                                                          let uu___14 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               x.FStar_Syntax_Syntax.sort in
-                                                          [uu____14387] in
+                                                          [uu___14] in
                                                         FStar_Syntax_Util.mk_app
-                                                          repr uu____14376 in
+                                                          repr uu___13 in
                                                       {
                                                         FStar_Syntax_Syntax.lbname
                                                           =
@@ -4982,7 +4887,7 @@ and (do_reify_monadic :
                                                         FStar_Syntax_Syntax.lbunivs
                                                           = [];
                                                         FStar_Syntax_Syntax.lbtyp
-                                                          = uu____14373;
+                                                          = uu___12;
                                                         FStar_Syntax_Syntax.lbeff
                                                           =
                                                           (if is_total_effect
@@ -4998,202 +4903,193 @@ and (do_reify_monadic :
                                                           =
                                                           (head.FStar_Syntax_Syntax.pos)
                                                       } in
-                                                    let uu____14415 =
+                                                    let uu___12 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         bv in
-                                                    (lb1, bv, uu____14415) in
-                                                  match uu____14364 with
+                                                    (lb1, bv, uu___12) in
+                                                  match uu___11 with
                                                   | (lb_head, head_bv, head1)
                                                       ->
-                                                      let uu____14419 =
-                                                        let uu____14420 =
-                                                          let uu____14433 =
-                                                            let uu____14436 =
-                                                              let uu____14443
-                                                                =
-                                                                let uu____14444
-                                                                  =
+                                                      let uu___12 =
+                                                        let uu___13 =
+                                                          let uu___14 =
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                let uu___17 =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     head_bv in
-                                                                [uu____14444] in
+                                                                [uu___17] in
                                                               FStar_Syntax_Subst.close
-                                                                uu____14443 in
-                                                            let uu____14463 =
-                                                              let uu____14464
-                                                                =
-                                                                let uu____14465
-                                                                  =
-                                                                  let uu____14482
+                                                                uu___16 in
+                                                            let uu___16 =
+                                                              let uu___17 =
+                                                                let uu___18 =
+                                                                  let uu___19
                                                                     =
                                                                     bind_inst_args
                                                                     head1 in
                                                                   (bind_inst,
-                                                                    uu____14482) in
+                                                                    uu___19) in
                                                                 FStar_Syntax_Syntax.Tm_app
-                                                                  uu____14465 in
+                                                                  uu___18 in
                                                               FStar_Syntax_Syntax.mk
-                                                                uu____14464
-                                                                rng in
+                                                                uu___17 rng in
                                                             FStar_All.pipe_left
-                                                              uu____14436
-                                                              uu____14463 in
+                                                              uu___15 uu___16 in
                                                           ((false, [lb_head]),
-                                                            uu____14433) in
+                                                            uu___14) in
                                                         FStar_Syntax_Syntax.Tm_let
-                                                          uu____14420 in
+                                                          uu___13 in
                                                       FStar_Syntax_Syntax.mk
-                                                        uu____14419 rng) in
+                                                        uu___12 rng) in
                                              FStar_TypeChecker_Cfg.log cfg
-                                               (fun uu____14521 ->
-                                                  let uu____14522 =
+                                               (fun uu___11 ->
+                                                  let uu___12 =
                                                     FStar_Syntax_Print.term_to_string
                                                       top0 in
-                                                  let uu____14523 =
+                                                  let uu___13 =
                                                     FStar_Syntax_Print.term_to_string
                                                       reified in
                                                   FStar_Util.print2
                                                     "Reified (1) <%s> to %s\n"
-                                                    uu____14522 uu____14523);
-                                             (let uu____14524 =
+                                                    uu___12 uu___13);
+                                             (let uu___11 =
                                                 FStar_List.tl stack1 in
-                                              norm cfg env1 uu____14524
-                                                reified))))))
+                                              norm cfg env1 uu___11 reified))))))
                   | FStar_Syntax_Syntax.Tm_app (head, args) ->
-                      ((let uu____14552 = FStar_Options.defensive () in
-                        if uu____14552
+                      ((let uu___4 = FStar_Options.defensive () in
+                        if uu___4
                         then
-                          let is_arg_impure uu____14564 =
-                            match uu____14564 with
+                          let is_arg_impure uu___5 =
+                            match uu___5 with
                             | (e, q) ->
-                                let uu____14577 =
-                                  let uu____14578 =
-                                    FStar_Syntax_Subst.compress e in
-                                  uu____14578.FStar_Syntax_Syntax.n in
-                                (match uu____14577 with
+                                let uu___6 =
+                                  let uu___7 = FStar_Syntax_Subst.compress e in
+                                  uu___7.FStar_Syntax_Syntax.n in
+                                (match uu___6 with
                                  | FStar_Syntax_Syntax.Tm_meta
                                      (e0,
                                       FStar_Syntax_Syntax.Meta_monadic_lift
                                       (m1, m2, t'))
                                      ->
-                                     let uu____14593 =
+                                     let uu___7 =
                                        FStar_Syntax_Util.is_pure_effect m1 in
-                                     Prims.op_Negation uu____14593
-                                 | uu____14594 -> false) in
-                          let uu____14595 =
-                            let uu____14596 =
-                              let uu____14607 =
-                                FStar_Syntax_Syntax.as_arg head in
-                              uu____14607 :: args in
-                            FStar_Util.for_some is_arg_impure uu____14596 in
-                          (if uu____14595
+                                     Prims.op_Negation uu___7
+                                 | uu___7 -> false) in
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 = FStar_Syntax_Syntax.as_arg head in
+                              uu___7 :: args in
+                            FStar_Util.for_some is_arg_impure uu___6 in
+                          (if uu___5
                            then
-                             let uu____14632 =
-                               let uu____14637 =
-                                 let uu____14638 =
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Print.term_to_string top2 in
                                  FStar_Util.format1
                                    "Incompatibility between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                   uu____14638 in
-                               (FStar_Errors.Warning_Defensive, uu____14637) in
+                                   uu___8 in
+                               (FStar_Errors.Warning_Defensive, uu___7) in
                              FStar_Errors.log_issue
-                               top2.FStar_Syntax_Syntax.pos uu____14632
+                               top2.FStar_Syntax_Syntax.pos uu___6
                            else ())
                         else ());
-                       (let fallback1 uu____14646 =
+                       (let fallback1 uu___4 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____14650 ->
-                               let uu____14651 =
+                            (fun uu___6 ->
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string top0 in
                                FStar_Util.print2 "Reified (2) <%s> to %s\n"
-                                 uu____14651 "");
-                          (let uu____14652 = FStar_List.tl stack1 in
-                           let uu____14653 = FStar_Syntax_Util.mk_reify top2 in
-                           norm cfg env1 uu____14652 uu____14653) in
-                        let fallback2 uu____14659 =
+                                 uu___7 "");
+                          (let uu___6 = FStar_List.tl stack1 in
+                           let uu___7 = FStar_Syntax_Util.mk_reify top2 in
+                           norm cfg env1 uu___6 uu___7) in
+                        let fallback2 uu___4 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____14663 ->
-                               let uu____14664 =
+                            (fun uu___6 ->
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string top0 in
                                FStar_Util.print2 "Reified (3) <%s> to %s\n"
-                                 uu____14664 "");
-                          (let uu____14665 = FStar_List.tl stack1 in
-                           let uu____14666 =
+                                 uu___7 "");
+                          (let uu___6 = FStar_List.tl stack1 in
+                           let uu___7 =
                              FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_meta
                                   (top2,
                                     (FStar_Syntax_Syntax.Meta_monadic (m, t))))
                                top0.FStar_Syntax_Syntax.pos in
-                           norm cfg env1 uu____14665 uu____14666) in
-                        let uu____14671 =
-                          let uu____14672 = FStar_Syntax_Util.un_uinst head in
-                          uu____14672.FStar_Syntax_Syntax.n in
-                        match uu____14671 with
+                           norm cfg env1 uu___6 uu___7) in
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Util.un_uinst head in
+                          uu___5.FStar_Syntax_Syntax.n in
+                        match uu___4 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                             let qninfo =
                               FStar_TypeChecker_Env.lookup_qname
                                 cfg.FStar_TypeChecker_Cfg.tcenv lid in
-                            let uu____14678 =
-                              let uu____14679 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_TypeChecker_Env.is_action
                                   cfg.FStar_TypeChecker_Cfg.tcenv lid in
-                              Prims.op_Negation uu____14679 in
-                            if uu____14678
+                              Prims.op_Negation uu___6 in
+                            if uu___5
                             then fallback1 ()
                             else
-                              (let uu____14681 =
-                                 let uu____14682 =
+                              (let uu___7 =
+                                 let uu___8 =
                                    FStar_TypeChecker_Env.lookup_definition_qninfo
                                      cfg.FStar_TypeChecker_Cfg.delta_level
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
-                                 FStar_Option.isNone uu____14682 in
-                               if uu____14681
+                                 FStar_Option.isNone uu___8 in
+                               if uu___7
                                then fallback2 ()
                                else
                                  (let t1 =
-                                    let uu____14695 =
+                                    let uu___9 =
                                       FStar_Syntax_Util.mk_reify head in
-                                    FStar_Syntax_Syntax.mk_Tm_app uu____14695
-                                      args t.FStar_Syntax_Syntax.pos in
-                                  let uu____14696 = FStar_List.tl stack1 in
-                                  norm cfg env1 uu____14696 t1))
-                        | uu____14697 -> fallback1 ()))
+                                    FStar_Syntax_Syntax.mk_Tm_app uu___9 args
+                                      t.FStar_Syntax_Syntax.pos in
+                                  let uu___9 = FStar_List.tl stack1 in
+                                  norm cfg env1 uu___9 t1))
+                        | uu___5 -> fallback1 ()))
                   | FStar_Syntax_Syntax.Tm_meta
-                      (e, FStar_Syntax_Syntax.Meta_monadic uu____14699) ->
+                      (e, FStar_Syntax_Syntax.Meta_monadic uu___3) ->
                       do_reify_monadic fallback cfg env1 stack1 e m t
                   | FStar_Syntax_Syntax.Tm_meta
                       (e, FStar_Syntax_Syntax.Meta_monadic_lift
                        (msrc, mtgt, t'))
                       ->
                       let lifted =
-                        let uu____14723 = closure_as_term cfg env1 t' in
-                        reify_lift cfg e msrc mtgt uu____14723 in
+                        let uu___3 = closure_as_term cfg env1 t' in
+                        reify_lift cfg e msrc mtgt uu___3 in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____14727 ->
-                            let uu____14728 =
+                         (fun uu___4 ->
+                            let uu___5 =
                               FStar_Syntax_Print.term_to_string lifted in
                             FStar_Util.print1 "Reified lift to (2): %s\n"
-                              uu____14728);
-                       (let uu____14729 = FStar_List.tl stack1 in
-                        norm cfg env1 uu____14729 lifted))
+                              uu___5);
+                       (let uu___4 = FStar_List.tl stack1 in
+                        norm cfg env1 uu___4 lifted))
                   | FStar_Syntax_Syntax.Tm_match (e, branches1) ->
                       let branches2 =
                         FStar_All.pipe_right branches1
                           (FStar_List.map
-                             (fun uu____14850 ->
-                                match uu____14850 with
+                             (fun uu___3 ->
+                                match uu___3 with
                                 | (pat, wopt, tm) ->
-                                    let uu____14898 =
+                                    let uu___4 =
                                       FStar_Syntax_Util.mk_reify tm in
-                                    (pat, wopt, uu____14898))) in
+                                    (pat, wopt, uu___4))) in
                       let tm =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_match (e, branches2))
                           top2.FStar_Syntax_Syntax.pos in
-                      let uu____14930 = FStar_List.tl stack1 in
-                      norm cfg env1 uu____14930 tm
-                  | uu____14931 -> fallback ()))
+                      let uu___3 = FStar_List.tl stack1 in
+                      norm cfg env1 uu___3 tm
+                  | uu___3 -> fallback ()))
 and (reify_lift :
   FStar_TypeChecker_Cfg.cfg ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -5208,166 +5104,163 @@ and (reify_lift :
           fun t ->
             let env1 = cfg.FStar_TypeChecker_Cfg.tcenv in
             FStar_TypeChecker_Cfg.log cfg
-              (fun uu____14945 ->
-                 let uu____14946 = FStar_Ident.string_of_lid msrc in
-                 let uu____14947 = FStar_Ident.string_of_lid mtgt in
-                 let uu____14948 = FStar_Syntax_Print.term_to_string e in
-                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____14946
-                   uu____14947 uu____14948);
-            (let uu____14949 =
+              (fun uu___1 ->
+                 let uu___2 = FStar_Ident.string_of_lid msrc in
+                 let uu___3 = FStar_Ident.string_of_lid mtgt in
+                 let uu___4 = FStar_Syntax_Print.term_to_string e in
+                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu___2
+                   uu___3 uu___4);
+            (let uu___1 =
                ((FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc))
                  &&
-                 (let uu____14951 =
+                 (let uu___2 =
                     FStar_All.pipe_right mtgt
                       (FStar_TypeChecker_Env.is_layered_effect env1) in
-                  Prims.op_Negation uu____14951) in
-             if uu____14949
+                  Prims.op_Negation uu___2) in
+             if uu___1
              then
                let ed =
-                 let uu____14953 =
+                 let uu___2 =
                    FStar_TypeChecker_Env.norm_eff_name
                      cfg.FStar_TypeChecker_Cfg.tcenv mtgt in
-                 FStar_TypeChecker_Env.get_effect_decl env1 uu____14953 in
-               let uu____14954 =
-                 let uu____14963 =
+                 FStar_TypeChecker_Env.get_effect_decl env1 uu___2 in
+               let uu___2 =
+                 let uu___3 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
-                 FStar_All.pipe_right uu____14963 FStar_Util.must in
-               match uu____14954 with
-               | (uu____15010, repr) ->
-                   let uu____15020 =
-                     let uu____15029 =
+                 FStar_All.pipe_right uu___3 FStar_Util.must in
+               match uu___2 with
+               | (uu___3, repr) ->
+                   let uu___4 =
+                     let uu___5 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_return_repr in
-                     FStar_All.pipe_right uu____15029 FStar_Util.must in
-                   (match uu____15020 with
-                    | (uu____15076, return_repr) ->
+                     FStar_All.pipe_right uu___5 FStar_Util.must in
+                   (match uu___4 with
+                    | (uu___5, return_repr) ->
                         let return_inst =
-                          let uu____15089 =
-                            let uu____15090 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_Syntax_Subst.compress return_repr in
-                            uu____15090.FStar_Syntax_Syntax.n in
-                          match uu____15089 with
+                            uu___7.FStar_Syntax_Syntax.n in
+                          match uu___6 with
                           | FStar_Syntax_Syntax.Tm_uinst
-                              (return_tm, uu____15096::[]) ->
-                              let uu____15101 =
-                                let uu____15102 =
-                                  let uu____15109 =
-                                    let uu____15110 =
+                              (return_tm, uu___7::[]) ->
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
+                                    let uu___11 =
                                       env1.FStar_TypeChecker_Env.universe_of
                                         env1 t in
-                                    [uu____15110] in
-                                  (return_tm, uu____15109) in
-                                FStar_Syntax_Syntax.Tm_uinst uu____15102 in
-                              FStar_Syntax_Syntax.mk uu____15101
+                                    [uu___11] in
+                                  (return_tm, uu___10) in
+                                FStar_Syntax_Syntax.Tm_uinst uu___9 in
+                              FStar_Syntax_Syntax.mk uu___8
                                 e.FStar_Syntax_Syntax.pos
-                          | uu____15113 ->
+                          | uu___7 ->
                               failwith "NIY : Reification of indexed effects" in
-                        let uu____15116 =
+                        let uu___6 =
                           let bv =
                             FStar_Syntax_Syntax.new_bv
                               FStar_Pervasives_Native.None t in
                           let lb =
-                            let uu____15127 =
-                              let uu____15130 =
-                                let uu____15141 =
-                                  FStar_Syntax_Syntax.as_arg t in
-                                [uu____15141] in
-                              FStar_Syntax_Util.mk_app repr uu____15130 in
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 = FStar_Syntax_Syntax.as_arg t in
+                                [uu___9] in
+                              FStar_Syntax_Util.mk_app repr uu___8 in
                             {
                               FStar_Syntax_Syntax.lbname =
                                 (FStar_Util.Inl bv);
                               FStar_Syntax_Syntax.lbunivs = [];
-                              FStar_Syntax_Syntax.lbtyp = uu____15127;
+                              FStar_Syntax_Syntax.lbtyp = uu___7;
                               FStar_Syntax_Syntax.lbeff = msrc;
                               FStar_Syntax_Syntax.lbdef = e;
                               FStar_Syntax_Syntax.lbattrs = [];
                               FStar_Syntax_Syntax.lbpos =
                                 (e.FStar_Syntax_Syntax.pos)
                             } in
-                          let uu____15168 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (lb, bv, uu____15168) in
-                        (match uu____15116 with
+                          let uu___7 = FStar_Syntax_Syntax.bv_to_name bv in
+                          (lb, bv, uu___7) in
+                        (match uu___6 with
                          | (lb_e, e_bv, e1) ->
-                             let uu____15180 =
-                               let uu____15181 =
-                                 let uu____15194 =
-                                   let uu____15197 =
-                                     let uu____15204 =
-                                       let uu____15205 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 =
+                                   let uu___10 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_Syntax_Syntax.mk_binder e_bv in
-                                       [uu____15205] in
-                                     FStar_Syntax_Subst.close uu____15204 in
-                                   let uu____15224 =
-                                     let uu____15225 =
-                                       let uu____15226 =
-                                         let uu____15243 =
-                                           let uu____15254 =
+                                       [uu___12] in
+                                     FStar_Syntax_Subst.close uu___11 in
+                                   let uu___11 =
+                                     let uu___12 =
+                                       let uu___13 =
+                                         let uu___14 =
+                                           let uu___15 =
                                              FStar_Syntax_Syntax.as_arg t in
-                                           let uu____15263 =
-                                             let uu____15274 =
+                                           let uu___16 =
+                                             let uu___17 =
                                                FStar_Syntax_Syntax.as_arg e1 in
-                                             [uu____15274] in
-                                           uu____15254 :: uu____15263 in
-                                         (return_inst, uu____15243) in
-                                       FStar_Syntax_Syntax.Tm_app uu____15226 in
-                                     FStar_Syntax_Syntax.mk uu____15225
+                                             [uu___17] in
+                                           uu___15 :: uu___16 in
+                                         (return_inst, uu___14) in
+                                       FStar_Syntax_Syntax.Tm_app uu___13 in
+                                     FStar_Syntax_Syntax.mk uu___12
                                        e1.FStar_Syntax_Syntax.pos in
-                                   FStar_All.pipe_left uu____15197
-                                     uu____15224 in
-                                 ((false, [lb_e]), uu____15194) in
-                               FStar_Syntax_Syntax.Tm_let uu____15181 in
-                             FStar_Syntax_Syntax.mk uu____15180
+                                   FStar_All.pipe_left uu___10 uu___11 in
+                                 ((false, [lb_e]), uu___9) in
+                               FStar_Syntax_Syntax.Tm_let uu___8 in
+                             FStar_Syntax_Syntax.mk uu___7
                                e1.FStar_Syntax_Syntax.pos))
              else
-               (let uu____15332 =
-                  FStar_TypeChecker_Env.monad_leq env1 msrc mtgt in
-                match uu____15332 with
+               (let uu___3 = FStar_TypeChecker_Env.monad_leq env1 msrc mtgt in
+                match uu___3 with
                 | FStar_Pervasives_Native.None ->
-                    let uu____15335 =
-                      let uu____15336 = FStar_Ident.string_of_lid msrc in
-                      let uu____15337 = FStar_Ident.string_of_lid mtgt in
+                    let uu___4 =
+                      let uu___5 = FStar_Ident.string_of_lid msrc in
+                      let uu___6 = FStar_Ident.string_of_lid mtgt in
                       FStar_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                        uu____15336 uu____15337 in
-                    failwith uu____15335
+                        uu___5 uu___6 in
+                    failwith uu___4
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15338;
-                      FStar_TypeChecker_Env.mtarget = uu____15339;
+                    { FStar_TypeChecker_Env.msource = uu___4;
+                      FStar_TypeChecker_Env.mtarget = uu___5;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15340;
+                        { FStar_TypeChecker_Env.mlift_wp = uu___6;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.None;_};_}
                     ->
-                    let uu____15360 =
-                      let uu____15361 = FStar_Ident.string_of_lid msrc in
-                      let uu____15362 = FStar_Ident.string_of_lid mtgt in
+                    let uu___7 =
+                      let uu___8 = FStar_Ident.string_of_lid msrc in
+                      let uu___9 = FStar_Ident.string_of_lid mtgt in
                       FStar_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                        uu____15361 uu____15362 in
-                    failwith uu____15360
+                        uu___8 uu___9 in
+                    failwith uu___7
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15363;
-                      FStar_TypeChecker_Env.mtarget = uu____15364;
+                    { FStar_TypeChecker_Env.msource = uu___4;
+                      FStar_TypeChecker_Env.mtarget = uu___5;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15365;
+                        { FStar_TypeChecker_Env.mlift_wp = uu___6;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.Some lift;_};_}
                     ->
                     let e1 =
-                      let uu____15396 =
+                      let uu___7 =
                         FStar_TypeChecker_Env.is_reifiable_effect env1 msrc in
-                      if uu____15396
+                      if uu___7
                       then FStar_Syntax_Util.mk_reify e
                       else
-                        (let uu____15398 =
-                           let uu____15399 =
-                             let uu____15418 =
-                               let uu____15427 =
+                        (let uu___9 =
+                           let uu___10 =
+                             let uu___11 =
+                               let uu___12 =
                                  FStar_Syntax_Syntax.null_binder
                                    FStar_Syntax_Syntax.t_unit in
-                               [uu____15427] in
-                             (uu____15418, e,
+                               [uu___12] in
+                             (uu___11, e,
                                (FStar_Pervasives_Native.Some
                                   {
                                     FStar_Syntax_Syntax.residual_effect =
@@ -5376,12 +5269,12 @@ and (reify_lift :
                                       (FStar_Pervasives_Native.Some t);
                                     FStar_Syntax_Syntax.residual_flags = []
                                   })) in
-                           FStar_Syntax_Syntax.Tm_abs uu____15399 in
-                         FStar_Syntax_Syntax.mk uu____15398
+                           FStar_Syntax_Syntax.Tm_abs uu___10 in
+                         FStar_Syntax_Syntax.mk uu___9
                            e.FStar_Syntax_Syntax.pos) in
-                    let uu____15460 =
+                    let uu___7 =
                       env1.FStar_TypeChecker_Env.universe_of env1 t in
-                    lift uu____15460 t e1))
+                    lift uu___7 t e1))
 and (norm_pattern_args :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -5398,11 +5291,10 @@ and (norm_pattern_args :
         FStar_All.pipe_right args
           (FStar_List.map
              (FStar_List.map
-                (fun uu____15530 ->
-                   match uu____15530 with
+                (fun uu___ ->
+                   match uu___ with
                    | (a, imp) ->
-                       let uu____15549 = norm cfg env1 [] a in
-                       (uu____15549, imp))))
+                       let uu___1 = norm cfg env1 [] a in (uu___1, imp))))
 and (norm_comp :
   FStar_TypeChecker_Cfg.cfg ->
     env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -5411,50 +5303,45 @@ and (norm_comp :
     fun env1 ->
       fun comp ->
         FStar_TypeChecker_Cfg.log cfg
-          (fun uu____15559 ->
-             let uu____15560 = FStar_Syntax_Print.comp_to_string comp in
-             let uu____15561 =
-               FStar_Util.string_of_int (FStar_List.length env1) in
+          (fun uu___1 ->
+             let uu___2 = FStar_Syntax_Print.comp_to_string comp in
+             let uu___3 = FStar_Util.string_of_int (FStar_List.length env1) in
              FStar_Util.print2 ">>> %s\nNormComp with with %s env elements\n"
-               uu____15560 uu____15561);
+               uu___2 uu___3);
         (match comp.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Total (t, uopt) ->
              let t1 = norm cfg env1 [] t in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____15585 = norm_universe cfg env1 u in
+                   let uu___1 = norm_universe cfg env1 u in
                    FStar_All.pipe_left
-                     (fun uu____15588 ->
-                        FStar_Pervasives_Native.Some uu____15588) uu____15585
+                     (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+                     uu___1
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
-             let uu___2128_15589 = comp in
+             let uu___1 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Total (t1, uopt1));
-               FStar_Syntax_Syntax.pos =
-                 (uu___2128_15589.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___2128_15589.FStar_Syntax_Syntax.vars)
+               FStar_Syntax_Syntax.pos = (uu___1.FStar_Syntax_Syntax.pos);
+               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.GTotal (t, uopt) ->
              let t1 = norm cfg env1 [] t in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____15611 = norm_universe cfg env1 u in
+                   let uu___1 = norm_universe cfg env1 u in
                    FStar_All.pipe_left
-                     (fun uu____15614 ->
-                        FStar_Pervasives_Native.Some uu____15614) uu____15611
+                     (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+                     uu___1
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
-             let uu___2139_15615 = comp in
+             let uu___1 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.GTotal (t1, uopt1));
-               FStar_Syntax_Syntax.pos =
-                 (uu___2139_15615.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___2139_15615.FStar_Syntax_Syntax.vars)
+               FStar_Syntax_Syntax.pos = (uu___1.FStar_Syntax_Syntax.pos);
+               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.Comp ct ->
              let effect_args =
@@ -5463,48 +5350,45 @@ and (norm_comp :
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                   then
                     FStar_List.map
-                      (fun uu____15678 ->
+                      (fun uu___1 ->
                          FStar_All.pipe_right FStar_Syntax_Syntax.unit_const
                            FStar_Syntax_Syntax.as_arg)
                   else
                     FStar_List.mapi
                       (fun idx ->
-                         fun uu____15704 ->
-                           match uu____15704 with
+                         fun uu___2 ->
+                           match uu___2 with
                            | (a, i) ->
-                               let uu____15723 = norm cfg env1 [] a in
-                               (uu____15723, i))) in
+                               let uu___3 = norm cfg env1 [] a in (uu___3, i))) in
              let flags =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                  (FStar_List.map
-                    (fun uu___14_15736 ->
-                       match uu___14_15736 with
+                    (fun uu___1 ->
+                       match uu___1 with
                        | FStar_Syntax_Syntax.DECREASES t ->
-                           let uu____15740 = norm cfg env1 [] t in
-                           FStar_Syntax_Syntax.DECREASES uu____15740
+                           let uu___2 = norm cfg env1 [] t in
+                           FStar_Syntax_Syntax.DECREASES uu___2
                        | f -> f)) in
              let comp_univs =
                FStar_List.map (norm_universe cfg env1)
                  ct.FStar_Syntax_Syntax.comp_univs in
              let result_typ =
                norm cfg env1 [] ct.FStar_Syntax_Syntax.result_typ in
-             let uu___2157_15748 = comp in
+             let uu___1 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Comp
-                    (let uu___2159_15751 = ct in
+                    (let uu___2 = ct in
                      {
                        FStar_Syntax_Syntax.comp_univs = comp_univs;
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___2159_15751.FStar_Syntax_Syntax.effect_name);
+                         (uu___2.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ = result_typ;
                        FStar_Syntax_Syntax.effect_args = effect_args;
                        FStar_Syntax_Syntax.flags = flags
                      }));
-               FStar_Syntax_Syntax.pos =
-                 (uu___2157_15748.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars =
-                 (uu___2157_15748.FStar_Syntax_Syntax.vars)
+               FStar_Syntax_Syntax.pos = (uu___1.FStar_Syntax_Syntax.pos);
+               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
              })
 and (norm_binder :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5513,37 +5397,37 @@ and (norm_binder :
   fun cfg ->
     fun env1 ->
       fun b ->
-        let uu____15755 = b in
-        match uu____15755 with
+        let uu___ = b in
+        match uu___ with
         | (x, imp) ->
             let x1 =
-              let uu___2167_15763 = x in
-              let uu____15764 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
+              let uu___1 = x in
+              let uu___2 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___2167_15763.FStar_Syntax_Syntax.ppname);
+                  (uu___1.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___2167_15763.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____15764
+                  (uu___1.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu___2
               } in
             let imp1 =
               match imp with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                   (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-                  let uu____15775 =
-                    let uu____15776 =
-                      let uu____15777 = closure_as_term cfg env1 t in
-                      FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____15777 in
-                    FStar_Syntax_Syntax.Meta uu____15776 in
-                  FStar_Pervasives_Native.Some uu____15775
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = closure_as_term cfg env1 t in
+                      FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu___3 in
+                    FStar_Syntax_Syntax.Meta uu___2 in
+                  FStar_Pervasives_Native.Some uu___1
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                   (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-                  let uu____15783 =
-                    let uu____15784 =
-                      let uu____15785 = closure_as_term cfg env1 t in
-                      FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____15785 in
-                    FStar_Syntax_Syntax.Meta uu____15784 in
-                  FStar_Pervasives_Native.Some uu____15783
+                  let uu___1 =
+                    let uu___2 =
+                      let uu___3 = closure_as_term cfg env1 t in
+                      FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu___3 in
+                    FStar_Syntax_Syntax.Meta uu___2 in
+                  FStar_Pervasives_Native.Some uu___1
               | i -> i in
             (x1, imp1)
 and (norm_binders :
@@ -5553,15 +5437,15 @@ and (norm_binders :
   fun cfg ->
     fun env1 ->
       fun bs ->
-        let uu____15796 =
+        let uu___ =
           FStar_List.fold_left
-            (fun uu____15830 ->
+            (fun uu___1 ->
                fun b ->
-                 match uu____15830 with
+                 match uu___1 with
                  | (nbs', env2) ->
                      let b1 = norm_binder cfg env2 b in
                      ((b1 :: nbs'), (dummy :: env2))) ([], env1) bs in
-        match uu____15796 with | (nbs, uu____15910) -> FStar_List.rev nbs
+        match uu___ with | (nbs, uu___1) -> FStar_List.rev nbs
 and (norm_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -5575,9 +5459,9 @@ and (norm_lcomp_opt :
         | FStar_Pervasives_Native.Some rc ->
             let flags =
               filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags in
-            let uu____15942 =
-              let uu___2197_15943 = rc in
-              let uu____15944 =
+            let uu___ =
+              let uu___1 = rc in
+              let uu___2 =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                 then FStar_Pervasives_Native.None
@@ -5586,13 +5470,13 @@ and (norm_lcomp_opt :
                     (norm cfg env1 []) in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___2197_15943.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____15944;
+                  (uu___1.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu___2;
                 FStar_Syntax_Syntax.residual_flags =
-                  (uu___2197_15943.FStar_Syntax_Syntax.residual_flags)
+                  (uu___1.FStar_Syntax_Syntax.residual_flags)
               } in
-            FStar_Pervasives_Native.Some uu____15942
-        | uu____15960 -> lopt
+            FStar_Pervasives_Native.Some uu___
+        | uu___ -> lopt
 and (maybe_simplify :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -5604,33 +5488,33 @@ and (maybe_simplify :
           let tm' = maybe_simplify_aux cfg env1 stack1 tm in
           if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.b380
           then
-            (let uu____15969 = FStar_Syntax_Print.term_to_string tm in
-             let uu____15970 = FStar_Syntax_Print.term_to_string tm' in
+            (let uu___1 = FStar_Syntax_Print.term_to_string tm in
+             let uu___2 = FStar_Syntax_Print.term_to_string tm' in
              FStar_Util.print3 "%sSimplified\n\t%s to\n\t%s\n"
                (if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
                 then ""
-                else "NOT ") uu____15969 uu____15970)
+                else "NOT ") uu___1 uu___2)
           else ();
           tm'
 and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
   =
   fun cfg ->
-    fun uu___15_15974 ->
-      match uu___15_15974 with
+    fun uu___ ->
+      match uu___ with
       | FStar_Util.Inr x -> norm cfg [] [] x
       | FStar_Util.Inl l ->
-          let uu____15987 =
+          let uu___1 =
             FStar_Syntax_DsEnv.try_lookup_lid
               (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.dsenv l in
-          (match uu____15987 with
+          (match uu___1 with
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None ->
-               let uu____15991 =
+               let uu___2 =
                  FStar_Syntax_Syntax.lid_as_fv l
                    FStar_Syntax_Syntax.delta_constant
                    FStar_Pervasives_Native.None in
-               FStar_Syntax_Syntax.fv_to_tm uu____15991)
+               FStar_Syntax_Syntax.fv_to_tm uu___2)
 and (maybe_simplify_aux :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -5640,28 +5524,25 @@ and (maybe_simplify_aux :
       fun stack1 ->
         fun tm ->
           let tm1 =
-            let uu____15999 = norm_cb cfg in
-            reduce_primops uu____15999 cfg env1 tm in
-          let uu____16004 =
+            let uu___ = norm_cb cfg in reduce_primops uu___ cfg env1 tm in
+          let uu___ =
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify in
-          if uu____16004
+          if uu___
           then tm1
           else
             (let w t =
-               let uu___2226_16018 = t in
+               let uu___2 = t in
                {
-                 FStar_Syntax_Syntax.n =
-                   (uu___2226_16018.FStar_Syntax_Syntax.n);
+                 FStar_Syntax_Syntax.n = (uu___2.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
-                 FStar_Syntax_Syntax.vars =
-                   (uu___2226_16018.FStar_Syntax_Syntax.vars)
+                 FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars)
                } in
              let simp_t t =
-               let uu____16029 =
-                 let uu____16030 = FStar_Syntax_Util.unmeta t in
-                 uu____16030.FStar_Syntax_Syntax.n in
-               match uu____16029 with
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Util.unmeta t in
+                 uu___3.FStar_Syntax_Syntax.n in
+               match uu___2 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
@@ -5670,137 +5551,131 @@ and (maybe_simplify_aux :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.false_lid
                    -> FStar_Pervasives_Native.Some false
-               | uu____16037 -> FStar_Pervasives_Native.None in
+               | uu___3 -> FStar_Pervasives_Native.None in
              let rec args_are_binders args bs =
                match (args, bs) with
-               | ((t, uu____16098)::args1, (bv, uu____16101)::bs1) ->
-                   let uu____16155 =
-                     let uu____16156 = FStar_Syntax_Subst.compress t in
-                     uu____16156.FStar_Syntax_Syntax.n in
-                   (match uu____16155 with
+               | ((t, uu___2)::args1, (bv, uu___3)::bs1) ->
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Subst.compress t in
+                     uu___5.FStar_Syntax_Syntax.n in
+                   (match uu___4 with
                     | FStar_Syntax_Syntax.Tm_name bv' ->
                         (FStar_Syntax_Syntax.bv_eq bv bv') &&
                           (args_are_binders args1 bs1)
-                    | uu____16160 -> false)
+                    | uu___5 -> false)
                | ([], []) -> true
-               | (uu____16189, uu____16190) -> false in
+               | (uu___2, uu___3) -> false in
              let is_applied bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16239 = FStar_Syntax_Print.term_to_string t in
-                  let uu____16240 = FStar_Syntax_Print.tag_of_term t in
-                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____16239
-                    uu____16240)
+                 (let uu___3 = FStar_Syntax_Print.term_to_string t in
+                  let uu___4 = FStar_Syntax_Print.tag_of_term t in
+                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu___3
+                    uu___4)
                else ();
-               (let uu____16242 = FStar_Syntax_Util.head_and_args' t in
-                match uu____16242 with
+               (let uu___3 = FStar_Syntax_Util.head_and_args' t in
+                match uu___3 with
                 | (hd, args) ->
-                    let uu____16281 =
-                      let uu____16282 = FStar_Syntax_Subst.compress hd in
-                      uu____16282.FStar_Syntax_Syntax.n in
-                    (match uu____16281 with
+                    let uu___4 =
+                      let uu___5 = FStar_Syntax_Subst.compress hd in
+                      uu___5.FStar_Syntax_Syntax.n in
+                    (match uu___4 with
                      | FStar_Syntax_Syntax.Tm_name bv when
                          args_are_binders args bs ->
                          (if
                             (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                           then
-                            (let uu____16289 =
-                               FStar_Syntax_Print.term_to_string t in
-                             let uu____16290 =
-                               FStar_Syntax_Print.bv_to_string bv in
-                             let uu____16291 =
+                            (let uu___6 = FStar_Syntax_Print.term_to_string t in
+                             let uu___7 = FStar_Syntax_Print.bv_to_string bv in
+                             let uu___8 =
                                FStar_Syntax_Print.term_to_string hd in
                              FStar_Util.print3
                                "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                               uu____16289 uu____16290 uu____16291)
+                               uu___6 uu___7 uu___8)
                           else ();
                           FStar_Pervasives_Native.Some bv)
-                     | uu____16293 -> FStar_Pervasives_Native.None)) in
+                     | uu___5 -> FStar_Pervasives_Native.None)) in
              let is_applied_maybe_squashed bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16310 = FStar_Syntax_Print.term_to_string t in
-                  let uu____16311 = FStar_Syntax_Print.tag_of_term t in
+                 (let uu___3 = FStar_Syntax_Print.term_to_string t in
+                  let uu___4 = FStar_Syntax_Print.tag_of_term t in
                   FStar_Util.print2
-                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____16310
-                    uu____16311)
+                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu___3 uu___4)
                else ();
-               (let uu____16313 = FStar_Syntax_Util.is_squash t in
-                match uu____16313 with
-                | FStar_Pervasives_Native.Some (uu____16324, t') ->
+               (let uu___3 = FStar_Syntax_Util.is_squash t in
+                match uu___3 with
+                | FStar_Pervasives_Native.Some (uu___4, t') ->
                     is_applied bs t'
-                | uu____16336 ->
-                    let uu____16345 = FStar_Syntax_Util.is_auto_squash t in
-                    (match uu____16345 with
-                     | FStar_Pervasives_Native.Some (uu____16356, t') ->
+                | uu___4 ->
+                    let uu___5 = FStar_Syntax_Util.is_auto_squash t in
+                    (match uu___5 with
+                     | FStar_Pervasives_Native.Some (uu___6, t') ->
                          is_applied bs t'
-                     | uu____16368 -> is_applied bs t)) in
+                     | uu___6 -> is_applied bs t)) in
              let is_quantified_const bv phi =
-               let uu____16392 =
-                 FStar_Syntax_Util.destruct_typ_as_formula phi in
-               match uu____16392 with
+               let uu___2 = FStar_Syntax_Util.destruct_typ_as_formula phi in
+               match uu___2 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-                   (lid, (p, uu____16399)::(q, uu____16401)::[])) when
+                   (lid, (p, uu___3)::(q, uu___4)::[])) when
                    FStar_Ident.lid_equals lid FStar_Parser_Const.imp_lid ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____16443 = FStar_Syntax_Print.term_to_string p in
-                       let uu____16444 = FStar_Syntax_Print.term_to_string q in
-                       FStar_Util.print2 "WPE> p = (%s); q = (%s)\n"
-                         uu____16443 uu____16444)
+                      (let uu___6 = FStar_Syntax_Print.term_to_string p in
+                       let uu___7 = FStar_Syntax_Print.term_to_string q in
+                       FStar_Util.print2 "WPE> p = (%s); q = (%s)\n" uu___6
+                         uu___7)
                     else ();
-                    (let uu____16446 =
-                       FStar_Syntax_Util.destruct_typ_as_formula p in
-                     match uu____16446 with
+                    (let uu___6 = FStar_Syntax_Util.destruct_typ_as_formula p in
+                     match uu___6 with
                      | FStar_Pervasives_Native.None ->
-                         let uu____16451 =
-                           let uu____16452 = FStar_Syntax_Subst.compress p in
-                           uu____16452.FStar_Syntax_Syntax.n in
-                         (match uu____16451 with
+                         let uu___7 =
+                           let uu___8 = FStar_Syntax_Subst.compress p in
+                           uu___8.FStar_Syntax_Syntax.n in
+                         (match uu___7 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 1\n"
                                else ();
-                               (let uu____16460 =
+                               (let uu___9 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_true)] q in
-                                FStar_Pervasives_Native.Some uu____16460))
-                          | uu____16463 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu___9))
+                          | uu___8 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some
                          (FStar_Syntax_Util.BaseConn
-                         (lid1, (p1, uu____16466)::[])) when
+                         (lid1, (p1, uu___7)::[])) when
                          FStar_Ident.lid_equals lid1
                            FStar_Parser_Const.not_lid
                          ->
-                         let uu____16491 =
-                           let uu____16492 = FStar_Syntax_Subst.compress p1 in
-                           uu____16492.FStar_Syntax_Syntax.n in
-                         (match uu____16491 with
+                         let uu___8 =
+                           let uu___9 = FStar_Syntax_Subst.compress p1 in
+                           uu___9.FStar_Syntax_Syntax.n in
+                         (match uu___8 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 2\n"
                                else ();
-                               (let uu____16500 =
+                               (let uu___10 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_false)] q in
-                                FStar_Pervasives_Native.Some uu____16500))
-                          | uu____16503 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu___10))
+                          | uu___9 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
                          (bs, pats, phi1)) ->
-                         let uu____16507 =
+                         let uu___7 =
                            FStar_Syntax_Util.destruct_typ_as_formula phi1 in
-                         (match uu____16507 with
+                         (match uu___7 with
                           | FStar_Pervasives_Native.None ->
-                              let uu____16512 =
-                                is_applied_maybe_squashed bs phi1 in
-                              (match uu____16512 with
+                              let uu___8 = is_applied_maybe_squashed bs phi1 in
+                              (match uu___8 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5814,21 +5689,20 @@ and (maybe_simplify_aux :
                                          (FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0)) in
-                                     let uu____16523 =
+                                     let uu___10 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ftrue)]
                                          q in
-                                     FStar_Pervasives_Native.Some uu____16523))
-                               | uu____16526 -> FStar_Pervasives_Native.None)
+                                     FStar_Pervasives_Native.Some uu___10))
+                               | uu___9 -> FStar_Pervasives_Native.None)
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.BaseConn
-                              (lid1, (p1, uu____16531)::[])) when
+                              (lid1, (p1, uu___8)::[])) when
                               FStar_Ident.lid_equals lid1
                                 FStar_Parser_Const.not_lid
                               ->
-                              let uu____16556 =
-                                is_applied_maybe_squashed bs p1 in
-                              (match uu____16556 with
+                              let uu___9 = is_applied_maybe_squashed bs p1 in
+                              (match uu___9 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5842,91 +5716,88 @@ and (maybe_simplify_aux :
                                          (FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0)) in
-                                     let uu____16567 =
+                                     let uu___11 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ffalse)]
                                          q in
-                                     FStar_Pervasives_Native.Some uu____16567))
-                               | uu____16570 -> FStar_Pervasives_Native.None)
-                          | uu____16573 -> FStar_Pervasives_Native.None)
-                     | uu____16576 -> FStar_Pervasives_Native.None))
-               | uu____16579 -> FStar_Pervasives_Native.None in
+                                     FStar_Pervasives_Native.Some uu___11))
+                               | uu___10 -> FStar_Pervasives_Native.None)
+                          | uu___8 -> FStar_Pervasives_Native.None)
+                     | uu___7 -> FStar_Pervasives_Native.None))
+               | uu___3 -> FStar_Pervasives_Native.None in
              let is_forall_const phi =
-               let uu____16592 =
-                 FStar_Syntax_Util.destruct_typ_as_formula phi in
-               match uu____16592 with
+               let uu___2 = FStar_Syntax_Util.destruct_typ_as_formula phi in
+               match uu___2 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
-                   ((bv, uu____16598)::[], uu____16599, phi')) ->
+                   ((bv, uu___3)::[], uu___4, phi')) ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____16618 = FStar_Syntax_Print.bv_to_string bv in
-                       let uu____16619 =
-                         FStar_Syntax_Print.term_to_string phi' in
-                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____16618
-                         uu____16619)
+                      (let uu___6 = FStar_Syntax_Print.bv_to_string bv in
+                       let uu___7 = FStar_Syntax_Print.term_to_string phi' in
+                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu___6 uu___7)
                     else ();
                     is_quantified_const bv phi')
-               | uu____16621 -> FStar_Pervasives_Native.None in
+               | uu___3 -> FStar_Pervasives_Native.None in
              let is_const_match phi =
-               let uu____16634 =
-                 let uu____16635 = FStar_Syntax_Subst.compress phi in
-                 uu____16635.FStar_Syntax_Syntax.n in
-               match uu____16634 with
-               | FStar_Syntax_Syntax.Tm_match (uu____16640, br::brs) ->
-                   let uu____16707 = br in
-                   (match uu____16707 with
-                    | (uu____16724, uu____16725, e) ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress phi in
+                 uu___3.FStar_Syntax_Syntax.n in
+               match uu___2 with
+               | FStar_Syntax_Syntax.Tm_match (uu___3, br::brs) ->
+                   let uu___4 = br in
+                   (match uu___4 with
+                    | (uu___5, uu___6, e) ->
                         let r =
-                          let uu____16746 = simp_t e in
-                          match uu____16746 with
+                          let uu___7 = simp_t e in
+                          match uu___7 with
                           | FStar_Pervasives_Native.None ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some b ->
-                              let uu____16752 =
+                              let uu___8 =
                                 FStar_List.for_all
-                                  (fun uu____16770 ->
-                                     match uu____16770 with
-                                     | (uu____16783, uu____16784, e') ->
-                                         let uu____16798 = simp_t e' in
-                                         uu____16798 =
+                                  (fun uu___9 ->
+                                     match uu___9 with
+                                     | (uu___10, uu___11, e') ->
+                                         let uu___12 = simp_t e' in
+                                         uu___12 =
                                            (FStar_Pervasives_Native.Some b))
                                   brs in
-                              if uu____16752
+                              if uu___8
                               then FStar_Pervasives_Native.Some b
                               else FStar_Pervasives_Native.None in
                         r)
-               | uu____16806 -> FStar_Pervasives_Native.None in
+               | uu___3 -> FStar_Pervasives_Native.None in
              let maybe_auto_squash t =
-               let uu____16815 = FStar_Syntax_Util.is_sub_singleton t in
-               if uu____16815
+               let uu___2 = FStar_Syntax_Util.is_sub_singleton t in
+               if uu___2
                then t
                else
                  FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero
                    t in
              let squashed_head_un_auto_squash_args t =
-               let maybe_un_auto_squash_arg uu____16848 =
-                 match uu____16848 with
+               let maybe_un_auto_squash_arg uu___2 =
+                 match uu___2 with
                  | (t1, q) ->
-                     let uu____16869 = FStar_Syntax_Util.is_auto_squash t1 in
-                     (match uu____16869 with
+                     let uu___3 = FStar_Syntax_Util.is_auto_squash t1 in
+                     (match uu___3 with
                       | FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.U_zero, t2) -> (t2, q)
-                      | uu____16901 -> (t1, q)) in
-               let uu____16914 = FStar_Syntax_Util.head_and_args t in
-               match uu____16914 with
+                      | uu___4 -> (t1, q)) in
+               let uu___2 = FStar_Syntax_Util.head_and_args t in
+               match uu___2 with
                | (head, args) ->
                    let args1 = FStar_List.map maybe_un_auto_squash_arg args in
                    FStar_Syntax_Syntax.mk_Tm_app head args1
                      t.FStar_Syntax_Syntax.pos in
              let rec clearly_inhabited ty =
-               let uu____16990 =
-                 let uu____16991 = FStar_Syntax_Util.unmeta ty in
-                 uu____16991.FStar_Syntax_Syntax.n in
-               match uu____16990 with
-               | FStar_Syntax_Syntax.Tm_uinst (t, uu____16995) ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Util.unmeta ty in
+                 uu___3.FStar_Syntax_Syntax.n in
+               match uu___2 with
+               | FStar_Syntax_Syntax.Tm_uinst (t, uu___3) ->
                    clearly_inhabited t
-               | FStar_Syntax_Syntax.Tm_arrow (uu____17000, c) ->
+               | FStar_Syntax_Syntax.Tm_arrow (uu___3, c) ->
                    clearly_inhabited (FStar_Syntax_Util.comp_result c)
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv in
@@ -5935,238 +5806,222 @@ and (maybe_simplify_aux :
                       ||
                       (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
                      || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-               | uu____17024 -> false in
+               | uu___3 -> false in
              let simplify arg =
-               let uu____17055 = simp_t (FStar_Pervasives_Native.fst arg) in
-               (uu____17055, arg) in
-             let uu____17068 = is_forall_const tm1 in
-             match uu____17068 with
+               let uu___2 = simp_t (FStar_Pervasives_Native.fst arg) in
+               (uu___2, arg) in
+             let uu___2 = is_forall_const tm1 in
+             match uu___2 with
              | FStar_Pervasives_Native.Some tm' ->
                  (if
                     (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                   then
-                    (let uu____17073 = FStar_Syntax_Print.term_to_string tm1 in
-                     let uu____17074 = FStar_Syntax_Print.term_to_string tm' in
-                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____17073
-                       uu____17074)
+                    (let uu___4 = FStar_Syntax_Print.term_to_string tm1 in
+                     let uu___5 = FStar_Syntax_Print.term_to_string tm' in
+                     FStar_Util.print2 "WPE> %s ~> %s\n" uu___4 uu___5)
                   else ();
-                  (let uu____17076 = norm cfg env1 [] tm' in
-                   maybe_simplify_aux cfg env1 stack1 uu____17076))
+                  (let uu___4 = norm cfg env1 [] tm' in
+                   maybe_simplify_aux cfg env1 stack1 uu___4))
              | FStar_Pervasives_Native.None ->
-                 let uu____17077 =
-                   let uu____17078 = FStar_Syntax_Subst.compress tm1 in
-                   uu____17078.FStar_Syntax_Syntax.n in
-                 (match uu____17077 with
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Subst.compress tm1 in
+                   uu___4.FStar_Syntax_Syntax.n in
+                 (match uu___3 with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                            ({
                               FStar_Syntax_Syntax.n =
                                 FStar_Syntax_Syntax.Tm_fvar fv;
-                              FStar_Syntax_Syntax.pos = uu____17082;
-                              FStar_Syntax_Syntax.vars = uu____17083;_},
-                            uu____17084);
-                         FStar_Syntax_Syntax.pos = uu____17085;
-                         FStar_Syntax_Syntax.vars = uu____17086;_},
+                              FStar_Syntax_Syntax.pos = uu___4;
+                              FStar_Syntax_Syntax.vars = uu___5;_},
+                            uu___6);
+                         FStar_Syntax_Syntax.pos = uu___7;
+                         FStar_Syntax_Syntax.vars = uu___8;_},
                        args)
                       ->
-                      let uu____17116 =
+                      let uu___9 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu____17116
+                      if uu___9
                       then
-                        let uu____17117 =
+                        let uu___10 =
                           FStar_All.pipe_right args (FStar_List.map simplify) in
-                        (match uu____17117 with
-                         | (FStar_Pervasives_Native.Some (true), uu____17172)::
-                             (uu____17173, (arg, uu____17175))::[] ->
+                        (match uu___10 with
+                         | (FStar_Pervasives_Native.Some (true), uu___11)::
+                             (uu___12, (arg, uu___13))::[] ->
                              maybe_auto_squash arg
-                         | (uu____17240, (arg, uu____17242))::(FStar_Pervasives_Native.Some
-                                                               (true),
-                                                               uu____17243)::[]
+                         | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                       (true), uu___13)::[]
                              -> maybe_auto_squash arg
-                         | (FStar_Pervasives_Native.Some (false),
-                            uu____17308)::uu____17309::[] ->
-                             w FStar_Syntax_Util.t_false
-                         | uu____17372::(FStar_Pervasives_Native.Some
-                                         (false), uu____17373)::[]
+                         | (FStar_Pervasives_Native.Some (false), uu___11)::uu___12::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____17436 ->
-                             squashed_head_un_auto_squash_args tm1)
+                         | uu___11::(FStar_Pervasives_Native.Some (false),
+                                     uu___12)::[]
+                             -> w FStar_Syntax_Util.t_false
+                         | uu___11 -> squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____17452 =
+                        (let uu___11 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu____17452
+                         if uu___11
                          then
-                           let uu____17453 =
+                           let uu___12 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify) in
-                           match uu____17453 with
-                           | (FStar_Pervasives_Native.Some (true),
-                              uu____17508)::uu____17509::[] ->
-                               w FStar_Syntax_Util.t_true
-                           | uu____17572::(FStar_Pervasives_Native.Some
-                                           (true), uu____17573)::[]
+                           match uu___12 with
+                           | (FStar_Pervasives_Native.Some (true), uu___13)::uu___14::[]
                                -> w FStar_Syntax_Util.t_true
-                           | (FStar_Pervasives_Native.Some (false),
-                              uu____17636)::(uu____17637, (arg, uu____17639))::[]
+                           | uu___13::(FStar_Pervasives_Native.Some (true),
+                                       uu___14)::[]
+                               -> w FStar_Syntax_Util.t_true
+                           | (FStar_Pervasives_Native.Some (false), uu___13)::
+                               (uu___14, (arg, uu___15))::[] ->
+                               maybe_auto_squash arg
+                           | (uu___13, (arg, uu___14))::(FStar_Pervasives_Native.Some
+                                                         (false), uu___15)::[]
                                -> maybe_auto_squash arg
-                           | (uu____17704, (arg, uu____17706))::(FStar_Pervasives_Native.Some
-                                                                 (false),
-                                                                 uu____17707)::[]
-                               -> maybe_auto_squash arg
-                           | uu____17772 ->
-                               squashed_head_un_auto_squash_args tm1
+                           | uu___13 -> squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____17788 =
+                           (let uu___13 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu____17788
+                            if uu___13
                             then
-                              let uu____17789 =
+                              let uu___14 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify) in
-                              match uu____17789 with
-                              | uu____17844::(FStar_Pervasives_Native.Some
-                                              (true), uu____17845)::[]
+                              match uu___14 with
+                              | uu___15::(FStar_Pervasives_Native.Some
+                                          (true), uu___16)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu____17908)::uu____17909::[] ->
+                                 uu___15)::uu___16::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu____17972)::(uu____17973,
-                                                (arg, uu____17975))::[]
-                                  -> maybe_auto_squash arg
-                              | (uu____18040, (p, uu____18042))::(uu____18043,
-                                                                  (q,
-                                                                   uu____18045))::[]
+                                 uu___15)::(uu___16, (arg, uu___17))::[] ->
+                                  maybe_auto_squash arg
+                              | (uu___15, (p, uu___16))::(uu___17,
+                                                          (q, uu___18))::[]
                                   ->
-                                  let uu____18110 =
-                                    FStar_Syntax_Util.term_eq p q in
-                                  (if uu____18110
+                                  let uu___19 = FStar_Syntax_Util.term_eq p q in
+                                  (if uu___19
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____18112 ->
+                              | uu___15 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____18128 =
+                              (let uu___15 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu____18128
+                               if uu___15
                                then
-                                 let uu____18129 =
+                                 let uu___16 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify) in
-                                 match uu____18129 with
+                                 match uu___16 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18184)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____18185)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (true), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18250)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____18251)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (false), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18316)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____18317)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (false), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18382)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____18383)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (true), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____18448, (arg, uu____18450))::
-                                     (FStar_Pervasives_Native.Some (true),
-                                      uu____18451)::[]
+                                 | (uu___17, (arg, uu___18))::(FStar_Pervasives_Native.Some
+                                                               (true),
+                                                               uu___19)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18516)::(uu____18517,
-                                                   (arg, uu____18519))::[]
+                                    uu___17)::(uu___18, (arg, uu___19))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____18584, (arg, uu____18586))::
-                                     (FStar_Pervasives_Native.Some (false),
-                                      uu____18587)::[]
+                                 | (uu___17, (arg, uu___18))::(FStar_Pervasives_Native.Some
+                                                               (false),
+                                                               uu___19)::[]
                                      ->
-                                     let uu____18652 =
+                                     let uu___20 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____18652
+                                     maybe_auto_squash uu___20
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18653)::(uu____18654,
-                                                   (arg, uu____18656))::[]
+                                    uu___17)::(uu___18, (arg, uu___19))::[]
                                      ->
-                                     let uu____18721 =
+                                     let uu___20 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____18721
-                                 | (uu____18722, (p, uu____18724))::(uu____18725,
-                                                                    (q,
-                                                                    uu____18727))::[]
+                                     maybe_auto_squash uu___20
+                                 | (uu___17, (p, uu___18))::(uu___19,
+                                                             (q, uu___20))::[]
                                      ->
-                                     let uu____18792 =
+                                     let uu___21 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu____18792
+                                     (if uu___21
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____18794 ->
+                                 | uu___17 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____18810 =
+                                 (let uu___17 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu____18810
+                                  if uu___17
                                   then
-                                    let uu____18811 =
+                                    let uu___18 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify) in
-                                    match uu____18811 with
+                                    match uu___18 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu____18866)::[] ->
+                                       uu___19)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu____18905)::[] ->
+                                       uu___19)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____18944 ->
+                                    | uu___19 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____18960 =
+                                    (let uu___19 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu____18960
+                                     if uu___19
                                      then
                                        match args with
-                                       | (t, uu____18962)::[] ->
-                                           let uu____18987 =
-                                             let uu____18988 =
+                                       | (t, uu___20)::[] ->
+                                           let uu___21 =
+                                             let uu___22 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____18988.FStar_Syntax_Syntax.n in
-                                           (match uu____18987 with
+                                             uu___22.FStar_Syntax_Syntax.n in
+                                           (match uu___21 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____18991::[], body,
-                                                 uu____18993)
+                                                (uu___22::[], body, uu___23)
                                                 ->
-                                                let uu____19028 = simp_t body in
-                                                (match uu____19028 with
+                                                let uu___24 = simp_t body in
+                                                (match uu___24 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____19031 -> tm1)
-                                            | uu____19034 -> tm1)
+                                                 | uu___25 -> tm1)
+                                            | uu___22 -> tm1)
                                        | (ty, FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____19036))::(t, uu____19038)::[]
-                                           ->
-                                           let uu____19077 =
-                                             let uu____19078 =
+                                          uu___20))::(t, uu___21)::[] ->
+                                           let uu___22 =
+                                             let uu___23 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____19078.FStar_Syntax_Syntax.n in
-                                           (match uu____19077 with
+                                             uu___23.FStar_Syntax_Syntax.n in
+                                           (match uu___22 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____19081::[], body,
-                                                 uu____19083)
+                                                (uu___23::[], body, uu___24)
                                                 ->
-                                                let uu____19118 = simp_t body in
-                                                (match uu____19118 with
+                                                let uu___25 = simp_t body in
+                                                (match uu___25 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
@@ -6176,53 +6031,50 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____19121 -> tm1)
-                                            | uu____19124 -> tm1)
-                                       | uu____19125 -> tm1
+                                                 | uu___26 -> tm1)
+                                            | uu___23 -> tm1)
+                                       | uu___20 -> tm1
                                      else
-                                       (let uu____19137 =
+                                       (let uu___21 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu____19137
+                                        if uu___21
                                         then
                                           match args with
-                                          | (t, uu____19139)::[] ->
-                                              let uu____19164 =
-                                                let uu____19165 =
+                                          | (t, uu___22)::[] ->
+                                              let uu___23 =
+                                                let uu___24 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____19165.FStar_Syntax_Syntax.n in
-                                              (match uu____19164 with
+                                                uu___24.FStar_Syntax_Syntax.n in
+                                              (match uu___23 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____19168::[], body,
-                                                    uu____19170)
+                                                   (uu___24::[], body,
+                                                    uu___25)
                                                    ->
-                                                   let uu____19205 =
-                                                     simp_t body in
-                                                   (match uu____19205 with
+                                                   let uu___26 = simp_t body in
+                                                   (match uu___26 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____19208 -> tm1)
-                                               | uu____19211 -> tm1)
+                                                    | uu___27 -> tm1)
+                                               | uu___24 -> tm1)
                                           | (ty, FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____19213))::(t, uu____19215)::[]
-                                              ->
-                                              let uu____19254 =
-                                                let uu____19255 =
+                                             uu___22))::(t, uu___23)::[] ->
+                                              let uu___24 =
+                                                let uu___25 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____19255.FStar_Syntax_Syntax.n in
-                                              (match uu____19254 with
+                                                uu___25.FStar_Syntax_Syntax.n in
+                                              (match uu___24 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____19258::[], body,
-                                                    uu____19260)
+                                                   (uu___25::[], body,
+                                                    uu___26)
                                                    ->
-                                                   let uu____19295 =
-                                                     simp_t body in
-                                                   (match uu____19295 with
+                                                   let uu___27 = simp_t body in
+                                                   (match uu___27 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
@@ -6233,14 +6085,14 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____19298 -> tm1)
-                                               | uu____19301 -> tm1)
-                                          | uu____19302 -> tm1
+                                                    | uu___28 -> tm1)
+                                               | uu___25 -> tm1)
+                                          | uu___22 -> tm1
                                         else
-                                          (let uu____19314 =
+                                          (let uu___23 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu____19314
+                                           if uu___23
                                            then
                                              match args with
                                              | ({
@@ -6249,10 +6101,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____19315;
+                                                    uu___24;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____19316;_},
-                                                uu____19317)::[] ->
+                                                    uu___25;_},
+                                                uu___26)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6260,18 +6112,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____19342;
+                                                    uu___24;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____19343;_},
-                                                uu____19344)::[] ->
+                                                    uu___25;_},
+                                                uu___26)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____19369 -> tm1
+                                             | uu___24 -> tm1
                                            else
-                                             (let uu____19381 =
+                                             (let uu___25 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu____19381
+                                              if uu___25
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6279,12 +6131,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu____19391 =
-                                                    let uu____19392 =
+                                                  let uu___26 =
+                                                    let uu___27 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu____19392.FStar_Syntax_Syntax.n in
-                                                  match uu____19391 with
+                                                    uu___27.FStar_Syntax_Syntax.n in
+                                                  match uu___26 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6294,82 +6146,78 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____19400 -> false in
+                                                  | uu___27 -> false in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____19410 =
+                                                     let uu___26 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd in
                                                      FStar_All.pipe_right
-                                                       uu____19410
+                                                       uu___26
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu____19449 =
+                                                   let uu___26 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure in
-                                                   (if uu____19449
+                                                   (if uu___26
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____19451 =
-                                                         let uu____19452 =
+                                                      (let uu___28 =
+                                                         let uu___29 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu____19452.FStar_Syntax_Syntax.n in
-                                                       match uu____19451 with
+                                                         uu___29.FStar_Syntax_Syntax.n in
+                                                       match uu___28 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____19455 ->
+                                                           uu___29 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu____19463 =
+                                                           let uu___30 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu____19463
+                                                           if uu___30
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____19468
-                                                                  =
-                                                                  let uu____19469
+                                                                let uu___32 =
+                                                                  let uu___33
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu____19469.FStar_Syntax_Syntax.n in
-                                                                match uu____19468
+                                                                  uu___33.FStar_Syntax_Syntax.n in
+                                                                match uu___32
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu____19475)
+                                                                    uu___33)
                                                                     -> hd
-                                                                | uu____19500
-                                                                    ->
+                                                                | uu___33 ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu____19503
-                                                                =
-                                                                let uu____19514
-                                                                  =
+                                                              let uu___32 =
+                                                                let uu___33 =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____19514] in
+                                                                [uu___33] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____19503)
-                                                       | uu____19547 -> tm1))
+                                                                uu___32)
+                                                       | uu___29 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____19550 =
+                                                (let uu___27 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu____19550 with
+                                                 match uu___27 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6377,217 +6225,201 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____19570 ->
-                                                     let uu____19579 =
+                                                 | uu___28 ->
+                                                     let uu___29 =
                                                        norm_cb cfg in
-                                                     reduce_equality
-                                                       uu____19579 cfg env1
-                                                       tm1)))))))))
+                                                     reduce_equality uu___29
+                                                       cfg env1 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____19585;
-                         FStar_Syntax_Syntax.vars = uu____19586;_},
+                         FStar_Syntax_Syntax.pos = uu___4;
+                         FStar_Syntax_Syntax.vars = uu___5;_},
                        args)
                       ->
-                      let uu____19612 =
+                      let uu___6 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu____19612
+                      if uu___6
                       then
-                        let uu____19613 =
+                        let uu___7 =
                           FStar_All.pipe_right args (FStar_List.map simplify) in
-                        (match uu____19613 with
-                         | (FStar_Pervasives_Native.Some (true), uu____19668)::
-                             (uu____19669, (arg, uu____19671))::[] ->
+                        (match uu___7 with
+                         | (FStar_Pervasives_Native.Some (true), uu___8)::
+                             (uu___9, (arg, uu___10))::[] ->
                              maybe_auto_squash arg
-                         | (uu____19736, (arg, uu____19738))::(FStar_Pervasives_Native.Some
-                                                               (true),
-                                                               uu____19739)::[]
+                         | (uu___8, (arg, uu___9))::(FStar_Pervasives_Native.Some
+                                                     (true), uu___10)::[]
                              -> maybe_auto_squash arg
-                         | (FStar_Pervasives_Native.Some (false),
-                            uu____19804)::uu____19805::[] ->
-                             w FStar_Syntax_Util.t_false
-                         | uu____19868::(FStar_Pervasives_Native.Some
-                                         (false), uu____19869)::[]
+                         | (FStar_Pervasives_Native.Some (false), uu___8)::uu___9::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____19932 ->
-                             squashed_head_un_auto_squash_args tm1)
+                         | uu___8::(FStar_Pervasives_Native.Some (false),
+                                    uu___9)::[]
+                             -> w FStar_Syntax_Util.t_false
+                         | uu___8 -> squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____19948 =
+                        (let uu___8 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu____19948
+                         if uu___8
                          then
-                           let uu____19949 =
+                           let uu___9 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify) in
-                           match uu____19949 with
-                           | (FStar_Pervasives_Native.Some (true),
-                              uu____20004)::uu____20005::[] ->
-                               w FStar_Syntax_Util.t_true
-                           | uu____20068::(FStar_Pervasives_Native.Some
-                                           (true), uu____20069)::[]
+                           match uu___9 with
+                           | (FStar_Pervasives_Native.Some (true), uu___10)::uu___11::[]
                                -> w FStar_Syntax_Util.t_true
-                           | (FStar_Pervasives_Native.Some (false),
-                              uu____20132)::(uu____20133, (arg, uu____20135))::[]
+                           | uu___10::(FStar_Pervasives_Native.Some (true),
+                                       uu___11)::[]
+                               -> w FStar_Syntax_Util.t_true
+                           | (FStar_Pervasives_Native.Some (false), uu___10)::
+                               (uu___11, (arg, uu___12))::[] ->
+                               maybe_auto_squash arg
+                           | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
+                                                         (false), uu___12)::[]
                                -> maybe_auto_squash arg
-                           | (uu____20200, (arg, uu____20202))::(FStar_Pervasives_Native.Some
-                                                                 (false),
-                                                                 uu____20203)::[]
-                               -> maybe_auto_squash arg
-                           | uu____20268 ->
-                               squashed_head_un_auto_squash_args tm1
+                           | uu___10 -> squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____20284 =
+                           (let uu___10 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu____20284
+                            if uu___10
                             then
-                              let uu____20285 =
+                              let uu___11 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify) in
-                              match uu____20285 with
-                              | uu____20340::(FStar_Pervasives_Native.Some
-                                              (true), uu____20341)::[]
+                              match uu___11 with
+                              | uu___12::(FStar_Pervasives_Native.Some
+                                          (true), uu___13)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu____20404)::uu____20405::[] ->
+                                 uu___12)::uu___13::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu____20468)::(uu____20469,
-                                                (arg, uu____20471))::[]
-                                  -> maybe_auto_squash arg
-                              | (uu____20536, (p, uu____20538))::(uu____20539,
-                                                                  (q,
-                                                                   uu____20541))::[]
+                                 uu___12)::(uu___13, (arg, uu___14))::[] ->
+                                  maybe_auto_squash arg
+                              | (uu___12, (p, uu___13))::(uu___14,
+                                                          (q, uu___15))::[]
                                   ->
-                                  let uu____20606 =
-                                    FStar_Syntax_Util.term_eq p q in
-                                  (if uu____20606
+                                  let uu___16 = FStar_Syntax_Util.term_eq p q in
+                                  (if uu___16
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____20608 ->
+                              | uu___12 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____20624 =
+                              (let uu___12 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu____20624
+                               if uu___12
                                then
-                                 let uu____20625 =
+                                 let uu___13 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify) in
-                                 match uu____20625 with
+                                 match uu___13 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____20680)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____20681)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (true), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____20746)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____20747)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (false), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____20812)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____20813)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (false), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____20878)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____20879)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (true), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____20944, (arg, uu____20946))::
-                                     (FStar_Pervasives_Native.Some (true),
-                                      uu____20947)::[]
+                                 | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                               (true),
+                                                               uu___16)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____21012)::(uu____21013,
-                                                   (arg, uu____21015))::[]
+                                    uu___14)::(uu___15, (arg, uu___16))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____21080, (arg, uu____21082))::
-                                     (FStar_Pervasives_Native.Some (false),
-                                      uu____21083)::[]
+                                 | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                               (false),
+                                                               uu___16)::[]
                                      ->
-                                     let uu____21148 =
+                                     let uu___17 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____21148
+                                     maybe_auto_squash uu___17
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____21149)::(uu____21150,
-                                                   (arg, uu____21152))::[]
+                                    uu___14)::(uu___15, (arg, uu___16))::[]
                                      ->
-                                     let uu____21217 =
+                                     let uu___17 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____21217
-                                 | (uu____21218, (p, uu____21220))::(uu____21221,
-                                                                    (q,
-                                                                    uu____21223))::[]
+                                     maybe_auto_squash uu___17
+                                 | (uu___14, (p, uu___15))::(uu___16,
+                                                             (q, uu___17))::[]
                                      ->
-                                     let uu____21288 =
+                                     let uu___18 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu____21288
+                                     (if uu___18
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____21290 ->
+                                 | uu___14 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____21306 =
+                                 (let uu___14 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu____21306
+                                  if uu___14
                                   then
-                                    let uu____21307 =
+                                    let uu___15 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify) in
-                                    match uu____21307 with
+                                    match uu___15 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu____21362)::[] ->
+                                       uu___16)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu____21401)::[] ->
+                                       uu___16)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____21440 ->
+                                    | uu___16 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____21456 =
+                                    (let uu___16 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu____21456
+                                     if uu___16
                                      then
                                        match args with
-                                       | (t, uu____21458)::[] ->
-                                           let uu____21483 =
-                                             let uu____21484 =
+                                       | (t, uu___17)::[] ->
+                                           let uu___18 =
+                                             let uu___19 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____21484.FStar_Syntax_Syntax.n in
-                                           (match uu____21483 with
+                                             uu___19.FStar_Syntax_Syntax.n in
+                                           (match uu___18 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21487::[], body,
-                                                 uu____21489)
+                                                (uu___19::[], body, uu___20)
                                                 ->
-                                                let uu____21524 = simp_t body in
-                                                (match uu____21524 with
+                                                let uu___21 = simp_t body in
+                                                (match uu___21 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____21527 -> tm1)
-                                            | uu____21530 -> tm1)
+                                                 | uu___22 -> tm1)
+                                            | uu___19 -> tm1)
                                        | (ty, FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____21532))::(t, uu____21534)::[]
-                                           ->
-                                           let uu____21573 =
-                                             let uu____21574 =
+                                          uu___17))::(t, uu___18)::[] ->
+                                           let uu___19 =
+                                             let uu___20 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____21574.FStar_Syntax_Syntax.n in
-                                           (match uu____21573 with
+                                             uu___20.FStar_Syntax_Syntax.n in
+                                           (match uu___19 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21577::[], body,
-                                                 uu____21579)
+                                                (uu___20::[], body, uu___21)
                                                 ->
-                                                let uu____21614 = simp_t body in
-                                                (match uu____21614 with
+                                                let uu___22 = simp_t body in
+                                                (match uu___22 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
@@ -6597,53 +6429,50 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____21617 -> tm1)
-                                            | uu____21620 -> tm1)
-                                       | uu____21621 -> tm1
+                                                 | uu___23 -> tm1)
+                                            | uu___20 -> tm1)
+                                       | uu___17 -> tm1
                                      else
-                                       (let uu____21633 =
+                                       (let uu___18 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu____21633
+                                        if uu___18
                                         then
                                           match args with
-                                          | (t, uu____21635)::[] ->
-                                              let uu____21660 =
-                                                let uu____21661 =
+                                          | (t, uu___19)::[] ->
+                                              let uu___20 =
+                                                let uu___21 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____21661.FStar_Syntax_Syntax.n in
-                                              (match uu____21660 with
+                                                uu___21.FStar_Syntax_Syntax.n in
+                                              (match uu___20 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21664::[], body,
-                                                    uu____21666)
+                                                   (uu___21::[], body,
+                                                    uu___22)
                                                    ->
-                                                   let uu____21701 =
-                                                     simp_t body in
-                                                   (match uu____21701 with
+                                                   let uu___23 = simp_t body in
+                                                   (match uu___23 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____21704 -> tm1)
-                                               | uu____21707 -> tm1)
+                                                    | uu___24 -> tm1)
+                                               | uu___21 -> tm1)
                                           | (ty, FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____21709))::(t, uu____21711)::[]
-                                              ->
-                                              let uu____21750 =
-                                                let uu____21751 =
+                                             uu___19))::(t, uu___20)::[] ->
+                                              let uu___21 =
+                                                let uu___22 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____21751.FStar_Syntax_Syntax.n in
-                                              (match uu____21750 with
+                                                uu___22.FStar_Syntax_Syntax.n in
+                                              (match uu___21 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21754::[], body,
-                                                    uu____21756)
+                                                   (uu___22::[], body,
+                                                    uu___23)
                                                    ->
-                                                   let uu____21791 =
-                                                     simp_t body in
-                                                   (match uu____21791 with
+                                                   let uu___24 = simp_t body in
+                                                   (match uu___24 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
@@ -6654,14 +6483,14 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____21794 -> tm1)
-                                               | uu____21797 -> tm1)
-                                          | uu____21798 -> tm1
+                                                    | uu___25 -> tm1)
+                                               | uu___22 -> tm1)
+                                          | uu___19 -> tm1
                                         else
-                                          (let uu____21810 =
+                                          (let uu___20 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu____21810
+                                           if uu___20
                                            then
                                              match args with
                                              | ({
@@ -6670,10 +6499,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21811;
+                                                    uu___21;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21812;_},
-                                                uu____21813)::[] ->
+                                                    uu___22;_},
+                                                uu___23)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6681,18 +6510,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21838;
+                                                    uu___21;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21839;_},
-                                                uu____21840)::[] ->
+                                                    uu___22;_},
+                                                uu___23)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____21865 -> tm1
+                                             | uu___21 -> tm1
                                            else
-                                             (let uu____21877 =
+                                             (let uu___22 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu____21877
+                                              if uu___22
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6700,12 +6529,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu____21887 =
-                                                    let uu____21888 =
+                                                  let uu___23 =
+                                                    let uu___24 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu____21888.FStar_Syntax_Syntax.n in
-                                                  match uu____21887 with
+                                                    uu___24.FStar_Syntax_Syntax.n in
+                                                  match uu___23 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6715,82 +6544,78 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____21896 -> false in
+                                                  | uu___24 -> false in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____21906 =
+                                                     let uu___23 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd in
                                                      FStar_All.pipe_right
-                                                       uu____21906
+                                                       uu___23
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu____21941 =
+                                                   let uu___23 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure in
-                                                   (if uu____21941
+                                                   (if uu___23
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____21943 =
-                                                         let uu____21944 =
+                                                      (let uu___25 =
+                                                         let uu___26 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu____21944.FStar_Syntax_Syntax.n in
-                                                       match uu____21943 with
+                                                         uu___26.FStar_Syntax_Syntax.n in
+                                                       match uu___25 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____21947 ->
+                                                           uu___26 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu____21955 =
+                                                           let uu___27 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu____21955
+                                                           if uu___27
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____21960
-                                                                  =
-                                                                  let uu____21961
+                                                                let uu___29 =
+                                                                  let uu___30
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu____21961.FStar_Syntax_Syntax.n in
-                                                                match uu____21960
+                                                                  uu___30.FStar_Syntax_Syntax.n in
+                                                                match uu___29
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu____21967)
+                                                                    uu___30)
                                                                     -> hd
-                                                                | uu____21992
-                                                                    ->
+                                                                | uu___30 ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu____21995
-                                                                =
-                                                                let uu____22006
-                                                                  =
+                                                              let uu___29 =
+                                                                let uu___30 =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____22006] in
+                                                                [uu___30] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____21995)
-                                                       | uu____22039 -> tm1))
+                                                                uu___29)
+                                                       | uu___26 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____22042 =
+                                                (let uu___24 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu____22042 with
+                                                 match uu___24 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6798,28 +6623,27 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____22062 ->
-                                                     let uu____22071 =
+                                                 | uu___25 ->
+                                                     let uu___26 =
                                                        norm_cb cfg in
-                                                     reduce_equality
-                                                       uu____22071 cfg env1
-                                                       tm1)))))))))
+                                                     reduce_equality uu___26
+                                                       cfg env1 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_refine (bv, t) ->
-                      let uu____22082 = simp_t t in
-                      (match uu____22082 with
+                      let uu___4 = simp_t t in
+                      (match uu___4 with
                        | FStar_Pervasives_Native.Some (true) ->
                            bv.FStar_Syntax_Syntax.sort
                        | FStar_Pervasives_Native.Some (false) -> tm1
                        | FStar_Pervasives_Native.None -> tm1)
-                  | FStar_Syntax_Syntax.Tm_match uu____22085 ->
-                      let uu____22108 = is_const_match tm1 in
-                      (match uu____22108 with
+                  | FStar_Syntax_Syntax.Tm_match uu___4 ->
+                      let uu___5 = is_const_match tm1 in
+                      (match uu___5 with
                        | FStar_Pervasives_Native.Some (true) ->
                            w FStar_Syntax_Util.t_true
                        | FStar_Pervasives_Native.Some (false) ->
                            w FStar_Syntax_Util.t_false
                        | FStar_Pervasives_Native.None -> tm1)
-                  | uu____22111 -> tm1))
+                  | uu___4 -> tm1))
 and (rebuild :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -6829,52 +6653,51 @@ and (rebuild :
       fun stack1 ->
         fun t ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____22121 ->
-               (let uu____22123 = FStar_Syntax_Print.tag_of_term t in
-                let uu____22124 = FStar_Syntax_Print.term_to_string t in
-                let uu____22125 =
+            (fun uu___1 ->
+               (let uu___3 = FStar_Syntax_Print.tag_of_term t in
+                let uu___4 = FStar_Syntax_Print.term_to_string t in
+                let uu___5 =
                   FStar_Util.string_of_int (FStar_List.length env1) in
-                let uu____22132 =
-                  let uu____22133 =
-                    let uu____22136 = firstn (Prims.of_int (4)) stack1 in
-                    FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____22136 in
-                  stack_to_string uu____22133 in
+                let uu___6 =
+                  let uu___7 =
+                    let uu___8 = firstn (Prims.of_int (4)) stack1 in
+                    FStar_All.pipe_left FStar_Pervasives_Native.fst uu___8 in
+                  stack_to_string uu___7 in
                 FStar_Util.print4
                   ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
-                  uu____22123 uu____22124 uu____22125 uu____22132);
-               (let uu____22159 =
+                  uu___3 uu___4 uu___5 uu___6);
+               (let uu___3 =
                   FStar_TypeChecker_Env.debug cfg.FStar_TypeChecker_Cfg.tcenv
                     (FStar_Options.Other "NormRebuild") in
-                if uu____22159
+                if uu___3
                 then
-                  let uu____22160 = FStar_Syntax_Util.unbound_variables t in
-                  match uu____22160 with
+                  let uu___4 = FStar_Syntax_Util.unbound_variables t in
+                  match uu___4 with
                   | [] -> ()
                   | bvs ->
-                      ((let uu____22167 = FStar_Syntax_Print.tag_of_term t in
-                        let uu____22168 = FStar_Syntax_Print.term_to_string t in
-                        let uu____22169 =
-                          let uu____22170 =
+                      ((let uu___6 = FStar_Syntax_Print.tag_of_term t in
+                        let uu___7 = FStar_Syntax_Print.term_to_string t in
+                        let uu___8 =
+                          let uu___9 =
                             FStar_All.pipe_right bvs
                               (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-                          FStar_All.pipe_right uu____22170
+                          FStar_All.pipe_right uu___9
                             (FStar_String.concat ", ") in
                         FStar_Util.print3
-                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____22167
-                          uu____22168 uu____22169);
+                          "!!! Rebuild (%s) %s, free vars=%s\n" uu___6 uu___7
+                          uu___8);
                        failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t in
-           let uu____22183 =
+           let uu___1 =
              (FStar_All.pipe_right f_opt FStar_Util.is_some) &&
                (match stack1 with
-                | (Arg uu____22188)::uu____22189 -> true
-                | uu____22198 -> false) in
-           if uu____22183
+                | (Arg uu___2)::uu___3 -> true
+                | uu___2 -> false) in
+           if uu___1
            then
-             let uu____22199 = FStar_All.pipe_right f_opt FStar_Util.must in
-             FStar_All.pipe_right uu____22199 (norm cfg env1 stack1)
+             let uu___2 = FStar_All.pipe_right f_opt FStar_Util.must in
+             FStar_All.pipe_right uu___2 (norm cfg env1 stack1)
            else
              (let t1 = maybe_simplify cfg env1 stack1 t in
               match stack1 with
@@ -6884,23 +6707,22 @@ and (rebuild :
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                    then
                      (let time_now = FStar_Util.now () in
-                      let uu____22211 =
-                        let uu____22212 =
-                          let uu____22213 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
                             FStar_Util.time_diff time_then time_now in
-                          FStar_Pervasives_Native.snd uu____22213 in
-                        FStar_Util.string_of_int uu____22212 in
-                      let uu____22218 = FStar_Syntax_Print.term_to_string tm in
-                      let uu____22219 =
-                        FStar_TypeChecker_Cfg.cfg_to_string cfg in
-                      let uu____22220 = FStar_Syntax_Print.term_to_string t1 in
+                          FStar_Pervasives_Native.snd uu___6 in
+                        FStar_Util.string_of_int uu___5 in
+                      let uu___5 = FStar_Syntax_Print.term_to_string tm in
+                      let uu___6 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
+                      let uu___7 = FStar_Syntax_Print.term_to_string t1 in
                       FStar_Util.print4
                         "Normalizer result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                        uu____22211 uu____22218 uu____22219 uu____22220)
+                        uu___4 uu___5 uu___6 uu___7)
                    else ();
                    rebuild cfg env1 stack2 t1)
               | (Cfg cfg1)::stack2 -> rebuild cfg1 env1 stack2 t1
-              | (Meta (uu____22226, m, r))::stack2 ->
+              | (Meta (uu___3, m, r))::stack2 ->
                   let t2 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_meta (t1, m)) r in
@@ -6908,10 +6730,9 @@ and (rebuild :
               | (MemoLazy r)::stack2 ->
                   (set_memo cfg r (env1, t1);
                    FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____22255 ->
-                        let uu____22256 =
-                          FStar_Syntax_Print.term_to_string t1 in
-                        FStar_Util.print1 "\tSet memo %s\n" uu____22256);
+                     (fun uu___5 ->
+                        let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                        FStar_Util.print1 "\tSet memo %s\n" uu___6);
                    rebuild cfg env1 stack2 t1)
               | (Let (env', bs, lb, r))::stack2 ->
                   let body = FStar_Syntax_Subst.close bs t1 in
@@ -6922,52 +6743,47 @@ and (rebuild :
               | (Abs (env', bs, env'', lopt, r))::stack2 ->
                   let bs1 = norm_binders cfg env' bs in
                   let lopt1 = norm_lcomp_opt cfg env'' lopt in
-                  let uu____22294 =
-                    let uu___2855_22295 = FStar_Syntax_Util.abs bs1 t1 lopt1 in
+                  let uu___3 =
+                    let uu___4 = FStar_Syntax_Util.abs bs1 t1 lopt1 in
                     {
-                      FStar_Syntax_Syntax.n =
-                        (uu___2855_22295.FStar_Syntax_Syntax.n);
+                      FStar_Syntax_Syntax.n = (uu___4.FStar_Syntax_Syntax.n);
                       FStar_Syntax_Syntax.pos = r;
                       FStar_Syntax_Syntax.vars =
-                        (uu___2855_22295.FStar_Syntax_Syntax.vars)
+                        (uu___4.FStar_Syntax_Syntax.vars)
                     } in
-                  rebuild cfg env1 stack2 uu____22294
-              | (Arg
-                  (Univ uu____22298, uu____22299, uu____22300))::uu____22301
-                  -> failwith "Impossible"
-              | (Arg (Dummy, uu____22304, uu____22305))::uu____22306 ->
+                  rebuild cfg env1 stack2 uu___3
+              | (Arg (Univ uu___3, uu___4, uu___5))::uu___6 ->
+                  failwith "Impossible"
+              | (Arg (Dummy, uu___3, uu___4))::uu___5 ->
                   failwith "Impossible"
               | (UnivArgs (us, r))::stack2 ->
                   let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us in
                   rebuild cfg env1 stack2 t2
-              | (Arg
-                  (Clos (env_arg, tm, uu____22321, uu____22322), aq, r))::stack2
+              | (Arg (Clos (env_arg, tm, uu___3, uu___4), aq, r))::stack2
                   when
-                  let uu____22372 = head_of t1 in
-                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____22372 ->
+                  let uu___5 = head_of t1 in
+                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu___5 ->
                   let t2 =
-                    let uu____22374 =
-                      let uu____22375 = closure_as_term cfg env_arg tm in
-                      (uu____22375, aq) in
-                    FStar_Syntax_Syntax.extend_app t1 uu____22374 r in
+                    let uu___5 =
+                      let uu___6 = closure_as_term cfg env_arg tm in
+                      (uu___6, aq) in
+                    FStar_Syntax_Syntax.extend_app t1 uu___5 r in
                   rebuild cfg env1 stack2 t2
-              | (Arg (Clos (env_arg, tm, m, uu____22385), aq, r))::stack2 ->
+              | (Arg (Clos (env_arg, tm, m, uu___3), aq, r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____22438 ->
-                        let uu____22439 =
-                          FStar_Syntax_Print.term_to_string tm in
-                        FStar_Util.print1 "Rebuilding with arg %s\n"
-                          uu____22439);
+                     (fun uu___5 ->
+                        let uu___6 = FStar_Syntax_Print.term_to_string tm in
+                        FStar_Util.print1 "Rebuilding with arg %s\n" uu___6);
                    if
                      Prims.op_Negation
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                    then
-                     (let uu____22440 =
+                     (let uu___5 =
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
                           &&
-                          (let uu____22442 = is_partial_primop_app cfg t1 in
-                           Prims.op_Negation uu____22442) in
-                      if uu____22440
+                          (let uu___6 = is_partial_primop_app cfg t1 in
+                           Prims.op_Negation uu___6) in
+                      if uu___5
                       then
                         let arg = closure_as_term cfg env_arg tm in
                         let t2 =
@@ -6977,15 +6793,15 @@ and (rebuild :
                         (let stack3 = (App (env1, t1, aq, r)) :: stack2 in
                          norm cfg env_arg stack3 tm))
                    else
-                     (let uu____22454 = FStar_ST.op_Bang m in
-                      match uu____22454 with
+                     (let uu___6 = FStar_ST.op_Bang m in
+                      match uu___6 with
                       | FStar_Pervasives_Native.None ->
-                          let uu____22515 =
+                          let uu___7 =
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
                               &&
-                              (let uu____22517 = is_partial_primop_app cfg t1 in
-                               Prims.op_Negation uu____22517) in
-                          if uu____22515
+                              (let uu___8 = is_partial_primop_app cfg t1 in
+                               Prims.op_Negation uu___8) in
+                          if uu___7
                           then
                             let arg = closure_as_term cfg env_arg tm in
                             let t2 =
@@ -6995,64 +6811,61 @@ and (rebuild :
                             (let stack3 = (MemoLazy m) ::
                                (App (env1, t1, aq, r)) :: stack2 in
                              norm cfg env_arg stack3 tm)
-                      | FStar_Pervasives_Native.Some (uu____22528, a) ->
+                      | FStar_Pervasives_Native.Some (uu___7, a) ->
                           let t2 =
                             FStar_Syntax_Syntax.extend_app t1 (a, aq) r in
                           rebuild cfg env_arg stack2 t2))
               | (App (env2, head, aq, r))::stack' when
                   should_reify cfg stack1 ->
                   let t0 = t1 in
-                  let fallback msg uu____22581 =
+                  let fallback msg uu___3 =
                     FStar_TypeChecker_Cfg.log cfg
-                      (fun uu____22585 ->
-                         let uu____22586 =
-                           FStar_Syntax_Print.term_to_string t1 in
-                         FStar_Util.print2 "Not reifying%s: %s\n" msg
-                           uu____22586);
+                      (fun uu___5 ->
+                         let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                         FStar_Util.print2 "Not reifying%s: %s\n" msg uu___6);
                     (let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r in
                      rebuild cfg env2 stack' t2) in
                   let is_layered_effect m =
-                    let uu____22598 =
+                    let uu___3 =
                       FStar_All.pipe_right m
                         (FStar_TypeChecker_Env.norm_eff_name
                            cfg.FStar_TypeChecker_Cfg.tcenv) in
-                    FStar_All.pipe_right uu____22598
+                    FStar_All.pipe_right uu___3
                       (FStar_TypeChecker_Env.is_layered_effect
                          cfg.FStar_TypeChecker_Cfg.tcenv) in
-                  let uu____22599 =
-                    let uu____22600 = FStar_Syntax_Subst.compress t1 in
-                    uu____22600.FStar_Syntax_Syntax.n in
-                  (match uu____22599 with
+                  let uu___3 =
+                    let uu___4 = FStar_Syntax_Subst.compress t1 in
+                    uu___4.FStar_Syntax_Syntax.n in
+                  (match uu___3 with
                    | FStar_Syntax_Syntax.Tm_meta
-                       (uu____22603, FStar_Syntax_Syntax.Meta_monadic
-                        (m, uu____22605))
+                       (uu___4, FStar_Syntax_Syntax.Meta_monadic (m, uu___5))
                        when
                        (FStar_All.pipe_right m is_layered_effect) &&
                          (Prims.op_Negation
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction)
                        ->
-                       let uu____22614 =
-                         let uu____22615 = FStar_Ident.string_of_lid m in
+                       let uu___6 =
+                         let uu___7 = FStar_Ident.string_of_lid m in
                          FStar_Util.format1
                            "Meta_monadic for a layered effect %s in non-extraction mode"
-                           uu____22615 in
-                       fallback uu____22614 ()
+                           uu___7 in
+                       fallback uu___6 ()
                    | FStar_Syntax_Syntax.Tm_meta
-                       (uu____22616, FStar_Syntax_Syntax.Meta_monadic_lift
-                        (msrc, mtgt, uu____22619))
+                       (uu___4, FStar_Syntax_Syntax.Meta_monadic_lift
+                        (msrc, mtgt, uu___5))
                        when
                        ((is_layered_effect msrc) || (is_layered_effect mtgt))
                          &&
                          (Prims.op_Negation
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction)
                        ->
-                       let uu____22628 =
-                         let uu____22629 = FStar_Ident.string_of_lid msrc in
-                         let uu____22630 = FStar_Ident.string_of_lid mtgt in
+                       let uu___6 =
+                         let uu___7 = FStar_Ident.string_of_lid msrc in
+                         let uu___8 = FStar_Ident.string_of_lid mtgt in
                          FStar_Util.format2
                            "Meta_monadic_lift for layered effect %s ~> %s in non extraction mode"
-                           uu____22629 uu____22630 in
-                       fallback uu____22628 ()
+                           uu___7 uu___8 in
+                       fallback uu___6 ()
                    | FStar_Syntax_Syntax.Tm_meta
                        (t2, FStar_Syntax_Syntax.Meta_monadic (m, ty)) ->
                        do_reify_monadic (fallback " (1)") cfg env2 stack1 t2
@@ -7062,109 +6875,105 @@ and (rebuild :
                         (msrc, mtgt, ty))
                        ->
                        let lifted =
-                         let uu____22655 = closure_as_term cfg env2 ty in
-                         reify_lift cfg t2 msrc mtgt uu____22655 in
+                         let uu___4 = closure_as_term cfg env2 ty in
+                         reify_lift cfg t2 msrc mtgt uu___4 in
                        (FStar_TypeChecker_Cfg.log cfg
-                          (fun uu____22659 ->
-                             let uu____22660 =
+                          (fun uu___5 ->
+                             let uu___6 =
                                FStar_Syntax_Print.term_to_string lifted in
                              FStar_Util.print1 "Reified lift to (1): %s\n"
-                               uu____22660);
-                        (let uu____22661 = FStar_List.tl stack1 in
-                         norm cfg env2 uu____22661 lifted))
+                               uu___6);
+                        (let uu___5 = FStar_List.tl stack1 in
+                         norm cfg env2 uu___5 lifted))
                    | FStar_Syntax_Syntax.Tm_app
                        ({
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_constant
-                            (FStar_Const.Const_reflect uu____22662);
-                          FStar_Syntax_Syntax.pos = uu____22663;
-                          FStar_Syntax_Syntax.vars = uu____22664;_},
-                        (e, uu____22666)::[])
+                            (FStar_Const.Const_reflect uu___4);
+                          FStar_Syntax_Syntax.pos = uu___5;
+                          FStar_Syntax_Syntax.vars = uu___6;_},
+                        (e, uu___7)::[])
                        -> norm cfg env2 stack' e
-                   | FStar_Syntax_Syntax.Tm_app uu____22705 when
+                   | FStar_Syntax_Syntax.Tm_app uu___4 when
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
                        ->
-                       let uu____22722 = FStar_Syntax_Util.head_and_args t1 in
-                       (match uu____22722 with
+                       let uu___5 = FStar_Syntax_Util.head_and_args t1 in
+                       (match uu___5 with
                         | (hd, args) ->
-                            let uu____22765 =
-                              let uu____22766 = FStar_Syntax_Util.un_uinst hd in
-                              uu____22766.FStar_Syntax_Syntax.n in
-                            (match uu____22765 with
+                            let uu___6 =
+                              let uu___7 = FStar_Syntax_Util.un_uinst hd in
+                              uu___7.FStar_Syntax_Syntax.n in
+                            (match uu___6 with
                              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                 let uu____22770 =
+                                 let uu___7 =
                                    FStar_TypeChecker_Cfg.find_prim_step cfg
                                      fv in
-                                 (match uu____22770 with
+                                 (match uu___7 with
                                   | FStar_Pervasives_Native.Some
-                                      {
-                                        FStar_TypeChecker_Cfg.name =
-                                          uu____22773;
-                                        FStar_TypeChecker_Cfg.arity =
-                                          uu____22774;
+                                      { FStar_TypeChecker_Cfg.name = uu___8;
+                                        FStar_TypeChecker_Cfg.arity = uu___9;
                                         FStar_TypeChecker_Cfg.univ_arity =
-                                          uu____22775;
+                                          uu___10;
                                         FStar_TypeChecker_Cfg.auto_reflect =
                                           FStar_Pervasives_Native.Some n;
                                         FStar_TypeChecker_Cfg.strong_reduction_ok
-                                          = uu____22777;
+                                          = uu___11;
                                         FStar_TypeChecker_Cfg.requires_binder_substitution
-                                          = uu____22778;
+                                          = uu___12;
                                         FStar_TypeChecker_Cfg.interpretation
-                                          = uu____22779;
+                                          = uu___13;
                                         FStar_TypeChecker_Cfg.interpretation_nbe
-                                          = uu____22780;_}
+                                          = uu___14;_}
                                       when (FStar_List.length args) = n ->
                                       norm cfg env2 stack' t1
-                                  | uu____22809 -> fallback " (3)" ())
-                             | uu____22812 -> fallback " (4)" ()))
-                   | uu____22813 -> fallback " (2)" ())
+                                  | uu___8 -> fallback " (3)" ())
+                             | uu___7 -> fallback " (4)" ()))
+                   | uu___4 -> fallback " (2)" ())
               | (App (env2, head, aq, r))::stack2 ->
                   let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r in
                   rebuild cfg env2 stack2 t2
               | (CBVApp (env', head, aq, r))::stack2 ->
-                  let uu____22833 =
-                    let uu____22834 =
-                      let uu____22835 =
-                        let uu____22842 =
-                          let uu____22843 =
-                            let uu____22874 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
                               FStar_Util.mk_ref FStar_Pervasives_Native.None in
-                            (env1, t1, uu____22874, false) in
-                          Clos uu____22843 in
-                        (uu____22842, aq, (t1.FStar_Syntax_Syntax.pos)) in
-                      Arg uu____22835 in
-                    uu____22834 :: stack2 in
-                  norm cfg env' uu____22833 head
+                            (env1, t1, uu___8, false) in
+                          Clos uu___7 in
+                        (uu___6, aq, (t1.FStar_Syntax_Syntax.pos)) in
+                      Arg uu___5 in
+                    uu___4 :: stack2 in
+                  norm cfg env' uu___3 head
               | (Match (env', branches1, cfg1, r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg1
-                     (fun uu____22947 ->
-                        let uu____22948 =
-                          FStar_Syntax_Print.term_to_string t1 in
+                     (fun uu___4 ->
+                        let uu___5 = FStar_Syntax_Print.term_to_string t1 in
                         FStar_Util.print1
                           "Rebuilding with match, scrutinee is %s ...\n"
-                          uu____22948);
+                          uu___5);
                    (let scrutinee_env = env1 in
                     let env2 = env' in
                     let scrutinee = t1 in
-                    let norm_and_rebuild_match uu____22957 =
+                    let norm_and_rebuild_match uu___4 =
                       FStar_TypeChecker_Cfg.log cfg1
-                        (fun uu____22962 ->
-                           let uu____22963 =
+                        (fun uu___6 ->
+                           let uu___7 =
                              FStar_Syntax_Print.term_to_string scrutinee in
-                           let uu____22964 =
-                             let uu____22965 =
+                           let uu___8 =
+                             let uu___9 =
                                FStar_All.pipe_right branches1
                                  (FStar_List.map
-                                    (fun uu____22992 ->
-                                       match uu____22992 with
-                                       | (p, uu____23002, uu____23003) ->
+                                    (fun uu___10 ->
+                                       match uu___10 with
+                                       | (p, uu___11, uu___12) ->
                                            FStar_Syntax_Print.pat_to_string p)) in
-                             FStar_All.pipe_right uu____22965
+                             FStar_All.pipe_right uu___9
                                (FStar_String.concat "\n\t") in
                            FStar_Util.print2
                              "match is irreducible: scrutinee=%s\nbranches=%s\n"
-                             uu____22963 uu____22964);
+                             uu___7 uu___8);
                       (let whnf =
                          (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                            ||
@@ -7178,91 +6987,90 @@ and (rebuild :
                               FStar_All.pipe_right
                                 cfg1.FStar_TypeChecker_Cfg.delta_level
                                 (FStar_List.filter
-                                   (fun uu___16_23021 ->
-                                      match uu___16_23021 with
+                                   (fun uu___7 ->
+                                      match uu___7 with
                                       | FStar_TypeChecker_Env.InliningDelta
                                           -> true
                                       | FStar_TypeChecker_Env.Eager_unfolding_only
                                           -> true
-                                      | uu____23022 -> false)) in
+                                      | uu___8 -> false)) in
                             let steps =
-                              let uu___3049_23024 =
-                                cfg1.FStar_TypeChecker_Cfg.steps in
+                              let uu___7 = cfg1.FStar_TypeChecker_Cfg.steps in
                               {
                                 FStar_TypeChecker_Cfg.beta =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.beta);
+                                  (uu___7.FStar_TypeChecker_Cfg.beta);
                                 FStar_TypeChecker_Cfg.iota =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.iota);
+                                  (uu___7.FStar_TypeChecker_Cfg.iota);
                                 FStar_TypeChecker_Cfg.zeta = false;
                                 FStar_TypeChecker_Cfg.zeta_full =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.zeta_full);
+                                  (uu___7.FStar_TypeChecker_Cfg.zeta_full);
                                 FStar_TypeChecker_Cfg.weak =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.weak);
+                                  (uu___7.FStar_TypeChecker_Cfg.weak);
                                 FStar_TypeChecker_Cfg.hnf =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.hnf);
+                                  (uu___7.FStar_TypeChecker_Cfg.hnf);
                                 FStar_TypeChecker_Cfg.primops =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.primops);
+                                  (uu___7.FStar_TypeChecker_Cfg.primops);
                                 FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                   =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                  (uu___7.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                 FStar_TypeChecker_Cfg.unfold_until =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_only =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_fully =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unfold_fully);
+                                  (uu___7.FStar_TypeChecker_Cfg.unfold_fully);
                                 FStar_TypeChecker_Cfg.unfold_attr =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_tac = false;
                                 FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                   =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                  (uu___7.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                 FStar_TypeChecker_Cfg.simplify =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.simplify);
+                                  (uu___7.FStar_TypeChecker_Cfg.simplify);
                                 FStar_TypeChecker_Cfg.erase_universes =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.erase_universes);
+                                  (uu___7.FStar_TypeChecker_Cfg.erase_universes);
                                 FStar_TypeChecker_Cfg.allow_unbound_universes
                                   =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                  (uu___7.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                 FStar_TypeChecker_Cfg.reify_ =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.reify_);
+                                  (uu___7.FStar_TypeChecker_Cfg.reify_);
                                 FStar_TypeChecker_Cfg.compress_uvars =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.compress_uvars);
+                                  (uu___7.FStar_TypeChecker_Cfg.compress_uvars);
                                 FStar_TypeChecker_Cfg.no_full_norm =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.no_full_norm);
+                                  (uu___7.FStar_TypeChecker_Cfg.no_full_norm);
                                 FStar_TypeChecker_Cfg.check_no_uvars =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.check_no_uvars);
+                                  (uu___7.FStar_TypeChecker_Cfg.check_no_uvars);
                                 FStar_TypeChecker_Cfg.unmeta =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unmeta);
+                                  (uu___7.FStar_TypeChecker_Cfg.unmeta);
                                 FStar_TypeChecker_Cfg.unascribe =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unascribe);
+                                  (uu___7.FStar_TypeChecker_Cfg.unascribe);
                                 FStar_TypeChecker_Cfg.in_full_norm_request =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                  (uu___7.FStar_TypeChecker_Cfg.in_full_norm_request);
                                 FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                   =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                                  (uu___7.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                                 FStar_TypeChecker_Cfg.nbe_step =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.nbe_step);
+                                  (uu___7.FStar_TypeChecker_Cfg.nbe_step);
                                 FStar_TypeChecker_Cfg.for_extraction =
-                                  (uu___3049_23024.FStar_TypeChecker_Cfg.for_extraction)
+                                  (uu___7.FStar_TypeChecker_Cfg.for_extraction)
                               } in
-                            let uu___3052_23029 = cfg1 in
+                            let uu___7 = cfg1 in
                             {
                               FStar_TypeChecker_Cfg.steps = steps;
                               FStar_TypeChecker_Cfg.tcenv =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.tcenv);
+                                (uu___7.FStar_TypeChecker_Cfg.tcenv);
                               FStar_TypeChecker_Cfg.debug =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.debug);
+                                (uu___7.FStar_TypeChecker_Cfg.debug);
                               FStar_TypeChecker_Cfg.delta_level = new_delta;
                               FStar_TypeChecker_Cfg.primitive_steps =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.primitive_steps);
+                                (uu___7.FStar_TypeChecker_Cfg.primitive_steps);
                               FStar_TypeChecker_Cfg.strong = true;
                               FStar_TypeChecker_Cfg.memoize_lazy =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.memoize_lazy);
+                                (uu___7.FStar_TypeChecker_Cfg.memoize_lazy);
                               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                (uu___7.FStar_TypeChecker_Cfg.normalize_pure_lets);
                               FStar_TypeChecker_Cfg.reifying =
-                                (uu___3052_23029.FStar_TypeChecker_Cfg.reifying)
+                                (uu___7.FStar_TypeChecker_Cfg.reifying)
                             }) in
                        let norm_or_whnf env3 t2 =
                          if whnf
@@ -7270,104 +7078,102 @@ and (rebuild :
                          else norm cfg_exclude_zeta env3 [] t2 in
                        let rec norm_pat env3 p =
                          match p.FStar_Syntax_Syntax.v with
-                         | FStar_Syntax_Syntax.Pat_constant uu____23101 ->
+                         | FStar_Syntax_Syntax.Pat_constant uu___6 ->
                              (p, env3)
                          | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-                             let uu____23130 =
+                             let uu___6 =
                                FStar_All.pipe_right pats
                                  (FStar_List.fold_left
-                                    (fun uu____23214 ->
-                                       fun uu____23215 ->
-                                         match (uu____23214, uu____23215)
-                                         with
+                                    (fun uu___7 ->
+                                       fun uu___8 ->
+                                         match (uu___7, uu___8) with
                                          | ((pats1, env4), (p1, b)) ->
-                                             let uu____23354 =
-                                               norm_pat env4 p1 in
-                                             (match uu____23354 with
+                                             let uu___9 = norm_pat env4 p1 in
+                                             (match uu___9 with
                                               | (p2, env5) ->
                                                   (((p2, b) :: pats1), env5)))
                                     ([], env3)) in
-                             (match uu____23130 with
+                             (match uu___6 with
                               | (pats1, env4) ->
-                                  ((let uu___3080_23516 = p in
+                                  ((let uu___7 = p in
                                     {
                                       FStar_Syntax_Syntax.v =
                                         (FStar_Syntax_Syntax.Pat_cons
                                            (fv, (FStar_List.rev pats1)));
                                       FStar_Syntax_Syntax.p =
-                                        (uu___3080_23516.FStar_Syntax_Syntax.p)
+                                        (uu___7.FStar_Syntax_Syntax.p)
                                     }), env4))
                          | FStar_Syntax_Syntax.Pat_var x ->
                              let x1 =
-                               let uu___3084_23535 = x in
-                               let uu____23536 =
+                               let uu___6 = x in
+                               let uu___7 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3084_23535.FStar_Syntax_Syntax.ppname);
+                                   (uu___6.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3084_23535.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23536
+                                   (uu___6.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu___7
                                } in
-                             ((let uu___3087_23550 = p in
+                             ((let uu___6 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_var x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3087_23550.FStar_Syntax_Syntax.p)
+                                   (uu___6.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_wild x ->
                              let x1 =
-                               let uu___3091_23561 = x in
-                               let uu____23562 =
+                               let uu___6 = x in
+                               let uu___7 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3091_23561.FStar_Syntax_Syntax.ppname);
+                                   (uu___6.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3091_23561.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23562
+                                   (uu___6.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu___7
                                } in
-                             ((let uu___3094_23576 = p in
+                             ((let uu___6 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_wild x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3094_23576.FStar_Syntax_Syntax.p)
+                                   (uu___6.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_dot_term (x, t2) ->
                              let x1 =
-                               let uu___3100_23592 = x in
-                               let uu____23593 =
+                               let uu___6 = x in
+                               let uu___7 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3100_23592.FStar_Syntax_Syntax.ppname);
+                                   (uu___6.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3100_23592.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23593
+                                   (uu___6.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu___7
                                } in
                              let t3 = norm_or_whnf env3 t2 in
-                             ((let uu___3104_23608 = p in
+                             ((let uu___6 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3104_23608.FStar_Syntax_Syntax.p)
+                                   (uu___6.FStar_Syntax_Syntax.p)
                                }), env3) in
-                       let norm_branches uu____23628 =
+                       let norm_branches uu___6 =
                          match env2 with
                          | [] when whnf -> branches1
-                         | uu____23645 ->
+                         | uu___7 ->
                              FStar_All.pipe_right branches1
                                (FStar_List.map
                                   (fun branch ->
-                                     let uu____23661 =
+                                     let uu___8 =
                                        FStar_Syntax_Subst.open_branch branch in
-                                     match uu____23661 with
+                                     match uu___8 with
                                      | (p, wopt, e) ->
-                                         let uu____23681 = norm_pat env2 p in
-                                         (match uu____23681 with
+                                         let uu___9 = norm_pat env2 p in
+                                         (match uu___9 with
                                           | (p1, env3) ->
                                               let wopt1 =
                                                 match wopt with
@@ -7376,66 +7182,63 @@ and (rebuild :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     w ->
-                                                    let uu____23736 =
+                                                    let uu___10 =
                                                       norm_or_whnf env3 w in
                                                     FStar_Pervasives_Native.Some
-                                                      uu____23736 in
+                                                      uu___10 in
                                               let e1 = norm_or_whnf env3 e in
                                               FStar_Syntax_Util.branch
                                                 (p1, wopt1, e1)))) in
-                       let maybe_commute_matches uu____23755 =
+                       let maybe_commute_matches uu___6 =
                          let can_commute =
                            match branches1 with
                            | ({
                                 FStar_Syntax_Syntax.v =
-                                  FStar_Syntax_Syntax.Pat_cons
-                                  (fv, uu____23758);
-                                FStar_Syntax_Syntax.p = uu____23759;_},
-                              uu____23760, uu____23761)::uu____23762 ->
+                                  FStar_Syntax_Syntax.Pat_cons (fv, uu___7);
+                                FStar_Syntax_Syntax.p = uu___8;_},
+                              uu___9, uu___10)::uu___11 ->
                                FStar_TypeChecker_Env.fv_has_attr
                                  cfg1.FStar_TypeChecker_Cfg.tcenv fv
                                  FStar_Parser_Const.commute_nested_matches_lid
-                           | uu____23801 -> false in
-                         let uu____23802 =
-                           let uu____23803 =
-                             FStar_Syntax_Util.unascribe scrutinee in
-                           uu____23803.FStar_Syntax_Syntax.n in
-                         match uu____23802 with
+                           | uu___7 -> false in
+                         let uu___7 =
+                           let uu___8 = FStar_Syntax_Util.unascribe scrutinee in
+                           uu___8.FStar_Syntax_Syntax.n in
+                         match uu___7 with
                          | FStar_Syntax_Syntax.Tm_match (sc0, branches0) when
                              can_commute ->
                              let reduce_branch b =
                                let stack3 =
                                  [Match (env', branches1, cfg1, r)] in
-                               let uu____23853 =
-                                 FStar_Syntax_Subst.open_branch b in
-                               match uu____23853 with
+                               let uu___8 = FStar_Syntax_Subst.open_branch b in
+                               match uu___8 with
                                | (p, wopt, e) ->
-                                   let uu____23873 = norm_pat scrutinee_env p in
-                                   (match uu____23873 with
+                                   let uu___9 = norm_pat scrutinee_env p in
+                                   (match uu___9 with
                                     | (p1, branch_env) ->
                                         let wopt1 =
                                           match wopt with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____23928 =
+                                              let uu___10 =
                                                 norm_or_whnf branch_env w in
                                               FStar_Pervasives_Native.Some
-                                                uu____23928 in
+                                                uu___10 in
                                         let e1 =
                                           norm cfg1 branch_env stack3 e in
                                         FStar_Syntax_Util.branch
                                           (p1, wopt1, e1)) in
                              let branches01 =
                                FStar_List.map reduce_branch branches0 in
-                             let uu____23987 =
+                             let uu___8 =
                                FStar_Syntax_Syntax.mk
                                  (FStar_Syntax_Syntax.Tm_match
                                     (sc0, branches01)) r in
-                             rebuild cfg1 env2 stack2 uu____23987
-                         | uu____24006 ->
+                             rebuild cfg1 env2 stack2 uu___8
+                         | uu___8 ->
                              let scrutinee1 =
-                               let uu____24010 =
+                               let uu___9 =
                                  ((((cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                                       &&
                                       (Prims.op_Negation
@@ -7446,132 +7249,131 @@ and (rebuild :
                                     &&
                                     (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weakly_reduce_scrutinee)
                                    && (maybe_weakly_reduced scrutinee) in
-                               if uu____24010
+                               if uu___9
                                then
                                  norm
-                                   (let uu___3160_24015 = cfg1 in
+                                   (let uu___10 = cfg1 in
                                     {
                                       FStar_TypeChecker_Cfg.steps =
-                                        (let uu___3162_24018 =
+                                        (let uu___11 =
                                            cfg1.FStar_TypeChecker_Cfg.steps in
                                          {
                                            FStar_TypeChecker_Cfg.beta =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.beta);
+                                             (uu___11.FStar_TypeChecker_Cfg.beta);
                                            FStar_TypeChecker_Cfg.iota =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.iota);
+                                             (uu___11.FStar_TypeChecker_Cfg.iota);
                                            FStar_TypeChecker_Cfg.zeta =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.zeta);
+                                             (uu___11.FStar_TypeChecker_Cfg.zeta);
                                            FStar_TypeChecker_Cfg.zeta_full =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.zeta_full);
+                                             (uu___11.FStar_TypeChecker_Cfg.zeta_full);
                                            FStar_TypeChecker_Cfg.weak =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.weak);
+                                             (uu___11.FStar_TypeChecker_Cfg.weak);
                                            FStar_TypeChecker_Cfg.hnf =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.hnf);
+                                             (uu___11.FStar_TypeChecker_Cfg.hnf);
                                            FStar_TypeChecker_Cfg.primops =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.primops);
+                                             (uu___11.FStar_TypeChecker_Cfg.primops);
                                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                             (uu___11.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                            FStar_TypeChecker_Cfg.unfold_until
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_until);
+                                             (uu___11.FStar_TypeChecker_Cfg.unfold_until);
                                            FStar_TypeChecker_Cfg.unfold_only
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_only);
+                                             (uu___11.FStar_TypeChecker_Cfg.unfold_only);
                                            FStar_TypeChecker_Cfg.unfold_fully
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_fully);
+                                             (uu___11.FStar_TypeChecker_Cfg.unfold_fully);
                                            FStar_TypeChecker_Cfg.unfold_attr
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_attr);
+                                             (uu___11.FStar_TypeChecker_Cfg.unfold_attr);
                                            FStar_TypeChecker_Cfg.unfold_tac =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_tac);
+                                             (uu___11.FStar_TypeChecker_Cfg.unfold_tac);
                                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                             (uu___11.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                            FStar_TypeChecker_Cfg.simplify =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.simplify);
+                                             (uu___11.FStar_TypeChecker_Cfg.simplify);
                                            FStar_TypeChecker_Cfg.erase_universes
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.erase_universes);
+                                             (uu___11.FStar_TypeChecker_Cfg.erase_universes);
                                            FStar_TypeChecker_Cfg.allow_unbound_universes
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                             (uu___11.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                            FStar_TypeChecker_Cfg.reify_ =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.reify_);
+                                             (uu___11.FStar_TypeChecker_Cfg.reify_);
                                            FStar_TypeChecker_Cfg.compress_uvars
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.compress_uvars);
+                                             (uu___11.FStar_TypeChecker_Cfg.compress_uvars);
                                            FStar_TypeChecker_Cfg.no_full_norm
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.no_full_norm);
+                                             (uu___11.FStar_TypeChecker_Cfg.no_full_norm);
                                            FStar_TypeChecker_Cfg.check_no_uvars
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.check_no_uvars);
+                                             (uu___11.FStar_TypeChecker_Cfg.check_no_uvars);
                                            FStar_TypeChecker_Cfg.unmeta =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unmeta);
+                                             (uu___11.FStar_TypeChecker_Cfg.unmeta);
                                            FStar_TypeChecker_Cfg.unascribe =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unascribe);
+                                             (uu___11.FStar_TypeChecker_Cfg.unascribe);
                                            FStar_TypeChecker_Cfg.in_full_norm_request
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                             (uu___11.FStar_TypeChecker_Cfg.in_full_norm_request);
                                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                              = false;
                                            FStar_TypeChecker_Cfg.nbe_step =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.nbe_step);
+                                             (uu___11.FStar_TypeChecker_Cfg.nbe_step);
                                            FStar_TypeChecker_Cfg.for_extraction
                                              =
-                                             (uu___3162_24018.FStar_TypeChecker_Cfg.for_extraction)
+                                             (uu___11.FStar_TypeChecker_Cfg.for_extraction)
                                          });
                                       FStar_TypeChecker_Cfg.tcenv =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.tcenv);
+                                        (uu___10.FStar_TypeChecker_Cfg.tcenv);
                                       FStar_TypeChecker_Cfg.debug =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.debug);
+                                        (uu___10.FStar_TypeChecker_Cfg.debug);
                                       FStar_TypeChecker_Cfg.delta_level =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.delta_level);
+                                        (uu___10.FStar_TypeChecker_Cfg.delta_level);
                                       FStar_TypeChecker_Cfg.primitive_steps =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.primitive_steps);
+                                        (uu___10.FStar_TypeChecker_Cfg.primitive_steps);
                                       FStar_TypeChecker_Cfg.strong =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.strong);
+                                        (uu___10.FStar_TypeChecker_Cfg.strong);
                                       FStar_TypeChecker_Cfg.memoize_lazy =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.memoize_lazy);
+                                        (uu___10.FStar_TypeChecker_Cfg.memoize_lazy);
                                       FStar_TypeChecker_Cfg.normalize_pure_lets
                                         =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                        (uu___10.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                       FStar_TypeChecker_Cfg.reifying =
-                                        (uu___3160_24015.FStar_TypeChecker_Cfg.reifying)
+                                        (uu___10.FStar_TypeChecker_Cfg.reifying)
                                     }) scrutinee_env [] scrutinee
                                else scrutinee in
                              let branches2 = norm_branches () in
-                             let uu____24031 =
+                             let uu___9 =
                                FStar_Syntax_Syntax.mk
                                  (FStar_Syntax_Syntax.Tm_match
                                     (scrutinee1, branches2)) r in
-                             rebuild cfg1 env2 stack2 uu____24031 in
+                             rebuild cfg1 env2 stack2 uu___9 in
                        maybe_commute_matches ()) in
                     let rec is_cons head =
-                      let uu____24056 =
-                        let uu____24057 = FStar_Syntax_Subst.compress head in
-                        uu____24057.FStar_Syntax_Syntax.n in
-                      match uu____24056 with
-                      | FStar_Syntax_Syntax.Tm_uinst (h, uu____24061) ->
-                          is_cons h
-                      | FStar_Syntax_Syntax.Tm_constant uu____24066 -> true
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Subst.compress head in
+                        uu___5.FStar_Syntax_Syntax.n in
+                      match uu___4 with
+                      | FStar_Syntax_Syntax.Tm_uinst (h, uu___5) -> is_cons h
+                      | FStar_Syntax_Syntax.Tm_constant uu___5 -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24067;
-                            FStar_Syntax_Syntax.fv_delta = uu____24068;
+                          { FStar_Syntax_Syntax.fv_name = uu___5;
+                            FStar_Syntax_Syntax.fv_delta = uu___6;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Data_ctor);_}
                           -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24069;
-                            FStar_Syntax_Syntax.fv_delta = uu____24070;
+                          { FStar_Syntax_Syntax.fv_name = uu___5;
+                            FStar_Syntax_Syntax.fv_delta = uu___6;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Record_ctor uu____24071);_}
+                              (FStar_Syntax_Syntax.Record_ctor uu___7);_}
                           -> true
-                      | uu____24078 -> false in
+                      | uu___5 -> false in
                     let guard_when_clause wopt b rest =
                       match wopt with
                       | FStar_Pervasives_Native.None -> b
@@ -7587,109 +7389,104 @@ and (rebuild :
                       let scrutinee1 =
                         FStar_Syntax_Util.unmeta scrutinee_orig in
                       let scrutinee2 = FStar_Syntax_Util.unlazy scrutinee1 in
-                      let uu____24242 =
-                        FStar_Syntax_Util.head_and_args scrutinee2 in
-                      match uu____24242 with
+                      let uu___4 = FStar_Syntax_Util.head_and_args scrutinee2 in
+                      match uu___4 with
                       | (head, args) ->
                           (match p.FStar_Syntax_Syntax.v with
                            | FStar_Syntax_Syntax.Pat_var bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
                            | FStar_Syntax_Syntax.Pat_wild bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
-                           | FStar_Syntax_Syntax.Pat_dot_term uu____24335 ->
+                           | FStar_Syntax_Syntax.Pat_dot_term uu___5 ->
                                FStar_Util.Inl []
                            | FStar_Syntax_Syntax.Pat_constant s ->
                                (match scrutinee2.FStar_Syntax_Syntax.n with
                                 | FStar_Syntax_Syntax.Tm_constant s' when
                                     FStar_Const.eq_const s s' ->
                                     FStar_Util.Inl []
-                                | uu____24374 ->
-                                    let uu____24375 =
-                                      let uu____24376 = is_cons head in
-                                      Prims.op_Negation uu____24376 in
-                                    FStar_Util.Inr uu____24375)
+                                | uu___5 ->
+                                    let uu___6 =
+                                      let uu___7 = is_cons head in
+                                      Prims.op_Negation uu___7 in
+                                    FStar_Util.Inr uu___6)
                            | FStar_Syntax_Syntax.Pat_cons (fv, arg_pats) ->
-                               let uu____24401 =
-                                 let uu____24402 =
-                                   FStar_Syntax_Util.un_uinst head in
-                                 uu____24402.FStar_Syntax_Syntax.n in
-                               (match uu____24401 with
+                               let uu___5 =
+                                 let uu___6 = FStar_Syntax_Util.un_uinst head in
+                                 uu___6.FStar_Syntax_Syntax.n in
+                               (match uu___5 with
                                 | FStar_Syntax_Syntax.Tm_fvar fv' when
                                     FStar_Syntax_Syntax.fv_eq fv fv' ->
                                     matches_args [] args arg_pats
-                                | uu____24420 ->
-                                    let uu____24421 =
-                                      let uu____24422 = is_cons head in
-                                      Prims.op_Negation uu____24422 in
-                                    FStar_Util.Inr uu____24421))
+                                | uu___6 ->
+                                    let uu___7 =
+                                      let uu___8 = is_cons head in
+                                      Prims.op_Negation uu___8 in
+                                    FStar_Util.Inr uu___7))
                     and matches_args out a p =
                       match (a, p) with
                       | ([], []) -> FStar_Util.Inl out
-                      | ((t2, uu____24505)::rest_a,
-                         (p1, uu____24508)::rest_p) ->
-                          let uu____24562 = matches_pat t2 p1 in
-                          (match uu____24562 with
+                      | ((t2, uu___4)::rest_a, (p1, uu___5)::rest_p) ->
+                          let uu___6 = matches_pat t2 p1 in
+                          (match uu___6 with
                            | FStar_Util.Inl s ->
                                matches_args (FStar_List.append out s) rest_a
                                  rest_p
                            | m -> m)
-                      | uu____24611 -> FStar_Util.Inr false in
+                      | uu___4 -> FStar_Util.Inr false in
                     let rec matches scrutinee1 p =
                       match p with
                       | [] -> norm_and_rebuild_match ()
                       | (p1, wopt, b)::rest ->
-                          let uu____24731 = matches_pat scrutinee1 p1 in
-                          (match uu____24731 with
+                          let uu___4 = matches_pat scrutinee1 p1 in
+                          (match uu___4 with
                            | FStar_Util.Inr (false) ->
                                matches scrutinee1 rest
                            | FStar_Util.Inr (true) ->
                                norm_and_rebuild_match ()
                            | FStar_Util.Inl s ->
                                (FStar_TypeChecker_Cfg.log cfg1
-                                  (fun uu____24771 ->
-                                     let uu____24772 =
+                                  (fun uu___6 ->
+                                     let uu___7 =
                                        FStar_Syntax_Print.pat_to_string p1 in
-                                     let uu____24773 =
-                                       let uu____24774 =
+                                     let uu___8 =
+                                       let uu___9 =
                                          FStar_List.map
-                                           (fun uu____24784 ->
-                                              match uu____24784 with
-                                              | (uu____24789, t2) ->
+                                           (fun uu___10 ->
+                                              match uu___10 with
+                                              | (uu___11, t2) ->
                                                   FStar_Syntax_Print.term_to_string
                                                     t2) s in
-                                       FStar_All.pipe_right uu____24774
+                                       FStar_All.pipe_right uu___9
                                          (FStar_String.concat "; ") in
                                      FStar_Util.print2
                                        "Matches pattern %s with subst = %s\n"
-                                       uu____24772 uu____24773);
+                                       uu___7 uu___8);
                                 (let env0 = env2 in
                                  let env3 =
                                    FStar_List.fold_left
-                                     (fun env3 ->
-                                        fun uu____24821 ->
-                                          match uu____24821 with
+                                     (fun env4 ->
+                                        fun uu___6 ->
+                                          match uu___6 with
                                           | (bv, t2) ->
-                                              let uu____24844 =
-                                                let uu____24851 =
-                                                  let uu____24854 =
+                                              let uu___7 =
+                                                let uu___8 =
+                                                  let uu___9 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       bv in
                                                   FStar_Pervasives_Native.Some
-                                                    uu____24854 in
-                                                let uu____24855 =
-                                                  let uu____24856 =
-                                                    let uu____24887 =
+                                                    uu___9 in
+                                                let uu___9 =
+                                                  let uu___10 =
+                                                    let uu___11 =
                                                       FStar_Util.mk_ref
                                                         (FStar_Pervasives_Native.Some
                                                            ([], t2)) in
-                                                    ([], t2, uu____24887,
-                                                      false) in
-                                                  Clos uu____24856 in
-                                                (uu____24851, uu____24855) in
-                                              uu____24844 :: env3) env2 s in
-                                 let uu____24978 =
-                                   guard_when_clause wopt b rest in
-                                 norm cfg1 env3 stack2 uu____24978))) in
+                                                    ([], t2, uu___11, false) in
+                                                  Clos uu___10 in
+                                                (uu___8, uu___9) in
+                                              uu___7 :: env4) env2 s in
+                                 let uu___6 = guard_when_clause wopt b rest in
+                                 norm cfg1 env3 stack2 uu___6))) in
                     if
                       (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                     then matches scrutinee branches1
@@ -7711,55 +7508,53 @@ let (normalize_with_primitive_steps :
           FStar_ST.op_Colon_Equals reflection_env_hook
             (FStar_Pervasives_Native.Some e);
           FStar_TypeChecker_Cfg.log_cfg c
-            (fun uu____25025 ->
-               let uu____25026 = FStar_TypeChecker_Cfg.cfg_to_string c in
-               FStar_Util.print1 "Cfg = %s\n" uu____25026);
-          (let uu____25027 = is_nbe_request s in
-           if uu____25027
+            (fun uu___2 ->
+               let uu___3 = FStar_TypeChecker_Cfg.cfg_to_string c in
+               FStar_Util.print1 "Cfg = %s\n" uu___3);
+          (let uu___2 = is_nbe_request s in
+           if uu___2
            then
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25031 ->
-                   let uu____25032 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____25032);
+                (fun uu___4 ->
+                   let uu___5 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu___5);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25036 ->
-                   let uu____25037 = FStar_TypeChecker_Cfg.cfg_to_string c in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____25037);
-              (let uu____25038 =
-                 FStar_Util.record_time (fun uu____25044 -> nbe_eval c s t) in
-               match uu____25038 with
+                (fun uu___5 ->
+                   let uu___6 = FStar_TypeChecker_Cfg.cfg_to_string c in
+                   FStar_Util.print1 ">>> cfg = %s\n" uu___6);
+              (let uu___5 =
+                 FStar_Util.record_time (fun uu___6 -> nbe_eval c s t) in
+               match uu___5 with
                | (r, ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____25051 ->
-                         let uu____25052 =
-                           FStar_Syntax_Print.term_to_string r in
-                         let uu____25053 = FStar_Util.string_of_int ms in
+                      (fun uu___7 ->
+                         let uu___8 = FStar_Syntax_Print.term_to_string r in
+                         let uu___9 = FStar_Util.string_of_int ms in
                          FStar_Util.print2
-                           "}\nNormalization result = (%s) in %s ms\n"
-                           uu____25052 uu____25053);
+                           "}\nNormalization result = (%s) in %s ms\n" uu___8
+                           uu___9);
                     r)))
            else
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25058 ->
-                   let uu____25059 = FStar_Syntax_Print.term_to_string t in
+                (fun uu___5 ->
+                   let uu___6 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print1 "Starting normalizer for (%s) {\n"
-                     uu____25059);
+                     uu___6);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25063 ->
-                   let uu____25064 = FStar_TypeChecker_Cfg.cfg_to_string c in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____25064);
-              (let uu____25065 =
-                 FStar_Util.record_time (fun uu____25071 -> norm c [] [] t) in
-               match uu____25065 with
+                (fun uu___6 ->
+                   let uu___7 = FStar_TypeChecker_Cfg.cfg_to_string c in
+                   FStar_Util.print1 ">>> cfg = %s\n" uu___7);
+              (let uu___6 =
+                 FStar_Util.record_time (fun uu___7 -> norm c [] [] t) in
+               match uu___6 with
                | (r, ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____25084 ->
-                         let uu____25085 =
-                           FStar_Syntax_Print.term_to_string r in
-                         let uu____25086 = FStar_Util.string_of_int ms in
+                      (fun uu___8 ->
+                         let uu___9 = FStar_Syntax_Print.term_to_string r in
+                         let uu___10 = FStar_Util.string_of_int ms in
                          FStar_Util.print2
-                           "}\nNormalization result = (%s) in %s ms\n"
-                           uu____25085 uu____25086);
+                           "}\nNormalization result = (%s) in %s ms\n" uu___9
+                           uu___10);
                     r))))
 let (normalize :
   FStar_TypeChecker_Env.steps ->
@@ -7769,14 +7564,14 @@ let (normalize :
   fun s ->
     fun e ->
       fun t ->
-        let uu____25102 =
-          let uu____25105 =
-            let uu____25106 = FStar_TypeChecker_Env.current_module e in
-            FStar_Ident.string_of_lid uu____25106 in
-          FStar_Pervasives_Native.Some uu____25105 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module e in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
         FStar_Profiling.profile
-          (fun uu____25108 -> normalize_with_primitive_steps [] s e t)
-          uu____25102 "FStar.TypeChecker.Normalize"
+          (fun uu___1 -> normalize_with_primitive_steps [] s e t) uu___
+          "FStar.TypeChecker.Normalize"
 let (normalize_comp :
   FStar_TypeChecker_Env.steps ->
     FStar_TypeChecker_Env.env ->
@@ -7789,25 +7584,25 @@ let (normalize_comp :
         FStar_ST.op_Colon_Equals reflection_env_hook
           (FStar_Pervasives_Native.Some e);
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____25139 ->
-             let uu____25140 = FStar_Syntax_Print.comp_to_string c in
+          (fun uu___2 ->
+             let uu___3 = FStar_Syntax_Print.comp_to_string c in
              FStar_Util.print1 "Starting normalizer for computation (%s) {\n"
-               uu____25140);
+               uu___3);
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____25144 ->
-             let uu____25145 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
-             FStar_Util.print1 ">>> cfg = %s\n" uu____25145);
-        (let uu____25146 =
-           FStar_Util.record_time (fun uu____25152 -> norm_comp cfg [] c) in
-         match uu____25146 with
+          (fun uu___3 ->
+             let uu___4 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
+             FStar_Util.print1 ">>> cfg = %s\n" uu___4);
+        (let uu___3 =
+           FStar_Util.record_time (fun uu___4 -> norm_comp cfg [] c) in
+         match uu___3 with
          | (c1, ms) ->
              (FStar_TypeChecker_Cfg.log_top cfg
-                (fun uu____25165 ->
-                   let uu____25166 = FStar_Syntax_Print.comp_to_string c1 in
-                   let uu____25167 = FStar_Util.string_of_int ms in
+                (fun uu___5 ->
+                   let uu___6 = FStar_Syntax_Print.comp_to_string c1 in
+                   let uu___7 = FStar_Util.string_of_int ms in
                    FStar_Util.print2
-                     "}\nNormalization result = (%s) in %s ms\n" uu____25166
-                     uu____25167);
+                     "}\nNormalization result = (%s) in %s ms\n" uu___6
+                     uu___7);
               c1))
 let (normalize_universe :
   FStar_TypeChecker_Env.env ->
@@ -7815,8 +7610,8 @@ let (normalize_universe :
   =
   fun env1 ->
     fun u ->
-      let uu____25178 = FStar_TypeChecker_Cfg.config [] env1 in
-      norm_universe uu____25178 [] u
+      let uu___ = FStar_TypeChecker_Cfg.config [] env1 in
+      norm_universe uu___ [] u
 let (non_info_norm :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env1 ->
@@ -7828,8 +7623,8 @@ let (non_info_norm :
         FStar_TypeChecker_Env.HNF;
         FStar_TypeChecker_Env.Unascribe;
         FStar_TypeChecker_Env.ForExtraction] in
-      let uu____25198 = normalize steps env1 t in
-      FStar_TypeChecker_Env.non_informative env1 uu____25198
+      let uu___ = normalize steps env1 t in
+      FStar_TypeChecker_Env.non_informative env1 uu___
 let (ghost_to_pure :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -7837,102 +7632,98 @@ let (ghost_to_pure :
   fun env1 ->
     fun c ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____25209 -> c
+      | FStar_Syntax_Syntax.Total uu___ -> c
       | FStar_Syntax_Syntax.GTotal (t, uopt) when non_info_norm env1 t ->
-          let uu___3333_25228 = c in
+          let uu___ = c in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
-            FStar_Syntax_Syntax.pos =
-              (uu___3333_25228.FStar_Syntax_Syntax.pos);
-            FStar_Syntax_Syntax.vars =
-              (uu___3333_25228.FStar_Syntax_Syntax.vars)
+            FStar_Syntax_Syntax.pos = (uu___.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars)
           }
       | FStar_Syntax_Syntax.Comp ct ->
           let l =
             FStar_TypeChecker_Env.norm_eff_name env1
               ct.FStar_Syntax_Syntax.effect_name in
-          let uu____25235 =
+          let uu___ =
             (FStar_Syntax_Util.is_ghost_effect l) &&
               (non_info_norm env1 ct.FStar_Syntax_Syntax.result_typ) in
-          if uu____25235
+          if uu___
           then
             let ct1 =
-              let uu____25237 =
+              let uu___1 =
                 downgrade_ghost_effect_name
                   ct.FStar_Syntax_Syntax.effect_name in
-              match uu____25237 with
+              match uu___1 with
               | FStar_Pervasives_Native.Some pure_eff ->
                   let flags =
-                    let uu____25244 =
+                    let uu___2 =
                       FStar_Ident.lid_equals pure_eff
                         FStar_Parser_Const.effect_Tot_lid in
-                    if uu____25244
+                    if uu___2
                     then FStar_Syntax_Syntax.TOTAL ::
                       (ct.FStar_Syntax_Syntax.flags)
                     else ct.FStar_Syntax_Syntax.flags in
-                  let uu___3343_25248 = ct in
+                  let uu___2 = ct in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3343_25248.FStar_Syntax_Syntax.comp_univs);
+                      (uu___2.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name = pure_eff;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3343_25248.FStar_Syntax_Syntax.result_typ);
+                      (uu___2.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3343_25248.FStar_Syntax_Syntax.effect_args);
+                      (uu___2.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags = flags
                   }
               | FStar_Pervasives_Native.None ->
-                  let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env1 c in
-                  let uu___3347_25250 = ct1 in
+                  let ct2 = FStar_TypeChecker_Env.unfold_effect_abbrev env1 c in
+                  let uu___2 = ct2 in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3347_25250.FStar_Syntax_Syntax.comp_univs);
+                      (uu___2.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name =
                       FStar_Parser_Const.effect_PURE_lid;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3347_25250.FStar_Syntax_Syntax.result_typ);
+                      (uu___2.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3347_25250.FStar_Syntax_Syntax.effect_args);
+                      (uu___2.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags =
-                      (uu___3347_25250.FStar_Syntax_Syntax.flags)
+                      (uu___2.FStar_Syntax_Syntax.flags)
                   } in
-            let uu___3350_25251 = c in
+            let uu___1 = c in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-              FStar_Syntax_Syntax.pos =
-                (uu___3350_25251.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars =
-                (uu___3350_25251.FStar_Syntax_Syntax.vars)
+              FStar_Syntax_Syntax.pos = (uu___1.FStar_Syntax_Syntax.pos);
+              FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars)
             }
           else c
-      | uu____25253 -> c
+      | uu___ -> c
 let (ghost_to_pure_lcomp :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.lcomp -> FStar_TypeChecker_Common.lcomp)
   =
   fun env1 ->
     fun lc ->
-      let uu____25264 =
+      let uu___ =
         (FStar_Syntax_Util.is_ghost_effect
            lc.FStar_TypeChecker_Common.eff_name)
           && (non_info_norm env1 lc.FStar_TypeChecker_Common.res_typ) in
-      if uu____25264
+      if uu___
       then
-        let uu____25265 =
+        let uu___1 =
           downgrade_ghost_effect_name lc.FStar_TypeChecker_Common.eff_name in
-        match uu____25265 with
+        match uu___1 with
         | FStar_Pervasives_Native.Some pure_eff ->
-            let uu___3358_25269 =
+            let uu___2 =
               FStar_TypeChecker_Common.apply_lcomp (ghost_to_pure env1)
                 (fun g -> g) lc in
             {
               FStar_TypeChecker_Common.eff_name = pure_eff;
               FStar_TypeChecker_Common.res_typ =
-                (uu___3358_25269.FStar_TypeChecker_Common.res_typ);
+                (uu___2.FStar_TypeChecker_Common.res_typ);
               FStar_TypeChecker_Common.cflags =
-                (uu___3358_25269.FStar_TypeChecker_Common.cflags);
+                (uu___2.FStar_TypeChecker_Common.cflags);
               FStar_TypeChecker_Common.comp_thunk =
-                (uu___3358_25269.FStar_TypeChecker_Common.comp_thunk)
+                (uu___2.FStar_TypeChecker_Common.comp_thunk)
             }
         | FStar_Pervasives_Native.None -> lc
       else lc
@@ -7942,20 +7733,20 @@ let (term_to_string :
     fun t ->
       let t1 =
         try
-          (fun uu___3365_25285 ->
+          (fun uu___ ->
              match () with
              | () ->
                  normalize [FStar_TypeChecker_Env.AllowUnboundUniverses] env1
                    t) ()
         with
-        | uu___3364_25288 ->
-            ((let uu____25290 =
-                let uu____25295 =
-                  let uu____25296 = FStar_Util.message_of_exn uu___3364_25288 in
+        | uu___ ->
+            ((let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Util.message_of_exn uu___ in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____25296 in
-                (FStar_Errors.Warning_NormalizationFailure, uu____25295) in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____25290);
+                    uu___4 in
+                (FStar_Errors.Warning_NormalizationFailure, uu___3) in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___2);
              t) in
       FStar_Syntax_Print.term_to_string' env1.FStar_TypeChecker_Env.dsenv t1
 let (comp_to_string :
@@ -7964,22 +7755,22 @@ let (comp_to_string :
     fun c ->
       let c1 =
         try
-          (fun uu___3375_25310 ->
+          (fun uu___ ->
              match () with
              | () ->
-                 let uu____25311 =
+                 let uu___1 =
                    FStar_TypeChecker_Cfg.config
                      [FStar_TypeChecker_Env.AllowUnboundUniverses] env1 in
-                 norm_comp uu____25311 [] c) ()
+                 norm_comp uu___1 [] c) ()
         with
-        | uu___3374_25320 ->
-            ((let uu____25322 =
-                let uu____25327 =
-                  let uu____25328 = FStar_Util.message_of_exn uu___3374_25320 in
+        | uu___ ->
+            ((let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Util.message_of_exn uu___ in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____25328 in
-                (FStar_Errors.Warning_NormalizationFailure, uu____25327) in
-              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____25322);
+                    uu___4 in
+                (FStar_Errors.Warning_NormalizationFailure, uu___3) in
+              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu___2);
              c) in
       FStar_Syntax_Print.comp_to_string' env1.FStar_TypeChecker_Env.dsenv c1
 let (normalize_refinement :
@@ -8000,16 +7791,14 @@ let (normalize_refinement :
               let t01 = aux x.FStar_Syntax_Syntax.sort in
               (match t01.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_refine (y, phi1) ->
-                   let uu____25373 =
-                     let uu____25374 =
-                       let uu____25381 =
-                         FStar_Syntax_Util.mk_conj_simp phi1 phi in
-                       (y, uu____25381) in
-                     FStar_Syntax_Syntax.Tm_refine uu____25374 in
-                   FStar_Syntax_Syntax.mk uu____25373
-                     t01.FStar_Syntax_Syntax.pos
-               | uu____25386 -> t2)
-          | uu____25387 -> t2 in
+                   let uu___ =
+                     let uu___1 =
+                       let uu___2 = FStar_Syntax_Util.mk_conj_simp phi1 phi in
+                       (y, uu___2) in
+                     FStar_Syntax_Syntax.Tm_refine uu___1 in
+                   FStar_Syntax_Syntax.mk uu___ t01.FStar_Syntax_Syntax.pos
+               | uu___ -> t2)
+          | uu___ -> t2 in
         aux t
 let (whnf_steps : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.Primops;
@@ -8062,29 +7851,29 @@ let (eta_expand_with_type :
   fun env1 ->
     fun e ->
       fun t_e ->
-        let uu____25468 = FStar_Syntax_Util.arrow_formals_comp t_e in
-        match uu____25468 with
+        let uu___ = FStar_Syntax_Util.arrow_formals_comp t_e in
+        match uu___ with
         | (formals, c) ->
             (match formals with
              | [] -> e
-             | uu____25481 ->
-                 let uu____25482 = FStar_Syntax_Util.abs_formals e in
-                 (match uu____25482 with
-                  | (actuals, uu____25492, uu____25493) ->
+             | uu___1 ->
+                 let uu___2 = FStar_Syntax_Util.abs_formals e in
+                 (match uu___2 with
+                  | (actuals, uu___3, uu___4) ->
                       if
                         (FStar_List.length actuals) =
                           (FStar_List.length formals)
                       then e
                       else
-                        (let uu____25511 =
+                        (let uu___6 =
                            FStar_All.pipe_right formals
                              FStar_Syntax_Util.args_of_binders in
-                         match uu____25511 with
+                         match uu___6 with
                          | (binders, args) ->
-                             let uu____25522 =
+                             let uu___7 =
                                FStar_Syntax_Syntax.mk_Tm_app e args
                                  e.FStar_Syntax_Syntax.pos in
-                             FStar_Syntax_Util.abs binders uu____25522
+                             FStar_Syntax_Util.abs binders uu___7
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)))))
 let (eta_expand :
@@ -8096,458 +7885,431 @@ let (eta_expand :
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
           eta_expand_with_type env1 t x.FStar_Syntax_Syntax.sort
-      | uu____25536 ->
-          let uu____25537 = FStar_Syntax_Util.head_and_args t in
-          (match uu____25537 with
+      | uu___ ->
+          let uu___1 = FStar_Syntax_Util.head_and_args t in
+          (match uu___1 with
            | (head, args) ->
-               let uu____25580 =
-                 let uu____25581 = FStar_Syntax_Subst.compress head in
-                 uu____25581.FStar_Syntax_Syntax.n in
-               (match uu____25580 with
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress head in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
                 | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-                    let uu____25602 =
-                      let uu____25609 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Subst.subst' s
                           u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                      FStar_Syntax_Util.arrow_formals uu____25609 in
-                    (match uu____25602 with
+                      FStar_Syntax_Util.arrow_formals uu___4 in
+                    (match uu___3 with
                      | (formals, _tres) ->
                          if
                            (FStar_List.length formals) =
                              (FStar_List.length args)
                          then t
                          else
-                           (let uu____25631 =
+                           (let uu___5 =
                               env1.FStar_TypeChecker_Env.type_of
-                                (let uu___3445_25639 = env1 in
+                                (let uu___6 = env1 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.solver);
+                                     (uu___6.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.range);
+                                     (uu___6.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.curmodule);
+                                     (uu___6.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma);
+                                     (uu___6.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___6.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___6.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.modules);
+                                     (uu___6.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
                                      FStar_Pervasives_Native.None;
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.sigtab);
+                                     (uu___6.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.attrtab);
+                                     (uu___6.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.effects);
+                                     (uu___6.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.generalize);
+                                     (uu___6.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.letrecs);
+                                     (uu___6.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.top_level);
+                                     (uu___6.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___6.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.use_eq);
+                                     (uu___6.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.is_iface);
+                                     (uu___6.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.admit);
+                                     (uu___6.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___6.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.phase1);
+                                     (uu___6.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.failhard);
+                                     (uu___6.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.nosynth);
+                                     (uu___6.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.tc_term);
+                                     (uu___6.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.type_of);
+                                     (uu___6.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.universe_of);
+                                     (uu___6.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___6.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts = true;
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___6.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___6.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.splice);
+                                     (uu___6.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___6.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.postprocess);
+                                     (uu___6.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___6.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___6.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.dsenv);
+                                     (uu___6.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.nbe);
+                                     (uu___6.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___3445_25639.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) t in
-                            match uu____25631 with
-                            | (uu____25640, ty, uu____25642) ->
+                            match uu___5 with
+                            | (uu___6, ty, uu___7) ->
                                 eta_expand_with_type env1 t ty))
-                | uu____25643 ->
-                    let uu____25644 =
+                | uu___3 ->
+                    let uu___4 =
                       env1.FStar_TypeChecker_Env.type_of
-                        (let uu___3452_25652 = env1 in
+                        (let uu___5 = env1 in
                          {
                            FStar_TypeChecker_Env.solver =
-                             (uu___3452_25652.FStar_TypeChecker_Env.solver);
+                             (uu___5.FStar_TypeChecker_Env.solver);
                            FStar_TypeChecker_Env.range =
-                             (uu___3452_25652.FStar_TypeChecker_Env.range);
+                             (uu___5.FStar_TypeChecker_Env.range);
                            FStar_TypeChecker_Env.curmodule =
-                             (uu___3452_25652.FStar_TypeChecker_Env.curmodule);
+                             (uu___5.FStar_TypeChecker_Env.curmodule);
                            FStar_TypeChecker_Env.gamma =
-                             (uu___3452_25652.FStar_TypeChecker_Env.gamma);
+                             (uu___5.FStar_TypeChecker_Env.gamma);
                            FStar_TypeChecker_Env.gamma_sig =
-                             (uu___3452_25652.FStar_TypeChecker_Env.gamma_sig);
+                             (uu___5.FStar_TypeChecker_Env.gamma_sig);
                            FStar_TypeChecker_Env.gamma_cache =
-                             (uu___3452_25652.FStar_TypeChecker_Env.gamma_cache);
+                             (uu___5.FStar_TypeChecker_Env.gamma_cache);
                            FStar_TypeChecker_Env.modules =
-                             (uu___3452_25652.FStar_TypeChecker_Env.modules);
+                             (uu___5.FStar_TypeChecker_Env.modules);
                            FStar_TypeChecker_Env.expected_typ =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Env.sigtab =
-                             (uu___3452_25652.FStar_TypeChecker_Env.sigtab);
+                             (uu___5.FStar_TypeChecker_Env.sigtab);
                            FStar_TypeChecker_Env.attrtab =
-                             (uu___3452_25652.FStar_TypeChecker_Env.attrtab);
+                             (uu___5.FStar_TypeChecker_Env.attrtab);
                            FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___3452_25652.FStar_TypeChecker_Env.instantiate_imp);
+                             (uu___5.FStar_TypeChecker_Env.instantiate_imp);
                            FStar_TypeChecker_Env.effects =
-                             (uu___3452_25652.FStar_TypeChecker_Env.effects);
+                             (uu___5.FStar_TypeChecker_Env.effects);
                            FStar_TypeChecker_Env.generalize =
-                             (uu___3452_25652.FStar_TypeChecker_Env.generalize);
+                             (uu___5.FStar_TypeChecker_Env.generalize);
                            FStar_TypeChecker_Env.letrecs =
-                             (uu___3452_25652.FStar_TypeChecker_Env.letrecs);
+                             (uu___5.FStar_TypeChecker_Env.letrecs);
                            FStar_TypeChecker_Env.top_level =
-                             (uu___3452_25652.FStar_TypeChecker_Env.top_level);
+                             (uu___5.FStar_TypeChecker_Env.top_level);
                            FStar_TypeChecker_Env.check_uvars =
-                             (uu___3452_25652.FStar_TypeChecker_Env.check_uvars);
+                             (uu___5.FStar_TypeChecker_Env.check_uvars);
                            FStar_TypeChecker_Env.use_eq =
-                             (uu___3452_25652.FStar_TypeChecker_Env.use_eq);
+                             (uu___5.FStar_TypeChecker_Env.use_eq);
                            FStar_TypeChecker_Env.use_eq_strict =
-                             (uu___3452_25652.FStar_TypeChecker_Env.use_eq_strict);
+                             (uu___5.FStar_TypeChecker_Env.use_eq_strict);
                            FStar_TypeChecker_Env.is_iface =
-                             (uu___3452_25652.FStar_TypeChecker_Env.is_iface);
+                             (uu___5.FStar_TypeChecker_Env.is_iface);
                            FStar_TypeChecker_Env.admit =
-                             (uu___3452_25652.FStar_TypeChecker_Env.admit);
+                             (uu___5.FStar_TypeChecker_Env.admit);
                            FStar_TypeChecker_Env.lax = true;
                            FStar_TypeChecker_Env.lax_universes =
-                             (uu___3452_25652.FStar_TypeChecker_Env.lax_universes);
+                             (uu___5.FStar_TypeChecker_Env.lax_universes);
                            FStar_TypeChecker_Env.phase1 =
-                             (uu___3452_25652.FStar_TypeChecker_Env.phase1);
+                             (uu___5.FStar_TypeChecker_Env.phase1);
                            FStar_TypeChecker_Env.failhard =
-                             (uu___3452_25652.FStar_TypeChecker_Env.failhard);
+                             (uu___5.FStar_TypeChecker_Env.failhard);
                            FStar_TypeChecker_Env.nosynth =
-                             (uu___3452_25652.FStar_TypeChecker_Env.nosynth);
+                             (uu___5.FStar_TypeChecker_Env.nosynth);
                            FStar_TypeChecker_Env.uvar_subtyping =
-                             (uu___3452_25652.FStar_TypeChecker_Env.uvar_subtyping);
+                             (uu___5.FStar_TypeChecker_Env.uvar_subtyping);
                            FStar_TypeChecker_Env.tc_term =
-                             (uu___3452_25652.FStar_TypeChecker_Env.tc_term);
+                             (uu___5.FStar_TypeChecker_Env.tc_term);
                            FStar_TypeChecker_Env.type_of =
-                             (uu___3452_25652.FStar_TypeChecker_Env.type_of);
+                             (uu___5.FStar_TypeChecker_Env.type_of);
                            FStar_TypeChecker_Env.universe_of =
-                             (uu___3452_25652.FStar_TypeChecker_Env.universe_of);
+                             (uu___5.FStar_TypeChecker_Env.universe_of);
                            FStar_TypeChecker_Env.check_type_of =
-                             (uu___3452_25652.FStar_TypeChecker_Env.check_type_of);
+                             (uu___5.FStar_TypeChecker_Env.check_type_of);
                            FStar_TypeChecker_Env.use_bv_sorts = true;
                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                             (uu___3452_25652.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             (uu___5.FStar_TypeChecker_Env.qtbl_name_and_index);
                            FStar_TypeChecker_Env.normalized_eff_names =
-                             (uu___3452_25652.FStar_TypeChecker_Env.normalized_eff_names);
+                             (uu___5.FStar_TypeChecker_Env.normalized_eff_names);
                            FStar_TypeChecker_Env.fv_delta_depths =
-                             (uu___3452_25652.FStar_TypeChecker_Env.fv_delta_depths);
+                             (uu___5.FStar_TypeChecker_Env.fv_delta_depths);
                            FStar_TypeChecker_Env.proof_ns =
-                             (uu___3452_25652.FStar_TypeChecker_Env.proof_ns);
+                             (uu___5.FStar_TypeChecker_Env.proof_ns);
                            FStar_TypeChecker_Env.synth_hook =
-                             (uu___3452_25652.FStar_TypeChecker_Env.synth_hook);
+                             (uu___5.FStar_TypeChecker_Env.synth_hook);
                            FStar_TypeChecker_Env.try_solve_implicits_hook =
-                             (uu___3452_25652.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                             (uu___5.FStar_TypeChecker_Env.try_solve_implicits_hook);
                            FStar_TypeChecker_Env.splice =
-                             (uu___3452_25652.FStar_TypeChecker_Env.splice);
+                             (uu___5.FStar_TypeChecker_Env.splice);
                            FStar_TypeChecker_Env.mpreprocess =
-                             (uu___3452_25652.FStar_TypeChecker_Env.mpreprocess);
+                             (uu___5.FStar_TypeChecker_Env.mpreprocess);
                            FStar_TypeChecker_Env.postprocess =
-                             (uu___3452_25652.FStar_TypeChecker_Env.postprocess);
+                             (uu___5.FStar_TypeChecker_Env.postprocess);
                            FStar_TypeChecker_Env.identifier_info =
-                             (uu___3452_25652.FStar_TypeChecker_Env.identifier_info);
+                             (uu___5.FStar_TypeChecker_Env.identifier_info);
                            FStar_TypeChecker_Env.tc_hooks =
-                             (uu___3452_25652.FStar_TypeChecker_Env.tc_hooks);
+                             (uu___5.FStar_TypeChecker_Env.tc_hooks);
                            FStar_TypeChecker_Env.dsenv =
-                             (uu___3452_25652.FStar_TypeChecker_Env.dsenv);
+                             (uu___5.FStar_TypeChecker_Env.dsenv);
                            FStar_TypeChecker_Env.nbe =
-                             (uu___3452_25652.FStar_TypeChecker_Env.nbe);
+                             (uu___5.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___3452_25652.FStar_TypeChecker_Env.strict_args_tab);
+                             (uu___5.FStar_TypeChecker_Env.strict_args_tab);
                            FStar_TypeChecker_Env.erasable_types_tab =
-                             (uu___3452_25652.FStar_TypeChecker_Env.erasable_types_tab);
+                             (uu___5.FStar_TypeChecker_Env.erasable_types_tab);
                            FStar_TypeChecker_Env.enable_defer_to_tac =
-                             (uu___3452_25652.FStar_TypeChecker_Env.enable_defer_to_tac)
+                             (uu___5.FStar_TypeChecker_Env.enable_defer_to_tac)
                          }) t in
-                    (match uu____25644 with
-                     | (uu____25653, ty, uu____25655) ->
-                         eta_expand_with_type env1 t ty)))
+                    (match uu___4 with
+                     | (uu___5, ty, uu___6) -> eta_expand_with_type env1 t ty)))
 let rec (elim_delayed_subst_term :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
     let mk x = FStar_Syntax_Syntax.mk x t.FStar_Syntax_Syntax.pos in
     let t1 = FStar_Syntax_Subst.compress t in
     let elim_bv x =
-      let uu___3464_25740 = x in
-      let uu____25741 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
+      let uu___ = x in
+      let uu___1 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
       {
-        FStar_Syntax_Syntax.ppname =
-          (uu___3464_25740.FStar_Syntax_Syntax.ppname);
-        FStar_Syntax_Syntax.index =
-          (uu___3464_25740.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = uu____25741
+        FStar_Syntax_Syntax.ppname = (uu___.FStar_Syntax_Syntax.ppname);
+        FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = uu___1
       } in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____25744 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_bvar uu____25759 -> t1
-    | FStar_Syntax_Syntax.Tm_name uu____25760 -> t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____25761 -> t1
-    | FStar_Syntax_Syntax.Tm_uinst uu____25762 -> t1
-    | FStar_Syntax_Syntax.Tm_constant uu____25769 -> t1
-    | FStar_Syntax_Syntax.Tm_type uu____25770 -> t1
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_bvar uu___ -> t1
+    | FStar_Syntax_Syntax.Tm_name uu___ -> t1
+    | FStar_Syntax_Syntax.Tm_fvar uu___ -> t1
+    | FStar_Syntax_Syntax.Tm_uinst uu___ -> t1
+    | FStar_Syntax_Syntax.Tm_constant uu___ -> t1
+    | FStar_Syntax_Syntax.Tm_type uu___ -> t1
     | FStar_Syntax_Syntax.Tm_unknown -> t1
     | FStar_Syntax_Syntax.Tm_lazy li ->
-        let uu____25772 = FStar_Syntax_Util.unfold_lazy li in
-        elim_delayed_subst_term uu____25772
+        let uu___ = FStar_Syntax_Util.unfold_lazy li in
+        elim_delayed_subst_term uu___
     | FStar_Syntax_Syntax.Tm_abs (bs, t2, rc_opt) ->
         let elim_rc rc =
-          let uu___3490_25806 = rc in
-          let uu____25807 =
+          let uu___ = rc in
+          let uu___1 =
             FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
               elim_delayed_subst_term in
-          let uu____25816 =
+          let uu___2 =
             elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags in
           {
             FStar_Syntax_Syntax.residual_effect =
-              (uu___3490_25806.FStar_Syntax_Syntax.residual_effect);
-            FStar_Syntax_Syntax.residual_typ = uu____25807;
-            FStar_Syntax_Syntax.residual_flags = uu____25816
+              (uu___.FStar_Syntax_Syntax.residual_effect);
+            FStar_Syntax_Syntax.residual_typ = uu___1;
+            FStar_Syntax_Syntax.residual_flags = uu___2
           } in
-        let uu____25819 =
-          let uu____25820 =
-            let uu____25839 = elim_delayed_subst_binders bs in
-            let uu____25848 = elim_delayed_subst_term t2 in
-            let uu____25851 = FStar_Util.map_opt rc_opt elim_rc in
-            (uu____25839, uu____25848, uu____25851) in
-          FStar_Syntax_Syntax.Tm_abs uu____25820 in
-        mk uu____25819
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_binders bs in
+            let uu___3 = elim_delayed_subst_term t2 in
+            let uu___4 = FStar_Util.map_opt rc_opt elim_rc in
+            (uu___2, uu___3, uu___4) in
+          FStar_Syntax_Syntax.Tm_abs uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-        let uu____25888 =
-          let uu____25889 =
-            let uu____25904 = elim_delayed_subst_binders bs in
-            let uu____25913 = elim_delayed_subst_comp c in
-            (uu____25904, uu____25913) in
-          FStar_Syntax_Syntax.Tm_arrow uu____25889 in
-        mk uu____25888
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_binders bs in
+            let uu___3 = elim_delayed_subst_comp c in (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_arrow uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_refine (bv, phi) ->
-        let uu____25932 =
-          let uu____25933 =
-            let uu____25940 = elim_bv bv in
-            let uu____25941 = elim_delayed_subst_term phi in
-            (uu____25940, uu____25941) in
-          FStar_Syntax_Syntax.Tm_refine uu____25933 in
-        mk uu____25932
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_bv bv in
+            let uu___3 = elim_delayed_subst_term phi in (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_refine uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_app (t2, args) ->
-        let uu____25972 =
-          let uu____25973 =
-            let uu____25990 = elim_delayed_subst_term t2 in
-            let uu____25993 = elim_delayed_subst_args args in
-            (uu____25990, uu____25993) in
-          FStar_Syntax_Syntax.Tm_app uu____25973 in
-        mk uu____25972
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t2 in
+            let uu___3 = elim_delayed_subst_args args in (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_app uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_match (t2, branches1) ->
         let rec elim_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu___3512_26065 = p in
-              let uu____26066 =
-                let uu____26067 = elim_bv x in
-                FStar_Syntax_Syntax.Pat_var uu____26067 in
+              let uu___ = p in
+              let uu___1 =
+                let uu___2 = elim_bv x in FStar_Syntax_Syntax.Pat_var uu___2 in
               {
-                FStar_Syntax_Syntax.v = uu____26066;
-                FStar_Syntax_Syntax.p =
-                  (uu___3512_26065.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.v = uu___1;
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu___3516_26069 = p in
-              let uu____26070 =
-                let uu____26071 = elim_bv x in
-                FStar_Syntax_Syntax.Pat_wild uu____26071 in
+              let uu___ = p in
+              let uu___1 =
+                let uu___2 = elim_bv x in FStar_Syntax_Syntax.Pat_wild uu___2 in
               {
-                FStar_Syntax_Syntax.v = uu____26070;
-                FStar_Syntax_Syntax.p =
-                  (uu___3516_26069.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.v = uu___1;
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
-              let uu___3522_26078 = p in
-              let uu____26079 =
-                let uu____26080 =
-                  let uu____26087 = elim_bv x in
-                  let uu____26088 = elim_delayed_subst_term t0 in
-                  (uu____26087, uu____26088) in
-                FStar_Syntax_Syntax.Pat_dot_term uu____26080 in
+              let uu___ = p in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = elim_bv x in
+                  let uu___4 = elim_delayed_subst_term t0 in (uu___3, uu___4) in
+                FStar_Syntax_Syntax.Pat_dot_term uu___2 in
               {
-                FStar_Syntax_Syntax.v = uu____26079;
-                FStar_Syntax_Syntax.p =
-                  (uu___3522_26078.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.v = uu___1;
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-              let uu___3528_26111 = p in
-              let uu____26112 =
-                let uu____26113 =
-                  let uu____26126 =
+              let uu___ = p in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
                     FStar_List.map
-                      (fun uu____26149 ->
-                         match uu____26149 with
-                         | (x, b) ->
-                             let uu____26162 = elim_pat x in (uu____26162, b))
+                      (fun uu___4 ->
+                         match uu___4 with
+                         | (x, b) -> let uu___5 = elim_pat x in (uu___5, b))
                       pats in
-                  (fv, uu____26126) in
-                FStar_Syntax_Syntax.Pat_cons uu____26113 in
+                  (fv, uu___3) in
+                FStar_Syntax_Syntax.Pat_cons uu___2 in
               {
-                FStar_Syntax_Syntax.v = uu____26112;
-                FStar_Syntax_Syntax.p =
-                  (uu___3528_26111.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.v = uu___1;
+                FStar_Syntax_Syntax.p = (uu___.FStar_Syntax_Syntax.p)
               }
-          | uu____26175 -> p in
-        let elim_branch uu____26199 =
-          match uu____26199 with
+          | uu___ -> p in
+        let elim_branch uu___ =
+          match uu___ with
           | (pat, wopt, t3) ->
-              let uu____26225 = elim_pat pat in
-              let uu____26228 =
-                FStar_Util.map_opt wopt elim_delayed_subst_term in
-              let uu____26231 = elim_delayed_subst_term t3 in
-              (uu____26225, uu____26228, uu____26231) in
-        let uu____26236 =
-          let uu____26237 =
-            let uu____26260 = elim_delayed_subst_term t2 in
-            let uu____26263 = FStar_List.map elim_branch branches1 in
-            (uu____26260, uu____26263) in
-          FStar_Syntax_Syntax.Tm_match uu____26237 in
-        mk uu____26236
+              let uu___1 = elim_pat pat in
+              let uu___2 = FStar_Util.map_opt wopt elim_delayed_subst_term in
+              let uu___3 = elim_delayed_subst_term t3 in
+              (uu___1, uu___2, uu___3) in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t2 in
+            let uu___3 = FStar_List.map elim_branch branches1 in
+            (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_match uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_ascribed (t2, a, lopt) ->
-        let elim_ascription uu____26394 =
-          match uu____26394 with
+        let elim_ascription uu___ =
+          match uu___ with
           | (tc, topt) ->
-              let uu____26429 =
+              let uu___1 =
                 match tc with
                 | FStar_Util.Inl t3 ->
-                    let uu____26439 = elim_delayed_subst_term t3 in
-                    FStar_Util.Inl uu____26439
+                    let uu___2 = elim_delayed_subst_term t3 in
+                    FStar_Util.Inl uu___2
                 | FStar_Util.Inr c ->
-                    let uu____26441 = elim_delayed_subst_comp c in
-                    FStar_Util.Inr uu____26441 in
-              let uu____26442 =
-                FStar_Util.map_opt topt elim_delayed_subst_term in
-              (uu____26429, uu____26442) in
-        let uu____26451 =
-          let uu____26452 =
-            let uu____26479 = elim_delayed_subst_term t2 in
-            let uu____26482 = elim_ascription a in
-            (uu____26479, uu____26482, lopt) in
-          FStar_Syntax_Syntax.Tm_ascribed uu____26452 in
-        mk uu____26451
+                    let uu___2 = elim_delayed_subst_comp c in
+                    FStar_Util.Inr uu___2 in
+              let uu___2 = FStar_Util.map_opt topt elim_delayed_subst_term in
+              (uu___1, uu___2) in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t2 in
+            let uu___3 = elim_ascription a in (uu___2, uu___3, lopt) in
+          FStar_Syntax_Syntax.Tm_ascribed uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_let (lbs, t2) ->
         let elim_lb lb =
-          let uu___3558_26543 = lb in
-          let uu____26544 =
-            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp in
-          let uu____26547 =
-            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef in
+          let uu___ = lb in
+          let uu___1 = elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp in
+          let uu___2 = elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef in
           {
-            FStar_Syntax_Syntax.lbname =
-              (uu___3558_26543.FStar_Syntax_Syntax.lbname);
-            FStar_Syntax_Syntax.lbunivs =
-              (uu___3558_26543.FStar_Syntax_Syntax.lbunivs);
-            FStar_Syntax_Syntax.lbtyp = uu____26544;
-            FStar_Syntax_Syntax.lbeff =
-              (uu___3558_26543.FStar_Syntax_Syntax.lbeff);
-            FStar_Syntax_Syntax.lbdef = uu____26547;
-            FStar_Syntax_Syntax.lbattrs =
-              (uu___3558_26543.FStar_Syntax_Syntax.lbattrs);
-            FStar_Syntax_Syntax.lbpos =
-              (uu___3558_26543.FStar_Syntax_Syntax.lbpos)
+            FStar_Syntax_Syntax.lbname = (uu___.FStar_Syntax_Syntax.lbname);
+            FStar_Syntax_Syntax.lbunivs = (uu___.FStar_Syntax_Syntax.lbunivs);
+            FStar_Syntax_Syntax.lbtyp = uu___1;
+            FStar_Syntax_Syntax.lbeff = (uu___.FStar_Syntax_Syntax.lbeff);
+            FStar_Syntax_Syntax.lbdef = uu___2;
+            FStar_Syntax_Syntax.lbattrs = (uu___.FStar_Syntax_Syntax.lbattrs);
+            FStar_Syntax_Syntax.lbpos = (uu___.FStar_Syntax_Syntax.lbpos)
           } in
-        let uu____26550 =
-          let uu____26551 =
-            let uu____26564 =
-              let uu____26571 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
                 FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs) in
-              ((FStar_Pervasives_Native.fst lbs), uu____26571) in
-            let uu____26580 = elim_delayed_subst_term t2 in
-            (uu____26564, uu____26580) in
-          FStar_Syntax_Syntax.Tm_let uu____26551 in
-        mk uu____26550
+              ((FStar_Pervasives_Native.fst lbs), uu___3) in
+            let uu___3 = elim_delayed_subst_term t2 in (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_let uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
         mk (FStar_Syntax_Syntax.Tm_uvar (u, s))
     | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
         let qi1 =
           FStar_Syntax_Syntax.on_antiquoted elim_delayed_subst_term qi in
-        let uu____26624 =
-          let uu____26625 =
-            let uu____26632 = elim_delayed_subst_term tm in
-            (uu____26632, qi1) in
-          FStar_Syntax_Syntax.Tm_quoted uu____26625 in
-        mk uu____26624
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term tm in (uu___2, qi1) in
+          FStar_Syntax_Syntax.Tm_quoted uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Tm_meta (t2, md) ->
-        let uu____26643 =
-          let uu____26644 =
-            let uu____26651 = elim_delayed_subst_term t2 in
-            let uu____26654 = elim_delayed_subst_meta md in
-            (uu____26651, uu____26654) in
-          FStar_Syntax_Syntax.Tm_meta uu____26644 in
-        mk uu____26643
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t2 in
+            let uu___3 = elim_delayed_subst_meta md in (uu___2, uu___3) in
+          FStar_Syntax_Syntax.Tm_meta uu___1 in
+        mk uu___
 and (elim_delayed_subst_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun flags ->
     FStar_List.map
-      (fun uu___17_26663 ->
-         match uu___17_26663 with
+      (fun uu___ ->
+         match uu___ with
          | FStar_Syntax_Syntax.DECREASES t ->
-             let uu____26667 = elim_delayed_subst_term t in
-             FStar_Syntax_Syntax.DECREASES uu____26667
+             let uu___1 = elim_delayed_subst_term t in
+             FStar_Syntax_Syntax.DECREASES uu___1
          | f -> f) flags
 and (elim_delayed_subst_comp :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp) =
@@ -8555,57 +8317,52 @@ and (elim_delayed_subst_comp :
     let mk x = FStar_Syntax_Syntax.mk x c.FStar_Syntax_Syntax.pos in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t, uopt) ->
-        let uu____26690 =
-          let uu____26691 =
-            let uu____26700 = elim_delayed_subst_term t in
-            (uu____26700, uopt) in
-          FStar_Syntax_Syntax.Total uu____26691 in
-        mk uu____26690
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t in (uu___2, uopt) in
+          FStar_Syntax_Syntax.Total uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.GTotal (t, uopt) ->
-        let uu____26717 =
-          let uu____26718 =
-            let uu____26727 = elim_delayed_subst_term t in
-            (uu____26727, uopt) in
-          FStar_Syntax_Syntax.GTotal uu____26718 in
-        mk uu____26717
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t in (uu___2, uopt) in
+          FStar_Syntax_Syntax.GTotal uu___1 in
+        mk uu___
     | FStar_Syntax_Syntax.Comp ct ->
         let ct1 =
-          let uu___3591_26736 = ct in
-          let uu____26737 =
+          let uu___ = ct in
+          let uu___1 =
             elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ in
-          let uu____26740 =
+          let uu___2 =
             elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args in
-          let uu____26751 =
-            elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags in
+          let uu___3 = elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___3591_26736.FStar_Syntax_Syntax.comp_univs);
+              (uu___.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___3591_26736.FStar_Syntax_Syntax.effect_name);
-            FStar_Syntax_Syntax.result_typ = uu____26737;
-            FStar_Syntax_Syntax.effect_args = uu____26740;
-            FStar_Syntax_Syntax.flags = uu____26751
+              (uu___.FStar_Syntax_Syntax.effect_name);
+            FStar_Syntax_Syntax.result_typ = uu___1;
+            FStar_Syntax_Syntax.effect_args = uu___2;
+            FStar_Syntax_Syntax.flags = uu___3
           } in
         mk (FStar_Syntax_Syntax.Comp ct1)
 and (elim_delayed_subst_meta :
   FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata) =
-  fun uu___18_26754 ->
-    match uu___18_26754 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Syntax_Syntax.Meta_pattern (names, args) ->
-        let uu____26789 =
-          let uu____26810 = FStar_List.map elim_delayed_subst_term names in
-          let uu____26819 = FStar_List.map elim_delayed_subst_args args in
-          (uu____26810, uu____26819) in
-        FStar_Syntax_Syntax.Meta_pattern uu____26789
+        let uu___1 =
+          let uu___2 = FStar_List.map elim_delayed_subst_term names in
+          let uu___3 = FStar_List.map elim_delayed_subst_args args in
+          (uu___2, uu___3) in
+        FStar_Syntax_Syntax.Meta_pattern uu___1
     | FStar_Syntax_Syntax.Meta_monadic (m, t) ->
-        let uu____26874 =
-          let uu____26881 = elim_delayed_subst_term t in (m, uu____26881) in
-        FStar_Syntax_Syntax.Meta_monadic uu____26874
+        let uu___1 = let uu___2 = elim_delayed_subst_term t in (m, uu___2) in
+        FStar_Syntax_Syntax.Meta_monadic uu___1
     | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t) ->
-        let uu____26893 =
-          let uu____26902 = elim_delayed_subst_term t in
-          (m1, m2, uu____26902) in
-        FStar_Syntax_Syntax.Meta_monadic_lift uu____26893
+        let uu___1 =
+          let uu___2 = elim_delayed_subst_term t in (m1, m2, uu___2) in
+        FStar_Syntax_Syntax.Meta_monadic_lift uu___1
     | m -> m
 and (elim_delayed_subst_args :
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -8617,10 +8374,9 @@ and (elim_delayed_subst_args :
   =
   fun args ->
     FStar_List.map
-      (fun uu____26935 ->
-         match uu____26935 with
-         | (t, q) ->
-             let uu____26954 = elim_delayed_subst_term t in (uu____26954, q))
+      (fun uu___ ->
+         match uu___ with
+         | (t, q) -> let uu___1 = elim_delayed_subst_term t in (uu___1, q))
       args
 and (elim_delayed_subst_aqual :
   FStar_Syntax_Syntax.aqual -> FStar_Syntax_Syntax.aqual) =
@@ -8628,20 +8384,20 @@ and (elim_delayed_subst_aqual :
     match q with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
         (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-        let uu____26961 =
-          let uu____26962 =
-            let uu____26963 = elim_delayed_subst_term t in
-            FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____26963 in
-          FStar_Syntax_Syntax.Meta uu____26962 in
-        FStar_Pervasives_Native.Some uu____26961
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t in
+            FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu___2 in
+          FStar_Syntax_Syntax.Meta uu___1 in
+        FStar_Pervasives_Native.Some uu___
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
         (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-        let uu____26969 =
-          let uu____26970 =
-            let uu____26971 = elim_delayed_subst_term t in
-            FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____26971 in
-          FStar_Syntax_Syntax.Meta uu____26970 in
-        FStar_Pervasives_Native.Some uu____26969
+        let uu___ =
+          let uu___1 =
+            let uu___2 = elim_delayed_subst_term t in
+            FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu___2 in
+          FStar_Syntax_Syntax.Meta uu___1 in
+        FStar_Pervasives_Native.Some uu___
     | q1 -> q1
 and (elim_delayed_subst_binders :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -8651,19 +8407,19 @@ and (elim_delayed_subst_binders :
   =
   fun bs ->
     FStar_List.map
-      (fun uu____26997 ->
-         match uu____26997 with
+      (fun uu___ ->
+         match uu___ with
          | (x, q) ->
              let x1 =
-               let uu___3627_27009 = x in
-               let uu____27010 =
+               let uu___1 = x in
+               let uu___2 =
                  elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___3627_27009.FStar_Syntax_Syntax.ppname);
+                   (uu___1.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___3627_27009.FStar_Syntax_Syntax.index);
-                 FStar_Syntax_Syntax.sort = uu____27010
+                   (uu___1.FStar_Syntax_Syntax.index);
+                 FStar_Syntax_Syntax.sort = uu___2
                } in
              let q1 = elim_delayed_subst_aqual q in (x1, q1)) bs
 let (elim_uvars_aux_tc :
@@ -8685,47 +8441,47 @@ let (elim_uvars_aux_tc :
         fun tc ->
           let t =
             match (binders, tc) with
-            | ([], FStar_Util.Inl t) -> t
+            | ([], FStar_Util.Inl t1) -> t1
             | ([], FStar_Util.Inr c) ->
                 failwith "Impossible: empty bindes with a comp"
-            | (uu____27115, FStar_Util.Inr c) ->
+            | (uu___, FStar_Util.Inr c) ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (binders, c))
                   c.FStar_Syntax_Syntax.pos
-            | (uu____27147, FStar_Util.Inl t) ->
-                let uu____27169 =
-                  let uu____27170 =
-                    let uu____27185 = FStar_Syntax_Syntax.mk_Total t in
-                    (binders, uu____27185) in
-                  FStar_Syntax_Syntax.Tm_arrow uu____27170 in
-                FStar_Syntax_Syntax.mk uu____27169 t.FStar_Syntax_Syntax.pos in
-          let uu____27198 = FStar_Syntax_Subst.open_univ_vars univ_names t in
-          match uu____27198 with
+            | (uu___, FStar_Util.Inl t1) ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Syntax.mk_Total t1 in
+                    (binders, uu___3) in
+                  FStar_Syntax_Syntax.Tm_arrow uu___2 in
+                FStar_Syntax_Syntax.mk uu___1 t1.FStar_Syntax_Syntax.pos in
+          let uu___ = FStar_Syntax_Subst.open_univ_vars univ_names t in
+          match uu___ with
           | (univ_names1, t1) ->
               let t2 = remove_uvar_solutions env1 t1 in
               let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2 in
               let t4 = elim_delayed_subst_term t3 in
-              let uu____27230 =
+              let uu___1 =
                 match binders with
                 | [] -> ([], (FStar_Util.Inl t4))
-                | uu____27303 ->
-                    let uu____27304 =
-                      let uu____27313 =
-                        let uu____27314 = FStar_Syntax_Subst.compress t4 in
-                        uu____27314.FStar_Syntax_Syntax.n in
-                      (uu____27313, tc) in
-                    (match uu____27304 with
+                | uu___2 ->
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Subst.compress t4 in
+                        uu___5.FStar_Syntax_Syntax.n in
+                      (uu___4, tc) in
+                    (match uu___3 with
                      | (FStar_Syntax_Syntax.Tm_arrow (binders1, c),
-                        FStar_Util.Inr uu____27343) ->
+                        FStar_Util.Inr uu___4) ->
                          (binders1, (FStar_Util.Inr c))
                      | (FStar_Syntax_Syntax.Tm_arrow (binders1, c),
-                        FStar_Util.Inl uu____27390) ->
+                        FStar_Util.Inl uu___4) ->
                          (binders1,
                            (FStar_Util.Inl (FStar_Syntax_Util.comp_result c)))
-                     | (uu____27435, FStar_Util.Inl uu____27436) ->
+                     | (uu___4, FStar_Util.Inl uu___5) ->
                          ([], (FStar_Util.Inl t4))
-                     | uu____27467 -> failwith "Impossible") in
-              (match uu____27230 with
+                     | uu___4 -> failwith "Impossible") in
+              (match uu___1 with
                | (binders1, tc1) -> (univ_names1, binders1, tc1))
 let (elim_uvars_aux_t :
   FStar_TypeChecker_Env.env ->
@@ -8741,12 +8497,12 @@ let (elim_uvars_aux_t :
     fun univ_names ->
       fun binders ->
         fun t ->
-          let uu____27604 =
+          let uu___ =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inl t) in
-          match uu____27604 with
+          match uu___ with
           | (univ_names1, binders1, tc) ->
-              let uu____27678 = FStar_Util.left tc in
-              (univ_names1, binders1, uu____27678)
+              let uu___1 = FStar_Util.left tc in
+              (univ_names1, binders1, uu___1)
 let (elim_uvars_aux_c :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
@@ -8761,12 +8517,12 @@ let (elim_uvars_aux_c :
     fun univ_names ->
       fun binders ->
         fun c ->
-          let uu____27731 =
+          let uu___ =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inr c) in
-          match uu____27731 with
+          match uu___ with
           | (univ_names1, binders1, tc) ->
-              let uu____27805 = FStar_Util.right tc in
-              (univ_names1, binders1, uu____27805)
+              let uu___1 = FStar_Util.right tc in
+              (univ_names1, binders1, uu___1)
 let rec (elim_uvars :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
@@ -8776,245 +8532,231 @@ let rec (elim_uvars :
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (lid, univ_names, binders, typ, lids, lids') ->
-          let uu____27846 = elim_uvars_aux_t env1 univ_names binders typ in
-          (match uu____27846 with
+          let uu___ = elim_uvars_aux_t env1 univ_names binders typ in
+          (match uu___ with
            | (univ_names1, binders1, typ1) ->
-               let uu___3712_27886 = s in
+               let uu___1 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_inductive_typ
                       (lid, univ_names1, binders1, typ1, lids, lids'));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3712_27886.FStar_Syntax_Syntax.sigrng);
+                   (uu___1.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3712_27886.FStar_Syntax_Syntax.sigquals);
+                   (uu___1.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3712_27886.FStar_Syntax_Syntax.sigmeta);
+                   (uu___1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3712_27886.FStar_Syntax_Syntax.sigattrs);
+                   (uu___1.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3712_27886.FStar_Syntax_Syntax.sigopts)
+                   (uu___1.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_bundle (sigs, lids) ->
-          let uu___3718_27901 = s in
-          let uu____27902 =
-            let uu____27903 =
-              let uu____27912 = FStar_List.map (elim_uvars env1) sigs in
-              (uu____27912, lids) in
-            FStar_Syntax_Syntax.Sig_bundle uu____27903 in
+          let uu___ = s in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_List.map (elim_uvars env1) sigs in
+              (uu___3, lids) in
+            FStar_Syntax_Syntax.Sig_bundle uu___2 in
           {
-            FStar_Syntax_Syntax.sigel = uu____27902;
-            FStar_Syntax_Syntax.sigrng =
-              (uu___3718_27901.FStar_Syntax_Syntax.sigrng);
+            FStar_Syntax_Syntax.sigel = uu___1;
+            FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3718_27901.FStar_Syntax_Syntax.sigquals);
-            FStar_Syntax_Syntax.sigmeta =
-              (uu___3718_27901.FStar_Syntax_Syntax.sigmeta);
+              (uu___.FStar_Syntax_Syntax.sigquals);
+            FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3718_27901.FStar_Syntax_Syntax.sigattrs);
-            FStar_Syntax_Syntax.sigopts =
-              (uu___3718_27901.FStar_Syntax_Syntax.sigopts)
+              (uu___.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_datacon
           (lid, univ_names, typ, lident, i, lids) ->
-          let uu____27929 = elim_uvars_aux_t env1 univ_names [] typ in
-          (match uu____27929 with
-           | (univ_names1, uu____27953, typ1) ->
-               let uu___3732_27975 = s in
+          let uu___ = elim_uvars_aux_t env1 univ_names [] typ in
+          (match uu___ with
+           | (univ_names1, uu___1, typ1) ->
+               let uu___2 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_datacon
                       (lid, univ_names1, typ1, lident, i, lids));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3732_27975.FStar_Syntax_Syntax.sigrng);
+                   (uu___2.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3732_27975.FStar_Syntax_Syntax.sigquals);
+                   (uu___2.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3732_27975.FStar_Syntax_Syntax.sigmeta);
+                   (uu___2.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3732_27975.FStar_Syntax_Syntax.sigattrs);
+                   (uu___2.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3732_27975.FStar_Syntax_Syntax.sigopts)
+                   (uu___2.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univ_names, typ) ->
-          let uu____27981 = elim_uvars_aux_t env1 univ_names [] typ in
-          (match uu____27981 with
-           | (univ_names1, uu____28005, typ1) ->
-               let uu___3743_28027 = s in
+          let uu___ = elim_uvars_aux_t env1 univ_names [] typ in
+          (match uu___ with
+           | (univ_names1, uu___1, typ1) ->
+               let uu___2 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ
                       (lid, univ_names1, typ1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3743_28027.FStar_Syntax_Syntax.sigrng);
+                   (uu___2.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3743_28027.FStar_Syntax_Syntax.sigquals);
+                   (uu___2.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3743_28027.FStar_Syntax_Syntax.sigmeta);
+                   (uu___2.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3743_28027.FStar_Syntax_Syntax.sigattrs);
+                   (uu___2.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3743_28027.FStar_Syntax_Syntax.sigopts)
+                   (uu___2.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_let ((b, lbs), lids) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb ->
-                    let uu____28055 =
+                    let uu___ =
                       FStar_Syntax_Subst.univ_var_opening
                         lb.FStar_Syntax_Syntax.lbunivs in
-                    match uu____28055 with
+                    match uu___ with
                     | (opening, lbunivs) ->
                         let elim t =
-                          let uu____28080 =
-                            let uu____28081 =
-                              let uu____28082 =
-                                FStar_Syntax_Subst.subst opening t in
-                              remove_uvar_solutions env1 uu____28082 in
-                            FStar_Syntax_Subst.close_univ_vars lbunivs
-                              uu____28081 in
-                          elim_delayed_subst_term uu____28080 in
+                          let uu___1 =
+                            let uu___2 =
+                              let uu___3 = FStar_Syntax_Subst.subst opening t in
+                              remove_uvar_solutions env1 uu___3 in
+                            FStar_Syntax_Subst.close_univ_vars lbunivs uu___2 in
+                          elim_delayed_subst_term uu___1 in
                         let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp in
                         let lbdef = elim lb.FStar_Syntax_Syntax.lbdef in
-                        let uu___3759_28085 = lb in
+                        let uu___1 = lb in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___3759_28085.FStar_Syntax_Syntax.lbname);
+                            (uu___1.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = lbunivs;
                           FStar_Syntax_Syntax.lbtyp = lbtyp;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___3759_28085.FStar_Syntax_Syntax.lbeff);
+                            (uu___1.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = lbdef;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___3759_28085.FStar_Syntax_Syntax.lbattrs);
+                            (uu___1.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___3759_28085.FStar_Syntax_Syntax.lbpos)
+                            (uu___1.FStar_Syntax_Syntax.lbpos)
                         })) in
-          let uu___3762_28086 = s in
+          let uu___ = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let ((b, lbs1), lids));
-            FStar_Syntax_Syntax.sigrng =
-              (uu___3762_28086.FStar_Syntax_Syntax.sigrng);
+            FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3762_28086.FStar_Syntax_Syntax.sigquals);
-            FStar_Syntax_Syntax.sigmeta =
-              (uu___3762_28086.FStar_Syntax_Syntax.sigmeta);
+              (uu___.FStar_Syntax_Syntax.sigquals);
+            FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3762_28086.FStar_Syntax_Syntax.sigattrs);
-            FStar_Syntax_Syntax.sigopts =
-              (uu___3762_28086.FStar_Syntax_Syntax.sigopts)
+              (uu___.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_assume (l, us, t) ->
-          let uu____28094 = elim_uvars_aux_t env1 us [] t in
-          (match uu____28094 with
-           | (us1, uu____28118, t1) ->
-               let uu___3773_28140 = s in
+          let uu___ = elim_uvars_aux_t env1 us [] t in
+          (match uu___ with
+           | (us1, uu___1, t1) ->
+               let uu___2 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_assume (l, us1, t1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3773_28140.FStar_Syntax_Syntax.sigrng);
+                   (uu___2.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3773_28140.FStar_Syntax_Syntax.sigquals);
+                   (uu___2.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3773_28140.FStar_Syntax_Syntax.sigmeta);
+                   (uu___2.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3773_28140.FStar_Syntax_Syntax.sigattrs);
+                   (uu___2.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3773_28140.FStar_Syntax_Syntax.sigopts)
+                   (uu___2.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____28142 =
+          let uu___ =
             elim_uvars_aux_t env1 ed.FStar_Syntax_Syntax.univs
               ed.FStar_Syntax_Syntax.binders FStar_Syntax_Syntax.t_unit in
-          (match uu____28142 with
-           | (univs, binders, uu____28161) ->
-               let uu____28182 =
-                 let uu____28187 = FStar_Syntax_Subst.univ_var_opening univs in
-                 match uu____28187 with
+          (match uu___ with
+           | (univs, binders, uu___1) ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.univ_var_opening univs in
+                 match uu___3 with
                  | (univs_opening, univs1) ->
-                     let uu____28210 =
-                       FStar_Syntax_Subst.univ_var_closing univs1 in
-                     (univs_opening, uu____28210) in
-               (match uu____28182 with
+                     let uu___4 = FStar_Syntax_Subst.univ_var_closing univs1 in
+                     (univs_opening, uu___4) in
+               (match uu___2 with
                 | (univs_opening, univs_closing) ->
-                    let uu____28213 =
+                    let uu___3 =
                       let binders1 = FStar_Syntax_Subst.open_binders binders in
-                      let uu____28219 =
+                      let uu___4 =
                         FStar_Syntax_Subst.opening_of_binders binders1 in
-                      let uu____28220 =
+                      let uu___5 =
                         FStar_Syntax_Subst.closing_of_binders binders1 in
-                      (uu____28219, uu____28220) in
-                    (match uu____28213 with
+                      (uu___4, uu___5) in
+                    (match uu___3 with
                      | (b_opening, b_closing) ->
                          let n = FStar_List.length univs in
                          let n_binders = FStar_List.length binders in
-                         let elim_tscheme uu____28246 =
-                           match uu____28246 with
+                         let elim_tscheme uu___4 =
+                           match uu___4 with
                            | (us, t) ->
                                let n_us = FStar_List.length us in
-                               let uu____28264 =
+                               let uu___5 =
                                  FStar_Syntax_Subst.open_univ_vars us t in
-                               (match uu____28264 with
+                               (match uu___5 with
                                 | (us1, t1) ->
-                                    let uu____28275 =
-                                      let uu____28284 =
+                                    let uu___6 =
+                                      let uu___7 =
                                         FStar_All.pipe_right b_opening
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us) in
-                                      let uu____28289 =
+                                      let uu___8 =
                                         FStar_All.pipe_right b_closing
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us) in
-                                      (uu____28284, uu____28289) in
-                                    (match uu____28275 with
+                                      (uu___7, uu___8) in
+                                    (match uu___6 with
                                      | (b_opening1, b_closing1) ->
-                                         let uu____28312 =
-                                           let uu____28321 =
+                                         let uu___7 =
+                                           let uu___8 =
                                              FStar_All.pipe_right
                                                univs_opening
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders)) in
-                                           let uu____28326 =
+                                           let uu___9 =
                                              FStar_All.pipe_right
                                                univs_closing
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders)) in
-                                           (uu____28321, uu____28326) in
-                                         (match uu____28312 with
+                                           (uu___8, uu___9) in
+                                         (match uu___7 with
                                           | (univs_opening1, univs_closing1)
                                               ->
                                               let t2 =
-                                                let uu____28350 =
+                                                let uu___8 =
                                                   FStar_Syntax_Subst.subst
                                                     b_opening1 t1 in
                                                 FStar_Syntax_Subst.subst
-                                                  univs_opening1 uu____28350 in
-                                              let uu____28351 =
+                                                  univs_opening1 uu___8 in
+                                              let uu___8 =
                                                 elim_uvars_aux_t env1 [] []
                                                   t2 in
-                                              (match uu____28351 with
-                                               | (uu____28378, uu____28379,
-                                                  t3) ->
+                                              (match uu___8 with
+                                               | (uu___9, uu___10, t3) ->
                                                    let t4 =
-                                                     let uu____28402 =
-                                                       let uu____28403 =
+                                                     let uu___11 =
+                                                       let uu___12 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us1 t3 in
                                                        FStar_Syntax_Subst.subst
-                                                         b_closing1
-                                                         uu____28403 in
+                                                         b_closing1 uu___12 in
                                                      FStar_Syntax_Subst.subst
-                                                       univs_closing1
-                                                       uu____28402 in
+                                                       univs_closing1 uu___11 in
                                                    (us1, t4))))) in
                          let elim_term t =
-                           let uu____28412 =
-                             elim_uvars_aux_t env1 univs binders t in
-                           match uu____28412 with
-                           | (uu____28431, uu____28432, t1) -> t1 in
+                           let uu___4 = elim_uvars_aux_t env1 univs binders t in
+                           match uu___4 with | (uu___5, uu___6, t1) -> t1 in
                          let elim_action a =
                            let action_typ_templ =
                              let body =
@@ -9028,57 +8770,55 @@ let rec (elim_uvars :
                                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                              match a.FStar_Syntax_Syntax.action_params with
                              | [] -> body
-                             | uu____28508 ->
+                             | uu___4 ->
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_abs
                                       ((a.FStar_Syntax_Syntax.action_params),
                                         body, FStar_Pervasives_Native.None))
                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                            let destruct_action_body body =
-                             let uu____28535 =
-                               let uu____28536 =
-                                 FStar_Syntax_Subst.compress body in
-                               uu____28536.FStar_Syntax_Syntax.n in
-                             match uu____28535 with
+                             let uu___4 =
+                               let uu___5 = FStar_Syntax_Subst.compress body in
+                               uu___5.FStar_Syntax_Syntax.n in
+                             match uu___4 with
                              | FStar_Syntax_Syntax.Tm_ascribed
                                  (defn,
                                   (FStar_Util.Inl typ,
                                    FStar_Pervasives_Native.None),
                                   FStar_Pervasives_Native.None)
                                  -> (defn, typ)
-                             | uu____28595 -> failwith "Impossible" in
+                             | uu___5 -> failwith "Impossible" in
                            let destruct_action_typ_templ t =
-                             let uu____28628 =
-                               let uu____28629 =
-                                 FStar_Syntax_Subst.compress t in
-                               uu____28629.FStar_Syntax_Syntax.n in
-                             match uu____28628 with
+                             let uu___4 =
+                               let uu___5 = FStar_Syntax_Subst.compress t in
+                               uu___5.FStar_Syntax_Syntax.n in
+                             match uu___4 with
                              | FStar_Syntax_Syntax.Tm_abs
-                                 (pars, body, uu____28652) ->
-                                 let uu____28677 = destruct_action_body body in
-                                 (match uu____28677 with
+                                 (pars, body, uu___5) ->
+                                 let uu___6 = destruct_action_body body in
+                                 (match uu___6 with
                                   | (defn, typ) -> (pars, defn, typ))
-                             | uu____28726 ->
-                                 let uu____28727 = destruct_action_body t in
-                                 (match uu____28727 with
+                             | uu___5 ->
+                                 let uu___6 = destruct_action_body t in
+                                 (match uu___6 with
                                   | (defn, typ) -> ([], defn, typ)) in
-                           let uu____28782 =
+                           let uu___4 =
                              elim_tscheme
                                ((a.FStar_Syntax_Syntax.action_univs),
                                  action_typ_templ) in
-                           match uu____28782 with
+                           match uu___4 with
                            | (action_univs, t) ->
-                               let uu____28791 = destruct_action_typ_templ t in
-                               (match uu____28791 with
+                               let uu___5 = destruct_action_typ_templ t in
+                               (match uu___5 with
                                 | (action_params, action_defn, action_typ) ->
                                     let a' =
-                                      let uu___3857_28838 = a in
+                                      let uu___6 = a in
                                       {
                                         FStar_Syntax_Syntax.action_name =
-                                          (uu___3857_28838.FStar_Syntax_Syntax.action_name);
+                                          (uu___6.FStar_Syntax_Syntax.action_name);
                                         FStar_Syntax_Syntax.action_unqualified_name
                                           =
-                                          (uu___3857_28838.FStar_Syntax_Syntax.action_unqualified_name);
+                                          (uu___6.FStar_Syntax_Syntax.action_unqualified_name);
                                         FStar_Syntax_Syntax.action_univs =
                                           action_univs;
                                         FStar_Syntax_Syntax.action_params =
@@ -9090,153 +8830,146 @@ let rec (elim_uvars :
                                       } in
                                     a') in
                          let ed1 =
-                           let uu___3860_28840 = ed in
-                           let uu____28841 =
+                           let uu___4 = ed in
+                           let uu___5 =
                              elim_tscheme ed.FStar_Syntax_Syntax.signature in
-                           let uu____28842 =
+                           let uu___6 =
                              FStar_Syntax_Util.apply_eff_combinators
                                elim_tscheme
                                ed.FStar_Syntax_Syntax.combinators in
-                           let uu____28843 =
+                           let uu___7 =
                              FStar_List.map elim_action
                                ed.FStar_Syntax_Syntax.actions in
                            {
                              FStar_Syntax_Syntax.mname =
-                               (uu___3860_28840.FStar_Syntax_Syntax.mname);
+                               (uu___4.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___3860_28840.FStar_Syntax_Syntax.cattributes);
+                               (uu___4.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.univs = univs;
                              FStar_Syntax_Syntax.binders = binders;
-                             FStar_Syntax_Syntax.signature = uu____28841;
-                             FStar_Syntax_Syntax.combinators = uu____28842;
-                             FStar_Syntax_Syntax.actions = uu____28843;
+                             FStar_Syntax_Syntax.signature = uu___5;
+                             FStar_Syntax_Syntax.combinators = uu___6;
+                             FStar_Syntax_Syntax.actions = uu___7;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___3860_28840.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___4.FStar_Syntax_Syntax.eff_attrs)
                            } in
-                         let uu___3863_28846 = s in
+                         let uu___4 = s in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_new_effect ed1);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___3863_28846.FStar_Syntax_Syntax.sigrng);
+                             (uu___4.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___3863_28846.FStar_Syntax_Syntax.sigquals);
+                             (uu___4.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___3863_28846.FStar_Syntax_Syntax.sigmeta);
+                             (uu___4.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___3863_28846.FStar_Syntax_Syntax.sigattrs);
+                             (uu___4.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___3863_28846.FStar_Syntax_Syntax.sigopts)
+                             (uu___4.FStar_Syntax_Syntax.sigopts)
                          })))
       | FStar_Syntax_Syntax.Sig_sub_effect sub_eff ->
-          let elim_tscheme_opt uu___19_28867 =
-            match uu___19_28867 with
+          let elim_tscheme_opt uu___ =
+            match uu___ with
             | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (us, t) ->
-                let uu____28898 = elim_uvars_aux_t env1 us [] t in
-                (match uu____28898 with
-                 | (us1, uu____28930, t1) ->
+                let uu___1 = elim_uvars_aux_t env1 us [] t in
+                (match uu___1 with
+                 | (us1, uu___2, t1) ->
                      FStar_Pervasives_Native.Some (us1, t1)) in
           let sub_eff1 =
-            let uu___3878_28961 = sub_eff in
-            let uu____28962 =
-              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp in
-            let uu____28965 =
-              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift in
+            let uu___ = sub_eff in
+            let uu___1 = elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp in
+            let uu___2 = elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift in
             {
-              FStar_Syntax_Syntax.source =
-                (uu___3878_28961.FStar_Syntax_Syntax.source);
-              FStar_Syntax_Syntax.target =
-                (uu___3878_28961.FStar_Syntax_Syntax.target);
-              FStar_Syntax_Syntax.lift_wp = uu____28962;
-              FStar_Syntax_Syntax.lift = uu____28965
+              FStar_Syntax_Syntax.source = (uu___.FStar_Syntax_Syntax.source);
+              FStar_Syntax_Syntax.target = (uu___.FStar_Syntax_Syntax.target);
+              FStar_Syntax_Syntax.lift_wp = uu___1;
+              FStar_Syntax_Syntax.lift = uu___2
             } in
-          let uu___3881_28968 = s in
+          let uu___ = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_sub_effect sub_eff1);
-            FStar_Syntax_Syntax.sigrng =
-              (uu___3881_28968.FStar_Syntax_Syntax.sigrng);
+            FStar_Syntax_Syntax.sigrng = (uu___.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3881_28968.FStar_Syntax_Syntax.sigquals);
-            FStar_Syntax_Syntax.sigmeta =
-              (uu___3881_28968.FStar_Syntax_Syntax.sigmeta);
+              (uu___.FStar_Syntax_Syntax.sigquals);
+            FStar_Syntax_Syntax.sigmeta = (uu___.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3881_28968.FStar_Syntax_Syntax.sigattrs);
-            FStar_Syntax_Syntax.sigopts =
-              (uu___3881_28968.FStar_Syntax_Syntax.sigopts)
+              (uu___.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts = (uu___.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid, univ_names, binders, comp, flags) ->
-          let uu____28978 = elim_uvars_aux_c env1 univ_names binders comp in
-          (match uu____28978 with
+          let uu___ = elim_uvars_aux_c env1 univ_names binders comp in
+          (match uu___ with
            | (univ_names1, binders1, comp1) ->
-               let uu___3894_29018 = s in
+               let uu___1 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_effect_abbrev
                       (lid, univ_names1, binders1, comp1, flags));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3894_29018.FStar_Syntax_Syntax.sigrng);
+                   (uu___1.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3894_29018.FStar_Syntax_Syntax.sigquals);
+                   (uu___1.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3894_29018.FStar_Syntax_Syntax.sigmeta);
+                   (uu___1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3894_29018.FStar_Syntax_Syntax.sigattrs);
+                   (uu___1.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3894_29018.FStar_Syntax_Syntax.sigopts)
+                   (uu___1.FStar_Syntax_Syntax.sigopts)
                })
-      | FStar_Syntax_Syntax.Sig_pragma uu____29021 -> s
-      | FStar_Syntax_Syntax.Sig_fail uu____29022 -> s
-      | FStar_Syntax_Syntax.Sig_splice uu____29033 -> s
+      | FStar_Syntax_Syntax.Sig_pragma uu___ -> s
+      | FStar_Syntax_Syntax.Sig_fail uu___ -> s
+      | FStar_Syntax_Syntax.Sig_splice uu___ -> s
       | FStar_Syntax_Syntax.Sig_polymonadic_bind
           (m, n, p, (us_t, t), (us_ty, ty)) ->
-          let uu____29063 = elim_uvars_aux_t env1 us_t [] t in
-          (match uu____29063 with
-           | (us_t1, uu____29087, t1) ->
-               let uu____29109 = elim_uvars_aux_t env1 us_ty [] ty in
-               (match uu____29109 with
-                | (us_ty1, uu____29133, ty1) ->
-                    let uu___3921_29155 = s in
+          let uu___ = elim_uvars_aux_t env1 us_t [] t in
+          (match uu___ with
+           | (us_t1, uu___1, t1) ->
+               let uu___2 = elim_uvars_aux_t env1 us_ty [] ty in
+               (match uu___2 with
+                | (us_ty1, uu___3, ty1) ->
+                    let uu___4 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_polymonadic_bind
                            (m, n, p, (us_t1, t1), (us_ty1, ty1)));
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___3921_29155.FStar_Syntax_Syntax.sigrng);
+                        (uu___4.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___3921_29155.FStar_Syntax_Syntax.sigquals);
+                        (uu___4.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___3921_29155.FStar_Syntax_Syntax.sigmeta);
+                        (uu___4.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___3921_29155.FStar_Syntax_Syntax.sigattrs);
+                        (uu___4.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___3921_29155.FStar_Syntax_Syntax.sigopts)
+                        (uu___4.FStar_Syntax_Syntax.sigopts)
                     }))
       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
           (m, n, (us_t, t), (us_ty, ty)) ->
-          let uu____29186 = elim_uvars_aux_t env1 us_t [] t in
-          (match uu____29186 with
-           | (us_t1, uu____29210, t1) ->
-               let uu____29232 = elim_uvars_aux_t env1 us_ty [] ty in
-               (match uu____29232 with
-                | (us_ty1, uu____29256, ty1) ->
-                    let uu___3941_29278 = s in
+          let uu___ = elim_uvars_aux_t env1 us_t [] t in
+          (match uu___ with
+           | (us_t1, uu___1, t1) ->
+               let uu___2 = elim_uvars_aux_t env1 us_ty [] ty in
+               (match uu___2 with
+                | (us_ty1, uu___3, ty1) ->
+                    let uu___4 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                            (m, n, (us_t1, t1), (us_ty1, ty1)));
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___3941_29278.FStar_Syntax_Syntax.sigrng);
+                        (uu___4.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___3941_29278.FStar_Syntax_Syntax.sigquals);
+                        (uu___4.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___3941_29278.FStar_Syntax_Syntax.sigmeta);
+                        (uu___4.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___3941_29278.FStar_Syntax_Syntax.sigattrs);
+                        (uu___4.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___3941_29278.FStar_Syntax_Syntax.sigopts)
+                        (uu___4.FStar_Syntax_Syntax.sigopts)
                     }))
 let (erase_universes :
   FStar_TypeChecker_Env.env ->
@@ -9255,17 +8988,17 @@ let (unfold_head_once :
   fun env1 ->
     fun t ->
       let aux f us args =
-        let uu____29327 =
+        let uu___ =
           FStar_TypeChecker_Env.lookup_nonrec_definition
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
             env1 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        match uu____29327 with
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some head_def_ts ->
-            let uu____29349 =
+            let uu___1 =
               FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us in
-            (match uu____29349 with
-             | (uu____29356, head_def) ->
+            (match uu___1 with
+             | (uu___2, head_def) ->
                  let t' =
                    FStar_Syntax_Syntax.mk_Tm_app head_def args
                      t.FStar_Syntax_Syntax.pos in
@@ -9274,21 +9007,21 @@ let (unfold_head_once :
                      [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota]
                      env1 t' in
                  FStar_Pervasives_Native.Some t'1) in
-      let uu____29360 = FStar_Syntax_Util.head_and_args t in
-      match uu____29360 with
+      let uu___ = FStar_Syntax_Util.head_and_args t in
+      match uu___ with
       | (head, args) ->
-          let uu____29405 =
-            let uu____29406 = FStar_Syntax_Subst.compress head in
-            uu____29406.FStar_Syntax_Syntax.n in
-          (match uu____29405 with
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Subst.compress head in
+            uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
            | FStar_Syntax_Syntax.Tm_fvar fv -> aux fv [] args
            | FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____29413;
-                  FStar_Syntax_Syntax.vars = uu____29414;_},
+                  FStar_Syntax_Syntax.pos = uu___2;
+                  FStar_Syntax_Syntax.vars = uu___3;_},
                 us)
                -> aux fv us args
-           | uu____29420 -> FStar_Pervasives_Native.None)
+           | uu___2 -> FStar_Pervasives_Native.None)
 let (get_n_binders :
   FStar_TypeChecker_Env.env ->
     Prims.int ->
@@ -9299,32 +9032,31 @@ let (get_n_binders :
     fun n ->
       fun t ->
         let rec aux retry n1 t1 =
-          let uu____29476 = FStar_Syntax_Util.arrow_formals_comp t1 in
-          match uu____29476 with
+          let uu___ = FStar_Syntax_Util.arrow_formals_comp t1 in
+          match uu___ with
           | (bs, c) ->
               let len = FStar_List.length bs in
               (match (bs, c) with
-               | ([], uu____29512) when retry ->
-                   let uu____29531 = unfold_whnf env1 t1 in
-                   aux false n1 uu____29531
-               | ([], uu____29532) when Prims.op_Negation retry -> (bs, c)
+               | ([], uu___1) when retry ->
+                   let uu___2 = unfold_whnf env1 t1 in aux false n1 uu___2
+               | ([], uu___1) when Prims.op_Negation retry -> (bs, c)
                | (bs1, c1) when len = n1 -> (bs1, c1)
                | (bs1, c1) when len > n1 ->
-                   let uu____29599 = FStar_List.splitAt n1 bs1 in
-                   (match uu____29599 with
+                   let uu___1 = FStar_List.splitAt n1 bs1 in
+                   (match uu___1 with
                     | (bs_l, bs_r) ->
-                        let uu____29666 =
-                          let uu____29667 = FStar_Syntax_Util.arrow bs_r c1 in
-                          FStar_Syntax_Syntax.mk_Total uu____29667 in
-                        (bs_l, uu____29666))
+                        let uu___2 =
+                          let uu___3 = FStar_Syntax_Util.arrow bs_r c1 in
+                          FStar_Syntax_Syntax.mk_Total uu___3 in
+                        (bs_l, uu___2))
                | (bs1, c1) when
                    ((len < n1) && (FStar_Syntax_Util.is_total_comp c1)) &&
-                     (let uu____29693 = FStar_Syntax_Util.has_decreases c1 in
-                      Prims.op_Negation uu____29693)
+                     (let uu___1 = FStar_Syntax_Util.has_decreases c1 in
+                      Prims.op_Negation uu___1)
                    ->
-                   let uu____29694 =
+                   let uu___1 =
                      aux true (n1 - len) (FStar_Syntax_Util.comp_result c1) in
-                   (match uu____29694 with
+                   (match uu___1 with
                     | (bs', c') -> ((FStar_List.append bs1 bs'), c'))
                | (bs1, c1) -> (bs1, c1)) in
         aux true n t

--- a/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
+++ b/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
@@ -18,112 +18,109 @@ let rec (elaborate_pat :
       | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
           let pats1 =
             FStar_List.map
-              (fun uu____76 ->
-                 match uu____76 with
+              (fun uu___ ->
+                 match uu___ with
                  | (p1, imp) ->
-                     let uu____87 = elaborate_pat env p1 in (uu____87, imp))
-              pats in
-          let uu____88 =
+                     let uu___1 = elaborate_pat env p1 in (uu___1, imp)) pats in
+          let uu___ =
             FStar_TypeChecker_Env.lookup_datacon env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____88 with
-           | (uu____93, t) ->
-               let uu____95 = FStar_Syntax_Util.arrow_formals t in
-               (match uu____95 with
-                | (f, uu____103) ->
+          (match uu___ with
+           | (uu___1, t) ->
+               let uu___2 = FStar_Syntax_Util.arrow_formals t in
+               (match uu___2 with
+                | (f, uu___3) ->
                     let rec aux formals pats2 =
                       match (formals, pats2) with
                       | ([], []) -> []
-                      | ([], uu____217::uu____218) ->
-                          let uu____261 =
+                      | ([], uu___4::uu___5) ->
+                          let uu___6 =
                             FStar_Ident.range_of_lid
                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_TooManyPatternArguments,
-                              "Too many pattern arguments") uu____261
-                      | (uu____270::uu____271, []) ->
+                              "Too many pattern arguments") uu___6
+                      | (uu___4::uu___5, []) ->
                           FStar_All.pipe_right formals
                             (FStar_List.map
-                               (fun uu____349 ->
-                                  match uu____349 with
+                               (fun uu___6 ->
+                                  match uu___6 with
                                   | (t1, imp) ->
                                       (match imp with
                                        | FStar_Pervasives_Native.Some
                                            (FStar_Syntax_Syntax.Implicit
                                            inaccessible) ->
                                            let a =
-                                             let uu____376 =
-                                               let uu____379 =
+                                             let uu___7 =
+                                               let uu___8 =
                                                  FStar_Syntax_Syntax.range_of_bv
                                                    t1 in
                                                FStar_Pervasives_Native.Some
-                                                 uu____379 in
+                                                 uu___8 in
                                              FStar_Syntax_Syntax.new_bv
-                                               uu____376
-                                               FStar_Syntax_Syntax.tun in
+                                               uu___7 FStar_Syntax_Syntax.tun in
                                            let r =
                                              FStar_Ident.range_of_lid
                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                           let uu____381 =
+                                           let uu___7 =
                                              maybe_dot inaccessible a r in
-                                           (uu____381, true)
-                                       | uu____386 ->
-                                           let uu____389 =
-                                             let uu____394 =
-                                               let uu____395 =
+                                           (uu___7, true)
+                                       | uu___7 ->
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
                                                  FStar_Syntax_Print.pat_to_string
                                                    p in
                                                FStar_Util.format1
                                                  "Insufficient pattern arguments (%s)"
-                                                 uu____395 in
+                                                 uu___10 in
                                              (FStar_Errors.Fatal_InsufficientPatternArguments,
-                                               uu____394) in
-                                           let uu____396 =
+                                               uu___9) in
+                                           let uu___9 =
                                              FStar_Ident.range_of_lid
                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                           FStar_Errors.raise_error uu____389
-                                             uu____396)))
+                                           FStar_Errors.raise_error uu___8
+                                             uu___9)))
                       | (f1::formals', (p1, p_imp)::pats') ->
                           (match f1 with
-                           | (uu____470, FStar_Pervasives_Native.Some
+                           | (uu___4, FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit inaccessible))
                                when inaccessible && p_imp ->
                                (match p1.FStar_Syntax_Syntax.v with
-                                | FStar_Syntax_Syntax.Pat_dot_term uu____482
-                                    ->
-                                    let uu____489 = aux formals' pats' in
-                                    (p1, true) :: uu____489
-                                | FStar_Syntax_Syntax.Pat_wild uu____506 ->
+                                | FStar_Syntax_Syntax.Pat_dot_term uu___5 ->
+                                    let uu___6 = aux formals' pats' in
+                                    (p1, true) :: uu___6
+                                | FStar_Syntax_Syntax.Pat_wild uu___5 ->
                                     let a =
                                       FStar_Syntax_Syntax.new_bv
                                         (FStar_Pervasives_Native.Some
                                            (p1.FStar_Syntax_Syntax.p))
                                         FStar_Syntax_Syntax.tun in
                                     let p2 =
-                                      let uu____511 =
+                                      let uu___6 =
                                         FStar_Ident.range_of_lid
                                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                      maybe_dot inaccessible a uu____511 in
-                                    let uu____512 = aux formals' pats' in
-                                    (p2, true) :: uu____512
-                                | uu____529 ->
-                                    let uu____530 =
-                                      let uu____535 =
-                                        let uu____536 =
+                                      maybe_dot inaccessible a uu___6 in
+                                    let uu___6 = aux formals' pats' in
+                                    (p2, true) :: uu___6
+                                | uu___5 ->
+                                    let uu___6 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_Syntax_Print.pat_to_string p1 in
                                         FStar_Util.format1
                                           "This pattern (%s) binds an inaccesible argument; use a wildcard ('_') pattern"
-                                          uu____536 in
+                                          uu___8 in
                                       (FStar_Errors.Fatal_InsufficientPatternArguments,
-                                        uu____535) in
-                                    FStar_Errors.raise_error uu____530
+                                        uu___7) in
+                                    FStar_Errors.raise_error uu___6
                                       p1.FStar_Syntax_Syntax.p)
-                           | (uu____545, FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____546)) when
+                           | (uu___4, FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Implicit uu___5)) when
                                p_imp ->
-                               let uu____549 = aux formals' pats' in
-                               (p1, true) :: uu____549
-                           | (uu____566, FStar_Pervasives_Native.Some
+                               let uu___6 = aux formals' pats' in (p1, true)
+                                 :: uu___6
+                           | (uu___4, FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit inaccessible)) ->
                                let a =
                                  FStar_Syntax_Syntax.new_bv
@@ -131,30 +128,28 @@ let rec (elaborate_pat :
                                       (p1.FStar_Syntax_Syntax.p))
                                    FStar_Syntax_Syntax.tun in
                                let p2 =
-                                 let uu____574 =
+                                 let uu___5 =
                                    FStar_Ident.range_of_lid
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                 maybe_dot inaccessible a uu____574 in
-                               let uu____575 = aux formals' pats2 in
-                               (p2, true) :: uu____575
-                           | (uu____592, imp) ->
-                               let uu____598 =
-                                 let uu____605 =
+                                 maybe_dot inaccessible a uu___5 in
+                               let uu___5 = aux formals' pats2 in (p2, true)
+                                 :: uu___5
+                           | (uu___4, imp) ->
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_Syntax_Syntax.is_implicit imp in
-                                 (p1, uu____605) in
-                               let uu____608 = aux formals' pats' in
-                               uu____598 :: uu____608) in
-                    let uu___82_623 = p in
-                    let uu____624 =
-                      let uu____625 =
-                        let uu____638 = aux f pats1 in (fv, uu____638) in
-                      FStar_Syntax_Syntax.Pat_cons uu____625 in
+                                 (p1, uu___6) in
+                               let uu___6 = aux formals' pats' in uu___5 ::
+                                 uu___6) in
+                    let uu___4 = p in
+                    let uu___5 =
+                      let uu___6 = let uu___7 = aux f pats1 in (fv, uu___7) in
+                      FStar_Syntax_Syntax.Pat_cons uu___6 in
                     {
-                      FStar_Syntax_Syntax.v = uu____624;
-                      FStar_Syntax_Syntax.p =
-                        (uu___82_623.FStar_Syntax_Syntax.p)
+                      FStar_Syntax_Syntax.v = uu___5;
+                      FStar_Syntax_Syntax.p = (uu___4.FStar_Syntax_Syntax.p)
                     }))
-      | uu____655 -> p
+      | uu___ -> p
 let (pat_as_exp :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -168,37 +163,36 @@ let (pat_as_exp :
         let intro_bv env1 x =
           if Prims.op_Negation introduce_bv_uvars
           then
-            ((let uu___95_715 = x in
+            ((let uu___ = x in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___95_715.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index =
-                  (uu___95_715.FStar_Syntax_Syntax.index);
+                  (uu___.FStar_Syntax_Syntax.ppname);
+                FStar_Syntax_Syntax.index = (uu___.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = FStar_Syntax_Syntax.tun
               }), FStar_TypeChecker_Env.trivial_guard, env1)
           else
-            (let uu____717 = FStar_Syntax_Util.type_u () in
-             match uu____717 with
-             | (t, uu____729) ->
-                 let uu____730 =
-                   let uu____743 = FStar_Syntax_Syntax.range_of_bv x in
+            (let uu___1 = FStar_Syntax_Util.type_u () in
+             match uu___1 with
+             | (t, uu___2) ->
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Syntax.range_of_bv x in
                    FStar_TypeChecker_Env.new_implicit_var_aux
-                     "pattern bv type" uu____743 env1 t
+                     "pattern bv type" uu___4 env1 t
                      FStar_Syntax_Syntax.Allow_untyped
                      FStar_Pervasives_Native.None in
-                 (match uu____730 with
-                  | (t_x, uu____751, guard) ->
+                 (match uu___3 with
+                  | (t_x, uu___4, guard) ->
                       let x1 =
-                        let uu___104_766 = x in
+                        let uu___5 = x in
                         {
                           FStar_Syntax_Syntax.ppname =
-                            (uu___104_766.FStar_Syntax_Syntax.ppname);
+                            (uu___5.FStar_Syntax_Syntax.ppname);
                           FStar_Syntax_Syntax.index =
-                            (uu___104_766.FStar_Syntax_Syntax.index);
+                            (uu___5.FStar_Syntax_Syntax.index);
                           FStar_Syntax_Syntax.sort = t_x
                         } in
-                      let uu____767 = FStar_TypeChecker_Env.push_bv env1 x1 in
-                      (x1, guard, uu____767))) in
+                      let uu___5 = FStar_TypeChecker_Env.push_bv env1 x1 in
+                      (x1, guard, uu___5))) in
         let rec pat_as_arg_with_env env1 p1 =
           match p1.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_constant c ->
@@ -209,137 +203,136 @@ let (pat_as_exp :
                     FStar_ToSyntax_ToSyntax.desugar_machine_integer
                       env1.FStar_TypeChecker_Env.dsenv repr sw
                       p1.FStar_Syntax_Syntax.p
-                | uu____837 ->
+                | uu___ ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant c)
                       p1.FStar_Syntax_Syntax.p in
               ([], [], [], env1, e, FStar_TypeChecker_Common.trivial_guard,
                 p1)
-          | FStar_Syntax_Syntax.Pat_dot_term (x, uu____845) ->
-              let uu____850 = FStar_Syntax_Util.type_u () in
-              (match uu____850 with
-               | (k, uu____876) ->
-                   let uu____877 =
-                     let uu____890 = FStar_Syntax_Syntax.range_of_bv x in
+          | FStar_Syntax_Syntax.Pat_dot_term (x, uu___) ->
+              let uu___1 = FStar_Syntax_Util.type_u () in
+              (match uu___1 with
+               | (k, uu___2) ->
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Syntax.range_of_bv x in
                      FStar_TypeChecker_Env.new_implicit_var_aux
-                       "pat_dot_term type" uu____890 env1 k
+                       "pat_dot_term type" uu___4 env1 k
                        FStar_Syntax_Syntax.Allow_untyped
                        FStar_Pervasives_Native.None in
-                   (match uu____877 with
-                    | (t, uu____912, g) ->
+                   (match uu___3 with
+                    | (t, uu___4, g) ->
                         let x1 =
-                          let uu___130_927 = x in
+                          let uu___5 = x in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___130_927.FStar_Syntax_Syntax.ppname);
+                              (uu___5.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___130_927.FStar_Syntax_Syntax.index);
+                              (uu___5.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t
                           } in
-                        let uu____928 =
-                          let uu____941 = FStar_Syntax_Syntax.range_of_bv x1 in
+                        let uu___5 =
+                          let uu___6 = FStar_Syntax_Syntax.range_of_bv x1 in
                           FStar_TypeChecker_Env.new_implicit_var_aux
-                            "pat_dot_term" uu____941 env1 t
+                            "pat_dot_term" uu___6 env1 t
                             FStar_Syntax_Syntax.Allow_untyped
                             FStar_Pervasives_Native.None in
-                        (match uu____928 with
-                         | (e, uu____963, g') ->
+                        (match uu___5 with
+                         | (e, uu___6, g') ->
                              let p2 =
-                               let uu___137_980 = p1 in
+                               let uu___7 = p1 in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_dot_term (x1, e));
                                  FStar_Syntax_Syntax.p =
-                                   (uu___137_980.FStar_Syntax_Syntax.p)
+                                   (uu___7.FStar_Syntax_Syntax.p)
                                } in
-                             let uu____983 =
+                             let uu___7 =
                                FStar_TypeChecker_Common.conj_guard g g' in
-                             ([], [], [], env1, e, uu____983, p2))))
+                             ([], [], [], env1, e, uu___7, p2))))
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu____991 = intro_bv env1 x in
-              (match uu____991 with
+              let uu___ = intro_bv env1 x in
+              (match uu___ with
                | (x1, g, env2) ->
                    let e =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1)
                        p1.FStar_Syntax_Syntax.p in
                    ([x1], [], [x1], env2, e, g, p1))
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu____1031 = intro_bv env1 x in
-              (match uu____1031 with
+              let uu___ = intro_bv env1 x in
+              (match uu___ with
                | (x1, g, env2) ->
                    let e =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1)
                        p1.FStar_Syntax_Syntax.p in
                    ([x1], [x1], [], env2, e, g, p1))
           | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-              let uu____1088 =
+              let uu___ =
                 FStar_All.pipe_right pats
                   (FStar_List.fold_left
-                     (fun uu____1222 ->
-                        fun uu____1223 ->
-                          match (uu____1222, uu____1223) with
+                     (fun uu___1 ->
+                        fun uu___2 ->
+                          match (uu___1, uu___2) with
                           | ((b, a, w, env2, args, guard, pats1), (p2, imp))
                               ->
-                              let uu____1421 = pat_as_arg_with_env env2 p2 in
-                              (match uu____1421 with
+                              let uu___3 = pat_as_arg_with_env env2 p2 in
+                              (match uu___3 with
                                | (b', a', w', env3, te, guard', pat) ->
                                    let arg =
                                      if imp
                                      then FStar_Syntax_Syntax.iarg te
                                      else FStar_Syntax_Syntax.as_arg te in
-                                   let uu____1497 =
+                                   let uu___4 =
                                      FStar_TypeChecker_Common.conj_guard
                                        guard guard' in
                                    ((b' :: b), (a' :: a), (w' :: w), env3,
-                                     (arg :: args), uu____1497, ((pat, imp)
-                                     :: pats1))))
+                                     (arg :: args), uu___4, ((pat, imp) ::
+                                     pats1))))
                      ([], [], [], env1, [],
                        FStar_TypeChecker_Common.trivial_guard, [])) in
-              (match uu____1088 with
+              (match uu___ with
                | (b, a, w, env2, args, guard, pats1) ->
                    let e =
-                     let uu____1626 = FStar_Syntax_Syntax.fv_to_tm fv in
-                     let uu____1627 =
-                       FStar_All.pipe_right args FStar_List.rev in
-                     FStar_Syntax_Syntax.mk_Tm_app uu____1626 uu____1627
+                     let uu___1 = FStar_Syntax_Syntax.fv_to_tm fv in
+                     let uu___2 = FStar_All.pipe_right args FStar_List.rev in
+                     FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2
                        p1.FStar_Syntax_Syntax.p in
-                   let uu____1630 =
+                   let uu___1 =
                      FStar_All.pipe_right (FStar_List.rev b)
                        FStar_List.flatten in
-                   let uu____1641 =
+                   let uu___2 =
                      FStar_All.pipe_right (FStar_List.rev a)
                        FStar_List.flatten in
-                   let uu____1652 =
+                   let uu___3 =
                      FStar_All.pipe_right (FStar_List.rev w)
                        FStar_List.flatten in
-                   (uu____1630, uu____1641, uu____1652, env2, e, guard,
-                     (let uu___188_1670 = p1 in
+                   (uu___1, uu___2, uu___3, env2, e, guard,
+                     (let uu___4 = p1 in
                       {
                         FStar_Syntax_Syntax.v =
                           (FStar_Syntax_Syntax.Pat_cons
                              (fv, (FStar_List.rev pats1)));
                         FStar_Syntax_Syntax.p =
-                          (uu___188_1670.FStar_Syntax_Syntax.p)
+                          (uu___4.FStar_Syntax_Syntax.p)
                       }))) in
         let one_pat env1 p1 =
           let p2 = elaborate_pat env1 p1 in
-          let uu____1713 = pat_as_arg_with_env env1 p2 in
-          match uu____1713 with
+          let uu___ = pat_as_arg_with_env env1 p2 in
+          match uu___ with
           | (b, a, w, env2, arg, guard, p3) ->
-              let uu____1771 =
+              let uu___1 =
                 FStar_All.pipe_right b
                   (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq) in
-              (match uu____1771 with
+              (match uu___1 with
                | FStar_Pervasives_Native.Some x ->
                    let m = FStar_Syntax_Print.bv_to_string x in
                    let err =
-                     let uu____1803 =
+                     let uu___2 =
                        FStar_Util.format1
                          "The pattern variable \"%s\" was used more than once"
                          m in
-                     (FStar_Errors.Fatal_NonLinearPatternVars, uu____1803) in
+                     (FStar_Errors.Fatal_NonLinearPatternVars, uu___2) in
                    FStar_Errors.raise_error err p3.FStar_Syntax_Syntax.p
-               | uu____1822 -> (b, a, w, arg, guard, p3)) in
-        let uu____1831 = one_pat env p in
-        match uu____1831 with
-        | (b, uu____1861, uu____1862, tm, guard, p1) -> (b, tm, guard, p1)
+               | uu___2 -> (b, a, w, arg, guard, p3)) in
+        let uu___ = one_pat env p in
+        match uu___ with
+        | (b, uu___1, uu___2, tm, guard, p1) -> (b, tm, guard, p1)

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -6,7 +6,7 @@ let (mklstr : (unit -> Prims.string) -> Prims.string FStar_Thunk.thunk) =
   fun f ->
     let uf = FStar_Syntax_Unionfind.get () in
     FStar_Thunk.mk
-      (fun uu____36 ->
+      (fun uu___ ->
          let tx = FStar_Syntax_Unionfind.new_transaction () in
          FStar_Syntax_Unionfind.set uf;
          (let r = f () in FStar_Syntax_Unionfind.rollback tx; r))
@@ -15,12 +15,12 @@ type uvi =
   | UNIV of (FStar_Syntax_Syntax.universe_uvar *
   FStar_Syntax_Syntax.universe) 
 let (uu___is_TERM : uvi -> Prims.bool) =
-  fun projectee -> match projectee with | TERM _0 -> true | uu____69 -> false
+  fun projectee -> match projectee with | TERM _0 -> true | uu___ -> false
 let (__proj__TERM__item___0 :
   uvi -> (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.term)) =
   fun projectee -> match projectee with | TERM _0 -> _0
 let (uu___is_UNIV : uvi -> Prims.bool) =
-  fun projectee -> match projectee with | UNIV _0 -> true | uu____98 -> false
+  fun projectee -> match projectee with | UNIV _0 -> true | uu___ -> false
 let (__proj__UNIV__item___0 :
   uvi -> (FStar_Syntax_Syntax.universe_uvar * FStar_Syntax_Syntax.universe))
   = fun projectee -> match projectee with | UNIV _0 -> _0
@@ -114,10 +114,10 @@ let (as_deferred :
   =
   fun wl_def ->
     FStar_List.map
-      (fun uu____573 ->
-         match uu____573 with
-         | (uu____586, m, p) ->
-             let uu____593 = FStar_Thunk.force m in (uu____593, p)) wl_def
+      (fun uu___ ->
+         match uu___ with
+         | (uu___1, m, p) -> let uu___2 = FStar_Thunk.force m in (uu___2, p))
+      wl_def
 let (as_wl_deferred :
   worklist ->
     FStar_TypeChecker_Common.deferred ->
@@ -126,11 +126,10 @@ let (as_wl_deferred :
   fun wl ->
     fun d ->
       FStar_List.map
-        (fun uu____636 ->
-           match uu____636 with
+        (fun uu___ ->
+           match uu___ with
            | (m, p) ->
-               let uu____651 = FStar_Thunk.mkv m in ((wl.ctr), uu____651, p))
-        d
+               let uu___1 = FStar_Thunk.mkv m in ((wl.ctr), uu___1, p)) d
 let (new_uvar :
   Prims.string ->
     worklist ->
@@ -154,9 +153,9 @@ let (new_uvar :
               fun should_check ->
                 fun meta ->
                   let ctx_uvar =
-                    let uu____737 = FStar_Syntax_Unionfind.fresh r in
+                    let uu___ = FStar_Syntax_Unionfind.fresh r in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____737;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu___;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -179,32 +178,30 @@ let (new_uvar :
                        FStar_TypeChecker_Common.imp_tm = t;
                        FStar_TypeChecker_Common.imp_range = r
                      } in
-                   (let uu____770 =
+                   (let uu___2 =
                       FStar_TypeChecker_Env.debug wl.tcenv
                         (FStar_Options.Other "ImplicitTrace") in
-                    if uu____770
+                    if uu___2
                     then
-                      let uu____771 =
+                      let uu___3 =
                         FStar_Syntax_Print.uvar_to_string
                           ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
                       FStar_Util.print1 "Just created uvar (Rel) {%s}\n"
-                        uu____771
+                        uu___3
                     else ());
                    (ctx_uvar, t,
-                     ((let uu___94_774 = wl in
+                     ((let uu___2 = wl in
                        {
-                         attempting = (uu___94_774.attempting);
-                         wl_deferred = (uu___94_774.wl_deferred);
-                         wl_deferred_to_tac =
-                           (uu___94_774.wl_deferred_to_tac);
-                         ctr = (uu___94_774.ctr);
-                         defer_ok = (uu___94_774.defer_ok);
-                         smt_ok = (uu___94_774.smt_ok);
-                         umax_heuristic_ok = (uu___94_774.umax_heuristic_ok);
-                         tcenv = (uu___94_774.tcenv);
+                         attempting = (uu___2.attempting);
+                         wl_deferred = (uu___2.wl_deferred);
+                         wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
+                         ctr = (uu___2.ctr);
+                         defer_ok = (uu___2.defer_ok);
+                         smt_ok = (uu___2.smt_ok);
+                         umax_heuristic_ok = (uu___2.umax_heuristic_ok);
+                         tcenv = (uu___2.tcenv);
                          wl_implicits = (imp :: (wl.wl_implicits));
-                         repr_subcomp_allowed =
-                           (uu___94_774.repr_subcomp_allowed)
+                         repr_subcomp_allowed = (uu___2.repr_subcomp_allowed)
                        }))))
 let (copy_uvar :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -219,109 +216,107 @@ let (copy_uvar :
       fun t ->
         fun wl ->
           let env =
-            let uu___100_806 = wl.tcenv in
+            let uu___ = wl.tcenv in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___100_806.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___100_806.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___100_806.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
                 (u.FStar_Syntax_Syntax.ctx_uvar_gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___100_806.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___100_806.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___100_806.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___100_806.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___100_806.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___100_806.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___100_806.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___100_806.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___100_806.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___100_806.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___100_806.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___100_806.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___100_806.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___100_806.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___100_806.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___100_806.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___100_806.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___100_806.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___100_806.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___100_806.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___100_806.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___100_806.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___100_806.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___100_806.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___100_806.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___100_806.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___100_806.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___100_806.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___100_806.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___100_806.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___100_806.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___100_806.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___100_806.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___100_806.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___100_806.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___100_806.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___100_806.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___100_806.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___100_806.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___100_806.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___100_806.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___100_806.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___100_806.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
           let env1 = FStar_TypeChecker_Env.push_binders env bs in
-          let uu____808 = FStar_TypeChecker_Env.all_binders env1 in
+          let uu___ = FStar_TypeChecker_Env.all_binders env1 in
           new_uvar
             (Prims.op_Hat "copy:" u.FStar_Syntax_Syntax.ctx_uvar_reason) wl
             u.FStar_Syntax_Syntax.ctx_uvar_range
-            env1.FStar_TypeChecker_Env.gamma uu____808 t
+            env1.FStar_TypeChecker_Env.gamma uu___ t
             u.FStar_Syntax_Syntax.ctx_uvar_should_check
             u.FStar_Syntax_Syntax.ctx_uvar_meta
 type solution =
@@ -329,16 +324,14 @@ type solution =
   FStar_TypeChecker_Common.deferred * FStar_TypeChecker_Common.implicits) 
   | Failed of (FStar_TypeChecker_Common.prob * lstring) 
 let (uu___is_Success : solution -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Success _0 -> true | uu____854 -> false
+  fun projectee -> match projectee with | Success _0 -> true | uu___ -> false
 let (__proj__Success__item___0 :
   solution ->
     (FStar_TypeChecker_Common.deferred * FStar_TypeChecker_Common.deferred *
       FStar_TypeChecker_Common.implicits))
   = fun projectee -> match projectee with | Success _0 -> _0
 let (uu___is_Failed : solution -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Failed _0 -> true | uu____889 -> false
+  fun projectee -> match projectee with | Failed _0 -> true | uu___ -> false
 let (__proj__Failed__item___0 :
   solution -> (FStar_TypeChecker_Common.prob * lstring)) =
   fun projectee -> match projectee with | Failed _0 -> _0
@@ -350,145 +343,139 @@ let (extend_wl :
   fun wl ->
     fun defer_to_tac ->
       fun imps ->
-        let uu___109_923 = wl in
-        let uu____924 =
-          let uu____933 = as_wl_deferred wl defer_to_tac in
-          FStar_List.append wl.wl_deferred_to_tac uu____933 in
+        let uu___ = wl in
+        let uu___1 =
+          let uu___2 = as_wl_deferred wl defer_to_tac in
+          FStar_List.append wl.wl_deferred_to_tac uu___2 in
         {
-          attempting = (uu___109_923.attempting);
-          wl_deferred = (uu___109_923.wl_deferred);
-          wl_deferred_to_tac = uu____924;
-          ctr = (uu___109_923.ctr);
-          defer_ok = (uu___109_923.defer_ok);
-          smt_ok = (uu___109_923.smt_ok);
-          umax_heuristic_ok = (uu___109_923.umax_heuristic_ok);
-          tcenv = (uu___109_923.tcenv);
+          attempting = (uu___.attempting);
+          wl_deferred = (uu___.wl_deferred);
+          wl_deferred_to_tac = uu___1;
+          ctr = (uu___.ctr);
+          defer_ok = (uu___.defer_ok);
+          smt_ok = (uu___.smt_ok);
+          umax_heuristic_ok = (uu___.umax_heuristic_ok);
+          tcenv = (uu___.tcenv);
           wl_implicits = (FStar_List.append wl.wl_implicits imps);
-          repr_subcomp_allowed = (uu___109_923.repr_subcomp_allowed)
+          repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
         }
 type variance =
   | COVARIANT 
   | CONTRAVARIANT 
   | INVARIANT 
 let (uu___is_COVARIANT : variance -> Prims.bool) =
-  fun projectee ->
-    match projectee with | COVARIANT -> true | uu____953 -> false
+  fun projectee -> match projectee with | COVARIANT -> true | uu___ -> false
 let (uu___is_CONTRAVARIANT : variance -> Prims.bool) =
   fun projectee ->
-    match projectee with | CONTRAVARIANT -> true | uu____959 -> false
+    match projectee with | CONTRAVARIANT -> true | uu___ -> false
 let (uu___is_INVARIANT : variance -> Prims.bool) =
-  fun projectee ->
-    match projectee with | INVARIANT -> true | uu____965 -> false
+  fun projectee -> match projectee with | INVARIANT -> true | uu___ -> false
 type tprob = FStar_Syntax_Syntax.typ FStar_TypeChecker_Common.problem
 type cprob = FStar_Syntax_Syntax.comp FStar_TypeChecker_Common.problem
 type 'a problem_t = 'a FStar_TypeChecker_Common.problem
 let (rel_to_string : FStar_TypeChecker_Common.rel -> Prims.string) =
-  fun uu___0_980 ->
-    match uu___0_980 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.EQ -> "="
     | FStar_TypeChecker_Common.SUB -> "<:"
     | FStar_TypeChecker_Common.SUBINV -> ":>"
 let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t ->
-    let uu____986 = FStar_Syntax_Util.head_and_args t in
-    match uu____986 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, args) ->
         (match head.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-             let uu____1047 = FStar_Syntax_Print.ctx_uvar_to_string u in
-             let uu____1048 =
+             let uu___1 = FStar_Syntax_Print.ctx_uvar_to_string u in
+             let uu___2 =
                match FStar_Pervasives_Native.fst s with
                | [] -> ""
                | s1 ->
-                   let uu____1060 =
-                     let uu____1061 = FStar_List.hd s1 in
-                     FStar_Syntax_Print.subst_to_string uu____1061 in
-                   FStar_Util.format1 "@<%s>" uu____1060 in
-             let uu____1064 = FStar_Syntax_Print.args_to_string args in
-             FStar_Util.format3 "%s%s %s" uu____1047 uu____1048 uu____1064
-         | uu____1065 -> FStar_Syntax_Print.term_to_string t)
+                   let uu___3 =
+                     let uu___4 = FStar_List.hd s1 in
+                     FStar_Syntax_Print.subst_to_string uu___4 in
+                   FStar_Util.format1 "@<%s>" uu___3 in
+             let uu___3 = FStar_Syntax_Print.args_to_string args in
+             FStar_Util.format3 "%s%s %s" uu___1 uu___2 uu___3
+         | uu___1 -> FStar_Syntax_Print.term_to_string t)
 let (prob_to_string :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> Prims.string)
   =
   fun env ->
-    fun uu___1_1075 ->
-      match uu___1_1075 with
+    fun uu___ ->
+      match uu___ with
       | FStar_TypeChecker_Common.TProb p ->
-          let uu____1079 =
-            let uu____1082 =
+          let uu___1 =
+            let uu___2 =
               FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
-            let uu____1083 =
-              let uu____1086 = term_to_string p.FStar_TypeChecker_Common.lhs in
-              let uu____1087 =
-                let uu____1090 =
-                  let uu____1093 =
-                    term_to_string p.FStar_TypeChecker_Common.rhs in
-                  [uu____1093] in
-                (rel_to_string p.FStar_TypeChecker_Common.relation) ::
-                  uu____1090 in
-              uu____1086 :: uu____1087 in
-            uu____1082 :: uu____1083 in
-          FStar_Util.format "\n%s:\t%s \n\t\t%s\n\t%s\n" uu____1079
+            let uu___3 =
+              let uu___4 = term_to_string p.FStar_TypeChecker_Common.lhs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = term_to_string p.FStar_TypeChecker_Common.rhs in
+                  [uu___7] in
+                (rel_to_string p.FStar_TypeChecker_Common.relation) :: uu___6 in
+              uu___4 :: uu___5 in
+            uu___2 :: uu___3 in
+          FStar_Util.format "\n%s:\t%s \n\t\t%s\n\t%s\n" uu___1
       | FStar_TypeChecker_Common.CProb p ->
-          let uu____1097 =
+          let uu___1 =
             FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
-          let uu____1098 =
+          let uu___2 =
             FStar_TypeChecker_Normalize.comp_to_string env
               p.FStar_TypeChecker_Common.lhs in
-          let uu____1099 =
+          let uu___3 =
             FStar_TypeChecker_Normalize.comp_to_string env
               p.FStar_TypeChecker_Common.rhs in
-          FStar_Util.format4 "\n%s:\t%s \n\t\t%s\n\t%s" uu____1097 uu____1098
-            (rel_to_string p.FStar_TypeChecker_Common.relation) uu____1099
+          FStar_Util.format4 "\n%s:\t%s \n\t\t%s\n\t%s" uu___1 uu___2
+            (rel_to_string p.FStar_TypeChecker_Common.relation) uu___3
 let (uvi_to_string : FStar_TypeChecker_Env.env -> uvi -> Prims.string) =
   fun env ->
-    fun uu___2_1109 ->
-      match uu___2_1109 with
+    fun uu___ ->
+      match uu___ with
       | UNIV (u, t) ->
           let x =
-            let uu____1113 = FStar_Options.hide_uvar_nums () in
-            if uu____1113
+            let uu___1 = FStar_Options.hide_uvar_nums () in
+            if uu___1
             then "?"
             else
-              (let uu____1115 = FStar_Syntax_Unionfind.univ_uvar_id u in
-               FStar_All.pipe_right uu____1115 FStar_Util.string_of_int) in
-          let uu____1116 = FStar_Syntax_Print.univ_to_string t in
-          FStar_Util.format2 "UNIV %s <- %s" x uu____1116
+              (let uu___3 = FStar_Syntax_Unionfind.univ_uvar_id u in
+               FStar_All.pipe_right uu___3 FStar_Util.string_of_int) in
+          let uu___1 = FStar_Syntax_Print.univ_to_string t in
+          FStar_Util.format2 "UNIV %s <- %s" x uu___1
       | TERM (u, t) ->
           let x =
-            let uu____1120 = FStar_Options.hide_uvar_nums () in
-            if uu____1120
+            let uu___1 = FStar_Options.hide_uvar_nums () in
+            if uu___1
             then "?"
             else
-              (let uu____1122 =
+              (let uu___3 =
                  FStar_Syntax_Unionfind.uvar_id
                    u.FStar_Syntax_Syntax.ctx_uvar_head in
-               FStar_All.pipe_right uu____1122 FStar_Util.string_of_int) in
-          let uu____1123 = FStar_TypeChecker_Normalize.term_to_string env t in
-          FStar_Util.format2 "TERM %s <- %s" x uu____1123
+               FStar_All.pipe_right uu___3 FStar_Util.string_of_int) in
+          let uu___1 = FStar_TypeChecker_Normalize.term_to_string env t in
+          FStar_Util.format2 "TERM %s <- %s" x uu___1
 let (uvis_to_string :
   FStar_TypeChecker_Env.env -> uvi Prims.list -> Prims.string) =
   fun env -> fun uvis -> FStar_Common.string_of_list (uvi_to_string env) uvis
 let (names_to_string : FStar_Syntax_Syntax.bv FStar_Util.set -> Prims.string)
   =
   fun nms ->
-    let uu____1147 =
-      let uu____1150 = FStar_Util.set_elements nms in
-      FStar_All.pipe_right uu____1150
+    let uu___ =
+      let uu___1 = FStar_Util.set_elements nms in
+      FStar_All.pipe_right uu___1
         (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-    FStar_All.pipe_right uu____1147 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let args_to_string :
-  'uuuuuu1163 .
-    (FStar_Syntax_Syntax.term * 'uuuuuu1163) Prims.list -> Prims.string
-  =
+  'uuuuu . (FStar_Syntax_Syntax.term * 'uuuuu) Prims.list -> Prims.string =
   fun args ->
-    let uu____1181 =
+    let uu___ =
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____1199 ->
-              match uu____1199 with
-              | (x, uu____1205) -> FStar_Syntax_Print.term_to_string x)) in
-    FStar_All.pipe_right uu____1181 (FStar_String.concat " ")
+           (fun uu___1 ->
+              match uu___1 with
+              | (x, uu___2) -> FStar_Syntax_Print.term_to_string x)) in
+    FStar_All.pipe_right uu___ (FStar_String.concat " ")
 let (empty_worklist : FStar_TypeChecker_Env.env -> worklist) =
   fun env ->
     {
@@ -510,14 +497,14 @@ let (giveup :
   fun env ->
     fun reason ->
       fun prob ->
-        (let uu____1241 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____1241
+         if uu___1
          then
-           let uu____1242 = FStar_Thunk.force reason in
-           let uu____1243 = prob_to_string env prob in
-           FStar_Util.print2 "Failed %s:\n%s\n" uu____1242 uu____1243
+           let uu___2 = FStar_Thunk.force reason in
+           let uu___3 = prob_to_string env prob in
+           FStar_Util.print2 "Failed %s:\n%s\n" uu___2 uu___3
          else ());
         Failed (prob, reason)
 let (giveup_lit :
@@ -527,46 +514,42 @@ let (giveup_lit :
   fun env ->
     fun reason ->
       fun prob ->
-        let uu____1260 = mklstr (fun uu____1263 -> reason) in
-        giveup env uu____1260 prob
+        let uu___ = mklstr (fun uu___1 -> reason) in giveup env uu___ prob
 let (invert_rel :
   FStar_TypeChecker_Common.rel -> FStar_TypeChecker_Common.rel) =
-  fun uu___3_1268 ->
-    match uu___3_1268 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.EQ -> FStar_TypeChecker_Common.EQ
     | FStar_TypeChecker_Common.SUB -> FStar_TypeChecker_Common.SUBINV
     | FStar_TypeChecker_Common.SUBINV -> FStar_TypeChecker_Common.SUB
 let invert :
-  'uuuuuu1273 .
-    'uuuuuu1273 FStar_TypeChecker_Common.problem ->
-      'uuuuuu1273 FStar_TypeChecker_Common.problem
+  'uuuuu .
+    'uuuuu FStar_TypeChecker_Common.problem ->
+      'uuuuu FStar_TypeChecker_Common.problem
   =
   fun p ->
-    let uu___169_1285 = p in
+    let uu___ = p in
     {
-      FStar_TypeChecker_Common.pid =
-        (uu___169_1285.FStar_TypeChecker_Common.pid);
+      FStar_TypeChecker_Common.pid = (uu___.FStar_TypeChecker_Common.pid);
       FStar_TypeChecker_Common.lhs = (p.FStar_TypeChecker_Common.rhs);
       FStar_TypeChecker_Common.relation =
         (invert_rel p.FStar_TypeChecker_Common.relation);
       FStar_TypeChecker_Common.rhs = (p.FStar_TypeChecker_Common.lhs);
       FStar_TypeChecker_Common.element =
-        (uu___169_1285.FStar_TypeChecker_Common.element);
+        (uu___.FStar_TypeChecker_Common.element);
       FStar_TypeChecker_Common.logical_guard =
-        (uu___169_1285.FStar_TypeChecker_Common.logical_guard);
+        (uu___.FStar_TypeChecker_Common.logical_guard);
       FStar_TypeChecker_Common.logical_guard_uvar =
-        (uu___169_1285.FStar_TypeChecker_Common.logical_guard_uvar);
+        (uu___.FStar_TypeChecker_Common.logical_guard_uvar);
       FStar_TypeChecker_Common.reason =
-        (uu___169_1285.FStar_TypeChecker_Common.reason);
-      FStar_TypeChecker_Common.loc =
-        (uu___169_1285.FStar_TypeChecker_Common.loc);
-      FStar_TypeChecker_Common.rank =
-        (uu___169_1285.FStar_TypeChecker_Common.rank)
+        (uu___.FStar_TypeChecker_Common.reason);
+      FStar_TypeChecker_Common.loc = (uu___.FStar_TypeChecker_Common.loc);
+      FStar_TypeChecker_Common.rank = (uu___.FStar_TypeChecker_Common.rank)
     }
 let maybe_invert :
-  'uuuuuu1292 .
-    'uuuuuu1292 FStar_TypeChecker_Common.problem ->
-      'uuuuuu1292 FStar_TypeChecker_Common.problem
+  'uuuuu .
+    'uuuuu FStar_TypeChecker_Common.problem ->
+      'uuuuu FStar_TypeChecker_Common.problem
   =
   fun p ->
     if p.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.SUBINV
@@ -574,136 +557,135 @@ let maybe_invert :
     else p
 let (maybe_invert_p :
   FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
-  fun uu___4_1309 ->
-    match uu___4_1309 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
         FStar_All.pipe_right (maybe_invert p)
-          (fun uu____1315 -> FStar_TypeChecker_Common.TProb uu____1315)
+          (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1)
     | FStar_TypeChecker_Common.CProb p ->
         FStar_All.pipe_right (maybe_invert p)
-          (fun uu____1321 -> FStar_TypeChecker_Common.CProb uu____1321)
+          (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1)
 let (make_prob_eq :
   FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
-  fun uu___5_1326 ->
-    match uu___5_1326 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
         FStar_TypeChecker_Common.TProb
-          (let uu___181_1332 = p in
+          (let uu___1 = p in
            {
              FStar_TypeChecker_Common.pid =
-               (uu___181_1332.FStar_TypeChecker_Common.pid);
+               (uu___1.FStar_TypeChecker_Common.pid);
              FStar_TypeChecker_Common.lhs =
-               (uu___181_1332.FStar_TypeChecker_Common.lhs);
+               (uu___1.FStar_TypeChecker_Common.lhs);
              FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ;
              FStar_TypeChecker_Common.rhs =
-               (uu___181_1332.FStar_TypeChecker_Common.rhs);
+               (uu___1.FStar_TypeChecker_Common.rhs);
              FStar_TypeChecker_Common.element =
-               (uu___181_1332.FStar_TypeChecker_Common.element);
+               (uu___1.FStar_TypeChecker_Common.element);
              FStar_TypeChecker_Common.logical_guard =
-               (uu___181_1332.FStar_TypeChecker_Common.logical_guard);
+               (uu___1.FStar_TypeChecker_Common.logical_guard);
              FStar_TypeChecker_Common.logical_guard_uvar =
-               (uu___181_1332.FStar_TypeChecker_Common.logical_guard_uvar);
+               (uu___1.FStar_TypeChecker_Common.logical_guard_uvar);
              FStar_TypeChecker_Common.reason =
-               (uu___181_1332.FStar_TypeChecker_Common.reason);
+               (uu___1.FStar_TypeChecker_Common.reason);
              FStar_TypeChecker_Common.loc =
-               (uu___181_1332.FStar_TypeChecker_Common.loc);
+               (uu___1.FStar_TypeChecker_Common.loc);
              FStar_TypeChecker_Common.rank =
-               (uu___181_1332.FStar_TypeChecker_Common.rank)
+               (uu___1.FStar_TypeChecker_Common.rank)
            })
     | FStar_TypeChecker_Common.CProb p ->
         FStar_TypeChecker_Common.CProb
-          (let uu___185_1340 = p in
+          (let uu___1 = p in
            {
              FStar_TypeChecker_Common.pid =
-               (uu___185_1340.FStar_TypeChecker_Common.pid);
+               (uu___1.FStar_TypeChecker_Common.pid);
              FStar_TypeChecker_Common.lhs =
-               (uu___185_1340.FStar_TypeChecker_Common.lhs);
+               (uu___1.FStar_TypeChecker_Common.lhs);
              FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.EQ;
              FStar_TypeChecker_Common.rhs =
-               (uu___185_1340.FStar_TypeChecker_Common.rhs);
+               (uu___1.FStar_TypeChecker_Common.rhs);
              FStar_TypeChecker_Common.element =
-               (uu___185_1340.FStar_TypeChecker_Common.element);
+               (uu___1.FStar_TypeChecker_Common.element);
              FStar_TypeChecker_Common.logical_guard =
-               (uu___185_1340.FStar_TypeChecker_Common.logical_guard);
+               (uu___1.FStar_TypeChecker_Common.logical_guard);
              FStar_TypeChecker_Common.logical_guard_uvar =
-               (uu___185_1340.FStar_TypeChecker_Common.logical_guard_uvar);
+               (uu___1.FStar_TypeChecker_Common.logical_guard_uvar);
              FStar_TypeChecker_Common.reason =
-               (uu___185_1340.FStar_TypeChecker_Common.reason);
+               (uu___1.FStar_TypeChecker_Common.reason);
              FStar_TypeChecker_Common.loc =
-               (uu___185_1340.FStar_TypeChecker_Common.loc);
+               (uu___1.FStar_TypeChecker_Common.loc);
              FStar_TypeChecker_Common.rank =
-               (uu___185_1340.FStar_TypeChecker_Common.rank)
+               (uu___1.FStar_TypeChecker_Common.rank)
            })
 let (vary_rel :
   FStar_TypeChecker_Common.rel -> variance -> FStar_TypeChecker_Common.rel) =
   fun rel ->
-    fun uu___6_1352 ->
-      match uu___6_1352 with
+    fun uu___ ->
+      match uu___ with
       | INVARIANT -> FStar_TypeChecker_Common.EQ
       | CONTRAVARIANT -> invert_rel rel
       | COVARIANT -> rel
 let (p_pid : FStar_TypeChecker_Common.prob -> Prims.int) =
-  fun uu___7_1357 ->
-    match uu___7_1357 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.pid
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.pid
 let (p_rel : FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.rel) =
-  fun uu___8_1368 ->
-    match uu___8_1368 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.relation
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.relation
 let (p_reason : FStar_TypeChecker_Common.prob -> Prims.string Prims.list) =
-  fun uu___9_1381 ->
-    match uu___9_1381 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.reason
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.reason
 let (p_loc : FStar_TypeChecker_Common.prob -> FStar_Range.range) =
-  fun uu___10_1394 ->
-    match uu___10_1394 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.loc
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.loc
 let (p_element :
   FStar_TypeChecker_Common.prob ->
     FStar_Syntax_Syntax.bv FStar_Pervasives_Native.option)
   =
-  fun uu___11_1407 ->
-    match uu___11_1407 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.element
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.element
 let (p_guard : FStar_TypeChecker_Common.prob -> FStar_Syntax_Syntax.term) =
-  fun uu___12_1420 ->
-    match uu___12_1420 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
         p.FStar_TypeChecker_Common.logical_guard
     | FStar_TypeChecker_Common.CProb p ->
         p.FStar_TypeChecker_Common.logical_guard
 let (p_guard_uvar :
   FStar_TypeChecker_Common.prob -> FStar_Syntax_Syntax.ctx_uvar) =
-  fun uu___13_1431 ->
-    match uu___13_1431 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
         p.FStar_TypeChecker_Common.logical_guard_uvar
     | FStar_TypeChecker_Common.CProb p ->
         p.FStar_TypeChecker_Common.logical_guard_uvar
 let def_scope_wf :
-  'uuuuuu1446 .
+  'uuuuu .
     Prims.string ->
       FStar_Range.range ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu1446) Prims.list -> unit
+        (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list -> unit
   =
   fun msg ->
     fun rng ->
       fun r ->
-        let uu____1474 =
-          let uu____1475 = FStar_Options.defensive () in
-          Prims.op_Negation uu____1475 in
-        if uu____1474
+        let uu___ =
+          let uu___1 = FStar_Options.defensive () in Prims.op_Negation uu___1 in
+        if uu___
         then ()
         else
           (let rec aux prev next =
              match next with
              | [] -> ()
-             | (bv, uu____1509)::bs ->
+             | (bv, uu___2)::bs ->
                  (FStar_TypeChecker_Env.def_check_closed_in rng msg prev
                     bv.FStar_Syntax_Syntax.sort;
                   aux (FStar_List.append prev [bv]) bs) in
@@ -717,25 +699,23 @@ let (p_scope :
     let r =
       match prob with
       | FStar_TypeChecker_Common.TProb p ->
-          let uu____1555 =
+          let uu___ =
             match p_element prob with
             | FStar_Pervasives_Native.None -> []
             | FStar_Pervasives_Native.Some x ->
-                let uu____1579 = FStar_Syntax_Syntax.mk_binder x in
-                [uu____1579] in
+                let uu___1 = FStar_Syntax_Syntax.mk_binder x in [uu___1] in
           FStar_List.append
             (p.FStar_TypeChecker_Common.logical_guard_uvar).FStar_Syntax_Syntax.ctx_uvar_binders
-            uu____1555
+            uu___
       | FStar_TypeChecker_Common.CProb p ->
-          let uu____1607 =
+          let uu___ =
             match p_element prob with
             | FStar_Pervasives_Native.None -> []
             | FStar_Pervasives_Native.Some x ->
-                let uu____1631 = FStar_Syntax_Syntax.mk_binder x in
-                [uu____1631] in
+                let uu___1 = FStar_Syntax_Syntax.mk_binder x in [uu___1] in
           FStar_List.append
             (p.FStar_TypeChecker_Common.logical_guard_uvar).FStar_Syntax_Syntax.ctx_uvar_binders
-            uu____1607 in
+            uu___ in
     def_scope_wf "p_scope" (p_loc prob) r; r
 let (def_check_scoped :
   Prims.string ->
@@ -744,18 +724,17 @@ let (def_check_scoped :
   fun msg ->
     fun prob ->
       fun phi ->
-        let uu____1674 =
-          let uu____1675 = FStar_Options.defensive () in
-          Prims.op_Negation uu____1675 in
-        if uu____1674
+        let uu___ =
+          let uu___1 = FStar_Options.defensive () in Prims.op_Negation uu___1 in
+        if uu___
         then ()
         else
-          (let uu____1677 =
-             let uu____1680 = p_scope prob in
+          (let uu___2 =
+             let uu___3 = p_scope prob in
              FStar_All.pipe_left (FStar_List.map FStar_Pervasives_Native.fst)
-               uu____1680 in
-           FStar_TypeChecker_Env.def_check_closed_in (p_loc prob) msg
-             uu____1677 phi)
+               uu___3 in
+           FStar_TypeChecker_Env.def_check_closed_in (p_loc prob) msg uu___2
+             phi)
 let (def_check_scoped_comp :
   Prims.string ->
     FStar_TypeChecker_Common.prob ->
@@ -764,137 +743,132 @@ let (def_check_scoped_comp :
   fun msg ->
     fun prob ->
       fun comp ->
-        let uu____1726 =
-          let uu____1727 = FStar_Options.defensive () in
-          Prims.op_Negation uu____1727 in
-        if uu____1726
+        let uu___ =
+          let uu___1 = FStar_Options.defensive () in Prims.op_Negation uu___1 in
+        if uu___
         then ()
         else
-          (let uu____1729 = FStar_Syntax_Util.arrow [] comp in
-           def_check_scoped msg prob uu____1729)
+          (let uu___2 = FStar_Syntax_Util.arrow [] comp in
+           def_check_scoped msg prob uu___2)
 let (def_check_prob : Prims.string -> FStar_TypeChecker_Common.prob -> unit)
   =
   fun msg ->
     fun prob ->
-      let uu____1746 =
-        let uu____1747 = FStar_Options.defensive () in
-        Prims.op_Negation uu____1747 in
-      if uu____1746
+      let uu___ =
+        let uu___1 = FStar_Options.defensive () in Prims.op_Negation uu___1 in
+      if uu___
       then ()
       else
         (let msgf m =
-           let uu____1755 =
-             let uu____1756 =
-               let uu____1757 = FStar_Util.string_of_int (p_pid prob) in
-               Prims.op_Hat uu____1757 (Prims.op_Hat "." m) in
-             Prims.op_Hat "." uu____1756 in
-           Prims.op_Hat msg uu____1755 in
-         (let uu____1759 = msgf "scope" in
-          let uu____1760 = p_scope prob in
-          def_scope_wf uu____1759 (p_loc prob) uu____1760);
-         (let uu____1772 = msgf "guard" in
-          def_check_scoped uu____1772 prob (p_guard prob));
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_Util.string_of_int (p_pid prob) in
+               Prims.op_Hat uu___4 (Prims.op_Hat "." m) in
+             Prims.op_Hat "." uu___3 in
+           Prims.op_Hat msg uu___2 in
+         (let uu___3 = msgf "scope" in
+          let uu___4 = p_scope prob in
+          def_scope_wf uu___3 (p_loc prob) uu___4);
+         (let uu___4 = msgf "guard" in
+          def_check_scoped uu___4 prob (p_guard prob));
          (match prob with
           | FStar_TypeChecker_Common.TProb p ->
-              ((let uu____1777 = msgf "lhs" in
-                def_check_scoped uu____1777 prob
-                  p.FStar_TypeChecker_Common.lhs);
-               (let uu____1778 = msgf "rhs" in
-                def_check_scoped uu____1778 prob
-                  p.FStar_TypeChecker_Common.rhs))
+              ((let uu___5 = msgf "lhs" in
+                def_check_scoped uu___5 prob p.FStar_TypeChecker_Common.lhs);
+               (let uu___5 = msgf "rhs" in
+                def_check_scoped uu___5 prob p.FStar_TypeChecker_Common.rhs))
           | FStar_TypeChecker_Common.CProb p ->
-              ((let uu____1783 = msgf "lhs" in
-                def_check_scoped_comp uu____1783 prob
+              ((let uu___5 = msgf "lhs" in
+                def_check_scoped_comp uu___5 prob
                   p.FStar_TypeChecker_Common.lhs);
-               (let uu____1784 = msgf "rhs" in
-                def_check_scoped_comp uu____1784 prob
+               (let uu___5 = msgf "rhs" in
+                def_check_scoped_comp uu___5 prob
                   p.FStar_TypeChecker_Common.rhs))))
 let (singleton :
   worklist -> FStar_TypeChecker_Common.prob -> Prims.bool -> worklist) =
   fun wl ->
     fun prob ->
       fun smt_ok ->
-        let uu___278_1800 = wl in
+        let uu___ = wl in
         {
           attempting = [prob];
-          wl_deferred = (uu___278_1800.wl_deferred);
-          wl_deferred_to_tac = (uu___278_1800.wl_deferred_to_tac);
-          ctr = (uu___278_1800.ctr);
-          defer_ok = (uu___278_1800.defer_ok);
+          wl_deferred = (uu___.wl_deferred);
+          wl_deferred_to_tac = (uu___.wl_deferred_to_tac);
+          ctr = (uu___.ctr);
+          defer_ok = (uu___.defer_ok);
           smt_ok;
-          umax_heuristic_ok = (uu___278_1800.umax_heuristic_ok);
-          tcenv = (uu___278_1800.tcenv);
-          wl_implicits = (uu___278_1800.wl_implicits);
-          repr_subcomp_allowed = (uu___278_1800.repr_subcomp_allowed)
+          umax_heuristic_ok = (uu___.umax_heuristic_ok);
+          tcenv = (uu___.tcenv);
+          wl_implicits = (uu___.wl_implicits);
+          repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
         }
 let wl_of_guard :
-  'uuuuuu1807 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      ('uuuuuu1807 * FStar_TypeChecker_Common.prob) Prims.list -> worklist
+      ('uuuuu * FStar_TypeChecker_Common.prob) Prims.list -> worklist
   =
   fun env ->
     fun g ->
-      let uu___282_1830 = empty_worklist env in
-      let uu____1831 = FStar_List.map FStar_Pervasives_Native.snd g in
+      let uu___ = empty_worklist env in
+      let uu___1 = FStar_List.map FStar_Pervasives_Native.snd g in
       {
-        attempting = uu____1831;
-        wl_deferred = (uu___282_1830.wl_deferred);
-        wl_deferred_to_tac = (uu___282_1830.wl_deferred_to_tac);
-        ctr = (uu___282_1830.ctr);
-        defer_ok = (uu___282_1830.defer_ok);
-        smt_ok = (uu___282_1830.smt_ok);
-        umax_heuristic_ok = (uu___282_1830.umax_heuristic_ok);
-        tcenv = (uu___282_1830.tcenv);
-        wl_implicits = (uu___282_1830.wl_implicits);
-        repr_subcomp_allowed = (uu___282_1830.repr_subcomp_allowed)
+        attempting = uu___1;
+        wl_deferred = (uu___.wl_deferred);
+        wl_deferred_to_tac = (uu___.wl_deferred_to_tac);
+        ctr = (uu___.ctr);
+        defer_ok = (uu___.defer_ok);
+        smt_ok = (uu___.smt_ok);
+        umax_heuristic_ok = (uu___.umax_heuristic_ok);
+        tcenv = (uu___.tcenv);
+        wl_implicits = (uu___.wl_implicits);
+        repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
       }
 let (defer :
   lstring -> FStar_TypeChecker_Common.prob -> worklist -> worklist) =
   fun reason ->
     fun prob ->
       fun wl ->
-        let uu___287_1851 = wl in
+        let uu___ = wl in
         {
-          attempting = (uu___287_1851.attempting);
+          attempting = (uu___.attempting);
           wl_deferred = (((wl.ctr), reason, prob) :: (wl.wl_deferred));
-          wl_deferred_to_tac = (uu___287_1851.wl_deferred_to_tac);
-          ctr = (uu___287_1851.ctr);
-          defer_ok = (uu___287_1851.defer_ok);
-          smt_ok = (uu___287_1851.smt_ok);
-          umax_heuristic_ok = (uu___287_1851.umax_heuristic_ok);
-          tcenv = (uu___287_1851.tcenv);
-          wl_implicits = (uu___287_1851.wl_implicits);
-          repr_subcomp_allowed = (uu___287_1851.repr_subcomp_allowed)
+          wl_deferred_to_tac = (uu___.wl_deferred_to_tac);
+          ctr = (uu___.ctr);
+          defer_ok = (uu___.defer_ok);
+          smt_ok = (uu___.smt_ok);
+          umax_heuristic_ok = (uu___.umax_heuristic_ok);
+          tcenv = (uu___.tcenv);
+          wl_implicits = (uu___.wl_implicits);
+          repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
         }
 let (defer_lit :
   Prims.string -> FStar_TypeChecker_Common.prob -> worklist -> worklist) =
   fun reason ->
     fun prob ->
-      fun wl ->
-        let uu____1873 = FStar_Thunk.mkv reason in defer uu____1873 prob wl
+      fun wl -> let uu___ = FStar_Thunk.mkv reason in defer uu___ prob wl
 let (attempt :
   FStar_TypeChecker_Common.prob Prims.list -> worklist -> worklist) =
   fun probs ->
     fun wl ->
       FStar_List.iter (def_check_prob "attempt") probs;
-      (let uu___295_1889 = wl in
+      (let uu___1 = wl in
        {
          attempting = (FStar_List.append probs wl.attempting);
-         wl_deferred = (uu___295_1889.wl_deferred);
-         wl_deferred_to_tac = (uu___295_1889.wl_deferred_to_tac);
-         ctr = (uu___295_1889.ctr);
-         defer_ok = (uu___295_1889.defer_ok);
-         smt_ok = (uu___295_1889.smt_ok);
-         umax_heuristic_ok = (uu___295_1889.umax_heuristic_ok);
-         tcenv = (uu___295_1889.tcenv);
-         wl_implicits = (uu___295_1889.wl_implicits);
-         repr_subcomp_allowed = (uu___295_1889.repr_subcomp_allowed)
+         wl_deferred = (uu___1.wl_deferred);
+         wl_deferred_to_tac = (uu___1.wl_deferred_to_tac);
+         ctr = (uu___1.ctr);
+         defer_ok = (uu___1.defer_ok);
+         smt_ok = (uu___1.smt_ok);
+         umax_heuristic_ok = (uu___1.umax_heuristic_ok);
+         tcenv = (uu___1.tcenv);
+         wl_implicits = (uu___1.wl_implicits);
+         repr_subcomp_allowed = (uu___1.repr_subcomp_allowed)
        })
 let mk_eq2 :
-  'uuuuuu1902 .
+  'uuuuu .
     worklist ->
       FStar_TypeChecker_Env.env ->
-        'uuuuuu1902 ->
+        'uuuuu ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
             FStar_Syntax_Syntax.term -> (FStar_Syntax_Syntax.term * worklist)
   =
@@ -903,50 +877,48 @@ let mk_eq2 :
       fun prob ->
         fun t1 ->
           fun t2 ->
-            let uu____1936 = FStar_Syntax_Util.type_u () in
-            match uu____1936 with
+            let uu___ = FStar_Syntax_Util.type_u () in
+            match uu___ with
             | (t_type, u) ->
                 let binders = FStar_TypeChecker_Env.all_binders env in
-                let uu____1948 =
+                let uu___1 =
                   new_uvar "eq2" wl t1.FStar_Syntax_Syntax.pos
                     env.FStar_TypeChecker_Env.gamma binders t_type
                     FStar_Syntax_Syntax.Allow_unresolved
                     FStar_Pervasives_Native.None in
-                (match uu____1948 with
-                 | (uu____1959, tt, wl1) ->
-                     let uu____1962 = FStar_Syntax_Util.mk_eq2 u tt t1 t2 in
-                     (uu____1962, wl1))
+                (match uu___1 with
+                 | (uu___2, tt, wl1) ->
+                     let uu___3 = FStar_Syntax_Util.mk_eq2 u tt t1 t2 in
+                     (uu___3, wl1))
 let (p_invert :
   FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
-  fun uu___14_1967 ->
-    match uu___14_1967 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
         FStar_All.pipe_left
-          (fun uu____1973 -> FStar_TypeChecker_Common.TProb uu____1973)
-          (invert p)
+          (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1) (invert p)
     | FStar_TypeChecker_Common.CProb p ->
         FStar_All.pipe_left
-          (fun uu____1979 -> FStar_TypeChecker_Common.CProb uu____1979)
-          (invert p)
+          (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1) (invert p)
 let (is_top_level_prob : FStar_TypeChecker_Common.prob -> Prims.bool) =
   fun p ->
-    let uu____1985 = FStar_All.pipe_right (p_reason p) FStar_List.length in
-    uu____1985 = Prims.int_one
+    let uu___ = FStar_All.pipe_right (p_reason p) FStar_List.length in
+    uu___ = Prims.int_one
 let (next_pid : unit -> Prims.int) =
   let ctr = FStar_Util.mk_ref Prims.int_zero in
-  fun uu____1995 -> FStar_Util.incr ctr; FStar_ST.op_Bang ctr
+  fun uu___ -> FStar_Util.incr ctr; FStar_ST.op_Bang ctr
 let mk_problem :
-  'uuuuuu2021 .
+  'uuuuu .
     worklist ->
       (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
         FStar_Pervasives_Native.option) Prims.list ->
         FStar_TypeChecker_Common.prob ->
-          'uuuuuu2021 ->
+          'uuuuu ->
             FStar_TypeChecker_Common.rel ->
-              'uuuuuu2021 ->
+              'uuuuu ->
                 FStar_Syntax_Syntax.bv FStar_Pervasives_Native.option ->
                   Prims.string ->
-                    ('uuuuuu2021 FStar_TypeChecker_Common.problem * worklist)
+                    ('uuuuu FStar_TypeChecker_Common.problem * worklist)
   =
   fun wl ->
     fun scope ->
@@ -960,37 +932,37 @@ let mk_problem :
                     match elt with
                     | FStar_Pervasives_Native.None -> scope
                     | FStar_Pervasives_Native.Some x ->
-                        let uu____2106 =
-                          let uu____2115 = FStar_Syntax_Syntax.mk_binder x in
-                          [uu____2115] in
-                        FStar_List.append scope uu____2106 in
+                        let uu___ =
+                          let uu___1 = FStar_Syntax_Syntax.mk_binder x in
+                          [uu___1] in
+                        FStar_List.append scope uu___ in
                   let bs =
                     FStar_List.append
                       (p_guard_uvar orig).FStar_Syntax_Syntax.ctx_uvar_binders
                       scope1 in
                   let gamma =
-                    let uu____2158 =
-                      let uu____2161 =
+                    let uu___ =
+                      let uu___1 =
                         FStar_List.map
                           (fun b ->
                              FStar_Syntax_Syntax.Binding_var
                                (FStar_Pervasives_Native.fst b)) scope1 in
-                      FStar_List.rev uu____2161 in
-                    FStar_List.append uu____2158
+                      FStar_List.rev uu___1 in
+                    FStar_List.append uu___
                       (p_guard_uvar orig).FStar_Syntax_Syntax.ctx_uvar_gamma in
-                  let uu____2180 =
+                  let uu___ =
                     new_uvar
                       (Prims.op_Hat "mk_problem: logical guard for " reason)
                       wl FStar_Range.dummyRange gamma bs
                       FStar_Syntax_Util.ktype0
                       FStar_Syntax_Syntax.Allow_untyped
                       FStar_Pervasives_Native.None in
-                  match uu____2180 with
+                  match uu___ with
                   | (ctx_uvar, lg, wl1) ->
                       let prob =
-                        let uu____2199 = next_pid () in
+                        let uu___1 = next_pid () in
                         {
-                          FStar_TypeChecker_Common.pid = uu____2199;
+                          FStar_TypeChecker_Common.pid = uu___1;
                           FStar_TypeChecker_Common.lhs = lhs;
                           FStar_TypeChecker_Common.relation = rel;
                           FStar_TypeChecker_Common.rhs = rhs;
@@ -1025,9 +997,9 @@ let (mk_t_problem :
               fun elt ->
                 fun reason ->
                   def_check_prob (Prims.op_Hat reason ".mk_t.arg") orig;
-                  (let uu____2267 =
+                  (let uu___1 =
                      mk_problem wl scope orig lhs rel rhs elt reason in
-                   match uu____2267 with
+                   match uu___1 with
                    | (p, wl1) ->
                        (def_check_prob (Prims.op_Hat reason ".mk_t")
                           (FStar_TypeChecker_Common.TProb p);
@@ -1052,24 +1024,24 @@ let (mk_c_problem :
               fun elt ->
                 fun reason ->
                   def_check_prob (Prims.op_Hat reason ".mk_c.arg") orig;
-                  (let uu____2350 =
+                  (let uu___1 =
                      mk_problem wl scope orig lhs rel rhs elt reason in
-                   match uu____2350 with
+                   match uu___1 with
                    | (p, wl1) ->
                        (def_check_prob (Prims.op_Hat reason ".mk_c")
                           (FStar_TypeChecker_Common.CProb p);
                         ((FStar_TypeChecker_Common.CProb p), wl1)))
 let new_problem :
-  'uuuuuu2386 .
+  'uuuuu .
     worklist ->
       FStar_TypeChecker_Env.env ->
-        'uuuuuu2386 ->
+        'uuuuu ->
           FStar_TypeChecker_Common.rel ->
-            'uuuuuu2386 ->
+            'uuuuu ->
               FStar_Syntax_Syntax.bv FStar_Pervasives_Native.option ->
                 FStar_Range.range ->
                   Prims.string ->
-                    ('uuuuuu2386 FStar_TypeChecker_Common.problem * worklist)
+                    ('uuuuu FStar_TypeChecker_Common.problem * worklist)
   =
   fun wl ->
     fun env ->
@@ -1085,52 +1057,48 @@ let new_problem :
                         FStar_Syntax_Util.ktype0
                     | FStar_Pervasives_Native.Some x ->
                         let bs =
-                          let uu____2452 = FStar_Syntax_Syntax.mk_binder x in
-                          [uu____2452] in
-                        let uu____2471 =
+                          let uu___ = FStar_Syntax_Syntax.mk_binder x in
+                          [uu___] in
+                        let uu___ =
                           FStar_Syntax_Syntax.mk_Total
                             FStar_Syntax_Util.ktype0 in
-                        FStar_Syntax_Util.arrow bs uu____2471 in
-                  let uu____2474 =
-                    let uu____2481 = FStar_TypeChecker_Env.all_binders env in
+                        FStar_Syntax_Util.arrow bs uu___ in
+                  let uu___ =
+                    let uu___1 = FStar_TypeChecker_Env.all_binders env in
                     new_uvar
                       (Prims.op_Hat "new_problem: logical guard for " reason)
-                      (let uu___378_2491 = wl in
+                      (let uu___2 = wl in
                        {
-                         attempting = (uu___378_2491.attempting);
-                         wl_deferred = (uu___378_2491.wl_deferred);
-                         wl_deferred_to_tac =
-                           (uu___378_2491.wl_deferred_to_tac);
-                         ctr = (uu___378_2491.ctr);
-                         defer_ok = (uu___378_2491.defer_ok);
-                         smt_ok = (uu___378_2491.smt_ok);
-                         umax_heuristic_ok =
-                           (uu___378_2491.umax_heuristic_ok);
+                         attempting = (uu___2.attempting);
+                         wl_deferred = (uu___2.wl_deferred);
+                         wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
+                         ctr = (uu___2.ctr);
+                         defer_ok = (uu___2.defer_ok);
+                         smt_ok = (uu___2.smt_ok);
+                         umax_heuristic_ok = (uu___2.umax_heuristic_ok);
                          tcenv = env;
-                         wl_implicits = (uu___378_2491.wl_implicits);
-                         repr_subcomp_allowed =
-                           (uu___378_2491.repr_subcomp_allowed)
-                       }) loc env.FStar_TypeChecker_Env.gamma uu____2481
-                      lg_ty FStar_Syntax_Syntax.Allow_untyped
+                         wl_implicits = (uu___2.wl_implicits);
+                         repr_subcomp_allowed = (uu___2.repr_subcomp_allowed)
+                       }) loc env.FStar_TypeChecker_Env.gamma uu___1 lg_ty
+                      FStar_Syntax_Syntax.Allow_untyped
                       FStar_Pervasives_Native.None in
-                  match uu____2474 with
+                  match uu___ with
                   | (ctx_uvar, lg, wl1) ->
                       let lg1 =
                         match subject with
                         | FStar_Pervasives_Native.None -> lg
                         | FStar_Pervasives_Native.Some x ->
-                            let uu____2503 =
-                              let uu____2504 =
-                                let uu____2513 =
-                                  FStar_Syntax_Syntax.bv_to_name x in
+                            let uu___1 =
+                              let uu___2 =
+                                let uu___3 = FStar_Syntax_Syntax.bv_to_name x in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.as_arg uu____2513 in
-                              [uu____2504] in
-                            FStar_Syntax_Syntax.mk_Tm_app lg uu____2503 loc in
+                                  FStar_Syntax_Syntax.as_arg uu___3 in
+                              [uu___2] in
+                            FStar_Syntax_Syntax.mk_Tm_app lg uu___1 loc in
                       let prob =
-                        let uu____2541 = next_pid () in
+                        let uu___1 = next_pid () in
                         {
-                          FStar_TypeChecker_Common.pid = uu____2541;
+                          FStar_TypeChecker_Common.pid = uu___1;
                           FStar_TypeChecker_Common.lhs = lhs;
                           FStar_TypeChecker_Common.relation = rel;
                           FStar_TypeChecker_Common.rhs = rhs;
@@ -1160,9 +1128,9 @@ let (problem_using_guard :
           fun elt ->
             fun reason ->
               let p =
-                let uu____2583 = next_pid () in
+                let uu___ = next_pid () in
                 {
-                  FStar_TypeChecker_Common.pid = uu____2583;
+                  FStar_TypeChecker_Common.pid = uu___;
                   FStar_TypeChecker_Common.lhs = lhs;
                   FStar_TypeChecker_Common.relation = rel;
                   FStar_TypeChecker_Common.rhs = rhs;
@@ -1178,9 +1146,9 @@ let (problem_using_guard :
                 } in
               def_check_prob reason (FStar_TypeChecker_Common.TProb p); p
 let guard_on_element :
-  'uuuuuu2595 .
+  'uuuuu .
     worklist ->
-      'uuuuuu2595 FStar_TypeChecker_Common.problem ->
+      'uuuuu FStar_TypeChecker_Common.problem ->
         FStar_Syntax_Syntax.bv ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
@@ -1196,14 +1164,14 @@ let guard_on_element :
                   x.FStar_Syntax_Syntax.sort in
               FStar_Syntax_Util.mk_forall u x phi
           | FStar_Pervasives_Native.Some e ->
-              let uu____2628 =
-                let uu____2631 =
-                  let uu____2632 =
-                    let uu____2639 = FStar_Syntax_Syntax.bv_to_name e in
-                    (x, uu____2639) in
-                  FStar_Syntax_Syntax.NT uu____2632 in
-                [uu____2631] in
-              FStar_Syntax_Subst.subst uu____2628 phi
+              let uu___ =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Syntax.bv_to_name e in
+                    (x, uu___3) in
+                  FStar_Syntax_Syntax.NT uu___2 in
+                [uu___1] in
+              FStar_Syntax_Subst.subst uu___ phi
 let (explain :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob -> lstring -> Prims.string)
@@ -1211,31 +1179,31 @@ let (explain :
   fun env ->
     fun d ->
       fun s ->
-        let uu____2659 =
+        let uu___ =
           (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "ExplainRel"))
             ||
             (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel")) in
-        if uu____2659
+        if uu___
         then
-          let uu____2660 =
+          let uu___1 =
             FStar_All.pipe_left FStar_Range.string_of_range (p_loc d) in
-          let uu____2661 = prob_to_string env d in
-          let uu____2662 =
+          let uu___2 = prob_to_string env d in
+          let uu___3 =
             FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>") in
-          let uu____2665 = FStar_Thunk.force s in
+          let uu___4 = FStar_Thunk.force s in
           FStar_Util.format4
             "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n"
-            uu____2660 uu____2661 uu____2662 uu____2665
+            uu___1 uu___2 uu___3 uu___4
         else
           (let d1 = maybe_invert_p d in
            let rel =
              match p_rel d1 with
              | FStar_TypeChecker_Common.EQ -> "equal to"
              | FStar_TypeChecker_Common.SUB -> "a subtype of"
-             | uu____2669 -> failwith "impossible" in
-           let uu____2670 =
+             | uu___2 -> failwith "impossible" in
+           let uu___2 =
              match d1 with
              | FStar_TypeChecker_Common.TProb tp ->
                  FStar_TypeChecker_Err.print_discrepancy
@@ -1247,7 +1215,7 @@ let (explain :
                    (FStar_TypeChecker_Normalize.comp_to_string env)
                    cp.FStar_TypeChecker_Common.lhs
                    cp.FStar_TypeChecker_Common.rhs in
-           match uu____2670 with
+           match uu___2 with
            | (lhs, rhs) ->
                FStar_Util.format3 "%s is not %s the expected type %s" lhs rel
                  rhs)
@@ -1255,19 +1223,19 @@ let (commit : uvi Prims.list -> unit) =
   fun uvis ->
     FStar_All.pipe_right uvis
       (FStar_List.iter
-         (fun uu___15_2702 ->
-            match uu___15_2702 with
+         (fun uu___ ->
+            match uu___ with
             | UNIV (u, t) ->
                 (match t with
                  | FStar_Syntax_Syntax.U_unif u' ->
                      FStar_Syntax_Unionfind.univ_union u u'
-                 | uu____2716 -> FStar_Syntax_Unionfind.univ_change u t)
+                 | uu___1 -> FStar_Syntax_Unionfind.univ_change u t)
             | TERM (u, t) ->
-                ((let uu____2720 =
+                ((let uu___2 =
                     FStar_List.map FStar_Pervasives_Native.fst
                       u.FStar_Syntax_Syntax.ctx_uvar_binders in
                   FStar_TypeChecker_Env.def_check_closed_in
-                    t.FStar_Syntax_Syntax.pos "commit" uu____2720 t);
+                    t.FStar_Syntax_Syntax.pos "commit" uu___2 t);
                  FStar_Syntax_Util.set_uvar
                    u.FStar_Syntax_Syntax.ctx_uvar_head t)))
 let (find_term_uvar :
@@ -1277,14 +1245,14 @@ let (find_term_uvar :
   fun uv ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___16_2749 ->
-           match uu___16_2749 with
-           | UNIV uu____2752 -> FStar_Pervasives_Native.None
+        (fun uu___ ->
+           match uu___ with
+           | UNIV uu___1 -> FStar_Pervasives_Native.None
            | TERM (u, t) ->
-               let uu____2759 =
+               let uu___1 =
                  FStar_Syntax_Unionfind.equiv uv
                    u.FStar_Syntax_Syntax.ctx_uvar_head in
-               if uu____2759
+               if uu___1
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None)
 let (find_univ_uvar :
@@ -1295,54 +1263,54 @@ let (find_univ_uvar :
   fun u ->
     fun s ->
       FStar_Util.find_map s
-        (fun uu___17_2783 ->
-           match uu___17_2783 with
+        (fun uu___ ->
+           match uu___ with
            | UNIV (u', t) ->
-               let uu____2788 = FStar_Syntax_Unionfind.univ_equiv u u' in
-               if uu____2788
+               let uu___1 = FStar_Syntax_Unionfind.univ_equiv u u' in
+               if uu___1
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None
-           | uu____2792 -> FStar_Pervasives_Native.None)
+           | uu___1 -> FStar_Pervasives_Native.None)
 let (whnf' :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun env ->
     fun t ->
-      let uu____2803 =
-        let uu____2804 =
-          let uu____2805 = FStar_Syntax_Util.unmeta t in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Util.unmeta t in
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Env.Beta;
             FStar_TypeChecker_Env.Reify;
             FStar_TypeChecker_Env.Weak;
-            FStar_TypeChecker_Env.HNF] env uu____2805 in
-        FStar_Syntax_Subst.compress uu____2804 in
-      FStar_All.pipe_right uu____2803 FStar_Syntax_Util.unlazy_emb
+            FStar_TypeChecker_Env.HNF] env uu___2 in
+        FStar_Syntax_Subst.compress uu___1 in
+      FStar_All.pipe_right uu___ FStar_Syntax_Util.unlazy_emb
 let (sn' :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun env ->
     fun t ->
-      let uu____2816 =
-        let uu____2817 =
+      let uu___ =
+        let uu___1 =
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Reify] env t in
-        FStar_Syntax_Subst.compress uu____2817 in
-      FStar_All.pipe_right uu____2816 FStar_Syntax_Util.unlazy_emb
+        FStar_Syntax_Subst.compress uu___1 in
+      FStar_All.pipe_right uu___ FStar_Syntax_Util.unlazy_emb
 let (sn :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun env ->
     fun t ->
-      let uu____2828 =
-        let uu____2831 =
-          let uu____2832 = FStar_TypeChecker_Env.current_module env in
-          FStar_Ident.string_of_lid uu____2832 in
-        FStar_Pervasives_Native.Some uu____2831 in
-      FStar_Profiling.profile (fun uu____2834 -> sn' env t) uu____2828
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_TypeChecker_Env.current_module env in
+          FStar_Ident.string_of_lid uu___2 in
+        FStar_Pervasives_Native.Some uu___1 in
+      FStar_Profiling.profile (fun uu___1 -> sn' env t) uu___
         "FStar.TypeChecker.Rel.sn"
 let (norm_with_steps :
   Prims.string ->
@@ -1354,63 +1322,62 @@ let (norm_with_steps :
     fun steps ->
       fun env ->
         fun t ->
-          let uu____2855 =
-            let uu____2858 =
-              let uu____2859 = FStar_TypeChecker_Env.current_module env in
-              FStar_Ident.string_of_lid uu____2859 in
-            FStar_Pervasives_Native.Some uu____2858 in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_Env.current_module env in
+              FStar_Ident.string_of_lid uu___2 in
+            FStar_Pervasives_Native.Some uu___1 in
           FStar_Profiling.profile
-            (fun uu____2861 ->
-               FStar_TypeChecker_Normalize.normalize steps env t) uu____2855
-            profiling_tag
+            (fun uu___1 -> FStar_TypeChecker_Normalize.normalize steps env t)
+            uu___ profiling_tag
 let (should_strongly_reduce : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____2867 = FStar_Syntax_Util.head_and_args t in
-    match uu____2867 with
-    | (h, uu____2885) ->
-        let uu____2910 =
-          let uu____2911 = FStar_Syntax_Subst.compress h in
-          uu____2911.FStar_Syntax_Syntax.n in
-        (match uu____2910 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
+    | (h, uu___1) ->
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Subst.compress h in
+          uu___3.FStar_Syntax_Syntax.n in
+        (match uu___2 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) -> true
-         | uu____2914 -> false)
+         | uu___3 -> false)
 let (whnf :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun env ->
     fun t ->
-      let uu____2925 =
-        let uu____2928 =
-          let uu____2929 = FStar_TypeChecker_Env.current_module env in
-          FStar_Ident.string_of_lid uu____2929 in
-        FStar_Pervasives_Native.Some uu____2928 in
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_TypeChecker_Env.current_module env in
+          FStar_Ident.string_of_lid uu___2 in
+        FStar_Pervasives_Native.Some uu___1 in
       FStar_Profiling.profile
-        (fun uu____2933 ->
-           let uu____2934 = should_strongly_reduce t in
-           if uu____2934
+        (fun uu___1 ->
+           let uu___2 = should_strongly_reduce t in
+           if uu___2
            then
-             let uu____2935 =
-               let uu____2936 =
+             let uu___3 =
+               let uu___4 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta;
                    FStar_TypeChecker_Env.Reify;
                    FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                    FStar_TypeChecker_Env.UnfoldUntil
                      FStar_Syntax_Syntax.delta_constant] env t in
-               FStar_Syntax_Subst.compress uu____2936 in
-             FStar_All.pipe_right uu____2935 FStar_Syntax_Util.unlazy_emb
-           else whnf' env t) uu____2925 "FStar.TypeChecker.Rel.whnf"
+               FStar_Syntax_Subst.compress uu___4 in
+             FStar_All.pipe_right uu___3 FStar_Syntax_Util.unlazy_emb
+           else whnf' env t) uu___ "FStar.TypeChecker.Rel.whnf"
 let norm_arg :
-  'uuuuuu2944 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu2944) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu2944)
+      (FStar_Syntax_Syntax.term * 'uuuuu) ->
+        (FStar_Syntax_Syntax.term * 'uuuuu)
   =
   fun env ->
     fun t ->
-      let uu____2967 = sn env (FStar_Pervasives_Native.fst t) in
-      (uu____2967, (FStar_Pervasives_Native.snd t))
+      let uu___ = sn env (FStar_Pervasives_Native.fst t) in
+      (uu___, (FStar_Pervasives_Native.snd t))
 let (sn_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -1421,20 +1388,20 @@ let (sn_binders :
     fun binders ->
       FStar_All.pipe_right binders
         (FStar_List.map
-           (fun uu____3018 ->
-              match uu____3018 with
+           (fun uu___ ->
+              match uu___ with
               | (x, imp) ->
-                  let uu____3037 =
-                    let uu___484_3038 = x in
-                    let uu____3039 = sn env x.FStar_Syntax_Syntax.sort in
+                  let uu___1 =
+                    let uu___2 = x in
+                    let uu___3 = sn env x.FStar_Syntax_Syntax.sort in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___484_3038.FStar_Syntax_Syntax.ppname);
+                        (uu___2.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___484_3038.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu____3039
+                        (uu___2.FStar_Syntax_Syntax.index);
+                      FStar_Syntax_Syntax.sort = uu___3
                     } in
-                  (uu____3037, imp)))
+                  (uu___1, imp)))
 let (norm_univ :
   worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) =
   fun wl ->
@@ -1443,13 +1410,13 @@ let (norm_univ :
         let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____3062 = aux u3 in FStar_Syntax_Syntax.U_succ uu____3062
+            let uu___ = aux u3 in FStar_Syntax_Syntax.U_succ uu___
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____3066 = FStar_List.map aux us in
-            FStar_Syntax_Syntax.U_max uu____3066
-        | uu____3069 -> u2 in
-      let uu____3070 = aux u in
-      FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____3070
+            let uu___ = FStar_List.map aux us in
+            FStar_Syntax_Syntax.U_max uu___
+        | uu___ -> u2 in
+      let uu___ = aux u in
+      FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu___
 let (normalize_refinement :
   FStar_TypeChecker_Env.steps ->
     FStar_TypeChecker_Env.env ->
@@ -1458,15 +1425,15 @@ let (normalize_refinement :
   fun steps ->
     fun env ->
       fun t0 ->
-        let uu____3086 =
-          let uu____3089 =
-            let uu____3090 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.string_of_lid uu____3090 in
-          FStar_Pervasives_Native.Some uu____3089 in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.string_of_lid uu___2 in
+          FStar_Pervasives_Native.Some uu___1 in
         FStar_Profiling.profile
-          (fun uu____3092 ->
+          (fun uu___1 ->
              FStar_TypeChecker_Normalize.normalize_refinement steps env t0)
-          uu____3086 "FStar.TypeChecker.Rel.normalize_refinement"
+          uu___ "FStar.TypeChecker.Rel.normalize_refinement"
 let (base_and_refinement_maybe_delta :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -1496,107 +1463,106 @@ let (base_and_refinement_maybe_delta :
                 ((x.FStar_Syntax_Syntax.sort),
                   (FStar_Pervasives_Native.Some (x, phi)))
               else
-                (let uu____3204 = norm_refinement env t12 in
-                 match uu____3204 with
+                (let uu___1 = norm_refinement env t12 in
+                 match uu___1 with
                  | {
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
                        (x1, phi1);
-                     FStar_Syntax_Syntax.pos = uu____3219;
-                     FStar_Syntax_Syntax.vars = uu____3220;_} ->
+                     FStar_Syntax_Syntax.pos = uu___2;
+                     FStar_Syntax_Syntax.vars = uu___3;_} ->
                      ((x1.FStar_Syntax_Syntax.sort),
                        (FStar_Pervasives_Native.Some (x1, phi1)))
                  | tt ->
-                     let uu____3244 =
-                       let uu____3245 = FStar_Syntax_Print.term_to_string tt in
-                       let uu____3246 = FStar_Syntax_Print.tag_of_term tt in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Print.term_to_string tt in
+                       let uu___4 = FStar_Syntax_Print.tag_of_term tt in
                        FStar_Util.format2 "impossible: Got %s ... %s\n"
-                         uu____3245 uu____3246 in
-                     failwith uu____3244)
+                         uu___3 uu___4 in
+                     failwith uu___2)
           | FStar_Syntax_Syntax.Tm_lazy i ->
-              let uu____3260 = FStar_Syntax_Util.unfold_lazy i in
-              aux norm uu____3260
-          | FStar_Syntax_Syntax.Tm_uinst uu____3261 ->
+              let uu___ = FStar_Syntax_Util.unfold_lazy i in aux norm uu___
+          | FStar_Syntax_Syntax.Tm_uinst uu___ ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3296 =
-                   let uu____3297 = FStar_Syntax_Subst.compress t1' in
-                   uu____3297.FStar_Syntax_Syntax.n in
-                 match uu____3296 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3312 -> aux true t1'
-                 | uu____3319 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_fvar uu____3334 ->
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t1' in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
+                 | FStar_Syntax_Syntax.Tm_refine uu___3 -> aux true t1'
+                 | uu___3 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_fvar uu___ ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3363 =
-                   let uu____3364 = FStar_Syntax_Subst.compress t1' in
-                   uu____3364.FStar_Syntax_Syntax.n in
-                 match uu____3363 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3379 -> aux true t1'
-                 | uu____3386 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_app uu____3401 ->
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t1' in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
+                 | FStar_Syntax_Syntax.Tm_refine uu___3 -> aux true t1'
+                 | uu___3 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_app uu___ ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3446 =
-                   let uu____3447 = FStar_Syntax_Subst.compress t1' in
-                   uu____3447.FStar_Syntax_Syntax.n in
-                 match uu____3446 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3462 -> aux true t1'
-                 | uu____3469 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_type uu____3484 ->
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t1' in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 match uu___2 with
+                 | FStar_Syntax_Syntax.Tm_refine uu___3 -> aux true t1'
+                 | uu___3 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_type uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_constant uu____3499 ->
+          | FStar_Syntax_Syntax.Tm_constant uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_name uu____3514 ->
+          | FStar_Syntax_Syntax.Tm_name uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_bvar uu____3529 ->
+          | FStar_Syntax_Syntax.Tm_bvar uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_arrow uu____3544 ->
+          | FStar_Syntax_Syntax.Tm_arrow uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_abs uu____3573 ->
+          | FStar_Syntax_Syntax.Tm_abs uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_quoted uu____3606 ->
+          | FStar_Syntax_Syntax.Tm_quoted uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_uvar uu____3627 ->
+          | FStar_Syntax_Syntax.Tm_uvar uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_let uu____3654 ->
+          | FStar_Syntax_Syntax.Tm_let uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_match uu____3681 ->
+          | FStar_Syntax_Syntax.Tm_match uu___ ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_meta uu____3718 ->
-              let uu____3725 =
-                let uu____3726 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3727 = FStar_Syntax_Print.tag_of_term t12 in
+          | FStar_Syntax_Syntax.Tm_meta uu___ ->
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t12 in
+                let uu___3 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3726 uu____3727 in
-              failwith uu____3725
-          | FStar_Syntax_Syntax.Tm_ascribed uu____3740 ->
-              let uu____3767 =
-                let uu____3768 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3769 = FStar_Syntax_Print.tag_of_term t12 in
+                  uu___2 uu___3 in
+              failwith uu___1
+          | FStar_Syntax_Syntax.Tm_ascribed uu___ ->
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t12 in
+                let uu___3 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3768 uu____3769 in
-              failwith uu____3767
-          | FStar_Syntax_Syntax.Tm_delayed uu____3782 ->
-              let uu____3797 =
-                let uu____3798 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3799 = FStar_Syntax_Print.tag_of_term t12 in
+                  uu___2 uu___3 in
+              failwith uu___1
+          | FStar_Syntax_Syntax.Tm_delayed uu___ ->
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.term_to_string t12 in
+                let uu___3 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3798 uu____3799 in
-              failwith uu____3797
+                  uu___2 uu___3 in
+              failwith uu___1
           | FStar_Syntax_Syntax.Tm_unknown ->
-              let uu____3812 =
-                let uu____3813 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3814 = FStar_Syntax_Print.tag_of_term t12 in
+              let uu___ =
+                let uu___1 = FStar_Syntax_Print.term_to_string t12 in
+                let uu___2 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3813 uu____3814 in
-              failwith uu____3812 in
-        let uu____3827 = whnf env t1 in aux false uu____3827
+                  uu___1 uu___2 in
+              failwith uu___ in
+        let uu___ = whnf env t1 in aux false uu___
 let (base_and_refinement :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -1609,15 +1575,15 @@ let (unrefine :
   =
   fun env ->
     fun t ->
-      let uu____3868 = base_and_refinement env t in
-      FStar_All.pipe_right uu____3868 FStar_Pervasives_Native.fst
+      let uu___ = base_and_refinement env t in
+      FStar_All.pipe_right uu___ FStar_Pervasives_Native.fst
 let (trivial_refinement :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
   =
   fun t ->
-    let uu____3908 = FStar_Syntax_Syntax.null_bv t in
-    (uu____3908, FStar_Syntax_Util.t_true)
+    let uu___ = FStar_Syntax_Syntax.null_bv t in
+    (uu___, FStar_Syntax_Util.t_true)
 let (as_refinement :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -1627,8 +1593,8 @@ let (as_refinement :
   fun delta ->
     fun env ->
       fun t ->
-        let uu____3932 = base_and_refinement_maybe_delta delta env t in
-        match uu____3932 with
+        let uu___ = base_and_refinement_maybe_delta delta env t in
+        match uu___ with
         | (t_base, refinement) ->
             (match refinement with
              | FStar_Pervasives_Native.None -> trivial_refinement t_base
@@ -1638,14 +1604,14 @@ let (force_refinement :
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.option) -> FStar_Syntax_Syntax.term)
   =
-  fun uu____3991 ->
-    match uu____3991 with
+  fun uu___ ->
+    match uu___ with
     | (t_base, refopt) ->
-        let uu____4022 =
+        let uu___1 =
           match refopt with
           | FStar_Pervasives_Native.Some (y, phi) -> (y, phi)
           | FStar_Pervasives_Native.None -> trivial_refinement t_base in
-        (match uu____4022 with
+        (match uu___1 with
          | (y, phi) ->
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (y, phi))
                t_base.FStar_Syntax_Syntax.pos)
@@ -1654,16 +1620,15 @@ let (wl_prob_to_string :
   fun wl -> fun prob -> prob_to_string wl.tcenv prob
 let (wl_to_string : worklist -> Prims.string) =
   fun wl ->
-    let uu____4060 =
-      let uu____4063 =
-        let uu____4066 =
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
           FStar_All.pipe_right wl.wl_deferred
             (FStar_List.map
-               (fun uu____4089 ->
-                  match uu____4089 with | (uu____4096, uu____4097, x) -> x)) in
-        FStar_List.append wl.attempting uu____4066 in
-      FStar_List.map (wl_prob_to_string wl) uu____4063 in
-    FStar_All.pipe_right uu____4060 (FStar_String.concat "\n\t")
+               (fun uu___3 -> match uu___3 with | (uu___4, uu___5, x) -> x)) in
+        FStar_List.append wl.attempting uu___2 in
+      FStar_List.map (wl_prob_to_string wl) uu___1 in
+    FStar_All.pipe_right uu___ (FStar_String.concat "\n\t")
 type flex_t =
   | Flex of (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar *
   FStar_Syntax_Syntax.args) 
@@ -1674,40 +1639,39 @@ let (__proj__Flex__item___0 :
       FStar_Syntax_Syntax.args))
   = fun projectee -> match projectee with | Flex _0 -> _0
 let (flex_reason : flex_t -> Prims.string) =
-  fun uu____4145 ->
-    match uu____4145 with
-    | Flex (uu____4146, u, uu____4148) ->
-        u.FStar_Syntax_Syntax.ctx_uvar_reason
+  fun uu___ ->
+    match uu___ with
+    | Flex (uu___1, u, uu___2) -> u.FStar_Syntax_Syntax.ctx_uvar_reason
 let (flex_t_to_string : flex_t -> Prims.string) =
-  fun uu____4153 ->
-    match uu____4153 with
-    | Flex (uu____4154, c, args) ->
-        let uu____4157 = print_ctx_uvar c in
-        let uu____4158 = FStar_Syntax_Print.args_to_string args in
-        FStar_Util.format2 "%s [%s]" uu____4157 uu____4158
+  fun uu___ ->
+    match uu___ with
+    | Flex (uu___1, c, args) ->
+        let uu___2 = print_ctx_uvar c in
+        let uu___3 = FStar_Syntax_Print.args_to_string args in
+        FStar_Util.format2 "%s [%s]" uu___2 uu___3
 let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4164 = FStar_Syntax_Util.head_and_args t in
-    match uu____4164 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, _args) ->
-        let uu____4207 =
-          let uu____4208 = FStar_Syntax_Subst.compress head in
-          uu____4208.FStar_Syntax_Syntax.n in
-        (match uu____4207 with
-         | FStar_Syntax_Syntax.Tm_uvar uu____4211 -> true
-         | uu____4224 -> false)
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress head in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
+         | FStar_Syntax_Syntax.Tm_uvar uu___2 -> true
+         | uu___2 -> false)
 let (flex_uvar_head :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar) =
   fun t ->
-    let uu____4230 = FStar_Syntax_Util.head_and_args t in
-    match uu____4230 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, _args) ->
-        let uu____4273 =
-          let uu____4274 = FStar_Syntax_Subst.compress head in
-          uu____4274.FStar_Syntax_Syntax.n in
-        (match uu____4273 with
-         | FStar_Syntax_Syntax.Tm_uvar (u, uu____4278) -> u
-         | uu____4295 -> failwith "Not a flex-uvar")
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress head in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
+         | FStar_Syntax_Syntax.Tm_uvar (u, uu___2) -> u
+         | uu___2 -> failwith "Not a flex-uvar")
 let (ensure_no_uvar_subst :
   FStar_Syntax_Syntax.term ->
     worklist -> (FStar_Syntax_Syntax.term * worklist))
@@ -1717,66 +1681,66 @@ let (ensure_no_uvar_subst :
       let bv_not_affected_by s x =
         let t_x = FStar_Syntax_Syntax.bv_to_name x in
         let t_x' = FStar_Syntax_Subst.subst' s t_x in
-        let uu____4327 =
-          let uu____4328 = FStar_Syntax_Subst.compress t_x' in
-          uu____4328.FStar_Syntax_Syntax.n in
-        match uu____4327 with
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress t_x' in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
         | FStar_Syntax_Syntax.Tm_name y -> FStar_Syntax_Syntax.bv_eq x y
-        | uu____4332 -> false in
+        | uu___1 -> false in
       let binding_not_affected_by s b =
         match b with
         | FStar_Syntax_Syntax.Binding_var x -> bv_not_affected_by s x
-        | uu____4345 -> true in
-      let uu____4346 = FStar_Syntax_Util.head_and_args t0 in
-      match uu____4346 with
+        | uu___ -> true in
+      let uu___ = FStar_Syntax_Util.head_and_args t0 in
+      match uu___ with
       | (head, args) ->
-          let uu____4393 =
-            let uu____4394 = FStar_Syntax_Subst.compress head in
-            uu____4394.FStar_Syntax_Syntax.n in
-          (match uu____4393 with
-           | FStar_Syntax_Syntax.Tm_uvar (uv, ([], uu____4402)) -> (t0, wl)
-           | FStar_Syntax_Syntax.Tm_uvar (uv, uu____4418) when
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Subst.compress head in
+            uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
+           | FStar_Syntax_Syntax.Tm_uvar (uv, ([], uu___2)) -> (t0, wl)
+           | FStar_Syntax_Syntax.Tm_uvar (uv, uu___2) when
                FStar_List.isEmpty uv.FStar_Syntax_Syntax.ctx_uvar_binders ->
                (t0, wl)
            | FStar_Syntax_Syntax.Tm_uvar (uv, s) ->
-               let uu____4459 =
+               let uu___2 =
                  FStar_Common.max_suffix (binding_not_affected_by s)
                    uv.FStar_Syntax_Syntax.ctx_uvar_gamma in
-               (match uu____4459 with
+               (match uu___2 with
                 | (gamma_aff, new_gamma) ->
                     (match gamma_aff with
                      | [] -> (t0, wl)
-                     | uu____4486 ->
+                     | uu___3 ->
                          let dom_binders =
                            FStar_TypeChecker_Env.binders_of_bindings
                              gamma_aff in
-                         let uu____4490 =
-                           let uu____4497 =
+                         let uu___4 =
+                           let uu___5 =
                              FStar_TypeChecker_Env.binders_of_bindings
                                new_gamma in
-                           let uu____4506 =
-                             let uu____4509 =
+                           let uu___6 =
+                             let uu___7 =
                                FStar_Syntax_Syntax.mk_Total
                                  uv.FStar_Syntax_Syntax.ctx_uvar_typ in
-                             FStar_Syntax_Util.arrow dom_binders uu____4509 in
+                             FStar_Syntax_Util.arrow dom_binders uu___7 in
                            new_uvar
                              (Prims.op_Hat
                                 uv.FStar_Syntax_Syntax.ctx_uvar_reason
                                 "; force delayed") wl
-                             t0.FStar_Syntax_Syntax.pos new_gamma uu____4497
-                             uu____4506
+                             t0.FStar_Syntax_Syntax.pos new_gamma uu___5
+                             uu___6
                              uv.FStar_Syntax_Syntax.ctx_uvar_should_check
                              uv.FStar_Syntax_Syntax.ctx_uvar_meta in
-                         (match uu____4490 with
+                         (match uu___4 with
                           | (v, t_v, wl1) ->
                               let args_sol =
                                 FStar_List.map
-                                  (fun uu____4544 ->
-                                     match uu____4544 with
+                                  (fun uu___5 ->
+                                     match uu___5 with
                                      | (x, i) ->
-                                         let uu____4563 =
+                                         let uu___6 =
                                            FStar_Syntax_Syntax.bv_to_name x in
-                                         (uu____4563, i)) dom_binders in
+                                         (uu___6, i)) dom_binders in
                               let sol =
                                 FStar_Syntax_Syntax.mk_Tm_app t_v args_sol
                                   t0.FStar_Syntax_Syntax.pos in
@@ -1784,38 +1748,37 @@ let (ensure_no_uvar_subst :
                                  uv.FStar_Syntax_Syntax.ctx_uvar_head sol;
                                (let args_sol_s =
                                   FStar_List.map
-                                    (fun uu____4593 ->
-                                       match uu____4593 with
+                                    (fun uu___6 ->
+                                       match uu___6 with
                                        | (a, i) ->
-                                           let uu____4612 =
+                                           let uu___7 =
                                              FStar_Syntax_Subst.subst' s a in
-                                           (uu____4612, i)) args_sol in
+                                           (uu___7, i)) args_sol in
                                 let t =
                                   FStar_Syntax_Syntax.mk_Tm_app t_v
                                     (FStar_List.append args_sol_s args)
                                     t0.FStar_Syntax_Syntax.pos in
                                 (t, wl1))))))
-           | uu____4622 ->
+           | uu___2 ->
                failwith "ensure_no_uvar_subst: expected a uvar at the head")
 let (destruct_flex_t' : FStar_Syntax_Syntax.term -> flex_t) =
   fun t ->
-    let uu____4632 = FStar_Syntax_Util.head_and_args t in
-    match uu____4632 with
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
     | (head, args) ->
-        let uu____4675 =
-          let uu____4676 = FStar_Syntax_Subst.compress head in
-          uu____4676.FStar_Syntax_Syntax.n in
-        (match uu____4675 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress head in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_uvar (uv, s) -> Flex (t, uv, args)
-         | uu____4697 -> failwith "Not a flex-uvar")
+         | uu___2 -> failwith "Not a flex-uvar")
 let (destruct_flex_t :
   FStar_Syntax_Syntax.term -> worklist -> (flex_t * worklist)) =
   fun t ->
     fun wl ->
-      let uu____4716 = ensure_no_uvar_subst t wl in
-      match uu____4716 with
-      | (t1, wl1) ->
-          let uu____4727 = destruct_flex_t' t1 in (uu____4727, wl1)
+      let uu___ = ensure_no_uvar_subst t wl in
+      match uu___ with
+      | (t1, wl1) -> let uu___1 = destruct_flex_t' t1 in (uu___1, wl1)
 let (u_abs :
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.binders ->
@@ -1824,28 +1787,27 @@ let (u_abs :
   fun k ->
     fun ys ->
       fun t ->
-        let uu____4743 =
-          let uu____4766 =
-            let uu____4767 = FStar_Syntax_Subst.compress k in
-            uu____4767.FStar_Syntax_Syntax.n in
-          match uu____4766 with
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Subst.compress k in
+            uu___2.FStar_Syntax_Syntax.n in
+          match uu___1 with
           | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
               if (FStar_List.length bs) = (FStar_List.length ys)
               then
-                let uu____4848 = FStar_Syntax_Subst.open_comp bs c in
-                ((ys, t), uu____4848)
+                let uu___2 = FStar_Syntax_Subst.open_comp bs c in
+                ((ys, t), uu___2)
               else
-                (let uu____4882 = FStar_Syntax_Util.abs_formals t in
-                 match uu____4882 with
-                 | (ys', t1, uu____4915) ->
-                     let uu____4920 = FStar_Syntax_Util.arrow_formals_comp k in
-                     (((FStar_List.append ys ys'), t1), uu____4920))
-          | uu____4959 ->
-              let uu____4960 =
-                let uu____4965 = FStar_Syntax_Syntax.mk_Total k in
-                ([], uu____4965) in
-              ((ys, t), uu____4960) in
-        match uu____4743 with
+                (let uu___3 = FStar_Syntax_Util.abs_formals t in
+                 match uu___3 with
+                 | (ys', t1, uu___4) ->
+                     let uu___5 = FStar_Syntax_Util.arrow_formals_comp k in
+                     (((FStar_List.append ys ys'), t1), uu___5))
+          | uu___2 ->
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Syntax.mk_Total k in ([], uu___4) in
+              ((ys, t), uu___3) in
+        match uu___ with
         | ((ys1, t1), (xs, c)) ->
             if (FStar_List.length xs) <> (FStar_List.length ys1)
             then
@@ -1856,8 +1818,8 @@ let (u_abs :
                       FStar_Pervasives_Native.None []))
             else
               (let c1 =
-                 let uu____5058 = FStar_Syntax_Util.rename_binders xs ys1 in
-                 FStar_Syntax_Subst.subst_comp uu____5058 c in
+                 let uu___2 = FStar_Syntax_Util.rename_binders xs ys1 in
+                 FStar_Syntax_Subst.subst_comp uu___2 c in
                FStar_Syntax_Util.abs ys1 t1
                  (FStar_Pervasives_Native.Some
                     (FStar_Syntax_Util.residual_comp_of_comp c1)))
@@ -1877,110 +1839,110 @@ let (solve_prob' :
             (let phi =
                match logical_guard with
                | FStar_Pervasives_Native.None -> FStar_Syntax_Util.t_true
-               | FStar_Pervasives_Native.Some phi -> phi in
+               | FStar_Pervasives_Native.Some phi1 -> phi1 in
              let assign_solution xs uv phi1 =
-               (let uu____5132 =
+               (let uu___2 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                     (FStar_Options.Other "Rel") in
-                if uu____5132
+                if uu___2
                 then
-                  let uu____5133 = FStar_Util.string_of_int (p_pid prob) in
-                  let uu____5134 = print_ctx_uvar uv in
-                  let uu____5135 = FStar_Syntax_Print.term_to_string phi1 in
+                  let uu___3 = FStar_Util.string_of_int (p_pid prob) in
+                  let uu___4 = print_ctx_uvar uv in
+                  let uu___5 = FStar_Syntax_Print.term_to_string phi1 in
                   FStar_Util.print3 "Solving %s (%s) with formula %s\n"
-                    uu____5133 uu____5134 uu____5135
+                    uu___3 uu___4 uu___5
                 else ());
                (let phi2 =
                   FStar_Syntax_Util.abs xs phi1
                     (FStar_Pervasives_Native.Some
                        (FStar_Syntax_Util.residual_tot
                           FStar_Syntax_Util.ktype0)) in
-                (let uu____5141 =
-                   let uu____5142 = FStar_Util.string_of_int (p_pid prob) in
-                   Prims.op_Hat "solve_prob'.sol." uu____5142 in
-                 let uu____5143 =
-                   let uu____5146 = p_scope prob in
+                (let uu___3 =
+                   let uu___4 = FStar_Util.string_of_int (p_pid prob) in
+                   Prims.op_Hat "solve_prob'.sol." uu___4 in
+                 let uu___4 =
+                   let uu___5 = p_scope prob in
                    FStar_All.pipe_left
-                     (FStar_List.map FStar_Pervasives_Native.fst) uu____5146 in
+                     (FStar_List.map FStar_Pervasives_Native.fst) uu___5 in
                  FStar_TypeChecker_Env.def_check_closed_in (p_loc prob)
-                   uu____5141 uu____5143 phi2);
+                   uu___3 uu___4 phi2);
                 FStar_Syntax_Util.set_uvar
                   uv.FStar_Syntax_Syntax.ctx_uvar_head phi2) in
              let uv = p_guard_uvar prob in
-             let fail uu____5179 =
-               let uu____5180 =
-                 let uu____5181 = FStar_Syntax_Print.ctx_uvar_to_string uv in
-                 let uu____5182 =
+             let fail uu___1 =
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Print.ctx_uvar_to_string uv in
+                 let uu___4 =
                    FStar_Syntax_Print.term_to_string (p_guard prob) in
                  FStar_Util.format2
                    "Impossible: this instance %s has already been assigned a solution\n%s\n"
-                   uu____5181 uu____5182 in
-               failwith uu____5180 in
+                   uu___3 uu___4 in
+               failwith uu___2 in
              let args_as_binders args =
                FStar_All.pipe_right args
                  (FStar_List.collect
-                    (fun uu____5246 ->
-                       match uu____5246 with
+                    (fun uu___1 ->
+                       match uu___1 with
                        | (a, i) ->
-                           let uu____5267 =
-                             let uu____5268 = FStar_Syntax_Subst.compress a in
-                             uu____5268.FStar_Syntax_Syntax.n in
-                           (match uu____5267 with
+                           let uu___2 =
+                             let uu___3 = FStar_Syntax_Subst.compress a in
+                             uu___3.FStar_Syntax_Syntax.n in
+                           (match uu___2 with
                             | FStar_Syntax_Syntax.Tm_name x -> [(x, i)]
-                            | uu____5294 -> (fail (); [])))) in
+                            | uu___3 -> (fail (); [])))) in
              let wl1 =
                let g = whnf wl.tcenv (p_guard prob) in
-               let uu____5304 =
-                 let uu____5305 = is_flex g in Prims.op_Negation uu____5305 in
-               if uu____5304
+               let uu___1 =
+                 let uu___2 = is_flex g in Prims.op_Negation uu___2 in
+               if uu___1
                then (if resolve_ok then wl else (fail (); wl))
                else
-                 (let uu____5309 = destruct_flex_t g wl in
-                  match uu____5309 with
-                  | (Flex (uu____5314, uv1, args), wl1) ->
-                      ((let uu____5319 = args_as_binders args in
-                        assign_solution uu____5319 uv1 phi);
-                       wl1)) in
+                 (let uu___3 = destruct_flex_t g wl in
+                  match uu___3 with
+                  | (Flex (uu___4, uv1, args), wl2) ->
+                      ((let uu___6 = args_as_binders args in
+                        assign_solution uu___6 uv1 phi);
+                       wl2)) in
              commit uvis;
-             (let uu___762_5321 = wl1 in
+             (let uu___2 = wl1 in
               {
-                attempting = (uu___762_5321.attempting);
-                wl_deferred = (uu___762_5321.wl_deferred);
-                wl_deferred_to_tac = (uu___762_5321.wl_deferred_to_tac);
+                attempting = (uu___2.attempting);
+                wl_deferred = (uu___2.wl_deferred);
+                wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
                 ctr = (wl1.ctr + Prims.int_one);
-                defer_ok = (uu___762_5321.defer_ok);
-                smt_ok = (uu___762_5321.smt_ok);
-                umax_heuristic_ok = (uu___762_5321.umax_heuristic_ok);
-                tcenv = (uu___762_5321.tcenv);
-                wl_implicits = (uu___762_5321.wl_implicits);
-                repr_subcomp_allowed = (uu___762_5321.repr_subcomp_allowed)
+                defer_ok = (uu___2.defer_ok);
+                smt_ok = (uu___2.smt_ok);
+                umax_heuristic_ok = (uu___2.umax_heuristic_ok);
+                tcenv = (uu___2.tcenv);
+                wl_implicits = (uu___2.wl_implicits);
+                repr_subcomp_allowed = (uu___2.repr_subcomp_allowed)
               }))
 let (extend_solution : Prims.int -> uvi Prims.list -> worklist -> worklist) =
   fun pid ->
     fun sol ->
       fun wl ->
-        (let uu____5342 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
              (FStar_Options.Other "Rel") in
-         if uu____5342
+         if uu___1
          then
-           let uu____5343 = FStar_Util.string_of_int pid in
-           let uu____5344 = uvis_to_string wl.tcenv sol in
-           FStar_Util.print2 "Solving %s: with [%s]\n" uu____5343 uu____5344
+           let uu___2 = FStar_Util.string_of_int pid in
+           let uu___3 = uvis_to_string wl.tcenv sol in
+           FStar_Util.print2 "Solving %s: with [%s]\n" uu___2 uu___3
          else ());
         commit sol;
-        (let uu___770_5347 = wl in
+        (let uu___2 = wl in
          {
-           attempting = (uu___770_5347.attempting);
-           wl_deferred = (uu___770_5347.wl_deferred);
-           wl_deferred_to_tac = (uu___770_5347.wl_deferred_to_tac);
+           attempting = (uu___2.attempting);
+           wl_deferred = (uu___2.wl_deferred);
+           wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
            ctr = (wl.ctr + Prims.int_one);
-           defer_ok = (uu___770_5347.defer_ok);
-           smt_ok = (uu___770_5347.smt_ok);
-           umax_heuristic_ok = (uu___770_5347.umax_heuristic_ok);
-           tcenv = (uu___770_5347.tcenv);
-           wl_implicits = (uu___770_5347.wl_implicits);
-           repr_subcomp_allowed = (uu___770_5347.repr_subcomp_allowed)
+           defer_ok = (uu___2.defer_ok);
+           smt_ok = (uu___2.smt_ok);
+           umax_heuristic_ok = (uu___2.umax_heuristic_ok);
+           tcenv = (uu___2.tcenv);
+           wl_implicits = (uu___2.wl_implicits);
+           repr_subcomp_allowed = (uu___2.repr_subcomp_allowed)
          })
 let (solve_prob :
   FStar_TypeChecker_Common.prob ->
@@ -1994,15 +1956,15 @@ let (solve_prob :
           def_check_prob "solve_prob.prob" prob;
           FStar_Util.iter_opt logical_guard
             (def_check_scoped "solve_prob.guard" prob);
-          (let uu____5379 =
+          (let uu___3 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                (FStar_Options.Other "Rel") in
-           if uu____5379
+           if uu___3
            then
-             let uu____5380 =
+             let uu___4 =
                FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob) in
-             let uu____5381 = uvis_to_string wl.tcenv uvis in
-             FStar_Util.print2 "Solving %s: with %s\n" uu____5380 uu____5381
+             let uu___5 = uvis_to_string wl.tcenv uvis in
+             FStar_Util.print2 "Solving %s: with %s\n" uu___4 uu___5
            else ());
           solve_prob' false prob logical_guard uvis wl
 let (occurs :
@@ -2013,16 +1975,16 @@ let (occurs :
   fun uk ->
     fun t ->
       let uvars =
-        let uu____5402 = FStar_Syntax_Free.uvars t in
-        FStar_All.pipe_right uu____5402 FStar_Util.set_elements in
-      let occurs =
+        let uu___ = FStar_Syntax_Free.uvars t in
+        FStar_All.pipe_right uu___ FStar_Util.set_elements in
+      let occurs1 =
         FStar_All.pipe_right uvars
           (FStar_Util.for_some
              (fun uv ->
                 FStar_Syntax_Unionfind.equiv
                   uv.FStar_Syntax_Syntax.ctx_uvar_head
                   uk.FStar_Syntax_Syntax.ctx_uvar_head)) in
-      (uvars, occurs)
+      (uvars, occurs1)
 let (occurs_check :
   FStar_Syntax_Syntax.ctx_uvar ->
     FStar_Syntax_Syntax.term ->
@@ -2031,21 +1993,21 @@ let (occurs_check :
   =
   fun uk ->
     fun t ->
-      let uu____5436 = occurs uk t in
-      match uu____5436 with
+      let uu___ = occurs uk t in
+      match uu___ with
       | (uvars, occurs1) ->
           let msg =
             if Prims.op_Negation occurs1
             then FStar_Pervasives_Native.None
             else
-              (let uu____5465 =
-                 let uu____5466 =
+              (let uu___2 =
+                 let uu___3 =
                    FStar_Syntax_Print.uvar_to_string
                      uk.FStar_Syntax_Syntax.ctx_uvar_head in
-                 let uu____5467 = FStar_Syntax_Print.term_to_string t in
+                 let uu___4 = FStar_Syntax_Print.term_to_string t in
                  FStar_Util.format2 "occurs-check failed (%s occurs in %s)"
-                   uu____5466 uu____5467 in
-               FStar_Pervasives_Native.Some uu____5465) in
+                   uu___3 uu___4 in
+               FStar_Pervasives_Native.Some uu___2) in
           (uvars, (Prims.op_Negation occurs1), msg)
 let rec (maximal_prefix :
   FStar_Syntax_Syntax.binders ->
@@ -2057,13 +2019,13 @@ let rec (maximal_prefix :
     fun bs' ->
       match (bs, bs') with
       | ((b, i)::bs_tail, (b', i')::bs'_tail) ->
-          let uu____5572 = FStar_Syntax_Syntax.bv_eq b b' in
-          if uu____5572
+          let uu___ = FStar_Syntax_Syntax.bv_eq b b' in
+          if uu___
           then
-            let uu____5581 = maximal_prefix bs_tail bs'_tail in
-            (match uu____5581 with | (pfx, rest) -> (((b, i) :: pfx), rest))
+            let uu___1 = maximal_prefix bs_tail bs'_tail in
+            (match uu___1 with | (pfx, rest) -> (((b, i) :: pfx), rest))
           else ([], (bs, bs'))
-      | uu____5631 -> ([], (bs, bs'))
+      | uu___ -> ([], (bs, bs'))
 let (extend_gamma :
   FStar_Syntax_Syntax.gamma ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binding Prims.list)
@@ -2072,31 +2034,29 @@ let (extend_gamma :
     fun bs ->
       FStar_List.fold_left
         (fun g1 ->
-           fun uu____5687 ->
-             match uu____5687 with
-             | (x, uu____5699) -> (FStar_Syntax_Syntax.Binding_var x) :: g1)
-        g bs
+           fun uu___ ->
+             match uu___ with
+             | (x, uu___1) -> (FStar_Syntax_Syntax.Binding_var x) :: g1) g bs
 let (gamma_until :
   FStar_Syntax_Syntax.gamma ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binding Prims.list)
   =
   fun g ->
     fun bs ->
-      let uu____5716 = FStar_List.last bs in
-      match uu____5716 with
+      let uu___ = FStar_List.last bs in
+      match uu___ with
       | FStar_Pervasives_Native.None -> []
-      | FStar_Pervasives_Native.Some (x, uu____5740) ->
-          let uu____5751 =
+      | FStar_Pervasives_Native.Some (x, uu___1) ->
+          let uu___2 =
             FStar_Util.prefix_until
-              (fun uu___18_5766 ->
-                 match uu___18_5766 with
+              (fun uu___3 ->
+                 match uu___3 with
                  | FStar_Syntax_Syntax.Binding_var x' ->
                      FStar_Syntax_Syntax.bv_eq x x'
-                 | uu____5768 -> false) g in
-          (match uu____5751 with
+                 | uu___4 -> false) g in
+          (match uu___2 with
            | FStar_Pervasives_Native.None -> []
-           | FStar_Pervasives_Native.Some (uu____5781, bx, rest) -> bx ::
-               rest)
+           | FStar_Pervasives_Native.Some (uu___3, bx, rest) -> bx :: rest)
 let (restrict_ctx :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.ctx_uvar ->
@@ -2108,81 +2068,79 @@ let (restrict_ctx :
       fun bs ->
         fun src ->
           fun wl ->
-            let uu____5827 =
+            let uu___ =
               maximal_prefix tgt.FStar_Syntax_Syntax.ctx_uvar_binders
                 src.FStar_Syntax_Syntax.ctx_uvar_binders in
-            match uu____5827 with
-            | (pfx, uu____5837) ->
+            match uu___ with
+            | (pfx, uu___1) ->
                 let g =
                   gamma_until src.FStar_Syntax_Syntax.ctx_uvar_gamma pfx in
                 let aux t f =
-                  let uu____5865 =
-                    let uu____5872 =
-                      let uu____5873 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Print.uvar_to_string
                           src.FStar_Syntax_Syntax.ctx_uvar_head in
-                      Prims.op_Hat "restricted " uu____5873 in
-                    new_uvar uu____5872 wl
-                      src.FStar_Syntax_Syntax.ctx_uvar_range g pfx t
-                      src.FStar_Syntax_Syntax.ctx_uvar_should_check
+                      Prims.op_Hat "restricted " uu___4 in
+                    new_uvar uu___3 wl src.FStar_Syntax_Syntax.ctx_uvar_range
+                      g pfx t src.FStar_Syntax_Syntax.ctx_uvar_should_check
                       src.FStar_Syntax_Syntax.ctx_uvar_meta in
-                  match uu____5865 with
-                  | (uu____5874, src', wl1) ->
-                      ((let uu____5878 = f src' in
+                  match uu___2 with
+                  | (uu___3, src', wl1) ->
+                      ((let uu___5 = f src' in
                         FStar_Syntax_Util.set_uvar
-                          src.FStar_Syntax_Syntax.ctx_uvar_head uu____5878);
+                          src.FStar_Syntax_Syntax.ctx_uvar_head uu___5);
                        wl1) in
                 let bs1 =
                   FStar_All.pipe_right bs
                     (FStar_List.filter
-                       (fun uu____5913 ->
-                          match uu____5913 with
-                          | (bv1, uu____5921) ->
+                       (fun uu___2 ->
+                          match uu___2 with
+                          | (bv1, uu___3) ->
                               (FStar_All.pipe_right
                                  src.FStar_Syntax_Syntax.ctx_uvar_binders
                                  (FStar_List.existsb
-                                    (fun uu____5943 ->
-                                       match uu____5943 with
-                                       | (bv2, uu____5951) ->
+                                    (fun uu___4 ->
+                                       match uu___4 with
+                                       | (bv2, uu___5) ->
                                            FStar_Syntax_Syntax.bv_eq bv1 bv2)))
                                 &&
-                                (let uu____5957 =
+                                (let uu___4 =
                                    FStar_All.pipe_right pfx
                                      (FStar_List.existsb
-                                        (fun uu____5975 ->
-                                           match uu____5975 with
-                                           | (bv2, uu____5983) ->
+                                        (fun uu___5 ->
+                                           match uu___5 with
+                                           | (bv2, uu___6) ->
                                                FStar_Syntax_Syntax.bv_eq bv1
                                                  bv2)) in
-                                 Prims.op_Negation uu____5957))) in
+                                 Prims.op_Negation uu___4))) in
                 if (FStar_List.length bs1) = Prims.int_zero
                 then
                   aux src.FStar_Syntax_Syntax.ctx_uvar_typ (fun src' -> src')
                 else
-                  (let uu____5997 =
-                     let uu____5998 =
-                       let uu____6001 =
-                         let uu____6004 =
+                  (let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
+                         let uu___6 =
                            FStar_All.pipe_right
                              src.FStar_Syntax_Syntax.ctx_uvar_typ
                              (env.FStar_TypeChecker_Env.universe_of env) in
-                         FStar_All.pipe_right uu____6004
-                           (fun uu____6007 ->
-                              FStar_Pervasives_Native.Some uu____6007) in
-                       FStar_All.pipe_right uu____6001
+                         FStar_All.pipe_right uu___6
+                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7) in
+                       FStar_All.pipe_right uu___5
                          (FStar_Syntax_Syntax.mk_Total'
                             src.FStar_Syntax_Syntax.ctx_uvar_typ) in
-                     FStar_All.pipe_right uu____5998
+                     FStar_All.pipe_right uu___4
                        (FStar_Syntax_Util.arrow bs1) in
-                   aux uu____5997
+                   aux uu___3
                      (fun src' ->
-                        let uu____6017 =
-                          let uu____6018 =
+                        let uu___4 =
+                          let uu___5 =
                             FStar_All.pipe_right bs1
                               FStar_Syntax_Syntax.binders_to_names in
-                          FStar_All.pipe_right uu____6018
+                          FStar_All.pipe_right uu___5
                             (FStar_List.map FStar_Syntax_Syntax.as_arg) in
-                        FStar_Syntax_Syntax.mk_Tm_app src' uu____6017
+                        FStar_Syntax_Syntax.mk_Tm_app src' uu___4
                           src.FStar_Syntax_Syntax.ctx_uvar_range))
 let (restrict_all_uvars :
   FStar_TypeChecker_Env.env ->
@@ -2219,60 +2177,60 @@ let (intersect_binders :
                  match b with
                  | FStar_Syntax_Syntax.Binding_var x ->
                      FStar_Util.set_add x out
-                 | uu____6143 -> out) FStar_Syntax_Syntax.no_names g in
-        let uu____6144 =
+                 | uu___ -> out) FStar_Syntax_Syntax.no_names g in
+        let uu___ =
           FStar_All.pipe_right v2
             (FStar_List.fold_left
-               (fun uu____6208 ->
-                  fun uu____6209 ->
-                    match (uu____6208, uu____6209) with
+               (fun uu___1 ->
+                  fun uu___2 ->
+                    match (uu___1, uu___2) with
                     | ((isect, isect_set), (x, imp)) ->
-                        let uu____6312 =
-                          let uu____6313 = FStar_Util.set_mem x v1_set in
-                          FStar_All.pipe_left Prims.op_Negation uu____6313 in
-                        if uu____6312
+                        let uu___3 =
+                          let uu___4 = FStar_Util.set_mem x v1_set in
+                          FStar_All.pipe_left Prims.op_Negation uu___4 in
+                        if uu___3
                         then (isect, isect_set)
                         else
                           (let fvs =
                              FStar_Syntax_Free.names
                                x.FStar_Syntax_Syntax.sort in
-                           let uu____6342 =
+                           let uu___5 =
                              FStar_Util.set_is_subset_of fvs isect_set in
-                           if uu____6342
+                           if uu___5
                            then
-                             let uu____6357 = FStar_Util.set_add x isect_set in
-                             (((x, imp) :: isect), uu____6357)
+                             let uu___6 = FStar_Util.set_add x isect_set in
+                             (((x, imp) :: isect), uu___6)
                            else (isect, isect_set))) ([], ctx_binders)) in
-        match uu____6144 with | (isect, uu____6406) -> FStar_List.rev isect
+        match uu___ with | (isect, uu___1) -> FStar_List.rev isect
 let binders_eq :
-  'uuuuuu6441 'uuuuuu6442 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu6441) Prims.list ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6442) Prims.list -> Prims.bool
+  'uuuuu 'uuuuu1 .
+    (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuu1) Prims.list -> Prims.bool
   =
   fun v1 ->
     fun v2 ->
       ((FStar_List.length v1) = (FStar_List.length v2)) &&
         (FStar_List.forall2
-           (fun uu____6499 ->
-              fun uu____6500 ->
-                match (uu____6499, uu____6500) with
-                | ((a, uu____6518), (b, uu____6520)) ->
-                    FStar_Syntax_Syntax.bv_eq a b) v1 v2)
+           (fun uu___ ->
+              fun uu___1 ->
+                match (uu___, uu___1) with
+                | ((a, uu___2), (b, uu___3)) -> FStar_Syntax_Syntax.bv_eq a b)
+           v1 v2)
 let name_exists_in_binders :
-  'uuuuuu6535 .
+  'uuuuu .
     FStar_Syntax_Syntax.bv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6535) Prims.list -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list -> Prims.bool
   =
   fun x ->
     fun bs ->
       FStar_Util.for_some
-        (fun uu____6565 ->
-           match uu____6565 with
-           | (y, uu____6571) -> FStar_Syntax_Syntax.bv_eq x y) bs
+        (fun uu___ ->
+           match uu___ with | (y, uu___1) -> FStar_Syntax_Syntax.bv_eq x y)
+        bs
 let pat_vars :
-  'uuuuuu6580 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6580) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
         (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option) Prims.list ->
           FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option
@@ -2287,13 +2245,13 @@ let pat_vars :
               let hd = sn env arg in
               (match hd.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_name a ->
-                   let uu____6742 =
+                   let uu___ =
                      (name_exists_in_binders a seen) ||
                        (name_exists_in_binders a ctx) in
-                   if uu____6742
+                   if uu___
                    then FStar_Pervasives_Native.None
                    else aux ((a, i) :: seen) args2
-               | uu____6772 -> FStar_Pervasives_Native.None) in
+               | uu___ -> FStar_Pervasives_Native.None) in
         aux [] args
 type match_result =
   | MisMatch of (FStar_Syntax_Syntax.delta_depth
@@ -2303,7 +2261,7 @@ type match_result =
   | FullMatch 
 let (uu___is_MisMatch : match_result -> Prims.bool) =
   fun projectee ->
-    match projectee with | MisMatch _0 -> true | uu____6819 -> false
+    match projectee with | MisMatch _0 -> true | uu___ -> false
 let (__proj__MisMatch__item___0 :
   match_result ->
     (FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option *
@@ -2311,39 +2269,38 @@ let (__proj__MisMatch__item___0 :
   = fun projectee -> match projectee with | MisMatch _0 -> _0
 let (uu___is_HeadMatch : match_result -> Prims.bool) =
   fun projectee ->
-    match projectee with | HeadMatch _0 -> true | uu____6856 -> false
+    match projectee with | HeadMatch _0 -> true | uu___ -> false
 let (__proj__HeadMatch__item___0 : match_result -> Prims.bool) =
   fun projectee -> match projectee with | HeadMatch _0 -> _0
 let (uu___is_FullMatch : match_result -> Prims.bool) =
-  fun projectee ->
-    match projectee with | FullMatch -> true | uu____6868 -> false
+  fun projectee -> match projectee with | FullMatch -> true | uu___ -> false
 let (string_of_match_result : match_result -> Prims.string) =
-  fun uu___19_6873 ->
-    match uu___19_6873 with
+  fun uu___ ->
+    match uu___ with
     | MisMatch (d1, d2) ->
-        let uu____6884 =
-          let uu____6885 =
+        let uu___1 =
+          let uu___2 =
             FStar_Common.string_of_option
               FStar_Syntax_Print.delta_depth_to_string d1 in
-          let uu____6886 =
-            let uu____6887 =
-              let uu____6888 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
                 FStar_Common.string_of_option
                   FStar_Syntax_Print.delta_depth_to_string d2 in
-              Prims.op_Hat uu____6888 ")" in
-            Prims.op_Hat ") (" uu____6887 in
-          Prims.op_Hat uu____6885 uu____6886 in
-        Prims.op_Hat "MisMatch (" uu____6884
+              Prims.op_Hat uu___5 ")" in
+            Prims.op_Hat ") (" uu___4 in
+          Prims.op_Hat uu___2 uu___3 in
+        Prims.op_Hat "MisMatch (" uu___1
     | HeadMatch u ->
-        let uu____6890 = FStar_Util.string_of_bool u in
-        Prims.op_Hat "HeadMatch " uu____6890
+        let uu___1 = FStar_Util.string_of_bool u in
+        Prims.op_Hat "HeadMatch " uu___1
     | FullMatch -> "FullMatch"
 let (head_match : match_result -> match_result) =
-  fun uu___20_6895 ->
-    match uu___20_6895 with
+  fun uu___ ->
+    match uu___ with
     | MisMatch (i, j) -> MisMatch (i, j)
     | HeadMatch (true) -> HeadMatch true
-    | uu____6910 -> HeadMatch false
+    | uu___1 -> HeadMatch false
 let (fv_delta_depth :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth)
@@ -2353,26 +2310,26 @@ let (fv_delta_depth :
       let d = FStar_TypeChecker_Env.delta_depth_of_fv env fv in
       match d with
       | FStar_Syntax_Syntax.Delta_abstract d1 ->
-          let uu____6923 =
-            (let uu____6928 =
+          let uu___ =
+            (let uu___1 =
                FStar_Ident.string_of_lid env.FStar_TypeChecker_Env.curmodule in
-             let uu____6929 =
+             let uu___2 =
                FStar_Ident.nsstr
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             uu____6928 = uu____6929) &&
+             uu___1 = uu___2) &&
               (Prims.op_Negation env.FStar_TypeChecker_Env.is_iface) in
-          if uu____6923 then d1 else FStar_Syntax_Syntax.delta_constant
+          if uu___ then d1 else FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Delta_constant_at_level i when i > Prims.int_zero
           ->
-          let uu____6932 =
+          let uu___ =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
                  FStar_Syntax_Syntax.delta_constant] env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____6932 with
+          (match uu___ with
            | FStar_Pervasives_Native.None ->
                FStar_Syntax_Syntax.delta_constant
-           | uu____6943 -> d)
+           | uu___1 -> d)
       | d1 -> d1
 let rec (delta_depth_of_term :
   FStar_TypeChecker_Env.env ->
@@ -2383,46 +2340,41 @@ let rec (delta_depth_of_term :
     fun t ->
       let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta uu____6966 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____6975 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu___ -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____6993 = FStar_Syntax_Util.unfold_lazy i in
-          delta_depth_of_term env uu____6993
+          let uu___ = FStar_Syntax_Util.unfold_lazy i in
+          delta_depth_of_term env uu___
       | FStar_Syntax_Syntax.Tm_unknown -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_bvar uu____6994 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_name uu____6995 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uvar uu____6996 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____7009 -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_match uu____7022 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst (t2, uu____7046) ->
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_name uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_uvar uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_let uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_match uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_uinst (t2, uu___) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____7052, uu____7053) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___, uu___1) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_app (t2, uu____7095) ->
-          delta_depth_of_term env t2
+      | FStar_Syntax_Syntax.Tm_app (t2, uu___) -> delta_depth_of_term env t2
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7120;
-             FStar_Syntax_Syntax.index = uu____7121;
+          ({ FStar_Syntax_Syntax.ppname = uu___;
+             FStar_Syntax_Syntax.index = uu___1;
              FStar_Syntax_Syntax.sort = t2;_},
-           uu____7123)
+           uu___2)
           -> delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_constant uu____7130 ->
+      | FStar_Syntax_Syntax.Tm_constant uu___ ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_type uu____7131 ->
+      | FStar_Syntax_Syntax.Tm_type uu___ ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_arrow uu____7132 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu___ ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_quoted uu____7147 ->
+      | FStar_Syntax_Syntax.Tm_quoted uu___ ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_abs uu____7154 ->
+      | FStar_Syntax_Syntax.Tm_abs uu___ ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____7174 = fv_delta_depth env fv in
-          FStar_Pervasives_Native.Some uu____7174
+          let uu___ = fv_delta_depth env fv in
+          FStar_Pervasives_Native.Some uu___
 let rec (head_matches :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> match_result)
@@ -2434,112 +2386,111 @@ let rec (head_matches :
         let t21 = FStar_Syntax_Util.unmeta t2 in
         match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7192;
+           { FStar_Syntax_Syntax.blob = uu___;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7193;
-             FStar_Syntax_Syntax.ltyp = uu____7194;
-             FStar_Syntax_Syntax.rng = uu____7195;_},
-           uu____7196) ->
-            let uu____7207 = FStar_Syntax_Util.unlazy t11 in
-            head_matches env uu____7207 t21
-        | (uu____7208, FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7209;
+               uu___1;
+             FStar_Syntax_Syntax.ltyp = uu___2;
+             FStar_Syntax_Syntax.rng = uu___3;_},
+           uu___4) ->
+            let uu___5 = FStar_Syntax_Util.unlazy t11 in
+            head_matches env uu___5 t21
+        | (uu___, FStar_Syntax_Syntax.Tm_lazy
+           { FStar_Syntax_Syntax.blob = uu___1;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7210;
-             FStar_Syntax_Syntax.ltyp = uu____7211;
-             FStar_Syntax_Syntax.rng = uu____7212;_})
+               uu___2;
+             FStar_Syntax_Syntax.ltyp = uu___3;
+             FStar_Syntax_Syntax.rng = uu___4;_})
             ->
-            let uu____7223 = FStar_Syntax_Util.unlazy t21 in
-            head_matches env t11 uu____7223
+            let uu___5 = FStar_Syntax_Util.unlazy t21 in
+            head_matches env t11 uu___5
         | (FStar_Syntax_Syntax.Tm_name x, FStar_Syntax_Syntax.Tm_name y) ->
-            let uu____7226 = FStar_Syntax_Syntax.bv_eq x y in
-            if uu____7226
+            let uu___ = FStar_Syntax_Syntax.bv_eq x y in
+            if uu___
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____7234 = FStar_Syntax_Syntax.fv_eq f g in
-            if uu____7234
+            let uu___ = FStar_Syntax_Syntax.fv_eq f g in
+            if uu___
             then FullMatch
             else
-              (let uu____7236 =
-                 let uu____7245 =
-                   let uu____7248 = fv_delta_depth env f in
-                   FStar_Pervasives_Native.Some uu____7248 in
-                 let uu____7249 =
-                   let uu____7252 = fv_delta_depth env g in
-                   FStar_Pervasives_Native.Some uu____7252 in
-                 (uu____7245, uu____7249) in
-               MisMatch uu____7236)
-        | (FStar_Syntax_Syntax.Tm_uinst (f, uu____7258),
-           FStar_Syntax_Syntax.Tm_uinst (g, uu____7260)) ->
-            let uu____7269 = head_matches env f g in
-            FStar_All.pipe_right uu____7269 head_match
+              (let uu___2 =
+                 let uu___3 =
+                   let uu___4 = fv_delta_depth env f in
+                   FStar_Pervasives_Native.Some uu___4 in
+                 let uu___4 =
+                   let uu___5 = fv_delta_depth env g in
+                   FStar_Pervasives_Native.Some uu___5 in
+                 (uu___3, uu___4) in
+               MisMatch uu___2)
+        | (FStar_Syntax_Syntax.Tm_uinst (f, uu___),
+           FStar_Syntax_Syntax.Tm_uinst (g, uu___1)) ->
+            let uu___2 = head_matches env f g in
+            FStar_All.pipe_right uu___2 head_match
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify),
            FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify)) ->
             FullMatch
-        | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify),
-           uu____7270) -> HeadMatch true
-        | (uu____7271, FStar_Syntax_Syntax.Tm_constant
-           (FStar_Const.Const_reify)) -> HeadMatch true
+        | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify), uu___)
+            -> HeadMatch true
+        | (uu___, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify))
+            -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_constant c, FStar_Syntax_Syntax.Tm_constant
            d) ->
-            let uu____7274 = FStar_Const.eq_const c d in
-            if uu____7274
+            let uu___ = FStar_Const.eq_const c d in
+            if uu___
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_uvar (uv, uu____7281),
-           FStar_Syntax_Syntax.Tm_uvar (uv', uu____7283)) ->
-            let uu____7316 =
+        | (FStar_Syntax_Syntax.Tm_uvar (uv, uu___),
+           FStar_Syntax_Syntax.Tm_uvar (uv', uu___1)) ->
+            let uu___2 =
               FStar_Syntax_Unionfind.equiv
                 uv.FStar_Syntax_Syntax.ctx_uvar_head
                 uv'.FStar_Syntax_Syntax.ctx_uvar_head in
-            if uu____7316
+            if uu___2
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7323),
-           FStar_Syntax_Syntax.Tm_refine (y, uu____7325)) ->
-            let uu____7334 =
+        | (FStar_Syntax_Syntax.Tm_refine (x, uu___),
+           FStar_Syntax_Syntax.Tm_refine (y, uu___1)) ->
+            let uu___2 =
               head_matches env x.FStar_Syntax_Syntax.sort
                 y.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____7334 head_match
-        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7336), uu____7337) ->
-            let uu____7342 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
-            FStar_All.pipe_right uu____7342 head_match
-        | (uu____7343, FStar_Syntax_Syntax.Tm_refine (x, uu____7345)) ->
-            let uu____7350 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____7350 head_match
-        | (FStar_Syntax_Syntax.Tm_type uu____7351,
-           FStar_Syntax_Syntax.Tm_type uu____7352) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_arrow uu____7353,
-           FStar_Syntax_Syntax.Tm_arrow uu____7354) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_app (head, uu____7384),
-           FStar_Syntax_Syntax.Tm_app (head', uu____7386)) ->
-            let uu____7435 = head_matches env head head' in
-            FStar_All.pipe_right uu____7435 head_match
-        | (FStar_Syntax_Syntax.Tm_app (head, uu____7437), uu____7438) ->
-            let uu____7463 = head_matches env head t21 in
-            FStar_All.pipe_right uu____7463 head_match
-        | (uu____7464, FStar_Syntax_Syntax.Tm_app (head, uu____7466)) ->
-            let uu____7491 = head_matches env t11 head in
-            FStar_All.pipe_right uu____7491 head_match
-        | (FStar_Syntax_Syntax.Tm_let uu____7492, FStar_Syntax_Syntax.Tm_let
-           uu____7493) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_match uu____7518,
-           FStar_Syntax_Syntax.Tm_match uu____7519) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_abs uu____7564, FStar_Syntax_Syntax.Tm_abs
-           uu____7565) -> HeadMatch true
-        | uu____7602 ->
-            let uu____7607 =
-              let uu____7616 = delta_depth_of_term env t11 in
-              let uu____7619 = delta_depth_of_term env t21 in
-              (uu____7616, uu____7619) in
-            MisMatch uu____7607
+            FStar_All.pipe_right uu___2 head_match
+        | (FStar_Syntax_Syntax.Tm_refine (x, uu___), uu___1) ->
+            let uu___2 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
+            FStar_All.pipe_right uu___2 head_match
+        | (uu___, FStar_Syntax_Syntax.Tm_refine (x, uu___1)) ->
+            let uu___2 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
+            FStar_All.pipe_right uu___2 head_match
+        | (FStar_Syntax_Syntax.Tm_type uu___, FStar_Syntax_Syntax.Tm_type
+           uu___1) -> HeadMatch false
+        | (FStar_Syntax_Syntax.Tm_arrow uu___, FStar_Syntax_Syntax.Tm_arrow
+           uu___1) -> HeadMatch false
+        | (FStar_Syntax_Syntax.Tm_app (head, uu___),
+           FStar_Syntax_Syntax.Tm_app (head', uu___1)) ->
+            let uu___2 = head_matches env head head' in
+            FStar_All.pipe_right uu___2 head_match
+        | (FStar_Syntax_Syntax.Tm_app (head, uu___), uu___1) ->
+            let uu___2 = head_matches env head t21 in
+            FStar_All.pipe_right uu___2 head_match
+        | (uu___, FStar_Syntax_Syntax.Tm_app (head, uu___1)) ->
+            let uu___2 = head_matches env t11 head in
+            FStar_All.pipe_right uu___2 head_match
+        | (FStar_Syntax_Syntax.Tm_let uu___, FStar_Syntax_Syntax.Tm_let
+           uu___1) -> HeadMatch true
+        | (FStar_Syntax_Syntax.Tm_match uu___, FStar_Syntax_Syntax.Tm_match
+           uu___1) -> HeadMatch true
+        | (FStar_Syntax_Syntax.Tm_abs uu___, FStar_Syntax_Syntax.Tm_abs
+           uu___1) -> HeadMatch true
+        | uu___ ->
+            let uu___1 =
+              let uu___2 = delta_depth_of_term env t11 in
+              let uu___3 = delta_depth_of_term env t21 in (uu___2, uu___3) in
+            MisMatch uu___1
 let (head_matches_delta :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -2554,43 +2505,41 @@ let (head_matches_delta :
         fun t2 ->
           let maybe_inline t =
             let head =
-              let uu____7687 = unrefine env t in
-              FStar_Syntax_Util.head_of uu____7687 in
-            (let uu____7689 =
+              let uu___ = unrefine env t in FStar_Syntax_Util.head_of uu___ in
+            (let uu___1 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta") in
-             if uu____7689
+             if uu___1
              then
-               let uu____7690 = FStar_Syntax_Print.term_to_string t in
-               let uu____7691 = FStar_Syntax_Print.term_to_string head in
-               FStar_Util.print2 "Head of %s is %s\n" uu____7690 uu____7691
+               let uu___2 = FStar_Syntax_Print.term_to_string t in
+               let uu___3 = FStar_Syntax_Print.term_to_string head in
+               FStar_Util.print2 "Head of %s is %s\n" uu___2 uu___3
              else ());
-            (let uu____7693 =
-               let uu____7694 = FStar_Syntax_Util.un_uinst head in
-               uu____7694.FStar_Syntax_Syntax.n in
-             match uu____7693 with
+            (let uu___1 =
+               let uu___2 = FStar_Syntax_Util.un_uinst head in
+               uu___2.FStar_Syntax_Syntax.n in
+             match uu___1 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____7700 =
+                 let uu___2 =
                    FStar_TypeChecker_Env.lookup_definition
                      [FStar_TypeChecker_Env.Unfold
                         FStar_Syntax_Syntax.delta_constant;
                      FStar_TypeChecker_Env.Eager_unfolding_only] env
                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                 (match uu____7700 with
+                 (match uu___2 with
                   | FStar_Pervasives_Native.None ->
-                      ((let uu____7714 =
+                      ((let uu___4 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "RelDelta") in
-                        if uu____7714
+                        if uu___4
                         then
-                          let uu____7715 =
-                            FStar_Syntax_Print.term_to_string head in
+                          let uu___5 = FStar_Syntax_Print.term_to_string head in
                           FStar_Util.print1 "No definition found for %s\n"
-                            uu____7715
+                            uu___5
                         else ());
                        FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____7717 ->
+                  | FStar_Pervasives_Native.Some uu___3 ->
                       let basic_steps =
                         [FStar_TypeChecker_Env.UnfoldUntil
                            FStar_Syntax_Syntax.delta_constant;
@@ -2611,27 +2560,25 @@ let (head_matches_delta :
                         norm_with_steps
                           "FStar.TypeChecker.Rel.norm_with_steps.1" steps env
                           t in
-                      let uu____7732 =
-                        let uu____7733 = FStar_Syntax_Util.eq_tm t t' in
-                        uu____7733 = FStar_Syntax_Util.Equal in
-                      if uu____7732
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Util.eq_tm t t' in
+                        uu___5 = FStar_Syntax_Util.Equal in
+                      if uu___4
                       then FStar_Pervasives_Native.None
                       else
-                        ((let uu____7738 =
+                        ((let uu___7 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelDelta") in
-                          if uu____7738
+                          if uu___7
                           then
-                            let uu____7739 =
-                              FStar_Syntax_Print.term_to_string t in
-                            let uu____7740 =
-                              FStar_Syntax_Print.term_to_string t' in
-                            FStar_Util.print2 "Inlined %s to %s\n" uu____7739
-                              uu____7740
+                            let uu___8 = FStar_Syntax_Print.term_to_string t in
+                            let uu___9 = FStar_Syntax_Print.term_to_string t' in
+                            FStar_Util.print2 "Inlined %s to %s\n" uu___8
+                              uu___9
                           else ());
                          FStar_Pervasives_Native.Some t'))
-             | uu____7742 -> FStar_Pervasives_Native.None) in
+             | uu___2 -> FStar_Pervasives_Native.None) in
           let success d r t11 t21 =
             (r,
               (if d > Prims.int_zero
@@ -2644,21 +2591,21 @@ let (head_matches_delta :
                else FStar_Pervasives_Native.None)) in
           let rec aux retry n_delta t11 t21 =
             let r = head_matches env t11 t21 in
-            (let uu____7880 =
+            (let uu___1 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta") in
-             if uu____7880
+             if uu___1
              then
-               let uu____7881 = FStar_Syntax_Print.term_to_string t11 in
-               let uu____7882 = FStar_Syntax_Print.term_to_string t21 in
-               let uu____7883 = string_of_match_result r in
-               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____7881
-                 uu____7882 uu____7883
+               let uu___2 = FStar_Syntax_Print.term_to_string t11 in
+               let uu___3 = FStar_Syntax_Print.term_to_string t21 in
+               let uu___4 = string_of_match_result r in
+               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu___2 uu___3
+                 uu___4
              else ());
             (let reduce_one_and_try_again d1 d2 =
                let d1_greater_than_d2 =
                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2 in
-               let uu____7907 =
+               let uu___1 =
                  if d1_greater_than_d2
                  then
                    let t1' =
@@ -2674,11 +2621,11 @@ let (head_matches_delta :
                         FStar_TypeChecker_Env.Weak;
                         FStar_TypeChecker_Env.HNF] env t21 in
                     (t11, t2')) in
-               match uu____7907 with
+               match uu___1 with
                | (t12, t22) -> aux retry (n_delta + Prims.int_one) t12 t22 in
              let reduce_both_and_try_again d r1 =
-               let uu____7952 = FStar_TypeChecker_Common.decr_delta_depth d in
-               match uu____7952 with
+               let uu___1 = FStar_TypeChecker_Common.decr_delta_depth d in
+               match uu___1 with
                | FStar_Pervasives_Native.None -> fail n_delta r1 t11 t21
                | FStar_Pervasives_Native.Some d1 ->
                    let t12 =
@@ -2706,17 +2653,16 @@ let (head_matches_delta :
                    (FStar_Syntax_Syntax.Delta_equational_at_level j)
              | MisMatch
                  (FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____7984),
-                  uu____7985)
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu___1),
+                  uu___2)
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8003 =
-                      let uu____8012 = maybe_inline t11 in
-                      let uu____8015 = maybe_inline t21 in
-                      (uu____8012, uu____8015) in
-                    match uu____8003 with
+                   (let uu___4 =
+                      let uu___5 = maybe_inline t11 in
+                      let uu___6 = maybe_inline t21 in (uu___5, uu___6) in
+                    match uu___4 with
                     | (FStar_Pervasives_Native.None,
                        FStar_Pervasives_Native.None) ->
                         fail n_delta r t11 t21
@@ -2730,17 +2676,16 @@ let (head_matches_delta :
                        FStar_Pervasives_Native.Some t22) ->
                         aux false (n_delta + Prims.int_one) t12 t22)
              | MisMatch
-                 (uu____8052, FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8053))
+                 (uu___1, FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu___2))
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8071 =
-                      let uu____8080 = maybe_inline t11 in
-                      let uu____8083 = maybe_inline t21 in
-                      (uu____8080, uu____8083) in
-                    match uu____8071 with
+                   (let uu___4 =
+                      let uu___5 = maybe_inline t11 in
+                      let uu___6 = maybe_inline t21 in (uu___5, uu___6) in
+                    match uu___4 with
                     | (FStar_Pervasives_Native.None,
                        FStar_Pervasives_Native.None) ->
                         fail n_delta r t11 t21
@@ -2761,38 +2706,37 @@ let (head_matches_delta :
                  (FStar_Pervasives_Native.Some d1,
                   FStar_Pervasives_Native.Some d2)
                  -> reduce_one_and_try_again d1 d2
-             | MisMatch uu____8132 -> fail n_delta r t11 t21
-             | uu____8141 -> success n_delta r t11 t21) in
+             | MisMatch uu___1 -> fail n_delta r t11 t21
+             | uu___1 -> success n_delta r t11 t21) in
           let r = aux true Prims.int_zero t1 t2 in
-          (let uu____8154 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "RelDelta") in
-           if uu____8154
+           if uu___1
            then
-             let uu____8155 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____8156 = FStar_Syntax_Print.term_to_string t2 in
-             let uu____8157 =
+             let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+             let uu___3 = FStar_Syntax_Print.term_to_string t2 in
+             let uu___4 =
                string_of_match_result (FStar_Pervasives_Native.fst r) in
-             let uu____8164 =
+             let uu___5 =
                if FStar_Option.isNone (FStar_Pervasives_Native.snd r)
                then "None"
                else
-                 (let uu____8176 =
+                 (let uu___7 =
                     FStar_All.pipe_right (FStar_Pervasives_Native.snd r)
                       FStar_Util.must in
-                  FStar_All.pipe_right uu____8176
-                    (fun uu____8210 ->
-                       match uu____8210 with
+                  FStar_All.pipe_right uu___7
+                    (fun uu___8 ->
+                       match uu___8 with
                        | (t11, t21) ->
-                           let uu____8217 =
-                             FStar_Syntax_Print.term_to_string t11 in
-                           let uu____8218 =
-                             let uu____8219 =
+                           let uu___9 = FStar_Syntax_Print.term_to_string t11 in
+                           let uu___10 =
+                             let uu___11 =
                                FStar_Syntax_Print.term_to_string t21 in
-                             Prims.op_Hat "; " uu____8219 in
-                           Prims.op_Hat uu____8217 uu____8218)) in
+                             Prims.op_Hat "; " uu___11 in
+                           Prims.op_Hat uu___9 uu___10)) in
              FStar_Util.print4 "head_matches_delta (%s, %s) = %s (%s)\n"
-               uu____8155 uu____8156 uu____8157 uu____8164
+               uu___2 uu___3 uu___4 uu___5
            else ());
           r
 let (kind_type :
@@ -2800,11 +2744,11 @@ let (kind_type :
   =
   fun binders ->
     fun r ->
-      let uu____8231 = FStar_Syntax_Util.type_u () in
-      FStar_All.pipe_right uu____8231 FStar_Pervasives_Native.fst
+      let uu___ = FStar_Syntax_Util.type_u () in
+      FStar_All.pipe_right uu___ FStar_Pervasives_Native.fst
 let (rank_t_num : FStar_TypeChecker_Common.rank_t -> Prims.int) =
-  fun uu___21_8244 ->
-    match uu___21_8244 with
+  fun uu___ ->
+    match uu___ with
     | FStar_TypeChecker_Common.Rigid_rigid -> Prims.int_zero
     | FStar_TypeChecker_Common.Flex_rigid_eq -> Prims.int_one
     | FStar_TypeChecker_Common.Flex_flex_pattern_eq -> (Prims.of_int (2))
@@ -2826,28 +2770,25 @@ let (compress_tprob :
   =
   fun tcenv ->
     fun p ->
-      let uu___1279_8281 = p in
-      let uu____8284 = whnf tcenv p.FStar_TypeChecker_Common.lhs in
-      let uu____8285 = whnf tcenv p.FStar_TypeChecker_Common.rhs in
+      let uu___ = p in
+      let uu___1 = whnf tcenv p.FStar_TypeChecker_Common.lhs in
+      let uu___2 = whnf tcenv p.FStar_TypeChecker_Common.rhs in
       {
-        FStar_TypeChecker_Common.pid =
-          (uu___1279_8281.FStar_TypeChecker_Common.pid);
-        FStar_TypeChecker_Common.lhs = uu____8284;
+        FStar_TypeChecker_Common.pid = (uu___.FStar_TypeChecker_Common.pid);
+        FStar_TypeChecker_Common.lhs = uu___1;
         FStar_TypeChecker_Common.relation =
-          (uu___1279_8281.FStar_TypeChecker_Common.relation);
-        FStar_TypeChecker_Common.rhs = uu____8285;
+          (uu___.FStar_TypeChecker_Common.relation);
+        FStar_TypeChecker_Common.rhs = uu___2;
         FStar_TypeChecker_Common.element =
-          (uu___1279_8281.FStar_TypeChecker_Common.element);
+          (uu___.FStar_TypeChecker_Common.element);
         FStar_TypeChecker_Common.logical_guard =
-          (uu___1279_8281.FStar_TypeChecker_Common.logical_guard);
+          (uu___.FStar_TypeChecker_Common.logical_guard);
         FStar_TypeChecker_Common.logical_guard_uvar =
-          (uu___1279_8281.FStar_TypeChecker_Common.logical_guard_uvar);
+          (uu___.FStar_TypeChecker_Common.logical_guard_uvar);
         FStar_TypeChecker_Common.reason =
-          (uu___1279_8281.FStar_TypeChecker_Common.reason);
-        FStar_TypeChecker_Common.loc =
-          (uu___1279_8281.FStar_TypeChecker_Common.loc);
-        FStar_TypeChecker_Common.rank =
-          (uu___1279_8281.FStar_TypeChecker_Common.rank)
+          (uu___.FStar_TypeChecker_Common.reason);
+        FStar_TypeChecker_Common.loc = (uu___.FStar_TypeChecker_Common.loc);
+        FStar_TypeChecker_Common.rank = (uu___.FStar_TypeChecker_Common.rank)
       }
 let (compress_prob :
   FStar_TypeChecker_Env.env ->
@@ -2857,10 +2798,10 @@ let (compress_prob :
     fun p ->
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____8299 = compress_tprob tcenv p1 in
-          FStar_All.pipe_right uu____8299
-            (fun uu____8304 -> FStar_TypeChecker_Common.TProb uu____8304)
-      | FStar_TypeChecker_Common.CProb uu____8305 -> p
+          let uu___ = compress_tprob tcenv p1 in
+          FStar_All.pipe_right uu___
+            (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1)
+      | FStar_TypeChecker_Common.CProb uu___ -> p
 let (rank :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -2869,25 +2810,25 @@ let (rank :
   fun tcenv ->
     fun pr ->
       let prob =
-        let uu____8327 = compress_prob tcenv pr in
-        FStar_All.pipe_right uu____8327 maybe_invert_p in
+        let uu___ = compress_prob tcenv pr in
+        FStar_All.pipe_right uu___ maybe_invert_p in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
-          let uu____8335 =
+          let uu___ =
             FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
-          (match uu____8335 with
+          (match uu___ with
            | (lh, lhs_args) ->
-               let uu____8382 =
+               let uu___1 =
                  FStar_Syntax_Util.head_and_args
                    tp.FStar_TypeChecker_Common.rhs in
-               (match uu____8382 with
+               (match uu___1 with
                 | (rh, rhs_args) ->
-                    let uu____8429 =
+                    let uu___2 =
                       match ((lh.FStar_Syntax_Syntax.n),
                               (rh.FStar_Syntax_Syntax.n))
                       with
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8442,
-                         FStar_Syntax_Syntax.Tm_uvar uu____8443) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu___3,
+                         FStar_Syntax_Syntax.Tm_uvar uu___4) ->
                           (match (lhs_args, rhs_args) with
                            | ([], []) when
                                tp.FStar_TypeChecker_Common.relation =
@@ -2895,171 +2836,168 @@ let (rank :
                                ->
                                (FStar_TypeChecker_Common.Flex_flex_pattern_eq,
                                  tp)
-                           | uu____8532 ->
+                           | uu___5 ->
                                (FStar_TypeChecker_Common.Flex_flex, tp))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8559, uu____8560)
-                          when
+                      | (FStar_Syntax_Syntax.Tm_uvar uu___3, uu___4) when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (uu____8575, FStar_Syntax_Syntax.Tm_uvar uu____8576)
-                          when
+                      | (uu___3, FStar_Syntax_Syntax.Tm_uvar uu___4) when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8591,
-                         FStar_Syntax_Syntax.Tm_arrow uu____8592) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu___3,
+                         FStar_Syntax_Syntax.Tm_arrow uu___4) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8622 = tp in
+                            (let uu___5 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.pid);
+                                 (uu___5.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.lhs);
+                                 (uu___5.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.rhs);
+                                 (uu___5.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.element);
+                                 (uu___5.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.reason);
+                                 (uu___5.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.loc);
+                                 (uu___5.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.rank)
+                                 (uu___5.FStar_TypeChecker_Common.rank)
                              }))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8625,
-                         FStar_Syntax_Syntax.Tm_type uu____8626) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu___3,
+                         FStar_Syntax_Syntax.Tm_type uu___4) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8642 = tp in
+                            (let uu___5 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.pid);
+                                 (uu___5.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.lhs);
+                                 (uu___5.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.rhs);
+                                 (uu___5.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.element);
+                                 (uu___5.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.reason);
+                                 (uu___5.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.loc);
+                                 (uu___5.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.rank)
+                                 (uu___5.FStar_TypeChecker_Common.rank)
                              }))
-                      | (FStar_Syntax_Syntax.Tm_type uu____8645,
-                         FStar_Syntax_Syntax.Tm_uvar uu____8646) ->
+                      | (FStar_Syntax_Syntax.Tm_type uu___3,
+                         FStar_Syntax_Syntax.Tm_uvar uu___4) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8662 = tp in
+                            (let uu___5 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.pid);
+                                 (uu___5.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.lhs);
+                                 (uu___5.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.rhs);
+                                 (uu___5.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.element);
+                                 (uu___5.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___5.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.reason);
+                                 (uu___5.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.loc);
+                                 (uu___5.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.rank)
+                                 (uu___5.FStar_TypeChecker_Common.rank)
                              }))
-                      | (uu____8665, FStar_Syntax_Syntax.Tm_uvar uu____8666)
-                          -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8681, uu____8682)
-                          -> (FStar_TypeChecker_Common.Flex_rigid, tp)
-                      | (uu____8697, FStar_Syntax_Syntax.Tm_uvar uu____8698)
-                          -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (uu____8713, uu____8714) ->
+                      | (uu___3, FStar_Syntax_Syntax.Tm_uvar uu___4) ->
+                          (FStar_TypeChecker_Common.Rigid_flex, tp)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu___3, uu___4) ->
+                          (FStar_TypeChecker_Common.Flex_rigid, tp)
+                      | (uu___3, FStar_Syntax_Syntax.Tm_uvar uu___4) ->
+                          (FStar_TypeChecker_Common.Rigid_flex, tp)
+                      | (uu___3, uu___4) ->
                           (FStar_TypeChecker_Common.Rigid_rigid, tp) in
-                    (match uu____8429 with
-                     | (rank, tp1) ->
-                         let uu____8727 =
+                    (match uu___2 with
+                     | (rank1, tp1) ->
+                         let uu___3 =
                            FStar_All.pipe_right
-                             (let uu___1350_8731 = tp1 in
+                             (let uu___4 = tp1 in
                               {
                                 FStar_TypeChecker_Common.pid =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.pid);
+                                  (uu___4.FStar_TypeChecker_Common.pid);
                                 FStar_TypeChecker_Common.lhs =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.lhs);
+                                  (uu___4.FStar_TypeChecker_Common.lhs);
                                 FStar_TypeChecker_Common.relation =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.relation);
+                                  (uu___4.FStar_TypeChecker_Common.relation);
                                 FStar_TypeChecker_Common.rhs =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.rhs);
+                                  (uu___4.FStar_TypeChecker_Common.rhs);
                                 FStar_TypeChecker_Common.element =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.element);
+                                  (uu___4.FStar_TypeChecker_Common.element);
                                 FStar_TypeChecker_Common.logical_guard =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.logical_guard);
+                                  (uu___4.FStar_TypeChecker_Common.logical_guard);
                                 FStar_TypeChecker_Common.logical_guard_uvar =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.logical_guard_uvar);
+                                  (uu___4.FStar_TypeChecker_Common.logical_guard_uvar);
                                 FStar_TypeChecker_Common.reason =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.reason);
+                                  (uu___4.FStar_TypeChecker_Common.reason);
                                 FStar_TypeChecker_Common.loc =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.loc);
+                                  (uu___4.FStar_TypeChecker_Common.loc);
                                 FStar_TypeChecker_Common.rank =
-                                  (FStar_Pervasives_Native.Some rank)
+                                  (FStar_Pervasives_Native.Some rank1)
                               })
-                             (fun uu____8734 ->
-                                FStar_TypeChecker_Common.TProb uu____8734) in
-                         (rank, uu____8727))))
+                             (fun uu___4 ->
+                                FStar_TypeChecker_Common.TProb uu___4) in
+                         (rank1, uu___3))))
       | FStar_TypeChecker_Common.CProb cp ->
-          let uu____8738 =
+          let uu___ =
             FStar_All.pipe_right
-              (let uu___1354_8742 = cp in
+              (let uu___1 = cp in
                {
                  FStar_TypeChecker_Common.pid =
-                   (uu___1354_8742.FStar_TypeChecker_Common.pid);
+                   (uu___1.FStar_TypeChecker_Common.pid);
                  FStar_TypeChecker_Common.lhs =
-                   (uu___1354_8742.FStar_TypeChecker_Common.lhs);
+                   (uu___1.FStar_TypeChecker_Common.lhs);
                  FStar_TypeChecker_Common.relation =
-                   (uu___1354_8742.FStar_TypeChecker_Common.relation);
+                   (uu___1.FStar_TypeChecker_Common.relation);
                  FStar_TypeChecker_Common.rhs =
-                   (uu___1354_8742.FStar_TypeChecker_Common.rhs);
+                   (uu___1.FStar_TypeChecker_Common.rhs);
                  FStar_TypeChecker_Common.element =
-                   (uu___1354_8742.FStar_TypeChecker_Common.element);
+                   (uu___1.FStar_TypeChecker_Common.element);
                  FStar_TypeChecker_Common.logical_guard =
-                   (uu___1354_8742.FStar_TypeChecker_Common.logical_guard);
+                   (uu___1.FStar_TypeChecker_Common.logical_guard);
                  FStar_TypeChecker_Common.logical_guard_uvar =
-                   (uu___1354_8742.FStar_TypeChecker_Common.logical_guard_uvar);
+                   (uu___1.FStar_TypeChecker_Common.logical_guard_uvar);
                  FStar_TypeChecker_Common.reason =
-                   (uu___1354_8742.FStar_TypeChecker_Common.reason);
+                   (uu___1.FStar_TypeChecker_Common.reason);
                  FStar_TypeChecker_Common.loc =
-                   (uu___1354_8742.FStar_TypeChecker_Common.loc);
+                   (uu___1.FStar_TypeChecker_Common.loc);
                  FStar_TypeChecker_Common.rank =
                    (FStar_Pervasives_Native.Some
                       FStar_TypeChecker_Common.Rigid_rigid)
-               })
-              (fun uu____8745 -> FStar_TypeChecker_Common.CProb uu____8745) in
-          (FStar_TypeChecker_Common.Rigid_rigid, uu____8738)
+               }) (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1) in
+          (FStar_TypeChecker_Common.Rigid_rigid, uu___)
 let (next_prob :
   worklist ->
     (FStar_TypeChecker_Common.prob * FStar_TypeChecker_Common.prob Prims.list
       * FStar_TypeChecker_Common.rank_t) FStar_Pervasives_Native.option)
   =
   fun wl ->
-    let rec aux uu____8804 probs =
-      match uu____8804 with
+    let rec aux uu___ probs =
+      match uu___ with
       | (min_rank, min, out) ->
           (match probs with
            | [] ->
@@ -3067,10 +3005,10 @@ let (next_prob :
                 | (FStar_Pervasives_Native.Some p,
                    FStar_Pervasives_Native.Some r) ->
                     FStar_Pervasives_Native.Some (p, out, r)
-                | uu____8885 -> FStar_Pervasives_Native.None)
+                | uu___1 -> FStar_Pervasives_Native.None)
            | hd::tl ->
-               let uu____8906 = rank wl.tcenv hd in
-               (match uu____8906 with
+               let uu___1 = rank wl.tcenv hd in
+               (match uu___1 with
                 | (rank1, hd1) ->
                     if rank_leq rank1 FStar_TypeChecker_Common.Flex_rigid_eq
                     then
@@ -3082,11 +3020,11 @@ let (next_prob :
                            FStar_Pervasives_Native.Some
                              (hd1, (FStar_List.append out (m :: tl)), rank1))
                     else
-                      (let uu____8965 =
+                      (let uu___3 =
                          (min_rank = FStar_Pervasives_Native.None) ||
-                           (let uu____8969 = FStar_Option.get min_rank in
-                            rank_less_than rank1 uu____8969) in
-                       if uu____8965
+                           (let uu___4 = FStar_Option.get min_rank in
+                            rank_less_than rank1 uu___4) in
+                       if uu___3
                        then
                          match min with
                          | FStar_Pervasives_Native.None ->
@@ -3110,32 +3048,32 @@ let (flex_prob_closing :
     fun bs ->
       fun p ->
         let flex_will_be_closed t =
-          let uu____9037 = FStar_Syntax_Util.head_and_args t in
-          match uu____9037 with
-          | (hd, uu____9055) ->
-              let uu____9080 =
-                let uu____9081 = FStar_Syntax_Subst.compress hd in
-                uu____9081.FStar_Syntax_Syntax.n in
-              (match uu____9080 with
-               | FStar_Syntax_Syntax.Tm_uvar (u, uu____9085) ->
+          let uu___ = FStar_Syntax_Util.head_and_args t in
+          match uu___ with
+          | (hd, uu___1) ->
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Subst.compress hd in
+                uu___3.FStar_Syntax_Syntax.n in
+              (match uu___2 with
+               | FStar_Syntax_Syntax.Tm_uvar (u, uu___3) ->
                    FStar_All.pipe_right
                      u.FStar_Syntax_Syntax.ctx_uvar_binders
                      (FStar_Util.for_some
-                        (fun uu____9119 ->
-                           match uu____9119 with
-                           | (y, uu____9127) ->
+                        (fun uu___4 ->
+                           match uu___4 with
+                           | (y, uu___5) ->
                                FStar_All.pipe_right bs
                                  (FStar_Util.for_some
-                                    (fun uu____9149 ->
-                                       match uu____9149 with
-                                       | (x, uu____9157) ->
+                                    (fun uu___6 ->
+                                       match uu___6 with
+                                       | (x, uu___7) ->
                                            FStar_Syntax_Syntax.bv_eq x y))))
-               | uu____9162 -> false) in
-        let uu____9163 = rank tcenv p in
-        match uu____9163 with
+               | uu___3 -> false) in
+        let uu___ = rank tcenv p in
+        match uu___ with
         | (r, p1) ->
             (match p1 with
-             | FStar_TypeChecker_Common.CProb uu____9170 -> true
+             | FStar_TypeChecker_Common.CProb uu___1 -> true
              | FStar_TypeChecker_Common.TProb p2 ->
                  (match r with
                   | FStar_TypeChecker_Common.Rigid_rigid -> true
@@ -3159,23 +3097,21 @@ type univ_eq_sol =
   | UFailed of lstring 
 let (uu___is_UDeferred : univ_eq_sol -> Prims.bool) =
   fun projectee ->
-    match projectee with | UDeferred _0 -> true | uu____9202 -> false
+    match projectee with | UDeferred _0 -> true | uu___ -> false
 let (__proj__UDeferred__item___0 : univ_eq_sol -> worklist) =
   fun projectee -> match projectee with | UDeferred _0 -> _0
 let (uu___is_USolved : univ_eq_sol -> Prims.bool) =
-  fun projectee ->
-    match projectee with | USolved _0 -> true | uu____9215 -> false
+  fun projectee -> match projectee with | USolved _0 -> true | uu___ -> false
 let (__proj__USolved__item___0 : univ_eq_sol -> worklist) =
   fun projectee -> match projectee with | USolved _0 -> _0
 let (uu___is_UFailed : univ_eq_sol -> Prims.bool) =
-  fun projectee ->
-    match projectee with | UFailed _0 -> true | uu____9228 -> false
+  fun projectee -> match projectee with | UFailed _0 -> true | uu___ -> false
 let (__proj__UFailed__item___0 : univ_eq_sol -> lstring) =
   fun projectee -> match projectee with | UFailed _0 -> _0
 let (ufailed_simple : Prims.string -> univ_eq_sol) =
-  fun s -> let uu____9240 = FStar_Thunk.mkv s in UFailed uu____9240
+  fun s -> let uu___ = FStar_Thunk.mkv s in UFailed uu___
 let (ufailed_thunk : (unit -> Prims.string) -> univ_eq_sol) =
-  fun s -> let uu____9251 = mklstr s in UFailed uu____9251
+  fun s -> let uu___ = mklstr s in UFailed uu___
 let rec (really_solve_universe_eq :
   Prims.int ->
     worklist ->
@@ -3196,35 +3132,35 @@ let rec (really_solve_universe_eq :
                 FStar_All.pipe_right us
                   (FStar_Util.for_some
                      (fun u3 ->
-                        let uu____9296 = FStar_Syntax_Util.univ_kernel u3 in
-                        match uu____9296 with
-                        | (k, uu____9302) ->
+                        let uu___ = FStar_Syntax_Util.univ_kernel u3 in
+                        match uu___ with
+                        | (k, uu___1) ->
                             (match k with
                              | FStar_Syntax_Syntax.U_unif v2 ->
                                  FStar_Syntax_Unionfind.univ_equiv v1 v2
-                             | uu____9314 -> false)))
-            | uu____9315 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
+                             | uu___2 -> false)))
+            | uu___ -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
           let rec filter_out_common_univs u12 u22 =
             let common_elts =
               FStar_All.pipe_right u12
                 (FStar_List.fold_left
                    (fun uvs ->
                       fun uv1 ->
-                        let uu____9367 =
+                        let uu___ =
                           FStar_All.pipe_right u22
                             (FStar_List.existsML
                                (fun uv2 -> FStar_Syntax_Util.eq_univs uv1 uv2)) in
-                        if uu____9367 then uv1 :: uvs else uvs) []) in
+                        if uu___ then uv1 :: uvs else uvs) []) in
             let filter =
               FStar_List.filter
                 (fun u ->
-                   let uu____9387 =
+                   let uu___ =
                      FStar_All.pipe_right common_elts
                        (FStar_List.existsML
                           (fun u' -> FStar_Syntax_Util.eq_univs u u')) in
-                   Prims.op_Negation uu____9387) in
-            let uu____9392 = filter u12 in
-            let uu____9395 = filter u22 in (uu____9392, uu____9395) in
+                   Prims.op_Negation uu___) in
+            let uu___ = filter u12 in
+            let uu___1 = filter u22 in (uu___, uu___1) in
           let try_umax_components u12 u22 msg =
             if Prims.op_Negation wl.umax_heuristic_ok
             then ufailed_simple "Unable to unify universe terms with umax"
@@ -3232,8 +3168,8 @@ let rec (really_solve_universe_eq :
               (match (u12, u22) with
                | (FStar_Syntax_Syntax.U_max us1, FStar_Syntax_Syntax.U_max
                   us2) ->
-                   let uu____9425 = filter_out_common_univs us1 us2 in
-                   (match uu____9425 with
+                   let uu___1 = filter_out_common_univs us1 us2 in
+                   (match uu___1 with
                     | (us11, us21) ->
                         if
                           (FStar_List.length us11) = (FStar_List.length us21)
@@ -3241,32 +3177,32 @@ let rec (really_solve_universe_eq :
                           let rec aux wl1 us12 us22 =
                             match (us12, us22) with
                             | (u13::us13, u23::us23) ->
-                                let uu____9484 =
+                                let uu___2 =
                                   really_solve_universe_eq pid_orig wl1 u13
                                     u23 in
-                                (match uu____9484 with
+                                (match uu___2 with
                                  | USolved wl2 -> aux wl2 us13 us23
                                  | failed -> failed)
-                            | uu____9487 -> USolved wl1 in
+                            | uu___2 -> USolved wl1 in
                           aux wl us11 us21
                         else
                           ufailed_thunk
-                            (fun uu____9503 ->
-                               let uu____9504 =
+                            (fun uu___3 ->
+                               let uu___4 =
                                  FStar_Syntax_Print.univ_to_string u12 in
-                               let uu____9505 =
+                               let uu___5 =
                                  FStar_Syntax_Print.univ_to_string u22 in
                                FStar_Util.format2
                                  "Unable to unify universes: %s and %s"
-                                 uu____9504 uu____9505))
+                                 uu___4 uu___5))
                | (FStar_Syntax_Syntax.U_max us, u') ->
                    let rec aux wl1 us1 =
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____9529 =
+                         let uu___1 =
                            really_solve_universe_eq pid_orig wl1 u u' in
-                         (match uu____9529 with
+                         (match uu___1 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed) in
                    aux wl us
@@ -3275,61 +3211,58 @@ let rec (really_solve_universe_eq :
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____9555 =
+                         let uu___1 =
                            really_solve_universe_eq pid_orig wl1 u u' in
-                         (match uu____9555 with
+                         (match uu___1 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed) in
                    aux wl us
-               | uu____9558 ->
+               | uu___1 ->
                    ufailed_thunk
-                     (fun uu____9569 ->
-                        let uu____9570 =
-                          FStar_Syntax_Print.univ_to_string u12 in
-                        let uu____9571 =
-                          FStar_Syntax_Print.univ_to_string u22 in
+                     (fun uu___2 ->
+                        let uu___3 = FStar_Syntax_Print.univ_to_string u12 in
+                        let uu___4 = FStar_Syntax_Print.univ_to_string u22 in
                         FStar_Util.format3
-                          "Unable to unify universes: %s and %s (%s)"
-                          uu____9570 uu____9571 msg)) in
+                          "Unable to unify universes: %s and %s (%s)" uu___3
+                          uu___4 msg)) in
           match (u11, u21) with
-          | (FStar_Syntax_Syntax.U_bvar uu____9572, uu____9573) ->
-              let uu____9574 =
-                let uu____9575 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9576 = FStar_Syntax_Print.univ_to_string u21 in
+          | (FStar_Syntax_Syntax.U_bvar uu___, uu___1) ->
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu___4 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9575 uu____9576 in
-              failwith uu____9574
-          | (FStar_Syntax_Syntax.U_unknown, uu____9577) ->
-              let uu____9578 =
-                let uu____9579 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9580 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu___3 uu___4 in
+              failwith uu___2
+          | (FStar_Syntax_Syntax.U_unknown, uu___) ->
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu___3 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9579 uu____9580 in
-              failwith uu____9578
-          | (uu____9581, FStar_Syntax_Syntax.U_bvar uu____9582) ->
-              let uu____9583 =
-                let uu____9584 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9585 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu___2 uu___3 in
+              failwith uu___1
+          | (uu___, FStar_Syntax_Syntax.U_bvar uu___1) ->
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu___4 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9584 uu____9585 in
-              failwith uu____9583
-          | (uu____9586, FStar_Syntax_Syntax.U_unknown) ->
-              let uu____9587 =
-                let uu____9588 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9589 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu___3 uu___4 in
+              failwith uu___2
+          | (uu___, FStar_Syntax_Syntax.U_unknown) ->
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu___3 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9588 uu____9589 in
-              failwith uu____9587
+                  uu___2 uu___3 in
+              failwith uu___1
           | (FStar_Syntax_Syntax.U_name x, FStar_Syntax_Syntax.U_name y) ->
-              let uu____9592 =
-                let uu____9593 = FStar_Ident.string_of_id x in
-                let uu____9594 = FStar_Ident.string_of_id y in
-                uu____9593 = uu____9594 in
-              if uu____9592
+              let uu___ =
+                let uu___1 = FStar_Ident.string_of_id x in
+                let uu___2 = FStar_Ident.string_of_id y in uu___1 = uu___2 in
+              if uu___
               then USolved wl
               else ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) ->
@@ -3337,79 +3270,75 @@ let rec (really_solve_universe_eq :
           | (FStar_Syntax_Syntax.U_succ u12, FStar_Syntax_Syntax.U_succ u22)
               -> really_solve_universe_eq pid_orig wl u12 u22
           | (FStar_Syntax_Syntax.U_unif v1, FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____9620 = FStar_Syntax_Unionfind.univ_equiv v1 v2 in
-              if uu____9620
+              let uu___ = FStar_Syntax_Unionfind.univ_equiv v1 v2 in
+              if uu___
               then USolved wl
               else
                 (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl in
                  USolved wl1)
           | (FStar_Syntax_Syntax.U_unif v1, u) ->
               let u3 = norm_univ wl u in
-              let uu____9636 = occurs_univ v1 u3 in
-              if uu____9636
+              let uu___ = occurs_univ v1 u3 in
+              if uu___
               then
-                let uu____9637 =
-                  let uu____9638 =
+                let uu___1 =
+                  let uu___2 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1) in
-                  let uu____9639 = FStar_Syntax_Print.univ_to_string u3 in
+                  let uu___3 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9638 uu____9639 in
-                try_umax_components u11 u21 uu____9637
+                    uu___2 uu___3 in
+                try_umax_components u11 u21 uu___1
               else
-                (let uu____9641 = extend_solution pid_orig [UNIV (v1, u3)] wl in
-                 USolved uu____9641)
+                (let uu___2 = extend_solution pid_orig [UNIV (v1, u3)] wl in
+                 USolved uu___2)
           | (u, FStar_Syntax_Syntax.U_unif v1) ->
               let u3 = norm_univ wl u in
-              let uu____9655 = occurs_univ v1 u3 in
-              if uu____9655
+              let uu___ = occurs_univ v1 u3 in
+              if uu___
               then
-                let uu____9656 =
-                  let uu____9657 =
+                let uu___1 =
+                  let uu___2 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1) in
-                  let uu____9658 = FStar_Syntax_Print.univ_to_string u3 in
+                  let uu___3 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9657 uu____9658 in
-                try_umax_components u11 u21 uu____9656
+                    uu___2 uu___3 in
+                try_umax_components u11 u21 uu___1
               else
-                (let uu____9660 = extend_solution pid_orig [UNIV (v1, u3)] wl in
-                 USolved uu____9660)
-          | (FStar_Syntax_Syntax.U_max uu____9661, uu____9662) ->
+                (let uu___2 = extend_solution pid_orig [UNIV (v1, u3)] wl in
+                 USolved uu___2)
+          | (FStar_Syntax_Syntax.U_max uu___, uu___1) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11 in
                  let u22 = norm_univ wl u21 in
-                 let uu____9668 = FStar_Syntax_Util.eq_univs u12 u22 in
-                 if uu____9668
+                 let uu___3 = FStar_Syntax_Util.eq_univs u12 u22 in
+                 if uu___3
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (uu____9670, FStar_Syntax_Syntax.U_max uu____9671) ->
+          | (uu___, FStar_Syntax_Syntax.U_max uu___1) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11 in
                  let u22 = norm_univ wl u21 in
-                 let uu____9677 = FStar_Syntax_Util.eq_univs u12 u22 in
-                 if uu____9677
+                 let uu___3 = FStar_Syntax_Util.eq_univs u12 u22 in
+                 if uu___3
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (FStar_Syntax_Syntax.U_succ uu____9679,
-             FStar_Syntax_Syntax.U_zero) ->
+          | (FStar_Syntax_Syntax.U_succ uu___, FStar_Syntax_Syntax.U_zero) ->
               ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_succ uu____9680,
-             FStar_Syntax_Syntax.U_name uu____9681) ->
+          | (FStar_Syntax_Syntax.U_succ uu___, FStar_Syntax_Syntax.U_name
+             uu___1) -> ufailed_simple "Incompatible universes"
+          | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_succ uu___) ->
               ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_succ
-             uu____9682) -> ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_name
-             uu____9683) -> ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_name uu____9684,
-             FStar_Syntax_Syntax.U_succ uu____9685) ->
+          | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_name uu___) ->
               ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_name uu____9686,
-             FStar_Syntax_Syntax.U_zero) ->
+          | (FStar_Syntax_Syntax.U_name uu___, FStar_Syntax_Syntax.U_succ
+             uu___1) -> ufailed_simple "Incompatible universes"
+          | (FStar_Syntax_Syntax.U_name uu___, FStar_Syntax_Syntax.U_zero) ->
               ufailed_simple "Incompatible universes"
 let (solve_universe_eq :
   Prims.int ->
@@ -3432,25 +3361,23 @@ let match_num_binders :
   =
   fun bc1 ->
     fun bc2 ->
-      let uu____9786 = bc1 in
-      match uu____9786 with
+      let uu___ = bc1 in
+      match uu___ with
       | (bs1, mk_cod1) ->
-          let uu____9830 = bc2 in
-          (match uu____9830 with
+          let uu___1 = bc2 in
+          (match uu___1 with
            | (bs2, mk_cod2) ->
                let rec aux bs11 bs21 =
                  match (bs11, bs21) with
                  | (x::xs, y::ys) ->
-                     let uu____9941 = aux xs ys in
-                     (match uu____9941 with
+                     let uu___2 = aux xs ys in
+                     (match uu___2 with
                       | ((xs1, xr), (ys1, yr)) ->
                           (((x :: xs1), xr), ((y :: ys1), yr)))
                  | (xs, ys) ->
-                     let uu____10024 =
-                       let uu____10031 = mk_cod1 xs in ([], uu____10031) in
-                     let uu____10034 =
-                       let uu____10041 = mk_cod2 ys in ([], uu____10041) in
-                     (uu____10024, uu____10034) in
+                     let uu___2 = let uu___3 = mk_cod1 xs in ([], uu___3) in
+                     let uu___3 = let uu___4 = mk_cod2 ys in ([], uu___4) in
+                     (uu___2, uu___3) in
                aux bs1 bs2)
 let (guard_of_prob :
   FStar_TypeChecker_Env.env ->
@@ -3467,51 +3394,49 @@ let (guard_of_prob :
             let has_type_guard t11 t21 =
               match problem.FStar_TypeChecker_Common.element with
               | FStar_Pervasives_Native.Some t ->
-                  let uu____10109 = FStar_Syntax_Syntax.bv_to_name t in
-                  FStar_Syntax_Util.mk_has_type t11 uu____10109 t21
+                  let uu___ = FStar_Syntax_Syntax.bv_to_name t in
+                  FStar_Syntax_Util.mk_has_type t11 uu___ t21
               | FStar_Pervasives_Native.None ->
                   let x =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       t11 in
                   let u_x = env.FStar_TypeChecker_Env.universe_of env t11 in
-                  let uu____10112 =
-                    let uu____10113 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Util.mk_has_type t11 uu____10113 t21 in
-                  FStar_Syntax_Util.mk_forall u_x x uu____10112 in
+                  let uu___ =
+                    let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
+                    FStar_Syntax_Util.mk_has_type t11 uu___1 t21 in
+                  FStar_Syntax_Util.mk_forall u_x x uu___ in
             match problem.FStar_TypeChecker_Common.relation with
             | FStar_TypeChecker_Common.EQ ->
                 mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
             | FStar_TypeChecker_Common.SUB ->
-                let uu____10118 = has_type_guard t1 t2 in (uu____10118, wl)
+                let uu___ = has_type_guard t1 t2 in (uu___, wl)
             | FStar_TypeChecker_Common.SUBINV ->
-                let uu____10119 = has_type_guard t2 t1 in (uu____10119, wl)
+                let uu___ = has_type_guard t2 t1 in (uu___, wl)
 let (is_flex_pat : flex_t -> Prims.bool) =
-  fun uu___22_10124 ->
-    match uu___22_10124 with
-    | Flex (uu____10125, uu____10126, []) -> true
-    | uu____10135 -> false
+  fun uu___ ->
+    match uu___ with | Flex (uu___1, uu___2, []) -> true | uu___1 -> false
 let (should_defer_flex_to_user_tac :
   FStar_TypeChecker_Env.env -> worklist -> flex_t -> Prims.bool) =
   fun env ->
     fun wl ->
       fun f ->
-        let uu____10151 = f in
-        match uu____10151 with
-        | Flex (uu____10152, u, uu____10154) ->
+        let uu___ = f in
+        match uu___ with
+        | Flex (uu___1, u, uu___2) ->
             let b =
               FStar_TypeChecker_DeferredImplicits.should_defer_uvar_to_user_tac
                 wl.tcenv u in
-            ((let uu____10157 =
+            ((let uu___4 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "ResolveImplicitsHook") in
-              if uu____10157
+              if uu___4
               then
-                let uu____10158 =
+                let uu___5 =
                   FStar_Syntax_Print.ctx_uvar_to_string_no_reason u in
-                let uu____10159 = FStar_Util.string_of_bool b in
+                let uu___6 = FStar_Util.string_of_bool b in
                 FStar_Util.print2
                   "Rel.should_defer_flex_to_user_tac for %s returning %s\n"
-                  uu____10158 uu____10159
+                  uu___5 uu___6
               else ());
              b)
 let (quasi_pattern :
@@ -3522,157 +3447,155 @@ let (quasi_pattern :
   =
   fun env ->
     fun f ->
-      let uu____10183 = f in
-      match uu____10183 with
+      let uu___ = f in
+      match uu___ with
       | Flex
-          (uu____10190,
-           { FStar_Syntax_Syntax.ctx_uvar_head = uu____10191;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10192;
+          (uu___1,
+           { FStar_Syntax_Syntax.ctx_uvar_head = uu___2;
+             FStar_Syntax_Syntax.ctx_uvar_gamma = uu___3;
              FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
              FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu____10195;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____10196;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu____10197;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu____10198;_},
+             FStar_Syntax_Syntax.ctx_uvar_reason = uu___4;
+             FStar_Syntax_Syntax.ctx_uvar_should_check = uu___5;
+             FStar_Syntax_Syntax.ctx_uvar_range = uu___6;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu___7;_},
            args)
           ->
           let name_exists_in x bs =
             FStar_Util.for_some
-              (fun uu____10262 ->
-                 match uu____10262 with
-                 | (y, uu____10270) -> FStar_Syntax_Syntax.bv_eq x y) bs in
+              (fun uu___8 ->
+                 match uu___8 with
+                 | (y, uu___9) -> FStar_Syntax_Syntax.bv_eq x y) bs in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([], []) ->
-                let uu____10424 =
-                  let uu____10439 =
-                    let uu____10442 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu____10442 in
-                  ((FStar_List.rev pat_binders), uu____10439) in
-                FStar_Pervasives_Native.Some uu____10424
-            | (uu____10475, []) ->
-                let uu____10506 =
-                  let uu____10521 =
-                    let uu____10524 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu____10524 in
-                  ((FStar_List.rev pat_binders), uu____10521) in
-                FStar_Pervasives_Native.Some uu____10506
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu___10 in
+                  ((FStar_List.rev pat_binders), uu___9) in
+                FStar_Pervasives_Native.Some uu___8
+            | (uu___8, []) ->
+                let uu___9 =
+                  let uu___10 =
+                    let uu___11 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu___11 in
+                  ((FStar_List.rev pat_binders), uu___10) in
+                FStar_Pervasives_Native.Some uu___9
             | ((formal, formal_imp)::formals1, (a, a_imp)::args2) ->
-                let uu____10615 =
-                  let uu____10616 = FStar_Syntax_Subst.compress a in
-                  uu____10616.FStar_Syntax_Syntax.n in
-                (match uu____10615 with
+                let uu___8 =
+                  let uu___9 = FStar_Syntax_Subst.compress a in
+                  uu___9.FStar_Syntax_Syntax.n in
+                (match uu___8 with
                  | FStar_Syntax_Syntax.Tm_name x ->
-                     let uu____10636 =
+                     let uu___9 =
                        (name_exists_in x ctx) ||
                          (name_exists_in x pat_binders) in
-                     if uu____10636
+                     if uu___9
                      then
                        aux ((formal, formal_imp) :: pat_binders) formals1
                          t_res args2
                      else
                        (let x1 =
-                          let uu___1695_10663 = x in
+                          let uu___11 = x in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1695_10663.FStar_Syntax_Syntax.ppname);
+                              (uu___11.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1695_10663.FStar_Syntax_Syntax.index);
+                              (uu___11.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort =
                               (formal.FStar_Syntax_Syntax.sort)
                           } in
                         let subst =
-                          let uu____10667 =
-                            let uu____10668 =
-                              let uu____10675 =
-                                FStar_Syntax_Syntax.bv_to_name x1 in
-                              (formal, uu____10675) in
-                            FStar_Syntax_Syntax.NT uu____10668 in
-                          [uu____10667] in
+                          let uu___11 =
+                            let uu___12 =
+                              let uu___13 = FStar_Syntax_Syntax.bv_to_name x1 in
+                              (formal, uu___13) in
+                            FStar_Syntax_Syntax.NT uu___12 in
+                          [uu___11] in
                         let formals2 =
                           FStar_Syntax_Subst.subst_binders subst formals1 in
                         let t_res1 = FStar_Syntax_Subst.subst subst t_res in
                         aux
-                          (((let uu___1701_10691 = x1 in
+                          (((let uu___11 = x1 in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1701_10691.FStar_Syntax_Syntax.ppname);
+                                 (uu___11.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1701_10691.FStar_Syntax_Syntax.index);
+                                 (uu___11.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort =
                                  (formal.FStar_Syntax_Syntax.sort)
                              }), a_imp) :: pat_binders) formals2 t_res1 args2)
-                 | uu____10692 ->
+                 | uu___9 ->
                      aux ((formal, formal_imp) :: pat_binders) formals1 t_res
                        args2)
             | ([], args2) ->
-                let uu____10732 =
-                  let uu____10739 =
+                let uu___8 =
+                  let uu___9 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res in
-                  FStar_Syntax_Util.arrow_formals uu____10739 in
-                (match uu____10732 with
+                  FStar_Syntax_Util.arrow_formals uu___9 in
+                (match uu___8 with
                  | (more_formals, t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu____10798 ->
-                          aux pat_binders more_formals t_res1 args2)) in
+                      | uu___9 -> aux pat_binders more_formals t_res1 args2)) in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu____10823 ->
-               let uu____10824 = FStar_Syntax_Util.arrow_formals t_hd in
-               (match uu____10824 with
+           | uu___8 ->
+               let uu___9 = FStar_Syntax_Util.arrow_formals t_hd in
+               (match uu___9 with
                 | (formals, t_res) -> aux [] formals t_res args))
 let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
   fun env ->
     fun probs ->
-      (let uu____11153 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Rel") in
-       if uu____11153
+       if uu___1
        then
-         let uu____11154 = wl_to_string probs in
-         FStar_Util.print1 "solve:\n\t%s\n" uu____11154
+         let uu___2 = wl_to_string probs in
+         FStar_Util.print1 "solve:\n\t%s\n" uu___2
        else ());
-      (let uu____11157 =
+      (let uu___2 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ImplicitTrace") in
-       if uu____11157
+       if uu___2
        then
-         let uu____11158 =
+         let uu___3 =
            FStar_TypeChecker_Common.implicits_to_string probs.wl_implicits in
-         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11158
+         FStar_Util.print1 "solve: wl_implicits = %s\n" uu___3
        else ());
-      (let uu____11160 = next_prob probs in
-       match uu____11160 with
+      (let uu___2 = next_prob probs in
+       match uu___2 with
        | FStar_Pervasives_Native.Some (hd, tl, rank1) ->
            let probs1 =
-             let uu___1728_11187 = probs in
+             let uu___3 = probs in
              {
                attempting = tl;
-               wl_deferred = (uu___1728_11187.wl_deferred);
-               wl_deferred_to_tac = (uu___1728_11187.wl_deferred_to_tac);
-               ctr = (uu___1728_11187.ctr);
-               defer_ok = (uu___1728_11187.defer_ok);
-               smt_ok = (uu___1728_11187.smt_ok);
-               umax_heuristic_ok = (uu___1728_11187.umax_heuristic_ok);
-               tcenv = (uu___1728_11187.tcenv);
-               wl_implicits = (uu___1728_11187.wl_implicits);
-               repr_subcomp_allowed = (uu___1728_11187.repr_subcomp_allowed)
+               wl_deferred = (uu___3.wl_deferred);
+               wl_deferred_to_tac = (uu___3.wl_deferred_to_tac);
+               ctr = (uu___3.ctr);
+               defer_ok = (uu___3.defer_ok);
+               smt_ok = (uu___3.smt_ok);
+               umax_heuristic_ok = (uu___3.umax_heuristic_ok);
+               tcenv = (uu___3.tcenv);
+               wl_implicits = (uu___3.wl_implicits);
+               repr_subcomp_allowed = (uu___3.repr_subcomp_allowed)
              } in
            (def_check_prob "solve,hd" hd;
             (match hd with
              | FStar_TypeChecker_Common.CProb cp ->
                  solve_c env (maybe_invert cp) probs1
              | FStar_TypeChecker_Common.TProb tp ->
-                 let uu____11195 =
+                 let uu___4 =
                    FStar_Util.physical_equality
                      tp.FStar_TypeChecker_Common.lhs
                      tp.FStar_TypeChecker_Common.rhs in
-                 if uu____11195
+                 if uu___4
                  then
-                   let uu____11196 =
+                   let uu___5 =
                      solve_prob hd FStar_Pervasives_Native.None [] probs1 in
-                   solve env uu____11196
+                   solve env uu___5
                  else
                    if
                      (rank1 = FStar_TypeChecker_Common.Rigid_rigid) ||
@@ -3689,28 +3612,28 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                        if rank1 = FStar_TypeChecker_Common.Flex_flex
                        then
                          solve_t env
-                           (let uu___1740_11201 = tp in
+                           (let uu___8 = tp in
                             {
                               FStar_TypeChecker_Common.pid =
-                                (uu___1740_11201.FStar_TypeChecker_Common.pid);
+                                (uu___8.FStar_TypeChecker_Common.pid);
                               FStar_TypeChecker_Common.lhs =
-                                (uu___1740_11201.FStar_TypeChecker_Common.lhs);
+                                (uu___8.FStar_TypeChecker_Common.lhs);
                               FStar_TypeChecker_Common.relation =
                                 FStar_TypeChecker_Common.EQ;
                               FStar_TypeChecker_Common.rhs =
-                                (uu___1740_11201.FStar_TypeChecker_Common.rhs);
+                                (uu___8.FStar_TypeChecker_Common.rhs);
                               FStar_TypeChecker_Common.element =
-                                (uu___1740_11201.FStar_TypeChecker_Common.element);
+                                (uu___8.FStar_TypeChecker_Common.element);
                               FStar_TypeChecker_Common.logical_guard =
-                                (uu___1740_11201.FStar_TypeChecker_Common.logical_guard);
+                                (uu___8.FStar_TypeChecker_Common.logical_guard);
                               FStar_TypeChecker_Common.logical_guard_uvar =
-                                (uu___1740_11201.FStar_TypeChecker_Common.logical_guard_uvar);
+                                (uu___8.FStar_TypeChecker_Common.logical_guard_uvar);
                               FStar_TypeChecker_Common.reason =
-                                (uu___1740_11201.FStar_TypeChecker_Common.reason);
+                                (uu___8.FStar_TypeChecker_Common.reason);
                               FStar_TypeChecker_Common.loc =
-                                (uu___1740_11201.FStar_TypeChecker_Common.loc);
+                                (uu___8.FStar_TypeChecker_Common.loc);
                               FStar_TypeChecker_Common.rank =
-                                (uu___1740_11201.FStar_TypeChecker_Common.rank)
+                                (uu___8.FStar_TypeChecker_Common.rank)
                             }) probs1
                        else
                          solve_rigid_flex_or_flex_rigid_subtyping rank1 env
@@ -3718,52 +3641,50 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
        | FStar_Pervasives_Native.None ->
            (match probs.wl_deferred with
             | [] ->
-                let uu____11219 =
-                  let uu____11226 = as_deferred probs.wl_deferred_to_tac in
-                  ([], uu____11226, (probs.wl_implicits)) in
-                Success uu____11219
-            | uu____11231 ->
-                let uu____11240 =
+                let uu___3 =
+                  let uu___4 = as_deferred probs.wl_deferred_to_tac in
+                  ([], uu___4, (probs.wl_implicits)) in
+                Success uu___3
+            | uu___3 ->
+                let uu___4 =
                   FStar_All.pipe_right probs.wl_deferred
                     (FStar_List.partition
-                       (fun uu____11299 ->
-                          match uu____11299 with
-                          | (c, uu____11307, uu____11308) -> c < probs.ctr)) in
-                (match uu____11240 with
+                       (fun uu___5 ->
+                          match uu___5 with
+                          | (c, uu___6, uu___7) -> c < probs.ctr)) in
+                (match uu___4 with
                  | (attempt1, rest) ->
                      (match attempt1 with
                       | [] ->
-                          let uu____11349 =
-                            let uu____11356 = as_deferred probs.wl_deferred in
-                            let uu____11357 =
-                              as_deferred probs.wl_deferred_to_tac in
-                            (uu____11356, uu____11357, (probs.wl_implicits)) in
-                          Success uu____11349
-                      | uu____11358 ->
-                          let uu____11367 =
-                            let uu___1754_11368 = probs in
-                            let uu____11369 =
+                          let uu___5 =
+                            let uu___6 = as_deferred probs.wl_deferred in
+                            let uu___7 = as_deferred probs.wl_deferred_to_tac in
+                            (uu___6, uu___7, (probs.wl_implicits)) in
+                          Success uu___5
+                      | uu___5 ->
+                          let uu___6 =
+                            let uu___7 = probs in
+                            let uu___8 =
                               FStar_All.pipe_right attempt1
                                 (FStar_List.map
-                                   (fun uu____11388 ->
-                                      match uu____11388 with
-                                      | (uu____11395, uu____11396, y) -> y)) in
+                                   (fun uu___9 ->
+                                      match uu___9 with
+                                      | (uu___10, uu___11, y) -> y)) in
                             {
-                              attempting = uu____11369;
+                              attempting = uu___8;
                               wl_deferred = rest;
                               wl_deferred_to_tac =
-                                (uu___1754_11368.wl_deferred_to_tac);
-                              ctr = (uu___1754_11368.ctr);
-                              defer_ok = (uu___1754_11368.defer_ok);
-                              smt_ok = (uu___1754_11368.smt_ok);
-                              umax_heuristic_ok =
-                                (uu___1754_11368.umax_heuristic_ok);
-                              tcenv = (uu___1754_11368.tcenv);
-                              wl_implicits = (uu___1754_11368.wl_implicits);
+                                (uu___7.wl_deferred_to_tac);
+                              ctr = (uu___7.ctr);
+                              defer_ok = (uu___7.defer_ok);
+                              smt_ok = (uu___7.smt_ok);
+                              umax_heuristic_ok = (uu___7.umax_heuristic_ok);
+                              tcenv = (uu___7.tcenv);
+                              wl_implicits = (uu___7.wl_implicits);
                               repr_subcomp_allowed =
-                                (uu___1754_11368.repr_subcomp_allowed)
+                                (uu___7.repr_subcomp_allowed)
                             } in
-                          solve env uu____11367))))
+                          solve env uu___6))))
 and (solve_one_universe_eq :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -3775,16 +3696,15 @@ and (solve_one_universe_eq :
       fun u1 ->
         fun u2 ->
           fun wl ->
-            let uu____11403 = solve_universe_eq (p_pid orig) wl u1 u2 in
-            match uu____11403 with
+            let uu___ = solve_universe_eq (p_pid orig) wl u1 u2 in
+            match uu___ with
             | USolved wl1 ->
-                let uu____11405 =
+                let uu___1 =
                   solve_prob orig FStar_Pervasives_Native.None [] wl1 in
-                solve env uu____11405
+                solve env uu___1
             | UFailed msg -> giveup env msg orig
             | UDeferred wl1 ->
-                let uu____11408 = defer_lit "" orig wl1 in
-                solve env uu____11408
+                let uu___1 = defer_lit "" orig wl1 in solve env uu___1
 and (solve_maybe_uinsts :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -3800,31 +3720,31 @@ and (solve_maybe_uinsts :
               match (us1, us2) with
               | ([], []) -> USolved wl1
               | (u1::us11, u2::us21) ->
-                  let uu____11458 = solve_universe_eq (p_pid orig) wl1 u1 u2 in
-                  (match uu____11458 with
+                  let uu___ = solve_universe_eq (p_pid orig) wl1 u1 u2 in
+                  (match uu___ with
                    | USolved wl2 -> aux wl2 us11 us21
                    | failed_or_deferred -> failed_or_deferred)
-              | uu____11461 -> ufailed_simple "Unequal number of universes" in
+              | uu___ -> ufailed_simple "Unequal number of universes" in
             let t11 = whnf env t1 in
             let t21 = whnf env t2 in
             match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))
             with
             | (FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                  FStar_Syntax_Syntax.pos = uu____11473;
-                  FStar_Syntax_Syntax.vars = uu____11474;_},
+                  FStar_Syntax_Syntax.pos = uu___;
+                  FStar_Syntax_Syntax.vars = uu___1;_},
                 us1),
                FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                  FStar_Syntax_Syntax.pos = uu____11477;
-                  FStar_Syntax_Syntax.vars = uu____11478;_},
+                  FStar_Syntax_Syntax.pos = uu___2;
+                  FStar_Syntax_Syntax.vars = uu___3;_},
                 us2)) ->
                 let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
-            | (FStar_Syntax_Syntax.Tm_uinst uu____11490, uu____11491) ->
+            | (FStar_Syntax_Syntax.Tm_uinst uu___, uu___1) ->
                 failwith "Impossible: expect head symbols to match"
-            | (uu____11498, FStar_Syntax_Syntax.Tm_uinst uu____11499) ->
+            | (uu___, FStar_Syntax_Syntax.Tm_uinst uu___1) ->
                 failwith "Impossible: expect head symbols to match"
-            | uu____11506 -> USolved wl
+            | uu___ -> USolved wl
 and (giveup_or_defer :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob -> worklist -> lstring -> solution)
@@ -3835,15 +3755,15 @@ and (giveup_or_defer :
         fun msg ->
           if wl.defer_ok
           then
-            ((let uu____11516 =
+            ((let uu___1 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel") in
-              if uu____11516
+              if uu___1
               then
-                let uu____11517 = prob_to_string env orig in
-                let uu____11518 = FStar_Thunk.force msg in
+                let uu___2 = prob_to_string env orig in
+                let uu___3 = FStar_Thunk.force msg in
                 FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
-                  uu____11517 uu____11518
+                  uu___2 uu___3
               else ());
              solve env (defer msg orig wl))
           else giveup env msg orig
@@ -3855,33 +3775,33 @@ and (defer_to_user_tac :
     fun orig ->
       fun reason ->
         fun wl ->
-          (let uu____11526 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____11526
+           if uu___1
            then
-             let uu____11527 = prob_to_string env orig in
-             FStar_Util.print1 "\n\t\tDeferring %s to a tactic\n" uu____11527
+             let uu___2 = prob_to_string env orig in
+             FStar_Util.print1 "\n\t\tDeferring %s to a tactic\n" uu___2
            else ());
           (let wl1 = solve_prob orig FStar_Pervasives_Native.None [] wl in
            let wl2 =
-             let uu___1838_11531 = wl1 in
-             let uu____11532 =
-               let uu____11541 =
-                 let uu____11548 = FStar_Thunk.mkv reason in
-                 ((wl1.ctr), uu____11548, orig) in
-               uu____11541 :: (wl1.wl_deferred_to_tac) in
+             let uu___1 = wl1 in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Thunk.mkv reason in
+                 ((wl1.ctr), uu___4, orig) in
+               uu___3 :: (wl1.wl_deferred_to_tac) in
              {
-               attempting = (uu___1838_11531.attempting);
-               wl_deferred = (uu___1838_11531.wl_deferred);
-               wl_deferred_to_tac = uu____11532;
-               ctr = (uu___1838_11531.ctr);
-               defer_ok = (uu___1838_11531.defer_ok);
-               smt_ok = (uu___1838_11531.smt_ok);
-               umax_heuristic_ok = (uu___1838_11531.umax_heuristic_ok);
-               tcenv = (uu___1838_11531.tcenv);
-               wl_implicits = (uu___1838_11531.wl_implicits);
-               repr_subcomp_allowed = (uu___1838_11531.repr_subcomp_allowed)
+               attempting = (uu___1.attempting);
+               wl_deferred = (uu___1.wl_deferred);
+               wl_deferred_to_tac = uu___2;
+               ctr = (uu___1.ctr);
+               defer_ok = (uu___1.defer_ok);
+               smt_ok = (uu___1.smt_ok);
+               umax_heuristic_ok = (uu___1.umax_heuristic_ok);
+               tcenv = (uu___1.tcenv);
+               wl_implicits = (uu___1.wl_implicits);
+               repr_subcomp_allowed = (uu___1.repr_subcomp_allowed)
              } in
            solve env wl2)
 and (maybe_defer_to_user_tac :
@@ -3896,27 +3816,25 @@ and (maybe_defer_to_user_tac :
           match prob.FStar_TypeChecker_Common.relation with
           | FStar_TypeChecker_Common.EQ ->
               let should_defer_tac t =
-                let uu____11571 = FStar_Syntax_Util.head_and_args t in
-                match uu____11571 with
-                | (head, uu____11593) ->
-                    let uu____11618 =
-                      let uu____11619 = FStar_Syntax_Subst.compress head in
-                      uu____11619.FStar_Syntax_Syntax.n in
-                    (match uu____11618 with
-                     | FStar_Syntax_Syntax.Tm_uvar (uv, uu____11627) ->
-                         let uu____11644 =
+                let uu___ = FStar_Syntax_Util.head_and_args t in
+                match uu___ with
+                | (head, uu___1) ->
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Subst.compress head in
+                      uu___3.FStar_Syntax_Syntax.n in
+                    (match uu___2 with
+                     | FStar_Syntax_Syntax.Tm_uvar (uv, uu___3) ->
+                         let uu___4 =
                            FStar_TypeChecker_DeferredImplicits.should_defer_uvar_to_user_tac
                              wl.tcenv uv in
-                         (uu____11644,
-                           (uv.FStar_Syntax_Syntax.ctx_uvar_reason))
-                     | uu____11645 -> (false, "")) in
-              let uu____11646 =
-                should_defer_tac prob.FStar_TypeChecker_Common.lhs in
-              (match uu____11646 with
+                         (uu___4, (uv.FStar_Syntax_Syntax.ctx_uvar_reason))
+                     | uu___3 -> (false, "")) in
+              let uu___ = should_defer_tac prob.FStar_TypeChecker_Common.lhs in
+              (match uu___ with
                | (l1, r1) ->
-                   let uu____11653 =
+                   let uu___1 =
                      should_defer_tac prob.FStar_TypeChecker_Common.rhs in
-                   (match uu____11653 with
+                   (match uu___1 with
                     | (l2, r2) ->
                         if l1 || l2
                         then
@@ -3924,14 +3842,14 @@ and (maybe_defer_to_user_tac :
                             (FStar_TypeChecker_Common.TProb prob)
                             (Prims.op_Hat r1 (Prims.op_Hat ", " r2)) wl
                         else
-                          (let uu____11661 =
+                          (let uu___3 =
                              defer_lit reason
                                (FStar_TypeChecker_Common.TProb prob) wl in
-                           solve env uu____11661)))
-          | uu____11662 ->
-              let uu____11663 =
+                           solve env uu___3)))
+          | uu___ ->
+              let uu___1 =
                 defer_lit reason (FStar_TypeChecker_Common.TProb prob) wl in
-              solve env uu____11663
+              solve env uu___1
 and (solve_rigid_flex_or_flex_rigid_subtyping :
   FStar_TypeChecker_Common.rank_t ->
     FStar_TypeChecker_Env.env -> tprob -> worklist -> solution)
@@ -3945,165 +3863,156 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
           (let flip = rank1 = FStar_TypeChecker_Common.Flex_rigid in
            let meet_or_join op ts env1 wl1 =
              let eq_prob t1 t2 wl2 =
-               let uu____11747 =
+               let uu___1 =
                  new_problem wl2 env1 t1 FStar_TypeChecker_Common.EQ t2
                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                    "join/meet refinements" in
-               match uu____11747 with
+               match uu___1 with
                | (p, wl3) ->
                    (def_check_prob "meet_or_join"
                       (FStar_TypeChecker_Common.TProb p);
                     ((FStar_TypeChecker_Common.TProb p), wl3)) in
              let pairwise t1 t2 wl2 =
-               (let uu____11800 =
+               (let uu___2 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                     (FStar_Options.Other "Rel") in
-                if uu____11800
+                if uu___2
                 then
-                  let uu____11801 = FStar_Syntax_Print.term_to_string t1 in
-                  let uu____11802 = FStar_Syntax_Print.term_to_string t2 in
+                  let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+                  let uu___4 = FStar_Syntax_Print.term_to_string t2 in
                   FStar_Util.print2 "[meet/join]: pairwise: %s and %s\n"
-                    uu____11801 uu____11802
+                    uu___3 uu___4
                 else ());
-               (let uu____11804 = head_matches_delta env1 wl2 t1 t2 in
-                match uu____11804 with
+               (let uu___2 = head_matches_delta env1 wl2 t1 t2 in
+                match uu___2 with
                 | (mr, ts1) ->
                     (match mr with
                      | HeadMatch (true) ->
-                         let uu____11849 = eq_prob t1 t2 wl2 in
-                         (match uu____11849 with | (p, wl3) -> (t1, [p], wl3))
-                     | MisMatch uu____11870 ->
-                         let uu____11879 = eq_prob t1 t2 wl2 in
-                         (match uu____11879 with | (p, wl3) -> (t1, [p], wl3))
+                         let uu___3 = eq_prob t1 t2 wl2 in
+                         (match uu___3 with | (p, wl3) -> (t1, [p], wl3))
+                     | MisMatch uu___3 ->
+                         let uu___4 = eq_prob t1 t2 wl2 in
+                         (match uu___4 with | (p, wl3) -> (t1, [p], wl3))
                      | FullMatch ->
                          (match ts1 with
                           | FStar_Pervasives_Native.None -> (t1, [], wl2)
                           | FStar_Pervasives_Native.Some (t11, t21) ->
                               (t11, [], wl2))
                      | HeadMatch (false) ->
-                         let uu____11928 =
+                         let uu___3 =
                            match ts1 with
                            | FStar_Pervasives_Native.Some (t11, t21) ->
-                               let uu____11943 =
-                                 FStar_Syntax_Subst.compress t11 in
-                               let uu____11944 =
-                                 FStar_Syntax_Subst.compress t21 in
-                               (uu____11943, uu____11944)
+                               let uu___4 = FStar_Syntax_Subst.compress t11 in
+                               let uu___5 = FStar_Syntax_Subst.compress t21 in
+                               (uu___4, uu___5)
                            | FStar_Pervasives_Native.None ->
-                               let uu____11949 =
-                                 FStar_Syntax_Subst.compress t1 in
-                               let uu____11950 =
-                                 FStar_Syntax_Subst.compress t2 in
-                               (uu____11949, uu____11950) in
-                         (match uu____11928 with
+                               let uu___4 = FStar_Syntax_Subst.compress t1 in
+                               let uu___5 = FStar_Syntax_Subst.compress t2 in
+                               (uu___4, uu___5) in
+                         (match uu___3 with
                           | (t11, t21) ->
                               let try_eq t12 t22 wl3 =
-                                let uu____11981 =
+                                let uu___4 =
                                   FStar_Syntax_Util.head_and_args t12 in
-                                match uu____11981 with
+                                match uu___4 with
                                 | (t1_hd, t1_args) ->
-                                    let uu____12026 =
+                                    let uu___5 =
                                       FStar_Syntax_Util.head_and_args t22 in
-                                    (match uu____12026 with
+                                    (match uu___5 with
                                      | (t2_hd, t2_args) ->
                                          if
                                            (FStar_List.length t1_args) <>
                                              (FStar_List.length t2_args)
                                          then FStar_Pervasives_Native.None
                                          else
-                                           (let uu____12090 =
-                                              let uu____12097 =
-                                                let uu____12108 =
+                                           (let uu___7 =
+                                              let uu___8 =
+                                                let uu___9 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t1_hd in
-                                                uu____12108 :: t1_args in
-                                              let uu____12125 =
-                                                let uu____12134 =
+                                                uu___9 :: t1_args in
+                                              let uu___9 =
+                                                let uu___10 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t2_hd in
-                                                uu____12134 :: t2_args in
+                                                uu___10 :: t2_args in
                                               FStar_List.fold_left2
-                                                (fun uu____12183 ->
-                                                   fun uu____12184 ->
-                                                     fun uu____12185 ->
-                                                       match (uu____12183,
-                                                               uu____12184,
-                                                               uu____12185)
+                                                (fun uu___10 ->
+                                                   fun uu___11 ->
+                                                     fun uu___12 ->
+                                                       match (uu___10,
+                                                               uu___11,
+                                                               uu___12)
                                                        with
                                                        | ((probs, wl4),
-                                                          (a1, uu____12235),
-                                                          (a2, uu____12237))
-                                                           ->
-                                                           let uu____12274 =
+                                                          (a1, uu___13),
+                                                          (a2, uu___14)) ->
+                                                           let uu___15 =
                                                              eq_prob a1 a2
                                                                wl4 in
-                                                           (match uu____12274
+                                                           (match uu___15
                                                             with
                                                             | (p, wl5) ->
                                                                 ((p ::
                                                                   probs),
                                                                   wl5)))
-                                                ([], wl3) uu____12097
-                                                uu____12125 in
-                                            match uu____12090 with
+                                                ([], wl3) uu___8 uu___9 in
+                                            match uu___7 with
                                             | (probs, wl4) ->
                                                 let wl' =
-                                                  let uu___1941_12300 = wl4 in
+                                                  let uu___8 = wl4 in
                                                   {
                                                     attempting = probs;
                                                     wl_deferred = [];
                                                     wl_deferred_to_tac =
-                                                      (uu___1941_12300.wl_deferred_to_tac);
-                                                    ctr =
-                                                      (uu___1941_12300.ctr);
+                                                      (uu___8.wl_deferred_to_tac);
+                                                    ctr = (uu___8.ctr);
                                                     defer_ok = false;
                                                     smt_ok = false;
                                                     umax_heuristic_ok =
-                                                      (uu___1941_12300.umax_heuristic_ok);
-                                                    tcenv =
-                                                      (uu___1941_12300.tcenv);
+                                                      (uu___8.umax_heuristic_ok);
+                                                    tcenv = (uu___8.tcenv);
                                                     wl_implicits = [];
                                                     repr_subcomp_allowed =
-                                                      (uu___1941_12300.repr_subcomp_allowed)
+                                                      (uu___8.repr_subcomp_allowed)
                                                   } in
                                                 let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     () in
-                                                let uu____12308 =
-                                                  solve env1 wl' in
-                                                (match uu____12308 with
+                                                let uu___8 = solve env1 wl' in
+                                                (match uu___8 with
                                                  | Success
-                                                     (uu____12311,
-                                                      defer_to_tac, imps)
+                                                     (uu___9, defer_to_tac,
+                                                      imps)
                                                      ->
                                                      (FStar_Syntax_Unionfind.commit
                                                         tx;
-                                                      (let uu____12315 =
+                                                      (let uu___11 =
                                                          extend_wl wl4
                                                            defer_to_tac imps in
                                                        FStar_Pervasives_Native.Some
-                                                         uu____12315))
-                                                 | Failed uu____12316 ->
+                                                         uu___11))
+                                                 | Failed uu___9 ->
                                                      (FStar_Syntax_Unionfind.rollback
                                                         tx;
                                                       FStar_Pervasives_Native.None)))) in
                               let combine t12 t22 wl3 =
-                                let uu____12348 =
+                                let uu___4 =
                                   base_and_refinement_maybe_delta false env1
                                     t12 in
-                                match uu____12348 with
+                                match uu___4 with
                                 | (t1_base, p1_opt) ->
-                                    let uu____12383 =
+                                    let uu___5 =
                                       base_and_refinement_maybe_delta false
                                         env1 t22 in
-                                    (match uu____12383 with
+                                    (match uu___5 with
                                      | (t2_base, p2_opt) ->
                                          let combine_refinements t_base
                                            p1_opt1 p2_opt1 =
                                            let refine x t =
-                                             let uu____12481 =
+                                             let uu___6 =
                                                FStar_Syntax_Util.is_t_true t in
-                                             if uu____12481
+                                             if uu___6
                                              then x.FStar_Syntax_Syntax.sort
                                              else
                                                FStar_Syntax_Util.refine x t in
@@ -4124,9 +4033,8 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi21 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi2 in
-                                               let uu____12529 =
-                                                 op phi11 phi21 in
-                                               refine x1 uu____12529
+                                               let uu___6 = op phi11 phi21 in
+                                               refine x1 uu___6
                                            | (FStar_Pervasives_Native.None,
                                               FStar_Pervasives_Native.Some
                                               (x, phi)) ->
@@ -4139,10 +4047,10 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi1 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi in
-                                               let uu____12559 =
+                                               let uu___6 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1 in
-                                               refine x1 uu____12559
+                                               refine x1 uu___6
                                            | (FStar_Pervasives_Native.Some
                                               (x, phi),
                                               FStar_Pervasives_Native.None)
@@ -4156,36 +4064,35 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi1 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi in
-                                               let uu____12589 =
+                                               let uu___6 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1 in
-                                               refine x1 uu____12589
-                                           | uu____12592 -> t_base in
-                                         let uu____12609 =
+                                               refine x1 uu___6
+                                           | uu___6 -> t_base in
+                                         let uu___6 =
                                            try_eq t1_base t2_base wl3 in
-                                         (match uu____12609 with
+                                         (match uu___6 with
                                           | FStar_Pervasives_Native.Some wl4
                                               ->
-                                              let uu____12623 =
+                                              let uu___7 =
                                                 combine_refinements t1_base
                                                   p1_opt p2_opt in
-                                              (uu____12623, [], wl4)
+                                              (uu___7, [], wl4)
                                           | FStar_Pervasives_Native.None ->
-                                              let uu____12630 =
+                                              let uu___7 =
                                                 base_and_refinement_maybe_delta
                                                   true env1 t12 in
-                                              (match uu____12630 with
+                                              (match uu___7 with
                                                | (t1_base1, p1_opt1) ->
-                                                   let uu____12665 =
+                                                   let uu___8 =
                                                      base_and_refinement_maybe_delta
                                                        true env1 t22 in
-                                                   (match uu____12665 with
+                                                   (match uu___8 with
                                                     | (t2_base1, p2_opt1) ->
-                                                        let uu____12700 =
+                                                        let uu___9 =
                                                           eq_prob t1_base1
                                                             t2_base1 wl3 in
-                                                        (match uu____12700
-                                                         with
+                                                        (match uu___9 with
                                                          | (p, wl4) ->
                                                              let t =
                                                                combine_refinements
@@ -4193,40 +4100,38 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                  p1_opt1
                                                                  p2_opt1 in
                                                              (t, [p], wl4)))))) in
-                              let uu____12724 = combine t11 t21 wl2 in
-                              (match uu____12724 with
+                              let uu___4 = combine t11 t21 wl2 in
+                              (match uu___4 with
                                | (t12, ps, wl3) ->
-                                   ((let uu____12757 =
+                                   ((let uu___6 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____12757
+                                     if uu___6
                                      then
-                                       let uu____12758 =
+                                       let uu___7 =
                                          FStar_Syntax_Print.term_to_string
                                            t12 in
                                        FStar_Util.print1
                                          "pairwise fallback2 succeeded: %s"
-                                         uu____12758
+                                         uu___7
                                      else ());
                                     (t12, ps, wl3)))))) in
-             let rec aux uu____12797 ts1 =
-               match uu____12797 with
+             let rec aux uu___1 ts1 =
+               match uu___1 with
                | (out, probs, wl2) ->
                    (match ts1 with
                     | [] -> (out, probs, wl2)
                     | t::ts2 ->
-                        let uu____12860 = pairwise out t wl2 in
-                        (match uu____12860 with
+                        let uu___2 = pairwise out t wl2 in
+                        (match uu___2 with
                          | (out1, probs', wl3) ->
                              aux
                                (out1, (FStar_List.append probs probs'), wl3)
                                ts2)) in
-             let uu____12896 =
-               let uu____12907 = FStar_List.hd ts in (uu____12907, [], wl1) in
-             let uu____12916 = FStar_List.tl ts in
-             aux uu____12896 uu____12916 in
-           let uu____12923 =
+             let uu___1 = let uu___2 = FStar_List.hd ts in (uu___2, [], wl1) in
+             let uu___2 = FStar_List.tl ts in aux uu___1 uu___2 in
+           let uu___1 =
              if flip
              then
                ((tp.FStar_TypeChecker_Common.lhs),
@@ -4234,40 +4139,39 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
              else
                ((tp.FStar_TypeChecker_Common.rhs),
                  (tp.FStar_TypeChecker_Common.lhs)) in
-           match uu____12923 with
+           match uu___1 with
            | (this_flex, this_rigid) ->
-               let uu____12947 =
-                 let uu____12948 = FStar_Syntax_Subst.compress this_rigid in
-                 uu____12948.FStar_Syntax_Syntax.n in
-               (match uu____12947 with
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress this_rigid in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
                 | FStar_Syntax_Syntax.Tm_arrow (_bs, comp) ->
-                    let uu____12973 =
-                      FStar_Syntax_Util.is_tot_or_gtot_comp comp in
-                    if uu____12973
+                    let uu___3 = FStar_Syntax_Util.is_tot_or_gtot_comp comp in
+                    if uu___3
                     then
-                      let uu____12974 = destruct_flex_t this_flex wl in
-                      (match uu____12974 with
+                      let uu___4 = destruct_flex_t this_flex wl in
+                      (match uu___4 with
                        | (flex, wl1) ->
-                           let uu____12981 = quasi_pattern env flex in
-                           (match uu____12981 with
+                           let uu___5 = quasi_pattern env flex in
+                           (match uu___5 with
                             | FStar_Pervasives_Native.None ->
                                 giveup_lit env
                                   "flex-arrow subtyping, not a quasi pattern"
                                   (FStar_TypeChecker_Common.TProb tp)
                             | FStar_Pervasives_Native.Some (flex_bs, flex_t1)
                                 ->
-                                ((let uu____12999 =
+                                ((let uu___7 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "Rel") in
-                                  if uu____12999
+                                  if uu___7
                                   then
-                                    let uu____13000 =
+                                    let uu___8 =
                                       FStar_Util.string_of_int
                                         tp.FStar_TypeChecker_Common.pid in
                                     FStar_Util.print1
                                       "Trying to solve by imitating arrow:%s\n"
-                                      uu____13000
+                                      uu___8
                                   else ());
                                  imitate_arrow
                                    (FStar_TypeChecker_Common.TProb tp) env
@@ -4275,77 +4179,76 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                    tp.FStar_TypeChecker_Common.relation
                                    this_rigid)))
                     else
-                      (let uu____13003 =
+                      (let uu___5 =
                          attempt
                            [FStar_TypeChecker_Common.TProb
-                              ((let uu___2051_13006 = tp in
+                              ((let uu___6 = tp in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.pid);
+                                    (uu___6.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.lhs);
+                                    (uu___6.FStar_TypeChecker_Common.lhs);
                                   FStar_TypeChecker_Common.relation =
                                     FStar_TypeChecker_Common.EQ;
                                   FStar_TypeChecker_Common.rhs =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.rhs);
+                                    (uu___6.FStar_TypeChecker_Common.rhs);
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.element);
+                                    (uu___6.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___6.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___6.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.reason);
+                                    (uu___6.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.loc);
+                                    (uu___6.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.rank)
+                                    (uu___6.FStar_TypeChecker_Common.rank)
                                 }))] wl in
-                       solve env uu____13003)
-                | uu____13007 ->
-                    ((let uu____13009 =
+                       solve env uu___5)
+                | uu___3 ->
+                    ((let uu___5 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Rel") in
-                      if uu____13009
+                      if uu___5
                       then
-                        let uu____13010 =
+                        let uu___6 =
                           FStar_Util.string_of_int
                             tp.FStar_TypeChecker_Common.pid in
                         FStar_Util.print1
                           "Trying to solve by meeting refinements:%s\n"
-                          uu____13010
+                          uu___6
                       else ());
-                     (let uu____13012 =
-                        FStar_Syntax_Util.head_and_args this_flex in
-                      match uu____13012 with
+                     (let uu___5 = FStar_Syntax_Util.head_and_args this_flex in
+                      match uu___5 with
                       | (u, _args) ->
-                          let uu____13055 =
-                            let uu____13056 = FStar_Syntax_Subst.compress u in
-                            uu____13056.FStar_Syntax_Syntax.n in
-                          (match uu____13055 with
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Subst.compress u in
+                            uu___7.FStar_Syntax_Syntax.n in
+                          (match uu___6 with
                            | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar, _subst)
                                ->
                                let equiv t =
-                                 let uu____13083 =
+                                 let uu___7 =
                                    FStar_Syntax_Util.head_and_args t in
-                                 match uu____13083 with
-                                 | (u', uu____13101) ->
-                                     let uu____13126 =
-                                       let uu____13127 = whnf env u' in
-                                       uu____13127.FStar_Syntax_Syntax.n in
-                                     (match uu____13126 with
+                                 match uu___7 with
+                                 | (u', uu___8) ->
+                                     let uu___9 =
+                                       let uu___10 = whnf env u' in
+                                       uu___10.FStar_Syntax_Syntax.n in
+                                     (match uu___9 with
                                       | FStar_Syntax_Syntax.Tm_uvar
                                           (ctx_uvar', _subst') ->
                                           FStar_Syntax_Unionfind.equiv
                                             ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                                             ctx_uvar'.FStar_Syntax_Syntax.ctx_uvar_head
-                                      | uu____13148 -> false) in
-                               let uu____13149 =
+                                      | uu___10 -> false) in
+                               let uu___7 =
                                  FStar_All.pipe_right wl.attempting
                                    (FStar_List.partition
-                                      (fun uu___23_13172 ->
-                                         match uu___23_13172 with
+                                      (fun uu___8 ->
+                                         match uu___8 with
                                          | FStar_TypeChecker_Common.TProb tp1
                                              ->
                                              let tp2 = maybe_invert tp1 in
@@ -4360,19 +4263,19 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                   else
                                                     equiv
                                                       tp2.FStar_TypeChecker_Common.rhs
-                                              | uu____13181 -> false)
-                                         | uu____13184 -> false)) in
-                               (match uu____13149 with
+                                              | uu___9 -> false)
+                                         | uu___9 -> false)) in
+                               (match uu___7 with
                                 | (bounds_probs, rest) ->
                                     let bounds_typs =
-                                      let uu____13198 = whnf env this_rigid in
-                                      let uu____13199 =
+                                      let uu___8 = whnf env this_rigid in
+                                      let uu___9 =
                                         FStar_List.collect
-                                          (fun uu___24_13205 ->
-                                             match uu___24_13205 with
+                                          (fun uu___10 ->
+                                             match uu___10 with
                                              | FStar_TypeChecker_Common.TProb
                                                  p ->
-                                                 let uu____13211 =
+                                                 let uu___11 =
                                                    if flip
                                                    then
                                                      whnf env
@@ -4380,43 +4283,42 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                    else
                                                      whnf env
                                                        (maybe_invert p).FStar_TypeChecker_Common.lhs in
-                                                 [uu____13211]
-                                             | uu____13213 -> [])
-                                          bounds_probs in
-                                      uu____13198 :: uu____13199 in
-                                    let uu____13214 =
+                                                 [uu___11]
+                                             | uu___11 -> []) bounds_probs in
+                                      uu___8 :: uu___9 in
+                                    let uu___8 =
                                       meet_or_join
                                         (if flip
                                          then FStar_Syntax_Util.mk_conj_simp
                                          else FStar_Syntax_Util.mk_disj_simp)
                                         bounds_typs env wl in
-                                    (match uu____13214 with
+                                    (match uu___8 with
                                      | (bound, sub_probs, wl1) ->
-                                         let uu____13245 =
+                                         let uu___9 =
                                            let flex_u =
                                              flex_uvar_head this_flex in
                                            let bound1 =
-                                             let uu____13260 =
-                                               let uu____13261 =
+                                             let uu___10 =
+                                               let uu___11 =
                                                  FStar_Syntax_Subst.compress
                                                    bound in
-                                               uu____13261.FStar_Syntax_Syntax.n in
-                                             match uu____13260 with
+                                               uu___11.FStar_Syntax_Syntax.n in
+                                             match uu___10 with
                                              | FStar_Syntax_Syntax.Tm_refine
                                                  (x, phi) when
                                                  (tp.FStar_TypeChecker_Common.relation
                                                     =
                                                     FStar_TypeChecker_Common.SUB)
                                                    &&
-                                                   (let uu____13273 =
+                                                   (let uu___11 =
                                                       occurs flex_u
                                                         x.FStar_Syntax_Syntax.sort in
                                                     FStar_Pervasives_Native.snd
-                                                      uu____13273)
+                                                      uu___11)
                                                  ->
                                                  x.FStar_Syntax_Syntax.sort
-                                             | uu____13282 -> bound in
-                                           let uu____13283 =
+                                             | uu___11 -> bound in
+                                           let uu___10 =
                                              new_problem wl1 env bound1
                                                FStar_TypeChecker_Common.EQ
                                                this_flex
@@ -4425,117 +4327,111 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                (if flip
                                                 then "joining refinements"
                                                 else "meeting refinements") in
-                                           (bound1, uu____13283) in
-                                         (match uu____13245 with
+                                           (bound1, uu___10) in
+                                         (match uu___9 with
                                           | (bound_typ, (eq_prob, wl')) ->
                                               (def_check_prob "meet_or_join2"
                                                  (FStar_TypeChecker_Common.TProb
                                                     eq_prob);
-                                               (let uu____13312 =
+                                               (let uu___12 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env)
                                                     (FStar_Options.Other
                                                        "Rel") in
-                                                if uu____13312
+                                                if uu___12
                                                 then
                                                   let wl'1 =
-                                                    let uu___2111_13314 = wl1 in
+                                                    let uu___13 = wl1 in
                                                     {
                                                       attempting =
                                                         ((FStar_TypeChecker_Common.TProb
                                                             eq_prob) ::
                                                         sub_probs);
                                                       wl_deferred =
-                                                        (uu___2111_13314.wl_deferred);
+                                                        (uu___13.wl_deferred);
                                                       wl_deferred_to_tac =
-                                                        (uu___2111_13314.wl_deferred_to_tac);
-                                                      ctr =
-                                                        (uu___2111_13314.ctr);
+                                                        (uu___13.wl_deferred_to_tac);
+                                                      ctr = (uu___13.ctr);
                                                       defer_ok =
-                                                        (uu___2111_13314.defer_ok);
+                                                        (uu___13.defer_ok);
                                                       smt_ok =
-                                                        (uu___2111_13314.smt_ok);
+                                                        (uu___13.smt_ok);
                                                       umax_heuristic_ok =
-                                                        (uu___2111_13314.umax_heuristic_ok);
-                                                      tcenv =
-                                                        (uu___2111_13314.tcenv);
+                                                        (uu___13.umax_heuristic_ok);
+                                                      tcenv = (uu___13.tcenv);
                                                       wl_implicits =
-                                                        (uu___2111_13314.wl_implicits);
+                                                        (uu___13.wl_implicits);
                                                       repr_subcomp_allowed =
-                                                        (uu___2111_13314.repr_subcomp_allowed)
+                                                        (uu___13.repr_subcomp_allowed)
                                                     } in
-                                                  let uu____13315 =
+                                                  let uu___13 =
                                                     wl_to_string wl'1 in
                                                   FStar_Util.print1
                                                     "After meet/join refinements: %s\n"
-                                                    uu____13315
+                                                    uu___13
                                                 else ());
                                                (let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     () in
-                                                let uu____13318 =
+                                                let uu___12 =
                                                   solve_t env eq_prob
-                                                    (let uu___2116_13320 =
-                                                       wl' in
+                                                    (let uu___13 = wl' in
                                                      {
                                                        attempting = sub_probs;
                                                        wl_deferred =
-                                                         (uu___2116_13320.wl_deferred);
+                                                         (uu___13.wl_deferred);
                                                        wl_deferred_to_tac =
-                                                         (uu___2116_13320.wl_deferred_to_tac);
-                                                       ctr =
-                                                         (uu___2116_13320.ctr);
+                                                         (uu___13.wl_deferred_to_tac);
+                                                       ctr = (uu___13.ctr);
                                                        defer_ok = false;
                                                        smt_ok =
-                                                         (uu___2116_13320.smt_ok);
+                                                         (uu___13.smt_ok);
                                                        umax_heuristic_ok =
-                                                         (uu___2116_13320.umax_heuristic_ok);
+                                                         (uu___13.umax_heuristic_ok);
                                                        tcenv =
-                                                         (uu___2116_13320.tcenv);
+                                                         (uu___13.tcenv);
                                                        wl_implicits = [];
                                                        repr_subcomp_allowed =
-                                                         (uu___2116_13320.repr_subcomp_allowed)
+                                                         (uu___13.repr_subcomp_allowed)
                                                      }) in
-                                                match uu____13318 with
+                                                match uu___12 with
                                                 | Success
-                                                    (uu____13321,
-                                                     defer_to_tac, imps)
+                                                    (uu___13, defer_to_tac,
+                                                     imps)
                                                     ->
                                                     let wl2 =
-                                                      let uu___2123_13325 =
-                                                        wl' in
+                                                      let uu___14 = wl' in
                                                       {
                                                         attempting = rest;
                                                         wl_deferred =
-                                                          (uu___2123_13325.wl_deferred);
+                                                          (uu___14.wl_deferred);
                                                         wl_deferred_to_tac =
-                                                          (uu___2123_13325.wl_deferred_to_tac);
-                                                        ctr =
-                                                          (uu___2123_13325.ctr);
+                                                          (uu___14.wl_deferred_to_tac);
+                                                        ctr = (uu___14.ctr);
                                                         defer_ok =
-                                                          (uu___2123_13325.defer_ok);
+                                                          (uu___14.defer_ok);
                                                         smt_ok =
-                                                          (uu___2123_13325.smt_ok);
+                                                          (uu___14.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2123_13325.umax_heuristic_ok);
+                                                          (uu___14.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2123_13325.tcenv);
+                                                          (uu___14.tcenv);
                                                         wl_implicits =
-                                                          (uu___2123_13325.wl_implicits);
+                                                          (uu___14.wl_implicits);
                                                         repr_subcomp_allowed
                                                           =
-                                                          (uu___2123_13325.repr_subcomp_allowed)
+                                                          (uu___14.repr_subcomp_allowed)
                                                       } in
                                                     let wl3 =
                                                       extend_wl wl2
                                                         defer_to_tac imps in
                                                     let g =
                                                       FStar_List.fold_left
-                                                        (fun g ->
+                                                        (fun g1 ->
                                                            fun p ->
                                                              FStar_Syntax_Util.mk_conj
-                                                               g (p_guard p))
+                                                               g1 (p_guard p))
                                                         eq_prob.FStar_TypeChecker_Common.logical_guard
                                                         sub_probs in
                                                     let wl4 =
@@ -4544,7 +4440,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                            tp)
                                                         (FStar_Pervasives_Native.Some
                                                            g) [] wl3 in
-                                                    let uu____13341 =
+                                                    let uu___14 =
                                                       FStar_List.fold_left
                                                         (fun wl5 ->
                                                            fun p ->
@@ -4557,16 +4453,16 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                        tx;
                                                      solve env wl4)
                                                 | Failed (p, msg) ->
-                                                    ((let uu____13352 =
+                                                    ((let uu___14 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "Rel") in
-                                                      if uu____13352
+                                                      if uu___14
                                                       then
-                                                        let uu____13353 =
-                                                          let uu____13354 =
+                                                        let uu___15 =
+                                                          let uu___16 =
                                                             FStar_List.map
                                                               (prob_to_string
                                                                  env)
@@ -4574,26 +4470,26 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                   eq_prob) ::
                                                               sub_probs) in
                                                           FStar_All.pipe_right
-                                                            uu____13354
+                                                            uu___16
                                                             (FStar_String.concat
                                                                "\n") in
                                                         FStar_Util.print1
                                                           "meet/join attempted and failed to solve problems:\n%s\n"
-                                                          uu____13353
+                                                          uu___15
                                                       else ());
-                                                     (let uu____13360 =
-                                                        let uu____13375 =
+                                                     (let uu___14 =
+                                                        let uu___15 =
                                                           base_and_refinement
                                                             env bound_typ in
-                                                        (rank1, uu____13375) in
-                                                      match uu____13360 with
+                                                        (rank1, uu___15) in
+                                                      match uu___14 with
                                                       | (FStar_TypeChecker_Common.Rigid_flex,
                                                          (t_base,
                                                           FStar_Pervasives_Native.Some
-                                                          uu____13397)) ->
+                                                          uu___15)) ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____13423 =
+                                                           (let uu___17 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4601,7 +4497,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 FStar_Pervasives_Native.None
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping" in
-                                                            match uu____13423
+                                                            match uu___17
                                                             with
                                                             | (eq_prob1, wl2)
                                                                 ->
@@ -4619,7 +4515,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     eq_prob1)))
                                                                     [] wl2 in
-                                                                  let uu____13440
+                                                                  let uu___19
                                                                     =
                                                                     attempt
                                                                     [
@@ -4627,14 +4523,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3 in
                                                                   solve env
-                                                                    uu____13440))))
+                                                                    uu___19))))
                                                       | (FStar_TypeChecker_Common.Flex_rigid,
                                                          (t_base,
                                                           FStar_Pervasives_Native.Some
                                                           (x, phi))) ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____13465 =
+                                                           (let uu___16 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4642,7 +4538,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 FStar_Pervasives_Native.None
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping" in
-                                                            match uu____13465
+                                                            match uu___16
                                                             with
                                                             | (eq_prob1, wl2)
                                                                 ->
@@ -4655,9 +4551,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     wl2 tp x
                                                                     phi in
                                                                   let wl3 =
-                                                                    let uu____13483
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____13488
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Util.mk_conj
                                                                     phi1
@@ -4665,14 +4561,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     eq_prob1)) in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____13488 in
+                                                                    uu___19 in
                                                                     solve_prob'
                                                                     false
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     tp)
-                                                                    uu____13483
+                                                                    uu___18
                                                                     [] wl2 in
-                                                                  let uu____13493
+                                                                  let uu___18
                                                                     =
                                                                     attempt
                                                                     [
@@ -4680,40 +4576,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3 in
                                                                   solve env
-                                                                    uu____13493))))
-                                                      | uu____13494 ->
-                                                          let uu____13509 =
+                                                                    uu___18))))
+                                                      | uu___15 ->
+                                                          let uu___16 =
                                                             FStar_Thunk.map
                                                               (fun s ->
                                                                  Prims.op_Hat
                                                                    "failed to solve the sub-problems: "
                                                                    s) msg in
-                                                          giveup env
-                                                            uu____13509 p)))))))
-                           | uu____13512 when flip ->
-                               let uu____13513 =
-                                 let uu____13514 =
+                                                          giveup env uu___16
+                                                            p)))))))
+                           | uu___7 when flip ->
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1) in
-                                 let uu____13515 =
+                                 let uu___10 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp) in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a flex-rigid: %s"
-                                   uu____13514 uu____13515 in
-                               failwith uu____13513
-                           | uu____13516 ->
-                               let uu____13517 =
-                                 let uu____13518 =
+                                   uu___9 uu___10 in
+                               failwith uu___8
+                           | uu___7 ->
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1) in
-                                 let uu____13519 =
+                                 let uu___10 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp) in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a rigid-flex: %s"
-                                   uu____13518 uu____13519 in
-                               failwith uu____13517)))))
+                                   uu___9 uu___10 in
+                               failwith uu___8)))))
 and (imitate_arrow :
   FStar_TypeChecker_Common.prob ->
     FStar_TypeChecker_Env.env ->
@@ -4734,37 +4630,36 @@ and (imitate_arrow :
                 fun arrow ->
                   let bs_lhs_args =
                     FStar_List.map
-                      (fun uu____13553 ->
-                         match uu____13553 with
+                      (fun uu___ ->
+                         match uu___ with
                          | (x, i) ->
-                             let uu____13572 =
-                               FStar_Syntax_Syntax.bv_to_name x in
-                             (uu____13572, i)) bs_lhs in
-                  let uu____13575 = lhs in
-                  match uu____13575 with
-                  | Flex (uu____13576, u_lhs, uu____13578) ->
+                             let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
+                             (uu___1, i)) bs_lhs in
+                  let uu___ = lhs in
+                  match uu___ with
+                  | Flex (uu___1, u_lhs, uu___2) ->
                       let imitate_comp bs bs_terms c wl1 =
                         let imitate_tot_or_gtot t uopt f wl2 =
-                          let uu____13675 =
+                          let uu___3 =
                             match uopt with
                             | FStar_Pervasives_Native.None ->
                                 FStar_Syntax_Util.type_u ()
                             | FStar_Pervasives_Native.Some univ ->
-                                let uu____13685 =
+                                let uu___4 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type univ)
                                     t.FStar_Syntax_Syntax.pos in
-                                (uu____13685, univ) in
-                          match uu____13675 with
+                                (uu___4, univ) in
+                          match uu___3 with
                           | (k, univ) ->
-                              let uu____13692 =
+                              let uu___4 =
                                 copy_uvar u_lhs (FStar_List.append bs_lhs bs)
                                   k wl2 in
-                              (match uu____13692 with
-                               | (uu____13709, u, wl3) ->
-                                   let uu____13712 =
+                              (match uu___4 with
+                               | (uu___5, u, wl3) ->
+                                   let uu___6 =
                                      f u (FStar_Pervasives_Native.Some univ) in
-                                   (uu____13712, wl3)) in
+                                   (uu___6, wl3)) in
                         match c.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Total (t, uopt) ->
                             imitate_tot_or_gtot t uopt
@@ -4773,152 +4668,141 @@ and (imitate_arrow :
                             imitate_tot_or_gtot t uopt
                               FStar_Syntax_Syntax.mk_GTotal' wl1
                         | FStar_Syntax_Syntax.Comp ct ->
-                            let uu____13738 =
-                              let uu____13751 =
-                                let uu____13762 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
                                   FStar_Syntax_Syntax.as_arg
                                     ct.FStar_Syntax_Syntax.result_typ in
-                                uu____13762 ::
+                                uu___5 ::
                                   (ct.FStar_Syntax_Syntax.effect_args) in
                               FStar_List.fold_right
-                                (fun uu____13813 ->
-                                   fun uu____13814 ->
-                                     match (uu____13813, uu____13814) with
+                                (fun uu___5 ->
+                                   fun uu___6 ->
+                                     match (uu___5, uu___6) with
                                      | ((a, i), (out_args, wl2)) ->
-                                         let uu____13915 =
-                                           let uu____13922 =
-                                             let uu____13925 =
+                                         let uu___7 =
+                                           let uu___8 =
+                                             let uu___9 =
                                                FStar_Syntax_Util.type_u () in
                                              FStar_All.pipe_left
                                                FStar_Pervasives_Native.fst
-                                               uu____13925 in
-                                           copy_uvar u_lhs [] uu____13922 wl2 in
-                                         (match uu____13915 with
-                                          | (uu____13954, t_a, wl3) ->
-                                              let uu____13957 =
+                                               uu___9 in
+                                           copy_uvar u_lhs [] uu___8 wl2 in
+                                         (match uu___7 with
+                                          | (uu___8, t_a, wl3) ->
+                                              let uu___9 =
                                                 copy_uvar u_lhs bs t_a wl3 in
-                                              (match uu____13957 with
-                                               | (uu____13976, a', wl4) ->
+                                              (match uu___9 with
+                                               | (uu___10, a', wl4) ->
                                                    (((a', i) :: out_args),
-                                                     wl4)))) uu____13751
-                                ([], wl1) in
-                            (match uu____13738 with
+                                                     wl4)))) uu___4 ([], wl1) in
+                            (match uu___3 with
                              | (out_args, wl2) ->
                                  let nodec flags =
                                    FStar_List.filter
-                                     (fun uu___25_14045 ->
-                                        match uu___25_14045 with
+                                     (fun uu___4 ->
+                                        match uu___4 with
                                         | FStar_Syntax_Syntax.DECREASES
-                                            uu____14046 -> false
-                                        | uu____14049 -> true) flags in
+                                            uu___5 -> false
+                                        | uu___5 -> true) flags in
                                  let ct' =
-                                   let uu___2242_14051 = ct in
-                                   let uu____14052 =
-                                     let uu____14055 = FStar_List.hd out_args in
-                                     FStar_Pervasives_Native.fst uu____14055 in
-                                   let uu____14070 = FStar_List.tl out_args in
-                                   let uu____14087 =
+                                   let uu___4 = ct in
+                                   let uu___5 =
+                                     let uu___6 = FStar_List.hd out_args in
+                                     FStar_Pervasives_Native.fst uu___6 in
+                                   let uu___6 = FStar_List.tl out_args in
+                                   let uu___7 =
                                      nodec ct.FStar_Syntax_Syntax.flags in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
-                                       (uu___2242_14051.FStar_Syntax_Syntax.comp_univs);
+                                       (uu___4.FStar_Syntax_Syntax.comp_univs);
                                      FStar_Syntax_Syntax.effect_name =
-                                       (uu___2242_14051.FStar_Syntax_Syntax.effect_name);
-                                     FStar_Syntax_Syntax.result_typ =
-                                       uu____14052;
-                                     FStar_Syntax_Syntax.effect_args =
-                                       uu____14070;
-                                     FStar_Syntax_Syntax.flags = uu____14087
+                                       (uu___4.FStar_Syntax_Syntax.effect_name);
+                                     FStar_Syntax_Syntax.result_typ = uu___5;
+                                     FStar_Syntax_Syntax.effect_args = uu___6;
+                                     FStar_Syntax_Syntax.flags = uu___7
                                    } in
-                                 ((let uu___2245_14091 = c in
+                                 ((let uu___4 = c in
                                    {
                                      FStar_Syntax_Syntax.n =
                                        (FStar_Syntax_Syntax.Comp ct');
                                      FStar_Syntax_Syntax.pos =
-                                       (uu___2245_14091.FStar_Syntax_Syntax.pos);
+                                       (uu___4.FStar_Syntax_Syntax.pos);
                                      FStar_Syntax_Syntax.vars =
-                                       (uu___2245_14091.FStar_Syntax_Syntax.vars)
+                                       (uu___4.FStar_Syntax_Syntax.vars)
                                    }), wl2)) in
-                      let uu____14094 =
-                        FStar_Syntax_Util.arrow_formals_comp arrow in
-                      (match uu____14094 with
+                      let uu___3 = FStar_Syntax_Util.arrow_formals_comp arrow in
+                      (match uu___3 with
                        | (formals, c) ->
                            let rec aux bs bs_terms formals1 wl1 =
                              match formals1 with
                              | [] ->
-                                 let uu____14132 =
-                                   imitate_comp bs bs_terms c wl1 in
-                                 (match uu____14132 with
+                                 let uu___4 = imitate_comp bs bs_terms c wl1 in
+                                 (match uu___4 with
                                   | (c', wl2) ->
                                       let lhs' =
                                         FStar_Syntax_Util.arrow bs c' in
                                       let sol =
-                                        let uu____14143 =
-                                          let uu____14148 =
+                                        let uu___5 =
+                                          let uu___6 =
                                             FStar_Syntax_Util.abs bs_lhs lhs'
                                               (FStar_Pervasives_Native.Some
                                                  (FStar_Syntax_Util.residual_tot
                                                     t_res_lhs)) in
-                                          (u_lhs, uu____14148) in
-                                        TERM uu____14143 in
-                                      let uu____14149 =
+                                          (u_lhs, uu___6) in
+                                        TERM uu___5 in
+                                      let uu___5 =
                                         mk_t_problem wl2 [] orig lhs' rel
                                           arrow FStar_Pervasives_Native.None
                                           "arrow imitation" in
-                                      (match uu____14149 with
+                                      (match uu___5 with
                                        | (sub_prob, wl3) ->
-                                           let uu____14162 =
-                                             let uu____14163 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                solve_prob orig
                                                  FStar_Pervasives_Native.None
                                                  [sol] wl3 in
-                                             attempt [sub_prob] uu____14163 in
-                                           solve env uu____14162))
+                                             attempt [sub_prob] uu___7 in
+                                           solve env uu___6))
                              | (x, imp)::formals2 ->
-                                 let uu____14185 =
-                                   let uu____14192 =
-                                     let uu____14195 =
-                                       FStar_Syntax_Util.type_u () in
-                                     FStar_All.pipe_right uu____14195
+                                 let uu___4 =
+                                   let uu___5 =
+                                     let uu___6 = FStar_Syntax_Util.type_u () in
+                                     FStar_All.pipe_right uu___6
                                        FStar_Pervasives_Native.fst in
                                    copy_uvar u_lhs
-                                     (FStar_List.append bs_lhs bs)
-                                     uu____14192 wl1 in
-                                 (match uu____14185 with
+                                     (FStar_List.append bs_lhs bs) uu___5 wl1 in
+                                 (match uu___4 with
                                   | (_ctx_u_x, u_x, wl2) ->
                                       let y =
-                                        let uu____14216 =
-                                          let uu____14219 =
+                                        let uu___5 =
+                                          let uu___6 =
                                             FStar_Syntax_Syntax.range_of_bv x in
-                                          FStar_Pervasives_Native.Some
-                                            uu____14219 in
-                                        FStar_Syntax_Syntax.new_bv
-                                          uu____14216 u_x in
-                                      let uu____14220 =
-                                        let uu____14223 =
-                                          let uu____14226 =
-                                            let uu____14227 =
+                                          FStar_Pervasives_Native.Some uu___6 in
+                                        FStar_Syntax_Syntax.new_bv uu___5 u_x in
+                                      let uu___5 =
+                                        let uu___6 =
+                                          let uu___7 =
+                                            let uu___8 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 y in
-                                            (uu____14227, imp) in
-                                          [uu____14226] in
-                                        FStar_List.append bs_terms
-                                          uu____14223 in
+                                            (uu___8, imp) in
+                                          [uu___7] in
+                                        FStar_List.append bs_terms uu___6 in
                                       aux (FStar_List.append bs [(y, imp)])
-                                        uu____14220 formals2 wl2) in
-                           let uu____14254 = occurs_check u_lhs arrow in
-                           (match uu____14254 with
-                            | (uu____14265, occurs_ok, msg) ->
+                                        uu___5 formals2 wl2) in
+                           let uu___4 = occurs_check u_lhs arrow in
+                           (match uu___4 with
+                            | (uu___5, occurs_ok, msg) ->
                                 if Prims.op_Negation occurs_ok
                                 then
-                                  let uu____14276 =
+                                  let uu___6 =
                                     mklstr
-                                      (fun uu____14281 ->
-                                         let uu____14282 =
-                                           FStar_Option.get msg in
+                                      (fun uu___7 ->
+                                         let uu___8 = FStar_Option.get msg in
                                          Prims.op_Hat "occurs-check failed: "
-                                           uu____14282) in
-                                  giveup_or_defer env orig wl uu____14276
+                                           uu___8) in
+                                  giveup_or_defer env orig wl uu___6
                                 else aux [] [] formals wl))
 and (solve_binders :
   FStar_TypeChecker_Env.env ->
@@ -4939,122 +4823,119 @@ and (solve_binders :
         fun orig ->
           fun wl ->
             fun rhs ->
-              (let uu____14311 =
+              (let uu___1 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel") in
-               if uu____14311
+               if uu___1
                then
-                 let uu____14312 =
-                   FStar_Syntax_Print.binders_to_string ", " bs1 in
-                 let uu____14313 =
-                   FStar_Syntax_Print.binders_to_string ", " bs2 in
-                 FStar_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n"
-                   uu____14312 (rel_to_string (p_rel orig)) uu____14313
+                 let uu___2 = FStar_Syntax_Print.binders_to_string ", " bs1 in
+                 let uu___3 = FStar_Syntax_Print.binders_to_string ", " bs2 in
+                 FStar_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n" uu___2
+                   (rel_to_string (p_rel orig)) uu___3
                else ());
               (let rec aux wl1 scope env1 subst xs ys =
                  match (xs, ys) with
                  | ([], []) ->
-                     let uu____14438 = rhs wl1 scope env1 subst in
-                     (match uu____14438 with
+                     let uu___1 = rhs wl1 scope env1 subst in
+                     (match uu___1 with
                       | (rhs_prob, wl2) ->
-                          ((let uu____14460 =
+                          ((let uu___3 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "Rel") in
-                            if uu____14460
+                            if uu___3
                             then
-                              let uu____14461 = prob_to_string env1 rhs_prob in
-                              FStar_Util.print1 "rhs_prob = %s\n" uu____14461
+                              let uu___4 = prob_to_string env1 rhs_prob in
+                              FStar_Util.print1 "rhs_prob = %s\n" uu___4
                             else ());
                            (let formula = p_guard rhs_prob in
                             (env1, (FStar_Util.Inl ([rhs_prob], formula)),
                               wl2))))
                  | ((hd1, imp)::xs1, (hd2, imp')::ys1) when
-                     let uu____14534 = FStar_Syntax_Util.eq_aqual imp imp' in
-                     uu____14534 = FStar_Syntax_Util.Equal ->
+                     let uu___1 = FStar_Syntax_Util.eq_aqual imp imp' in
+                     uu___1 = FStar_Syntax_Util.Equal ->
                      let hd11 =
-                       let uu___2315_14536 = hd1 in
-                       let uu____14537 =
+                       let uu___1 = hd1 in
+                       let uu___2 =
                          FStar_Syntax_Subst.subst subst
                            hd1.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2315_14536.FStar_Syntax_Syntax.ppname);
+                           (uu___1.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2315_14536.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____14537
+                           (uu___1.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu___2
                        } in
                      let hd21 =
-                       let uu___2318_14541 = hd2 in
-                       let uu____14542 =
+                       let uu___1 = hd2 in
+                       let uu___2 =
                          FStar_Syntax_Subst.subst subst
                            hd2.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2318_14541.FStar_Syntax_Syntax.ppname);
+                           (uu___1.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2318_14541.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____14542
+                           (uu___1.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu___2
                        } in
-                     let uu____14545 =
-                       let uu____14550 =
+                     let uu___1 =
+                       let uu___2 =
                          FStar_All.pipe_left invert_rel (p_rel orig) in
                        mk_t_problem wl1 scope orig
-                         hd11.FStar_Syntax_Syntax.sort uu____14550
+                         hd11.FStar_Syntax_Syntax.sort uu___2
                          hd21.FStar_Syntax_Syntax.sort
                          FStar_Pervasives_Native.None "Formal parameter" in
-                     (match uu____14545 with
+                     (match uu___1 with
                       | (prob, wl2) ->
                           let hd12 = FStar_Syntax_Syntax.freshen_bv hd11 in
                           let subst1 =
-                            let uu____14571 =
+                            let uu___2 =
                               FStar_Syntax_Subst.shift_subst Prims.int_one
                                 subst in
                             (FStar_Syntax_Syntax.DB (Prims.int_zero, hd12))
-                              :: uu____14571 in
+                              :: uu___2 in
                           let env2 = FStar_TypeChecker_Env.push_bv env1 hd12 in
-                          let uu____14575 =
+                          let uu___2 =
                             aux wl2 (FStar_List.append scope [(hd12, imp)])
                               env2 subst1 xs1 ys1 in
-                          (match uu____14575 with
+                          (match uu___2 with
                            | (env3, FStar_Util.Inl (sub_probs, phi), wl3) ->
                                let phi1 =
-                                 let uu____14643 =
+                                 let uu___3 =
                                    FStar_TypeChecker_Env.close_forall env3
                                      [(hd12, imp)] phi in
                                  FStar_Syntax_Util.mk_conj (p_guard prob)
-                                   uu____14643 in
-                               ((let uu____14661 =
+                                   uu___3 in
+                               ((let uu___4 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env3)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____14661
+                                 if uu___4
                                  then
-                                   let uu____14662 =
+                                   let uu___5 =
                                      FStar_Syntax_Print.term_to_string phi1 in
-                                   let uu____14663 =
+                                   let uu___6 =
                                      FStar_Syntax_Print.bv_to_string hd12 in
                                    FStar_Util.print2
-                                     "Formula is %s\n\thd1=%s\n" uu____14662
-                                     uu____14663
+                                     "Formula is %s\n\thd1=%s\n" uu___5
+                                     uu___6
                                  else ());
                                 (env3,
                                   (FStar_Util.Inl ((prob :: sub_probs), phi1)),
                                   wl3))
                            | fail -> fail))
-                 | uu____14692 ->
+                 | uu___1 ->
                      (env1,
                        (FStar_Util.Inr "arity or argument-qualifier mismatch"),
                        wl1) in
-               let uu____14725 = aux wl [] env [] bs1 bs2 in
-               match uu____14725 with
+               let uu___1 = aux wl [] env [] bs1 bs2 in
+               match uu___1 with
                | (env1, FStar_Util.Inr msg, wl1) -> giveup_lit env1 msg orig
                | (env1, FStar_Util.Inl (sub_probs, phi), wl1) ->
                    let wl2 =
                      solve_prob orig (FStar_Pervasives_Native.Some phi) []
                        wl1 in
-                   let uu____14778 = attempt sub_probs wl2 in
-                   solve env1 uu____14778)
+                   let uu___2 = attempt sub_probs wl2 in solve env1 uu___2)
 and (try_solve_without_smt_or_else :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -5068,23 +4949,23 @@ and (try_solve_without_smt_or_else :
       fun try_solve ->
         fun else_solve ->
           let wl' =
-            let uu___2356_14798 = wl in
+            let uu___ = wl in
             {
               attempting = [];
               wl_deferred = [];
-              wl_deferred_to_tac = (uu___2356_14798.wl_deferred_to_tac);
-              ctr = (uu___2356_14798.ctr);
+              wl_deferred_to_tac = (uu___.wl_deferred_to_tac);
+              ctr = (uu___.ctr);
               defer_ok = false;
               smt_ok = false;
               umax_heuristic_ok = false;
-              tcenv = (uu___2356_14798.tcenv);
+              tcenv = (uu___.tcenv);
               wl_implicits = [];
-              repr_subcomp_allowed = (uu___2356_14798.repr_subcomp_allowed)
+              repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
             } in
           let tx = FStar_Syntax_Unionfind.new_transaction () in
-          let uu____14806 = try_solve env wl' in
-          match uu____14806 with
-          | Success (uu____14807, defer_to_tac, imps) ->
+          let uu___ = try_solve env wl' in
+          match uu___ with
+          | Success (uu___1, defer_to_tac, imps) ->
               (FStar_Syntax_Unionfind.commit tx;
                (let wl1 = extend_wl wl defer_to_tac imps in solve env wl1))
           | Failed (p, s) ->
@@ -5094,8 +4975,8 @@ and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
     fun problem ->
       fun wl ->
         def_check_prob "solve_t" (FStar_TypeChecker_Common.TProb problem);
-        (let uu____14819 = compress_tprob wl.tcenv problem in
-         solve_t' env uu____14819 wl)
+        (let uu___1 = compress_tprob wl.tcenv problem in
+         solve_t' env uu___1 wl)
 and (solve_t_flex_rigid_eq :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -5106,60 +4987,59 @@ and (solve_t_flex_rigid_eq :
       fun wl ->
         fun lhs ->
           fun rhs ->
-            (let uu____14826 =
+            (let uu___1 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Rel") in
-             if uu____14826
+             if uu___1
              then FStar_Util.print_string "solve_t_flex_rigid_eq\n"
              else ());
-            (let uu____14828 = should_defer_flex_to_user_tac env wl lhs in
-             if uu____14828
+            (let uu___1 = should_defer_flex_to_user_tac env wl lhs in
+             if uu___1
              then defer_to_user_tac env orig (flex_reason lhs) wl
              else
                (let binders_as_bv_set bs =
-                  let uu____14838 =
-                    FStar_List.map FStar_Pervasives_Native.fst bs in
-                  FStar_Util.as_set uu____14838 FStar_Syntax_Syntax.order_bv in
+                  let uu___3 = FStar_List.map FStar_Pervasives_Native.fst bs in
+                  FStar_Util.as_set uu___3 FStar_Syntax_Syntax.order_bv in
                 let mk_solution env1 lhs1 bs rhs1 =
-                  let uu____14872 = lhs1 in
-                  match uu____14872 with
-                  | Flex (uu____14875, ctx_u, uu____14877) ->
+                  let uu___3 = lhs1 in
+                  match uu___3 with
+                  | Flex (uu___4, ctx_u, uu___5) ->
                       let sol =
                         match bs with
                         | [] -> rhs1
-                        | uu____14885 ->
-                            let uu____14886 = sn_binders env1 bs in
+                        | uu___6 ->
+                            let uu___7 = sn_binders env1 bs in
                             u_abs ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
-                              uu____14886 rhs1 in
+                              uu___7 rhs1 in
                       [TERM (ctx_u, sol)] in
                 let try_quasi_pattern orig1 env1 wl1 lhs1 rhs1 =
-                  (let uu____14934 =
+                  (let uu___4 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                        (FStar_Options.Other "Rel") in
-                   if uu____14934
+                   if uu___4
                    then FStar_Util.print_string "try_quasi_pattern\n"
                    else ());
-                  (let uu____14936 = quasi_pattern env1 lhs1 in
-                   match uu____14936 with
+                  (let uu___4 = quasi_pattern env1 lhs1 in
+                   match uu___4 with
                    | FStar_Pervasives_Native.None ->
                        ((FStar_Util.Inl "Not a quasi-pattern"), wl1)
-                   | FStar_Pervasives_Native.Some (bs, uu____14966) ->
-                       let uu____14971 = lhs1 in
-                       (match uu____14971 with
+                   | FStar_Pervasives_Native.Some (bs, uu___5) ->
+                       let uu___6 = lhs1 in
+                       (match uu___6 with
                         | Flex (t_lhs, ctx_u, args) ->
-                            let uu____14985 = occurs_check ctx_u rhs1 in
-                            (match uu____14985 with
+                            let uu___7 = occurs_check ctx_u rhs1 in
+                            (match uu___7 with
                              | (uvars, occurs_ok, msg) ->
                                  if Prims.op_Negation occurs_ok
                                  then
-                                   let uu____15027 =
-                                     let uu____15034 =
-                                       let uu____15035 = FStar_Option.get msg in
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 = FStar_Option.get msg in
                                        Prims.op_Hat
                                          "quasi-pattern, occurs-check failed: "
-                                         uu____15035 in
-                                     FStar_Util.Inl uu____15034 in
-                                   (uu____15027, wl1)
+                                         uu___10 in
+                                     FStar_Util.Inl uu___9 in
+                                   (uu___8, wl1)
                                  else
                                    (let fvs_lhs =
                                       binders_as_bv_set
@@ -5168,115 +5048,112 @@ and (solve_t_flex_rigid_eq :
                                            bs) in
                                     let fvs_rhs =
                                       FStar_Syntax_Free.names rhs1 in
-                                    let uu____15057 =
-                                      let uu____15058 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_Util.set_is_subset_of fvs_rhs
                                           fvs_lhs in
-                                      Prims.op_Negation uu____15058 in
-                                    if uu____15057
+                                      Prims.op_Negation uu___10 in
+                                    if uu___9
                                     then
                                       ((FStar_Util.Inl
                                           "quasi-pattern, free names on the RHS are not included in the LHS"),
                                         wl1)
                                     else
-                                      (let uu____15078 =
-                                         let uu____15085 =
+                                      (let uu___11 =
+                                         let uu___12 =
                                            mk_solution env1 lhs1 bs rhs1 in
-                                         FStar_Util.Inr uu____15085 in
-                                       let uu____15090 =
+                                         FStar_Util.Inr uu___12 in
+                                       let uu___12 =
                                          restrict_all_uvars env1 ctx_u []
                                            uvars wl1 in
-                                       (uu____15078, uu____15090)))))) in
+                                       (uu___11, uu___12)))))) in
                 let imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1 =
-                  let uu____15139 = FStar_Syntax_Util.head_and_args rhs1 in
-                  match uu____15139 with
+                  let uu___3 = FStar_Syntax_Util.head_and_args rhs1 in
+                  match uu___3 with
                   | (rhs_hd, args) ->
-                      let uu____15182 = FStar_Util.prefix args in
-                      (match uu____15182 with
+                      let uu___4 = FStar_Util.prefix args in
+                      (match uu___4 with
                        | (args_rhs, last_arg_rhs) ->
                            let rhs' =
                              FStar_Syntax_Syntax.mk_Tm_app rhs_hd args_rhs
                                rhs1.FStar_Syntax_Syntax.pos in
-                           let uu____15252 = lhs1 in
-                           (match uu____15252 with
+                           let uu___5 = lhs1 in
+                           (match uu___5 with
                             | Flex (t_lhs, u_lhs, _lhs_args) ->
-                                let uu____15256 =
-                                  let uu____15267 =
-                                    let uu____15274 =
-                                      let uu____15277 =
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_Syntax_Util.type_u () in
                                       FStar_All.pipe_left
-                                        FStar_Pervasives_Native.fst
-                                        uu____15277 in
-                                    copy_uvar u_lhs [] uu____15274 wl1 in
-                                  match uu____15267 with
-                                  | (uu____15304, t_last_arg, wl2) ->
-                                      let uu____15307 =
+                                        FStar_Pervasives_Native.fst uu___9 in
+                                    copy_uvar u_lhs [] uu___8 wl1 in
+                                  match uu___7 with
+                                  | (uu___8, t_last_arg, wl2) ->
+                                      let uu___9 =
                                         let b =
                                           FStar_Syntax_Syntax.null_binder
                                             t_last_arg in
-                                        let uu____15315 =
-                                          let uu____15318 =
-                                            let uu____15321 =
-                                              let uu____15324 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              let uu___13 =
                                                 FStar_All.pipe_right
                                                   t_res_lhs
                                                   (env1.FStar_TypeChecker_Env.universe_of
                                                      env1) in
-                                              FStar_All.pipe_right
-                                                uu____15324
-                                                (fun uu____15327 ->
+                                              FStar_All.pipe_right uu___13
+                                                (fun uu___14 ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____15327) in
-                                            FStar_All.pipe_right uu____15321
+                                                     uu___14) in
+                                            FStar_All.pipe_right uu___12
                                               (FStar_Syntax_Syntax.mk_Total'
                                                  t_res_lhs) in
-                                          FStar_All.pipe_right uu____15318
+                                          FStar_All.pipe_right uu___11
                                             (FStar_Syntax_Util.arrow [b]) in
                                         copy_uvar u_lhs
                                           (FStar_List.append bs_lhs [b])
-                                          uu____15315 wl2 in
-                                      (match uu____15307 with
-                                       | (uu____15376, lhs', wl3) ->
-                                           let uu____15379 =
+                                          uu___10 wl2 in
+                                      (match uu___9 with
+                                       | (uu___10, lhs', wl3) ->
+                                           let uu___11 =
                                              copy_uvar u_lhs bs_lhs
                                                t_last_arg wl3 in
-                                           (match uu____15379 with
-                                            | (uu____15396, lhs'_last_arg,
-                                               wl4) ->
-                                                (lhs', lhs'_last_arg, wl4))) in
-                                (match uu____15256 with
+                                           (match uu___11 with
+                                            | (uu___12, lhs'_last_arg, wl4)
+                                                -> (lhs', lhs'_last_arg, wl4))) in
+                                (match uu___6 with
                                  | (lhs', lhs'_last_arg, wl2) ->
                                      let sol =
-                                       let uu____15417 =
-                                         let uu____15418 =
-                                           let uu____15423 =
-                                             let uu____15424 =
-                                               let uu____15427 =
-                                                 let uu____15428 =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 =
+                                                 let uu___12 =
                                                    FStar_Syntax_Syntax.as_arg
                                                      lhs'_last_arg in
-                                                 [uu____15428] in
+                                                 [uu___12] in
                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                 lhs' uu____15427
+                                                 lhs' uu___11
                                                  t_lhs.FStar_Syntax_Syntax.pos in
                                              FStar_Syntax_Util.abs bs_lhs
-                                               uu____15424
+                                               uu___10
                                                (FStar_Pervasives_Native.Some
                                                   (FStar_Syntax_Util.residual_tot
                                                      t_res_lhs)) in
-                                           (u_lhs, uu____15423) in
-                                         TERM uu____15418 in
-                                       [uu____15417] in
-                                     let uu____15453 =
-                                       let uu____15460 =
+                                           (u_lhs, uu___9) in
+                                         TERM uu___8 in
+                                       [uu___7] in
+                                     let uu___7 =
+                                       let uu___8 =
                                          mk_t_problem wl2 [] orig1 lhs'
                                            FStar_TypeChecker_Common.EQ rhs'
                                            FStar_Pervasives_Native.None
                                            "first-order lhs" in
-                                       match uu____15460 with
+                                       match uu___8 with
                                        | (p1, wl3) ->
-                                           let uu____15479 =
+                                           let uu___9 =
                                              mk_t_problem wl3 [] orig1
                                                lhs'_last_arg
                                                FStar_TypeChecker_Common.EQ
@@ -5284,115 +5161,110 @@ and (solve_t_flex_rigid_eq :
                                                   last_arg_rhs)
                                                FStar_Pervasives_Native.None
                                                "first-order rhs" in
-                                           (match uu____15479 with
+                                           (match uu___9 with
                                             | (p2, wl4) -> ([p1; p2], wl4)) in
-                                     (match uu____15453 with
+                                     (match uu___7 with
                                       | (sub_probs, wl3) ->
-                                          let uu____15510 =
-                                            let uu____15511 =
+                                          let uu___8 =
+                                            let uu___9 =
                                               solve_prob orig1
                                                 FStar_Pervasives_Native.None
                                                 sol wl3 in
-                                            attempt sub_probs uu____15511 in
-                                          solve env1 uu____15510)))) in
+                                            attempt sub_probs uu___9 in
+                                          solve env1 uu___8)))) in
                 let first_order orig1 env1 wl1 lhs1 rhs1 =
-                  (let uu____15539 =
+                  (let uu___4 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                        (FStar_Options.Other "Rel") in
-                   if uu____15539
+                   if uu___4
                    then FStar_Util.print_string "first_order\n"
                    else ());
                   (let is_app rhs2 =
-                     let uu____15547 = FStar_Syntax_Util.head_and_args rhs2 in
-                     match uu____15547 with
-                     | (uu____15564, args) ->
-                         (match args with | [] -> false | uu____15598 -> true) in
+                     let uu___4 = FStar_Syntax_Util.head_and_args rhs2 in
+                     match uu___4 with
+                     | (uu___5, args) ->
+                         (match args with | [] -> false | uu___6 -> true) in
                    let is_arrow rhs2 =
-                     let uu____15615 =
-                       let uu____15616 = FStar_Syntax_Subst.compress rhs2 in
-                       uu____15616.FStar_Syntax_Syntax.n in
-                     match uu____15615 with
-                     | FStar_Syntax_Syntax.Tm_arrow uu____15619 -> true
-                     | uu____15634 -> false in
-                   let uu____15635 = quasi_pattern env1 lhs1 in
-                   match uu____15635 with
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Subst.compress rhs2 in
+                       uu___5.FStar_Syntax_Syntax.n in
+                     match uu___4 with
+                     | FStar_Syntax_Syntax.Tm_arrow uu___5 -> true
+                     | uu___5 -> false in
+                   let uu___4 = quasi_pattern env1 lhs1 in
+                   match uu___4 with
                    | FStar_Pervasives_Native.None ->
                        let msg =
                          mklstr
-                           (fun uu____15653 ->
-                              let uu____15654 = prob_to_string env1 orig1 in
+                           (fun uu___5 ->
+                              let uu___6 = prob_to_string env1 orig1 in
                               FStar_Util.format1
                                 "first_order heuristic cannot solve %s; lhs not a quasi-pattern"
-                                uu____15654) in
+                                uu___6) in
                        giveup_or_defer env1 orig1 wl1 msg
                    | FStar_Pervasives_Native.Some (bs_lhs, t_res_lhs) ->
-                       let uu____15661 = is_app rhs1 in
-                       if uu____15661
+                       let uu___5 = is_app rhs1 in
+                       if uu___5
                        then
                          imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs
                            rhs1
                        else
-                         (let uu____15663 = is_arrow rhs1 in
-                          if uu____15663
+                         (let uu___7 = is_arrow rhs1 in
+                          if uu___7
                           then
                             imitate_arrow orig1 env1 wl1 lhs1 bs_lhs
                               t_res_lhs FStar_TypeChecker_Common.EQ rhs1
                           else
                             (let msg =
                                mklstr
-                                 (fun uu____15672 ->
-                                    let uu____15673 =
-                                      prob_to_string env1 orig1 in
+                                 (fun uu___9 ->
+                                    let uu___10 = prob_to_string env1 orig1 in
                                     FStar_Util.format1
                                       "first_order heuristic cannot solve %s; rhs not an app or arrow"
-                                      uu____15673) in
+                                      uu___10) in
                              giveup_or_defer env1 orig1 wl1 msg))) in
                 match p_rel orig with
                 | FStar_TypeChecker_Common.SUB ->
                     if wl.defer_ok
                     then
-                      let uu____15674 =
-                        FStar_Thunk.mkv "flex-rigid subtyping" in
-                      giveup_or_defer env orig wl uu____15674
+                      let uu___3 = FStar_Thunk.mkv "flex-rigid subtyping" in
+                      giveup_or_defer env orig wl uu___3
                     else
                       solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs
                         rhs
                 | FStar_TypeChecker_Common.SUBINV ->
                     if wl.defer_ok
                     then
-                      let uu____15676 =
-                        FStar_Thunk.mkv "flex-rigid subtyping" in
-                      giveup_or_defer env orig wl uu____15676
+                      let uu___3 = FStar_Thunk.mkv "flex-rigid subtyping" in
+                      giveup_or_defer env orig wl uu___3
                     else
                       solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs
                         rhs
                 | FStar_TypeChecker_Common.EQ ->
-                    let uu____15678 = lhs in
-                    (match uu____15678 with
+                    let uu___3 = lhs in
+                    (match uu___3 with
                      | Flex (_t1, ctx_uv, args_lhs) ->
-                         let uu____15682 =
+                         let uu___4 =
                            pat_vars env
                              ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders
                              args_lhs in
-                         (match uu____15682 with
+                         (match uu___4 with
                           | FStar_Pervasives_Native.Some lhs_binders ->
-                              ((let uu____15689 =
+                              ((let uu___6 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "Rel") in
-                                if uu____15689
+                                if uu___6
                                 then
                                   FStar_Util.print_string "it's a pattern\n"
                                 else ());
                                (let rhs1 = sn env rhs in
                                 let names_to_string1 fvs =
-                                  let uu____15702 =
-                                    let uu____15705 =
-                                      FStar_Util.set_elements fvs in
+                                  let uu___6 =
+                                    let uu___7 = FStar_Util.set_elements fvs in
                                     FStar_List.map
-                                      FStar_Syntax_Print.bv_to_string
-                                      uu____15705 in
-                                  FStar_All.pipe_right uu____15702
+                                      FStar_Syntax_Print.bv_to_string uu___7 in
+                                  FStar_All.pipe_right uu___6
                                     (FStar_String.concat ", ") in
                                 let fvs1 =
                                   binders_as_bv_set
@@ -5400,26 +5272,24 @@ and (solve_t_flex_rigid_eq :
                                        ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders
                                        lhs_binders) in
                                 let fvs2 = FStar_Syntax_Free.names rhs1 in
-                                let uu____15722 = occurs_check ctx_uv rhs1 in
-                                match uu____15722 with
+                                let uu___6 = occurs_check ctx_uv rhs1 in
+                                match uu___6 with
                                 | (uvars, occurs_ok, msg) ->
                                     if Prims.op_Negation occurs_ok
                                     then
-                                      let uu____15744 =
-                                        let uu____15745 =
-                                          let uu____15746 =
-                                            FStar_Option.get msg in
+                                      let uu___7 =
+                                        let uu___8 =
+                                          let uu___9 = FStar_Option.get msg in
                                           Prims.op_Hat
-                                            "occurs-check failed: "
-                                            uu____15746 in
+                                            "occurs-check failed: " uu___9 in
                                         FStar_All.pipe_left FStar_Thunk.mkv
-                                          uu____15745 in
-                                      giveup_or_defer env orig wl uu____15744
+                                          uu___8 in
+                                      giveup_or_defer env orig wl uu___7
                                     else
-                                      (let uu____15748 =
+                                      (let uu___8 =
                                          FStar_Util.set_is_subset_of fvs2
                                            fvs1 in
-                                       if uu____15748
+                                       if uu___8
                                        then
                                          let sol =
                                            mk_solution env lhs lhs_binders
@@ -5427,22 +5297,22 @@ and (solve_t_flex_rigid_eq :
                                          let wl1 =
                                            restrict_all_uvars env ctx_uv
                                              lhs_binders uvars wl in
-                                         let uu____15753 =
+                                         let uu___9 =
                                            solve_prob orig
                                              FStar_Pervasives_Native.None sol
                                              wl1 in
-                                         solve env uu____15753
+                                         solve env uu___9
                                        else
                                          if wl.defer_ok
                                          then
                                            (let msg1 =
                                               mklstr
-                                                (fun uu____15766 ->
-                                                   let uu____15767 =
+                                                (fun uu___10 ->
+                                                   let uu___11 =
                                                      names_to_string1 fvs2 in
-                                                   let uu____15768 =
+                                                   let uu___12 =
                                                      names_to_string1 fvs1 in
-                                                   let uu____15769 =
+                                                   let uu___13 =
                                                      FStar_Syntax_Print.binders_to_string
                                                        ", "
                                                        (FStar_List.append
@@ -5450,27 +5320,25 @@ and (solve_t_flex_rigid_eq :
                                                           lhs_binders) in
                                                    FStar_Util.format3
                                                      "free names in the RHS {%s} are out of scope for the LHS: {%s}, {%s}"
-                                                     uu____15767 uu____15768
-                                                     uu____15769) in
+                                                     uu___11 uu___12 uu___13) in
                                             giveup_or_defer env orig wl msg1)
                                          else
                                            first_order orig env wl lhs rhs1)))
-                          | uu____15777 ->
+                          | uu___5 ->
                               if wl.defer_ok
                               then
-                                let uu____15780 =
-                                  FStar_Thunk.mkv "Not a pattern" in
-                                giveup_or_defer env orig wl uu____15780
+                                let uu___6 = FStar_Thunk.mkv "Not a pattern" in
+                                giveup_or_defer env orig wl uu___6
                               else
-                                (let uu____15782 =
+                                (let uu___7 =
                                    try_quasi_pattern orig env wl lhs rhs in
-                                 match uu____15782 with
+                                 match uu___7 with
                                  | (FStar_Util.Inr sol, wl1) ->
-                                     let uu____15805 =
+                                     let uu___8 =
                                        solve_prob orig
                                          FStar_Pervasives_Native.None sol wl1 in
-                                     solve env uu____15805
-                                 | (FStar_Util.Inl msg, uu____15807) ->
+                                     solve env uu___8
+                                 | (FStar_Util.Inl msg, uu___8) ->
                                      first_order orig env wl lhs rhs)))))
 and (solve_t_flex_flex :
   FStar_TypeChecker_Env.env ->
@@ -5485,20 +5353,20 @@ and (solve_t_flex_flex :
             | FStar_TypeChecker_Common.SUB ->
                 if wl.defer_ok
                 then
-                  let uu____15821 = FStar_Thunk.mkv "flex-flex subtyping" in
-                  giveup_or_defer env orig wl uu____15821
+                  let uu___ = FStar_Thunk.mkv "flex-flex subtyping" in
+                  giveup_or_defer env orig wl uu___
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV ->
                 if wl.defer_ok
                 then
-                  let uu____15823 = FStar_Thunk.mkv "flex-flex subtyping" in
-                  giveup_or_defer env orig wl uu____15823
+                  let uu___ = FStar_Thunk.mkv "flex-flex subtyping" in
+                  giveup_or_defer env orig wl uu___
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ ->
-                let uu____15825 =
+                let uu___ =
                   (should_defer_flex_to_user_tac env wl lhs) ||
                     (should_defer_flex_to_user_tac env wl rhs) in
-                if uu____15825
+                if uu___
                 then
                   defer_to_user_tac env orig
                     (Prims.op_Hat (flex_reason lhs)
@@ -5509,48 +5377,46 @@ and (solve_t_flex_flex :
                       ((Prims.op_Negation (is_flex_pat lhs)) ||
                          (Prims.op_Negation (is_flex_pat rhs)))
                   then
-                    (let uu____15827 =
-                       FStar_Thunk.mkv "flex-flex non-pattern" in
-                     giveup_or_defer env orig wl uu____15827)
+                    (let uu___2 = FStar_Thunk.mkv "flex-flex non-pattern" in
+                     giveup_or_defer env orig wl uu___2)
                   else
-                    (let uu____15829 =
-                       let uu____15846 = quasi_pattern env lhs in
-                       let uu____15853 = quasi_pattern env rhs in
-                       (uu____15846, uu____15853) in
-                     match uu____15829 with
+                    (let uu___3 =
+                       let uu___4 = quasi_pattern env lhs in
+                       let uu___5 = quasi_pattern env rhs in (uu___4, uu___5) in
+                     match uu___3 with
                      | (FStar_Pervasives_Native.Some
                         (binders_lhs, t_res_lhs),
                         FStar_Pervasives_Native.Some
                         (binders_rhs, t_res_rhs)) ->
-                         let uu____15896 = lhs in
-                         (match uu____15896 with
+                         let uu___4 = lhs in
+                         (match uu___4 with
                           | Flex
-                              ({ FStar_Syntax_Syntax.n = uu____15897;
+                              ({ FStar_Syntax_Syntax.n = uu___5;
                                  FStar_Syntax_Syntax.pos = range;
-                                 FStar_Syntax_Syntax.vars = uu____15899;_},
-                               u_lhs, uu____15901)
+                                 FStar_Syntax_Syntax.vars = uu___6;_},
+                               u_lhs, uu___7)
                               ->
-                              let uu____15904 = rhs in
-                              (match uu____15904 with
-                               | Flex (uu____15905, u_rhs, uu____15907) ->
-                                   let uu____15908 =
+                              let uu___8 = rhs in
+                              (match uu___8 with
+                               | Flex (uu___9, u_rhs, uu___10) ->
+                                   let uu___11 =
                                      (FStar_Syntax_Unionfind.equiv
                                         u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_head)
                                        &&
                                        (binders_eq binders_lhs binders_rhs) in
-                                   if uu____15908
+                                   if uu___11
                                    then
-                                     let uu____15913 =
+                                     let uu___12 =
                                        solve_prob orig
                                          FStar_Pervasives_Native.None [] wl in
-                                     solve env uu____15913
+                                     solve env uu___12
                                    else
-                                     (let uu____15915 =
+                                     (let uu___13 =
                                         maximal_prefix
                                           u_lhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                           u_rhs.FStar_Syntax_Syntax.ctx_uvar_binders in
-                                      match uu____15915 with
+                                      match uu___13 with
                                       | (ctx_w, (ctx_l, ctx_r)) ->
                                           let gamma_w =
                                             gamma_until
@@ -5562,13 +5428,13 @@ and (solve_t_flex_flex :
                                                  binders_lhs)
                                               (FStar_List.append ctx_r
                                                  binders_rhs) in
-                                          let uu____15947 =
-                                            let uu____15954 =
-                                              let uu____15957 =
+                                          let uu___14 =
+                                            let uu___15 =
+                                              let uu___16 =
                                                 FStar_Syntax_Syntax.mk_Total
                                                   t_res_lhs in
                                               FStar_Syntax_Util.arrow zs
-                                                uu____15957 in
+                                                uu___16 in
                                             new_uvar
                                               (Prims.op_Hat
                                                  "flex-flex quasi:"
@@ -5577,8 +5443,7 @@ and (solve_t_flex_flex :
                                                        u_lhs.FStar_Syntax_Syntax.ctx_uvar_reason
                                                        (Prims.op_Hat "\trhs="
                                                           u_rhs.FStar_Syntax_Syntax.ctx_uvar_reason))))
-                                              wl range gamma_w ctx_w
-                                              uu____15954
+                                              wl range gamma_w ctx_w uu___15
                                               (if
                                                  (u_lhs.FStar_Syntax_Syntax.ctx_uvar_should_check
                                                     =
@@ -5592,116 +5457,107 @@ and (solve_t_flex_flex :
                                                else
                                                  FStar_Syntax_Syntax.Strict)
                                               FStar_Pervasives_Native.None in
-                                          (match uu____15947 with
-                                           | (uu____15961, w, wl1) ->
+                                          (match uu___14 with
+                                           | (uu___15, w, wl1) ->
                                                let w_app =
-                                                 let uu____15965 =
+                                                 let uu___16 =
                                                    FStar_List.map
-                                                     (fun uu____15976 ->
-                                                        match uu____15976
-                                                        with
-                                                        | (z, uu____15984) ->
-                                                            let uu____15989 =
+                                                     (fun uu___17 ->
+                                                        match uu___17 with
+                                                        | (z, uu___18) ->
+                                                            let uu___19 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 z in
                                                             FStar_Syntax_Syntax.as_arg
-                                                              uu____15989) zs in
+                                                              uu___19) zs in
                                                  FStar_Syntax_Syntax.mk_Tm_app
-                                                   w uu____15965
+                                                   w uu___16
                                                    w.FStar_Syntax_Syntax.pos in
-                                               ((let uu____15991 =
+                                               ((let uu___17 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____15991
+                                                 if uu___17
                                                  then
-                                                   let uu____15992 =
-                                                     let uu____15995 =
+                                                   let uu___18 =
+                                                     let uu___19 =
                                                        flex_t_to_string lhs in
-                                                     let uu____15996 =
-                                                       let uu____15999 =
+                                                     let uu___20 =
+                                                       let uu___21 =
                                                          flex_t_to_string rhs in
-                                                       let uu____16000 =
-                                                         let uu____16003 =
+                                                       let uu___22 =
+                                                         let uu___23 =
                                                            term_to_string w in
-                                                         let uu____16004 =
-                                                           let uu____16007 =
+                                                         let uu___24 =
+                                                           let uu___25 =
                                                              FStar_Syntax_Print.binders_to_string
                                                                ", "
                                                                (FStar_List.append
                                                                   ctx_l
                                                                   binders_lhs) in
-                                                           let uu____16014 =
-                                                             let uu____16017
-                                                               =
+                                                           let uu___26 =
+                                                             let uu___27 =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", "
                                                                  (FStar_List.append
                                                                     ctx_r
                                                                     binders_rhs) in
-                                                             let uu____16024
-                                                               =
-                                                               let uu____16027
-                                                                 =
+                                                             let uu___28 =
+                                                               let uu___29 =
                                                                  FStar_Syntax_Print.binders_to_string
                                                                    ", " zs in
-                                                               [uu____16027] in
-                                                             uu____16017 ::
-                                                               uu____16024 in
-                                                           uu____16007 ::
-                                                             uu____16014 in
-                                                         uu____16003 ::
-                                                           uu____16004 in
-                                                       uu____15999 ::
-                                                         uu____16000 in
-                                                     uu____15995 ::
-                                                       uu____15996 in
+                                                               [uu___29] in
+                                                             uu___27 ::
+                                                               uu___28 in
+                                                           uu___25 :: uu___26 in
+                                                         uu___23 :: uu___24 in
+                                                       uu___21 :: uu___22 in
+                                                     uu___19 :: uu___20 in
                                                    FStar_Util.print
                                                      "flex-flex quasi:\n\tlhs=%s\n\trhs=%s\n\tsol=%s\n\tctx_l@binders_lhs=%s\n\tctx_r@binders_rhs=%s\n\tzs=%s\n"
-                                                     uu____15992
+                                                     uu___18
                                                  else ());
                                                 (let sol =
                                                    let s1 =
-                                                     let uu____16033 =
-                                                       let uu____16038 =
+                                                     let uu___17 =
+                                                       let uu___18 =
                                                          FStar_Syntax_Util.abs
                                                            binders_lhs w_app
                                                            (FStar_Pervasives_Native.Some
                                                               (FStar_Syntax_Util.residual_tot
                                                                  t_res_lhs)) in
-                                                       (u_lhs, uu____16038) in
-                                                     TERM uu____16033 in
-                                                   let uu____16039 =
+                                                       (u_lhs, uu___18) in
+                                                     TERM uu___17 in
+                                                   let uu___17 =
                                                      FStar_Syntax_Unionfind.equiv
                                                        u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                        u_rhs.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                   if uu____16039
+                                                   if uu___17
                                                    then [s1]
                                                    else
                                                      (let s2 =
-                                                        let uu____16044 =
-                                                          let uu____16049 =
+                                                        let uu___19 =
+                                                          let uu___20 =
                                                             FStar_Syntax_Util.abs
                                                               binders_rhs
                                                               w_app
                                                               (FStar_Pervasives_Native.Some
                                                                  (FStar_Syntax_Util.residual_tot
                                                                     t_res_lhs)) in
-                                                          (u_rhs,
-                                                            uu____16049) in
-                                                        TERM uu____16044 in
+                                                          (u_rhs, uu___20) in
+                                                        TERM uu___19 in
                                                       [s1; s2]) in
-                                                 let uu____16050 =
+                                                 let uu___17 =
                                                    solve_prob orig
                                                      FStar_Pervasives_Native.None
                                                      sol wl1 in
-                                                 solve env uu____16050))))))
-                     | uu____16051 ->
-                         let uu____16068 =
+                                                 solve env uu___17))))))
+                     | uu___4 ->
+                         let uu___5 =
                            FStar_Thunk.mkv "flex-flex: non-patterns" in
-                         giveup_or_defer env orig wl uu____16068)
+                         giveup_or_defer env orig wl uu___5)
 and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
   fun env ->
     fun problem ->
@@ -5710,87 +5566,86 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
         (let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg in
          let rigid_heads_match env1 need_unif torig wl1 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig in
-           (let uu____16117 =
+           (let uu___2 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "Rel") in
-            if uu____16117
+            if uu___2
             then
-              let uu____16118 = FStar_Syntax_Print.term_to_string t1 in
-              let uu____16119 = FStar_Syntax_Print.tag_of_term t1 in
-              let uu____16120 = FStar_Syntax_Print.term_to_string t2 in
-              let uu____16121 = FStar_Syntax_Print.tag_of_term t2 in
+              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+              let uu___4 = FStar_Syntax_Print.tag_of_term t1 in
+              let uu___5 = FStar_Syntax_Print.term_to_string t2 in
+              let uu___6 = FStar_Syntax_Print.tag_of_term t2 in
               FStar_Util.print5 "Heads %s: %s (%s) and %s (%s)\n"
-                (if need_unif then "need unification" else "match")
-                uu____16118 uu____16119 uu____16120 uu____16121
+                (if need_unif then "need unification" else "match") uu___3
+                uu___4 uu___5 uu___6
             else ());
-           (let uu____16124 = FStar_Syntax_Util.head_and_args t1 in
-            match uu____16124 with
+           (let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+            match uu___2 with
             | (head1, args1) ->
-                let uu____16167 = FStar_Syntax_Util.head_and_args t2 in
-                (match uu____16167 with
+                let uu___3 = FStar_Syntax_Util.head_and_args t2 in
+                (match uu___3 with
                  | (head2, args2) ->
                      let solve_head_then wl2 k =
                        if need_unif
                        then k true wl2
                        else
-                         (let uu____16232 =
+                         (let uu___5 =
                             solve_maybe_uinsts env1 orig head1 head2 wl2 in
-                          match uu____16232 with
+                          match uu___5 with
                           | USolved wl3 -> k true wl3
                           | UFailed msg -> giveup env1 msg orig
                           | UDeferred wl3 ->
-                              let uu____16236 =
+                              let uu___6 =
                                 defer_lit "universe constraints" orig wl3 in
-                              k false uu____16236) in
+                              k false uu___6) in
                      let nargs = FStar_List.length args1 in
                      if nargs <> (FStar_List.length args2)
                      then
-                       let uu____16254 =
+                       let uu___4 =
                          mklstr
-                           (fun uu____16265 ->
-                              let uu____16266 =
+                           (fun uu___5 ->
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string head1 in
-                              let uu____16267 = args_to_string args1 in
-                              let uu____16270 =
+                              let uu___7 = args_to_string args1 in
+                              let uu___8 =
                                 FStar_Syntax_Print.term_to_string head2 in
-                              let uu____16271 = args_to_string args2 in
+                              let uu___9 = args_to_string args2 in
                               FStar_Util.format4
                                 "unequal number of arguments: %s[%s] and %s[%s]"
-                                uu____16266 uu____16267 uu____16270
-                                uu____16271) in
-                       giveup env1 uu____16254 orig
+                                uu___6 uu___7 uu___8 uu___9) in
+                       giveup env1 uu___4 orig
                      else
-                       (let uu____16275 =
+                       (let uu___5 =
                           (nargs = Prims.int_zero) ||
-                            (let uu____16277 =
+                            (let uu___6 =
                                FStar_Syntax_Util.eq_args args1 args2 in
-                             uu____16277 = FStar_Syntax_Util.Equal) in
-                        if uu____16275
+                             uu___6 = FStar_Syntax_Util.Equal) in
+                        if uu___5
                         then
                           (if need_unif
                            then
                              solve_t env1
-                               (let uu___2638_16279 = problem in
+                               (let uu___6 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.pid);
+                                    (uu___6.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs = head1;
                                   FStar_TypeChecker_Common.relation =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.relation);
+                                    (uu___6.FStar_TypeChecker_Common.relation);
                                   FStar_TypeChecker_Common.rhs = head2;
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.element);
+                                    (uu___6.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___6.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___6.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.reason);
+                                    (uu___6.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.loc);
+                                    (uu___6.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.rank)
+                                    (uu___6.FStar_TypeChecker_Common.rank)
                                 }) wl1
                            else
                              solve_head_then wl1
@@ -5798,17 +5653,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   fun wl2 ->
                                     if ok
                                     then
-                                      let uu____16286 =
+                                      let uu___7 =
                                         solve_prob orig
                                           FStar_Pervasives_Native.None [] wl2 in
-                                      solve env1 uu____16286
+                                      solve env1 uu___7
                                     else solve env1 wl2))
                         else
-                          (let uu____16289 = base_and_refinement env1 t1 in
-                           match uu____16289 with
+                          (let uu___7 = base_and_refinement env1 t1 in
+                           match uu___7 with
                            | (base1, refinement1) ->
-                               let uu____16314 = base_and_refinement env1 t2 in
-                               (match uu____16314 with
+                               let uu___8 = base_and_refinement env1 t2 in
+                               (match uu___8 with
                                 | (base2, refinement2) ->
                                     (match (refinement1, refinement2) with
                                      | (FStar_Pervasives_Native.None,
@@ -5825,51 +5680,49 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                     FStar_Pervasives_Native.None)
                                                  :: args2)
                                              else FStar_List.zip args1 args2 in
-                                           let uu____16477 =
+                                           let uu___9 =
                                              FStar_List.fold_right
-                                               (fun uu____16517 ->
-                                                  fun uu____16518 ->
-                                                    match (uu____16517,
-                                                            uu____16518)
+                                               (fun uu___10 ->
+                                                  fun uu___11 ->
+                                                    match (uu___10, uu___11)
                                                     with
-                                                    | (((a1, uu____16570),
-                                                        (a2, uu____16572)),
+                                                    | (((a1, uu___12),
+                                                        (a2, uu___13)),
                                                        (probs, wl3)) ->
-                                                        let uu____16621 =
+                                                        let uu___14 =
                                                           mk_problem wl3 []
                                                             orig a1
                                                             FStar_TypeChecker_Common.EQ
                                                             a2
                                                             FStar_Pervasives_Native.None
                                                             "index" in
-                                                        (match uu____16621
-                                                         with
+                                                        (match uu___14 with
                                                          | (prob', wl4) ->
                                                              (((FStar_TypeChecker_Common.TProb
                                                                   prob') ::
                                                                probs), wl4)))
                                                argp ([], wl2) in
-                                           match uu____16477 with
+                                           match uu___9 with
                                            | (subprobs, wl3) ->
-                                               ((let uu____16663 =
+                                               ((let uu___11 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env1)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____16663
+                                                 if uu___11
                                                  then
-                                                   let uu____16664 =
+                                                   let uu___12 =
                                                      FStar_Syntax_Print.list_to_string
                                                        (prob_to_string env1)
                                                        subprobs in
                                                    FStar_Util.print1
                                                      "Adding subproblems for arguments: %s"
-                                                     uu____16664
+                                                     uu___12
                                                  else ());
-                                                (let uu____16667 =
+                                                (let uu___12 =
                                                    FStar_Options.defensive () in
-                                                 if uu____16667
+                                                 if uu___12
                                                  then
                                                    FStar_List.iter
                                                      (def_check_prob
@@ -5884,120 +5737,116 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                   if Prims.op_Negation ok
                                                   then solve env2 wl3
                                                   else
-                                                    (let uu____16687 =
+                                                    (let uu___10 =
                                                        mk_sub_probs wl3 in
-                                                     match uu____16687 with
+                                                     match uu___10 with
                                                      | (subprobs, wl4) ->
                                                          let formula =
-                                                           let uu____16703 =
+                                                           let uu___11 =
                                                              FStar_List.map
                                                                (fun p ->
                                                                   p_guard p)
                                                                subprobs in
                                                            FStar_Syntax_Util.mk_conj_l
-                                                             uu____16703 in
+                                                             uu___11 in
                                                          let wl5 =
                                                            solve_prob orig
                                                              (FStar_Pervasives_Native.Some
                                                                 formula) []
                                                              wl4 in
-                                                         let uu____16711 =
+                                                         let uu___11 =
                                                            attempt subprobs
                                                              wl5 in
-                                                         solve env2
-                                                           uu____16711)) in
+                                                         solve env2 uu___11)) in
                                          let solve_sub_probs_no_smt env2 wl2
                                            =
                                            solve_head_then wl2
                                              (fun ok ->
                                                 fun wl3 ->
-                                                  let uu____16735 =
+                                                  let uu___10 =
                                                     mk_sub_probs wl3 in
-                                                  match uu____16735 with
+                                                  match uu___10 with
                                                   | (subprobs, wl4) ->
                                                       let formula =
-                                                        let uu____16751 =
+                                                        let uu___11 =
                                                           FStar_List.map
                                                             (fun p ->
                                                                p_guard p)
                                                             subprobs in
                                                         FStar_Syntax_Util.mk_conj_l
-                                                          uu____16751 in
+                                                          uu___11 in
                                                       let wl5 =
                                                         solve_prob orig
                                                           (FStar_Pervasives_Native.Some
                                                              formula) [] wl4 in
-                                                      let uu____16759 =
+                                                      let uu___11 =
                                                         attempt subprobs wl5 in
-                                                      solve env2 uu____16759) in
+                                                      solve env2 uu___11) in
                                          let unfold_and_retry d env2 wl2
-                                           uu____16786 =
-                                           match uu____16786 with
+                                           uu___9 =
+                                           match uu___9 with
                                            | (prob, reason) ->
-                                               ((let uu____16800 =
+                                               ((let uu___11 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env2)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____16800
+                                                 if uu___11
                                                  then
-                                                   let uu____16801 =
+                                                   let uu___12 =
                                                      prob_to_string env2 orig in
-                                                   let uu____16802 =
+                                                   let uu___13 =
                                                      FStar_Thunk.force reason in
                                                    FStar_Util.print2
                                                      "Failed to solve %s because a sub-problem is not solvable without SMT because %s"
-                                                     uu____16801 uu____16802
+                                                     uu___12 uu___13
                                                  else ());
-                                                (let uu____16804 =
-                                                   let uu____16813 =
+                                                (let uu___11 =
+                                                   let uu___12 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t1 in
-                                                   let uu____16816 =
+                                                   let uu___13 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t2 in
-                                                   (uu____16813, uu____16816) in
-                                                 match uu____16804 with
+                                                   (uu___12, uu___13) in
+                                                 match uu___11 with
                                                  | (FStar_Pervasives_Native.Some
                                                     t1',
                                                     FStar_Pervasives_Native.Some
                                                     t2') ->
-                                                     let uu____16829 =
+                                                     let uu___12 =
                                                        FStar_Syntax_Util.head_and_args
                                                          t1' in
-                                                     (match uu____16829 with
-                                                      | (head1', uu____16847)
-                                                          ->
-                                                          let uu____16872 =
+                                                     (match uu___12 with
+                                                      | (head1', uu___13) ->
+                                                          let uu___14 =
                                                             FStar_Syntax_Util.head_and_args
                                                               t2' in
-                                                          (match uu____16872
-                                                           with
+                                                          (match uu___14 with
                                                            | (head2',
-                                                              uu____16890) ->
-                                                               let uu____16915
-                                                                 =
-                                                                 let uu____16920
+                                                              uu___15) ->
+                                                               let uu___16 =
+                                                                 let uu___17
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head1'
                                                                     head1 in
-                                                                 let uu____16921
+                                                                 let uu___18
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head2'
                                                                     head2 in
-                                                                 (uu____16920,
-                                                                   uu____16921) in
-                                                               (match uu____16915
+                                                                 (uu___17,
+                                                                   uu___18) in
+                                                               (match uu___16
                                                                 with
                                                                 | (FStar_Syntax_Util.Equal,
                                                                    FStar_Syntax_Util.Equal)
                                                                     ->
                                                                     (
                                                                     (
-                                                                    let uu____16923
+                                                                    let uu___18
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6005,71 +5854,70 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
-                                                                    uu____16923
+                                                                    uu___18
                                                                     then
-                                                                    let uu____16924
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1 in
-                                                                    let uu____16925
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1' in
-                                                                    let uu____16926
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2 in
-                                                                    let uu____16927
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2' in
                                                                     FStar_Util.print4
                                                                     "Unfolding didn't make progress ... got %s ~> %s;\nand %s ~> %s\n"
-                                                                    uu____16924
-                                                                    uu____16925
-                                                                    uu____16926
-                                                                    uu____16927
+                                                                    uu___19
+                                                                    uu___20
+                                                                    uu___21
+                                                                    uu___22
                                                                     else ());
                                                                     solve_sub_probs
                                                                     env2 wl2)
-                                                                | uu____16929
-                                                                    ->
+                                                                | uu___17 ->
                                                                     let torig'
                                                                     =
-                                                                    let uu___2726_16937
+                                                                    let uu___18
                                                                     = torig in
                                                                     {
                                                                     FStar_TypeChecker_Common.pid
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.pid);
+                                                                    (uu___18.FStar_TypeChecker_Common.pid);
                                                                     FStar_TypeChecker_Common.lhs
                                                                     = t1';
                                                                     FStar_TypeChecker_Common.relation
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.relation);
+                                                                    (uu___18.FStar_TypeChecker_Common.relation);
                                                                     FStar_TypeChecker_Common.rhs
                                                                     = t2';
                                                                     FStar_TypeChecker_Common.element
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.element);
+                                                                    (uu___18.FStar_TypeChecker_Common.element);
                                                                     FStar_TypeChecker_Common.logical_guard
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.logical_guard);
+                                                                    (uu___18.FStar_TypeChecker_Common.logical_guard);
                                                                     FStar_TypeChecker_Common.logical_guard_uvar
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                                    (uu___18.FStar_TypeChecker_Common.logical_guard_uvar);
                                                                     FStar_TypeChecker_Common.reason
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.reason);
+                                                                    (uu___18.FStar_TypeChecker_Common.reason);
                                                                     FStar_TypeChecker_Common.loc
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.loc);
+                                                                    (uu___18.FStar_TypeChecker_Common.loc);
                                                                     FStar_TypeChecker_Common.rank
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.rank)
+                                                                    (uu___18.FStar_TypeChecker_Common.rank)
                                                                     } in
                                                                     ((
-                                                                    let uu____16939
+                                                                    let uu___19
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6077,9 +5925,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
-                                                                    uu____16939
+                                                                    uu___19
                                                                     then
-                                                                    let uu____16940
+                                                                    let uu___20
                                                                     =
                                                                     prob_to_string
                                                                     env2
@@ -6087,37 +5935,37 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     torig') in
                                                                     FStar_Util.print1
                                                                     "Unfolded and now trying %s\n"
-                                                                    uu____16940
+                                                                    uu___20
                                                                     else ());
                                                                     solve_t
                                                                     env2
                                                                     torig'
                                                                     wl2))))
-                                                 | uu____16942 ->
+                                                 | uu___12 ->
                                                      solve_sub_probs env2 wl2)) in
                                          let d =
-                                           let uu____16954 =
+                                           let uu___9 =
                                              delta_depth_of_term env1 head1 in
-                                           match uu____16954 with
+                                           match uu___9 with
                                            | FStar_Pervasives_Native.None ->
                                                FStar_Pervasives_Native.None
-                                           | FStar_Pervasives_Native.Some d
+                                           | FStar_Pervasives_Native.Some d1
                                                ->
                                                FStar_TypeChecker_Common.decr_delta_depth
-                                                 d in
+                                                 d1 in
                                          let treat_as_injective =
-                                           let uu____16961 =
-                                             let uu____16962 =
+                                           let uu___9 =
+                                             let uu___10 =
                                                FStar_Syntax_Util.un_uinst
                                                  head1 in
-                                             uu____16962.FStar_Syntax_Syntax.n in
-                                           match uu____16961 with
+                                             uu___10.FStar_Syntax_Syntax.n in
+                                           match uu___9 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
                                                FStar_TypeChecker_Env.fv_has_attr
                                                  env1 fv
                                                  FStar_Parser_Const.unifier_hint_injective_lid
-                                           | uu____16966 -> false in
+                                           | uu___10 -> false in
                                          (match d with
                                           | FStar_Pervasives_Native.Some d1
                                               when
@@ -6129,9 +5977,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 env1 wl1
                                                 solve_sub_probs_no_smt
                                                 (unfold_and_retry d1)
-                                          | uu____16968 ->
+                                          | uu___9 ->
                                               solve_sub_probs env1 wl1)
-                                     | uu____16971 ->
+                                     | uu___9 ->
                                          let lhs =
                                            force_refinement
                                              (base1, refinement1) in
@@ -6139,610 +5987,591 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            force_refinement
                                              (base2, refinement2) in
                                          solve_t env1
-                                           (let uu___2746_17007 = problem in
+                                           (let uu___10 = problem in
                                             {
                                               FStar_TypeChecker_Common.pid =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.pid);
+                                                (uu___10.FStar_TypeChecker_Common.pid);
                                               FStar_TypeChecker_Common.lhs =
                                                 lhs;
                                               FStar_TypeChecker_Common.relation
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.relation);
+                                                (uu___10.FStar_TypeChecker_Common.relation);
                                               FStar_TypeChecker_Common.rhs =
                                                 rhs;
                                               FStar_TypeChecker_Common.element
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.element);
+                                                (uu___10.FStar_TypeChecker_Common.element);
                                               FStar_TypeChecker_Common.logical_guard
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.logical_guard);
+                                                (uu___10.FStar_TypeChecker_Common.logical_guard);
                                               FStar_TypeChecker_Common.logical_guard_uvar
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                                               FStar_TypeChecker_Common.reason
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.reason);
+                                                (uu___10.FStar_TypeChecker_Common.reason);
                                               FStar_TypeChecker_Common.loc =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.loc);
+                                                (uu___10.FStar_TypeChecker_Common.loc);
                                               FStar_TypeChecker_Common.rank =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.rank)
+                                                (uu___10.FStar_TypeChecker_Common.rank)
                                             }) wl1)))))) in
          let try_match_heuristic env1 orig wl1 s1 s2 t1t2_opt =
            let try_solve_branch scrutinee p =
-             let uu____17082 = destruct_flex_t scrutinee wl1 in
-             match uu____17082 with
+             let uu___1 = destruct_flex_t scrutinee wl1 in
+             match uu___1 with
              | (Flex (_t, uv, _args), wl2) ->
-                 let uu____17093 =
+                 let uu___2 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp true env1 p in
-                 (match uu____17093 with
-                  | (xs, pat_term, uu____17108, uu____17109) ->
-                      let uu____17114 =
+                 (match uu___2 with
+                  | (xs, pat_term, uu___3, uu___4) ->
+                      let uu___5 =
                         FStar_List.fold_left
-                          (fun uu____17137 ->
+                          (fun uu___6 ->
                              fun x ->
-                               match uu____17137 with
+                               match uu___6 with
                                | (subst, wl3) ->
                                    let t_x =
                                      FStar_Syntax_Subst.subst subst
                                        x.FStar_Syntax_Syntax.sort in
-                                   let uu____17158 = copy_uvar uv [] t_x wl3 in
-                                   (match uu____17158 with
-                                    | (uu____17177, u, wl4) ->
+                                   let uu___7 = copy_uvar uv [] t_x wl3 in
+                                   (match uu___7 with
+                                    | (uu___8, u, wl4) ->
                                         let subst1 =
                                           (FStar_Syntax_Syntax.NT (x, u)) ::
                                           subst in
                                         (subst1, wl4))) ([], wl2) xs in
-                      (match uu____17114 with
+                      (match uu___5 with
                        | (subst, wl3) ->
                            let pat_term1 =
                              FStar_Syntax_Subst.subst subst pat_term in
-                           let uu____17198 =
+                           let uu___6 =
                              new_problem wl3 env1 scrutinee
                                FStar_TypeChecker_Common.EQ pat_term1
                                FStar_Pervasives_Native.None
                                scrutinee.FStar_Syntax_Syntax.pos
                                "match heuristic" in
-                           (match uu____17198 with
+                           (match uu___6 with
                             | (prob, wl4) ->
                                 let wl' =
-                                  let uu___2787_17214 = wl4 in
+                                  let uu___7 = wl4 in
                                   {
                                     attempting =
                                       [FStar_TypeChecker_Common.TProb prob];
                                     wl_deferred = [];
                                     wl_deferred_to_tac =
-                                      (uu___2787_17214.wl_deferred_to_tac);
-                                    ctr = (uu___2787_17214.ctr);
+                                      (uu___7.wl_deferred_to_tac);
+                                    ctr = (uu___7.ctr);
                                     defer_ok = false;
                                     smt_ok = false;
                                     umax_heuristic_ok =
-                                      (uu___2787_17214.umax_heuristic_ok);
-                                    tcenv = (uu___2787_17214.tcenv);
+                                      (uu___7.umax_heuristic_ok);
+                                    tcenv = (uu___7.tcenv);
                                     wl_implicits = [];
                                     repr_subcomp_allowed =
-                                      (uu___2787_17214.repr_subcomp_allowed)
+                                      (uu___7.repr_subcomp_allowed)
                                   } in
                                 let tx =
                                   FStar_Syntax_Unionfind.new_transaction () in
-                                let uu____17222 = solve env1 wl' in
-                                (match uu____17222 with
-                                 | Success (uu____17225, defer_to_tac, imps)
-                                     ->
+                                let uu___7 = solve env1 wl' in
+                                (match uu___7 with
+                                 | Success (uu___8, defer_to_tac, imps) ->
                                      let wl'1 =
-                                       let uu___2796_17229 = wl' in
+                                       let uu___9 = wl' in
                                        {
                                          attempting = [orig];
-                                         wl_deferred =
-                                           (uu___2796_17229.wl_deferred);
+                                         wl_deferred = (uu___9.wl_deferred);
                                          wl_deferred_to_tac =
-                                           (uu___2796_17229.wl_deferred_to_tac);
-                                         ctr = (uu___2796_17229.ctr);
-                                         defer_ok =
-                                           (uu___2796_17229.defer_ok);
-                                         smt_ok = (uu___2796_17229.smt_ok);
+                                           (uu___9.wl_deferred_to_tac);
+                                         ctr = (uu___9.ctr);
+                                         defer_ok = (uu___9.defer_ok);
+                                         smt_ok = (uu___9.smt_ok);
                                          umax_heuristic_ok =
-                                           (uu___2796_17229.umax_heuristic_ok);
-                                         tcenv = (uu___2796_17229.tcenv);
-                                         wl_implicits =
-                                           (uu___2796_17229.wl_implicits);
+                                           (uu___9.umax_heuristic_ok);
+                                         tcenv = (uu___9.tcenv);
+                                         wl_implicits = (uu___9.wl_implicits);
                                          repr_subcomp_allowed =
-                                           (uu___2796_17229.repr_subcomp_allowed)
+                                           (uu___9.repr_subcomp_allowed)
                                        } in
-                                     let uu____17230 = solve env1 wl'1 in
-                                     (match uu____17230 with
+                                     let uu___9 = solve env1 wl'1 in
+                                     (match uu___9 with
                                       | Success
-                                          (uu____17233, defer_to_tac', imps')
-                                          ->
+                                          (uu___10, defer_to_tac', imps') ->
                                           (FStar_Syntax_Unionfind.commit tx;
-                                           (let uu____17237 =
+                                           (let uu___12 =
                                               extend_wl wl4
                                                 (FStar_List.append
                                                    defer_to_tac defer_to_tac')
                                                 (FStar_List.append imps imps') in
                                             FStar_Pervasives_Native.Some
-                                              uu____17237))
-                                      | Failed uu____17242 ->
+                                              uu___12))
+                                      | Failed uu___10 ->
                                           (FStar_Syntax_Unionfind.rollback tx;
                                            FStar_Pervasives_Native.None))
-                                 | uu____17248 ->
+                                 | uu___8 ->
                                      (FStar_Syntax_Unionfind.rollback tx;
                                       FStar_Pervasives_Native.None))))) in
            match t1t2_opt with
            | FStar_Pervasives_Native.None ->
                FStar_Util.Inr FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some (t1, t2) ->
-               ((let uu____17269 =
+               ((let uu___2 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Rel") in
-                 if uu____17269
+                 if uu___2
                  then
-                   let uu____17270 = FStar_Syntax_Print.term_to_string t1 in
-                   let uu____17271 = FStar_Syntax_Print.term_to_string t2 in
+                   let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+                   let uu___4 = FStar_Syntax_Print.term_to_string t2 in
                    FStar_Util.print2 "Trying match heuristic for %s vs. %s\n"
-                     uu____17270 uu____17271
+                     uu___3 uu___4
                  else ());
-                (let uu____17273 =
-                   let uu____17294 =
-                     let uu____17303 = FStar_Syntax_Util.unmeta t1 in
-                     (s1, uu____17303) in
-                   let uu____17310 =
-                     let uu____17319 = FStar_Syntax_Util.unmeta t2 in
-                     (s2, uu____17319) in
-                   (uu____17294, uu____17310) in
-                 match uu____17273 with
-                 | ((uu____17348,
+                (let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Util.unmeta t1 in (s1, uu___4) in
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Util.unmeta t2 in (s2, uu___5) in
+                   (uu___3, uu___4) in
+                 match uu___2 with
+                 | ((uu___3,
                      {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                          (scrutinee, branches);
-                       FStar_Syntax_Syntax.pos = uu____17351;
-                       FStar_Syntax_Syntax.vars = uu____17352;_}),
+                       FStar_Syntax_Syntax.pos = uu___4;
+                       FStar_Syntax_Syntax.vars = uu___5;_}),
                     (s, t)) ->
-                     let uu____17423 =
-                       let uu____17424 = is_flex scrutinee in
-                       Prims.op_Negation uu____17424 in
-                     if uu____17423
+                     let uu___6 =
+                       let uu___7 = is_flex scrutinee in
+                       Prims.op_Negation uu___7 in
+                     if uu___6
                      then
-                       ((let uu____17432 =
+                       ((let uu___8 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel") in
-                         if uu____17432
+                         if uu___8
                          then
-                           let uu____17433 =
+                           let uu___9 =
                              FStar_Syntax_Print.term_to_string scrutinee in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____17433
+                             "match head %s is not a flex term\n" uu___9
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____17445 =
+                         ((let uu___9 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____17445
+                           if uu___9
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____17451 =
+                         ((let uu___10 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____17451
+                           if uu___10
                            then
-                             let uu____17452 =
+                             let uu___11 =
                                FStar_Syntax_Print.term_to_string scrutinee in
-                             let uu____17453 =
+                             let uu___12 =
                                FStar_Syntax_Print.term_to_string t in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____17452 uu____17453
+                               uu___11 uu___12
                            else ());
-                          (let pat_discriminates uu___26_17474 =
-                             match uu___26_17474 with
+                          (let pat_discriminates uu___10 =
+                             match uu___10 with
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_constant
-                                    uu____17489;
-                                  FStar_Syntax_Syntax.p = uu____17490;_},
-                                FStar_Pervasives_Native.None, uu____17491) ->
+                                    FStar_Syntax_Syntax.Pat_constant uu___11;
+                                  FStar_Syntax_Syntax.p = uu___12;_},
+                                FStar_Pervasives_Native.None, uu___13) ->
                                  true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____17504;
-                                  FStar_Syntax_Syntax.p = uu____17505;_},
-                                FStar_Pervasives_Native.None, uu____17506) ->
+                                    FStar_Syntax_Syntax.Pat_cons uu___11;
+                                  FStar_Syntax_Syntax.p = uu___12;_},
+                                FStar_Pervasives_Native.None, uu___13) ->
                                  true
-                             | uu____17531 -> false in
+                             | uu___11 -> false in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b ->
                                      if pat_discriminates b
                                      then
-                                       let uu____17631 =
+                                       let uu___10 =
                                          FStar_Syntax_Subst.open_branch b in
-                                       match uu____17631 with
-                                       | (uu____17632, uu____17633, t') ->
-                                           let uu____17651 =
+                                       match uu___10 with
+                                       | (uu___11, uu___12, t') ->
+                                           let uu___13 =
                                              head_matches_delta env1 wl1 s t' in
-                                           (match uu____17651 with
-                                            | (FullMatch, uu____17662) ->
+                                           (match uu___13 with
+                                            | (FullMatch, uu___14) -> true
+                                            | (HeadMatch uu___14, uu___15) ->
                                                 true
-                                            | (HeadMatch uu____17675,
-                                               uu____17676) -> true
-                                            | uu____17689 -> false)
+                                            | uu___14 -> false)
                                      else false)) in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None ->
-                               ((let uu____17722 =
+                               ((let uu___11 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____17722
+                                 if uu___11
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____17727 =
+                                   let uu___11 =
                                      FStar_Util.prefix_until
                                        (fun b ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches in
-                                   match uu____17727 with
+                                   match uu___11 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1, uu____17815, uu____17816)
-                                       -> branches1
-                                   | uu____17961 -> branches in
-                                 let uu____18016 =
+                                       (branches1, uu___12, uu___13) ->
+                                       branches1
+                                   | uu___12 -> branches in
+                                 let uu___11 =
                                    FStar_Util.find_map try_branches
                                      (fun b ->
-                                        let uu____18025 =
+                                        let uu___12 =
                                           FStar_Syntax_Subst.open_branch b in
-                                        match uu____18025 with
-                                        | (p, uu____18029, uu____18030) ->
+                                        match uu___12 with
+                                        | (p, uu___13, uu___14) ->
                                             try_solve_branch scrutinee p) in
                                  FStar_All.pipe_left
-                                   (fun uu____18057 ->
-                                      FStar_Util.Inr uu____18057) uu____18016))
+                                   (fun uu___12 -> FStar_Util.Inr uu___12)
+                                   uu___11))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____18087 =
-                                 FStar_Syntax_Subst.open_branch b in
-                               (match uu____18087 with
-                                | (p, uu____18095, e) ->
-                                    ((let uu____18114 =
+                               let uu___10 = FStar_Syntax_Subst.open_branch b in
+                               (match uu___10 with
+                                | (p, uu___11, e) ->
+                                    ((let uu___13 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel") in
-                                      if uu____18114
+                                      if uu___13
                                       then
-                                        let uu____18115 =
+                                        let uu___14 =
                                           FStar_Syntax_Print.pat_to_string p in
-                                        let uu____18116 =
+                                        let uu___15 =
                                           FStar_Syntax_Print.term_to_string e in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____18115 uu____18116
+                                          uu___14 uu___15
                                       else ());
-                                     (let uu____18118 =
+                                     (let uu___13 =
                                         try_solve_branch scrutinee p in
                                       FStar_All.pipe_left
-                                        (fun uu____18131 ->
-                                           FStar_Util.Inr uu____18131)
-                                        uu____18118)))))
+                                        (fun uu___14 ->
+                                           FStar_Util.Inr uu___14) uu___13)))))
                  | ((s, t),
-                    (uu____18134,
+                    (uu___3,
                      {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                          (scrutinee, branches);
-                       FStar_Syntax_Syntax.pos = uu____18137;
-                       FStar_Syntax_Syntax.vars = uu____18138;_}))
+                       FStar_Syntax_Syntax.pos = uu___4;
+                       FStar_Syntax_Syntax.vars = uu___5;_}))
                      ->
-                     let uu____18207 =
-                       let uu____18208 = is_flex scrutinee in
-                       Prims.op_Negation uu____18208 in
-                     if uu____18207
+                     let uu___6 =
+                       let uu___7 = is_flex scrutinee in
+                       Prims.op_Negation uu___7 in
+                     if uu___6
                      then
-                       ((let uu____18216 =
+                       ((let uu___8 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel") in
-                         if uu____18216
+                         if uu___8
                          then
-                           let uu____18217 =
+                           let uu___9 =
                              FStar_Syntax_Print.term_to_string scrutinee in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____18217
+                             "match head %s is not a flex term\n" uu___9
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____18229 =
+                         ((let uu___9 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____18229
+                           if uu___9
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____18235 =
+                         ((let uu___10 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____18235
+                           if uu___10
                            then
-                             let uu____18236 =
+                             let uu___11 =
                                FStar_Syntax_Print.term_to_string scrutinee in
-                             let uu____18237 =
+                             let uu___12 =
                                FStar_Syntax_Print.term_to_string t in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____18236 uu____18237
+                               uu___11 uu___12
                            else ());
-                          (let pat_discriminates uu___26_18258 =
-                             match uu___26_18258 with
+                          (let pat_discriminates uu___10 =
+                             match uu___10 with
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_constant
-                                    uu____18273;
-                                  FStar_Syntax_Syntax.p = uu____18274;_},
-                                FStar_Pervasives_Native.None, uu____18275) ->
+                                    FStar_Syntax_Syntax.Pat_constant uu___11;
+                                  FStar_Syntax_Syntax.p = uu___12;_},
+                                FStar_Pervasives_Native.None, uu___13) ->
                                  true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____18288;
-                                  FStar_Syntax_Syntax.p = uu____18289;_},
-                                FStar_Pervasives_Native.None, uu____18290) ->
+                                    FStar_Syntax_Syntax.Pat_cons uu___11;
+                                  FStar_Syntax_Syntax.p = uu___12;_},
+                                FStar_Pervasives_Native.None, uu___13) ->
                                  true
-                             | uu____18315 -> false in
+                             | uu___11 -> false in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b ->
                                      if pat_discriminates b
                                      then
-                                       let uu____18415 =
+                                       let uu___10 =
                                          FStar_Syntax_Subst.open_branch b in
-                                       match uu____18415 with
-                                       | (uu____18416, uu____18417, t') ->
-                                           let uu____18435 =
+                                       match uu___10 with
+                                       | (uu___11, uu___12, t') ->
+                                           let uu___13 =
                                              head_matches_delta env1 wl1 s t' in
-                                           (match uu____18435 with
-                                            | (FullMatch, uu____18446) ->
+                                           (match uu___13 with
+                                            | (FullMatch, uu___14) -> true
+                                            | (HeadMatch uu___14, uu___15) ->
                                                 true
-                                            | (HeadMatch uu____18459,
-                                               uu____18460) -> true
-                                            | uu____18473 -> false)
+                                            | uu___14 -> false)
                                      else false)) in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None ->
-                               ((let uu____18506 =
+                               ((let uu___11 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____18506
+                                 if uu___11
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____18511 =
+                                   let uu___11 =
                                      FStar_Util.prefix_until
                                        (fun b ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches in
-                                   match uu____18511 with
+                                   match uu___11 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1, uu____18599, uu____18600)
-                                       -> branches1
-                                   | uu____18745 -> branches in
-                                 let uu____18800 =
+                                       (branches1, uu___12, uu___13) ->
+                                       branches1
+                                   | uu___12 -> branches in
+                                 let uu___11 =
                                    FStar_Util.find_map try_branches
                                      (fun b ->
-                                        let uu____18809 =
+                                        let uu___12 =
                                           FStar_Syntax_Subst.open_branch b in
-                                        match uu____18809 with
-                                        | (p, uu____18813, uu____18814) ->
+                                        match uu___12 with
+                                        | (p, uu___13, uu___14) ->
                                             try_solve_branch scrutinee p) in
                                  FStar_All.pipe_left
-                                   (fun uu____18841 ->
-                                      FStar_Util.Inr uu____18841) uu____18800))
+                                   (fun uu___12 -> FStar_Util.Inr uu___12)
+                                   uu___11))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____18871 =
-                                 FStar_Syntax_Subst.open_branch b in
-                               (match uu____18871 with
-                                | (p, uu____18879, e) ->
-                                    ((let uu____18898 =
+                               let uu___10 = FStar_Syntax_Subst.open_branch b in
+                               (match uu___10 with
+                                | (p, uu___11, e) ->
+                                    ((let uu___13 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel") in
-                                      if uu____18898
+                                      if uu___13
                                       then
-                                        let uu____18899 =
+                                        let uu___14 =
                                           FStar_Syntax_Print.pat_to_string p in
-                                        let uu____18900 =
+                                        let uu___15 =
                                           FStar_Syntax_Print.term_to_string e in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____18899 uu____18900
+                                          uu___14 uu___15
                                       else ());
-                                     (let uu____18902 =
+                                     (let uu___13 =
                                         try_solve_branch scrutinee p in
                                       FStar_All.pipe_left
-                                        (fun uu____18915 ->
-                                           FStar_Util.Inr uu____18915)
-                                        uu____18902)))))
-                 | uu____18916 ->
-                     ((let uu____18938 =
+                                        (fun uu___14 ->
+                                           FStar_Util.Inr uu___14) uu___13)))))
+                 | uu___3 ->
+                     ((let uu___5 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "Rel") in
-                       if uu____18938
+                       if uu___5
                        then
-                         let uu____18939 = FStar_Syntax_Print.tag_of_term t1 in
-                         let uu____18940 = FStar_Syntax_Print.tag_of_term t2 in
+                         let uu___6 = FStar_Syntax_Print.tag_of_term t1 in
+                         let uu___7 = FStar_Syntax_Print.tag_of_term t2 in
                          FStar_Util.print2
                            "Heuristic not applicable: tag lhs=%s, rhs=%s\n"
-                           uu____18939 uu____18940
+                           uu___6 uu___7
                        else ());
                       FStar_Util.Inr FStar_Pervasives_Native.None))) in
          let rigid_rigid_delta env1 torig wl1 head1 head2 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig in
-           (let uu____18982 =
+           (let uu___2 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "RelDelta") in
-            if uu____18982
+            if uu___2
             then
-              let uu____18983 = FStar_Syntax_Print.tag_of_term t1 in
-              let uu____18984 = FStar_Syntax_Print.tag_of_term t2 in
-              let uu____18985 = FStar_Syntax_Print.term_to_string t1 in
-              let uu____18986 = FStar_Syntax_Print.term_to_string t2 in
+              let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
+              let uu___4 = FStar_Syntax_Print.tag_of_term t2 in
+              let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+              let uu___6 = FStar_Syntax_Print.term_to_string t2 in
               FStar_Util.print4 "rigid_rigid_delta of %s-%s (%s, %s)\n"
-                uu____18983 uu____18984 uu____18985 uu____18986
+                uu___3 uu___4 uu___5 uu___6
             else ());
-           (let uu____18988 = head_matches_delta env1 wl1 t1 t2 in
-            match uu____18988 with
+           (let uu___2 = head_matches_delta env1 wl1 t1 t2 in
+            match uu___2 with
             | (m, o) ->
                 (match (m, o) with
-                 | (MisMatch uu____19019, uu____19020) ->
+                 | (MisMatch uu___3, uu___4) ->
                      let rec may_relate head =
-                       let uu____19047 =
-                         let uu____19048 = FStar_Syntax_Subst.compress head in
-                         uu____19048.FStar_Syntax_Syntax.n in
-                       match uu____19047 with
-                       | FStar_Syntax_Syntax.Tm_name uu____19051 -> true
-                       | FStar_Syntax_Syntax.Tm_match uu____19052 -> true
+                       let uu___5 =
+                         let uu___6 = FStar_Syntax_Subst.compress head in
+                         uu___6.FStar_Syntax_Syntax.n in
+                       match uu___5 with
+                       | FStar_Syntax_Syntax.Tm_name uu___6 -> true
+                       | FStar_Syntax_Syntax.Tm_match uu___6 -> true
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
-                           let uu____19076 =
+                           let uu___6 =
                              FStar_TypeChecker_Env.delta_depth_of_fv env1 fv in
-                           (match uu____19076 with
+                           (match uu___6 with
                             | FStar_Syntax_Syntax.Delta_equational_at_level
-                                uu____19077 -> true
-                            | FStar_Syntax_Syntax.Delta_abstract uu____19078
-                                ->
+                                uu___7 -> true
+                            | FStar_Syntax_Syntax.Delta_abstract uu___7 ->
                                 problem.FStar_TypeChecker_Common.relation =
                                   FStar_TypeChecker_Common.EQ
-                            | uu____19079 -> false)
-                       | FStar_Syntax_Syntax.Tm_ascribed
-                           (t, uu____19081, uu____19082) -> may_relate t
-                       | FStar_Syntax_Syntax.Tm_uinst (t, uu____19124) ->
+                            | uu___7 -> false)
+                       | FStar_Syntax_Syntax.Tm_ascribed (t, uu___6, uu___7)
+                           -> may_relate t
+                       | FStar_Syntax_Syntax.Tm_uinst (t, uu___6) ->
                            may_relate t
-                       | FStar_Syntax_Syntax.Tm_meta (t, uu____19130) ->
+                       | FStar_Syntax_Syntax.Tm_meta (t, uu___6) ->
                            may_relate t
-                       | uu____19135 -> false in
-                     let uu____19136 =
-                       try_match_heuristic env1 orig wl1 t1 t2 o in
-                     (match uu____19136 with
+                       | uu___6 -> false in
+                     let uu___5 = try_match_heuristic env1 orig wl1 t1 t2 o in
+                     (match uu___5 with
                       | FStar_Util.Inl _defer_ok ->
-                          let uu____19146 =
+                          let uu___6 =
                             FStar_Thunk.mkv "delaying match heuristic" in
-                          giveup_or_defer1 orig uu____19146
+                          giveup_or_defer1 orig uu___6
                       | FStar_Util.Inr (FStar_Pervasives_Native.Some wl2) ->
                           solve env1 wl2
                       | FStar_Util.Inr (FStar_Pervasives_Native.None) ->
-                          let uu____19152 =
+                          let uu___6 =
                             ((may_relate head1) || (may_relate head2)) &&
                               wl1.smt_ok in
-                          if uu____19152
+                          if uu___6
                           then
-                            let uu____19153 =
-                              guard_of_prob env1 wl1 problem t1 t2 in
-                            (match uu____19153 with
+                            let uu___7 = guard_of_prob env1 wl1 problem t1 t2 in
+                            (match uu___7 with
                              | (guard, wl2) ->
-                                 let uu____19160 =
+                                 let uu___8 =
                                    solve_prob orig
                                      (FStar_Pervasives_Native.Some guard) []
                                      wl2 in
-                                 solve env1 uu____19160)
+                                 solve env1 uu___8)
                           else
-                            (let uu____19162 =
+                            (let uu___8 =
                                mklstr
-                                 (fun uu____19173 ->
-                                    let uu____19174 =
+                                 (fun uu___9 ->
+                                    let uu___10 =
                                       FStar_Syntax_Print.term_to_string head1 in
-                                    let uu____19175 =
-                                      let uu____19176 =
-                                        let uu____19179 =
+                                    let uu___11 =
+                                      let uu___12 =
+                                        let uu___13 =
                                           delta_depth_of_term env1 head1 in
-                                        FStar_Util.bind_opt uu____19179
+                                        FStar_Util.bind_opt uu___13
                                           (fun x ->
-                                             let uu____19185 =
+                                             let uu___14 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x in
                                              FStar_Pervasives_Native.Some
-                                               uu____19185) in
-                                      FStar_Util.dflt "" uu____19176 in
-                                    let uu____19186 =
+                                               uu___14) in
+                                      FStar_Util.dflt "" uu___12 in
+                                    let uu___12 =
                                       FStar_Syntax_Print.term_to_string head2 in
-                                    let uu____19187 =
-                                      let uu____19188 =
-                                        let uu____19191 =
+                                    let uu___13 =
+                                      let uu___14 =
+                                        let uu___15 =
                                           delta_depth_of_term env1 head2 in
-                                        FStar_Util.bind_opt uu____19191
+                                        FStar_Util.bind_opt uu___15
                                           (fun x ->
-                                             let uu____19197 =
+                                             let uu___16 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x in
                                              FStar_Pervasives_Native.Some
-                                               uu____19197) in
-                                      FStar_Util.dflt "" uu____19188 in
+                                               uu___16) in
+                                      FStar_Util.dflt "" uu___14 in
                                     FStar_Util.format4
                                       "head mismatch (%s (%s) vs %s (%s))"
-                                      uu____19174 uu____19175 uu____19186
-                                      uu____19187) in
-                             giveup env1 uu____19162 orig))
-                 | (HeadMatch (true), uu____19198) when
+                                      uu___10 uu___11 uu___12 uu___13) in
+                             giveup env1 uu___8 orig))
+                 | (HeadMatch (true), uu___3) when
                      problem.FStar_TypeChecker_Common.relation <>
                        FStar_TypeChecker_Common.EQ
                      ->
                      if wl1.smt_ok
                      then
-                       let uu____19211 = guard_of_prob env1 wl1 problem t1 t2 in
-                       (match uu____19211 with
+                       let uu___4 = guard_of_prob env1 wl1 problem t1 t2 in
+                       (match uu___4 with
                         | (guard, wl2) ->
-                            let uu____19218 =
+                            let uu___5 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some guard) [] wl2 in
-                            solve env1 uu____19218)
+                            solve env1 uu___5)
                      else
-                       (let uu____19220 =
+                       (let uu___5 =
                           mklstr
-                            (fun uu____19227 ->
-                               let uu____19228 =
+                            (fun uu___6 ->
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string t1 in
-                               let uu____19229 =
+                               let uu___8 =
                                  FStar_Syntax_Print.term_to_string t2 in
                                FStar_Util.format2
                                  "head mismatch for subtyping (%s vs %s)"
-                                 uu____19228 uu____19229) in
-                        giveup env1 uu____19220 orig)
-                 | (uu____19230, FStar_Pervasives_Native.Some (t11, t21)) ->
+                                 uu___7 uu___8) in
+                        giveup env1 uu___5 orig)
+                 | (uu___3, FStar_Pervasives_Native.Some (t11, t21)) ->
                      solve_t env1
-                       (let uu___2978_19244 = problem in
+                       (let uu___4 = problem in
                         {
                           FStar_TypeChecker_Common.pid =
-                            (uu___2978_19244.FStar_TypeChecker_Common.pid);
+                            (uu___4.FStar_TypeChecker_Common.pid);
                           FStar_TypeChecker_Common.lhs = t11;
                           FStar_TypeChecker_Common.relation =
-                            (uu___2978_19244.FStar_TypeChecker_Common.relation);
+                            (uu___4.FStar_TypeChecker_Common.relation);
                           FStar_TypeChecker_Common.rhs = t21;
                           FStar_TypeChecker_Common.element =
-                            (uu___2978_19244.FStar_TypeChecker_Common.element);
+                            (uu___4.FStar_TypeChecker_Common.element);
                           FStar_TypeChecker_Common.logical_guard =
-                            (uu___2978_19244.FStar_TypeChecker_Common.logical_guard);
+                            (uu___4.FStar_TypeChecker_Common.logical_guard);
                           FStar_TypeChecker_Common.logical_guard_uvar =
-                            (uu___2978_19244.FStar_TypeChecker_Common.logical_guard_uvar);
+                            (uu___4.FStar_TypeChecker_Common.logical_guard_uvar);
                           FStar_TypeChecker_Common.reason =
-                            (uu___2978_19244.FStar_TypeChecker_Common.reason);
+                            (uu___4.FStar_TypeChecker_Common.reason);
                           FStar_TypeChecker_Common.loc =
-                            (uu___2978_19244.FStar_TypeChecker_Common.loc);
+                            (uu___4.FStar_TypeChecker_Common.loc);
                           FStar_TypeChecker_Common.rank =
-                            (uu___2978_19244.FStar_TypeChecker_Common.rank)
+                            (uu___4.FStar_TypeChecker_Common.rank)
                         }) wl1
                  | (HeadMatch need_unif, FStar_Pervasives_Native.None) ->
                      rigid_heads_match env1 need_unif torig wl1 t1 t2
@@ -6750,188 +6579,187 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      rigid_heads_match env1 false torig wl1 t1 t2)) in
          let orig = FStar_TypeChecker_Common.TProb problem in
          def_check_prob "solve_t'.2" orig;
-         (let uu____19268 =
+         (let uu___2 =
             FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
               problem.FStar_TypeChecker_Common.rhs in
-          if uu____19268
+          if uu___2
           then
-            let uu____19269 =
-              solve_prob orig FStar_Pervasives_Native.None [] wl in
-            solve env uu____19269
+            let uu___3 = solve_prob orig FStar_Pervasives_Native.None [] wl in
+            solve env uu___3
           else
             (let t1 = problem.FStar_TypeChecker_Common.lhs in
              let t2 = problem.FStar_TypeChecker_Common.rhs in
-             (let uu____19274 =
-                let uu____19277 = p_scope orig in
-                FStar_List.map FStar_Pervasives_Native.fst uu____19277 in
+             (let uu___5 =
+                let uu___6 = p_scope orig in
+                FStar_List.map FStar_Pervasives_Native.fst uu___6 in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t1"
-                uu____19274 t1);
-             (let uu____19295 =
-                let uu____19298 = p_scope orig in
-                FStar_List.map FStar_Pervasives_Native.fst uu____19298 in
+                uu___5 t1);
+             (let uu___6 =
+                let uu___7 = p_scope orig in
+                FStar_List.map FStar_Pervasives_Native.fst uu___7 in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t2"
-                uu____19295 t2);
-             (let uu____19316 =
+                uu___6 t2);
+             (let uu___7 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
-              if uu____19316
+              if uu___7
               then
-                let uu____19317 =
+                let uu___8 =
                   FStar_Util.string_of_int
                     problem.FStar_TypeChecker_Common.pid in
-                let uu____19318 =
-                  let uu____19319 = FStar_Syntax_Print.tag_of_term t1 in
-                  let uu____19320 =
-                    let uu____19321 = FStar_Syntax_Print.term_to_string t1 in
-                    Prims.op_Hat "::" uu____19321 in
-                  Prims.op_Hat uu____19319 uu____19320 in
-                let uu____19322 =
-                  let uu____19323 = FStar_Syntax_Print.tag_of_term t2 in
-                  let uu____19324 =
-                    let uu____19325 = FStar_Syntax_Print.term_to_string t2 in
-                    Prims.op_Hat "::" uu____19325 in
-                  Prims.op_Hat uu____19323 uu____19324 in
+                let uu___9 =
+                  let uu___10 = FStar_Syntax_Print.tag_of_term t1 in
+                  let uu___11 =
+                    let uu___12 = FStar_Syntax_Print.term_to_string t1 in
+                    Prims.op_Hat "::" uu___12 in
+                  Prims.op_Hat uu___10 uu___11 in
+                let uu___10 =
+                  let uu___11 = FStar_Syntax_Print.tag_of_term t2 in
+                  let uu___12 =
+                    let uu___13 = FStar_Syntax_Print.term_to_string t2 in
+                    Prims.op_Hat "::" uu___13 in
+                  Prims.op_Hat uu___11 uu___12 in
                 FStar_Util.print4 "Attempting %s (%s vs %s); rel = (%s)\n"
-                  uu____19317 uu____19318 uu____19322
+                  uu___8 uu___9 uu___10
                   (rel_to_string problem.FStar_TypeChecker_Common.relation)
               else ());
              (let r = FStar_TypeChecker_Env.get_range env in
               match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
               with
-              | (FStar_Syntax_Syntax.Tm_delayed uu____19328, uu____19329) ->
+              | (FStar_Syntax_Syntax.Tm_delayed uu___7, uu___8) ->
                   failwith "Impossible: terms were not compressed"
-              | (uu____19344, FStar_Syntax_Syntax.Tm_delayed uu____19345) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_delayed uu___8) ->
                   failwith "Impossible: terms were not compressed"
-              | (FStar_Syntax_Syntax.Tm_ascribed uu____19360, uu____19361) ->
-                  let uu____19388 =
-                    let uu___3009_19389 = problem in
-                    let uu____19390 = FStar_Syntax_Util.unascribe t1 in
+              | (FStar_Syntax_Syntax.Tm_ascribed uu___7, uu___8) ->
+                  let uu___9 =
+                    let uu___10 = problem in
+                    let uu___11 = FStar_Syntax_Util.unascribe t1 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3009_19389.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____19390;
+                        (uu___10.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu___11;
                       FStar_TypeChecker_Common.relation =
-                        (uu___3009_19389.FStar_TypeChecker_Common.relation);
+                        (uu___10.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___3009_19389.FStar_TypeChecker_Common.rhs);
+                        (uu___10.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___3009_19389.FStar_TypeChecker_Common.element);
+                        (uu___10.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3009_19389.FStar_TypeChecker_Common.logical_guard);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3009_19389.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3009_19389.FStar_TypeChecker_Common.reason);
+                        (uu___10.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3009_19389.FStar_TypeChecker_Common.loc);
+                        (uu___10.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3009_19389.FStar_TypeChecker_Common.rank)
+                        (uu___10.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19388 wl
-              | (FStar_Syntax_Syntax.Tm_meta uu____19391, uu____19392) ->
-                  let uu____19399 =
-                    let uu___3015_19400 = problem in
-                    let uu____19401 = FStar_Syntax_Util.unmeta t1 in
+                  solve_t' env uu___9 wl
+              | (FStar_Syntax_Syntax.Tm_meta uu___7, uu___8) ->
+                  let uu___9 =
+                    let uu___10 = problem in
+                    let uu___11 = FStar_Syntax_Util.unmeta t1 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3015_19400.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____19401;
+                        (uu___10.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu___11;
                       FStar_TypeChecker_Common.relation =
-                        (uu___3015_19400.FStar_TypeChecker_Common.relation);
+                        (uu___10.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___3015_19400.FStar_TypeChecker_Common.rhs);
+                        (uu___10.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___3015_19400.FStar_TypeChecker_Common.element);
+                        (uu___10.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3015_19400.FStar_TypeChecker_Common.logical_guard);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3015_19400.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3015_19400.FStar_TypeChecker_Common.reason);
+                        (uu___10.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3015_19400.FStar_TypeChecker_Common.loc);
+                        (uu___10.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3015_19400.FStar_TypeChecker_Common.rank)
+                        (uu___10.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19399 wl
-              | (uu____19402, FStar_Syntax_Syntax.Tm_ascribed uu____19403) ->
-                  let uu____19430 =
-                    let uu___3021_19431 = problem in
-                    let uu____19432 = FStar_Syntax_Util.unascribe t2 in
+                  solve_t' env uu___9 wl
+              | (uu___7, FStar_Syntax_Syntax.Tm_ascribed uu___8) ->
+                  let uu___9 =
+                    let uu___10 = problem in
+                    let uu___11 = FStar_Syntax_Util.unascribe t2 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3021_19431.FStar_TypeChecker_Common.pid);
+                        (uu___10.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___3021_19431.FStar_TypeChecker_Common.lhs);
+                        (uu___10.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___3021_19431.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____19432;
+                        (uu___10.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu___11;
                       FStar_TypeChecker_Common.element =
-                        (uu___3021_19431.FStar_TypeChecker_Common.element);
+                        (uu___10.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3021_19431.FStar_TypeChecker_Common.logical_guard);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3021_19431.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3021_19431.FStar_TypeChecker_Common.reason);
+                        (uu___10.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3021_19431.FStar_TypeChecker_Common.loc);
+                        (uu___10.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3021_19431.FStar_TypeChecker_Common.rank)
+                        (uu___10.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19430 wl
-              | (uu____19433, FStar_Syntax_Syntax.Tm_meta uu____19434) ->
-                  let uu____19441 =
-                    let uu___3027_19442 = problem in
-                    let uu____19443 = FStar_Syntax_Util.unmeta t2 in
+                  solve_t' env uu___9 wl
+              | (uu___7, FStar_Syntax_Syntax.Tm_meta uu___8) ->
+                  let uu___9 =
+                    let uu___10 = problem in
+                    let uu___11 = FStar_Syntax_Util.unmeta t2 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3027_19442.FStar_TypeChecker_Common.pid);
+                        (uu___10.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___3027_19442.FStar_TypeChecker_Common.lhs);
+                        (uu___10.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___3027_19442.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____19443;
+                        (uu___10.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu___11;
                       FStar_TypeChecker_Common.element =
-                        (uu___3027_19442.FStar_TypeChecker_Common.element);
+                        (uu___10.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3027_19442.FStar_TypeChecker_Common.logical_guard);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3027_19442.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3027_19442.FStar_TypeChecker_Common.reason);
+                        (uu___10.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3027_19442.FStar_TypeChecker_Common.loc);
+                        (uu___10.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3027_19442.FStar_TypeChecker_Common.rank)
+                        (uu___10.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19441 wl
-              | (FStar_Syntax_Syntax.Tm_quoted (t11, uu____19445),
-                 FStar_Syntax_Syntax.Tm_quoted (t21, uu____19447)) ->
-                  let uu____19456 =
+                  solve_t' env uu___9 wl
+              | (FStar_Syntax_Syntax.Tm_quoted (t11, uu___7),
+                 FStar_Syntax_Syntax.Tm_quoted (t21, uu___8)) ->
+                  let uu___9 =
                     solve_prob orig FStar_Pervasives_Native.None [] wl in
-                  solve env uu____19456
-              | (FStar_Syntax_Syntax.Tm_bvar uu____19457, uu____19458) ->
+                  solve env uu___9
+              | (FStar_Syntax_Syntax.Tm_bvar uu___7, uu___8) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
-              | (uu____19459, FStar_Syntax_Syntax.Tm_bvar uu____19460) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_bvar uu___8) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
               | (FStar_Syntax_Syntax.Tm_type u1, FStar_Syntax_Syntax.Tm_type
                  u2) -> solve_one_universe_eq env orig u1 u2 wl
               | (FStar_Syntax_Syntax.Tm_arrow (bs1, c1),
                  FStar_Syntax_Syntax.Tm_arrow (bs2, c2)) ->
-                  let mk_c c uu___27_19529 =
-                    match uu___27_19529 with
+                  let mk_c c uu___7 =
+                    match uu___7 with
                     | [] -> c
                     | bs ->
-                        let uu____19557 =
+                        let uu___8 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (bs, c))
                             c.FStar_Syntax_Syntax.pos in
-                        FStar_Syntax_Syntax.mk_Total uu____19557 in
-                  let uu____19568 =
+                        FStar_Syntax_Syntax.mk_Total uu___8 in
+                  let uu___7 =
                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2)) in
-                  (match uu____19568 with
+                  (match uu___7 with
                    | ((bs11, c11), (bs21, c21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1 ->
@@ -6943,9 +6771,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   let c22 =
                                     FStar_Syntax_Subst.subst_comp subst c21 in
                                   let rel =
-                                    let uu____19717 =
+                                    let uu___8 =
                                       FStar_Options.use_eq_at_higher_order () in
-                                    if uu____19717
+                                    if uu___8
                                     then FStar_TypeChecker_Common.EQ
                                     else
                                       problem.FStar_TypeChecker_Common.relation in
@@ -6954,36 +6782,36 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     "function co-domain"))
               | (FStar_Syntax_Syntax.Tm_abs (bs1, tbody1, lopt1),
                  FStar_Syntax_Syntax.Tm_abs (bs2, tbody2, lopt2)) ->
-                  let mk_t t l uu___28_19802 =
-                    match uu___28_19802 with
+                  let mk_t t l uu___7 =
+                    match uu___7 with
                     | [] -> t
                     | bs ->
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_abs (bs, t, l))
                           t.FStar_Syntax_Syntax.pos in
-                  let uu____19844 =
+                  let uu___7 =
                     match_num_binders (bs1, (mk_t tbody1 lopt1))
                       (bs2, (mk_t tbody2 lopt2)) in
-                  (match uu____19844 with
+                  (match uu___7 with
                    | ((bs11, tbody11), (bs21, tbody21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1 ->
                             fun scope ->
                               fun env1 ->
                                 fun subst ->
-                                  let uu____19989 =
+                                  let uu___8 =
                                     FStar_Syntax_Subst.subst subst tbody11 in
-                                  let uu____19990 =
+                                  let uu___9 =
                                     FStar_Syntax_Subst.subst subst tbody21 in
-                                  mk_t_problem wl1 scope orig uu____19989
+                                  mk_t_problem wl1 scope orig uu___8
                                     problem.FStar_TypeChecker_Common.relation
-                                    uu____19990 FStar_Pervasives_Native.None
+                                    uu___9 FStar_Pervasives_Native.None
                                     "lambda co-domain"))
-              | (FStar_Syntax_Syntax.Tm_abs uu____19991, uu____19992) ->
+              | (FStar_Syntax_Syntax.Tm_abs uu___7, uu___8) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____20021 -> true
-                    | uu____20040 -> false in
+                    | FStar_Syntax_Syntax.Tm_abs uu___9 -> true
+                    | uu___9 -> false in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -6997,182 +6825,180 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____20093 =
+                      (let uu___10 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3129_20101 = env in
+                           (let uu___11 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3129_20101.FStar_TypeChecker_Env.solver);
+                                (uu___11.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3129_20101.FStar_TypeChecker_Env.range);
+                                (uu___11.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3129_20101.FStar_TypeChecker_Env.curmodule);
+                                (uu___11.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma);
+                                (uu___11.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___11.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___11.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3129_20101.FStar_TypeChecker_Env.modules);
+                                (uu___11.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.sigtab);
+                                (uu___11.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.attrtab);
+                                (uu___11.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3129_20101.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___11.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3129_20101.FStar_TypeChecker_Env.effects);
+                                (uu___11.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3129_20101.FStar_TypeChecker_Env.generalize);
+                                (uu___11.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3129_20101.FStar_TypeChecker_Env.letrecs);
+                                (uu___11.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3129_20101.FStar_TypeChecker_Env.top_level);
+                                (uu___11.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3129_20101.FStar_TypeChecker_Env.check_uvars);
+                                (uu___11.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3129_20101.FStar_TypeChecker_Env.use_eq);
+                                (uu___11.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3129_20101.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___11.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3129_20101.FStar_TypeChecker_Env.is_iface);
+                                (uu___11.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3129_20101.FStar_TypeChecker_Env.admit);
+                                (uu___11.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3129_20101.FStar_TypeChecker_Env.lax_universes);
+                                (uu___11.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3129_20101.FStar_TypeChecker_Env.phase1);
+                                (uu___11.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3129_20101.FStar_TypeChecker_Env.failhard);
+                                (uu___11.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3129_20101.FStar_TypeChecker_Env.nosynth);
+                                (uu___11.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3129_20101.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___11.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3129_20101.FStar_TypeChecker_Env.tc_term);
+                                (uu___11.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.type_of);
+                                (uu___11.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.universe_of);
+                                (uu___11.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.check_type_of);
+                                (uu___11.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3129_20101.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___11.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3129_20101.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___11.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3129_20101.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___11.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3129_20101.FStar_TypeChecker_Env.proof_ns);
+                                (uu___11.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3129_20101.FStar_TypeChecker_Env.synth_hook);
+                                (uu___11.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3129_20101.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___11.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3129_20101.FStar_TypeChecker_Env.splice);
+                                (uu___11.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3129_20101.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___11.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3129_20101.FStar_TypeChecker_Env.postprocess);
+                                (uu___11.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3129_20101.FStar_TypeChecker_Env.identifier_info);
+                                (uu___11.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3129_20101.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___11.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3129_20101.FStar_TypeChecker_Env.dsenv);
+                                (uu___11.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3129_20101.FStar_TypeChecker_Env.nbe);
+                                (uu___11.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___11.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___11.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___3129_20101.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___11.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) t in
-                       match uu____20093 with
-                       | (uu____20104, ty, uu____20106) ->
+                       match uu___10 with
+                       | (uu___11, ty, uu___12) ->
                            let ty1 =
-                             let rec aux ty1 =
-                               let ty2 =
+                             let rec aux ty2 =
+                               let ty3 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
-                                   ty1 in
-                               let uu____20115 =
-                                 let uu____20116 =
-                                   FStar_Syntax_Subst.compress ty2 in
-                                 uu____20116.FStar_Syntax_Syntax.n in
-                               match uu____20115 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____20119 ->
-                                   let uu____20126 =
-                                     FStar_Syntax_Util.unrefine ty2 in
-                                   aux uu____20126
-                               | uu____20127 -> ty2 in
+                                   ty2 in
+                               let uu___13 =
+                                 let uu___14 =
+                                   FStar_Syntax_Subst.compress ty3 in
+                                 uu___14.FStar_Syntax_Syntax.n in
+                               match uu___13 with
+                               | FStar_Syntax_Syntax.Tm_refine uu___14 ->
+                                   let uu___15 =
+                                     FStar_Syntax_Util.unrefine ty3 in
+                                   aux uu___15
+                               | uu___14 -> ty3 in
                              aux ty in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1 in
-                           ((let uu____20130 =
+                           ((let uu___14 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel") in
-                             if uu____20130
+                             if uu___14
                              then
-                               let uu____20131 =
+                               let uu___15 =
                                  FStar_Syntax_Print.term_to_string t in
-                               let uu____20132 =
-                                 let uu____20133 =
+                               let uu___16 =
+                                 let uu___17 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1 in
-                                 FStar_Syntax_Print.term_to_string
-                                   uu____20133 in
-                               let uu____20134 =
+                                 FStar_Syntax_Print.term_to_string uu___17 in
+                               let uu___17 =
                                  FStar_Syntax_Print.term_to_string r1 in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____20131 uu____20132 uu____20134
+                                 uu___15 uu___16 uu___17
                              else ());
                             r1)) in
-                  let uu____20136 =
-                    let uu____20153 = maybe_eta t1 in
-                    let uu____20160 = maybe_eta t2 in
-                    (uu____20153, uu____20160) in
-                  (match uu____20136 with
+                  let uu___9 =
+                    let uu___10 = maybe_eta t1 in
+                    let uu___11 = maybe_eta t2 in (uu___10, uu___11) in
+                  (match uu___9 with
                    | (FStar_Util.Inl t11, FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3150_20202 = problem in
+                         (let uu___10 = problem in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3150_20202.FStar_TypeChecker_Common.pid);
+                              (uu___10.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3150_20202.FStar_TypeChecker_Common.relation);
+                              (uu___10.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3150_20202.FStar_TypeChecker_Common.element);
+                              (uu___10.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3150_20202.FStar_TypeChecker_Common.logical_guard);
+                              (uu___10.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3150_20202.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3150_20202.FStar_TypeChecker_Common.reason);
+                              (uu___10.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3150_20202.FStar_TypeChecker_Common.loc);
+                              (uu___10.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3150_20202.FStar_TypeChecker_Common.rank)
+                              (uu___10.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs, FStar_Util.Inr not_abs) ->
-                       let uu____20223 =
+                       let uu___10 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20223
+                       if uu___10
                        then
-                         let uu____20224 = destruct_flex_t not_abs wl in
-                         (match uu____20224 with
+                         let uu___11 = destruct_flex_t not_abs wl in
+                         (match uu___11 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7181,41 +7007,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20239 = problem in
+                              (let uu___12 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.pid);
+                                   (uu___12.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.relation);
+                                   (uu___12.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.element);
+                                   (uu___12.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.reason);
+                                   (uu___12.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.loc);
+                                   (uu___12.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.rank)
+                                   (uu___12.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20241 =
+                            (let uu___13 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20241 orig))
+                             giveup env uu___13 orig))
                    | (FStar_Util.Inr not_abs, FStar_Util.Inl t_abs) ->
-                       let uu____20262 =
+                       let uu___10 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20262
+                       if uu___10
                        then
-                         let uu____20263 = destruct_flex_t not_abs wl in
-                         (match uu____20263 with
+                         let uu___11 = destruct_flex_t not_abs wl in
+                         (match uu___11 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7224,41 +7050,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20278 = problem in
+                              (let uu___12 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.pid);
+                                   (uu___12.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.relation);
+                                   (uu___12.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.element);
+                                   (uu___12.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.reason);
+                                   (uu___12.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.loc);
+                                   (uu___12.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.rank)
+                                   (uu___12.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20280 =
+                            (let uu___13 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20280 orig))
-                   | uu____20281 ->
+                             giveup env uu___13 orig))
+                   | uu___10 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
-              | (uu____20298, FStar_Syntax_Syntax.Tm_abs uu____20299) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_abs uu___8) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____20328 -> true
-                    | uu____20347 -> false in
+                    | FStar_Syntax_Syntax.Tm_abs uu___9 -> true
+                    | uu___9 -> false in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7272,182 +7098,180 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____20400 =
+                      (let uu___10 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3129_20408 = env in
+                           (let uu___11 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3129_20408.FStar_TypeChecker_Env.solver);
+                                (uu___11.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3129_20408.FStar_TypeChecker_Env.range);
+                                (uu___11.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3129_20408.FStar_TypeChecker_Env.curmodule);
+                                (uu___11.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma);
+                                (uu___11.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___11.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___11.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3129_20408.FStar_TypeChecker_Env.modules);
+                                (uu___11.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.sigtab);
+                                (uu___11.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.attrtab);
+                                (uu___11.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3129_20408.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___11.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3129_20408.FStar_TypeChecker_Env.effects);
+                                (uu___11.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3129_20408.FStar_TypeChecker_Env.generalize);
+                                (uu___11.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3129_20408.FStar_TypeChecker_Env.letrecs);
+                                (uu___11.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3129_20408.FStar_TypeChecker_Env.top_level);
+                                (uu___11.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3129_20408.FStar_TypeChecker_Env.check_uvars);
+                                (uu___11.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3129_20408.FStar_TypeChecker_Env.use_eq);
+                                (uu___11.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3129_20408.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___11.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3129_20408.FStar_TypeChecker_Env.is_iface);
+                                (uu___11.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3129_20408.FStar_TypeChecker_Env.admit);
+                                (uu___11.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3129_20408.FStar_TypeChecker_Env.lax_universes);
+                                (uu___11.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3129_20408.FStar_TypeChecker_Env.phase1);
+                                (uu___11.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3129_20408.FStar_TypeChecker_Env.failhard);
+                                (uu___11.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3129_20408.FStar_TypeChecker_Env.nosynth);
+                                (uu___11.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3129_20408.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___11.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3129_20408.FStar_TypeChecker_Env.tc_term);
+                                (uu___11.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.type_of);
+                                (uu___11.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.universe_of);
+                                (uu___11.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.check_type_of);
+                                (uu___11.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3129_20408.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___11.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3129_20408.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___11.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3129_20408.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___11.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3129_20408.FStar_TypeChecker_Env.proof_ns);
+                                (uu___11.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3129_20408.FStar_TypeChecker_Env.synth_hook);
+                                (uu___11.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3129_20408.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___11.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3129_20408.FStar_TypeChecker_Env.splice);
+                                (uu___11.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3129_20408.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___11.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3129_20408.FStar_TypeChecker_Env.postprocess);
+                                (uu___11.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3129_20408.FStar_TypeChecker_Env.identifier_info);
+                                (uu___11.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3129_20408.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___11.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3129_20408.FStar_TypeChecker_Env.dsenv);
+                                (uu___11.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3129_20408.FStar_TypeChecker_Env.nbe);
+                                (uu___11.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___11.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___11.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___3129_20408.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___11.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) t in
-                       match uu____20400 with
-                       | (uu____20411, ty, uu____20413) ->
+                       match uu___10 with
+                       | (uu___11, ty, uu___12) ->
                            let ty1 =
-                             let rec aux ty1 =
-                               let ty2 =
+                             let rec aux ty2 =
+                               let ty3 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
-                                   ty1 in
-                               let uu____20422 =
-                                 let uu____20423 =
-                                   FStar_Syntax_Subst.compress ty2 in
-                                 uu____20423.FStar_Syntax_Syntax.n in
-                               match uu____20422 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____20426 ->
-                                   let uu____20433 =
-                                     FStar_Syntax_Util.unrefine ty2 in
-                                   aux uu____20433
-                               | uu____20434 -> ty2 in
+                                   ty2 in
+                               let uu___13 =
+                                 let uu___14 =
+                                   FStar_Syntax_Subst.compress ty3 in
+                                 uu___14.FStar_Syntax_Syntax.n in
+                               match uu___13 with
+                               | FStar_Syntax_Syntax.Tm_refine uu___14 ->
+                                   let uu___15 =
+                                     FStar_Syntax_Util.unrefine ty3 in
+                                   aux uu___15
+                               | uu___14 -> ty3 in
                              aux ty in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1 in
-                           ((let uu____20437 =
+                           ((let uu___14 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel") in
-                             if uu____20437
+                             if uu___14
                              then
-                               let uu____20438 =
+                               let uu___15 =
                                  FStar_Syntax_Print.term_to_string t in
-                               let uu____20439 =
-                                 let uu____20440 =
+                               let uu___16 =
+                                 let uu___17 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1 in
-                                 FStar_Syntax_Print.term_to_string
-                                   uu____20440 in
-                               let uu____20441 =
+                                 FStar_Syntax_Print.term_to_string uu___17 in
+                               let uu___17 =
                                  FStar_Syntax_Print.term_to_string r1 in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____20438 uu____20439 uu____20441
+                                 uu___15 uu___16 uu___17
                              else ());
                             r1)) in
-                  let uu____20443 =
-                    let uu____20460 = maybe_eta t1 in
-                    let uu____20467 = maybe_eta t2 in
-                    (uu____20460, uu____20467) in
-                  (match uu____20443 with
+                  let uu___9 =
+                    let uu___10 = maybe_eta t1 in
+                    let uu___11 = maybe_eta t2 in (uu___10, uu___11) in
+                  (match uu___9 with
                    | (FStar_Util.Inl t11, FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3150_20509 = problem in
+                         (let uu___10 = problem in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3150_20509.FStar_TypeChecker_Common.pid);
+                              (uu___10.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3150_20509.FStar_TypeChecker_Common.relation);
+                              (uu___10.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3150_20509.FStar_TypeChecker_Common.element);
+                              (uu___10.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3150_20509.FStar_TypeChecker_Common.logical_guard);
+                              (uu___10.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3150_20509.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___10.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3150_20509.FStar_TypeChecker_Common.reason);
+                              (uu___10.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3150_20509.FStar_TypeChecker_Common.loc);
+                              (uu___10.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3150_20509.FStar_TypeChecker_Common.rank)
+                              (uu___10.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs, FStar_Util.Inr not_abs) ->
-                       let uu____20530 =
+                       let uu___10 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20530
+                       if uu___10
                        then
-                         let uu____20531 = destruct_flex_t not_abs wl in
-                         (match uu____20531 with
+                         let uu___11 = destruct_flex_t not_abs wl in
+                         (match uu___11 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7456,41 +7280,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20546 = problem in
+                              (let uu___12 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.pid);
+                                   (uu___12.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.relation);
+                                   (uu___12.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.element);
+                                   (uu___12.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.reason);
+                                   (uu___12.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.loc);
+                                   (uu___12.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.rank)
+                                   (uu___12.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20548 =
+                            (let uu___13 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20548 orig))
+                             giveup env uu___13 orig))
                    | (FStar_Util.Inr not_abs, FStar_Util.Inl t_abs) ->
-                       let uu____20569 =
+                       let uu___10 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20569
+                       if uu___10
                        then
-                         let uu____20570 = destruct_flex_t not_abs wl in
-                         (match uu____20570 with
+                         let uu___11 = destruct_flex_t not_abs wl in
+                         (match uu___11 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7499,125 +7323,125 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20585 = problem in
+                              (let uu___12 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.pid);
+                                   (uu___12.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.relation);
+                                   (uu___12.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.element);
+                                   (uu___12.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___12.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.reason);
+                                   (uu___12.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.loc);
+                                   (uu___12.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.rank)
+                                   (uu___12.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20587 =
+                            (let uu___13 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20587 orig))
-                   | uu____20588 ->
+                             giveup env uu___13 orig))
+                   | uu___10 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
               | (FStar_Syntax_Syntax.Tm_refine (x1, phi1),
                  FStar_Syntax_Syntax.Tm_refine (x2, phi2)) ->
-                  let uu____20617 =
-                    let uu____20622 =
+                  let uu___7 =
+                    let uu___8 =
                       head_matches_delta env wl x1.FStar_Syntax_Syntax.sort
                         x2.FStar_Syntax_Syntax.sort in
-                    match uu____20622 with
+                    match uu___8 with
                     | (FullMatch, FStar_Pervasives_Native.Some (t11, t21)) ->
-                        ((let uu___3190_20650 = x1 in
+                        ((let uu___9 = x1 in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3190_20650.FStar_Syntax_Syntax.ppname);
+                              (uu___9.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3190_20650.FStar_Syntax_Syntax.index);
+                              (uu___9.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3192_20652 = x2 in
+                          (let uu___9 = x2 in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3192_20652.FStar_Syntax_Syntax.ppname);
+                               (uu___9.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3192_20652.FStar_Syntax_Syntax.index);
+                               (uu___9.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | (HeadMatch uu____20653, FStar_Pervasives_Native.Some
+                    | (HeadMatch uu___9, FStar_Pervasives_Native.Some
                        (t11, t21)) ->
-                        ((let uu___3190_20667 = x1 in
+                        ((let uu___10 = x1 in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3190_20667.FStar_Syntax_Syntax.ppname);
+                              (uu___10.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3190_20667.FStar_Syntax_Syntax.index);
+                              (uu___10.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3192_20669 = x2 in
+                          (let uu___10 = x2 in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3192_20669.FStar_Syntax_Syntax.ppname);
+                               (uu___10.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3192_20669.FStar_Syntax_Syntax.index);
+                               (uu___10.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | uu____20670 -> (x1, x2) in
-                  (match uu____20617 with
+                    | uu___9 -> (x1, x2) in
+                  (match uu___7 with
                    | (x11, x21) ->
                        let t11 = FStar_Syntax_Util.refine x11 phi1 in
                        let t21 = FStar_Syntax_Util.refine x21 phi2 in
-                       let uu____20689 = as_refinement false env t11 in
-                       (match uu____20689 with
+                       let uu___8 = as_refinement false env t11 in
+                       (match uu___8 with
                         | (x12, phi11) ->
-                            let uu____20696 = as_refinement false env t21 in
-                            (match uu____20696 with
+                            let uu___9 = as_refinement false env t21 in
+                            (match uu___9 with
                              | (x22, phi21) ->
-                                 ((let uu____20704 =
+                                 ((let uu___11 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "Rel") in
-                                   if uu____20704
+                                   if uu___11
                                    then
-                                     ((let uu____20706 =
+                                     ((let uu___13 =
                                          FStar_Syntax_Print.bv_to_string x12 in
-                                       let uu____20707 =
+                                       let uu___14 =
                                          FStar_Syntax_Print.term_to_string
                                            x12.FStar_Syntax_Syntax.sort in
-                                       let uu____20708 =
+                                       let uu___15 =
                                          FStar_Syntax_Print.term_to_string
                                            phi11 in
                                        FStar_Util.print3
-                                         "ref1 = (%s):(%s){%s}\n" uu____20706
-                                         uu____20707 uu____20708);
-                                      (let uu____20709 =
+                                         "ref1 = (%s):(%s){%s}\n" uu___13
+                                         uu___14 uu___15);
+                                      (let uu___13 =
                                          FStar_Syntax_Print.bv_to_string x22 in
-                                       let uu____20710 =
+                                       let uu___14 =
                                          FStar_Syntax_Print.term_to_string
                                            x22.FStar_Syntax_Syntax.sort in
-                                       let uu____20711 =
+                                       let uu___15 =
                                          FStar_Syntax_Print.term_to_string
                                            phi21 in
                                        FStar_Util.print3
-                                         "ref2 = (%s):(%s){%s}\n" uu____20709
-                                         uu____20710 uu____20711))
+                                         "ref2 = (%s):(%s){%s}\n" uu___13
+                                         uu___14 uu___15))
                                    else ());
-                                  (let uu____20713 =
+                                  (let uu___11 =
                                      mk_t_problem wl [] orig
                                        x12.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.relation
                                        x22.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.element
                                        "refinement base type" in
-                                   match uu____20713 with
+                                   match uu___11 with
                                    | (base_prob, wl1) ->
                                        let x13 =
                                          FStar_Syntax_Syntax.freshen_bv x12 in
@@ -7632,10 +7456,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                          FStar_TypeChecker_Env.push_bv env
                                            x13 in
                                        let mk_imp imp phi13 phi23 =
-                                         let uu____20781 = imp phi13 phi23 in
-                                         FStar_All.pipe_right uu____20781
+                                         let uu___12 = imp phi13 phi23 in
+                                         FStar_All.pipe_right uu___12
                                            (guard_on_element wl1 problem x13) in
-                                       let fallback uu____20793 =
+                                       let fallback uu___12 =
                                          let impl =
                                            if
                                              problem.FStar_TypeChecker_Common.relation
@@ -7649,42 +7473,39 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                          let guard =
                                            FStar_Syntax_Util.mk_conj
                                              (p_guard base_prob) impl in
-                                         (let uu____20804 =
-                                            let uu____20807 = p_scope orig in
+                                         (let uu___14 =
+                                            let uu___15 = p_scope orig in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____20807 in
+                                              uu___15 in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.1" uu____20804
+                                            (p_loc orig) "ref.1" uu___14
                                             (p_guard base_prob));
-                                         (let uu____20825 =
-                                            let uu____20828 = p_scope orig in
+                                         (let uu___15 =
+                                            let uu___16 = p_scope orig in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____20828 in
+                                              uu___16 in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.2" uu____20825
-                                            impl);
+                                            (p_loc orig) "ref.2" uu___15 impl);
                                          (let wl2 =
                                             solve_prob orig
                                               (FStar_Pervasives_Native.Some
                                                  guard) [] wl1 in
-                                          let uu____20846 =
+                                          let uu___15 =
                                             attempt [base_prob] wl2 in
-                                          solve env1 uu____20846) in
+                                          solve env1 uu___15) in
                                        let has_uvars =
-                                         (let uu____20850 =
-                                            let uu____20851 =
+                                         (let uu___12 =
+                                            let uu___13 =
                                               FStar_Syntax_Free.uvars phi12 in
-                                            FStar_Util.set_is_empty
-                                              uu____20851 in
-                                          Prims.op_Negation uu____20850) ||
-                                           (let uu____20855 =
-                                              let uu____20856 =
+                                            FStar_Util.set_is_empty uu___13 in
+                                          Prims.op_Negation uu___12) ||
+                                           (let uu___12 =
+                                              let uu___13 =
                                                 FStar_Syntax_Free.uvars phi22 in
-                                              FStar_Util.set_is_empty
-                                                uu____20856 in
-                                            Prims.op_Negation uu____20855) in
+                                              FStar_Util.set_is_empty uu___13 in
+                                            Prims.op_Negation uu___12) in
                                        if
                                          (problem.FStar_TypeChecker_Common.relation
                                             = FStar_TypeChecker_Common.EQ)
@@ -7693,46 +7514,44 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                env1.FStar_TypeChecker_Env.uvar_subtyping)
                                               && has_uvars)
                                        then
-                                         let uu____20859 =
-                                           let uu____20864 =
-                                             let uu____20873 =
+                                         let uu___12 =
+                                           let uu___13 =
+                                             let uu___14 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  x13 in
-                                             [uu____20873] in
-                                           mk_t_problem wl1 uu____20864 orig
+                                             [uu___14] in
+                                           mk_t_problem wl1 uu___13 orig
                                              phi12
                                              FStar_TypeChecker_Common.EQ
                                              phi22
                                              FStar_Pervasives_Native.None
                                              "refinement formula" in
-                                         (match uu____20859 with
+                                         (match uu___12 with
                                           | (ref_prob, wl2) ->
                                               let tx =
                                                 FStar_Syntax_Unionfind.new_transaction
                                                   () in
-                                              let uu____20895 =
+                                              let uu___13 =
                                                 solve env1
-                                                  (let uu___3235_20897 = wl2 in
+                                                  (let uu___14 = wl2 in
                                                    {
                                                      attempting = [ref_prob];
                                                      wl_deferred = [];
                                                      wl_deferred_to_tac =
-                                                       (uu___3235_20897.wl_deferred_to_tac);
-                                                     ctr =
-                                                       (uu___3235_20897.ctr);
+                                                       (uu___14.wl_deferred_to_tac);
+                                                     ctr = (uu___14.ctr);
                                                      defer_ok = false;
                                                      smt_ok =
-                                                       (uu___3235_20897.smt_ok);
+                                                       (uu___14.smt_ok);
                                                      umax_heuristic_ok =
-                                                       (uu___3235_20897.umax_heuristic_ok);
-                                                     tcenv =
-                                                       (uu___3235_20897.tcenv);
+                                                       (uu___14.umax_heuristic_ok);
+                                                     tcenv = (uu___14.tcenv);
                                                      wl_implicits =
-                                                       (uu___3235_20897.wl_implicits);
+                                                       (uu___14.wl_implicits);
                                                      repr_subcomp_allowed =
-                                                       (uu___3235_20897.repr_subcomp_allowed)
+                                                       (uu___14.repr_subcomp_allowed)
                                                    }) in
-                                              (match uu____20895 with
+                                              (match uu___13 with
                                                | Failed (prob, msg) ->
                                                    (FStar_Syntax_Unionfind.rollback
                                                       tx;
@@ -7746,67 +7565,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                     then giveup env1 msg prob
                                                     else fallback ())
                                                | Success
-                                                   (uu____20908,
-                                                    defer_to_tac,
-                                                    uu____20910)
+                                                   (uu___14, defer_to_tac,
+                                                    uu___15)
                                                    ->
                                                    (FStar_Syntax_Unionfind.commit
                                                       tx;
                                                     (let guard =
-                                                       let uu____20915 =
+                                                       let uu___17 =
                                                          FStar_All.pipe_right
                                                            (p_guard ref_prob)
                                                            (guard_on_element
                                                               wl2 problem x13) in
                                                        FStar_Syntax_Util.mk_conj
                                                          (p_guard base_prob)
-                                                         uu____20915 in
+                                                         uu___17 in
                                                      let wl3 =
                                                        solve_prob orig
                                                          (FStar_Pervasives_Native.Some
                                                             guard) [] wl2 in
                                                      let wl4 =
-                                                       let uu___3251_20924 =
-                                                         wl3 in
+                                                       let uu___17 = wl3 in
                                                        {
                                                          attempting =
-                                                           (uu___3251_20924.attempting);
+                                                           (uu___17.attempting);
                                                          wl_deferred =
-                                                           (uu___3251_20924.wl_deferred);
+                                                           (uu___17.wl_deferred);
                                                          wl_deferred_to_tac =
-                                                           (uu___3251_20924.wl_deferred_to_tac);
+                                                           (uu___17.wl_deferred_to_tac);
                                                          ctr =
                                                            (wl3.ctr +
                                                               Prims.int_one);
                                                          defer_ok =
-                                                           (uu___3251_20924.defer_ok);
+                                                           (uu___17.defer_ok);
                                                          smt_ok =
-                                                           (uu___3251_20924.smt_ok);
+                                                           (uu___17.smt_ok);
                                                          umax_heuristic_ok =
-                                                           (uu___3251_20924.umax_heuristic_ok);
+                                                           (uu___17.umax_heuristic_ok);
                                                          tcenv =
-                                                           (uu___3251_20924.tcenv);
+                                                           (uu___17.tcenv);
                                                          wl_implicits =
-                                                           (uu___3251_20924.wl_implicits);
+                                                           (uu___17.wl_implicits);
                                                          repr_subcomp_allowed
                                                            =
-                                                           (uu___3251_20924.repr_subcomp_allowed)
+                                                           (uu___17.repr_subcomp_allowed)
                                                        } in
                                                      let wl5 =
                                                        extend_wl wl4
                                                          defer_to_tac [] in
-                                                     let uu____20926 =
+                                                     let uu___17 =
                                                        attempt [base_prob]
                                                          wl5 in
-                                                     solve env1 uu____20926))))
+                                                     solve env1 uu___17))))
                                        else fallback ())))))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____20928,
-                 FStar_Syntax_Syntax.Tm_uvar uu____20929) ->
-                  let uu____20954 = ensure_no_uvar_subst t1 wl in
-                  (match uu____20954 with
+              | (FStar_Syntax_Syntax.Tm_uvar uu___7,
+                 FStar_Syntax_Syntax.Tm_uvar uu___8) ->
+                  let uu___9 = ensure_no_uvar_subst t1 wl in
+                  (match uu___9 with
                    | (t11, wl1) ->
-                       let uu____20961 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____20961 with
+                       let uu___10 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu___10 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
@@ -7814,33 +7631,33 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____20970;
-                    FStar_Syntax_Syntax.pos = uu____20971;
-                    FStar_Syntax_Syntax.vars = uu____20972;_},
-                  uu____20973),
-                 FStar_Syntax_Syntax.Tm_uvar uu____20974) ->
-                  let uu____21023 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21023 with
+                      uu___7;
+                    FStar_Syntax_Syntax.pos = uu___8;
+                    FStar_Syntax_Syntax.vars = uu___9;_},
+                  uu___10),
+                 FStar_Syntax_Syntax.Tm_uvar uu___11) ->
+                  let uu___12 = ensure_no_uvar_subst t1 wl in
+                  (match uu___12 with
                    | (t11, wl1) ->
-                       let uu____21030 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21030 with
+                       let uu___13 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu___13 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
                             solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21039,
+              | (FStar_Syntax_Syntax.Tm_uvar uu___7,
                  FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21040;
-                    FStar_Syntax_Syntax.pos = uu____21041;
-                    FStar_Syntax_Syntax.vars = uu____21042;_},
-                  uu____21043)) ->
-                  let uu____21092 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21092 with
+                      uu___8;
+                    FStar_Syntax_Syntax.pos = uu___9;
+                    FStar_Syntax_Syntax.vars = uu___10;_},
+                  uu___11)) ->
+                  let uu___12 = ensure_no_uvar_subst t1 wl in
+                  (match uu___12 with
                    | (t11, wl1) ->
-                       let uu____21099 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21099 with
+                       let uu___13 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu___13 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
@@ -7848,234 +7665,234 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21108;
-                    FStar_Syntax_Syntax.pos = uu____21109;
-                    FStar_Syntax_Syntax.vars = uu____21110;_},
-                  uu____21111),
+                      uu___7;
+                    FStar_Syntax_Syntax.pos = uu___8;
+                    FStar_Syntax_Syntax.vars = uu___9;_},
+                  uu___10),
                  FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21112;
-                    FStar_Syntax_Syntax.pos = uu____21113;
-                    FStar_Syntax_Syntax.vars = uu____21114;_},
-                  uu____21115)) ->
-                  let uu____21188 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21188 with
+                      uu___11;
+                    FStar_Syntax_Syntax.pos = uu___12;
+                    FStar_Syntax_Syntax.vars = uu___13;_},
+                  uu___14)) ->
+                  let uu___15 = ensure_no_uvar_subst t1 wl in
+                  (match uu___15 with
                    | (t11, wl1) ->
-                       let uu____21195 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21195 with
+                       let uu___16 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu___16 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
                             solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21204, uu____21205) when
+              | (FStar_Syntax_Syntax.Tm_uvar uu___7, uu___8) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____21218 = destruct_flex_t t1 wl in
-                  (match uu____21218 with
+                  let uu___9 = destruct_flex_t t1 wl in
+                  (match uu___9 with
                    | (f1, wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21225;
-                    FStar_Syntax_Syntax.pos = uu____21226;
-                    FStar_Syntax_Syntax.vars = uu____21227;_},
-                  uu____21228),
-                 uu____21229) when
+                      uu___7;
+                    FStar_Syntax_Syntax.pos = uu___8;
+                    FStar_Syntax_Syntax.vars = uu___9;_},
+                  uu___10),
+                 uu___11) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____21266 = destruct_flex_t t1 wl in
-                  (match uu____21266 with
+                  let uu___12 = destruct_flex_t t1 wl in
+                  (match uu___12 with
                    | (f1, wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
-              | (uu____21273, FStar_Syntax_Syntax.Tm_uvar uu____21274) when
+              | (uu___7, FStar_Syntax_Syntax.Tm_uvar uu___8) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (uu____21287, FStar_Syntax_Syntax.Tm_app
+              | (uu___7, FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21288;
-                    FStar_Syntax_Syntax.pos = uu____21289;
-                    FStar_Syntax_Syntax.vars = uu____21290;_},
-                  uu____21291)) when
+                      uu___8;
+                    FStar_Syntax_Syntax.pos = uu___9;
+                    FStar_Syntax_Syntax.vars = uu___10;_},
+                  uu___11)) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21328,
-                 FStar_Syntax_Syntax.Tm_arrow uu____21329) ->
+              | (FStar_Syntax_Syntax.Tm_uvar uu___7,
+                 FStar_Syntax_Syntax.Tm_arrow uu___8) ->
                   solve_t' env
-                    (let uu___3354_21357 = problem in
+                    (let uu___9 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3354_21357.FStar_TypeChecker_Common.pid);
+                         (uu___9.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3354_21357.FStar_TypeChecker_Common.lhs);
+                         (uu___9.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3354_21357.FStar_TypeChecker_Common.rhs);
+                         (uu___9.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3354_21357.FStar_TypeChecker_Common.element);
+                         (uu___9.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3354_21357.FStar_TypeChecker_Common.logical_guard);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3354_21357.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3354_21357.FStar_TypeChecker_Common.reason);
+                         (uu___9.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3354_21357.FStar_TypeChecker_Common.loc);
+                         (uu___9.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3354_21357.FStar_TypeChecker_Common.rank)
+                         (uu___9.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21358;
-                    FStar_Syntax_Syntax.pos = uu____21359;
-                    FStar_Syntax_Syntax.vars = uu____21360;_},
-                  uu____21361),
-                 FStar_Syntax_Syntax.Tm_arrow uu____21362) ->
+                      uu___7;
+                    FStar_Syntax_Syntax.pos = uu___8;
+                    FStar_Syntax_Syntax.vars = uu___9;_},
+                  uu___10),
+                 FStar_Syntax_Syntax.Tm_arrow uu___11) ->
                   solve_t' env
-                    (let uu___3354_21414 = problem in
+                    (let uu___12 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3354_21414.FStar_TypeChecker_Common.pid);
+                         (uu___12.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3354_21414.FStar_TypeChecker_Common.lhs);
+                         (uu___12.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3354_21414.FStar_TypeChecker_Common.rhs);
+                         (uu___12.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3354_21414.FStar_TypeChecker_Common.element);
+                         (uu___12.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3354_21414.FStar_TypeChecker_Common.logical_guard);
+                         (uu___12.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3354_21414.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___12.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3354_21414.FStar_TypeChecker_Common.reason);
+                         (uu___12.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3354_21414.FStar_TypeChecker_Common.loc);
+                         (uu___12.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3354_21414.FStar_TypeChecker_Common.rank)
+                         (uu___12.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____21415, FStar_Syntax_Syntax.Tm_uvar uu____21416) ->
-                  let uu____21429 =
+              | (uu___7, FStar_Syntax_Syntax.Tm_uvar uu___8) ->
+                  let uu___9 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21429
-              | (uu____21430, FStar_Syntax_Syntax.Tm_app
+                  solve env uu___9
+              | (uu___7, FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21431;
-                    FStar_Syntax_Syntax.pos = uu____21432;
-                    FStar_Syntax_Syntax.vars = uu____21433;_},
-                  uu____21434)) ->
-                  let uu____21471 =
+                      uu___8;
+                    FStar_Syntax_Syntax.pos = uu___9;
+                    FStar_Syntax_Syntax.vars = uu___10;_},
+                  uu___11)) ->
+                  let uu___12 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21471
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21472, uu____21473) ->
-                  let uu____21486 =
+                  solve env uu___12
+              | (FStar_Syntax_Syntax.Tm_uvar uu___7, uu___8) ->
+                  let uu___9 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21486
+                  solve env uu___9
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21487;
-                    FStar_Syntax_Syntax.pos = uu____21488;
-                    FStar_Syntax_Syntax.vars = uu____21489;_},
-                  uu____21490),
-                 uu____21491) ->
-                  let uu____21528 =
+                      uu___7;
+                    FStar_Syntax_Syntax.pos = uu___8;
+                    FStar_Syntax_Syntax.vars = uu___9;_},
+                  uu___10),
+                 uu___11) ->
+                  let uu___12 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21528
-              | (FStar_Syntax_Syntax.Tm_refine uu____21529, uu____21530) ->
+                  solve env uu___12
+              | (FStar_Syntax_Syntax.Tm_refine uu___7, uu___8) ->
                   let t21 =
-                    let uu____21538 = base_and_refinement env t2 in
-                    FStar_All.pipe_left force_refinement uu____21538 in
+                    let uu___9 = base_and_refinement env t2 in
+                    FStar_All.pipe_left force_refinement uu___9 in
                   solve_t env
-                    (let uu___3389_21564 = problem in
+                    (let uu___9 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3389_21564.FStar_TypeChecker_Common.pid);
+                         (uu___9.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3389_21564.FStar_TypeChecker_Common.lhs);
+                         (uu___9.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
-                         (uu___3389_21564.FStar_TypeChecker_Common.relation);
+                         (uu___9.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs = t21;
                        FStar_TypeChecker_Common.element =
-                         (uu___3389_21564.FStar_TypeChecker_Common.element);
+                         (uu___9.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3389_21564.FStar_TypeChecker_Common.logical_guard);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3389_21564.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3389_21564.FStar_TypeChecker_Common.reason);
+                         (uu___9.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3389_21564.FStar_TypeChecker_Common.loc);
+                         (uu___9.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3389_21564.FStar_TypeChecker_Common.rank)
+                         (uu___9.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____21565, FStar_Syntax_Syntax.Tm_refine uu____21566) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_refine uu___8) ->
                   let t11 =
-                    let uu____21574 = base_and_refinement env t1 in
-                    FStar_All.pipe_left force_refinement uu____21574 in
+                    let uu___9 = base_and_refinement env t1 in
+                    FStar_All.pipe_left force_refinement uu___9 in
                   solve_t env
-                    (let uu___3396_21600 = problem in
+                    (let uu___9 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3396_21600.FStar_TypeChecker_Common.pid);
+                         (uu___9.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs = t11;
                        FStar_TypeChecker_Common.relation =
-                         (uu___3396_21600.FStar_TypeChecker_Common.relation);
+                         (uu___9.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3396_21600.FStar_TypeChecker_Common.rhs);
+                         (uu___9.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3396_21600.FStar_TypeChecker_Common.element);
+                         (uu___9.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3396_21600.FStar_TypeChecker_Common.logical_guard);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3396_21600.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___9.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3396_21600.FStar_TypeChecker_Common.reason);
+                         (uu___9.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3396_21600.FStar_TypeChecker_Common.loc);
+                         (uu___9.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3396_21600.FStar_TypeChecker_Common.rank)
+                         (uu___9.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_match (s1, brs1),
                  FStar_Syntax_Syntax.Tm_match (s2, brs2)) ->
-                  let by_smt uu____21682 =
-                    let uu____21683 = guard_of_prob env wl problem t1 t2 in
-                    match uu____21683 with
+                  let by_smt uu___7 =
+                    let uu___8 = guard_of_prob env wl problem t1 t2 in
+                    match uu___8 with
                     | (guard, wl1) ->
-                        let uu____21690 =
+                        let uu___9 =
                           solve_prob orig
                             (FStar_Pervasives_Native.Some guard) [] wl1 in
-                        solve env uu____21690 in
+                        solve env uu___9 in
                   let rec solve_branches wl1 brs11 brs21 =
                     match (brs11, brs21) with
                     | (br1::rs1, br2::rs2) ->
-                        let uu____21909 = br1 in
-                        (match uu____21909 with
-                         | (p1, w1, uu____21938) ->
-                             let uu____21955 = br2 in
-                             (match uu____21955 with
-                              | (p2, w2, uu____21978) ->
-                                  let uu____21983 =
-                                    let uu____21984 =
+                        let uu___7 = br1 in
+                        (match uu___7 with
+                         | (p1, w1, uu___8) ->
+                             let uu___9 = br2 in
+                             (match uu___9 with
+                              | (p2, w2, uu___10) ->
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_Syntax_Syntax.eq_pat p1 p2 in
-                                    Prims.op_Negation uu____21984 in
-                                  if uu____21983
+                                    Prims.op_Negation uu___12 in
+                                  if uu___11
                                   then FStar_Pervasives_Native.None
                                   else
-                                    (let uu____22008 =
+                                    (let uu___13 =
                                        FStar_Syntax_Subst.open_branch' br1 in
-                                     match uu____22008 with
+                                     match uu___13 with
                                      | ((p11, w11, e1), s) ->
-                                         let uu____22045 = br2 in
-                                         (match uu____22045 with
+                                         let uu___14 = br2 in
+                                         (match uu___14 with
                                           | (p21, w21, e2) ->
                                               let w22 =
                                                 FStar_Util.map_opt w21
@@ -8083,23 +7900,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                               let e21 =
                                                 FStar_Syntax_Subst.subst s e2 in
                                               let scope =
-                                                let uu____22078 =
+                                                let uu___15 =
                                                   FStar_Syntax_Syntax.pat_bvs
                                                     p11 in
                                                 FStar_All.pipe_left
                                                   (FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder)
-                                                  uu____22078 in
-                                              let uu____22083 =
+                                                  uu___15 in
+                                              let uu___15 =
                                                 match (w11, w22) with
                                                 | (FStar_Pervasives_Native.Some
-                                                   uu____22114,
+                                                   uu___16,
                                                    FStar_Pervasives_Native.None)
                                                     ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None,
                                                    FStar_Pervasives_Native.Some
-                                                   uu____22135) ->
+                                                   uu___16) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None,
                                                    FStar_Pervasives_Native.None)
@@ -8110,65 +7927,59 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                    w12,
                                                    FStar_Pervasives_Native.Some
                                                    w23) ->
-                                                    let uu____22194 =
+                                                    let uu___16 =
                                                       mk_t_problem wl1 scope
                                                         orig w12
                                                         FStar_TypeChecker_Common.EQ
                                                         w23
                                                         FStar_Pervasives_Native.None
                                                         "when clause" in
-                                                    (match uu____22194 with
+                                                    (match uu___16 with
                                                      | (p, wl2) ->
                                                          FStar_Pervasives_Native.Some
                                                            ([(scope, p)],
                                                              wl2)) in
-                                              FStar_Util.bind_opt uu____22083
-                                                (fun uu____22265 ->
-                                                   match uu____22265 with
+                                              FStar_Util.bind_opt uu___15
+                                                (fun uu___16 ->
+                                                   match uu___16 with
                                                    | (wprobs, wl2) ->
-                                                       let uu____22302 =
+                                                       let uu___17 =
                                                          mk_t_problem wl2
                                                            scope orig e1
                                                            FStar_TypeChecker_Common.EQ
                                                            e21
                                                            FStar_Pervasives_Native.None
                                                            "branch body" in
-                                                       (match uu____22302
-                                                        with
+                                                       (match uu___17 with
                                                         | (prob, wl3) ->
-                                                            ((let uu____22322
-                                                                =
+                                                            ((let uu___19 =
                                                                 FStar_All.pipe_left
                                                                   (FStar_TypeChecker_Env.debug
                                                                     wl3.tcenv)
                                                                   (FStar_Options.Other
                                                                     "Rel") in
-                                                              if uu____22322
+                                                              if uu___19
                                                               then
-                                                                let uu____22323
-                                                                  =
+                                                                let uu___20 =
                                                                   prob_to_string
                                                                     env prob in
-                                                                let uu____22324
-                                                                  =
+                                                                let uu___21 =
                                                                   FStar_Syntax_Print.binders_to_string
                                                                     ", "
                                                                     scope in
                                                                 FStar_Util.print2
                                                                   "Created problem for branches %s with scope %s\n"
-                                                                  uu____22323
-                                                                  uu____22324
+                                                                  uu___20
+                                                                  uu___21
                                                               else ());
-                                                             (let uu____22326
-                                                                =
+                                                             (let uu___19 =
                                                                 solve_branches
                                                                   wl3 rs1 rs2 in
                                                               FStar_Util.bind_opt
-                                                                uu____22326
-                                                                (fun
-                                                                   uu____22362
+                                                                uu___19
+                                                                (fun uu___20
                                                                    ->
-                                                                   match uu____22362
+                                                                   match uu___20
                                                                    with
                                                                    | 
                                                                    (r1, wl4)
@@ -8180,108 +7991,101 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     wprobs r1)),
                                                                     wl4))))))))))
                     | ([], []) -> FStar_Pervasives_Native.Some ([], wl1)
-                    | uu____22491 -> FStar_Pervasives_Native.None in
-                  let uu____22532 = solve_branches wl brs1 brs2 in
-                  (match uu____22532 with
+                    | uu___7 -> FStar_Pervasives_Native.None in
+                  let uu___7 = solve_branches wl brs1 brs2 in
+                  (match uu___7 with
                    | FStar_Pervasives_Native.None ->
                        if wl.smt_ok
                        then by_smt ()
                        else
-                         (let uu____22556 =
+                         (let uu___9 =
                             FStar_Thunk.mkv "Tm_match branches don't match" in
-                          giveup env uu____22556 orig)
+                          giveup env uu___9 orig)
                    | FStar_Pervasives_Native.Some (sub_probs, wl1) ->
-                       let uu____22581 =
+                       let uu___8 =
                          mk_t_problem wl1 [] orig s1
                            FStar_TypeChecker_Common.EQ s2
                            FStar_Pervasives_Native.None "match scrutinee" in
-                       (match uu____22581 with
+                       (match uu___8 with
                         | (sc_prob, wl2) ->
                             let sub_probs1 = ([], sc_prob) :: sub_probs in
                             let formula =
-                              let uu____22614 =
+                              let uu___9 =
                                 FStar_List.map
-                                  (fun uu____22626 ->
-                                     match uu____22626 with
+                                  (fun uu___10 ->
+                                     match uu___10 with
                                      | (scope, p) ->
                                          FStar_TypeChecker_Env.close_forall
                                            wl2.tcenv scope (p_guard p))
                                   sub_probs1 in
-                              FStar_Syntax_Util.mk_conj_l uu____22614 in
+                              FStar_Syntax_Util.mk_conj_l uu___9 in
                             let tx =
                               FStar_Syntax_Unionfind.new_transaction () in
                             let wl3 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some formula) [] wl2 in
-                            let uu____22635 =
-                              let uu____22636 =
-                                let uu____22637 =
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     sub_probs1 in
-                                attempt uu____22637
-                                  (let uu___3495_22645 = wl3 in
+                                attempt uu___11
+                                  (let uu___12 = wl3 in
                                    {
-                                     attempting =
-                                       (uu___3495_22645.attempting);
-                                     wl_deferred =
-                                       (uu___3495_22645.wl_deferred);
+                                     attempting = (uu___12.attempting);
+                                     wl_deferred = (uu___12.wl_deferred);
                                      wl_deferred_to_tac =
-                                       (uu___3495_22645.wl_deferred_to_tac);
-                                     ctr = (uu___3495_22645.ctr);
-                                     defer_ok = (uu___3495_22645.defer_ok);
+                                       (uu___12.wl_deferred_to_tac);
+                                     ctr = (uu___12.ctr);
+                                     defer_ok = (uu___12.defer_ok);
                                      smt_ok = false;
                                      umax_heuristic_ok =
-                                       (uu___3495_22645.umax_heuristic_ok);
-                                     tcenv = (uu___3495_22645.tcenv);
-                                     wl_implicits =
-                                       (uu___3495_22645.wl_implicits);
+                                       (uu___12.umax_heuristic_ok);
+                                     tcenv = (uu___12.tcenv);
+                                     wl_implicits = (uu___12.wl_implicits);
                                      repr_subcomp_allowed =
-                                       (uu___3495_22645.repr_subcomp_allowed)
+                                       (uu___12.repr_subcomp_allowed)
                                    }) in
-                              solve env uu____22636 in
-                            (match uu____22635 with
+                              solve env uu___10 in
+                            (match uu___9 with
                              | Success (ds, ds', imp) ->
                                  (FStar_Syntax_Unionfind.commit tx;
                                   Success (ds, ds', imp))
-                             | Failed uu____22650 ->
+                             | Failed uu___10 ->
                                  (FStar_Syntax_Unionfind.rollback tx;
                                   if wl3.smt_ok
                                   then by_smt ()
                                   else
-                                    (let uu____22657 =
+                                    (let uu___13 =
                                        FStar_Thunk.mkv
                                          "Could not unify matches without SMT" in
-                                     giveup env uu____22657 orig)))))
-              | (FStar_Syntax_Syntax.Tm_match uu____22658, uu____22659) ->
+                                     giveup env uu___13 orig)))))
+              | (FStar_Syntax_Syntax.Tm_match uu___7, uu___8) ->
                   let head1 =
-                    let uu____22683 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____22683
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____22729 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____22729
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____22775 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____22775
+                    if uu___10
                     then
-                      let uu____22776 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____22777 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____22778 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____22776 uu____22777 uu____22778
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____22788 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____22788) &&
-                        (let uu____22792 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____22792) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8301,9 +8105,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____22808 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____22808 = FStar_Syntax_Util.Equal in
-                    let uu____22809 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8311,65 +8115,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____22809
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____22810 = equal t1 t2 in
-                         (if uu____22810
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____22811 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____22811
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____22814 =
-                            let uu____22821 = equal t1 t2 in
-                            if uu____22821
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____22831 = mk_eq2 wl env orig t1 t2 in
-                               match uu____22831 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____22814 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____22852 = solve_prob orig guard [] wl1 in
-                              solve env uu____22852))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_uinst uu____22854, uu____22855) ->
+              | (FStar_Syntax_Syntax.Tm_uinst uu___7, uu___8) ->
                   let head1 =
-                    let uu____22863 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____22863
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____22909 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____22909
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____22955 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____22955
+                    if uu___10
                     then
-                      let uu____22956 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____22957 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____22958 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____22956 uu____22957 uu____22958
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____22968 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____22968) &&
-                        (let uu____22972 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____22972) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8389,9 +8189,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____22988 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____22988 = FStar_Syntax_Util.Equal in
-                    let uu____22989 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8399,65 +8199,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____22989
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____22990 = equal t1 t2 in
-                         (if uu____22990
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____22991 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____22991
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____22994 =
-                            let uu____23001 = equal t1 t2 in
-                            if uu____23001
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23011 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23011 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____22994 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23032 = solve_prob orig guard [] wl1 in
-                              solve env uu____23032))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_name uu____23034, uu____23035) ->
+              | (FStar_Syntax_Syntax.Tm_name uu___7, uu___8) ->
                   let head1 =
-                    let uu____23037 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23037
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23083 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23083
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23129 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23129
+                    if uu___10
                     then
-                      let uu____23130 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23131 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23132 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23130 uu____23131 uu____23132
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23142 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23142) &&
-                        (let uu____23146 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23146) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8477,9 +8273,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23162 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23162 = FStar_Syntax_Util.Equal in
-                    let uu____23163 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8487,65 +8283,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23163
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23164 = equal t1 t2 in
-                         (if uu____23164
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____23165 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23165
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23168 =
-                            let uu____23175 = equal t1 t2 in
-                            if uu____23175
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23185 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23185 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23168 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23206 = solve_prob orig guard [] wl1 in
-                              solve env uu____23206))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_constant uu____23208, uu____23209) ->
+              | (FStar_Syntax_Syntax.Tm_constant uu___7, uu___8) ->
                   let head1 =
-                    let uu____23211 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23211
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23257 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23257
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23303 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23303
+                    if uu___10
                     then
-                      let uu____23304 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23305 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23306 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23304 uu____23305 uu____23306
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23316 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23316) &&
-                        (let uu____23320 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23320) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8565,9 +8357,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23336 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23336 = FStar_Syntax_Util.Equal in
-                    let uu____23337 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8575,65 +8367,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23337
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23338 = equal t1 t2 in
-                         (if uu____23338
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____23339 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23339
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23342 =
-                            let uu____23349 = equal t1 t2 in
-                            if uu____23349
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23359 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23359 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23342 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23380 = solve_prob orig guard [] wl1 in
-                              solve env uu____23380))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_fvar uu____23382, uu____23383) ->
+              | (FStar_Syntax_Syntax.Tm_fvar uu___7, uu___8) ->
                   let head1 =
-                    let uu____23385 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23385
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23425 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23425
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23465 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23465
+                    if uu___10
                     then
-                      let uu____23466 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23467 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23468 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23466 uu____23467 uu____23468
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23478 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23478) &&
-                        (let uu____23482 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23482) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8653,9 +8441,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23498 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23498 = FStar_Syntax_Util.Equal in
-                    let uu____23499 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8663,65 +8451,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23499
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23500 = equal t1 t2 in
-                         (if uu____23500
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____23501 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23501
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23504 =
-                            let uu____23511 = equal t1 t2 in
-                            if uu____23511
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23521 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23521 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23504 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23542 = solve_prob orig guard [] wl1 in
-                              solve env uu____23542))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_app uu____23544, uu____23545) ->
+              | (FStar_Syntax_Syntax.Tm_app uu___7, uu___8) ->
                   let head1 =
-                    let uu____23563 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23563
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23603 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23603
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23643 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23643
+                    if uu___10
                     then
-                      let uu____23644 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23645 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23646 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23644 uu____23645 uu____23646
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23656 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23656) &&
-                        (let uu____23660 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23660) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8741,9 +8525,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23676 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23676 = FStar_Syntax_Util.Equal in
-                    let uu____23677 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8751,65 +8535,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23677
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23678 = equal t1 t2 in
-                         (if uu____23678
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____23679 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23679
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23682 =
-                            let uu____23689 = equal t1 t2 in
-                            if uu____23689
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23699 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23699 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23682 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23720 = solve_prob orig guard [] wl1 in
-                              solve env uu____23720))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____23722, FStar_Syntax_Syntax.Tm_match uu____23723) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_match uu___8) ->
                   let head1 =
-                    let uu____23747 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23747
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23787 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23787
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23827 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23827
+                    if uu___10
                     then
-                      let uu____23828 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23829 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23830 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23828 uu____23829 uu____23830
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23840 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23840) &&
-                        (let uu____23844 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23844) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8829,9 +8609,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23860 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23860 = FStar_Syntax_Util.Equal in
-                    let uu____23861 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8839,65 +8619,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23861
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23862 = equal t1 t2 in
-                         (if uu____23862
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____23863 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23863
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23866 =
-                            let uu____23873 = equal t1 t2 in
-                            if uu____23873
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23883 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23883 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23866 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____23904 = solve_prob orig guard [] wl1 in
-                              solve env uu____23904))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____23906, FStar_Syntax_Syntax.Tm_uinst uu____23907) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_uinst uu___8) ->
                   let head1 =
-                    let uu____23915 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23915
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23955 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23955
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____23995 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23995
+                    if uu___10
                     then
-                      let uu____23996 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____23997 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23998 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23996 uu____23997 uu____23998
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24008 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24008) &&
-                        (let uu____24012 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24012) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8917,9 +8693,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24028 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24028 = FStar_Syntax_Util.Equal in
-                    let uu____24029 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8927,65 +8703,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24029
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24030 = equal t1 t2 in
-                         (if uu____24030
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____24031 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24031
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24034 =
-                            let uu____24041 = equal t1 t2 in
-                            if uu____24041
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24051 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24051 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24034 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____24072 = solve_prob orig guard [] wl1 in
-                              solve env uu____24072))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24074, FStar_Syntax_Syntax.Tm_name uu____24075) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_name uu___8) ->
                   let head1 =
-                    let uu____24077 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24077
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24117 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24117
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____24157 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24157
+                    if uu___10
                     then
-                      let uu____24158 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____24159 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24160 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24158 uu____24159 uu____24160
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24170 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24170) &&
-                        (let uu____24174 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24174) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9005,9 +8777,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24190 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24190 = FStar_Syntax_Util.Equal in
-                    let uu____24191 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9015,65 +8787,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24191
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24192 = equal t1 t2 in
-                         (if uu____24192
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____24193 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24193
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24196 =
-                            let uu____24203 = equal t1 t2 in
-                            if uu____24203
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24213 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24213 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24196 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____24234 = solve_prob orig guard [] wl1 in
-                              solve env uu____24234))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24236, FStar_Syntax_Syntax.Tm_constant uu____24237) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_constant uu___8) ->
                   let head1 =
-                    let uu____24239 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24239
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24279 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24279
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____24319 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24319
+                    if uu___10
                     then
-                      let uu____24320 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____24321 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24322 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24320 uu____24321 uu____24322
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24332 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24332) &&
-                        (let uu____24336 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24336) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9093,9 +8861,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24352 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24352 = FStar_Syntax_Util.Equal in
-                    let uu____24353 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9103,65 +8871,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24353
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24354 = equal t1 t2 in
-                         (if uu____24354
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____24355 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24355
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24358 =
-                            let uu____24365 = equal t1 t2 in
-                            if uu____24365
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24375 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24375 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24358 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____24396 = solve_prob orig guard [] wl1 in
-                              solve env uu____24396))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24398, FStar_Syntax_Syntax.Tm_fvar uu____24399) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_fvar uu___8) ->
                   let head1 =
-                    let uu____24401 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24401
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24447 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24447
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____24493 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24493
+                    if uu___10
                     then
-                      let uu____24494 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____24495 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24496 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24494 uu____24495 uu____24496
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24506 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24506) &&
-                        (let uu____24510 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24510) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9181,9 +8945,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24526 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24526 = FStar_Syntax_Util.Equal in
-                    let uu____24527 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9191,65 +8955,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24527
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24528 = equal t1 t2 in
-                         (if uu____24528
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____24529 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24529
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24532 =
-                            let uu____24539 = equal t1 t2 in
-                            if uu____24539
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24549 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24549 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24532 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____24570 = solve_prob orig guard [] wl1 in
-                              solve env uu____24570))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24572, FStar_Syntax_Syntax.Tm_app uu____24573) ->
+              | (uu___7, FStar_Syntax_Syntax.Tm_app uu___8) ->
                   let head1 =
-                    let uu____24591 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24591
-                      FStar_Pervasives_Native.fst in
+                    let uu___9 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24631 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24631
-                      FStar_Pervasives_Native.fst in
-                  ((let uu____24671 =
+                    let uu___9 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu___9 FStar_Pervasives_Native.fst in
+                  ((let uu___10 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24671
+                    if uu___10
                     then
-                      let uu____24672 =
+                      let uu___11 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____24673 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24674 =
-                        FStar_Syntax_Print.term_to_string head2 in
+                      let uu___12 = FStar_Syntax_Print.term_to_string head1 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
-                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24672 uu____24673 uu____24674
+                        ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n" uu___11
+                        uu___12 uu___13
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24684 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24684) &&
-                        (let uu____24688 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24688) in
+                      (let uu___10 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu___10) &&
+                        (let uu___10 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu___10) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9269,9 +9029,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24704 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24704 = FStar_Syntax_Util.Equal in
-                    let uu____24705 =
+                      let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu___10 = FStar_Syntax_Util.Equal in
+                    let uu___10 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9279,77 +9039,73 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24705
+                    if uu___10
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24706 = equal t1 t2 in
-                         (if uu____24706
+                         let uu___11 = equal t1 t2 in
+                         (if uu___11
                           then
-                            let uu____24707 =
+                            let uu___12 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24707
+                            solve env uu___12
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24710 =
-                            let uu____24717 = equal t1 t2 in
-                            if uu____24717
+                         (let uu___12 =
+                            let uu___13 = equal t1 t2 in
+                            if uu___13
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24727 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24727 with
+                              (let uu___15 = mk_eq2 wl env orig t1 t2 in
+                               match uu___15 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24710 with
+                          match uu___12 with
                           | (guard, wl1) ->
-                              let uu____24748 = solve_prob orig guard [] wl1 in
-                              solve env uu____24748))
+                              let uu___13 = solve_prob orig guard [] wl1 in
+                              solve env uu___13))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_let uu____24750,
-                 FStar_Syntax_Syntax.Tm_let uu____24751) ->
-                  let uu____24776 = FStar_Syntax_Util.term_eq t1 t2 in
-                  if uu____24776
+              | (FStar_Syntax_Syntax.Tm_let uu___7,
+                 FStar_Syntax_Syntax.Tm_let uu___8) ->
+                  let uu___9 = FStar_Syntax_Util.term_eq t1 t2 in
+                  if uu___9
                   then
-                    let uu____24777 =
+                    let uu___10 =
                       solve_prob orig FStar_Pervasives_Native.None [] wl in
-                    solve env uu____24777
+                    solve env uu___10
                   else
-                    (let uu____24779 = FStar_Thunk.mkv "Tm_let mismatch" in
-                     giveup env uu____24779 orig)
-              | (FStar_Syntax_Syntax.Tm_let uu____24780, uu____24781) ->
-                  let uu____24794 =
-                    let uu____24799 =
-                      let uu____24800 = FStar_Syntax_Print.tag_of_term t1 in
-                      let uu____24801 = FStar_Syntax_Print.tag_of_term t2 in
-                      let uu____24802 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____24803 = FStar_Syntax_Print.term_to_string t2 in
+                    (let uu___11 = FStar_Thunk.mkv "Tm_let mismatch" in
+                     giveup env uu___11 orig)
+              | (FStar_Syntax_Syntax.Tm_let uu___7, uu___8) ->
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 = FStar_Syntax_Print.tag_of_term t1 in
+                      let uu___12 = FStar_Syntax_Print.tag_of_term t2 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu___14 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____24800 uu____24801 uu____24802 uu____24803 in
-                    (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____24799) in
-                  FStar_Errors.raise_error uu____24794
-                    t1.FStar_Syntax_Syntax.pos
-              | (uu____24804, FStar_Syntax_Syntax.Tm_let uu____24805) ->
-                  let uu____24818 =
-                    let uu____24823 =
-                      let uu____24824 = FStar_Syntax_Print.tag_of_term t1 in
-                      let uu____24825 = FStar_Syntax_Print.tag_of_term t2 in
-                      let uu____24826 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____24827 = FStar_Syntax_Print.term_to_string t2 in
+                        uu___11 uu___12 uu___13 uu___14 in
+                    (FStar_Errors.Fatal_UnificationNotWellFormed, uu___10) in
+                  FStar_Errors.raise_error uu___9 t1.FStar_Syntax_Syntax.pos
+              | (uu___7, FStar_Syntax_Syntax.Tm_let uu___8) ->
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 = FStar_Syntax_Print.tag_of_term t1 in
+                      let uu___12 = FStar_Syntax_Print.tag_of_term t2 in
+                      let uu___13 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu___14 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____24824 uu____24825 uu____24826 uu____24827 in
-                    (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____24823) in
-                  FStar_Errors.raise_error uu____24818
-                    t1.FStar_Syntax_Syntax.pos
-              | uu____24828 ->
-                  let uu____24833 = FStar_Thunk.mkv "head tag mismatch" in
-                  giveup env uu____24833 orig))))
+                        uu___11 uu___12 uu___13 uu___14 in
+                    (FStar_Errors.Fatal_UnificationNotWellFormed, uu___10) in
+                  FStar_Errors.raise_error uu___9 t1.FStar_Syntax_Syntax.pos
+              | uu___7 ->
+                  let uu___8 = FStar_Thunk.mkv "head tag mismatch" in
+                  giveup env uu___8 orig))))
 and (solve_c :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp FStar_TypeChecker_Common.problem ->
@@ -9365,181 +9121,175 @@ and (solve_c :
           mk_t_problem wl1 [] orig t1 rel t2 FStar_Pervasives_Native.None
             reason in
         let solve_eq c1_comp c2_comp g_lift =
-          (let uu____24895 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "EQ") in
-           if uu____24895
+           if uu___1
            then
-             let uu____24896 =
-               let uu____24897 = FStar_Syntax_Syntax.mk_Comp c1_comp in
-               FStar_Syntax_Print.comp_to_string uu____24897 in
-             let uu____24898 =
-               let uu____24899 = FStar_Syntax_Syntax.mk_Comp c2_comp in
-               FStar_Syntax_Print.comp_to_string uu____24899 in
+             let uu___2 =
+               let uu___3 = FStar_Syntax_Syntax.mk_Comp c1_comp in
+               FStar_Syntax_Print.comp_to_string uu___3 in
+             let uu___3 =
+               let uu___4 = FStar_Syntax_Syntax.mk_Comp c2_comp in
+               FStar_Syntax_Print.comp_to_string uu___4 in
              FStar_Util.print2
-               "solve_c is using an equality constraint (%s vs %s)\n"
-               uu____24896 uu____24898
+               "solve_c is using an equality constraint (%s vs %s)\n" uu___2
+               uu___3
            else ());
-          (let uu____24901 =
-             let uu____24902 =
+          (let uu___1 =
+             let uu___2 =
                FStar_Ident.lid_equals c1_comp.FStar_Syntax_Syntax.effect_name
                  c2_comp.FStar_Syntax_Syntax.effect_name in
-             Prims.op_Negation uu____24902 in
-           if uu____24901
+             Prims.op_Negation uu___2 in
+           if uu___1
            then
-             let uu____24903 =
+             let uu___2 =
                mklstr
-                 (fun uu____24910 ->
-                    let uu____24911 =
+                 (fun uu___3 ->
+                    let uu___4 =
                       FStar_Syntax_Print.lid_to_string
                         c1_comp.FStar_Syntax_Syntax.effect_name in
-                    let uu____24912 =
+                    let uu___5 =
                       FStar_Syntax_Print.lid_to_string
                         c2_comp.FStar_Syntax_Syntax.effect_name in
                     FStar_Util.format2 "incompatible effects: %s <> %s"
-                      uu____24911 uu____24912) in
-             giveup env uu____24903 orig
+                      uu___4 uu___5) in
+             giveup env uu___2 orig
            else
              if
                (FStar_List.length c1_comp.FStar_Syntax_Syntax.effect_args) <>
                  (FStar_List.length c2_comp.FStar_Syntax_Syntax.effect_args)
              then
-               (let uu____24930 =
+               (let uu___3 =
                   mklstr
-                    (fun uu____24937 ->
-                       let uu____24938 =
+                    (fun uu___4 ->
+                       let uu___5 =
                          FStar_Syntax_Print.args_to_string
                            c1_comp.FStar_Syntax_Syntax.effect_args in
-                       let uu____24939 =
+                       let uu___6 =
                          FStar_Syntax_Print.args_to_string
                            c2_comp.FStar_Syntax_Syntax.effect_args in
                        FStar_Util.format2
-                         "incompatible effect arguments: %s <> %s"
-                         uu____24938 uu____24939) in
-                giveup env uu____24930 orig)
+                         "incompatible effect arguments: %s <> %s" uu___5
+                         uu___6) in
+                giveup env uu___3 orig)
              else
-               (let uu____24941 =
+               (let uu___4 =
                   FStar_List.fold_left2
-                    (fun uu____24962 ->
+                    (fun uu___5 ->
                        fun u1 ->
                          fun u2 ->
-                           match uu____24962 with
+                           match uu___5 with
                            | (univ_sub_probs, wl1) ->
-                               let uu____24983 =
-                                 let uu____24988 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u1)
                                      FStar_Range.dummyRange in
-                                 let uu____24989 =
+                                 let uu___8 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u2)
                                      FStar_Range.dummyRange in
-                                 sub_prob wl1 uu____24988
-                                   FStar_TypeChecker_Common.EQ uu____24989
+                                 sub_prob wl1 uu___7
+                                   FStar_TypeChecker_Common.EQ uu___8
                                    "effect universes" in
-                               (match uu____24983 with
+                               (match uu___6 with
                                 | (p, wl2) ->
                                     ((FStar_List.append univ_sub_probs [p]),
                                       wl2))) ([], wl)
                     c1_comp.FStar_Syntax_Syntax.comp_univs
                     c2_comp.FStar_Syntax_Syntax.comp_univs in
-                match uu____24941 with
+                match uu___4 with
                 | (univ_sub_probs, wl1) ->
-                    let uu____25008 =
+                    let uu___5 =
                       sub_prob wl1 c1_comp.FStar_Syntax_Syntax.result_typ
                         FStar_TypeChecker_Common.EQ
                         c2_comp.FStar_Syntax_Syntax.result_typ
                         "effect ret type" in
-                    (match uu____25008 with
+                    (match uu___5 with
                      | (ret_sub_prob, wl2) ->
-                         let uu____25015 =
+                         let uu___6 =
                            FStar_List.fold_right2
-                             (fun uu____25052 ->
-                                fun uu____25053 ->
-                                  fun uu____25054 ->
-                                    match (uu____25052, uu____25053,
-                                            uu____25054)
-                                    with
-                                    | ((a1, uu____25098), (a2, uu____25100),
+                             (fun uu___7 ->
+                                fun uu___8 ->
+                                  fun uu___9 ->
+                                    match (uu___7, uu___8, uu___9) with
+                                    | ((a1, uu___10), (a2, uu___11),
                                        (arg_sub_probs, wl3)) ->
-                                        let uu____25133 =
+                                        let uu___12 =
                                           sub_prob wl3 a1
                                             FStar_TypeChecker_Common.EQ a2
                                             "effect arg" in
-                                        (match uu____25133 with
+                                        (match uu___12 with
                                          | (p, wl4) ->
                                              ((p :: arg_sub_probs), wl4)))
                              c1_comp.FStar_Syntax_Syntax.effect_args
                              c2_comp.FStar_Syntax_Syntax.effect_args
                              ([], wl2) in
-                         (match uu____25015 with
+                         (match uu___6 with
                           | (arg_sub_probs, wl3) ->
                               let sub_probs =
-                                let uu____25159 =
-                                  let uu____25162 =
-                                    let uu____25165 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
                                       FStar_All.pipe_right
                                         g_lift.FStar_TypeChecker_Common.deferred
                                         (FStar_List.map
                                            FStar_Pervasives_Native.snd) in
-                                    FStar_List.append arg_sub_probs
-                                      uu____25165 in
-                                  FStar_List.append [ret_sub_prob]
-                                    uu____25162 in
-                                FStar_List.append univ_sub_probs uu____25159 in
+                                    FStar_List.append arg_sub_probs uu___9 in
+                                  FStar_List.append [ret_sub_prob] uu___8 in
+                                FStar_List.append univ_sub_probs uu___7 in
                               let guard =
-                                let guard =
-                                  let uu____25184 =
+                                let guard1 =
+                                  let uu___7 =
                                     FStar_List.map p_guard sub_probs in
-                                  FStar_Syntax_Util.mk_conj_l uu____25184 in
+                                  FStar_Syntax_Util.mk_conj_l uu___7 in
                                 match g_lift.FStar_TypeChecker_Common.guard_f
                                 with
-                                | FStar_TypeChecker_Common.Trivial -> guard
+                                | FStar_TypeChecker_Common.Trivial -> guard1
                                 | FStar_TypeChecker_Common.NonTrivial f ->
-                                    FStar_Syntax_Util.mk_conj guard f in
+                                    FStar_Syntax_Util.mk_conj guard1 f in
                               let wl4 =
-                                let uu___3648_25193 = wl3 in
+                                let uu___7 = wl3 in
                                 {
-                                  attempting = (uu___3648_25193.attempting);
-                                  wl_deferred = (uu___3648_25193.wl_deferred);
+                                  attempting = (uu___7.attempting);
+                                  wl_deferred = (uu___7.wl_deferred);
                                   wl_deferred_to_tac =
-                                    (uu___3648_25193.wl_deferred_to_tac);
-                                  ctr = (uu___3648_25193.ctr);
-                                  defer_ok = (uu___3648_25193.defer_ok);
-                                  smt_ok = (uu___3648_25193.smt_ok);
+                                    (uu___7.wl_deferred_to_tac);
+                                  ctr = (uu___7.ctr);
+                                  defer_ok = (uu___7.defer_ok);
+                                  smt_ok = (uu___7.smt_ok);
                                   umax_heuristic_ok =
-                                    (uu___3648_25193.umax_heuristic_ok);
-                                  tcenv = (uu___3648_25193.tcenv);
+                                    (uu___7.umax_heuristic_ok);
+                                  tcenv = (uu___7.tcenv);
                                   wl_implicits =
                                     (FStar_List.append
                                        g_lift.FStar_TypeChecker_Common.implicits
                                        wl3.wl_implicits);
                                   repr_subcomp_allowed =
-                                    (uu___3648_25193.repr_subcomp_allowed)
+                                    (uu___7.repr_subcomp_allowed)
                                 } in
                               let wl5 =
                                 solve_prob orig
                                   (FStar_Pervasives_Native.Some guard) [] wl4 in
-                              let uu____25195 = attempt sub_probs wl5 in
-                              solve env uu____25195)))) in
+                              let uu___7 = attempt sub_probs wl5 in
+                              solve env uu___7)))) in
         let solve_layered_sub c11 c21 =
-          (let uu____25208 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffectsApp") in
-           if uu____25208
+           if uu___1
            then
-             let uu____25209 =
-               let uu____25210 =
+             let uu___2 =
+               let uu___3 =
                  FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____25210
-                 FStar_Syntax_Print.comp_to_string in
-             let uu____25211 =
-               let uu____25212 =
+               FStar_All.pipe_right uu___3 FStar_Syntax_Print.comp_to_string in
+             let uu___3 =
+               let uu___4 =
                  FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____25212
-                 FStar_Syntax_Print.comp_to_string in
-             FStar_Util.print2 "solve_layered_sub c1: %s and c2: %s\n"
-               uu____25209 uu____25211
+               FStar_All.pipe_right uu___4 FStar_Syntax_Print.comp_to_string in
+             FStar_Util.print2 "solve_layered_sub c1: %s and c2: %s\n" uu___2
+               uu___3
            else ());
           if
             problem.FStar_TypeChecker_Common.relation =
@@ -9548,459 +9298,435 @@ and (solve_c :
           else
             (let r = FStar_TypeChecker_Env.get_range env in
              let subcomp_name =
-               let uu____25217 =
-                 let uu____25218 =
+               let uu___2 =
+                 let uu___3 =
                    FStar_All.pipe_right c11.FStar_Syntax_Syntax.effect_name
                      FStar_Ident.ident_of_lid in
-                 FStar_All.pipe_right uu____25218 FStar_Ident.string_of_id in
-               let uu____25219 =
-                 let uu____25220 =
+                 FStar_All.pipe_right uu___3 FStar_Ident.string_of_id in
+               let uu___3 =
+                 let uu___4 =
                    FStar_All.pipe_right c21.FStar_Syntax_Syntax.effect_name
                      FStar_Ident.ident_of_lid in
-                 FStar_All.pipe_right uu____25220 FStar_Ident.string_of_id in
-               FStar_Util.format2 "%s <: %s" uu____25217 uu____25219 in
+                 FStar_All.pipe_right uu___4 FStar_Ident.string_of_id in
+               FStar_Util.format2 "%s <: %s" uu___2 uu___3 in
              let lift_c1 edge =
-               let uu____25235 =
-                 let uu____25240 =
+               let uu___2 =
+                 let uu___3 =
                    FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp in
-                 FStar_All.pipe_right uu____25240
+                 FStar_All.pipe_right uu___3
                    ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                       env) in
-               FStar_All.pipe_right uu____25235
-                 (fun uu____25257 ->
-                    match uu____25257 with
+               FStar_All.pipe_right uu___2
+                 (fun uu___3 ->
+                    match uu___3 with
                     | (c, g) ->
-                        let uu____25268 =
-                          FStar_Syntax_Util.comp_to_comp_typ c in
-                        (uu____25268, g)) in
-             let uu____25269 =
-               let uu____25280 =
+                        let uu___4 = FStar_Syntax_Util.comp_to_comp_typ c in
+                        (uu___4, g)) in
+             let uu___2 =
+               let uu___3 =
                  FStar_TypeChecker_Env.exists_polymonadic_subcomp env
                    c11.FStar_Syntax_Syntax.effect_name
                    c21.FStar_Syntax_Syntax.effect_name in
-               match uu____25280 with
+               match uu___3 with
                | FStar_Pervasives_Native.None ->
-                   let uu____25293 =
+                   let uu___4 =
                      FStar_TypeChecker_Env.monad_leq env
                        c11.FStar_Syntax_Syntax.effect_name
                        c21.FStar_Syntax_Syntax.effect_name in
-                   (match uu____25293 with
+                   (match uu___4 with
                     | FStar_Pervasives_Native.None ->
                         (c11, FStar_TypeChecker_Env.trivial_guard,
                           FStar_Pervasives_Native.None, false)
                     | FStar_Pervasives_Native.Some edge ->
-                        let uu____25309 = lift_c1 edge in
-                        (match uu____25309 with
+                        let uu___5 = lift_c1 edge in
+                        (match uu___5 with
                          | (c12, g_lift) ->
-                             let uu____25326 =
-                               let uu____25329 =
-                                 let uu____25330 =
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_All.pipe_right
                                      c21.FStar_Syntax_Syntax.effect_name
                                      (FStar_TypeChecker_Env.get_effect_decl
                                         env) in
-                                 FStar_All.pipe_right uu____25330
+                                 FStar_All.pipe_right uu___8
                                    FStar_Syntax_Util.get_stronger_vc_combinator in
-                               FStar_All.pipe_right uu____25329
+                               FStar_All.pipe_right uu___7
                                  (fun ts ->
-                                    let uu____25336 =
-                                      let uu____25337 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_TypeChecker_Env.inst_tscheme_with
                                           ts
                                           c21.FStar_Syntax_Syntax.comp_univs in
-                                      FStar_All.pipe_right uu____25337
+                                      FStar_All.pipe_right uu___9
                                         FStar_Pervasives_Native.snd in
-                                    FStar_All.pipe_right uu____25336
-                                      (fun uu____25348 ->
-                                         FStar_Pervasives_Native.Some
-                                           uu____25348)) in
-                             (c12, g_lift, uu____25326, false)))
+                                    FStar_All.pipe_right uu___8
+                                      (fun uu___9 ->
+                                         FStar_Pervasives_Native.Some uu___9)) in
+                             (c12, g_lift, uu___6, false)))
                | FStar_Pervasives_Native.Some t ->
-                   let uu____25352 =
-                     let uu____25355 =
-                       let uu____25356 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_TypeChecker_Env.inst_tscheme_with t
                            c21.FStar_Syntax_Syntax.comp_univs in
-                       FStar_All.pipe_right uu____25356
+                       FStar_All.pipe_right uu___6
                          FStar_Pervasives_Native.snd in
-                     FStar_All.pipe_right uu____25355
-                       (fun uu____25367 ->
-                          FStar_Pervasives_Native.Some uu____25367) in
-                   (c11, FStar_TypeChecker_Env.trivial_guard, uu____25352,
-                     true) in
-             match uu____25269 with
+                     FStar_All.pipe_right uu___5
+                       (fun uu___6 -> FStar_Pervasives_Native.Some uu___6) in
+                   (c11, FStar_TypeChecker_Env.trivial_guard, uu___4, true) in
+             match uu___2 with
              | (c12, g_lift, stronger_t_opt, is_polymonadic) ->
                  if FStar_Util.is_none stronger_t_opt
                  then
-                   let uu____25378 =
+                   let uu___3 =
                      mklstr
-                       (fun uu____25385 ->
-                          let uu____25386 =
+                       (fun uu___4 ->
+                          let uu___5 =
                             FStar_Syntax_Print.lid_to_string
                               c12.FStar_Syntax_Syntax.effect_name in
-                          let uu____25387 =
+                          let uu___6 =
                             FStar_Syntax_Print.lid_to_string
                               c21.FStar_Syntax_Syntax.effect_name in
                           FStar_Util.format2
-                            "incompatible monad ordering: %s </: %s"
-                            uu____25386 uu____25387) in
-                   giveup env uu____25378 orig
+                            "incompatible monad ordering: %s </: %s" uu___5
+                            uu___6) in
+                   giveup env uu___3 orig
                  else
                    (let stronger_t =
                       FStar_All.pipe_right stronger_t_opt FStar_Util.must in
                     let wl1 =
-                      let uu___3683_25393 = wl in
+                      let uu___4 = wl in
                       {
-                        attempting = (uu___3683_25393.attempting);
-                        wl_deferred = (uu___3683_25393.wl_deferred);
-                        wl_deferred_to_tac =
-                          (uu___3683_25393.wl_deferred_to_tac);
-                        ctr = (uu___3683_25393.ctr);
-                        defer_ok = (uu___3683_25393.defer_ok);
-                        smt_ok = (uu___3683_25393.smt_ok);
-                        umax_heuristic_ok =
-                          (uu___3683_25393.umax_heuristic_ok);
-                        tcenv = (uu___3683_25393.tcenv);
+                        attempting = (uu___4.attempting);
+                        wl_deferred = (uu___4.wl_deferred);
+                        wl_deferred_to_tac = (uu___4.wl_deferred_to_tac);
+                        ctr = (uu___4.ctr);
+                        defer_ok = (uu___4.defer_ok);
+                        smt_ok = (uu___4.smt_ok);
+                        umax_heuristic_ok = (uu___4.umax_heuristic_ok);
+                        tcenv = (uu___4.tcenv);
                         wl_implicits =
                           (FStar_List.append
                              g_lift.FStar_TypeChecker_Common.implicits
                              wl.wl_implicits);
-                        repr_subcomp_allowed =
-                          (uu___3683_25393.repr_subcomp_allowed)
+                        repr_subcomp_allowed = (uu___4.repr_subcomp_allowed)
                       } in
-                    let uu____25394 =
+                    let uu___4 =
                       if is_polymonadic
                       then ([], wl1)
                       else
                         (let rec is_uvar t =
-                           let uu____25416 =
-                             let uu____25417 = FStar_Syntax_Subst.compress t in
-                             uu____25417.FStar_Syntax_Syntax.n in
-                           match uu____25416 with
-                           | FStar_Syntax_Syntax.Tm_uvar uu____25420 -> true
-                           | FStar_Syntax_Syntax.Tm_uinst (t1, uu____25434)
-                               -> is_uvar t1
-                           | FStar_Syntax_Syntax.Tm_app (t1, uu____25440) ->
+                           let uu___6 =
+                             let uu___7 = FStar_Syntax_Subst.compress t in
+                             uu___7.FStar_Syntax_Syntax.n in
+                           match uu___6 with
+                           | FStar_Syntax_Syntax.Tm_uvar uu___7 -> true
+                           | FStar_Syntax_Syntax.Tm_uinst (t1, uu___7) ->
                                is_uvar t1
-                           | uu____25465 -> false in
+                           | FStar_Syntax_Syntax.Tm_app (t1, uu___7) ->
+                               is_uvar t1
+                           | uu___7 -> false in
                          FStar_List.fold_right2
-                           (fun uu____25498 ->
-                              fun uu____25499 ->
-                                fun uu____25500 ->
-                                  match (uu____25498, uu____25499,
-                                          uu____25500)
-                                  with
-                                  | ((a1, uu____25544), (a2, uu____25546),
+                           (fun uu___6 ->
+                              fun uu___7 ->
+                                fun uu___8 ->
+                                  match (uu___6, uu___7, uu___8) with
+                                  | ((a1, uu___9), (a2, uu___10),
                                      (is_sub_probs, wl2)) ->
-                                      let uu____25579 = is_uvar a1 in
-                                      if uu____25579
+                                      let uu___11 = is_uvar a1 in
+                                      if uu___11
                                       then
-                                        ((let uu____25587 =
+                                        ((let uu___13 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env)
                                               (FStar_Options.Other
                                                  "LayeredEffectsEqns") in
-                                          if uu____25587
+                                          if uu___13
                                           then
-                                            let uu____25588 =
+                                            let uu___14 =
                                               FStar_Syntax_Print.term_to_string
                                                 a1 in
-                                            let uu____25589 =
+                                            let uu___15 =
                                               FStar_Syntax_Print.term_to_string
                                                 a2 in
                                             FStar_Util.print2
                                               "Layered Effects teq (rel c1 index uvar) %s = %s\n"
-                                              uu____25588 uu____25589
+                                              uu___14 uu___15
                                           else ());
-                                         (let uu____25591 =
+                                         (let uu___13 =
                                             sub_prob wl2 a1
                                               FStar_TypeChecker_Common.EQ a2
                                               "l.h.s. effect index uvar" in
-                                          match uu____25591 with
+                                          match uu___13 with
                                           | (p, wl3) ->
                                               ((p :: is_sub_probs), wl3)))
                                       else (is_sub_probs, wl2))
                            c12.FStar_Syntax_Syntax.effect_args
                            c21.FStar_Syntax_Syntax.effect_args ([], wl1)) in
-                    match uu____25394 with
+                    match uu___4 with
                     | (is_sub_probs, wl2) ->
-                        let uu____25617 =
+                        let uu___5 =
                           sub_prob wl2 c12.FStar_Syntax_Syntax.result_typ
                             problem.FStar_TypeChecker_Common.relation
                             c21.FStar_Syntax_Syntax.result_typ "result type" in
-                        (match uu____25617 with
+                        (match uu___5 with
                          | (ret_sub_prob, wl3) ->
                              let stronger_t_shape_error s =
-                               let uu____25630 =
+                               let uu___6 =
                                  FStar_Ident.string_of_lid
                                    c21.FStar_Syntax_Syntax.effect_name in
-                               let uu____25631 =
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string stronger_t in
                                FStar_Util.format3
                                  "Unexpected shape of stronger for %s, reason: %s (t:%s)"
-                                 uu____25630 s uu____25631 in
-                             let uu____25632 =
-                               let uu____25661 =
-                                 let uu____25662 =
+                                 uu___6 s uu___7 in
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Subst.compress stronger_t in
-                                 uu____25662.FStar_Syntax_Syntax.n in
-                               match uu____25661 with
+                                 uu___8.FStar_Syntax_Syntax.n in
+                               match uu___7 with
                                | FStar_Syntax_Syntax.Tm_arrow (bs, c) when
                                    (FStar_List.length bs) >=
                                      (Prims.of_int (2))
                                    ->
-                                   let uu____25721 =
+                                   let uu___8 =
                                      FStar_Syntax_Subst.open_comp bs c in
-                                   (match uu____25721 with
+                                   (match uu___8 with
                                     | (bs', c3) ->
                                         let a = FStar_List.hd bs' in
                                         let bs1 = FStar_List.tail bs' in
-                                        let uu____25784 =
-                                          let uu____25803 =
+                                        let uu___9 =
+                                          let uu___10 =
                                             FStar_All.pipe_right bs1
                                               (FStar_List.splitAt
                                                  ((FStar_List.length bs1) -
                                                     Prims.int_one)) in
-                                          FStar_All.pipe_right uu____25803
-                                            (fun uu____25906 ->
-                                               match uu____25906 with
+                                          FStar_All.pipe_right uu___10
+                                            (fun uu___11 ->
+                                               match uu___11 with
                                                | (l1, l2) ->
-                                                   let uu____25979 =
+                                                   let uu___12 =
                                                      FStar_List.hd l2 in
-                                                   (l1, uu____25979)) in
-                                        (match uu____25784 with
+                                                   (l1, uu___12)) in
+                                        (match uu___9 with
                                          | (rest_bs, f_b) ->
                                              (a, rest_bs, f_b, c3)))
-                               | uu____26084 ->
-                                   let uu____26085 =
-                                     let uu____26090 =
+                               | uu___8 ->
+                                   let uu___9 =
+                                     let uu___10 =
                                        stronger_t_shape_error
                                          "not an arrow or not enough binders" in
                                      (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                       uu____26090) in
-                                   FStar_Errors.raise_error uu____26085 r in
-                             (match uu____25632 with
+                                       uu___10) in
+                                   FStar_Errors.raise_error uu___9 r in
+                             (match uu___6 with
                               | (a_b, rest_bs, f_b, stronger_c) ->
-                                  let uu____26163 =
-                                    let uu____26170 =
-                                      let uu____26171 =
-                                        let uu____26172 =
-                                          let uu____26179 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
                                             FStar_All.pipe_right a_b
                                               FStar_Pervasives_Native.fst in
-                                          (uu____26179,
+                                          (uu___11,
                                             (c21.FStar_Syntax_Syntax.result_typ)) in
-                                        FStar_Syntax_Syntax.NT uu____26172 in
-                                      [uu____26171] in
+                                        FStar_Syntax_Syntax.NT uu___10 in
+                                      [uu___9] in
                                     FStar_TypeChecker_Env.uvars_for_binders
-                                      env rest_bs uu____26170
+                                      env rest_bs uu___8
                                       (fun b ->
-                                         let uu____26195 =
+                                         let uu___9 =
                                            FStar_Syntax_Print.binder_to_string
                                              b in
-                                         let uu____26196 =
+                                         let uu___10 =
                                            FStar_Ident.string_of_lid
                                              c21.FStar_Syntax_Syntax.effect_name in
-                                         let uu____26197 =
+                                         let uu___11 =
                                            FStar_Range.string_of_range r in
                                          FStar_Util.format3
                                            "implicit for binder %s in subcomp of %s at %s"
-                                           uu____26195 uu____26196
-                                           uu____26197) r in
-                                  (match uu____26163 with
+                                           uu___9 uu___10 uu___11) r in
+                                  (match uu___7 with
                                    | (rest_bs_uvars, g_uvars) ->
                                        let wl4 =
-                                         let uu___3748_26205 = wl3 in
+                                         let uu___8 = wl3 in
                                          {
-                                           attempting =
-                                             (uu___3748_26205.attempting);
-                                           wl_deferred =
-                                             (uu___3748_26205.wl_deferred);
+                                           attempting = (uu___8.attempting);
+                                           wl_deferred = (uu___8.wl_deferred);
                                            wl_deferred_to_tac =
-                                             (uu___3748_26205.wl_deferred_to_tac);
-                                           ctr = (uu___3748_26205.ctr);
-                                           defer_ok =
-                                             (uu___3748_26205.defer_ok);
-                                           smt_ok = (uu___3748_26205.smt_ok);
+                                             (uu___8.wl_deferred_to_tac);
+                                           ctr = (uu___8.ctr);
+                                           defer_ok = (uu___8.defer_ok);
+                                           smt_ok = (uu___8.smt_ok);
                                            umax_heuristic_ok =
-                                             (uu___3748_26205.umax_heuristic_ok);
-                                           tcenv = (uu___3748_26205.tcenv);
+                                             (uu___8.umax_heuristic_ok);
+                                           tcenv = (uu___8.tcenv);
                                            wl_implicits =
                                              (FStar_List.append
                                                 g_uvars.FStar_TypeChecker_Common.implicits
                                                 wl3.wl_implicits);
                                            repr_subcomp_allowed =
-                                             (uu___3748_26205.repr_subcomp_allowed)
+                                             (uu___8.repr_subcomp_allowed)
                                          } in
                                        let substs =
                                          FStar_List.map2
                                            (fun b ->
                                               fun t ->
-                                                let uu____26230 =
-                                                  let uu____26237 =
+                                                let uu___8 =
+                                                  let uu___9 =
                                                     FStar_All.pipe_right b
                                                       FStar_Pervasives_Native.fst in
-                                                  (uu____26237, t) in
-                                                FStar_Syntax_Syntax.NT
-                                                  uu____26230) (a_b ::
-                                           rest_bs)
+                                                  (uu___9, t) in
+                                                FStar_Syntax_Syntax.NT uu___8)
+                                           (a_b :: rest_bs)
                                            ((c21.FStar_Syntax_Syntax.result_typ)
                                            :: rest_bs_uvars) in
-                                       let uu____26254 =
+                                       let uu___8 =
                                          let f_sort_is =
-                                           let uu____26264 =
-                                             let uu____26267 =
-                                               let uu____26268 =
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 =
                                                  FStar_All.pipe_right f_b
                                                    FStar_Pervasives_Native.fst in
-                                               uu____26268.FStar_Syntax_Syntax.sort in
-                                             let uu____26277 =
+                                               uu___11.FStar_Syntax_Syntax.sort in
+                                             let uu___11 =
                                                FStar_TypeChecker_Env.is_layered_effect
                                                  env
                                                  c12.FStar_Syntax_Syntax.effect_name in
-                                             let uu____26278 =
+                                             let uu___12 =
                                                stronger_t_shape_error
                                                  "type of f is not a repr type" in
                                              FStar_Syntax_Util.effect_indices_from_repr
-                                               uu____26267 uu____26277 r
-                                               uu____26278 in
-                                           FStar_All.pipe_right uu____26264
+                                               uu___10 uu___11 r uu___12 in
+                                           FStar_All.pipe_right uu___9
                                              (FStar_List.map
                                                 (FStar_Syntax_Subst.subst
                                                    substs)) in
-                                         let uu____26283 =
+                                         let uu___9 =
                                            FStar_All.pipe_right
                                              c12.FStar_Syntax_Syntax.effect_args
                                              (FStar_List.map
                                                 FStar_Pervasives_Native.fst) in
                                          FStar_List.fold_left2
-                                           (fun uu____26319 ->
+                                           (fun uu___10 ->
                                               fun f_sort_i ->
                                                 fun c1_i ->
-                                                  match uu____26319 with
+                                                  match uu___10 with
                                                   | (ps, wl5) ->
-                                                      ((let uu____26341 =
+                                                      ((let uu___12 =
                                                           FStar_All.pipe_left
                                                             (FStar_TypeChecker_Env.debug
                                                                env)
                                                             (FStar_Options.Other
                                                                "LayeredEffectsEqns") in
-                                                        if uu____26341
+                                                        if uu___12
                                                         then
-                                                          let uu____26342 =
+                                                          let uu___13 =
                                                             FStar_Syntax_Print.term_to_string
                                                               f_sort_i in
-                                                          let uu____26343 =
+                                                          let uu___14 =
                                                             FStar_Syntax_Print.term_to_string
                                                               c1_i in
                                                           FStar_Util.print3
                                                             "Layered Effects (%s) %s = %s\n"
                                                             subcomp_name
-                                                            uu____26342
-                                                            uu____26343
+                                                            uu___13 uu___14
                                                         else ());
-                                                       (let uu____26345 =
+                                                       (let uu___12 =
                                                           sub_prob wl5
                                                             f_sort_i
                                                             FStar_TypeChecker_Common.EQ
                                                             c1_i
                                                             "indices of c1" in
-                                                        match uu____26345
-                                                        with
+                                                        match uu___12 with
                                                         | (p, wl6) ->
                                                             ((FStar_List.append
                                                                 ps [p]), wl6))))
-                                           ([], wl4) f_sort_is uu____26283 in
-                                       (match uu____26254 with
+                                           ([], wl4) f_sort_is uu___9 in
+                                       (match uu___8 with
                                         | (f_sub_probs, wl5) ->
                                             let stronger_ct =
-                                              let uu____26369 =
+                                              let uu___9 =
                                                 FStar_All.pipe_right
                                                   stronger_c
                                                   (FStar_Syntax_Subst.subst_comp
                                                      substs) in
-                                              FStar_All.pipe_right
-                                                uu____26369
+                                              FStar_All.pipe_right uu___9
                                                 FStar_Syntax_Util.comp_to_comp_typ in
-                                            let uu____26370 =
+                                            let uu___9 =
                                               let g_sort_is =
-                                                let uu____26380 =
+                                                let uu___10 =
                                                   FStar_TypeChecker_Env.is_layered_effect
                                                     env
                                                     c21.FStar_Syntax_Syntax.effect_name in
-                                                let uu____26381 =
+                                                let uu___11 =
                                                   stronger_t_shape_error
                                                     "subcomp return type is not a repr" in
                                                 FStar_Syntax_Util.effect_indices_from_repr
                                                   stronger_ct.FStar_Syntax_Syntax.result_typ
-                                                  uu____26380 r uu____26381 in
-                                              let uu____26382 =
+                                                  uu___10 r uu___11 in
+                                              let uu___10 =
                                                 FStar_All.pipe_right
                                                   c21.FStar_Syntax_Syntax.effect_args
                                                   (FStar_List.map
                                                      FStar_Pervasives_Native.fst) in
                                               FStar_List.fold_left2
-                                                (fun uu____26418 ->
+                                                (fun uu___11 ->
                                                    fun g_sort_i ->
                                                      fun c2_i ->
-                                                       match uu____26418 with
+                                                       match uu___11 with
                                                        | (ps, wl6) ->
-                                                           ((let uu____26440
-                                                               =
+                                                           ((let uu___13 =
                                                                FStar_All.pipe_left
                                                                  (FStar_TypeChecker_Env.debug
                                                                     env)
                                                                  (FStar_Options.Other
                                                                     "LayeredEffectsEqns") in
-                                                             if uu____26440
+                                                             if uu___13
                                                              then
-                                                               let uu____26441
-                                                                 =
+                                                               let uu___14 =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    g_sort_i in
-                                                               let uu____26442
-                                                                 =
+                                                               let uu___15 =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    c2_i in
                                                                FStar_Util.print3
                                                                  "Layered Effects (%s) %s = %s\n"
                                                                  subcomp_name
-                                                                 uu____26441
-                                                                 uu____26442
+                                                                 uu___14
+                                                                 uu___15
                                                              else ());
-                                                            (let uu____26444
-                                                               =
+                                                            (let uu___13 =
                                                                sub_prob wl6
                                                                  g_sort_i
                                                                  FStar_TypeChecker_Common.EQ
                                                                  c2_i
                                                                  "indices of c2" in
-                                                             match uu____26444
+                                                             match uu___13
                                                              with
                                                              | (p, wl7) ->
                                                                  ((FStar_List.append
                                                                     ps 
                                                                     [p]),
                                                                    wl7))))
-                                                ([], wl5) g_sort_is
-                                                uu____26382 in
-                                            (match uu____26370 with
+                                                ([], wl5) g_sort_is uu___10 in
+                                            (match uu___9 with
                                              | (g_sub_probs, wl6) ->
                                                  let fml =
-                                                   let uu____26470 =
-                                                     let uu____26475 =
+                                                   let uu___10 =
+                                                     let uu___11 =
                                                        FStar_List.hd
                                                          stronger_ct.FStar_Syntax_Syntax.comp_univs in
-                                                     let uu____26476 =
-                                                       let uu____26477 =
+                                                     let uu___12 =
+                                                       let uu___13 =
                                                          FStar_List.hd
                                                            stronger_ct.FStar_Syntax_Syntax.effect_args in
                                                        FStar_Pervasives_Native.fst
-                                                         uu____26477 in
-                                                     (uu____26475,
-                                                       uu____26476) in
-                                                   match uu____26470 with
+                                                         uu___13 in
+                                                     (uu___11, uu___12) in
+                                                   match uu___10 with
                                                    | (u, wp) ->
                                                        FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                          env u
@@ -10008,55 +9734,51 @@ and (solve_c :
                                                          wp
                                                          FStar_Range.dummyRange in
                                                  let sub_probs =
-                                                   let uu____26505 =
-                                                     let uu____26508 =
-                                                       let uu____26511 =
-                                                         let uu____26514 =
+                                                   let uu___10 =
+                                                     let uu___11 =
+                                                       let uu___12 =
+                                                         let uu___13 =
                                                            FStar_All.pipe_right
                                                              g_lift.FStar_TypeChecker_Common.deferred
                                                              (FStar_List.map
                                                                 FStar_Pervasives_Native.snd) in
                                                          FStar_List.append
                                                            g_sub_probs
-                                                           uu____26514 in
+                                                           uu___13 in
                                                        FStar_List.append
-                                                         f_sub_probs
-                                                         uu____26511 in
+                                                         f_sub_probs uu___12 in
                                                      FStar_List.append
-                                                       is_sub_probs
-                                                       uu____26508 in
-                                                   ret_sub_prob ::
-                                                     uu____26505 in
+                                                       is_sub_probs uu___11 in
+                                                   ret_sub_prob :: uu___10 in
                                                  let guard =
-                                                   let guard =
-                                                     let uu____26535 =
+                                                   let guard1 =
+                                                     let uu___10 =
                                                        FStar_List.map p_guard
                                                          sub_probs in
                                                      FStar_Syntax_Util.mk_conj_l
-                                                       uu____26535 in
+                                                       uu___10 in
                                                    match g_lift.FStar_TypeChecker_Common.guard_f
                                                    with
                                                    | FStar_TypeChecker_Common.Trivial
-                                                       -> guard
+                                                       -> guard1
                                                    | FStar_TypeChecker_Common.NonTrivial
                                                        f ->
                                                        FStar_Syntax_Util.mk_conj
-                                                         guard f in
+                                                         guard1 f in
                                                  let wl7 =
-                                                   let uu____26546 =
-                                                     let uu____26549 =
+                                                   let uu___10 =
+                                                     let uu___11 =
                                                        FStar_Syntax_Util.mk_conj
                                                          guard fml in
                                                      FStar_All.pipe_left
-                                                       (fun uu____26552 ->
+                                                       (fun uu___12 ->
                                                           FStar_Pervasives_Native.Some
-                                                            uu____26552)
-                                                       uu____26549 in
-                                                   solve_prob orig
-                                                     uu____26546 [] wl6 in
-                                                 let uu____26553 =
+                                                            uu___12) uu___11 in
+                                                   solve_prob orig uu___10 []
+                                                     wl6 in
+                                                 let uu___10 =
                                                    attempt sub_probs wl7 in
-                                                 solve env uu____26553))))))) in
+                                                 solve env uu___10))))))) in
         let solve_sub c11 edge c21 =
           if
             problem.FStar_TypeChecker_Common.relation <>
@@ -10064,219 +9786,217 @@ and (solve_c :
           then failwith "impossible: solve_sub"
           else ();
           (let r = FStar_TypeChecker_Env.get_range env in
-           let lift_c1 uu____26578 =
+           let lift_c1 uu___1 =
              let univs =
                match c11.FStar_Syntax_Syntax.comp_univs with
                | [] ->
-                   let uu____26580 =
+                   let uu___2 =
                      env.FStar_TypeChecker_Env.universe_of env
                        c11.FStar_Syntax_Syntax.result_typ in
-                   [uu____26580]
+                   [uu___2]
                | x -> x in
              let c12 =
-               let uu___3806_26583 = c11 in
+               let uu___2 = c11 in
                {
                  FStar_Syntax_Syntax.comp_univs = univs;
                  FStar_Syntax_Syntax.effect_name =
-                   (uu___3806_26583.FStar_Syntax_Syntax.effect_name);
+                   (uu___2.FStar_Syntax_Syntax.effect_name);
                  FStar_Syntax_Syntax.result_typ =
-                   (uu___3806_26583.FStar_Syntax_Syntax.result_typ);
+                   (uu___2.FStar_Syntax_Syntax.result_typ);
                  FStar_Syntax_Syntax.effect_args =
-                   (uu___3806_26583.FStar_Syntax_Syntax.effect_args);
+                   (uu___2.FStar_Syntax_Syntax.effect_args);
                  FStar_Syntax_Syntax.flags =
-                   (uu___3806_26583.FStar_Syntax_Syntax.flags)
+                   (uu___2.FStar_Syntax_Syntax.flags)
                } in
-             let uu____26584 =
-               let uu____26589 =
+             let uu___2 =
+               let uu___3 =
                  FStar_All.pipe_right
-                   (let uu___3809_26591 = c12 in
+                   (let uu___4 = c12 in
                     {
                       FStar_Syntax_Syntax.comp_univs = univs;
                       FStar_Syntax_Syntax.effect_name =
-                        (uu___3809_26591.FStar_Syntax_Syntax.effect_name);
+                        (uu___4.FStar_Syntax_Syntax.effect_name);
                       FStar_Syntax_Syntax.result_typ =
-                        (uu___3809_26591.FStar_Syntax_Syntax.result_typ);
+                        (uu___4.FStar_Syntax_Syntax.result_typ);
                       FStar_Syntax_Syntax.effect_args =
-                        (uu___3809_26591.FStar_Syntax_Syntax.effect_args);
+                        (uu___4.FStar_Syntax_Syntax.effect_args);
                       FStar_Syntax_Syntax.flags =
-                        (uu___3809_26591.FStar_Syntax_Syntax.flags)
+                        (uu___4.FStar_Syntax_Syntax.flags)
                     }) FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____26589
+               FStar_All.pipe_right uu___3
                  ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                     env) in
-             FStar_All.pipe_right uu____26584
-               (fun uu____26605 ->
-                  match uu____26605 with
+             FStar_All.pipe_right uu___2
+               (fun uu___3 ->
+                  match uu___3 with
                   | (c, g) ->
-                      let uu____26612 =
-                        let uu____26613 = FStar_TypeChecker_Env.is_trivial g in
-                        Prims.op_Negation uu____26613 in
-                      if uu____26612
+                      let uu___4 =
+                        let uu___5 = FStar_TypeChecker_Env.is_trivial g in
+                        Prims.op_Negation uu___5 in
+                      if uu___4
                       then
-                        let uu____26614 =
-                          let uu____26619 =
-                            let uu____26620 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_Ident.string_of_lid
                                 c12.FStar_Syntax_Syntax.effect_name in
-                            let uu____26621 =
+                            let uu___8 =
                               FStar_Ident.string_of_lid
                                 c21.FStar_Syntax_Syntax.effect_name in
                             FStar_Util.format2
                               "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
-                              uu____26620 uu____26621 in
-                          (FStar_Errors.Fatal_UnexpectedEffect, uu____26619) in
-                        FStar_Errors.raise_error uu____26614 r
+                              uu___7 uu___8 in
+                          (FStar_Errors.Fatal_UnexpectedEffect, uu___6) in
+                        FStar_Errors.raise_error uu___5 r
                       else FStar_Syntax_Util.comp_to_comp_typ c) in
-           let uu____26623 =
+           let uu___1 =
              ((Prims.op_Negation wl.repr_subcomp_allowed) &&
-                (let uu____26625 =
+                (let uu___2 =
                    FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
                      c21.FStar_Syntax_Syntax.effect_name in
-                 Prims.op_Negation uu____26625))
+                 Prims.op_Negation uu___2))
                &&
                (FStar_TypeChecker_Env.is_reifiable_effect env
                   c21.FStar_Syntax_Syntax.effect_name) in
-           if uu____26623
+           if uu___1
            then
-             let uu____26626 =
+             let uu___2 =
                mklstr
-                 (fun uu____26633 ->
-                    let uu____26634 =
+                 (fun uu___3 ->
+                    let uu___4 =
                       FStar_Ident.string_of_lid
                         c11.FStar_Syntax_Syntax.effect_name in
-                    let uu____26635 =
+                    let uu___5 =
                       FStar_Ident.string_of_lid
                         c21.FStar_Syntax_Syntax.effect_name in
                     FStar_Util.format2
-                      "Cannot lift from %s to %s, it needs a lift\n"
-                      uu____26634 uu____26635) in
-             giveup env uu____26626 orig
+                      "Cannot lift from %s to %s, it needs a lift\n" uu___4
+                      uu___5) in
+             giveup env uu___2 orig
            else
              (let is_null_wp_2 =
                 FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
                   (FStar_Util.for_some
-                     (fun uu___29_26641 ->
-                        match uu___29_26641 with
+                     (fun uu___3 ->
+                        match uu___3 with
                         | FStar_Syntax_Syntax.TOTAL -> true
                         | FStar_Syntax_Syntax.MLEFFECT -> true
                         | FStar_Syntax_Syntax.SOMETRIVIAL -> true
-                        | uu____26642 -> false)) in
-              let uu____26643 =
+                        | uu___4 -> false)) in
+              let uu___3 =
                 match ((c11.FStar_Syntax_Syntax.effect_args),
                         (c21.FStar_Syntax_Syntax.effect_args))
                 with
-                | ((wp1, uu____26673)::uu____26674,
-                   (wp2, uu____26676)::uu____26677) -> (wp1, wp2)
-                | uu____26750 ->
-                    let uu____26775 =
-                      let uu____26780 =
-                        let uu____26781 =
+                | ((wp1, uu___4)::uu___5, (wp2, uu___6)::uu___7) ->
+                    (wp1, wp2)
+                | uu___4 ->
+                    let uu___5 =
+                      let uu___6 =
+                        let uu___7 =
                           FStar_Syntax_Print.lid_to_string
                             c11.FStar_Syntax_Syntax.effect_name in
-                        let uu____26782 =
+                        let uu___8 =
                           FStar_Syntax_Print.lid_to_string
                             c21.FStar_Syntax_Syntax.effect_name in
                         FStar_Util.format2
                           "Got effects %s and %s, expected normalized effects"
-                          uu____26781 uu____26782 in
-                      (FStar_Errors.Fatal_ExpectNormalizedEffect,
-                        uu____26780) in
-                    FStar_Errors.raise_error uu____26775
+                          uu___7 uu___8 in
+                      (FStar_Errors.Fatal_ExpectNormalizedEffect, uu___6) in
+                    FStar_Errors.raise_error uu___5
                       env.FStar_TypeChecker_Env.range in
-              match uu____26643 with
+              match uu___3 with
               | (wpc1, wpc2) ->
-                  let uu____26789 = FStar_Util.physical_equality wpc1 wpc2 in
-                  if uu____26789
+                  let uu___4 = FStar_Util.physical_equality wpc1 wpc2 in
+                  if uu___4
                   then
-                    let uu____26790 =
+                    let uu___5 =
                       problem_using_guard orig
                         c11.FStar_Syntax_Syntax.result_typ
                         problem.FStar_TypeChecker_Common.relation
                         c21.FStar_Syntax_Syntax.result_typ
                         FStar_Pervasives_Native.None "result type" in
-                    solve_t env uu____26790 wl
+                    solve_t env uu___5 wl
                   else
-                    (let uu____26792 =
-                       let uu____26799 =
+                    (let uu___6 =
+                       let uu___7 =
                          FStar_TypeChecker_Env.effect_decl_opt env
                            c21.FStar_Syntax_Syntax.effect_name in
-                       FStar_Util.must uu____26799 in
-                     match uu____26792 with
+                       FStar_Util.must uu___7 in
+                     match uu___6 with
                      | (c2_decl, qualifiers) ->
-                         let uu____26820 =
+                         let uu___7 =
                            FStar_All.pipe_right qualifiers
                              (FStar_List.contains
                                 FStar_Syntax_Syntax.Reifiable) in
-                         if uu____26820
+                         if uu___7
                          then
                            let c1_repr =
-                             let uu____26824 =
-                               let uu____26825 =
-                                 let uu____26826 = lift_c1 () in
-                                 FStar_Syntax_Syntax.mk_Comp uu____26826 in
-                               let uu____26827 =
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 = lift_c1 () in
+                                 FStar_Syntax_Syntax.mk_Comp uu___10 in
+                               let uu___10 =
                                  env.FStar_TypeChecker_Env.universe_of env
                                    c11.FStar_Syntax_Syntax.result_typ in
-                               FStar_TypeChecker_Env.reify_comp env
-                                 uu____26825 uu____26827 in
+                               FStar_TypeChecker_Env.reify_comp env uu___9
+                                 uu___10 in
                              norm_with_steps
                                "FStar.TypeChecker.Rel.norm_with_steps.4"
                                [FStar_TypeChecker_Env.UnfoldUntil
                                   FStar_Syntax_Syntax.delta_constant;
                                FStar_TypeChecker_Env.Weak;
-                               FStar_TypeChecker_Env.HNF] env uu____26824 in
+                               FStar_TypeChecker_Env.HNF] env uu___8 in
                            let c2_repr =
-                             let uu____26829 =
-                               let uu____26830 =
-                                 FStar_Syntax_Syntax.mk_Comp c21 in
-                               let uu____26831 =
+                             let uu___8 =
+                               let uu___9 = FStar_Syntax_Syntax.mk_Comp c21 in
+                               let uu___10 =
                                  env.FStar_TypeChecker_Env.universe_of env
                                    c21.FStar_Syntax_Syntax.result_typ in
-                               FStar_TypeChecker_Env.reify_comp env
-                                 uu____26830 uu____26831 in
+                               FStar_TypeChecker_Env.reify_comp env uu___9
+                                 uu___10 in
                              norm_with_steps
                                "FStar.TypeChecker.Rel.norm_with_steps.5"
                                [FStar_TypeChecker_Env.UnfoldUntil
                                   FStar_Syntax_Syntax.delta_constant;
                                FStar_TypeChecker_Env.Weak;
-                               FStar_TypeChecker_Env.HNF] env uu____26829 in
-                           let uu____26832 =
-                             let uu____26837 =
-                               let uu____26838 =
+                               FStar_TypeChecker_Env.HNF] env uu___8 in
+                           let uu___8 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Print.term_to_string c1_repr in
-                               let uu____26839 =
+                               let uu___11 =
                                  FStar_Syntax_Print.term_to_string c2_repr in
                                FStar_Util.format2 "sub effect repr: %s <: %s"
-                                 uu____26838 uu____26839 in
+                                 uu___10 uu___11 in
                              sub_prob wl c1_repr
                                problem.FStar_TypeChecker_Common.relation
-                               c2_repr uu____26837 in
-                           (match uu____26832 with
+                               c2_repr uu___9 in
+                           (match uu___8 with
                             | (prob, wl1) ->
                                 let wl2 =
                                   solve_prob orig
                                     (FStar_Pervasives_Native.Some
                                        (p_guard prob)) [] wl1 in
-                                let uu____26843 = attempt [prob] wl2 in
-                                solve env uu____26843)
+                                let uu___9 = attempt [prob] wl2 in
+                                solve env uu___9)
                          else
                            (let g =
                               if env.FStar_TypeChecker_Env.lax
                               then FStar_Syntax_Util.t_true
                               else
                                 (let wpc1_2 =
-                                   let uu____26860 = lift_c1 () in
-                                   FStar_All.pipe_right uu____26860
+                                   let uu___10 = lift_c1 () in
+                                   FStar_All.pipe_right uu___10
                                      (fun ct ->
                                         FStar_List.hd
                                           ct.FStar_Syntax_Syntax.effect_args) in
                                  if is_null_wp_2
                                  then
-                                   ((let uu____26882 =
+                                   ((let uu___11 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____26882
+                                     if uu___11
                                      then
                                        FStar_Util.print_string
                                          "Using trivial wp ... \n"
@@ -10286,27 +10006,27 @@ and (solve_c :
                                          env
                                          c11.FStar_Syntax_Syntax.result_typ in
                                      let trivial =
-                                       let uu____26886 =
+                                       let uu___11 =
                                          FStar_All.pipe_right c2_decl
                                            FStar_Syntax_Util.get_wp_trivial_combinator in
-                                       match uu____26886 with
+                                       match uu___11 with
                                        | FStar_Pervasives_Native.None ->
                                            failwith
                                              "Rel doesn't yet handle undefined trivial combinator in an effect"
                                        | FStar_Pervasives_Native.Some t -> t in
-                                     let uu____26892 =
-                                       let uu____26893 =
-                                         let uu____26910 =
+                                     let uu___11 =
+                                       let uu___12 =
+                                         let uu___13 =
                                            FStar_TypeChecker_Env.inst_effect_fun_with
                                              [c1_univ] env c2_decl trivial in
-                                         let uu____26913 =
-                                           let uu____26924 =
+                                         let uu___14 =
+                                           let uu___15 =
                                              FStar_Syntax_Syntax.as_arg
                                                c11.FStar_Syntax_Syntax.result_typ in
-                                           [uu____26924; wpc1_2] in
-                                         (uu____26910, uu____26913) in
-                                       FStar_Syntax_Syntax.Tm_app uu____26893 in
-                                     FStar_Syntax_Syntax.mk uu____26892 r))
+                                           [uu___15; wpc1_2] in
+                                         (uu___13, uu___14) in
+                                       FStar_Syntax_Syntax.Tm_app uu___12 in
+                                     FStar_Syntax_Syntax.mk uu___11 r))
                                  else
                                    (let c2_univ =
                                       env.FStar_TypeChecker_Env.universe_of
@@ -10315,258 +10035,254 @@ and (solve_c :
                                     let stronger =
                                       FStar_All.pipe_right c2_decl
                                         FStar_Syntax_Util.get_stronger_vc_combinator in
-                                    let uu____26972 =
-                                      let uu____26973 =
-                                        let uu____26990 =
+                                    let uu___11 =
+                                      let uu___12 =
+                                        let uu___13 =
                                           FStar_TypeChecker_Env.inst_effect_fun_with
                                             [c2_univ] env c2_decl stronger in
-                                        let uu____26993 =
-                                          let uu____27004 =
+                                        let uu___14 =
+                                          let uu___15 =
                                             FStar_Syntax_Syntax.as_arg
                                               c21.FStar_Syntax_Syntax.result_typ in
-                                          let uu____27013 =
-                                            let uu____27024 =
+                                          let uu___16 =
+                                            let uu___17 =
                                               FStar_Syntax_Syntax.as_arg wpc2 in
-                                            [uu____27024; wpc1_2] in
-                                          uu____27004 :: uu____27013 in
-                                        (uu____26990, uu____26993) in
-                                      FStar_Syntax_Syntax.Tm_app uu____26973 in
-                                    FStar_Syntax_Syntax.mk uu____26972 r)) in
-                            (let uu____27078 =
+                                            [uu___17; wpc1_2] in
+                                          uu___15 :: uu___16 in
+                                        (uu___13, uu___14) in
+                                      FStar_Syntax_Syntax.Tm_app uu___12 in
+                                    FStar_Syntax_Syntax.mk uu___11 r)) in
+                            (let uu___10 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  (FStar_Options.Other "Rel") in
-                             if uu____27078
+                             if uu___10
                              then
-                               let uu____27079 =
-                                 let uu____27080 =
+                               let uu___11 =
+                                 let uu___12 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Env.Iota;
                                      FStar_TypeChecker_Env.Eager_unfolding;
                                      FStar_TypeChecker_Env.Primops;
                                      FStar_TypeChecker_Env.Simplify] env g in
-                                 FStar_Syntax_Print.term_to_string
-                                   uu____27080 in
+                                 FStar_Syntax_Print.term_to_string uu___12 in
                                FStar_Util.print1
-                                 "WP guard (simplifed) is (%s)\n" uu____27079
+                                 "WP guard (simplifed) is (%s)\n" uu___11
                              else ());
-                            (let uu____27082 =
+                            (let uu___10 =
                                sub_prob wl c11.FStar_Syntax_Syntax.result_typ
                                  problem.FStar_TypeChecker_Common.relation
                                  c21.FStar_Syntax_Syntax.result_typ
                                  "result type" in
-                             match uu____27082 with
+                             match uu___10 with
                              | (base_prob, wl1) ->
                                  let wl2 =
-                                   let uu____27090 =
-                                     let uu____27093 =
+                                   let uu___11 =
+                                     let uu___12 =
                                        FStar_Syntax_Util.mk_conj
                                          (p_guard base_prob) g in
                                      FStar_All.pipe_left
-                                       (fun uu____27096 ->
+                                       (fun uu___13 ->
                                           FStar_Pervasives_Native.Some
-                                            uu____27096) uu____27093 in
-                                   solve_prob orig uu____27090 [] wl1 in
-                                 let uu____27097 = attempt [base_prob] wl2 in
-                                 solve env uu____27097))))) in
-        let uu____27098 = FStar_Util.physical_equality c1 c2 in
-        if uu____27098
+                                            uu___13) uu___12 in
+                                   solve_prob orig uu___11 [] wl1 in
+                                 let uu___11 = attempt [base_prob] wl2 in
+                                 solve env uu___11))))) in
+        let uu___ = FStar_Util.physical_equality c1 c2 in
+        if uu___
         then
-          let uu____27099 =
-            solve_prob orig FStar_Pervasives_Native.None [] wl in
-          solve env uu____27099
+          let uu___1 = solve_prob orig FStar_Pervasives_Native.None [] wl in
+          solve env uu___1
         else
-          ((let uu____27102 =
+          ((let uu___3 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Rel") in
-            if uu____27102
+            if uu___3
             then
-              let uu____27103 = FStar_Syntax_Print.comp_to_string c1 in
-              let uu____27104 = FStar_Syntax_Print.comp_to_string c2 in
-              FStar_Util.print3 "solve_c %s %s %s\n" uu____27103
+              let uu___4 = FStar_Syntax_Print.comp_to_string c1 in
+              let uu___5 = FStar_Syntax_Print.comp_to_string c2 in
+              FStar_Util.print3 "solve_c %s %s %s\n" uu___4
                 (rel_to_string problem.FStar_TypeChecker_Common.relation)
-                uu____27104
+                uu___5
             else ());
-           (let uu____27106 =
-              let uu____27115 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c1 in
-              let uu____27118 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c2 in
-              (uu____27115, uu____27118) in
-            match uu____27106 with
+           (let uu___3 =
+              let uu___4 = FStar_TypeChecker_Normalize.ghost_to_pure env c1 in
+              let uu___5 = FStar_TypeChecker_Normalize.ghost_to_pure env c2 in
+              (uu___4, uu___5) in
+            match uu___3 with
             | (c11, c21) ->
                 (match ((c11.FStar_Syntax_Syntax.n),
                          (c21.FStar_Syntax_Syntax.n))
                  with
-                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27136),
-                    FStar_Syntax_Syntax.Total (t2, uu____27138)) when
+                 | (FStar_Syntax_Syntax.GTotal (t1, uu___4),
+                    FStar_Syntax_Syntax.Total (t2, uu___5)) when
                      FStar_TypeChecker_Env.non_informative env t2 ->
-                     let uu____27155 =
+                     let uu___6 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27155 wl
-                 | (FStar_Syntax_Syntax.GTotal uu____27156,
-                    FStar_Syntax_Syntax.Total uu____27157) ->
-                     let uu____27174 =
+                     solve_t env uu___6 wl
+                 | (FStar_Syntax_Syntax.GTotal uu___4,
+                    FStar_Syntax_Syntax.Total uu___5) ->
+                     let uu___6 =
                        FStar_Thunk.mkv
                          "incompatible monad ordering: GTot </: Tot" in
-                     giveup env uu____27174 orig
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27176),
-                    FStar_Syntax_Syntax.Total (t2, uu____27178)) ->
-                     let uu____27195 =
+                     giveup env uu___6 orig
+                 | (FStar_Syntax_Syntax.Total (t1, uu___4),
+                    FStar_Syntax_Syntax.Total (t2, uu___5)) ->
+                     let uu___6 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27195 wl
-                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27197),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27199)) ->
-                     let uu____27216 =
+                     solve_t env uu___6 wl
+                 | (FStar_Syntax_Syntax.GTotal (t1, uu___4),
+                    FStar_Syntax_Syntax.GTotal (t2, uu___5)) ->
+                     let uu___6 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27216 wl
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27218),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27220)) when
+                     solve_t env uu___6 wl
+                 | (FStar_Syntax_Syntax.Total (t1, uu___4),
+                    FStar_Syntax_Syntax.GTotal (t2, uu___5)) when
                      problem.FStar_TypeChecker_Common.relation =
                        FStar_TypeChecker_Common.SUB
                      ->
-                     let uu____27237 =
+                     let uu___6 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27237 wl
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27239),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27241)) ->
-                     let uu____27258 = FStar_Thunk.mkv "GTot =/= Tot" in
-                     giveup env uu____27258 orig
-                 | (FStar_Syntax_Syntax.GTotal uu____27259,
-                    FStar_Syntax_Syntax.Comp uu____27260) ->
-                     let uu____27269 =
-                       let uu___3933_27272 = problem in
-                       let uu____27275 =
-                         let uu____27276 =
+                     solve_t env uu___6 wl
+                 | (FStar_Syntax_Syntax.Total (t1, uu___4),
+                    FStar_Syntax_Syntax.GTotal (t2, uu___5)) ->
+                     let uu___6 = FStar_Thunk.mkv "GTot =/= Tot" in
+                     giveup env uu___6 orig
+                 | (FStar_Syntax_Syntax.GTotal uu___4,
+                    FStar_Syntax_Syntax.Comp uu___5) ->
+                     let uu___6 =
+                       let uu___7 = problem in
+                       let uu___8 =
+                         let uu___9 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27276 in
+                           uu___9 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3933_27272.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____27275;
+                           (uu___7.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu___8;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3933_27272.FStar_TypeChecker_Common.relation);
+                           (uu___7.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3933_27272.FStar_TypeChecker_Common.rhs);
+                           (uu___7.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3933_27272.FStar_TypeChecker_Common.element);
+                           (uu___7.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3933_27272.FStar_TypeChecker_Common.logical_guard);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3933_27272.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3933_27272.FStar_TypeChecker_Common.reason);
+                           (uu___7.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3933_27272.FStar_TypeChecker_Common.loc);
+                           (uu___7.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3933_27272.FStar_TypeChecker_Common.rank)
+                           (uu___7.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27269 wl
-                 | (FStar_Syntax_Syntax.Total uu____27277,
-                    FStar_Syntax_Syntax.Comp uu____27278) ->
-                     let uu____27287 =
-                       let uu___3933_27290 = problem in
-                       let uu____27293 =
-                         let uu____27294 =
+                     solve_c env uu___6 wl
+                 | (FStar_Syntax_Syntax.Total uu___4,
+                    FStar_Syntax_Syntax.Comp uu___5) ->
+                     let uu___6 =
+                       let uu___7 = problem in
+                       let uu___8 =
+                         let uu___9 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27294 in
+                           uu___9 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3933_27290.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____27293;
+                           (uu___7.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu___8;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3933_27290.FStar_TypeChecker_Common.relation);
+                           (uu___7.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3933_27290.FStar_TypeChecker_Common.rhs);
+                           (uu___7.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3933_27290.FStar_TypeChecker_Common.element);
+                           (uu___7.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3933_27290.FStar_TypeChecker_Common.logical_guard);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3933_27290.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3933_27290.FStar_TypeChecker_Common.reason);
+                           (uu___7.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3933_27290.FStar_TypeChecker_Common.loc);
+                           (uu___7.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3933_27290.FStar_TypeChecker_Common.rank)
+                           (uu___7.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27287 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27295,
-                    FStar_Syntax_Syntax.GTotal uu____27296) ->
-                     let uu____27305 =
-                       let uu___3945_27308 = problem in
-                       let uu____27311 =
-                         let uu____27312 =
+                     solve_c env uu___6 wl
+                 | (FStar_Syntax_Syntax.Comp uu___4,
+                    FStar_Syntax_Syntax.GTotal uu___5) ->
+                     let uu___6 =
+                       let uu___7 = problem in
+                       let uu___8 =
+                         let uu___9 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27312 in
+                           uu___9 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3945_27308.FStar_TypeChecker_Common.pid);
+                           (uu___7.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3945_27308.FStar_TypeChecker_Common.lhs);
+                           (uu___7.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3945_27308.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____27311;
+                           (uu___7.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu___8;
                          FStar_TypeChecker_Common.element =
-                           (uu___3945_27308.FStar_TypeChecker_Common.element);
+                           (uu___7.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3945_27308.FStar_TypeChecker_Common.logical_guard);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3945_27308.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3945_27308.FStar_TypeChecker_Common.reason);
+                           (uu___7.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3945_27308.FStar_TypeChecker_Common.loc);
+                           (uu___7.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3945_27308.FStar_TypeChecker_Common.rank)
+                           (uu___7.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27305 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27313,
-                    FStar_Syntax_Syntax.Total uu____27314) ->
-                     let uu____27323 =
-                       let uu___3945_27326 = problem in
-                       let uu____27329 =
-                         let uu____27330 =
+                     solve_c env uu___6 wl
+                 | (FStar_Syntax_Syntax.Comp uu___4,
+                    FStar_Syntax_Syntax.Total uu___5) ->
+                     let uu___6 =
+                       let uu___7 = problem in
+                       let uu___8 =
+                         let uu___9 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27330 in
+                           uu___9 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3945_27326.FStar_TypeChecker_Common.pid);
+                           (uu___7.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3945_27326.FStar_TypeChecker_Common.lhs);
+                           (uu___7.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3945_27326.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____27329;
+                           (uu___7.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu___8;
                          FStar_TypeChecker_Common.element =
-                           (uu___3945_27326.FStar_TypeChecker_Common.element);
+                           (uu___7.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3945_27326.FStar_TypeChecker_Common.logical_guard);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3945_27326.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___7.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3945_27326.FStar_TypeChecker_Common.reason);
+                           (uu___7.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3945_27326.FStar_TypeChecker_Common.loc);
+                           (uu___7.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3945_27326.FStar_TypeChecker_Common.rank)
+                           (uu___7.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27323 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27331,
-                    FStar_Syntax_Syntax.Comp uu____27332) ->
-                     let uu____27333 =
+                     solve_c env uu___6 wl
+                 | (FStar_Syntax_Syntax.Comp uu___4, FStar_Syntax_Syntax.Comp
+                    uu___5) ->
+                     let uu___6 =
                        (((FStar_Syntax_Util.is_ml_comp c11) &&
                            (FStar_Syntax_Util.is_ml_comp c21))
                           ||
@@ -10578,15 +10294,15 @@ and (solve_c :
                             &&
                             (problem.FStar_TypeChecker_Common.relation =
                                FStar_TypeChecker_Common.SUB)) in
-                     if uu____27333
+                     if uu___6
                      then
-                       let uu____27334 =
+                       let uu___7 =
                          problem_using_guard orig
                            (FStar_Syntax_Util.comp_result c11)
                            problem.FStar_TypeChecker_Common.relation
                            (FStar_Syntax_Util.comp_result c21)
                            FStar_Pervasives_Native.None "result type" in
-                       solve_t env uu____27334 wl
+                       solve_t env uu___7 wl
                      else
                        (let c1_comp =
                           FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
@@ -10596,22 +10312,22 @@ and (solve_c :
                           problem.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                         then
-                          let uu____27338 =
-                            let uu____27343 =
+                          let uu___8 =
+                            let uu___9 =
                               FStar_Ident.lid_equals
                                 c1_comp.FStar_Syntax_Syntax.effect_name
                                 c2_comp.FStar_Syntax_Syntax.effect_name in
-                            if uu____27343
+                            if uu___9
                             then (c1_comp, c2_comp)
                             else
-                              (let uu____27349 =
+                              (let uu___11 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c11 in
-                               let uu____27350 =
+                               let uu___12 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c21 in
-                               (uu____27349, uu____27350)) in
-                          match uu____27338 with
+                               (uu___11, uu___12)) in
+                          match uu___8 with
                           | (c1_comp1, c2_comp1) ->
                               solve_eq c1_comp1 c2_comp1
                                 FStar_TypeChecker_Env.trivial_guard
@@ -10622,79 +10338,79 @@ and (solve_c :
                            let c22 =
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
                                c21 in
-                           (let uu____27357 =
+                           (let uu___10 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Rel") in
-                            if uu____27357
+                            if uu___10
                             then
-                              let uu____27358 =
+                              let uu___11 =
                                 FStar_Ident.string_of_lid
                                   c12.FStar_Syntax_Syntax.effect_name in
-                              let uu____27359 =
+                              let uu___12 =
                                 FStar_Ident.string_of_lid
                                   c22.FStar_Syntax_Syntax.effect_name in
                               FStar_Util.print2 "solve_c for %s and %s\n"
-                                uu____27358 uu____27359
+                                uu___11 uu___12
                             else ());
-                           (let uu____27361 =
+                           (let uu___10 =
                               FStar_TypeChecker_Env.is_layered_effect env
                                 c22.FStar_Syntax_Syntax.effect_name in
-                            if uu____27361
+                            if uu___10
                             then solve_layered_sub c12 c22
                             else
-                              (let uu____27363 =
+                              (let uu___12 =
                                  FStar_TypeChecker_Env.monad_leq env
                                    c12.FStar_Syntax_Syntax.effect_name
                                    c22.FStar_Syntax_Syntax.effect_name in
-                               match uu____27363 with
+                               match uu___12 with
                                | FStar_Pervasives_Native.None ->
-                                   let uu____27366 =
+                                   let uu___13 =
                                      mklstr
-                                       (fun uu____27373 ->
-                                          let uu____27374 =
+                                       (fun uu___14 ->
+                                          let uu___15 =
                                             FStar_Syntax_Print.lid_to_string
                                               c12.FStar_Syntax_Syntax.effect_name in
-                                          let uu____27375 =
+                                          let uu___16 =
                                             FStar_Syntax_Print.lid_to_string
                                               c22.FStar_Syntax_Syntax.effect_name in
                                           FStar_Util.format2
                                             "incompatible monad ordering: %s </: %s"
-                                            uu____27374 uu____27375) in
-                                   giveup env uu____27366 orig
+                                            uu___15 uu___16) in
+                                   giveup env uu___13 orig
                                | FStar_Pervasives_Native.Some edge ->
                                    solve_sub c12 edge c22)))))))
 let (print_pending_implicits :
   FStar_TypeChecker_Common.guard_t -> Prims.string) =
   fun g ->
-    let uu____27382 =
+    let uu___ =
       FStar_All.pipe_right g.FStar_TypeChecker_Common.implicits
         (FStar_List.map
            (fun i ->
               FStar_Syntax_Print.term_to_string
                 i.FStar_TypeChecker_Common.imp_tm)) in
-    FStar_All.pipe_right uu____27382 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu___ (FStar_String.concat ", ")
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
     FStar_Syntax_Syntax.universe) Prims.list) -> Prims.string)
   =
   fun ineqs ->
     let vars =
-      let uu____27423 =
+      let uu___ =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst ineqs)
           (FStar_List.map FStar_Syntax_Print.univ_to_string) in
-      FStar_All.pipe_right uu____27423 (FStar_String.concat ", ") in
+      FStar_All.pipe_right uu___ (FStar_String.concat ", ") in
     let ineqs1 =
-      let uu____27441 =
+      let uu___ =
         FStar_All.pipe_right (FStar_Pervasives_Native.snd ineqs)
           (FStar_List.map
-             (fun uu____27469 ->
-                match uu____27469 with
+             (fun uu___1 ->
+                match uu___1 with
                 | (u1, u2) ->
-                    let uu____27476 = FStar_Syntax_Print.univ_to_string u1 in
-                    let uu____27477 = FStar_Syntax_Print.univ_to_string u2 in
-                    FStar_Util.format2 "%s < %s" uu____27476 uu____27477)) in
-      FStar_All.pipe_right uu____27441 (FStar_String.concat ", ") in
+                    let uu___2 = FStar_Syntax_Print.univ_to_string u1 in
+                    let uu___3 = FStar_Syntax_Print.univ_to_string u2 in
+                    FStar_Util.format2 "%s < %s" uu___2 uu___3)) in
+      FStar_All.pipe_right uu___ (FStar_String.concat ", ") in
     FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
 let (guard_to_string :
   FStar_TypeChecker_Env.env ->
@@ -10706,43 +10422,42 @@ let (guard_to_string :
               (g.FStar_TypeChecker_Common.deferred),
               (g.FStar_TypeChecker_Common.univ_ineqs))
       with
-      | (FStar_TypeChecker_Common.Trivial, [], (uu____27504, [])) when
-          let uu____27529 = FStar_Options.print_implicits () in
-          Prims.op_Negation uu____27529 -> "{}"
-      | uu____27530 ->
+      | (FStar_TypeChecker_Common.Trivial, [], (uu___, [])) when
+          let uu___1 = FStar_Options.print_implicits () in
+          Prims.op_Negation uu___1 -> "{}"
+      | uu___ ->
           let form =
             match g.FStar_TypeChecker_Common.guard_f with
             | FStar_TypeChecker_Common.Trivial -> "trivial"
             | FStar_TypeChecker_Common.NonTrivial f ->
-                let uu____27553 =
+                let uu___1 =
                   ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "Rel"))
                      ||
                      (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                         FStar_Options.Extreme))
                     || (FStar_Options.print_implicits ()) in
-                if uu____27553
+                if uu___1
                 then FStar_TypeChecker_Normalize.term_to_string env f
                 else "non-trivial" in
           let carry defs =
-            let uu____27573 =
+            let uu___1 =
               FStar_List.map
-                (fun uu____27584 ->
-                   match uu____27584 with
+                (fun uu___2 ->
+                   match uu___2 with
                    | (msg, x) ->
-                       let uu____27591 =
-                         let uu____27592 = prob_to_string env x in
-                         Prims.op_Hat ": " uu____27592 in
-                       Prims.op_Hat msg uu____27591) defs in
-            FStar_All.pipe_right uu____27573 (FStar_String.concat ",\n") in
+                       let uu___3 =
+                         let uu___4 = prob_to_string env x in
+                         Prims.op_Hat ": " uu___4 in
+                       Prims.op_Hat msg uu___3) defs in
+            FStar_All.pipe_right uu___1 (FStar_String.concat ",\n") in
           let imps = print_pending_implicits g in
-          let uu____27596 = carry g.FStar_TypeChecker_Common.deferred in
-          let uu____27597 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
-          let uu____27598 =
-            ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs in
+          let uu___1 = carry g.FStar_TypeChecker_Common.deferred in
+          let uu___2 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
+          let uu___3 = ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs in
           FStar_Util.format5
             "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t deferred_to_tac={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
-            form uu____27596 uu____27597 uu____27598 imps
+            form uu___1 uu___2 uu___3 imps
 let (new_t_problem :
   worklist ->
     FStar_TypeChecker_Env.env ->
@@ -10760,24 +10475,23 @@ let (new_t_problem :
             fun elt ->
               fun loc ->
                 let reason =
-                  let uu____27651 =
+                  let uu___ =
                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "ExplainRel"))
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Rel")) in
-                  if uu____27651
+                  if uu___
                   then
-                    let uu____27652 =
+                    let uu___1 =
                       FStar_TypeChecker_Normalize.term_to_string env lhs in
-                    let uu____27653 =
+                    let uu___2 =
                       FStar_TypeChecker_Normalize.term_to_string env rhs in
-                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____27652
-                      (rel_to_string rel) uu____27653
+                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu___1
+                      (rel_to_string rel) uu___2
                   else "TOP" in
-                let uu____27655 =
-                  new_problem wl env lhs rel rhs elt loc reason in
-                match uu____27655 with
+                let uu___ = new_problem wl env lhs rel rhs elt loc reason in
+                match uu___ with
                 | (p, wl1) ->
                     (def_check_prob (Prims.op_Hat "new_t_problem." reason)
                        (FStar_TypeChecker_Common.TProb p);
@@ -10797,17 +10511,16 @@ let (new_t_prob :
         fun rel ->
           fun t2 ->
             let x =
-              let uu____27713 =
-                let uu____27716 = FStar_TypeChecker_Env.get_range env in
+              let uu___ =
+                let uu___1 = FStar_TypeChecker_Env.get_range env in
                 FStar_All.pipe_left
-                  (fun uu____27719 ->
-                     FStar_Pervasives_Native.Some uu____27719) uu____27716 in
-              FStar_Syntax_Syntax.new_bv uu____27713 t1 in
-            let uu____27720 =
-              let uu____27725 = FStar_TypeChecker_Env.get_range env in
+                  (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) uu___1 in
+              FStar_Syntax_Syntax.new_bv uu___ t1 in
+            let uu___ =
+              let uu___1 = FStar_TypeChecker_Env.get_range env in
               new_t_problem wl env t1 rel t2 (FStar_Pervasives_Native.Some x)
-                uu____27725 in
-            match uu____27720 with | (p, wl1) -> (p, x, wl1)
+                uu___1 in
+            match uu___ with | (p, wl1) -> (p, x, wl1)
 let (solve_and_commit :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -10824,60 +10537,57 @@ let (solve_and_commit :
     fun probs ->
       fun err ->
         let tx = FStar_Syntax_Unionfind.new_transaction () in
-        (let uu____27796 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "RelBench") in
-         if uu____27796
+         if uu___1
          then
-           let uu____27797 =
+           let uu___2 =
              FStar_Common.string_of_list
                (fun p -> FStar_Util.string_of_int (p_pid p)) probs.attempting in
-           FStar_Util.print1 "solving problems %s {\n" uu____27797
+           FStar_Util.print1 "solving problems %s {\n" uu___2
          else ());
-        (let uu____27801 =
-           FStar_Util.record_time (fun uu____27807 -> solve env probs) in
-         match uu____27801 with
+        (let uu___1 = FStar_Util.record_time (fun uu___2 -> solve env probs) in
+         match uu___1 with
          | (sol, ms) ->
-             ((let uu____27819 =
+             ((let uu___3 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "RelBench") in
-               if uu____27819
+               if uu___3
                then
-                 let uu____27820 = FStar_Util.string_of_int ms in
-                 FStar_Util.print1 "} solved in %s ms\n" uu____27820
+                 let uu___4 = FStar_Util.string_of_int ms in
+                 FStar_Util.print1 "} solved in %s ms\n" uu___4
                else ());
               (match sol with
                | Success (deferred, defer_to_tac, implicits) ->
-                   let uu____27833 =
+                   let uu___3 =
                      FStar_Util.record_time
-                       (fun uu____27839 -> FStar_Syntax_Unionfind.commit tx) in
-                   (match uu____27833 with
+                       (fun uu___4 -> FStar_Syntax_Unionfind.commit tx) in
+                   (match uu___3 with
                     | ((), ms1) ->
-                        ((let uu____27850 =
+                        ((let uu___5 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelBench") in
-                          if uu____27850
+                          if uu___5
                           then
-                            let uu____27851 = FStar_Util.string_of_int ms1 in
-                            FStar_Util.print1 "committed in %s ms\n"
-                              uu____27851
+                            let uu___6 = FStar_Util.string_of_int ms1 in
+                            FStar_Util.print1 "committed in %s ms\n" uu___6
                           else ());
                          FStar_Pervasives_Native.Some
                            (deferred, defer_to_tac, implicits)))
                | Failed (d, s) ->
-                   ((let uu____27862 =
+                   ((let uu___4 =
                        (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "ExplainRel"))
                          ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "Rel")) in
-                     if uu____27862
+                     if uu___4
                      then
-                       let uu____27863 = explain env d s in
-                       FStar_All.pipe_left FStar_Util.print_string
-                         uu____27863
+                       let uu___5 = explain env d s in
+                       FStar_All.pipe_left FStar_Util.print_string uu___5
                      else ());
                     (let result = err (d, s) in
                      FStar_Syntax_Unionfind.rollback tx; result)))))
@@ -10890,13 +10600,13 @@ let (simplify_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          ((let uu____27887 =
+          ((let uu___1 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Simplification") in
-            if uu____27887
+            if uu___1
             then
-              let uu____27888 = FStar_Syntax_Print.term_to_string f in
-              FStar_Util.print1 "Simplifying guard %s\n" uu____27888
+              let uu___2 = FStar_Syntax_Print.term_to_string f in
+              FStar_Util.print1 "Simplifying guard %s\n" uu___2
             else ());
            (let f1 =
               norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.6"
@@ -10905,35 +10615,35 @@ let (simplify_guard :
                 FStar_TypeChecker_Env.Simplify;
                 FStar_TypeChecker_Env.Primops;
                 FStar_TypeChecker_Env.NoFullNorm] env f in
-            (let uu____27892 =
+            (let uu___2 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Simplification") in
-             if uu____27892
+             if uu___2
              then
-               let uu____27893 = FStar_Syntax_Print.term_to_string f1 in
-               FStar_Util.print1 "Simplified guard to %s\n" uu____27893
+               let uu___3 = FStar_Syntax_Print.term_to_string f1 in
+               FStar_Util.print1 "Simplified guard to %s\n" uu___3
              else ());
             (let f2 =
-               let uu____27896 =
-                 let uu____27897 = FStar_Syntax_Util.unmeta f1 in
-                 uu____27897.FStar_Syntax_Syntax.n in
-               match uu____27896 with
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Util.unmeta f1 in
+                 uu___3.FStar_Syntax_Syntax.n in
+               match uu___2 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
                    -> FStar_TypeChecker_Common.Trivial
-               | uu____27901 -> FStar_TypeChecker_Common.NonTrivial f1 in
-             let uu___4065_27902 = g in
+               | uu___3 -> FStar_TypeChecker_Common.NonTrivial f1 in
+             let uu___2 = g in
              {
                FStar_TypeChecker_Common.guard_f = f2;
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4065_27902.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___2.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4065_27902.FStar_TypeChecker_Common.deferred);
+                 (uu___2.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___4065_27902.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___2.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4065_27902.FStar_TypeChecker_Common.implicits)
+                 (uu___2.FStar_TypeChecker_Common.implicits)
              })))
 let (with_guard :
   FStar_TypeChecker_Env.env ->
@@ -10948,26 +10658,24 @@ let (with_guard :
         match dopt with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred, defer_to_tac, implicits) ->
-            let uu____27953 =
-              let uu____27954 =
-                let uu____27955 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
                   FStar_All.pipe_right (p_guard prob)
-                    (fun uu____27956 ->
-                       FStar_TypeChecker_Common.NonTrivial uu____27956) in
+                    (fun uu___3 -> FStar_TypeChecker_Common.NonTrivial uu___3) in
                 {
-                  FStar_TypeChecker_Common.guard_f = uu____27955;
+                  FStar_TypeChecker_Common.guard_f = uu___2;
                   FStar_TypeChecker_Common.deferred_to_tac = defer_to_tac;
                   FStar_TypeChecker_Common.deferred = deferred;
                   FStar_TypeChecker_Common.univ_ineqs = ([], []);
                   FStar_TypeChecker_Common.implicits = implicits
                 } in
-              simplify_guard env uu____27954 in
+              simplify_guard env uu___1 in
             FStar_All.pipe_left
-              (fun uu____27963 -> FStar_Pervasives_Native.Some uu____27963)
-              uu____27953
+              (fun uu___1 -> FStar_Pervasives_Native.Some uu___1) uu___
 let with_guard_no_simp :
-  'uuuuuu27972 .
-    'uuuuuu27972 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_TypeChecker_Common.prob ->
         (FStar_TypeChecker_Common.deferred *
           FStar_TypeChecker_Common.deferred *
@@ -10980,19 +10688,18 @@ let with_guard_no_simp :
         match dopt with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred, defer_to_tac, implicits) ->
-            let uu____28021 =
-              let uu____28022 =
+            let uu___ =
+              let uu___1 =
                 FStar_All.pipe_right (p_guard prob)
-                  (fun uu____28023 ->
-                     FStar_TypeChecker_Common.NonTrivial uu____28023) in
+                  (fun uu___2 -> FStar_TypeChecker_Common.NonTrivial uu___2) in
               {
-                FStar_TypeChecker_Common.guard_f = uu____28022;
+                FStar_TypeChecker_Common.guard_f = uu___1;
                 FStar_TypeChecker_Common.deferred_to_tac = defer_to_tac;
                 FStar_TypeChecker_Common.deferred = deferred;
                 FStar_TypeChecker_Common.univ_ineqs = ([], []);
                 FStar_TypeChecker_Common.implicits = implicits
               } in
-            FStar_Pervasives_Native.Some uu____28021
+            FStar_Pervasives_Native.Some uu___
 let (try_teq :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -11004,36 +10711,35 @@ let (try_teq :
     fun env ->
       fun t1 ->
         fun t2 ->
-          (let uu____28053 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____28053
+           if uu___1
            then
-             let uu____28054 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____28055 = FStar_Syntax_Print.term_to_string t2 in
-             FStar_Util.print2 "try_teq of %s and %s {\n" uu____28054
-               uu____28055
+             let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+             let uu___3 = FStar_Syntax_Print.term_to_string t2 in
+             FStar_Util.print2 "try_teq of %s and %s {\n" uu___2 uu___3
            else ());
-          (let uu____28057 =
-             let uu____28062 = FStar_TypeChecker_Env.get_range env in
+          (let uu___1 =
+             let uu___2 = FStar_TypeChecker_Env.get_range env in
              new_t_problem (empty_worklist env) env t1
                FStar_TypeChecker_Common.EQ t2 FStar_Pervasives_Native.None
-               uu____28062 in
-           match uu____28057 with
+               uu___2 in
+           match uu___1 with
            | (prob, wl) ->
                let g =
-                 let uu____28070 =
+                 let uu___2 =
                    solve_and_commit env (singleton wl prob smt_ok)
-                     (fun uu____28080 -> FStar_Pervasives_Native.None) in
-                 FStar_All.pipe_left (with_guard env prob) uu____28070 in
-               ((let uu____28102 =
+                     (fun uu___3 -> FStar_Pervasives_Native.None) in
+                 FStar_All.pipe_left (with_guard env prob) uu___2 in
+               ((let uu___3 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "Rel") in
-                 if uu____28102
+                 if uu___3
                  then
-                   let uu____28103 =
+                   let uu___4 =
                      FStar_Common.string_of_option (guard_to_string env) g in
-                   FStar_Util.print1 "} res = %s\n" uu____28103
+                   FStar_Util.print1 "} res = %s\n" uu___4
                  else ());
                 g))
 let (teq :
@@ -11044,27 +10750,27 @@ let (teq :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____28120 = try_teq true env t1 t2 in
-        match uu____28120 with
+        let uu___ = try_teq true env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
-            ((let uu____28124 = FStar_TypeChecker_Env.get_range env in
-              let uu____28125 =
+            ((let uu___2 = FStar_TypeChecker_Env.get_range env in
+              let uu___3 =
                 FStar_TypeChecker_Err.basic_type_error env
                   FStar_Pervasives_Native.None t2 t1 in
-              FStar_Errors.log_issue uu____28124 uu____28125);
+              FStar_Errors.log_issue uu___2 uu___3);
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
-            ((let uu____28132 =
+            ((let uu___2 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel") in
-              if uu____28132
+              if uu___2
               then
-                let uu____28133 = FStar_Syntax_Print.term_to_string t1 in
-                let uu____28134 = FStar_Syntax_Print.term_to_string t2 in
-                let uu____28135 = guard_to_string env g in
+                let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+                let uu___4 = FStar_Syntax_Print.term_to_string t2 in
+                let uu___5 = guard_to_string env g in
                 FStar_Util.print3
-                  "teq of %s and %s succeeded with guard %s\n" uu____28133
-                  uu____28134 uu____28135
+                  "teq of %s and %s succeeded with guard %s\n" uu___3 uu___4
+                  uu___5
               else ());
              g)
 let (get_teq_predicate :
@@ -11076,42 +10782,42 @@ let (get_teq_predicate :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____28155 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____28155
+         if uu___1
          then
-           let uu____28156 = FStar_Syntax_Print.term_to_string t1 in
-           let uu____28157 = FStar_Syntax_Print.term_to_string t2 in
-           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____28156
-             uu____28157
+           let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+           let uu___3 = FStar_Syntax_Print.term_to_string t2 in
+           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu___2
+             uu___3
          else ());
-        (let uu____28159 =
+        (let uu___1 =
            new_t_prob (empty_worklist env) env t1 FStar_TypeChecker_Common.EQ
              t2 in
-         match uu____28159 with
+         match uu___1 with
          | (prob, x, wl) ->
              let g =
-               let uu____28174 =
+               let uu___2 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____28184 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____28174 in
-             ((let uu____28206 =
+                   (fun uu___3 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu___2 in
+             ((let uu___3 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel") in
-               if uu____28206
+               if uu___3
                then
-                 let uu____28207 =
+                 let uu___4 =
                    FStar_Common.string_of_option (guard_to_string env) g in
-                 FStar_Util.print1 "} res teq predicate = %s\n" uu____28207
+                 FStar_Util.print1 "} res teq predicate = %s\n" uu___4
                else ());
               (match g with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some g1 ->
-                   let uu____28212 =
-                     let uu____28213 = FStar_Syntax_Syntax.mk_binder x in
-                     FStar_TypeChecker_Env.abstract_guard uu____28213 g1 in
-                   FStar_Pervasives_Native.Some uu____28212)))
+                   let uu___3 =
+                     let uu___4 = FStar_Syntax_Syntax.mk_binder x in
+                     FStar_TypeChecker_Env.abstract_guard uu___4 g1 in
+                   FStar_Pervasives_Native.Some uu___3)))
 let (subtype_fail :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11121,11 +10827,11 @@ let (subtype_fail :
     fun e ->
       fun t1 ->
         fun t2 ->
-          let uu____28234 = FStar_TypeChecker_Env.get_range env in
-          let uu____28235 =
+          let uu___ = FStar_TypeChecker_Env.get_range env in
+          let uu___1 =
             FStar_TypeChecker_Err.basic_type_error env
               (FStar_Pervasives_Native.Some e) t2 t1 in
-          FStar_Errors.log_issue uu____28234 uu____28235
+          FStar_Errors.log_issue uu___ uu___1
 let (sub_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
@@ -11139,62 +10845,62 @@ let (sub_comp :
           if env.FStar_TypeChecker_Env.use_eq
           then FStar_TypeChecker_Common.EQ
           else FStar_TypeChecker_Common.SUB in
-        (let uu____28260 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____28260
+         if uu___1
          then
-           let uu____28261 = FStar_Syntax_Print.comp_to_string c1 in
-           let uu____28262 = FStar_Syntax_Print.comp_to_string c2 in
-           FStar_Util.print3 "sub_comp of %s --and-- %s --with-- %s\n"
-             uu____28261 uu____28262
+           let uu___2 = FStar_Syntax_Print.comp_to_string c1 in
+           let uu___3 = FStar_Syntax_Print.comp_to_string c2 in
+           FStar_Util.print3 "sub_comp of %s --and-- %s --with-- %s\n" uu___2
+             uu___3
              (if rel = FStar_TypeChecker_Common.EQ then "EQ" else "SUB")
          else ());
-        (let uu____28265 =
-           let uu____28272 = FStar_TypeChecker_Env.get_range env in
+        (let uu___1 =
+           let uu___2 = FStar_TypeChecker_Env.get_range env in
            new_problem (empty_worklist env) env c1 rel c2
-             FStar_Pervasives_Native.None uu____28272 "sub_comp" in
-         match uu____28265 with
+             FStar_Pervasives_Native.None uu___2 "sub_comp" in
+         match uu___1 with
          | (prob, wl) ->
              let wl1 =
-               let uu___4138_28282 = wl in
+               let uu___2 = wl in
                {
-                 attempting = (uu___4138_28282.attempting);
-                 wl_deferred = (uu___4138_28282.wl_deferred);
-                 wl_deferred_to_tac = (uu___4138_28282.wl_deferred_to_tac);
-                 ctr = (uu___4138_28282.ctr);
-                 defer_ok = (uu___4138_28282.defer_ok);
-                 smt_ok = (uu___4138_28282.smt_ok);
-                 umax_heuristic_ok = (uu___4138_28282.umax_heuristic_ok);
-                 tcenv = (uu___4138_28282.tcenv);
-                 wl_implicits = (uu___4138_28282.wl_implicits);
+                 attempting = (uu___2.attempting);
+                 wl_deferred = (uu___2.wl_deferred);
+                 wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
+                 ctr = (uu___2.ctr);
+                 defer_ok = (uu___2.defer_ok);
+                 smt_ok = (uu___2.smt_ok);
+                 umax_heuristic_ok = (uu___2.umax_heuristic_ok);
+                 tcenv = (uu___2.tcenv);
+                 wl_implicits = (uu___2.wl_implicits);
                  repr_subcomp_allowed = true
                } in
              let prob1 = FStar_TypeChecker_Common.CProb prob in
              (def_check_prob "sub_comp" prob1;
-              (let uu____28285 =
+              (let uu___3 =
                  FStar_Util.record_time
-                   (fun uu____28296 ->
-                      let uu____28297 =
+                   (fun uu___4 ->
+                      let uu___5 =
                         solve_and_commit env (singleton wl1 prob1 true)
-                          (fun uu____28307 -> FStar_Pervasives_Native.None) in
-                      FStar_All.pipe_left (with_guard env prob1) uu____28297) in
-               match uu____28285 with
+                          (fun uu___6 -> FStar_Pervasives_Native.None) in
+                      FStar_All.pipe_left (with_guard env prob1) uu___5) in
+               match uu___3 with
                | (r, ms) ->
-                   ((let uu____28337 =
+                   ((let uu___5 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "RelBench") in
-                     if uu____28337
+                     if uu___5
                      then
-                       let uu____28338 = FStar_Syntax_Print.comp_to_string c1 in
-                       let uu____28339 = FStar_Syntax_Print.comp_to_string c2 in
-                       let uu____28340 = FStar_Util.string_of_int ms in
+                       let uu___6 = FStar_Syntax_Print.comp_to_string c1 in
+                       let uu___7 = FStar_Syntax_Print.comp_to_string c2 in
+                       let uu___8 = FStar_Util.string_of_int ms in
                        FStar_Util.print4
                          "sub_comp of %s --and-- %s --with-- %s --- solved in %s ms\n"
-                         uu____28338 uu____28339
+                         uu___6 uu___7
                          (if rel = FStar_TypeChecker_Common.EQ
                           then "EQ"
-                          else "SUB") uu____28340
+                          else "SUB") uu___8
                      else ());
                     r))))
 let (solve_universe_inequalities' :
@@ -11206,91 +10912,90 @@ let (solve_universe_inequalities' :
   =
   fun tx ->
     fun env ->
-      fun uu____28369 ->
-        match uu____28369 with
+      fun uu___ ->
+        match uu___ with
         | (variables, ineqs) ->
             let fail u1 u2 =
               FStar_Syntax_Unionfind.rollback tx;
-              (let uu____28412 =
-                 let uu____28417 =
-                   let uu____28418 = FStar_Syntax_Print.univ_to_string u1 in
-                   let uu____28419 = FStar_Syntax_Print.univ_to_string u2 in
+              (let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Print.univ_to_string u1 in
+                   let uu___5 = FStar_Syntax_Print.univ_to_string u2 in
                    FStar_Util.format2 "Universe %s and %s are incompatible"
-                     uu____28418 uu____28419 in
-                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____28417) in
-               let uu____28420 = FStar_TypeChecker_Env.get_range env in
-               FStar_Errors.raise_error uu____28412 uu____28420) in
+                     uu___4 uu___5 in
+                 (FStar_Errors.Fatal_IncompatibleUniverse, uu___3) in
+               let uu___3 = FStar_TypeChecker_Env.get_range env in
+               FStar_Errors.raise_error uu___2 uu___3) in
             let equiv v v' =
-              let uu____28432 =
-                let uu____28437 = FStar_Syntax_Subst.compress_univ v in
-                let uu____28438 = FStar_Syntax_Subst.compress_univ v' in
-                (uu____28437, uu____28438) in
-              match uu____28432 with
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Subst.compress_univ v in
+                let uu___3 = FStar_Syntax_Subst.compress_univ v' in
+                (uu___2, uu___3) in
+              match uu___1 with
               | (FStar_Syntax_Syntax.U_unif v0, FStar_Syntax_Syntax.U_unif
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
-              | uu____28461 -> false in
+              | uu___2 -> false in
             let sols =
               FStar_All.pipe_right variables
                 (FStar_List.collect
                    (fun v ->
-                      let uu____28491 = FStar_Syntax_Subst.compress_univ v in
-                      match uu____28491 with
-                      | FStar_Syntax_Syntax.U_unif uu____28498 ->
+                      let uu___1 = FStar_Syntax_Subst.compress_univ v in
+                      match uu___1 with
+                      | FStar_Syntax_Syntax.U_unif uu___2 ->
                           let lower_bounds_of_v =
                             FStar_All.pipe_right ineqs
                               (FStar_List.collect
-                                 (fun uu____28529 ->
-                                    match uu____28529 with
+                                 (fun uu___3 ->
+                                    match uu___3 with
                                     | (u, v') ->
-                                        let uu____28538 = equiv v v' in
-                                        if uu____28538
+                                        let uu___4 = equiv v v' in
+                                        if uu___4
                                         then
-                                          let uu____28541 =
+                                          let uu___5 =
                                             FStar_All.pipe_right variables
                                               (FStar_Util.for_some (equiv u)) in
-                                          (if uu____28541 then [] else [u])
+                                          (if uu___5 then [] else [u])
                                         else [])) in
                           let lb =
                             FStar_TypeChecker_Normalize.normalize_universe
                               env
                               (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
                           [(lb, v)]
-                      | uu____28557 -> [])) in
-            let uu____28562 =
+                      | uu___2 -> [])) in
+            let uu___1 =
               let wl =
-                let uu___4181_28566 = empty_worklist env in
+                let uu___2 = empty_worklist env in
                 {
-                  attempting = (uu___4181_28566.attempting);
-                  wl_deferred = (uu___4181_28566.wl_deferred);
-                  wl_deferred_to_tac = (uu___4181_28566.wl_deferred_to_tac);
-                  ctr = (uu___4181_28566.ctr);
+                  attempting = (uu___2.attempting);
+                  wl_deferred = (uu___2.wl_deferred);
+                  wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
+                  ctr = (uu___2.ctr);
                   defer_ok = false;
-                  smt_ok = (uu___4181_28566.smt_ok);
-                  umax_heuristic_ok = (uu___4181_28566.umax_heuristic_ok);
-                  tcenv = (uu___4181_28566.tcenv);
-                  wl_implicits = (uu___4181_28566.wl_implicits);
-                  repr_subcomp_allowed =
-                    (uu___4181_28566.repr_subcomp_allowed)
+                  smt_ok = (uu___2.smt_ok);
+                  umax_heuristic_ok = (uu___2.umax_heuristic_ok);
+                  tcenv = (uu___2.tcenv);
+                  wl_implicits = (uu___2.wl_implicits);
+                  repr_subcomp_allowed = (uu___2.repr_subcomp_allowed)
                 } in
               FStar_All.pipe_right sols
                 (FStar_List.map
-                   (fun uu____28584 ->
-                      match uu____28584 with
+                   (fun uu___2 ->
+                      match uu___2 with
                       | (lb, v) ->
-                          let uu____28591 =
+                          let uu___3 =
                             solve_universe_eq (~- Prims.int_one) wl lb v in
-                          (match uu____28591 with
+                          (match uu___3 with
                            | USolved wl1 -> ()
-                           | uu____28593 -> fail lb v))) in
-            let rec check_ineq uu____28603 =
-              match uu____28603 with
+                           | uu___4 -> fail lb v))) in
+            let rec check_ineq uu___2 =
+              match uu___2 with
               | (u, v) ->
                   let u1 =
                     FStar_TypeChecker_Normalize.normalize_universe env u in
                   let v1 =
                     FStar_TypeChecker_Normalize.normalize_universe env v in
                   (match (u1, v1) with
-                   | (FStar_Syntax_Syntax.U_zero, uu____28612) -> true
+                   | (FStar_Syntax_Syntax.U_zero, uu___3) -> true
                    | (FStar_Syntax_Syntax.U_succ u0,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u0, v0)
                    | (FStar_Syntax_Syntax.U_name u0,
@@ -11299,64 +11004,63 @@ let (solve_universe_inequalities' :
                    | (FStar_Syntax_Syntax.U_unif u0,
                       FStar_Syntax_Syntax.U_unif v0) ->
                        FStar_Syntax_Unionfind.univ_equiv u0 v0
-                   | (FStar_Syntax_Syntax.U_name uu____28639,
+                   | (FStar_Syntax_Syntax.U_name uu___3,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_unif uu____28641,
+                   | (FStar_Syntax_Syntax.U_unif uu___3,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_max us, uu____28654) ->
+                   | (FStar_Syntax_Syntax.U_max us, uu___3) ->
                        FStar_All.pipe_right us
                          (FStar_Util.for_all (fun u2 -> check_ineq (u2, v1)))
-                   | (uu____28661, FStar_Syntax_Syntax.U_max vs) ->
+                   | (uu___3, FStar_Syntax_Syntax.U_max vs) ->
                        FStar_All.pipe_right vs
                          (FStar_Util.for_some (fun v2 -> check_ineq (u1, v2)))
-                   | uu____28669 -> false) in
-            let uu____28674 =
+                   | uu___3 -> false) in
+            let uu___2 =
               FStar_All.pipe_right ineqs
                 (FStar_Util.for_all
-                   (fun uu____28689 ->
-                      match uu____28689 with
+                   (fun uu___3 ->
+                      match uu___3 with
                       | (u, v) ->
-                          let uu____28696 = check_ineq (u, v) in
-                          if uu____28696
+                          let uu___4 = check_ineq (u, v) in
+                          if uu___4
                           then true
                           else
-                            ((let uu____28699 =
+                            ((let uu___7 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "GenUniverses") in
-                              if uu____28699
+                              if uu___7
                               then
-                                let uu____28700 =
+                                let uu___8 =
                                   FStar_Syntax_Print.univ_to_string u in
-                                let uu____28701 =
+                                let uu___9 =
                                   FStar_Syntax_Print.univ_to_string v in
-                                FStar_Util.print2 "%s </= %s" uu____28700
-                                  uu____28701
+                                FStar_Util.print2 "%s </= %s" uu___8 uu___9
                               else ());
                              false))) in
-            if uu____28674
+            if uu___2
             then ()
             else
-              ((let uu____28705 =
+              ((let uu___5 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "GenUniverses") in
-                if uu____28705
+                if uu___5
                 then
-                  ((let uu____28707 = ineqs_to_string (variables, ineqs) in
+                  ((let uu___7 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Partially solved inequality constraints are: %s\n"
-                      uu____28707);
+                      uu___7);
                    FStar_Syntax_Unionfind.rollback tx;
-                   (let uu____28717 = ineqs_to_string (variables, ineqs) in
+                   (let uu___8 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Original solved inequality constraints are: %s\n"
-                      uu____28717))
+                      uu___8))
                 else ());
-               (let uu____28727 = FStar_TypeChecker_Env.get_range env in
+               (let uu___5 = FStar_TypeChecker_Env.get_range env in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_FailToSolveUniverseInEquality,
                     "Failed to solve universe inequalities for inductives")
-                  uu____28727))
+                  uu___5))
 let (solve_universe_inequalities :
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe
@@ -11377,94 +11081,92 @@ let (try_solve_deferred_constraints :
     fun smt_ok ->
       fun env ->
         fun g ->
-          let fail uu____28801 =
-            match uu____28801 with
+          let fail uu___ =
+            match uu___ with
             | (d, s) ->
                 let msg = explain env d s in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_ErrorInSolveDeferredConstraints, msg)
                   (p_loc d) in
           let wl =
-            let uu___4259_28826 =
-              wl_of_guard env g.FStar_TypeChecker_Common.deferred in
+            let uu___ = wl_of_guard env g.FStar_TypeChecker_Common.deferred in
             {
-              attempting = (uu___4259_28826.attempting);
-              wl_deferred = (uu___4259_28826.wl_deferred);
-              wl_deferred_to_tac = (uu___4259_28826.wl_deferred_to_tac);
-              ctr = (uu___4259_28826.ctr);
+              attempting = (uu___.attempting);
+              wl_deferred = (uu___.wl_deferred);
+              wl_deferred_to_tac = (uu___.wl_deferred_to_tac);
+              ctr = (uu___.ctr);
               defer_ok;
               smt_ok;
-              umax_heuristic_ok = (uu___4259_28826.umax_heuristic_ok);
-              tcenv = (uu___4259_28826.tcenv);
-              wl_implicits = (uu___4259_28826.wl_implicits);
-              repr_subcomp_allowed = (uu___4259_28826.repr_subcomp_allowed)
+              umax_heuristic_ok = (uu___.umax_heuristic_ok);
+              tcenv = (uu___.tcenv);
+              wl_implicits = (uu___.wl_implicits);
+              repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
             } in
-          (let uu____28828 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____28828
+           if uu___1
            then
-             let uu____28829 = FStar_Util.string_of_bool defer_ok in
-             let uu____28830 = wl_to_string wl in
-             let uu____28831 =
+             let uu___2 = FStar_Util.string_of_bool defer_ok in
+             let uu___3 = wl_to_string wl in
+             let uu___4 =
                FStar_Util.string_of_int
                  (FStar_List.length g.FStar_TypeChecker_Common.implicits) in
              FStar_Util.print3
                "Trying to solve carried problems (defer_ok=%s): begin\n\t%s\nend\n and %s implicits\n"
-               uu____28829 uu____28830 uu____28831
+               uu___2 uu___3 uu___4
            else ());
           (let g1 =
-             let uu____28834 = solve_and_commit env wl fail in
-             match uu____28834 with
-             | FStar_Pervasives_Native.Some
-                 (uu____28843::uu____28844, uu____28845, uu____28846) when
-                 Prims.op_Negation defer_ok ->
+             let uu___1 = solve_and_commit env wl fail in
+             match uu___1 with
+             | FStar_Pervasives_Native.Some (uu___2::uu___3, uu___4, uu___5)
+                 when Prims.op_Negation defer_ok ->
                  failwith
                    "Impossible: Unexpected deferred constraints remain"
              | FStar_Pervasives_Native.Some (deferred, defer_to_tac, imps) ->
-                 let uu___4276_28876 = g in
+                 let uu___2 = g in
                  {
                    FStar_TypeChecker_Common.guard_f =
-                     (uu___4276_28876.FStar_TypeChecker_Common.guard_f);
+                     (uu___2.FStar_TypeChecker_Common.guard_f);
                    FStar_TypeChecker_Common.deferred_to_tac =
                      (FStar_List.append
                         g.FStar_TypeChecker_Common.deferred_to_tac
                         defer_to_tac);
                    FStar_TypeChecker_Common.deferred = deferred;
                    FStar_TypeChecker_Common.univ_ineqs =
-                     (uu___4276_28876.FStar_TypeChecker_Common.univ_ineqs);
+                     (uu___2.FStar_TypeChecker_Common.univ_ineqs);
                    FStar_TypeChecker_Common.implicits =
                      (FStar_List.append g.FStar_TypeChecker_Common.implicits
                         imps)
                  }
-             | uu____28881 ->
+             | uu___2 ->
                  failwith "Impossible: should have raised a failure already" in
            solve_universe_inequalities env
              g1.FStar_TypeChecker_Common.univ_ineqs;
            (let g2 =
               FStar_TypeChecker_DeferredImplicits.solve_deferred_to_tactic_goals
                 env g1 in
-            (let uu____28893 =
+            (let uu___3 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "ResolveImplicitsHook") in
-             if uu____28893
+             if uu___3
              then
-               let uu____28894 = guard_to_string env g2 in
+               let uu___4 = guard_to_string env g2 in
                FStar_Util.print1
                  "ResolveImplicitsHook: Solved deferred to tactic goals, remaining guard is\n%s\n"
-                 uu____28894
+                 uu___4
              else ());
-            (let uu___4284_28896 = g2 in
+            (let uu___3 = g2 in
              {
                FStar_TypeChecker_Common.guard_f =
-                 (uu___4284_28896.FStar_TypeChecker_Common.guard_f);
+                 (uu___3.FStar_TypeChecker_Common.guard_f);
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4284_28896.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___3.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4284_28896.FStar_TypeChecker_Common.deferred);
+                 (uu___3.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs = ([], []);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4284_28896.FStar_TypeChecker_Common.implicits)
+                 (uu___3.FStar_TypeChecker_Common.implicits)
              })))
 let (solve_deferred_constraints' :
   Prims.bool ->
@@ -11501,35 +11203,35 @@ let (discharge_guard' :
               ||
               (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Tac")) in
-          (let uu____28971 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "ResolveImplicitsHook") in
-           if uu____28971
+           if uu___1
            then
-             let uu____28972 = guard_to_string env g in
+             let uu___2 = guard_to_string env g in
              FStar_Util.print1
                "///////////////////ResolveImplicitsHook: discharge_guard'\nguard = %s\n"
-               uu____28972
+               uu___2
            else ());
           (let g1 = solve_deferred_constraints' use_smt env g in
            let ret_g =
-             let uu___4301_28976 = g1 in
+             let uu___1 = g1 in
              {
                FStar_TypeChecker_Common.guard_f =
                  FStar_TypeChecker_Common.Trivial;
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4301_28976.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___1.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4301_28976.FStar_TypeChecker_Common.deferred);
+                 (uu___1.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___4301_28976.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___1.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4301_28976.FStar_TypeChecker_Common.implicits)
+                 (uu___1.FStar_TypeChecker_Common.implicits)
              } in
-           let uu____28977 =
-             let uu____28978 = FStar_TypeChecker_Env.should_verify env in
-             Prims.op_Negation uu____28978 in
-           if uu____28977
+           let uu___1 =
+             let uu___2 = FStar_TypeChecker_Env.should_verify env in
+             Prims.op_Negation uu___2 in
+           if uu___1
            then FStar_Pervasives_Native.Some ret_g
            else
              (match g1.FStar_TypeChecker_Common.guard_f with
@@ -11538,44 +11240,41 @@ let (discharge_guard' :
               | FStar_TypeChecker_Common.NonTrivial vc ->
                   (if debug
                    then
-                     (let uu____28986 = FStar_TypeChecker_Env.get_range env in
-                      let uu____28987 =
-                        let uu____28988 =
-                          FStar_Syntax_Print.term_to_string vc in
+                     (let uu___4 = FStar_TypeChecker_Env.get_range env in
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Print.term_to_string vc in
                         FStar_Util.format1 "Before normalization VC=\n%s\n"
-                          uu____28988 in
-                      FStar_Errors.diag uu____28986 uu____28987)
+                          uu___6 in
+                      FStar_Errors.diag uu___4 uu___5)
                    else ();
                    (let vc1 =
-                      let uu____28991 =
-                        let uu____28994 =
-                          let uu____28995 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
                             FStar_TypeChecker_Env.current_module env in
-                          FStar_Ident.string_of_lid uu____28995 in
-                        FStar_Pervasives_Native.Some uu____28994 in
+                          FStar_Ident.string_of_lid uu___6 in
+                        FStar_Pervasives_Native.Some uu___5 in
                       FStar_Profiling.profile
-                        (fun uu____28997 ->
+                        (fun uu___5 ->
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.Eager_unfolding;
                              FStar_TypeChecker_Env.Simplify;
-                             FStar_TypeChecker_Env.Primops] env vc)
-                        uu____28991 "FStar.TypeChecker.Rel.vc_normalization" in
+                             FStar_TypeChecker_Env.Primops] env vc) uu___4
+                        "FStar.TypeChecker.Rel.vc_normalization" in
                     if debug
                     then
-                      (let uu____28999 = FStar_TypeChecker_Env.get_range env in
-                       let uu____29000 =
-                         let uu____29001 =
-                           FStar_Syntax_Print.term_to_string vc1 in
+                      (let uu___5 = FStar_TypeChecker_Env.get_range env in
+                       let uu___6 =
+                         let uu___7 = FStar_Syntax_Print.term_to_string vc1 in
                          FStar_Util.format1 "After normalization VC=\n%s\n"
-                           uu____29001 in
-                       FStar_Errors.diag uu____28999 uu____29000)
+                           uu___7 in
+                       FStar_Errors.diag uu___5 uu___6)
                     else ();
-                    (let uu____29004 = FStar_TypeChecker_Env.get_range env in
-                     FStar_TypeChecker_Env.def_check_closed_in_env
-                       uu____29004 "discharge_guard'" env vc1);
-                    (let uu____29005 =
-                       FStar_TypeChecker_Common.check_trivial vc1 in
-                     match uu____29005 with
+                    (let uu___6 = FStar_TypeChecker_Env.get_range env in
+                     FStar_TypeChecker_Env.def_check_closed_in_env uu___6
+                       "discharge_guard'" env vc1);
+                    (let uu___6 = FStar_TypeChecker_Common.check_trivial vc1 in
+                     match uu___6 with
                      | FStar_TypeChecker_Common.Trivial ->
                          FStar_Pervasives_Native.Some ret_g
                      | FStar_TypeChecker_Common.NonTrivial vc2 ->
@@ -11583,69 +11282,68 @@ let (discharge_guard' :
                          then
                            (if debug
                             then
-                              (let uu____29012 =
+                              (let uu___8 =
                                  FStar_TypeChecker_Env.get_range env in
-                               let uu____29013 =
-                                 let uu____29014 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_Syntax_Print.term_to_string vc2 in
                                  FStar_Util.format1
-                                   "Cannot solve without SMT : %s\n"
-                                   uu____29014 in
-                               FStar_Errors.diag uu____29012 uu____29013)
+                                   "Cannot solve without SMT : %s\n" uu___10 in
+                               FStar_Errors.diag uu___8 uu___9)
                             else ();
                             FStar_Pervasives_Native.None)
                          else
                            (if debug
                             then
-                              (let uu____29019 =
+                              (let uu___10 =
                                  FStar_TypeChecker_Env.get_range env in
-                               let uu____29020 =
-                                 let uu____29021 =
+                               let uu___11 =
+                                 let uu___12 =
                                    FStar_Syntax_Print.term_to_string vc2 in
                                  FStar_Util.format1 "Checking VC=\n%s\n"
-                                   uu____29021 in
-                               FStar_Errors.diag uu____29019 uu____29020)
+                                   uu___12 in
+                               FStar_Errors.diag uu___10 uu___11)
                             else ();
                             (let vcs =
-                               let uu____29032 = FStar_Options.use_tactics () in
-                               if uu____29032
+                               let uu___10 = FStar_Options.use_tactics () in
+                               if uu___10
                                then
                                  FStar_Options.with_saved_options
-                                   (fun uu____29052 ->
-                                      (let uu____29054 =
+                                   (fun uu___11 ->
+                                      (let uu___13 =
                                          FStar_Options.set_options
                                            "--no_tactics" in
                                        FStar_All.pipe_left
-                                         (fun uu____29055 -> ()) uu____29054);
-                                      (let vcs =
+                                         (fun uu___14 -> ()) uu___13);
+                                      (let vcs1 =
                                          (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                                            env vc2 in
-                                       FStar_All.pipe_right vcs
+                                       FStar_All.pipe_right vcs1
                                          (FStar_List.map
-                                            (fun uu____29098 ->
-                                               match uu____29098 with
+                                            (fun uu___13 ->
+                                               match uu___13 with
                                                | (env1, goal, opts) ->
-                                                   let uu____29114 =
+                                                   let uu___14 =
                                                      norm_with_steps
                                                        "FStar.TypeChecker.Rel.norm_with_steps.7"
                                                        [FStar_TypeChecker_Env.Simplify;
                                                        FStar_TypeChecker_Env.Primops]
                                                        env1 goal in
-                                                   (env1, uu____29114, opts)))))
+                                                   (env1, uu___14, opts)))))
                                else
-                                 (let uu____29116 =
-                                    let uu____29123 = FStar_Options.peek () in
-                                    (env, vc2, uu____29123) in
-                                  [uu____29116]) in
+                                 (let uu___12 =
+                                    let uu___13 = FStar_Options.peek () in
+                                    (env, vc2, uu___13) in
+                                  [uu___12]) in
                              FStar_All.pipe_right vcs
                                (FStar_List.iter
-                                  (fun uu____29156 ->
-                                     match uu____29156 with
+                                  (fun uu___10 ->
+                                     match uu___10 with
                                      | (env1, goal, opts) ->
-                                         let uu____29166 =
+                                         let uu___11 =
                                            FStar_TypeChecker_Common.check_trivial
                                              goal in
-                                         (match uu____29166 with
+                                         (match uu___11 with
                                           | FStar_TypeChecker_Common.Trivial
                                               ->
                                               if debug
@@ -11659,36 +11357,36 @@ let (discharge_guard' :
                                                FStar_Options.set opts;
                                                if debug
                                                then
-                                                 (let uu____29173 =
+                                                 (let uu___15 =
                                                     FStar_TypeChecker_Env.get_range
                                                       env1 in
-                                                  let uu____29174 =
-                                                    let uu____29175 =
+                                                  let uu___16 =
+                                                    let uu___17 =
                                                       FStar_Syntax_Print.term_to_string
                                                         goal1 in
-                                                    let uu____29176 =
+                                                    let uu___18 =
                                                       FStar_TypeChecker_Env.string_of_proof_ns
                                                         env1 in
                                                     FStar_Util.format2
                                                       "Trying to solve:\n> %s\nWith proof_ns:\n %s\n"
-                                                      uu____29175 uu____29176 in
-                                                  FStar_Errors.diag
-                                                    uu____29173 uu____29174)
+                                                      uu___17 uu___18 in
+                                                  FStar_Errors.diag uu___15
+                                                    uu___16)
                                                else ();
                                                if debug
                                                then
-                                                 (let uu____29179 =
+                                                 (let uu___16 =
                                                     FStar_TypeChecker_Env.get_range
                                                       env1 in
-                                                  let uu____29180 =
-                                                    let uu____29181 =
+                                                  let uu___17 =
+                                                    let uu___18 =
                                                       FStar_Syntax_Print.term_to_string
                                                         goal1 in
                                                     FStar_Util.format1
                                                       "Before calling solver VC=\n%s\n"
-                                                      uu____29181 in
-                                                  FStar_Errors.diag
-                                                    uu____29179 uu____29180)
+                                                      uu___18 in
+                                                  FStar_Errors.diag uu___16
+                                                    uu___17)
                                                else ();
                                                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
                                                  use_env_range_msg env1 goal1;
@@ -11700,24 +11398,22 @@ let (discharge_guard_no_smt :
   =
   fun env ->
     fun g ->
-      let uu____29195 =
-        discharge_guard' FStar_Pervasives_Native.None env g false in
-      match uu____29195 with
+      let uu___ = discharge_guard' FStar_Pervasives_Native.None env g false in
+      match uu___ with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None ->
-          let uu____29202 = FStar_TypeChecker_Env.get_range env in
+          let uu___1 = FStar_TypeChecker_Env.get_range env in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExpectTrivialPreCondition,
-              "Expected a trivial pre-condition") uu____29202
+              "Expected a trivial pre-condition") uu___1
 let (discharge_guard :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.guard_t -> FStar_TypeChecker_Common.guard_t)
   =
   fun env ->
     fun g ->
-      let uu____29213 =
-        discharge_guard' FStar_Pervasives_Native.None env g true in
-      match uu____29213 with
+      let uu___ = discharge_guard' FStar_Pervasives_Native.None env g true in
+      match uu___ with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None ->
           failwith
@@ -11731,8 +11427,8 @@ let (teq_nosmt :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29239 = try_teq false env t1 t2 in
-        match uu____29239 with
+        let uu___ = try_teq false env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some g ->
             discharge_guard' FStar_Pervasives_Native.None env g false
@@ -11749,58 +11445,56 @@ let (try_solve_single_valued_implicits :
         then (imps, false)
         else
           (let imp_value imp =
-             let uu____29282 =
+             let uu___1 =
                ((imp.FStar_TypeChecker_Common.imp_uvar),
                  (imp.FStar_TypeChecker_Common.imp_range)) in
-             match uu____29282 with
+             match uu___1 with
              | (ctx_u, r) ->
                  let t_norm =
                    FStar_TypeChecker_Normalize.normalize
                      FStar_TypeChecker_Normalize.whnf_steps env
                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                 let uu____29292 =
-                   let uu____29293 = FStar_Syntax_Subst.compress t_norm in
-                   uu____29293.FStar_Syntax_Syntax.n in
-                 (match uu____29292 with
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Subst.compress t_norm in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (match uu___2 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.unit_lid
                       ->
-                      let uu____29299 =
+                      let uu___3 =
                         FStar_All.pipe_right r
                           FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_All.pipe_right uu____29299
-                        (fun uu____29302 ->
-                           FStar_Pervasives_Native.Some uu____29302)
-                  | FStar_Syntax_Syntax.Tm_refine (b, uu____29304) when
+                      FStar_All.pipe_right uu___3
+                        (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  | FStar_Syntax_Syntax.Tm_refine (b, uu___3) when
                       FStar_Syntax_Util.is_unit b.FStar_Syntax_Syntax.sort ->
-                      let uu____29309 =
+                      let uu___4 =
                         FStar_All.pipe_right r
                           FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_All.pipe_right uu____29309
-                        (fun uu____29312 ->
-                           FStar_Pervasives_Native.Some uu____29312)
-                  | uu____29313 -> FStar_Pervasives_Native.None) in
+                      FStar_All.pipe_right uu___4
+                        (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                  | uu___3 -> FStar_Pervasives_Native.None) in
            let b =
              FStar_List.fold_left
-               (fun b ->
+               (fun b1 ->
                   fun imp ->
-                    let uu____29323 =
-                      let uu____29324 =
+                    let uu___1 =
+                      let uu___2 =
                         FStar_Syntax_Unionfind.find
                           (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                      FStar_All.pipe_right uu____29324 FStar_Util.is_none in
-                    if uu____29323
+                      FStar_All.pipe_right uu___2 FStar_Util.is_none in
+                    if uu___1
                     then
-                      let uu____29329 = imp_value imp in
-                      match uu____29329 with
+                      let uu___2 = imp_value imp in
+                      match uu___2 with
                       | FStar_Pervasives_Native.Some tm ->
                           (commit
                              [TERM
                                 ((imp.FStar_TypeChecker_Common.imp_uvar), tm)];
                            true)
-                      | FStar_Pervasives_Native.None -> b
-                    else b) false imps in
+                      | FStar_Pervasives_Native.None -> b1
+                    else b1) false imps in
            (imps, b))
 let (resolve_implicits' :
   FStar_TypeChecker_Env.env ->
@@ -11810,50 +11504,50 @@ let (resolve_implicits' :
   fun env ->
     fun is_tac ->
       fun g ->
-        let uu____29350 =
+        let uu___ =
           if is_tac
           then (false, true)
           else
             (((Prims.op_Negation env.FStar_TypeChecker_Env.phase1) &&
                 (Prims.op_Negation env.FStar_TypeChecker_Env.lax)), false) in
-        match uu____29350 with
+        match uu___ with
         | (must_total, forcelax) ->
             let rec unresolved ctx_u =
-              let uu____29368 =
+              let uu___1 =
                 FStar_Syntax_Unionfind.find
                   ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-              match uu____29368 with
+              match uu___1 with
               | FStar_Pervasives_Native.Some r ->
                   (match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta with
                    | FStar_Pervasives_Native.None -> false
-                   | FStar_Pervasives_Native.Some uu____29372 ->
-                       let uu____29373 =
-                         let uu____29374 = FStar_Syntax_Subst.compress r in
-                         uu____29374.FStar_Syntax_Syntax.n in
-                       (match uu____29373 with
-                        | FStar_Syntax_Syntax.Tm_uvar (ctx_u', uu____29378)
-                            -> unresolved ctx_u'
-                        | uu____29395 -> false))
+                   | FStar_Pervasives_Native.Some uu___2 ->
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Subst.compress r in
+                         uu___4.FStar_Syntax_Syntax.n in
+                       (match uu___3 with
+                        | FStar_Syntax_Syntax.Tm_uvar (ctx_u', uu___4) ->
+                            unresolved ctx_u'
+                        | uu___4 -> false))
               | FStar_Pervasives_Native.None -> true in
             let rec until_fixpoint acc implicits =
-              let uu____29415 = acc in
-              match uu____29415 with
+              let uu___1 = acc in
+              match uu___1 with
               | (out, changed) ->
                   (match implicits with
                    | [] ->
                        if Prims.op_Negation changed
                        then
-                         let uu____29422 =
+                         let uu___2 =
                            try_solve_single_valued_implicits env is_tac out in
-                         (match uu____29422 with
+                         (match uu___2 with
                           | (out1, changed1) ->
                               if changed1
                               then until_fixpoint ([], false) out1
                               else out1)
                        else until_fixpoint ([], false) out
                    | hd::tl ->
-                       let uu____29435 = hd in
-                       (match uu____29435 with
+                       let uu___2 = hd in
+                       (match uu___2 with
                         | { FStar_TypeChecker_Common.imp_reason = reason;
                             FStar_TypeChecker_Common.imp_uvar = ctx_u;
                             FStar_TypeChecker_Common.imp_tm = tm;
@@ -11863,8 +11557,8 @@ let (resolve_implicits' :
                                 = FStar_Syntax_Syntax.Allow_unresolved
                             then until_fixpoint (out, true) tl
                             else
-                              (let uu____29441 = unresolved ctx_u in
-                               if uu____29441
+                              (let uu___4 = unresolved ctx_u in
+                               if uu___4
                                then
                                  match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta
                                  with
@@ -11872,17 +11566,17 @@ let (resolve_implicits' :
                                      (FStar_Syntax_Syntax.Ctx_uvar_meta_tac
                                      (env_dyn, tau)) ->
                                      let env1 = FStar_Dyn.undyn env_dyn in
-                                     ((let uu____29450 =
+                                     ((let uu___6 =
                                          FStar_TypeChecker_Env.debug env1
                                            (FStar_Options.Other "Tac") in
-                                       if uu____29450
+                                       if uu___6
                                        then
-                                         let uu____29451 =
+                                         let uu___7 =
                                            FStar_Syntax_Print.ctx_uvar_to_string
                                              ctx_u in
                                          FStar_Util.print1
                                            "Running tactic for meta-arg %s\n"
-                                           uu____29451
+                                           uu___7
                                        else ());
                                       (let t =
                                          env1.FStar_TypeChecker_Env.synth_hook
@@ -11890,57 +11584,56 @@ let (resolve_implicits' :
                                            (hd.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
                                            tau in
                                        let extra =
-                                         let uu____29457 =
-                                           teq_nosmt env1 t tm in
-                                         match uu____29457 with
+                                         let uu___6 = teq_nosmt env1 t tm in
+                                         match uu___6 with
                                          | FStar_Pervasives_Native.None ->
                                              failwith
                                                "resolve_implicits: unifying with an unresolved uvar failed?"
                                          | FStar_Pervasives_Native.Some g1 ->
                                              g1.FStar_TypeChecker_Common.implicits in
                                        let ctx_u1 =
-                                         let uu___4446_29466 = ctx_u in
+                                         let uu___6 = ctx_u in
                                          {
                                            FStar_Syntax_Syntax.ctx_uvar_head
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_head);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_head);
                                            FStar_Syntax_Syntax.ctx_uvar_gamma
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                            FStar_Syntax_Syntax.ctx_uvar_binders
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_binders);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_binders);
                                            FStar_Syntax_Syntax.ctx_uvar_typ =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_typ);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_typ);
                                            FStar_Syntax_Syntax.ctx_uvar_reason
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_reason);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_reason);
                                            FStar_Syntax_Syntax.ctx_uvar_should_check
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_should_check);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_should_check);
                                            FStar_Syntax_Syntax.ctx_uvar_range
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_range);
+                                             (uu___6.FStar_Syntax_Syntax.ctx_uvar_range);
                                            FStar_Syntax_Syntax.ctx_uvar_meta
                                              = FStar_Pervasives_Native.None
                                          } in
                                        let hd1 =
-                                         let uu___4449_29468 = hd in
+                                         let uu___6 = hd in
                                          {
                                            FStar_TypeChecker_Common.imp_reason
                                              =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_reason);
+                                             (uu___6.FStar_TypeChecker_Common.imp_reason);
                                            FStar_TypeChecker_Common.imp_uvar
                                              = ctx_u1;
                                            FStar_TypeChecker_Common.imp_tm =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_tm);
+                                             (uu___6.FStar_TypeChecker_Common.imp_tm);
                                            FStar_TypeChecker_Common.imp_range
                                              =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_range)
+                                             (uu___6.FStar_TypeChecker_Common.imp_range)
                                          } in
                                        until_fixpoint (out, true)
                                          (FStar_List.append extra tl)))
-                                 | uu____29469 ->
+                                 | uu___5 ->
                                      until_fixpoint ((hd :: out), changed) tl
                                else
                                  if
@@ -11949,112 +11642,112 @@ let (resolve_implicits' :
                                  then until_fixpoint (out, true) tl
                                  else
                                    (let env1 =
-                                      let uu___4454_29475 = env in
+                                      let uu___7 = env in
                                       {
                                         FStar_TypeChecker_Env.solver =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.solver);
+                                          (uu___7.FStar_TypeChecker_Env.solver);
                                         FStar_TypeChecker_Env.range =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.range);
+                                          (uu___7.FStar_TypeChecker_Env.range);
                                         FStar_TypeChecker_Env.curmodule =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.curmodule);
+                                          (uu___7.FStar_TypeChecker_Env.curmodule);
                                         FStar_TypeChecker_Env.gamma =
                                           (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                         FStar_TypeChecker_Env.gamma_sig =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.gamma_sig);
+                                          (uu___7.FStar_TypeChecker_Env.gamma_sig);
                                         FStar_TypeChecker_Env.gamma_cache =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.gamma_cache);
+                                          (uu___7.FStar_TypeChecker_Env.gamma_cache);
                                         FStar_TypeChecker_Env.modules =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.modules);
+                                          (uu___7.FStar_TypeChecker_Env.modules);
                                         FStar_TypeChecker_Env.expected_typ =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.expected_typ);
+                                          (uu___7.FStar_TypeChecker_Env.expected_typ);
                                         FStar_TypeChecker_Env.sigtab =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.sigtab);
+                                          (uu___7.FStar_TypeChecker_Env.sigtab);
                                         FStar_TypeChecker_Env.attrtab =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.attrtab);
+                                          (uu___7.FStar_TypeChecker_Env.attrtab);
                                         FStar_TypeChecker_Env.instantiate_imp
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.instantiate_imp);
+                                          (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                                         FStar_TypeChecker_Env.effects =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.effects);
+                                          (uu___7.FStar_TypeChecker_Env.effects);
                                         FStar_TypeChecker_Env.generalize =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.generalize);
+                                          (uu___7.FStar_TypeChecker_Env.generalize);
                                         FStar_TypeChecker_Env.letrecs =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.letrecs);
+                                          (uu___7.FStar_TypeChecker_Env.letrecs);
                                         FStar_TypeChecker_Env.top_level =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.top_level);
+                                          (uu___7.FStar_TypeChecker_Env.top_level);
                                         FStar_TypeChecker_Env.check_uvars =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.check_uvars);
+                                          (uu___7.FStar_TypeChecker_Env.check_uvars);
                                         FStar_TypeChecker_Env.use_eq =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_eq);
+                                          (uu___7.FStar_TypeChecker_Env.use_eq);
                                         FStar_TypeChecker_Env.use_eq_strict =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_eq_strict);
+                                          (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                                         FStar_TypeChecker_Env.is_iface =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.is_iface);
+                                          (uu___7.FStar_TypeChecker_Env.is_iface);
                                         FStar_TypeChecker_Env.admit =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.admit);
+                                          (uu___7.FStar_TypeChecker_Env.admit);
                                         FStar_TypeChecker_Env.lax =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.lax);
+                                          (uu___7.FStar_TypeChecker_Env.lax);
                                         FStar_TypeChecker_Env.lax_universes =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.lax_universes);
+                                          (uu___7.FStar_TypeChecker_Env.lax_universes);
                                         FStar_TypeChecker_Env.phase1 =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.phase1);
+                                          (uu___7.FStar_TypeChecker_Env.phase1);
                                         FStar_TypeChecker_Env.failhard =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.failhard);
+                                          (uu___7.FStar_TypeChecker_Env.failhard);
                                         FStar_TypeChecker_Env.nosynth =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.nosynth);
+                                          (uu___7.FStar_TypeChecker_Env.nosynth);
                                         FStar_TypeChecker_Env.uvar_subtyping
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.uvar_subtyping);
+                                          (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                         FStar_TypeChecker_Env.tc_term =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.tc_term);
+                                          (uu___7.FStar_TypeChecker_Env.tc_term);
                                         FStar_TypeChecker_Env.type_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.type_of);
+                                          (uu___7.FStar_TypeChecker_Env.type_of);
                                         FStar_TypeChecker_Env.universe_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.universe_of);
+                                          (uu___7.FStar_TypeChecker_Env.universe_of);
                                         FStar_TypeChecker_Env.check_type_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.check_type_of);
+                                          (uu___7.FStar_TypeChecker_Env.check_type_of);
                                         FStar_TypeChecker_Env.use_bv_sorts =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_bv_sorts);
+                                          (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                                         FStar_TypeChecker_Env.qtbl_name_and_index
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                                         FStar_TypeChecker_Env.normalized_eff_names
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.normalized_eff_names);
+                                          (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                                         FStar_TypeChecker_Env.fv_delta_depths
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.fv_delta_depths);
+                                          (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                                         FStar_TypeChecker_Env.proof_ns =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.proof_ns);
+                                          (uu___7.FStar_TypeChecker_Env.proof_ns);
                                         FStar_TypeChecker_Env.synth_hook =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.synth_hook);
+                                          (uu___7.FStar_TypeChecker_Env.synth_hook);
                                         FStar_TypeChecker_Env.try_solve_implicits_hook
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                          (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                         FStar_TypeChecker_Env.splice =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.splice);
+                                          (uu___7.FStar_TypeChecker_Env.splice);
                                         FStar_TypeChecker_Env.mpreprocess =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.mpreprocess);
+                                          (uu___7.FStar_TypeChecker_Env.mpreprocess);
                                         FStar_TypeChecker_Env.postprocess =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.postprocess);
+                                          (uu___7.FStar_TypeChecker_Env.postprocess);
                                         FStar_TypeChecker_Env.identifier_info
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.identifier_info);
+                                          (uu___7.FStar_TypeChecker_Env.identifier_info);
                                         FStar_TypeChecker_Env.tc_hooks =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.tc_hooks);
+                                          (uu___7.FStar_TypeChecker_Env.tc_hooks);
                                         FStar_TypeChecker_Env.dsenv =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.dsenv);
+                                          (uu___7.FStar_TypeChecker_Env.dsenv);
                                         FStar_TypeChecker_Env.nbe =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.nbe);
+                                          (uu___7.FStar_TypeChecker_Env.nbe);
                                         FStar_TypeChecker_Env.strict_args_tab
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.strict_args_tab);
+                                          (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                                         FStar_TypeChecker_Env.erasable_types_tab
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.erasable_types_tab);
+                                          (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                                         FStar_TypeChecker_Env.enable_defer_to_tac
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                          (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                                       } in
                                     let tm1 =
                                       norm_with_steps
@@ -12063,143 +11756,143 @@ let (resolve_implicits' :
                                     let env2 =
                                       if forcelax
                                       then
-                                        let uu___4459_29478 = env1 in
+                                        let uu___7 = env1 in
                                         {
                                           FStar_TypeChecker_Env.solver =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.solver);
+                                            (uu___7.FStar_TypeChecker_Env.solver);
                                           FStar_TypeChecker_Env.range =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.range);
+                                            (uu___7.FStar_TypeChecker_Env.range);
                                           FStar_TypeChecker_Env.curmodule =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.curmodule);
+                                            (uu___7.FStar_TypeChecker_Env.curmodule);
                                           FStar_TypeChecker_Env.gamma =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma);
+                                            (uu___7.FStar_TypeChecker_Env.gamma);
                                           FStar_TypeChecker_Env.gamma_sig =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma_sig);
+                                            (uu___7.FStar_TypeChecker_Env.gamma_sig);
                                           FStar_TypeChecker_Env.gamma_cache =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma_cache);
+                                            (uu___7.FStar_TypeChecker_Env.gamma_cache);
                                           FStar_TypeChecker_Env.modules =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.modules);
+                                            (uu___7.FStar_TypeChecker_Env.modules);
                                           FStar_TypeChecker_Env.expected_typ
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.expected_typ);
+                                            (uu___7.FStar_TypeChecker_Env.expected_typ);
                                           FStar_TypeChecker_Env.sigtab =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.sigtab);
+                                            (uu___7.FStar_TypeChecker_Env.sigtab);
                                           FStar_TypeChecker_Env.attrtab =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.attrtab);
+                                            (uu___7.FStar_TypeChecker_Env.attrtab);
                                           FStar_TypeChecker_Env.instantiate_imp
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.instantiate_imp);
+                                            (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                                           FStar_TypeChecker_Env.effects =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.effects);
+                                            (uu___7.FStar_TypeChecker_Env.effects);
                                           FStar_TypeChecker_Env.generalize =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.generalize);
+                                            (uu___7.FStar_TypeChecker_Env.generalize);
                                           FStar_TypeChecker_Env.letrecs =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.letrecs);
+                                            (uu___7.FStar_TypeChecker_Env.letrecs);
                                           FStar_TypeChecker_Env.top_level =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.top_level);
+                                            (uu___7.FStar_TypeChecker_Env.top_level);
                                           FStar_TypeChecker_Env.check_uvars =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.check_uvars);
+                                            (uu___7.FStar_TypeChecker_Env.check_uvars);
                                           FStar_TypeChecker_Env.use_eq =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_eq);
+                                            (uu___7.FStar_TypeChecker_Env.use_eq);
                                           FStar_TypeChecker_Env.use_eq_strict
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_eq_strict);
+                                            (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                                           FStar_TypeChecker_Env.is_iface =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.is_iface);
+                                            (uu___7.FStar_TypeChecker_Env.is_iface);
                                           FStar_TypeChecker_Env.admit =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.admit);
+                                            (uu___7.FStar_TypeChecker_Env.admit);
                                           FStar_TypeChecker_Env.lax = true;
                                           FStar_TypeChecker_Env.lax_universes
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.lax_universes);
+                                            (uu___7.FStar_TypeChecker_Env.lax_universes);
                                           FStar_TypeChecker_Env.phase1 =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.phase1);
+                                            (uu___7.FStar_TypeChecker_Env.phase1);
                                           FStar_TypeChecker_Env.failhard =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.failhard);
+                                            (uu___7.FStar_TypeChecker_Env.failhard);
                                           FStar_TypeChecker_Env.nosynth =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.nosynth);
+                                            (uu___7.FStar_TypeChecker_Env.nosynth);
                                           FStar_TypeChecker_Env.uvar_subtyping
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.uvar_subtyping);
+                                            (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                           FStar_TypeChecker_Env.tc_term =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.tc_term);
+                                            (uu___7.FStar_TypeChecker_Env.tc_term);
                                           FStar_TypeChecker_Env.type_of =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.type_of);
+                                            (uu___7.FStar_TypeChecker_Env.type_of);
                                           FStar_TypeChecker_Env.universe_of =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.universe_of);
+                                            (uu___7.FStar_TypeChecker_Env.universe_of);
                                           FStar_TypeChecker_Env.check_type_of
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.check_type_of);
+                                            (uu___7.FStar_TypeChecker_Env.check_type_of);
                                           FStar_TypeChecker_Env.use_bv_sorts
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_bv_sorts);
+                                            (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                                           FStar_TypeChecker_Env.qtbl_name_and_index
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                            (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                                           FStar_TypeChecker_Env.normalized_eff_names
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.normalized_eff_names);
+                                            (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                                           FStar_TypeChecker_Env.fv_delta_depths
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.fv_delta_depths);
+                                            (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                                           FStar_TypeChecker_Env.proof_ns =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.proof_ns);
+                                            (uu___7.FStar_TypeChecker_Env.proof_ns);
                                           FStar_TypeChecker_Env.synth_hook =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.synth_hook);
+                                            (uu___7.FStar_TypeChecker_Env.synth_hook);
                                           FStar_TypeChecker_Env.try_solve_implicits_hook
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                            (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                           FStar_TypeChecker_Env.splice =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.splice);
+                                            (uu___7.FStar_TypeChecker_Env.splice);
                                           FStar_TypeChecker_Env.mpreprocess =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.mpreprocess);
+                                            (uu___7.FStar_TypeChecker_Env.mpreprocess);
                                           FStar_TypeChecker_Env.postprocess =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.postprocess);
+                                            (uu___7.FStar_TypeChecker_Env.postprocess);
                                           FStar_TypeChecker_Env.identifier_info
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.identifier_info);
+                                            (uu___7.FStar_TypeChecker_Env.identifier_info);
                                           FStar_TypeChecker_Env.tc_hooks =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.tc_hooks);
+                                            (uu___7.FStar_TypeChecker_Env.tc_hooks);
                                           FStar_TypeChecker_Env.dsenv =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.dsenv);
+                                            (uu___7.FStar_TypeChecker_Env.dsenv);
                                           FStar_TypeChecker_Env.nbe =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.nbe);
+                                            (uu___7.FStar_TypeChecker_Env.nbe);
                                           FStar_TypeChecker_Env.strict_args_tab
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.strict_args_tab);
+                                            (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                                           FStar_TypeChecker_Env.erasable_types_tab
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.erasable_types_tab);
+                                            (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                                           FStar_TypeChecker_Env.enable_defer_to_tac
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                            (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                                         }
                                       else env1 in
-                                    (let uu____29481 =
+                                    (let uu___8 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env2)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____29481
+                                     if uu___8
                                      then
-                                       let uu____29482 =
+                                       let uu___9 =
                                          FStar_Syntax_Print.uvar_to_string
                                            ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                       let uu____29483 =
+                                       let uu___10 =
                                          FStar_Syntax_Print.term_to_string
                                            tm1 in
-                                       let uu____29484 =
+                                       let uu___11 =
                                          FStar_Syntax_Print.term_to_string
                                            ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                       let uu____29485 =
+                                       let uu___12 =
                                          FStar_Range.string_of_range r in
                                        FStar_Util.print5
                                          "Checking uvar %s resolved to %s at type %s, introduce for %s at %s\n"
-                                         uu____29482 uu____29483 uu____29484
-                                         reason uu____29485
+                                         uu___9 uu___10 uu___11 reason
+                                         uu___12
                                      else ());
                                     (let g1 =
                                        try
-                                         (fun uu___4465_29489 ->
+                                         (fun uu___8 ->
                                             match () with
                                             | () ->
                                                 env2.FStar_TypeChecker_Env.check_type_of
@@ -12208,49 +11901,46 @@ let (resolve_implicits' :
                                            ()
                                        with
                                        | e when FStar_Errors.handleable e ->
-                                           ((let uu____29496 =
-                                               let uu____29505 =
-                                                 let uu____29512 =
-                                                   let uu____29513 =
+                                           ((let uu___10 =
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_Syntax_Print.uvar_to_string
                                                        ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                   let uu____29514 =
+                                                   let uu___14 =
                                                      FStar_TypeChecker_Normalize.term_to_string
                                                        env2 tm1 in
-                                                   let uu____29515 =
+                                                   let uu___15 =
                                                      FStar_TypeChecker_Normalize.term_to_string
                                                        env2
                                                        ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
                                                    FStar_Util.format3
                                                      "Failed while checking implicit %s set to %s of expected type %s"
-                                                     uu____29513 uu____29514
-                                                     uu____29515 in
+                                                     uu___13 uu___14 uu___15 in
                                                  (FStar_Errors.Error_BadImplicit,
-                                                   uu____29512, r) in
-                                               [uu____29505] in
-                                             FStar_Errors.add_errors
-                                               uu____29496);
+                                                   uu___12, r) in
+                                               [uu___11] in
+                                             FStar_Errors.add_errors uu___10);
                                             FStar_Exn.raise e) in
                                      let g' =
-                                       let uu____29529 =
+                                       let uu___8 =
                                          discharge_guard'
                                            (FStar_Pervasives_Native.Some
-                                              (fun uu____29539 ->
-                                                 let uu____29540 =
+                                              (fun uu___9 ->
+                                                 let uu___10 =
                                                    FStar_Syntax_Print.term_to_string
                                                      tm1 in
-                                                 let uu____29541 =
+                                                 let uu___11 =
                                                    FStar_Range.string_of_range
                                                      r in
-                                                 let uu____29542 =
+                                                 let uu___12 =
                                                    FStar_Range.string_of_range
                                                      tm1.FStar_Syntax_Syntax.pos in
                                                  FStar_Util.format4
                                                    "%s (Introduced at %s for %s resolved at %s)"
-                                                   uu____29540 uu____29541
-                                                   reason uu____29542)) env2
-                                           g1 true in
-                                       match uu____29529 with
+                                                   uu___10 uu___11 reason
+                                                   uu___12)) env2 g1 true in
+                                       match uu___8 with
                                        | FStar_Pervasives_Native.Some g2 ->
                                            g2
                                        | FStar_Pervasives_Native.None ->
@@ -12260,19 +11950,19 @@ let (resolve_implicits' :
                                        ((FStar_List.append
                                            g'.FStar_TypeChecker_Common.implicits
                                            out), true) tl))))) in
-            let uu___4477_29544 = g in
-            let uu____29545 =
+            let uu___1 = g in
+            let uu___2 =
               until_fixpoint ([], false) g.FStar_TypeChecker_Common.implicits in
             {
               FStar_TypeChecker_Common.guard_f =
-                (uu___4477_29544.FStar_TypeChecker_Common.guard_f);
+                (uu___1.FStar_TypeChecker_Common.guard_f);
               FStar_TypeChecker_Common.deferred_to_tac =
-                (uu___4477_29544.FStar_TypeChecker_Common.deferred_to_tac);
+                (uu___1.FStar_TypeChecker_Common.deferred_to_tac);
               FStar_TypeChecker_Common.deferred =
-                (uu___4477_29544.FStar_TypeChecker_Common.deferred);
+                (uu___1.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___4477_29544.FStar_TypeChecker_Common.univ_ineqs);
-              FStar_TypeChecker_Common.implicits = uu____29545
+                (uu___1.FStar_TypeChecker_Common.univ_ineqs);
+              FStar_TypeChecker_Common.implicits = uu___2
             }
 let (resolve_implicits :
   FStar_TypeChecker_Env.env ->
@@ -12280,15 +11970,15 @@ let (resolve_implicits :
   =
   fun env ->
     fun g ->
-      (let uu____29557 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ResolveImplicitsHook") in
-       if uu____29557
+       if uu___1
        then
-         let uu____29558 = guard_to_string env g in
+         let uu___2 = guard_to_string env g in
          FStar_Util.print1
            "//////////////////////////ResolveImplicitsHook: resolve_implicits////////////\nguard = %s\n"
-           uu____29558
+           uu___2
        else ());
       resolve_implicits' env false g
 let (resolve_implicits_tac :
@@ -12299,37 +11989,36 @@ let (force_trivial_guard :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.guard_t -> unit) =
   fun env ->
     fun g ->
-      (let uu____29581 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ResolveImplicitsHook") in
-       if uu____29581
+       if uu___1
        then
-         let uu____29582 = guard_to_string env g in
+         let uu___2 = guard_to_string env g in
          FStar_Util.print1
            "//////////////////////////ResolveImplicitsHook: force_trivial_guard////////////\nguard = %s\n"
-           uu____29582
+           uu___2
        else ());
       (let g1 = solve_deferred_constraints env g in
        let g2 = resolve_implicits env g1 in
        match g2.FStar_TypeChecker_Common.implicits with
        | [] ->
-           let uu____29586 = discharge_guard env g2 in
-           FStar_All.pipe_left (fun uu____29587 -> ()) uu____29586
-       | imp::uu____29589 ->
-           let uu____29592 =
-             let uu____29597 =
-               let uu____29598 =
+           let uu___1 = discharge_guard env g2 in
+           FStar_All.pipe_left (fun uu___2 -> ()) uu___1
+       | imp::uu___1 ->
+           let uu___2 =
+             let uu___3 =
+               let uu___4 =
                  FStar_Syntax_Print.uvar_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-               let uu____29599 =
+               let uu___5 =
                  FStar_TypeChecker_Normalize.term_to_string env
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
                FStar_Util.format3
                  "Failed to resolve implicit argument %s of type %s introduced for %s"
-                 uu____29598 uu____29599
-                 imp.FStar_TypeChecker_Common.imp_reason in
-             (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____29597) in
-           FStar_Errors.raise_error uu____29592
+                 uu___4 uu___5 imp.FStar_TypeChecker_Common.imp_reason in
+             (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu___3) in
+           FStar_Errors.raise_error uu___2
              imp.FStar_TypeChecker_Common.imp_range)
 let (teq_force :
   FStar_TypeChecker_Env.env ->
@@ -12337,9 +12026,7 @@ let (teq_force :
   =
   fun env ->
     fun t1 ->
-      fun t2 ->
-        let uu____29615 = teq env t1 t2 in
-        force_trivial_guard env uu____29615
+      fun t2 -> let uu___ = teq env t1 t2 in force_trivial_guard env uu___
 let (teq_nosmt_force :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool)
@@ -12347,8 +12034,8 @@ let (teq_nosmt_force :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29631 = teq_nosmt env t1 t2 in
-        match uu____29631 with
+        let uu___ = teq_nosmt env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
 let (layered_effect_teq :
@@ -12362,21 +12049,20 @@ let (layered_effect_teq :
     fun t1 ->
       fun t2 ->
         fun reason ->
-          (let uu____29661 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffectsEqns") in
-           if uu____29661
+           if uu___1
            then
-             let uu____29662 =
-               let uu____29663 =
-                 FStar_All.pipe_right reason FStar_Util.is_none in
-               if uu____29663
+             let uu___2 =
+               let uu___3 = FStar_All.pipe_right reason FStar_Util.is_none in
+               if uu___3
                then "_"
                else FStar_All.pipe_right reason FStar_Util.must in
-             let uu____29669 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____29670 = FStar_Syntax_Print.term_to_string t2 in
-             FStar_Util.print3 "Layered Effect (%s) %s = %s\n" uu____29662
-               uu____29669 uu____29670
+             let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+             let uu___4 = FStar_Syntax_Print.term_to_string t2 in
+             FStar_Util.print3 "Layered Effect (%s) %s = %s\n" uu___2 uu___3
+               uu___4
            else ());
           teq env t1 t2
 let (universe_inequality :
@@ -12385,17 +12071,17 @@ let (universe_inequality :
   =
   fun u1 ->
     fun u2 ->
-      let uu___4515_29682 = FStar_TypeChecker_Common.trivial_guard in
+      let uu___ = FStar_TypeChecker_Common.trivial_guard in
       {
         FStar_TypeChecker_Common.guard_f =
-          (uu___4515_29682.FStar_TypeChecker_Common.guard_f);
+          (uu___.FStar_TypeChecker_Common.guard_f);
         FStar_TypeChecker_Common.deferred_to_tac =
-          (uu___4515_29682.FStar_TypeChecker_Common.deferred_to_tac);
+          (uu___.FStar_TypeChecker_Common.deferred_to_tac);
         FStar_TypeChecker_Common.deferred =
-          (uu___4515_29682.FStar_TypeChecker_Common.deferred);
+          (uu___.FStar_TypeChecker_Common.deferred);
         FStar_TypeChecker_Common.univ_ineqs = ([], [(u1, u2)]);
         FStar_TypeChecker_Common.implicits =
-          (uu___4515_29682.FStar_TypeChecker_Common.implicits)
+          (uu___.FStar_TypeChecker_Common.implicits)
       }
 let (check_subtyping :
   FStar_TypeChecker_Env.env ->
@@ -12407,44 +12093,41 @@ let (check_subtyping :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____29717 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____29717
+         if uu___1
          then
-           let uu____29718 =
-             FStar_TypeChecker_Normalize.term_to_string env t1 in
-           let uu____29719 =
-             FStar_TypeChecker_Normalize.term_to_string env t2 in
-           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____29718
-             uu____29719
+           let uu___2 = FStar_TypeChecker_Normalize.term_to_string env t1 in
+           let uu___3 = FStar_TypeChecker_Normalize.term_to_string env t2 in
+           FStar_Util.print2 "check_subtyping of %s and %s\n" uu___2 uu___3
          else ());
-        (let uu____29721 =
+        (let uu___1 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2 in
-         match uu____29721 with
+         match uu___1 with
          | (prob, x, wl) ->
              let g =
-               let uu____29740 =
+               let uu___2 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____29750 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____29740 in
-             ((let uu____29772 =
+                   (fun uu___3 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu___2 in
+             ((let uu___3 =
                  (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "Rel"))
                    && (FStar_Util.is_some g) in
-               if uu____29772
+               if uu___3
                then
-                 let uu____29773 =
+                 let uu___4 =
                    FStar_TypeChecker_Normalize.term_to_string env t1 in
-                 let uu____29774 =
+                 let uu___5 =
                    FStar_TypeChecker_Normalize.term_to_string env t2 in
-                 let uu____29775 =
-                   let uu____29776 = FStar_Util.must g in
-                   guard_to_string env uu____29776 in
+                 let uu___6 =
+                   let uu___7 = FStar_Util.must g in
+                   guard_to_string env uu___7 in
                  FStar_Util.print3
                    "check_subtyping succeeded: %s <: %s\n\tguard is %s\n"
-                   uu____29773 uu____29774 uu____29775
+                   uu___4 uu___5 uu___6
                else ());
               (match g with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -12459,14 +12142,14 @@ let (get_subtyping_predicate :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29810 = check_subtyping env t1 t2 in
-        match uu____29810 with
+        let uu___ = check_subtyping env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x, g) ->
-            let uu____29829 =
-              let uu____29830 = FStar_Syntax_Syntax.mk_binder x in
-              FStar_TypeChecker_Env.abstract_guard uu____29830 g in
-            FStar_Pervasives_Native.Some uu____29829
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Syntax.mk_binder x in
+              FStar_TypeChecker_Env.abstract_guard uu___2 g in
+            FStar_Pervasives_Native.Some uu___1
 let (get_subtyping_prop :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -12476,16 +12159,15 @@ let (get_subtyping_prop :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29848 = check_subtyping env t1 t2 in
-        match uu____29848 with
+        let uu___ = check_subtyping env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x, g) ->
-            let uu____29867 =
-              let uu____29868 =
-                let uu____29869 = FStar_Syntax_Syntax.mk_binder x in
-                [uu____29869] in
-              FStar_TypeChecker_Env.close_guard env uu____29868 g in
-            FStar_Pervasives_Native.Some uu____29867
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Syntax.mk_binder x in [uu___3] in
+              FStar_TypeChecker_Env.close_guard env uu___2 g in
+            FStar_Pervasives_Native.Some uu___1
 let (subtype_nosmt :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -12495,36 +12177,34 @@ let (subtype_nosmt :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____29906 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____29906
+         if uu___1
          then
-           let uu____29907 =
-             FStar_TypeChecker_Normalize.term_to_string env t1 in
-           let uu____29908 =
-             FStar_TypeChecker_Normalize.term_to_string env t2 in
-           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____29907
-             uu____29908
+           let uu___2 = FStar_TypeChecker_Normalize.term_to_string env t1 in
+           let uu___3 = FStar_TypeChecker_Normalize.term_to_string env t2 in
+           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu___2
+             uu___3
          else ());
-        (let uu____29910 =
+        (let uu___1 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2 in
-         match uu____29910 with
+         match uu___1 with
          | (prob, x, wl) ->
              let g =
-               let uu____29925 =
+               let uu___2 =
                  solve_and_commit env (singleton wl prob false)
-                   (fun uu____29935 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____29925 in
+                   (fun uu___3 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu___2 in
              (match g with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some g1 ->
                   let g2 =
-                    let uu____29960 =
-                      let uu____29961 = FStar_Syntax_Syntax.mk_binder x in
-                      [uu____29961] in
-                    FStar_TypeChecker_Env.close_guard env uu____29960 g1 in
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu___3] in
+                    FStar_TypeChecker_Env.close_guard env uu___2 g1 in
                   discharge_guard' FStar_Pervasives_Native.None env g2 false))
 let (subtype_nosmt_force :
   FStar_TypeChecker_Env.env ->
@@ -12533,7 +12213,7 @@ let (subtype_nosmt_force :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29998 = subtype_nosmt env t1 t2 in
-        match uu____29998 with
+        let uu___ = subtype_nosmt env t1 t2 in
+        match uu___ with
         | FStar_Pervasives_Native.None -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -10,242 +10,238 @@ let (set_hint_correlator :
           FStar_Pervasives_Native.fst in
       let get_n lid =
         let n_opt =
-          let uu____44 = FStar_Ident.string_of_lid lid in
-          FStar_Util.smap_try_find tbl uu____44 in
+          let uu___ = FStar_Ident.string_of_lid lid in
+          FStar_Util.smap_try_find tbl uu___ in
         if FStar_Util.is_some n_opt
         then FStar_All.pipe_right n_opt FStar_Util.must
         else Prims.int_zero in
-      let uu____48 = FStar_Options.reuse_hint_for () in
-      match uu____48 with
+      let uu___ = FStar_Options.reuse_hint_for () in
+      match uu___ with
       | FStar_Pervasives_Native.Some l ->
           let lid =
-            let uu____53 = FStar_TypeChecker_Env.current_module env in
-            FStar_Ident.lid_add_suffix uu____53 l in
-          let uu___13_54 = env in
-          let uu____55 =
-            let uu____68 =
-              let uu____75 = let uu____80 = get_n lid in (lid, uu____80) in
-              FStar_Pervasives_Native.Some uu____75 in
-            (tbl, uu____68) in
+            let uu___1 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.lid_add_suffix uu___1 l in
+          let uu___1 = env in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = let uu___5 = get_n lid in (lid, uu___5) in
+              FStar_Pervasives_Native.Some uu___4 in
+            (tbl, uu___3) in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___13_54.FStar_TypeChecker_Env.solver);
+              (uu___1.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___13_54.FStar_TypeChecker_Env.range);
+              (uu___1.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___13_54.FStar_TypeChecker_Env.curmodule);
+              (uu___1.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___13_54.FStar_TypeChecker_Env.gamma);
+              (uu___1.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___13_54.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___13_54.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___13_54.FStar_TypeChecker_Env.modules);
+              (uu___1.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___13_54.FStar_TypeChecker_Env.expected_typ);
+              (uu___1.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___13_54.FStar_TypeChecker_Env.sigtab);
+              (uu___1.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___13_54.FStar_TypeChecker_Env.attrtab);
+              (uu___1.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___13_54.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___13_54.FStar_TypeChecker_Env.effects);
+              (uu___1.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___13_54.FStar_TypeChecker_Env.generalize);
+              (uu___1.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___13_54.FStar_TypeChecker_Env.letrecs);
+              (uu___1.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___13_54.FStar_TypeChecker_Env.top_level);
+              (uu___1.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___13_54.FStar_TypeChecker_Env.check_uvars);
+              (uu___1.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___13_54.FStar_TypeChecker_Env.use_eq);
+              (uu___1.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___13_54.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___13_54.FStar_TypeChecker_Env.is_iface);
+              (uu___1.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___13_54.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___13_54.FStar_TypeChecker_Env.lax);
+              (uu___1.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___13_54.FStar_TypeChecker_Env.lax_universes);
+              (uu___1.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___13_54.FStar_TypeChecker_Env.phase1);
+              (uu___1.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___13_54.FStar_TypeChecker_Env.failhard);
+              (uu___1.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___13_54.FStar_TypeChecker_Env.nosynth);
+              (uu___1.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___13_54.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___13_54.FStar_TypeChecker_Env.tc_term);
+              (uu___1.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___13_54.FStar_TypeChecker_Env.type_of);
+              (uu___1.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___13_54.FStar_TypeChecker_Env.universe_of);
+              (uu___1.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___13_54.FStar_TypeChecker_Env.check_type_of);
+              (uu___1.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___13_54.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qtbl_name_and_index = uu____55;
+              (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
+            FStar_TypeChecker_Env.qtbl_name_and_index = uu___2;
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___13_54.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___13_54.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___13_54.FStar_TypeChecker_Env.proof_ns);
+              (uu___1.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___13_54.FStar_TypeChecker_Env.synth_hook);
+              (uu___1.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___13_54.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___13_54.FStar_TypeChecker_Env.splice);
+              (uu___1.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___13_54.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___13_54.FStar_TypeChecker_Env.postprocess);
+              (uu___1.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___13_54.FStar_TypeChecker_Env.identifier_info);
+              (uu___1.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___13_54.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___13_54.FStar_TypeChecker_Env.dsenv);
-            FStar_TypeChecker_Env.nbe =
-              (uu___13_54.FStar_TypeChecker_Env.nbe);
+              (uu___1.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___13_54.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___13_54.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___13_54.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
           }
       | FStar_Pervasives_Native.None ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se in
           let lid =
             match lids with
             | [] ->
-                let uu____97 = FStar_TypeChecker_Env.current_module env in
-                let uu____98 =
-                  let uu____99 = FStar_Ident.next_id () in
-                  FStar_All.pipe_right uu____99 FStar_Util.string_of_int in
-                FStar_Ident.lid_add_suffix uu____97 uu____98
-            | l::uu____101 -> l in
-          let uu___22_104 = env in
-          let uu____105 =
-            let uu____118 =
-              let uu____125 = let uu____130 = get_n lid in (lid, uu____130) in
-              FStar_Pervasives_Native.Some uu____125 in
-            (tbl, uu____118) in
+                let uu___1 = FStar_TypeChecker_Env.current_module env in
+                let uu___2 =
+                  let uu___3 = FStar_Ident.next_id () in
+                  FStar_All.pipe_right uu___3 FStar_Util.string_of_int in
+                FStar_Ident.lid_add_suffix uu___1 uu___2
+            | l::uu___1 -> l in
+          let uu___1 = env in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = let uu___5 = get_n lid in (lid, uu___5) in
+              FStar_Pervasives_Native.Some uu___4 in
+            (tbl, uu___3) in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___22_104.FStar_TypeChecker_Env.solver);
+              (uu___1.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___22_104.FStar_TypeChecker_Env.range);
+              (uu___1.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___22_104.FStar_TypeChecker_Env.curmodule);
+              (uu___1.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___22_104.FStar_TypeChecker_Env.gamma);
+              (uu___1.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___22_104.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___22_104.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___22_104.FStar_TypeChecker_Env.modules);
+              (uu___1.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___22_104.FStar_TypeChecker_Env.expected_typ);
+              (uu___1.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___22_104.FStar_TypeChecker_Env.sigtab);
+              (uu___1.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___22_104.FStar_TypeChecker_Env.attrtab);
+              (uu___1.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___22_104.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___22_104.FStar_TypeChecker_Env.effects);
+              (uu___1.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___22_104.FStar_TypeChecker_Env.generalize);
+              (uu___1.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___22_104.FStar_TypeChecker_Env.letrecs);
+              (uu___1.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___22_104.FStar_TypeChecker_Env.top_level);
+              (uu___1.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___22_104.FStar_TypeChecker_Env.check_uvars);
+              (uu___1.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___22_104.FStar_TypeChecker_Env.use_eq);
+              (uu___1.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___22_104.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___22_104.FStar_TypeChecker_Env.is_iface);
+              (uu___1.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___22_104.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax =
-              (uu___22_104.FStar_TypeChecker_Env.lax);
+              (uu___1.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___22_104.FStar_TypeChecker_Env.lax_universes);
+              (uu___1.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___22_104.FStar_TypeChecker_Env.phase1);
+              (uu___1.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___22_104.FStar_TypeChecker_Env.failhard);
+              (uu___1.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___22_104.FStar_TypeChecker_Env.nosynth);
+              (uu___1.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___22_104.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___22_104.FStar_TypeChecker_Env.tc_term);
+              (uu___1.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___22_104.FStar_TypeChecker_Env.type_of);
+              (uu___1.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___22_104.FStar_TypeChecker_Env.universe_of);
+              (uu___1.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___22_104.FStar_TypeChecker_Env.check_type_of);
+              (uu___1.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___22_104.FStar_TypeChecker_Env.use_bv_sorts);
-            FStar_TypeChecker_Env.qtbl_name_and_index = uu____105;
+              (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
+            FStar_TypeChecker_Env.qtbl_name_and_index = uu___2;
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___22_104.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___22_104.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___22_104.FStar_TypeChecker_Env.proof_ns);
+              (uu___1.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___22_104.FStar_TypeChecker_Env.synth_hook);
+              (uu___1.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___22_104.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___22_104.FStar_TypeChecker_Env.splice);
+              (uu___1.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___22_104.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___22_104.FStar_TypeChecker_Env.postprocess);
+              (uu___1.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___22_104.FStar_TypeChecker_Env.identifier_info);
+              (uu___1.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___22_104.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___22_104.FStar_TypeChecker_Env.dsenv);
-            FStar_TypeChecker_Env.nbe =
-              (uu___22_104.FStar_TypeChecker_Env.nbe);
+              (uu___1.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___22_104.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___22_104.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___22_104.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
           }
 let (log : FStar_TypeChecker_Env.env -> Prims.bool) =
   fun env ->
     (FStar_Options.log_types ()) &&
-      (let uu____149 =
-         let uu____150 = FStar_TypeChecker_Env.current_module env in
-         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____150 in
-       Prims.op_Negation uu____149)
+      (let uu___ =
+         let uu___1 = FStar_TypeChecker_Env.current_module env in
+         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu___1 in
+       Prims.op_Negation uu___)
 let tc_lex_t :
-  'uuuuuu161 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
-        'uuuuuu161 Prims.list ->
+        'uuuuu Prims.list ->
           FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt
   =
   fun env ->
@@ -253,8 +249,8 @@ let tc_lex_t :
       fun quals ->
         fun lids ->
           let err_range =
-            let uu____196 = FStar_List.hd ses in
-            uu____196.FStar_Syntax_Syntax.sigrng in
+            let uu___1 = FStar_List.hd ses in
+            uu___1.FStar_Syntax_Syntax.sigrng in
           (match lids with
            | lex_t::lex_top::lex_cons::[] when
                ((FStar_Ident.lid_equals lex_t FStar_Parser_Const.lex_t_lid)
@@ -265,7 +261,7 @@ let tc_lex_t :
                  (FStar_Ident.lid_equals lex_cons
                     FStar_Parser_Const.lexcons_lid)
                -> ()
-           | uu____201 ->
+           | uu___2 ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT,
                    "Invalid (partial) redefinition of lex_t") err_range);
@@ -273,43 +269,40 @@ let tc_lex_t :
            | {
                FStar_Syntax_Syntax.sigel =
                  FStar_Syntax_Syntax.Sig_inductive_typ
-                 (lex_t, uu____205, [], t, uu____207, uu____208);
+                 (lex_t, uu___2, [], t, uu___3, uu___4);
                FStar_Syntax_Syntax.sigrng = r;
                FStar_Syntax_Syntax.sigquals = [];
-               FStar_Syntax_Syntax.sigmeta = uu____210;
-               FStar_Syntax_Syntax.sigattrs = uu____211;
-               FStar_Syntax_Syntax.sigopts = uu____212;_}::{
-                                                             FStar_Syntax_Syntax.sigel
-                                                               =
-                                                               FStar_Syntax_Syntax.Sig_datacon
-                                                               (lex_top,
-                                                                uu____214,
-                                                                _t_top,
-                                                                _lex_t_top,
-                                                                uu____251,
-                                                                uu____217);
-                                                             FStar_Syntax_Syntax.sigrng
-                                                               = r1;
-                                                             FStar_Syntax_Syntax.sigquals
-                                                               = [];
-                                                             FStar_Syntax_Syntax.sigmeta
-                                                               = uu____219;
-                                                             FStar_Syntax_Syntax.sigattrs
-                                                               = uu____220;
-                                                             FStar_Syntax_Syntax.sigopts
-                                                               = uu____221;_}::
+               FStar_Syntax_Syntax.sigmeta = uu___5;
+               FStar_Syntax_Syntax.sigattrs = uu___6;
+               FStar_Syntax_Syntax.sigopts = uu___7;_}::{
+                                                          FStar_Syntax_Syntax.sigel
+                                                            =
+                                                            FStar_Syntax_Syntax.Sig_datacon
+                                                            (lex_top, uu___8,
+                                                             _t_top,
+                                                             _lex_t_top,
+                                                             uu___9, uu___10);
+                                                          FStar_Syntax_Syntax.sigrng
+                                                            = r1;
+                                                          FStar_Syntax_Syntax.sigquals
+                                                            = [];
+                                                          FStar_Syntax_Syntax.sigmeta
+                                                            = uu___11;
+                                                          FStar_Syntax_Syntax.sigattrs
+                                                            = uu___12;
+                                                          FStar_Syntax_Syntax.sigopts
+                                                            = uu___13;_}::
                {
                  FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-                   (lex_cons, uu____223, _t_cons, _lex_t_cons, uu____260,
-                    uu____226);
+                   (lex_cons, uu___14, _t_cons, _lex_t_cons, uu___15,
+                    uu___16);
                  FStar_Syntax_Syntax.sigrng = r2;
                  FStar_Syntax_Syntax.sigquals = [];
-                 FStar_Syntax_Syntax.sigmeta = uu____228;
-                 FStar_Syntax_Syntax.sigattrs = uu____229;
-                 FStar_Syntax_Syntax.sigopts = uu____230;_}::[]
+                 FStar_Syntax_Syntax.sigmeta = uu___17;
+                 FStar_Syntax_Syntax.sigattrs = uu___18;
+                 FStar_Syntax_Syntax.sigopts = uu___19;_}::[]
                when
-               ((uu____251 = Prims.int_zero) && (uu____260 = Prims.int_zero))
-                 &&
+               ((uu___9 = Prims.int_zero) && (uu___15 = Prims.int_zero)) &&
                  (((FStar_Ident.lid_equals lex_t FStar_Parser_Const.lex_t_lid)
                      &&
                      (FStar_Ident.lid_equals lex_top
@@ -344,18 +337,18 @@ let tc_lex_t :
                  FStar_Syntax_Syntax.new_univ_name
                    (FStar_Pervasives_Native.Some r1) in
                let lex_top_t =
-                 let uu____287 =
-                   let uu____288 =
-                     let uu____295 =
-                       let uu____298 =
+                 let uu___20 =
+                   let uu___21 =
+                     let uu___22 =
+                       let uu___23 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.lex_t_lid r1 in
-                       FStar_Syntax_Syntax.fvar uu____298
+                       FStar_Syntax_Syntax.fvar uu___23
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None in
-                     (uu____295, [FStar_Syntax_Syntax.U_name utop]) in
-                   FStar_Syntax_Syntax.Tm_uinst uu____288 in
-                 FStar_Syntax_Syntax.mk uu____287 r1 in
+                     (uu___22, [FStar_Syntax_Syntax.U_name utop]) in
+                   FStar_Syntax_Syntax.Tm_uinst uu___21 in
+                 FStar_Syntax_Syntax.mk uu___20 r1 in
                let lex_top_t1 =
                  FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t in
                let dc_lextop =
@@ -379,55 +372,55 @@ let tc_lex_t :
                    (FStar_Pervasives_Native.Some r2) in
                let lex_cons_t =
                  let a =
-                   let uu____311 =
+                   let uu___20 =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_type
                           (FStar_Syntax_Syntax.U_name ucons1)) r2 in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____311 in
+                     (FStar_Pervasives_Native.Some r2) uu___20 in
                  let hd =
-                   let uu____313 = FStar_Syntax_Syntax.bv_to_name a in
+                   let uu___20 = FStar_Syntax_Syntax.bv_to_name a in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____313 in
+                     (FStar_Pervasives_Native.Some r2) uu___20 in
                  let tl =
-                   let uu____315 =
-                     let uu____316 =
-                       let uu____317 =
-                         let uu____324 =
-                           let uu____327 =
+                   let uu___20 =
+                     let uu___21 =
+                       let uu___22 =
+                         let uu___23 =
+                           let uu___24 =
                              FStar_Ident.set_lid_range
                                FStar_Parser_Const.lex_t_lid r2 in
-                           FStar_Syntax_Syntax.fvar uu____327
+                           FStar_Syntax_Syntax.fvar uu___24
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None in
-                         (uu____324, [FStar_Syntax_Syntax.U_name ucons2]) in
-                       FStar_Syntax_Syntax.Tm_uinst uu____317 in
-                     FStar_Syntax_Syntax.mk uu____316 r2 in
+                         (uu___23, [FStar_Syntax_Syntax.U_name ucons2]) in
+                       FStar_Syntax_Syntax.Tm_uinst uu___22 in
+                     FStar_Syntax_Syntax.mk uu___21 r2 in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____315 in
+                     (FStar_Pervasives_Native.Some r2) uu___20 in
                  let res =
-                   let uu____333 =
-                     let uu____334 =
-                       let uu____341 =
-                         let uu____344 =
+                   let uu___20 =
+                     let uu___21 =
+                       let uu___22 =
+                         let uu___23 =
                            FStar_Ident.set_lid_range
                              FStar_Parser_Const.lex_t_lid r2 in
-                         FStar_Syntax_Syntax.fvar uu____344
+                         FStar_Syntax_Syntax.fvar uu___23
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None in
-                       (uu____341,
+                       (uu___22,
                          [FStar_Syntax_Syntax.U_max
                             [FStar_Syntax_Syntax.U_name ucons1;
                             FStar_Syntax_Syntax.U_name ucons2]]) in
-                     FStar_Syntax_Syntax.Tm_uinst uu____334 in
-                   FStar_Syntax_Syntax.mk uu____333 r2 in
-                 let uu____347 = FStar_Syntax_Syntax.mk_Total res in
+                     FStar_Syntax_Syntax.Tm_uinst uu___21 in
+                   FStar_Syntax_Syntax.mk uu___20 r2 in
+                 let uu___20 = FStar_Syntax_Syntax.mk_Total res in
                  FStar_Syntax_Util.arrow
                    [(a,
                       (FStar_Pervasives_Native.Some
                          FStar_Syntax_Syntax.imp_tag));
                    (hd, FStar_Pervasives_Native.None);
-                   (tl, FStar_Pervasives_Native.None)] uu____347 in
+                   (tl, FStar_Pervasives_Native.None)] uu___20 in
                let lex_cons_t1 =
                  FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
                    lex_cons_t in
@@ -444,27 +437,27 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigattrs = [];
                    FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  } in
-               let uu____384 = FStar_TypeChecker_Env.get_range env in
+               let uu___20 = FStar_TypeChecker_Env.get_range env in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_bundle
                       ([tc; dc_lextop; dc_lexcons], lids));
-                 FStar_Syntax_Syntax.sigrng = uu____384;
+                 FStar_Syntax_Syntax.sigrng = uu___20;
                  FStar_Syntax_Syntax.sigquals = [];
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
                  FStar_Syntax_Syntax.sigattrs = [];
                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }
-           | uu____389 ->
+           | uu___2 ->
                let err_msg =
-                 let uu____393 =
-                   let uu____394 =
+                 let uu___3 =
+                   let uu___4 =
                      FStar_Syntax_Syntax.mk_sigelt
                        (FStar_Syntax_Syntax.Sig_bundle (ses, lids)) in
-                   FStar_Syntax_Print.sigelt_to_string uu____394 in
+                   FStar_Syntax_Print.sigelt_to_string uu___4 in
                  FStar_Util.format1 "Invalid (re)definition of lex_t: %s\n"
-                   uu____393 in
+                   uu___3 in
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT, err_msg)
                  err_range)
@@ -475,13 +468,13 @@ let (tc_type_common :
         FStar_Range.range -> FStar_Syntax_Syntax.tscheme)
   =
   fun env ->
-    fun uu____416 ->
+    fun uu___ ->
       fun expected_typ ->
         fun r ->
-          match uu____416 with
+          match uu___ with
           | (uvs, t) ->
-              let uu____429 = FStar_Syntax_Subst.open_univ_vars uvs t in
-              (match uu____429 with
+              let uu___1 = FStar_Syntax_Subst.open_univ_vars uvs t in
+              (match uu___1 with
                | (uvs1, t1) ->
                    let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1 in
                    let t2 =
@@ -489,22 +482,22 @@ let (tc_type_common :
                        expected_typ in
                    if uvs1 = []
                    then
-                     let uu____440 =
+                     let uu___2 =
                        FStar_TypeChecker_Generalize.generalize_universes env1
                          t2 in
-                     (match uu____440 with
+                     (match uu___2 with
                       | (uvs2, t3) ->
                           (FStar_TypeChecker_Util.check_uvars r t3;
                            (uvs2, t3)))
                    else
-                     (let uu____457 =
-                        let uu____460 =
+                     (let uu___3 =
+                        let uu___4 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                env1) in
-                        FStar_All.pipe_right uu____460
+                        FStar_All.pipe_right uu___4
                           (FStar_Syntax_Subst.close_univ_vars uvs1) in
-                      (uvs1, uu____457)))
+                      (uvs1, uu___3)))
 let (tc_declare_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.tscheme ->
@@ -513,10 +506,10 @@ let (tc_declare_typ :
   fun env ->
     fun ts ->
       fun r ->
-        let uu____482 =
-          let uu____483 = FStar_Syntax_Util.type_u () in
-          FStar_All.pipe_right uu____483 FStar_Pervasives_Native.fst in
-        tc_type_common env ts uu____482 r
+        let uu___ =
+          let uu___1 = FStar_Syntax_Util.type_u () in
+          FStar_All.pipe_right uu___1 FStar_Pervasives_Native.fst in
+        tc_type_common env ts uu___ r
 let (tc_assume :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.tscheme ->
@@ -525,10 +518,10 @@ let (tc_assume :
   fun env ->
     fun ts ->
       fun r ->
-        let uu____507 =
-          let uu____508 = FStar_Syntax_Util.type_u () in
-          FStar_All.pipe_right uu____508 FStar_Pervasives_Native.fst in
-        tc_type_common env ts uu____507 r
+        let uu___ =
+          let uu___1 = FStar_Syntax_Util.type_u () in
+          FStar_All.pipe_right uu___1 FStar_Pervasives_Native.fst in
+        tc_type_common env ts uu___ r
 let (tc_inductive' :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -543,35 +536,33 @@ let (tc_inductive' :
       fun quals ->
         fun attrs ->
           fun lids ->
-            (let uu____565 =
-               FStar_TypeChecker_Env.debug env FStar_Options.Low in
-             if uu____565
+            (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
+             if uu___1
              then
-               let uu____566 =
+               let uu___2 =
                  FStar_Common.string_of_list
                    FStar_Syntax_Print.sigelt_to_string ses in
-               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____566
+               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu___2
              else ());
-            (let uu____568 =
+            (let uu___1 =
                FStar_TypeChecker_TcInductive.check_inductive_well_typedness
                  env ses quals lids in
-             match uu____568 with
+             match uu___1 with
              | (sig_bndle, tcs, datas) ->
                  let attrs' =
                    FStar_Syntax_Util.remove_attr
                      FStar_Parser_Const.erasable_attr attrs in
                  let data_ops_ses =
-                   let uu____602 =
+                   let uu___2 =
                      FStar_List.map
                        (FStar_TypeChecker_TcInductive.mk_data_operations
                           quals attrs' env tcs) datas in
-                   FStar_All.pipe_right uu____602 FStar_List.flatten in
-                 ((let uu____616 =
+                   FStar_All.pipe_right uu___2 FStar_List.flatten in
+                 ((let uu___3 =
                      (FStar_Options.no_positivity ()) ||
-                       (let uu____618 =
-                          FStar_TypeChecker_Env.should_verify env in
-                        Prims.op_Negation uu____618) in
-                   if uu____616
+                       (let uu___4 = FStar_TypeChecker_Env.should_verify env in
+                        Prims.op_Negation uu___4) in
+                   if uu___3
                    then ()
                    else
                      (let env1 =
@@ -583,86 +574,85 @@ let (tc_inductive' :
                                ty env1 in
                            if Prims.op_Negation b
                            then
-                             let uu____630 =
+                             let uu___6 =
                                match ty.FStar_Syntax_Syntax.sigel with
                                | FStar_Syntax_Syntax.Sig_inductive_typ
-                                   (lid, uu____640, uu____641, uu____642,
-                                    uu____643, uu____644)
+                                   (lid, uu___7, uu___8, uu___9, uu___10,
+                                    uu___11)
                                    -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                               | uu____653 -> failwith "Impossible!" in
-                             match uu____630 with
+                               | uu___7 -> failwith "Impossible!" in
+                             match uu___6 with
                              | (lid, r) ->
-                                 let uu____660 =
-                                   let uu____665 =
-                                     let uu____666 =
-                                       let uu____667 =
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 =
                                          FStar_Ident.string_of_lid lid in
-                                       Prims.op_Hat uu____667
+                                       Prims.op_Hat uu___10
                                          " does not satisfy the positivity condition" in
-                                     Prims.op_Hat "Inductive type " uu____666 in
+                                     Prims.op_Hat "Inductive type " uu___9 in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     uu____665) in
-                                 FStar_Errors.log_issue r uu____660
+                                     uu___8) in
+                                 FStar_Errors.log_issue r uu___7
                            else ()) tcs;
                       FStar_List.iter
                         (fun d ->
-                           let uu____676 =
+                           let uu___6 =
                              match d.FStar_Syntax_Syntax.sigel with
                              | FStar_Syntax_Syntax.Sig_datacon
-                                 (data_lid, uu____686, uu____687, ty_lid,
-                                  uu____689, uu____690)
+                                 (data_lid, uu___7, uu___8, ty_lid, uu___9,
+                                  uu___10)
                                  -> (data_lid, ty_lid)
-                             | uu____695 -> failwith "Impossible" in
-                           match uu____676 with
+                             | uu___7 -> failwith "Impossible" in
+                           match uu___6 with
                            | (data_lid, ty_lid) ->
-                               let uu____702 =
+                               let uu___7 =
                                  (FStar_Ident.lid_equals ty_lid
                                     FStar_Parser_Const.exn_lid)
                                    &&
-                                   (let uu____704 =
+                                   (let uu___8 =
                                       FStar_TypeChecker_TcInductive.check_exn_positivity
                                         data_lid env1 in
-                                    Prims.op_Negation uu____704) in
-                               if uu____702
+                                    Prims.op_Negation uu___8) in
+                               if uu___7
                                then
-                                 let uu____705 =
-                                   let uu____710 =
-                                     let uu____711 =
-                                       let uu____712 =
+                                 let uu___8 =
+                                   let uu___9 =
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_Ident.string_of_lid data_lid in
-                                       Prims.op_Hat uu____712
+                                       Prims.op_Hat uu___11
                                          " does not satisfy the positivity condition" in
-                                     Prims.op_Hat "Exception " uu____711 in
+                                     Prims.op_Hat "Exception " uu___10 in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     uu____710) in
+                                     uu___9) in
                                  FStar_Errors.log_issue
-                                   d.FStar_Syntax_Syntax.sigrng uu____705
+                                   d.FStar_Syntax_Syntax.sigrng uu___8
                                else ()) datas));
                   (let skip_haseq =
-                     let skip_prims_type uu____720 =
+                     let skip_prims_type uu___3 =
                        let lid =
                          let ty = FStar_List.hd tcs in
                          match ty.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid, uu____724, uu____725, uu____726,
-                              uu____727, uu____728)
-                             -> lid
-                         | uu____737 -> failwith "Impossible" in
+                             (lid1, uu___4, uu___5, uu___6, uu___7, uu___8)
+                             -> lid1
+                         | uu___4 -> failwith "Impossible" in
                        FStar_List.existsb
                          (fun s ->
-                            let uu____741 =
-                              let uu____742 = FStar_Ident.ident_of_lid lid in
-                              FStar_Ident.string_of_id uu____742 in
-                            s = uu____741)
+                            let uu___4 =
+                              let uu___5 = FStar_Ident.ident_of_lid lid in
+                              FStar_Ident.string_of_id uu___5 in
+                            s = uu___4)
                          FStar_TypeChecker_TcInductive.early_prims_inductives in
                      let is_noeq =
                        FStar_List.existsb
                          (fun q -> q = FStar_Syntax_Syntax.Noeq) quals in
-                     let is_erasable uu____751 =
-                       let uu____752 =
-                         let uu____755 = FStar_List.hd tcs in
-                         uu____755.FStar_Syntax_Syntax.sigattrs in
-                       FStar_Syntax_Util.has_attribute uu____752
+                     let is_erasable uu___3 =
+                       let uu___4 =
+                         let uu___5 = FStar_List.hd tcs in
+                         uu___5.FStar_Syntax_Syntax.sigattrs in
+                       FStar_Syntax_Util.has_attribute uu___4
                          FStar_Parser_Const.erasable_attr in
                      ((((FStar_List.length tcs) = Prims.int_zero) ||
                          ((FStar_Ident.lid_equals
@@ -703,39 +693,36 @@ let (tc_inductive :
         fun attrs ->
           fun lids ->
             let env1 = FStar_TypeChecker_Env.push env "tc_inductive" in
-            let pop uu____836 =
-              let uu____837 = FStar_TypeChecker_Env.pop env1 "tc_inductive" in
+            let pop uu___ =
+              let uu___1 = FStar_TypeChecker_Env.pop env1 "tc_inductive" in
               () in
-            let uu____838 = FStar_Options.trace_error () in
-            if uu____838
+            let uu___ = FStar_Options.trace_error () in
+            if uu___
             then
               let r = tc_inductive' env1 ses quals attrs lids in (pop (); r)
             else
               (try
-                 (fun uu___204_862 ->
+                 (fun uu___2 ->
                     match () with
                     | () ->
-                        let uu____869 =
-                          tc_inductive' env1 ses quals attrs lids in
-                        FStar_All.pipe_right uu____869 (fun r -> pop (); r))
-                   ()
-               with | uu___203_900 -> (pop (); FStar_Exn.raise uu___203_900))
+                        let uu___3 = tc_inductive' env1 ses quals attrs lids in
+                        FStar_All.pipe_right uu___3 (fun r -> pop (); r)) ()
+               with | uu___2 -> (pop (); FStar_Exn.raise uu___2))
 let (check_must_erase_attribute :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env ->
     fun se ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_let (lbs, l) ->
-          let uu____930 =
-            let uu____931 = FStar_Options.ide () in
-            Prims.op_Negation uu____931 in
-          if uu____930
+          let uu___ =
+            let uu___1 = FStar_Options.ide () in Prims.op_Negation uu___1 in
+          if uu___
           then
-            let uu____932 =
-              let uu____937 = FStar_TypeChecker_Env.dsenv env in
-              let uu____938 = FStar_TypeChecker_Env.current_module env in
-              FStar_Syntax_DsEnv.iface_decls uu____937 uu____938 in
-            (match uu____932 with
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_Env.dsenv env in
+              let uu___3 = FStar_TypeChecker_Env.current_module env in
+              FStar_Syntax_DsEnv.iface_decls uu___2 uu___3 in
+            (match uu___1 with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some iface_decls ->
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
@@ -744,14 +731,14 @@ let (check_must_erase_attribute :
                          let lbname =
                            FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                          let has_iface_val =
-                           let uu____960 =
-                             let uu____967 =
-                               let uu____972 =
+                           let uu___2 =
+                             let uu___3 =
+                               let uu___4 =
                                  FStar_Ident.ident_of_lid
                                    (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               FStar_Parser_AST.decl_is_val uu____972 in
-                             FStar_Util.for_some uu____967 in
-                           FStar_All.pipe_right iface_decls uu____960 in
+                               FStar_Parser_AST.decl_is_val uu___4 in
+                             FStar_Util.for_some uu___3 in
+                           FStar_All.pipe_right iface_decls uu___2 in
                          if has_iface_val
                          then
                            let must_erase =
@@ -762,39 +749,38 @@ let (check_must_erase_attribute :
                                FStar_Parser_Const.must_erase_for_extraction_attr in
                            (if must_erase && (Prims.op_Negation has_attr)
                             then
-                              let uu____977 =
+                              let uu___2 =
                                 FStar_Syntax_Syntax.range_of_fv lbname in
-                              let uu____978 =
-                                let uu____983 =
-                                  let uu____984 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_Syntax_Print.fv_to_string lbname in
-                                  let uu____985 =
+                                  let uu___6 =
                                     FStar_Syntax_Print.fv_to_string lbname in
                                   FStar_Util.format2
                                     "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
-                                    uu____984 uu____985 in
-                                (FStar_Errors.Error_MustEraseMissing,
-                                  uu____983) in
-                              FStar_Errors.log_issue uu____977 uu____978
+                                    uu___5 uu___6 in
+                                (FStar_Errors.Error_MustEraseMissing, uu___4) in
+                              FStar_Errors.log_issue uu___2 uu___3
                             else
                               if has_attr && (Prims.op_Negation must_erase)
                               then
-                                (let uu____987 =
+                                (let uu___3 =
                                    FStar_Syntax_Syntax.range_of_fv lbname in
-                                 let uu____988 =
-                                   let uu____993 =
-                                     let uu____994 =
+                                 let uu___4 =
+                                   let uu___5 =
+                                     let uu___6 =
                                        FStar_Syntax_Print.fv_to_string lbname in
                                      FStar_Util.format1
                                        "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
-                                       uu____994 in
+                                       uu___6 in
                                    (FStar_Errors.Error_MustEraseMissing,
-                                     uu____993) in
-                                 FStar_Errors.log_issue uu____987 uu____988)
+                                     uu___5) in
+                                 FStar_Errors.log_issue uu___3 uu___4)
                               else ())
                          else ())))
           else ()
-      | uu____998 -> ()
+      | uu___ -> ()
 let (unembed_optionstate_knot :
   FStar_Options.optionstate FStar_Syntax_Embeddings.embedding
     FStar_Pervasives_Native.option FStar_ST.ref)
@@ -804,31 +790,31 @@ let (unembed_optionstate :
     FStar_Options.optionstate FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____1026 =
-      let uu____1033 =
-        let uu____1036 = FStar_ST.op_Bang unembed_optionstate_knot in
-        FStar_Util.must uu____1036 in
-      FStar_Syntax_Embeddings.unembed uu____1033 t in
-    uu____1026 true FStar_Syntax_Embeddings.id_norm_cb
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_ST.op_Bang unembed_optionstate_knot in
+        FStar_Util.must uu___2 in
+      FStar_Syntax_Embeddings.unembed uu___1 t in
+    uu___ true FStar_Syntax_Embeddings.id_norm_cb
 let proc_check_with :
   'a . FStar_Syntax_Syntax.attribute Prims.list -> (unit -> 'a) -> 'a =
   fun attrs ->
     fun kont ->
-      let uu____1083 =
+      let uu___ =
         FStar_Syntax_Util.get_attribute FStar_Parser_Const.check_with_lid
           attrs in
-      match uu____1083 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> kont ()
       | FStar_Pervasives_Native.Some ((a1, FStar_Pervasives_Native.None)::[])
           ->
           FStar_Options.with_saved_options
-            (fun uu____1111 ->
-               (let uu____1113 =
-                  let uu____1114 = unembed_optionstate a1 in
-                  FStar_All.pipe_right uu____1114 FStar_Util.must in
-                FStar_Options.set uu____1113);
+            (fun uu___1 ->
+               (let uu___3 =
+                  let uu___4 = unembed_optionstate a1 in
+                  FStar_All.pipe_right uu___4 FStar_Util.must in
+                FStar_Options.set uu___3);
                kont ())
-      | uu____1119 -> failwith "huh?"
+      | uu___1 -> failwith "huh?"
 let (tc_decls_knot :
   (FStar_TypeChecker_Env.env ->
      FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -846,177 +832,174 @@ let (tc_decl' :
       let env = env0 in
       FStar_TypeChecker_Util.check_sigelt_quals env se;
       proc_check_with se.FStar_Syntax_Syntax.sigattrs
-        (fun uu____1216 ->
+        (fun uu___1 ->
            let r = se.FStar_Syntax_Syntax.sigrng in
            let se1 =
-             let uu____1219 = FStar_Options.record_options () in
-             if uu____1219
+             let uu___2 = FStar_Options.record_options () in
+             if uu___2
              then
-               let uu___251_1220 = se in
-               let uu____1221 =
-                 let uu____1224 = FStar_Options.peek () in
-                 FStar_Pervasives_Native.Some uu____1224 in
+               let uu___3 = se in
+               let uu___4 =
+                 let uu___5 = FStar_Options.peek () in
+                 FStar_Pervasives_Native.Some uu___5 in
                {
                  FStar_Syntax_Syntax.sigel =
-                   (uu___251_1220.FStar_Syntax_Syntax.sigel);
+                   (uu___3.FStar_Syntax_Syntax.sigel);
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___251_1220.FStar_Syntax_Syntax.sigrng);
+                   (uu___3.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___251_1220.FStar_Syntax_Syntax.sigquals);
+                   (uu___3.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___251_1220.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___251_1220.FStar_Syntax_Syntax.sigattrs);
-                 FStar_Syntax_Syntax.sigopts = uu____1221
+                   (uu___3.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts = uu___4
                }
              else se in
            match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_inductive_typ uu____1236 ->
+           | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_datacon uu____1263 ->
+           | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_fail (uu____1288, false, uu____1289)
-               when
-               (let uu____1300 = FStar_TypeChecker_Env.should_verify env in
-                Prims.op_Negation uu____1300) ||
+           | FStar_Syntax_Syntax.Sig_fail (uu___2, false, uu___3) when
+               (let uu___4 = FStar_TypeChecker_Env.should_verify env in
+                Prims.op_Negation uu___4) ||
                  (FStar_Options.admit_smt_queries ())
                -> ([], [], env)
            | FStar_Syntax_Syntax.Sig_fail (expected_errors, lax, ses) ->
                let env' =
                  if lax
                  then
-                   let uu___269_1317 = env in
+                   let uu___2 = env in
                    {
                      FStar_TypeChecker_Env.solver =
-                       (uu___269_1317.FStar_TypeChecker_Env.solver);
+                       (uu___2.FStar_TypeChecker_Env.solver);
                      FStar_TypeChecker_Env.range =
-                       (uu___269_1317.FStar_TypeChecker_Env.range);
+                       (uu___2.FStar_TypeChecker_Env.range);
                      FStar_TypeChecker_Env.curmodule =
-                       (uu___269_1317.FStar_TypeChecker_Env.curmodule);
+                       (uu___2.FStar_TypeChecker_Env.curmodule);
                      FStar_TypeChecker_Env.gamma =
-                       (uu___269_1317.FStar_TypeChecker_Env.gamma);
+                       (uu___2.FStar_TypeChecker_Env.gamma);
                      FStar_TypeChecker_Env.gamma_sig =
-                       (uu___269_1317.FStar_TypeChecker_Env.gamma_sig);
+                       (uu___2.FStar_TypeChecker_Env.gamma_sig);
                      FStar_TypeChecker_Env.gamma_cache =
-                       (uu___269_1317.FStar_TypeChecker_Env.gamma_cache);
+                       (uu___2.FStar_TypeChecker_Env.gamma_cache);
                      FStar_TypeChecker_Env.modules =
-                       (uu___269_1317.FStar_TypeChecker_Env.modules);
+                       (uu___2.FStar_TypeChecker_Env.modules);
                      FStar_TypeChecker_Env.expected_typ =
-                       (uu___269_1317.FStar_TypeChecker_Env.expected_typ);
+                       (uu___2.FStar_TypeChecker_Env.expected_typ);
                      FStar_TypeChecker_Env.sigtab =
-                       (uu___269_1317.FStar_TypeChecker_Env.sigtab);
+                       (uu___2.FStar_TypeChecker_Env.sigtab);
                      FStar_TypeChecker_Env.attrtab =
-                       (uu___269_1317.FStar_TypeChecker_Env.attrtab);
+                       (uu___2.FStar_TypeChecker_Env.attrtab);
                      FStar_TypeChecker_Env.instantiate_imp =
-                       (uu___269_1317.FStar_TypeChecker_Env.instantiate_imp);
+                       (uu___2.FStar_TypeChecker_Env.instantiate_imp);
                      FStar_TypeChecker_Env.effects =
-                       (uu___269_1317.FStar_TypeChecker_Env.effects);
+                       (uu___2.FStar_TypeChecker_Env.effects);
                      FStar_TypeChecker_Env.generalize =
-                       (uu___269_1317.FStar_TypeChecker_Env.generalize);
+                       (uu___2.FStar_TypeChecker_Env.generalize);
                      FStar_TypeChecker_Env.letrecs =
-                       (uu___269_1317.FStar_TypeChecker_Env.letrecs);
+                       (uu___2.FStar_TypeChecker_Env.letrecs);
                      FStar_TypeChecker_Env.top_level =
-                       (uu___269_1317.FStar_TypeChecker_Env.top_level);
+                       (uu___2.FStar_TypeChecker_Env.top_level);
                      FStar_TypeChecker_Env.check_uvars =
-                       (uu___269_1317.FStar_TypeChecker_Env.check_uvars);
+                       (uu___2.FStar_TypeChecker_Env.check_uvars);
                      FStar_TypeChecker_Env.use_eq =
-                       (uu___269_1317.FStar_TypeChecker_Env.use_eq);
+                       (uu___2.FStar_TypeChecker_Env.use_eq);
                      FStar_TypeChecker_Env.use_eq_strict =
-                       (uu___269_1317.FStar_TypeChecker_Env.use_eq_strict);
+                       (uu___2.FStar_TypeChecker_Env.use_eq_strict);
                      FStar_TypeChecker_Env.is_iface =
-                       (uu___269_1317.FStar_TypeChecker_Env.is_iface);
+                       (uu___2.FStar_TypeChecker_Env.is_iface);
                      FStar_TypeChecker_Env.admit =
-                       (uu___269_1317.FStar_TypeChecker_Env.admit);
+                       (uu___2.FStar_TypeChecker_Env.admit);
                      FStar_TypeChecker_Env.lax = true;
                      FStar_TypeChecker_Env.lax_universes =
-                       (uu___269_1317.FStar_TypeChecker_Env.lax_universes);
+                       (uu___2.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =
-                       (uu___269_1317.FStar_TypeChecker_Env.phase1);
+                       (uu___2.FStar_TypeChecker_Env.phase1);
                      FStar_TypeChecker_Env.failhard =
-                       (uu___269_1317.FStar_TypeChecker_Env.failhard);
+                       (uu___2.FStar_TypeChecker_Env.failhard);
                      FStar_TypeChecker_Env.nosynth =
-                       (uu___269_1317.FStar_TypeChecker_Env.nosynth);
+                       (uu___2.FStar_TypeChecker_Env.nosynth);
                      FStar_TypeChecker_Env.uvar_subtyping =
-                       (uu___269_1317.FStar_TypeChecker_Env.uvar_subtyping);
+                       (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
                      FStar_TypeChecker_Env.tc_term =
-                       (uu___269_1317.FStar_TypeChecker_Env.tc_term);
+                       (uu___2.FStar_TypeChecker_Env.tc_term);
                      FStar_TypeChecker_Env.type_of =
-                       (uu___269_1317.FStar_TypeChecker_Env.type_of);
+                       (uu___2.FStar_TypeChecker_Env.type_of);
                      FStar_TypeChecker_Env.universe_of =
-                       (uu___269_1317.FStar_TypeChecker_Env.universe_of);
+                       (uu___2.FStar_TypeChecker_Env.universe_of);
                      FStar_TypeChecker_Env.check_type_of =
-                       (uu___269_1317.FStar_TypeChecker_Env.check_type_of);
+                       (uu___2.FStar_TypeChecker_Env.check_type_of);
                      FStar_TypeChecker_Env.use_bv_sorts =
-                       (uu___269_1317.FStar_TypeChecker_Env.use_bv_sorts);
+                       (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
                      FStar_TypeChecker_Env.qtbl_name_and_index =
-                       (uu___269_1317.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
                      FStar_TypeChecker_Env.normalized_eff_names =
-                       (uu___269_1317.FStar_TypeChecker_Env.normalized_eff_names);
+                       (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
                      FStar_TypeChecker_Env.fv_delta_depths =
-                       (uu___269_1317.FStar_TypeChecker_Env.fv_delta_depths);
+                       (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
                      FStar_TypeChecker_Env.proof_ns =
-                       (uu___269_1317.FStar_TypeChecker_Env.proof_ns);
+                       (uu___2.FStar_TypeChecker_Env.proof_ns);
                      FStar_TypeChecker_Env.synth_hook =
-                       (uu___269_1317.FStar_TypeChecker_Env.synth_hook);
+                       (uu___2.FStar_TypeChecker_Env.synth_hook);
                      FStar_TypeChecker_Env.try_solve_implicits_hook =
-                       (uu___269_1317.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
                      FStar_TypeChecker_Env.splice =
-                       (uu___269_1317.FStar_TypeChecker_Env.splice);
+                       (uu___2.FStar_TypeChecker_Env.splice);
                      FStar_TypeChecker_Env.mpreprocess =
-                       (uu___269_1317.FStar_TypeChecker_Env.mpreprocess);
+                       (uu___2.FStar_TypeChecker_Env.mpreprocess);
                      FStar_TypeChecker_Env.postprocess =
-                       (uu___269_1317.FStar_TypeChecker_Env.postprocess);
+                       (uu___2.FStar_TypeChecker_Env.postprocess);
                      FStar_TypeChecker_Env.identifier_info =
-                       (uu___269_1317.FStar_TypeChecker_Env.identifier_info);
+                       (uu___2.FStar_TypeChecker_Env.identifier_info);
                      FStar_TypeChecker_Env.tc_hooks =
-                       (uu___269_1317.FStar_TypeChecker_Env.tc_hooks);
+                       (uu___2.FStar_TypeChecker_Env.tc_hooks);
                      FStar_TypeChecker_Env.dsenv =
-                       (uu___269_1317.FStar_TypeChecker_Env.dsenv);
+                       (uu___2.FStar_TypeChecker_Env.dsenv);
                      FStar_TypeChecker_Env.nbe =
-                       (uu___269_1317.FStar_TypeChecker_Env.nbe);
+                       (uu___2.FStar_TypeChecker_Env.nbe);
                      FStar_TypeChecker_Env.strict_args_tab =
-                       (uu___269_1317.FStar_TypeChecker_Env.strict_args_tab);
+                       (uu___2.FStar_TypeChecker_Env.strict_args_tab);
                      FStar_TypeChecker_Env.erasable_types_tab =
-                       (uu___269_1317.FStar_TypeChecker_Env.erasable_types_tab);
+                       (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
                      FStar_TypeChecker_Env.enable_defer_to_tac =
-                       (uu___269_1317.FStar_TypeChecker_Env.enable_defer_to_tac)
+                       (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
                    }
                  else env in
                let env'1 = FStar_TypeChecker_Env.push env' "expect_failure" in
-               ((let uu____1321 =
+               ((let uu___3 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Low in
-                 if uu____1321
+                 if uu___3
                  then
-                   let uu____1322 =
-                     let uu____1323 =
+                   let uu___4 =
+                     let uu___5 =
                        FStar_List.map FStar_Util.string_of_int
                          expected_errors in
-                     FStar_All.pipe_left (FStar_String.concat "; ")
-                       uu____1323 in
-                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____1322
+                     FStar_All.pipe_left (FStar_String.concat "; ") uu___5 in
+                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu___4
                  else ());
-                (let uu____1329 =
+                (let uu___3 =
                    FStar_Errors.catch_errors
-                     (fun uu____1351 ->
+                     (fun uu___4 ->
                         FStar_Options.with_saved_options
-                          (fun uu____1360 ->
-                             let uu____1361 =
-                               let uu____1378 =
-                                 FStar_ST.op_Bang tc_decls_knot in
-                               FStar_Util.must uu____1378 in
-                             uu____1361 env'1 ses)) in
-                 match uu____1329 with
-                 | (errs, uu____1458) ->
-                     ((let uu____1480 =
+                          (fun uu___5 ->
+                             let uu___6 =
+                               let uu___7 = FStar_ST.op_Bang tc_decls_knot in
+                               FStar_Util.must uu___7 in
+                             uu___6 env'1 ses)) in
+                 match uu___3 with
+                 | (errs, uu___4) ->
+                     ((let uu___6 =
                          (FStar_Options.print_expected_failures ()) ||
                            (FStar_TypeChecker_Env.debug env FStar_Options.Low) in
-                       if uu____1480
+                       if uu___6
                        then
                          (FStar_Util.print_string ">> Got issues: [\n";
                           FStar_List.iter FStar_Errors.print_issue errs;
                           FStar_Util.print_string ">>]\n")
                        else ());
-                      (let uu____1484 =
+                      (let uu___6 =
                          FStar_TypeChecker_Env.pop env'1 "expect_failure" in
                        let actual_errors =
                          FStar_List.concatMap
@@ -1030,42 +1013,41 @@ let (tc_decl' :
                                se1.FStar_Syntax_Syntax.sigrng
                                (FStar_Errors.Error_DidNotFail,
                                  "This top-level definition was expected to fail, but it succeeded"))
-                        | uu____1492 ->
+                        | uu___8 ->
                             if expected_errors <> []
                             then
-                              let uu____1497 =
+                              let uu___9 =
                                 FStar_Errors.find_multiset_discrepancy
                                   expected_errors actual_errors in
-                              (match uu____1497 with
+                              (match uu___9 with
                                | FStar_Pervasives_Native.None -> ()
                                | FStar_Pervasives_Native.Some (e, n1, n2) ->
                                    (FStar_List.iter FStar_Errors.print_issue
                                       errs;
-                                    (let uu____1522 =
-                                       let uu____1527 =
-                                         let uu____1528 =
+                                    (let uu___11 =
+                                       let uu___12 =
+                                         let uu___13 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              expected_errors in
-                                         let uu____1529 =
+                                         let uu___14 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              actual_errors in
-                                         let uu____1530 =
+                                         let uu___15 =
                                            FStar_Util.string_of_int e in
-                                         let uu____1531 =
+                                         let uu___16 =
                                            FStar_Util.string_of_int n2 in
-                                         let uu____1532 =
+                                         let uu___17 =
                                            FStar_Util.string_of_int n1 in
                                          FStar_Util.format5
                                            "This top-level definition was expected to raise error codes %s, but it raised %s. Error #%s was raised %s times, instead of %s."
-                                           uu____1528 uu____1529 uu____1530
-                                           uu____1531 uu____1532 in
+                                           uu___13 uu___14 uu___15 uu___16
+                                           uu___17 in
                                        (FStar_Errors.Error_DidNotFail,
-                                         uu____1527) in
+                                         uu___12) in
                                      FStar_Errors.log_issue
-                                       se1.FStar_Syntax_Syntax.sigrng
-                                       uu____1522)))
+                                       se1.FStar_Syntax_Syntax.sigrng uu___11)))
                             else ());
                        ([], [], env)))))
            | FStar_Syntax_Syntax.Sig_bundle (ses, lids) when
@@ -1080,166 +1062,166 @@ let (tc_decl' :
            | FStar_Syntax_Syntax.Sig_bundle (ses, lids) ->
                let env1 = FStar_TypeChecker_Env.set_range env r in
                let ses1 =
-                 let uu____1570 =
+                 let uu___2 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env1) in
-                 if uu____1570
+                 if uu___2
                  then
-                   let ses1 =
-                     let uu____1576 =
-                       let uu____1577 =
-                         let uu____1578 =
+                   let ses2 =
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
                            tc_inductive
-                             (let uu___311_1587 = env1 in
+                             (let uu___6 = env1 in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___311_1587.FStar_TypeChecker_Env.solver);
+                                  (uu___6.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___311_1587.FStar_TypeChecker_Env.range);
+                                  (uu___6.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___311_1587.FStar_TypeChecker_Env.curmodule);
+                                  (uu___6.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___311_1587.FStar_TypeChecker_Env.gamma);
+                                  (uu___6.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___311_1587.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___6.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___311_1587.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___6.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___311_1587.FStar_TypeChecker_Env.modules);
+                                  (uu___6.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___311_1587.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___6.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___311_1587.FStar_TypeChecker_Env.sigtab);
+                                  (uu___6.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___311_1587.FStar_TypeChecker_Env.attrtab);
+                                  (uu___6.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___311_1587.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___311_1587.FStar_TypeChecker_Env.effects);
+                                  (uu___6.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___311_1587.FStar_TypeChecker_Env.generalize);
+                                  (uu___6.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___311_1587.FStar_TypeChecker_Env.letrecs);
+                                  (uu___6.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___311_1587.FStar_TypeChecker_Env.top_level);
+                                  (uu___6.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___311_1587.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___6.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___311_1587.FStar_TypeChecker_Env.use_eq);
+                                  (uu___6.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___311_1587.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___311_1587.FStar_TypeChecker_Env.is_iface);
+                                  (uu___6.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___311_1587.FStar_TypeChecker_Env.admit);
+                                  (uu___6.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___311_1587.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___6.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___311_1587.FStar_TypeChecker_Env.failhard);
+                                  (uu___6.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___311_1587.FStar_TypeChecker_Env.nosynth);
+                                  (uu___6.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___311_1587.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___311_1587.FStar_TypeChecker_Env.tc_term);
+                                  (uu___6.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___311_1587.FStar_TypeChecker_Env.type_of);
+                                  (uu___6.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___311_1587.FStar_TypeChecker_Env.universe_of);
+                                  (uu___6.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___311_1587.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___6.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___311_1587.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___311_1587.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___311_1587.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___311_1587.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___311_1587.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___6.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___311_1587.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___6.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___311_1587.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___311_1587.FStar_TypeChecker_Env.splice);
+                                  (uu___6.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___311_1587.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___6.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___311_1587.FStar_TypeChecker_Env.postprocess);
+                                  (uu___6.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___311_1587.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___6.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___311_1587.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___6.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___311_1587.FStar_TypeChecker_Env.dsenv);
+                                  (uu___6.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___311_1587.FStar_TypeChecker_Env.nbe);
+                                  (uu___6.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___311_1587.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___311_1587.FStar_TypeChecker_Env.erasable_types_tab);
+                                  (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                                  (uu___311_1587.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                  (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                               }) ses se1.FStar_Syntax_Syntax.sigquals
                              se1.FStar_Syntax_Syntax.sigattrs lids in
-                         FStar_All.pipe_right uu____1578
+                         FStar_All.pipe_right uu___5
                            FStar_Pervasives_Native.fst in
-                       FStar_All.pipe_right uu____1577
+                       FStar_All.pipe_right uu___4
                          (FStar_TypeChecker_Normalize.elim_uvars env1) in
-                     FStar_All.pipe_right uu____1576
+                     FStar_All.pipe_right uu___3
                        FStar_Syntax_Util.ses_of_sigbundle in
-                   ((let uu____1599 =
+                   ((let uu___4 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "TwoPhases") in
-                     if uu____1599
+                     if uu___4
                      then
-                       let uu____1600 =
+                       let uu___5 =
                          FStar_Syntax_Print.sigelt_to_string
-                           (let uu___315_1603 = se1 in
+                           (let uu___6 = se1 in
                             {
                               FStar_Syntax_Syntax.sigel =
-                                (FStar_Syntax_Syntax.Sig_bundle (ses1, lids));
+                                (FStar_Syntax_Syntax.Sig_bundle (ses2, lids));
                               FStar_Syntax_Syntax.sigrng =
-                                (uu___315_1603.FStar_Syntax_Syntax.sigrng);
+                                (uu___6.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (uu___315_1603.FStar_Syntax_Syntax.sigquals);
+                                (uu___6.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (uu___315_1603.FStar_Syntax_Syntax.sigmeta);
+                                (uu___6.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (uu___315_1603.FStar_Syntax_Syntax.sigattrs);
+                                (uu___6.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (uu___315_1603.FStar_Syntax_Syntax.sigopts)
+                                (uu___6.FStar_Syntax_Syntax.sigopts)
                             }) in
                        FStar_Util.print1 "Inductive after phase 1: %s\n"
-                         uu____1600
+                         uu___5
                      else ());
-                    ses1)
+                    ses2)
                  else ses in
-               let uu____1610 =
+               let uu___2 =
                  tc_inductive env1 ses1 se1.FStar_Syntax_Syntax.sigquals
                    se1.FStar_Syntax_Syntax.sigattrs lids in
-               (match uu____1610 with
+               (match uu___2 with
                 | (sigbndle, projectors_ses) ->
                     let sigbndle1 =
-                      let uu___322_1634 = sigbndle in
+                      let uu___3 = sigbndle in
                       {
                         FStar_Syntax_Syntax.sigel =
-                          (uu___322_1634.FStar_Syntax_Syntax.sigel);
+                          (uu___3.FStar_Syntax_Syntax.sigel);
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___322_1634.FStar_Syntax_Syntax.sigrng);
+                          (uu___3.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___322_1634.FStar_Syntax_Syntax.sigquals);
+                          (uu___3.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___322_1634.FStar_Syntax_Syntax.sigmeta);
+                          (uu___3.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se1.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___322_1634.FStar_Syntax_Syntax.sigopts)
+                          (uu___3.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([sigbndle1], projectors_ses, env0))
            | FStar_Syntax_Syntax.Sig_pragma p ->
@@ -1248,776 +1230,776 @@ let (tc_decl' :
                let is_unelaborated_dm4f =
                  match ne.FStar_Syntax_Syntax.combinators with
                  | FStar_Syntax_Syntax.DM4F_eff combs ->
-                     let uu____1648 =
-                       let uu____1651 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_All.pipe_right
                            combs.FStar_Syntax_Syntax.ret_wp
                            FStar_Pervasives_Native.snd in
-                       FStar_All.pipe_right uu____1651
+                       FStar_All.pipe_right uu___3
                          FStar_Syntax_Subst.compress in
-                     (match uu____1648 with
+                     (match uu___2 with
                       | {
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_unknown;
-                          FStar_Syntax_Syntax.pos = uu____1662;
-                          FStar_Syntax_Syntax.vars = uu____1663;_} -> true
-                      | uu____1666 -> false)
-                 | uu____1669 -> false in
+                          FStar_Syntax_Syntax.pos = uu___3;
+                          FStar_Syntax_Syntax.vars = uu___4;_} -> true
+                      | uu___3 -> false)
+                 | uu___2 -> false in
                if is_unelaborated_dm4f
                then
                  let env1 = FStar_TypeChecker_Env.set_range env r in
-                 let uu____1681 =
+                 let uu___2 =
                    FStar_TypeChecker_TcEffect.dmff_cps_and_elaborate env1 ne in
-                 (match uu____1681 with
+                 (match uu___2 with
                   | (ses, ne1, lift_from_pure_opt) ->
                       let effect_and_lift_ses =
                         match lift_from_pure_opt with
                         | FStar_Pervasives_Native.Some lift ->
-                            [(let uu___347_1720 = se1 in
+                            [(let uu___3 = se1 in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___347_1720.FStar_Syntax_Syntax.sigrng);
+                                  (uu___3.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___347_1720.FStar_Syntax_Syntax.sigquals);
+                                  (uu___3.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___347_1720.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___3.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___347_1720.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___3.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___347_1720.FStar_Syntax_Syntax.sigopts)
+                                  (uu___3.FStar_Syntax_Syntax.sigopts)
                               });
                             lift]
                         | FStar_Pervasives_Native.None ->
-                            [(let uu___350_1722 = se1 in
+                            [(let uu___3 = se1 in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___350_1722.FStar_Syntax_Syntax.sigrng);
+                                  (uu___3.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___350_1722.FStar_Syntax_Syntax.sigquals);
+                                  (uu___3.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___350_1722.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___3.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___350_1722.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___3.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___350_1722.FStar_Syntax_Syntax.sigopts)
+                                  (uu___3.FStar_Syntax_Syntax.sigopts)
                               })] in
                       ([], (FStar_List.append ses effect_and_lift_ses), env0))
                else
                  (let ne1 =
-                    let uu____1729 =
+                    let uu___3 =
                       (FStar_Options.use_two_phase_tc ()) &&
                         (FStar_TypeChecker_Env.should_verify env) in
-                    if uu____1729
+                    if uu___3
                     then
-                      let ne1 =
-                        let uu____1731 =
-                          let uu____1732 =
-                            let uu____1733 =
+                      let ne2 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_TypeChecker_TcEffect.tc_eff_decl
-                                (let uu___354_1736 = env in
+                                (let uu___7 = env in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___354_1736.FStar_TypeChecker_Env.solver);
+                                     (uu___7.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___354_1736.FStar_TypeChecker_Env.range);
+                                     (uu___7.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___354_1736.FStar_TypeChecker_Env.curmodule);
+                                     (uu___7.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___354_1736.FStar_TypeChecker_Env.gamma);
+                                     (uu___7.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___354_1736.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___7.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___354_1736.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___7.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___354_1736.FStar_TypeChecker_Env.modules);
+                                     (uu___7.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___354_1736.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___7.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___354_1736.FStar_TypeChecker_Env.sigtab);
+                                     (uu___7.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___354_1736.FStar_TypeChecker_Env.attrtab);
+                                     (uu___7.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___354_1736.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___354_1736.FStar_TypeChecker_Env.effects);
+                                     (uu___7.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___354_1736.FStar_TypeChecker_Env.generalize);
+                                     (uu___7.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___354_1736.FStar_TypeChecker_Env.letrecs);
+                                     (uu___7.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___354_1736.FStar_TypeChecker_Env.top_level);
+                                     (uu___7.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___354_1736.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___7.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___354_1736.FStar_TypeChecker_Env.use_eq);
+                                     (uu___7.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___354_1736.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___354_1736.FStar_TypeChecker_Env.is_iface);
+                                     (uu___7.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___354_1736.FStar_TypeChecker_Env.admit);
+                                     (uu___7.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___354_1736.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___7.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 = true;
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___354_1736.FStar_TypeChecker_Env.failhard);
+                                     (uu___7.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___354_1736.FStar_TypeChecker_Env.nosynth);
+                                     (uu___7.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___354_1736.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___354_1736.FStar_TypeChecker_Env.tc_term);
+                                     (uu___7.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___354_1736.FStar_TypeChecker_Env.type_of);
+                                     (uu___7.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___354_1736.FStar_TypeChecker_Env.universe_of);
+                                     (uu___7.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___354_1736.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___7.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___354_1736.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___354_1736.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___354_1736.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___354_1736.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___354_1736.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___7.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___354_1736.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___7.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___354_1736.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___354_1736.FStar_TypeChecker_Env.splice);
+                                     (uu___7.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___354_1736.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___7.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___354_1736.FStar_TypeChecker_Env.postprocess);
+                                     (uu___7.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___354_1736.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___7.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___354_1736.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___7.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___354_1736.FStar_TypeChecker_Env.dsenv);
+                                     (uu___7.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___354_1736.FStar_TypeChecker_Env.nbe);
+                                     (uu___7.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___354_1736.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___354_1736.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___354_1736.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) ne se1.FStar_Syntax_Syntax.sigquals
                                 se1.FStar_Syntax_Syntax.sigattrs in
-                            FStar_All.pipe_right uu____1733
-                              (fun ne1 ->
-                                 let uu___357_1740 = se1 in
+                            FStar_All.pipe_right uu___6
+                              (fun ne3 ->
+                                 let uu___7 = se1 in
                                  {
                                    FStar_Syntax_Syntax.sigel =
-                                     (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                                     (FStar_Syntax_Syntax.Sig_new_effect ne3);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___357_1740.FStar_Syntax_Syntax.sigrng);
+                                     (uu___7.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals =
-                                     (uu___357_1740.FStar_Syntax_Syntax.sigquals);
+                                     (uu___7.FStar_Syntax_Syntax.sigquals);
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___357_1740.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___7.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___357_1740.FStar_Syntax_Syntax.sigattrs);
+                                     (uu___7.FStar_Syntax_Syntax.sigattrs);
                                    FStar_Syntax_Syntax.sigopts =
-                                     (uu___357_1740.FStar_Syntax_Syntax.sigopts)
+                                     (uu___7.FStar_Syntax_Syntax.sigopts)
                                  }) in
-                          FStar_All.pipe_right uu____1732
+                          FStar_All.pipe_right uu___5
                             (FStar_TypeChecker_Normalize.elim_uvars env) in
-                        FStar_All.pipe_right uu____1731
+                        FStar_All.pipe_right uu___4
                           FStar_Syntax_Util.eff_decl_of_new_effect in
-                      ((let uu____1742 =
+                      ((let uu___5 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "TwoPhases") in
-                        if uu____1742
+                        if uu___5
                         then
-                          let uu____1743 =
+                          let uu___6 =
                             FStar_Syntax_Print.sigelt_to_string
-                              (let uu___361_1746 = se1 in
+                              (let uu___7 = se1 in
                                {
                                  FStar_Syntax_Syntax.sigel =
-                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
+                                   (FStar_Syntax_Syntax.Sig_new_effect ne2);
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___361_1746.FStar_Syntax_Syntax.sigrng);
+                                   (uu___7.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (uu___361_1746.FStar_Syntax_Syntax.sigquals);
+                                   (uu___7.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___361_1746.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___7.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___361_1746.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___7.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___361_1746.FStar_Syntax_Syntax.sigopts)
+                                   (uu___7.FStar_Syntax_Syntax.sigopts)
                                }) in
                           FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                            uu____1743
+                            uu___6
                         else ());
-                       ne1)
+                       ne2)
                     else ne in
                   let ne2 =
                     FStar_TypeChecker_TcEffect.tc_eff_decl env ne1
                       se1.FStar_Syntax_Syntax.sigquals
                       se1.FStar_Syntax_Syntax.sigattrs in
                   let se2 =
-                    let uu___366_1751 = se1 in
+                    let uu___3 = se1 in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_new_effect ne2);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___366_1751.FStar_Syntax_Syntax.sigrng);
+                        (uu___3.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___366_1751.FStar_Syntax_Syntax.sigquals);
+                        (uu___3.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___366_1751.FStar_Syntax_Syntax.sigmeta);
+                        (uu___3.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___366_1751.FStar_Syntax_Syntax.sigattrs);
+                        (uu___3.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___366_1751.FStar_Syntax_Syntax.sigopts)
+                        (uu___3.FStar_Syntax_Syntax.sigopts)
                     } in
                   ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r in
                let se2 =
-                 let uu___372_1759 = se1 in
+                 let uu___2 = se1 in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_sub_effect sub1);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___372_1759.FStar_Syntax_Syntax.sigrng);
+                     (uu___2.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___372_1759.FStar_Syntax_Syntax.sigquals);
+                     (uu___2.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___372_1759.FStar_Syntax_Syntax.sigmeta);
+                     (uu___2.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___372_1759.FStar_Syntax_Syntax.sigattrs);
+                     (uu___2.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___372_1759.FStar_Syntax_Syntax.sigopts)
+                     (uu___2.FStar_Syntax_Syntax.sigopts)
                  } in
                ([se2], [], env)
            | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uvs, tps, c, flags)
                ->
-               let uu____1773 =
-                 let uu____1782 =
+               let uu___2 =
+                 let uu___3 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____1782
+                 if uu___3
                  then
-                   let uu____1791 =
-                     let uu____1792 =
-                       let uu____1793 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_TypeChecker_TcEffect.tc_effect_abbrev
-                           (let uu___383_1804 = env in
+                           (let uu___7 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___383_1804.FStar_TypeChecker_Env.solver);
+                                (uu___7.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___383_1804.FStar_TypeChecker_Env.range);
+                                (uu___7.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___383_1804.FStar_TypeChecker_Env.curmodule);
+                                (uu___7.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___383_1804.FStar_TypeChecker_Env.gamma);
+                                (uu___7.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___383_1804.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___7.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___383_1804.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___7.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___383_1804.FStar_TypeChecker_Env.modules);
+                                (uu___7.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___383_1804.FStar_TypeChecker_Env.expected_typ);
+                                (uu___7.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___383_1804.FStar_TypeChecker_Env.sigtab);
+                                (uu___7.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___383_1804.FStar_TypeChecker_Env.attrtab);
+                                (uu___7.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___383_1804.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___383_1804.FStar_TypeChecker_Env.effects);
+                                (uu___7.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___383_1804.FStar_TypeChecker_Env.generalize);
+                                (uu___7.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___383_1804.FStar_TypeChecker_Env.letrecs);
+                                (uu___7.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___383_1804.FStar_TypeChecker_Env.top_level);
+                                (uu___7.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___383_1804.FStar_TypeChecker_Env.check_uvars);
+                                (uu___7.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___383_1804.FStar_TypeChecker_Env.use_eq);
+                                (uu___7.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___383_1804.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___383_1804.FStar_TypeChecker_Env.is_iface);
+                                (uu___7.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___383_1804.FStar_TypeChecker_Env.admit);
+                                (uu___7.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___383_1804.FStar_TypeChecker_Env.lax_universes);
+                                (uu___7.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 = true;
                               FStar_TypeChecker_Env.failhard =
-                                (uu___383_1804.FStar_TypeChecker_Env.failhard);
+                                (uu___7.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___383_1804.FStar_TypeChecker_Env.nosynth);
+                                (uu___7.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___383_1804.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___383_1804.FStar_TypeChecker_Env.tc_term);
+                                (uu___7.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___383_1804.FStar_TypeChecker_Env.type_of);
+                                (uu___7.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___383_1804.FStar_TypeChecker_Env.universe_of);
+                                (uu___7.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___383_1804.FStar_TypeChecker_Env.check_type_of);
+                                (uu___7.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___383_1804.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___383_1804.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___383_1804.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___383_1804.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___383_1804.FStar_TypeChecker_Env.proof_ns);
+                                (uu___7.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___383_1804.FStar_TypeChecker_Env.synth_hook);
+                                (uu___7.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___383_1804.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___383_1804.FStar_TypeChecker_Env.splice);
+                                (uu___7.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___383_1804.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___7.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___383_1804.FStar_TypeChecker_Env.postprocess);
+                                (uu___7.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___383_1804.FStar_TypeChecker_Env.identifier_info);
+                                (uu___7.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___383_1804.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___7.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___383_1804.FStar_TypeChecker_Env.dsenv);
+                                (uu___7.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___383_1804.FStar_TypeChecker_Env.nbe);
+                                (uu___7.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___383_1804.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___383_1804.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___383_1804.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) (lid, uvs, tps, c) r in
-                       FStar_All.pipe_right uu____1793
-                         (fun uu____1819 ->
-                            match uu____1819 with
+                       FStar_All.pipe_right uu___6
+                         (fun uu___7 ->
+                            match uu___7 with
                             | (lid1, uvs1, tps1, c1) ->
-                                let uu___390_1832 = se1 in
+                                let uu___8 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_effect_abbrev
                                        (lid1, uvs1, tps1, c1, flags));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___390_1832.FStar_Syntax_Syntax.sigrng);
+                                    (uu___8.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___390_1832.FStar_Syntax_Syntax.sigquals);
+                                    (uu___8.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___390_1832.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___8.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___390_1832.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___8.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___390_1832.FStar_Syntax_Syntax.sigopts)
+                                    (uu___8.FStar_Syntax_Syntax.sigopts)
                                 }) in
-                     FStar_All.pipe_right uu____1792
+                     FStar_All.pipe_right uu___5
                        (FStar_TypeChecker_Normalize.elim_uvars env) in
-                   FStar_All.pipe_right uu____1791
+                   FStar_All.pipe_right uu___4
                      (fun se2 ->
                         match se2.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_effect_abbrev
-                            (lid1, uvs1, tps1, c1, uu____1862) ->
+                            (lid1, uvs1, tps1, c1, uu___5) ->
                             (lid1, uvs1, tps1, c1)
-                        | uu____1867 ->
+                        | uu___5 ->
                             failwith
                               "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c) in
-               (match uu____1773 with
+               (match uu___2 with
                 | (lid1, uvs1, tps1, c1) ->
-                    let uu____1891 =
+                    let uu___3 =
                       FStar_TypeChecker_TcEffect.tc_effect_abbrev env
                         (lid1, uvs1, tps1, c1) r in
-                    (match uu____1891 with
+                    (match uu___3 with
                      | (lid2, uvs2, tps2, c2) ->
                          let se2 =
-                           let uu___411_1915 = se1 in
+                           let uu___4 = se1 in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
                                   (lid2, uvs2, tps2, c2, flags));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___411_1915.FStar_Syntax_Syntax.sigrng);
+                               (uu___4.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___411_1915.FStar_Syntax_Syntax.sigquals);
+                               (uu___4.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___411_1915.FStar_Syntax_Syntax.sigmeta);
+                               (uu___4.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___411_1915.FStar_Syntax_Syntax.sigattrs);
+                               (uu___4.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___411_1915.FStar_Syntax_Syntax.sigopts)
+                               (uu___4.FStar_Syntax_Syntax.sigopts)
                            } in
                          ([se2], [], env0)))
-           | FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____1922, uu____1923, uu____1924) when
+           | FStar_Syntax_Syntax.Sig_declare_typ (uu___2, uu___3, uu___4)
+               when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_1928 ->
-                       match uu___0_1928 with
+                    (fun uu___5 ->
+                       match uu___5 with
                        | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu____1929 -> false))
+                       | uu___6 -> false))
                -> ([], [], env0)
-           | FStar_Syntax_Syntax.Sig_let (uu____1934, uu____1935) when
+           | FStar_Syntax_Syntax.Sig_let (uu___2, uu___3) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_1943 ->
-                       match uu___0_1943 with
+                    (fun uu___4 ->
+                       match uu___4 with
                        | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu____1944 -> false))
+                       | uu___5 -> false))
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t) ->
                let env1 = FStar_TypeChecker_Env.set_range env r in
-               ((let uu____1954 = FStar_TypeChecker_Env.lid_exists env1 lid in
-                 if uu____1954
+               ((let uu___3 = FStar_TypeChecker_Env.lid_exists env1 lid in
+                 if uu___3
                  then
-                   let uu____1955 =
-                     let uu____1960 =
-                       let uu____1961 = FStar_Ident.string_of_lid lid in
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_Ident.string_of_lid lid in
                        FStar_Util.format1
                          "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                         uu____1961 in
+                         uu___6 in
                      (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                       uu____1960) in
-                   FStar_Errors.raise_error uu____1955 r
+                       uu___5) in
+                   FStar_Errors.raise_error uu___4 r
                  else ());
-                (let uu____1963 =
-                   let uu____1972 =
+                (let uu___3 =
+                   let uu___4 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1) in
-                   if uu____1972
+                   if uu___4
                    then
-                     let uu____1981 =
+                     let uu___5 =
                        tc_declare_typ
-                         (let uu___435_1984 = env1 in
+                         (let uu___6 = env1 in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___435_1984.FStar_TypeChecker_Env.solver);
+                              (uu___6.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___435_1984.FStar_TypeChecker_Env.range);
+                              (uu___6.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___435_1984.FStar_TypeChecker_Env.curmodule);
+                              (uu___6.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___435_1984.FStar_TypeChecker_Env.gamma);
+                              (uu___6.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___435_1984.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___6.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___435_1984.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___6.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___435_1984.FStar_TypeChecker_Env.modules);
+                              (uu___6.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___435_1984.FStar_TypeChecker_Env.expected_typ);
+                              (uu___6.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___435_1984.FStar_TypeChecker_Env.sigtab);
+                              (uu___6.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___435_1984.FStar_TypeChecker_Env.attrtab);
+                              (uu___6.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___435_1984.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___435_1984.FStar_TypeChecker_Env.effects);
+                              (uu___6.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___435_1984.FStar_TypeChecker_Env.generalize);
+                              (uu___6.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___435_1984.FStar_TypeChecker_Env.letrecs);
+                              (uu___6.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___435_1984.FStar_TypeChecker_Env.top_level);
+                              (uu___6.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___435_1984.FStar_TypeChecker_Env.check_uvars);
+                              (uu___6.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___435_1984.FStar_TypeChecker_Env.use_eq);
+                              (uu___6.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___435_1984.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___435_1984.FStar_TypeChecker_Env.is_iface);
+                              (uu___6.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___435_1984.FStar_TypeChecker_Env.admit);
+                              (uu___6.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___435_1984.FStar_TypeChecker_Env.lax_universes);
+                              (uu___6.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___435_1984.FStar_TypeChecker_Env.failhard);
+                              (uu___6.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___435_1984.FStar_TypeChecker_Env.nosynth);
+                              (uu___6.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___435_1984.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___435_1984.FStar_TypeChecker_Env.tc_term);
+                              (uu___6.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___435_1984.FStar_TypeChecker_Env.type_of);
+                              (uu___6.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___435_1984.FStar_TypeChecker_Env.universe_of);
+                              (uu___6.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___435_1984.FStar_TypeChecker_Env.check_type_of);
+                              (uu___6.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___435_1984.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___435_1984.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___435_1984.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___435_1984.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___435_1984.FStar_TypeChecker_Env.proof_ns);
+                              (uu___6.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___435_1984.FStar_TypeChecker_Env.synth_hook);
+                              (uu___6.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___435_1984.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___435_1984.FStar_TypeChecker_Env.splice);
+                              (uu___6.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___435_1984.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___6.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___435_1984.FStar_TypeChecker_Env.postprocess);
+                              (uu___6.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___435_1984.FStar_TypeChecker_Env.identifier_info);
+                              (uu___6.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___435_1984.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___6.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___435_1984.FStar_TypeChecker_Env.dsenv);
+                              (uu___6.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___435_1984.FStar_TypeChecker_Env.nbe);
+                              (uu___6.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___435_1984.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___435_1984.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___435_1984.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
-                     match uu____1981 with
+                     match uu___5 with
                      | (uvs1, t1) ->
-                         ((let uu____2008 =
+                         ((let uu___7 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases") in
-                           if uu____2008
+                           if uu___7
                            then
-                             let uu____2009 =
+                             let uu___8 =
                                FStar_Syntax_Print.term_to_string t1 in
-                             let uu____2010 =
+                             let uu___9 =
                                FStar_Syntax_Print.univ_names_to_string uvs1 in
                              FStar_Util.print2
                                "Val declaration after phase 1: %s and uvs: %s\n"
-                               uu____2009 uu____2010
+                               uu___8 uu___9
                            else ());
                           (uvs1, t1))
                    else (uvs, t) in
-                 match uu____1963 with
+                 match uu___3 with
                  | (uvs1, t1) ->
-                     let uu____2041 =
+                     let uu___4 =
                        tc_declare_typ env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng in
-                     (match uu____2041 with
+                     (match uu___4 with
                       | (uvs2, t2) ->
-                          ([(let uu___448_2071 = se1 in
+                          ([(let uu___5 = se1 in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_declare_typ
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___448_2071.FStar_Syntax_Syntax.sigrng);
+                                 (uu___5.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___448_2071.FStar_Syntax_Syntax.sigquals);
+                                 (uu___5.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___448_2071.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___5.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___448_2071.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___5.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___448_2071.FStar_Syntax_Syntax.sigopts)
+                                 (uu___5.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_assume (lid, uvs, t) ->
-               ((let uu____2076 =
-                   let uu____2081 =
-                     let uu____2082 = FStar_Syntax_Print.lid_to_string lid in
+               ((let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Print.lid_to_string lid in
                      FStar_Util.format1 "Admitting a top-level assumption %s"
-                       uu____2082 in
-                   (FStar_Errors.Warning_WarnOnUse, uu____2081) in
-                 FStar_Errors.log_issue r uu____2076);
+                       uu___5 in
+                   (FStar_Errors.Warning_WarnOnUse, uu___4) in
+                 FStar_Errors.log_issue r uu___3);
                 (let env1 = FStar_TypeChecker_Env.set_range env r in
-                 let uu____2084 =
-                   let uu____2093 =
+                 let uu___3 =
+                   let uu___4 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1) in
-                   if uu____2093
+                   if uu___4
                    then
-                     let uu____2102 =
+                     let uu___5 =
                        tc_assume
-                         (let uu___458_2105 = env1 in
+                         (let uu___6 = env1 in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___458_2105.FStar_TypeChecker_Env.solver);
+                              (uu___6.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___458_2105.FStar_TypeChecker_Env.range);
+                              (uu___6.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___458_2105.FStar_TypeChecker_Env.curmodule);
+                              (uu___6.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___458_2105.FStar_TypeChecker_Env.gamma);
+                              (uu___6.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___458_2105.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___6.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___458_2105.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___6.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___458_2105.FStar_TypeChecker_Env.modules);
+                              (uu___6.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___458_2105.FStar_TypeChecker_Env.expected_typ);
+                              (uu___6.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___458_2105.FStar_TypeChecker_Env.sigtab);
+                              (uu___6.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___458_2105.FStar_TypeChecker_Env.attrtab);
+                              (uu___6.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___458_2105.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___458_2105.FStar_TypeChecker_Env.effects);
+                              (uu___6.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___458_2105.FStar_TypeChecker_Env.generalize);
+                              (uu___6.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___458_2105.FStar_TypeChecker_Env.letrecs);
+                              (uu___6.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___458_2105.FStar_TypeChecker_Env.top_level);
+                              (uu___6.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___458_2105.FStar_TypeChecker_Env.check_uvars);
+                              (uu___6.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___458_2105.FStar_TypeChecker_Env.use_eq);
+                              (uu___6.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___458_2105.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___458_2105.FStar_TypeChecker_Env.is_iface);
+                              (uu___6.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___458_2105.FStar_TypeChecker_Env.admit);
+                              (uu___6.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___458_2105.FStar_TypeChecker_Env.lax_universes);
+                              (uu___6.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___458_2105.FStar_TypeChecker_Env.failhard);
+                              (uu___6.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___458_2105.FStar_TypeChecker_Env.nosynth);
+                              (uu___6.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___458_2105.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___458_2105.FStar_TypeChecker_Env.tc_term);
+                              (uu___6.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___458_2105.FStar_TypeChecker_Env.type_of);
+                              (uu___6.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___458_2105.FStar_TypeChecker_Env.universe_of);
+                              (uu___6.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___458_2105.FStar_TypeChecker_Env.check_type_of);
+                              (uu___6.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___458_2105.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___458_2105.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___458_2105.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___458_2105.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___458_2105.FStar_TypeChecker_Env.proof_ns);
+                              (uu___6.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___458_2105.FStar_TypeChecker_Env.synth_hook);
+                              (uu___6.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___458_2105.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___458_2105.FStar_TypeChecker_Env.splice);
+                              (uu___6.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___458_2105.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___6.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___458_2105.FStar_TypeChecker_Env.postprocess);
+                              (uu___6.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___458_2105.FStar_TypeChecker_Env.identifier_info);
+                              (uu___6.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___458_2105.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___6.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___458_2105.FStar_TypeChecker_Env.dsenv);
+                              (uu___6.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___458_2105.FStar_TypeChecker_Env.nbe);
+                              (uu___6.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___458_2105.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___458_2105.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___458_2105.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
-                     match uu____2102 with
+                     match uu___5 with
                      | (uvs1, t1) ->
-                         ((let uu____2129 =
+                         ((let uu___7 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases") in
-                           if uu____2129
+                           if uu___7
                            then
-                             let uu____2130 =
+                             let uu___8 =
                                FStar_Syntax_Print.term_to_string t1 in
-                             let uu____2131 =
+                             let uu___9 =
                                FStar_Syntax_Print.univ_names_to_string uvs1 in
                              FStar_Util.print2
                                "Assume after phase 1: %s and uvs: %s\n"
-                               uu____2130 uu____2131
+                               uu___8 uu___9
                            else ());
                           (uvs1, t1))
                    else (uvs, t) in
-                 match uu____2084 with
+                 match uu___3 with
                  | (uvs1, t1) ->
-                     let uu____2162 =
+                     let uu___4 =
                        tc_assume env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng in
-                     (match uu____2162 with
+                     (match uu___4 with
                       | (uvs2, t2) ->
-                          ([(let uu___471_2192 = se1 in
+                          ([(let uu___5 = se1 in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_assume
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___471_2192.FStar_Syntax_Syntax.sigrng);
+                                 (uu___5.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___471_2192.FStar_Syntax_Syntax.sigquals);
+                                 (uu___5.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___471_2192.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___5.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___471_2192.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___5.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___471_2192.FStar_Syntax_Syntax.sigopts)
+                                 (uu___5.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
-               ((let uu____2200 = FStar_Options.debug_any () in
-                 if uu____2200
+               ((let uu___3 = FStar_Options.debug_any () in
+                 if uu___3
                  then
-                   let uu____2201 =
+                   let uu___4 =
                      FStar_Ident.string_of_lid
                        env.FStar_TypeChecker_Env.curmodule in
-                   let uu____2202 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2201
-                     uu____2202
+                   let uu___5 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu___4
+                     uu___5
                  else ());
-                (let uu____2204 =
+                (let uu___3 =
                    FStar_TypeChecker_TcTerm.tc_tactic
                      FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_decls
                      env t in
-                 match uu____2204 with
-                 | (t1, uu____2222, g) ->
+                 match uu___3 with
+                 | (t1, uu___4, g) ->
                      (FStar_TypeChecker_Rel.force_trivial_guard env g;
                       (let ses =
                          env.FStar_TypeChecker_Env.splice env
@@ -2027,144 +2009,143 @@ let (tc_decl' :
                            ses in
                        FStar_List.iter
                          (fun lid ->
-                            let uu____2236 =
+                            let uu___7 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids' in
-                            match uu____2236 with
+                            match uu___7 with
                             | FStar_Pervasives_Native.None when
                                 Prims.op_Negation
                                   env.FStar_TypeChecker_Env.nosynth
                                 ->
-                                let uu____2239 =
-                                  let uu____2244 =
-                                    let uu____2245 =
+                                let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 =
                                       FStar_Ident.string_of_lid lid in
-                                    let uu____2246 =
-                                      let uu____2247 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_List.map
                                           FStar_Ident.string_of_lid lids' in
                                       FStar_All.pipe_left
-                                        (FStar_String.concat ", ") uu____2247 in
+                                        (FStar_String.concat ", ") uu___12 in
                                     FStar_Util.format2
                                       "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                      uu____2245 uu____2246 in
-                                  (FStar_Errors.Fatal_SplicedUndef,
-                                    uu____2244) in
-                                FStar_Errors.raise_error uu____2239 r
-                            | uu____2252 -> ()) lids;
+                                      uu___10 uu___11 in
+                                  (FStar_Errors.Fatal_SplicedUndef, uu___9) in
+                                FStar_Errors.raise_error uu___8 r
+                            | uu___8 -> ()) lids;
                        (let dsenv =
                           FStar_List.fold_left
                             FStar_Syntax_DsEnv.push_sigelt_force
                             env.FStar_TypeChecker_Env.dsenv ses in
                         let env1 =
-                          let uu___491_2257 = env in
+                          let uu___7 = env in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___491_2257.FStar_TypeChecker_Env.solver);
+                              (uu___7.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___491_2257.FStar_TypeChecker_Env.range);
+                              (uu___7.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___491_2257.FStar_TypeChecker_Env.curmodule);
+                              (uu___7.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___491_2257.FStar_TypeChecker_Env.gamma);
+                              (uu___7.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___491_2257.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___7.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___491_2257.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___7.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___491_2257.FStar_TypeChecker_Env.modules);
+                              (uu___7.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___491_2257.FStar_TypeChecker_Env.expected_typ);
+                              (uu___7.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___491_2257.FStar_TypeChecker_Env.sigtab);
+                              (uu___7.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___491_2257.FStar_TypeChecker_Env.attrtab);
+                              (uu___7.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___491_2257.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___491_2257.FStar_TypeChecker_Env.effects);
+                              (uu___7.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___491_2257.FStar_TypeChecker_Env.generalize);
+                              (uu___7.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___491_2257.FStar_TypeChecker_Env.letrecs);
+                              (uu___7.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___491_2257.FStar_TypeChecker_Env.top_level);
+                              (uu___7.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___491_2257.FStar_TypeChecker_Env.check_uvars);
+                              (uu___7.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___491_2257.FStar_TypeChecker_Env.use_eq);
+                              (uu___7.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___491_2257.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___491_2257.FStar_TypeChecker_Env.is_iface);
+                              (uu___7.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___491_2257.FStar_TypeChecker_Env.admit);
+                              (uu___7.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax =
-                              (uu___491_2257.FStar_TypeChecker_Env.lax);
+                              (uu___7.FStar_TypeChecker_Env.lax);
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___491_2257.FStar_TypeChecker_Env.lax_universes);
+                              (uu___7.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___491_2257.FStar_TypeChecker_Env.phase1);
+                              (uu___7.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___491_2257.FStar_TypeChecker_Env.failhard);
+                              (uu___7.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___491_2257.FStar_TypeChecker_Env.nosynth);
+                              (uu___7.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___491_2257.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___491_2257.FStar_TypeChecker_Env.tc_term);
+                              (uu___7.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___491_2257.FStar_TypeChecker_Env.type_of);
+                              (uu___7.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___491_2257.FStar_TypeChecker_Env.universe_of);
+                              (uu___7.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___491_2257.FStar_TypeChecker_Env.check_type_of);
+                              (uu___7.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___491_2257.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___491_2257.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___491_2257.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___491_2257.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___491_2257.FStar_TypeChecker_Env.proof_ns);
+                              (uu___7.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___491_2257.FStar_TypeChecker_Env.synth_hook);
+                              (uu___7.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___491_2257.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___491_2257.FStar_TypeChecker_Env.splice);
+                              (uu___7.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___491_2257.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___7.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___491_2257.FStar_TypeChecker_Env.postprocess);
+                              (uu___7.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___491_2257.FStar_TypeChecker_Env.identifier_info);
+                              (uu___7.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___491_2257.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___7.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv = dsenv;
                             FStar_TypeChecker_Env.nbe =
-                              (uu___491_2257.FStar_TypeChecker_Env.nbe);
+                              (uu___7.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___491_2257.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___491_2257.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___491_2257.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
                           } in
-                        (let uu____2259 =
+                        (let uu___8 =
                            FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-                         if uu____2259
+                         if uu___8
                          then
-                           let uu____2260 =
-                             let uu____2261 =
+                           let uu___9 =
+                             let uu___10 =
                                FStar_List.map
                                  FStar_Syntax_Print.sigelt_to_string ses in
                              FStar_All.pipe_left (FStar_String.concat "\n")
-                               uu____2261 in
+                               uu___10 in
                            FStar_Util.print1
-                             "Splice returned sigelts {\n%s\n}\n" uu____2260
+                             "Splice returned sigelts {\n%s\n}\n" uu___9
                          else ());
                         ([], ses, env1))))))
            | FStar_Syntax_Syntax.Sig_let (lbs, lids) ->
@@ -2178,138 +2159,134 @@ let (tc_decl' :
                        FStar_List.filter
                          (fun x ->
                             Prims.op_Negation (x = FStar_Syntax_Syntax.Logic)) in
-                     let uu____2334 =
-                       let uu____2335 =
-                         let uu____2344 = drop_logic val_q in
-                         let uu____2347 = drop_logic q' in
-                         (uu____2344, uu____2347) in
-                       match uu____2335 with
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = drop_logic val_q in
+                         let uu___5 = drop_logic q' in (uu___4, uu___5) in
+                       match uu___3 with
                        | (val_q1, q'1) ->
                            ((FStar_List.length val_q1) =
                               (FStar_List.length q'1))
                              &&
                              (FStar_List.forall2
                                 FStar_Syntax_Util.qualifier_equal val_q1 q'1) in
-                     if uu____2334
+                     if uu___2
                      then FStar_Pervasives_Native.Some q'
                      else
-                       (let uu____2371 =
-                          let uu____2376 =
-                            let uu____2377 =
-                              FStar_Syntax_Print.lid_to_string l in
-                            let uu____2378 =
+                       (let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Print.lid_to_string l in
+                            let uu___7 =
                               FStar_Syntax_Print.quals_to_string val_q in
-                            let uu____2379 =
+                            let uu___8 =
                               FStar_Syntax_Print.quals_to_string q' in
                             FStar_Util.format3
                               "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                              uu____2377 uu____2378 uu____2379 in
+                              uu___6 uu___7 uu___8 in
                           (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                            uu____2376) in
-                        FStar_Errors.raise_error uu____2371 r) in
+                            uu___5) in
+                        FStar_Errors.raise_error uu___4 r) in
                let rename_parameters lb =
                  let rename_in_typ def typ =
                    let typ1 = FStar_Syntax_Subst.compress typ in
                    let def_bs =
-                     let uu____2413 =
-                       let uu____2414 = FStar_Syntax_Subst.compress def in
-                       uu____2414.FStar_Syntax_Syntax.n in
-                     match uu____2413 with
-                     | FStar_Syntax_Syntax.Tm_abs
-                         (binders, uu____2426, uu____2427) -> binders
-                     | uu____2452 -> [] in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Subst.compress def in
+                       uu___3.FStar_Syntax_Syntax.n in
+                     match uu___2 with
+                     | FStar_Syntax_Syntax.Tm_abs (binders, uu___3, uu___4)
+                         -> binders
+                     | uu___3 -> [] in
                    match typ1 with
                    | {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                          (val_bs, c);
                        FStar_Syntax_Syntax.pos = r1;
-                       FStar_Syntax_Syntax.vars = uu____2464;_} ->
+                       FStar_Syntax_Syntax.vars = uu___2;_} ->
                        let has_auto_name bv =
-                         let uu____2493 =
+                         let uu___3 =
                            FStar_Ident.string_of_id
                              bv.FStar_Syntax_Syntax.ppname in
-                         FStar_Util.starts_with uu____2493
+                         FStar_Util.starts_with uu___3
                            FStar_Ident.reserved_prefix in
                        let rec rename_binders def_bs1 val_bs1 =
                          match (def_bs1, val_bs1) with
-                         | ([], uu____2569) -> val_bs1
-                         | (uu____2600, []) -> val_bs1
-                         | ((body_bv, uu____2632)::bt, (val_bv, aqual)::vt)
-                             ->
-                             let uu____2689 =
-                               let uu____2696 =
-                                 let uu____2701 = has_auto_name body_bv in
-                                 let uu____2702 = has_auto_name val_bv in
-                                 (uu____2701, uu____2702) in
-                               match uu____2696 with
-                               | (true, uu____2709) -> (val_bv, aqual)
+                         | ([], uu___3) -> val_bs1
+                         | (uu___3, []) -> val_bs1
+                         | ((body_bv, uu___3)::bt, (val_bv, aqual)::vt) ->
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 = has_auto_name body_bv in
+                                 let uu___7 = has_auto_name val_bv in
+                                 (uu___6, uu___7) in
+                               match uu___5 with
+                               | (true, uu___6) -> (val_bv, aqual)
                                | (false, true) ->
-                                   let uu____2712 =
-                                     let uu___562_2713 = val_bv in
-                                     let uu____2714 =
-                                       let uu____2715 =
-                                         let uu____2720 =
+                                   let uu___6 =
+                                     let uu___7 = val_bv in
+                                     let uu___8 =
+                                       let uu___9 =
+                                         let uu___10 =
                                            FStar_Ident.string_of_id
                                              body_bv.FStar_Syntax_Syntax.ppname in
-                                         let uu____2721 =
+                                         let uu___11 =
                                            FStar_Ident.range_of_id
                                              val_bv.FStar_Syntax_Syntax.ppname in
-                                         (uu____2720, uu____2721) in
-                                       FStar_Ident.mk_ident uu____2715 in
+                                         (uu___10, uu___11) in
+                                       FStar_Ident.mk_ident uu___9 in
                                      {
-                                       FStar_Syntax_Syntax.ppname =
-                                         uu____2714;
+                                       FStar_Syntax_Syntax.ppname = uu___8;
                                        FStar_Syntax_Syntax.index =
-                                         (uu___562_2713.FStar_Syntax_Syntax.index);
+                                         (uu___7.FStar_Syntax_Syntax.index);
                                        FStar_Syntax_Syntax.sort =
-                                         (uu___562_2713.FStar_Syntax_Syntax.sort)
+                                         (uu___7.FStar_Syntax_Syntax.sort)
                                      } in
-                                   (uu____2712, aqual)
+                                   (uu___6, aqual)
                                | (false, false) -> (val_bv, aqual) in
-                             let uu____2726 = rename_binders bt vt in
-                             uu____2689 :: uu____2726 in
-                       let uu____2741 =
-                         let uu____2742 =
-                           let uu____2757 = rename_binders def_bs val_bs in
-                           (uu____2757, c) in
-                         FStar_Syntax_Syntax.Tm_arrow uu____2742 in
-                       FStar_Syntax_Syntax.mk uu____2741 r1
-                   | uu____2776 -> typ1 in
-                 let uu___568_2777 = lb in
-                 let uu____2778 =
+                             let uu___5 = rename_binders bt vt in uu___4 ::
+                               uu___5 in
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = rename_binders def_bs val_bs in
+                           (uu___5, c) in
+                         FStar_Syntax_Syntax.Tm_arrow uu___4 in
+                       FStar_Syntax_Syntax.mk uu___3 r1
+                   | uu___2 -> typ1 in
+                 let uu___2 = lb in
+                 let uu___3 =
                    rename_in_typ lb.FStar_Syntax_Syntax.lbdef
                      lb.FStar_Syntax_Syntax.lbtyp in
                  {
                    FStar_Syntax_Syntax.lbname =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbname);
+                     (uu___2.FStar_Syntax_Syntax.lbname);
                    FStar_Syntax_Syntax.lbunivs =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbunivs);
-                   FStar_Syntax_Syntax.lbtyp = uu____2778;
+                     (uu___2.FStar_Syntax_Syntax.lbunivs);
+                   FStar_Syntax_Syntax.lbtyp = uu___3;
                    FStar_Syntax_Syntax.lbeff =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbeff);
+                     (uu___2.FStar_Syntax_Syntax.lbeff);
                    FStar_Syntax_Syntax.lbdef =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbdef);
+                     (uu___2.FStar_Syntax_Syntax.lbdef);
                    FStar_Syntax_Syntax.lbattrs =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbattrs);
+                     (uu___2.FStar_Syntax_Syntax.lbattrs);
                    FStar_Syntax_Syntax.lbpos =
-                     (uu___568_2777.FStar_Syntax_Syntax.lbpos)
+                     (uu___2.FStar_Syntax_Syntax.lbpos)
                  } in
-               let uu____2781 =
+               let uu___2 =
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                    (FStar_List.fold_left
-                      (fun uu____2832 ->
+                      (fun uu___3 ->
                          fun lb ->
-                           match uu____2832 with
+                           match uu___3 with
                            | (gen, lbs1, quals_opt) ->
                                let lbname =
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname in
-                               let uu____2874 =
-                                 let uu____2885 =
+                               let uu___4 =
+                                 let uu___5 =
                                    FStar_TypeChecker_Env.try_lookup_val_decl
                                      env1
                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                 match uu____2885 with
+                                 match uu___5 with
                                  | FStar_Pervasives_Native.None ->
                                      if lb.FStar_Syntax_Syntax.lbunivs <> []
                                      then (false, lb, quals_opt)
@@ -2325,7 +2302,7 @@ let (tc_decl' :
                                        with
                                        | FStar_Syntax_Syntax.Tm_unknown ->
                                            lb.FStar_Syntax_Syntax.lbdef
-                                       | uu____2958 ->
+                                       | uu___6 ->
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_ascribed
                                                 ((lb.FStar_Syntax_Syntax.lbdef),
@@ -2346,14 +2323,14 @@ let (tc_decl' :
                                             "Inline universes are incoherent with annotation from val declaration")
                                           r
                                       else ();
-                                      (let uu____3001 =
+                                      (let uu___7 =
                                          FStar_Syntax_Syntax.mk_lb
                                            ((FStar_Util.Inr lbname), uvs,
                                              FStar_Parser_Const.effect_ALL_lid,
                                              tval, def, [],
                                              (lb.FStar_Syntax_Syntax.lbpos)) in
-                                       (false, uu____3001, quals_opt1))) in
-                               (match uu____2874 with
+                                       (false, uu___7, quals_opt1))) in
+                               (match uu___4 with
                                 | (gen1, lb1, quals_opt1) ->
                                     (gen1, (lb1 :: lbs1), quals_opt1)))
                       (true, [],
@@ -2362,34 +2339,34 @@ let (tc_decl' :
                          else
                            FStar_Pervasives_Native.Some
                              (se1.FStar_Syntax_Syntax.sigquals)))) in
-               (match uu____2781 with
+               (match uu___2 with
                 | (should_generalize, lbs', quals_opt) ->
                     let quals =
                       match quals_opt with
                       | FStar_Pervasives_Native.None ->
                           [FStar_Syntax_Syntax.Visible_default]
                       | FStar_Pervasives_Native.Some q ->
-                          let uu____3093 =
+                          let uu___3 =
                             FStar_All.pipe_right q
                               (FStar_Util.for_some
-                                 (fun uu___1_3097 ->
-                                    match uu___1_3097 with
+                                 (fun uu___4 ->
+                                    match uu___4 with
                                     | FStar_Syntax_Syntax.Irreducible -> true
                                     | FStar_Syntax_Syntax.Visible_default ->
                                         true
                                     | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                         -> true
-                                    | uu____3098 -> false)) in
-                          if uu____3093
+                                    | uu___5 -> false)) in
+                          if uu___3
                           then q
                           else FStar_Syntax_Syntax.Visible_default :: q in
                     let lbs'1 = FStar_List.rev lbs' in
-                    let uu____3105 =
-                      let uu____3114 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Util.extract_attr'
                           FStar_Parser_Const.preprocess_with
                           se1.FStar_Syntax_Syntax.sigattrs in
-                      match uu____3114 with
+                      match uu___4 with
                       | FStar_Pervasives_Native.None ->
                           ((se1.FStar_Syntax_Syntax.sigattrs),
                             FStar_Pervasives_Native.None)
@@ -2402,53 +2379,53 @@ let (tc_decl' :
                                "Ill-formed application of `preprocess_with`");
                            ((se1.FStar_Syntax_Syntax.sigattrs),
                              FStar_Pervasives_Native.None)) in
-                    (match uu____3105 with
+                    (match uu___3 with
                      | (attrs, pre_tau) ->
                          let se2 =
-                           let uu___626_3217 = se1 in
+                           let uu___4 = se1 in
                            {
                              FStar_Syntax_Syntax.sigel =
-                               (uu___626_3217.FStar_Syntax_Syntax.sigel);
+                               (uu___4.FStar_Syntax_Syntax.sigel);
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___626_3217.FStar_Syntax_Syntax.sigrng);
+                               (uu___4.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___626_3217.FStar_Syntax_Syntax.sigquals);
+                               (uu___4.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___626_3217.FStar_Syntax_Syntax.sigmeta);
+                               (uu___4.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs = attrs;
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___626_3217.FStar_Syntax_Syntax.sigopts)
+                               (uu___4.FStar_Syntax_Syntax.sigopts)
                            } in
                          let preprocess_lb tau lb =
                            let lbdef =
                              FStar_TypeChecker_Env.preprocess env1 tau
                                lb.FStar_Syntax_Syntax.lbdef in
-                           (let uu____3231 =
+                           (let uu___5 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "TwoPhases") in
-                            if uu____3231
+                            if uu___5
                             then
-                              let uu____3232 =
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string lbdef in
                               FStar_Util.print1 "lb preprocessed into: %s\n"
-                                uu____3232
+                                uu___6
                             else ());
-                           (let uu___635_3234 = lb in
+                           (let uu___5 = lb in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbname);
+                                (uu___5.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbunivs);
+                                (uu___5.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbtyp);
+                                (uu___5.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbeff);
+                                (uu___5.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbattrs);
+                                (uu___5.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___635_3234.FStar_Syntax_Syntax.lbpos)
+                                (uu___5.FStar_Syntax_Syntax.lbpos)
                             }) in
                          let lbs'2 =
                            match pre_tau with
@@ -2456,361 +2433,358 @@ let (tc_decl' :
                                FStar_List.map (preprocess_lb tau) lbs'1
                            | FStar_Pervasives_Native.None -> lbs'1 in
                          let e =
-                           let uu____3244 =
-                             let uu____3245 =
-                               let uu____3258 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_constant
                                       FStar_Const.Const_unit) r in
                                (((FStar_Pervasives_Native.fst lbs), lbs'2),
-                                 uu____3258) in
-                             FStar_Syntax_Syntax.Tm_let uu____3245 in
-                           FStar_Syntax_Syntax.mk uu____3244 r in
+                                 uu___6) in
+                             FStar_Syntax_Syntax.Tm_let uu___5 in
+                           FStar_Syntax_Syntax.mk uu___4 r in
                          let env' =
-                           let uu___642_3274 = env1 in
+                           let uu___4 = env1 in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___642_3274.FStar_TypeChecker_Env.solver);
+                               (uu___4.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___642_3274.FStar_TypeChecker_Env.range);
+                               (uu___4.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___642_3274.FStar_TypeChecker_Env.curmodule);
+                               (uu___4.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___642_3274.FStar_TypeChecker_Env.gamma);
+                               (uu___4.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___642_3274.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___4.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___642_3274.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___4.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___642_3274.FStar_TypeChecker_Env.modules);
+                               (uu___4.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___642_3274.FStar_TypeChecker_Env.expected_typ);
+                               (uu___4.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___642_3274.FStar_TypeChecker_Env.sigtab);
+                               (uu___4.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___642_3274.FStar_TypeChecker_Env.attrtab);
+                               (uu___4.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___642_3274.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___642_3274.FStar_TypeChecker_Env.effects);
+                               (uu___4.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
                                should_generalize;
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___642_3274.FStar_TypeChecker_Env.letrecs);
+                               (uu___4.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level = true;
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___642_3274.FStar_TypeChecker_Env.check_uvars);
+                               (uu___4.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___642_3274.FStar_TypeChecker_Env.use_eq);
+                               (uu___4.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___642_3274.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___642_3274.FStar_TypeChecker_Env.is_iface);
+                               (uu___4.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___642_3274.FStar_TypeChecker_Env.admit);
+                               (uu___4.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___642_3274.FStar_TypeChecker_Env.lax);
+                               (uu___4.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___642_3274.FStar_TypeChecker_Env.lax_universes);
+                               (uu___4.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___642_3274.FStar_TypeChecker_Env.phase1);
+                               (uu___4.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___642_3274.FStar_TypeChecker_Env.failhard);
+                               (uu___4.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___642_3274.FStar_TypeChecker_Env.nosynth);
+                               (uu___4.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___642_3274.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___642_3274.FStar_TypeChecker_Env.tc_term);
+                               (uu___4.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___642_3274.FStar_TypeChecker_Env.type_of);
+                               (uu___4.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___642_3274.FStar_TypeChecker_Env.universe_of);
+                               (uu___4.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___642_3274.FStar_TypeChecker_Env.check_type_of);
+                               (uu___4.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___642_3274.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___642_3274.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___642_3274.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___642_3274.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___642_3274.FStar_TypeChecker_Env.proof_ns);
+                               (uu___4.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___642_3274.FStar_TypeChecker_Env.synth_hook);
+                               (uu___4.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___642_3274.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___642_3274.FStar_TypeChecker_Env.splice);
+                               (uu___4.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___642_3274.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___4.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___642_3274.FStar_TypeChecker_Env.postprocess);
+                               (uu___4.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___642_3274.FStar_TypeChecker_Env.identifier_info);
+                               (uu___4.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___642_3274.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___4.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___642_3274.FStar_TypeChecker_Env.dsenv);
+                               (uu___4.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___642_3274.FStar_TypeChecker_Env.nbe);
+                               (uu___4.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___642_3274.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___642_3274.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___642_3274.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let e1 =
-                           let uu____3276 =
+                           let uu___4 =
                              (FStar_Options.use_two_phase_tc ()) &&
                                (FStar_TypeChecker_Env.should_verify env') in
-                           if uu____3276
+                           if uu___4
                            then
                              let drop_lbtyp e_lax =
-                               let uu____3283 =
-                                 let uu____3284 =
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_Syntax_Subst.compress e_lax in
-                                 uu____3284.FStar_Syntax_Syntax.n in
-                               match uu____3283 with
+                                 uu___6.FStar_Syntax_Syntax.n in
+                               match uu___5 with
                                | FStar_Syntax_Syntax.Tm_let
                                    ((false, lb::[]), e2) ->
                                    let lb_unannotated =
-                                     let uu____3302 =
-                                       let uu____3303 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_Syntax_Subst.compress e in
-                                       uu____3303.FStar_Syntax_Syntax.n in
-                                     match uu____3302 with
+                                       uu___7.FStar_Syntax_Syntax.n in
+                                     match uu___6 with
                                      | FStar_Syntax_Syntax.Tm_let
-                                         ((uu____3306, lb1::[]), uu____3308)
-                                         ->
-                                         let uu____3321 =
-                                           let uu____3322 =
+                                         ((uu___7, lb1::[]), uu___8) ->
+                                         let uu___9 =
+                                           let uu___10 =
                                              FStar_Syntax_Subst.compress
                                                lb1.FStar_Syntax_Syntax.lbtyp in
-                                           uu____3322.FStar_Syntax_Syntax.n in
-                                         (match uu____3321 with
+                                           uu___10.FStar_Syntax_Syntax.n in
+                                         (match uu___9 with
                                           | FStar_Syntax_Syntax.Tm_unknown ->
                                               true
-                                          | uu____3325 -> false)
-                                     | uu____3326 ->
+                                          | uu___10 -> false)
+                                     | uu___7 ->
                                          failwith
                                            "Impossible: first phase lb and second phase lb differ in structure!" in
                                    if lb_unannotated
                                    then
-                                     let uu___667_3327 = e_lax in
+                                     let uu___6 = e_lax in
                                      {
                                        FStar_Syntax_Syntax.n =
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((false,
-                                               [(let uu___669_3339 = lb in
+                                               [(let uu___7 = lb in
                                                  {
                                                    FStar_Syntax_Syntax.lbname
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbname);
+                                                     (uu___7.FStar_Syntax_Syntax.lbname);
                                                    FStar_Syntax_Syntax.lbunivs
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbunivs);
+                                                     (uu___7.FStar_Syntax_Syntax.lbunivs);
                                                    FStar_Syntax_Syntax.lbtyp
                                                      =
                                                      FStar_Syntax_Syntax.tun;
                                                    FStar_Syntax_Syntax.lbeff
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbeff);
+                                                     (uu___7.FStar_Syntax_Syntax.lbeff);
                                                    FStar_Syntax_Syntax.lbdef
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbdef);
+                                                     (uu___7.FStar_Syntax_Syntax.lbdef);
                                                    FStar_Syntax_Syntax.lbattrs
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbattrs);
+                                                     (uu___7.FStar_Syntax_Syntax.lbattrs);
                                                    FStar_Syntax_Syntax.lbpos
                                                      =
-                                                     (uu___669_3339.FStar_Syntax_Syntax.lbpos)
+                                                     (uu___7.FStar_Syntax_Syntax.lbpos)
                                                  })]), e2));
                                        FStar_Syntax_Syntax.pos =
-                                         (uu___667_3327.FStar_Syntax_Syntax.pos);
+                                         (uu___6.FStar_Syntax_Syntax.pos);
                                        FStar_Syntax_Syntax.vars =
-                                         (uu___667_3327.FStar_Syntax_Syntax.vars)
+                                         (uu___6.FStar_Syntax_Syntax.vars)
                                      }
                                    else e_lax
-                               | uu____3341 -> e_lax in
-                             let uu____3342 =
+                               | uu___6 -> e_lax in
+                             let uu___5 =
                                FStar_Util.record_time
-                                 (fun uu____3352 ->
-                                    let uu____3353 =
+                                 (fun uu___6 ->
+                                    let uu___7 =
                                       FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                        (let uu___673_3362 = env' in
+                                        (let uu___8 = env' in
                                          {
                                            FStar_TypeChecker_Env.solver =
-                                             (uu___673_3362.FStar_TypeChecker_Env.solver);
+                                             (uu___8.FStar_TypeChecker_Env.solver);
                                            FStar_TypeChecker_Env.range =
-                                             (uu___673_3362.FStar_TypeChecker_Env.range);
+                                             (uu___8.FStar_TypeChecker_Env.range);
                                            FStar_TypeChecker_Env.curmodule =
-                                             (uu___673_3362.FStar_TypeChecker_Env.curmodule);
+                                             (uu___8.FStar_TypeChecker_Env.curmodule);
                                            FStar_TypeChecker_Env.gamma =
-                                             (uu___673_3362.FStar_TypeChecker_Env.gamma);
+                                             (uu___8.FStar_TypeChecker_Env.gamma);
                                            FStar_TypeChecker_Env.gamma_sig =
-                                             (uu___673_3362.FStar_TypeChecker_Env.gamma_sig);
+                                             (uu___8.FStar_TypeChecker_Env.gamma_sig);
                                            FStar_TypeChecker_Env.gamma_cache
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.gamma_cache);
+                                             (uu___8.FStar_TypeChecker_Env.gamma_cache);
                                            FStar_TypeChecker_Env.modules =
-                                             (uu___673_3362.FStar_TypeChecker_Env.modules);
+                                             (uu___8.FStar_TypeChecker_Env.modules);
                                            FStar_TypeChecker_Env.expected_typ
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.expected_typ);
+                                             (uu___8.FStar_TypeChecker_Env.expected_typ);
                                            FStar_TypeChecker_Env.sigtab =
-                                             (uu___673_3362.FStar_TypeChecker_Env.sigtab);
+                                             (uu___8.FStar_TypeChecker_Env.sigtab);
                                            FStar_TypeChecker_Env.attrtab =
-                                             (uu___673_3362.FStar_TypeChecker_Env.attrtab);
+                                             (uu___8.FStar_TypeChecker_Env.attrtab);
                                            FStar_TypeChecker_Env.instantiate_imp
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.instantiate_imp);
+                                             (uu___8.FStar_TypeChecker_Env.instantiate_imp);
                                            FStar_TypeChecker_Env.effects =
-                                             (uu___673_3362.FStar_TypeChecker_Env.effects);
+                                             (uu___8.FStar_TypeChecker_Env.effects);
                                            FStar_TypeChecker_Env.generalize =
-                                             (uu___673_3362.FStar_TypeChecker_Env.generalize);
+                                             (uu___8.FStar_TypeChecker_Env.generalize);
                                            FStar_TypeChecker_Env.letrecs =
-                                             (uu___673_3362.FStar_TypeChecker_Env.letrecs);
+                                             (uu___8.FStar_TypeChecker_Env.letrecs);
                                            FStar_TypeChecker_Env.top_level =
-                                             (uu___673_3362.FStar_TypeChecker_Env.top_level);
+                                             (uu___8.FStar_TypeChecker_Env.top_level);
                                            FStar_TypeChecker_Env.check_uvars
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.check_uvars);
+                                             (uu___8.FStar_TypeChecker_Env.check_uvars);
                                            FStar_TypeChecker_Env.use_eq =
-                                             (uu___673_3362.FStar_TypeChecker_Env.use_eq);
+                                             (uu___8.FStar_TypeChecker_Env.use_eq);
                                            FStar_TypeChecker_Env.use_eq_strict
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.use_eq_strict);
+                                             (uu___8.FStar_TypeChecker_Env.use_eq_strict);
                                            FStar_TypeChecker_Env.is_iface =
-                                             (uu___673_3362.FStar_TypeChecker_Env.is_iface);
+                                             (uu___8.FStar_TypeChecker_Env.is_iface);
                                            FStar_TypeChecker_Env.admit =
-                                             (uu___673_3362.FStar_TypeChecker_Env.admit);
+                                             (uu___8.FStar_TypeChecker_Env.admit);
                                            FStar_TypeChecker_Env.lax = true;
                                            FStar_TypeChecker_Env.lax_universes
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.lax_universes);
+                                             (uu___8.FStar_TypeChecker_Env.lax_universes);
                                            FStar_TypeChecker_Env.phase1 =
                                              true;
                                            FStar_TypeChecker_Env.failhard =
-                                             (uu___673_3362.FStar_TypeChecker_Env.failhard);
+                                             (uu___8.FStar_TypeChecker_Env.failhard);
                                            FStar_TypeChecker_Env.nosynth =
-                                             (uu___673_3362.FStar_TypeChecker_Env.nosynth);
+                                             (uu___8.FStar_TypeChecker_Env.nosynth);
                                            FStar_TypeChecker_Env.uvar_subtyping
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.uvar_subtyping);
+                                             (uu___8.FStar_TypeChecker_Env.uvar_subtyping);
                                            FStar_TypeChecker_Env.tc_term =
-                                             (uu___673_3362.FStar_TypeChecker_Env.tc_term);
+                                             (uu___8.FStar_TypeChecker_Env.tc_term);
                                            FStar_TypeChecker_Env.type_of =
-                                             (uu___673_3362.FStar_TypeChecker_Env.type_of);
+                                             (uu___8.FStar_TypeChecker_Env.type_of);
                                            FStar_TypeChecker_Env.universe_of
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.universe_of);
+                                             (uu___8.FStar_TypeChecker_Env.universe_of);
                                            FStar_TypeChecker_Env.check_type_of
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.check_type_of);
+                                             (uu___8.FStar_TypeChecker_Env.check_type_of);
                                            FStar_TypeChecker_Env.use_bv_sorts
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.use_bv_sorts);
+                                             (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                            FStar_TypeChecker_Env.qtbl_name_and_index
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                             (uu___8.FStar_TypeChecker_Env.qtbl_name_and_index);
                                            FStar_TypeChecker_Env.normalized_eff_names
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.normalized_eff_names);
+                                             (uu___8.FStar_TypeChecker_Env.normalized_eff_names);
                                            FStar_TypeChecker_Env.fv_delta_depths
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.fv_delta_depths);
+                                             (uu___8.FStar_TypeChecker_Env.fv_delta_depths);
                                            FStar_TypeChecker_Env.proof_ns =
-                                             (uu___673_3362.FStar_TypeChecker_Env.proof_ns);
+                                             (uu___8.FStar_TypeChecker_Env.proof_ns);
                                            FStar_TypeChecker_Env.synth_hook =
-                                             (uu___673_3362.FStar_TypeChecker_Env.synth_hook);
+                                             (uu___8.FStar_TypeChecker_Env.synth_hook);
                                            FStar_TypeChecker_Env.try_solve_implicits_hook
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                             (uu___8.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                            FStar_TypeChecker_Env.splice =
-                                             (uu___673_3362.FStar_TypeChecker_Env.splice);
+                                             (uu___8.FStar_TypeChecker_Env.splice);
                                            FStar_TypeChecker_Env.mpreprocess
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.mpreprocess);
+                                             (uu___8.FStar_TypeChecker_Env.mpreprocess);
                                            FStar_TypeChecker_Env.postprocess
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.postprocess);
+                                             (uu___8.FStar_TypeChecker_Env.postprocess);
                                            FStar_TypeChecker_Env.identifier_info
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.identifier_info);
+                                             (uu___8.FStar_TypeChecker_Env.identifier_info);
                                            FStar_TypeChecker_Env.tc_hooks =
-                                             (uu___673_3362.FStar_TypeChecker_Env.tc_hooks);
+                                             (uu___8.FStar_TypeChecker_Env.tc_hooks);
                                            FStar_TypeChecker_Env.dsenv =
-                                             (uu___673_3362.FStar_TypeChecker_Env.dsenv);
+                                             (uu___8.FStar_TypeChecker_Env.dsenv);
                                            FStar_TypeChecker_Env.nbe =
-                                             (uu___673_3362.FStar_TypeChecker_Env.nbe);
+                                             (uu___8.FStar_TypeChecker_Env.nbe);
                                            FStar_TypeChecker_Env.strict_args_tab
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.strict_args_tab);
+                                             (uu___8.FStar_TypeChecker_Env.strict_args_tab);
                                            FStar_TypeChecker_Env.erasable_types_tab
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.erasable_types_tab);
+                                             (uu___8.FStar_TypeChecker_Env.erasable_types_tab);
                                            FStar_TypeChecker_Env.enable_defer_to_tac
                                              =
-                                             (uu___673_3362.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                             (uu___8.FStar_TypeChecker_Env.enable_defer_to_tac)
                                          }) e in
-                                    match uu____3353 with
-                                    | (e1, uu____3364, uu____3365) -> e1) in
-                             match uu____3342 with
-                             | (e1, ms) ->
-                                 ((let uu____3369 =
+                                    match uu___7 with
+                                    | (e2, uu___8, uu___9) -> e2) in
+                             match uu___5 with
+                             | (e2, ms) ->
+                                 ((let uu___7 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TCDeclTime") in
-                                   if uu____3369
+                                   if uu___7
                                    then
-                                     let uu____3370 =
-                                       FStar_Util.string_of_int ms in
+                                     let uu___8 = FStar_Util.string_of_int ms in
                                      FStar_Util.print1
                                        "Let binding elaborated (phase 1) in %s milliseconds, now removing uvars\n"
-                                       uu____3370
+                                       uu___8
                                    else ());
-                                  (let uu____3373 =
+                                  (let uu___8 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TwoPhases") in
-                                   if uu____3373
+                                   if uu___8
                                    then
-                                     let uu____3374 =
-                                       FStar_Syntax_Print.term_to_string e1 in
+                                     let uu___9 =
+                                       FStar_Syntax_Print.term_to_string e2 in
                                      FStar_Util.print1
                                        "Let binding after phase 1, before removing uvars: %s\n"
-                                       uu____3374
+                                       uu___9
                                    else ());
-                                  (let e2 =
-                                     let uu____3377 =
+                                  (let e3 =
+                                     let uu___8 =
                                        FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                         env' e1 in
-                                     FStar_All.pipe_right uu____3377
-                                       drop_lbtyp in
-                                   (let uu____3379 =
+                                         env' e2 in
+                                     FStar_All.pipe_right uu___8 drop_lbtyp in
+                                   (let uu___9 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env1)
                                         (FStar_Options.Other "TwoPhases") in
-                                    if uu____3379
+                                    if uu___9
                                     then
-                                      let uu____3380 =
-                                        FStar_Syntax_Print.term_to_string e2 in
+                                      let uu___10 =
+                                        FStar_Syntax_Print.term_to_string e3 in
                                       FStar_Util.print1
                                         "Let binding after phase 1, uvars removed: %s\n"
-                                        uu____3380
+                                        uu___10
                                     else ());
-                                   e2))
+                                   e3))
                            else e in
-                         let uu____3383 =
-                           let uu____3392 =
+                         let uu___4 =
+                           let uu___5 =
                              FStar_Syntax_Util.extract_attr'
                                FStar_Parser_Const.postprocess_with
                                se2.FStar_Syntax_Syntax.sigattrs in
-                           match uu____3392 with
+                           match uu___5 with
                            | FStar_Pervasives_Native.None ->
                                ((se2.FStar_Syntax_Syntax.sigattrs),
                                  FStar_Pervasives_Native.None)
@@ -2823,28 +2797,28 @@ let (tc_decl' :
                                     "Ill-formed application of `postprocess_with`");
                                 ((se2.FStar_Syntax_Syntax.sigattrs),
                                   FStar_Pervasives_Native.None)) in
-                         (match uu____3383 with
+                         (match uu___4 with
                           | (attrs1, post_tau) ->
                               let se3 =
-                                let uu___706_3495 = se2 in
+                                let uu___5 = se2 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
-                                    (uu___706_3495.FStar_Syntax_Syntax.sigel);
+                                    (uu___5.FStar_Syntax_Syntax.sigel);
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___706_3495.FStar_Syntax_Syntax.sigrng);
+                                    (uu___5.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___706_3495.FStar_Syntax_Syntax.sigquals);
+                                    (uu___5.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___706_3495.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___5.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs = attrs1;
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___706_3495.FStar_Syntax_Syntax.sigopts)
+                                    (uu___5.FStar_Syntax_Syntax.sigopts)
                                 } in
                               let postprocess_lb tau lb =
-                                let uu____3507 =
+                                let uu___5 =
                                   FStar_Syntax_Subst.univ_var_opening
                                     lb.FStar_Syntax_Syntax.lbunivs in
-                                match uu____3507 with
+                                match uu___5 with
                                 | (s, univnames) ->
                                     let lbdef =
                                       FStar_Syntax_Subst.subst s
@@ -2861,65 +2835,63 @@ let (tc_decl' :
                                     let lbdef2 =
                                       FStar_Syntax_Subst.close_univ_vars
                                         univnames lbdef1 in
-                                    let uu___720_3531 = lb in
+                                    let uu___6 = lb in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbname);
+                                        (uu___6.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___6.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbtyp);
+                                        (uu___6.FStar_Syntax_Syntax.lbtyp);
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbeff);
+                                        (uu___6.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = lbdef2;
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___6.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___720_3531.FStar_Syntax_Syntax.lbpos)
+                                        (uu___6.FStar_Syntax_Syntax.lbpos)
                                     } in
-                              let uu____3532 =
+                              let uu___5 =
                                 FStar_Util.record_time
-                                  (fun uu____3550 ->
+                                  (fun uu___6 ->
                                      FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
                                        env' e1) in
-                              (match uu____3532 with
+                              (match uu___5 with
                                | (r1, ms) ->
-                                   ((let uu____3576 =
+                                   ((let uu___7 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "TCDeclTime") in
-                                     if uu____3576
+                                     if uu___7
                                      then
-                                       let uu____3577 =
+                                       let uu___8 =
                                          FStar_Util.string_of_int ms in
                                        FStar_Util.print1
                                          "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                         uu____3577
+                                         uu___8
                                      else ());
-                                    (let uu____3579 =
+                                    (let uu___7 =
                                        match r1 with
                                        | ({
                                             FStar_Syntax_Syntax.n =
                                               FStar_Syntax_Syntax.Tm_let
                                               (lbs1, e2);
-                                            FStar_Syntax_Syntax.pos =
-                                              uu____3602;
-                                            FStar_Syntax_Syntax.vars =
-                                              uu____3603;_},
-                                          uu____3604, g) when
+                                            FStar_Syntax_Syntax.pos = uu___8;
+                                            FStar_Syntax_Syntax.vars = uu___9;_},
+                                          uu___10, g) when
                                            FStar_TypeChecker_Env.is_trivial g
                                            ->
                                            let lbs2 =
-                                             let uu____3631 =
+                                             let uu___11 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.snd
                                                     lbs1)
                                                  (FStar_List.map
                                                     rename_parameters) in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs1), uu____3631) in
+                                                 lbs1), uu___11) in
                                            let lbs3 =
-                                             let uu____3651 =
+                                             let uu___11 =
                                                match post_tau with
                                                | FStar_Pervasives_Native.Some
                                                    tau ->
@@ -2932,38 +2904,38 @@ let (tc_decl' :
                                                    FStar_Pervasives_Native.snd
                                                      lbs2 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs2), uu____3651) in
+                                                 lbs2), uu___11) in
                                            let quals1 =
                                              match e2.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_meta
-                                                 (uu____3670,
+                                                 (uu___11,
                                                   FStar_Syntax_Syntax.Meta_desugared
                                                   (FStar_Syntax_Syntax.Masked_effect))
                                                  ->
                                                  FStar_Syntax_Syntax.HasMaskedEffect
                                                  :: quals
-                                             | uu____3675 -> quals in
-                                           ((let uu___750_3683 = se3 in
+                                             | uu___11 -> quals in
+                                           ((let uu___11 = se3 in
                                              {
                                                FStar_Syntax_Syntax.sigel =
                                                  (FStar_Syntax_Syntax.Sig_let
                                                     (lbs3, lids));
                                                FStar_Syntax_Syntax.sigrng =
-                                                 (uu___750_3683.FStar_Syntax_Syntax.sigrng);
+                                                 (uu___11.FStar_Syntax_Syntax.sigrng);
                                                FStar_Syntax_Syntax.sigquals =
                                                  quals1;
                                                FStar_Syntax_Syntax.sigmeta =
-                                                 (uu___750_3683.FStar_Syntax_Syntax.sigmeta);
+                                                 (uu___11.FStar_Syntax_Syntax.sigmeta);
                                                FStar_Syntax_Syntax.sigattrs =
-                                                 (uu___750_3683.FStar_Syntax_Syntax.sigattrs);
+                                                 (uu___11.FStar_Syntax_Syntax.sigattrs);
                                                FStar_Syntax_Syntax.sigopts =
-                                                 (uu___750_3683.FStar_Syntax_Syntax.sigopts)
+                                                 (uu___11.FStar_Syntax_Syntax.sigopts)
                                              }), lbs3)
-                                       | uu____3686 ->
+                                       | uu___8 ->
                                            failwith
                                              "impossible (typechecking should preserve Tm_let)" in
-                                     match uu____3579 with
+                                     match uu___7 with
                                      | (se4, lbs1) ->
                                          (FStar_All.pipe_right
                                             (FStar_Pervasives_Native.snd lbs1)
@@ -2975,442 +2947,430 @@ let (tc_decl' :
                                                   FStar_TypeChecker_Env.insert_fv_info
                                                     env1 fv
                                                     lb.FStar_Syntax_Syntax.lbtyp));
-                                          (let uu____3737 = log env1 in
-                                           if uu____3737
+                                          (let uu___10 = log env1 in
+                                           if uu___10
                                            then
-                                             let uu____3738 =
-                                               let uu____3739 =
+                                             let uu___11 =
+                                               let uu___12 =
                                                  FStar_All.pipe_right
                                                    (FStar_Pervasives_Native.snd
                                                       lbs1)
                                                    (FStar_List.map
                                                       (fun lb ->
                                                          let should_log =
-                                                           let uu____3754 =
-                                                             let uu____3763 =
-                                                               let uu____3764
-                                                                 =
-                                                                 let uu____3767
+                                                           let uu___13 =
+                                                             let uu___14 =
+                                                               let uu___15 =
+                                                                 let uu___16
                                                                    =
                                                                    FStar_Util.right
                                                                     lb.FStar_Syntax_Syntax.lbname in
-                                                                 uu____3767.FStar_Syntax_Syntax.fv_name in
-                                                               uu____3764.FStar_Syntax_Syntax.v in
+                                                                 uu___16.FStar_Syntax_Syntax.fv_name in
+                                                               uu___15.FStar_Syntax_Syntax.v in
                                                              FStar_TypeChecker_Env.try_lookup_val_decl
-                                                               env1
-                                                               uu____3763 in
-                                                           match uu____3754
-                                                           with
+                                                               env1 uu___14 in
+                                                           match uu___13 with
                                                            | FStar_Pervasives_Native.None
                                                                -> true
-                                                           | uu____3774 ->
-                                                               false in
+                                                           | uu___14 -> false in
                                                          if should_log
                                                          then
-                                                           let uu____3783 =
+                                                           let uu___13 =
                                                              FStar_Syntax_Print.lbname_to_string
                                                                lb.FStar_Syntax_Syntax.lbname in
-                                                           let uu____3784 =
+                                                           let uu___14 =
                                                              FStar_Syntax_Print.term_to_string
                                                                lb.FStar_Syntax_Syntax.lbtyp in
                                                            FStar_Util.format2
                                                              "let %s : %s"
-                                                             uu____3783
-                                                             uu____3784
+                                                             uu___13 uu___14
                                                          else "")) in
-                                               FStar_All.pipe_right
-                                                 uu____3739
+                                               FStar_All.pipe_right uu___12
                                                  (FStar_String.concat "\n") in
-                                             FStar_Util.print1 "%s\n"
-                                               uu____3738
+                                             FStar_Util.print1 "%s\n" uu___11
                                            else ());
                                           check_must_erase_attribute env0 se4;
                                           ([se4], [], env0))))))))
-           | FStar_Syntax_Syntax.Sig_polymonadic_bind
-               (m, n, p, t, uu____3798) ->
+           | FStar_Syntax_Syntax.Sig_polymonadic_bind (m, n, p, t, uu___2) ->
                let t1 =
-                 let uu____3800 =
+                 let uu___3 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____3800
+                 if uu___3
                  then
-                   let uu____3801 =
-                     let uu____3806 =
-                       let uu____3807 =
-                         let uu____3808 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_bind
-                             (let uu___775_3815 = env in
+                             (let uu___8 = env in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___775_3815.FStar_TypeChecker_Env.solver);
+                                  (uu___8.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___775_3815.FStar_TypeChecker_Env.range);
+                                  (uu___8.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___775_3815.FStar_TypeChecker_Env.curmodule);
+                                  (uu___8.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___775_3815.FStar_TypeChecker_Env.gamma);
+                                  (uu___8.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___775_3815.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___8.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___775_3815.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___8.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___775_3815.FStar_TypeChecker_Env.modules);
+                                  (uu___8.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___775_3815.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___8.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___775_3815.FStar_TypeChecker_Env.sigtab);
+                                  (uu___8.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___775_3815.FStar_TypeChecker_Env.attrtab);
+                                  (uu___8.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___775_3815.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___8.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___775_3815.FStar_TypeChecker_Env.effects);
+                                  (uu___8.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___775_3815.FStar_TypeChecker_Env.generalize);
+                                  (uu___8.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___775_3815.FStar_TypeChecker_Env.letrecs);
+                                  (uu___8.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___775_3815.FStar_TypeChecker_Env.top_level);
+                                  (uu___8.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___775_3815.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___8.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___775_3815.FStar_TypeChecker_Env.use_eq);
+                                  (uu___8.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___775_3815.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___8.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___775_3815.FStar_TypeChecker_Env.is_iface);
+                                  (uu___8.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___775_3815.FStar_TypeChecker_Env.admit);
+                                  (uu___8.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___775_3815.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___8.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___775_3815.FStar_TypeChecker_Env.failhard);
+                                  (uu___8.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___775_3815.FStar_TypeChecker_Env.nosynth);
+                                  (uu___8.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___775_3815.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___8.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___775_3815.FStar_TypeChecker_Env.tc_term);
+                                  (uu___8.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___775_3815.FStar_TypeChecker_Env.type_of);
+                                  (uu___8.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___775_3815.FStar_TypeChecker_Env.universe_of);
+                                  (uu___8.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___775_3815.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___8.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___775_3815.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___775_3815.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___8.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___775_3815.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___8.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___775_3815.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___8.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___775_3815.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___8.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___775_3815.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___8.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___775_3815.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___8.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___775_3815.FStar_TypeChecker_Env.splice);
+                                  (uu___8.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___775_3815.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___8.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___775_3815.FStar_TypeChecker_Env.postprocess);
+                                  (uu___8.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___775_3815.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___8.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___775_3815.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___8.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___775_3815.FStar_TypeChecker_Env.dsenv);
+                                  (uu___8.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___775_3815.FStar_TypeChecker_Env.nbe);
+                                  (uu___8.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___775_3815.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___8.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___775_3815.FStar_TypeChecker_Env.erasable_types_tab);
+                                  (uu___8.FStar_TypeChecker_Env.erasable_types_tab);
                                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                                  (uu___775_3815.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                  (uu___8.FStar_TypeChecker_Env.enable_defer_to_tac)
                               }) m n p t in
-                         FStar_All.pipe_right uu____3808
-                           (fun uu____3824 ->
-                              match uu____3824 with
-                              | (t1, ty) ->
-                                  let uu___780_3831 = se1 in
+                         FStar_All.pipe_right uu___7
+                           (fun uu___8 ->
+                              match uu___8 with
+                              | (t2, ty) ->
+                                  let uu___9 = se1 in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_bind
-                                         (m, n, p, t1, ty));
+                                         (m, n, p, t2, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___780_3831.FStar_Syntax_Syntax.sigrng);
+                                      (uu___9.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___780_3831.FStar_Syntax_Syntax.sigquals);
+                                      (uu___9.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___780_3831.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___9.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___780_3831.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___9.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___780_3831.FStar_Syntax_Syntax.sigopts)
+                                      (uu___9.FStar_Syntax_Syntax.sigopts)
                                   }) in
-                       FStar_All.pipe_right uu____3807
+                       FStar_All.pipe_right uu___6
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
-                     FStar_All.pipe_right uu____3806
+                     FStar_All.pipe_right uu___5
                        (fun se2 ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                              (uu____3847, uu____3848, uu____3849, t1, ty) ->
-                              (t1, ty)
-                          | uu____3852 ->
+                              (uu___6, uu___7, uu___8, t2, ty) -> (t2, ty)
+                          | uu___6 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind") in
-                   match uu____3801 with
-                   | (t1, ty) ->
-                       ((let uu____3860 =
+                   match uu___4 with
+                   | (t2, ty) ->
+                       ((let uu___6 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases") in
-                         if uu____3860
+                         if uu___6
                          then
-                           let uu____3861 =
+                           let uu___7 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___795_3864 = se1 in
+                               (let uu___8 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_bind
-                                       (m, n, p, t1, ty));
+                                       (m, n, p, t2, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___795_3864.FStar_Syntax_Syntax.sigrng);
+                                    (uu___8.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___795_3864.FStar_Syntax_Syntax.sigquals);
+                                    (uu___8.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___795_3864.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___8.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___795_3864.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___8.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___795_3864.FStar_Syntax_Syntax.sigopts)
+                                    (uu___8.FStar_Syntax_Syntax.sigopts)
                                 }) in
                            FStar_Util.print1
-                             "Polymonadic bind after phase 1: %s\n"
-                             uu____3861
+                             "Polymonadic bind after phase 1: %s\n" uu___7
                          else ());
-                        t1)
+                        t2)
                  else t in
-               let uu____3867 =
+               let uu___3 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_bind env m n p t1 in
-               (match uu____3867 with
+               (match uu___3 with
                 | (t2, ty) ->
                     let se2 =
-                      let uu___802_3885 = se1 in
+                      let uu___4 = se1 in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
                              (m, n, p, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___802_3885.FStar_Syntax_Syntax.sigrng);
+                          (uu___4.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___802_3885.FStar_Syntax_Syntax.sigquals);
+                          (uu___4.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___802_3885.FStar_Syntax_Syntax.sigmeta);
+                          (uu___4.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___802_3885.FStar_Syntax_Syntax.sigattrs);
+                          (uu___4.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___802_3885.FStar_Syntax_Syntax.sigopts)
+                          (uu___4.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([se2], [], env0))
-           | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-               (m, n, t, uu____3893) ->
+           | FStar_Syntax_Syntax.Sig_polymonadic_subcomp (m, n, t, uu___2) ->
                let t1 =
-                 let uu____3895 =
+                 let uu___3 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____3895
+                 if uu___3
                  then
-                   let uu____3896 =
-                     let uu____3901 =
-                       let uu____3902 =
-                         let uu____3903 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_subcomp
-                             (let uu___812_3910 = env in
+                             (let uu___8 = env in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___812_3910.FStar_TypeChecker_Env.solver);
+                                  (uu___8.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___812_3910.FStar_TypeChecker_Env.range);
+                                  (uu___8.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___812_3910.FStar_TypeChecker_Env.curmodule);
+                                  (uu___8.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___812_3910.FStar_TypeChecker_Env.gamma);
+                                  (uu___8.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___812_3910.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___8.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___812_3910.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___8.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___812_3910.FStar_TypeChecker_Env.modules);
+                                  (uu___8.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___812_3910.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___8.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___812_3910.FStar_TypeChecker_Env.sigtab);
+                                  (uu___8.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___812_3910.FStar_TypeChecker_Env.attrtab);
+                                  (uu___8.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___812_3910.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___8.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___812_3910.FStar_TypeChecker_Env.effects);
+                                  (uu___8.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___812_3910.FStar_TypeChecker_Env.generalize);
+                                  (uu___8.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___812_3910.FStar_TypeChecker_Env.letrecs);
+                                  (uu___8.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___812_3910.FStar_TypeChecker_Env.top_level);
+                                  (uu___8.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___812_3910.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___8.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___812_3910.FStar_TypeChecker_Env.use_eq);
+                                  (uu___8.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___812_3910.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___8.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___812_3910.FStar_TypeChecker_Env.is_iface);
+                                  (uu___8.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___812_3910.FStar_TypeChecker_Env.admit);
+                                  (uu___8.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___812_3910.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___8.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___812_3910.FStar_TypeChecker_Env.failhard);
+                                  (uu___8.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___812_3910.FStar_TypeChecker_Env.nosynth);
+                                  (uu___8.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___812_3910.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___8.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___812_3910.FStar_TypeChecker_Env.tc_term);
+                                  (uu___8.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___812_3910.FStar_TypeChecker_Env.type_of);
+                                  (uu___8.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___812_3910.FStar_TypeChecker_Env.universe_of);
+                                  (uu___8.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___812_3910.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___8.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___812_3910.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___812_3910.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___8.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___812_3910.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___8.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___812_3910.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___8.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___812_3910.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___8.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___812_3910.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___8.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___812_3910.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___8.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___812_3910.FStar_TypeChecker_Env.splice);
+                                  (uu___8.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___812_3910.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___8.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___812_3910.FStar_TypeChecker_Env.postprocess);
+                                  (uu___8.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___812_3910.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___8.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___812_3910.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___8.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___812_3910.FStar_TypeChecker_Env.dsenv);
+                                  (uu___8.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___812_3910.FStar_TypeChecker_Env.nbe);
+                                  (uu___8.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___812_3910.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___8.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___812_3910.FStar_TypeChecker_Env.erasable_types_tab);
+                                  (uu___8.FStar_TypeChecker_Env.erasable_types_tab);
                                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                                  (uu___812_3910.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                  (uu___8.FStar_TypeChecker_Env.enable_defer_to_tac)
                               }) m n t in
-                         FStar_All.pipe_right uu____3903
-                           (fun uu____3919 ->
-                              match uu____3919 with
-                              | (t1, ty) ->
-                                  let uu___817_3926 = se1 in
+                         FStar_All.pipe_right uu___7
+                           (fun uu___8 ->
+                              match uu___8 with
+                              | (t2, ty) ->
+                                  let uu___9 = se1 in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                                         (m, n, t1, ty));
+                                         (m, n, t2, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___817_3926.FStar_Syntax_Syntax.sigrng);
+                                      (uu___9.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___817_3926.FStar_Syntax_Syntax.sigquals);
+                                      (uu___9.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___817_3926.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___9.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___817_3926.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___9.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___817_3926.FStar_Syntax_Syntax.sigopts)
+                                      (uu___9.FStar_Syntax_Syntax.sigopts)
                                   }) in
-                       FStar_All.pipe_right uu____3902
+                       FStar_All.pipe_right uu___6
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
-                     FStar_All.pipe_right uu____3901
+                     FStar_All.pipe_right uu___5
                        (fun se2 ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                              (uu____3941, uu____3942, t1, ty) -> (t1, ty)
-                          | uu____3945 ->
+                              (uu___6, uu___7, t2, ty) -> (t2, ty)
+                          | uu___6 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_subcomp must be a Sig_polymonadic_subcomp") in
-                   match uu____3896 with
-                   | (t1, ty) ->
-                       ((let uu____3953 =
+                   match uu___4 with
+                   | (t2, ty) ->
+                       ((let uu___6 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases") in
-                         if uu____3953
+                         if uu___6
                          then
-                           let uu____3954 =
+                           let uu___7 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___831_3957 = se1 in
+                               (let uu___8 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                                       (m, n, t1, ty));
+                                       (m, n, t2, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___831_3957.FStar_Syntax_Syntax.sigrng);
+                                    (uu___8.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___831_3957.FStar_Syntax_Syntax.sigquals);
+                                    (uu___8.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___831_3957.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___8.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___831_3957.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___8.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___831_3957.FStar_Syntax_Syntax.sigopts)
+                                    (uu___8.FStar_Syntax_Syntax.sigopts)
                                 }) in
                            FStar_Util.print1
-                             "Polymonadic subcomp after phase 1: %s\n"
-                             uu____3954
+                             "Polymonadic subcomp after phase 1: %s\n" uu___7
                          else ());
-                        t1)
+                        t2)
                  else t in
-               let uu____3960 =
+               let uu___3 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_subcomp env m n t1 in
-               (match uu____3960 with
+               (match uu___3 with
                 | (t2, ty) ->
                     let se2 =
-                      let uu___838_3978 = se1 in
+                      let uu___4 = se1 in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                              (m, n, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___838_3978.FStar_Syntax_Syntax.sigrng);
+                          (uu___4.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___838_3978.FStar_Syntax_Syntax.sigquals);
+                          (uu___4.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___838_3978.FStar_Syntax_Syntax.sigmeta);
+                          (uu___4.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___838_3978.FStar_Syntax_Syntax.sigattrs);
+                          (uu___4.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___838_3978.FStar_Syntax_Syntax.sigopts)
+                          (uu___4.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([se2], [], env0)))
 let (tc_decl :
@@ -3422,24 +3382,24 @@ let (tc_decl :
   fun env ->
     fun se ->
       let env1 = set_hint_correlator env se in
-      (let uu____4015 =
-         let uu____4016 =
+      (let uu___1 =
+         let uu___2 =
            FStar_Ident.string_of_lid env1.FStar_TypeChecker_Env.curmodule in
-         FStar_Options.debug_module uu____4016 in
-       if uu____4015
+         FStar_Options.debug_module uu___2 in
+       if uu___1
        then
-         let uu____4017 =
-           let uu____4018 =
+         let uu___2 =
+           let uu___3 =
              FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                (FStar_List.map FStar_Ident.string_of_lid) in
-           FStar_All.pipe_right uu____4018 (FStar_String.concat ", ") in
-         FStar_Util.print1 "Processing %s\n" uu____4017
+           FStar_All.pipe_right uu___3 (FStar_String.concat ", ") in
+         FStar_Util.print1 "Processing %s\n" uu___2
        else ());
-      (let uu____4029 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-       if uu____4029
+      (let uu___2 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
+       if uu___2
        then
-         let uu____4030 = FStar_Syntax_Print.sigelt_to_string se in
-         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4030
+         let uu___3 = FStar_Syntax_Print.sigelt_to_string se in
+         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu___3
        else ());
       if (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
       then
@@ -3455,463 +3415,460 @@ let (add_sigelt_to_env :
   fun env ->
     fun se ->
       fun from_cache ->
-        (let uu____4073 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
-         if uu____4073
+        (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
+         if uu___1
          then
-           let uu____4074 = FStar_Syntax_Print.sigelt_to_string se in
-           let uu____4075 = FStar_Util.string_of_bool from_cache in
+           let uu___2 = FStar_Syntax_Print.sigelt_to_string se in
+           let uu___3 = FStar_Util.string_of_bool from_cache in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____4074 uu____4075
+             uu___2 uu___3
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____4077 ->
-             let uu____4094 =
-               let uu____4099 =
-                 let uu____4100 = FStar_Syntax_Print.sigelt_to_string se in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu___1 ->
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Print.sigelt_to_string se in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____4100 in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4099) in
-             FStar_Errors.raise_error uu____4094
-               se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____4101 ->
-             let uu____4116 =
-               let uu____4121 =
-                 let uu____4122 = FStar_Syntax_Print.sigelt_to_string se in
+                   uu___4 in
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu___3) in
+             FStar_Errors.raise_error uu___2 se.FStar_Syntax_Syntax.sigrng
+         | FStar_Syntax_Syntax.Sig_datacon uu___1 ->
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Print.sigelt_to_string se in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____4122 in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4121) in
-             FStar_Errors.raise_error uu____4116
-               se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____4123, uu____4124, uu____4125) when
+                   uu___4 in
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu___3) in
+             FStar_Errors.raise_error uu___2 se.FStar_Syntax_Syntax.sigrng
+         | FStar_Syntax_Syntax.Sig_declare_typ (uu___1, uu___2, uu___3) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___2_4129 ->
-                     match uu___2_4129 with
+                  (fun uu___4 ->
+                     match uu___4 with
                      | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu____4130 -> false))
+                     | uu___5 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____4131, uu____4132) when
+         | FStar_Syntax_Syntax.Sig_let (uu___1, uu___2) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___2_4140 ->
-                     match uu___2_4140 with
+                  (fun uu___3 ->
+                     match uu___3 with
                      | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu____4141 -> false))
+                     | uu___4 -> false))
              -> env
-         | uu____4142 ->
+         | uu___1 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____4144) ->
+                  (FStar_Syntax_Syntax.PushOptions uu___2) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___888_4148 = env1 in
-                     let uu____4149 = FStar_Options.using_facts_from () in
+                    (let uu___4 = env1 in
+                     let uu___5 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___888_4148.FStar_TypeChecker_Env.solver);
+                         (uu___4.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___888_4148.FStar_TypeChecker_Env.range);
+                         (uu___4.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___888_4148.FStar_TypeChecker_Env.curmodule);
+                         (uu___4.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___888_4148.FStar_TypeChecker_Env.gamma);
+                         (uu___4.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___888_4148.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___4.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___888_4148.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___4.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___888_4148.FStar_TypeChecker_Env.modules);
+                         (uu___4.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___888_4148.FStar_TypeChecker_Env.expected_typ);
+                         (uu___4.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___888_4148.FStar_TypeChecker_Env.sigtab);
+                         (uu___4.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___888_4148.FStar_TypeChecker_Env.attrtab);
+                         (uu___4.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___888_4148.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___888_4148.FStar_TypeChecker_Env.effects);
+                         (uu___4.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___888_4148.FStar_TypeChecker_Env.generalize);
+                         (uu___4.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___888_4148.FStar_TypeChecker_Env.letrecs);
+                         (uu___4.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___888_4148.FStar_TypeChecker_Env.top_level);
+                         (uu___4.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___888_4148.FStar_TypeChecker_Env.check_uvars);
+                         (uu___4.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___888_4148.FStar_TypeChecker_Env.use_eq);
+                         (uu___4.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___888_4148.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___888_4148.FStar_TypeChecker_Env.is_iface);
+                         (uu___4.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___888_4148.FStar_TypeChecker_Env.admit);
+                         (uu___4.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___888_4148.FStar_TypeChecker_Env.lax);
+                         (uu___4.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___888_4148.FStar_TypeChecker_Env.lax_universes);
+                         (uu___4.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___888_4148.FStar_TypeChecker_Env.phase1);
+                         (uu___4.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___888_4148.FStar_TypeChecker_Env.failhard);
+                         (uu___4.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___888_4148.FStar_TypeChecker_Env.nosynth);
+                         (uu___4.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___888_4148.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___888_4148.FStar_TypeChecker_Env.tc_term);
+                         (uu___4.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___888_4148.FStar_TypeChecker_Env.type_of);
+                         (uu___4.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___888_4148.FStar_TypeChecker_Env.universe_of);
+                         (uu___4.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___888_4148.FStar_TypeChecker_Env.check_type_of);
+                         (uu___4.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___888_4148.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___888_4148.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___888_4148.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___888_4148.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4149;
+                         (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu___5;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___888_4148.FStar_TypeChecker_Env.synth_hook);
+                         (uu___4.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___888_4148.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___888_4148.FStar_TypeChecker_Env.splice);
+                         (uu___4.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___888_4148.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___4.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___888_4148.FStar_TypeChecker_Env.postprocess);
+                         (uu___4.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___888_4148.FStar_TypeChecker_Env.identifier_info);
+                         (uu___4.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___888_4148.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___4.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___888_4148.FStar_TypeChecker_Env.dsenv);
+                         (uu___4.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___888_4148.FStar_TypeChecker_Env.nbe);
+                         (uu___4.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___888_4148.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___888_4148.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___888_4148.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___888_4151 = env1 in
-                     let uu____4152 = FStar_Options.using_facts_from () in
+                    (let uu___3 = env1 in
+                     let uu___4 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___888_4151.FStar_TypeChecker_Env.solver);
+                         (uu___3.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___888_4151.FStar_TypeChecker_Env.range);
+                         (uu___3.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___888_4151.FStar_TypeChecker_Env.curmodule);
+                         (uu___3.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___888_4151.FStar_TypeChecker_Env.gamma);
+                         (uu___3.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___888_4151.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___3.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___888_4151.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___3.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___888_4151.FStar_TypeChecker_Env.modules);
+                         (uu___3.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___888_4151.FStar_TypeChecker_Env.expected_typ);
+                         (uu___3.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___888_4151.FStar_TypeChecker_Env.sigtab);
+                         (uu___3.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___888_4151.FStar_TypeChecker_Env.attrtab);
+                         (uu___3.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___888_4151.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___3.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___888_4151.FStar_TypeChecker_Env.effects);
+                         (uu___3.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___888_4151.FStar_TypeChecker_Env.generalize);
+                         (uu___3.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___888_4151.FStar_TypeChecker_Env.letrecs);
+                         (uu___3.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___888_4151.FStar_TypeChecker_Env.top_level);
+                         (uu___3.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___888_4151.FStar_TypeChecker_Env.check_uvars);
+                         (uu___3.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___888_4151.FStar_TypeChecker_Env.use_eq);
+                         (uu___3.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___888_4151.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___3.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___888_4151.FStar_TypeChecker_Env.is_iface);
+                         (uu___3.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___888_4151.FStar_TypeChecker_Env.admit);
+                         (uu___3.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___888_4151.FStar_TypeChecker_Env.lax);
+                         (uu___3.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___888_4151.FStar_TypeChecker_Env.lax_universes);
+                         (uu___3.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___888_4151.FStar_TypeChecker_Env.phase1);
+                         (uu___3.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___888_4151.FStar_TypeChecker_Env.failhard);
+                         (uu___3.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___888_4151.FStar_TypeChecker_Env.nosynth);
+                         (uu___3.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___888_4151.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___888_4151.FStar_TypeChecker_Env.tc_term);
+                         (uu___3.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___888_4151.FStar_TypeChecker_Env.type_of);
+                         (uu___3.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___888_4151.FStar_TypeChecker_Env.universe_of);
+                         (uu___3.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___888_4151.FStar_TypeChecker_Env.check_type_of);
+                         (uu___3.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___888_4151.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___3.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___888_4151.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___3.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___888_4151.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___3.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___888_4151.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4152;
+                         (uu___3.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu___4;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___888_4151.FStar_TypeChecker_Env.synth_hook);
+                         (uu___3.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___888_4151.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___3.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___888_4151.FStar_TypeChecker_Env.splice);
+                         (uu___3.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___888_4151.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___3.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___888_4151.FStar_TypeChecker_Env.postprocess);
+                         (uu___3.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___888_4151.FStar_TypeChecker_Env.identifier_info);
+                         (uu___3.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___888_4151.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___3.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___888_4151.FStar_TypeChecker_Env.dsenv);
+                         (uu___3.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___888_4151.FStar_TypeChecker_Env.nbe);
+                         (uu___3.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___888_4151.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___3.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___888_4151.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___3.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___888_4151.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___3.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____4153) ->
+                  (FStar_Syntax_Syntax.SetOptions uu___2) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___888_4155 = env1 in
-                     let uu____4156 = FStar_Options.using_facts_from () in
+                    (let uu___4 = env1 in
+                     let uu___5 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___888_4155.FStar_TypeChecker_Env.solver);
+                         (uu___4.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___888_4155.FStar_TypeChecker_Env.range);
+                         (uu___4.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___888_4155.FStar_TypeChecker_Env.curmodule);
+                         (uu___4.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___888_4155.FStar_TypeChecker_Env.gamma);
+                         (uu___4.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___888_4155.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___4.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___888_4155.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___4.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___888_4155.FStar_TypeChecker_Env.modules);
+                         (uu___4.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___888_4155.FStar_TypeChecker_Env.expected_typ);
+                         (uu___4.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___888_4155.FStar_TypeChecker_Env.sigtab);
+                         (uu___4.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___888_4155.FStar_TypeChecker_Env.attrtab);
+                         (uu___4.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___888_4155.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___888_4155.FStar_TypeChecker_Env.effects);
+                         (uu___4.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___888_4155.FStar_TypeChecker_Env.generalize);
+                         (uu___4.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___888_4155.FStar_TypeChecker_Env.letrecs);
+                         (uu___4.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___888_4155.FStar_TypeChecker_Env.top_level);
+                         (uu___4.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___888_4155.FStar_TypeChecker_Env.check_uvars);
+                         (uu___4.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___888_4155.FStar_TypeChecker_Env.use_eq);
+                         (uu___4.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___888_4155.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___888_4155.FStar_TypeChecker_Env.is_iface);
+                         (uu___4.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___888_4155.FStar_TypeChecker_Env.admit);
+                         (uu___4.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___888_4155.FStar_TypeChecker_Env.lax);
+                         (uu___4.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___888_4155.FStar_TypeChecker_Env.lax_universes);
+                         (uu___4.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___888_4155.FStar_TypeChecker_Env.phase1);
+                         (uu___4.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___888_4155.FStar_TypeChecker_Env.failhard);
+                         (uu___4.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___888_4155.FStar_TypeChecker_Env.nosynth);
+                         (uu___4.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___888_4155.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___888_4155.FStar_TypeChecker_Env.tc_term);
+                         (uu___4.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___888_4155.FStar_TypeChecker_Env.type_of);
+                         (uu___4.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___888_4155.FStar_TypeChecker_Env.universe_of);
+                         (uu___4.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___888_4155.FStar_TypeChecker_Env.check_type_of);
+                         (uu___4.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___888_4155.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___888_4155.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___888_4155.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___888_4155.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4156;
+                         (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu___5;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___888_4155.FStar_TypeChecker_Env.synth_hook);
+                         (uu___4.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___888_4155.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___888_4155.FStar_TypeChecker_Env.splice);
+                         (uu___4.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___888_4155.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___4.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___888_4155.FStar_TypeChecker_Env.postprocess);
+                         (uu___4.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___888_4155.FStar_TypeChecker_Env.identifier_info);
+                         (uu___4.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___888_4155.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___4.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___888_4155.FStar_TypeChecker_Env.dsenv);
+                         (uu___4.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___888_4155.FStar_TypeChecker_Env.nbe);
+                         (uu___4.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___888_4155.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___888_4155.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___888_4155.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____4157) ->
+                  (FStar_Syntax_Syntax.ResetOptions uu___2) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___888_4161 = env1 in
-                     let uu____4162 = FStar_Options.using_facts_from () in
+                    (let uu___4 = env1 in
+                     let uu___5 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___888_4161.FStar_TypeChecker_Env.solver);
+                         (uu___4.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___888_4161.FStar_TypeChecker_Env.range);
+                         (uu___4.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___888_4161.FStar_TypeChecker_Env.curmodule);
+                         (uu___4.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___888_4161.FStar_TypeChecker_Env.gamma);
+                         (uu___4.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___888_4161.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___4.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___888_4161.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___4.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___888_4161.FStar_TypeChecker_Env.modules);
+                         (uu___4.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___888_4161.FStar_TypeChecker_Env.expected_typ);
+                         (uu___4.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___888_4161.FStar_TypeChecker_Env.sigtab);
+                         (uu___4.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___888_4161.FStar_TypeChecker_Env.attrtab);
+                         (uu___4.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___888_4161.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___888_4161.FStar_TypeChecker_Env.effects);
+                         (uu___4.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___888_4161.FStar_TypeChecker_Env.generalize);
+                         (uu___4.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___888_4161.FStar_TypeChecker_Env.letrecs);
+                         (uu___4.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___888_4161.FStar_TypeChecker_Env.top_level);
+                         (uu___4.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___888_4161.FStar_TypeChecker_Env.check_uvars);
+                         (uu___4.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___888_4161.FStar_TypeChecker_Env.use_eq);
+                         (uu___4.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___888_4161.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___888_4161.FStar_TypeChecker_Env.is_iface);
+                         (uu___4.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___888_4161.FStar_TypeChecker_Env.admit);
+                         (uu___4.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___888_4161.FStar_TypeChecker_Env.lax);
+                         (uu___4.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___888_4161.FStar_TypeChecker_Env.lax_universes);
+                         (uu___4.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___888_4161.FStar_TypeChecker_Env.phase1);
+                         (uu___4.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___888_4161.FStar_TypeChecker_Env.failhard);
+                         (uu___4.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___888_4161.FStar_TypeChecker_Env.nosynth);
+                         (uu___4.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___888_4161.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___888_4161.FStar_TypeChecker_Env.tc_term);
+                         (uu___4.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___888_4161.FStar_TypeChecker_Env.type_of);
+                         (uu___4.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___888_4161.FStar_TypeChecker_Env.universe_of);
+                         (uu___4.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___888_4161.FStar_TypeChecker_Env.check_type_of);
+                         (uu___4.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___888_4161.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___888_4161.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___888_4161.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___888_4161.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4162;
+                         (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu___5;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___888_4161.FStar_TypeChecker_Env.synth_hook);
+                         (uu___4.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___888_4161.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___888_4161.FStar_TypeChecker_Env.splice);
+                         (uu___4.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___888_4161.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___4.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___888_4161.FStar_TypeChecker_Env.postprocess);
+                         (uu___4.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___888_4161.FStar_TypeChecker_Env.identifier_info);
+                         (uu___4.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___888_4161.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___4.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___888_4161.FStar_TypeChecker_Env.dsenv);
+                         (uu___4.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___888_4161.FStar_TypeChecker_Env.nbe);
+                         (uu___4.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___888_4161.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___888_4161.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___888_4161.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver) ->
@@ -3929,23 +3886,23 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3 ->
                           fun a ->
-                            let uu____4176 =
+                            let uu___2 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                            FStar_TypeChecker_Env.push_sigelt env3 uu____4176)
+                            FStar_TypeChecker_Env.push_sigelt env3 uu___2)
                        env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                   FStar_TypeChecker_Util.update_env_sub_eff env1 sub
                     se.FStar_Syntax_Syntax.sigrng
               | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                  (m, n, p, uu____4181, ty) ->
+                  (m, n, p, uu___2, ty) ->
                   FStar_TypeChecker_Util.update_env_polymonadic_bind env1 m n
                     p ty
               | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                  (m, n, uu____4185, ty) ->
+                  (m, n, uu___2, ty) ->
                   FStar_TypeChecker_Env.add_polymonadic_subcomp env1 m n ty
-              | uu____4187 -> env1))
+              | uu___2 -> env1))
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -3953,57 +3910,57 @@ let (tc_decls :
   =
   fun env ->
     fun ses ->
-      let rec process_one_decl uu____4235 se =
-        match uu____4235 with
+      let rec process_one_decl uu___ se =
+        match uu___ with
         | (ses1, env1) ->
-            let uu____4261 =
+            let uu___1 =
               env1.FStar_TypeChecker_Env.nosynth &&
                 (FStar_Options.debug_any ()) in
-            if uu____4261
+            if uu___1
             then ((ses1, env1), [])
             else
-              ((let uu____4286 =
+              ((let uu___4 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-                if uu____4286
+                if uu___4
                 then
-                  let uu____4287 = FStar_Syntax_Print.tag_of_sigelt se in
-                  let uu____4288 = FStar_Syntax_Print.sigelt_to_string se in
+                  let uu___5 = FStar_Syntax_Print.tag_of_sigelt se in
+                  let uu___6 = FStar_Syntax_Print.sigelt_to_string se in
                   FStar_Util.print2
-                    ">>>>>>>>>>>>>>Checking top-level %s decl %s\n"
-                    uu____4287 uu____4288
+                    ">>>>>>>>>>>>>>Checking top-level %s decl %s\n" uu___5
+                    uu___6
                 else ());
-               (let uu____4290 = tc_decl env1 se in
-                match uu____4290 with
+               (let uu___4 = tc_decl env1 se in
+                match uu___4 with
                 | (ses', ses_elaborated, env2) ->
                     let ses'1 =
                       FStar_All.pipe_right ses'
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu____4335 =
+                              (let uu___6 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu____4335
+                               if uu___6
                                then
-                                 let uu____4336 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
-                                   "About to elim vars from %s\n" uu____4336
+                                   "About to elim vars from %s\n" uu___7
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     let ses_elaborated1 =
                       FStar_All.pipe_right ses_elaborated
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu____4349 =
+                              (let uu___6 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu____4349
+                               if uu___6
                                then
-                                 let uu____4350 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
                                    "About to elim vars from (elaborated) %s\n"
-                                   uu____4350
+                                   uu___7
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     (FStar_TypeChecker_Env.promote_id_info env2
@@ -4022,27 +3979,27 @@ let (tc_decls :
                      (let env3 =
                         FStar_All.pipe_right ses'1
                           (FStar_List.fold_left
-                             (fun env3 ->
-                                fun se1 -> add_sigelt_to_env env3 se1 false)
+                             (fun env4 ->
+                                fun se1 -> add_sigelt_to_env env4 se1 false)
                              env2) in
                       FStar_Syntax_Unionfind.reset ();
-                      (let uu____4364 =
+                      (let uu___8 =
                          (FStar_Options.log_types ()) ||
                            (FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env3)
                               (FStar_Options.Other "LogTypes")) in
-                       if uu____4364
+                       if uu___8
                        then
-                         let uu____4365 =
+                         let uu___9 =
                            FStar_List.fold_left
                              (fun s ->
                                 fun se1 ->
-                                  let uu____4371 =
-                                    let uu____4372 =
+                                  let uu___10 =
+                                    let uu___11 =
                                       FStar_Syntax_Print.sigelt_to_string se1 in
-                                    Prims.op_Hat uu____4372 "\n" in
-                                  Prims.op_Hat s uu____4371) "" ses'1 in
-                         FStar_Util.print1 "Checked: %s\n" uu____4365
+                                    Prims.op_Hat uu___11 "\n" in
+                                  Prims.op_Hat s uu___10) "" ses'1 in
+                         FStar_Util.print1 "Checked: %s\n" uu___9
                        else ());
                       FStar_List.iter
                         (fun se1 ->
@@ -4051,35 +4008,34 @@ let (tc_decls :
                       (((FStar_List.rev_append ses'1 ses1), env3),
                         ses_elaborated1))))) in
       let process_one_decl_timed acc se =
-        let uu____4422 = acc in
-        match uu____4422 with
-        | (uu____4441, env1) ->
+        let uu___ = acc in
+        match uu___ with
+        | (uu___1, env1) ->
             let r =
-              let uu____4460 =
-                let uu____4463 =
-                  let uu____4464 = FStar_TypeChecker_Env.current_module env1 in
-                  FStar_Ident.string_of_lid uu____4464 in
-                FStar_Pervasives_Native.Some uu____4463 in
-              FStar_Profiling.profile
-                (fun uu____4478 -> process_one_decl acc se) uu____4460
-                "FStar.TypeChecker.Tc.process_one_decl" in
-            ((let uu____4480 = FStar_Options.profile_group_by_decls () in
-              if uu____4480
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_TypeChecker_Env.current_module env1 in
+                  FStar_Ident.string_of_lid uu___4 in
+                FStar_Pervasives_Native.Some uu___3 in
+              FStar_Profiling.profile (fun uu___3 -> process_one_decl acc se)
+                uu___2 "FStar.TypeChecker.Tc.process_one_decl" in
+            ((let uu___3 = FStar_Options.profile_group_by_decls () in
+              if uu___3
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd::uu____4483 -> FStar_Ident.string_of_lid hd
-                  | uu____4486 ->
+                  | hd::uu___4 -> FStar_Ident.string_of_lid hd
+                  | uu___4 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se) in
                 FStar_Profiling.report_and_clear tag
               else ());
              r) in
-      let uu____4490 =
+      let uu___ =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____4504 ->
+          (fun uu___1 ->
              FStar_Util.fold_flatten process_one_decl_timed ([], env) ses) in
-      match uu____4490 with
+      match uu___ with
       | (ses1, env1) -> ((FStar_List.rev_append ses1 []), env1)
 let (uu___968 : unit) =
   FStar_ST.op_Colon_Equals tc_decls_knot
@@ -4093,7 +4049,7 @@ let (snapshot_context :
   fun env ->
     fun msg ->
       FStar_Util.atomically
-        (fun uu____4606 -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu___ -> FStar_TypeChecker_Env.snapshot env msg)
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
     Prims.string ->
@@ -4105,14 +4061,14 @@ let (rollback_context :
     fun msg ->
       fun depth ->
         FStar_Util.atomically
-          (fun uu____4644 ->
+          (fun uu___ ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth in env)
 let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env ->
     fun msg ->
-      let uu____4656 = snapshot_context env msg in
-      FStar_Pervasives_Native.snd uu____4656
+      let uu___ = snapshot_context env msg in
+      FStar_Pervasives_Native.snd uu___
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env ->
@@ -4127,138 +4083,131 @@ let (tc_partial_modul :
   fun env ->
     fun modul ->
       let verify =
-        let uu____4710 =
-          FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-        FStar_Options.should_verify uu____4710 in
+        let uu___ = FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
+        FStar_Options.should_verify uu___ in
       let action = if verify then "Verifying" else "Lax-checking" in
       let label =
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation" in
-      (let uu____4716 = FStar_Options.debug_any () in
-       if uu____4716
+      (let uu___1 = FStar_Options.debug_any () in
+       if uu___1
        then
-         let uu____4717 =
+         let uu___2 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-         FStar_Util.print3 "%s %s of %s\n" action label uu____4717
+         FStar_Util.print3 "%s %s of %s\n" action label uu___2
        else ());
       (let name =
-         let uu____4720 =
+         let uu___1 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
          FStar_Util.format2 "%s %s"
            (if modul.FStar_Syntax_Syntax.is_interface
             then "interface"
-            else "module") uu____4720 in
+            else "module") uu___1 in
        let env1 =
-         let uu___992_4723 = env in
+         let uu___1 = env in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___992_4723.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___992_4723.FStar_TypeChecker_Env.range);
+             (uu___1.FStar_TypeChecker_Env.solver);
+           FStar_TypeChecker_Env.range = (uu___1.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___992_4723.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___992_4723.FStar_TypeChecker_Env.gamma);
+             (uu___1.FStar_TypeChecker_Env.curmodule);
+           FStar_TypeChecker_Env.gamma = (uu___1.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___992_4723.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___992_4723.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___992_4723.FStar_TypeChecker_Env.modules);
+             (uu___1.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___992_4723.FStar_TypeChecker_Env.expected_typ);
+             (uu___1.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___992_4723.FStar_TypeChecker_Env.sigtab);
+             (uu___1.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___992_4723.FStar_TypeChecker_Env.attrtab);
+             (uu___1.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___992_4723.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___992_4723.FStar_TypeChecker_Env.effects);
+             (uu___1.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___992_4723.FStar_TypeChecker_Env.generalize);
+             (uu___1.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___992_4723.FStar_TypeChecker_Env.letrecs);
+             (uu___1.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___992_4723.FStar_TypeChecker_Env.top_level);
+             (uu___1.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___992_4723.FStar_TypeChecker_Env.check_uvars);
+             (uu___1.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___992_4723.FStar_TypeChecker_Env.use_eq);
+             (uu___1.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___992_4723.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
-           FStar_TypeChecker_Env.lax =
-             (uu___992_4723.FStar_TypeChecker_Env.lax);
+           FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___992_4723.FStar_TypeChecker_Env.lax_universes);
+             (uu___1.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___992_4723.FStar_TypeChecker_Env.phase1);
+             (uu___1.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___992_4723.FStar_TypeChecker_Env.failhard);
+             (uu___1.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___992_4723.FStar_TypeChecker_Env.nosynth);
+             (uu___1.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___992_4723.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___992_4723.FStar_TypeChecker_Env.tc_term);
+             (uu___1.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___992_4723.FStar_TypeChecker_Env.type_of);
+             (uu___1.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___992_4723.FStar_TypeChecker_Env.universe_of);
+             (uu___1.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___992_4723.FStar_TypeChecker_Env.check_type_of);
+             (uu___1.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___992_4723.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___992_4723.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___992_4723.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___992_4723.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___992_4723.FStar_TypeChecker_Env.proof_ns);
+             (uu___1.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___992_4723.FStar_TypeChecker_Env.synth_hook);
+             (uu___1.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___992_4723.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___992_4723.FStar_TypeChecker_Env.splice);
+             (uu___1.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___992_4723.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___992_4723.FStar_TypeChecker_Env.postprocess);
+             (uu___1.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___992_4723.FStar_TypeChecker_Env.identifier_info);
+             (uu___1.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___992_4723.FStar_TypeChecker_Env.tc_hooks);
-           FStar_TypeChecker_Env.dsenv =
-             (uu___992_4723.FStar_TypeChecker_Env.dsenv);
-           FStar_TypeChecker_Env.nbe =
-             (uu___992_4723.FStar_TypeChecker_Env.nbe);
+             (uu___1.FStar_TypeChecker_Env.tc_hooks);
+           FStar_TypeChecker_Env.dsenv = (uu___1.FStar_TypeChecker_Env.dsenv);
+           FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___992_4723.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___992_4723.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___992_4723.FStar_TypeChecker_Env.enable_defer_to_tac)
+             (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
          } in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name in
-       let uu____4725 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
-       match uu____4725 with
+       let uu___1 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
+       match uu___1 with
        | (ses, env3) ->
-           ((let uu___999_4743 = modul in
+           ((let uu___2 = modul in
              {
-               FStar_Syntax_Syntax.name =
-                 (uu___999_4743.FStar_Syntax_Syntax.name);
+               FStar_Syntax_Syntax.name = (uu___2.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.is_interface =
-                 (uu___999_4743.FStar_Syntax_Syntax.is_interface)
+                 (uu___2.FStar_Syntax_Syntax.is_interface)
              }), env3))
 let (tc_more_partial_modul :
   FStar_TypeChecker_Env.env ->
@@ -4270,19 +4219,18 @@ let (tc_more_partial_modul :
   fun env ->
     fun modul ->
       fun decls ->
-        let uu____4771 = tc_decls env decls in
-        match uu____4771 with
+        let uu___ = tc_decls env decls in
+        match uu___ with
         | (ses, env1) ->
             let modul1 =
-              let uu___1007_4793 = modul in
+              let uu___1 = modul in
               {
-                FStar_Syntax_Syntax.name =
-                  (uu___1007_4793.FStar_Syntax_Syntax.name);
+                FStar_Syntax_Syntax.name = (uu___1.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___1007_4793.FStar_Syntax_Syntax.is_interface)
+                  (uu___1.FStar_Syntax_Syntax.is_interface)
               } in
             (modul1, ses, env1)
 let (finish_partial_modul :
@@ -4297,18 +4245,18 @@ let (finish_partial_modul :
       fun en ->
         fun m ->
           let env = FStar_TypeChecker_Env.finish_module en m in
-          (let uu____4826 =
+          (let uu___1 =
              FStar_All.pipe_right
                env.FStar_TypeChecker_Env.qtbl_name_and_index
                FStar_Pervasives_Native.fst in
-           FStar_All.pipe_right uu____4826 FStar_Util.smap_clear);
-          (let uu____4854 =
-             let uu____4855 =
-               let uu____4856 =
+           FStar_All.pipe_right uu___1 FStar_Util.smap_clear);
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-               Prims.op_Hat "Ending modul " uu____4856 in
-             pop_context env uu____4855 in
-           FStar_All.pipe_right uu____4854 (fun uu____4857 -> ()));
+               Prims.op_Hat "Ending modul " uu___4 in
+             pop_context env uu___3 in
+           FStar_All.pipe_right uu___2 (fun uu___3 -> ()));
           (m, env)
 let (tc_modul :
   FStar_TypeChecker_Env.env ->
@@ -4319,12 +4267,11 @@ let (tc_modul :
     fun m ->
       fun iface_exists ->
         let msg =
-          let uu____4882 =
-            FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-          Prims.op_Hat "Internals for " uu____4882 in
+          let uu___ = FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+          Prims.op_Hat "Internals for " uu___ in
         let env01 = push_context env0 msg in
-        let uu____4884 = tc_partial_modul env01 m in
-        match uu____4884 with
+        let uu___ = tc_partial_modul env01 m in
+        match uu___ with
         | (modul, env) -> finish_partial_modul false iface_exists env modul
 let (load_checked_module :
   FStar_TypeChecker_Env.env ->
@@ -4336,26 +4283,25 @@ let (load_checked_module :
         FStar_TypeChecker_Env.set_current_module en
           m.FStar_Syntax_Syntax.name in
       let env1 =
-        let uu____4907 =
-          let uu____4908 =
-            FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-          Prims.op_Hat "Internals for " uu____4908 in
-        push_context env uu____4907 in
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+          Prims.op_Hat "Internals for " uu___1 in
+        push_context env uu___ in
       let env2 =
         FStar_List.fold_left
-          (fun env2 ->
+          (fun env3 ->
              fun se ->
-               let env3 = add_sigelt_to_env env2 se true in
+               let env4 = add_sigelt_to_env env3 se true in
                let lids = FStar_Syntax_Util.lids_of_sigelt se in
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid ->
-                       let uu____4927 =
-                         FStar_TypeChecker_Env.lookup_sigelt env3 lid in
+                       let uu___1 =
+                         FStar_TypeChecker_Env.lookup_sigelt env4 lid in
                        ()));
-               env3) env1 m.FStar_Syntax_Syntax.declarations in
-      let uu____4930 = finish_partial_modul true true env2 m in
-      match uu____4930 with | (uu____4935, env3) -> env3
+               env4) env1 m.FStar_Syntax_Syntax.declarations in
+      let uu___ = finish_partial_modul true true env2 m in
+      match uu___ with | (uu___1, env3) -> env3
 let (check_module :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
@@ -4364,150 +4310,147 @@ let (check_module :
   fun env ->
     fun m ->
       fun b ->
-        (let uu____4957 = FStar_Options.debug_any () in
-         if uu____4957
+        (let uu___1 = FStar_Options.debug_any () in
+         if uu___1
          then
-           let uu____4958 =
+           let uu___2 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____4958
+              else "module") uu___2
          else ());
-        (let uu____4962 =
-           let uu____4963 =
-             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-           FStar_Options.dump_module uu____4963 in
-         if uu____4962
+        (let uu___2 =
+           let uu___3 = FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+           FStar_Options.dump_module uu___3 in
+         if uu___2
          then
-           let uu____4964 = FStar_Syntax_Print.modul_to_string m in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____4964
+           let uu___3 = FStar_Syntax_Print.modul_to_string m in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu___3
          else ());
         (let env1 =
-           let uu___1047_4967 = env in
-           let uu____4968 =
-             let uu____4969 =
-               let uu____4970 =
+           let uu___2 = env in
+           let uu___3 =
+             let uu___4 =
+               let uu___5 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-               FStar_Options.should_verify uu____4970 in
-             Prims.op_Negation uu____4969 in
+               FStar_Options.should_verify uu___5 in
+             Prims.op_Negation uu___4 in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___1047_4967.FStar_TypeChecker_Env.solver);
+               (uu___2.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___1047_4967.FStar_TypeChecker_Env.range);
+               (uu___2.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___1047_4967.FStar_TypeChecker_Env.curmodule);
+               (uu___2.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___1047_4967.FStar_TypeChecker_Env.gamma);
+               (uu___2.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___1047_4967.FStar_TypeChecker_Env.gamma_sig);
+               (uu___2.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___1047_4967.FStar_TypeChecker_Env.gamma_cache);
+               (uu___2.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___1047_4967.FStar_TypeChecker_Env.modules);
+               (uu___2.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___1047_4967.FStar_TypeChecker_Env.expected_typ);
+               (uu___2.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___1047_4967.FStar_TypeChecker_Env.sigtab);
+               (uu___2.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___1047_4967.FStar_TypeChecker_Env.attrtab);
+               (uu___2.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___1047_4967.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___2.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___1047_4967.FStar_TypeChecker_Env.effects);
+               (uu___2.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___1047_4967.FStar_TypeChecker_Env.generalize);
+               (uu___2.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___1047_4967.FStar_TypeChecker_Env.letrecs);
+               (uu___2.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___1047_4967.FStar_TypeChecker_Env.top_level);
+               (uu___2.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___1047_4967.FStar_TypeChecker_Env.check_uvars);
+               (uu___2.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___1047_4967.FStar_TypeChecker_Env.use_eq);
+               (uu___2.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict =
-               (uu___1047_4967.FStar_TypeChecker_Env.use_eq_strict);
+               (uu___2.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (uu___1047_4967.FStar_TypeChecker_Env.is_iface);
+               (uu___2.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___1047_4967.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____4968;
+               (uu___2.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu___3;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___1047_4967.FStar_TypeChecker_Env.lax_universes);
+               (uu___2.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___1047_4967.FStar_TypeChecker_Env.phase1);
+               (uu___2.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___1047_4967.FStar_TypeChecker_Env.failhard);
+               (uu___2.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___1047_4967.FStar_TypeChecker_Env.nosynth);
+               (uu___2.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___1047_4967.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___1047_4967.FStar_TypeChecker_Env.tc_term);
+               (uu___2.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___1047_4967.FStar_TypeChecker_Env.type_of);
+               (uu___2.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___1047_4967.FStar_TypeChecker_Env.universe_of);
+               (uu___2.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___1047_4967.FStar_TypeChecker_Env.check_type_of);
+               (uu___2.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___1047_4967.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___1047_4967.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___1047_4967.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___1047_4967.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___1047_4967.FStar_TypeChecker_Env.proof_ns);
+               (uu___2.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___1047_4967.FStar_TypeChecker_Env.synth_hook);
+               (uu___2.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___1047_4967.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___1047_4967.FStar_TypeChecker_Env.splice);
+               (uu___2.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___1047_4967.FStar_TypeChecker_Env.mpreprocess);
+               (uu___2.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___1047_4967.FStar_TypeChecker_Env.postprocess);
+               (uu___2.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___1047_4967.FStar_TypeChecker_Env.identifier_info);
+               (uu___2.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___1047_4967.FStar_TypeChecker_Env.tc_hooks);
+               (uu___2.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___1047_4967.FStar_TypeChecker_Env.dsenv);
-             FStar_TypeChecker_Env.nbe =
-               (uu___1047_4967.FStar_TypeChecker_Env.nbe);
+               (uu___2.FStar_TypeChecker_Env.dsenv);
+             FStar_TypeChecker_Env.nbe = (uu___2.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___1047_4967.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___2.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___1047_4967.FStar_TypeChecker_Env.erasable_types_tab);
+               (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
              FStar_TypeChecker_Env.enable_defer_to_tac =
-               (uu___1047_4967.FStar_TypeChecker_Env.enable_defer_to_tac)
+               (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
            } in
-         let uu____4971 = tc_modul env1 m b in
-         match uu____4971 with
+         let uu___2 = tc_modul env1 m b in
+         match uu___2 with
          | (m1, env2) ->
-             ((let uu____4983 =
-                 let uu____4984 =
+             ((let uu___4 =
+                 let uu___5 =
                    FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                 FStar_Options.dump_module uu____4984 in
-               if uu____4983
+                 FStar_Options.dump_module uu___5 in
+               if uu___4
                then
-                 let uu____4985 = FStar_Syntax_Print.modul_to_string m1 in
-                 FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____4985
+                 let uu___5 = FStar_Syntax_Print.modul_to_string m1 in
+                 FStar_Util.print1 "Module after type checking:\n%s\n" uu___5
                else ());
-              (let uu____4988 =
-                 (let uu____4991 =
+              (let uu___5 =
+                 (let uu___6 =
                     FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                  FStar_Options.dump_module uu____4991) &&
-                   (let uu____4993 =
+                  FStar_Options.dump_module uu___6) &&
+                   (let uu___6 =
                       FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                    FStar_Options.debug_at_level uu____4993
+                    FStar_Options.debug_at_level uu___6
                       (FStar_Options.Other "Normalize")) in
-               if uu____4988
+               if uu___5
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -4523,69 +4466,69 @@ let (check_module :
                              FStar_Syntax_Syntax.delta_constant;
                            FStar_TypeChecker_Env.AllowUnboundUniverses] in
                        let update lb =
-                         let uu____5026 =
+                         let uu___6 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef in
-                         match uu____5026 with
+                         match uu___6 with
                          | (univnames, e) ->
-                             let uu___1069_5033 = lb in
-                             let uu____5034 =
-                               let uu____5037 =
+                             let uu___7 = lb in
+                             let uu___8 =
+                               let uu___9 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames in
-                               n uu____5037 e in
+                               n uu___9 e in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbname);
+                                 (uu___7.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___7.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___7.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____5034;
+                                 (uu___7.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu___8;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___7.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1069_5033.FStar_Syntax_Syntax.lbpos)
+                                 (uu___7.FStar_Syntax_Syntax.lbpos)
                              } in
-                       let uu___1071_5038 = se in
-                       let uu____5039 =
-                         let uu____5040 =
-                           let uu____5047 =
-                             let uu____5048 = FStar_List.map update lbs in
-                             (b1, uu____5048) in
-                           (uu____5047, ids) in
-                         FStar_Syntax_Syntax.Sig_let uu____5040 in
+                       let uu___6 = se in
+                       let uu___7 =
+                         let uu___8 =
+                           let uu___9 =
+                             let uu___10 = FStar_List.map update lbs in
+                             (b1, uu___10) in
+                           (uu___9, ids) in
+                         FStar_Syntax_Syntax.Sig_let uu___8 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____5039;
+                         FStar_Syntax_Syntax.sigel = uu___7;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___1071_5038.FStar_Syntax_Syntax.sigrng);
+                           (uu___6.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___1071_5038.FStar_Syntax_Syntax.sigquals);
+                           (uu___6.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___1071_5038.FStar_Syntax_Syntax.sigmeta);
+                           (uu___6.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___1071_5038.FStar_Syntax_Syntax.sigattrs);
+                           (uu___6.FStar_Syntax_Syntax.sigattrs);
                          FStar_Syntax_Syntax.sigopts =
-                           (uu___1071_5038.FStar_Syntax_Syntax.sigopts)
+                           (uu___6.FStar_Syntax_Syntax.sigopts)
                        }
-                   | uu____5055 -> se in
+                   | uu___6 -> se in
                  let normalized_module =
-                   let uu___1075_5057 = m1 in
-                   let uu____5058 =
+                   let uu___6 = m1 in
+                   let uu___7 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___1075_5057.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____5058;
+                       (uu___6.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu___7;
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___1075_5057.FStar_Syntax_Syntax.is_interface)
+                       (uu___6.FStar_Syntax_Syntax.is_interface)
                    } in
-                 let uu____5059 =
+                 let uu___6 =
                    FStar_Syntax_Print.modul_to_string normalized_module in
-                 FStar_Util.print1 "%s\n" uu____5059
+                 FStar_Util.print1 "%s\n" uu___6
                else ());
               (m1, env2)))

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -18,86 +18,83 @@ let (check_and_gen :
     fun eff_name ->
       fun comb ->
         fun n ->
-          fun uu____54 ->
-            match uu____54 with
+          fun uu___ ->
+            match uu___ with
             | (us, t) ->
-                let uu____73 = FStar_Syntax_Subst.open_univ_vars us t in
-                (match uu____73 with
+                let uu___1 = FStar_Syntax_Subst.open_univ_vars us t in
+                (match uu___1 with
                  | (us1, t1) ->
-                     let uu____86 =
-                       let uu____91 =
-                         let uu____98 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_TypeChecker_Env.push_univ_vars env us1 in
-                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                           uu____98 t1 in
-                       match uu____91 with
+                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term uu___4
+                           t1 in
+                       match uu___3 with
                        | (t2, lc, g) ->
                            (FStar_TypeChecker_Rel.force_trivial_guard env g;
                             (t2, (lc.FStar_TypeChecker_Common.res_typ))) in
-                     (match uu____86 with
+                     (match uu___2 with
                       | (t2, ty) ->
-                          let uu____115 =
+                          let uu___3 =
                             FStar_TypeChecker_Generalize.generalize_universes
                               env t2 in
-                          (match uu____115 with
+                          (match uu___3 with
                            | (g_us, t3) ->
                                let ty1 =
                                  FStar_Syntax_Subst.close_univ_vars g_us ty in
                                (if (FStar_List.length g_us) <> n
                                 then
                                   (let error =
-                                     let uu____135 =
-                                       FStar_Util.string_of_int n in
-                                     let uu____136 =
-                                       let uu____137 =
+                                     let uu___4 = FStar_Util.string_of_int n in
+                                     let uu___5 =
+                                       let uu___6 =
                                          FStar_All.pipe_right g_us
                                            FStar_List.length in
-                                       FStar_All.pipe_right uu____137
+                                       FStar_All.pipe_right uu___6
                                          FStar_Util.string_of_int in
-                                     let uu____140 =
+                                     let uu___6 =
                                        FStar_Syntax_Print.tscheme_to_string
                                          (g_us, t3) in
                                      FStar_Util.format5
                                        "Expected %s:%s to be universe-polymorphic in %s universes, but found %s (tscheme: %s)"
-                                       eff_name comb uu____135 uu____136
-                                       uu____140 in
+                                       eff_name comb uu___4 uu___5 uu___6 in
                                    FStar_Errors.raise_error
                                      (FStar_Errors.Fatal_MismatchUniversePolymorphic,
                                        error) t3.FStar_Syntax_Syntax.pos;
                                    (match us1 with
                                     | [] -> ()
-                                    | uu____146 ->
-                                        let uu____147 =
+                                    | uu___5 ->
+                                        let uu___6 =
                                           ((FStar_List.length us1) =
                                              (FStar_List.length g_us))
                                             &&
                                             (FStar_List.forall2
                                                (fun u1 ->
                                                   fun u2 ->
-                                                    let uu____153 =
+                                                    let uu___7 =
                                                       FStar_Syntax_Syntax.order_univ_name
                                                         u1 u2 in
-                                                    uu____153 =
-                                                      Prims.int_zero) us1
-                                               g_us) in
-                                        if uu____147
+                                                    uu___7 = Prims.int_zero)
+                                               us1 g_us) in
+                                        if uu___6
                                         then ()
                                         else
-                                          (let uu____155 =
-                                             let uu____160 =
-                                               let uu____161 =
+                                          (let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
                                                  FStar_Syntax_Print.univ_names_to_string
                                                    us1 in
-                                               let uu____162 =
+                                               let uu___11 =
                                                  FStar_Syntax_Print.univ_names_to_string
                                                    g_us in
                                                FStar_Util.format4
                                                  "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                 eff_name comb uu____161
-                                                 uu____162 in
+                                                 eff_name comb uu___10
+                                                 uu___11 in
                                              (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                               uu____160) in
-                                           FStar_Errors.raise_error uu____155
+                                               uu___9) in
+                                           FStar_Errors.raise_error uu___8
                                              t3.FStar_Syntax_Syntax.pos)))
                                 else ();
                                 (g_us, t3, ty1)))))
@@ -114,23 +111,23 @@ let (pure_wp_uvar :
         fun r ->
           let pure_wp_t =
             let pure_wp_ts =
-              let uu____194 =
+              let uu___ =
                 FStar_TypeChecker_Env.lookup_definition
                   [FStar_TypeChecker_Env.NoDelta] env
                   FStar_Parser_Const.pure_wp_lid in
-              FStar_All.pipe_right uu____194 FStar_Util.must in
-            let uu____199 = FStar_TypeChecker_Env.inst_tscheme pure_wp_ts in
-            match uu____199 with
-            | (uu____204, pure_wp_t) ->
-                let uu____206 =
-                  let uu____207 =
+              FStar_All.pipe_right uu___ FStar_Util.must in
+            let uu___ = FStar_TypeChecker_Env.inst_tscheme pure_wp_ts in
+            match uu___ with
+            | (uu___1, pure_wp_t1) ->
+                let uu___2 =
+                  let uu___3 =
                     FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg in
-                  [uu____207] in
-                FStar_Syntax_Syntax.mk_Tm_app pure_wp_t uu____206 r in
-          let uu____240 =
+                  [uu___3] in
+                FStar_Syntax_Syntax.mk_Tm_app pure_wp_t1 uu___2 r in
+          let uu___ =
             FStar_TypeChecker_Util.new_implicit_var reason r env pure_wp_t in
-          match uu____240 with
-          | (pure_wp_uvar, uu____258, guard_wp) -> (pure_wp_uvar, guard_wp)
+          match uu___ with
+          | (pure_wp_uvar1, uu___1, guard_wp) -> (pure_wp_uvar1, guard_wp)
 let (check_no_subtyping_for_layered_combinator :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -139,124 +136,122 @@ let (check_no_subtyping_for_layered_combinator :
   fun env ->
     fun t ->
       fun k ->
-        (let uu____292 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "LayeredEffectsTc") in
-         if uu____292
+         if uu___1
          then
-           let uu____293 = FStar_Syntax_Print.term_to_string t in
-           let uu____294 =
+           let uu___2 = FStar_Syntax_Print.term_to_string t in
+           let uu___3 =
              match k with
              | FStar_Pervasives_Native.None -> "None"
              | FStar_Pervasives_Native.Some k1 ->
                  FStar_Syntax_Print.term_to_string k1 in
            FStar_Util.print2
              "Checking that %s is well typed with no subtyping (k:%s)\n"
-             uu____293 uu____294
+             uu___2 uu___3
          else ());
         (let env1 =
-           let uu___54_298 = env in
+           let uu___1 = env in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___54_298.FStar_TypeChecker_Env.solver);
+               (uu___1.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___54_298.FStar_TypeChecker_Env.range);
+               (uu___1.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___54_298.FStar_TypeChecker_Env.curmodule);
+               (uu___1.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___54_298.FStar_TypeChecker_Env.gamma);
+               (uu___1.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___54_298.FStar_TypeChecker_Env.gamma_sig);
+               (uu___1.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___54_298.FStar_TypeChecker_Env.gamma_cache);
+               (uu___1.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___54_298.FStar_TypeChecker_Env.modules);
+               (uu___1.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___54_298.FStar_TypeChecker_Env.expected_typ);
+               (uu___1.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___54_298.FStar_TypeChecker_Env.sigtab);
+               (uu___1.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___54_298.FStar_TypeChecker_Env.attrtab);
+               (uu___1.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___54_298.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___1.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___54_298.FStar_TypeChecker_Env.effects);
+               (uu___1.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___54_298.FStar_TypeChecker_Env.generalize);
+               (uu___1.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___54_298.FStar_TypeChecker_Env.letrecs);
+               (uu___1.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___54_298.FStar_TypeChecker_Env.top_level);
+               (uu___1.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___54_298.FStar_TypeChecker_Env.check_uvars);
+               (uu___1.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___54_298.FStar_TypeChecker_Env.use_eq);
+               (uu___1.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict = true;
              FStar_TypeChecker_Env.is_iface =
-               (uu___54_298.FStar_TypeChecker_Env.is_iface);
+               (uu___1.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___54_298.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax =
-               (uu___54_298.FStar_TypeChecker_Env.lax);
+               (uu___1.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
              FStar_TypeChecker_Env.lax_universes =
-               (uu___54_298.FStar_TypeChecker_Env.lax_universes);
+               (uu___1.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___54_298.FStar_TypeChecker_Env.phase1);
+               (uu___1.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___54_298.FStar_TypeChecker_Env.failhard);
+               (uu___1.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___54_298.FStar_TypeChecker_Env.nosynth);
+               (uu___1.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___54_298.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___54_298.FStar_TypeChecker_Env.tc_term);
+               (uu___1.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___54_298.FStar_TypeChecker_Env.type_of);
+               (uu___1.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___54_298.FStar_TypeChecker_Env.universe_of);
+               (uu___1.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___54_298.FStar_TypeChecker_Env.check_type_of);
+               (uu___1.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___54_298.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___54_298.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___54_298.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___54_298.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___54_298.FStar_TypeChecker_Env.proof_ns);
+               (uu___1.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___54_298.FStar_TypeChecker_Env.synth_hook);
+               (uu___1.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___54_298.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___54_298.FStar_TypeChecker_Env.splice);
+               (uu___1.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___54_298.FStar_TypeChecker_Env.mpreprocess);
+               (uu___1.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___54_298.FStar_TypeChecker_Env.postprocess);
+               (uu___1.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___54_298.FStar_TypeChecker_Env.identifier_info);
+               (uu___1.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___54_298.FStar_TypeChecker_Env.tc_hooks);
+               (uu___1.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___54_298.FStar_TypeChecker_Env.dsenv);
-             FStar_TypeChecker_Env.nbe =
-               (uu___54_298.FStar_TypeChecker_Env.nbe);
+               (uu___1.FStar_TypeChecker_Env.dsenv);
+             FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___54_298.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___1.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___54_298.FStar_TypeChecker_Env.erasable_types_tab);
+               (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
              FStar_TypeChecker_Env.enable_defer_to_tac =
-               (uu___54_298.FStar_TypeChecker_Env.enable_defer_to_tac)
+               (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
            } in
          match k with
          | FStar_Pervasives_Native.None ->
-             let uu____299 = FStar_TypeChecker_TcTerm.tc_trivial_guard env1 t in
+             let uu___1 = FStar_TypeChecker_TcTerm.tc_trivial_guard env1 t in
              ()
          | FStar_Pervasives_Native.Some k1 ->
-             let uu____305 =
+             let uu___1 =
                FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k1 in
              ())
 let (validate_layered_effect_binders :
@@ -271,133 +266,132 @@ let (validate_layered_effect_binders :
         fun check_non_informatve_binders ->
           fun r ->
             let repr_args repr =
-              let uu____351 =
-                let uu____352 = FStar_Syntax_Subst.compress repr in
-                uu____352.FStar_Syntax_Syntax.n in
-              match uu____351 with
-              | FStar_Syntax_Syntax.Tm_app (uu____365, args) -> args
-              | FStar_Syntax_Syntax.Tm_arrow (uu____391::[], c) ->
+              let uu___ =
+                let uu___1 = FStar_Syntax_Subst.compress repr in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
+              | FStar_Syntax_Syntax.Tm_app (uu___1, args) -> args
+              | FStar_Syntax_Syntax.Tm_arrow (uu___1::[], c) ->
                   FStar_All.pipe_right c FStar_Syntax_Util.comp_effect_args
-              | uu____433 ->
-                  let uu____434 =
-                    let uu____439 =
-                      let uu____440 = FStar_Syntax_Print.term_to_string repr in
+              | uu___1 ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Print.term_to_string repr in
                       FStar_Util.format1
                         "Unexpected repr term %s when validating layered effect combinator binders"
-                        uu____440 in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____439) in
-                  FStar_Errors.raise_error uu____434 r in
+                        uu___4 in
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                  FStar_Errors.raise_error uu___2 r in
             let rec head_names_in_term arg =
-              let uu____461 =
-                let uu____462 = FStar_Syntax_Subst.compress arg in
-                uu____462.FStar_Syntax_Syntax.n in
-              match uu____461 with
-              | FStar_Syntax_Syntax.Tm_name uu____469 -> [arg]
-              | FStar_Syntax_Syntax.Tm_app (head, uu____475) ->
-                  let uu____500 =
-                    let uu____501 = FStar_Syntax_Subst.compress head in
-                    uu____501.FStar_Syntax_Syntax.n in
-                  (match uu____500 with
-                   | FStar_Syntax_Syntax.Tm_name uu____508 -> [head]
-                   | uu____513 -> [])
-              | FStar_Syntax_Syntax.Tm_abs (uu____516, body, uu____518) ->
+              let uu___ =
+                let uu___1 = FStar_Syntax_Subst.compress arg in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
+              | FStar_Syntax_Syntax.Tm_name uu___1 -> [arg]
+              | FStar_Syntax_Syntax.Tm_app (head, uu___1) ->
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Subst.compress head in
+                    uu___3.FStar_Syntax_Syntax.n in
+                  (match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_name uu___3 -> [head]
+                   | uu___3 -> [])
+              | FStar_Syntax_Syntax.Tm_abs (uu___1, body, uu___2) ->
                   head_names_in_term body
-              | uu____543 -> [] in
+              | uu___1 -> [] in
             let head_names_in_args args =
-              let uu____572 =
+              let uu___ =
                 FStar_All.pipe_right args
                   (FStar_List.map FStar_Pervasives_Native.fst) in
-              FStar_All.pipe_right uu____572
+              FStar_All.pipe_right uu___
                 (FStar_List.collect head_names_in_term) in
             let repr_names_args =
               FStar_List.collect
                 (fun repr ->
-                   let uu____611 = FStar_All.pipe_right repr repr_args in
-                   FStar_All.pipe_right uu____611 head_names_in_args)
-                repr_terms in
-            (let uu____641 =
+                   let uu___ = FStar_All.pipe_right repr repr_args in
+                   FStar_All.pipe_right uu___ head_names_in_args) repr_terms in
+            (let uu___1 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "LayeredEffectsTc") in
-             if uu____641
+             if uu___1
              then
-               let uu____642 =
+               let uu___2 =
                  FStar_List.fold_left
                    (fun s ->
                       fun t ->
-                        let uu____648 =
-                          let uu____649 = FStar_Syntax_Print.term_to_string t in
-                          Prims.op_Hat "; " uu____649 in
-                        Prims.op_Hat s uu____648) "" repr_names_args in
-               let uu____650 = FStar_Syntax_Print.binders_to_string "; " bs in
+                        let uu___3 =
+                          let uu___4 = FStar_Syntax_Print.term_to_string t in
+                          Prims.op_Hat "; " uu___4 in
+                        Prims.op_Hat s uu___3) "" repr_names_args in
+               let uu___3 = FStar_Syntax_Print.binders_to_string "; " bs in
                FStar_Util.print2
                  "Checking layered effect combinator binders validity, names: %s, binders: %s\n\n"
-                 uu____642 uu____650
+                 uu___2 uu___3
              else ());
             (let valid_binder b =
                (FStar_List.existsb
                   (fun t ->
-                     let uu____673 =
-                       let uu____674 =
-                         let uu____675 =
+                     let uu___1 =
+                       let uu___2 =
+                         let uu___3 =
                            FStar_All.pipe_right b FStar_Pervasives_Native.fst in
-                         FStar_All.pipe_right uu____675
+                         FStar_All.pipe_right uu___3
                            FStar_Syntax_Syntax.bv_to_name in
-                       FStar_Syntax_Util.eq_tm uu____674 t in
-                     uu____673 = FStar_Syntax_Util.Equal) repr_names_args)
+                       FStar_Syntax_Util.eq_tm uu___2 t in
+                     uu___1 = FStar_Syntax_Util.Equal) repr_names_args)
                  ||
                  (match FStar_Pervasives_Native.snd b with
                   | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
-                      (FStar_Syntax_Syntax.Arg_qualifier_meta_attr
-                      uu____687)) -> true
-                  | uu____690 -> false) in
+                      (FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu___1))
+                      -> true
+                  | uu___1 -> false) in
              let invalid_binders =
                FStar_List.filter
                  (fun b -> Prims.op_Negation (valid_binder b)) bs in
              if (FStar_List.length invalid_binders) <> Prims.int_zero
              then
-               (let uu____723 =
-                  let uu____728 =
-                    let uu____729 =
+               (let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
                       FStar_Syntax_Print.binders_to_string "; "
                         invalid_binders in
                     FStar_Util.format1
                       "Binders %s neither appear as repr indices nor have an associated tactic"
-                      uu____729 in
-                  (FStar_Errors.Fatal_UnexpectedEffect, uu____728) in
-                FStar_Errors.raise_error uu____723 r)
+                      uu___4 in
+                  (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                FStar_Errors.raise_error uu___2 r)
              else ();
              if check_non_informatve_binders
              then
-               (let uu____731 =
+               (let uu___2 =
                   FStar_List.fold_left
-                    (fun uu____768 ->
+                    (fun uu___3 ->
                        fun b ->
-                         match uu____768 with
+                         match uu___3 with
                          | (env1, bs1) ->
                              let env2 =
                                FStar_TypeChecker_Env.push_binders env1 [b] in
-                             let uu____831 =
+                             let uu___4 =
                                FStar_TypeChecker_Normalize.non_info_norm env2
                                  (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                             if uu____831
+                             if uu___4
                              then (env2, bs1)
                              else (env2, (b :: bs1))) (env, []) bs in
-                match uu____731 with
-                | (uu____883, informative_binders) ->
+                match uu___2 with
+                | (uu___3, informative_binders) ->
                     if
                       (FStar_List.length informative_binders) <>
                         Prims.int_zero
                     then
-                      let uu____907 =
-                        let uu____912 =
-                          let uu____913 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
                             FStar_Syntax_Print.binders_to_string "; "
                               informative_binders in
                           FStar_Util.format1
                             "Binders %s are informative while the effect is reifiable"
-                            uu____913 in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu____912) in
-                      FStar_Errors.raise_error uu____907 r
+                            uu___6 in
+                        (FStar_Errors.Fatal_UnexpectedEffect, uu___5) in
+                      FStar_Errors.raise_error uu___4 r
                     else ())
              else ())
 let (tc_layered_eff_decl :
@@ -411,14 +405,13 @@ let (tc_layered_eff_decl :
     fun ed ->
       fun quals ->
         fun attrs ->
-          (let uu____945 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                (FStar_Options.Other "LayeredEffectsTc") in
-           if uu____945
+           if uu___1
            then
-             let uu____946 = FStar_Syntax_Print.eff_decl_to_string false ed in
-             FStar_Util.print1 "Typechecking layered effect: \n\t%s\n"
-               uu____946
+             let uu___2 = FStar_Syntax_Print.eff_decl_to_string false ed in
+             FStar_Util.print1 "Typechecking layered effect: \n\t%s\n" uu___2
            else ());
           if
             ((FStar_List.length ed.FStar_Syntax_Syntax.univs) <>
@@ -427,310 +420,298 @@ let (tc_layered_eff_decl :
               ((FStar_List.length ed.FStar_Syntax_Syntax.binders) <>
                  Prims.int_zero)
           then
-            (let uu____955 =
-               let uu____960 =
-                 let uu____961 =
-                   let uu____962 =
+            (let uu___2 =
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 =
                      FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-                   Prims.op_Hat uu____962 ")" in
+                   Prims.op_Hat uu___5 ")" in
                  Prims.op_Hat
-                   "Binders are not supported for layered effects ("
-                   uu____961 in
-               (FStar_Errors.Fatal_UnexpectedEffect, uu____960) in
-             let uu____963 =
+                   "Binders are not supported for layered effects (" uu___4 in
+               (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+             let uu___3 =
                FStar_Ident.range_of_lid ed.FStar_Syntax_Syntax.mname in
-             FStar_Errors.raise_error uu____955 uu____963)
+             FStar_Errors.raise_error uu___2 uu___3)
           else ();
-          (let log_combinator s uu____987 =
-             match uu____987 with
+          (let log_combinator s uu___2 =
+             match uu___2 with
              | (us, t, ty) ->
-                 let uu____1015 =
+                 let uu___3 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                      (FStar_Options.Other "LayeredEffectsTc") in
-                 if uu____1015
+                 if uu___3
                  then
-                   let uu____1016 =
+                   let uu___4 =
                      FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-                   let uu____1017 =
-                     FStar_Syntax_Print.tscheme_to_string (us, t) in
-                   let uu____1022 =
-                     FStar_Syntax_Print.tscheme_to_string (us, ty) in
-                   FStar_Util.print4 "Typechecked %s:%s = %s:%s\n" uu____1016
-                     s uu____1017 uu____1022
+                   let uu___5 = FStar_Syntax_Print.tscheme_to_string (us, t) in
+                   let uu___6 = FStar_Syntax_Print.tscheme_to_string (us, ty) in
+                   FStar_Util.print4 "Typechecked %s:%s = %s:%s\n" uu___4 s
+                     uu___5 uu___6
                  else () in
            let fresh_a_and_u_a a =
-             let uu____1042 = FStar_Syntax_Util.type_u () in
-             FStar_All.pipe_right uu____1042
-               (fun uu____1059 ->
-                  match uu____1059 with
+             let uu___2 = FStar_Syntax_Util.type_u () in
+             FStar_All.pipe_right uu___2
+               (fun uu___3 ->
+                  match uu___3 with
                   | (t, u) ->
-                      let uu____1070 =
-                        let uu____1071 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Syntax_Syntax.gen_bv a
                             FStar_Pervasives_Native.None t in
-                        FStar_All.pipe_right uu____1071
+                        FStar_All.pipe_right uu___5
                           FStar_Syntax_Syntax.mk_binder in
-                      (uu____1070, u)) in
+                      (uu___4, u)) in
            let fresh_x_a x a =
-             let uu____1083 =
-               let uu____1084 =
-                 let uu____1085 =
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 =
                    FStar_All.pipe_right a FStar_Pervasives_Native.fst in
-                 FStar_All.pipe_right uu____1085
-                   FStar_Syntax_Syntax.bv_to_name in
+                 FStar_All.pipe_right uu___4 FStar_Syntax_Syntax.bv_to_name in
                FStar_Syntax_Syntax.gen_bv x FStar_Pervasives_Native.None
-                 uu____1084 in
-             FStar_All.pipe_right uu____1083 FStar_Syntax_Syntax.mk_binder in
+                 uu___3 in
+             FStar_All.pipe_right uu___2 FStar_Syntax_Syntax.mk_binder in
            let check_and_gen1 =
-             let uu____1117 =
+             let uu___2 =
                FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-             check_and_gen env0 uu____1117 in
+             check_and_gen env0 uu___2 in
            let signature =
              let r =
                (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos in
-             let uu____1136 =
+             let uu___2 =
                check_and_gen1 "signature" Prims.int_one
                  ed.FStar_Syntax_Syntax.signature in
-             match uu____1136 with
+             match uu___2 with
              | (sig_us, sig_t, sig_ty) ->
-                 let uu____1158 =
-                   FStar_Syntax_Subst.open_univ_vars sig_us sig_t in
-                 (match uu____1158 with
+                 let uu___3 = FStar_Syntax_Subst.open_univ_vars sig_us sig_t in
+                 (match uu___3 with
                   | (us, t) ->
                       let env = FStar_TypeChecker_Env.push_univ_vars env0 us in
-                      let uu____1178 = fresh_a_and_u_a "a" in
-                      (match uu____1178 with
+                      let uu___4 = fresh_a_and_u_a "a" in
+                      (match uu___4 with
                        | (a, u) ->
                            let rest_bs =
-                             let uu____1198 =
-                               let uu____1199 =
+                             let uu___5 =
+                               let uu___6 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____1199
+                               FStar_All.pipe_right uu___6
                                  FStar_Syntax_Syntax.bv_to_name in
                              FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                env r ed.FStar_Syntax_Syntax.mname
-                               (sig_us, sig_t) u uu____1198 in
+                               (sig_us, sig_t) u uu___5 in
                            let bs = a :: rest_bs in
                            let k =
-                             let uu____1230 =
+                             let uu___5 =
                                FStar_Syntax_Syntax.mk_Total
                                  FStar_Syntax_Syntax.teff in
-                             FStar_Syntax_Util.arrow bs uu____1230 in
+                             FStar_Syntax_Util.arrow bs uu___5 in
                            let g_eq = FStar_TypeChecker_Rel.teq env t k in
                            (FStar_TypeChecker_Rel.force_trivial_guard env
                               g_eq;
-                            (let uu____1235 =
-                               let uu____1238 =
+                            (let uu___6 =
+                               let uu___7 =
                                  FStar_All.pipe_right k
                                    (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                       env) in
-                               FStar_Syntax_Subst.close_univ_vars us
-                                 uu____1238 in
-                             (sig_us, uu____1235, sig_ty))))) in
+                               FStar_Syntax_Subst.close_univ_vars us uu___7 in
+                             (sig_us, uu___6, sig_ty))))) in
            log_combinator "signature" signature;
            (let repr =
               let repr_ts =
-                let uu____1264 =
+                let uu___3 =
                   FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
-                FStar_All.pipe_right uu____1264 FStar_Util.must in
+                FStar_All.pipe_right uu___3 FStar_Util.must in
               let r =
                 (FStar_Pervasives_Native.snd repr_ts).FStar_Syntax_Syntax.pos in
-              let uu____1292 = check_and_gen1 "repr" Prims.int_one repr_ts in
-              match uu____1292 with
+              let uu___3 = check_and_gen1 "repr" Prims.int_one repr_ts in
+              match uu___3 with
               | (repr_us, repr_t, repr_ty) ->
-                  let uu____1314 =
+                  let uu___4 =
                     FStar_Syntax_Subst.open_univ_vars repr_us repr_ty in
-                  (match uu____1314 with
+                  (match uu___4 with
                    | (us, ty) ->
                        let env = FStar_TypeChecker_Env.push_univ_vars env0 us in
-                       let uu____1334 = fresh_a_and_u_a "a" in
-                       (match uu____1334 with
+                       let uu___5 = fresh_a_and_u_a "a" in
+                       (match uu___5 with
                         | (a, u) ->
                             let rest_bs =
                               let signature_ts =
-                                let uu____1355 = signature in
-                                match uu____1355 with
-                                | (us1, t, uu____1370) -> (us1, t) in
-                              let uu____1387 =
-                                let uu____1388 =
+                                let uu___6 = signature in
+                                match uu___6 with
+                                | (us1, t, uu___7) -> (us1, t) in
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_All.pipe_right a
                                     FStar_Pervasives_Native.fst in
-                                FStar_All.pipe_right uu____1388
+                                FStar_All.pipe_right uu___7
                                   FStar_Syntax_Syntax.bv_to_name in
                               FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                 env r ed.FStar_Syntax_Syntax.mname
-                                signature_ts u uu____1387 in
+                                signature_ts u uu___6 in
                             let bs = a :: rest_bs in
                             let k =
-                              let uu____1415 =
-                                let uu____1418 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____1418
-                                  (fun uu____1431 ->
-                                     match uu____1431 with
+                              let uu___6 =
+                                let uu___7 = FStar_Syntax_Util.type_u () in
+                                FStar_All.pipe_right uu___7
+                                  (fun uu___8 ->
+                                     match uu___8 with
                                      | (t, u1) ->
-                                         let uu____1438 =
-                                           let uu____1441 =
+                                         let uu___9 =
+                                           let uu___10 =
                                              FStar_TypeChecker_Env.new_u_univ
                                                () in
                                            FStar_Pervasives_Native.Some
-                                             uu____1441 in
+                                             uu___10 in
                                          FStar_Syntax_Syntax.mk_Total' t
-                                           uu____1438) in
-                              FStar_Syntax_Util.arrow bs uu____1415 in
+                                           uu___9) in
+                              FStar_Syntax_Util.arrow bs uu___6 in
                             let g = FStar_TypeChecker_Rel.teq env ty k in
                             (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                             (let uu____1444 =
-                                let uu____1447 =
+                             (let uu___7 =
+                                let uu___8 =
                                   FStar_All.pipe_right k
                                     (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                        env) in
-                                FStar_Syntax_Subst.close_univ_vars us
-                                  uu____1447 in
-                              (repr_us, repr_t, uu____1444))))) in
+                                FStar_Syntax_Subst.close_univ_vars us uu___8 in
+                              (repr_us, repr_t, uu___7))))) in
             log_combinator "repr" repr;
             (let fresh_repr r env u a_tm =
                let signature_ts =
-                 let uu____1481 = signature in
-                 match uu____1481 with | (us, t, uu____1496) -> (us, t) in
+                 let uu___4 = signature in
+                 match uu___4 with | (us, t, uu___5) -> (us, t) in
                let repr_ts =
-                 let uu____1514 = repr in
-                 match uu____1514 with | (us, t, uu____1529) -> (us, t) in
+                 let uu___4 = repr in
+                 match uu___4 with | (us, t, uu___5) -> (us, t) in
                FStar_TypeChecker_Util.fresh_effect_repr env r
                  ed.FStar_Syntax_Syntax.mname signature_ts
                  (FStar_Pervasives_Native.Some repr_ts) u a_tm in
              let not_an_arrow_error comb n t r =
-               let uu____1575 =
-                 let uu____1580 =
-                   let uu____1581 =
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
                      FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-                   let uu____1582 = FStar_Util.string_of_int n in
-                   let uu____1583 = FStar_Syntax_Print.tag_of_term t in
-                   let uu____1584 = FStar_Syntax_Print.term_to_string t in
+                   let uu___7 = FStar_Util.string_of_int n in
+                   let uu___8 = FStar_Syntax_Print.tag_of_term t in
+                   let uu___9 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.format5
                      "Type of %s:%s is not an arrow with >= %s binders (%s::%s)"
-                     uu____1581 comb uu____1582 uu____1583 uu____1584 in
-                 (FStar_Errors.Fatal_UnexpectedEffect, uu____1580) in
-               FStar_Errors.raise_error uu____1575 r in
+                     uu___6 comb uu___7 uu___8 uu___9 in
+                 (FStar_Errors.Fatal_UnexpectedEffect, uu___5) in
+               FStar_Errors.raise_error uu___4 r in
              let check_non_informative_binders =
                (FStar_List.contains FStar_Syntax_Syntax.Reifiable quals) &&
-                 (let uu____1595 =
+                 (let uu___4 =
                     FStar_Syntax_Util.has_attribute attrs
                       FStar_Parser_Const.allow_informative_binders_attr in
-                  Prims.op_Negation uu____1595) in
+                  Prims.op_Negation uu___4) in
              let return_repr =
                let return_repr_ts =
-                 let uu____1614 =
+                 let uu___4 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_return_repr in
-                 FStar_All.pipe_right uu____1614 FStar_Util.must in
+                 FStar_All.pipe_right uu___4 FStar_Util.must in
                let r =
                  (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos in
-               let uu____1626 =
+               let uu___4 =
                  check_and_gen1 "return_repr" Prims.int_one return_repr_ts in
-               match uu____1626 with
+               match uu___4 with
                | (ret_us, ret_t, ret_ty) ->
-                   let uu____1648 =
+                   let uu___5 =
                      FStar_Syntax_Subst.open_univ_vars ret_us ret_ty in
-                   (match uu____1648 with
+                   (match uu___5 with
                     | (us, ty) ->
                         let env =
                           FStar_TypeChecker_Env.push_univ_vars env0 us in
                         (check_no_subtyping_for_layered_combinator env ty
                            FStar_Pervasives_Native.None;
-                         (let uu____1669 = fresh_a_and_u_a "a" in
-                          match uu____1669 with
+                         (let uu___7 = fresh_a_and_u_a "a" in
+                          match uu___7 with
                           | (a, u_a) ->
                               let x_a = fresh_x_a "x" a in
                               let rest_bs =
-                                let uu____1698 =
-                                  let uu____1699 =
-                                    FStar_Syntax_Subst.compress ty in
-                                  uu____1699.FStar_Syntax_Syntax.n in
-                                match uu____1698 with
-                                | FStar_Syntax_Syntax.Tm_arrow
-                                    (bs, uu____1711) when
+                                let uu___8 =
+                                  let uu___9 = FStar_Syntax_Subst.compress ty in
+                                  uu___9.FStar_Syntax_Syntax.n in
+                                match uu___8 with
+                                | FStar_Syntax_Syntax.Tm_arrow (bs, uu___9)
+                                    when
                                     (FStar_List.length bs) >=
                                       (Prims.of_int (2))
                                     ->
-                                    let uu____1738 =
+                                    let uu___10 =
                                       FStar_Syntax_Subst.open_binders bs in
-                                    (match uu____1738 with
-                                     | (a', uu____1748)::(x', uu____1750)::bs1
-                                         ->
-                                         let uu____1780 =
-                                           let uu____1781 =
-                                             let uu____1786 =
-                                               let uu____1789 =
-                                                 let uu____1790 =
-                                                   let uu____1797 =
+                                    (match uu___10 with
+                                     | (a', uu___11)::(x', uu___12)::bs1 ->
+                                         let uu___13 =
+                                           let uu___14 =
+                                             let uu___15 =
+                                               let uu___16 =
+                                                 let uu___17 =
+                                                   let uu___18 =
                                                      FStar_Syntax_Syntax.bv_to_name
                                                        (FStar_Pervasives_Native.fst
                                                           a) in
-                                                   (a', uu____1797) in
+                                                   (a', uu___18) in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____1790 in
-                                               [uu____1789] in
+                                                   uu___17 in
+                                               [uu___16] in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____1786 in
-                                           FStar_All.pipe_right bs1
-                                             uu____1781 in
-                                         let uu____1804 =
-                                           let uu____1817 =
-                                             let uu____1820 =
-                                               let uu____1821 =
-                                                 let uu____1828 =
+                                               uu___15 in
+                                           FStar_All.pipe_right bs1 uu___14 in
+                                         let uu___14 =
+                                           let uu___15 =
+                                             let uu___16 =
+                                               let uu___17 =
+                                                 let uu___18 =
                                                    FStar_Syntax_Syntax.bv_to_name
                                                      (FStar_Pervasives_Native.fst
                                                         x_a) in
-                                                 (x', uu____1828) in
-                                               FStar_Syntax_Syntax.NT
-                                                 uu____1821 in
-                                             [uu____1820] in
+                                                 (x', uu___18) in
+                                               FStar_Syntax_Syntax.NT uu___17 in
+                                             [uu___16] in
                                            FStar_Syntax_Subst.subst_binders
-                                             uu____1817 in
-                                         FStar_All.pipe_right uu____1780
-                                           uu____1804)
-                                | uu____1843 ->
+                                             uu___15 in
+                                         FStar_All.pipe_right uu___13 uu___14)
+                                | uu___9 ->
                                     not_an_arrow_error "return"
                                       (Prims.of_int (2)) ty r in
                               let bs = a :: x_a :: rest_bs in
-                              let uu____1865 =
-                                let uu____1870 =
+                              let uu___8 =
+                                let uu___9 =
                                   FStar_TypeChecker_Env.push_binders env bs in
-                                let uu____1871 =
+                                let uu___10 =
                                   FStar_All.pipe_right
                                     (FStar_Pervasives_Native.fst a)
                                     FStar_Syntax_Syntax.bv_to_name in
-                                fresh_repr r uu____1870 u_a uu____1871 in
-                              (match uu____1865 with
+                                fresh_repr r uu___9 u_a uu___10 in
+                              (match uu___8 with
                                | (repr1, g) ->
                                    let k =
-                                     let uu____1891 =
+                                     let uu___9 =
                                        FStar_Syntax_Syntax.mk_Total' repr1
                                          (FStar_Pervasives_Native.Some u_a) in
-                                     FStar_Syntax_Util.arrow bs uu____1891 in
+                                     FStar_Syntax_Util.arrow bs uu___9 in
                                    let g_eq =
                                      FStar_TypeChecker_Rel.teq env ty k in
-                                   ((let uu____1896 =
+                                   ((let uu___10 =
                                        FStar_TypeChecker_Env.conj_guard g
                                          g_eq in
                                      FStar_TypeChecker_Rel.force_trivial_guard
-                                       env uu____1896);
+                                       env uu___10);
                                     (let k1 =
                                        FStar_All.pipe_right k
                                          (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                             env) in
-                                     (let uu____1899 =
-                                        let uu____1900 =
+                                     (let uu___10 =
+                                        let uu___11 =
                                           FStar_Syntax_Subst.compress k1 in
-                                        uu____1900.FStar_Syntax_Syntax.n in
-                                      match uu____1899 with
+                                        uu___11.FStar_Syntax_Syntax.n in
+                                      match uu___10 with
                                       | FStar_Syntax_Syntax.Tm_arrow 
                                           (bs1, c) ->
-                                          let uu____1925 =
+                                          let uu___11 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               c in
-                                          (match uu____1925 with
+                                          (match uu___11 with
                                            | (a1::x::bs2, c1) ->
                                                let res_t =
                                                  FStar_Syntax_Util.comp_result
@@ -742,228 +723,217 @@ let (tc_layered_eff_decl :
                                                  env1 bs2 [res_t]
                                                  check_non_informative_binders
                                                  r));
-                                     (let uu____1988 =
+                                     (let uu___10 =
                                         FStar_All.pipe_right k1
                                           (FStar_Syntax_Subst.close_univ_vars
                                              us) in
-                                      (ret_us, ret_t, uu____1988)))))))) in
+                                      (ret_us, ret_t, uu___10)))))))) in
              log_combinator "return_repr" return_repr;
              (let bind_repr =
                 let bind_repr_ts =
-                  let uu____2018 =
+                  let uu___5 =
                     FStar_All.pipe_right ed FStar_Syntax_Util.get_bind_repr in
-                  FStar_All.pipe_right uu____2018 FStar_Util.must in
+                  FStar_All.pipe_right uu___5 FStar_Util.must in
                 let r =
                   (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos in
-                let uu____2046 =
+                let uu___5 =
                   check_and_gen1 "bind_repr" (Prims.of_int (2)) bind_repr_ts in
-                match uu____2046 with
+                match uu___5 with
                 | (bind_us, bind_t, bind_ty) ->
-                    let uu____2068 =
+                    let uu___6 =
                       FStar_Syntax_Subst.open_univ_vars bind_us bind_ty in
-                    (match uu____2068 with
+                    (match uu___6 with
                      | (us, ty) ->
                          let env =
                            FStar_TypeChecker_Env.push_univ_vars env0 us in
                          (check_no_subtyping_for_layered_combinator env ty
                             FStar_Pervasives_Native.None;
-                          (let uu____2089 = fresh_a_and_u_a "a" in
-                           match uu____2089 with
+                          (let uu___8 = fresh_a_and_u_a "a" in
+                           match uu___8 with
                            | (a, u_a) ->
-                               let uu____2108 = fresh_a_and_u_a "b" in
-                               (match uu____2108 with
+                               let uu___9 = fresh_a_and_u_a "b" in
+                               (match uu___9 with
                                 | (b, u_b) ->
                                     let rest_bs =
-                                      let uu____2136 =
-                                        let uu____2137 =
+                                      let uu___10 =
+                                        let uu___11 =
                                           FStar_Syntax_Subst.compress ty in
-                                        uu____2137.FStar_Syntax_Syntax.n in
-                                      match uu____2136 with
+                                        uu___11.FStar_Syntax_Syntax.n in
+                                      match uu___10 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs, uu____2149) when
+                                          (bs, uu___11) when
                                           (FStar_List.length bs) >=
                                             (Prims.of_int (4))
                                           ->
-                                          let uu____2176 =
+                                          let uu___12 =
                                             FStar_Syntax_Subst.open_binders
                                               bs in
-                                          (match uu____2176 with
-                                           | (a', uu____2186)::(b',
-                                                                uu____2188)::bs1
+                                          (match uu___12 with
+                                           | (a', uu___13)::(b', uu___14)::bs1
                                                ->
-                                               let uu____2218 =
-                                                 let uu____2219 =
+                                               let uu___15 =
+                                                 let uu___16 =
                                                    FStar_All.pipe_right bs1
                                                      (FStar_List.splitAt
                                                         ((FStar_List.length
                                                             bs1)
                                                            -
                                                            (Prims.of_int (2)))) in
-                                                 FStar_All.pipe_right
-                                                   uu____2219
+                                                 FStar_All.pipe_right uu___16
                                                    FStar_Pervasives_Native.fst in
-                                               let uu____2284 =
-                                                 let uu____2297 =
-                                                   let uu____2300 =
-                                                     let uu____2301 =
-                                                       let uu____2308 =
+                                               let uu___16 =
+                                                 let uu___17 =
+                                                   let uu___18 =
+                                                     let uu___19 =
+                                                       let uu___20 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            (FStar_Pervasives_Native.fst
                                                               a) in
-                                                       (a', uu____2308) in
+                                                       (a', uu___20) in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____2301 in
-                                                   let uu____2315 =
-                                                     let uu____2318 =
-                                                       let uu____2319 =
-                                                         let uu____2326 =
+                                                       uu___19 in
+                                                   let uu___19 =
+                                                     let uu___20 =
+                                                       let uu___21 =
+                                                         let uu___22 =
                                                            FStar_Syntax_Syntax.bv_to_name
                                                              (FStar_Pervasives_Native.fst
                                                                 b) in
-                                                         (b', uu____2326) in
+                                                         (b', uu___22) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____2319 in
-                                                     [uu____2318] in
-                                                   uu____2300 :: uu____2315 in
+                                                         uu___21 in
+                                                     [uu___20] in
+                                                   uu___18 :: uu___19 in
                                                  FStar_Syntax_Subst.subst_binders
-                                                   uu____2297 in
-                                               FStar_All.pipe_right
-                                                 uu____2218 uu____2284)
-                                      | uu____2341 ->
+                                                   uu___17 in
+                                               FStar_All.pipe_right uu___15
+                                                 uu___16)
+                                      | uu___11 ->
                                           not_an_arrow_error "bind"
                                             (Prims.of_int (4)) ty r in
                                     let bs = a :: b :: rest_bs in
-                                    let uu____2363 =
-                                      let uu____2374 =
-                                        let uu____2379 =
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs in
-                                        let uu____2380 =
+                                        let uu___13 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name in
-                                        fresh_repr r uu____2379 u_a
-                                          uu____2380 in
-                                      match uu____2374 with
+                                        fresh_repr r uu___12 u_a uu___13 in
+                                      match uu___11 with
                                       | (repr1, g) ->
-                                          let uu____2395 =
-                                            let uu____2402 =
+                                          let uu___12 =
+                                            let uu___13 =
                                               FStar_Syntax_Syntax.gen_bv "f"
                                                 FStar_Pervasives_Native.None
                                                 repr1 in
-                                            FStar_All.pipe_right uu____2402
+                                            FStar_All.pipe_right uu___13
                                               FStar_Syntax_Syntax.mk_binder in
-                                          (uu____2395, g) in
-                                    (match uu____2363 with
+                                          (uu___12, g) in
+                                    (match uu___10 with
                                      | (f, guard_f) ->
-                                         let uu____2441 =
+                                         let uu___11 =
                                            let x_a = fresh_x_a "x" a in
-                                           let uu____2453 =
-                                             let uu____2458 =
+                                           let uu___12 =
+                                             let uu___13 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env
                                                  (FStar_List.append bs [x_a]) in
-                                             let uu____2477 =
+                                             let uu___14 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.fst
                                                     b)
                                                  FStar_Syntax_Syntax.bv_to_name in
-                                             fresh_repr r uu____2458 u_b
-                                               uu____2477 in
-                                           match uu____2453 with
+                                             fresh_repr r uu___13 u_b uu___14 in
+                                           match uu___12 with
                                            | (repr1, g) ->
-                                               let uu____2492 =
-                                                 let uu____2499 =
-                                                   let uu____2500 =
-                                                     let uu____2501 =
-                                                       let uu____2504 =
-                                                         let uu____2507 =
+                                               let uu___13 =
+                                                 let uu___14 =
+                                                   let uu___15 =
+                                                     let uu___16 =
+                                                       let uu___17 =
+                                                         let uu___18 =
                                                            FStar_TypeChecker_Env.new_u_univ
                                                              () in
                                                          FStar_Pervasives_Native.Some
-                                                           uu____2507 in
+                                                           uu___18 in
                                                        FStar_Syntax_Syntax.mk_Total'
-                                                         repr1 uu____2504 in
+                                                         repr1 uu___17 in
                                                      FStar_Syntax_Util.arrow
-                                                       [x_a] uu____2501 in
+                                                       [x_a] uu___16 in
                                                    FStar_Syntax_Syntax.gen_bv
                                                      "g"
                                                      FStar_Pervasives_Native.None
-                                                     uu____2500 in
-                                                 FStar_All.pipe_right
-                                                   uu____2499
+                                                     uu___15 in
+                                                 FStar_All.pipe_right uu___14
                                                    FStar_Syntax_Syntax.mk_binder in
-                                               (uu____2492, g) in
-                                         (match uu____2441 with
+                                               (uu___13, g) in
+                                         (match uu___11 with
                                           | (g, guard_g) ->
-                                              let uu____2558 =
-                                                let uu____2563 =
+                                              let uu___12 =
+                                                let uu___13 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env bs in
-                                                let uu____2564 =
+                                                let uu___14 =
                                                   FStar_All.pipe_right
                                                     (FStar_Pervasives_Native.fst
                                                        b)
                                                     FStar_Syntax_Syntax.bv_to_name in
-                                                fresh_repr r uu____2563 u_b
-                                                  uu____2564 in
-                                              (match uu____2558 with
+                                                fresh_repr r uu___13 u_b
+                                                  uu___14 in
+                                              (match uu___12 with
                                                | (repr1, guard_repr) ->
-                                                   let uu____2581 =
-                                                     let uu____2586 =
+                                                   let uu___13 =
+                                                     let uu___14 =
                                                        FStar_TypeChecker_Env.push_binders
                                                          env bs in
-                                                     let uu____2587 =
-                                                       let uu____2588 =
+                                                     let uu___15 =
+                                                       let uu___16 =
                                                          FStar_Ident.string_of_lid
                                                            ed.FStar_Syntax_Syntax.mname in
                                                        FStar_Util.format1
                                                          "implicit for pure_wp in checking bind for %s"
-                                                         uu____2588 in
-                                                     pure_wp_uvar uu____2586
-                                                       repr1 uu____2587 r in
-                                                   (match uu____2581 with
+                                                         uu___16 in
+                                                     pure_wp_uvar uu___14
+                                                       repr1 uu___15 r in
+                                                   (match uu___13 with
                                                     | (pure_wp_uvar1,
                                                        g_pure_wp_uvar) ->
                                                         let k =
-                                                          let uu____2606 =
-                                                            let uu____2609 =
-                                                              let uu____2610
-                                                                =
-                                                                let uu____2611
-                                                                  =
+                                                          let uu___14 =
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                let uu___17 =
                                                                   FStar_TypeChecker_Env.new_u_univ
                                                                     () in
-                                                                [uu____2611] in
-                                                              let uu____2612
-                                                                =
-                                                                let uu____2623
-                                                                  =
+                                                                [uu___17] in
+                                                              let uu___17 =
+                                                                let uu___18 =
                                                                   FStar_All.pipe_right
                                                                     pure_wp_uvar1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____2623] in
+                                                                [uu___18] in
                                                               {
                                                                 FStar_Syntax_Syntax.comp_univs
-                                                                  =
-                                                                  uu____2610;
+                                                                  = uu___16;
                                                                 FStar_Syntax_Syntax.effect_name
                                                                   =
                                                                   FStar_Parser_Const.effect_PURE_lid;
                                                                 FStar_Syntax_Syntax.result_typ
                                                                   = repr1;
                                                                 FStar_Syntax_Syntax.effect_args
-                                                                  =
-                                                                  uu____2612;
+                                                                  = uu___17;
                                                                 FStar_Syntax_Syntax.flags
                                                                   = []
                                                               } in
                                                             FStar_Syntax_Syntax.mk_Comp
-                                                              uu____2609 in
+                                                              uu___15 in
                                                           FStar_Syntax_Util.arrow
                                                             (FStar_List.append
                                                                bs [f; g])
-                                                            uu____2606 in
+                                                            uu___14 in
                                                         let guard_eq =
                                                           FStar_TypeChecker_Rel.teq
                                                             env ty k in
@@ -980,20 +950,18 @@ let (tc_layered_eff_decl :
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env) in
-                                                          (let uu____2684 =
-                                                             let uu____2685 =
+                                                          (let uu___15 =
+                                                             let uu___16 =
                                                                FStar_Syntax_Subst.compress
                                                                  k1 in
-                                                             uu____2685.FStar_Syntax_Syntax.n in
-                                                           match uu____2684
-                                                           with
+                                                             uu___16.FStar_Syntax_Syntax.n in
+                                                           match uu___15 with
                                                            | FStar_Syntax_Syntax.Tm_arrow
                                                                (bs1, c) ->
-                                                               let uu____2710
-                                                                 =
+                                                               let uu___16 =
                                                                  FStar_Syntax_Subst.open_comp
                                                                    bs1 c in
-                                                               (match uu____2710
+                                                               (match uu___16
                                                                 with
                                                                 | (a1::b1::bs2,
                                                                    c1) ->
@@ -1001,9 +969,9 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     FStar_Syntax_Util.comp_result
                                                                     c1 in
-                                                                    let uu____2754
+                                                                    let uu___17
                                                                     =
-                                                                    let uu____2781
+                                                                    let uu___18
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -1011,34 +979,34 @@ let (tc_layered_eff_decl :
                                                                     (Prims.of_int (2)))
                                                                     bs2 in
                                                                     FStar_All.pipe_right
-                                                                    uu____2781
+                                                                    uu___18
                                                                     (fun
-                                                                    uu____2865
+                                                                    uu___19
                                                                     ->
-                                                                    match uu____2865
+                                                                    match uu___19
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____2946
+                                                                    let uu___20
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____2973
+                                                                    let uu___21
                                                                     =
-                                                                    let uu____2980
+                                                                    let uu___22
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____2980
+                                                                    uu___22
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____2946,
-                                                                    uu____2973)) in
-                                                                    (match uu____2754
+                                                                    uu___20,
+                                                                    uu___21)) in
+                                                                    (match uu___17
                                                                     with
                                                                     | 
                                                                     (bs3,
@@ -1046,19 +1014,19 @@ let (tc_layered_eff_decl :
                                                                     ->
                                                                     let g_sort
                                                                     =
-                                                                    let uu____3095
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____3096
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Pervasives_Native.fst
                                                                     g_b).FStar_Syntax_Syntax.sort in
-                                                                    uu____3096.FStar_Syntax_Syntax.n in
-                                                                    match uu____3095
+                                                                    uu___19.FStar_Syntax_Syntax.n in
+                                                                    match uu___18
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
-                                                                    (uu____3101,
+                                                                    (uu___19,
                                                                     c2) ->
                                                                     FStar_Syntax_Util.comp_result
                                                                     c2 in
@@ -1076,264 +1044,263 @@ let (tc_layered_eff_decl :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                          (let uu____3144 =
+                                                          (let uu___15 =
                                                              FStar_All.pipe_right
                                                                k1
                                                                (FStar_Syntax_Subst.close_univ_vars
                                                                   bind_us) in
                                                            (bind_us, bind_t,
-                                                             uu____3144)))))))))))) in
+                                                             uu___15)))))))))))) in
               log_combinator "bind_repr" bind_repr;
               (let stronger_repr =
-                 let stronger_repr =
+                 let stronger_repr1 =
                    let ts =
-                     let uu____3179 =
+                     let uu___6 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_stronger_repr in
-                     FStar_All.pipe_right uu____3179 FStar_Util.must in
-                   let uu____3190 =
-                     let uu____3191 =
-                       let uu____3194 =
+                     FStar_All.pipe_right uu___6 FStar_Util.must in
+                   let uu___6 =
+                     let uu___7 =
+                       let uu___8 =
                          FStar_All.pipe_right ts FStar_Pervasives_Native.snd in
-                       FStar_All.pipe_right uu____3194
+                       FStar_All.pipe_right uu___8
                          FStar_Syntax_Subst.compress in
-                     uu____3191.FStar_Syntax_Syntax.n in
-                   match uu____3190 with
+                     uu___7.FStar_Syntax_Syntax.n in
+                   match uu___6 with
                    | FStar_Syntax_Syntax.Tm_unknown ->
                        let signature_ts =
-                         let uu____3206 = signature in
-                         match uu____3206 with
-                         | (us, t, uu____3221) -> (us, t) in
-                       let uu____3238 =
+                         let uu___7 = signature in
+                         match uu___7 with | (us, t, uu___8) -> (us, t) in
+                       let uu___7 =
                          FStar_TypeChecker_Env.inst_tscheme_with signature_ts
                            [FStar_Syntax_Syntax.U_unknown] in
-                       (match uu____3238 with
-                        | (uu____3247, signature_t) ->
-                            let uu____3249 =
-                              let uu____3250 =
+                       (match uu___7 with
+                        | (uu___8, signature_t) ->
+                            let uu___9 =
+                              let uu___10 =
                                 FStar_Syntax_Subst.compress signature_t in
-                              uu____3250.FStar_Syntax_Syntax.n in
-                            (match uu____3249 with
-                             | FStar_Syntax_Syntax.Tm_arrow (bs, uu____3258)
-                                 ->
+                              uu___10.FStar_Syntax_Syntax.n in
+                            (match uu___9 with
+                             | FStar_Syntax_Syntax.Tm_arrow (bs, uu___10) ->
                                  let bs1 = FStar_Syntax_Subst.open_binders bs in
                                  let repr_t =
                                    let repr_ts =
-                                     let uu____3284 = repr in
-                                     match uu____3284 with
-                                     | (us, t, uu____3299) -> (us, t) in
-                                   let uu____3316 =
+                                     let uu___11 = repr in
+                                     match uu___11 with
+                                     | (us, t, uu___12) -> (us, t) in
+                                   let uu___11 =
                                      FStar_TypeChecker_Env.inst_tscheme_with
                                        repr_ts
                                        [FStar_Syntax_Syntax.U_unknown] in
-                                   FStar_All.pipe_right uu____3316
+                                   FStar_All.pipe_right uu___11
                                      FStar_Pervasives_Native.snd in
                                  let repr_t_applied =
-                                   let uu____3330 =
-                                     let uu____3331 =
-                                       let uu____3348 =
-                                         let uu____3359 =
-                                           let uu____3362 =
+                                   let uu___11 =
+                                     let uu___12 =
+                                       let uu___13 =
+                                         let uu___14 =
+                                           let uu___15 =
                                              FStar_All.pipe_right bs1
                                                (FStar_List.map
                                                   FStar_Pervasives_Native.fst) in
-                                           FStar_All.pipe_right uu____3362
+                                           FStar_All.pipe_right uu___15
                                              (FStar_List.map
                                                 FStar_Syntax_Syntax.bv_to_name) in
-                                         FStar_All.pipe_right uu____3359
+                                         FStar_All.pipe_right uu___14
                                            (FStar_List.map
                                               FStar_Syntax_Syntax.as_arg) in
-                                       (repr_t, uu____3348) in
-                                     FStar_Syntax_Syntax.Tm_app uu____3331 in
-                                   FStar_Syntax_Syntax.mk uu____3330
+                                       (repr_t, uu___13) in
+                                     FStar_Syntax_Syntax.Tm_app uu___12 in
+                                   FStar_Syntax_Syntax.mk uu___11
                                      FStar_Range.dummyRange in
                                  let f_b =
                                    FStar_Syntax_Syntax.null_binder
                                      repr_t_applied in
-                                 let uu____3412 =
-                                   let uu____3413 =
-                                     let uu____3416 =
+                                 let uu___11 =
+                                   let uu___12 =
+                                     let uu___13 =
                                        FStar_All.pipe_right f_b
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____3416
+                                     FStar_All.pipe_right uu___13
                                        FStar_Syntax_Syntax.bv_to_name in
                                    FStar_Syntax_Util.abs
-                                     (FStar_List.append bs1 [f_b]) uu____3413
+                                     (FStar_List.append bs1 [f_b]) uu___12
                                      FStar_Pervasives_Native.None in
-                                 ([], uu____3412)
-                             | uu____3445 -> failwith "Impossible!"))
-                   | uu____3450 -> ts in
+                                 ([], uu___11)
+                             | uu___10 -> failwith "Impossible!"))
+                   | uu___7 -> ts in
                  let r =
-                   (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos in
-                 let uu____3452 =
-                   check_and_gen1 "stronger_repr" Prims.int_one stronger_repr in
-                 match uu____3452 with
+                   (FStar_Pervasives_Native.snd stronger_repr1).FStar_Syntax_Syntax.pos in
+                 let uu___6 =
+                   check_and_gen1 "stronger_repr" Prims.int_one
+                     stronger_repr1 in
+                 match uu___6 with
                  | (stronger_us, stronger_t, stronger_ty) ->
-                     ((let uu____3475 =
+                     ((let uu___8 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env0)
                            (FStar_Options.Other "LayeredEffectsTc") in
-                       if uu____3475
+                       if uu___8
                        then
-                         let uu____3476 =
+                         let uu___9 =
                            FStar_Syntax_Print.tscheme_to_string
                              (stronger_us, stronger_t) in
-                         let uu____3481 =
+                         let uu___10 =
                            FStar_Syntax_Print.tscheme_to_string
                              (stronger_us, stronger_ty) in
                          FStar_Util.print2
                            "stronger combinator typechecked with term: %s and type: %s\n"
-                           uu____3476 uu____3481
+                           uu___9 uu___10
                        else ());
-                      (let uu____3487 =
+                      (let uu___8 =
                          FStar_Syntax_Subst.open_univ_vars stronger_us
                            stronger_ty in
-                       match uu____3487 with
+                       match uu___8 with
                        | (us, ty) ->
                            let env =
                              FStar_TypeChecker_Env.push_univ_vars env0 us in
                            (check_no_subtyping_for_layered_combinator env ty
                               FStar_Pervasives_Native.None;
-                            (let uu____3508 = fresh_a_and_u_a "a" in
-                             match uu____3508 with
+                            (let uu___10 = fresh_a_and_u_a "a" in
+                             match uu___10 with
                              | (a, u) ->
                                  let rest_bs =
-                                   let uu____3536 =
-                                     let uu____3537 =
+                                   let uu___11 =
+                                     let uu___12 =
                                        FStar_Syntax_Subst.compress ty in
-                                     uu____3537.FStar_Syntax_Syntax.n in
-                                   match uu____3536 with
+                                     uu___12.FStar_Syntax_Syntax.n in
+                                   match uu___11 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs, uu____3549) when
+                                       (bs, uu___12) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____3576 =
+                                       let uu___13 =
                                          FStar_Syntax_Subst.open_binders bs in
-                                       (match uu____3576 with
-                                        | (a', uu____3586)::bs1 ->
-                                            let uu____3606 =
-                                              let uu____3607 =
+                                       (match uu___13 with
+                                        | (a', uu___14)::bs1 ->
+                                            let uu___15 =
+                                              let uu___16 =
                                                 FStar_All.pipe_right bs1
                                                   (FStar_List.splitAt
                                                      ((FStar_List.length bs1)
                                                         - Prims.int_one)) in
-                                              FStar_All.pipe_right uu____3607
+                                              FStar_All.pipe_right uu___16
                                                 FStar_Pervasives_Native.fst in
-                                            let uu____3704 =
-                                              let uu____3717 =
-                                                let uu____3720 =
-                                                  let uu____3721 =
-                                                    let uu____3728 =
+                                            let uu___16 =
+                                              let uu___17 =
+                                                let uu___18 =
+                                                  let uu___19 =
+                                                    let uu___20 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         (FStar_Pervasives_Native.fst
                                                            a) in
-                                                    (a', uu____3728) in
+                                                    (a', uu___20) in
                                                   FStar_Syntax_Syntax.NT
-                                                    uu____3721 in
-                                                [uu____3720] in
+                                                    uu___19 in
+                                                [uu___18] in
                                               FStar_Syntax_Subst.subst_binders
-                                                uu____3717 in
-                                            FStar_All.pipe_right uu____3606
-                                              uu____3704)
-                                   | uu____3743 ->
+                                                uu___17 in
+                                            FStar_All.pipe_right uu___15
+                                              uu___16)
+                                   | uu___12 ->
                                        not_an_arrow_error "stronger"
                                          (Prims.of_int (2)) ty r in
                                  let bs = a :: rest_bs in
-                                 let uu____3759 =
-                                   let uu____3770 =
-                                     let uu____3775 =
+                                 let uu___11 =
+                                   let uu___12 =
+                                     let uu___13 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____3776 =
+                                     let uu___14 =
                                        FStar_All.pipe_right
                                          (FStar_Pervasives_Native.fst a)
                                          FStar_Syntax_Syntax.bv_to_name in
-                                     fresh_repr r uu____3775 u uu____3776 in
-                                   match uu____3770 with
+                                     fresh_repr r uu___13 u uu___14 in
+                                   match uu___12 with
                                    | (repr1, g) ->
-                                       let uu____3791 =
-                                         let uu____3798 =
+                                       let uu___13 =
+                                         let uu___14 =
                                            FStar_Syntax_Syntax.gen_bv "f"
                                              FStar_Pervasives_Native.None
                                              repr1 in
-                                         FStar_All.pipe_right uu____3798
+                                         FStar_All.pipe_right uu___14
                                            FStar_Syntax_Syntax.mk_binder in
-                                       (uu____3791, g) in
-                                 (match uu____3759 with
+                                       (uu___13, g) in
+                                 (match uu___11 with
                                   | (f, guard_f) ->
-                                      let uu____3837 =
-                                        let uu____3842 =
+                                      let uu___12 =
+                                        let uu___13 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs in
-                                        let uu____3843 =
+                                        let uu___14 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name in
-                                        fresh_repr r uu____3842 u uu____3843 in
-                                      (match uu____3837 with
+                                        fresh_repr r uu___13 u uu___14 in
+                                      (match uu___12 with
                                        | (ret_t, guard_ret_t) ->
-                                           let uu____3860 =
-                                             let uu____3865 =
+                                           let uu___13 =
+                                             let uu___14 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env bs in
-                                             let uu____3866 =
-                                               let uu____3867 =
+                                             let uu___15 =
+                                               let uu___16 =
                                                  FStar_Ident.string_of_lid
                                                    ed.FStar_Syntax_Syntax.mname in
                                                FStar_Util.format1
                                                  "implicit for pure_wp in checking stronger for %s"
-                                                 uu____3867 in
-                                             pure_wp_uvar uu____3865 ret_t
-                                               uu____3866 r in
-                                           (match uu____3860 with
+                                                 uu___16 in
+                                             pure_wp_uvar uu___14 ret_t
+                                               uu___15 r in
+                                           (match uu___13 with
                                             | (pure_wp_uvar1, guard_wp) ->
                                                 let c =
-                                                  let uu____3883 =
-                                                    let uu____3884 =
-                                                      let uu____3885 =
+                                                  let uu___14 =
+                                                    let uu___15 =
+                                                      let uu___16 =
                                                         FStar_TypeChecker_Env.new_u_univ
                                                           () in
-                                                      [uu____3885] in
-                                                    let uu____3886 =
-                                                      let uu____3897 =
+                                                      [uu___16] in
+                                                    let uu___16 =
+                                                      let uu___17 =
                                                         FStar_All.pipe_right
                                                           pure_wp_uvar1
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      [uu____3897] in
+                                                      [uu___17] in
                                                     {
                                                       FStar_Syntax_Syntax.comp_univs
-                                                        = uu____3884;
+                                                        = uu___15;
                                                       FStar_Syntax_Syntax.effect_name
                                                         =
                                                         FStar_Parser_Const.effect_PURE_lid;
                                                       FStar_Syntax_Syntax.result_typ
                                                         = ret_t;
                                                       FStar_Syntax_Syntax.effect_args
-                                                        = uu____3886;
+                                                        = uu___16;
                                                       FStar_Syntax_Syntax.flags
                                                         = []
                                                     } in
                                                   FStar_Syntax_Syntax.mk_Comp
-                                                    uu____3883 in
+                                                    uu___14 in
                                                 let k =
                                                   FStar_Syntax_Util.arrow
                                                     (FStar_List.append bs [f])
                                                     c in
-                                                ((let uu____3952 =
+                                                ((let uu___15 =
                                                     FStar_All.pipe_left
                                                       (FStar_TypeChecker_Env.debug
                                                          env)
                                                       (FStar_Options.Other
                                                          "LayeredEffectsTc") in
-                                                  if uu____3952
+                                                  if uu___15
                                                   then
-                                                    let uu____3953 =
+                                                    let uu___16 =
                                                       FStar_Syntax_Print.term_to_string
                                                         k in
                                                     FStar_Util.print1
                                                       "Expected type of subcomp before unification: %s\n"
-                                                      uu____3953
+                                                      uu___16
                                                   else ());
                                                  (let guard_eq =
                                                     FStar_TypeChecker_Rel.teq
@@ -1346,58 +1313,55 @@ let (tc_layered_eff_decl :
                                                     guard_wp;
                                                     guard_eq];
                                                   (let k1 =
-                                                     let uu____3958 =
+                                                     let uu___16 =
                                                        FStar_All.pipe_right k
                                                          (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                             env) in
                                                      FStar_All.pipe_right
-                                                       uu____3958
+                                                       uu___16
                                                        (FStar_TypeChecker_Normalize.normalize
                                                           [FStar_TypeChecker_Env.Beta;
                                                           FStar_TypeChecker_Env.Eager_unfolding]
                                                           env) in
-                                                   (let uu____3960 =
-                                                      let uu____3961 =
+                                                   (let uu___16 =
+                                                      let uu___17 =
                                                         FStar_Syntax_Subst.compress
                                                           k1 in
-                                                      uu____3961.FStar_Syntax_Syntax.n in
-                                                    match uu____3960 with
+                                                      uu___17.FStar_Syntax_Syntax.n in
+                                                    match uu___16 with
                                                     | FStar_Syntax_Syntax.Tm_arrow
                                                         (bs1, c1) ->
-                                                        let uu____3986 =
+                                                        let uu___17 =
                                                           FStar_Syntax_Subst.open_comp
                                                             bs1 c1 in
-                                                        (match uu____3986
-                                                         with
+                                                        (match uu___17 with
                                                          | (a1::bs2, c2) ->
                                                              let res_t =
                                                                FStar_Syntax_Util.comp_result
                                                                  c2 in
-                                                             let uu____4017 =
-                                                               let uu____4036
-                                                                 =
+                                                             let uu___18 =
+                                                               let uu___19 =
                                                                  FStar_List.splitAt
                                                                    ((FStar_List.length
                                                                     bs2) -
                                                                     Prims.int_one)
                                                                    bs2 in
                                                                FStar_All.pipe_right
-                                                                 uu____4036
-                                                                 (fun
-                                                                    uu____4111
+                                                                 uu___19
+                                                                 (fun uu___20
                                                                     ->
-                                                                    match uu____4111
+                                                                    match uu___20
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____4184
+                                                                    let uu___21
                                                                     =
                                                                     FStar_List.hd
                                                                     l2 in
                                                                     (l1,
-                                                                    uu____4184)) in
-                                                             (match uu____4017
+                                                                    uu___21)) in
+                                                             (match uu___18
                                                               with
                                                               | (bs3, f_b) ->
                                                                   let env1 =
@@ -1412,76 +1376,74 @@ let (tc_layered_eff_decl :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                   (let uu____4256 =
+                                                   (let uu___16 =
                                                       FStar_All.pipe_right k1
                                                         (FStar_Syntax_Subst.close_univ_vars
                                                            stronger_us) in
                                                     (stronger_us, stronger_t,
-                                                      uu____4256)))))))))))) in
+                                                      uu___16)))))))))))) in
                log_combinator "stronger_repr" stronger_repr;
                (let if_then_else =
                   let if_then_else_ts =
                     let ts =
-                      let uu____4291 =
+                      let uu___7 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                      FStar_All.pipe_right uu____4291 FStar_Util.must in
-                    let uu____4318 =
-                      let uu____4319 =
-                        let uu____4322 =
+                      FStar_All.pipe_right uu___7 FStar_Util.must in
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
                           FStar_All.pipe_right ts FStar_Pervasives_Native.snd in
-                        FStar_All.pipe_right uu____4322
+                        FStar_All.pipe_right uu___9
                           FStar_Syntax_Subst.compress in
-                      uu____4319.FStar_Syntax_Syntax.n in
-                    match uu____4318 with
+                      uu___8.FStar_Syntax_Syntax.n in
+                    match uu___7 with
                     | FStar_Syntax_Syntax.Tm_unknown ->
                         let signature_ts =
-                          let uu____4334 = signature in
-                          match uu____4334 with
-                          | (us, t, uu____4349) -> (us, t) in
-                        let uu____4366 =
+                          let uu___8 = signature in
+                          match uu___8 with | (us, t, uu___9) -> (us, t) in
+                        let uu___8 =
                           FStar_TypeChecker_Env.inst_tscheme_with
                             signature_ts [FStar_Syntax_Syntax.U_unknown] in
-                        (match uu____4366 with
-                         | (uu____4375, signature_t) ->
-                             let uu____4377 =
-                               let uu____4378 =
+                        (match uu___8 with
+                         | (uu___9, signature_t) ->
+                             let uu___10 =
+                               let uu___11 =
                                  FStar_Syntax_Subst.compress signature_t in
-                               uu____4378.FStar_Syntax_Syntax.n in
-                             (match uu____4377 with
-                              | FStar_Syntax_Syntax.Tm_arrow (bs, uu____4386)
-                                  ->
+                               uu___11.FStar_Syntax_Syntax.n in
+                             (match uu___10 with
+                              | FStar_Syntax_Syntax.Tm_arrow (bs, uu___11) ->
                                   let bs1 =
                                     FStar_Syntax_Subst.open_binders bs in
                                   let repr_t =
                                     let repr_ts =
-                                      let uu____4412 = repr in
-                                      match uu____4412 with
-                                      | (us, t, uu____4427) -> (us, t) in
-                                    let uu____4444 =
+                                      let uu___12 = repr in
+                                      match uu___12 with
+                                      | (us, t, uu___13) -> (us, t) in
+                                    let uu___12 =
                                       FStar_TypeChecker_Env.inst_tscheme_with
                                         repr_ts
                                         [FStar_Syntax_Syntax.U_unknown] in
-                                    FStar_All.pipe_right uu____4444
+                                    FStar_All.pipe_right uu___12
                                       FStar_Pervasives_Native.snd in
                                   let repr_t_applied =
-                                    let uu____4458 =
-                                      let uu____4459 =
-                                        let uu____4476 =
-                                          let uu____4487 =
-                                            let uu____4490 =
+                                    let uu___12 =
+                                      let uu___13 =
+                                        let uu___14 =
+                                          let uu___15 =
+                                            let uu___16 =
                                               FStar_All.pipe_right bs1
                                                 (FStar_List.map
                                                    FStar_Pervasives_Native.fst) in
-                                            FStar_All.pipe_right uu____4490
+                                            FStar_All.pipe_right uu___16
                                               (FStar_List.map
                                                  FStar_Syntax_Syntax.bv_to_name) in
-                                          FStar_All.pipe_right uu____4487
+                                          FStar_All.pipe_right uu___15
                                             (FStar_List.map
                                                FStar_Syntax_Syntax.as_arg) in
-                                        (repr_t, uu____4476) in
-                                      FStar_Syntax_Syntax.Tm_app uu____4459 in
-                                    FStar_Syntax_Syntax.mk uu____4458
+                                        (repr_t, uu___14) in
+                                      FStar_Syntax_Syntax.Tm_app uu___13 in
+                                    FStar_Syntax_Syntax.mk uu___12
                                       FStar_Range.dummyRange in
                                   let f_b =
                                     FStar_Syntax_Syntax.null_binder
@@ -1492,57 +1454,57 @@ let (tc_layered_eff_decl :
                                   let b_b =
                                     FStar_Syntax_Syntax.null_binder
                                       FStar_Syntax_Util.t_bool in
-                                  let uu____4542 =
+                                  let uu___12 =
                                     FStar_Syntax_Util.abs
                                       (FStar_List.append bs1 [f_b; g_b; b_b])
                                       repr_t_applied
                                       FStar_Pervasives_Native.None in
-                                  ([], uu____4542)
-                              | uu____4573 -> failwith "Impossible!"))
-                    | uu____4578 -> ts in
+                                  ([], uu___12)
+                              | uu___11 -> failwith "Impossible!"))
+                    | uu___8 -> ts in
                   let r =
                     (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos in
-                  let uu____4580 =
+                  let uu___7 =
                     check_and_gen1 "if_then_else" Prims.int_one
                       if_then_else_ts in
-                  match uu____4580 with
+                  match uu___7 with
                   | (if_then_else_us, if_then_else_t, if_then_else_ty) ->
-                      let uu____4602 =
+                      let uu___8 =
                         FStar_Syntax_Subst.open_univ_vars if_then_else_us
                           if_then_else_t in
-                      (match uu____4602 with
+                      (match uu___8 with
                        | (us, t) ->
-                           let uu____4621 =
+                           let uu___9 =
                              FStar_Syntax_Subst.open_univ_vars
                                if_then_else_us if_then_else_ty in
-                           (match uu____4621 with
-                            | (uu____4638, ty) ->
+                           (match uu___9 with
+                            | (uu___10, ty) ->
                                 let env =
                                   FStar_TypeChecker_Env.push_univ_vars env0
                                     us in
                                 (check_no_subtyping_for_layered_combinator
                                    env t (FStar_Pervasives_Native.Some ty);
-                                 (let uu____4642 = fresh_a_and_u_a "a" in
-                                  match uu____4642 with
+                                 (let uu___12 = fresh_a_and_u_a "a" in
+                                  match uu___12 with
                                   | (a, u_a) ->
                                       let rest_bs =
-                                        let uu____4670 =
-                                          let uu____4671 =
+                                        let uu___13 =
+                                          let uu___14 =
                                             FStar_Syntax_Subst.compress ty in
-                                          uu____4671.FStar_Syntax_Syntax.n in
-                                        match uu____4670 with
+                                          uu___14.FStar_Syntax_Syntax.n in
+                                        match uu___13 with
                                         | FStar_Syntax_Syntax.Tm_arrow
-                                            (bs, uu____4683) when
+                                            (bs, uu___14) when
                                             (FStar_List.length bs) >=
                                               (Prims.of_int (4))
                                             ->
-                                            let uu____4710 =
+                                            let uu___15 =
                                               FStar_Syntax_Subst.open_binders
                                                 bs in
-                                            (match uu____4710 with
-                                             | (a', uu____4720)::bs1 ->
-                                                 let uu____4740 =
-                                                   let uu____4741 =
+                                            (match uu___15 with
+                                             | (a', uu___16)::bs1 ->
+                                                 let uu___17 =
+                                                   let uu___18 =
                                                      FStar_All.pipe_right bs1
                                                        (FStar_List.splitAt
                                                           ((FStar_List.length
@@ -1550,111 +1512,109 @@ let (tc_layered_eff_decl :
                                                              -
                                                              (Prims.of_int (3)))) in
                                                    FStar_All.pipe_right
-                                                     uu____4741
+                                                     uu___18
                                                      FStar_Pervasives_Native.fst in
-                                                 let uu____4838 =
-                                                   let uu____4851 =
-                                                     let uu____4854 =
-                                                       let uu____4855 =
-                                                         let uu____4862 =
-                                                           let uu____4865 =
+                                                 let uu___18 =
+                                                   let uu___19 =
+                                                     let uu___20 =
+                                                       let uu___21 =
+                                                         let uu___22 =
+                                                           let uu___23 =
                                                              FStar_All.pipe_right
                                                                a
                                                                FStar_Pervasives_Native.fst in
                                                            FStar_All.pipe_right
-                                                             uu____4865
+                                                             uu___23
                                                              FStar_Syntax_Syntax.bv_to_name in
-                                                         (a', uu____4862) in
+                                                         (a', uu___22) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____4855 in
-                                                     [uu____4854] in
+                                                         uu___21 in
+                                                     [uu___20] in
                                                    FStar_Syntax_Subst.subst_binders
-                                                     uu____4851 in
-                                                 FStar_All.pipe_right
-                                                   uu____4740 uu____4838)
-                                        | uu____4886 ->
+                                                     uu___19 in
+                                                 FStar_All.pipe_right uu___17
+                                                   uu___18)
+                                        | uu___14 ->
                                             not_an_arrow_error "if_then_else"
                                               (Prims.of_int (4)) ty r in
                                       let bs = a :: rest_bs in
-                                      let uu____4902 =
-                                        let uu____4913 =
-                                          let uu____4918 =
+                                      let uu___13 =
+                                        let uu___14 =
+                                          let uu___15 =
                                             FStar_TypeChecker_Env.push_binders
                                               env bs in
-                                          let uu____4919 =
-                                            let uu____4920 =
+                                          let uu___16 =
+                                            let uu___17 =
                                               FStar_All.pipe_right a
                                                 FStar_Pervasives_Native.fst in
-                                            FStar_All.pipe_right uu____4920
+                                            FStar_All.pipe_right uu___17
                                               FStar_Syntax_Syntax.bv_to_name in
-                                          fresh_repr r uu____4918 u_a
-                                            uu____4919 in
-                                        match uu____4913 with
+                                          fresh_repr r uu___15 u_a uu___16 in
+                                        match uu___14 with
                                         | (repr1, g) ->
-                                            let uu____4941 =
-                                              let uu____4948 =
+                                            let uu___15 =
+                                              let uu___16 =
                                                 FStar_Syntax_Syntax.gen_bv
                                                   "f"
                                                   FStar_Pervasives_Native.None
                                                   repr1 in
-                                              FStar_All.pipe_right uu____4948
+                                              FStar_All.pipe_right uu___16
                                                 FStar_Syntax_Syntax.mk_binder in
-                                            (uu____4941, g) in
-                                      (match uu____4902 with
+                                            (uu___15, g) in
+                                      (match uu___13 with
                                        | (f_bs, guard_f) ->
-                                           let uu____4987 =
-                                             let uu____4998 =
-                                               let uu____5003 =
+                                           let uu___14 =
+                                             let uu___15 =
+                                               let uu___16 =
                                                  FStar_TypeChecker_Env.push_binders
                                                    env bs in
-                                               let uu____5004 =
-                                                 let uu____5005 =
+                                               let uu___17 =
+                                                 let uu___18 =
                                                    FStar_All.pipe_right a
                                                      FStar_Pervasives_Native.fst in
-                                                 FStar_All.pipe_right
-                                                   uu____5005
+                                                 FStar_All.pipe_right uu___18
                                                    FStar_Syntax_Syntax.bv_to_name in
-                                               fresh_repr r uu____5003 u_a
-                                                 uu____5004 in
-                                             match uu____4998 with
+                                               fresh_repr r uu___16 u_a
+                                                 uu___17 in
+                                             match uu___15 with
                                              | (repr1, g) ->
-                                                 let uu____5026 =
-                                                   let uu____5033 =
+                                                 let uu___16 =
+                                                   let uu___17 =
                                                      FStar_Syntax_Syntax.gen_bv
                                                        "g"
                                                        FStar_Pervasives_Native.None
                                                        repr1 in
                                                    FStar_All.pipe_right
-                                                     uu____5033
+                                                     uu___17
                                                      FStar_Syntax_Syntax.mk_binder in
-                                                 (uu____5026, g) in
-                                           (match uu____4987 with
+                                                 (uu___16, g) in
+                                           (match uu___14 with
                                             | (g_bs, guard_g) ->
                                                 let p_b =
-                                                  let uu____5079 =
+                                                  let uu___15 =
                                                     FStar_Syntax_Syntax.gen_bv
                                                       "p"
                                                       FStar_Pervasives_Native.None
                                                       FStar_Syntax_Util.t_bool in
                                                   FStar_All.pipe_right
-                                                    uu____5079
+                                                    uu___15
                                                     FStar_Syntax_Syntax.mk_binder in
-                                                let uu____5086 =
-                                                  let uu____5091 =
+                                                let uu___15 =
+                                                  let uu___16 =
                                                     FStar_TypeChecker_Env.push_binders
                                                       env
                                                       (FStar_List.append bs
                                                          [p_b]) in
-                                                  let uu____5110 =
-                                                    let uu____5111 =
+                                                  let uu___17 =
+                                                    let uu___18 =
                                                       FStar_All.pipe_right a
                                                         FStar_Pervasives_Native.fst in
                                                     FStar_All.pipe_right
-                                                      uu____5111
+                                                      uu___18
                                                       FStar_Syntax_Syntax.bv_to_name in
-                                                  fresh_repr r uu____5091 u_a
-                                                    uu____5110 in
-                                                (match uu____5086 with
+                                                  fresh_repr r uu___16 u_a
+                                                    uu___17 in
+                                                (match uu___15 with
                                                  | (t_body, guard_body) ->
                                                      let k =
                                                        FStar_Syntax_Util.abs
@@ -1679,26 +1639,26 @@ let (tc_layered_eff_decl :
                                                            k
                                                            (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                               env) in
-                                                       (let uu____5173 =
-                                                          let uu____5174 =
+                                                       (let uu___17 =
+                                                          let uu___18 =
                                                             FStar_Syntax_Subst.compress
                                                               k1 in
-                                                          uu____5174.FStar_Syntax_Syntax.n in
-                                                        match uu____5173 with
+                                                          uu___18.FStar_Syntax_Syntax.n in
+                                                        match uu___17 with
                                                         | FStar_Syntax_Syntax.Tm_abs
                                                             (bs1, body,
-                                                             uu____5179)
+                                                             uu___18)
                                                             ->
-                                                            let uu____5204 =
+                                                            let uu___19 =
                                                               FStar_Syntax_Subst.open_term
                                                                 bs1 body in
-                                                            (match uu____5204
+                                                            (match uu___19
                                                              with
                                                              | (a1::bs2,
                                                                 body1) ->
-                                                                 let uu____5232
+                                                                 let uu___20
                                                                    =
-                                                                   let uu____5259
+                                                                   let uu___21
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -1706,34 +1666,34 @@ let (tc_layered_eff_decl :
                                                                     (Prims.of_int (3)))
                                                                     bs2 in
                                                                    FStar_All.pipe_right
-                                                                    uu____5259
+                                                                    uu___21
                                                                     (fun
-                                                                    uu____5343
+                                                                    uu___22
                                                                     ->
-                                                                    match uu____5343
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____5424
+                                                                    let uu___23
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____5451
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____5458
+                                                                    let uu___25
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____5458
+                                                                    uu___25
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____5424,
-                                                                    uu____5451)) in
-                                                                 (match uu____5232
+                                                                    uu___23,
+                                                                    uu___24)) in
+                                                                 (match uu___20
                                                                   with
                                                                   | (bs3,
                                                                     f_b, g_b)
@@ -1753,125 +1713,124 @@ let (tc_layered_eff_decl :
                                                                     body1]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                       (let uu____5589 =
+                                                       (let uu___17 =
                                                           FStar_All.pipe_right
                                                             k1
                                                             (FStar_Syntax_Subst.close_univ_vars
                                                                if_then_else_us) in
                                                         (if_then_else_us,
-                                                          uu____5589,
+                                                          uu___17,
                                                           if_then_else_ty))))))))))) in
                 log_combinator "if_then_else" if_then_else;
                 (let r =
-                   let uu____5603 =
-                     let uu____5606 =
-                       let uu____5615 =
+                   let uu___8 =
+                     let uu___9 =
+                       let uu___10 =
                          FStar_All.pipe_right ed
                            FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                       FStar_All.pipe_right uu____5615 FStar_Util.must in
-                     FStar_All.pipe_right uu____5606
-                       FStar_Pervasives_Native.snd in
-                   uu____5603.FStar_Syntax_Syntax.pos in
+                       FStar_All.pipe_right uu___10 FStar_Util.must in
+                     FStar_All.pipe_right uu___9 FStar_Pervasives_Native.snd in
+                   uu___8.FStar_Syntax_Syntax.pos in
                  let binder_aq_to_arg_aq aq =
                    match aq with
                    | FStar_Pervasives_Native.Some
-                       (FStar_Syntax_Syntax.Implicit uu____5690) -> aq
+                       (FStar_Syntax_Syntax.Implicit uu___8) -> aq
                    | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
-                       uu____5691) ->
+                       uu___8) ->
                        FStar_Pervasives_Native.Some
                          (FStar_Syntax_Syntax.Implicit false)
-                   | uu____5692 -> FStar_Pervasives_Native.None in
-                 let uu____5695 = if_then_else in
-                 match uu____5695 with
-                 | (ite_us, ite_t, uu____5710) ->
-                     let uu____5723 =
+                   | uu___8 -> FStar_Pervasives_Native.None in
+                 let uu___8 = if_then_else in
+                 match uu___8 with
+                 | (ite_us, ite_t, uu___9) ->
+                     let uu___10 =
                        FStar_Syntax_Subst.open_univ_vars ite_us ite_t in
-                     (match uu____5723 with
+                     (match uu___10 with
                       | (us, ite_t1) ->
-                          let uu____5730 =
-                            let uu____5747 =
-                              let uu____5748 =
+                          let uu___11 =
+                            let uu___12 =
+                              let uu___13 =
                                 FStar_Syntax_Subst.compress ite_t1 in
-                              uu____5748.FStar_Syntax_Syntax.n in
-                            match uu____5747 with
+                              uu___13.FStar_Syntax_Syntax.n in
+                            match uu___12 with
                             | FStar_Syntax_Syntax.Tm_abs
-                                (bs, uu____5768, uu____5769) ->
+                                (bs, uu___13, uu___14) ->
                                 let bs1 = FStar_Syntax_Subst.open_binders bs in
-                                let uu____5795 =
-                                  let uu____5808 =
-                                    let uu____5813 =
-                                      let uu____5816 =
-                                        let uu____5825 =
+                                let uu___15 =
+                                  let uu___16 =
+                                    let uu___17 =
+                                      let uu___18 =
+                                        let uu___19 =
                                           FStar_All.pipe_right bs1
                                             (FStar_List.splitAt
                                                ((FStar_List.length bs1) -
                                                   (Prims.of_int (3)))) in
-                                        FStar_All.pipe_right uu____5825
+                                        FStar_All.pipe_right uu___19
                                           FStar_Pervasives_Native.snd in
-                                      FStar_All.pipe_right uu____5816
+                                      FStar_All.pipe_right uu___18
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst) in
-                                    FStar_All.pipe_right uu____5813
+                                    FStar_All.pipe_right uu___17
                                       (FStar_List.map
                                          FStar_Syntax_Syntax.bv_to_name) in
-                                  FStar_All.pipe_right uu____5808
+                                  FStar_All.pipe_right uu___16
                                     (fun l ->
-                                       let uu____5980 = l in
-                                       match uu____5980 with
+                                       let uu___17 = l in
+                                       match uu___17 with
                                        | f::g::p::[] -> (f, g, p)) in
-                                (match uu____5795 with
+                                (match uu___15 with
                                  | (f, g, p) ->
-                                     let uu____6051 =
-                                       let uu____6052 =
+                                     let uu___16 =
+                                       let uu___17 =
                                          FStar_TypeChecker_Env.push_univ_vars
                                            env0 us in
                                        FStar_TypeChecker_Env.push_binders
-                                         uu____6052 bs1 in
-                                     let uu____6053 =
-                                       let uu____6054 =
+                                         uu___17 bs1 in
+                                     let uu___17 =
+                                       let uu___18 =
                                          FStar_All.pipe_right bs1
                                            (FStar_List.map
-                                              (fun uu____6079 ->
-                                                 match uu____6079 with
+                                              (fun uu___19 ->
+                                                 match uu___19 with
                                                  | (b, qual) ->
-                                                     let uu____6098 =
+                                                     let uu___20 =
                                                        FStar_Syntax_Syntax.bv_to_name
                                                          b in
-                                                     (uu____6098,
+                                                     (uu___20,
                                                        (binder_aq_to_arg_aq
                                                           qual)))) in
                                        FStar_Syntax_Syntax.mk_Tm_app ite_t1
-                                         uu____6054 r in
-                                     (uu____6051, uu____6053, f, g, p))
-                            | uu____6107 ->
+                                         uu___18 r in
+                                     (uu___16, uu___17, f, g, p))
+                            | uu___13 ->
                                 failwith
                                   "Impossible! ite_t must have been an abstraction with at least 3 binders" in
-                          (match uu____5730 with
+                          (match uu___11 with
                            | (env, ite_t_applied, f_t, g_t, p_t) ->
-                               let uu____6141 =
-                                 let uu____6150 = stronger_repr in
-                                 match uu____6150 with
-                                 | (uu____6171, subcomp_t, subcomp_ty) ->
-                                     let uu____6186 =
+                               let uu___12 =
+                                 let uu___13 = stronger_repr in
+                                 match uu___13 with
+                                 | (uu___14, subcomp_t, subcomp_ty) ->
+                                     let uu___15 =
                                        FStar_Syntax_Subst.open_univ_vars us
                                          subcomp_t in
-                                     (match uu____6186 with
-                                      | (uu____6199, subcomp_t1) ->
-                                          let uu____6201 =
-                                            let uu____6212 =
+                                     (match uu___15 with
+                                      | (uu___16, subcomp_t1) ->
+                                          let uu___17 =
+                                            let uu___18 =
                                               FStar_Syntax_Subst.open_univ_vars
                                                 us subcomp_ty in
-                                            match uu____6212 with
-                                            | (uu____6227, subcomp_ty1) ->
-                                                let uu____6229 =
-                                                  let uu____6230 =
+                                            match uu___18 with
+                                            | (uu___19, subcomp_ty1) ->
+                                                let uu___20 =
+                                                  let uu___21 =
                                                     FStar_Syntax_Subst.compress
                                                       subcomp_ty1 in
-                                                  uu____6230.FStar_Syntax_Syntax.n in
-                                                (match uu____6229 with
+                                                  uu___21.FStar_Syntax_Syntax.n in
+                                                (match uu___20 with
                                                  | FStar_Syntax_Syntax.Tm_arrow
-                                                     (bs, uu____6244) ->
-                                                     let uu____6265 =
+                                                     (bs, uu___21) ->
+                                                     let uu___22 =
                                                        FStar_All.pipe_right
                                                          bs
                                                          (FStar_List.splitAt
@@ -1879,41 +1838,40 @@ let (tc_layered_eff_decl :
                                                                 bs)
                                                                -
                                                                Prims.int_one)) in
-                                                     (match uu____6265 with
+                                                     (match uu___22 with
                                                       | (bs_except_last,
                                                          last_b) ->
-                                                          let uu____6370 =
+                                                          let uu___23 =
                                                             FStar_All.pipe_right
                                                               bs_except_last
                                                               (FStar_List.map
                                                                  FStar_Pervasives_Native.snd) in
-                                                          let uu____6397 =
-                                                            let uu____6400 =
+                                                          let uu___24 =
+                                                            let uu___25 =
                                                               FStar_All.pipe_right
                                                                 last_b
                                                                 FStar_List.hd in
                                                             FStar_All.pipe_right
-                                                              uu____6400
+                                                              uu___25
                                                               FStar_Pervasives_Native.snd in
-                                                          (uu____6370,
-                                                            uu____6397))
-                                                 | uu____6443 ->
+                                                          (uu___23, uu___24))
+                                                 | uu___21 ->
                                                      failwith
                                                        "Impossible! subcomp_ty must have been an arrow with at lease 1 binder") in
-                                          (match uu____6201 with
+                                          (match uu___17 with
                                            | (aqs_except_last, last_aq) ->
-                                               let uu____6476 =
-                                                 let uu____6487 =
+                                               let uu___18 =
+                                                 let uu___19 =
                                                    FStar_All.pipe_right
                                                      aqs_except_last
                                                      (FStar_List.map
                                                         binder_aq_to_arg_aq) in
-                                                 let uu____6504 =
+                                                 let uu___20 =
                                                    FStar_All.pipe_right
                                                      last_aq
                                                      binder_aq_to_arg_aq in
-                                                 (uu____6487, uu____6504) in
-                                               (match uu____6476 with
+                                                 (uu___19, uu___20) in
+                                               (match uu___18 with
                                                 | (aqs_except_last1,
                                                    last_aq1) ->
                                                     let aux t =
@@ -1929,106 +1887,104 @@ let (tc_layered_eff_decl :
                                                         (FStar_List.append
                                                            tun_args
                                                            [(t, last_aq1)]) r in
-                                                    let uu____6616 = aux f_t in
-                                                    let uu____6619 = aux g_t in
-                                                    (uu____6616, uu____6619)))) in
-                               (match uu____6141 with
+                                                    let uu___19 = aux f_t in
+                                                    let uu___20 = aux g_t in
+                                                    (uu___19, uu___20)))) in
+                               (match uu___12 with
                                 | (subcomp_f, subcomp_g) ->
-                                    let uu____6636 =
+                                    let uu___13 =
                                       let aux t =
-                                        let uu____6653 =
-                                          let uu____6654 =
-                                            let uu____6681 =
-                                              let uu____6698 =
-                                                let uu____6707 =
+                                        let uu___14 =
+                                          let uu___15 =
+                                            let uu___16 =
+                                              let uu___17 =
+                                                let uu___18 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     ite_t_applied in
-                                                FStar_Util.Inr uu____6707 in
-                                              (uu____6698,
+                                                FStar_Util.Inr uu___18 in
+                                              (uu___17,
                                                 FStar_Pervasives_Native.None) in
-                                            (t, uu____6681,
+                                            (t, uu___16,
                                               FStar_Pervasives_Native.None) in
                                           FStar_Syntax_Syntax.Tm_ascribed
-                                            uu____6654 in
-                                        FStar_Syntax_Syntax.mk uu____6653 r in
-                                      let uu____6748 = aux subcomp_f in
-                                      let uu____6749 = aux subcomp_g in
-                                      (uu____6748, uu____6749) in
-                                    (match uu____6636 with
+                                            uu___15 in
+                                        FStar_Syntax_Syntax.mk uu___14 r in
+                                      let uu___14 = aux subcomp_f in
+                                      let uu___15 = aux subcomp_g in
+                                      (uu___14, uu___15) in
+                                    (match uu___13 with
                                      | (tm_subcomp_ascribed_f,
                                         tm_subcomp_ascribed_g) ->
-                                         ((let uu____6753 =
+                                         ((let uu___15 =
                                              FStar_All.pipe_left
                                                (FStar_TypeChecker_Env.debug
                                                   env)
                                                (FStar_Options.Other
                                                   "LayeredEffectsTc") in
-                                           if uu____6753
+                                           if uu___15
                                            then
-                                             let uu____6754 =
+                                             let uu___16 =
                                                FStar_Syntax_Print.term_to_string
                                                  tm_subcomp_ascribed_f in
-                                             let uu____6755 =
+                                             let uu___17 =
                                                FStar_Syntax_Print.term_to_string
                                                  tm_subcomp_ascribed_g in
                                              FStar_Util.print2
                                                "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
-                                               uu____6754 uu____6755
+                                               uu___16 uu___17
                                            else ());
                                           (let env1 =
-                                             let uu____6759 =
-                                               let uu____6760 =
-                                                 let uu____6761 =
+                                             let uu___15 =
+                                               let uu___16 =
+                                                 let uu___17 =
                                                    FStar_All.pipe_right p_t
                                                      FStar_Syntax_Util.b2t in
                                                  FStar_Syntax_Util.mk_squash
                                                    FStar_Syntax_Syntax.U_zero
-                                                   uu____6761 in
+                                                   uu___17 in
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
-                                                 uu____6760 in
+                                                 uu___16 in
                                              FStar_TypeChecker_Env.push_bv
-                                               env uu____6759 in
-                                           let uu____6764 =
+                                               env uu___15 in
+                                           let uu___15 =
                                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                env1 tm_subcomp_ascribed_f in
-                                           match uu____6764 with
-                                           | (uu____6771, uu____6772, g_f) ->
+                                           match uu___15 with
+                                           | (uu___16, uu___17, g_f) ->
                                                FStar_TypeChecker_Rel.force_trivial_guard
                                                  env1 g_f);
                                           (let not_p =
-                                             let uu____6776 =
-                                               let uu____6777 =
+                                             let uu___15 =
+                                               let uu___16 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    FStar_Parser_Const.not_lid
                                                    FStar_Syntax_Syntax.delta_constant
                                                    FStar_Pervasives_Native.None in
-                                               FStar_All.pipe_right
-                                                 uu____6777
+                                               FStar_All.pipe_right uu___16
                                                  FStar_Syntax_Syntax.fv_to_tm in
-                                             let uu____6778 =
-                                               let uu____6779 =
-                                                 let uu____6788 =
+                                             let uu___16 =
+                                               let uu___17 =
+                                                 let uu___18 =
                                                    FStar_All.pipe_right p_t
                                                      FStar_Syntax_Util.b2t in
-                                                 FStar_All.pipe_right
-                                                   uu____6788
+                                                 FStar_All.pipe_right uu___18
                                                    FStar_Syntax_Syntax.as_arg in
-                                               [uu____6779] in
+                                               [uu___17] in
                                              FStar_Syntax_Syntax.mk_Tm_app
-                                               uu____6776 uu____6778 r in
+                                               uu___15 uu___16 r in
                                            let env1 =
-                                             let uu____6816 =
+                                             let uu___15 =
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
                                                  not_p in
                                              FStar_TypeChecker_Env.push_bv
-                                               env uu____6816 in
-                                           let uu____6817 =
+                                               env uu___15 in
+                                           let uu___15 =
                                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                env1 tm_subcomp_ascribed_g in
-                                           match uu____6817 with
-                                           | (uu____6824, uu____6825, g_g) ->
+                                           match uu___15 with
+                                           | (uu___16, uu___17, g_g) ->
                                                FStar_TypeChecker_Rel.force_trivial_guard
                                                  env1 g_g)))))));
                 (let tc_action env act =
@@ -2039,334 +1995,326 @@ let (tc_layered_eff_decl :
                      (FStar_List.length act.FStar_Syntax_Syntax.action_params)
                        <> Prims.int_zero
                    then
-                     (let uu____6847 =
-                        let uu____6852 =
-                          let uu____6853 =
+                     (let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
                             FStar_Ident.string_of_lid
                               ed.FStar_Syntax_Syntax.mname in
-                          let uu____6854 =
+                          let uu___12 =
                             FStar_Ident.string_of_lid
                               act.FStar_Syntax_Syntax.action_name in
-                          let uu____6855 =
+                          let uu___13 =
                             FStar_Syntax_Print.binders_to_string "; "
                               act.FStar_Syntax_Syntax.action_params in
                           FStar_Util.format3
                             "Action %s:%s has non-empty action params (%s)"
-                            uu____6853 uu____6854 uu____6855 in
+                            uu___11 uu___12 uu___13 in
                         (FStar_Errors.Fatal_MalformedActionDeclaration,
-                          uu____6852) in
-                      FStar_Errors.raise_error uu____6847 r)
+                          uu___10) in
+                      FStar_Errors.raise_error uu___9 r)
                    else ();
-                   (let uu____6857 =
-                      let uu____6862 =
+                   (let uu___9 =
+                      let uu___10 =
                         FStar_Syntax_Subst.univ_var_opening
                           act.FStar_Syntax_Syntax.action_univs in
-                      match uu____6862 with
+                      match uu___10 with
                       | (usubst, us) ->
-                          let uu____6885 =
+                          let uu___11 =
                             FStar_TypeChecker_Env.push_univ_vars env us in
-                          let uu____6886 =
-                            let uu___651_6887 = act in
-                            let uu____6888 =
+                          let uu___12 =
+                            let uu___13 = act in
+                            let uu___14 =
                               FStar_Syntax_Subst.subst usubst
                                 act.FStar_Syntax_Syntax.action_defn in
-                            let uu____6889 =
+                            let uu___15 =
                               FStar_Syntax_Subst.subst usubst
                                 act.FStar_Syntax_Syntax.action_typ in
                             {
                               FStar_Syntax_Syntax.action_name =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_name);
+                                (uu___13.FStar_Syntax_Syntax.action_name);
                               FStar_Syntax_Syntax.action_unqualified_name =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_unqualified_name);
+                                (uu___13.FStar_Syntax_Syntax.action_unqualified_name);
                               FStar_Syntax_Syntax.action_univs = us;
                               FStar_Syntax_Syntax.action_params =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_params);
-                              FStar_Syntax_Syntax.action_defn = uu____6888;
-                              FStar_Syntax_Syntax.action_typ = uu____6889
+                                (uu___13.FStar_Syntax_Syntax.action_params);
+                              FStar_Syntax_Syntax.action_defn = uu___14;
+                              FStar_Syntax_Syntax.action_typ = uu___15
                             } in
-                          (uu____6885, uu____6886) in
-                    match uu____6857 with
+                          (uu___11, uu___12) in
+                    match uu___9 with
                     | (env1, act1) ->
                         let act_typ =
-                          let uu____6893 =
-                            let uu____6894 =
+                          let uu___10 =
+                            let uu___11 =
                               FStar_Syntax_Subst.compress
                                 act1.FStar_Syntax_Syntax.action_typ in
-                            uu____6894.FStar_Syntax_Syntax.n in
-                          match uu____6893 with
+                            uu___11.FStar_Syntax_Syntax.n in
+                          match uu___10 with
                           | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                               let ct = FStar_Syntax_Util.comp_to_comp_typ c in
-                              let uu____6920 =
+                              let uu___11 =
                                 FStar_Ident.lid_equals
                                   ct.FStar_Syntax_Syntax.effect_name
                                   ed.FStar_Syntax_Syntax.mname in
-                              if uu____6920
+                              if uu___11
                               then
                                 let repr_ts =
-                                  let uu____6922 = repr in
-                                  match uu____6922 with
-                                  | (us, t, uu____6937) -> (us, t) in
+                                  let uu___12 = repr in
+                                  match uu___12 with
+                                  | (us, t, uu___13) -> (us, t) in
                                 let repr1 =
-                                  let uu____6955 =
+                                  let uu___12 =
                                     FStar_TypeChecker_Env.inst_tscheme_with
                                       repr_ts
                                       ct.FStar_Syntax_Syntax.comp_univs in
-                                  FStar_All.pipe_right uu____6955
+                                  FStar_All.pipe_right uu___12
                                     FStar_Pervasives_Native.snd in
                                 let repr2 =
-                                  let uu____6965 =
-                                    let uu____6966 =
+                                  let uu___12 =
+                                    let uu___13 =
                                       FStar_Syntax_Syntax.as_arg
                                         ct.FStar_Syntax_Syntax.result_typ in
-                                    uu____6966 ::
+                                    uu___13 ::
                                       (ct.FStar_Syntax_Syntax.effect_args) in
-                                  FStar_Syntax_Syntax.mk_Tm_app repr1
-                                    uu____6965 r in
+                                  FStar_Syntax_Syntax.mk_Tm_app repr1 uu___12
+                                    r in
                                 let c1 =
-                                  let uu____6984 =
-                                    let uu____6987 =
+                                  let uu___12 =
+                                    let uu___13 =
                                       FStar_TypeChecker_Env.new_u_univ () in
-                                    FStar_Pervasives_Native.Some uu____6987 in
-                                  FStar_Syntax_Syntax.mk_Total' repr2
-                                    uu____6984 in
+                                    FStar_Pervasives_Native.Some uu___13 in
+                                  FStar_Syntax_Syntax.mk_Total' repr2 uu___12 in
                                 FStar_Syntax_Util.arrow bs c1
                               else act1.FStar_Syntax_Syntax.action_typ
-                          | uu____6989 -> act1.FStar_Syntax_Syntax.action_typ in
-                        let uu____6990 =
+                          | uu___11 -> act1.FStar_Syntax_Syntax.action_typ in
+                        let uu___10 =
                           FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1
                             act_typ in
-                        (match uu____6990 with
-                         | (act_typ1, uu____6998, g_t) ->
-                             let uu____7000 =
-                               let uu____7007 =
-                                 let uu___676_7008 =
+                        (match uu___10 with
+                         | (act_typ1, uu___11, g_t) ->
+                             let uu___12 =
+                               let uu___13 =
+                                 let uu___14 =
                                    FStar_TypeChecker_Env.set_expected_typ
                                      env1 act_typ1 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___676_7008.FStar_TypeChecker_Env.solver);
+                                     (uu___14.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___676_7008.FStar_TypeChecker_Env.range);
+                                     (uu___14.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___676_7008.FStar_TypeChecker_Env.curmodule);
+                                     (uu___14.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma);
+                                     (uu___14.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___14.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___14.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___676_7008.FStar_TypeChecker_Env.modules);
+                                     (uu___14.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___676_7008.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___14.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.sigtab);
+                                     (uu___14.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.attrtab);
+                                     (uu___14.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
                                      false;
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___676_7008.FStar_TypeChecker_Env.effects);
+                                     (uu___14.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___676_7008.FStar_TypeChecker_Env.generalize);
+                                     (uu___14.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___676_7008.FStar_TypeChecker_Env.letrecs);
+                                     (uu___14.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___676_7008.FStar_TypeChecker_Env.top_level);
+                                     (uu___14.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___676_7008.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___14.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_eq);
+                                     (uu___14.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___14.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___676_7008.FStar_TypeChecker_Env.is_iface);
+                                     (uu___14.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___676_7008.FStar_TypeChecker_Env.admit);
+                                     (uu___14.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax =
-                                     (uu___676_7008.FStar_TypeChecker_Env.lax);
+                                     (uu___14.FStar_TypeChecker_Env.lax);
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___676_7008.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___14.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___676_7008.FStar_TypeChecker_Env.phase1);
+                                     (uu___14.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___676_7008.FStar_TypeChecker_Env.failhard);
+                                     (uu___14.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___676_7008.FStar_TypeChecker_Env.nosynth);
+                                     (uu___14.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___676_7008.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___14.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___676_7008.FStar_TypeChecker_Env.tc_term);
+                                     (uu___14.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.type_of);
+                                     (uu___14.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.universe_of);
+                                     (uu___14.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___14.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___14.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___14.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___14.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___676_7008.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___14.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___676_7008.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___14.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___676_7008.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___14.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___14.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___676_7008.FStar_TypeChecker_Env.splice);
+                                     (uu___14.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___676_7008.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___14.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___676_7008.FStar_TypeChecker_Env.postprocess);
+                                     (uu___14.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___676_7008.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___14.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___676_7008.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___14.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___676_7008.FStar_TypeChecker_Env.dsenv);
+                                     (uu___14.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___676_7008.FStar_TypeChecker_Env.nbe);
+                                     (uu___14.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___14.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___14.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___14.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  } in
                                FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                 uu____7007
-                                 act1.FStar_Syntax_Syntax.action_defn in
-                             (match uu____7000 with
-                              | (act_defn, uu____7010, g_d) ->
-                                  ((let uu____7013 =
+                                 uu___13 act1.FStar_Syntax_Syntax.action_defn in
+                             (match uu___12 with
+                              | (act_defn, uu___13, g_d) ->
+                                  ((let uu___15 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env1)
                                         (FStar_Options.Other
                                            "LayeredEffectsTc") in
-                                    if uu____7013
+                                    if uu___15
                                     then
-                                      let uu____7014 =
+                                      let uu___16 =
                                         FStar_Syntax_Print.term_to_string
                                           act_defn in
-                                      let uu____7015 =
+                                      let uu___17 =
                                         FStar_Syntax_Print.term_to_string
                                           act_typ1 in
                                       FStar_Util.print2
                                         "Typechecked action definition: %s and action type: %s\n"
-                                        uu____7014 uu____7015
+                                        uu___16 uu___17
                                     else ());
-                                   (let uu____7017 =
+                                   (let uu___15 =
                                       let act_typ2 =
                                         FStar_TypeChecker_Normalize.normalize
                                           [FStar_TypeChecker_Env.Beta] env1
                                           act_typ1 in
-                                      let uu____7025 =
-                                        let uu____7026 =
+                                      let uu___16 =
+                                        let uu___17 =
                                           FStar_Syntax_Subst.compress
                                             act_typ2 in
-                                        uu____7026.FStar_Syntax_Syntax.n in
-                                      match uu____7025 with
+                                        uu___17.FStar_Syntax_Syntax.n in
+                                      match uu___16 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs, uu____7036) ->
+                                          (bs, uu___17) ->
                                           let bs1 =
                                             FStar_Syntax_Subst.open_binders
                                               bs in
                                           let env2 =
                                             FStar_TypeChecker_Env.push_binders
                                               env1 bs1 in
-                                          let uu____7059 =
+                                          let uu___18 =
                                             FStar_Syntax_Util.type_u () in
-                                          (match uu____7059 with
+                                          (match uu___18 with
                                            | (t, u) ->
                                                let reason =
-                                                 let uu____7073 =
+                                                 let uu___19 =
                                                    FStar_Ident.string_of_lid
                                                      ed.FStar_Syntax_Syntax.mname in
-                                                 let uu____7074 =
+                                                 let uu___20 =
                                                    FStar_Ident.string_of_lid
                                                      act1.FStar_Syntax_Syntax.action_name in
                                                  FStar_Util.format2
                                                    "implicit for return type of action %s:%s"
-                                                   uu____7073 uu____7074 in
-                                               let uu____7075 =
+                                                   uu___19 uu___20 in
+                                               let uu___19 =
                                                  FStar_TypeChecker_Util.new_implicit_var
                                                    reason r env2 t in
-                                               (match uu____7075 with
-                                                | (a_tm, uu____7095, g_tm) ->
-                                                    let uu____7109 =
+                                               (match uu___19 with
+                                                | (a_tm, uu___20, g_tm) ->
+                                                    let uu___21 =
                                                       fresh_repr r env2 u
                                                         a_tm in
-                                                    (match uu____7109 with
+                                                    (match uu___21 with
                                                      | (repr1, g) ->
-                                                         let uu____7122 =
-                                                           let uu____7125 =
-                                                             let uu____7128 =
-                                                               let uu____7131
-                                                                 =
+                                                         let uu___22 =
+                                                           let uu___23 =
+                                                             let uu___24 =
+                                                               let uu___25 =
                                                                  FStar_TypeChecker_Env.new_u_univ
                                                                    () in
                                                                FStar_All.pipe_right
-                                                                 uu____7131
-                                                                 (fun
-                                                                    uu____7134
+                                                                 uu___25
+                                                                 (fun uu___26
                                                                     ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____7134) in
+                                                                    uu___26) in
                                                              FStar_Syntax_Syntax.mk_Total'
-                                                               repr1
-                                                               uu____7128 in
+                                                               repr1 uu___24 in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____7125 in
-                                                         let uu____7135 =
+                                                             bs1 uu___23 in
+                                                         let uu___23 =
                                                            FStar_TypeChecker_Env.conj_guard
                                                              g g_tm in
-                                                         (uu____7122,
-                                                           uu____7135))))
-                                      | uu____7138 ->
-                                          let uu____7139 =
-                                            let uu____7144 =
-                                              let uu____7145 =
+                                                         (uu___22, uu___23))))
+                                      | uu___17 ->
+                                          let uu___18 =
+                                            let uu___19 =
+                                              let uu___20 =
                                                 FStar_Ident.string_of_lid
                                                   ed.FStar_Syntax_Syntax.mname in
-                                              let uu____7146 =
+                                              let uu___21 =
                                                 FStar_Ident.string_of_lid
                                                   act1.FStar_Syntax_Syntax.action_name in
-                                              let uu____7147 =
+                                              let uu___22 =
                                                 FStar_Syntax_Print.term_to_string
                                                   act_typ2 in
                                               FStar_Util.format3
                                                 "Unexpected non-function type for action %s:%s (%s)"
-                                                uu____7145 uu____7146
-                                                uu____7147 in
+                                                uu___20 uu___21 uu___22 in
                                             (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                              uu____7144) in
-                                          FStar_Errors.raise_error uu____7139
-                                            r in
-                                    match uu____7017 with
+                                              uu___19) in
+                                          FStar_Errors.raise_error uu___18 r in
+                                    match uu___15 with
                                     | (k, g_k) ->
-                                        ((let uu____7161 =
+                                        ((let uu___17 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env1)
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
-                                          if uu____7161
+                                          if uu___17
                                           then
-                                            let uu____7162 =
+                                            let uu___18 =
                                               FStar_Syntax_Print.term_to_string
                                                 k in
                                             FStar_Util.print1
                                               "Expected action type: %s\n"
-                                              uu____7162
+                                              uu___18
                                           else ());
                                          (let g =
                                             FStar_TypeChecker_Rel.teq env1
@@ -2374,94 +2322,92 @@ let (tc_layered_eff_decl :
                                           FStar_List.iter
                                             (FStar_TypeChecker_Rel.force_trivial_guard
                                                env1) [g_t; g_d; g_k; g];
-                                          (let uu____7167 =
+                                          (let uu___19 =
                                              FStar_All.pipe_left
                                                (FStar_TypeChecker_Env.debug
                                                   env1)
                                                (FStar_Options.Other
                                                   "LayeredEffectsTc") in
-                                           if uu____7167
+                                           if uu___19
                                            then
-                                             let uu____7168 =
+                                             let uu___20 =
                                                FStar_Syntax_Print.term_to_string
                                                  k in
                                              FStar_Util.print1
                                                "Expected action type after unification: %s\n"
-                                               uu____7168
+                                               uu___20
                                            else ());
                                           (let act_typ2 =
                                              let err_msg t =
-                                               let uu____7177 =
+                                               let uu___19 =
                                                  FStar_Ident.string_of_lid
                                                    ed.FStar_Syntax_Syntax.mname in
-                                               let uu____7178 =
+                                               let uu___20 =
                                                  FStar_Ident.string_of_lid
                                                    act1.FStar_Syntax_Syntax.action_name in
-                                               let uu____7179 =
+                                               let uu___21 =
                                                  FStar_Syntax_Print.term_to_string
                                                    t in
                                                FStar_Util.format3
                                                  "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-                                                 uu____7177 uu____7178
-                                                 uu____7179 in
+                                                 uu___19 uu___20 uu___21 in
                                              let repr_args t =
-                                               let uu____7198 =
-                                                 let uu____7199 =
+                                               let uu___19 =
+                                                 let uu___20 =
                                                    FStar_Syntax_Subst.compress
                                                      t in
-                                                 uu____7199.FStar_Syntax_Syntax.n in
-                                               match uu____7198 with
+                                                 uu___20.FStar_Syntax_Syntax.n in
+                                               match uu___19 with
                                                | FStar_Syntax_Syntax.Tm_app
                                                    (head, a::is) ->
-                                                   let uu____7251 =
-                                                     let uu____7252 =
+                                                   let uu___20 =
+                                                     let uu___21 =
                                                        FStar_Syntax_Subst.compress
                                                          head in
-                                                     uu____7252.FStar_Syntax_Syntax.n in
-                                                   (match uu____7251 with
+                                                     uu___21.FStar_Syntax_Syntax.n in
+                                                   (match uu___20 with
                                                     | FStar_Syntax_Syntax.Tm_uinst
-                                                        (uu____7261, us) ->
+                                                        (uu___21, us) ->
                                                         (us,
                                                           (FStar_Pervasives_Native.fst
                                                              a), is)
-                                                    | uu____7271 ->
-                                                        let uu____7272 =
-                                                          let uu____7277 =
+                                                    | uu___21 ->
+                                                        let uu___22 =
+                                                          let uu___23 =
                                                             err_msg t in
                                                           (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                            uu____7277) in
+                                                            uu___23) in
                                                         FStar_Errors.raise_error
-                                                          uu____7272 r)
-                                               | uu____7284 ->
-                                                   let uu____7285 =
-                                                     let uu____7290 =
-                                                       err_msg t in
+                                                          uu___22 r)
+                                               | uu___20 ->
+                                                   let uu___21 =
+                                                     let uu___22 = err_msg t in
                                                      (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                       uu____7290) in
+                                                       uu___22) in
                                                    FStar_Errors.raise_error
-                                                     uu____7285 r in
+                                                     uu___21 r in
                                              let k1 =
                                                FStar_TypeChecker_Normalize.normalize
                                                  [FStar_TypeChecker_Env.Beta]
                                                  env1 k in
-                                             let uu____7298 =
-                                               let uu____7299 =
+                                             let uu___19 =
+                                               let uu___20 =
                                                  FStar_Syntax_Subst.compress
                                                    k1 in
-                                               uu____7299.FStar_Syntax_Syntax.n in
-                                             match uu____7298 with
+                                               uu___20.FStar_Syntax_Syntax.n in
+                                             match uu___19 with
                                              | FStar_Syntax_Syntax.Tm_arrow
                                                  (bs, c) ->
-                                                 let uu____7324 =
+                                                 let uu___20 =
                                                    FStar_Syntax_Subst.open_comp
                                                      bs c in
-                                                 (match uu____7324 with
+                                                 (match uu___20 with
                                                   | (bs1, c1) ->
-                                                      let uu____7331 =
+                                                      let uu___21 =
                                                         repr_args
                                                           (FStar_Syntax_Util.comp_result
                                                              c1) in
-                                                      (match uu____7331 with
+                                                      (match uu___21 with
                                                        | (us, a, is) ->
                                                            let ct =
                                                              {
@@ -2477,67 +2423,66 @@ let (tc_layered_eff_decl :
                                                                FStar_Syntax_Syntax.flags
                                                                  = []
                                                              } in
-                                                           let uu____7342 =
+                                                           let uu___22 =
                                                              FStar_Syntax_Syntax.mk_Comp
                                                                ct in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____7342))
-                                             | uu____7345 ->
-                                                 let uu____7346 =
-                                                   let uu____7351 =
-                                                     err_msg k1 in
+                                                             bs1 uu___22))
+                                             | uu___20 ->
+                                                 let uu___21 =
+                                                   let uu___22 = err_msg k1 in
                                                    (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                     uu____7351) in
+                                                     uu___22) in
                                                  FStar_Errors.raise_error
-                                                   uu____7346 r in
-                                           (let uu____7353 =
+                                                   uu___21 r in
+                                           (let uu___20 =
                                               FStar_All.pipe_left
                                                 (FStar_TypeChecker_Env.debug
                                                    env1)
                                                 (FStar_Options.Other
                                                    "LayeredEffectsTc") in
-                                            if uu____7353
+                                            if uu___20
                                             then
-                                              let uu____7354 =
+                                              let uu___21 =
                                                 FStar_Syntax_Print.term_to_string
                                                   act_typ2 in
                                               FStar_Util.print1
                                                 "Action type after injecting it into the monad: %s\n"
-                                                uu____7354
+                                                uu___21
                                             else ());
                                            (let act2 =
-                                              let uu____7357 =
+                                              let uu___20 =
                                                 FStar_TypeChecker_Generalize.generalize_universes
                                                   env1 act_defn in
-                                              match uu____7357 with
+                                              match uu___20 with
                                               | (us, act_defn1) ->
                                                   if
                                                     act1.FStar_Syntax_Syntax.action_univs
                                                       = []
                                                   then
-                                                    let uu___749_7370 = act1 in
-                                                    let uu____7371 =
+                                                    let uu___21 = act1 in
+                                                    let uu___22 =
                                                       FStar_Syntax_Subst.close_univ_vars
                                                         us act_typ2 in
                                                     {
                                                       FStar_Syntax_Syntax.action_name
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_name);
+                                                        (uu___21.FStar_Syntax_Syntax.action_name);
                                                       FStar_Syntax_Syntax.action_unqualified_name
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_unqualified_name);
+                                                        (uu___21.FStar_Syntax_Syntax.action_unqualified_name);
                                                       FStar_Syntax_Syntax.action_univs
                                                         = us;
                                                       FStar_Syntax_Syntax.action_params
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_params);
+                                                        (uu___21.FStar_Syntax_Syntax.action_params);
                                                       FStar_Syntax_Syntax.action_defn
                                                         = act_defn1;
                                                       FStar_Syntax_Syntax.action_typ
-                                                        = uu____7371
+                                                        = uu___22
                                                     }
                                                   else
-                                                    (let uu____7373 =
+                                                    (let uu___22 =
                                                        ((FStar_List.length us)
                                                           =
                                                           (FStar_List.length
@@ -2546,103 +2491,100 @@ let (tc_layered_eff_decl :
                                                          (FStar_List.forall2
                                                             (fun u1 ->
                                                                fun u2 ->
-                                                                 let uu____7379
+                                                                 let uu___23
                                                                    =
                                                                    FStar_Syntax_Syntax.order_univ_name
                                                                     u1 u2 in
-                                                                 uu____7379 =
+                                                                 uu___23 =
                                                                    Prims.int_zero)
                                                             us
                                                             act1.FStar_Syntax_Syntax.action_univs) in
-                                                     if uu____7373
+                                                     if uu___22
                                                      then
-                                                       let uu___754_7380 =
-                                                         act1 in
-                                                       let uu____7381 =
+                                                       let uu___23 = act1 in
+                                                       let uu___24 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            act1.FStar_Syntax_Syntax.action_univs
                                                            act_typ2 in
                                                        {
                                                          FStar_Syntax_Syntax.action_name
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_name);
+                                                           (uu___23.FStar_Syntax_Syntax.action_name);
                                                          FStar_Syntax_Syntax.action_unqualified_name
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_unqualified_name);
+                                                           (uu___23.FStar_Syntax_Syntax.action_unqualified_name);
                                                          FStar_Syntax_Syntax.action_univs
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_univs);
+                                                           (uu___23.FStar_Syntax_Syntax.action_univs);
                                                          FStar_Syntax_Syntax.action_params
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_params);
+                                                           (uu___23.FStar_Syntax_Syntax.action_params);
                                                          FStar_Syntax_Syntax.action_defn
                                                            = act_defn1;
                                                          FStar_Syntax_Syntax.action_typ
-                                                           = uu____7381
+                                                           = uu___24
                                                        }
                                                      else
-                                                       (let uu____7383 =
-                                                          let uu____7388 =
-                                                            let uu____7389 =
+                                                       (let uu___24 =
+                                                          let uu___25 =
+                                                            let uu___26 =
                                                               FStar_Ident.string_of_lid
                                                                 ed.FStar_Syntax_Syntax.mname in
-                                                            let uu____7390 =
+                                                            let uu___27 =
                                                               FStar_Ident.string_of_lid
                                                                 act1.FStar_Syntax_Syntax.action_name in
-                                                            let uu____7391 =
+                                                            let uu___28 =
                                                               FStar_Syntax_Print.univ_names_to_string
                                                                 us in
-                                                            let uu____7392 =
+                                                            let uu___29 =
                                                               FStar_Syntax_Print.univ_names_to_string
                                                                 act1.FStar_Syntax_Syntax.action_univs in
                                                             FStar_Util.format4
                                                               "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                              uu____7389
-                                                              uu____7390
-                                                              uu____7391
-                                                              uu____7392 in
+                                                              uu___26 uu___27
+                                                              uu___28 uu___29 in
                                                           (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                            uu____7388) in
+                                                            uu___25) in
                                                         FStar_Errors.raise_error
-                                                          uu____7383 r)) in
+                                                          uu___24 r)) in
                                             act2))))))))) in
-                 let tschemes_of uu____7414 =
-                   match uu____7414 with | (us, t, ty) -> ((us, t), (us, ty)) in
+                 let tschemes_of uu___8 =
+                   match uu___8 with | (us, t, ty) -> ((us, t), (us, ty)) in
                  let combinators =
-                   let uu____7459 =
-                     let uu____7460 = tschemes_of repr in
-                     let uu____7465 = tschemes_of return_repr in
-                     let uu____7470 = tschemes_of bind_repr in
-                     let uu____7475 = tschemes_of stronger_repr in
-                     let uu____7480 = tschemes_of if_then_else in
+                   let uu___8 =
+                     let uu___9 = tschemes_of repr in
+                     let uu___10 = tschemes_of return_repr in
+                     let uu___11 = tschemes_of bind_repr in
+                     let uu___12 = tschemes_of stronger_repr in
+                     let uu___13 = tschemes_of if_then_else in
                      {
-                       FStar_Syntax_Syntax.l_repr = uu____7460;
-                       FStar_Syntax_Syntax.l_return = uu____7465;
-                       FStar_Syntax_Syntax.l_bind = uu____7470;
-                       FStar_Syntax_Syntax.l_subcomp = uu____7475;
-                       FStar_Syntax_Syntax.l_if_then_else = uu____7480
+                       FStar_Syntax_Syntax.l_repr = uu___9;
+                       FStar_Syntax_Syntax.l_return = uu___10;
+                       FStar_Syntax_Syntax.l_bind = uu___11;
+                       FStar_Syntax_Syntax.l_subcomp = uu___12;
+                       FStar_Syntax_Syntax.l_if_then_else = uu___13
                      } in
-                   FStar_Syntax_Syntax.Layered_eff uu____7459 in
-                 let uu___763_7485 = ed in
-                 let uu____7486 =
+                   FStar_Syntax_Syntax.Layered_eff uu___8 in
+                 let uu___8 = ed in
+                 let uu___9 =
                    FStar_List.map (tc_action env0)
                      ed.FStar_Syntax_Syntax.actions in
                  {
                    FStar_Syntax_Syntax.mname =
-                     (uu___763_7485.FStar_Syntax_Syntax.mname);
+                     (uu___8.FStar_Syntax_Syntax.mname);
                    FStar_Syntax_Syntax.cattributes =
-                     (uu___763_7485.FStar_Syntax_Syntax.cattributes);
+                     (uu___8.FStar_Syntax_Syntax.cattributes);
                    FStar_Syntax_Syntax.univs =
-                     (uu___763_7485.FStar_Syntax_Syntax.univs);
+                     (uu___8.FStar_Syntax_Syntax.univs);
                    FStar_Syntax_Syntax.binders =
-                     (uu___763_7485.FStar_Syntax_Syntax.binders);
+                     (uu___8.FStar_Syntax_Syntax.binders);
                    FStar_Syntax_Syntax.signature =
-                     (let uu____7493 = signature in
-                      match uu____7493 with | (us, t, uu____7508) -> (us, t));
+                     (let uu___10 = signature in
+                      match uu___10 with | (us, t, uu___11) -> (us, t));
                    FStar_Syntax_Syntax.combinators = combinators;
-                   FStar_Syntax_Syntax.actions = uu____7486;
+                   FStar_Syntax_Syntax.actions = uu___9;
                    FStar_Syntax_Syntax.eff_attrs =
-                     (uu___763_7485.FStar_Syntax_Syntax.eff_attrs)
+                     (uu___8.FStar_Syntax_Syntax.eff_attrs)
                  })))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
@@ -2655,216 +2597,211 @@ let (tc_non_layered_eff_decl :
     fun ed ->
       fun _quals ->
         fun _attrs ->
-          (let uu____7554 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                (FStar_Options.Other "ED") in
-           if uu____7554
+           if uu___1
            then
-             let uu____7555 = FStar_Syntax_Print.eff_decl_to_string false ed in
-             FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____7555
+             let uu___2 = FStar_Syntax_Print.eff_decl_to_string false ed in
+             FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu___2
            else ());
-          (let uu____7557 =
-             let uu____7562 =
+          (let uu___1 =
+             let uu___2 =
                FStar_Syntax_Subst.univ_var_opening
                  ed.FStar_Syntax_Syntax.univs in
-             match uu____7562 with
+             match uu___2 with
              | (ed_univs_subst, ed_univs) ->
                  let bs =
-                   let uu____7586 =
+                   let uu___3 =
                      FStar_Syntax_Subst.subst_binders ed_univs_subst
                        ed.FStar_Syntax_Syntax.binders in
-                   FStar_Syntax_Subst.open_binders uu____7586 in
-                 let uu____7587 =
-                   let uu____7594 =
+                   FStar_Syntax_Subst.open_binders uu___3 in
+                 let uu___3 =
+                   let uu___4 =
                      FStar_TypeChecker_Env.push_univ_vars env0 ed_univs in
-                   FStar_TypeChecker_TcTerm.tc_tparams uu____7594 bs in
-                 (match uu____7587 with
-                  | (bs1, uu____7600, uu____7601) ->
-                      let uu____7602 =
+                   FStar_TypeChecker_TcTerm.tc_tparams uu___4 bs in
+                 (match uu___3 with
+                  | (bs1, uu___4, uu___5) ->
+                      let uu___6 =
                         let tmp_t =
-                          let uu____7612 =
-                            let uu____7615 =
+                          let uu___7 =
+                            let uu___8 =
                               FStar_All.pipe_right FStar_Syntax_Syntax.U_zero
-                                (fun uu____7620 ->
-                                   FStar_Pervasives_Native.Some uu____7620) in
+                                (fun uu___9 ->
+                                   FStar_Pervasives_Native.Some uu___9) in
                             FStar_Syntax_Syntax.mk_Total'
-                              FStar_Syntax_Syntax.t_unit uu____7615 in
-                          FStar_Syntax_Util.arrow bs1 uu____7612 in
-                        let uu____7621 =
+                              FStar_Syntax_Syntax.t_unit uu___8 in
+                          FStar_Syntax_Util.arrow bs1 uu___7 in
+                        let uu___7 =
                           FStar_TypeChecker_Generalize.generalize_universes
                             env0 tmp_t in
-                        match uu____7621 with
+                        match uu___7 with
                         | (us, tmp_t1) ->
-                            let uu____7638 =
-                              let uu____7639 =
-                                let uu____7640 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 =
                                   FStar_All.pipe_right tmp_t1
                                     FStar_Syntax_Util.arrow_formals in
-                                FStar_All.pipe_right uu____7640
+                                FStar_All.pipe_right uu___10
                                   FStar_Pervasives_Native.fst in
-                              FStar_All.pipe_right uu____7639
+                              FStar_All.pipe_right uu___9
                                 FStar_Syntax_Subst.close_binders in
-                            (us, uu____7638) in
-                      (match uu____7602 with
+                            (us, uu___8) in
+                      (match uu___6 with
                        | (us, bs2) ->
                            (match ed_univs with
                             | [] -> (us, bs2)
-                            | uu____7677 ->
-                                let uu____7680 =
+                            | uu___7 ->
+                                let uu___8 =
                                   ((FStar_List.length ed_univs) =
                                      (FStar_List.length us))
                                     &&
                                     (FStar_List.forall2
                                        (fun u1 ->
                                           fun u2 ->
-                                            let uu____7686 =
+                                            let uu___9 =
                                               FStar_Syntax_Syntax.order_univ_name
                                                 u1 u2 in
-                                            uu____7686 = Prims.int_zero)
-                                       ed_univs us) in
-                                if uu____7680
+                                            uu___9 = Prims.int_zero) ed_univs
+                                       us) in
+                                if uu___8
                                 then (us, bs2)
                                 else
-                                  (let uu____7692 =
-                                     let uu____7697 =
-                                       let uu____7698 =
+                                  (let uu___10 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_Ident.string_of_lid
                                            ed.FStar_Syntax_Syntax.mname in
-                                       let uu____7699 =
+                                       let uu___13 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length ed_univs) in
-                                       let uu____7700 =
+                                       let uu___14 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length us) in
                                        FStar_Util.format3
                                          "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-                                         uu____7698 uu____7699 uu____7700 in
+                                         uu___12 uu___13 uu___14 in
                                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                       uu____7697) in
-                                   let uu____7701 =
+                                       uu___11) in
+                                   let uu___11 =
                                      FStar_Ident.range_of_lid
                                        ed.FStar_Syntax_Syntax.mname in
-                                   FStar_Errors.raise_error uu____7692
-                                     uu____7701)))) in
-           match uu____7557 with
+                                   FStar_Errors.raise_error uu___10 uu___11)))) in
+           match uu___1 with
            | (us, bs) ->
                let ed1 =
-                 let uu___798_7709 = ed in
+                 let uu___2 = ed in
                  {
                    FStar_Syntax_Syntax.mname =
-                     (uu___798_7709.FStar_Syntax_Syntax.mname);
+                     (uu___2.FStar_Syntax_Syntax.mname);
                    FStar_Syntax_Syntax.cattributes =
-                     (uu___798_7709.FStar_Syntax_Syntax.cattributes);
+                     (uu___2.FStar_Syntax_Syntax.cattributes);
                    FStar_Syntax_Syntax.univs = us;
                    FStar_Syntax_Syntax.binders = bs;
                    FStar_Syntax_Syntax.signature =
-                     (uu___798_7709.FStar_Syntax_Syntax.signature);
+                     (uu___2.FStar_Syntax_Syntax.signature);
                    FStar_Syntax_Syntax.combinators =
-                     (uu___798_7709.FStar_Syntax_Syntax.combinators);
+                     (uu___2.FStar_Syntax_Syntax.combinators);
                    FStar_Syntax_Syntax.actions =
-                     (uu___798_7709.FStar_Syntax_Syntax.actions);
+                     (uu___2.FStar_Syntax_Syntax.actions);
                    FStar_Syntax_Syntax.eff_attrs =
-                     (uu___798_7709.FStar_Syntax_Syntax.eff_attrs)
+                     (uu___2.FStar_Syntax_Syntax.eff_attrs)
                  } in
-               let uu____7710 = FStar_Syntax_Subst.univ_var_opening us in
-               (match uu____7710 with
+               let uu___2 = FStar_Syntax_Subst.univ_var_opening us in
+               (match uu___2 with
                 | (ed_univs_subst, ed_univs) ->
-                    let uu____7729 =
-                      let uu____7734 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Subst.subst_binders ed_univs_subst bs in
-                      FStar_Syntax_Subst.open_binders' uu____7734 in
-                    (match uu____7729 with
+                      FStar_Syntax_Subst.open_binders' uu___4 in
+                    (match uu___3 with
                      | (ed_bs, ed_bs_subst) ->
                          let ed2 =
-                           let op uu____7755 =
-                             match uu____7755 with
+                           let op uu___4 =
+                             match uu___4 with
                              | (us1, t) ->
                                  let t1 =
-                                   let uu____7775 =
+                                   let uu___5 =
                                      FStar_Syntax_Subst.shift_subst
                                        ((FStar_List.length ed_bs) +
                                           (FStar_List.length us1))
                                        ed_univs_subst in
-                                   FStar_Syntax_Subst.subst uu____7775 t in
-                                 let uu____7784 =
-                                   let uu____7785 =
+                                   FStar_Syntax_Subst.subst uu___5 t in
+                                 let uu___5 =
+                                   let uu___6 =
                                      FStar_Syntax_Subst.shift_subst
                                        (FStar_List.length us1) ed_bs_subst in
-                                   FStar_Syntax_Subst.subst uu____7785 t1 in
-                                 (us1, uu____7784) in
-                           let uu___812_7790 = ed1 in
-                           let uu____7791 =
-                             op ed1.FStar_Syntax_Syntax.signature in
-                           let uu____7792 =
+                                   FStar_Syntax_Subst.subst uu___6 t1 in
+                                 (us1, uu___5) in
+                           let uu___4 = ed1 in
+                           let uu___5 = op ed1.FStar_Syntax_Syntax.signature in
+                           let uu___6 =
                              FStar_Syntax_Util.apply_eff_combinators op
                                ed1.FStar_Syntax_Syntax.combinators in
-                           let uu____7793 =
+                           let uu___7 =
                              FStar_List.map
                                (fun a ->
-                                  let uu___815_7801 = a in
-                                  let uu____7802 =
-                                    let uu____7803 =
+                                  let uu___8 = a in
+                                  let uu___9 =
+                                    let uu___10 =
                                       op
                                         ((a.FStar_Syntax_Syntax.action_univs),
                                           (a.FStar_Syntax_Syntax.action_defn)) in
-                                    FStar_Pervasives_Native.snd uu____7803 in
-                                  let uu____7814 =
-                                    let uu____7815 =
+                                    FStar_Pervasives_Native.snd uu___10 in
+                                  let uu___10 =
+                                    let uu___11 =
                                       op
                                         ((a.FStar_Syntax_Syntax.action_univs),
                                           (a.FStar_Syntax_Syntax.action_typ)) in
-                                    FStar_Pervasives_Native.snd uu____7815 in
+                                    FStar_Pervasives_Native.snd uu___11 in
                                   {
                                     FStar_Syntax_Syntax.action_name =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_name);
+                                      (uu___8.FStar_Syntax_Syntax.action_name);
                                     FStar_Syntax_Syntax.action_unqualified_name
                                       =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_unqualified_name);
+                                      (uu___8.FStar_Syntax_Syntax.action_unqualified_name);
                                     FStar_Syntax_Syntax.action_univs =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_univs);
+                                      (uu___8.FStar_Syntax_Syntax.action_univs);
                                     FStar_Syntax_Syntax.action_params =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_params);
-                                    FStar_Syntax_Syntax.action_defn =
-                                      uu____7802;
-                                    FStar_Syntax_Syntax.action_typ =
-                                      uu____7814
+                                      (uu___8.FStar_Syntax_Syntax.action_params);
+                                    FStar_Syntax_Syntax.action_defn = uu___9;
+                                    FStar_Syntax_Syntax.action_typ = uu___10
                                   }) ed1.FStar_Syntax_Syntax.actions in
                            {
                              FStar_Syntax_Syntax.mname =
-                               (uu___812_7790.FStar_Syntax_Syntax.mname);
+                               (uu___4.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___812_7790.FStar_Syntax_Syntax.cattributes);
+                               (uu___4.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.univs =
-                               (uu___812_7790.FStar_Syntax_Syntax.univs);
+                               (uu___4.FStar_Syntax_Syntax.univs);
                              FStar_Syntax_Syntax.binders =
-                               (uu___812_7790.FStar_Syntax_Syntax.binders);
-                             FStar_Syntax_Syntax.signature = uu____7791;
-                             FStar_Syntax_Syntax.combinators = uu____7792;
-                             FStar_Syntax_Syntax.actions = uu____7793;
+                               (uu___4.FStar_Syntax_Syntax.binders);
+                             FStar_Syntax_Syntax.signature = uu___5;
+                             FStar_Syntax_Syntax.combinators = uu___6;
+                             FStar_Syntax_Syntax.actions = uu___7;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___812_7790.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___4.FStar_Syntax_Syntax.eff_attrs)
                            } in
-                         ((let uu____7827 =
+                         ((let uu___5 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env0)
                                (FStar_Options.Other "ED") in
-                           if uu____7827
+                           if uu___5
                            then
-                             let uu____7828 =
+                             let uu___6 =
                                FStar_Syntax_Print.eff_decl_to_string false
                                  ed2 in
                              FStar_Util.print1
                                "After typechecking binders eff_decl: \n\t%s\n"
-                               uu____7828
+                               uu___6
                            else ());
                           (let env =
-                             let uu____7831 =
+                             let uu___5 =
                                FStar_TypeChecker_Env.push_univ_vars env0
                                  ed_univs in
-                             FStar_TypeChecker_Env.push_binders uu____7831
-                               ed_bs in
-                           let check_and_gen' comb n env_opt uu____7864 k =
-                             match uu____7864 with
+                             FStar_TypeChecker_Env.push_binders uu___5 ed_bs in
+                           let check_and_gen' comb n env_opt uu___5 k =
+                             match uu___5 with
                              | (us1, t) ->
                                  let env1 =
                                    if FStar_Util.is_some env_opt
@@ -2872,54 +2809,54 @@ let (tc_non_layered_eff_decl :
                                      FStar_All.pipe_right env_opt
                                        FStar_Util.must
                                    else env in
-                                 let uu____7880 =
+                                 let uu___6 =
                                    FStar_Syntax_Subst.open_univ_vars us1 t in
-                                 (match uu____7880 with
+                                 (match uu___6 with
                                   | (us2, t1) ->
                                       let t2 =
                                         match k with
                                         | FStar_Pervasives_Native.Some k1 ->
-                                            let uu____7889 =
+                                            let uu___7 =
                                               FStar_TypeChecker_Env.push_univ_vars
                                                 env1 us2 in
                                             FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                              uu____7889 t1 k1
+                                              uu___7 t1 k1
                                         | FStar_Pervasives_Native.None ->
-                                            let uu____7890 =
-                                              let uu____7897 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_TypeChecker_Env.push_univ_vars
                                                   env1 us2 in
                                               FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                uu____7897 t1 in
-                                            (match uu____7890 with
-                                             | (t2, uu____7899, g) ->
+                                                uu___8 t1 in
+                                            (match uu___7 with
+                                             | (t3, uu___8, g) ->
                                                  (FStar_TypeChecker_Rel.force_trivial_guard
                                                     env1 g;
-                                                  t2)) in
-                                      let uu____7902 =
+                                                  t3)) in
+                                      let uu___7 =
                                         FStar_TypeChecker_Generalize.generalize_universes
                                           env1 t2 in
-                                      (match uu____7902 with
+                                      (match uu___7 with
                                        | (g_us, t3) ->
                                            (if (FStar_List.length g_us) <> n
                                             then
                                               (let error =
-                                                 let uu____7915 =
+                                                 let uu___9 =
                                                    FStar_Ident.string_of_lid
                                                      ed2.FStar_Syntax_Syntax.mname in
-                                                 let uu____7916 =
+                                                 let uu___10 =
                                                    FStar_Util.string_of_int n in
-                                                 let uu____7917 =
-                                                   let uu____7918 =
+                                                 let uu___11 =
+                                                   let uu___12 =
                                                      FStar_All.pipe_right
                                                        g_us FStar_List.length in
                                                    FStar_All.pipe_right
-                                                     uu____7918
+                                                     uu___12
                                                      FStar_Util.string_of_int in
                                                  FStar_Util.format4
                                                    "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-                                                   uu____7915 comb uu____7916
-                                                   uu____7917 in
+                                                   uu___9 comb uu___10
+                                                   uu___11 in
                                                FStar_Errors.raise_error
                                                  (FStar_Errors.Fatal_MismatchUniversePolymorphic,
                                                    error)
@@ -2927,602 +2864,587 @@ let (tc_non_layered_eff_decl :
                                             else ();
                                             (match us2 with
                                              | [] -> (g_us, t3)
-                                             | uu____7926 ->
-                                                 let uu____7927 =
+                                             | uu___9 ->
+                                                 let uu___10 =
                                                    ((FStar_List.length us2) =
                                                       (FStar_List.length g_us))
                                                      &&
                                                      (FStar_List.forall2
                                                         (fun u1 ->
                                                            fun u2 ->
-                                                             let uu____7933 =
+                                                             let uu___11 =
                                                                FStar_Syntax_Syntax.order_univ_name
                                                                  u1 u2 in
-                                                             uu____7933 =
+                                                             uu___11 =
                                                                Prims.int_zero)
                                                         us2 g_us) in
-                                                 if uu____7927
+                                                 if uu___10
                                                  then (g_us, t3)
                                                  else
-                                                   (let uu____7939 =
-                                                      let uu____7944 =
-                                                        let uu____7945 =
+                                                   (let uu___12 =
+                                                      let uu___13 =
+                                                        let uu___14 =
                                                           FStar_Ident.string_of_lid
                                                             ed2.FStar_Syntax_Syntax.mname in
-                                                        let uu____7946 =
+                                                        let uu___15 =
                                                           FStar_Util.string_of_int
                                                             (FStar_List.length
                                                                us2) in
-                                                        let uu____7947 =
+                                                        let uu___16 =
                                                           FStar_Util.string_of_int
                                                             (FStar_List.length
                                                                g_us) in
                                                         FStar_Util.format4
                                                           "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-                                                          uu____7945 comb
-                                                          uu____7946
-                                                          uu____7947 in
+                                                          uu___14 comb
+                                                          uu___15 uu___16 in
                                                       (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                        uu____7944) in
+                                                        uu___13) in
                                                     FStar_Errors.raise_error
-                                                      uu____7939
+                                                      uu___12
                                                       t3.FStar_Syntax_Syntax.pos))))) in
                            let signature =
                              check_and_gen' "signature" Prims.int_one
                                FStar_Pervasives_Native.None
                                ed2.FStar_Syntax_Syntax.signature
                                FStar_Pervasives_Native.None in
-                           (let uu____7950 =
+                           (let uu___6 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "ED") in
-                            if uu____7950
+                            if uu___6
                             then
-                              let uu____7951 =
+                              let uu___7 =
                                 FStar_Syntax_Print.tscheme_to_string
                                   signature in
                               FStar_Util.print1 "Typechecked signature: %s\n"
-                                uu____7951
+                                uu___7
                             else ());
-                           (let fresh_a_and_wp uu____7964 =
+                           (let fresh_a_and_wp uu___6 =
                               let fail t =
-                                let uu____7977 =
+                                let uu___7 =
                                   FStar_TypeChecker_Err.unexpected_signature_for_monad
                                     env ed2.FStar_Syntax_Syntax.mname t in
-                                FStar_Errors.raise_error uu____7977
+                                FStar_Errors.raise_error uu___7
                                   (FStar_Pervasives_Native.snd
                                      ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos in
-                              let uu____7992 =
+                              let uu___7 =
                                 FStar_TypeChecker_Env.inst_tscheme signature in
-                              match uu____7992 with
-                              | (uu____8003, signature1) ->
-                                  let uu____8005 =
-                                    let uu____8006 =
+                              match uu___7 with
+                              | (uu___8, signature1) ->
+                                  let uu___9 =
+                                    let uu___10 =
                                       FStar_Syntax_Subst.compress signature1 in
-                                    uu____8006.FStar_Syntax_Syntax.n in
-                                  (match uu____8005 with
+                                    uu___10.FStar_Syntax_Syntax.n in
+                                  (match uu___9 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs1, uu____8016) ->
+                                       (bs1, uu___10) ->
                                        let bs2 =
                                          FStar_Syntax_Subst.open_binders bs1 in
                                        (match bs2 with
-                                        | (a, uu____8045)::(wp, uu____8047)::[]
-                                            ->
+                                        | (a, uu___11)::(wp, uu___12)::[] ->
                                             (a,
                                               (wp.FStar_Syntax_Syntax.sort))
-                                        | uu____8076 -> fail signature1)
-                                   | uu____8077 -> fail signature1) in
+                                        | uu___11 -> fail signature1)
+                                   | uu___10 -> fail signature1) in
                             let log_combinator s ts =
-                              let uu____8089 =
+                              let uu___6 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "ED") in
-                              if uu____8089
+                              if uu___6
                               then
-                                let uu____8090 =
+                                let uu___7 =
                                   FStar_Ident.string_of_lid
                                     ed2.FStar_Syntax_Syntax.mname in
-                                let uu____8091 =
+                                let uu___8 =
                                   FStar_Syntax_Print.tscheme_to_string ts in
                                 FStar_Util.print3 "Typechecked %s:%s = %s\n"
-                                  uu____8090 s uu____8091
+                                  uu___7 s uu___8
                               else () in
                             let ret_wp =
-                              let uu____8094 = fresh_a_and_wp () in
-                              match uu____8094 with
+                              let uu___6 = fresh_a_and_wp () in
+                              match uu___6 with
                               | (a, wp_sort) ->
                                   let k =
-                                    let uu____8110 =
-                                      let uu____8119 =
+                                    let uu___7 =
+                                      let uu___8 =
                                         FStar_Syntax_Syntax.mk_binder a in
-                                      let uu____8126 =
-                                        let uu____8135 =
-                                          let uu____8142 =
+                                      let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
                                             FStar_Syntax_Syntax.bv_to_name a in
                                           FStar_Syntax_Syntax.null_binder
-                                            uu____8142 in
-                                        [uu____8135] in
-                                      uu____8119 :: uu____8126 in
-                                    let uu____8161 =
+                                            uu___11 in
+                                        [uu___10] in
+                                      uu___8 :: uu___9 in
+                                    let uu___8 =
                                       FStar_Syntax_Syntax.mk_GTotal wp_sort in
-                                    FStar_Syntax_Util.arrow uu____8110
-                                      uu____8161 in
-                                  let uu____8164 =
+                                    FStar_Syntax_Util.arrow uu___7 uu___8 in
+                                  let uu___7 =
                                     FStar_All.pipe_right ed2
                                       FStar_Syntax_Util.get_return_vc_combinator in
                                   check_and_gen' "ret_wp" Prims.int_one
-                                    FStar_Pervasives_Native.None uu____8164
+                                    FStar_Pervasives_Native.None uu___7
                                     (FStar_Pervasives_Native.Some k) in
                             log_combinator "ret_wp" ret_wp;
                             (let bind_wp =
-                               let uu____8175 = fresh_a_and_wp () in
-                               match uu____8175 with
+                               let uu___7 = fresh_a_and_wp () in
+                               match uu___7 with
                                | (a, wp_sort_a) ->
-                                   let uu____8188 = fresh_a_and_wp () in
-                                   (match uu____8188 with
+                                   let uu___8 = fresh_a_and_wp () in
+                                   (match uu___8 with
                                     | (b, wp_sort_b) ->
                                         let wp_sort_a_b =
-                                          let uu____8204 =
-                                            let uu____8213 =
-                                              let uu____8220 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_Syntax_Syntax.bv_to_name
                                                   a in
                                               FStar_Syntax_Syntax.null_binder
-                                                uu____8220 in
-                                            [uu____8213] in
-                                          let uu____8233 =
+                                                uu___11 in
+                                            [uu___10] in
+                                          let uu___10 =
                                             FStar_Syntax_Syntax.mk_Total
                                               wp_sort_b in
-                                          FStar_Syntax_Util.arrow uu____8204
-                                            uu____8233 in
+                                          FStar_Syntax_Util.arrow uu___9
+                                            uu___10 in
                                         let k =
-                                          let uu____8239 =
-                                            let uu____8248 =
+                                          let uu___9 =
+                                            let uu___10 =
                                               FStar_Syntax_Syntax.null_binder
                                                 FStar_Syntax_Syntax.t_range in
-                                            let uu____8255 =
-                                              let uu____8264 =
+                                            let uu___11 =
+                                              let uu___12 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   a in
-                                              let uu____8271 =
-                                                let uu____8280 =
+                                              let uu___13 =
+                                                let uu___14 =
                                                   FStar_Syntax_Syntax.mk_binder
                                                     b in
-                                                let uu____8287 =
-                                                  let uu____8296 =
+                                                let uu___15 =
+                                                  let uu___16 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       wp_sort_a in
-                                                  let uu____8303 =
-                                                    let uu____8312 =
+                                                  let uu___17 =
+                                                    let uu___18 =
                                                       FStar_Syntax_Syntax.null_binder
                                                         wp_sort_a_b in
-                                                    [uu____8312] in
-                                                  uu____8296 :: uu____8303 in
-                                                uu____8280 :: uu____8287 in
-                                              uu____8264 :: uu____8271 in
-                                            uu____8248 :: uu____8255 in
-                                          let uu____8355 =
+                                                    [uu___18] in
+                                                  uu___16 :: uu___17 in
+                                                uu___14 :: uu___15 in
+                                              uu___12 :: uu___13 in
+                                            uu___10 :: uu___11 in
+                                          let uu___10 =
                                             FStar_Syntax_Syntax.mk_Total
                                               wp_sort_b in
-                                          FStar_Syntax_Util.arrow uu____8239
-                                            uu____8355 in
-                                        let uu____8358 =
+                                          FStar_Syntax_Util.arrow uu___9
+                                            uu___10 in
+                                        let uu___9 =
                                           FStar_All.pipe_right ed2
                                             FStar_Syntax_Util.get_bind_vc_combinator in
                                         check_and_gen' "bind_wp"
                                           (Prims.of_int (2))
-                                          FStar_Pervasives_Native.None
-                                          uu____8358
+                                          FStar_Pervasives_Native.None uu___9
                                           (FStar_Pervasives_Native.Some k)) in
                              log_combinator "bind_wp" bind_wp;
                              (let stronger =
-                                let uu____8369 = fresh_a_and_wp () in
-                                match uu____8369 with
+                                let uu___8 = fresh_a_and_wp () in
+                                match uu___8 with
                                 | (a, wp_sort_a) ->
-                                    let uu____8382 =
-                                      FStar_Syntax_Util.type_u () in
-                                    (match uu____8382 with
-                                     | (t, uu____8388) ->
+                                    let uu___9 = FStar_Syntax_Util.type_u () in
+                                    (match uu___9 with
+                                     | (t, uu___10) ->
                                          let k =
-                                           let uu____8392 =
-                                             let uu____8401 =
+                                           let uu___11 =
+                                             let uu___12 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a in
-                                             let uu____8408 =
-                                               let uu____8417 =
+                                             let uu___13 =
+                                               let uu___14 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a in
-                                               let uu____8424 =
-                                                 let uu____8433 =
+                                               let uu___15 =
+                                                 let uu___16 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      wp_sort_a in
-                                                 [uu____8433] in
-                                               uu____8417 :: uu____8424 in
-                                             uu____8401 :: uu____8408 in
-                                           let uu____8464 =
+                                                 [uu___16] in
+                                               uu___14 :: uu___15 in
+                                             uu___12 :: uu___13 in
+                                           let uu___12 =
                                              FStar_Syntax_Syntax.mk_Total t in
-                                           FStar_Syntax_Util.arrow uu____8392
-                                             uu____8464 in
-                                         let uu____8467 =
+                                           FStar_Syntax_Util.arrow uu___11
+                                             uu___12 in
+                                         let uu___11 =
                                            FStar_All.pipe_right ed2
                                              FStar_Syntax_Util.get_stronger_vc_combinator in
                                          check_and_gen' "stronger"
                                            Prims.int_one
                                            FStar_Pervasives_Native.None
-                                           uu____8467
+                                           uu___11
                                            (FStar_Pervasives_Native.Some k)) in
                               log_combinator "stronger" stronger;
                               (let if_then_else =
-                                 let uu____8478 = fresh_a_and_wp () in
-                                 match uu____8478 with
+                                 let uu___9 = fresh_a_and_wp () in
+                                 match uu___9 with
                                  | (a, wp_sort_a) ->
                                      let p =
-                                       let uu____8492 =
-                                         let uu____8495 =
+                                       let uu___10 =
+                                         let uu___11 =
                                            FStar_Ident.range_of_lid
                                              ed2.FStar_Syntax_Syntax.mname in
-                                         FStar_Pervasives_Native.Some
-                                           uu____8495 in
-                                       let uu____8496 =
-                                         let uu____8497 =
+                                         FStar_Pervasives_Native.Some uu___11 in
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_Syntax_Util.type_u () in
-                                         FStar_All.pipe_right uu____8497
+                                         FStar_All.pipe_right uu___12
                                            FStar_Pervasives_Native.fst in
-                                       FStar_Syntax_Syntax.new_bv uu____8492
-                                         uu____8496 in
+                                       FStar_Syntax_Syntax.new_bv uu___10
+                                         uu___11 in
                                      let k =
-                                       let uu____8509 =
-                                         let uu____8518 =
+                                       let uu___10 =
+                                         let uu___11 =
                                            FStar_Syntax_Syntax.mk_binder a in
-                                         let uu____8525 =
-                                           let uu____8534 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_Syntax_Syntax.mk_binder p in
-                                           let uu____8541 =
-                                             let uu____8550 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a in
-                                             let uu____8557 =
-                                               let uu____8566 =
+                                             let uu___16 =
+                                               let uu___17 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a in
-                                               [uu____8566] in
-                                             uu____8550 :: uu____8557 in
-                                           uu____8534 :: uu____8541 in
-                                         uu____8518 :: uu____8525 in
-                                       let uu____8603 =
+                                               [uu___17] in
+                                             uu___15 :: uu___16 in
+                                           uu___13 :: uu___14 in
+                                         uu___11 :: uu___12 in
+                                       let uu___11 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a in
-                                       FStar_Syntax_Util.arrow uu____8509
-                                         uu____8603 in
-                                     let uu____8606 =
-                                       let uu____8611 =
+                                       FStar_Syntax_Util.arrow uu___10
+                                         uu___11 in
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                                       FStar_All.pipe_right uu____8611
+                                       FStar_All.pipe_right uu___11
                                          FStar_Util.must in
                                      check_and_gen' "if_then_else"
                                        Prims.int_one
-                                       FStar_Pervasives_Native.None
-                                       uu____8606
+                                       FStar_Pervasives_Native.None uu___10
                                        (FStar_Pervasives_Native.Some k) in
                                log_combinator "if_then_else" if_then_else;
                                (let ite_wp =
-                                  let uu____8640 = fresh_a_and_wp () in
-                                  match uu____8640 with
+                                  let uu___10 = fresh_a_and_wp () in
+                                  match uu___10 with
                                   | (a, wp_sort_a) ->
                                       let k =
-                                        let uu____8656 =
-                                          let uu____8665 =
+                                        let uu___11 =
+                                          let uu___12 =
                                             FStar_Syntax_Syntax.mk_binder a in
-                                          let uu____8672 =
-                                            let uu____8681 =
+                                          let uu___13 =
+                                            let uu___14 =
                                               FStar_Syntax_Syntax.null_binder
                                                 wp_sort_a in
-                                            [uu____8681] in
-                                          uu____8665 :: uu____8672 in
-                                        let uu____8706 =
+                                            [uu___14] in
+                                          uu___12 :: uu___13 in
+                                        let uu___12 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_a in
-                                        FStar_Syntax_Util.arrow uu____8656
-                                          uu____8706 in
-                                      let uu____8709 =
-                                        let uu____8714 =
+                                        FStar_Syntax_Util.arrow uu___11
+                                          uu___12 in
+                                      let uu___11 =
+                                        let uu___12 =
                                           FStar_All.pipe_right ed2
                                             FStar_Syntax_Util.get_wp_ite_combinator in
-                                        FStar_All.pipe_right uu____8714
+                                        FStar_All.pipe_right uu___12
                                           FStar_Util.must in
                                       check_and_gen' "ite_wp" Prims.int_one
-                                        FStar_Pervasives_Native.None
-                                        uu____8709
+                                        FStar_Pervasives_Native.None uu___11
                                         (FStar_Pervasives_Native.Some k) in
                                 log_combinator "ite_wp" ite_wp;
                                 (let close_wp =
-                                   let uu____8727 = fresh_a_and_wp () in
-                                   match uu____8727 with
+                                   let uu___11 = fresh_a_and_wp () in
+                                   match uu___11 with
                                    | (a, wp_sort_a) ->
                                        let b =
-                                         let uu____8741 =
-                                           let uu____8744 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_Ident.range_of_lid
                                                ed2.FStar_Syntax_Syntax.mname in
                                            FStar_Pervasives_Native.Some
-                                             uu____8744 in
-                                         let uu____8745 =
-                                           let uu____8746 =
+                                             uu___13 in
+                                         let uu___13 =
+                                           let uu___14 =
                                              FStar_Syntax_Util.type_u () in
-                                           FStar_All.pipe_right uu____8746
+                                           FStar_All.pipe_right uu___14
                                              FStar_Pervasives_Native.fst in
-                                         FStar_Syntax_Syntax.new_bv
-                                           uu____8741 uu____8745 in
+                                         FStar_Syntax_Syntax.new_bv uu___12
+                                           uu___13 in
                                        let wp_sort_b_a =
-                                         let uu____8758 =
-                                           let uu____8767 =
-                                             let uu____8774 =
+                                         let uu___12 =
+                                           let uu___13 =
+                                             let uu___14 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  b in
                                              FStar_Syntax_Syntax.null_binder
-                                               uu____8774 in
-                                           [uu____8767] in
-                                         let uu____8787 =
+                                               uu___14 in
+                                           [uu___13] in
+                                         let uu___13 =
                                            FStar_Syntax_Syntax.mk_Total
                                              wp_sort_a in
-                                         FStar_Syntax_Util.arrow uu____8758
-                                           uu____8787 in
+                                         FStar_Syntax_Util.arrow uu___12
+                                           uu___13 in
                                        let k =
-                                         let uu____8793 =
-                                           let uu____8802 =
+                                         let uu___12 =
+                                           let uu___13 =
                                              FStar_Syntax_Syntax.mk_binder a in
-                                           let uu____8809 =
-                                             let uu____8818 =
+                                           let uu___14 =
+                                             let uu___15 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  b in
-                                             let uu____8825 =
-                                               let uu____8834 =
+                                             let uu___16 =
+                                               let uu___17 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_b_a in
-                                               [uu____8834] in
-                                             uu____8818 :: uu____8825 in
-                                           uu____8802 :: uu____8809 in
-                                         let uu____8865 =
+                                               [uu___17] in
+                                             uu___15 :: uu___16 in
+                                           uu___13 :: uu___14 in
+                                         let uu___13 =
                                            FStar_Syntax_Syntax.mk_Total
                                              wp_sort_a in
-                                         FStar_Syntax_Util.arrow uu____8793
-                                           uu____8865 in
-                                       let uu____8868 =
-                                         let uu____8873 =
+                                         FStar_Syntax_Util.arrow uu___12
+                                           uu___13 in
+                                       let uu___12 =
+                                         let uu___13 =
                                            FStar_All.pipe_right ed2
                                              FStar_Syntax_Util.get_wp_close_combinator in
-                                         FStar_All.pipe_right uu____8873
+                                         FStar_All.pipe_right uu___13
                                            FStar_Util.must in
                                        check_and_gen' "close_wp"
                                          (Prims.of_int (2))
-                                         FStar_Pervasives_Native.None
-                                         uu____8868
+                                         FStar_Pervasives_Native.None uu___12
                                          (FStar_Pervasives_Native.Some k) in
                                  log_combinator "close_wp" close_wp;
                                  (let trivial =
-                                    let uu____8886 = fresh_a_and_wp () in
-                                    match uu____8886 with
+                                    let uu___12 = fresh_a_and_wp () in
+                                    match uu___12 with
                                     | (a, wp_sort_a) ->
-                                        let uu____8899 =
+                                        let uu___13 =
                                           FStar_Syntax_Util.type_u () in
-                                        (match uu____8899 with
-                                         | (t, uu____8905) ->
+                                        (match uu___13 with
+                                         | (t, uu___14) ->
                                              let k =
-                                               let uu____8909 =
-                                                 let uu____8918 =
+                                               let uu___15 =
+                                                 let uu___16 =
                                                    FStar_Syntax_Syntax.mk_binder
                                                      a in
-                                                 let uu____8925 =
-                                                   let uu____8934 =
+                                                 let uu___17 =
+                                                   let uu___18 =
                                                      FStar_Syntax_Syntax.null_binder
                                                        wp_sort_a in
-                                                   [uu____8934] in
-                                                 uu____8918 :: uu____8925 in
-                                               let uu____8959 =
+                                                   [uu___18] in
+                                                 uu___16 :: uu___17 in
+                                               let uu___16 =
                                                  FStar_Syntax_Syntax.mk_GTotal
                                                    t in
                                                FStar_Syntax_Util.arrow
-                                                 uu____8909 uu____8959 in
-                                             let trivial =
-                                               let uu____8963 =
-                                                 let uu____8968 =
+                                                 uu___15 uu___16 in
+                                             let trivial1 =
+                                               let uu___15 =
+                                                 let uu___16 =
                                                    FStar_All.pipe_right ed2
                                                      FStar_Syntax_Util.get_wp_trivial_combinator in
-                                                 FStar_All.pipe_right
-                                                   uu____8968 FStar_Util.must in
+                                                 FStar_All.pipe_right uu___16
+                                                   FStar_Util.must in
                                                check_and_gen' "trivial"
                                                  Prims.int_one
                                                  FStar_Pervasives_Native.None
-                                                 uu____8963
+                                                 uu___15
                                                  (FStar_Pervasives_Native.Some
                                                     k) in
                                              (log_combinator "trivial"
-                                                trivial;
-                                              trivial)) in
-                                  let uu____8980 =
-                                    let uu____8997 =
+                                                trivial1;
+                                              trivial1)) in
+                                  let uu___12 =
+                                    let uu___13 =
                                       FStar_All.pipe_right ed2
                                         FStar_Syntax_Util.get_eff_repr in
-                                    match uu____8997 with
+                                    match uu___13 with
                                     | FStar_Pervasives_Native.None ->
                                         (FStar_Pervasives_Native.None,
                                           FStar_Pervasives_Native.None,
                                           FStar_Pervasives_Native.None,
                                           (ed2.FStar_Syntax_Syntax.actions))
-                                    | uu____9026 ->
+                                    | uu___14 ->
                                         let repr =
-                                          let uu____9030 = fresh_a_and_wp () in
-                                          match uu____9030 with
+                                          let uu___15 = fresh_a_and_wp () in
+                                          match uu___15 with
                                           | (a, wp_sort_a) ->
-                                              let uu____9043 =
+                                              let uu___16 =
                                                 FStar_Syntax_Util.type_u () in
-                                              (match uu____9043 with
-                                               | (t, uu____9049) ->
+                                              (match uu___16 with
+                                               | (t, uu___17) ->
                                                    let k =
-                                                     let uu____9053 =
-                                                       let uu____9062 =
+                                                     let uu___18 =
+                                                       let uu___19 =
                                                          FStar_Syntax_Syntax.mk_binder
                                                            a in
-                                                       let uu____9069 =
-                                                         let uu____9078 =
+                                                       let uu___20 =
+                                                         let uu___21 =
                                                            FStar_Syntax_Syntax.null_binder
                                                              wp_sort_a in
-                                                         [uu____9078] in
-                                                       uu____9062 ::
-                                                         uu____9069 in
-                                                     let uu____9103 =
+                                                         [uu___21] in
+                                                       uu___19 :: uu___20 in
+                                                     let uu___19 =
                                                        FStar_Syntax_Syntax.mk_GTotal
                                                          t in
                                                      FStar_Syntax_Util.arrow
-                                                       uu____9053 uu____9103 in
-                                                   let uu____9106 =
-                                                     let uu____9111 =
+                                                       uu___18 uu___19 in
+                                                   let uu___18 =
+                                                     let uu___19 =
                                                        FStar_All.pipe_right
                                                          ed2
                                                          FStar_Syntax_Util.get_eff_repr in
                                                      FStar_All.pipe_right
-                                                       uu____9111
+                                                       uu___19
                                                        FStar_Util.must in
                                                    check_and_gen' "repr"
                                                      Prims.int_one
                                                      FStar_Pervasives_Native.None
-                                                     uu____9106
+                                                     uu___18
                                                      (FStar_Pervasives_Native.Some
                                                         k)) in
                                         (log_combinator "repr" repr;
                                          (let mk_repr' t wp =
-                                            let uu____9152 =
+                                            let uu___16 =
                                               FStar_TypeChecker_Env.inst_tscheme
                                                 repr in
-                                            match uu____9152 with
-                                            | (uu____9159, repr1) ->
+                                            match uu___16 with
+                                            | (uu___17, repr1) ->
                                                 let repr2 =
                                                   FStar_TypeChecker_Normalize.normalize
                                                     [FStar_TypeChecker_Env.EraseUniverses;
                                                     FStar_TypeChecker_Env.AllowUnboundUniverses]
                                                     env repr1 in
-                                                let uu____9162 =
-                                                  let uu____9163 =
-                                                    let uu____9180 =
-                                                      let uu____9191 =
+                                                let uu___18 =
+                                                  let uu___19 =
+                                                    let uu___20 =
+                                                      let uu___21 =
                                                         FStar_All.pipe_right
                                                           t
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      let uu____9208 =
-                                                        let uu____9219 =
+                                                      let uu___22 =
+                                                        let uu___23 =
                                                           FStar_All.pipe_right
                                                             wp
                                                             FStar_Syntax_Syntax.as_arg in
-                                                        [uu____9219] in
-                                                      uu____9191 ::
-                                                        uu____9208 in
-                                                    (repr2, uu____9180) in
+                                                        [uu___23] in
+                                                      uu___21 :: uu___22 in
+                                                    (repr2, uu___20) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____9163 in
+                                                    uu___19 in
                                                 FStar_Syntax_Syntax.mk
-                                                  uu____9162
+                                                  uu___18
                                                   FStar_Range.dummyRange in
                                           let mk_repr a wp =
-                                            let uu____9285 =
+                                            let uu___16 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a in
-                                            mk_repr' uu____9285 wp in
+                                            mk_repr' uu___16 wp in
                                           let destruct_repr t =
-                                            let uu____9300 =
-                                              let uu____9301 =
+                                            let uu___16 =
+                                              let uu___17 =
                                                 FStar_Syntax_Subst.compress t in
-                                              uu____9301.FStar_Syntax_Syntax.n in
-                                            match uu____9300 with
+                                              uu___17.FStar_Syntax_Syntax.n in
+                                            match uu___16 with
                                             | FStar_Syntax_Syntax.Tm_app
-                                                (uu____9312,
-                                                 (t1, uu____9314)::(wp,
-                                                                    uu____9316)::[])
+                                                (uu___17,
+                                                 (t1, uu___18)::(wp, uu___19)::[])
                                                 -> (t1, wp)
-                                            | uu____9375 ->
+                                            | uu___17 ->
                                                 failwith
                                                   "Unexpected repr type" in
                                           let return_repr =
                                             let return_repr_ts =
-                                              let uu____9390 =
+                                              let uu___16 =
                                                 FStar_All.pipe_right ed2
                                                   FStar_Syntax_Util.get_return_repr in
-                                              FStar_All.pipe_right uu____9390
+                                              FStar_All.pipe_right uu___16
                                                 FStar_Util.must in
-                                            let uu____9417 =
-                                              fresh_a_and_wp () in
-                                            match uu____9417 with
-                                            | (a, uu____9425) ->
+                                            let uu___16 = fresh_a_and_wp () in
+                                            match uu___16 with
+                                            | (a, uu___17) ->
                                                 let x_a =
-                                                  let uu____9431 =
+                                                  let uu___18 =
                                                     FStar_Syntax_Syntax.bv_to_name
                                                       a in
                                                   FStar_Syntax_Syntax.gen_bv
                                                     "x_a"
                                                     FStar_Pervasives_Native.None
-                                                    uu____9431 in
+                                                    uu___18 in
                                                 let res =
                                                   let wp =
-                                                    let uu____9436 =
-                                                      let uu____9437 =
+                                                    let uu___18 =
+                                                      let uu___19 =
                                                         FStar_TypeChecker_Env.inst_tscheme
                                                           ret_wp in
                                                       FStar_All.pipe_right
-                                                        uu____9437
+                                                        uu___19
                                                         FStar_Pervasives_Native.snd in
-                                                    let uu____9446 =
-                                                      let uu____9447 =
-                                                        let uu____9456 =
+                                                    let uu___19 =
+                                                      let uu___20 =
+                                                        let uu___21 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             a in
                                                         FStar_All.pipe_right
-                                                          uu____9456
+                                                          uu___21
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      let uu____9465 =
-                                                        let uu____9476 =
-                                                          let uu____9485 =
+                                                      let uu___21 =
+                                                        let uu___22 =
+                                                          let uu___23 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x_a in
                                                           FStar_All.pipe_right
-                                                            uu____9485
+                                                            uu___23
                                                             FStar_Syntax_Syntax.as_arg in
-                                                        [uu____9476] in
-                                                      uu____9447 ::
-                                                        uu____9465 in
+                                                        [uu___22] in
+                                                      uu___20 :: uu___21 in
                                                     FStar_Syntax_Syntax.mk_Tm_app
-                                                      uu____9436 uu____9446
+                                                      uu___18 uu___19
                                                       FStar_Range.dummyRange in
                                                   mk_repr a wp in
                                                 let k =
-                                                  let uu____9521 =
-                                                    let uu____9530 =
+                                                  let uu___18 =
+                                                    let uu___19 =
                                                       FStar_Syntax_Syntax.mk_binder
                                                         a in
-                                                    let uu____9537 =
-                                                      let uu____9546 =
+                                                    let uu___20 =
+                                                      let uu___21 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           x_a in
-                                                      [uu____9546] in
-                                                    uu____9530 :: uu____9537 in
-                                                  let uu____9571 =
+                                                      [uu___21] in
+                                                    uu___19 :: uu___20 in
+                                                  let uu___19 =
                                                     FStar_Syntax_Syntax.mk_Total
                                                       res in
                                                   FStar_Syntax_Util.arrow
-                                                    uu____9521 uu____9571 in
-                                                let uu____9574 =
+                                                    uu___18 uu___19 in
+                                                let uu___18 =
                                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                     env k in
-                                                (match uu____9574 with
-                                                 | (k1, uu____9582,
-                                                    uu____9583) ->
+                                                (match uu___18 with
+                                                 | (k1, uu___19, uu___20) ->
                                                      let env1 =
-                                                       let uu____9587 =
+                                                       let uu___21 =
                                                          FStar_TypeChecker_Env.set_range
                                                            env
                                                            (FStar_Pervasives_Native.snd
                                                               return_repr_ts).FStar_Syntax_Syntax.pos in
                                                        FStar_Pervasives_Native.Some
-                                                         uu____9587 in
+                                                         uu___21 in
                                                      check_and_gen'
                                                        "return_repr"
                                                        Prims.int_one env1
@@ -3533,43 +3455,40 @@ let (tc_non_layered_eff_decl :
                                             return_repr;
                                           (let bind_repr =
                                              let bind_repr_ts =
-                                               let uu____9597 =
+                                               let uu___17 =
                                                  FStar_All.pipe_right ed2
                                                    FStar_Syntax_Util.get_bind_repr in
-                                               FStar_All.pipe_right
-                                                 uu____9597 FStar_Util.must in
+                                               FStar_All.pipe_right uu___17
+                                                 FStar_Util.must in
                                              let r =
-                                               let uu____9635 =
+                                               let uu___17 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    FStar_Parser_Const.range_0
                                                    FStar_Syntax_Syntax.delta_constant
                                                    FStar_Pervasives_Native.None in
-                                               FStar_All.pipe_right
-                                                 uu____9635
+                                               FStar_All.pipe_right uu___17
                                                  FStar_Syntax_Syntax.fv_to_tm in
-                                             let uu____9636 =
-                                               fresh_a_and_wp () in
-                                             match uu____9636 with
+                                             let uu___17 = fresh_a_and_wp () in
+                                             match uu___17 with
                                              | (a, wp_sort_a) ->
-                                                 let uu____9649 =
+                                                 let uu___18 =
                                                    fresh_a_and_wp () in
-                                                 (match uu____9649 with
+                                                 (match uu___18 with
                                                   | (b, wp_sort_b) ->
                                                       let wp_sort_a_b =
-                                                        let uu____9665 =
-                                                          let uu____9674 =
-                                                            let uu____9681 =
+                                                        let uu___19 =
+                                                          let uu___20 =
+                                                            let uu___21 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 a in
                                                             FStar_Syntax_Syntax.null_binder
-                                                              uu____9681 in
-                                                          [uu____9674] in
-                                                        let uu____9694 =
+                                                              uu___21 in
+                                                          [uu___20] in
+                                                        let uu___20 =
                                                           FStar_Syntax_Syntax.mk_Total
                                                             wp_sort_b in
                                                         FStar_Syntax_Util.arrow
-                                                          uu____9665
-                                                          uu____9694 in
+                                                          uu___19 uu___20 in
                                                       let wp_f =
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "wp_f"
@@ -3581,195 +3500,180 @@ let (tc_non_layered_eff_decl :
                                                           FStar_Pervasives_Native.None
                                                           wp_sort_a_b in
                                                       let x_a =
-                                                        let uu____9700 =
+                                                        let uu___19 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             a in
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "x_a"
                                                           FStar_Pervasives_Native.None
-                                                          uu____9700 in
+                                                          uu___19 in
                                                       let wp_g_x =
-                                                        let uu____9702 =
+                                                        let uu___19 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             wp_g in
-                                                        let uu____9703 =
-                                                          let uu____9704 =
-                                                            let uu____9713 =
+                                                        let uu___20 =
+                                                          let uu___21 =
+                                                            let uu___22 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 x_a in
                                                             FStar_All.pipe_right
-                                                              uu____9713
+                                                              uu___22
                                                               FStar_Syntax_Syntax.as_arg in
-                                                          [uu____9704] in
+                                                          [uu___21] in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____9702
-                                                          uu____9703
+                                                          uu___19 uu___20
                                                           FStar_Range.dummyRange in
                                                       let res =
                                                         let wp =
-                                                          let uu____9742 =
-                                                            let uu____9743 =
+                                                          let uu___19 =
+                                                            let uu___20 =
                                                               FStar_TypeChecker_Env.inst_tscheme
                                                                 bind_wp in
                                                             FStar_All.pipe_right
-                                                              uu____9743
+                                                              uu___20
                                                               FStar_Pervasives_Native.snd in
-                                                          let uu____9752 =
-                                                            let uu____9753 =
-                                                              let uu____9756
-                                                                =
-                                                                let uu____9759
-                                                                  =
+                                                          let uu___20 =
+                                                            let uu___21 =
+                                                              let uu___22 =
+                                                                let uu___23 =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a in
-                                                                let uu____9760
-                                                                  =
-                                                                  let uu____9763
+                                                                let uu___24 =
+                                                                  let uu___25
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b in
-                                                                  let uu____9764
+                                                                  let uu___26
                                                                     =
-                                                                    let uu____9767
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
-                                                                    let uu____9768
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____9771
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_g in
-                                                                    [uu____9771] in
-                                                                    uu____9767
+                                                                    [uu___29] in
+                                                                    uu___27
                                                                     ::
-                                                                    uu____9768 in
-                                                                  uu____9763
-                                                                    ::
-                                                                    uu____9764 in
-                                                                uu____9759 ::
-                                                                  uu____9760 in
-                                                              r :: uu____9756 in
+                                                                    uu___28 in
+                                                                  uu___25 ::
+                                                                    uu___26 in
+                                                                uu___23 ::
+                                                                  uu___24 in
+                                                              r :: uu___22 in
                                                             FStar_List.map
                                                               FStar_Syntax_Syntax.as_arg
-                                                              uu____9753 in
+                                                              uu___21 in
                                                           FStar_Syntax_Syntax.mk_Tm_app
-                                                            uu____9742
-                                                            uu____9752
+                                                            uu___19 uu___20
                                                             FStar_Range.dummyRange in
                                                         mk_repr b wp in
                                                       let maybe_range_arg =
-                                                        let uu____9789 =
+                                                        let uu___19 =
                                                           FStar_Util.for_some
                                                             (FStar_Syntax_Util.attr_eq
                                                                FStar_Syntax_Util.dm4f_bind_range_attr)
                                                             ed2.FStar_Syntax_Syntax.eff_attrs in
-                                                        if uu____9789
+                                                        if uu___19
                                                         then
-                                                          let uu____9798 =
+                                                          let uu___20 =
                                                             FStar_Syntax_Syntax.null_binder
                                                               FStar_Syntax_Syntax.t_range in
-                                                          let uu____9805 =
-                                                            let uu____9814 =
+                                                          let uu___21 =
+                                                            let uu___22 =
                                                               FStar_Syntax_Syntax.null_binder
                                                                 FStar_Syntax_Syntax.t_range in
-                                                            [uu____9814] in
-                                                          uu____9798 ::
-                                                            uu____9805
+                                                            [uu___22] in
+                                                          uu___20 :: uu___21
                                                         else [] in
                                                       let k =
-                                                        let uu____9849 =
-                                                          let uu____9858 =
-                                                            let uu____9867 =
+                                                        let uu___19 =
+                                                          let uu___20 =
+                                                            let uu___21 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 a in
-                                                            let uu____9874 =
-                                                              let uu____9883
-                                                                =
+                                                            let uu___22 =
+                                                              let uu___23 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   b in
-                                                              [uu____9883] in
-                                                            uu____9867 ::
-                                                              uu____9874 in
-                                                          let uu____9908 =
-                                                            let uu____9917 =
-                                                              let uu____9926
-                                                                =
+                                                              [uu___23] in
+                                                            uu___21 ::
+                                                              uu___22 in
+                                                          let uu___21 =
+                                                            let uu___22 =
+                                                              let uu___23 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   wp_f in
-                                                              let uu____9933
-                                                                =
-                                                                let uu____9942
-                                                                  =
-                                                                  let uu____9949
+                                                              let uu___24 =
+                                                                let uu___25 =
+                                                                  let uu___26
                                                                     =
-                                                                    let uu____9950
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
                                                                     mk_repr a
-                                                                    uu____9950 in
+                                                                    uu___27 in
                                                                   FStar_Syntax_Syntax.null_binder
-                                                                    uu____9949 in
-                                                                let uu____9951
-                                                                  =
-                                                                  let uu____9960
+                                                                    uu___26 in
+                                                                let uu___26 =
+                                                                  let uu___27
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     wp_g in
-                                                                  let uu____9967
+                                                                  let uu___28
                                                                     =
-                                                                    let uu____9976
+                                                                    let uu___29
                                                                     =
-                                                                    let uu____9983
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____9984
+                                                                    let uu___31
                                                                     =
-                                                                    let uu____9993
+                                                                    let uu___32
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x_a in
-                                                                    [uu____9993] in
-                                                                    let uu____10012
+                                                                    [uu___32] in
+                                                                    let uu___32
                                                                     =
-                                                                    let uu____10015
+                                                                    let uu___33
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu____10015 in
+                                                                    uu___33 in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____9984
-                                                                    uu____10012 in
+                                                                    uu___31
+                                                                    uu___32 in
                                                                     FStar_Syntax_Syntax.null_binder
-                                                                    uu____9983 in
-                                                                    [uu____9976] in
-                                                                  uu____9960
-                                                                    ::
-                                                                    uu____9967 in
-                                                                uu____9942 ::
-                                                                  uu____9951 in
-                                                              uu____9926 ::
-                                                                uu____9933 in
+                                                                    uu___30 in
+                                                                    [uu___29] in
+                                                                  uu___27 ::
+                                                                    uu___28 in
+                                                                uu___25 ::
+                                                                  uu___26 in
+                                                              uu___23 ::
+                                                                uu___24 in
                                                             FStar_List.append
                                                               maybe_range_arg
-                                                              uu____9917 in
+                                                              uu___22 in
                                                           FStar_List.append
-                                                            uu____9858
-                                                            uu____9908 in
-                                                        let uu____10060 =
+                                                            uu___20 uu___21 in
+                                                        let uu___20 =
                                                           FStar_Syntax_Syntax.mk_Total
                                                             res in
                                                         FStar_Syntax_Util.arrow
-                                                          uu____9849
-                                                          uu____10060 in
-                                                      let uu____10063 =
+                                                          uu___19 uu___20 in
+                                                      let uu___19 =
                                                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                           env k in
-                                                      (match uu____10063 with
-                                                       | (k1, uu____10071,
-                                                          uu____10072) ->
+                                                      (match uu___19 with
+                                                       | (k1, uu___20,
+                                                          uu___21) ->
                                                            let env1 =
                                                              FStar_TypeChecker_Env.set_range
                                                                env
@@ -3777,201 +3681,200 @@ let (tc_non_layered_eff_decl :
                                                                   bind_repr_ts).FStar_Syntax_Syntax.pos in
                                                            let env2 =
                                                              FStar_All.pipe_right
-                                                               (let uu___1010_10082
-                                                                  = env1 in
+                                                               (let uu___22 =
+                                                                  env1 in
                                                                 {
                                                                   FStar_TypeChecker_Env.solver
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.solver);
+                                                                    uu___22.FStar_TypeChecker_Env.solver);
                                                                   FStar_TypeChecker_Env.range
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.range);
+                                                                    uu___22.FStar_TypeChecker_Env.range);
                                                                   FStar_TypeChecker_Env.curmodule
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.curmodule);
+                                                                    uu___22.FStar_TypeChecker_Env.curmodule);
                                                                   FStar_TypeChecker_Env.gamma
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma);
+                                                                    uu___22.FStar_TypeChecker_Env.gamma);
                                                                   FStar_TypeChecker_Env.gamma_sig
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma_sig);
+                                                                    uu___22.FStar_TypeChecker_Env.gamma_sig);
                                                                   FStar_TypeChecker_Env.gamma_cache
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma_cache);
+                                                                    uu___22.FStar_TypeChecker_Env.gamma_cache);
                                                                   FStar_TypeChecker_Env.modules
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.modules);
+                                                                    uu___22.FStar_TypeChecker_Env.modules);
                                                                   FStar_TypeChecker_Env.expected_typ
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.expected_typ);
+                                                                    uu___22.FStar_TypeChecker_Env.expected_typ);
                                                                   FStar_TypeChecker_Env.sigtab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.sigtab);
+                                                                    uu___22.FStar_TypeChecker_Env.sigtab);
                                                                   FStar_TypeChecker_Env.attrtab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.attrtab);
+                                                                    uu___22.FStar_TypeChecker_Env.attrtab);
                                                                   FStar_TypeChecker_Env.instantiate_imp
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    uu___22.FStar_TypeChecker_Env.instantiate_imp);
                                                                   FStar_TypeChecker_Env.effects
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.effects);
+                                                                    uu___22.FStar_TypeChecker_Env.effects);
                                                                   FStar_TypeChecker_Env.generalize
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.generalize);
+                                                                    uu___22.FStar_TypeChecker_Env.generalize);
                                                                   FStar_TypeChecker_Env.letrecs
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.letrecs);
+                                                                    uu___22.FStar_TypeChecker_Env.letrecs);
                                                                   FStar_TypeChecker_Env.top_level
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.top_level);
+                                                                    uu___22.FStar_TypeChecker_Env.top_level);
                                                                   FStar_TypeChecker_Env.check_uvars
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.check_uvars);
+                                                                    uu___22.FStar_TypeChecker_Env.check_uvars);
                                                                   FStar_TypeChecker_Env.use_eq
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_eq);
+                                                                    uu___22.FStar_TypeChecker_Env.use_eq);
                                                                   FStar_TypeChecker_Env.use_eq_strict
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    uu___22.FStar_TypeChecker_Env.use_eq_strict);
                                                                   FStar_TypeChecker_Env.is_iface
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.is_iface);
+                                                                    uu___22.FStar_TypeChecker_Env.is_iface);
                                                                   FStar_TypeChecker_Env.admit
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.admit);
+                                                                    uu___22.FStar_TypeChecker_Env.admit);
                                                                   FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                   FStar_TypeChecker_Env.lax_universes
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.lax_universes);
+                                                                    uu___22.FStar_TypeChecker_Env.lax_universes);
                                                                   FStar_TypeChecker_Env.phase1
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.phase1);
+                                                                    uu___22.FStar_TypeChecker_Env.phase1);
                                                                   FStar_TypeChecker_Env.failhard
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.failhard);
+                                                                    uu___22.FStar_TypeChecker_Env.failhard);
                                                                   FStar_TypeChecker_Env.nosynth
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.nosynth);
+                                                                    uu___22.FStar_TypeChecker_Env.nosynth);
                                                                   FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    uu___22.FStar_TypeChecker_Env.uvar_subtyping);
                                                                   FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.tc_term);
+                                                                    uu___22.FStar_TypeChecker_Env.tc_term);
                                                                   FStar_TypeChecker_Env.type_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.type_of);
+                                                                    uu___22.FStar_TypeChecker_Env.type_of);
                                                                   FStar_TypeChecker_Env.universe_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.universe_of);
+                                                                    uu___22.FStar_TypeChecker_Env.universe_of);
                                                                   FStar_TypeChecker_Env.check_type_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.check_type_of);
+                                                                    uu___22.FStar_TypeChecker_Env.check_type_of);
                                                                   FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    uu___22.FStar_TypeChecker_Env.use_bv_sorts);
                                                                   FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    uu___22.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                   FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    uu___22.FStar_TypeChecker_Env.normalized_eff_names);
                                                                   FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    uu___22.FStar_TypeChecker_Env.fv_delta_depths);
                                                                   FStar_TypeChecker_Env.proof_ns
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.proof_ns);
+                                                                    uu___22.FStar_TypeChecker_Env.proof_ns);
                                                                   FStar_TypeChecker_Env.synth_hook
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.synth_hook);
+                                                                    uu___22.FStar_TypeChecker_Env.synth_hook);
                                                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    uu___22.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                   FStar_TypeChecker_Env.splice
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.splice);
+                                                                    uu___22.FStar_TypeChecker_Env.splice);
                                                                   FStar_TypeChecker_Env.mpreprocess
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.mpreprocess);
+                                                                    uu___22.FStar_TypeChecker_Env.mpreprocess);
                                                                   FStar_TypeChecker_Env.postprocess
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.postprocess);
+                                                                    uu___22.FStar_TypeChecker_Env.postprocess);
                                                                   FStar_TypeChecker_Env.identifier_info
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.identifier_info);
+                                                                    uu___22.FStar_TypeChecker_Env.identifier_info);
                                                                   FStar_TypeChecker_Env.tc_hooks
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.tc_hooks);
+                                                                    uu___22.FStar_TypeChecker_Env.tc_hooks);
                                                                   FStar_TypeChecker_Env.dsenv
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.dsenv);
+                                                                    uu___22.FStar_TypeChecker_Env.dsenv);
                                                                   FStar_TypeChecker_Env.nbe
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.nbe);
+                                                                    uu___22.FStar_TypeChecker_Env.nbe);
                                                                   FStar_TypeChecker_Env.strict_args_tab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    uu___22.FStar_TypeChecker_Env.strict_args_tab);
                                                                   FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                    uu___22.FStar_TypeChecker_Env.erasable_types_tab);
                                                                   FStar_TypeChecker_Env.enable_defer_to_tac
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                    uu___22.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                                 })
-                                                               (fun
-                                                                  uu____10083
+                                                               (fun uu___22
                                                                   ->
                                                                   FStar_Pervasives_Native.Some
-                                                                    uu____10083) in
+                                                                    uu___22) in
                                                            check_and_gen'
                                                              "bind_repr"
                                                              (Prims.of_int (2))
@@ -3991,281 +3894,272 @@ let (tc_non_layered_eff_decl :
                                                   failwith
                                                     "tc_eff_decl: expected action_params to be empty"
                                                 else ();
-                                                (let uu____10102 =
+                                                (let uu___19 =
                                                    if
                                                      act.FStar_Syntax_Syntax.action_univs
                                                        = []
                                                    then (env, act)
                                                    else
-                                                     (let uu____10114 =
+                                                     (let uu___21 =
                                                         FStar_Syntax_Subst.univ_var_opening
                                                           act.FStar_Syntax_Syntax.action_univs in
-                                                      match uu____10114 with
+                                                      match uu___21 with
                                                       | (usubst, uvs) ->
-                                                          let uu____10137 =
+                                                          let uu___22 =
                                                             FStar_TypeChecker_Env.push_univ_vars
                                                               env uvs in
-                                                          let uu____10138 =
-                                                            let uu___1023_10139
-                                                              = act in
-                                                            let uu____10140 =
+                                                          let uu___23 =
+                                                            let uu___24 = act in
+                                                            let uu___25 =
                                                               FStar_Syntax_Subst.subst
                                                                 usubst
                                                                 act.FStar_Syntax_Syntax.action_defn in
-                                                            let uu____10141 =
+                                                            let uu___26 =
                                                               FStar_Syntax_Subst.subst
                                                                 usubst
                                                                 act.FStar_Syntax_Syntax.action_typ in
                                                             {
                                                               FStar_Syntax_Syntax.action_name
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_name);
+                                                                (uu___24.FStar_Syntax_Syntax.action_name);
                                                               FStar_Syntax_Syntax.action_unqualified_name
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                (uu___24.FStar_Syntax_Syntax.action_unqualified_name);
                                                               FStar_Syntax_Syntax.action_univs
                                                                 = uvs;
                                                               FStar_Syntax_Syntax.action_params
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_params);
+                                                                (uu___24.FStar_Syntax_Syntax.action_params);
                                                               FStar_Syntax_Syntax.action_defn
-                                                                = uu____10140;
+                                                                = uu___25;
                                                               FStar_Syntax_Syntax.action_typ
-                                                                = uu____10141
+                                                                = uu___26
                                                             } in
-                                                          (uu____10137,
-                                                            uu____10138)) in
-                                                 match uu____10102 with
+                                                          (uu___22, uu___23)) in
+                                                 match uu___19 with
                                                  | (env1, act1) ->
                                                      let act_typ =
-                                                       let uu____10145 =
-                                                         let uu____10146 =
+                                                       let uu___20 =
+                                                         let uu___21 =
                                                            FStar_Syntax_Subst.compress
                                                              act1.FStar_Syntax_Syntax.action_typ in
-                                                         uu____10146.FStar_Syntax_Syntax.n in
-                                                       match uu____10145 with
+                                                         uu___21.FStar_Syntax_Syntax.n in
+                                                       match uu___20 with
                                                        | FStar_Syntax_Syntax.Tm_arrow
                                                            (bs1, c) ->
                                                            let c1 =
                                                              FStar_Syntax_Util.comp_to_comp_typ
                                                                c in
-                                                           let uu____10172 =
+                                                           let uu___21 =
                                                              FStar_Ident.lid_equals
                                                                c1.FStar_Syntax_Syntax.effect_name
                                                                ed2.FStar_Syntax_Syntax.mname in
-                                                           if uu____10172
+                                                           if uu___21
                                                            then
-                                                             let uu____10173
-                                                               =
-                                                               let uu____10176
-                                                                 =
-                                                                 let uu____10177
+                                                             let uu___22 =
+                                                               let uu___23 =
+                                                                 let uu___24
                                                                    =
-                                                                   let uu____10178
+                                                                   let uu___25
                                                                     =
                                                                     FStar_List.hd
                                                                     c1.FStar_Syntax_Syntax.effect_args in
                                                                    FStar_Pervasives_Native.fst
-                                                                    uu____10178 in
+                                                                    uu___25 in
                                                                  mk_repr'
                                                                    c1.FStar_Syntax_Syntax.result_typ
-                                                                   uu____10177 in
+                                                                   uu___24 in
                                                                FStar_Syntax_Syntax.mk_Total
-                                                                 uu____10176 in
+                                                                 uu___23 in
                                                              FStar_Syntax_Util.arrow
-                                                               bs1
-                                                               uu____10173
+                                                               bs1 uu___22
                                                            else
                                                              act1.FStar_Syntax_Syntax.action_typ
-                                                       | uu____10200 ->
+                                                       | uu___21 ->
                                                            act1.FStar_Syntax_Syntax.action_typ in
-                                                     let uu____10201 =
+                                                     let uu___20 =
                                                        FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                          env1 act_typ in
-                                                     (match uu____10201 with
-                                                      | (act_typ1,
-                                                         uu____10209, g_t) ->
+                                                     (match uu___20 with
+                                                      | (act_typ1, uu___21,
+                                                         g_t) ->
                                                           let env' =
-                                                            let uu___1040_10212
-                                                              =
+                                                            let uu___22 =
                                                               FStar_TypeChecker_Env.set_expected_typ
                                                                 env1 act_typ1 in
                                                             {
                                                               FStar_TypeChecker_Env.solver
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.solver);
+                                                                (uu___22.FStar_TypeChecker_Env.solver);
                                                               FStar_TypeChecker_Env.range
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.range);
+                                                                (uu___22.FStar_TypeChecker_Env.range);
                                                               FStar_TypeChecker_Env.curmodule
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.curmodule);
+                                                                (uu___22.FStar_TypeChecker_Env.curmodule);
                                                               FStar_TypeChecker_Env.gamma
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma);
+                                                                (uu___22.FStar_TypeChecker_Env.gamma);
                                                               FStar_TypeChecker_Env.gamma_sig
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma_sig);
+                                                                (uu___22.FStar_TypeChecker_Env.gamma_sig);
                                                               FStar_TypeChecker_Env.gamma_cache
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma_cache);
+                                                                (uu___22.FStar_TypeChecker_Env.gamma_cache);
                                                               FStar_TypeChecker_Env.modules
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.modules);
+                                                                (uu___22.FStar_TypeChecker_Env.modules);
                                                               FStar_TypeChecker_Env.expected_typ
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.expected_typ);
+                                                                (uu___22.FStar_TypeChecker_Env.expected_typ);
                                                               FStar_TypeChecker_Env.sigtab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.sigtab);
+                                                                (uu___22.FStar_TypeChecker_Env.sigtab);
                                                               FStar_TypeChecker_Env.attrtab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.attrtab);
+                                                                (uu___22.FStar_TypeChecker_Env.attrtab);
                                                               FStar_TypeChecker_Env.instantiate_imp
                                                                 = false;
                                                               FStar_TypeChecker_Env.effects
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.effects);
+                                                                (uu___22.FStar_TypeChecker_Env.effects);
                                                               FStar_TypeChecker_Env.generalize
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.generalize);
+                                                                (uu___22.FStar_TypeChecker_Env.generalize);
                                                               FStar_TypeChecker_Env.letrecs
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.letrecs);
+                                                                (uu___22.FStar_TypeChecker_Env.letrecs);
                                                               FStar_TypeChecker_Env.top_level
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.top_level);
+                                                                (uu___22.FStar_TypeChecker_Env.top_level);
                                                               FStar_TypeChecker_Env.check_uvars
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.check_uvars);
+                                                                (uu___22.FStar_TypeChecker_Env.check_uvars);
                                                               FStar_TypeChecker_Env.use_eq
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_eq);
+                                                                (uu___22.FStar_TypeChecker_Env.use_eq);
                                                               FStar_TypeChecker_Env.use_eq_strict
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_eq_strict);
+                                                                (uu___22.FStar_TypeChecker_Env.use_eq_strict);
                                                               FStar_TypeChecker_Env.is_iface
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.is_iface);
+                                                                (uu___22.FStar_TypeChecker_Env.is_iface);
                                                               FStar_TypeChecker_Env.admit
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.admit);
+                                                                (uu___22.FStar_TypeChecker_Env.admit);
                                                               FStar_TypeChecker_Env.lax
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.lax);
+                                                                (uu___22.FStar_TypeChecker_Env.lax);
                                                               FStar_TypeChecker_Env.lax_universes
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.lax_universes);
+                                                                (uu___22.FStar_TypeChecker_Env.lax_universes);
                                                               FStar_TypeChecker_Env.phase1
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.phase1);
+                                                                (uu___22.FStar_TypeChecker_Env.phase1);
                                                               FStar_TypeChecker_Env.failhard
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.failhard);
+                                                                (uu___22.FStar_TypeChecker_Env.failhard);
                                                               FStar_TypeChecker_Env.nosynth
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.nosynth);
+                                                                (uu___22.FStar_TypeChecker_Env.nosynth);
                                                               FStar_TypeChecker_Env.uvar_subtyping
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                (uu___22.FStar_TypeChecker_Env.uvar_subtyping);
                                                               FStar_TypeChecker_Env.tc_term
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.tc_term);
+                                                                (uu___22.FStar_TypeChecker_Env.tc_term);
                                                               FStar_TypeChecker_Env.type_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.type_of);
+                                                                (uu___22.FStar_TypeChecker_Env.type_of);
                                                               FStar_TypeChecker_Env.universe_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.universe_of);
+                                                                (uu___22.FStar_TypeChecker_Env.universe_of);
                                                               FStar_TypeChecker_Env.check_type_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.check_type_of);
+                                                                (uu___22.FStar_TypeChecker_Env.check_type_of);
                                                               FStar_TypeChecker_Env.use_bv_sorts
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                (uu___22.FStar_TypeChecker_Env.use_bv_sorts);
                                                               FStar_TypeChecker_Env.qtbl_name_and_index
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                (uu___22.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                               FStar_TypeChecker_Env.normalized_eff_names
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                (uu___22.FStar_TypeChecker_Env.normalized_eff_names);
                                                               FStar_TypeChecker_Env.fv_delta_depths
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                (uu___22.FStar_TypeChecker_Env.fv_delta_depths);
                                                               FStar_TypeChecker_Env.proof_ns
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.proof_ns);
+                                                                (uu___22.FStar_TypeChecker_Env.proof_ns);
                                                               FStar_TypeChecker_Env.synth_hook
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.synth_hook);
+                                                                (uu___22.FStar_TypeChecker_Env.synth_hook);
                                                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                (uu___22.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                               FStar_TypeChecker_Env.splice
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.splice);
+                                                                (uu___22.FStar_TypeChecker_Env.splice);
                                                               FStar_TypeChecker_Env.mpreprocess
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.mpreprocess);
+                                                                (uu___22.FStar_TypeChecker_Env.mpreprocess);
                                                               FStar_TypeChecker_Env.postprocess
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.postprocess);
+                                                                (uu___22.FStar_TypeChecker_Env.postprocess);
                                                               FStar_TypeChecker_Env.identifier_info
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.identifier_info);
+                                                                (uu___22.FStar_TypeChecker_Env.identifier_info);
                                                               FStar_TypeChecker_Env.tc_hooks
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.tc_hooks);
+                                                                (uu___22.FStar_TypeChecker_Env.tc_hooks);
                                                               FStar_TypeChecker_Env.dsenv
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.dsenv);
+                                                                (uu___22.FStar_TypeChecker_Env.dsenv);
                                                               FStar_TypeChecker_Env.nbe
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.nbe);
+                                                                (uu___22.FStar_TypeChecker_Env.nbe);
                                                               FStar_TypeChecker_Env.strict_args_tab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.strict_args_tab);
+                                                                (uu___22.FStar_TypeChecker_Env.strict_args_tab);
                                                               FStar_TypeChecker_Env.erasable_types_tab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                (uu___22.FStar_TypeChecker_Env.erasable_types_tab);
                                                               FStar_TypeChecker_Env.enable_defer_to_tac
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                (uu___22.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                             } in
-                                                          ((let uu____10214 =
+                                                          ((let uu___23 =
                                                               FStar_TypeChecker_Env.debug
                                                                 env1
                                                                 (FStar_Options.Other
                                                                    "ED") in
-                                                            if uu____10214
+                                                            if uu___23
                                                             then
-                                                              let uu____10215
-                                                                =
+                                                              let uu___24 =
                                                                 FStar_Ident.string_of_lid
                                                                   act1.FStar_Syntax_Syntax.action_name in
-                                                              let uu____10216
-                                                                =
+                                                              let uu___25 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   act1.FStar_Syntax_Syntax.action_defn in
-                                                              let uu____10217
-                                                                =
+                                                              let uu___26 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   act_typ1 in
                                                               FStar_Util.print3
                                                                 "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                                                uu____10215
-                                                                uu____10216
-                                                                uu____10217
+                                                                uu___24
+                                                                uu___25
+                                                                uu___26
                                                             else ());
-                                                           (let uu____10219 =
+                                                           (let uu___23 =
                                                               FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                 env'
                                                                 act1.FStar_Syntax_Syntax.action_defn in
-                                                            match uu____10219
+                                                            match uu___23
                                                             with
                                                             | (act_defn,
-                                                               uu____10227,
-                                                               g_a) ->
+                                                               uu___24, g_a)
+                                                                ->
                                                                 let act_defn1
                                                                   =
                                                                   FStar_TypeChecker_Normalize.normalize
@@ -4284,8 +4178,7 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.Beta]
                                                                     env1
                                                                     act_typ1 in
-                                                                let uu____10231
-                                                                  =
+                                                                let uu___25 =
                                                                   let act_typ3
                                                                     =
                                                                     FStar_Syntax_Subst.compress
@@ -4296,63 +4189,63 @@ let (tc_non_layered_eff_decl :
                                                                   | FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____10267
+                                                                    let uu___26
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____10267
+                                                                    (match uu___26
                                                                     with
                                                                     | 
                                                                     (bs2,
-                                                                    uu____10279)
+                                                                    uu___27)
                                                                     ->
                                                                     let res =
                                                                     mk_repr'
                                                                     FStar_Syntax_Syntax.tun
                                                                     FStar_Syntax_Syntax.tun in
                                                                     let k =
-                                                                    let uu____10286
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     res in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____10286 in
-                                                                    let uu____10289
+                                                                    uu___28 in
+                                                                    let uu___28
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                     env1 k in
-                                                                    (match uu____10289
+                                                                    (match uu___28
                                                                     with
                                                                     | 
                                                                     (k1,
-                                                                    uu____10303,
+                                                                    uu___29,
                                                                     g) ->
                                                                     (k1, g)))
-                                                                  | uu____10307
+                                                                  | uu___26
                                                                     ->
-                                                                    let uu____10308
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10313
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____10314
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     act_typ3 in
-                                                                    let uu____10315
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Print.tag_of_term
                                                                     act_typ3 in
                                                                     FStar_Util.format2
                                                                     "Actions must have function types (not: %s, a.k.a. %s)"
-                                                                    uu____10314
-                                                                    uu____10315 in
+                                                                    uu___29
+                                                                    uu___30 in
                                                                     (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                                    uu____10313) in
+                                                                    uu___28) in
                                                                     FStar_Errors.raise_error
-                                                                    uu____10308
+                                                                    uu___27
                                                                     act_defn1.FStar_Syntax_Syntax.pos in
-                                                                (match uu____10231
+                                                                (match uu___25
                                                                  with
                                                                  | (expected_k,
                                                                     g_k) ->
@@ -4362,100 +4255,98 @@ let (tc_non_layered_eff_decl :
                                                                     act_typ2
                                                                     expected_k in
                                                                     ((
-                                                                    let uu____10330
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10331
+                                                                    let uu___28
                                                                     =
-                                                                    let uu____10332
+                                                                    let uu___29
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_t g in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_k
-                                                                    uu____10332 in
+                                                                    uu___29 in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_a
-                                                                    uu____10331 in
+                                                                    uu___28 in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1
-                                                                    uu____10330);
+                                                                    uu___27);
                                                                     (let act_typ3
                                                                     =
-                                                                    let uu____10334
+                                                                    let uu___27
                                                                     =
-                                                                    let uu____10335
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     expected_k in
-                                                                    uu____10335.FStar_Syntax_Syntax.n in
-                                                                    match uu____10334
+                                                                    uu___28.FStar_Syntax_Syntax.n in
+                                                                    match uu___27
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____10360
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____10360
+                                                                    (match uu___28
                                                                     with
                                                                     | 
                                                                     (bs2, c1)
                                                                     ->
-                                                                    let uu____10367
+                                                                    let uu___29
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c1) in
-                                                                    (match uu____10367
+                                                                    (match uu___29
                                                                     with
                                                                     | 
                                                                     (a, wp)
                                                                     ->
                                                                     let c2 =
-                                                                    let uu____10387
+                                                                    let uu___30
                                                                     =
-                                                                    let uu____10388
+                                                                    let uu___31
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 a in
-                                                                    [uu____10388] in
-                                                                    let uu____10389
+                                                                    [uu___31] in
+                                                                    let uu___31
                                                                     =
-                                                                    let uu____10400
+                                                                    let uu___32
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     wp in
-                                                                    [uu____10400] in
+                                                                    [uu___32] in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
-                                                                    =
-                                                                    uu____10387;
+                                                                    = uu___30;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     = a;
                                                                     FStar_Syntax_Syntax.effect_args
-                                                                    =
-                                                                    uu____10389;
+                                                                    = uu___31;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
                                                                     } in
-                                                                    let uu____10425
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
                                                                     c2 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____10425))
+                                                                    uu___30))
                                                                     | 
-                                                                    uu____10428
+                                                                    uu___28
                                                                     ->
                                                                     failwith
                                                                     "Impossible (expected_k is an arrow)" in
-                                                                    let uu____10429
+                                                                    let uu___27
                                                                     =
                                                                     if
                                                                     act1.FStar_Syntax_Syntax.action_univs
@@ -4465,14 +4356,14 @@ let (tc_non_layered_eff_decl :
                                                                     env1
                                                                     act_defn1
                                                                     else
-                                                                    (let uu____10449
+                                                                    (let uu___29
                                                                     =
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     act1.FStar_Syntax_Syntax.action_univs
                                                                     act_defn1 in
                                                                     ((act1.FStar_Syntax_Syntax.action_univs),
-                                                                    uu____10449)) in
-                                                                    match uu____10429
+                                                                    uu___29)) in
+                                                                    match uu___27
                                                                     with
                                                                     | 
                                                                     (univs,
@@ -4489,20 +4380,20 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     univs
                                                                     act_typ4 in
-                                                                    let uu___1090_10468
+                                                                    let uu___28
                                                                     = act1 in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___28.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___28.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     = univs;
                                                                     FStar_Syntax_Syntax.action_params
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_params);
+                                                                    (uu___28.FStar_Syntax_Syntax.action_params);
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
                                                                     act_defn2;
@@ -4519,7 +4410,7 @@ let (tc_non_layered_eff_decl :
                                                  return_repr),
                                               (FStar_Pervasives_Native.Some
                                                  bind_repr), actions))))) in
-                                  match uu____8980 with
+                                  match uu___12 with
                                   | (repr, return_repr, bind_repr, actions)
                                       ->
                                       let cl ts =
@@ -4529,12 +4420,12 @@ let (tc_non_layered_eff_decl :
                                         let ed_univs_closing =
                                           FStar_Syntax_Subst.univ_var_closing
                                             ed_univs in
-                                        let uu____10511 =
+                                        let uu___13 =
                                           FStar_Syntax_Subst.shift_subst
                                             (FStar_List.length ed_bs)
                                             ed_univs_closing in
                                         FStar_Syntax_Subst.subst_tscheme
-                                          uu____10511 ts1 in
+                                          uu___13 ts1 in
                                       let combinators =
                                         {
                                           FStar_Syntax_Syntax.ret_wp = ret_wp;
@@ -4562,87 +4453,85 @@ let (tc_non_layered_eff_decl :
                                         match ed2.FStar_Syntax_Syntax.combinators
                                         with
                                         | FStar_Syntax_Syntax.Primitive_eff
-                                            uu____10523 ->
+                                            uu___13 ->
                                             FStar_Syntax_Syntax.Primitive_eff
                                               combinators1
                                         | FStar_Syntax_Syntax.DM4F_eff
-                                            uu____10524 ->
+                                            uu___13 ->
                                             FStar_Syntax_Syntax.DM4F_eff
                                               combinators1
-                                        | uu____10525 ->
+                                        | uu___13 ->
                                             failwith
                                               "Impossible! tc_eff_decl on a layered effect is not expected" in
                                       let ed3 =
-                                        let uu___1110_10527 = ed2 in
-                                        let uu____10528 = cl signature in
-                                        let uu____10529 =
+                                        let uu___13 = ed2 in
+                                        let uu___14 = cl signature in
+                                        let uu___15 =
                                           FStar_List.map
                                             (fun a ->
-                                               let uu___1113_10537 = a in
-                                               let uu____10538 =
-                                                 let uu____10539 =
+                                               let uu___16 = a in
+                                               let uu___17 =
+                                                 let uu___18 =
                                                    cl
                                                      ((a.FStar_Syntax_Syntax.action_univs),
                                                        (a.FStar_Syntax_Syntax.action_defn)) in
-                                                 FStar_All.pipe_right
-                                                   uu____10539
+                                                 FStar_All.pipe_right uu___18
                                                    FStar_Pervasives_Native.snd in
-                                               let uu____10564 =
-                                                 let uu____10565 =
+                                               let uu___18 =
+                                                 let uu___19 =
                                                    cl
                                                      ((a.FStar_Syntax_Syntax.action_univs),
                                                        (a.FStar_Syntax_Syntax.action_typ)) in
-                                                 FStar_All.pipe_right
-                                                   uu____10565
+                                                 FStar_All.pipe_right uu___19
                                                    FStar_Pervasives_Native.snd in
                                                {
                                                  FStar_Syntax_Syntax.action_name
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_name);
+                                                   (uu___16.FStar_Syntax_Syntax.action_name);
                                                  FStar_Syntax_Syntax.action_unqualified_name
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_unqualified_name);
+                                                   (uu___16.FStar_Syntax_Syntax.action_unqualified_name);
                                                  FStar_Syntax_Syntax.action_univs
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_univs);
+                                                   (uu___16.FStar_Syntax_Syntax.action_univs);
                                                  FStar_Syntax_Syntax.action_params
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_params);
+                                                   (uu___16.FStar_Syntax_Syntax.action_params);
                                                  FStar_Syntax_Syntax.action_defn
-                                                   = uu____10538;
+                                                   = uu___17;
                                                  FStar_Syntax_Syntax.action_typ
-                                                   = uu____10564
+                                                   = uu___18
                                                }) actions in
                                         {
                                           FStar_Syntax_Syntax.mname =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.mname);
+                                            (uu___13.FStar_Syntax_Syntax.mname);
                                           FStar_Syntax_Syntax.cattributes =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.cattributes);
+                                            (uu___13.FStar_Syntax_Syntax.cattributes);
                                           FStar_Syntax_Syntax.univs =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.univs);
+                                            (uu___13.FStar_Syntax_Syntax.univs);
                                           FStar_Syntax_Syntax.binders =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.binders);
+                                            (uu___13.FStar_Syntax_Syntax.binders);
                                           FStar_Syntax_Syntax.signature =
-                                            uu____10528;
+                                            uu___14;
                                           FStar_Syntax_Syntax.combinators =
                                             combinators2;
                                           FStar_Syntax_Syntax.actions =
-                                            uu____10529;
+                                            uu___15;
                                           FStar_Syntax_Syntax.eff_attrs =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.eff_attrs)
+                                            (uu___13.FStar_Syntax_Syntax.eff_attrs)
                                         } in
-                                      ((let uu____10591 =
+                                      ((let uu___14 =
                                           FStar_All.pipe_left
                                             (FStar_TypeChecker_Env.debug env)
                                             (FStar_Options.Other "ED") in
-                                        if uu____10591
+                                        if uu___14
                                         then
-                                          let uu____10592 =
+                                          let uu___15 =
                                             FStar_Syntax_Print.eff_decl_to_string
                                               false ed3 in
                                           FStar_Util.print1
                                             "Typechecked effect declaration:\n\t%s\n"
-                                            uu____10592
+                                            uu___15
                                         else ());
                                        ed3)))))))))))))
 let (tc_eff_decl :
@@ -4656,13 +4545,10 @@ let (tc_eff_decl :
     fun ed ->
       fun quals ->
         fun attrs ->
-          let uu____10622 =
-            let uu____10643 =
-              FStar_All.pipe_right ed FStar_Syntax_Util.is_layered in
-            if uu____10643
-            then tc_layered_eff_decl
-            else tc_non_layered_eff_decl in
-          uu____10622 env ed quals attrs
+          let uu___ =
+            let uu___1 = FStar_All.pipe_right ed FStar_Syntax_Util.is_layered in
+            if uu___1 then tc_layered_eff_decl else tc_non_layered_eff_decl in
+          uu___ env ed quals attrs
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -4673,256 +4559,247 @@ let (monad_signature :
   fun env ->
     fun m ->
       fun s ->
-        let fail uu____10693 =
-          let uu____10694 =
+        let fail uu___ =
+          let uu___1 =
             FStar_TypeChecker_Err.unexpected_signature_for_monad env m s in
-          let uu____10699 = FStar_Ident.range_of_lid m in
-          FStar_Errors.raise_error uu____10694 uu____10699 in
+          let uu___2 = FStar_Ident.range_of_lid m in
+          FStar_Errors.raise_error uu___1 uu___2 in
         let s1 = FStar_Syntax_Subst.compress s in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
             let bs1 = FStar_Syntax_Subst.open_binders bs in
             (match bs1 with
-             | (a, uu____10743)::(wp, uu____10745)::[] ->
+             | (a, uu___)::(wp, uu___1)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____10774 -> fail ())
-        | uu____10775 -> fail ()
+             | uu___ -> fail ())
+        | uu___ -> fail ()
 let (tc_layered_lift :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sub_eff -> FStar_Syntax_Syntax.sub_eff)
   =
   fun env0 ->
     fun sub ->
-      (let uu____10787 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
            (FStar_Options.Other "LayeredEffectsTc") in
-       if uu____10787
+       if uu___1
        then
-         let uu____10788 = FStar_Syntax_Print.sub_eff_to_string sub in
-         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____10788
+         let uu___2 = FStar_Syntax_Print.sub_eff_to_string sub in
+         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu___2
        else ());
       (let lift_ts =
          FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift FStar_Util.must in
        let r =
-         let uu____10802 =
+         let uu___1 =
            FStar_All.pipe_right lift_ts FStar_Pervasives_Native.snd in
-         uu____10802.FStar_Syntax_Syntax.pos in
-       let uu____10811 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
-       match uu____10811 with
+         uu___1.FStar_Syntax_Syntax.pos in
+       let uu___1 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
+       match uu___1 with
        | (us, lift, lift_ty) ->
-           ((let uu____10822 =
+           ((let uu___3 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                  (FStar_Options.Other "LayeredEffectsTc") in
-             if uu____10822
+             if uu___3
              then
-               let uu____10823 =
-                 FStar_Syntax_Print.tscheme_to_string (us, lift) in
-               let uu____10828 =
+               let uu___4 = FStar_Syntax_Print.tscheme_to_string (us, lift) in
+               let uu___5 =
                  FStar_Syntax_Print.tscheme_to_string (us, lift_ty) in
                FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
-                 uu____10823 uu____10828
+                 uu___4 uu___5
              else ());
-            (let uu____10834 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
-             match uu____10834 with
+            (let uu___3 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
+             match uu___3 with
              | (us1, lift_ty1) ->
                  let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
                  (check_no_subtyping_for_layered_combinator env lift_ty1
                     FStar_Pervasives_Native.None;
                   (let lift_t_shape_error s =
-                     let uu____10849 =
+                     let uu___5 =
                        FStar_Ident.string_of_lid
                          sub.FStar_Syntax_Syntax.source in
-                     let uu____10850 =
+                     let uu___6 =
                        FStar_Ident.string_of_lid
                          sub.FStar_Syntax_Syntax.target in
-                     let uu____10851 =
-                       FStar_Syntax_Print.term_to_string lift_ty1 in
+                     let uu___7 = FStar_Syntax_Print.term_to_string lift_ty1 in
                      FStar_Util.format4
                        "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
-                       uu____10849 uu____10850 s uu____10851 in
-                   let uu____10852 =
-                     let uu____10859 =
-                       let uu____10864 = FStar_Syntax_Util.type_u () in
-                       FStar_All.pipe_right uu____10864
-                         (fun uu____10881 ->
-                            match uu____10881 with
+                       uu___5 uu___6 s uu___7 in
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Util.type_u () in
+                       FStar_All.pipe_right uu___7
+                         (fun uu___8 ->
+                            match uu___8 with
                             | (t, u) ->
-                                let uu____10892 =
-                                  let uu____10893 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_Syntax_Syntax.gen_bv "a"
                                       FStar_Pervasives_Native.None t in
-                                  FStar_All.pipe_right uu____10893
+                                  FStar_All.pipe_right uu___10
                                     FStar_Syntax_Syntax.mk_binder in
-                                (uu____10892, u)) in
-                     match uu____10859 with
+                                (uu___9, u)) in
+                     match uu___6 with
                      | (a, u_a) ->
                          let rest_bs =
-                           let uu____10911 =
-                             let uu____10912 =
+                           let uu___7 =
+                             let uu___8 =
                                FStar_Syntax_Subst.compress lift_ty1 in
-                             uu____10912.FStar_Syntax_Syntax.n in
-                           match uu____10911 with
-                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____10924)
-                               when
+                             uu___8.FStar_Syntax_Syntax.n in
+                           match uu___7 with
+                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu___8) when
                                (FStar_List.length bs) >= (Prims.of_int (2))
                                ->
-                               let uu____10951 =
+                               let uu___9 =
                                  FStar_Syntax_Subst.open_binders bs in
-                               (match uu____10951 with
-                                | (a', uu____10961)::bs1 ->
-                                    let uu____10981 =
-                                      let uu____10982 =
+                               (match uu___9 with
+                                | (a', uu___10)::bs1 ->
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_All.pipe_right bs1
                                           (FStar_List.splitAt
                                              ((FStar_List.length bs1) -
                                                 Prims.int_one)) in
-                                      FStar_All.pipe_right uu____10982
+                                      FStar_All.pipe_right uu___12
                                         FStar_Pervasives_Native.fst in
-                                    let uu____11047 =
-                                      let uu____11060 =
-                                        let uu____11063 =
-                                          let uu____11064 =
-                                            let uu____11071 =
+                                    let uu___12 =
+                                      let uu___13 =
+                                        let uu___14 =
+                                          let uu___15 =
+                                            let uu___16 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 (FStar_Pervasives_Native.fst
                                                    a) in
-                                            (a', uu____11071) in
-                                          FStar_Syntax_Syntax.NT uu____11064 in
-                                        [uu____11063] in
+                                            (a', uu___16) in
+                                          FStar_Syntax_Syntax.NT uu___15 in
+                                        [uu___14] in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____11060 in
-                                    FStar_All.pipe_right uu____10981
-                                      uu____11047)
-                           | uu____11086 ->
-                               let uu____11087 =
-                                 let uu____11092 =
+                                        uu___13 in
+                                    FStar_All.pipe_right uu___11 uu___12)
+                           | uu___8 ->
+                               let uu___9 =
+                                 let uu___10 =
                                    lift_t_shape_error
                                      "either not an arrow, or not enough binders" in
                                  (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                   uu____11092) in
-                               FStar_Errors.raise_error uu____11087 r in
-                         let uu____11101 =
-                           let uu____11112 =
-                             let uu____11117 =
+                                   uu___10) in
+                               FStar_Errors.raise_error uu___9 r in
+                         let uu___7 =
+                           let uu___8 =
+                             let uu___9 =
                                FStar_TypeChecker_Env.push_binders env (a ::
                                  rest_bs) in
-                             let uu____11124 =
-                               let uu____11125 =
+                             let uu___10 =
+                               let uu___11 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____11125
+                               FStar_All.pipe_right uu___11
                                  FStar_Syntax_Syntax.bv_to_name in
                              FStar_TypeChecker_Util.fresh_effect_repr_en
-                               uu____11117 r sub.FStar_Syntax_Syntax.source
-                               u_a uu____11124 in
-                           match uu____11112 with
+                               uu___9 r sub.FStar_Syntax_Syntax.source u_a
+                               uu___10 in
+                           match uu___8 with
                            | (f_sort, g) ->
-                               let uu____11146 =
-                                 let uu____11153 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_Syntax_Syntax.gen_bv "f"
                                      FStar_Pervasives_Native.None f_sort in
-                                 FStar_All.pipe_right uu____11153
+                                 FStar_All.pipe_right uu___10
                                    FStar_Syntax_Syntax.mk_binder in
-                               (uu____11146, g) in
-                         (match uu____11101 with
+                               (uu___9, g) in
+                         (match uu___7 with
                           | (f_b, g_f_b) ->
                               let bs = a :: (FStar_List.append rest_bs [f_b]) in
-                              let uu____11219 =
-                                let uu____11224 =
+                              let uu___8 =
+                                let uu___9 =
                                   FStar_TypeChecker_Env.push_binders env bs in
-                                let uu____11225 =
-                                  let uu____11226 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_All.pipe_right a
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____11226
+                                  FStar_All.pipe_right uu___11
                                     FStar_Syntax_Syntax.bv_to_name in
                                 FStar_TypeChecker_Util.fresh_effect_repr_en
-                                  uu____11224 r
-                                  sub.FStar_Syntax_Syntax.target u_a
-                                  uu____11225 in
-                              (match uu____11219 with
+                                  uu___9 r sub.FStar_Syntax_Syntax.target u_a
+                                  uu___10 in
+                              (match uu___8 with
                                | (repr, g_repr) ->
-                                   let uu____11243 =
-                                     let uu____11248 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____11249 =
-                                       let uu____11250 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_Ident.string_of_lid
                                            sub.FStar_Syntax_Syntax.source in
-                                       let uu____11251 =
+                                       let uu___13 =
                                          FStar_Ident.string_of_lid
                                            sub.FStar_Syntax_Syntax.target in
                                        FStar_Util.format2
                                          "implicit for pure_wp in typechecking lift %s~>%s"
-                                         uu____11250 uu____11251 in
-                                     pure_wp_uvar uu____11248 repr
-                                       uu____11249 r in
-                                   (match uu____11243 with
+                                         uu___12 uu___13 in
+                                     pure_wp_uvar uu___10 repr uu___11 r in
+                                   (match uu___9 with
                                     | (pure_wp_uvar1, guard_wp) ->
                                         let c =
-                                          let uu____11261 =
-                                            let uu____11262 =
-                                              let uu____11263 =
+                                          let uu___10 =
+                                            let uu___11 =
+                                              let uu___12 =
                                                 FStar_TypeChecker_Env.new_u_univ
                                                   () in
-                                              [uu____11263] in
-                                            let uu____11264 =
-                                              let uu____11275 =
+                                              [uu___12] in
+                                            let uu___12 =
+                                              let uu___13 =
                                                 FStar_All.pipe_right
                                                   pure_wp_uvar1
                                                   FStar_Syntax_Syntax.as_arg in
-                                              [uu____11275] in
+                                              [uu___13] in
                                             {
                                               FStar_Syntax_Syntax.comp_univs
-                                                = uu____11262;
+                                                = uu___11;
                                               FStar_Syntax_Syntax.effect_name
                                                 =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.result_typ
                                                 = repr;
                                               FStar_Syntax_Syntax.effect_args
-                                                = uu____11264;
+                                                = uu___12;
                                               FStar_Syntax_Syntax.flags = []
                                             } in
-                                          FStar_Syntax_Syntax.mk_Comp
-                                            uu____11261 in
-                                        let uu____11308 =
+                                          FStar_Syntax_Syntax.mk_Comp uu___10 in
+                                        let uu___10 =
                                           FStar_Syntax_Util.arrow bs c in
-                                        let uu____11311 =
-                                          let uu____11312 =
+                                        let uu___11 =
+                                          let uu___12 =
                                             FStar_TypeChecker_Env.conj_guard
                                               g_f_b g_repr in
                                           FStar_TypeChecker_Env.conj_guard
-                                            uu____11312 guard_wp in
-                                        (uu____11308, uu____11311)))) in
-                   match uu____10852 with
+                                            uu___12 guard_wp in
+                                        (uu___10, uu___11)))) in
+                   match uu___5 with
                    | (k, g_k) ->
-                       ((let uu____11322 =
+                       ((let uu___7 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "LayeredEffectsTc") in
-                         if uu____11322
+                         if uu___7
                          then
-                           let uu____11323 =
-                             FStar_Syntax_Print.term_to_string k in
+                           let uu___8 = FStar_Syntax_Print.term_to_string k in
                            FStar_Util.print1
                              "tc_layered_lift: before unification k: %s\n"
-                             uu____11323
+                             uu___8
                          else ());
                         (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k in
                          FStar_TypeChecker_Rel.force_trivial_guard env g_k;
                          FStar_TypeChecker_Rel.force_trivial_guard env g;
-                         (let uu____11329 =
+                         (let uu___10 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "LayeredEffectsTc") in
-                          if uu____11329
+                          if uu___10
                           then
-                            let uu____11330 =
-                              FStar_Syntax_Print.term_to_string k in
+                            let uu___11 = FStar_Syntax_Print.term_to_string k in
                             FStar_Util.print1 "After unification k: %s\n"
-                              uu____11330
+                              uu___11
                           else ());
                          (let k1 =
                             FStar_All.pipe_right k
@@ -4932,35 +4809,34 @@ let (tc_layered_lift :
                             (FStar_TypeChecker_Env.is_reifiable_effect env
                                sub.FStar_Syntax_Syntax.target)
                               &&
-                              (let uu____11335 =
+                              (let uu___10 =
                                  FStar_TypeChecker_Env.fv_with_lid_has_attr
                                    env sub.FStar_Syntax_Syntax.target
                                    FStar_Parser_Const.allow_informative_binders_attr in
-                               Prims.op_Negation uu____11335) in
-                          (let uu____11337 =
-                             let uu____11338 = FStar_Syntax_Subst.compress k1 in
-                             uu____11338.FStar_Syntax_Syntax.n in
-                           match uu____11337 with
+                               Prims.op_Negation uu___10) in
+                          (let uu___10 =
+                             let uu___11 = FStar_Syntax_Subst.compress k1 in
+                             uu___11.FStar_Syntax_Syntax.n in
+                           match uu___10 with
                            | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                               let uu____11363 =
+                               let uu___11 =
                                  FStar_Syntax_Subst.open_comp bs c in
-                               (match uu____11363 with
+                               (match uu___11 with
                                 | (a::bs1, c1) ->
                                     let res_t =
                                       FStar_Syntax_Util.comp_result c1 in
-                                    let uu____11394 =
-                                      let uu____11413 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_List.splitAt
                                           ((FStar_List.length bs1) -
                                              Prims.int_one) bs1 in
-                                      FStar_All.pipe_right uu____11413
-                                        (fun uu____11488 ->
-                                           match uu____11488 with
+                                      FStar_All.pipe_right uu___13
+                                        (fun uu___14 ->
+                                           match uu___14 with
                                            | (l1, l2) ->
-                                               let uu____11561 =
-                                                 FStar_List.hd l2 in
-                                               (l1, uu____11561)) in
-                                    (match uu____11394 with
+                                               let uu___15 = FStar_List.hd l2 in
+                                               (l1, uu___15)) in
+                                    (match uu___12 with
                                      | (bs2, f_b) ->
                                          let env1 =
                                            FStar_TypeChecker_Env.push_binders
@@ -4971,33 +4847,33 @@ let (tc_layered_lift :
                                            res_t]
                                            check_non_informative_binders r)));
                           (let sub1 =
-                             let uu___1223_11634 = sub in
-                             let uu____11635 =
-                               let uu____11638 =
-                                 let uu____11639 =
+                             let uu___10 = sub in
+                             let uu___11 =
+                               let uu___12 =
+                                 let uu___13 =
                                    FStar_All.pipe_right k1
                                      (FStar_Syntax_Subst.close_univ_vars us1) in
-                                 (us1, uu____11639) in
-                               FStar_Pervasives_Native.Some uu____11638 in
+                                 (us1, uu___13) in
+                               FStar_Pervasives_Native.Some uu___12 in
                              {
                                FStar_Syntax_Syntax.source =
-                                 (uu___1223_11634.FStar_Syntax_Syntax.source);
+                                 (uu___10.FStar_Syntax_Syntax.source);
                                FStar_Syntax_Syntax.target =
-                                 (uu___1223_11634.FStar_Syntax_Syntax.target);
-                               FStar_Syntax_Syntax.lift_wp = uu____11635;
+                                 (uu___10.FStar_Syntax_Syntax.target);
+                               FStar_Syntax_Syntax.lift_wp = uu___11;
                                FStar_Syntax_Syntax.lift =
                                  (FStar_Pervasives_Native.Some (us1, lift))
                              } in
-                           (let uu____11653 =
+                           (let uu___11 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "LayeredEffectsTc") in
-                            if uu____11653
+                            if uu___11
                             then
-                              let uu____11654 =
+                              let uu___12 =
                                 FStar_Syntax_Print.sub_eff_to_string sub1 in
                               FStar_Util.print1 "Final sub_effect: %s\n"
-                                uu____11654
+                                uu___12
                             else ());
                            sub1)))))))))
 let (tc_lift :
@@ -5009,109 +4885,100 @@ let (tc_lift :
     fun sub ->
       fun r ->
         let check_and_gen1 env1 t k =
-          let uu____11687 =
+          let uu___ =
             FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k in
-          FStar_TypeChecker_Generalize.generalize_universes env1 uu____11687 in
+          FStar_TypeChecker_Generalize.generalize_universes env1 uu___ in
         let ed_src =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.source in
         let ed_tgt =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.target in
-        let uu____11690 =
+        let uu___ =
           (FStar_All.pipe_right ed_src FStar_Syntax_Util.is_layered) ||
             (FStar_All.pipe_right ed_tgt FStar_Syntax_Util.is_layered) in
-        if uu____11690
+        if uu___
         then tc_layered_lift env sub
         else
-          (let uu____11692 =
-             let uu____11699 =
+          (let uu___2 =
+             let uu___3 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub.FStar_Syntax_Syntax.source in
-             monad_signature env sub.FStar_Syntax_Syntax.source uu____11699 in
-           match uu____11692 with
+             monad_signature env sub.FStar_Syntax_Syntax.source uu___3 in
+           match uu___2 with
            | (a, wp_a_src) ->
-               let uu____11706 =
-                 let uu____11713 =
+               let uu___3 =
+                 let uu___4 =
                    FStar_TypeChecker_Env.lookup_effect_lid env
                      sub.FStar_Syntax_Syntax.target in
-                 monad_signature env sub.FStar_Syntax_Syntax.target
-                   uu____11713 in
-               (match uu____11706 with
+                 monad_signature env sub.FStar_Syntax_Syntax.target uu___4 in
+               (match uu___3 with
                 | (b, wp_b_tgt) ->
                     let wp_a_tgt =
-                      let uu____11721 =
-                        let uu____11724 =
-                          let uu____11725 =
-                            let uu____11732 =
-                              FStar_Syntax_Syntax.bv_to_name a in
-                            (b, uu____11732) in
-                          FStar_Syntax_Syntax.NT uu____11725 in
-                        [uu____11724] in
-                      FStar_Syntax_Subst.subst uu____11721 wp_b_tgt in
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Syntax.bv_to_name a in
+                            (b, uu___7) in
+                          FStar_Syntax_Syntax.NT uu___6 in
+                        [uu___5] in
+                      FStar_Syntax_Subst.subst uu___4 wp_b_tgt in
                     let expected_k =
-                      let uu____11740 =
-                        let uu____11749 = FStar_Syntax_Syntax.mk_binder a in
-                        let uu____11756 =
-                          let uu____11765 =
+                      let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.mk_binder a in
+                        let uu___6 =
+                          let uu___7 =
                             FStar_Syntax_Syntax.null_binder wp_a_src in
-                          [uu____11765] in
-                        uu____11749 :: uu____11756 in
-                      let uu____11790 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
-                      FStar_Syntax_Util.arrow uu____11740 uu____11790 in
+                          [uu___7] in
+                        uu___5 :: uu___6 in
+                      let uu___5 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
+                      FStar_Syntax_Util.arrow uu___4 uu___5 in
                     let repr_type eff_name a1 wp =
-                      (let uu____11812 =
-                         let uu____11813 =
+                      (let uu___5 =
+                         let uu___6 =
                            FStar_TypeChecker_Env.is_reifiable_effect env
                              eff_name in
-                         Prims.op_Negation uu____11813 in
-                       if uu____11812
+                         Prims.op_Negation uu___6 in
+                       if uu___5
                        then
-                         let uu____11814 =
-                           let uu____11819 =
-                             let uu____11820 =
-                               FStar_Ident.string_of_lid eff_name in
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 = FStar_Ident.string_of_lid eff_name in
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               uu____11820 in
-                           (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____11819) in
-                         let uu____11821 =
-                           FStar_TypeChecker_Env.get_range env in
-                         FStar_Errors.raise_error uu____11814 uu____11821
+                               uu___8 in
+                           (FStar_Errors.Fatal_EffectCannotBeReified, uu___7) in
+                         let uu___7 = FStar_TypeChecker_Env.get_range env in
+                         FStar_Errors.raise_error uu___6 uu___7
                        else ());
-                      (let uu____11823 =
+                      (let uu___5 =
                          FStar_TypeChecker_Env.effect_decl_opt env eff_name in
-                       match uu____11823 with
+                       match uu___5 with
                        | FStar_Pervasives_Native.None ->
                            failwith
                              "internal error: reifiable effect has no decl?"
                        | FStar_Pervasives_Native.Some (ed, qualifiers) ->
                            let repr =
-                             let uu____11855 =
-                               let uu____11856 =
+                             let uu___6 =
+                               let uu___7 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr in
-                               FStar_All.pipe_right uu____11856
-                                 FStar_Util.must in
+                               FStar_All.pipe_right uu___7 FStar_Util.must in
                              FStar_TypeChecker_Env.inst_effect_fun_with
-                               [FStar_Syntax_Syntax.U_unknown] env ed
-                               uu____11855 in
-                           let uu____11863 =
-                             let uu____11864 =
-                               let uu____11881 =
-                                 let uu____11892 =
-                                   FStar_Syntax_Syntax.as_arg a1 in
-                                 let uu____11901 =
-                                   let uu____11912 =
+                               [FStar_Syntax_Syntax.U_unknown] env ed uu___6 in
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = FStar_Syntax_Syntax.as_arg a1 in
+                                 let uu___10 =
+                                   let uu___11 =
                                      FStar_Syntax_Syntax.as_arg wp in
-                                   [uu____11912] in
-                                 uu____11892 :: uu____11901 in
-                               (repr, uu____11881) in
-                             FStar_Syntax_Syntax.Tm_app uu____11864 in
-                           let uu____11957 =
-                             FStar_TypeChecker_Env.get_range env in
-                           FStar_Syntax_Syntax.mk uu____11863 uu____11957) in
-                    let uu____11958 =
+                                   [uu___11] in
+                                 uu___9 :: uu___10 in
+                               (repr, uu___8) in
+                             FStar_Syntax_Syntax.Tm_app uu___7 in
+                           let uu___7 = FStar_TypeChecker_Env.get_range env in
+                           FStar_Syntax_Syntax.mk uu___6 uu___7) in
+                    let uu___4 =
                       match ((sub.FStar_Syntax_Syntax.lift),
                               (sub.FStar_Syntax_Syntax.lift_wp))
                       with
@@ -5120,76 +4987,76 @@ let (tc_lift :
                           failwith "Impossible (parser)"
                       | (lift, FStar_Pervasives_Native.Some (uvs, lift_wp))
                           ->
-                          let uu____12130 =
+                          let uu___5 =
                             if (FStar_List.length uvs) > Prims.int_zero
                             then
-                              let uu____12139 =
+                              let uu___6 =
                                 FStar_Syntax_Subst.univ_var_opening uvs in
-                              match uu____12139 with
+                              match uu___6 with
                               | (usubst, uvs1) ->
-                                  let uu____12162 =
+                                  let uu___7 =
                                     FStar_TypeChecker_Env.push_univ_vars env
                                       uvs1 in
-                                  let uu____12163 =
+                                  let uu___8 =
                                     FStar_Syntax_Subst.subst usubst lift_wp in
-                                  (uu____12162, uu____12163)
+                                  (uu___7, uu___8)
                             else (env, lift_wp) in
-                          (match uu____12130 with
+                          (match uu___5 with
                            | (env1, lift_wp1) ->
                                let lift_wp2 =
                                  if (FStar_List.length uvs) = Prims.int_zero
                                  then check_and_gen1 env1 lift_wp1 expected_k
                                  else
-                                   (let lift_wp2 =
+                                   (let lift_wp3 =
                                       FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                         env1 lift_wp1 expected_k in
-                                    let uu____12208 =
+                                    let uu___7 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
-                                        lift_wp2 in
-                                    (uvs, uu____12208)) in
+                                        lift_wp3 in
+                                    (uvs, uu___7)) in
                                (lift, lift_wp2))
                       | (FStar_Pervasives_Native.Some (what, lift),
                          FStar_Pervasives_Native.None) ->
-                          let uu____12279 =
+                          let uu___5 =
                             if (FStar_List.length what) > Prims.int_zero
                             then
-                              let uu____12292 =
+                              let uu___6 =
                                 FStar_Syntax_Subst.univ_var_opening what in
-                              match uu____12292 with
+                              match uu___6 with
                               | (usubst, uvs) ->
-                                  let uu____12317 =
+                                  let uu___7 =
                                     FStar_Syntax_Subst.subst usubst lift in
-                                  (uvs, uu____12317)
+                                  (uvs, uu___7)
                             else ([], lift) in
-                          (match uu____12279 with
+                          (match uu___5 with
                            | (uvs, lift1) ->
-                               ((let uu____12352 =
+                               ((let uu___7 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "ED") in
-                                 if uu____12352
+                                 if uu___7
                                  then
-                                   let uu____12353 =
+                                   let uu___8 =
                                      FStar_Syntax_Print.term_to_string lift1 in
                                    FStar_Util.print1 "Lift for free : %s\n"
-                                     uu____12353
+                                     uu___8
                                  else ());
                                 (let dmff_env =
                                    FStar_TypeChecker_DMFF.empty env
                                      (FStar_TypeChecker_TcTerm.tc_constant
                                         env FStar_Range.dummyRange) in
-                                 let uu____12356 =
-                                   let uu____12363 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs in
-                                   FStar_TypeChecker_TcTerm.tc_term
-                                     uu____12363 lift1 in
-                                 match uu____12356 with
-                                 | (lift2, comp, uu____12388) ->
-                                     let uu____12389 =
+                                   FStar_TypeChecker_TcTerm.tc_term uu___8
+                                     lift1 in
+                                 match uu___7 with
+                                 | (lift2, comp, uu___8) ->
+                                     let uu___9 =
                                        FStar_TypeChecker_DMFF.star_expr
                                          dmff_env lift2 in
-                                     (match uu____12389 with
-                                      | (uu____12418, lift_wp, lift_elab) ->
+                                     (match uu___9 with
+                                      | (uu___10, lift_wp, lift_elab) ->
                                           let lift_wp1 =
                                             FStar_TypeChecker_DMFF.recheck_debug
                                               "lift-wp" env lift_wp in
@@ -5200,156 +5067,155 @@ let (tc_lift :
                                             (FStar_List.length uvs) =
                                               Prims.int_zero
                                           then
-                                            let uu____12445 =
-                                              let uu____12456 =
+                                            let uu___11 =
+                                              let uu___12 =
                                                 FStar_TypeChecker_Generalize.generalize_universes
                                                   env lift_elab1 in
                                               FStar_Pervasives_Native.Some
-                                                uu____12456 in
-                                            let uu____12473 =
+                                                uu___12 in
+                                            let uu___12 =
                                               FStar_TypeChecker_Generalize.generalize_universes
                                                 env lift_wp1 in
-                                            (uu____12445, uu____12473)
+                                            (uu___11, uu___12)
                                           else
-                                            (let uu____12501 =
-                                               let uu____12512 =
-                                                 let uu____12521 =
+                                            (let uu___12 =
+                                               let uu___13 =
+                                                 let uu___14 =
                                                    FStar_Syntax_Subst.close_univ_vars
                                                      uvs lift_elab1 in
-                                                 (uvs, uu____12521) in
+                                                 (uvs, uu___14) in
                                                FStar_Pervasives_Native.Some
-                                                 uu____12512 in
-                                             let uu____12536 =
-                                               let uu____12545 =
+                                                 uu___13 in
+                                             let uu___13 =
+                                               let uu___14 =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs lift_wp1 in
-                                               (uvs, uu____12545) in
-                                             (uu____12501, uu____12536)))))) in
-                    (match uu____11958 with
+                                               (uvs, uu___14) in
+                                             (uu___12, uu___13)))))) in
+                    (match uu___4 with
                      | (lift, lift_wp) ->
                          let env1 =
-                           let uu___1307_12609 = env in
+                           let uu___5 = env in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1307_12609.FStar_TypeChecker_Env.solver);
+                               (uu___5.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1307_12609.FStar_TypeChecker_Env.range);
+                               (uu___5.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1307_12609.FStar_TypeChecker_Env.curmodule);
+                               (uu___5.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma);
+                               (uu___5.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___5.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___5.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1307_12609.FStar_TypeChecker_Env.modules);
+                               (uu___5.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1307_12609.FStar_TypeChecker_Env.expected_typ);
+                               (uu___5.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.sigtab);
+                               (uu___5.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.attrtab);
+                               (uu___5.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1307_12609.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___5.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1307_12609.FStar_TypeChecker_Env.effects);
+                               (uu___5.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1307_12609.FStar_TypeChecker_Env.generalize);
+                               (uu___5.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___1307_12609.FStar_TypeChecker_Env.letrecs);
+                               (uu___5.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1307_12609.FStar_TypeChecker_Env.top_level);
+                               (uu___5.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1307_12609.FStar_TypeChecker_Env.check_uvars);
+                               (uu___5.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_eq);
+                               (uu___5.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___5.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1307_12609.FStar_TypeChecker_Env.is_iface);
+                               (uu___5.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1307_12609.FStar_TypeChecker_Env.admit);
+                               (uu___5.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1307_12609.FStar_TypeChecker_Env.lax_universes);
+                               (uu___5.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1307_12609.FStar_TypeChecker_Env.phase1);
+                               (uu___5.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1307_12609.FStar_TypeChecker_Env.failhard);
+                               (uu___5.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1307_12609.FStar_TypeChecker_Env.nosynth);
+                               (uu___5.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1307_12609.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___5.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1307_12609.FStar_TypeChecker_Env.tc_term);
+                               (uu___5.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.type_of);
+                               (uu___5.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.universe_of);
+                               (uu___5.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.check_type_of);
+                               (uu___5.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___5.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1307_12609.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___5.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1307_12609.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___5.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1307_12609.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___5.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1307_12609.FStar_TypeChecker_Env.proof_ns);
+                               (uu___5.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1307_12609.FStar_TypeChecker_Env.synth_hook);
+                               (uu___5.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1307_12609.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___5.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1307_12609.FStar_TypeChecker_Env.splice);
+                               (uu___5.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1307_12609.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___5.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1307_12609.FStar_TypeChecker_Env.postprocess);
+                               (uu___5.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1307_12609.FStar_TypeChecker_Env.identifier_info);
+                               (uu___5.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1307_12609.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___5.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1307_12609.FStar_TypeChecker_Env.dsenv);
+                               (uu___5.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1307_12609.FStar_TypeChecker_Env.nbe);
+                               (uu___5.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___5.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___5.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___1307_12609.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___5.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let lift1 =
                            match lift with
                            | FStar_Pervasives_Native.None ->
                                FStar_Pervasives_Native.None
-                           | FStar_Pervasives_Native.Some (uvs, lift1) ->
-                               let uu____12641 =
-                                 let uu____12646 =
+                           | FStar_Pervasives_Native.Some (uvs, lift2) ->
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_Syntax_Subst.univ_var_opening uvs in
-                                 match uu____12646 with
+                                 match uu___6 with
                                  | (usubst, uvs1) ->
-                                     let uu____12669 =
+                                     let uu___7 =
                                        FStar_TypeChecker_Env.push_univ_vars
                                          env1 uvs1 in
-                                     let uu____12670 =
-                                       FStar_Syntax_Subst.subst usubst lift1 in
-                                     (uu____12669, uu____12670) in
-                               (match uu____12641 with
-                                | (env2, lift2) ->
-                                    let uu____12675 =
-                                      let uu____12682 =
+                                     let uu___8 =
+                                       FStar_Syntax_Subst.subst usubst lift2 in
+                                     (uu___7, uu___8) in
+                               (match uu___5 with
+                                | (env2, lift3) ->
+                                    let uu___6 =
+                                      let uu___7 =
                                         FStar_TypeChecker_Env.lookup_effect_lid
                                           env2 sub.FStar_Syntax_Syntax.source in
                                       monad_signature env2
-                                        sub.FStar_Syntax_Syntax.source
-                                        uu____12682 in
-                                    (match uu____12675 with
+                                        sub.FStar_Syntax_Syntax.source uu___7 in
+                                    (match uu___6 with
                                      | (a1, wp_a_src1) ->
                                          let wp_a =
                                            FStar_Syntax_Syntax.new_bv
@@ -5373,154 +5239,150 @@ let (tc_lift :
                                                (FStar_Pervasives_Native.snd
                                                   lift_wp) in
                                            let lift_wp_a =
-                                             let uu____12708 =
-                                               let uu____12709 =
-                                                 let uu____12726 =
-                                                   let uu____12737 =
+                                             let uu___7 =
+                                               let uu___8 =
+                                                 let uu___9 =
+                                                   let uu___10 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        a_typ in
-                                                   let uu____12746 =
-                                                     let uu____12757 =
+                                                   let uu___11 =
+                                                     let uu___12 =
                                                        FStar_Syntax_Syntax.as_arg
                                                          wp_a_typ in
-                                                     [uu____12757] in
-                                                   uu____12737 :: uu____12746 in
-                                                 (lift_wp1, uu____12726) in
+                                                     [uu___12] in
+                                                   uu___10 :: uu___11 in
+                                                 (lift_wp1, uu___9) in
                                                FStar_Syntax_Syntax.Tm_app
-                                                 uu____12709 in
-                                             let uu____12802 =
+                                                 uu___8 in
+                                             let uu___8 =
                                                FStar_TypeChecker_Env.get_range
                                                  env2 in
-                                             FStar_Syntax_Syntax.mk
-                                               uu____12708 uu____12802 in
+                                             FStar_Syntax_Syntax.mk uu___7
+                                               uu___8 in
                                            repr_type
                                              sub.FStar_Syntax_Syntax.target
                                              a_typ lift_wp_a in
                                          let expected_k1 =
-                                           let uu____12806 =
-                                             let uu____12815 =
+                                           let uu___7 =
+                                             let uu___8 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a1 in
-                                             let uu____12822 =
-                                               let uu____12831 =
+                                             let uu___9 =
+                                               let uu___10 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    wp_a in
-                                               let uu____12838 =
-                                                 let uu____12847 =
+                                               let uu___11 =
+                                                 let uu___12 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      repr_f in
-                                                 [uu____12847] in
-                                               uu____12831 :: uu____12838 in
-                                             uu____12815 :: uu____12822 in
-                                           let uu____12878 =
+                                                 [uu___12] in
+                                               uu___10 :: uu___11 in
+                                             uu___8 :: uu___9 in
+                                           let uu___8 =
                                              FStar_Syntax_Syntax.mk_Total
                                                repr_result in
-                                           FStar_Syntax_Util.arrow
-                                             uu____12806 uu____12878 in
-                                         let uu____12881 =
+                                           FStar_Syntax_Util.arrow uu___7
+                                             uu___8 in
+                                         let uu___7 =
                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                              env2 expected_k1 in
-                                         (match uu____12881 with
-                                          | (expected_k2, uu____12891,
-                                             uu____12892) ->
-                                              let lift3 =
+                                         (match uu___7 with
+                                          | (expected_k2, uu___8, uu___9) ->
+                                              let lift4 =
                                                 if
                                                   (FStar_List.length uvs) =
                                                     Prims.int_zero
                                                 then
-                                                  check_and_gen1 env2 lift2
+                                                  check_and_gen1 env2 lift3
                                                     expected_k2
                                                 else
-                                                  (let lift3 =
+                                                  (let lift5 =
                                                      FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                                       env2 lift2 expected_k2 in
-                                                   let uu____12896 =
+                                                       env2 lift3 expected_k2 in
+                                                   let uu___11 =
                                                      FStar_Syntax_Subst.close_univ_vars
-                                                       uvs lift3 in
-                                                   (uvs, uu____12896)) in
+                                                       uvs lift5 in
+                                                   (uvs, uu___11)) in
                                               FStar_Pervasives_Native.Some
-                                                lift3))) in
-                         ((let uu____12904 =
-                             let uu____12905 =
-                               let uu____12906 =
+                                                lift4))) in
+                         ((let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_All.pipe_right lift_wp
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____12906
-                                 FStar_List.length in
-                             uu____12905 <> Prims.int_one in
-                           if uu____12904
+                               FStar_All.pipe_right uu___8 FStar_List.length in
+                             uu___7 <> Prims.int_one in
+                           if uu___6
                            then
-                             let uu____12925 =
-                               let uu____12930 =
-                                 let uu____12931 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____12932 =
+                                 let uu___10 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____12933 =
-                                   let uu____12934 =
-                                     let uu____12935 =
+                                 let uu___11 =
+                                   let uu___12 =
+                                     let uu___13 =
                                        FStar_All.pipe_right lift_wp
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____12935
+                                     FStar_All.pipe_right uu___13
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____12934
+                                   FStar_All.pipe_right uu___12
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____12931 uu____12932 uu____12933 in
-                               (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____12930) in
-                             FStar_Errors.raise_error uu____12925 r
+                                   uu___9 uu___10 uu___11 in
+                               (FStar_Errors.Fatal_TooManyUniverse, uu___8) in
+                             FStar_Errors.raise_error uu___7 r
                            else ());
-                          (let uu____12956 =
+                          (let uu___7 =
                              (FStar_Util.is_some lift1) &&
-                               (let uu____12958 =
-                                  let uu____12959 =
-                                    let uu____12962 =
+                               (let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 =
                                       FStar_All.pipe_right lift1
                                         FStar_Util.must in
-                                    FStar_All.pipe_right uu____12962
+                                    FStar_All.pipe_right uu___10
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____12959
+                                  FStar_All.pipe_right uu___9
                                     FStar_List.length in
-                                uu____12958 <> Prims.int_one) in
-                           if uu____12956
+                                uu___8 <> Prims.int_one) in
+                           if uu___7
                            then
-                             let uu____12997 =
-                               let uu____13002 =
-                                 let uu____13003 =
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____13004 =
+                                 let uu___11 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____13005 =
-                                   let uu____13006 =
-                                     let uu____13007 =
-                                       let uu____13010 =
+                                 let uu___12 =
+                                   let uu___13 =
+                                     let uu___14 =
+                                       let uu___15 =
                                          FStar_All.pipe_right lift1
                                            FStar_Util.must in
-                                       FStar_All.pipe_right uu____13010
+                                       FStar_All.pipe_right uu___15
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____13007
+                                     FStar_All.pipe_right uu___14
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____13006
+                                   FStar_All.pipe_right uu___13
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____13003 uu____13004 uu____13005 in
-                               (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____13002) in
-                             FStar_Errors.raise_error uu____12997 r
+                                   uu___10 uu___11 uu___12 in
+                               (FStar_Errors.Fatal_TooManyUniverse, uu___9) in
+                             FStar_Errors.raise_error uu___8 r
                            else ());
-                          (let uu___1344_13046 = sub in
+                          (let uu___7 = sub in
                            {
                              FStar_Syntax_Syntax.source =
-                               (uu___1344_13046.FStar_Syntax_Syntax.source);
+                               (uu___7.FStar_Syntax_Syntax.source);
                              FStar_Syntax_Syntax.target =
-                               (uu___1344_13046.FStar_Syntax_Syntax.target);
+                               (uu___7.FStar_Syntax_Syntax.target);
                              FStar_Syntax_Syntax.lift_wp =
                                (FStar_Pervasives_Native.Some lift_wp);
                              FStar_Syntax_Syntax.lift = lift1
@@ -5534,139 +5396,138 @@ let (tc_effect_abbrev :
           FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun env ->
-    fun uu____13076 ->
+    fun uu___ ->
       fun r ->
-        match uu____13076 with
+        match uu___ with
         | (lid, uvs, tps, c) ->
             let env0 = env in
-            let uu____13099 =
+            let uu___1 =
               if (FStar_List.length uvs) = Prims.int_zero
               then (env, uvs, tps, c)
               else
-                (let uu____13123 = FStar_Syntax_Subst.univ_var_opening uvs in
-                 match uu____13123 with
+                (let uu___3 = FStar_Syntax_Subst.univ_var_opening uvs in
+                 match uu___3 with
                  | (usubst, uvs1) ->
                      let tps1 = FStar_Syntax_Subst.subst_binders usubst tps in
                      let c1 =
-                       let uu____13154 =
+                       let uu___4 =
                          FStar_Syntax_Subst.shift_subst
                            (FStar_List.length tps1) usubst in
-                       FStar_Syntax_Subst.subst_comp uu____13154 c in
-                     let uu____13163 =
+                       FStar_Syntax_Subst.subst_comp uu___4 c in
+                     let uu___4 =
                        FStar_TypeChecker_Env.push_univ_vars env uvs1 in
-                     (uu____13163, uvs1, tps1, c1)) in
-            (match uu____13099 with
+                     (uu___4, uvs1, tps1, c1)) in
+            (match uu___1 with
              | (env1, uvs1, tps1, c1) ->
                  let env2 = FStar_TypeChecker_Env.set_range env1 r in
-                 let uu____13183 = FStar_Syntax_Subst.open_comp tps1 c1 in
-                 (match uu____13183 with
+                 let uu___2 = FStar_Syntax_Subst.open_comp tps1 c1 in
+                 (match uu___2 with
                   | (tps2, c2) ->
-                      let uu____13198 =
+                      let uu___3 =
                         FStar_TypeChecker_TcTerm.tc_tparams env2 tps2 in
-                      (match uu____13198 with
+                      (match uu___3 with
                        | (tps3, env3, us) ->
-                           let uu____13216 =
+                           let uu___4 =
                              FStar_TypeChecker_TcTerm.tc_comp env3 c2 in
-                           (match uu____13216 with
+                           (match uu___4 with
                             | (c3, u, g) ->
                                 (FStar_TypeChecker_Rel.force_trivial_guard
                                    env3 g;
                                  (let expected_result_typ =
                                     match tps3 with
-                                    | (x, uu____13242)::uu____13243 ->
+                                    | (x, uu___7)::uu___8 ->
                                         FStar_Syntax_Syntax.bv_to_name x
-                                    | uu____13262 ->
+                                    | uu___7 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                             "Effect abbreviations must bind at least the result type")
                                           r in
                                   let def_result_typ =
                                     FStar_Syntax_Util.comp_result c3 in
-                                  let uu____13268 =
-                                    let uu____13269 =
+                                  let uu___7 =
+                                    let uu___8 =
                                       FStar_TypeChecker_Rel.teq_nosmt_force
                                         env3 expected_result_typ
                                         def_result_typ in
-                                    Prims.op_Negation uu____13269 in
-                                  if uu____13268
+                                    Prims.op_Negation uu___8 in
+                                  if uu___7
                                   then
-                                    let uu____13270 =
-                                      let uu____13275 =
-                                        let uu____13276 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        let uu___10 =
                                           FStar_Syntax_Print.term_to_string
                                             expected_result_typ in
-                                        let uu____13277 =
+                                        let uu___11 =
                                           FStar_Syntax_Print.term_to_string
                                             def_result_typ in
                                         FStar_Util.format2
                                           "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                          uu____13276 uu____13277 in
+                                          uu___10 uu___11 in
                                       (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                        uu____13275) in
-                                    FStar_Errors.raise_error uu____13270 r
+                                        uu___9) in
+                                    FStar_Errors.raise_error uu___8 r
                                   else ());
                                  (let tps4 =
                                     FStar_Syntax_Subst.close_binders tps3 in
                                   let c4 =
                                     FStar_Syntax_Subst.close_comp tps4 c3 in
-                                  let uu____13281 =
-                                    let uu____13282 =
+                                  let uu___7 =
+                                    let uu___8 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_arrow
                                            (tps4, c4)) r in
                                     FStar_TypeChecker_Generalize.generalize_universes
-                                      env0 uu____13282 in
-                                  match uu____13281 with
+                                      env0 uu___8 in
+                                  match uu___7 with
                                   | (uvs2, t) ->
-                                      let uu____13311 =
-                                        let uu____13316 =
-                                          let uu____13329 =
-                                            let uu____13330 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_Syntax_Subst.compress t in
-                                            uu____13330.FStar_Syntax_Syntax.n in
-                                          (tps4, uu____13329) in
-                                        match uu____13316 with
+                                            uu___11.FStar_Syntax_Syntax.n in
+                                          (tps4, uu___10) in
+                                        match uu___9 with
                                         | ([], FStar_Syntax_Syntax.Tm_arrow
-                                           (uu____13345, c5)) -> ([], c5)
-                                        | (uu____13387,
+                                           (uu___10, c5)) -> ([], c5)
+                                        | (uu___10,
                                            FStar_Syntax_Syntax.Tm_arrow
                                            (tps5, c5)) -> (tps5, c5)
-                                        | uu____13426 ->
+                                        | uu___10 ->
                                             failwith
                                               "Impossible (t is an arrow)" in
-                                      (match uu____13311 with
+                                      (match uu___8 with
                                        | (tps5, c5) ->
                                            (if
                                               (FStar_List.length uvs2) <>
                                                 Prims.int_one
                                             then
-                                              (let uu____13454 =
+                                              (let uu___10 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    uvs2 t in
-                                               match uu____13454 with
-                                               | (uu____13459, t1) ->
-                                                   let uu____13461 =
-                                                     let uu____13466 =
-                                                       let uu____13467 =
+                                               match uu___10 with
+                                               | (uu___11, t1) ->
+                                                   let uu___12 =
+                                                     let uu___13 =
+                                                       let uu___14 =
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid in
-                                                       let uu____13468 =
+                                                       let uu___15 =
                                                          FStar_All.pipe_right
                                                            (FStar_List.length
                                                               uvs2)
                                                            FStar_Util.string_of_int in
-                                                       let uu____13469 =
+                                                       let uu___16 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1 in
                                                        FStar_Util.format3
                                                          "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                         uu____13467
-                                                         uu____13468
-                                                         uu____13469 in
+                                                         uu___14 uu___15
+                                                         uu___16 in
                                                      (FStar_Errors.Fatal_TooManyUniverse,
-                                                       uu____13466) in
+                                                       uu___13) in
                                                    FStar_Errors.raise_error
-                                                     uu____13461 r)
+                                                     uu___12 r)
                                             else ();
                                             (lid, uvs2, tps5, c5)))))))))
 let (tc_polymonadic_bind :
@@ -5683,272 +5544,265 @@ let (tc_polymonadic_bind :
         fun p ->
           fun ts ->
             let eff_name =
-              let uu____13505 =
-                let uu____13506 =
-                  FStar_All.pipe_right m FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13506 FStar_Ident.string_of_id in
-              let uu____13507 =
-                let uu____13508 =
-                  FStar_All.pipe_right n FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13508 FStar_Ident.string_of_id in
-              let uu____13509 =
-                let uu____13510 =
-                  FStar_All.pipe_right p FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13510 FStar_Ident.string_of_id in
-              FStar_Util.format3 "(%s, %s) |> %s)" uu____13505 uu____13507
-                uu____13509 in
+              let uu___ =
+                let uu___1 = FStar_All.pipe_right m FStar_Ident.ident_of_lid in
+                FStar_All.pipe_right uu___1 FStar_Ident.string_of_id in
+              let uu___1 =
+                let uu___2 = FStar_All.pipe_right n FStar_Ident.ident_of_lid in
+                FStar_All.pipe_right uu___2 FStar_Ident.string_of_id in
+              let uu___2 =
+                let uu___3 = FStar_All.pipe_right p FStar_Ident.ident_of_lid in
+                FStar_All.pipe_right uu___3 FStar_Ident.string_of_id in
+              FStar_Util.format3 "(%s, %s) |> %s)" uu___ uu___1 uu___2 in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
-            let uu____13516 =
+            let uu___ =
               check_and_gen env eff_name "polymonadic_bind"
                 (Prims.of_int (2)) ts in
-            match uu____13516 with
+            match uu___ with
             | (us, t, ty) ->
-                let uu____13530 = FStar_Syntax_Subst.open_univ_vars us ty in
-                (match uu____13530 with
+                let uu___1 = FStar_Syntax_Subst.open_univ_vars us ty in
+                (match uu___1 with
                  | (us1, ty1) ->
                      let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
                      (check_no_subtyping_for_layered_combinator env1 ty1
                         FStar_Pervasives_Native.None;
-                      (let uu____13543 =
-                         let uu____13548 = FStar_Syntax_Util.type_u () in
-                         FStar_All.pipe_right uu____13548
-                           (fun uu____13565 ->
-                              match uu____13565 with
+                      (let uu___3 =
+                         let uu___4 = FStar_Syntax_Util.type_u () in
+                         FStar_All.pipe_right uu___4
+                           (fun uu___5 ->
+                              match uu___5 with
                               | (t1, u) ->
-                                  let uu____13576 =
-                                    let uu____13577 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_Syntax_Syntax.gen_bv "a"
                                         FStar_Pervasives_Native.None t1 in
-                                    FStar_All.pipe_right uu____13577
+                                    FStar_All.pipe_right uu___7
                                       FStar_Syntax_Syntax.mk_binder in
-                                  (uu____13576, u)) in
-                       match uu____13543 with
+                                  (uu___6, u)) in
+                       match uu___3 with
                        | (a, u_a) ->
-                           let uu____13584 =
-                             let uu____13589 = FStar_Syntax_Util.type_u () in
-                             FStar_All.pipe_right uu____13589
-                               (fun uu____13606 ->
-                                  match uu____13606 with
+                           let uu___4 =
+                             let uu___5 = FStar_Syntax_Util.type_u () in
+                             FStar_All.pipe_right uu___5
+                               (fun uu___6 ->
+                                  match uu___6 with
                                   | (t1, u) ->
-                                      let uu____13617 =
-                                        let uu____13618 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_Syntax_Syntax.gen_bv "b"
                                             FStar_Pervasives_Native.None t1 in
-                                        FStar_All.pipe_right uu____13618
+                                        FStar_All.pipe_right uu___8
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____13617, u)) in
-                           (match uu____13584 with
+                                      (uu___7, u)) in
+                           (match uu___4 with
                             | (b, u_b) ->
                                 let rest_bs =
-                                  let uu____13634 =
-                                    let uu____13635 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       FStar_Syntax_Subst.compress ty1 in
-                                    uu____13635.FStar_Syntax_Syntax.n in
-                                  match uu____13634 with
-                                  | FStar_Syntax_Syntax.Tm_arrow
-                                      (bs, uu____13647) when
+                                    uu___6.FStar_Syntax_Syntax.n in
+                                  match uu___5 with
+                                  | FStar_Syntax_Syntax.Tm_arrow (bs, uu___6)
+                                      when
                                       (FStar_List.length bs) >=
                                         (Prims.of_int (4))
                                       ->
-                                      let uu____13674 =
+                                      let uu___7 =
                                         FStar_Syntax_Subst.open_binders bs in
-                                      (match uu____13674 with
-                                       | (a', uu____13684)::(b', uu____13686)::bs1
-                                           ->
-                                           let uu____13716 =
-                                             let uu____13717 =
+                                      (match uu___7 with
+                                       | (a', uu___8)::(b', uu___9)::bs1 ->
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_All.pipe_right bs1
                                                  (FStar_List.splitAt
                                                     ((FStar_List.length bs1)
                                                        - (Prims.of_int (2)))) in
-                                             FStar_All.pipe_right uu____13717
+                                             FStar_All.pipe_right uu___11
                                                FStar_Pervasives_Native.fst in
-                                           let uu____13782 =
-                                             let uu____13795 =
-                                               let uu____13798 =
-                                                 let uu____13799 =
-                                                   let uu____13806 =
-                                                     let uu____13809 =
+                                           let uu___11 =
+                                             let uu___12 =
+                                               let uu___13 =
+                                                 let uu___14 =
+                                                   let uu___15 =
+                                                     let uu___16 =
                                                        FStar_All.pipe_right a
                                                          FStar_Pervasives_Native.fst in
                                                      FStar_All.pipe_right
-                                                       uu____13809
+                                                       uu___16
                                                        FStar_Syntax_Syntax.bv_to_name in
-                                                   (a', uu____13806) in
+                                                   (a', uu___15) in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____13799 in
-                                               let uu____13822 =
-                                                 let uu____13825 =
-                                                   let uu____13826 =
-                                                     let uu____13833 =
-                                                       let uu____13836 =
+                                                   uu___14 in
+                                               let uu___14 =
+                                                 let uu___15 =
+                                                   let uu___16 =
+                                                     let uu___17 =
+                                                       let uu___18 =
                                                          FStar_All.pipe_right
                                                            b
                                                            FStar_Pervasives_Native.fst in
                                                        FStar_All.pipe_right
-                                                         uu____13836
+                                                         uu___18
                                                          FStar_Syntax_Syntax.bv_to_name in
-                                                     (b', uu____13833) in
+                                                     (b', uu___17) in
                                                    FStar_Syntax_Syntax.NT
-                                                     uu____13826 in
-                                                 [uu____13825] in
-                                               uu____13798 :: uu____13822 in
+                                                     uu___16 in
+                                                 [uu___15] in
+                                               uu___13 :: uu___14 in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____13795 in
-                                           FStar_All.pipe_right uu____13716
-                                             uu____13782)
-                                  | uu____13857 ->
-                                      let uu____13858 =
-                                        let uu____13863 =
-                                          let uu____13864 =
+                                               uu___12 in
+                                           FStar_All.pipe_right uu___10
+                                             uu___11)
+                                  | uu___6 ->
+                                      let uu___7 =
+                                        let uu___8 =
+                                          let uu___9 =
                                             FStar_Syntax_Print.tag_of_term
                                               ty1 in
-                                          let uu____13865 =
+                                          let uu___10 =
                                             FStar_Syntax_Print.term_to_string
                                               ty1 in
                                           FStar_Util.format3
                                             "Type of %s is not an arrow with >= 4 binders (%s::%s)"
-                                            eff_name uu____13864 uu____13865 in
+                                            eff_name uu___9 uu___10 in
                                         (FStar_Errors.Fatal_UnexpectedEffect,
-                                          uu____13863) in
-                                      FStar_Errors.raise_error uu____13858 r in
+                                          uu___8) in
+                                      FStar_Errors.raise_error uu___7 r in
                                 let bs = a :: b :: rest_bs in
-                                let uu____13895 =
-                                  let uu____13906 =
-                                    let uu____13911 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         bs in
-                                    let uu____13912 =
-                                      let uu____13913 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_All.pipe_right a
                                           FStar_Pervasives_Native.fst in
-                                      FStar_All.pipe_right uu____13913
+                                      FStar_All.pipe_right uu___9
                                         FStar_Syntax_Syntax.bv_to_name in
                                     FStar_TypeChecker_Util.fresh_effect_repr_en
-                                      uu____13911 r m u_a uu____13912 in
-                                  match uu____13906 with
+                                      uu___7 r m u_a uu___8 in
+                                  match uu___6 with
                                   | (repr, g) ->
-                                      let uu____13934 =
-                                        let uu____13941 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_Syntax_Syntax.gen_bv "f"
                                             FStar_Pervasives_Native.None repr in
-                                        FStar_All.pipe_right uu____13941
+                                        FStar_All.pipe_right uu___8
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____13934, g) in
-                                (match uu____13895 with
+                                      (uu___7, g) in
+                                (match uu___5 with
                                  | (f, guard_f) ->
-                                     let uu____13972 =
+                                     let uu___6 =
                                        let x_a =
-                                         let uu____13990 =
-                                           let uu____13991 =
-                                             let uu____13992 =
+                                         let uu___7 =
+                                           let uu___8 =
+                                             let uu___9 =
                                                FStar_All.pipe_right a
                                                  FStar_Pervasives_Native.fst in
-                                             FStar_All.pipe_right uu____13992
+                                             FStar_All.pipe_right uu___9
                                                FStar_Syntax_Syntax.bv_to_name in
                                            FStar_Syntax_Syntax.gen_bv "x"
                                              FStar_Pervasives_Native.None
-                                             uu____13991 in
-                                         FStar_All.pipe_right uu____13990
+                                             uu___8 in
+                                         FStar_All.pipe_right uu___7
                                            FStar_Syntax_Syntax.mk_binder in
-                                       let uu____14007 =
-                                         let uu____14012 =
+                                       let uu___7 =
+                                         let uu___8 =
                                            FStar_TypeChecker_Env.push_binders
                                              env1
                                              (FStar_List.append bs [x_a]) in
-                                         let uu____14031 =
-                                           let uu____14032 =
+                                         let uu___9 =
+                                           let uu___10 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst in
-                                           FStar_All.pipe_right uu____14032
+                                           FStar_All.pipe_right uu___10
                                              FStar_Syntax_Syntax.bv_to_name in
                                          FStar_TypeChecker_Util.fresh_effect_repr_en
-                                           uu____14012 r n u_b uu____14031 in
-                                       match uu____14007 with
+                                           uu___8 r n u_b uu___9 in
+                                       match uu___7 with
                                        | (repr, g) ->
-                                           let uu____14053 =
-                                             let uu____14060 =
-                                               let uu____14061 =
-                                                 let uu____14062 =
-                                                   let uu____14065 =
-                                                     let uu____14068 =
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
+                                                 let uu___11 =
+                                                   let uu___12 =
+                                                     let uu___13 =
                                                        FStar_TypeChecker_Env.new_u_univ
                                                          () in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____14068 in
+                                                       uu___13 in
                                                    FStar_Syntax_Syntax.mk_Total'
-                                                     repr uu____14065 in
+                                                     repr uu___12 in
                                                  FStar_Syntax_Util.arrow
-                                                   [x_a] uu____14062 in
+                                                   [x_a] uu___11 in
                                                FStar_Syntax_Syntax.gen_bv "g"
                                                  FStar_Pervasives_Native.None
-                                                 uu____14061 in
-                                             FStar_All.pipe_right uu____14060
+                                                 uu___10 in
+                                             FStar_All.pipe_right uu___9
                                                FStar_Syntax_Syntax.mk_binder in
-                                           (uu____14053, g) in
-                                     (match uu____13972 with
+                                           (uu___8, g) in
+                                     (match uu___6 with
                                       | (g, guard_g) ->
-                                          let uu____14111 =
-                                            let uu____14116 =
+                                          let uu___7 =
+                                            let uu___8 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 bs in
-                                            let uu____14117 =
-                                              let uu____14118 =
+                                            let uu___9 =
+                                              let uu___10 =
                                                 FStar_All.pipe_right b
                                                   FStar_Pervasives_Native.fst in
-                                              FStar_All.pipe_right
-                                                uu____14118
+                                              FStar_All.pipe_right uu___10
                                                 FStar_Syntax_Syntax.bv_to_name in
                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                              uu____14116 r p u_b uu____14117 in
-                                          (match uu____14111 with
+                                              uu___8 r p u_b uu___9 in
+                                          (match uu___7 with
                                            | (repr, guard_repr) ->
-                                               let uu____14133 =
-                                                 let uu____14138 =
+                                               let uu___8 =
+                                                 let uu___9 =
                                                    FStar_TypeChecker_Env.push_binders
                                                      env1 bs in
-                                                 let uu____14139 =
+                                                 let uu___10 =
                                                    FStar_Util.format1
                                                      "implicit for pure_wp in checking %s"
                                                      eff_name in
-                                                 pure_wp_uvar uu____14138
-                                                   repr uu____14139 r in
-                                               (match uu____14133 with
+                                                 pure_wp_uvar uu___9 repr
+                                                   uu___10 r in
+                                               (match uu___8 with
                                                 | (pure_wp_uvar1,
                                                    g_pure_wp_uvar) ->
                                                     let k =
-                                                      let uu____14149 =
-                                                        let uu____14152 =
-                                                          let uu____14153 =
-                                                            let uu____14154 =
+                                                      let uu___9 =
+                                                        let uu___10 =
+                                                          let uu___11 =
+                                                            let uu___12 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 () in
-                                                            [uu____14154] in
-                                                          let uu____14155 =
-                                                            let uu____14166 =
+                                                            [uu___12] in
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               FStar_All.pipe_right
                                                                 pure_wp_uvar1
                                                                 FStar_Syntax_Syntax.as_arg in
-                                                            [uu____14166] in
+                                                            [uu___13] in
                                                           {
                                                             FStar_Syntax_Syntax.comp_univs
-                                                              = uu____14153;
+                                                              = uu___11;
                                                             FStar_Syntax_Syntax.effect_name
                                                               =
                                                               FStar_Parser_Const.effect_PURE_lid;
                                                             FStar_Syntax_Syntax.result_typ
                                                               = repr;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____14155;
+                                                              = uu___12;
                                                             FStar_Syntax_Syntax.flags
                                                               = []
                                                           } in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____14152 in
+                                                          uu___10 in
                                                       FStar_Syntax_Util.arrow
                                                         (FStar_List.append bs
-                                                           [f; g])
-                                                        uu____14149 in
+                                                           [f; g]) uu___9 in
                                                     let guard_eq =
                                                       FStar_TypeChecker_Rel.teq
                                                         env1 ty1 k in
@@ -5960,24 +5814,23 @@ let (tc_polymonadic_bind :
                                                        guard_repr;
                                                        g_pure_wp_uvar;
                                                        guard_eq];
-                                                     (let uu____14226 =
+                                                     (let uu___11 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env1)
                                                           FStar_Options.Extreme in
-                                                      if uu____14226
+                                                      if uu___11
                                                       then
-                                                        let uu____14227 =
+                                                        let uu___12 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, t) in
-                                                        let uu____14232 =
+                                                        let uu___13 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, k) in
                                                         FStar_Util.print3
                                                           "Polymonadic bind %s after typechecking (%s::%s)\n"
-                                                          eff_name
-                                                          uu____14227
-                                                          uu____14232
+                                                          eff_name uu___12
+                                                          uu___13
                                                       else ());
                                                      (let k1 =
                                                         FStar_All.pipe_right
@@ -5989,33 +5842,32 @@ let (tc_polymonadic_bind :
                                                         (FStar_TypeChecker_Env.is_reifiable_effect
                                                            env1 p)
                                                           &&
-                                                          (let uu____14241 =
+                                                          (let uu___11 =
                                                              FStar_TypeChecker_Env.fv_with_lid_has_attr
                                                                env1 p
                                                                FStar_Parser_Const.allow_informative_binders_attr in
                                                            Prims.op_Negation
-                                                             uu____14241) in
-                                                      (let uu____14243 =
-                                                         let uu____14244 =
+                                                             uu___11) in
+                                                      (let uu___11 =
+                                                         let uu___12 =
                                                            FStar_Syntax_Subst.compress
                                                              k1 in
-                                                         uu____14244.FStar_Syntax_Syntax.n in
-                                                       match uu____14243 with
+                                                         uu___12.FStar_Syntax_Syntax.n in
+                                                       match uu___11 with
                                                        | FStar_Syntax_Syntax.Tm_arrow
                                                            (bs1, c) ->
-                                                           let uu____14269 =
+                                                           let uu___12 =
                                                              FStar_Syntax_Subst.open_comp
                                                                bs1 c in
-                                                           (match uu____14269
+                                                           (match uu___12
                                                             with
                                                             | (a1::b1::bs2,
                                                                c1) ->
                                                                 let res_t =
                                                                   FStar_Syntax_Util.comp_result
                                                                     c1 in
-                                                                let uu____14313
-                                                                  =
-                                                                  let uu____14340
+                                                                let uu___13 =
+                                                                  let uu___14
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -6023,53 +5875,53 @@ let (tc_polymonadic_bind :
                                                                     (Prims.of_int (2)))
                                                                     bs2 in
                                                                   FStar_All.pipe_right
-                                                                    uu____14340
+                                                                    uu___14
                                                                     (
                                                                     fun
-                                                                    uu____14424
+                                                                    uu___15
                                                                     ->
-                                                                    match uu____14424
+                                                                    match uu___15
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____14505
+                                                                    let uu___16
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____14532
+                                                                    let uu___17
                                                                     =
-                                                                    let uu____14539
+                                                                    let uu___18
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____14539
+                                                                    uu___18
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____14505,
-                                                                    uu____14532)) in
-                                                                (match uu____14313
+                                                                    uu___16,
+                                                                    uu___17)) in
+                                                                (match uu___13
                                                                  with
                                                                  | (bs3, f_b,
                                                                     g_b) ->
                                                                     let g_sort
                                                                     =
-                                                                    let uu____14654
+                                                                    let uu___14
                                                                     =
-                                                                    let uu____14655
+                                                                    let uu___15
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Pervasives_Native.fst
                                                                     g_b).FStar_Syntax_Syntax.sort in
-                                                                    uu____14655.FStar_Syntax_Syntax.n in
-                                                                    match uu____14654
+                                                                    uu___15.FStar_Syntax_Syntax.n in
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
-                                                                    (uu____14660,
+                                                                    (uu___15,
                                                                     c2) ->
                                                                     FStar_Syntax_Util.comp_result
                                                                     c2 in
@@ -6087,24 +5939,23 @@ let (tc_polymonadic_bind :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                      (let uu____14704 =
-                                                         let uu____14709 =
+                                                      (let uu___12 =
+                                                         let uu___13 =
                                                            FStar_Util.format1
                                                              "Polymonadic binds (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                              eff_name in
                                                          (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                           uu____14709) in
+                                                           uu___13) in
                                                        FStar_Errors.log_issue
-                                                         r uu____14704);
-                                                      (let uu____14710 =
-                                                         let uu____14711 =
+                                                         r uu___12);
+                                                      (let uu___12 =
+                                                         let uu___13 =
                                                            FStar_All.pipe_right
                                                              k1
                                                              (FStar_Syntax_Subst.close_univ_vars
                                                                 us1) in
-                                                         (us1, uu____14711) in
-                                                       ((us1, t),
-                                                         uu____14710))))))))))))
+                                                         (us1, uu___13) in
+                                                       ((us1, t), uu___12))))))))))))
 let (tc_polymonadic_subcomp :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -6118,186 +5969,179 @@ let (tc_polymonadic_subcomp :
         fun ts ->
           let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
           let combinator_name =
-            let uu____14758 =
-              let uu____14759 =
-                FStar_All.pipe_right m FStar_Ident.ident_of_lid in
-              FStar_All.pipe_right uu____14759 FStar_Ident.string_of_id in
-            let uu____14760 =
-              let uu____14761 =
-                let uu____14762 =
-                  FStar_All.pipe_right n FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____14762 FStar_Ident.string_of_id in
-              Prims.op_Hat " <: " uu____14761 in
-            Prims.op_Hat uu____14758 uu____14760 in
-          let uu____14763 =
+            let uu___ =
+              let uu___1 = FStar_All.pipe_right m FStar_Ident.ident_of_lid in
+              FStar_All.pipe_right uu___1 FStar_Ident.string_of_id in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_All.pipe_right n FStar_Ident.ident_of_lid in
+                FStar_All.pipe_right uu___3 FStar_Ident.string_of_id in
+              Prims.op_Hat " <: " uu___2 in
+            Prims.op_Hat uu___ uu___1 in
+          let uu___ =
             check_and_gen env0 combinator_name "polymonadic_subcomp"
               Prims.int_one ts in
-          match uu____14763 with
+          match uu___ with
           | (us, t, ty) ->
-              let uu____14777 = FStar_Syntax_Subst.open_univ_vars us ty in
-              (match uu____14777 with
+              let uu___1 = FStar_Syntax_Subst.open_univ_vars us ty in
+              (match uu___1 with
                | (us1, ty1) ->
                    let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
                    (check_no_subtyping_for_layered_combinator env ty1
                       FStar_Pervasives_Native.None;
-                    (let uu____14790 =
-                       let uu____14795 = FStar_Syntax_Util.type_u () in
-                       FStar_All.pipe_right uu____14795
-                         (fun uu____14812 ->
-                            match uu____14812 with
+                    (let uu___3 =
+                       let uu___4 = FStar_Syntax_Util.type_u () in
+                       FStar_All.pipe_right uu___4
+                         (fun uu___5 ->
+                            match uu___5 with
                             | (t1, u) ->
-                                let uu____14823 =
-                                  let uu____14824 =
+                                let uu___6 =
+                                  let uu___7 =
                                     FStar_Syntax_Syntax.gen_bv "a"
                                       FStar_Pervasives_Native.None t1 in
-                                  FStar_All.pipe_right uu____14824
+                                  FStar_All.pipe_right uu___7
                                     FStar_Syntax_Syntax.mk_binder in
-                                (uu____14823, u)) in
-                     match uu____14790 with
+                                (uu___6, u)) in
+                     match uu___3 with
                      | (a, u) ->
                          let rest_bs =
-                           let uu____14840 =
-                             let uu____14841 =
-                               FStar_Syntax_Subst.compress ty1 in
-                             uu____14841.FStar_Syntax_Syntax.n in
-                           match uu____14840 with
-                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____14853)
-                               when
+                           let uu___4 =
+                             let uu___5 = FStar_Syntax_Subst.compress ty1 in
+                             uu___5.FStar_Syntax_Syntax.n in
+                           match uu___4 with
+                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu___5) when
                                (FStar_List.length bs) >= (Prims.of_int (2))
                                ->
-                               let uu____14880 =
+                               let uu___6 =
                                  FStar_Syntax_Subst.open_binders bs in
-                               (match uu____14880 with
-                                | (a', uu____14890)::bs1 ->
-                                    let uu____14910 =
-                                      let uu____14911 =
+                               (match uu___6 with
+                                | (a', uu___7)::bs1 ->
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_All.pipe_right bs1
                                           (FStar_List.splitAt
                                              ((FStar_List.length bs1) -
                                                 Prims.int_one)) in
-                                      FStar_All.pipe_right uu____14911
+                                      FStar_All.pipe_right uu___9
                                         FStar_Pervasives_Native.fst in
-                                    let uu____15008 =
-                                      let uu____15021 =
-                                        let uu____15024 =
-                                          let uu____15025 =
-                                            let uu____15032 =
+                                    let uu___9 =
+                                      let uu___10 =
+                                        let uu___11 =
+                                          let uu___12 =
+                                            let uu___13 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 (FStar_Pervasives_Native.fst
                                                    a) in
-                                            (a', uu____15032) in
-                                          FStar_Syntax_Syntax.NT uu____15025 in
-                                        [uu____15024] in
+                                            (a', uu___13) in
+                                          FStar_Syntax_Syntax.NT uu___12 in
+                                        [uu___11] in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____15021 in
-                                    FStar_All.pipe_right uu____14910
-                                      uu____15008)
-                           | uu____15047 ->
-                               let uu____15048 =
-                                 let uu____15053 =
-                                   let uu____15054 =
+                                        uu___10 in
+                                    FStar_All.pipe_right uu___8 uu___9)
+                           | uu___5 ->
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_Syntax_Print.tag_of_term t in
-                                   let uu____15055 =
+                                   let uu___9 =
                                      FStar_Syntax_Print.term_to_string t in
                                    FStar_Util.format3
                                      "Type of polymonadic subcomp %s is not an arrow with >= 2 binders (%s::%s)"
-                                     combinator_name uu____15054 uu____15055 in
+                                     combinator_name uu___8 uu___9 in
                                  (FStar_Errors.Fatal_UnexpectedEffect,
-                                   uu____15053) in
-                               FStar_Errors.raise_error uu____15048 r in
+                                   uu___7) in
+                               FStar_Errors.raise_error uu___6 r in
                          let bs = a :: rest_bs in
-                         let uu____15079 =
-                           let uu____15090 =
-                             let uu____15095 =
+                         let uu___4 =
+                           let uu___5 =
+                             let uu___6 =
                                FStar_TypeChecker_Env.push_binders env bs in
-                             let uu____15096 =
-                               let uu____15097 =
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____15097
+                               FStar_All.pipe_right uu___8
                                  FStar_Syntax_Syntax.bv_to_name in
                              FStar_TypeChecker_Util.fresh_effect_repr_en
-                               uu____15095 r m u uu____15096 in
-                           match uu____15090 with
+                               uu___6 r m u uu___7 in
+                           match uu___5 with
                            | (repr, g) ->
-                               let uu____15118 =
-                                 let uu____15125 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.gen_bv "f"
                                      FStar_Pervasives_Native.None repr in
-                                 FStar_All.pipe_right uu____15125
+                                 FStar_All.pipe_right uu___7
                                    FStar_Syntax_Syntax.mk_binder in
-                               (uu____15118, g) in
-                         (match uu____15079 with
+                               (uu___6, g) in
+                         (match uu___4 with
                           | (f, guard_f) ->
-                              let uu____15156 =
-                                let uu____15161 =
+                              let uu___5 =
+                                let uu___6 =
                                   FStar_TypeChecker_Env.push_binders env bs in
-                                let uu____15162 =
-                                  let uu____15163 =
+                                let uu___7 =
+                                  let uu___8 =
                                     FStar_All.pipe_right a
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____15163
+                                  FStar_All.pipe_right uu___8
                                     FStar_Syntax_Syntax.bv_to_name in
                                 FStar_TypeChecker_Util.fresh_effect_repr_en
-                                  uu____15161 r n u uu____15162 in
-                              (match uu____15156 with
+                                  uu___6 r n u uu___7 in
+                              (match uu___5 with
                                | (ret_t, guard_ret_t) ->
-                                   let uu____15178 =
-                                     let uu____15183 =
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____15184 =
+                                     let uu___8 =
                                        FStar_Util.format1
                                          "implicit for pure_wp in checking polymonadic subcomp %s"
                                          combinator_name in
-                                     pure_wp_uvar uu____15183 ret_t
-                                       uu____15184 r in
-                                   (match uu____15178 with
+                                     pure_wp_uvar uu___7 ret_t uu___8 r in
+                                   (match uu___6 with
                                     | (pure_wp_uvar1, guard_wp) ->
                                         let c =
-                                          let uu____15192 =
-                                            let uu____15193 =
-                                              let uu____15194 =
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
                                                 FStar_TypeChecker_Env.new_u_univ
                                                   () in
-                                              [uu____15194] in
-                                            let uu____15195 =
-                                              let uu____15206 =
+                                              [uu___9] in
+                                            let uu___9 =
+                                              let uu___10 =
                                                 FStar_All.pipe_right
                                                   pure_wp_uvar1
                                                   FStar_Syntax_Syntax.as_arg in
-                                              [uu____15206] in
+                                              [uu___10] in
                                             {
                                               FStar_Syntax_Syntax.comp_univs
-                                                = uu____15193;
+                                                = uu___8;
                                               FStar_Syntax_Syntax.effect_name
                                                 =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.result_typ
                                                 = ret_t;
                                               FStar_Syntax_Syntax.effect_args
-                                                = uu____15195;
+                                                = uu___9;
                                               FStar_Syntax_Syntax.flags = []
                                             } in
-                                          FStar_Syntax_Syntax.mk_Comp
-                                            uu____15192 in
+                                          FStar_Syntax_Syntax.mk_Comp uu___7 in
                                         let k =
                                           FStar_Syntax_Util.arrow
                                             (FStar_List.append bs [f]) c in
-                                        ((let uu____15261 =
+                                        ((let uu___8 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env)
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
-                                          if uu____15261
+                                          if uu___8
                                           then
-                                            let uu____15262 =
+                                            let uu___9 =
                                               FStar_Syntax_Print.term_to_string
                                                 k in
                                             FStar_Util.print2
                                               "Expected type of polymonadic subcomp %s before unification: %s\n"
-                                              combinator_name uu____15262
+                                              combinator_name uu___9
                                           else ());
                                          (let guard_eq =
                                             FStar_TypeChecker_Rel.teq env ty1
@@ -6310,59 +6154,58 @@ let (tc_polymonadic_subcomp :
                                             guard_wp;
                                             guard_eq];
                                           (let k1 =
-                                             let uu____15269 =
+                                             let uu___9 =
                                                FStar_All.pipe_right k
                                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                     env) in
-                                             FStar_All.pipe_right uu____15269
+                                             FStar_All.pipe_right uu___9
                                                (FStar_TypeChecker_Normalize.normalize
                                                   [FStar_TypeChecker_Env.Beta;
                                                   FStar_TypeChecker_Env.Eager_unfolding]
                                                   env) in
-                                           (let uu____15273 =
+                                           (let uu___10 =
                                               FStar_All.pipe_left
                                                 (FStar_TypeChecker_Env.debug
                                                    env)
                                                 (FStar_Options.Other
                                                    "LayeredEffectsTc") in
-                                            if uu____15273
+                                            if uu___10
                                             then
-                                              let uu____15274 =
+                                              let uu___11 =
                                                 FStar_Syntax_Print.tscheme_to_string
                                                   (us1, k1) in
                                               FStar_Util.print2
                                                 "Polymonadic subcomp %s type after unification : %s\n"
-                                                combinator_name uu____15274
+                                                combinator_name uu___11
                                             else ());
                                            (let check_non_informative_binders
                                               =
                                               (FStar_TypeChecker_Env.is_reifiable_effect
                                                  env n)
                                                 &&
-                                                (let uu____15282 =
+                                                (let uu___10 =
                                                    FStar_TypeChecker_Env.fv_with_lid_has_attr
                                                      env n
                                                      FStar_Parser_Const.allow_informative_binders_attr in
-                                                 Prims.op_Negation
-                                                   uu____15282) in
-                                            (let uu____15284 =
-                                               let uu____15285 =
+                                                 Prims.op_Negation uu___10) in
+                                            (let uu___10 =
+                                               let uu___11 =
                                                  FStar_Syntax_Subst.compress
                                                    k1 in
-                                               uu____15285.FStar_Syntax_Syntax.n in
-                                             match uu____15284 with
+                                               uu___11.FStar_Syntax_Syntax.n in
+                                             match uu___10 with
                                              | FStar_Syntax_Syntax.Tm_arrow
                                                  (bs1, c1) ->
-                                                 let uu____15310 =
+                                                 let uu___11 =
                                                    FStar_Syntax_Subst.open_comp
                                                      bs1 c1 in
-                                                 (match uu____15310 with
+                                                 (match uu___11 with
                                                   | (a1::bs2, c2) ->
                                                       let res_t =
                                                         FStar_Syntax_Util.comp_result
                                                           c2 in
-                                                      let uu____15341 =
-                                                        let uu____15360 =
+                                                      let uu___12 =
+                                                        let uu___13 =
                                                           FStar_List.splitAt
                                                             ((FStar_List.length
                                                                 bs2)
@@ -6370,18 +6213,18 @@ let (tc_polymonadic_subcomp :
                                                                Prims.int_one)
                                                             bs2 in
                                                         FStar_All.pipe_right
-                                                          uu____15360
-                                                          (fun uu____15435 ->
-                                                             match uu____15435
+                                                          uu___13
+                                                          (fun uu___14 ->
+                                                             match uu___14
                                                              with
                                                              | (l1, l2) ->
-                                                                 let uu____15508
+                                                                 let uu___15
                                                                    =
                                                                    FStar_List.hd
                                                                     l2 in
                                                                  (l1,
-                                                                   uu____15508)) in
-                                                      (match uu____15341 with
+                                                                   uu___15)) in
+                                                      (match uu___12 with
                                                        | (bs3, f_b) ->
                                                            let env1 =
                                                              FStar_TypeChecker_Env.push_binders
@@ -6393,19 +6236,18 @@ let (tc_polymonadic_subcomp :
                                                              res_t]
                                                              check_non_informative_binders
                                                              r)));
-                                            (let uu____15581 =
-                                               let uu____15586 =
+                                            (let uu___11 =
+                                               let uu___12 =
                                                  FStar_Util.format1
                                                    "Polymonadic subcomp (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                    combinator_name in
                                                (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                 uu____15586) in
-                                             FStar_Errors.log_issue r
-                                               uu____15581);
-                                            (let uu____15587 =
-                                               let uu____15588 =
+                                                 uu___12) in
+                                             FStar_Errors.log_issue r uu___11);
+                                            (let uu___11 =
+                                               let uu___12 =
                                                  FStar_All.pipe_right k1
                                                    (FStar_Syntax_Subst.close_univ_vars
                                                       us1) in
-                                               (us1, uu____15588) in
-                                             ((us1, t), uu____15587))))))))))))
+                                               (us1, uu___12) in
+                                             ((us1, t), uu___11))))))))))))

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -17,33 +17,33 @@ let (tc_tycon :
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (tc, uvs, tps, k, mutuals, data) ->
           let env0 = env in
-          let uu____49 = FStar_Syntax_Subst.univ_var_opening uvs in
-          (match uu____49 with
+          let uu___ = FStar_Syntax_Subst.univ_var_opening uvs in
+          (match uu___ with
            | (usubst, uvs1) ->
-               let uu____76 =
-                 let uu____83 = FStar_TypeChecker_Env.push_univ_vars env uvs1 in
-                 let uu____84 = FStar_Syntax_Subst.subst_binders usubst tps in
-                 let uu____85 =
-                   let uu____86 =
+               let uu___1 =
+                 let uu___2 = FStar_TypeChecker_Env.push_univ_vars env uvs1 in
+                 let uu___3 = FStar_Syntax_Subst.subst_binders usubst tps in
+                 let uu___4 =
+                   let uu___5 =
                      FStar_Syntax_Subst.shift_subst (FStar_List.length tps)
                        usubst in
-                   FStar_Syntax_Subst.subst uu____86 k in
-                 (uu____83, uu____84, uu____85) in
-               (match uu____76 with
+                   FStar_Syntax_Subst.subst uu___5 k in
+                 (uu___2, uu___3, uu___4) in
+               (match uu___1 with
                 | (env1, tps1, k1) ->
-                    let uu____106 = FStar_Syntax_Subst.open_term tps1 k1 in
-                    (match uu____106 with
+                    let uu___2 = FStar_Syntax_Subst.open_term tps1 k1 in
+                    (match uu___2 with
                      | (tps2, k2) ->
-                         let uu____121 =
+                         let uu___3 =
                            FStar_TypeChecker_TcTerm.tc_binders env1 tps2 in
-                         (match uu____121 with
+                         (match uu___3 with
                           | (tps3, env_tps, guard_params, us) ->
-                              let uu____142 =
-                                let uu____161 =
+                              let uu___4 =
+                                let uu___5 =
                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                     env_tps k2 in
-                                match uu____161 with
-                                | (k3, uu____187, g) ->
+                                match uu___5 with
+                                | (k3, uu___6, g) ->
                                     let k4 =
                                       FStar_TypeChecker_Normalize.normalize
                                         [FStar_TypeChecker_Env.Exclude
@@ -55,56 +55,53 @@ let (tc_tycon :
                                         FStar_TypeChecker_Env.Exclude
                                           FStar_TypeChecker_Env.Beta] env_tps
                                         k3 in
-                                    let uu____190 =
+                                    let uu___7 =
                                       FStar_Syntax_Util.arrow_formals k4 in
-                                    let uu____205 =
-                                      let uu____206 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_TypeChecker_Env.conj_guard
                                           guard_params g in
                                       FStar_TypeChecker_Rel.discharge_guard
-                                        env_tps uu____206 in
-                                    (uu____190, uu____205) in
-                              (match uu____142 with
+                                        env_tps uu___9 in
+                                    (uu___7, uu___8) in
+                              (match uu___4 with
                                | ((indices, t), guard) ->
                                    let k3 =
-                                     let uu____269 =
+                                     let uu___5 =
                                        FStar_Syntax_Syntax.mk_Total t in
-                                     FStar_Syntax_Util.arrow indices
-                                       uu____269 in
-                                   let uu____272 =
-                                     FStar_Syntax_Util.type_u () in
-                                   (match uu____272 with
+                                     FStar_Syntax_Util.arrow indices uu___5 in
+                                   let uu___5 = FStar_Syntax_Util.type_u () in
+                                   (match uu___5 with
                                     | (t_type, u) ->
                                         let valid_type =
                                           ((FStar_Syntax_Util.is_eqtype_no_unrefine
                                               t)
                                              &&
-                                             (let uu____289 =
+                                             (let uu___6 =
                                                 FStar_All.pipe_right
                                                   s.FStar_Syntax_Syntax.sigquals
                                                   (FStar_List.contains
                                                      FStar_Syntax_Syntax.Unopteq) in
-                                              Prims.op_Negation uu____289))
+                                              Prims.op_Negation uu___6))
                                             ||
                                             (FStar_TypeChecker_Rel.teq_nosmt_force
                                                env1 t t_type) in
                                         (if Prims.op_Negation valid_type
                                          then
-                                           (let uu____293 =
-                                              let uu____298 =
-                                                let uu____299 =
+                                           (let uu___7 =
+                                              let uu___8 =
+                                                let uu___9 =
                                                   FStar_Syntax_Print.term_to_string
                                                     t in
-                                                let uu____300 =
+                                                let uu___10 =
                                                   FStar_Ident.string_of_lid
                                                     tc in
                                                 FStar_Util.format2
                                                   "Type annotation %s for inductive %s is not Type or eqtype, or it is eqtype but contains unopteq qualifier"
-                                                  uu____299 uu____300 in
+                                                  uu___9 uu___10 in
                                               (FStar_Errors.Error_InductiveAnnotNotAType,
-                                                uu____298) in
-                                            FStar_Errors.raise_error
-                                              uu____293
+                                                uu___8) in
+                                            FStar_Errors.raise_error uu___7
                                               s.FStar_Syntax_Syntax.sigrng)
                                          else ();
                                          (let usubst1 =
@@ -114,27 +111,26 @@ let (tc_tycon :
                                             FStar_TypeChecker_Util.close_guard_implicits
                                               env1 false tps3 guard in
                                           let t_tc =
-                                            let uu____309 =
-                                              let uu____318 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_All.pipe_right tps3
                                                   (FStar_Syntax_Subst.subst_binders
                                                      usubst1) in
-                                              let uu____335 =
-                                                let uu____344 =
-                                                  let uu____357 =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  let uu___11 =
                                                     FStar_Syntax_Subst.shift_subst
                                                       (FStar_List.length tps3)
                                                       usubst1 in
                                                   FStar_Syntax_Subst.subst_binders
-                                                    uu____357 in
+                                                    uu___11 in
                                                 FStar_All.pipe_right indices
-                                                  uu____344 in
-                                              FStar_List.append uu____318
-                                                uu____335 in
-                                            let uu____380 =
-                                              let uu____383 =
-                                                let uu____384 =
-                                                  let uu____389 =
+                                                  uu___10 in
+                                              FStar_List.append uu___8 uu___9 in
+                                            let uu___8 =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  let uu___11 =
                                                     FStar_Syntax_Subst.shift_subst
                                                       ((FStar_List.length
                                                           tps3)
@@ -142,49 +138,49 @@ let (tc_tycon :
                                                          (FStar_List.length
                                                             indices)) usubst1 in
                                                   FStar_Syntax_Subst.subst
-                                                    uu____389 in
+                                                    uu___11 in
                                                 FStar_All.pipe_right t
-                                                  uu____384 in
+                                                  uu___10 in
                                               FStar_Syntax_Syntax.mk_Total
-                                                uu____383 in
-                                            FStar_Syntax_Util.arrow uu____309
-                                              uu____380 in
+                                                uu___9 in
+                                            FStar_Syntax_Util.arrow uu___7
+                                              uu___8 in
                                           let tps4 =
                                             FStar_Syntax_Subst.close_binders
                                               tps3 in
                                           let k4 =
                                             FStar_Syntax_Subst.close tps4 k3 in
-                                          let uu____406 =
-                                            let uu____411 =
+                                          let uu___7 =
+                                            let uu___8 =
                                               FStar_Syntax_Subst.subst_binders
                                                 usubst1 tps4 in
-                                            let uu____412 =
-                                              let uu____413 =
+                                            let uu___9 =
+                                              let uu___10 =
                                                 FStar_Syntax_Subst.shift_subst
                                                   (FStar_List.length tps4)
                                                   usubst1 in
                                               FStar_Syntax_Subst.subst
-                                                uu____413 k4 in
-                                            (uu____411, uu____412) in
-                                          match uu____406 with
+                                                uu___10 k4 in
+                                            (uu___8, uu___9) in
+                                          match uu___7 with
                                           | (tps5, k5) ->
                                               let fv_tc =
                                                 FStar_Syntax_Syntax.lid_as_fv
                                                   tc
                                                   FStar_Syntax_Syntax.delta_constant
                                                   FStar_Pervasives_Native.None in
-                                              let uu____433 =
+                                              let uu___8 =
                                                 FStar_Syntax_Subst.open_univ_vars
                                                   uvs1 t_tc in
-                                              (match uu____433 with
+                                              (match uu___8 with
                                                | (uvs2, t_tc1) ->
-                                                   let uu____448 =
+                                                   let uu___9 =
                                                      FStar_TypeChecker_Env.push_let_binding
                                                        env0
                                                        (FStar_Util.Inr fv_tc)
                                                        (uvs2, t_tc1) in
-                                                   (uu____448,
-                                                     (let uu___63_454 = s in
+                                                   (uu___9,
+                                                     (let uu___10 = s in
                                                       {
                                                         FStar_Syntax_Syntax.sigel
                                                           =
@@ -194,21 +190,21 @@ let (tc_tycon :
                                                                data));
                                                         FStar_Syntax_Syntax.sigrng
                                                           =
-                                                          (uu___63_454.FStar_Syntax_Syntax.sigrng);
+                                                          (uu___10.FStar_Syntax_Syntax.sigrng);
                                                         FStar_Syntax_Syntax.sigquals
                                                           =
-                                                          (uu___63_454.FStar_Syntax_Syntax.sigquals);
+                                                          (uu___10.FStar_Syntax_Syntax.sigquals);
                                                         FStar_Syntax_Syntax.sigmeta
                                                           =
-                                                          (uu___63_454.FStar_Syntax_Syntax.sigmeta);
+                                                          (uu___10.FStar_Syntax_Syntax.sigmeta);
                                                         FStar_Syntax_Syntax.sigattrs
                                                           =
-                                                          (uu___63_454.FStar_Syntax_Syntax.sigattrs);
+                                                          (uu___10.FStar_Syntax_Syntax.sigattrs);
                                                         FStar_Syntax_Syntax.sigopts
                                                           =
-                                                          (uu___63_454.FStar_Syntax_Syntax.sigopts)
+                                                          (uu___10.FStar_Syntax_Syntax.sigopts)
                                                       }), u, guard1))))))))))
-      | uu____459 -> failwith "impossible"
+      | uu___ -> failwith "impossible"
 let (tc_data :
   FStar_TypeChecker_Env.env_t ->
     (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe) Prims.list ->
@@ -221,91 +217,91 @@ let (tc_data :
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
             (c, _uvs, t, tc_lid, ntps, _mutual_tcs) ->
-            let uu____519 = FStar_Syntax_Subst.univ_var_opening _uvs in
-            (match uu____519 with
+            let uu___ = FStar_Syntax_Subst.univ_var_opening _uvs in
+            (match uu___ with
              | (usubst, _uvs1) ->
-                 let uu____542 =
-                   let uu____547 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_TypeChecker_Env.push_univ_vars env _uvs1 in
-                   let uu____548 = FStar_Syntax_Subst.subst usubst t in
-                   (uu____547, uu____548) in
-                 (match uu____542 with
+                   let uu___3 = FStar_Syntax_Subst.subst usubst t in
+                   (uu___2, uu___3) in
+                 (match uu___1 with
                   | (env1, t1) ->
-                      let uu____555 =
+                      let uu___2 =
                         let tps_u_opt =
                           FStar_Util.find_map tcs
-                            (fun uu____594 ->
-                               match uu____594 with
+                            (fun uu___3 ->
+                               match uu___3 with
                                | (se1, u_tc) ->
-                                   let uu____609 =
-                                     let uu____610 =
-                                       let uu____611 =
+                                   let uu___4 =
+                                     let uu___5 =
+                                       let uu___6 =
                                          FStar_Syntax_Util.lid_of_sigelt se1 in
-                                       FStar_Util.must uu____611 in
-                                     FStar_Ident.lid_equals tc_lid uu____610 in
-                                   if uu____609
+                                       FStar_Util.must uu___6 in
+                                     FStar_Ident.lid_equals tc_lid uu___5 in
+                                   if uu___4
                                    then
                                      (match se1.FStar_Syntax_Syntax.sigel
                                       with
                                       | FStar_Syntax_Syntax.Sig_inductive_typ
-                                          (uu____630, uu____631, tps,
-                                           uu____633, uu____634, uu____635)
+                                          (uu___5, uu___6, tps, uu___7,
+                                           uu___8, uu___9)
                                           ->
                                           let tps1 =
-                                            let uu____645 =
+                                            let uu___10 =
                                               FStar_All.pipe_right tps
                                                 (FStar_Syntax_Subst.subst_binders
                                                    usubst) in
-                                            FStar_All.pipe_right uu____645
+                                            FStar_All.pipe_right uu___10
                                               (FStar_List.map
-                                                 (fun uu____685 ->
-                                                    match uu____685 with
-                                                    | (x, uu____699) ->
+                                                 (fun uu___11 ->
+                                                    match uu___11 with
+                                                    | (x, uu___12) ->
                                                         (x,
                                                           (FStar_Pervasives_Native.Some
                                                              FStar_Syntax_Syntax.imp_tag)))) in
                                           let tps2 =
                                             FStar_Syntax_Subst.open_binders
                                               tps1 in
-                                          let uu____707 =
-                                            let uu____714 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 tps2 in
-                                            (uu____714, tps2, u_tc) in
+                                            (uu___11, tps2, u_tc) in
                                           FStar_Pervasives_Native.Some
-                                            uu____707
-                                      | uu____721 -> failwith "Impossible")
+                                            uu___10
+                                      | uu___5 -> failwith "Impossible")
                                    else FStar_Pervasives_Native.None) in
                         match tps_u_opt with
                         | FStar_Pervasives_Native.Some x -> x
                         | FStar_Pervasives_Native.None ->
-                            let uu____762 =
+                            let uu___3 =
                               FStar_Ident.lid_equals tc_lid
                                 FStar_Parser_Const.exn_lid in
-                            if uu____762
+                            if uu___3
                             then (env1, [], FStar_Syntax_Syntax.U_zero)
                             else
                               FStar_Errors.raise_error
                                 (FStar_Errors.Fatal_UnexpectedDataConstructor,
                                   "Unexpected data constructor")
                                 se.FStar_Syntax_Syntax.sigrng in
-                      (match uu____555 with
+                      (match uu___2 with
                        | (env2, tps, u_tc) ->
-                           let uu____789 =
+                           let uu___3 =
                              let t2 =
                                FStar_TypeChecker_Normalize.normalize
                                  (FStar_List.append
                                     FStar_TypeChecker_Normalize.whnf_steps
                                     [FStar_TypeChecker_Env.AllowUnboundUniverses])
                                  env2 t1 in
-                             let uu____797 =
-                               let uu____798 = FStar_Syntax_Subst.compress t2 in
-                               uu____798.FStar_Syntax_Syntax.n in
-                             match uu____797 with
+                             let uu___4 =
+                               let uu___5 = FStar_Syntax_Subst.compress t2 in
+                               uu___5.FStar_Syntax_Syntax.n in
+                             match uu___4 with
                              | FStar_Syntax_Syntax.Tm_arrow (bs, res) ->
-                                 let uu____829 = FStar_Util.first_N ntps bs in
-                                 (match uu____829 with
-                                  | (uu____862, bs') ->
+                                 let uu___5 = FStar_Util.first_N ntps bs in
+                                 (match uu___5 with
+                                  | (uu___6, bs') ->
                                       let t3 =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_arrow
@@ -315,62 +311,62 @@ let (tc_data :
                                         FStar_All.pipe_right tps
                                           (FStar_List.mapi
                                              (fun i ->
-                                                fun uu____933 ->
-                                                  match uu____933 with
-                                                  | (x, uu____941) ->
+                                                fun uu___7 ->
+                                                  match uu___7 with
+                                                  | (x, uu___8) ->
                                                       FStar_Syntax_Syntax.DB
                                                         ((ntps -
                                                             (Prims.int_one +
                                                                i)), x))) in
-                                      let uu____946 =
-                                        let uu____951 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_Syntax_Subst.subst subst t3 in
                                         FStar_Syntax_Util.arrow_formals_comp
-                                          uu____951 in
-                                      (match uu____946 with
+                                          uu___8 in
+                                      (match uu___7 with
                                        | (bs1, c1) ->
-                                           let uu____960 =
+                                           let uu___8 =
                                              (FStar_Options.ml_ish ()) ||
                                                (FStar_Syntax_Util.is_total_comp
                                                   c1) in
-                                           if uu____960
+                                           if uu___8
                                            then
                                              (bs1,
                                                (FStar_Syntax_Util.comp_result
                                                   c1))
                                            else
-                                             (let uu____970 =
+                                             (let uu___10 =
                                                 FStar_Ident.range_of_lid
                                                   (FStar_Syntax_Util.comp_effect_name
                                                      c1) in
                                               FStar_Errors.raise_error
                                                 (FStar_Errors.Fatal_UnexpectedConstructorType,
                                                   "Constructors cannot have effects")
-                                                uu____970)))
-                             | uu____977 -> ([], t2) in
-                           (match uu____789 with
+                                                uu___10)))
+                             | uu___5 -> ([], t2) in
+                           (match uu___3 with
                             | (arguments, result) ->
-                                ((let uu____997 =
+                                ((let uu___5 =
                                     FStar_TypeChecker_Env.debug env2
                                       FStar_Options.Low in
-                                  if uu____997
+                                  if uu___5
                                   then
-                                    let uu____998 =
+                                    let uu___6 =
                                       FStar_Syntax_Print.lid_to_string c in
-                                    let uu____999 =
+                                    let uu___7 =
                                       FStar_Syntax_Print.binders_to_string
                                         "->" arguments in
-                                    let uu____1000 =
+                                    let uu___8 =
                                       FStar_Syntax_Print.term_to_string
                                         result in
                                     FStar_Util.print3
                                       "Checking datacon  %s : %s -> %s \n"
-                                      uu____998 uu____999 uu____1000
+                                      uu___6 uu___7 uu___8
                                   else ());
-                                 (let uu____1002 =
+                                 (let uu___5 =
                                     FStar_TypeChecker_TcTerm.tc_tparams env2
                                       arguments in
-                                  match uu____1002 with
+                                  match uu___5 with
                                   | (arguments1, env', us) ->
                                       let type_u_tc =
                                         FStar_Syntax_Syntax.mk
@@ -379,108 +375,105 @@ let (tc_data :
                                       let env'1 =
                                         FStar_TypeChecker_Env.set_expected_typ
                                           env' type_u_tc in
-                                      let uu____1020 =
+                                      let uu___6 =
                                         FStar_TypeChecker_TcTerm.tc_trivial_guard
                                           env'1 result in
-                                      (match uu____1020 with
+                                      (match uu___6 with
                                        | (result1, res_lcomp) ->
-                                           let uu____1031 =
+                                           let uu___7 =
                                              FStar_Syntax_Util.head_and_args'
                                                result1 in
-                                           (match uu____1031 with
+                                           (match uu___7 with
                                             | (head, args) ->
                                                 let p_args =
-                                                  let uu____1083 =
+                                                  let uu___8 =
                                                     FStar_Util.first_N
                                                       (FStar_List.length tps)
                                                       args in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____1083 in
+                                                    uu___8 in
                                                 (FStar_List.iter2
-                                                   (fun uu____1165 ->
-                                                      fun uu____1166 ->
-                                                        match (uu____1165,
-                                                                uu____1166)
+                                                   (fun uu___9 ->
+                                                      fun uu___10 ->
+                                                        match (uu___9,
+                                                                uu___10)
                                                         with
-                                                        | ((bv, uu____1196),
-                                                           (t2, uu____1198))
-                                                            ->
-                                                            let uu____1225 =
-                                                              let uu____1226
-                                                                =
+                                                        | ((bv, uu___11),
+                                                           (t2, uu___12)) ->
+                                                            let uu___13 =
+                                                              let uu___14 =
                                                                 FStar_Syntax_Subst.compress
                                                                   t2 in
-                                                              uu____1226.FStar_Syntax_Syntax.n in
-                                                            (match uu____1225
+                                                              uu___14.FStar_Syntax_Syntax.n in
+                                                            (match uu___13
                                                              with
                                                              | FStar_Syntax_Syntax.Tm_name
                                                                  bv' when
                                                                  FStar_Syntax_Syntax.bv_eq
                                                                    bv bv'
                                                                  -> ()
-                                                             | uu____1230 ->
-                                                                 let uu____1231
+                                                             | uu___14 ->
+                                                                 let uu___15
                                                                    =
-                                                                   let uu____1236
+                                                                   let uu___16
                                                                     =
-                                                                    let uu____1237
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     bv in
-                                                                    let uu____1238
+                                                                    let uu___18
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2 in
                                                                     FStar_Util.format2
                                                                     "This parameter is not constant: expected %s, got %s"
-                                                                    uu____1237
-                                                                    uu____1238 in
+                                                                    uu___17
+                                                                    uu___18 in
                                                                    (FStar_Errors.Error_BadInductiveParam,
-                                                                    uu____1236) in
+                                                                    uu___16) in
                                                                  FStar_Errors.raise_error
-                                                                   uu____1231
+                                                                   uu___15
                                                                    t2.FStar_Syntax_Syntax.pos))
                                                    tps p_args;
                                                  (let ty =
-                                                    let uu____1240 =
+                                                    let uu___9 =
                                                       unfold_whnf env2
                                                         res_lcomp.FStar_TypeChecker_Common.res_typ in
                                                     FStar_All.pipe_right
-                                                      uu____1240
+                                                      uu___9
                                                       FStar_Syntax_Util.unrefine in
-                                                  (let uu____1242 =
-                                                     let uu____1243 =
+                                                  (let uu___10 =
+                                                     let uu___11 =
                                                        FStar_Syntax_Subst.compress
                                                          ty in
-                                                     uu____1243.FStar_Syntax_Syntax.n in
-                                                   match uu____1242 with
+                                                     uu___11.FStar_Syntax_Syntax.n in
+                                                   match uu___10 with
                                                    | FStar_Syntax_Syntax.Tm_type
-                                                       uu____1246 -> ()
-                                                   | uu____1247 ->
-                                                       let uu____1248 =
-                                                         let uu____1253 =
-                                                           let uu____1254 =
+                                                       uu___11 -> ()
+                                                   | uu___11 ->
+                                                       let uu___12 =
+                                                         let uu___13 =
+                                                           let uu___14 =
                                                              FStar_Syntax_Print.term_to_string
                                                                result1 in
-                                                           let uu____1255 =
+                                                           let uu___15 =
                                                              FStar_Syntax_Print.term_to_string
                                                                ty in
                                                            FStar_Util.format2
                                                              "The type of %s is %s, but since this is the result type of a constructor its type should be Type"
-                                                             uu____1254
-                                                             uu____1255 in
+                                                             uu___14 uu___15 in
                                                          (FStar_Errors.Fatal_WrongResultTypeAfterConstrutor,
-                                                           uu____1253) in
+                                                           uu___13) in
                                                        FStar_Errors.raise_error
-                                                         uu____1248
+                                                         uu___12
                                                          se.FStar_Syntax_Syntax.sigrng);
                                                   (let g_uvs =
-                                                     let uu____1257 =
-                                                       let uu____1258 =
+                                                     let uu___10 =
+                                                       let uu___11 =
                                                          FStar_Syntax_Subst.compress
                                                            head in
-                                                       uu____1258.FStar_Syntax_Syntax.n in
-                                                     match uu____1257 with
+                                                       uu___11.FStar_Syntax_Syntax.n in
+                                                     match uu___10 with
                                                      | FStar_Syntax_Syntax.Tm_uinst
                                                          ({
                                                             FStar_Syntax_Syntax.n
@@ -488,9 +481,9 @@ let (tc_data :
                                                               FStar_Syntax_Syntax.Tm_fvar
                                                               fv;
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____1262;
+                                                              = uu___11;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____1263;_},
+                                                              = uu___12;_},
                                                           tuvs)
                                                          when
                                                          FStar_Syntax_Syntax.fv_eq_lid
@@ -507,15 +500,15 @@ let (tc_data :
                                                              (fun g ->
                                                                 fun u1 ->
                                                                   fun u2 ->
-                                                                    let uu____1276
+                                                                    let uu___13
                                                                     =
-                                                                    let uu____1277
+                                                                    let uu___14
                                                                     =
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_type
                                                                     u1)
                                                                     FStar_Range.dummyRange in
-                                                                    let uu____1278
+                                                                    let uu___15
                                                                     =
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_type
@@ -524,11 +517,10 @@ let (tc_data :
                                                                     FStar_Range.dummyRange in
                                                                     FStar_TypeChecker_Rel.teq
                                                                     env'1
-                                                                    uu____1277
-                                                                    uu____1278 in
+                                                                    uu___14
+                                                                    uu___15 in
                                                                     FStar_TypeChecker_Env.conj_guard
-                                                                    g
-                                                                    uu____1276)
+                                                                    g uu___13)
                                                              FStar_TypeChecker_Env.trivial_guard
                                                              tuvs _uvs1
                                                          else
@@ -542,71 +534,68 @@ let (tc_data :
                                                            fv tc_lid
                                                          ->
                                                          FStar_TypeChecker_Env.trivial_guard
-                                                     | uu____1281 ->
-                                                         let uu____1282 =
-                                                           let uu____1287 =
-                                                             let uu____1288 =
+                                                     | uu___11 ->
+                                                         let uu___12 =
+                                                           let uu___13 =
+                                                             let uu___14 =
                                                                FStar_Syntax_Print.lid_to_string
                                                                  tc_lid in
-                                                             let uu____1289 =
+                                                             let uu___15 =
                                                                FStar_Syntax_Print.term_to_string
                                                                  head in
                                                              FStar_Util.format2
                                                                "Expected a constructor of type %s; got %s"
-                                                               uu____1288
-                                                               uu____1289 in
+                                                               uu___14
+                                                               uu___15 in
                                                            (FStar_Errors.Fatal_UnexpectedConstructorType,
-                                                             uu____1287) in
+                                                             uu___13) in
                                                          FStar_Errors.raise_error
-                                                           uu____1282
+                                                           uu___12
                                                            se.FStar_Syntax_Syntax.sigrng in
                                                    let g =
                                                      FStar_List.fold_left2
-                                                       (fun g ->
-                                                          fun uu____1304 ->
+                                                       (fun g1 ->
+                                                          fun uu___10 ->
                                                             fun u_x ->
-                                                              match uu____1304
+                                                              match uu___10
                                                               with
-                                                              | (x,
-                                                                 uu____1313)
+                                                              | (x, uu___11)
                                                                   ->
-                                                                  let uu____1318
+                                                                  let uu___12
                                                                     =
                                                                     FStar_TypeChecker_Rel.universe_inequality
                                                                     u_x u_tc in
                                                                   FStar_TypeChecker_Env.conj_guard
-                                                                    g
-                                                                    uu____1318)
+                                                                    g1
+                                                                    uu___12)
                                                        g_uvs arguments1 us in
                                                    let t2 =
-                                                     let uu____1322 =
-                                                       let uu____1331 =
+                                                     let uu___10 =
+                                                       let uu___11 =
                                                          FStar_All.pipe_right
                                                            tps
                                                            (FStar_List.map
-                                                              (fun uu____1371
-                                                                 ->
-                                                                 match uu____1371
+                                                              (fun uu___12 ->
+                                                                 match uu___12
                                                                  with
                                                                  | (x,
-                                                                    uu____1385)
+                                                                    uu___13)
                                                                     ->
                                                                     (x,
                                                                     (FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
                                                                     true))))) in
                                                        FStar_List.append
-                                                         uu____1331
-                                                         arguments1 in
-                                                     let uu____1398 =
+                                                         uu___11 arguments1 in
+                                                     let uu___11 =
                                                        FStar_Syntax_Syntax.mk_Total
                                                          result1 in
                                                      FStar_Syntax_Util.arrow
-                                                       uu____1322 uu____1398 in
+                                                       uu___10 uu___11 in
                                                    let t3 =
                                                      FStar_Syntax_Subst.close_univ_vars
                                                        _uvs1 t2 in
-                                                   ((let uu___189_1403 = se in
+                                                   ((let uu___10 = se in
                                                      {
                                                        FStar_Syntax_Syntax.sigel
                                                          =
@@ -616,21 +605,21 @@ let (tc_data :
                                                               []));
                                                        FStar_Syntax_Syntax.sigrng
                                                          =
-                                                         (uu___189_1403.FStar_Syntax_Syntax.sigrng);
+                                                         (uu___10.FStar_Syntax_Syntax.sigrng);
                                                        FStar_Syntax_Syntax.sigquals
                                                          =
-                                                         (uu___189_1403.FStar_Syntax_Syntax.sigquals);
+                                                         (uu___10.FStar_Syntax_Syntax.sigquals);
                                                        FStar_Syntax_Syntax.sigmeta
                                                          =
-                                                         (uu___189_1403.FStar_Syntax_Syntax.sigmeta);
+                                                         (uu___10.FStar_Syntax_Syntax.sigmeta);
                                                        FStar_Syntax_Syntax.sigattrs
                                                          =
-                                                         (uu___189_1403.FStar_Syntax_Syntax.sigattrs);
+                                                         (uu___10.FStar_Syntax_Syntax.sigattrs);
                                                        FStar_Syntax_Syntax.sigopts
                                                          =
-                                                         (uu___189_1403.FStar_Syntax_Syntax.sigopts)
+                                                         (uu___10.FStar_Syntax_Syntax.sigopts)
                                                      }), g))))))))))))
-        | uu____1406 -> failwith "impossible"
+        | uu___ -> failwith "impossible"
 let (generalize_and_inst_within :
   FStar_TypeChecker_Env.env_t ->
     (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe) Prims.list ->
@@ -644,119 +633,112 @@ let (generalize_and_inst_within :
         let binders =
           FStar_All.pipe_right tcs
             (FStar_List.map
-               (fun uu____1495 ->
-                  match uu____1495 with
-                  | (se, uu____1501) ->
+               (fun uu___ ->
+                  match uu___ with
+                  | (se, uu___1) ->
                       (match se.FStar_Syntax_Syntax.sigel with
                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                           (uu____1502, uu____1503, tps, k, uu____1506,
-                            uu____1507)
-                           ->
-                           let uu____1516 =
-                             let uu____1517 = FStar_Syntax_Syntax.mk_Total k in
+                           (uu___2, uu___3, tps, k, uu___4, uu___5) ->
+                           let uu___6 =
+                             let uu___7 = FStar_Syntax_Syntax.mk_Total k in
                              FStar_All.pipe_left
-                               (FStar_Syntax_Util.arrow tps) uu____1517 in
-                           FStar_Syntax_Syntax.null_binder uu____1516
-                       | uu____1522 -> failwith "Impossible"))) in
+                               (FStar_Syntax_Util.arrow tps) uu___7 in
+                           FStar_Syntax_Syntax.null_binder uu___6
+                       | uu___2 -> failwith "Impossible"))) in
         let binders' =
           FStar_All.pipe_right datas
             (FStar_List.map
                (fun se ->
                   match se.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_datacon
-                      (uu____1550, uu____1551, t, uu____1553, uu____1554,
-                       uu____1555)
-                      -> FStar_Syntax_Syntax.null_binder t
-                  | uu____1560 -> failwith "Impossible")) in
+                      (uu___, uu___1, t, uu___2, uu___3, uu___4) ->
+                      FStar_Syntax_Syntax.null_binder t
+                  | uu___ -> failwith "Impossible")) in
         let t =
-          let uu____1564 =
-            FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit in
-          FStar_Syntax_Util.arrow (FStar_List.append binders binders')
-            uu____1564 in
-        (let uu____1574 =
+          let uu___ = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit in
+          FStar_Syntax_Util.arrow (FStar_List.append binders binders') uu___ in
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "GenUniverses") in
-         if uu____1574
+         if uu___1
          then
-           let uu____1575 = FStar_TypeChecker_Normalize.term_to_string env t in
+           let uu___2 = FStar_TypeChecker_Normalize.term_to_string env t in
            FStar_Util.print1 "@@@@@@Trying to generalize universes in %s\n"
-             uu____1575
+             uu___2
          else ());
-        (let uu____1577 =
-           FStar_TypeChecker_Generalize.generalize_universes env t in
-         match uu____1577 with
+        (let uu___1 = FStar_TypeChecker_Generalize.generalize_universes env t in
+         match uu___1 with
          | (uvs, t1) ->
-             ((let uu____1597 =
+             ((let uu___3 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "GenUniverses") in
-               if uu____1597
+               if uu___3
                then
-                 let uu____1598 =
-                   let uu____1599 =
+                 let uu___4 =
+                   let uu___5 =
                      FStar_All.pipe_right uvs
                        (FStar_List.map (fun u -> FStar_Ident.string_of_id u)) in
-                   FStar_All.pipe_right uu____1599 (FStar_String.concat ", ") in
-                 let uu____1610 = FStar_Syntax_Print.term_to_string t1 in
-                 FStar_Util.print2 "@@@@@@Generalized to (%s, %s)\n"
-                   uu____1598 uu____1610
+                   FStar_All.pipe_right uu___5 (FStar_String.concat ", ") in
+                 let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                 FStar_Util.print2 "@@@@@@Generalized to (%s, %s)\n" uu___4
+                   uu___5
                else ());
-              (let uu____1612 = FStar_Syntax_Subst.open_univ_vars uvs t1 in
-               match uu____1612 with
+              (let uu___3 = FStar_Syntax_Subst.open_univ_vars uvs t1 in
+               match uu___3 with
                | (uvs1, t2) ->
-                   let uu____1627 = FStar_Syntax_Util.arrow_formals t2 in
-                   (match uu____1627 with
-                    | (args, uu____1643) ->
-                        let uu____1648 =
+                   let uu___4 = FStar_Syntax_Util.arrow_formals t2 in
+                   (match uu___4 with
+                    | (args, uu___5) ->
+                        let uu___6 =
                           FStar_Util.first_N (FStar_List.length binders) args in
-                        (match uu____1648 with
+                        (match uu___6 with
                          | (tc_types, data_types) ->
                              let tcs1 =
                                FStar_List.map2
-                                 (fun uu____1753 ->
-                                    fun uu____1754 ->
-                                      match (uu____1753, uu____1754) with
-                                      | ((x, uu____1776), (se, uu____1778))
-                                          ->
+                                 (fun uu___7 ->
+                                    fun uu___8 ->
+                                      match (uu___7, uu___8) with
+                                      | ((x, uu___9), (se, uu___10)) ->
                                           (match se.FStar_Syntax_Syntax.sigel
                                            with
                                            | FStar_Syntax_Syntax.Sig_inductive_typ
-                                               (tc, uu____1794, tps,
-                                                uu____1796, mutuals, datas1)
+                                               (tc, uu___11, tps, uu___12,
+                                                mutuals, datas1)
                                                ->
                                                let ty =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs1
                                                    x.FStar_Syntax_Syntax.sort in
-                                               let uu____1808 =
-                                                 let uu____1813 =
-                                                   let uu____1814 =
+                                               let uu___13 =
+                                                 let uu___14 =
+                                                   let uu___15 =
                                                      FStar_Syntax_Subst.compress
                                                        ty in
-                                                   uu____1814.FStar_Syntax_Syntax.n in
-                                                 match uu____1813 with
+                                                   uu___15.FStar_Syntax_Syntax.n in
+                                                 match uu___14 with
                                                  | FStar_Syntax_Syntax.Tm_arrow
                                                      (binders1, c) ->
-                                                     let uu____1843 =
+                                                     let uu___15 =
                                                        FStar_Util.first_N
                                                          (FStar_List.length
                                                             tps) binders1 in
-                                                     (match uu____1843 with
+                                                     (match uu___15 with
                                                       | (tps1, rest) ->
                                                           let t3 =
                                                             match rest with
                                                             | [] ->
                                                                 FStar_Syntax_Util.comp_result
                                                                   c
-                                                            | uu____1921 ->
+                                                            | uu___16 ->
                                                                 FStar_Syntax_Syntax.mk
                                                                   (FStar_Syntax_Syntax.Tm_arrow
                                                                     (rest, c))
                                                                   (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
                                                           (tps1, t3))
-                                                 | uu____1940 -> ([], ty) in
-                                               (match uu____1808 with
+                                                 | uu___15 -> ([], ty) in
+                                               (match uu___13 with
                                                 | (tps1, t3) ->
-                                                    let uu___266_1949 = se in
+                                                    let uu___14 = se in
                                                     {
                                                       FStar_Syntax_Syntax.sigel
                                                         =
@@ -766,79 +748,77 @@ let (generalize_and_inst_within :
                                                              datas1));
                                                       FStar_Syntax_Syntax.sigrng
                                                         =
-                                                        (uu___266_1949.FStar_Syntax_Syntax.sigrng);
+                                                        (uu___14.FStar_Syntax_Syntax.sigrng);
                                                       FStar_Syntax_Syntax.sigquals
                                                         =
-                                                        (uu___266_1949.FStar_Syntax_Syntax.sigquals);
+                                                        (uu___14.FStar_Syntax_Syntax.sigquals);
                                                       FStar_Syntax_Syntax.sigmeta
                                                         =
-                                                        (uu___266_1949.FStar_Syntax_Syntax.sigmeta);
+                                                        (uu___14.FStar_Syntax_Syntax.sigmeta);
                                                       FStar_Syntax_Syntax.sigattrs
                                                         =
-                                                        (uu___266_1949.FStar_Syntax_Syntax.sigattrs);
+                                                        (uu___14.FStar_Syntax_Syntax.sigattrs);
                                                       FStar_Syntax_Syntax.sigopts
                                                         =
-                                                        (uu___266_1949.FStar_Syntax_Syntax.sigopts)
+                                                        (uu___14.FStar_Syntax_Syntax.sigopts)
                                                     })
-                                           | uu____1954 ->
-                                               failwith "Impossible"))
+                                           | uu___11 -> failwith "Impossible"))
                                  tc_types tcs in
                              let datas1 =
                                match uvs1 with
                                | [] -> datas
-                               | uu____1960 ->
+                               | uu___7 ->
                                    let uvs_universes =
                                      FStar_All.pipe_right uvs1
                                        (FStar_List.map
-                                          (fun uu____1964 ->
+                                          (fun uu___8 ->
                                              FStar_Syntax_Syntax.U_name
-                                               uu____1964)) in
+                                               uu___8)) in
                                    let tc_insts =
                                      FStar_All.pipe_right tcs1
                                        (FStar_List.map
-                                          (fun uu___0_1984 ->
-                                             match uu___0_1984 with
+                                          (fun uu___8 ->
+                                             match uu___8 with
                                              | {
                                                  FStar_Syntax_Syntax.sigel =
                                                    FStar_Syntax_Syntax.Sig_inductive_typ
-                                                   (tc, uu____1990,
-                                                    uu____1991, uu____1992,
-                                                    uu____1993, uu____1994);
+                                                   (tc, uu___9, uu___10,
+                                                    uu___11, uu___12,
+                                                    uu___13);
                                                  FStar_Syntax_Syntax.sigrng =
-                                                   uu____1995;
+                                                   uu___14;
                                                  FStar_Syntax_Syntax.sigquals
-                                                   = uu____1996;
+                                                   = uu___15;
                                                  FStar_Syntax_Syntax.sigmeta
-                                                   = uu____1997;
+                                                   = uu___16;
                                                  FStar_Syntax_Syntax.sigattrs
-                                                   = uu____1998;
+                                                   = uu___17;
                                                  FStar_Syntax_Syntax.sigopts
-                                                   = uu____1999;_}
+                                                   = uu___18;_}
                                                  -> (tc, uvs_universes)
-                                             | uu____2014 ->
+                                             | uu___9 ->
                                                  failwith "Impossible")) in
                                    FStar_List.map2
-                                     (fun uu____2037 ->
+                                     (fun uu___8 ->
                                         fun d ->
-                                          match uu____2037 with
-                                          | (t3, uu____2046) ->
+                                          match uu___8 with
+                                          | (t3, uu___9) ->
                                               (match d.FStar_Syntax_Syntax.sigel
                                                with
                                                | FStar_Syntax_Syntax.Sig_datacon
-                                                   (l, uu____2052,
-                                                    uu____2053, tc, ntps,
-                                                    mutuals)
+                                                   (l, uu___10, uu___11, tc,
+                                                    ntps, mutuals)
                                                    ->
                                                    let ty =
-                                                     let uu____2062 =
+                                                     let uu___12 =
                                                        FStar_Syntax_InstFV.instantiate
                                                          tc_insts
                                                          t3.FStar_Syntax_Syntax.sort in
                                                      FStar_All.pipe_right
-                                                       uu____2062
+                                                       uu___12
                                                        (FStar_Syntax_Subst.close_univ_vars
                                                           uvs1) in
-                                                   let uu___303_2063 = d in
+                                                   let uu___12 = d in
                                                    {
                                                      FStar_Syntax_Syntax.sigel
                                                        =
@@ -847,21 +827,21 @@ let (generalize_and_inst_within :
                                                             ntps, mutuals));
                                                      FStar_Syntax_Syntax.sigrng
                                                        =
-                                                       (uu___303_2063.FStar_Syntax_Syntax.sigrng);
+                                                       (uu___12.FStar_Syntax_Syntax.sigrng);
                                                      FStar_Syntax_Syntax.sigquals
                                                        =
-                                                       (uu___303_2063.FStar_Syntax_Syntax.sigquals);
+                                                       (uu___12.FStar_Syntax_Syntax.sigquals);
                                                      FStar_Syntax_Syntax.sigmeta
                                                        =
-                                                       (uu___303_2063.FStar_Syntax_Syntax.sigmeta);
+                                                       (uu___12.FStar_Syntax_Syntax.sigmeta);
                                                      FStar_Syntax_Syntax.sigattrs
                                                        =
-                                                       (uu___303_2063.FStar_Syntax_Syntax.sigattrs);
+                                                       (uu___12.FStar_Syntax_Syntax.sigattrs);
                                                      FStar_Syntax_Syntax.sigopts
                                                        =
-                                                       (uu___303_2063.FStar_Syntax_Syntax.sigopts)
+                                                       (uu___12.FStar_Syntax_Syntax.sigopts)
                                                    }
-                                               | uu____2066 ->
+                                               | uu___10 ->
                                                    failwith "Impossible"))
                                      data_types datas in
                              (tcs1, datas1))))))
@@ -869,52 +849,50 @@ let (debug_log :
   FStar_TypeChecker_Env.env_t -> (unit -> Prims.string) -> unit) =
   fun env ->
     fun msg ->
-      let uu____2086 =
+      let uu___ =
         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
           (FStar_Options.Other "Positivity") in
-      if uu____2086
+      if uu___
       then
-        let uu____2087 =
-          let uu____2088 =
-            let uu____2089 = msg () in Prims.op_Hat uu____2089 "\n" in
-          Prims.op_Hat "Positivity::" uu____2088 in
-        FStar_Util.print_string uu____2087
+        let uu___1 =
+          let uu___2 = let uu___3 = msg () in Prims.op_Hat uu___3 "\n" in
+          Prims.op_Hat "Positivity::" uu___2 in
+        FStar_Util.print_string uu___1
       else ()
 let (ty_occurs_in :
   FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun ty_lid ->
     fun t ->
-      let uu____2101 = FStar_Syntax_Free.fvars t in
-      FStar_Util.set_mem ty_lid uu____2101
+      let uu___ = FStar_Syntax_Free.fvars t in
+      FStar_Util.set_mem ty_lid uu___
 let rec (try_get_fv :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universes)
       FStar_Pervasives_Native.option)
   =
   fun t ->
-    let uu____2121 =
-      let uu____2122 = FStar_Syntax_Subst.compress t in
-      uu____2122.FStar_Syntax_Syntax.n in
-    match uu____2121 with
-    | FStar_Syntax_Syntax.Tm_name uu____2131 -> FStar_Pervasives_Native.None
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_name uu___1 -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Tm_fvar fv -> FStar_Pervasives_Native.Some (fv, [])
     | FStar_Syntax_Syntax.Tm_uinst (t1, us) ->
-        let uu____2147 =
-          let uu____2148 = FStar_Syntax_Subst.compress t1 in
-          uu____2148.FStar_Syntax_Syntax.n in
-        (match uu____2147 with
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Subst.compress t1 in
+          uu___2.FStar_Syntax_Syntax.n in
+        (match uu___1 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Pervasives_Native.Some (fv, us)
-         | uu____2162 ->
+         | uu___2 ->
              failwith
                "try_get_fv: Node is a Tm_uinst, but Tm_uinst is not an fvar")
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu____2170, uu____2171) ->
-        try_get_fv t1
-    | uu____2212 ->
-        let uu____2213 =
-          let uu____2214 = FStar_Syntax_Print.tag_of_term t in
-          Prims.op_Hat "try_get_fv: did not expect t to be a : " uu____2214 in
-        failwith uu____2213
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, uu___1, uu___2) -> try_get_fv t1
+    | uu___1 ->
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Print.tag_of_term t in
+          Prims.op_Hat "try_get_fv: did not expect t to be a : " uu___3 in
+        failwith uu___2
 type unfolded_memo_elt =
   (FStar_Ident.lident * FStar_Syntax_Syntax.args) Prims.list
 type unfolded_memo_t = unfolded_memo_elt FStar_ST.ref
@@ -927,16 +905,16 @@ let (already_unfolded :
     fun arrghs ->
       fun unfolded ->
         fun env ->
-          let uu____2249 = FStar_ST.op_Bang unfolded in
+          let uu___ = FStar_ST.op_Bang unfolded in
           FStar_List.existsML
-            (fun uu____2285 ->
-               match uu____2285 with
+            (fun uu___1 ->
+               match uu___1 with
                | (lid, l) ->
                    (FStar_Ident.lid_equals lid ilid) &&
                      (let args =
-                        let uu____2328 =
+                        let uu___2 =
                           FStar_List.splitAt (FStar_List.length l) arrghs in
-                        FStar_Pervasives_Native.fst uu____2328 in
+                        FStar_Pervasives_Native.fst uu___2 in
                       FStar_List.fold_left2
                         (fun b ->
                            fun a ->
@@ -945,7 +923,7 @@ let (already_unfolded :
                                  (FStar_TypeChecker_Rel.teq_nosmt_force env
                                     (FStar_Pervasives_Native.fst a)
                                     (FStar_Pervasives_Native.fst a'))) true
-                        args l)) uu____2249
+                        args l)) uu___
 let rec (ty_strictly_positive_in_type :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term ->
@@ -956,9 +934,9 @@ let rec (ty_strictly_positive_in_type :
       fun unfolded ->
         fun env ->
           debug_log env
-            (fun uu____2524 ->
-               let uu____2525 = FStar_Syntax_Print.term_to_string btype in
-               Prims.op_Hat "Checking strict positivity in type: " uu____2525);
+            (fun uu___1 ->
+               let uu___2 = FStar_Syntax_Print.term_to_string btype in
+               Prims.op_Hat "Checking strict positivity in type: " uu___2);
           (let btype1 =
              FStar_TypeChecker_Normalize.normalize
                [FStar_TypeChecker_Env.Beta;
@@ -971,162 +949,157 @@ let rec (ty_strictly_positive_in_type :
                FStar_TypeChecker_Env.Unascribe;
                FStar_TypeChecker_Env.AllowUnboundUniverses] env btype in
            debug_log env
-             (fun uu____2530 ->
-                let uu____2531 = FStar_Syntax_Print.term_to_string btype1 in
+             (fun uu___2 ->
+                let uu___3 = FStar_Syntax_Print.term_to_string btype1 in
                 Prims.op_Hat
                   "Checking strict positivity in type, after normalization: "
-                  uu____2531);
-           (let uu____2534 = ty_occurs_in ty_lid btype1 in
-            Prims.op_Negation uu____2534) ||
+                  uu___3);
+           (let uu___2 = ty_occurs_in ty_lid btype1 in
+            Prims.op_Negation uu___2) ||
              ((debug_log env
-                 (fun uu____2543 ->
-                    "ty does occur in this type, pressing ahead");
-               (let uu____2544 =
-                  let uu____2545 = FStar_Syntax_Subst.compress btype1 in
-                  uu____2545.FStar_Syntax_Syntax.n in
-                match uu____2544 with
+                 (fun uu___3 -> "ty does occur in this type, pressing ahead");
+               (let uu___3 =
+                  let uu___4 = FStar_Syntax_Subst.compress btype1 in
+                  uu___4.FStar_Syntax_Syntax.n in
+                match uu___3 with
                 | FStar_Syntax_Syntax.Tm_app (t, args) ->
                     let fv_us_opt = try_get_fv t in
-                    let uu____2581 =
+                    let uu___4 =
                       FStar_All.pipe_right fv_us_opt FStar_Util.is_none in
-                    if uu____2581
+                    if uu___4
                     then true
                     else
-                      (let uu____2593 =
+                      (let uu___6 =
                          FStar_All.pipe_right fv_us_opt FStar_Util.must in
-                       match uu____2593 with
+                       match uu___6 with
                        | (fv, us) ->
-                           let uu____2614 =
+                           let uu___7 =
                              FStar_Ident.lid_equals
                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                ty_lid in
-                           if uu____2614
+                           if uu___7
                            then
                              (debug_log env
-                                (fun uu____2617 ->
+                                (fun uu___9 ->
                                    "Checking strict positivity in the Tm_app node where head lid is ty itself, checking that ty does not occur in the arguments");
                               FStar_List.for_all
-                                (fun uu____2628 ->
-                                   match uu____2628 with
-                                   | (t1, uu____2636) ->
-                                       let uu____2641 =
-                                         ty_occurs_in ty_lid t1 in
-                                       Prims.op_Negation uu____2641) args)
+                                (fun uu___9 ->
+                                   match uu___9 with
+                                   | (t1, uu___10) ->
+                                       let uu___11 = ty_occurs_in ty_lid t1 in
+                                       Prims.op_Negation uu___11) args)
                            else
                              (debug_log env
-                                (fun uu____2645 ->
+                                (fun uu___10 ->
                                    "Checking strict positivity in the Tm_app node, head lid is not ty, so checking nested positivity");
                               ty_nested_positive_in_inductive ty_lid
                                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 us args unfolded env))
                 | FStar_Syntax_Syntax.Tm_arrow (sbs, c) ->
                     (debug_log env
-                       (fun uu____2670 ->
+                       (fun uu___5 ->
                           "Checking strict positivity in Tm_arrow");
                      (let check_comp =
                         let c1 =
-                          let uu____2675 =
+                          let uu___5 =
                             FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                          FStar_All.pipe_right uu____2675
+                          FStar_All.pipe_right uu___5
                             FStar_Syntax_Syntax.mk_Comp in
                         (FStar_Syntax_Util.is_pure_or_ghost_comp c1) ||
-                          (let uu____2679 =
+                          (let uu___5 =
                              FStar_TypeChecker_Env.lookup_effect_quals env
                                (FStar_Syntax_Util.comp_effect_name c1) in
-                           FStar_All.pipe_right uu____2679
+                           FStar_All.pipe_right uu___5
                              (FStar_List.existsb
                                 (fun q -> q = FStar_Syntax_Syntax.TotalEffect))) in
                       if Prims.op_Negation check_comp
                       then
                         (debug_log env
-                           (fun uu____2688 ->
+                           (fun uu___6 ->
                               "Checking strict positivity , the arrow is impure, so return true");
                          true)
                       else
                         (debug_log env
-                           (fun uu____2692 ->
+                           (fun uu___7 ->
                               "Checking struict positivity, Pure arrow, checking that ty does not occur in the binders, and that it is strictly positive in the return type");
                          (FStar_List.for_all
-                            (fun uu____2703 ->
-                               match uu____2703 with
-                               | (b, uu____2711) ->
-                                   let uu____2716 =
+                            (fun uu___7 ->
+                               match uu___7 with
+                               | (b, uu___8) ->
+                                   let uu___9 =
                                      ty_occurs_in ty_lid
                                        b.FStar_Syntax_Syntax.sort in
-                                   Prims.op_Negation uu____2716) sbs)
+                                   Prims.op_Negation uu___9) sbs)
                            &&
-                           ((let uu____2721 =
+                           ((let uu___7 =
                                FStar_Syntax_Subst.open_term sbs
                                  (FStar_Syntax_Util.comp_result c) in
-                             match uu____2721 with
-                             | (uu____2726, return_type) ->
-                                 let uu____2728 =
+                             match uu___7 with
+                             | (uu___8, return_type) ->
+                                 let uu___9 =
                                    FStar_TypeChecker_Env.push_binders env sbs in
                                  ty_strictly_positive_in_type ty_lid
-                                   return_type unfolded uu____2728)))))
-                | FStar_Syntax_Syntax.Tm_fvar uu____2729 ->
+                                   return_type unfolded uu___9)))))
+                | FStar_Syntax_Syntax.Tm_fvar uu___4 ->
                     (debug_log env
-                       (fun uu____2732 ->
+                       (fun uu___6 ->
                           "Checking strict positivity in an fvar, return true");
                      true)
-                | FStar_Syntax_Syntax.Tm_type uu____2733 ->
+                | FStar_Syntax_Syntax.Tm_type uu___4 ->
                     (debug_log env
-                       (fun uu____2736 ->
+                       (fun uu___6 ->
                           "Checking strict positivity in an Tm_type, return true");
                      true)
-                | FStar_Syntax_Syntax.Tm_uinst (t, uu____2738) ->
+                | FStar_Syntax_Syntax.Tm_uinst (t, uu___4) ->
                     (debug_log env
-                       (fun uu____2745 ->
+                       (fun uu___6 ->
                           "Checking strict positivity in an Tm_uinst, recur on the term inside (mostly it should be the same inductive)");
                      ty_strictly_positive_in_type ty_lid t unfolded env)
-                | FStar_Syntax_Syntax.Tm_refine (bv, uu____2747) ->
+                | FStar_Syntax_Syntax.Tm_refine (bv, uu___4) ->
                     (debug_log env
-                       (fun uu____2754 ->
+                       (fun uu___6 ->
                           "Checking strict positivity in an Tm_refine, recur in the bv sort)");
                      ty_strictly_positive_in_type ty_lid
                        bv.FStar_Syntax_Syntax.sort unfolded env)
-                | FStar_Syntax_Syntax.Tm_match (uu____2755, branches) ->
+                | FStar_Syntax_Syntax.Tm_match (uu___4, branches) ->
                     (debug_log env
-                       (fun uu____2795 ->
+                       (fun uu___6 ->
                           "Checking strict positivity in an Tm_match, recur in the branches)");
                      FStar_List.for_all
-                       (fun uu____2815 ->
-                          match uu____2815 with
-                          | (p, uu____2827, t) ->
+                       (fun uu___6 ->
+                          match uu___6 with
+                          | (p, uu___7, t) ->
                               let bs =
-                                let uu____2846 =
-                                  FStar_Syntax_Syntax.pat_bvs p in
+                                let uu___8 = FStar_Syntax_Syntax.pat_bvs p in
                                 FStar_List.map FStar_Syntax_Syntax.mk_binder
-                                  uu____2846 in
-                              let uu____2855 =
-                                FStar_Syntax_Subst.open_term bs t in
-                              (match uu____2855 with
+                                  uu___8 in
+                              let uu___8 = FStar_Syntax_Subst.open_term bs t in
+                              (match uu___8 with
                                | (bs1, t1) ->
-                                   let uu____2862 =
+                                   let uu___9 =
                                      FStar_TypeChecker_Env.push_binders env
                                        bs1 in
                                    ty_strictly_positive_in_type ty_lid t1
-                                     unfolded uu____2862)) branches)
-                | FStar_Syntax_Syntax.Tm_ascribed (t, uu____2864, uu____2865)
-                    ->
+                                     unfolded uu___9)) branches)
+                | FStar_Syntax_Syntax.Tm_ascribed (t, uu___4, uu___5) ->
                     (debug_log env
-                       (fun uu____2908 ->
+                       (fun uu___7 ->
                           "Checking strict positivity in an Tm_ascribed, recur)");
                      ty_strictly_positive_in_type ty_lid t unfolded env)
-                | uu____2909 ->
+                | uu___4 ->
                     (debug_log env
-                       (fun uu____2913 ->
-                          let uu____2914 =
-                            let uu____2915 =
+                       (fun uu___6 ->
+                          let uu___7 =
+                            let uu___8 =
                               FStar_Syntax_Print.tag_of_term btype1 in
-                            let uu____2916 =
-                              let uu____2917 =
+                            let uu___9 =
+                              let uu___10 =
                                 FStar_Syntax_Print.term_to_string btype1 in
-                              Prims.op_Hat " and term: " uu____2917 in
-                            Prims.op_Hat uu____2915 uu____2916 in
+                              Prims.op_Hat " and term: " uu___10 in
+                            Prims.op_Hat uu___8 uu___9 in
                           Prims.op_Hat
                             "Checking strict positivity, unexpected tag: "
-                            uu____2914);
+                            uu___7);
                      false)))))
 and (ty_nested_positive_in_inductive :
   FStar_Ident.lident ->
@@ -1142,81 +1115,76 @@ and (ty_nested_positive_in_inductive :
           fun unfolded ->
             fun env ->
               debug_log env
-                (fun uu____2927 ->
-                   let uu____2928 =
-                     let uu____2929 = FStar_Ident.string_of_lid ilid in
-                     let uu____2930 =
-                       let uu____2931 =
-                         FStar_Syntax_Print.args_to_string args in
-                       Prims.op_Hat " applied to arguments: " uu____2931 in
-                     Prims.op_Hat uu____2929 uu____2930 in
+                (fun uu___1 ->
+                   let uu___2 =
+                     let uu___3 = FStar_Ident.string_of_lid ilid in
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Print.args_to_string args in
+                       Prims.op_Hat " applied to arguments: " uu___5 in
+                     Prims.op_Hat uu___3 uu___4 in
                    Prims.op_Hat
-                     "Checking nested positivity in the inductive "
-                     uu____2928);
-              (let uu____2932 =
-                 FStar_TypeChecker_Env.datacons_of_typ env ilid in
-               match uu____2932 with
+                     "Checking nested positivity in the inductive " uu___2);
+              (let uu___1 = FStar_TypeChecker_Env.datacons_of_typ env ilid in
+               match uu___1 with
                | (b, idatas) ->
                    if Prims.op_Negation b
                    then
-                     let uu____2945 =
-                       let uu____2946 =
+                     let uu___2 =
+                       let uu___3 =
                          FStar_Syntax_Syntax.lid_as_fv ilid
                            FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None in
-                       FStar_TypeChecker_Env.fv_has_attr env uu____2946
+                       FStar_TypeChecker_Env.fv_has_attr env uu___3
                          FStar_Parser_Const.assume_strictly_positive_attr_lid in
-                     (if uu____2945
+                     (if uu___2
                       then
                         (debug_log env
-                           (fun uu____2950 ->
-                              let uu____2951 = FStar_Ident.string_of_lid ilid in
+                           (fun uu___4 ->
+                              let uu___5 = FStar_Ident.string_of_lid ilid in
                               FStar_Util.format1
                                 "Checking nested positivity, special case decorated with `assume_strictly_positive` %s; return true"
-                                uu____2951);
+                                uu___5);
                          true)
                       else
                         (debug_log env
-                           (fun uu____2955 ->
+                           (fun uu___5 ->
                               "Checking nested positivity, not an inductive, return false");
                          false))
                    else
-                     (let uu____2957 =
-                        already_unfolded ilid args unfolded env in
-                      if uu____2957
+                     (let uu___3 = already_unfolded ilid args unfolded env in
+                      if uu___3
                       then
                         (debug_log env
-                           (fun uu____2960 ->
+                           (fun uu___5 ->
                               "Checking nested positivity, we have already unfolded this inductive with these args");
                          true)
                       else
                         (let num_ibs =
-                           let uu____2963 =
+                           let uu___5 =
                              FStar_TypeChecker_Env.num_inductive_ty_params
                                env ilid in
-                           FStar_Option.get uu____2963 in
+                           FStar_Option.get uu___5 in
                          debug_log env
-                           (fun uu____2969 ->
-                              let uu____2970 =
-                                let uu____2971 =
-                                  FStar_Util.string_of_int num_ibs in
-                                Prims.op_Hat uu____2971
+                           (fun uu___6 ->
+                              let uu___7 =
+                                let uu___8 = FStar_Util.string_of_int num_ibs in
+                                Prims.op_Hat uu___8
                                   ", also adding to the memo table" in
                               Prims.op_Hat
                                 "Checking nested positivity, number of type parameters is "
-                                uu____2970);
-                         (let uu____2973 =
-                            let uu____2974 = FStar_ST.op_Bang unfolded in
-                            let uu____2987 =
-                              let uu____2994 =
-                                let uu____2999 =
-                                  let uu____3000 =
+                                uu___7);
+                         (let uu___7 =
+                            let uu___8 = FStar_ST.op_Bang unfolded in
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_List.splitAt num_ibs args in
-                                  FStar_Pervasives_Native.fst uu____3000 in
-                                (ilid, uu____2999) in
-                              [uu____2994] in
-                            FStar_List.append uu____2974 uu____2987 in
-                          FStar_ST.op_Colon_Equals unfolded uu____2973);
+                                  FStar_Pervasives_Native.fst uu___12 in
+                                (ilid, uu___11) in
+                              [uu___10] in
+                            FStar_List.append uu___8 uu___9 in
+                          FStar_ST.op_Colon_Equals unfolded uu___7);
                          FStar_List.for_all
                            (fun d ->
                               ty_nested_positive_in_dlid ty_lid d ilid us
@@ -1239,19 +1207,18 @@ and (ty_nested_positive_in_dlid :
               fun unfolded ->
                 fun env ->
                   debug_log env
-                    (fun uu____3084 ->
-                       let uu____3085 =
-                         let uu____3086 = FStar_Ident.string_of_lid dlid in
-                         let uu____3087 =
-                           let uu____3088 = FStar_Ident.string_of_lid ilid in
-                           Prims.op_Hat " of the inductive " uu____3088 in
-                         Prims.op_Hat uu____3086 uu____3087 in
+                    (fun uu___1 ->
+                       let uu___2 =
+                         let uu___3 = FStar_Ident.string_of_lid dlid in
+                         let uu___4 =
+                           let uu___5 = FStar_Ident.string_of_lid ilid in
+                           Prims.op_Hat " of the inductive " uu___5 in
+                         Prims.op_Hat uu___3 uu___4 in
                        Prims.op_Hat
                          "Checking nested positivity in data constructor "
-                         uu____3085);
-                  (let uu____3089 =
-                     FStar_TypeChecker_Env.lookup_datacon env dlid in
-                   match uu____3089 with
+                         uu___2);
+                  (let uu___1 = FStar_TypeChecker_Env.lookup_datacon env dlid in
+                   match uu___1 with
                    | (univ_unif_vars, dt) ->
                        (FStar_List.iter2
                           (fun u' ->
@@ -1259,53 +1226,51 @@ and (ty_nested_positive_in_dlid :
                                match u' with
                                | FStar_Syntax_Syntax.U_unif u'' ->
                                    FStar_Syntax_Unionfind.univ_change u'' u
-                               | uu____3113 ->
+                               | uu___3 ->
                                    failwith
                                      "Impossible! Expected universe unification variables")
                           univ_unif_vars us;
                         debug_log env
-                          (fun uu____3117 ->
-                             let uu____3118 =
+                          (fun uu___4 ->
+                             let uu___5 =
                                FStar_Syntax_Print.term_to_string dt in
                              Prims.op_Hat
                                "Checking nested positivity in the data constructor type: "
-                               uu____3118);
-                        (let uu____3119 =
-                           let uu____3120 = FStar_Syntax_Subst.compress dt in
-                           uu____3120.FStar_Syntax_Syntax.n in
-                         match uu____3119 with
+                               uu___5);
+                        (let uu___4 =
+                           let uu___5 = FStar_Syntax_Subst.compress dt in
+                           uu___5.FStar_Syntax_Syntax.n in
+                         match uu___4 with
                          | FStar_Syntax_Syntax.Tm_arrow (dbs, c) ->
                              (debug_log env
-                                (fun uu____3147 ->
+                                (fun uu___6 ->
                                    "Checked nested positivity in Tm_arrow data constructor type");
-                              (let uu____3148 =
-                                 FStar_List.splitAt num_ibs dbs in
-                               match uu____3148 with
+                              (let uu___6 = FStar_List.splitAt num_ibs dbs in
+                               match uu___6 with
                                | (ibs, dbs1) ->
                                    let ibs1 =
                                      FStar_Syntax_Subst.open_binders ibs in
                                    let dbs2 =
-                                     let uu____3211 =
+                                     let uu___7 =
                                        FStar_Syntax_Subst.opening_of_binders
                                          ibs1 in
-                                     FStar_Syntax_Subst.subst_binders
-                                       uu____3211 dbs1 in
+                                     FStar_Syntax_Subst.subst_binders uu___7
+                                       dbs1 in
                                    let c1 =
-                                     let uu____3215 =
+                                     let uu___7 =
                                        FStar_Syntax_Subst.opening_of_binders
                                          ibs1 in
-                                     FStar_Syntax_Subst.subst_comp uu____3215
-                                       c in
-                                   let uu____3218 =
+                                     FStar_Syntax_Subst.subst_comp uu___7 c in
+                                   let uu___7 =
                                      FStar_List.splitAt num_ibs args in
-                                   (match uu____3218 with
-                                    | (args1, uu____3252) ->
+                                   (match uu___7 with
+                                    | (args1, uu___8) ->
                                         let subst =
                                           FStar_List.fold_left2
-                                            (fun subst ->
+                                            (fun subst1 ->
                                                fun ib ->
                                                  fun arg ->
-                                                   FStar_List.append subst
+                                                   FStar_List.append subst1
                                                      [FStar_Syntax_Syntax.NT
                                                         ((FStar_Pervasives_Native.fst
                                                             ib),
@@ -1316,42 +1281,40 @@ and (ty_nested_positive_in_dlid :
                                           FStar_Syntax_Subst.subst_binders
                                             subst dbs2 in
                                         let c2 =
-                                          let uu____3344 =
+                                          let uu___9 =
                                             FStar_Syntax_Subst.shift_subst
                                               (FStar_List.length dbs3) subst in
                                           FStar_Syntax_Subst.subst_comp
-                                            uu____3344 c1 in
+                                            uu___9 c1 in
                                         (debug_log env
-                                           (fun uu____3356 ->
-                                              let uu____3357 =
-                                                let uu____3358 =
+                                           (fun uu___10 ->
+                                              let uu___11 =
+                                                let uu___12 =
                                                   FStar_Syntax_Print.binders_to_string
                                                     "; " dbs3 in
-                                                let uu____3359 =
-                                                  let uu____3360 =
+                                                let uu___13 =
+                                                  let uu___14 =
                                                     FStar_Syntax_Print.comp_to_string
                                                       c2 in
                                                   Prims.op_Hat ", and c: "
-                                                    uu____3360 in
-                                                Prims.op_Hat uu____3358
-                                                  uu____3359 in
+                                                    uu___14 in
+                                                Prims.op_Hat uu___12 uu___13 in
                                               Prims.op_Hat
                                                 "Checking nested positivity in the unfolded data constructor binders as: "
-                                                uu____3357);
+                                                uu___11);
                                          ty_nested_positive_in_type ty_lid
                                            (FStar_Syntax_Syntax.Tm_arrow
                                               (dbs3, c2)) ilid num_ibs
                                            unfolded env))))
-                         | uu____3371 ->
+                         | uu___5 ->
                              (debug_log env
-                                (fun uu____3374 ->
+                                (fun uu___7 ->
                                    "Checking nested positivity in the data constructor type that is not an arrow");
-                              (let uu____3375 =
-                                 let uu____3376 =
-                                   FStar_Syntax_Subst.compress dt in
-                                 uu____3376.FStar_Syntax_Syntax.n in
-                               ty_nested_positive_in_type ty_lid uu____3375
-                                 ilid num_ibs unfolded env)))))
+                              (let uu___7 =
+                                 let uu___8 = FStar_Syntax_Subst.compress dt in
+                                 uu___8.FStar_Syntax_Syntax.n in
+                               ty_nested_positive_in_type ty_lid uu___7 ilid
+                                 num_ibs unfolded env)))))
 and (ty_nested_positive_in_type :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term' ->
@@ -1368,51 +1331,49 @@ and (ty_nested_positive_in_type :
               match t with
               | FStar_Syntax_Syntax.Tm_app (t1, args) ->
                   (debug_log env
-                     (fun uu____3413 ->
+                     (fun uu___1 ->
                         "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself");
-                   (let uu____3414 =
-                      let uu____3419 = try_get_fv t1 in
-                      FStar_All.pipe_right uu____3419 FStar_Util.must in
-                    match uu____3414 with
-                    | (fv, uu____3441) ->
-                        let uu____3442 =
+                   (let uu___1 =
+                      let uu___2 = try_get_fv t1 in
+                      FStar_All.pipe_right uu___2 FStar_Util.must in
+                    match uu___1 with
+                    | (fv, uu___2) ->
+                        let uu___3 =
                           FStar_Ident.lid_equals
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                             ilid in
-                        if uu____3442
+                        if uu___3
                         then true
                         else
                           failwith "Impossible, expected the type to be ilid"))
               | FStar_Syntax_Syntax.Tm_arrow (sbs, c) ->
                   (debug_log env
-                     (fun uu____3469 ->
-                        let uu____3470 =
+                     (fun uu___1 ->
+                        let uu___2 =
                           FStar_Syntax_Print.binders_to_string "; " sbs in
                         Prims.op_Hat
                           "Checking nested positivity in an Tm_arrow node, with binders as: "
-                          uu____3470);
+                          uu___2);
                    (let sbs1 = FStar_Syntax_Subst.open_binders sbs in
-                    let uu____3472 =
+                    let uu___1 =
                       FStar_List.fold_left
-                        (fun uu____3491 ->
+                        (fun uu___2 ->
                            fun b ->
-                             match uu____3491 with
+                             match uu___2 with
                              | (r, env1) ->
                                  if Prims.op_Negation r
                                  then (r, env1)
                                  else
-                                   (let uu____3514 =
+                                   (let uu___4 =
                                       ty_strictly_positive_in_type ty_lid
                                         (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                         unfolded env1 in
-                                    let uu____3517 =
+                                    let uu___5 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         [b] in
-                                    (uu____3514, uu____3517))) (true, env)
-                        sbs1 in
-                    match uu____3472 with | (b, uu____3531) -> b))
-              | uu____3532 ->
-                  failwith "Nested positive check, unhandled case"
+                                    (uu___4, uu___5))) (true, env) sbs1 in
+                    match uu___1 with | (b, uu___2) -> b))
+              | uu___ -> failwith "Nested positive check, unhandled case"
 let (ty_positive_in_datacon :
   FStar_Ident.lident ->
     FStar_Ident.lident ->
@@ -1426,8 +1387,8 @@ let (ty_positive_in_datacon :
         fun us ->
           fun unfolded ->
             fun env ->
-              let uu____3563 = FStar_TypeChecker_Env.lookup_datacon env dlid in
-              match uu____3563 with
+              let uu___ = FStar_TypeChecker_Env.lookup_datacon env dlid in
+              match uu___ with
               | (univ_unif_vars, dt) ->
                   (FStar_List.iter2
                      (fun u' ->
@@ -1435,75 +1396,75 @@ let (ty_positive_in_datacon :
                           match u' with
                           | FStar_Syntax_Syntax.U_unif u'' ->
                               FStar_Syntax_Unionfind.univ_change u'' u
-                          | uu____3587 ->
+                          | uu___2 ->
                               failwith
                                 "Impossible! Expected universe unification variables")
                      univ_unif_vars us;
                    debug_log env
-                     (fun uu____3591 ->
-                        let uu____3592 = FStar_Syntax_Print.term_to_string dt in
+                     (fun uu___3 ->
+                        let uu___4 = FStar_Syntax_Print.term_to_string dt in
                         Prims.op_Hat "Checking data constructor type: "
-                          uu____3592);
-                   (let uu____3593 =
-                      let uu____3594 = FStar_Syntax_Subst.compress dt in
-                      uu____3594.FStar_Syntax_Syntax.n in
-                    match uu____3593 with
-                    | FStar_Syntax_Syntax.Tm_fvar uu____3597 ->
+                          uu___4);
+                   (let uu___3 =
+                      let uu___4 = FStar_Syntax_Subst.compress dt in
+                      uu___4.FStar_Syntax_Syntax.n in
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Tm_fvar uu___4 ->
                         (debug_log env
-                           (fun uu____3600 ->
+                           (fun uu___6 ->
                               "Data constructor type is simply an fvar, returning true");
                          true)
-                    | FStar_Syntax_Syntax.Tm_arrow (dbs, uu____3602) ->
+                    | FStar_Syntax_Syntax.Tm_arrow (dbs, uu___4) ->
                         let dbs1 =
-                          let uu____3632 =
+                          let uu___5 =
                             FStar_List.splitAt (FStar_List.length ty_bs) dbs in
-                          FStar_Pervasives_Native.snd uu____3632 in
+                          FStar_Pervasives_Native.snd uu___5 in
                         let dbs2 =
-                          let uu____3682 =
+                          let uu___5 =
                             FStar_Syntax_Subst.opening_of_binders ty_bs in
-                          FStar_Syntax_Subst.subst_binders uu____3682 dbs1 in
+                          FStar_Syntax_Subst.subst_binders uu___5 dbs1 in
                         let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
                         (debug_log env
-                           (fun uu____3689 ->
-                              let uu____3690 =
-                                let uu____3691 =
+                           (fun uu___6 ->
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_Util.string_of_int
                                     (FStar_List.length dbs3) in
-                                Prims.op_Hat uu____3691 " binders" in
+                                Prims.op_Hat uu___8 " binders" in
                               Prims.op_Hat
                                 "Data constructor type is an arrow type, so checking strict positivity in "
-                                uu____3690);
-                         (let uu____3698 =
+                                uu___7);
+                         (let uu___6 =
                             FStar_List.fold_left
-                              (fun uu____3717 ->
+                              (fun uu___7 ->
                                  fun b ->
-                                   match uu____3717 with
+                                   match uu___7 with
                                    | (r, env1) ->
                                        if Prims.op_Negation r
                                        then (r, env1)
                                        else
-                                         (let uu____3740 =
+                                         (let uu___9 =
                                             ty_strictly_positive_in_type
                                               ty_lid
                                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                               unfolded env1 in
-                                          let uu____3743 =
+                                          let uu___10 =
                                             FStar_TypeChecker_Env.push_binders
                                               env1 [b] in
-                                          (uu____3740, uu____3743)))
-                              (true, env) dbs3 in
-                          match uu____3698 with | (b, uu____3757) -> b))
-                    | FStar_Syntax_Syntax.Tm_app (uu____3758, uu____3759) ->
+                                          (uu___9, uu___10))) (true, env)
+                              dbs3 in
+                          match uu___6 with | (b, uu___7) -> b))
+                    | FStar_Syntax_Syntax.Tm_app (uu___4, uu___5) ->
                         (debug_log env
-                           (fun uu____3786 ->
+                           (fun uu___7 ->
                               "Data constructor type is a Tm_app, so returning true");
                          true)
                     | FStar_Syntax_Syntax.Tm_uinst (t, univs) ->
                         (debug_log env
-                           (fun uu____3795 ->
+                           (fun uu___5 ->
                               "Data constructor type is a Tm_uinst, so recursing in the base type");
                          ty_strictly_positive_in_type ty_lid t unfolded env)
-                    | uu____3796 ->
+                    | uu___4 ->
                         failwith
                           "Unexpected data constructor type when checking positivity"))
 let (check_positivity :
@@ -1511,32 +1472,31 @@ let (check_positivity :
   fun ty ->
     fun env ->
       let unfolded_inductives = FStar_Util.mk_ref [] in
-      let uu____3814 =
+      let uu___ =
         match ty.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid, us, bs, uu____3830, uu____3831, uu____3832) ->
-            (lid, us, bs)
-        | uu____3841 -> failwith "Impossible!" in
-      match uu____3814 with
+            (lid, us, bs, uu___1, uu___2, uu___3) -> (lid, us, bs)
+        | uu___1 -> failwith "Impossible!" in
+      match uu___ with
       | (ty_lid, ty_us, ty_bs) ->
-          let uu____3851 = FStar_Syntax_Subst.univ_var_opening ty_us in
-          (match uu____3851 with
+          let uu___1 = FStar_Syntax_Subst.univ_var_opening ty_us in
+          (match uu___1 with
            | (ty_usubst, ty_us1) ->
                let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
                let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
                let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
                let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
-               let uu____3874 =
-                 let uu____3877 =
+               let uu___2 =
+                 let uu___3 =
                    FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
-                 FStar_Pervasives_Native.snd uu____3877 in
+                 FStar_Pervasives_Native.snd uu___3 in
                FStar_List.for_all
                  (fun d ->
-                    let uu____3889 =
+                    let uu___3 =
                       FStar_List.map (fun s -> FStar_Syntax_Syntax.U_name s)
                         ty_us1 in
-                    ty_positive_in_datacon ty_lid d ty_bs2 uu____3889
-                      unfolded_inductives env2) uu____3874)
+                    ty_positive_in_datacon ty_lid d ty_bs2 uu___3
+                      unfolded_inductives env2) uu___2)
 let (check_exn_positivity :
   FStar_Ident.lid -> FStar_TypeChecker_Env.env -> Prims.bool) =
   fun data_ctor_lid ->
@@ -1548,8 +1508,8 @@ let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
   fun data ->
     match data.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
-        (uu____3920, uu____3921, t, uu____3923, uu____3924, uu____3925) -> t
-    | uu____3930 -> failwith "Impossible!"
+        (uu___, uu___1, t, uu___2, uu___3, uu___4) -> t
+    | uu___ -> failwith "Impossible!"
 let (haseq_suffix : Prims.string) = "__uu___haseq"
 let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
   fun lid ->
@@ -1557,27 +1517,27 @@ let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
     let len = FStar_String.length str in
     let haseq_suffix_len = FStar_String.length haseq_suffix in
     (len > haseq_suffix_len) &&
-      (let uu____3940 =
-         let uu____3941 =
+      (let uu___ =
+         let uu___1 =
            FStar_String.substring str (len - haseq_suffix_len)
              haseq_suffix_len in
-         FStar_String.compare uu____3941 haseq_suffix in
-       uu____3940 = Prims.int_zero)
+         FStar_String.compare uu___1 haseq_suffix in
+       uu___ = Prims.int_zero)
 let (get_haseq_axiom_lid : FStar_Ident.lid -> FStar_Ident.lid) =
   fun lid ->
-    let uu____3947 =
-      let uu____3948 = FStar_Ident.ns_of_lid lid in
-      let uu____3951 =
-        let uu____3954 =
-          let uu____3955 =
-            let uu____3956 =
-              let uu____3957 = FStar_Ident.ident_of_lid lid in
-              FStar_Ident.string_of_id uu____3957 in
-            Prims.op_Hat uu____3956 haseq_suffix in
-          FStar_Ident.id_of_text uu____3955 in
-        [uu____3954] in
-      FStar_List.append uu____3948 uu____3951 in
-    FStar_Ident.lid_of_ids uu____3947
+    let uu___ =
+      let uu___1 = FStar_Ident.ns_of_lid lid in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Ident.ident_of_lid lid in
+              FStar_Ident.string_of_id uu___6 in
+            Prims.op_Hat uu___5 haseq_suffix in
+          FStar_Ident.id_of_text uu___4 in
+        [uu___3] in
+      FStar_List.append uu___1 uu___2 in
+    FStar_Ident.lid_of_ids uu___
 let (get_optimized_haseq_axiom :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1591,155 +1551,154 @@ let (get_optimized_haseq_axiom :
     fun ty ->
       fun usubst ->
         fun us ->
-          let uu____4002 =
+          let uu___ =
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid, uu____4016, bs, t, uu____4019, uu____4020) ->
-                (lid, bs, t)
-            | uu____4029 -> failwith "Impossible!" in
-          match uu____4002 with
+                (lid, uu___1, bs, t, uu___2, uu___3) -> (lid, bs, t)
+            | uu___1 -> failwith "Impossible!" in
+          match uu___ with
           | (lid, bs, t) ->
               let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
               let t1 =
-                let uu____4051 =
+                let uu___1 =
                   FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                     usubst in
-                FStar_Syntax_Subst.subst uu____4051 t in
-              let uu____4060 = FStar_Syntax_Subst.open_term bs1 t1 in
-              (match uu____4060 with
+                FStar_Syntax_Subst.subst uu___1 t in
+              let uu___1 = FStar_Syntax_Subst.open_term bs1 t1 in
+              (match uu___1 with
                | (bs2, t2) ->
                    let ibs =
-                     let uu____4078 =
-                       let uu____4079 = FStar_Syntax_Subst.compress t2 in
-                       uu____4079.FStar_Syntax_Syntax.n in
-                     match uu____4078 with
-                     | FStar_Syntax_Syntax.Tm_arrow (ibs, uu____4083) -> ibs
-                     | uu____4104 -> [] in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Subst.compress t2 in
+                       uu___3.FStar_Syntax_Syntax.n in
+                     match uu___2 with
+                     | FStar_Syntax_Syntax.Tm_arrow (ibs1, uu___3) -> ibs1
+                     | uu___3 -> [] in
                    let ibs1 = FStar_Syntax_Subst.open_binders ibs in
                    let ind =
-                     let uu____4113 =
+                     let uu___2 =
                        FStar_Syntax_Syntax.fvar lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None in
-                     let uu____4114 =
+                     let uu___3 =
                        FStar_List.map (fun u -> FStar_Syntax_Syntax.U_name u)
                          us in
-                     FStar_Syntax_Syntax.mk_Tm_uinst uu____4113 uu____4114 in
+                     FStar_Syntax_Syntax.mk_Tm_uinst uu___2 uu___3 in
                    let ind1 =
-                     let uu____4118 =
+                     let uu___2 =
                        FStar_List.map
-                         (fun uu____4135 ->
-                            match uu____4135 with
+                         (fun uu___3 ->
+                            match uu___3 with
                             | (bv, aq) ->
-                                let uu____4154 =
+                                let uu___4 =
                                   FStar_Syntax_Syntax.bv_to_name bv in
-                                (uu____4154, aq)) bs2 in
-                     FStar_Syntax_Syntax.mk_Tm_app ind uu____4118
+                                (uu___4, aq)) bs2 in
+                     FStar_Syntax_Syntax.mk_Tm_app ind uu___2
                        FStar_Range.dummyRange in
                    let ind2 =
-                     let uu____4158 =
+                     let uu___2 =
                        FStar_List.map
-                         (fun uu____4175 ->
-                            match uu____4175 with
+                         (fun uu___3 ->
+                            match uu___3 with
                             | (bv, aq) ->
-                                let uu____4194 =
+                                let uu___4 =
                                   FStar_Syntax_Syntax.bv_to_name bv in
-                                (uu____4194, aq)) ibs1 in
-                     FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4158
+                                (uu___4, aq)) ibs1 in
+                     FStar_Syntax_Syntax.mk_Tm_app ind1 uu___2
                        FStar_Range.dummyRange in
                    let haseq_ind =
-                     let uu____4198 =
-                       let uu____4199 = FStar_Syntax_Syntax.as_arg ind2 in
-                       [uu____4199] in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Syntax.as_arg ind2 in
+                       [uu___3] in
                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq
-                       uu____4198 FStar_Range.dummyRange in
+                       uu___2 FStar_Range.dummyRange in
                    let bs' =
                      FStar_List.filter
                        (fun b ->
-                          let uu____4248 =
-                            let uu____4249 = FStar_Syntax_Util.type_u () in
-                            FStar_Pervasives_Native.fst uu____4249 in
+                          let uu___2 =
+                            let uu___3 = FStar_Syntax_Util.type_u () in
+                            FStar_Pervasives_Native.fst uu___3 in
                           FStar_TypeChecker_Rel.subtype_nosmt_force en
                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                            uu____4248) bs2 in
+                            uu___2) bs2 in
                    let haseq_bs =
                      FStar_List.fold_left
                        (fun t3 ->
                           fun b ->
-                            let uu____4262 =
-                              let uu____4265 =
-                                let uu____4266 =
-                                  let uu____4275 =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_Syntax_Syntax.bv_to_name
                                       (FStar_Pervasives_Native.fst b) in
-                                  FStar_Syntax_Syntax.as_arg uu____4275 in
-                                [uu____4266] in
+                                  FStar_Syntax_Syntax.as_arg uu___5 in
+                                [uu___4] in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.t_haseq uu____4265
+                                FStar_Syntax_Util.t_haseq uu___3
                                 FStar_Range.dummyRange in
-                            FStar_Syntax_Util.mk_conj t3 uu____4262)
+                            FStar_Syntax_Util.mk_conj t3 uu___2)
                        FStar_Syntax_Util.t_true bs' in
                    let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind in
                    let fml1 =
-                     let uu___677_4298 = fml in
-                     let uu____4299 =
-                       let uu____4300 =
-                         let uu____4307 =
-                           let uu____4308 =
-                             let uu____4329 =
+                     let uu___2 = fml in
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 =
                                FStar_Syntax_Syntax.binders_to_names ibs1 in
-                             let uu____4334 =
-                               let uu____4347 =
-                                 let uu____4358 =
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_Syntax_Syntax.as_arg haseq_ind in
-                                 [uu____4358] in
-                               [uu____4347] in
-                             (uu____4329, uu____4334) in
-                           FStar_Syntax_Syntax.Meta_pattern uu____4308 in
-                         (fml, uu____4307) in
-                       FStar_Syntax_Syntax.Tm_meta uu____4300 in
+                                 [uu___10] in
+                               [uu___9] in
+                             (uu___7, uu___8) in
+                           FStar_Syntax_Syntax.Meta_pattern uu___6 in
+                         (fml, uu___5) in
+                       FStar_Syntax_Syntax.Tm_meta uu___4 in
                      {
-                       FStar_Syntax_Syntax.n = uu____4299;
+                       FStar_Syntax_Syntax.n = uu___3;
                        FStar_Syntax_Syntax.pos =
-                         (uu___677_4298.FStar_Syntax_Syntax.pos);
+                         (uu___2.FStar_Syntax_Syntax.pos);
                        FStar_Syntax_Syntax.vars =
-                         (uu___677_4298.FStar_Syntax_Syntax.vars)
+                         (uu___2.FStar_Syntax_Syntax.vars)
                      } in
                    let fml2 =
                      FStar_List.fold_right
                        (fun b ->
                           fun t3 ->
-                            let uu____4427 =
-                              let uu____4428 =
-                                let uu____4437 =
-                                  let uu____4438 =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_Syntax_Subst.close [b] t3 in
                                   FStar_Syntax_Util.abs
                                     [((FStar_Pervasives_Native.fst b),
-                                       FStar_Pervasives_Native.None)]
-                                    uu____4438 FStar_Pervasives_Native.None in
-                                FStar_Syntax_Syntax.as_arg uu____4437 in
-                              [uu____4428] in
+                                       FStar_Pervasives_Native.None)] uu___5
+                                    FStar_Pervasives_Native.None in
+                                FStar_Syntax_Syntax.as_arg uu___4 in
+                              [uu___3] in
                             FStar_Syntax_Syntax.mk_Tm_app
-                              FStar_Syntax_Util.tforall uu____4427
+                              FStar_Syntax_Util.tforall uu___2
                               FStar_Range.dummyRange) ibs1 fml1 in
                    let fml3 =
                      FStar_List.fold_right
                        (fun b ->
                           fun t3 ->
-                            let uu____4491 =
-                              let uu____4492 =
-                                let uu____4501 =
-                                  let uu____4502 =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_Syntax_Subst.close [b] t3 in
                                   FStar_Syntax_Util.abs
                                     [((FStar_Pervasives_Native.fst b),
-                                       FStar_Pervasives_Native.None)]
-                                    uu____4502 FStar_Pervasives_Native.None in
-                                FStar_Syntax_Syntax.as_arg uu____4501 in
-                              [uu____4492] in
+                                       FStar_Pervasives_Native.None)] uu___5
+                                    FStar_Pervasives_Native.None in
+                                FStar_Syntax_Syntax.as_arg uu___4 in
+                              [uu___3] in
                             FStar_Syntax_Syntax.mk_Tm_app
-                              FStar_Syntax_Util.tforall uu____4491
+                              FStar_Syntax_Util.tforall uu___2
                               FStar_Range.dummyRange) bs2 fml2 in
                    let axiom_lid = get_haseq_axiom_lid lid in
                    (axiom_lid, fml3, bs2, ibs1, haseq_bs))
@@ -1755,60 +1714,59 @@ let (optimized_haseq_soundness_for_data :
         fun bs ->
           let dt = datacon_typ data in
           let dt1 = FStar_Syntax_Subst.subst usubst dt in
-          let uu____4576 =
-            let uu____4577 = FStar_Syntax_Subst.compress dt1 in
-            uu____4577.FStar_Syntax_Syntax.n in
-          match uu____4576 with
-          | FStar_Syntax_Syntax.Tm_arrow (dbs, uu____4581) ->
+          let uu___ =
+            let uu___1 = FStar_Syntax_Subst.compress dt1 in
+            uu___1.FStar_Syntax_Syntax.n in
+          match uu___ with
+          | FStar_Syntax_Syntax.Tm_arrow (dbs, uu___1) ->
               let dbs1 =
-                let uu____4611 =
-                  FStar_List.splitAt (FStar_List.length bs) dbs in
-                FStar_Pervasives_Native.snd uu____4611 in
+                let uu___2 = FStar_List.splitAt (FStar_List.length bs) dbs in
+                FStar_Pervasives_Native.snd uu___2 in
               let dbs2 =
-                let uu____4661 = FStar_Syntax_Subst.opening_of_binders bs in
-                FStar_Syntax_Subst.subst_binders uu____4661 dbs1 in
+                let uu___2 = FStar_Syntax_Subst.opening_of_binders bs in
+                FStar_Syntax_Subst.subst_binders uu___2 dbs1 in
               let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
               let cond =
                 FStar_List.fold_left
                   (fun t ->
                      fun b ->
                        let haseq_b =
-                         let uu____4674 =
-                           let uu____4675 =
+                         let uu___2 =
+                           let uu___3 =
                              FStar_Syntax_Syntax.as_arg
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                           [uu____4675] in
+                           [uu___3] in
                          FStar_Syntax_Syntax.mk_Tm_app
-                           FStar_Syntax_Util.t_haseq uu____4674
+                           FStar_Syntax_Util.t_haseq uu___2
                            FStar_Range.dummyRange in
                        let sort_range =
                          ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
                        let haseq_b1 =
-                         let uu____4706 =
-                           let uu____4707 = FStar_Ident.string_of_lid ty_lid in
+                         let uu___2 =
+                           let uu___3 = FStar_Ident.string_of_lid ty_lid in
                            FStar_Util.format1
                              "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
-                             uu____4707 in
-                         FStar_TypeChecker_Util.label uu____4706 sort_range
+                             uu___3 in
+                         FStar_TypeChecker_Util.label uu___2 sort_range
                            haseq_b in
                        FStar_Syntax_Util.mk_conj t haseq_b1)
                   FStar_Syntax_Util.t_true dbs3 in
               FStar_List.fold_right
                 (fun b ->
                    fun t ->
-                     let uu____4713 =
-                       let uu____4714 =
-                         let uu____4723 =
-                           let uu____4724 = FStar_Syntax_Subst.close [b] t in
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Syntax_Subst.close [b] t in
                            FStar_Syntax_Util.abs
                              [((FStar_Pervasives_Native.fst b),
-                                FStar_Pervasives_Native.None)] uu____4724
+                                FStar_Pervasives_Native.None)] uu___5
                              FStar_Pervasives_Native.None in
-                         FStar_Syntax_Syntax.as_arg uu____4723 in
-                       [uu____4714] in
+                         FStar_Syntax_Syntax.as_arg uu___4 in
+                       [uu___3] in
                      FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
-                       uu____4713 FStar_Range.dummyRange) dbs3 cond
-          | uu____4771 -> FStar_Syntax_Util.t_true
+                       uu___2 FStar_Range.dummyRange) dbs3 cond
+          | uu___1 -> FStar_Syntax_Util.t_true
 let (optimized_haseq_ty :
   FStar_Syntax_Syntax.sigelts ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -1831,19 +1789,17 @@ let (optimized_haseq_ty :
             let lid =
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid, uu____4861, uu____4862, uu____4863, uu____4864,
-                   uu____4865)
-                  -> lid
-              | uu____4874 -> failwith "Impossible!" in
-            let uu____4875 = acc in
-            match uu____4875 with
-            | (uu____4912, en, uu____4914, uu____4915) ->
-                let uu____4936 = get_optimized_haseq_axiom en ty usubst us in
-                (match uu____4936 with
+                  (lid1, uu___, uu___1, uu___2, uu___3, uu___4) -> lid1
+              | uu___ -> failwith "Impossible!" in
+            let uu___ = acc in
+            match uu___ with
+            | (uu___1, en, uu___2, uu___3) ->
+                let uu___4 = get_optimized_haseq_axiom en ty usubst us in
+                (match uu___4 with
                  | (axiom_lid, fml, bs, ibs, haseq_bs) ->
                      let guard = FStar_Syntax_Util.mk_conj haseq_bs fml in
-                     let uu____4973 = acc in
-                     (match uu____4973 with
+                     let uu___5 = acc in
+                     (match uu___5 with
                       | (l_axioms, env, guard', cond') ->
                           let env1 =
                             FStar_TypeChecker_Env.push_binders env bs in
@@ -1854,26 +1810,24 @@ let (optimized_haseq_ty :
                               (fun s ->
                                  match s.FStar_Syntax_Syntax.sigel with
                                  | FStar_Syntax_Syntax.Sig_datacon
-                                     (uu____5047, uu____5048, uu____5049,
-                                      t_lid, uu____5051, uu____5052)
+                                     (uu___6, uu___7, uu___8, t_lid, uu___9,
+                                      uu___10)
                                      -> t_lid = lid
-                                 | uu____5057 -> failwith "Impossible")
+                                 | uu___6 -> failwith "Impossible")
                               all_datas_in_the_bundle in
                           let cond =
                             FStar_List.fold_left
                               (fun acc1 ->
                                  fun d ->
-                                   let uu____5070 =
+                                   let uu___6 =
                                      optimized_haseq_soundness_for_data lid d
                                        usubst bs in
-                                   FStar_Syntax_Util.mk_conj acc1 uu____5070)
+                                   FStar_Syntax_Util.mk_conj acc1 uu___6)
                               FStar_Syntax_Util.t_true t_datas in
-                          let uu____5073 =
-                            FStar_Syntax_Util.mk_conj guard' guard in
-                          let uu____5076 =
-                            FStar_Syntax_Util.mk_conj cond' cond in
+                          let uu___6 = FStar_Syntax_Util.mk_conj guard' guard in
+                          let uu___7 = FStar_Syntax_Util.mk_conj cond' cond in
                           ((FStar_List.append l_axioms [(axiom_lid, fml)]),
-                            env2, uu____5073, uu____5076)))
+                            env2, uu___6, uu___7)))
 let (optimized_haseq_scheme :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -1884,17 +1838,16 @@ let (optimized_haseq_scheme :
     fun tcs ->
       fun datas ->
         fun env0 ->
-          let uu____5133 =
+          let uu___ =
             let ty = FStar_List.hd tcs in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____5143, us, uu____5145, t, uu____5147, uu____5148) ->
-                (us, t)
-            | uu____5157 -> failwith "Impossible!" in
-          match uu____5133 with
+                (uu___1, us, uu___2, t, uu___3, uu___4) -> (us, t)
+            | uu___1 -> failwith "Impossible!" in
+          match uu___ with
           | (us, t) ->
-              let uu____5166 = FStar_Syntax_Subst.univ_var_opening us in
-              (match uu____5166 with
+              let uu___1 = FStar_Syntax_Subst.univ_var_opening us in
+              (match uu___1 with
                | (usubst, us1) ->
                    let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
                    ((env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
@@ -1902,42 +1855,42 @@ let (optimized_haseq_scheme :
                     (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                       env sig_bndle;
                     (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
-                     let uu____5191 =
+                     let uu___4 =
                        FStar_List.fold_left
                          (optimized_haseq_ty datas usubst us1)
                          ([], env1, FStar_Syntax_Util.t_true,
                            FStar_Syntax_Util.t_true) tcs in
-                     match uu____5191 with
+                     match uu___4 with
                      | (axioms, env2, guard, cond) ->
                          let phi =
-                           let uu____5269 = FStar_Syntax_Util.arrow_formals t in
-                           match uu____5269 with
-                           | (uu____5276, t1) ->
-                               let uu____5282 =
+                           let uu___5 = FStar_Syntax_Util.arrow_formals t in
+                           match uu___5 with
+                           | (uu___6, t1) ->
+                               let uu___7 =
                                  FStar_Syntax_Util.is_eqtype_no_unrefine t1 in
-                               if uu____5282
+                               if uu___7
                                then cond
                                else FStar_Syntax_Util.mk_imp guard cond in
-                         let uu____5284 =
+                         let uu___5 =
                            FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi in
-                         (match uu____5284 with
-                          | (phi1, uu____5292) ->
-                              ((let uu____5294 =
+                         (match uu___5 with
+                          | (phi1, uu___6) ->
+                              ((let uu___8 =
                                   FStar_TypeChecker_Env.should_verify env2 in
-                                if uu____5294
+                                if uu___8
                                 then
-                                  let uu____5295 =
+                                  let uu___9 =
                                     FStar_TypeChecker_Env.guard_of_guard_formula
                                       (FStar_TypeChecker_Common.NonTrivial
                                          phi1) in
                                   FStar_TypeChecker_Rel.force_trivial_guard
-                                    env2 uu____5295
+                                    env2 uu___9
                                 else ());
                                (let ses =
                                   FStar_List.fold_left
                                     (fun l ->
-                                       fun uu____5312 ->
-                                         match uu____5312 with
+                                       fun uu___8 ->
+                                         match uu___8 with
                                          | (lid, fml) ->
                                              let fml1 =
                                                FStar_Syntax_Subst.close_univ_vars
@@ -1979,49 +1932,47 @@ let (unoptimized_haseq_data :
           fun acc ->
             fun data ->
               let rec is_mutual t =
-                let uu____5380 =
-                  let uu____5381 = FStar_Syntax_Subst.compress t in
-                  uu____5381.FStar_Syntax_Syntax.n in
-                match uu____5380 with
+                let uu___ =
+                  let uu___1 = FStar_Syntax_Subst.compress t in
+                  uu___1.FStar_Syntax_Syntax.n in
+                match uu___ with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_List.existsb
                       (fun lid ->
                          FStar_Ident.lid_equals lid
                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                       mutuals
-                | FStar_Syntax_Syntax.Tm_uinst (t', uu____5388) ->
-                    is_mutual t'
+                | FStar_Syntax_Syntax.Tm_uinst (t', uu___1) -> is_mutual t'
                 | FStar_Syntax_Syntax.Tm_refine (bv, t') ->
                     is_mutual bv.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_app (t', args) ->
-                    let uu____5425 = is_mutual t' in
-                    if uu____5425
+                    let uu___1 = is_mutual t' in
+                    if uu___1
                     then true
                     else
-                      (let uu____5427 =
+                      (let uu___3 =
                          FStar_List.map FStar_Pervasives_Native.fst args in
-                       exists_mutual uu____5427)
-                | FStar_Syntax_Syntax.Tm_meta (t', uu____5447) ->
-                    is_mutual t'
-                | uu____5452 -> false
-              and exists_mutual uu___1_5453 =
-                match uu___1_5453 with
+                       exists_mutual uu___3)
+                | FStar_Syntax_Syntax.Tm_meta (t', uu___1) -> is_mutual t'
+                | uu___1 -> false
+              and exists_mutual uu___ =
+                match uu___ with
                 | [] -> false
                 | hd::tl -> (is_mutual hd) || (exists_mutual tl) in
               let dt = datacon_typ data in
               let dt1 = FStar_Syntax_Subst.subst usubst dt in
-              let uu____5472 =
-                let uu____5473 = FStar_Syntax_Subst.compress dt1 in
-                uu____5473.FStar_Syntax_Syntax.n in
-              match uu____5472 with
-              | FStar_Syntax_Syntax.Tm_arrow (dbs, uu____5479) ->
+              let uu___ =
+                let uu___1 = FStar_Syntax_Subst.compress dt1 in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
+              | FStar_Syntax_Syntax.Tm_arrow (dbs, uu___1) ->
                   let dbs1 =
-                    let uu____5509 =
+                    let uu___2 =
                       FStar_List.splitAt (FStar_List.length bs) dbs in
-                    FStar_Pervasives_Native.snd uu____5509 in
+                    FStar_Pervasives_Native.snd uu___2 in
                   let dbs2 =
-                    let uu____5559 = FStar_Syntax_Subst.opening_of_binders bs in
-                    FStar_Syntax_Subst.subst_binders uu____5559 dbs1 in
+                    let uu___2 = FStar_Syntax_Subst.opening_of_binders bs in
+                    FStar_Syntax_Subst.subst_binders uu___2 dbs1 in
                   let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
                   let cond =
                     FStar_List.fold_left
@@ -2030,17 +1981,17 @@ let (unoptimized_haseq_data :
                            let sort =
                              (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
                            let haseq_sort =
-                             let uu____5577 =
-                               let uu____5578 =
+                             let uu___2 =
+                               let uu___3 =
                                  FStar_Syntax_Syntax.as_arg
                                    (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                               [uu____5578] in
+                               [uu___3] in
                              FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.t_haseq uu____5577
+                               FStar_Syntax_Util.t_haseq uu___2
                                FStar_Range.dummyRange in
                            let haseq_sort1 =
-                             let uu____5608 = is_mutual sort in
-                             if uu____5608
+                             let uu___2 = is_mutual sort in
+                             if uu___2
                              then
                                FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
                              else haseq_sort in
@@ -2050,22 +2001,21 @@ let (unoptimized_haseq_data :
                     FStar_List.fold_right
                       (fun b ->
                          fun t ->
-                           let uu____5618 =
-                             let uu____5619 =
-                               let uu____5628 =
-                                 let uu____5629 =
-                                   FStar_Syntax_Subst.close [b] t in
+                           let uu___2 =
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 = FStar_Syntax_Subst.close [b] t in
                                  FStar_Syntax_Util.abs
                                    [((FStar_Pervasives_Native.fst b),
-                                      FStar_Pervasives_Native.None)]
-                                   uu____5629 FStar_Pervasives_Native.None in
-                               FStar_Syntax_Syntax.as_arg uu____5628 in
-                             [uu____5619] in
+                                      FStar_Pervasives_Native.None)] uu___5
+                                   FStar_Pervasives_Native.None in
+                               FStar_Syntax_Syntax.as_arg uu___4 in
+                             [uu___3] in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.tforall uu____5618
+                             FStar_Syntax_Util.tforall uu___2
                              FStar_Range.dummyRange) dbs3 cond in
                   FStar_Syntax_Util.mk_conj acc cond1
-              | uu____5676 -> acc
+              | uu___1 -> acc
 let (unoptimized_haseq_ty :
   FStar_Syntax_Syntax.sigelt Prims.list ->
     FStar_Ident.lident Prims.list ->
@@ -2081,80 +2031,79 @@ let (unoptimized_haseq_ty :
         fun us ->
           fun acc ->
             fun ty ->
-              let uu____5725 =
+              let uu___ =
                 match ty.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_inductive_typ
-                    (lid, uu____5747, bs, t, uu____5750, d_lids) ->
+                    (lid, uu___1, bs, t, uu___2, d_lids) ->
                     (lid, bs, t, d_lids)
-                | uu____5762 -> failwith "Impossible!" in
-              match uu____5725 with
+                | uu___1 -> failwith "Impossible!" in
+              match uu___ with
               | (lid, bs, t, d_lids) ->
                   let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
                   let t1 =
-                    let uu____5785 =
+                    let uu___1 =
                       FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                         usubst in
-                    FStar_Syntax_Subst.subst uu____5785 t in
-                  let uu____5794 = FStar_Syntax_Subst.open_term bs1 t1 in
-                  (match uu____5794 with
+                    FStar_Syntax_Subst.subst uu___1 t in
+                  let uu___1 = FStar_Syntax_Subst.open_term bs1 t1 in
+                  (match uu___1 with
                    | (bs2, t2) ->
                        let ibs =
-                         let uu____5804 =
-                           let uu____5805 = FStar_Syntax_Subst.compress t2 in
-                           uu____5805.FStar_Syntax_Syntax.n in
-                         match uu____5804 with
-                         | FStar_Syntax_Syntax.Tm_arrow (ibs, uu____5809) ->
-                             ibs
-                         | uu____5830 -> [] in
+                         let uu___2 =
+                           let uu___3 = FStar_Syntax_Subst.compress t2 in
+                           uu___3.FStar_Syntax_Syntax.n in
+                         match uu___2 with
+                         | FStar_Syntax_Syntax.Tm_arrow (ibs1, uu___3) ->
+                             ibs1
+                         | uu___3 -> [] in
                        let ibs1 = FStar_Syntax_Subst.open_binders ibs in
                        let ind =
-                         let uu____5839 =
+                         let uu___2 =
                            FStar_Syntax_Syntax.fvar lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None in
-                         let uu____5840 =
+                         let uu___3 =
                            FStar_List.map
                              (fun u -> FStar_Syntax_Syntax.U_name u) us in
-                         FStar_Syntax_Syntax.mk_Tm_uinst uu____5839
-                           uu____5840 in
+                         FStar_Syntax_Syntax.mk_Tm_uinst uu___2 uu___3 in
                        let ind1 =
-                         let uu____5844 =
+                         let uu___2 =
                            FStar_List.map
-                             (fun uu____5861 ->
-                                match uu____5861 with
+                             (fun uu___3 ->
+                                match uu___3 with
                                 | (bv, aq) ->
-                                    let uu____5880 =
+                                    let uu___4 =
                                       FStar_Syntax_Syntax.bv_to_name bv in
-                                    (uu____5880, aq)) bs2 in
-                         FStar_Syntax_Syntax.mk_Tm_app ind uu____5844
+                                    (uu___4, aq)) bs2 in
+                         FStar_Syntax_Syntax.mk_Tm_app ind uu___2
                            FStar_Range.dummyRange in
                        let ind2 =
-                         let uu____5884 =
+                         let uu___2 =
                            FStar_List.map
-                             (fun uu____5901 ->
-                                match uu____5901 with
+                             (fun uu___3 ->
+                                match uu___3 with
                                 | (bv, aq) ->
-                                    let uu____5920 =
+                                    let uu___4 =
                                       FStar_Syntax_Syntax.bv_to_name bv in
-                                    (uu____5920, aq)) ibs1 in
-                         FStar_Syntax_Syntax.mk_Tm_app ind1 uu____5884
+                                    (uu___4, aq)) ibs1 in
+                         FStar_Syntax_Syntax.mk_Tm_app ind1 uu___2
                            FStar_Range.dummyRange in
                        let haseq_ind =
-                         let uu____5924 =
-                           let uu____5925 = FStar_Syntax_Syntax.as_arg ind2 in
-                           [uu____5925] in
+                         let uu___2 =
+                           let uu___3 = FStar_Syntax_Syntax.as_arg ind2 in
+                           [uu___3] in
                          FStar_Syntax_Syntax.mk_Tm_app
-                           FStar_Syntax_Util.t_haseq uu____5924
+                           FStar_Syntax_Util.t_haseq uu___2
                            FStar_Range.dummyRange in
                        let t_datas =
                          FStar_List.filter
                            (fun s ->
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_datacon
-                                  (uu____5961, uu____5962, uu____5963, t_lid,
-                                   uu____5965, uu____5966)
+                                  (uu___2, uu___3, uu___4, t_lid, uu___5,
+                                   uu___6)
                                   -> t_lid = lid
-                              | uu____5971 -> failwith "Impossible")
+                              | uu___2 -> failwith "Impossible")
                            all_datas_in_the_bundle in
                        let data_cond =
                          FStar_List.fold_left
@@ -2162,67 +2111,65 @@ let (unoptimized_haseq_ty :
                               mutuals) FStar_Syntax_Util.t_true t_datas in
                        let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind in
                        let fml1 =
-                         let uu___914_5981 = fml in
-                         let uu____5982 =
-                           let uu____5983 =
-                             let uu____5990 =
-                               let uu____5991 =
-                                 let uu____6012 =
+                         let uu___2 = fml in
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
                                    FStar_Syntax_Syntax.binders_to_names ibs1 in
-                                 let uu____6017 =
-                                   let uu____6030 =
-                                     let uu____6041 =
+                                 let uu___8 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_Syntax_Syntax.as_arg haseq_ind in
-                                     [uu____6041] in
-                                   [uu____6030] in
-                                 (uu____6012, uu____6017) in
-                               FStar_Syntax_Syntax.Meta_pattern uu____5991 in
-                             (fml, uu____5990) in
-                           FStar_Syntax_Syntax.Tm_meta uu____5983 in
+                                     [uu___10] in
+                                   [uu___9] in
+                                 (uu___7, uu___8) in
+                               FStar_Syntax_Syntax.Meta_pattern uu___6 in
+                             (fml, uu___5) in
+                           FStar_Syntax_Syntax.Tm_meta uu___4 in
                          {
-                           FStar_Syntax_Syntax.n = uu____5982;
+                           FStar_Syntax_Syntax.n = uu___3;
                            FStar_Syntax_Syntax.pos =
-                             (uu___914_5981.FStar_Syntax_Syntax.pos);
+                             (uu___2.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___914_5981.FStar_Syntax_Syntax.vars)
+                             (uu___2.FStar_Syntax_Syntax.vars)
                          } in
                        let fml2 =
                          FStar_List.fold_right
                            (fun b ->
                               fun t3 ->
-                                let uu____6110 =
-                                  let uu____6111 =
-                                    let uu____6120 =
-                                      let uu____6121 =
+                                let uu___2 =
+                                  let uu___3 =
+                                    let uu___4 =
+                                      let uu___5 =
                                         FStar_Syntax_Subst.close [b] t3 in
                                       FStar_Syntax_Util.abs
                                         [((FStar_Pervasives_Native.fst b),
                                            FStar_Pervasives_Native.None)]
-                                        uu____6121
-                                        FStar_Pervasives_Native.None in
-                                    FStar_Syntax_Syntax.as_arg uu____6120 in
-                                  [uu____6111] in
+                                        uu___5 FStar_Pervasives_Native.None in
+                                    FStar_Syntax_Syntax.as_arg uu___4 in
+                                  [uu___3] in
                                 FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.tforall uu____6110
+                                  FStar_Syntax_Util.tforall uu___2
                                   FStar_Range.dummyRange) ibs1 fml1 in
                        let fml3 =
                          FStar_List.fold_right
                            (fun b ->
                               fun t3 ->
-                                let uu____6174 =
-                                  let uu____6175 =
-                                    let uu____6184 =
-                                      let uu____6185 =
+                                let uu___2 =
+                                  let uu___3 =
+                                    let uu___4 =
+                                      let uu___5 =
                                         FStar_Syntax_Subst.close [b] t3 in
                                       FStar_Syntax_Util.abs
                                         [((FStar_Pervasives_Native.fst b),
                                            FStar_Pervasives_Native.None)]
-                                        uu____6185
-                                        FStar_Pervasives_Native.None in
-                                    FStar_Syntax_Syntax.as_arg uu____6184 in
-                                  [uu____6175] in
+                                        uu___5 FStar_Pervasives_Native.None in
+                                    FStar_Syntax_Syntax.as_arg uu___4 in
+                                  [uu___3] in
                                 FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.tforall uu____6174
+                                  FStar_Syntax_Util.tforall uu___2
                                   FStar_Range.dummyRange) bs2 fml2 in
                        FStar_Syntax_Util.mk_conj acc fml3)
 let (unoptimized_haseq_scheme :
@@ -2240,34 +2187,31 @@ let (unoptimized_haseq_scheme :
               (fun ty ->
                  match ty.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid, uu____6276, uu____6277, uu____6278, uu____6279,
-                      uu____6280)
-                     -> lid
-                 | uu____6289 -> failwith "Impossible!") tcs in
-          let uu____6290 =
+                     (lid, uu___, uu___1, uu___2, uu___3, uu___4) -> lid
+                 | uu___ -> failwith "Impossible!") tcs in
+          let uu___ =
             let ty = FStar_List.hd tcs in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid, us, uu____6302, uu____6303, uu____6304, uu____6305) ->
-                (lid, us)
-            | uu____6314 -> failwith "Impossible!" in
-          match uu____6290 with
+                (lid, us, uu___1, uu___2, uu___3, uu___4) -> (lid, us)
+            | uu___1 -> failwith "Impossible!" in
+          match uu___ with
           | (lid, us) ->
-              let uu____6323 = FStar_Syntax_Subst.univ_var_opening us in
-              (match uu____6323 with
+              let uu___1 = FStar_Syntax_Subst.univ_var_opening us in
+              (match uu___1 with
                | (usubst, us1) ->
                    let fml =
                      FStar_List.fold_left
                        (unoptimized_haseq_ty datas mutuals usubst us1)
                        FStar_Syntax_Util.t_true tcs in
                    let se =
-                     let uu____6350 =
-                       let uu____6351 =
-                         let uu____6358 = get_haseq_axiom_lid lid in
-                         (uu____6358, us1, fml) in
-                       FStar_Syntax_Syntax.Sig_assume uu____6351 in
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = get_haseq_axiom_lid lid in
+                         (uu___4, us1, fml) in
+                       FStar_Syntax_Syntax.Sig_assume uu___3 in
                      {
-                       FStar_Syntax_Syntax.sigel = uu____6350;
+                       FStar_Syntax_Syntax.sigel = uu___2;
                        FStar_Syntax_Syntax.sigrng = FStar_Range.dummyRange;
                        FStar_Syntax_Syntax.sigquals = [];
                        FStar_Syntax_Syntax.sigmeta =
@@ -2289,156 +2233,152 @@ let (check_inductive_well_typedness :
     fun ses ->
       fun quals ->
         fun lids ->
-          let uu____6411 =
+          let uu___ =
             FStar_All.pipe_right ses
               (FStar_List.partition
-                 (fun uu___2_6437 ->
-                    match uu___2_6437 with
+                 (fun uu___1 ->
+                    match uu___1 with
                     | {
                         FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6438;
-                        FStar_Syntax_Syntax.sigrng = uu____6439;
-                        FStar_Syntax_Syntax.sigquals = uu____6440;
-                        FStar_Syntax_Syntax.sigmeta = uu____6441;
-                        FStar_Syntax_Syntax.sigattrs = uu____6442;
-                        FStar_Syntax_Syntax.sigopts = uu____6443;_} -> true
-                    | uu____6466 -> false)) in
-          match uu____6411 with
+                          FStar_Syntax_Syntax.Sig_inductive_typ uu___2;
+                        FStar_Syntax_Syntax.sigrng = uu___3;
+                        FStar_Syntax_Syntax.sigquals = uu___4;
+                        FStar_Syntax_Syntax.sigmeta = uu___5;
+                        FStar_Syntax_Syntax.sigattrs = uu___6;
+                        FStar_Syntax_Syntax.sigopts = uu___7;_} -> true
+                    | uu___2 -> false)) in
+          match uu___ with
           | (tys, datas) ->
-              ((let uu____6488 =
+              ((let uu___2 =
                   FStar_All.pipe_right datas
                     (FStar_Util.for_some
-                       (fun uu___3_6498 ->
-                          match uu___3_6498 with
+                       (fun uu___3 ->
+                          match uu___3 with
                           | {
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_datacon uu____6499;
-                              FStar_Syntax_Syntax.sigrng = uu____6500;
-                              FStar_Syntax_Syntax.sigquals = uu____6501;
-                              FStar_Syntax_Syntax.sigmeta = uu____6502;
-                              FStar_Syntax_Syntax.sigattrs = uu____6503;
-                              FStar_Syntax_Syntax.sigopts = uu____6504;_} ->
+                                FStar_Syntax_Syntax.Sig_datacon uu___4;
+                              FStar_Syntax_Syntax.sigrng = uu___5;
+                              FStar_Syntax_Syntax.sigquals = uu___6;
+                              FStar_Syntax_Syntax.sigmeta = uu___7;
+                              FStar_Syntax_Syntax.sigattrs = uu___8;
+                              FStar_Syntax_Syntax.sigopts = uu___9;_} ->
                               false
-                          | uu____6525 -> true)) in
-                if uu____6488
+                          | uu___4 -> true)) in
+                if uu___2
                 then
-                  let uu____6526 = FStar_TypeChecker_Env.get_range env in
+                  let uu___3 = FStar_TypeChecker_Env.get_range env in
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                       "Mutually defined type contains a non-inductive element")
-                    uu____6526
+                    uu___3
                 else ());
                (let univs =
                   if (FStar_List.length tys) = Prims.int_zero
                   then []
                   else
-                    (let uu____6534 =
-                       let uu____6535 = FStar_List.hd tys in
-                       uu____6535.FStar_Syntax_Syntax.sigel in
-                     match uu____6534 with
+                    (let uu___3 =
+                       let uu___4 = FStar_List.hd tys in
+                       uu___4.FStar_Syntax_Syntax.sigel in
+                     match uu___3 with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (uu____6538, uvs, uu____6540, uu____6541,
-                          uu____6542, uu____6543)
-                         -> uvs
-                     | uu____6552 -> failwith "Impossible, can't happen!") in
+                         (uu___4, uvs, uu___5, uu___6, uu___7, uu___8) -> uvs
+                     | uu___4 -> failwith "Impossible, can't happen!") in
                 let env0 = env in
-                let uu____6556 =
+                let uu___2 =
                   FStar_List.fold_right
                     (fun tc ->
-                       fun uu____6595 ->
-                         match uu____6595 with
+                       fun uu___3 ->
+                         match uu___3 with
                          | (env1, all_tcs, g) ->
-                             let uu____6635 = tc_tycon env1 tc in
-                             (match uu____6635 with
+                             let uu___4 = tc_tycon env1 tc in
+                             (match uu___4 with
                               | (env2, tc1, tc_u, guard) ->
                                   let g' =
                                     FStar_TypeChecker_Rel.universe_inequality
                                       FStar_Syntax_Syntax.U_zero tc_u in
-                                  ((let uu____6662 =
+                                  ((let uu___6 =
                                       FStar_TypeChecker_Env.debug env2
                                         FStar_Options.Low in
-                                    if uu____6662
+                                    if uu___6
                                     then
-                                      let uu____6663 =
+                                      let uu___7 =
                                         FStar_Syntax_Print.sigelt_to_string
                                           tc1 in
                                       FStar_Util.print1
-                                        "Checked inductive: %s\n" uu____6663
+                                        "Checked inductive: %s\n" uu___7
                                     else ());
-                                   (let uu____6665 =
-                                      let uu____6666 =
+                                   (let uu___6 =
+                                      let uu___7 =
                                         FStar_TypeChecker_Env.conj_guard
                                           guard g' in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____6666 in
-                                    (env2, ((tc1, tc_u) :: all_tcs),
-                                      uu____6665))))) tys
-                    (env, [], FStar_TypeChecker_Env.trivial_guard) in
-                match uu____6556 with
+                                        uu___7 in
+                                    (env2, ((tc1, tc_u) :: all_tcs), uu___6)))))
+                    tys (env, [], FStar_TypeChecker_Env.trivial_guard) in
+                match uu___2 with
                 | (env1, tcs, g) ->
-                    let uu____6712 =
+                    let uu___3 =
                       FStar_List.fold_right
                         (fun se ->
-                           fun uu____6734 ->
-                             match uu____6734 with
+                           fun uu___4 ->
+                             match uu___4 with
                              | (datas1, g1) ->
-                                 let uu____6753 =
-                                   let uu____6758 = tc_data env1 tcs in
-                                   uu____6758 se in
-                                 (match uu____6753 with
+                                 let uu___5 =
+                                   let uu___6 = tc_data env1 tcs in uu___6 se in
+                                 (match uu___5 with
                                   | (data, g') ->
-                                      let uu____6775 =
+                                      let uu___6 =
                                         FStar_TypeChecker_Env.conj_guard g1
                                           g' in
-                                      ((data :: datas1), uu____6775))) datas
+                                      ((data :: datas1), uu___6))) datas
                         ([], g) in
-                    (match uu____6712 with
+                    (match uu___3 with
                      | (datas1, g1) ->
-                         let uu____6796 =
+                         let uu___4 =
                            let tc_universe_vars =
                              FStar_List.map FStar_Pervasives_Native.snd tcs in
                            let g2 =
-                             let uu___1025_6813 = g1 in
+                             let uu___5 = g1 in
                              {
                                FStar_TypeChecker_Common.guard_f =
-                                 (uu___1025_6813.FStar_TypeChecker_Common.guard_f);
+                                 (uu___5.FStar_TypeChecker_Common.guard_f);
                                FStar_TypeChecker_Common.deferred_to_tac =
-                                 (uu___1025_6813.FStar_TypeChecker_Common.deferred_to_tac);
+                                 (uu___5.FStar_TypeChecker_Common.deferred_to_tac);
                                FStar_TypeChecker_Common.deferred =
-                                 (uu___1025_6813.FStar_TypeChecker_Common.deferred);
+                                 (uu___5.FStar_TypeChecker_Common.deferred);
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (tc_universe_vars,
                                    (FStar_Pervasives_Native.snd
                                       g1.FStar_TypeChecker_Common.univ_ineqs));
                                FStar_TypeChecker_Common.implicits =
-                                 (uu___1025_6813.FStar_TypeChecker_Common.implicits)
+                                 (uu___5.FStar_TypeChecker_Common.implicits)
                              } in
-                           (let uu____6823 =
+                           (let uu___6 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "GenUniverses") in
-                            if uu____6823
+                            if uu___6
                             then
-                              let uu____6824 =
+                              let uu___7 =
                                 FStar_TypeChecker_Rel.guard_to_string env1 g2 in
                               FStar_Util.print1
                                 "@@@@@@Guard before (possible) generalization: %s\n"
-                                uu____6824
+                                uu___7
                             else ());
                            FStar_TypeChecker_Rel.force_trivial_guard env0 g2;
                            if (FStar_List.length univs) = Prims.int_zero
                            then generalize_and_inst_within env0 tcs datas1
                            else
-                             (let uu____6836 =
+                             (let uu___8 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   tcs in
-                              (uu____6836, datas1)) in
-                         (match uu____6796 with
+                              (uu___8, datas1)) in
+                         (match uu___4 with
                           | (tcs1, datas2) ->
                               let sig_bndle =
-                                let uu____6868 =
+                                let uu___5 =
                                   FStar_TypeChecker_Env.get_range env0 in
-                                let uu____6869 =
+                                let uu___6 =
                                   FStar_List.collect
                                     (fun s -> s.FStar_Syntax_Syntax.sigattrs)
                                     ses in
@@ -2447,11 +2387,11 @@ let (check_inductive_well_typedness :
                                     (FStar_Syntax_Syntax.Sig_bundle
                                        ((FStar_List.append tcs1 datas2),
                                          lids));
-                                  FStar_Syntax_Syntax.sigrng = uu____6868;
+                                  FStar_Syntax_Syntax.sigrng = uu___5;
                                   FStar_Syntax_Syntax.sigquals = quals;
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
-                                  FStar_Syntax_Syntax.sigattrs = uu____6869;
+                                  FStar_Syntax_Syntax.sigattrs = uu___6;
                                   FStar_Syntax_Syntax.sigopts =
                                     FStar_Pervasives_Native.None
                                 } in
@@ -2461,50 +2401,49 @@ let (check_inductive_well_typedness :
                                        match se.FStar_Syntax_Syntax.sigel
                                        with
                                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                                           (l, univs1, binders, typ,
-                                            uu____6895, uu____6896)
+                                           (l, univs1, binders, typ, uu___6,
+                                            uu___7)
                                            ->
                                            let fail expected inferred =
-                                             let uu____6916 =
-                                               let uu____6921 =
-                                                 let uu____6922 =
+                                             let uu___8 =
+                                               let uu___9 =
+                                                 let uu___10 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      expected in
-                                                 let uu____6923 =
+                                                 let uu___11 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      inferred in
                                                  FStar_Util.format2
                                                    "Expected an inductive with type %s; got %s"
-                                                   uu____6922 uu____6923 in
+                                                   uu___10 uu___11 in
                                                (FStar_Errors.Fatal_UnexpectedInductivetype,
-                                                 uu____6921) in
-                                             FStar_Errors.raise_error
-                                               uu____6916
+                                                 uu___9) in
+                                             FStar_Errors.raise_error uu___8
                                                se.FStar_Syntax_Syntax.sigrng in
-                                           let uu____6924 =
+                                           let uu___8 =
                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                env0 l in
-                                           (match uu____6924 with
+                                           (match uu___8 with
                                             | FStar_Pervasives_Native.None ->
                                                 ()
                                             | FStar_Pervasives_Native.Some
-                                                (expected_typ, uu____6940) ->
+                                                (expected_typ, uu___9) ->
                                                 let inferred_typ =
                                                   let body =
                                                     match binders with
                                                     | [] -> typ
-                                                    | uu____6971 ->
-                                                        let uu____6972 =
-                                                          let uu____6973 =
-                                                            let uu____6988 =
+                                                    | uu___10 ->
+                                                        let uu___11 =
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               FStar_Syntax_Syntax.mk_Total
                                                                 typ in
                                                             (binders,
-                                                              uu____6988) in
+                                                              uu___13) in
                                                           FStar_Syntax_Syntax.Tm_arrow
-                                                            uu____6973 in
+                                                            uu___12 in
                                                         FStar_Syntax_Syntax.mk
-                                                          uu____6972
+                                                          uu___11
                                                           se.FStar_Syntax_Syntax.sigrng in
                                                   (univs1, body) in
                                                 if
@@ -2514,23 +2453,22 @@ let (check_inductive_well_typedness :
                                                        (FStar_Pervasives_Native.fst
                                                           expected_typ))
                                                 then
-                                                  let uu____7009 =
+                                                  let uu___10 =
                                                     FStar_TypeChecker_Env.inst_tscheme
                                                       inferred_typ in
-                                                  (match uu____7009 with
-                                                   | (uu____7014, inferred)
-                                                       ->
-                                                       let uu____7016 =
+                                                  (match uu___10 with
+                                                   | (uu___11, inferred) ->
+                                                       let uu___12 =
                                                          FStar_TypeChecker_Env.inst_tscheme
                                                            expected_typ in
-                                                       (match uu____7016 with
-                                                        | (uu____7021,
-                                                           expected) ->
-                                                            let uu____7023 =
+                                                       (match uu___12 with
+                                                        | (uu___13, expected)
+                                                            ->
+                                                            let uu___14 =
                                                               FStar_TypeChecker_Rel.teq_nosmt_force
                                                                 env0 inferred
                                                                 expected in
-                                                            if uu____7023
+                                                            if uu___14
                                                             then ()
                                                             else
                                                               fail
@@ -2539,7 +2477,7 @@ let (check_inductive_well_typedness :
                                                 else
                                                   fail expected_typ
                                                     inferred_typ)
-                                       | uu____7026 -> ()));
+                                       | uu___6 -> ()));
                                (sig_bndle, tcs1, datas2))))))
 let (early_prims_inductives : Prims.string Prims.list) =
   ["c_False"; "c_True"; "equals"; "h_equals"; "c_and"; "c_or"]
@@ -2580,31 +2518,31 @@ let (mk_discriminator_and_indexed_projectors :
                           let tps = inductive_tps in
                           let arg_typ =
                             let inst_tc =
-                              let uu____7130 =
-                                let uu____7131 =
-                                  let uu____7138 =
-                                    let uu____7141 =
+                              let uu___ =
+                                let uu___1 =
+                                  let uu___2 =
+                                    let uu___3 =
                                       FStar_Syntax_Syntax.lid_as_fv tc
                                         FStar_Syntax_Syntax.delta_constant
                                         FStar_Pervasives_Native.None in
-                                    FStar_Syntax_Syntax.fv_to_tm uu____7141 in
-                                  (uu____7138, inst_univs) in
-                                FStar_Syntax_Syntax.Tm_uinst uu____7131 in
-                              FStar_Syntax_Syntax.mk uu____7130 p in
+                                    FStar_Syntax_Syntax.fv_to_tm uu___3 in
+                                  (uu___2, inst_univs) in
+                                FStar_Syntax_Syntax.Tm_uinst uu___1 in
+                              FStar_Syntax_Syntax.mk uu___ p in
                             let args =
                               FStar_All.pipe_right
                                 (FStar_List.append tps indices)
                                 (FStar_List.map
-                                   (fun uu____7175 ->
-                                      match uu____7175 with
+                                   (fun uu___ ->
+                                      match uu___ with
                                       | (x, imp) ->
-                                          let uu____7194 =
+                                          let uu___1 =
                                             FStar_Syntax_Syntax.bv_to_name x in
-                                          (uu____7194, imp))) in
+                                          (uu___1, imp))) in
                             FStar_Syntax_Syntax.mk_Tm_app inst_tc args p in
                           let unrefined_arg_binder =
-                            let uu____7198 = projectee arg_typ in
-                            FStar_Syntax_Syntax.mk_binder uu____7198 in
+                            let uu___ = projectee arg_typ in
+                            FStar_Syntax_Syntax.mk_binder uu___ in
                           let arg_binder =
                             if Prims.op_Negation refine_domain
                             then unrefined_arg_binder
@@ -2616,74 +2554,73 @@ let (mk_discriminator_and_indexed_projectors :
                                    (FStar_Pervasives_Native.Some p) arg_typ in
                                let sort =
                                  let disc_fvar =
-                                   let uu____7219 =
+                                   let uu___1 =
                                      FStar_Ident.set_lid_range disc_name p in
-                                   FStar_Syntax_Syntax.fvar uu____7219
+                                   FStar_Syntax_Syntax.fvar uu___1
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
                                         Prims.int_one)
                                      FStar_Pervasives_Native.None in
-                                 let uu____7220 =
-                                   let uu____7223 =
-                                     let uu____7226 =
+                                 let uu___1 =
+                                   let uu___2 =
+                                     let uu___3 =
                                        FStar_Syntax_Syntax.mk_Tm_uinst
                                          disc_fvar inst_univs in
-                                     let uu____7227 =
-                                       let uu____7228 =
-                                         let uu____7237 =
+                                     let uu___4 =
+                                       let uu___5 =
+                                         let uu___6 =
                                            FStar_Syntax_Syntax.bv_to_name x in
                                          FStar_All.pipe_left
-                                           FStar_Syntax_Syntax.as_arg
-                                           uu____7237 in
-                                       [uu____7228] in
-                                     FStar_Syntax_Syntax.mk_Tm_app uu____7226
-                                       uu____7227 p in
-                                   FStar_Syntax_Util.b2t uu____7223 in
-                                 FStar_Syntax_Util.refine x uu____7220 in
-                               let uu____7262 =
-                                 let uu___1100_7263 = projectee arg_typ in
+                                           FStar_Syntax_Syntax.as_arg uu___6 in
+                                       [uu___5] in
+                                     FStar_Syntax_Syntax.mk_Tm_app uu___3
+                                       uu___4 p in
+                                   FStar_Syntax_Util.b2t uu___2 in
+                                 FStar_Syntax_Util.refine x uu___1 in
+                               let uu___1 =
+                                 let uu___2 = projectee arg_typ in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1100_7263.FStar_Syntax_Syntax.ppname);
+                                     (uu___2.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1100_7263.FStar_Syntax_Syntax.index);
+                                     (uu___2.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort = sort
                                  } in
-                               FStar_Syntax_Syntax.mk_binder uu____7262) in
+                               FStar_Syntax_Syntax.mk_binder uu___1) in
                           let ntps = FStar_List.length tps in
                           let all_params =
-                            let uu____7280 =
+                            let uu___ =
                               FStar_List.map
-                                (fun uu____7304 ->
-                                   match uu____7304 with
-                                   | (x, uu____7318) ->
+                                (fun uu___1 ->
+                                   match uu___1 with
+                                   | (x, uu___2) ->
                                        (x,
                                          (FStar_Pervasives_Native.Some
                                             FStar_Syntax_Syntax.imp_tag)))
                                 tps in
-                            FStar_List.append uu____7280 fields in
+                            FStar_List.append uu___ fields in
                           let imp_binders =
                             FStar_All.pipe_right
                               (FStar_List.append tps indices)
                               (FStar_List.map
-                                 (fun uu____7377 ->
-                                    match uu____7377 with
-                                    | (x, uu____7391) ->
+                                 (fun uu___ ->
+                                    match uu___ with
+                                    | (x, uu___1) ->
                                         (x,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag)))) in
                           let early_prims_inductive =
-                            (let uu____7401 =
+                            (let uu___ =
                                FStar_TypeChecker_Env.current_module env in
                              FStar_Ident.lid_equals
-                               FStar_Parser_Const.prims_lid uu____7401)
+                               FStar_Parser_Const.prims_lid uu___)
                               &&
                               (FStar_List.existsb
                                  (fun s ->
-                                    let uu____7405 =
-                                      let uu____7406 =
+                                    let uu___ =
+                                      let uu___1 =
                                         FStar_Ident.ident_of_lid tc in
-                                      FStar_Ident.string_of_id uu____7406 in
-                                    s = uu____7405) early_prims_inductives) in
+                                      FStar_Ident.string_of_id uu___1 in
+                                    s = uu___) early_prims_inductives) in
                           let discriminator_ses =
                             if fvq <> FStar_Syntax_Syntax.Data_ctor
                             then []
@@ -2693,24 +2630,23 @@ let (mk_discriminator_and_indexed_projectors :
                                let no_decl = false in
                                let only_decl =
                                  early_prims_inductive ||
-                                   (let uu____7417 =
-                                      let uu____7418 =
+                                   (let uu___1 =
+                                      let uu___2 =
                                         FStar_TypeChecker_Env.current_module
                                           env in
-                                      FStar_Ident.string_of_lid uu____7418 in
-                                    FStar_Options.dont_gen_projectors
-                                      uu____7417) in
+                                      FStar_Ident.string_of_lid uu___2 in
+                                    FStar_Options.dont_gen_projectors uu___1) in
                                let quals =
-                                 let uu____7422 =
+                                 let uu___1 =
                                    FStar_List.filter
-                                     (fun uu___4_7426 ->
-                                        match uu___4_7426 with
+                                     (fun uu___2 ->
+                                        match uu___2 with
                                         | FStar_Syntax_Syntax.Inline_for_extraction
                                             -> true
                                         | FStar_Syntax_Syntax.NoExtract ->
                                             true
                                         | FStar_Syntax_Syntax.Private -> true
-                                        | uu____7427 -> false) iquals in
+                                        | uu___3 -> false) iquals in
                                  FStar_List.append
                                    ((FStar_Syntax_Syntax.Discriminator lid)
                                    ::
@@ -2718,7 +2654,7 @@ let (mk_discriminator_and_indexed_projectors :
                                     then
                                       [FStar_Syntax_Syntax.Logic;
                                       FStar_Syntax_Syntax.Assumption]
-                                    else [])) uu____7422 in
+                                    else [])) uu___1 in
                                let binders =
                                  FStar_List.append imp_binders
                                    [unrefined_arg_binder] in
@@ -2731,20 +2667,20 @@ let (mk_discriminator_and_indexed_projectors :
                                    else
                                      FStar_Syntax_Syntax.mk_Total
                                        FStar_Syntax_Util.t_bool in
-                                 let uu____7467 =
+                                 let uu___1 =
                                    FStar_Syntax_Util.arrow binders bool_typ in
                                  FStar_All.pipe_left
                                    (FStar_Syntax_Subst.close_univ_vars uvs)
-                                   uu____7467 in
+                                   uu___1 in
                                let decl =
-                                 let uu____7471 =
+                                 let uu___1 =
                                    FStar_Ident.range_of_lid
                                      discriminator_name in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_declare_typ
                                         (discriminator_name, uvs, t));
-                                   FStar_Syntax_Syntax.sigrng = uu____7471;
+                                   FStar_Syntax_Syntax.sigrng = uu___1;
                                    FStar_Syntax_Syntax.sigquals = quals;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
@@ -2752,16 +2688,16 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigopts =
                                      FStar_Pervasives_Native.None
                                  } in
-                               (let uu____7473 =
+                               (let uu___2 =
                                   FStar_TypeChecker_Env.debug env
                                     (FStar_Options.Other "LogTypes") in
-                                if uu____7473
+                                if uu___2
                                 then
-                                  let uu____7474 =
+                                  let uu___3 =
                                     FStar_Syntax_Print.sigelt_to_string decl in
                                   FStar_Util.print1
                                     "Declaration of a discriminator %s\n"
-                                    uu____7474
+                                    uu___3
                                 else ());
                                if only_decl
                                then [decl]
@@ -2774,100 +2710,95 @@ let (mk_discriminator_and_indexed_projectors :
                                          FStar_All.pipe_right all_params
                                            (FStar_List.mapi
                                               (fun j ->
-                                                 fun uu____7525 ->
-                                                   match uu____7525 with
+                                                 fun uu___4 ->
+                                                   match uu___4 with
                                                    | (x, imp) ->
                                                        let b =
                                                          FStar_Syntax_Syntax.is_implicit
                                                            imp in
                                                        if b && (j < ntps)
                                                        then
-                                                         let uu____7545 =
-                                                           let uu____7548 =
-                                                             let uu____7549 =
-                                                               let uu____7556
-                                                                 =
-                                                                 let uu____7557
-                                                                   =
+                                                         let uu___5 =
+                                                           let uu___6 =
+                                                             let uu___7 =
+                                                               let uu___8 =
+                                                                 let uu___9 =
                                                                    FStar_Ident.string_of_id
                                                                     x.FStar_Syntax_Syntax.ppname in
                                                                  FStar_Syntax_Syntax.gen_bv
-                                                                   uu____7557
+                                                                   uu___9
                                                                    FStar_Pervasives_Native.None
                                                                    FStar_Syntax_Syntax.tun in
-                                                               (uu____7556,
+                                                               (uu___8,
                                                                  FStar_Syntax_Syntax.tun) in
                                                              FStar_Syntax_Syntax.Pat_dot_term
-                                                               uu____7549 in
-                                                           pos uu____7548 in
-                                                         (uu____7545, b)
+                                                               uu___7 in
+                                                           pos uu___6 in
+                                                         (uu___5, b)
                                                        else
-                                                         (let uu____7563 =
-                                                            let uu____7566 =
-                                                              let uu____7567
-                                                                =
-                                                                let uu____7568
-                                                                  =
+                                                         (let uu___6 =
+                                                            let uu___7 =
+                                                              let uu___8 =
+                                                                let uu___9 =
                                                                   FStar_Ident.string_of_id
                                                                     x.FStar_Syntax_Syntax.ppname in
                                                                 FStar_Syntax_Syntax.gen_bv
-                                                                  uu____7568
+                                                                  uu___9
                                                                   FStar_Pervasives_Native.None
                                                                   FStar_Syntax_Syntax.tun in
                                                               FStar_Syntax_Syntax.Pat_wild
-                                                                uu____7567 in
-                                                            pos uu____7566 in
-                                                          (uu____7563, b)))) in
+                                                                uu___8 in
+                                                            pos uu___7 in
+                                                          (uu___6, b)))) in
                                        let pat_true =
-                                         let uu____7586 =
-                                           let uu____7589 =
-                                             let uu____7590 =
-                                               let uu____7603 =
+                                         let uu___4 =
+                                           let uu___5 =
+                                             let uu___6 =
+                                               let uu___7 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    lid
                                                    FStar_Syntax_Syntax.delta_constant
                                                    (FStar_Pervasives_Native.Some
                                                       fvq) in
-                                               (uu____7603, arg_pats) in
+                                               (uu___7, arg_pats) in
                                              FStar_Syntax_Syntax.Pat_cons
-                                               uu____7590 in
-                                           pos uu____7589 in
-                                         (uu____7586,
+                                               uu___6 in
+                                           pos uu___5 in
+                                         (uu___4,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_true_bool) in
                                        let pat_false =
-                                         let uu____7637 =
-                                           let uu____7640 =
-                                             let uu____7641 =
+                                         let uu___4 =
+                                           let uu___5 =
+                                             let uu___6 =
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
                                                  FStar_Syntax_Syntax.tun in
                                              FStar_Syntax_Syntax.Pat_wild
-                                               uu____7641 in
-                                           pos uu____7640 in
-                                         (uu____7637,
+                                               uu___6 in
+                                           pos uu___5 in
+                                         (uu___4,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_false_bool) in
                                        let arg_exp =
                                          FStar_Syntax_Syntax.bv_to_name
                                            (FStar_Pervasives_Native.fst
                                               unrefined_arg_binder) in
-                                       let uu____7655 =
-                                         let uu____7656 =
-                                           let uu____7679 =
-                                             let uu____7696 =
+                                       let uu___4 =
+                                         let uu___5 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                FStar_Syntax_Util.branch
                                                  pat_true in
-                                             let uu____7711 =
-                                               let uu____7728 =
+                                             let uu___8 =
+                                               let uu___9 =
                                                  FStar_Syntax_Util.branch
                                                    pat_false in
-                                               [uu____7728] in
-                                             uu____7696 :: uu____7711 in
-                                           (arg_exp, uu____7679) in
-                                         FStar_Syntax_Syntax.Tm_match
-                                           uu____7656 in
-                                       FStar_Syntax_Syntax.mk uu____7655 p) in
+                                               [uu___9] in
+                                             uu___7 :: uu___8 in
+                                           (arg_exp, uu___6) in
+                                         FStar_Syntax_Syntax.Tm_match uu___5 in
+                                       FStar_Syntax_Syntax.mk uu___4 p) in
                                   let dd =
                                     FStar_Syntax_Syntax.Delta_equational_at_level
                                       Prims.int_one in
@@ -2879,36 +2810,36 @@ let (mk_discriminator_and_indexed_projectors :
                                     then t
                                     else FStar_Syntax_Syntax.tun in
                                   let lb =
-                                    let uu____7814 =
-                                      let uu____7819 =
+                                    let uu___3 =
+                                      let uu___4 =
                                         FStar_Syntax_Syntax.lid_as_fv
                                           discriminator_name dd
                                           FStar_Pervasives_Native.None in
-                                      FStar_Util.Inr uu____7819 in
-                                    let uu____7820 =
+                                      FStar_Util.Inr uu___4 in
+                                    let uu___4 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         imp in
-                                    FStar_Syntax_Util.mk_letbinding
-                                      uu____7814 uvs lbtyp
+                                    FStar_Syntax_Util.mk_letbinding uu___3
+                                      uvs lbtyp
                                       FStar_Parser_Const.effect_Tot_lid
-                                      uu____7820 [] FStar_Range.dummyRange in
+                                      uu___4 [] FStar_Range.dummyRange in
                                   let impl =
-                                    let uu____7826 =
-                                      let uu____7827 =
-                                        let uu____7834 =
-                                          let uu____7837 =
-                                            let uu____7838 =
+                                    let uu___3 =
+                                      let uu___4 =
+                                        let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
                                               FStar_All.pipe_right
                                                 lb.FStar_Syntax_Syntax.lbname
                                                 FStar_Util.right in
-                                            FStar_All.pipe_right uu____7838
+                                            FStar_All.pipe_right uu___7
                                               (fun fv ->
                                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                          [uu____7837] in
-                                        ((false, [lb]), uu____7834) in
-                                      FStar_Syntax_Syntax.Sig_let uu____7827 in
+                                          [uu___6] in
+                                        ((false, [lb]), uu___5) in
+                                      FStar_Syntax_Syntax.Sig_let uu___4 in
                                     {
-                                      FStar_Syntax_Syntax.sigel = uu____7826;
+                                      FStar_Syntax_Syntax.sigel = uu___3;
                                       FStar_Syntax_Syntax.sigrng = p;
                                       FStar_Syntax_Syntax.sigquals = quals;
                                       FStar_Syntax_Syntax.sigmeta =
@@ -2917,17 +2848,17 @@ let (mk_discriminator_and_indexed_projectors :
                                       FStar_Syntax_Syntax.sigopts =
                                         FStar_Pervasives_Native.None
                                     } in
-                                  (let uu____7850 =
+                                  (let uu___4 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "LogTypes") in
-                                   if uu____7850
+                                   if uu___4
                                    then
-                                     let uu____7851 =
+                                     let uu___5 =
                                        FStar_Syntax_Print.sigelt_to_string
                                          impl in
                                      FStar_Util.print1
                                        "Implementation of a discriminator %s\n"
-                                       uu____7851
+                                       uu___5
                                    else ());
                                   [decl; impl])) in
                           let arg_exp =
@@ -2942,36 +2873,36 @@ let (mk_discriminator_and_indexed_projectors :
                             FStar_All.pipe_right fields
                               (FStar_List.mapi
                                  (fun i ->
-                                    fun uu____7919 ->
-                                      match uu____7919 with
-                                      | (a, uu____7927) ->
+                                    fun uu___ ->
+                                      match uu___ with
+                                      | (a, uu___1) ->
                                           let field_name =
                                             FStar_Syntax_Util.mk_field_projector_name
                                               lid a i in
                                           let field_proj_tm =
-                                            let uu____7934 =
-                                              let uu____7935 =
+                                            let uu___2 =
+                                              let uu___3 =
                                                 FStar_Syntax_Syntax.lid_as_fv
                                                   field_name
                                                   (FStar_Syntax_Syntax.Delta_equational_at_level
                                                      Prims.int_one)
                                                   FStar_Pervasives_Native.None in
                                               FStar_Syntax_Syntax.fv_to_tm
-                                                uu____7935 in
+                                                uu___3 in
                                             FStar_Syntax_Syntax.mk_Tm_uinst
-                                              uu____7934 inst_univs in
+                                              uu___2 inst_univs in
                                           let proj =
                                             FStar_Syntax_Syntax.mk_Tm_app
                                               field_proj_tm [arg] p in
                                           FStar_Syntax_Syntax.NT (a, proj))) in
                           let projectors_ses =
-                            let uu____7958 =
+                            let uu___ =
                               FStar_All.pipe_right fields
                                 (FStar_List.mapi
                                    (fun i ->
-                                      fun uu____7998 ->
-                                        match uu____7998 with
-                                        | (x, uu____8008) ->
+                                      fun uu___1 ->
+                                        match uu___1 with
+                                        | (x, uu___2) ->
                                             let p1 =
                                               FStar_Syntax_Syntax.range_of_bv
                                                 x in
@@ -2980,33 +2911,33 @@ let (mk_discriminator_and_indexed_projectors :
                                                 lid x i in
                                             let t =
                                               let result_comp =
-                                                let t =
+                                                let t1 =
                                                   FStar_Syntax_Subst.subst
                                                     subst
                                                     x.FStar_Syntax_Syntax.sort in
                                                 if erasable
                                                 then
                                                   FStar_Syntax_Syntax.mk_GTotal
-                                                    t
+                                                    t1
                                                 else
                                                   FStar_Syntax_Syntax.mk_Total
-                                                    t in
-                                              let uu____8025 =
+                                                    t1 in
+                                              let uu___3 =
                                                 FStar_Syntax_Util.arrow
                                                   binders result_comp in
                                               FStar_All.pipe_left
                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                   uvs) uu____8025 in
+                                                   uvs) uu___3 in
                                             let only_decl =
                                               early_prims_inductive ||
-                                                (let uu____8030 =
-                                                   let uu____8031 =
+                                                (let uu___3 =
+                                                   let uu___4 =
                                                      FStar_TypeChecker_Env.current_module
                                                        env in
                                                    FStar_Ident.string_of_lid
-                                                     uu____8031 in
+                                                     uu___4 in
                                                  FStar_Options.dont_gen_projectors
-                                                   uu____8030) in
+                                                   uu___3) in
                                             let no_decl = false in
                                             let quals q =
                                               if only_decl
@@ -3018,16 +2949,15 @@ let (mk_discriminator_and_indexed_projectors :
                                               let iquals1 =
                                                 FStar_All.pipe_right iquals
                                                   (FStar_List.filter
-                                                     (fun uu___5_8059 ->
-                                                        match uu___5_8059
-                                                        with
+                                                     (fun uu___3 ->
+                                                        match uu___3 with
                                                         | FStar_Syntax_Syntax.Inline_for_extraction
                                                             -> true
                                                         | FStar_Syntax_Syntax.NoExtract
                                                             -> true
                                                         | FStar_Syntax_Syntax.Private
                                                             -> true
-                                                        | uu____8060 -> false)) in
+                                                        | uu___4 -> false)) in
                                               quals
                                                 ((FStar_Syntax_Syntax.Projector
                                                     (lid,
@@ -3041,7 +2971,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                    [FStar_Syntax_Util.attr_substitute])
                                                 attrs in
                                             let decl =
-                                              let uu____8068 =
+                                              let uu___3 =
                                                 FStar_Ident.range_of_lid
                                                   field_name in
                                               {
@@ -3049,7 +2979,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                                      (field_name, uvs, t));
                                                 FStar_Syntax_Syntax.sigrng =
-                                                  uu____8068;
+                                                  uu___3;
                                                 FStar_Syntax_Syntax.sigquals
                                                   = quals1;
                                                 FStar_Syntax_Syntax.sigmeta =
@@ -3059,29 +2989,29 @@ let (mk_discriminator_and_indexed_projectors :
                                                 FStar_Syntax_Syntax.sigopts =
                                                   FStar_Pervasives_Native.None
                                               } in
-                                            ((let uu____8070 =
+                                            ((let uu___4 =
                                                 FStar_TypeChecker_Env.debug
                                                   env
                                                   (FStar_Options.Other
                                                      "LogTypes") in
-                                              if uu____8070
+                                              if uu___4
                                               then
-                                                let uu____8071 =
+                                                let uu___5 =
                                                   FStar_Syntax_Print.sigelt_to_string
                                                     decl in
                                                 FStar_Util.print1
                                                   "Declaration of a projector %s\n"
-                                                  uu____8071
+                                                  uu___5
                                               else ());
                                              if only_decl
                                              then [decl]
                                              else
                                                (let projection =
-                                                  let uu____8077 =
+                                                  let uu___5 =
                                                     FStar_Ident.string_of_id
                                                       x.FStar_Syntax_Syntax.ppname in
                                                   FStar_Syntax_Syntax.gen_bv
-                                                    uu____8077
+                                                    uu___5
                                                     FStar_Pervasives_Native.None
                                                     FStar_Syntax_Syntax.tun in
                                                 let arg_pats =
@@ -3089,9 +3019,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                     all_params
                                                     (FStar_List.mapi
                                                        (fun j ->
-                                                          fun uu____8118 ->
-                                                            match uu____8118
-                                                            with
+                                                          fun uu___5 ->
+                                                            match uu___5 with
                                                             | (x1, imp) ->
                                                                 let b =
                                                                   FStar_Syntax_Syntax.is_implicit
@@ -3100,99 +3029,97 @@ let (mk_discriminator_and_indexed_projectors :
                                                                   (i + ntps)
                                                                     = j
                                                                 then
-                                                                  let uu____8138
+                                                                  let uu___6
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
                                                                     projection) in
-                                                                  (uu____8138,
-                                                                    b)
+                                                                  (uu___6, b)
                                                                 else
                                                                   if
                                                                     b &&
                                                                     (j < ntps)
                                                                   then
                                                                     (
-                                                                    let uu____8150
+                                                                    let uu___7
                                                                     =
-                                                                    let uu____8153
+                                                                    let uu___8
                                                                     =
-                                                                    let uu____8154
+                                                                    let uu___9
                                                                     =
-                                                                    let uu____8161
+                                                                    let uu___10
                                                                     =
-                                                                    let uu____8162
+                                                                    let uu___11
                                                                     =
                                                                     FStar_Ident.string_of_id
                                                                     x1.FStar_Syntax_Syntax.ppname in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    uu____8162
+                                                                    uu___11
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
-                                                                    (uu____8161,
+                                                                    (uu___10,
                                                                     FStar_Syntax_Syntax.tun) in
                                                                     FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____8154 in
+                                                                    uu___9 in
                                                                     pos
-                                                                    uu____8153 in
-                                                                    (uu____8150,
+                                                                    uu___8 in
+                                                                    (uu___7,
                                                                     b))
                                                                   else
                                                                     (
-                                                                    let uu____8168
+                                                                    let uu___8
                                                                     =
-                                                                    let uu____8171
+                                                                    let uu___9
                                                                     =
-                                                                    let uu____8172
+                                                                    let uu___10
                                                                     =
-                                                                    let uu____8173
+                                                                    let uu___11
                                                                     =
                                                                     FStar_Ident.string_of_id
                                                                     x1.FStar_Syntax_Syntax.ppname in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    uu____8173
+                                                                    uu___11
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____8172 in
+                                                                    uu___10 in
                                                                     pos
-                                                                    uu____8171 in
-                                                                    (uu____8168,
+                                                                    uu___9 in
+                                                                    (uu___8,
                                                                     b)))) in
                                                 let pat =
-                                                  let uu____8191 =
-                                                    let uu____8194 =
-                                                      let uu____8195 =
-                                                        let uu____8208 =
+                                                  let uu___5 =
+                                                    let uu___6 =
+                                                      let uu___7 =
+                                                        let uu___8 =
                                                           FStar_Syntax_Syntax.lid_as_fv
                                                             lid
                                                             FStar_Syntax_Syntax.delta_constant
                                                             (FStar_Pervasives_Native.Some
                                                                fvq) in
-                                                        (uu____8208,
-                                                          arg_pats) in
+                                                        (uu___8, arg_pats) in
                                                       FStar_Syntax_Syntax.Pat_cons
-                                                        uu____8195 in
-                                                    pos uu____8194 in
-                                                  let uu____8217 =
+                                                        uu___7 in
+                                                    pos uu___6 in
+                                                  let uu___6 =
                                                     FStar_Syntax_Syntax.bv_to_name
                                                       projection in
-                                                  (uu____8191,
+                                                  (uu___5,
                                                     FStar_Pervasives_Native.None,
-                                                    uu____8217) in
+                                                    uu___6) in
                                                 let body =
-                                                  let uu____8233 =
-                                                    let uu____8234 =
-                                                      let uu____8257 =
-                                                        let uu____8274 =
+                                                  let uu___5 =
+                                                    let uu___6 =
+                                                      let uu___7 =
+                                                        let uu___8 =
                                                           FStar_Syntax_Util.branch
                                                             pat in
-                                                        [uu____8274] in
-                                                      (arg_exp, uu____8257) in
+                                                        [uu___8] in
+                                                      (arg_exp, uu___7) in
                                                     FStar_Syntax_Syntax.Tm_match
-                                                      uu____8234 in
+                                                      uu___6 in
                                                   FStar_Syntax_Syntax.mk
-                                                    uu____8233 p1 in
+                                                    uu___5 p1 in
                                                 let imp =
                                                   FStar_Syntax_Util.abs
                                                     binders body
@@ -3206,18 +3133,18 @@ let (mk_discriminator_and_indexed_projectors :
                                                   else
                                                     FStar_Syntax_Syntax.tun in
                                                 let lb =
-                                                  let uu____8346 =
-                                                    let uu____8351 =
+                                                  let uu___5 =
+                                                    let uu___6 =
                                                       FStar_Syntax_Syntax.lid_as_fv
                                                         field_name dd
                                                         FStar_Pervasives_Native.None in
-                                                    FStar_Util.Inr uu____8351 in
-                                                  let uu____8352 =
+                                                    FStar_Util.Inr uu___6 in
+                                                  let uu___6 =
                                                     FStar_Syntax_Subst.close_univ_vars
                                                       uvs imp in
                                                   {
                                                     FStar_Syntax_Syntax.lbname
-                                                      = uu____8346;
+                                                      = uu___5;
                                                     FStar_Syntax_Syntax.lbunivs
                                                       = uvs;
                                                     FStar_Syntax_Syntax.lbtyp
@@ -3226,7 +3153,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Parser_Const.effect_Tot_lid;
                                                     FStar_Syntax_Syntax.lbdef
-                                                      = uu____8352;
+                                                      = uu___6;
                                                     FStar_Syntax_Syntax.lbattrs
                                                       = [];
                                                     FStar_Syntax_Syntax.lbpos
@@ -3234,26 +3161,25 @@ let (mk_discriminator_and_indexed_projectors :
                                                       FStar_Range.dummyRange
                                                   } in
                                                 let impl =
-                                                  let uu____8358 =
-                                                    let uu____8359 =
-                                                      let uu____8366 =
-                                                        let uu____8369 =
-                                                          let uu____8370 =
+                                                  let uu___5 =
+                                                    let uu___6 =
+                                                      let uu___7 =
+                                                        let uu___8 =
+                                                          let uu___9 =
                                                             FStar_All.pipe_right
                                                               lb.FStar_Syntax_Syntax.lbname
                                                               FStar_Util.right in
                                                           FStar_All.pipe_right
-                                                            uu____8370
+                                                            uu___9
                                                             (fun fv ->
                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                                        [uu____8369] in
-                                                      ((false, [lb]),
-                                                        uu____8366) in
+                                                        [uu___8] in
+                                                      ((false, [lb]), uu___7) in
                                                     FStar_Syntax_Syntax.Sig_let
-                                                      uu____8359 in
+                                                      uu___6 in
                                                   {
                                                     FStar_Syntax_Syntax.sigel
-                                                      = uu____8358;
+                                                      = uu___5;
                                                     FStar_Syntax_Syntax.sigrng
                                                       = p1;
                                                     FStar_Syntax_Syntax.sigquals
@@ -3267,25 +3193,24 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Pervasives_Native.None
                                                   } in
-                                                (let uu____8382 =
+                                                (let uu___6 =
                                                    FStar_TypeChecker_Env.debug
                                                      env
                                                      (FStar_Options.Other
                                                         "LogTypes") in
-                                                 if uu____8382
+                                                 if uu___6
                                                  then
-                                                   let uu____8383 =
+                                                   let uu___7 =
                                                      FStar_Syntax_Print.sigelt_to_string
                                                        impl in
                                                    FStar_Util.print1
                                                      "Implementation of a projector %s\n"
-                                                     uu____8383
+                                                     uu___7
                                                  else ());
                                                 if no_decl
                                                 then [impl]
                                                 else [decl; impl])))) in
-                            FStar_All.pipe_right uu____7958
-                              FStar_List.flatten in
+                            FStar_All.pipe_right uu___ FStar_List.flatten in
                           FStar_List.append discriminator_ses projectors_ses
 let (mk_data_operations :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -3301,121 +3226,117 @@ let (mk_data_operations :
           fun se ->
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_datacon
-                (constr_lid, uvs, t, typ_lid, n_typars, uu____8440) when
-                let uu____8445 =
+                (constr_lid, uvs, t, typ_lid, n_typars, uu___) when
+                let uu___1 =
                   FStar_Ident.lid_equals constr_lid
                     FStar_Parser_Const.lexcons_lid in
-                Prims.op_Negation uu____8445 ->
-                let uu____8446 = FStar_Syntax_Subst.univ_var_opening uvs in
-                (match uu____8446 with
+                Prims.op_Negation uu___1 ->
+                let uu___1 = FStar_Syntax_Subst.univ_var_opening uvs in
+                (match uu___1 with
                  | (univ_opening, uvs1) ->
                      let t1 = FStar_Syntax_Subst.subst univ_opening t in
-                     let uu____8468 = FStar_Syntax_Util.arrow_formals t1 in
-                     (match uu____8468 with
-                      | (formals, uu____8478) ->
-                          let uu____8483 =
+                     let uu___2 = FStar_Syntax_Util.arrow_formals t1 in
+                     (match uu___2 with
+                      | (formals, uu___3) ->
+                          let uu___4 =
                             let tps_opt =
                               FStar_Util.find_map tcs
                                 (fun se1 ->
-                                   let uu____8515 =
-                                     let uu____8516 =
-                                       let uu____8517 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_Syntax_Util.lid_of_sigelt se1 in
-                                       FStar_Util.must uu____8517 in
-                                     FStar_Ident.lid_equals typ_lid
-                                       uu____8516 in
-                                   if uu____8515
+                                       FStar_Util.must uu___7 in
+                                     FStar_Ident.lid_equals typ_lid uu___6 in
+                                   if uu___5
                                    then
                                      match se1.FStar_Syntax_Syntax.sigel with
                                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                                         (uu____8536, uvs', tps, typ0,
-                                          uu____8540, constrs)
+                                         (uu___6, uvs', tps, typ0, uu___7,
+                                          constrs)
                                          ->
                                          FStar_Pervasives_Native.Some
                                            (tps, typ0,
                                              ((FStar_List.length constrs) >
                                                 Prims.int_one))
-                                     | uu____8557 -> failwith "Impossible"
+                                     | uu___6 -> failwith "Impossible"
                                    else FStar_Pervasives_Native.None) in
                             match tps_opt with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None ->
-                                let uu____8598 =
+                                let uu___5 =
                                   FStar_Ident.lid_equals typ_lid
                                     FStar_Parser_Const.exn_lid in
-                                if uu____8598
+                                if uu___5
                                 then ([], FStar_Syntax_Util.ktype0, true)
                                 else
                                   FStar_Errors.raise_error
                                     (FStar_Errors.Fatal_UnexpectedDataConstructor,
                                       "Unexpected data constructor")
                                     se.FStar_Syntax_Syntax.sigrng in
-                          (match uu____8483 with
+                          (match uu___4 with
                            | (inductive_tps, typ0, should_refine) ->
                                let inductive_tps1 =
                                  FStar_Syntax_Subst.subst_binders
                                    univ_opening inductive_tps in
                                let typ01 =
                                  FStar_Syntax_Subst.subst univ_opening typ0 in
-                               let uu____8625 =
+                               let uu___5 =
                                  FStar_Syntax_Util.arrow_formals typ01 in
-                               (match uu____8625 with
-                                | (indices, uu____8635) ->
+                               (match uu___5 with
+                                | (indices, uu___6) ->
                                     let refine_domain =
-                                      let uu____8641 =
+                                      let uu___7 =
                                         FStar_All.pipe_right
                                           se.FStar_Syntax_Syntax.sigquals
                                           (FStar_Util.for_some
-                                             (fun uu___6_8646 ->
-                                                match uu___6_8646 with
+                                             (fun uu___8 ->
+                                                match uu___8 with
                                                 | FStar_Syntax_Syntax.RecordConstructor
-                                                    uu____8647 -> true
-                                                | uu____8656 -> false)) in
-                                      if uu____8641
-                                      then false
-                                      else should_refine in
+                                                    uu___9 -> true
+                                                | uu___9 -> false)) in
+                                      if uu___7 then false else should_refine in
                                     let fv_qual =
-                                      let filter_records uu___7_8666 =
-                                        match uu___7_8666 with
+                                      let filter_records uu___7 =
+                                        match uu___7 with
                                         | FStar_Syntax_Syntax.RecordConstructor
-                                            (uu____8669, fns) ->
+                                            (uu___8, fns) ->
                                             FStar_Pervasives_Native.Some
                                               (FStar_Syntax_Syntax.Record_ctor
                                                  (typ_lid, fns))
-                                        | uu____8681 ->
+                                        | uu___8 ->
                                             FStar_Pervasives_Native.None in
-                                      let uu____8682 =
+                                      let uu___7 =
                                         FStar_Util.find_map
                                           se.FStar_Syntax_Syntax.sigquals
                                           filter_records in
-                                      match uu____8682 with
+                                      match uu___7 with
                                       | FStar_Pervasives_Native.None ->
                                           FStar_Syntax_Syntax.Data_ctor
                                       | FStar_Pervasives_Native.Some q -> q in
                                     let fields =
-                                      let uu____8687 =
+                                      let uu___7 =
                                         FStar_Util.first_N n_typars formals in
-                                      match uu____8687 with
-                                      | (imp_tps, fields) ->
+                                      match uu___7 with
+                                      | (imp_tps, fields1) ->
                                           let rename =
                                             FStar_List.map2
-                                              (fun uu____8770 ->
-                                                 fun uu____8771 ->
-                                                   match (uu____8770,
-                                                           uu____8771)
+                                              (fun uu___8 ->
+                                                 fun uu___9 ->
+                                                   match (uu___8, uu___9)
                                                    with
-                                                   | ((x, uu____8797),
-                                                      (x', uu____8799)) ->
-                                                       let uu____8820 =
-                                                         let uu____8827 =
+                                                   | ((x, uu___10),
+                                                      (x', uu___11)) ->
+                                                       let uu___12 =
+                                                         let uu___13 =
                                                            FStar_Syntax_Syntax.bv_to_name
                                                              x' in
-                                                         (x, uu____8827) in
+                                                         (x, uu___13) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____8820) imp_tps
+                                                         uu___12) imp_tps
                                               inductive_tps1 in
                                           FStar_Syntax_Subst.subst_binders
-                                            rename fields in
+                                            rename fields1 in
                                     let erasable =
                                       FStar_Syntax_Util.has_attribute
                                         se.FStar_Syntax_Syntax.sigattrs
@@ -3424,4 +3345,4 @@ let (mk_data_operations :
                                       iquals attrs fv_qual refine_domain env
                                       typ_lid constr_lid uvs1 inductive_tps1
                                       indices fields erasable))))
-            | uu____8833 -> []
+            | uu___ -> []

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2,182 +2,155 @@ open Prims
 let (instantiate_both :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env ->
-    let uu___8_5 = env in
+    let uu___ = env in
     {
-      FStar_TypeChecker_Env.solver = (uu___8_5.FStar_TypeChecker_Env.solver);
-      FStar_TypeChecker_Env.range = (uu___8_5.FStar_TypeChecker_Env.range);
+      FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+      FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
       FStar_TypeChecker_Env.curmodule =
-        (uu___8_5.FStar_TypeChecker_Env.curmodule);
-      FStar_TypeChecker_Env.gamma = (uu___8_5.FStar_TypeChecker_Env.gamma);
+        (uu___.FStar_TypeChecker_Env.curmodule);
+      FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
       FStar_TypeChecker_Env.gamma_sig =
-        (uu___8_5.FStar_TypeChecker_Env.gamma_sig);
+        (uu___.FStar_TypeChecker_Env.gamma_sig);
       FStar_TypeChecker_Env.gamma_cache =
-        (uu___8_5.FStar_TypeChecker_Env.gamma_cache);
-      FStar_TypeChecker_Env.modules =
-        (uu___8_5.FStar_TypeChecker_Env.modules);
+        (uu___.FStar_TypeChecker_Env.gamma_cache);
+      FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
       FStar_TypeChecker_Env.expected_typ =
-        (uu___8_5.FStar_TypeChecker_Env.expected_typ);
-      FStar_TypeChecker_Env.sigtab = (uu___8_5.FStar_TypeChecker_Env.sigtab);
-      FStar_TypeChecker_Env.attrtab =
-        (uu___8_5.FStar_TypeChecker_Env.attrtab);
+        (uu___.FStar_TypeChecker_Env.expected_typ);
+      FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+      FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
       FStar_TypeChecker_Env.instantiate_imp = true;
-      FStar_TypeChecker_Env.effects =
-        (uu___8_5.FStar_TypeChecker_Env.effects);
+      FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
       FStar_TypeChecker_Env.generalize =
-        (uu___8_5.FStar_TypeChecker_Env.generalize);
-      FStar_TypeChecker_Env.letrecs =
-        (uu___8_5.FStar_TypeChecker_Env.letrecs);
+        (uu___.FStar_TypeChecker_Env.generalize);
+      FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
       FStar_TypeChecker_Env.top_level =
-        (uu___8_5.FStar_TypeChecker_Env.top_level);
+        (uu___.FStar_TypeChecker_Env.top_level);
       FStar_TypeChecker_Env.check_uvars =
-        (uu___8_5.FStar_TypeChecker_Env.check_uvars);
-      FStar_TypeChecker_Env.use_eq = (uu___8_5.FStar_TypeChecker_Env.use_eq);
+        (uu___.FStar_TypeChecker_Env.check_uvars);
+      FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
       FStar_TypeChecker_Env.use_eq_strict =
-        (uu___8_5.FStar_TypeChecker_Env.use_eq_strict);
-      FStar_TypeChecker_Env.is_iface =
-        (uu___8_5.FStar_TypeChecker_Env.is_iface);
-      FStar_TypeChecker_Env.admit = (uu___8_5.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (uu___8_5.FStar_TypeChecker_Env.lax);
+        (uu___.FStar_TypeChecker_Env.use_eq_strict);
+      FStar_TypeChecker_Env.is_iface = (uu___.FStar_TypeChecker_Env.is_iface);
+      FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+      FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
       FStar_TypeChecker_Env.lax_universes =
-        (uu___8_5.FStar_TypeChecker_Env.lax_universes);
-      FStar_TypeChecker_Env.phase1 = (uu___8_5.FStar_TypeChecker_Env.phase1);
-      FStar_TypeChecker_Env.failhard =
-        (uu___8_5.FStar_TypeChecker_Env.failhard);
-      FStar_TypeChecker_Env.nosynth =
-        (uu___8_5.FStar_TypeChecker_Env.nosynth);
+        (uu___.FStar_TypeChecker_Env.lax_universes);
+      FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
+      FStar_TypeChecker_Env.failhard = (uu___.FStar_TypeChecker_Env.failhard);
+      FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
       FStar_TypeChecker_Env.uvar_subtyping =
-        (uu___8_5.FStar_TypeChecker_Env.uvar_subtyping);
-      FStar_TypeChecker_Env.tc_term =
-        (uu___8_5.FStar_TypeChecker_Env.tc_term);
-      FStar_TypeChecker_Env.type_of =
-        (uu___8_5.FStar_TypeChecker_Env.type_of);
+        (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+      FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+      FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
       FStar_TypeChecker_Env.universe_of =
-        (uu___8_5.FStar_TypeChecker_Env.universe_of);
+        (uu___.FStar_TypeChecker_Env.universe_of);
       FStar_TypeChecker_Env.check_type_of =
-        (uu___8_5.FStar_TypeChecker_Env.check_type_of);
+        (uu___.FStar_TypeChecker_Env.check_type_of);
       FStar_TypeChecker_Env.use_bv_sorts =
-        (uu___8_5.FStar_TypeChecker_Env.use_bv_sorts);
+        (uu___.FStar_TypeChecker_Env.use_bv_sorts);
       FStar_TypeChecker_Env.qtbl_name_and_index =
-        (uu___8_5.FStar_TypeChecker_Env.qtbl_name_and_index);
+        (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
       FStar_TypeChecker_Env.normalized_eff_names =
-        (uu___8_5.FStar_TypeChecker_Env.normalized_eff_names);
+        (uu___.FStar_TypeChecker_Env.normalized_eff_names);
       FStar_TypeChecker_Env.fv_delta_depths =
-        (uu___8_5.FStar_TypeChecker_Env.fv_delta_depths);
-      FStar_TypeChecker_Env.proof_ns =
-        (uu___8_5.FStar_TypeChecker_Env.proof_ns);
+        (uu___.FStar_TypeChecker_Env.fv_delta_depths);
+      FStar_TypeChecker_Env.proof_ns = (uu___.FStar_TypeChecker_Env.proof_ns);
       FStar_TypeChecker_Env.synth_hook =
-        (uu___8_5.FStar_TypeChecker_Env.synth_hook);
+        (uu___.FStar_TypeChecker_Env.synth_hook);
       FStar_TypeChecker_Env.try_solve_implicits_hook =
-        (uu___8_5.FStar_TypeChecker_Env.try_solve_implicits_hook);
-      FStar_TypeChecker_Env.splice = (uu___8_5.FStar_TypeChecker_Env.splice);
+        (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+      FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
       FStar_TypeChecker_Env.mpreprocess =
-        (uu___8_5.FStar_TypeChecker_Env.mpreprocess);
+        (uu___.FStar_TypeChecker_Env.mpreprocess);
       FStar_TypeChecker_Env.postprocess =
-        (uu___8_5.FStar_TypeChecker_Env.postprocess);
+        (uu___.FStar_TypeChecker_Env.postprocess);
       FStar_TypeChecker_Env.identifier_info =
-        (uu___8_5.FStar_TypeChecker_Env.identifier_info);
-      FStar_TypeChecker_Env.tc_hooks =
-        (uu___8_5.FStar_TypeChecker_Env.tc_hooks);
-      FStar_TypeChecker_Env.dsenv = (uu___8_5.FStar_TypeChecker_Env.dsenv);
-      FStar_TypeChecker_Env.nbe = (uu___8_5.FStar_TypeChecker_Env.nbe);
+        (uu___.FStar_TypeChecker_Env.identifier_info);
+      FStar_TypeChecker_Env.tc_hooks = (uu___.FStar_TypeChecker_Env.tc_hooks);
+      FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+      FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
       FStar_TypeChecker_Env.strict_args_tab =
-        (uu___8_5.FStar_TypeChecker_Env.strict_args_tab);
+        (uu___.FStar_TypeChecker_Env.strict_args_tab);
       FStar_TypeChecker_Env.erasable_types_tab =
-        (uu___8_5.FStar_TypeChecker_Env.erasable_types_tab);
+        (uu___.FStar_TypeChecker_Env.erasable_types_tab);
       FStar_TypeChecker_Env.enable_defer_to_tac =
-        (uu___8_5.FStar_TypeChecker_Env.enable_defer_to_tac)
+        (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
     }
 let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env ->
-    let uu___11_11 = env in
+    let uu___ = env in
     {
-      FStar_TypeChecker_Env.solver =
-        (uu___11_11.FStar_TypeChecker_Env.solver);
-      FStar_TypeChecker_Env.range = (uu___11_11.FStar_TypeChecker_Env.range);
+      FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+      FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
       FStar_TypeChecker_Env.curmodule =
-        (uu___11_11.FStar_TypeChecker_Env.curmodule);
-      FStar_TypeChecker_Env.gamma = (uu___11_11.FStar_TypeChecker_Env.gamma);
+        (uu___.FStar_TypeChecker_Env.curmodule);
+      FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
       FStar_TypeChecker_Env.gamma_sig =
-        (uu___11_11.FStar_TypeChecker_Env.gamma_sig);
+        (uu___.FStar_TypeChecker_Env.gamma_sig);
       FStar_TypeChecker_Env.gamma_cache =
-        (uu___11_11.FStar_TypeChecker_Env.gamma_cache);
-      FStar_TypeChecker_Env.modules =
-        (uu___11_11.FStar_TypeChecker_Env.modules);
+        (uu___.FStar_TypeChecker_Env.gamma_cache);
+      FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
       FStar_TypeChecker_Env.expected_typ =
-        (uu___11_11.FStar_TypeChecker_Env.expected_typ);
-      FStar_TypeChecker_Env.sigtab =
-        (uu___11_11.FStar_TypeChecker_Env.sigtab);
-      FStar_TypeChecker_Env.attrtab =
-        (uu___11_11.FStar_TypeChecker_Env.attrtab);
+        (uu___.FStar_TypeChecker_Env.expected_typ);
+      FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+      FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
       FStar_TypeChecker_Env.instantiate_imp = false;
-      FStar_TypeChecker_Env.effects =
-        (uu___11_11.FStar_TypeChecker_Env.effects);
+      FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
       FStar_TypeChecker_Env.generalize =
-        (uu___11_11.FStar_TypeChecker_Env.generalize);
-      FStar_TypeChecker_Env.letrecs =
-        (uu___11_11.FStar_TypeChecker_Env.letrecs);
+        (uu___.FStar_TypeChecker_Env.generalize);
+      FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
       FStar_TypeChecker_Env.top_level =
-        (uu___11_11.FStar_TypeChecker_Env.top_level);
+        (uu___.FStar_TypeChecker_Env.top_level);
       FStar_TypeChecker_Env.check_uvars =
-        (uu___11_11.FStar_TypeChecker_Env.check_uvars);
-      FStar_TypeChecker_Env.use_eq =
-        (uu___11_11.FStar_TypeChecker_Env.use_eq);
+        (uu___.FStar_TypeChecker_Env.check_uvars);
+      FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
       FStar_TypeChecker_Env.use_eq_strict =
-        (uu___11_11.FStar_TypeChecker_Env.use_eq_strict);
-      FStar_TypeChecker_Env.is_iface =
-        (uu___11_11.FStar_TypeChecker_Env.is_iface);
-      FStar_TypeChecker_Env.admit = (uu___11_11.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (uu___11_11.FStar_TypeChecker_Env.lax);
+        (uu___.FStar_TypeChecker_Env.use_eq_strict);
+      FStar_TypeChecker_Env.is_iface = (uu___.FStar_TypeChecker_Env.is_iface);
+      FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+      FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
       FStar_TypeChecker_Env.lax_universes =
-        (uu___11_11.FStar_TypeChecker_Env.lax_universes);
-      FStar_TypeChecker_Env.phase1 =
-        (uu___11_11.FStar_TypeChecker_Env.phase1);
-      FStar_TypeChecker_Env.failhard =
-        (uu___11_11.FStar_TypeChecker_Env.failhard);
-      FStar_TypeChecker_Env.nosynth =
-        (uu___11_11.FStar_TypeChecker_Env.nosynth);
+        (uu___.FStar_TypeChecker_Env.lax_universes);
+      FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
+      FStar_TypeChecker_Env.failhard = (uu___.FStar_TypeChecker_Env.failhard);
+      FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
       FStar_TypeChecker_Env.uvar_subtyping =
-        (uu___11_11.FStar_TypeChecker_Env.uvar_subtyping);
-      FStar_TypeChecker_Env.tc_term =
-        (uu___11_11.FStar_TypeChecker_Env.tc_term);
-      FStar_TypeChecker_Env.type_of =
-        (uu___11_11.FStar_TypeChecker_Env.type_of);
+        (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+      FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+      FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
       FStar_TypeChecker_Env.universe_of =
-        (uu___11_11.FStar_TypeChecker_Env.universe_of);
+        (uu___.FStar_TypeChecker_Env.universe_of);
       FStar_TypeChecker_Env.check_type_of =
-        (uu___11_11.FStar_TypeChecker_Env.check_type_of);
+        (uu___.FStar_TypeChecker_Env.check_type_of);
       FStar_TypeChecker_Env.use_bv_sorts =
-        (uu___11_11.FStar_TypeChecker_Env.use_bv_sorts);
+        (uu___.FStar_TypeChecker_Env.use_bv_sorts);
       FStar_TypeChecker_Env.qtbl_name_and_index =
-        (uu___11_11.FStar_TypeChecker_Env.qtbl_name_and_index);
+        (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
       FStar_TypeChecker_Env.normalized_eff_names =
-        (uu___11_11.FStar_TypeChecker_Env.normalized_eff_names);
+        (uu___.FStar_TypeChecker_Env.normalized_eff_names);
       FStar_TypeChecker_Env.fv_delta_depths =
-        (uu___11_11.FStar_TypeChecker_Env.fv_delta_depths);
-      FStar_TypeChecker_Env.proof_ns =
-        (uu___11_11.FStar_TypeChecker_Env.proof_ns);
+        (uu___.FStar_TypeChecker_Env.fv_delta_depths);
+      FStar_TypeChecker_Env.proof_ns = (uu___.FStar_TypeChecker_Env.proof_ns);
       FStar_TypeChecker_Env.synth_hook =
-        (uu___11_11.FStar_TypeChecker_Env.synth_hook);
+        (uu___.FStar_TypeChecker_Env.synth_hook);
       FStar_TypeChecker_Env.try_solve_implicits_hook =
-        (uu___11_11.FStar_TypeChecker_Env.try_solve_implicits_hook);
-      FStar_TypeChecker_Env.splice =
-        (uu___11_11.FStar_TypeChecker_Env.splice);
+        (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+      FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
       FStar_TypeChecker_Env.mpreprocess =
-        (uu___11_11.FStar_TypeChecker_Env.mpreprocess);
+        (uu___.FStar_TypeChecker_Env.mpreprocess);
       FStar_TypeChecker_Env.postprocess =
-        (uu___11_11.FStar_TypeChecker_Env.postprocess);
+        (uu___.FStar_TypeChecker_Env.postprocess);
       FStar_TypeChecker_Env.identifier_info =
-        (uu___11_11.FStar_TypeChecker_Env.identifier_info);
-      FStar_TypeChecker_Env.tc_hooks =
-        (uu___11_11.FStar_TypeChecker_Env.tc_hooks);
-      FStar_TypeChecker_Env.dsenv = (uu___11_11.FStar_TypeChecker_Env.dsenv);
-      FStar_TypeChecker_Env.nbe = (uu___11_11.FStar_TypeChecker_Env.nbe);
+        (uu___.FStar_TypeChecker_Env.identifier_info);
+      FStar_TypeChecker_Env.tc_hooks = (uu___.FStar_TypeChecker_Env.tc_hooks);
+      FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+      FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
       FStar_TypeChecker_Env.strict_args_tab =
-        (uu___11_11.FStar_TypeChecker_Env.strict_args_tab);
+        (uu___.FStar_TypeChecker_Env.strict_args_tab);
       FStar_TypeChecker_Env.erasable_types_tab =
-        (uu___11_11.FStar_TypeChecker_Env.erasable_types_tab);
+        (uu___.FStar_TypeChecker_Env.erasable_types_tab);
       FStar_TypeChecker_Env.enable_defer_to_tac =
-        (uu___11_11.FStar_TypeChecker_Env.enable_defer_to_tac)
+        (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
     }
 let (mk_lex_list :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list ->
@@ -193,23 +166,22 @@ let (mk_lex_list :
              else
                FStar_Range.union_ranges v.FStar_Syntax_Syntax.pos
                  tl.FStar_Syntax_Syntax.pos in
-           let uu____43 =
-             let uu____44 = FStar_Syntax_Syntax.as_arg v in
-             let uu____53 =
-               let uu____64 = FStar_Syntax_Syntax.as_arg tl in [uu____64] in
-             uu____44 :: uu____53 in
-           FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair uu____43
-             r) vs FStar_Syntax_Util.lex_top
+           let uu___ =
+             let uu___1 = FStar_Syntax_Syntax.as_arg v in
+             let uu___2 =
+               let uu___3 = FStar_Syntax_Syntax.as_arg tl in [uu___3] in
+             uu___1 :: uu___2 in
+           FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair uu___ r)
+      vs FStar_Syntax_Util.lex_top
 let (is_eq :
   FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
     Prims.bool)
   =
-  fun uu___0_103 ->
-    match uu___0_103 with
+  fun uu___ ->
+    match uu___ with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality) -> true
-    | uu____106 -> false
-let steps : 'uuuuuu113 . 'uuuuuu113 -> FStar_TypeChecker_Env.step Prims.list
-  =
+    | uu___1 -> false
+let steps : 'uuuuu . 'uuuuu -> FStar_TypeChecker_Env.step Prims.list =
   fun env ->
     [FStar_TypeChecker_Env.Beta;
     FStar_TypeChecker_Env.Eager_unfolding;
@@ -239,66 +211,65 @@ let (check_no_escape :
           let rec aux try_norm t =
             match fvs with
             | [] -> (t, FStar_TypeChecker_Env.trivial_guard)
-            | uu____196 ->
+            | uu___ ->
                 let t1 = if try_norm then norm env t else t in
                 let fvs' = FStar_Syntax_Free.names t1 in
-                let uu____208 =
+                let uu___1 =
                   FStar_List.tryFind (fun x -> FStar_Util.set_mem x fvs') fvs in
-                (match uu____208 with
+                (match uu___1 with
                  | FStar_Pervasives_Native.None ->
                      (t1, FStar_TypeChecker_Env.trivial_guard)
                  | FStar_Pervasives_Native.Some x ->
                      if Prims.op_Negation try_norm
                      then aux true t1
                      else
-                       (let fail uu____232 =
+                       (let fail uu___3 =
                           let msg =
                             match head_opt with
                             | FStar_Pervasives_Native.None ->
-                                let uu____234 =
+                                let uu___4 =
                                   FStar_Syntax_Print.bv_to_string x in
                                 FStar_Util.format1
                                   "Bound variables '%s' escapes; add a type annotation"
-                                  uu____234
+                                  uu___4
                             | FStar_Pervasives_Native.Some head ->
-                                let uu____236 =
+                                let uu___4 =
                                   FStar_Syntax_Print.bv_to_string x in
-                                let uu____237 =
+                                let uu___5 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env head in
                                 FStar_Util.format2
                                   "Bound variables '%s' in the type of '%s' escape because of impure applications; add explicit let-bindings"
-                                  uu____236 uu____237 in
-                          let uu____238 = FStar_TypeChecker_Env.get_range env in
+                                  uu___4 uu___5 in
+                          let uu___4 = FStar_TypeChecker_Env.get_range env in
                           FStar_Errors.raise_error
-                            (FStar_Errors.Fatal_EscapedBoundVar, msg)
-                            uu____238 in
-                        let uu____243 =
-                          let uu____256 = FStar_TypeChecker_Env.get_range env in
-                          let uu____257 =
-                            let uu____258 = FStar_Syntax_Util.type_u () in
+                            (FStar_Errors.Fatal_EscapedBoundVar, msg) uu___4 in
+                        let uu___3 =
+                          let uu___4 = FStar_TypeChecker_Env.get_range env in
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Util.type_u () in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____258 in
+                              uu___6 in
                           FStar_TypeChecker_Util.new_implicit_var "no escape"
-                            uu____256 env uu____257 in
-                        match uu____243 with
-                        | (s, uu____272, g0) ->
-                            let uu____286 =
+                            uu___4 env uu___5 in
+                        match uu___3 with
+                        | (s, uu___4, g0) ->
+                            let uu___5 =
                               FStar_TypeChecker_Rel.try_teq true env t1 s in
-                            (match uu____286 with
+                            (match uu___5 with
                              | FStar_Pervasives_Native.Some g ->
                                  let g1 =
-                                   let uu____295 =
+                                   let uu___6 =
                                      FStar_TypeChecker_Env.conj_guard g g0 in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____295 in
+                                     env uu___6 in
                                  (s, g1)
-                             | uu____296 -> fail ()))) in
+                             | uu___6 -> fail ()))) in
           aux false kt
 let push_binding :
-  'uuuuuu305 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu305) -> FStar_TypeChecker_Env.env
+      (FStar_Syntax_Syntax.bv * 'uuuuu) -> FStar_TypeChecker_Env.env
   =
   fun env ->
     fun b ->
@@ -313,8 +284,8 @@ let (maybe_extend_subst :
   fun s ->
     fun b ->
       fun v ->
-        let uu____359 = FStar_Syntax_Syntax.is_null_binder b in
-        if uu____359
+        let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+        if uu___
         then s
         else (FStar_Syntax_Syntax.NT ((FStar_Pervasives_Native.fst b), v)) ::
           s
@@ -327,15 +298,15 @@ let (set_lcomp_result :
     fun t ->
       FStar_TypeChecker_Common.apply_lcomp
         (fun c -> FStar_Syntax_Util.set_result_typ c t) (fun g -> g)
-        (let uu___66_385 = lc in
+        (let uu___ = lc in
          {
            FStar_TypeChecker_Common.eff_name =
-             (uu___66_385.FStar_TypeChecker_Common.eff_name);
+             (uu___.FStar_TypeChecker_Common.eff_name);
            FStar_TypeChecker_Common.res_typ = t;
            FStar_TypeChecker_Common.cflags =
-             (uu___66_385.FStar_TypeChecker_Common.cflags);
+             (uu___.FStar_TypeChecker_Common.cflags);
            FStar_TypeChecker_Common.comp_thunk =
-             (uu___66_385.FStar_TypeChecker_Common.comp_thunk)
+             (uu___.FStar_TypeChecker_Common.comp_thunk)
          })
 let (memo_tk :
   FStar_Syntax_Syntax.term ->
@@ -345,29 +316,29 @@ let (maybe_warn_on_use :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.fv -> unit) =
   fun env ->
     fun fv ->
-      let uu____406 =
+      let uu___ =
         FStar_TypeChecker_Env.lookup_attrs_of_lid env
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      match uu____406 with
+      match uu___ with
       | FStar_Pervasives_Native.None -> ()
       | FStar_Pervasives_Native.Some attrs ->
           FStar_All.pipe_right attrs
             (FStar_List.iter
                (fun a ->
-                  let uu____429 = FStar_Syntax_Util.head_and_args a in
-                  match uu____429 with
+                  let uu___1 = FStar_Syntax_Util.head_and_args a in
+                  match uu___1 with
                   | (head, args) ->
                       let msg_arg m =
                         match args with
                         | ({
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_string (s, uu____479));
-                             FStar_Syntax_Syntax.pos = uu____480;
-                             FStar_Syntax_Syntax.vars = uu____481;_},
-                           uu____482)::[] ->
+                               (FStar_Const.Const_string (s, uu___2));
+                             FStar_Syntax_Syntax.pos = uu___3;
+                             FStar_Syntax_Syntax.vars = uu___4;_},
+                           uu___5)::[] ->
                             Prims.op_Hat m (Prims.op_Hat ": " s)
-                        | uu____507 -> m in
+                        | uu___2 -> m in
                       (match head.FStar_Syntax_Syntax.n with
                        | FStar_Syntax_Syntax.Tm_fvar attr_fv when
                            FStar_Ident.lid_equals
@@ -375,15 +346,15 @@ let (maybe_warn_on_use :
                              FStar_Parser_Const.warn_on_use_attr
                            ->
                            let m =
-                             let uu____520 =
+                             let uu___2 =
                                FStar_Ident.string_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                              FStar_Util.format1
-                               "Every use of %s triggers a warning" uu____520 in
-                           let uu____521 =
+                               "Every use of %s triggers a warning" uu___2 in
+                           let uu___2 =
                              FStar_Ident.range_of_lid
                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           FStar_Errors.log_issue uu____521
+                           FStar_Errors.log_issue uu___2
                              (FStar_Errors.Warning_WarnOnUse, (msg_arg m))
                        | FStar_Syntax_Syntax.Tm_fvar attr_fv when
                            FStar_Ident.lid_equals
@@ -391,17 +362,17 @@ let (maybe_warn_on_use :
                              FStar_Parser_Const.deprecated_attr
                            ->
                            let m =
-                             let uu____524 =
+                             let uu___2 =
                                FStar_Ident.string_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                             FStar_Util.format1 "%s is deprecated" uu____524 in
-                           let uu____525 =
+                             FStar_Util.format1 "%s is deprecated" uu___2 in
+                           let uu___2 =
                              FStar_Ident.range_of_lid
                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           FStar_Errors.log_issue uu____525
+                           FStar_Errors.log_issue uu___2
                              (FStar_Errors.Warning_DeprecatedDefinition,
                                (msg_arg m))
-                       | uu____526 -> ())))
+                       | uu___2 -> ())))
 let (value_check_expected_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -420,58 +391,57 @@ let (value_check_expected_typ :
           (let lc =
              match tlc with
              | FStar_Util.Inl t ->
-                 let uu____570 = FStar_Syntax_Syntax.mk_Total t in
+                 let uu___1 = FStar_Syntax_Syntax.mk_Total t in
                  FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                   uu____570
-             | FStar_Util.Inr lc -> lc in
+                   uu___1
+             | FStar_Util.Inr lc1 -> lc1 in
            let t = lc.FStar_TypeChecker_Common.res_typ in
-           let uu____573 =
-             let uu____580 = FStar_TypeChecker_Env.expected_typ env in
-             match uu____580 with
+           let uu___1 =
+             let uu___2 = FStar_TypeChecker_Env.expected_typ env in
+             match uu___2 with
              | FStar_Pervasives_Native.None -> ((memo_tk e t), lc, guard)
              | FStar_Pervasives_Native.Some t' ->
-                 let uu____590 =
+                 let uu___3 =
                    FStar_TypeChecker_Util.check_has_type env e lc t' in
-                 (match uu____590 with
+                 (match uu___3 with
                   | (e1, lc1, g) ->
-                      ((let uu____607 =
+                      ((let uu___5 =
                           FStar_TypeChecker_Env.debug env
                             FStar_Options.Medium in
-                        if uu____607
+                        if uu___5
                         then
-                          let uu____608 =
+                          let uu___6 =
                             FStar_TypeChecker_Common.lcomp_to_string lc1 in
-                          let uu____609 =
-                            FStar_Syntax_Print.term_to_string t' in
-                          let uu____610 =
+                          let uu___7 = FStar_Syntax_Print.term_to_string t' in
+                          let uu___8 =
                             FStar_TypeChecker_Rel.guard_to_string env g in
-                          let uu____611 =
+                          let uu___9 =
                             FStar_TypeChecker_Rel.guard_to_string env guard in
                           FStar_Util.print4
                             "value_check_expected_typ: type is %s<:%s \tguard is %s, %s\n"
-                            uu____608 uu____609 uu____610 uu____611
+                            uu___6 uu___7 uu___8 uu___9
                         else ());
                        (let t1 = lc1.FStar_TypeChecker_Common.res_typ in
                         let g1 = FStar_TypeChecker_Env.conj_guard g guard in
                         let msg =
-                          let uu____621 =
+                          let uu___5 =
                             FStar_TypeChecker_Env.is_trivial_guard_formula g1 in
-                          if uu____621
+                          if uu___5
                           then FStar_Pervasives_Native.None
                           else
                             FStar_All.pipe_left
-                              (fun uu____642 ->
-                                 FStar_Pervasives_Native.Some uu____642)
+                              (fun uu___7 ->
+                                 FStar_Pervasives_Native.Some uu___7)
                               (FStar_TypeChecker_Err.subtyping_failed env t1
                                  t') in
-                        let uu____643 =
+                        let uu___5 =
                           FStar_TypeChecker_Util.strengthen_precondition msg
                             env e1 lc1 g1 in
-                        match uu____643 with
+                        match uu___5 with
                         | (lc2, g2) ->
-                            let uu____656 = set_lcomp_result lc2 t' in
-                            ((memo_tk e1 t'), uu____656, g2)))) in
-           match uu____573 with | (e1, lc1, g) -> (e1, lc1, g))
+                            let uu___6 = set_lcomp_result lc2 t' in
+                            ((memo_tk e1 t'), uu___6, g2)))) in
+           match uu___1 with | (e1, lc1, g) -> (e1, lc1, g))
 let (comp_check_expected_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -482,20 +452,20 @@ let (comp_check_expected_typ :
   fun env ->
     fun e ->
       fun lc ->
-        let uu____693 = FStar_TypeChecker_Env.expected_typ env in
-        match uu____693 with
+        let uu___ = FStar_TypeChecker_Env.expected_typ env in
+        match uu___ with
         | FStar_Pervasives_Native.None ->
             (e, lc, FStar_TypeChecker_Env.trivial_guard)
         | FStar_Pervasives_Native.Some t ->
-            let uu____703 = FStar_TypeChecker_Util.maybe_coerce_lc env e lc t in
-            (match uu____703 with
+            let uu___1 = FStar_TypeChecker_Util.maybe_coerce_lc env e lc t in
+            (match uu___1 with
              | (e1, lc1, g_c) ->
-                 let uu____719 =
+                 let uu___2 =
                    FStar_TypeChecker_Util.weaken_result_typ env e1 lc1 t in
-                 (match uu____719 with
+                 (match uu___2 with
                   | (e2, lc2, g) ->
-                      let uu____735 = FStar_TypeChecker_Env.conj_guard g g_c in
-                      (e2, lc2, uu____735)))
+                      let uu___3 = FStar_TypeChecker_Env.conj_guard g g_c in
+                      (e2, lc2, uu___3)))
 let (check_expected_effect :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp FStar_Pervasives_Native.option ->
@@ -506,29 +476,29 @@ let (check_expected_effect :
   fun env ->
     fun copt ->
       fun ec ->
-        let uu____775 = ec in
-        match uu____775 with
+        let uu___ = ec in
+        match uu___ with
         | (e, c) ->
             let tot_or_gtot c1 =
-              let uu____798 = FStar_Syntax_Util.is_pure_comp c1 in
-              if uu____798
+              let uu___1 = FStar_Syntax_Util.is_pure_comp c1 in
+              if uu___1
               then
                 FStar_Syntax_Syntax.mk_Total
                   (FStar_Syntax_Util.comp_result c1)
               else
-                (let uu____800 = FStar_Syntax_Util.is_pure_or_ghost_comp c1 in
-                 if uu____800
+                (let uu___3 = FStar_Syntax_Util.is_pure_or_ghost_comp c1 in
+                 if uu___3
                  then
                    FStar_Syntax_Syntax.mk_GTotal
                      (FStar_Syntax_Util.comp_result c1)
                  else failwith "Impossible: Expected pure_or_ghost comp") in
-            let uu____802 =
+            let uu___1 =
               let ct = FStar_Syntax_Util.comp_result c in
               match copt with
-              | FStar_Pervasives_Native.Some uu____826 ->
+              | FStar_Pervasives_Native.Some uu___2 ->
                   (copt, c, FStar_Pervasives_Native.None)
               | FStar_Pervasives_Native.None ->
-                  let uu____831 =
+                  let uu___2 =
                     ((FStar_Options.ml_ish ()) &&
                        (FStar_Ident.lid_equals
                           FStar_Parser_Const.effect_ALL_lid
@@ -537,78 +507,78 @@ let (check_expected_effect :
                       (((FStar_Options.ml_ish ()) &&
                           env.FStar_TypeChecker_Env.lax)
                          &&
-                         (let uu____833 =
+                         (let uu___3 =
                             FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                          Prims.op_Negation uu____833)) in
-                  if uu____831
+                          Prims.op_Negation uu___3)) in
+                  if uu___2
                   then
-                    let uu____844 =
-                      let uu____847 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Util.ml_comp ct
                           e.FStar_Syntax_Syntax.pos in
-                      FStar_Pervasives_Native.Some uu____847 in
-                    (uu____844, c, FStar_Pervasives_Native.None)
+                      FStar_Pervasives_Native.Some uu___4 in
+                    (uu___3, c, FStar_Pervasives_Native.None)
                   else
-                    (let uu____853 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                     if uu____853
+                    (let uu___4 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
+                     if uu___4
                      then
-                       let uu____864 = tot_or_gtot c in
-                       (FStar_Pervasives_Native.None, uu____864,
+                       let uu___5 = tot_or_gtot c in
+                       (FStar_Pervasives_Native.None, uu___5,
                          FStar_Pervasives_Native.None)
                      else
-                       (let uu____870 =
+                       (let uu___6 =
                           FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                        if uu____870
+                        if uu___6
                         then
-                          let uu____881 =
-                            let uu____884 = tot_or_gtot c in
-                            FStar_Pervasives_Native.Some uu____884 in
-                          (uu____881, c, FStar_Pervasives_Native.None)
+                          let uu___7 =
+                            let uu___8 = tot_or_gtot c in
+                            FStar_Pervasives_Native.Some uu___8 in
+                          (uu___7, c, FStar_Pervasives_Native.None)
                         else
-                          (let uu____890 =
-                             let uu____891 =
+                          (let uu___8 =
+                             let uu___9 =
                                FStar_All.pipe_right
                                  (FStar_Syntax_Util.comp_effect_name c)
                                  (FStar_TypeChecker_Env.norm_eff_name env) in
-                             FStar_All.pipe_right uu____891
+                             FStar_All.pipe_right uu___9
                                (FStar_TypeChecker_Env.is_layered_effect env) in
-                           if uu____890
+                           if uu___8
                            then
-                             let uu____902 =
-                               let uu____907 =
-                                 let uu____908 =
-                                   let uu____909 =
+                             let uu___9 =
+                               let uu___10 =
+                                 let uu___11 =
+                                   let uu___12 =
                                      FStar_All.pipe_right c
                                        FStar_Syntax_Util.comp_effect_name in
-                                   FStar_All.pipe_right uu____909
+                                   FStar_All.pipe_right uu___12
                                      FStar_Ident.string_of_lid in
-                                 let uu____912 =
+                                 let uu___12 =
                                    FStar_Range.string_of_range
                                      e.FStar_Syntax_Syntax.pos in
                                  FStar_Util.format2
                                    "Missing annotation for a layered effect (%s) computation at %s"
-                                   uu____908 uu____912 in
-                               (FStar_Errors.Fatal_IllTyped, uu____907) in
-                             FStar_Errors.raise_error uu____902
+                                   uu___11 uu___12 in
+                               (FStar_Errors.Fatal_IllTyped, uu___10) in
+                             FStar_Errors.raise_error uu___9
                                e.FStar_Syntax_Syntax.pos
                            else
-                             (let uu____924 =
+                             (let uu___10 =
                                 FStar_Options.trivial_pre_for_unannotated_effectful_fns
                                   () in
-                              if uu____924
+                              if uu___10
                               then
-                                let uu____935 =
-                                  let uu____938 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_TypeChecker_Util.check_trivial_precondition
                                       env c in
-                                  match uu____938 with
-                                  | (uu____947, uu____948, g) ->
+                                  match uu___12 with
+                                  | (uu___13, uu___14, g) ->
                                       FStar_Pervasives_Native.Some g in
-                                (FStar_Pervasives_Native.None, c, uu____935)
+                                (FStar_Pervasives_Native.None, c, uu___11)
                               else
                                 (FStar_Pervasives_Native.None, c,
                                   FStar_Pervasives_Native.None))))) in
-            (match uu____802 with
+            (match uu___1 with
              | (expected_c_opt, c1, gopt) ->
                  let c2 = norm_c env c1 in
                  (match expected_c_opt with
@@ -621,60 +591,58 @@ let (check_expected_effect :
                   | FStar_Pervasives_Native.Some expected_c ->
                       ((match gopt with
                         | FStar_Pervasives_Native.None -> ()
-                        | FStar_Pervasives_Native.Some uu____986 ->
+                        | FStar_Pervasives_Native.Some uu___3 ->
                             failwith
                               "Impossible! check_expected_effect, gopt should have been None");
                        (let c3 =
-                          let uu____988 =
+                          let uu___3 =
                             FStar_TypeChecker_Common.lcomp_of_comp c2 in
                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                            env e uu____988 in
-                        let uu____989 =
-                          FStar_TypeChecker_Common.lcomp_comp c3 in
-                        match uu____989 with
+                            env e uu___3 in
+                        let uu___3 = FStar_TypeChecker_Common.lcomp_comp c3 in
+                        match uu___3 with
                         | (c4, g_c) ->
-                            ((let uu____1003 =
+                            ((let uu___5 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Medium in
-                              if uu____1003
+                              if uu___5
                               then
-                                let uu____1004 =
+                                let uu___6 =
                                   FStar_Syntax_Print.term_to_string e in
-                                let uu____1005 =
+                                let uu___7 =
                                   FStar_Syntax_Print.comp_to_string c4 in
-                                let uu____1006 =
+                                let uu___8 =
                                   FStar_Syntax_Print.comp_to_string
                                     expected_c in
                                 FStar_Util.print3
                                   "In check_expected_effect, asking rel to solve the problem on e=(%s) and c=(%s) and expected_c=(%s)\n"
-                                  uu____1004 uu____1005 uu____1006
+                                  uu___6 uu___7 uu___8
                               else ());
-                             (let uu____1008 =
+                             (let uu___5 =
                                 FStar_TypeChecker_Util.check_comp env e c4
                                   expected_c in
-                              match uu____1008 with
-                              | (e1, uu____1022, g) ->
+                              match uu___5 with
+                              | (e1, uu___6, g) ->
                                   let g1 =
-                                    let uu____1025 =
+                                    let uu___7 =
                                       FStar_TypeChecker_Env.get_range env in
-                                    FStar_TypeChecker_Util.label_guard
-                                      uu____1025
+                                    FStar_TypeChecker_Util.label_guard uu___7
                                       "could not prove post-condition" g in
-                                  ((let uu____1027 =
+                                  ((let uu___8 =
                                       FStar_TypeChecker_Env.debug env
                                         FStar_Options.Medium in
-                                    if uu____1027
+                                    if uu___8
                                     then
-                                      let uu____1028 =
+                                      let uu___9 =
                                         FStar_Range.string_of_range
                                           e1.FStar_Syntax_Syntax.pos in
-                                      let uu____1029 =
+                                      let uu___10 =
                                         FStar_TypeChecker_Rel.guard_to_string
                                           env g1 in
                                       FStar_Util.print2
                                         "(%s) DONE check_expected_effect;\n\tguard is: %s\n"
-                                        uu____1028 uu____1029
+                                        uu___9 uu___10
                                     else ());
                                    (let e2 =
                                       FStar_TypeChecker_Util.maybe_lift env
@@ -684,37 +652,37 @@ let (check_expected_effect :
                                         (FStar_Syntax_Util.comp_effect_name
                                            expected_c)
                                         (FStar_Syntax_Util.comp_result c4) in
-                                    let uu____1032 =
+                                    let uu___8 =
                                       FStar_TypeChecker_Env.conj_guard g_c g1 in
-                                    (e2, expected_c, uu____1032)))))))))
+                                    (e2, expected_c, uu___8)))))))))
 let no_logical_guard :
-  'uuuuuu1041 'uuuuuu1042 .
+  'uuuuu 'uuuuu1 .
     FStar_TypeChecker_Env.env ->
-      ('uuuuuu1041 * 'uuuuuu1042 * FStar_TypeChecker_Env.guard_t) ->
-        ('uuuuuu1041 * 'uuuuuu1042 * FStar_TypeChecker_Env.guard_t)
+      ('uuuuu * 'uuuuu1 * FStar_TypeChecker_Env.guard_t) ->
+        ('uuuuu * 'uuuuu1 * FStar_TypeChecker_Env.guard_t)
   =
   fun env ->
-    fun uu____1064 ->
-      match uu____1064 with
+    fun uu___ ->
+      match uu___ with
       | (te, kt, f) ->
-          let uu____1074 = FStar_TypeChecker_Env.guard_form f in
-          (match uu____1074 with
+          let uu___1 = FStar_TypeChecker_Env.guard_form f in
+          (match uu___1 with
            | FStar_TypeChecker_Common.Trivial -> (te, kt, f)
            | FStar_TypeChecker_Common.NonTrivial f1 ->
-               let uu____1082 =
+               let uu___2 =
                  FStar_TypeChecker_Err.unexpected_non_trivial_precondition_on_term
                    env f1 in
-               let uu____1087 = FStar_TypeChecker_Env.get_range env in
-               FStar_Errors.raise_error uu____1082 uu____1087)
+               let uu___3 = FStar_TypeChecker_Env.get_range env in
+               FStar_Errors.raise_error uu___2 uu___3)
 let (print_expected_ty : FStar_TypeChecker_Env.env -> unit) =
   fun env ->
-    let uu____1099 = FStar_TypeChecker_Env.expected_typ env in
-    match uu____1099 with
+    let uu___ = FStar_TypeChecker_Env.expected_typ env in
+    match uu___ with
     | FStar_Pervasives_Native.None ->
         FStar_Util.print_string "Expected type is None\n"
     | FStar_Pervasives_Native.Some t ->
-        let uu____1103 = FStar_Syntax_Print.term_to_string t in
-        FStar_Util.print1 "Expected type is %s" uu____1103
+        let uu___1 = FStar_Syntax_Print.term_to_string t in
+        FStar_Util.print1 "Expected type is %s" uu___1
 let rec (get_pat_vars' :
   FStar_Syntax_Syntax.bv Prims.list ->
     Prims.bool ->
@@ -724,25 +692,25 @@ let rec (get_pat_vars' :
     fun andlist ->
       fun pats ->
         let pats1 = FStar_Syntax_Util.unmeta pats in
-        let uu____1128 = FStar_Syntax_Util.head_and_args pats1 in
-        match uu____1128 with
+        let uu___ = FStar_Syntax_Util.head_and_args pats1 in
+        match uu___ with
         | (head, args) ->
-            let uu____1173 =
-              let uu____1188 =
-                let uu____1189 = FStar_Syntax_Util.un_uinst head in
-                uu____1189.FStar_Syntax_Syntax.n in
-              (uu____1188, args) in
-            (match uu____1173 with
-             | (FStar_Syntax_Syntax.Tm_fvar fv, uu____1205) when
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Util.un_uinst head in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
+             | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid
                  ->
                  if andlist
                  then FStar_Util.as_set all FStar_Syntax_Syntax.order_bv
                  else FStar_Util.new_set FStar_Syntax_Syntax.order_bv
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____1230, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____1231))::(hd,
-                                                              FStar_Pervasives_Native.None)::
+                (uu___2, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___3))::(hd,
+                                                          FStar_Pervasives_Native.None)::
                 (tl, FStar_Pervasives_Native.None)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                  ->
@@ -752,9 +720,9 @@ let rec (get_pat_vars' :
                  then FStar_Util.set_intersect hdvs tlvs
                  else FStar_Util.set_union hdvs tlvs
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                (uu____1304, FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Syntax.Implicit uu____1305))::(pat,
-                                                              FStar_Pervasives_Native.None)::[])
+                (uu___2, FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Implicit uu___3))::(pat,
+                                                          FStar_Pervasives_Native.None)::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
@@ -764,74 +732,72 @@ let rec (get_pat_vars' :
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpatOr_lid
                  -> get_pat_vars' all true subpats
-             | uu____1387 -> FStar_Util.new_set FStar_Syntax_Syntax.order_bv)
+             | uu___2 -> FStar_Util.new_set FStar_Syntax_Syntax.order_bv)
 let (get_pat_vars :
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set)
   = fun all -> fun pats -> get_pat_vars' all false pats
 let check_pat_fvs :
-  'uuuuuu1428 .
+  'uuuuu .
     FStar_Range.range ->
       FStar_TypeChecker_Env.env ->
         FStar_Syntax_Syntax.term ->
-          (FStar_Syntax_Syntax.bv * 'uuuuuu1428) Prims.list -> unit
+          (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list -> unit
   =
   fun rng ->
     fun env ->
       fun pats ->
         fun bs ->
           let pat_vars =
-            let uu____1464 = FStar_List.map FStar_Pervasives_Native.fst bs in
-            let uu____1471 =
+            let uu___ = FStar_List.map FStar_Pervasives_Native.fst bs in
+            let uu___1 =
               FStar_TypeChecker_Normalize.normalize
                 [FStar_TypeChecker_Env.Beta] env pats in
-            get_pat_vars uu____1464 uu____1471 in
-          let uu____1472 =
+            get_pat_vars uu___ uu___1 in
+          let uu___ =
             FStar_All.pipe_right bs
               (FStar_Util.find_opt
-                 (fun uu____1499 ->
-                    match uu____1499 with
-                    | (b, uu____1505) ->
-                        let uu____1506 = FStar_Util.set_mem b pat_vars in
-                        Prims.op_Negation uu____1506)) in
-          match uu____1472 with
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | (b, uu___2) ->
+                        let uu___3 = FStar_Util.set_mem b pat_vars in
+                        Prims.op_Negation uu___3)) in
+          match uu___ with
           | FStar_Pervasives_Native.None -> ()
-          | FStar_Pervasives_Native.Some (x, uu____1512) ->
-              let uu____1517 =
-                let uu____1522 =
-                  let uu____1523 = FStar_Syntax_Print.bv_to_string x in
+          | FStar_Pervasives_Native.Some (x, uu___1) ->
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Print.bv_to_string x in
                   FStar_Util.format1
-                    "Pattern misses at least one bound variable: %s"
-                    uu____1523 in
-                (FStar_Errors.Warning_SMTPatternIllFormed, uu____1522) in
-              FStar_Errors.log_issue rng uu____1517
+                    "Pattern misses at least one bound variable: %s" uu___4 in
+                (FStar_Errors.Warning_SMTPatternIllFormed, uu___3) in
+              FStar_Errors.log_issue rng uu___2
 let (check_no_smt_theory_symbols :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> unit) =
   fun en ->
     fun t ->
       let rec pat_terms t1 =
         let t2 = FStar_Syntax_Util.unmeta t1 in
-        let uu____1545 = FStar_Syntax_Util.head_and_args t2 in
-        match uu____1545 with
+        let uu___ = FStar_Syntax_Util.head_and_args t2 in
+        match uu___ with
         | (head, args) ->
-            let uu____1590 =
-              let uu____1605 =
-                let uu____1606 = FStar_Syntax_Util.un_uinst head in
-                uu____1606.FStar_Syntax_Syntax.n in
-              (uu____1605, args) in
-            (match uu____1590 with
-             | (FStar_Syntax_Syntax.Tm_fvar fv, uu____1622) when
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Util.un_uinst head in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
+             | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid
                  -> []
              | (FStar_Syntax_Syntax.Tm_fvar fv,
-                uu____1644::(hd, uu____1646)::(tl, uu____1648)::[]) when
+                uu___2::(hd, uu___3)::(tl, uu___4)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                  ->
-                 let uu____1715 = pat_terms hd in
-                 let uu____1718 = pat_terms tl in
-                 FStar_List.append uu____1715 uu____1718
-             | (FStar_Syntax_Syntax.Tm_fvar fv,
-                uu____1722::(pat, uu____1724)::[]) when
+                 let uu___5 = pat_terms hd in
+                 let uu___6 = pat_terms tl in FStar_List.append uu___5 uu___6
+             | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(pat, uu___3)::[])
+                 when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> [pat]
@@ -840,47 +806,46 @@ let (check_no_smt_theory_symbols :
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpatOr_lid
                  -> pat_terms subpats
-             | uu____1809 -> []) in
+             | uu___2 -> []) in
       let rec aux t1 =
-        let uu____1834 =
-          let uu____1835 = FStar_Syntax_Subst.compress t1 in
-          uu____1835.FStar_Syntax_Syntax.n in
-        match uu____1834 with
-        | FStar_Syntax_Syntax.Tm_bvar uu____1840 -> []
-        | FStar_Syntax_Syntax.Tm_name uu____1841 -> []
-        | FStar_Syntax_Syntax.Tm_constant uu____1842 -> []
-        | FStar_Syntax_Syntax.Tm_type uu____1843 -> []
-        | FStar_Syntax_Syntax.Tm_uvar uu____1844 -> []
-        | FStar_Syntax_Syntax.Tm_lazy uu____1857 -> []
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress t1 in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_bvar uu___1 -> []
+        | FStar_Syntax_Syntax.Tm_name uu___1 -> []
+        | FStar_Syntax_Syntax.Tm_constant uu___1 -> []
+        | FStar_Syntax_Syntax.Tm_type uu___1 -> []
+        | FStar_Syntax_Syntax.Tm_uvar uu___1 -> []
+        | FStar_Syntax_Syntax.Tm_lazy uu___1 -> []
         | FStar_Syntax_Syntax.Tm_unknown -> []
-        | FStar_Syntax_Syntax.Tm_abs uu____1858 -> [t1]
-        | FStar_Syntax_Syntax.Tm_arrow uu____1877 -> [t1]
-        | FStar_Syntax_Syntax.Tm_refine uu____1892 -> [t1]
-        | FStar_Syntax_Syntax.Tm_match uu____1899 -> [t1]
-        | FStar_Syntax_Syntax.Tm_let uu____1922 -> [t1]
-        | FStar_Syntax_Syntax.Tm_delayed uu____1935 -> [t1]
-        | FStar_Syntax_Syntax.Tm_quoted uu____1950 -> [t1]
+        | FStar_Syntax_Syntax.Tm_abs uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_arrow uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_refine uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_match uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_let uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_delayed uu___1 -> [t1]
+        | FStar_Syntax_Syntax.Tm_quoted uu___1 -> [t1]
         | FStar_Syntax_Syntax.Tm_fvar fv ->
-            let uu____1958 =
+            let uu___1 =
               FStar_TypeChecker_Env.fv_has_attr en fv
                 FStar_Parser_Const.smt_theory_symbol_attr_lid in
-            if uu____1958 then [t1] else []
+            if uu___1 then [t1] else []
         | FStar_Syntax_Syntax.Tm_app (t2, args) ->
-            let uu____1988 = aux t2 in
+            let uu___1 = aux t2 in
             FStar_List.fold_left
               (fun acc ->
-                 fun uu____2005 ->
-                   match uu____2005 with
-                   | (t3, uu____2017) ->
-                       let uu____2022 = aux t3 in
-                       FStar_List.append acc uu____2022) uu____1988 args
-        | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____2026, uu____2027) ->
-            aux t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2, uu____2069) -> aux t2
-        | FStar_Syntax_Syntax.Tm_meta (t2, uu____2075) -> aux t2 in
+                 fun uu___2 ->
+                   match uu___2 with
+                   | (t3, uu___3) ->
+                       let uu___4 = aux t3 in FStar_List.append acc uu___4)
+              uu___1 args
+        | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___1, uu___2) -> aux t2
+        | FStar_Syntax_Syntax.Tm_uinst (t2, uu___1) -> aux t2
+        | FStar_Syntax_Syntax.Tm_meta (t2, uu___1) -> aux t2 in
       let tlist =
-        let uu____2083 = FStar_All.pipe_right t pat_terms in
-        FStar_All.pipe_right uu____2083 (FStar_List.collect aux) in
+        let uu___ = FStar_All.pipe_right t pat_terms in
+        FStar_All.pipe_right uu___ (FStar_List.collect aux) in
       if (FStar_List.length tlist) = Prims.int_zero
       then ()
       else
@@ -888,43 +853,43 @@ let (check_no_smt_theory_symbols :
            FStar_List.fold_left
              (fun s ->
                 fun t1 ->
-                  let uu____2099 =
-                    let uu____2100 = FStar_Syntax_Print.term_to_string t1 in
-                    Prims.op_Hat " " uu____2100 in
-                  Prims.op_Hat s uu____2099) "" tlist in
-         let uu____2101 =
-           let uu____2106 =
+                  let uu___1 =
+                    let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+                    Prims.op_Hat " " uu___2 in
+                  Prims.op_Hat s uu___1) "" tlist in
+         let uu___1 =
+           let uu___2 =
              FStar_Util.format1
                "Pattern uses these theory symbols or terms that should not be in an smt pattern: %s"
                msg in
-           (FStar_Errors.Warning_SMTPatternIllFormed, uu____2106) in
-         FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2101)
+           (FStar_Errors.Warning_SMTPatternIllFormed, uu___2) in
+         FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___1)
 let check_smt_pat :
-  'uuuuuu2117 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu2117) Prims.list ->
+        (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list ->
           FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> unit
   =
   fun env ->
     fun t ->
       fun bs ->
         fun c ->
-          let uu____2158 = FStar_Syntax_Util.is_smt_lemma t in
-          if uu____2158
+          let uu___ = FStar_Syntax_Util.is_smt_lemma t in
+          if uu___
           then
             match c.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Comp
-                { FStar_Syntax_Syntax.comp_univs = uu____2159;
-                  FStar_Syntax_Syntax.effect_name = uu____2160;
-                  FStar_Syntax_Syntax.result_typ = uu____2161;
+                { FStar_Syntax_Syntax.comp_univs = uu___1;
+                  FStar_Syntax_Syntax.effect_name = uu___2;
+                  FStar_Syntax_Syntax.result_typ = uu___3;
                   FStar_Syntax_Syntax.effect_args =
-                    _pre::_post::(pats, uu____2165)::[];
-                  FStar_Syntax_Syntax.flags = uu____2166;_}
+                    _pre::_post::(pats, uu___4)::[];
+                  FStar_Syntax_Syntax.flags = uu___5;_}
                 ->
                 (check_pat_fvs t.FStar_Syntax_Syntax.pos env pats bs;
                  check_no_smt_theory_symbols env pats)
-            | uu____2228 -> failwith "Impossible"
+            | uu___1 -> failwith "Impossible"
           else ()
 let (guard_letrecs :
   FStar_TypeChecker_Env.env ->
@@ -941,168 +906,165 @@ let (guard_letrecs :
         | letrecs ->
             let r = FStar_TypeChecker_Env.get_range env in
             let env1 =
-              let uu___396_2292 = env in
+              let uu___ = env in
               {
                 FStar_TypeChecker_Env.solver =
-                  (uu___396_2292.FStar_TypeChecker_Env.solver);
+                  (uu___.FStar_TypeChecker_Env.solver);
                 FStar_TypeChecker_Env.range =
-                  (uu___396_2292.FStar_TypeChecker_Env.range);
+                  (uu___.FStar_TypeChecker_Env.range);
                 FStar_TypeChecker_Env.curmodule =
-                  (uu___396_2292.FStar_TypeChecker_Env.curmodule);
+                  (uu___.FStar_TypeChecker_Env.curmodule);
                 FStar_TypeChecker_Env.gamma =
-                  (uu___396_2292.FStar_TypeChecker_Env.gamma);
+                  (uu___.FStar_TypeChecker_Env.gamma);
                 FStar_TypeChecker_Env.gamma_sig =
-                  (uu___396_2292.FStar_TypeChecker_Env.gamma_sig);
+                  (uu___.FStar_TypeChecker_Env.gamma_sig);
                 FStar_TypeChecker_Env.gamma_cache =
-                  (uu___396_2292.FStar_TypeChecker_Env.gamma_cache);
+                  (uu___.FStar_TypeChecker_Env.gamma_cache);
                 FStar_TypeChecker_Env.modules =
-                  (uu___396_2292.FStar_TypeChecker_Env.modules);
+                  (uu___.FStar_TypeChecker_Env.modules);
                 FStar_TypeChecker_Env.expected_typ =
-                  (uu___396_2292.FStar_TypeChecker_Env.expected_typ);
+                  (uu___.FStar_TypeChecker_Env.expected_typ);
                 FStar_TypeChecker_Env.sigtab =
-                  (uu___396_2292.FStar_TypeChecker_Env.sigtab);
+                  (uu___.FStar_TypeChecker_Env.sigtab);
                 FStar_TypeChecker_Env.attrtab =
-                  (uu___396_2292.FStar_TypeChecker_Env.attrtab);
+                  (uu___.FStar_TypeChecker_Env.attrtab);
                 FStar_TypeChecker_Env.instantiate_imp =
-                  (uu___396_2292.FStar_TypeChecker_Env.instantiate_imp);
+                  (uu___.FStar_TypeChecker_Env.instantiate_imp);
                 FStar_TypeChecker_Env.effects =
-                  (uu___396_2292.FStar_TypeChecker_Env.effects);
+                  (uu___.FStar_TypeChecker_Env.effects);
                 FStar_TypeChecker_Env.generalize =
-                  (uu___396_2292.FStar_TypeChecker_Env.generalize);
+                  (uu___.FStar_TypeChecker_Env.generalize);
                 FStar_TypeChecker_Env.letrecs = [];
                 FStar_TypeChecker_Env.top_level =
-                  (uu___396_2292.FStar_TypeChecker_Env.top_level);
+                  (uu___.FStar_TypeChecker_Env.top_level);
                 FStar_TypeChecker_Env.check_uvars =
-                  (uu___396_2292.FStar_TypeChecker_Env.check_uvars);
+                  (uu___.FStar_TypeChecker_Env.check_uvars);
                 FStar_TypeChecker_Env.use_eq =
-                  (uu___396_2292.FStar_TypeChecker_Env.use_eq);
+                  (uu___.FStar_TypeChecker_Env.use_eq);
                 FStar_TypeChecker_Env.use_eq_strict =
-                  (uu___396_2292.FStar_TypeChecker_Env.use_eq_strict);
+                  (uu___.FStar_TypeChecker_Env.use_eq_strict);
                 FStar_TypeChecker_Env.is_iface =
-                  (uu___396_2292.FStar_TypeChecker_Env.is_iface);
+                  (uu___.FStar_TypeChecker_Env.is_iface);
                 FStar_TypeChecker_Env.admit =
-                  (uu___396_2292.FStar_TypeChecker_Env.admit);
-                FStar_TypeChecker_Env.lax =
-                  (uu___396_2292.FStar_TypeChecker_Env.lax);
+                  (uu___.FStar_TypeChecker_Env.admit);
+                FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
                 FStar_TypeChecker_Env.lax_universes =
-                  (uu___396_2292.FStar_TypeChecker_Env.lax_universes);
+                  (uu___.FStar_TypeChecker_Env.lax_universes);
                 FStar_TypeChecker_Env.phase1 =
-                  (uu___396_2292.FStar_TypeChecker_Env.phase1);
+                  (uu___.FStar_TypeChecker_Env.phase1);
                 FStar_TypeChecker_Env.failhard =
-                  (uu___396_2292.FStar_TypeChecker_Env.failhard);
+                  (uu___.FStar_TypeChecker_Env.failhard);
                 FStar_TypeChecker_Env.nosynth =
-                  (uu___396_2292.FStar_TypeChecker_Env.nosynth);
+                  (uu___.FStar_TypeChecker_Env.nosynth);
                 FStar_TypeChecker_Env.uvar_subtyping =
-                  (uu___396_2292.FStar_TypeChecker_Env.uvar_subtyping);
+                  (uu___.FStar_TypeChecker_Env.uvar_subtyping);
                 FStar_TypeChecker_Env.tc_term =
-                  (uu___396_2292.FStar_TypeChecker_Env.tc_term);
+                  (uu___.FStar_TypeChecker_Env.tc_term);
                 FStar_TypeChecker_Env.type_of =
-                  (uu___396_2292.FStar_TypeChecker_Env.type_of);
+                  (uu___.FStar_TypeChecker_Env.type_of);
                 FStar_TypeChecker_Env.universe_of =
-                  (uu___396_2292.FStar_TypeChecker_Env.universe_of);
+                  (uu___.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.check_type_of =
-                  (uu___396_2292.FStar_TypeChecker_Env.check_type_of);
+                  (uu___.FStar_TypeChecker_Env.check_type_of);
                 FStar_TypeChecker_Env.use_bv_sorts =
-                  (uu___396_2292.FStar_TypeChecker_Env.use_bv_sorts);
+                  (uu___.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                  (uu___396_2292.FStar_TypeChecker_Env.qtbl_name_and_index);
+                  (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
                 FStar_TypeChecker_Env.normalized_eff_names =
-                  (uu___396_2292.FStar_TypeChecker_Env.normalized_eff_names);
+                  (uu___.FStar_TypeChecker_Env.normalized_eff_names);
                 FStar_TypeChecker_Env.fv_delta_depths =
-                  (uu___396_2292.FStar_TypeChecker_Env.fv_delta_depths);
+                  (uu___.FStar_TypeChecker_Env.fv_delta_depths);
                 FStar_TypeChecker_Env.proof_ns =
-                  (uu___396_2292.FStar_TypeChecker_Env.proof_ns);
+                  (uu___.FStar_TypeChecker_Env.proof_ns);
                 FStar_TypeChecker_Env.synth_hook =
-                  (uu___396_2292.FStar_TypeChecker_Env.synth_hook);
+                  (uu___.FStar_TypeChecker_Env.synth_hook);
                 FStar_TypeChecker_Env.try_solve_implicits_hook =
-                  (uu___396_2292.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                  (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
                 FStar_TypeChecker_Env.splice =
-                  (uu___396_2292.FStar_TypeChecker_Env.splice);
+                  (uu___.FStar_TypeChecker_Env.splice);
                 FStar_TypeChecker_Env.mpreprocess =
-                  (uu___396_2292.FStar_TypeChecker_Env.mpreprocess);
+                  (uu___.FStar_TypeChecker_Env.mpreprocess);
                 FStar_TypeChecker_Env.postprocess =
-                  (uu___396_2292.FStar_TypeChecker_Env.postprocess);
+                  (uu___.FStar_TypeChecker_Env.postprocess);
                 FStar_TypeChecker_Env.identifier_info =
-                  (uu___396_2292.FStar_TypeChecker_Env.identifier_info);
+                  (uu___.FStar_TypeChecker_Env.identifier_info);
                 FStar_TypeChecker_Env.tc_hooks =
-                  (uu___396_2292.FStar_TypeChecker_Env.tc_hooks);
+                  (uu___.FStar_TypeChecker_Env.tc_hooks);
                 FStar_TypeChecker_Env.dsenv =
-                  (uu___396_2292.FStar_TypeChecker_Env.dsenv);
-                FStar_TypeChecker_Env.nbe =
-                  (uu___396_2292.FStar_TypeChecker_Env.nbe);
+                  (uu___.FStar_TypeChecker_Env.dsenv);
+                FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
                 FStar_TypeChecker_Env.strict_args_tab =
-                  (uu___396_2292.FStar_TypeChecker_Env.strict_args_tab);
+                  (uu___.FStar_TypeChecker_Env.strict_args_tab);
                 FStar_TypeChecker_Env.erasable_types_tab =
-                  (uu___396_2292.FStar_TypeChecker_Env.erasable_types_tab);
+                  (uu___.FStar_TypeChecker_Env.erasable_types_tab);
                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                  (uu___396_2292.FStar_TypeChecker_Env.enable_defer_to_tac)
+                  (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
               } in
             let precedes =
               FStar_TypeChecker_Util.fvar_const env1
                 FStar_Parser_Const.precedes_lid in
             let decreases_clause bs c =
-              (let uu____2320 =
+              (let uu___1 =
                  FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-               if uu____2320
+               if uu___1
                then
-                 let uu____2321 =
-                   FStar_Syntax_Print.binders_to_string ", " bs in
-                 let uu____2322 = FStar_Syntax_Print.comp_to_string c in
+                 let uu___2 = FStar_Syntax_Print.binders_to_string ", " bs in
+                 let uu___3 = FStar_Syntax_Print.comp_to_string c in
                  FStar_Util.print2
-                   "Building a decreases clause over (%s) and %s\n"
-                   uu____2321 uu____2322
+                   "Building a decreases clause over (%s) and %s\n" uu___2
+                   uu___3
                else ());
               (let filter_types_and_functions bs1 =
                  FStar_All.pipe_right bs1
                    (FStar_List.collect
-                      (fun uu____2353 ->
-                         match uu____2353 with
-                         | (b, uu____2363) ->
+                      (fun uu___1 ->
+                         match uu___1 with
+                         | (b, uu___2) ->
                              let t =
-                               let uu____2369 =
+                               let uu___3 =
                                  FStar_Syntax_Util.unrefine
                                    b.FStar_Syntax_Syntax.sort in
                                FStar_TypeChecker_Normalize.unfold_whnf env1
-                                 uu____2369 in
+                                 uu___3 in
                              (match t.FStar_Syntax_Syntax.n with
-                              | FStar_Syntax_Syntax.Tm_type uu____2372 -> []
-                              | FStar_Syntax_Syntax.Tm_arrow uu____2373 -> []
-                              | uu____2388 ->
-                                  let uu____2389 =
+                              | FStar_Syntax_Syntax.Tm_type uu___3 -> []
+                              | FStar_Syntax_Syntax.Tm_arrow uu___3 -> []
+                              | uu___3 ->
+                                  let uu___4 =
                                     FStar_Syntax_Syntax.bv_to_name b in
-                                  [uu____2389]))) in
+                                  [uu___4]))) in
                let as_lex_list dec =
-                 let uu____2402 = FStar_Syntax_Util.head_and_args dec in
-                 match uu____2402 with
-                 | (head, uu____2422) ->
+                 let uu___1 = FStar_Syntax_Util.head_and_args dec in
+                 match uu___1 with
+                 | (head, uu___2) ->
                      (match head.FStar_Syntax_Syntax.n with
                       | FStar_Syntax_Syntax.Tm_fvar fv when
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           -> dec
-                      | uu____2450 -> mk_lex_list [dec]) in
+                      | uu___3 -> mk_lex_list [dec]) in
                let cflags = FStar_Syntax_Util.comp_flags c in
-               let uu____2458 =
+               let uu___1 =
                  FStar_All.pipe_right cflags
                    (FStar_List.tryFind
-                      (fun uu___1_2467 ->
-                         match uu___1_2467 with
-                         | FStar_Syntax_Syntax.DECREASES uu____2468 -> true
-                         | uu____2471 -> false)) in
-               match uu____2458 with
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | FStar_Syntax_Syntax.DECREASES uu___3 -> true
+                         | uu___3 -> false)) in
+               match uu___1 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                    dec) -> as_lex_list dec
-               | uu____2477 ->
+               | uu___2 ->
                    let xs =
                      FStar_All.pipe_right bs filter_types_and_functions in
                    mk_lex_list xs) in
             let previous_dec = decreases_clause actuals expected_c in
-            let guard_one_letrec uu____2513 =
-              match uu____2513 with
+            let guard_one_letrec uu___ =
+              match uu___ with
               | (l, arity, t, u_names) ->
-                  let uu____2534 =
+                  let uu___1 =
                     FStar_TypeChecker_Normalize.get_n_binders env1 arity t in
-                  (match uu____2534 with
+                  (match uu___1 with
                    | (formals, c) ->
                        (if arity > (FStar_List.length formals)
                         then
@@ -1112,72 +1074,70 @@ let (guard_letrecs :
                         (let formals1 =
                            FStar_All.pipe_right formals
                              (FStar_List.map
-                                (fun uu____2599 ->
-                                   match uu____2599 with
+                                (fun uu___3 ->
+                                   match uu___3 with
                                    | (x, imp) ->
-                                       let uu____2618 =
+                                       let uu___4 =
                                          FStar_Syntax_Syntax.is_null_bv x in
-                                       if uu____2618
+                                       if uu___4
                                        then
-                                         let uu____2625 =
-                                           let uu____2626 =
-                                             let uu____2629 =
+                                         let uu___5 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                FStar_Syntax_Syntax.range_of_bv
                                                  x in
                                              FStar_Pervasives_Native.Some
-                                               uu____2629 in
-                                           FStar_Syntax_Syntax.new_bv
-                                             uu____2626
+                                               uu___7 in
+                                           FStar_Syntax_Syntax.new_bv uu___6
                                              x.FStar_Syntax_Syntax.sort in
-                                         (uu____2625, imp)
+                                         (uu___5, imp)
                                        else (x, imp))) in
                          let dec = decreases_clause formals1 c in
                          let precedes1 =
-                           let uu____2639 =
-                             let uu____2640 = FStar_Syntax_Syntax.as_arg dec in
-                             let uu____2649 =
-                               let uu____2660 =
+                           let uu___3 =
+                             let uu___4 = FStar_Syntax_Syntax.as_arg dec in
+                             let uu___5 =
+                               let uu___6 =
                                  FStar_Syntax_Syntax.as_arg previous_dec in
-                               [uu____2660] in
-                             uu____2640 :: uu____2649 in
-                           FStar_Syntax_Syntax.mk_Tm_app precedes uu____2639
-                             r in
+                               [uu___6] in
+                             uu___4 :: uu___5 in
+                           FStar_Syntax_Syntax.mk_Tm_app precedes uu___3 r in
                          let precedes2 =
                            FStar_TypeChecker_Util.label
                              "Could not prove termination of this recursive call"
                              r precedes1 in
-                         let uu____2694 = FStar_Util.prefix formals1 in
-                         match uu____2694 with
+                         let uu___3 = FStar_Util.prefix formals1 in
+                         match uu___3 with
                          | (bs, (last, imp)) ->
                              let last1 =
-                               let uu___459_2757 = last in
-                               let uu____2758 =
+                               let uu___4 = last in
+                               let uu___5 =
                                  FStar_Syntax_Util.refine last precedes2 in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___459_2757.FStar_Syntax_Syntax.ppname);
+                                   (uu___4.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___459_2757.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____2758
+                                   (uu___4.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu___5
                                } in
                              let refined_formals =
                                FStar_List.append bs [(last1, imp)] in
                              let t' =
                                FStar_Syntax_Util.arrow refined_formals c in
-                             ((let uu____2794 =
+                             ((let uu___5 =
                                  FStar_TypeChecker_Env.debug env1
                                    FStar_Options.Medium in
-                               if uu____2794
+                               if uu___5
                                then
-                                 let uu____2795 =
+                                 let uu___6 =
                                    FStar_Syntax_Print.lbname_to_string l in
-                                 let uu____2796 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.term_to_string t in
-                                 let uu____2797 =
+                                 let uu___8 =
                                    FStar_Syntax_Print.term_to_string t' in
                                  FStar_Util.print3
                                    "Refined let rec %s\n\tfrom type %s\n\tto type %s\n"
-                                   uu____2795 uu____2796 uu____2797
+                                   uu___6 uu___7 uu___8
                                else ());
                               (l, t', u_names))))) in
             FStar_All.pipe_right letrecs (FStar_List.map guard_one_letrec)
@@ -1192,45 +1152,43 @@ let (wrap_guard_with_tactic_opt :
       | FStar_Pervasives_Native.Some tactic ->
           FStar_TypeChecker_Env.always_map_guard g
             (fun g1 ->
-               let uu____2853 =
+               let uu___ =
                  FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero g1 in
-               FStar_TypeChecker_Common.mk_by_tactic tactic uu____2853)
+               FStar_TypeChecker_Common.mk_by_tactic tactic uu___)
 let (is_comp_ascribed_reflect :
   FStar_Syntax_Syntax.term ->
     (FStar_Ident.lident * FStar_Syntax_Syntax.term *
       FStar_Syntax_Syntax.aqual) FStar_Pervasives_Native.option)
   =
   fun e ->
-    let uu____2875 =
-      let uu____2876 = FStar_Syntax_Subst.compress e in
-      uu____2876.FStar_Syntax_Syntax.n in
-    match uu____2875 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress e in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_ascribed
-        (e1, (FStar_Util.Inr uu____2888, uu____2889), uu____2890) ->
-        let uu____2937 =
-          let uu____2938 = FStar_Syntax_Subst.compress e1 in
-          uu____2938.FStar_Syntax_Syntax.n in
-        (match uu____2937 with
+        (e1, (FStar_Util.Inr uu___1, uu___2), uu___3) ->
+        let uu___4 =
+          let uu___5 = FStar_Syntax_Subst.compress e1 in
+          uu___5.FStar_Syntax_Syntax.n in
+        (match uu___4 with
          | FStar_Syntax_Syntax.Tm_app (head, args) when
              (FStar_List.length args) = Prims.int_one ->
-             let uu____2983 =
-               let uu____2984 = FStar_Syntax_Subst.compress head in
-               uu____2984.FStar_Syntax_Syntax.n in
-             (match uu____2983 with
+             let uu___5 =
+               let uu___6 = FStar_Syntax_Subst.compress head in
+               uu___6.FStar_Syntax_Syntax.n in
+             (match uu___5 with
               | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect l)
                   ->
-                  let uu____2996 =
-                    let uu____3003 = FStar_All.pipe_right args FStar_List.hd in
-                    FStar_All.pipe_right uu____3003
-                      (fun uu____3059 ->
-                         match uu____3059 with
-                         | (e2, aqual) -> (l, e2, aqual)) in
-                  FStar_All.pipe_right uu____2996
-                    (fun uu____3112 ->
-                       FStar_Pervasives_Native.Some uu____3112)
-              | uu____3113 -> FStar_Pervasives_Native.None)
-         | uu____3120 -> FStar_Pervasives_Native.None)
-    | uu____3127 -> FStar_Pervasives_Native.None
+                  let uu___6 =
+                    let uu___7 = FStar_All.pipe_right args FStar_List.hd in
+                    FStar_All.pipe_right uu___7
+                      (fun uu___8 ->
+                         match uu___8 with | (e2, aqual) -> (l, e2, aqual)) in
+                  FStar_All.pipe_right uu___6
+                    (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+              | uu___6 -> FStar_Pervasives_Native.None)
+         | uu___5 -> FStar_Pervasives_Native.None)
+    | uu___1 -> FStar_Pervasives_Native.None
 let rec (tc_term :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -1239,159 +1197,157 @@ let rec (tc_term :
   =
   fun env ->
     fun e ->
-      (let uu____3868 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-       if uu____3868
+      (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
+       if uu___1
        then
-         let uu____3869 =
-           let uu____3870 = FStar_TypeChecker_Env.get_range env in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____3870 in
-         let uu____3871 =
+         let uu___2 =
+           let uu___3 = FStar_TypeChecker_Env.get_range env in
+           FStar_All.pipe_left FStar_Range.string_of_range uu___3 in
+         let uu___3 =
            FStar_Util.string_of_bool env.FStar_TypeChecker_Env.phase1 in
-         let uu____3872 = FStar_Syntax_Print.term_to_string e in
-         let uu____3873 =
-           let uu____3874 = FStar_Syntax_Subst.compress e in
-           FStar_Syntax_Print.tag_of_term uu____3874 in
-         let uu____3875 =
-           let uu____3876 = FStar_TypeChecker_Env.expected_typ env in
-           match uu____3876 with
+         let uu___4 = FStar_Syntax_Print.term_to_string e in
+         let uu___5 =
+           let uu___6 = FStar_Syntax_Subst.compress e in
+           FStar_Syntax_Print.tag_of_term uu___6 in
+         let uu___6 =
+           let uu___7 = FStar_TypeChecker_Env.expected_typ env in
+           match uu___7 with
            | FStar_Pervasives_Native.None -> "None"
            | FStar_Pervasives_Native.Some t ->
                FStar_Syntax_Print.term_to_string t in
          FStar_Util.print5
            "(%s) Starting tc_term (phase1=%s) of %s (%s) with expected type: %s {\n"
-           uu____3869 uu____3871 uu____3872 uu____3873 uu____3875
+           uu___2 uu___3 uu___4 uu___5 uu___6
        else ());
-      (let uu____3881 =
+      (let uu___1 =
          FStar_Util.record_time
-           (fun uu____3899 ->
+           (fun uu___2 ->
               tc_maybe_toplevel_term
-                (let uu___502_3902 = env in
+                (let uu___3 = env in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___502_3902.FStar_TypeChecker_Env.solver);
+                     (uu___3.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___502_3902.FStar_TypeChecker_Env.range);
+                     (uu___3.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___502_3902.FStar_TypeChecker_Env.curmodule);
+                     (uu___3.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
-                     (uu___502_3902.FStar_TypeChecker_Env.gamma);
+                     (uu___3.FStar_TypeChecker_Env.gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___502_3902.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___3.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___502_3902.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___3.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___502_3902.FStar_TypeChecker_Env.modules);
+                     (uu___3.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___502_3902.FStar_TypeChecker_Env.expected_typ);
+                     (uu___3.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___502_3902.FStar_TypeChecker_Env.sigtab);
+                     (uu___3.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___502_3902.FStar_TypeChecker_Env.attrtab);
+                     (uu___3.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___502_3902.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___3.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___502_3902.FStar_TypeChecker_Env.effects);
+                     (uu___3.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___502_3902.FStar_TypeChecker_Env.generalize);
+                     (uu___3.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___502_3902.FStar_TypeChecker_Env.letrecs);
+                     (uu___3.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level = false;
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___502_3902.FStar_TypeChecker_Env.check_uvars);
+                     (uu___3.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___502_3902.FStar_TypeChecker_Env.use_eq);
+                     (uu___3.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___502_3902.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___3.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___502_3902.FStar_TypeChecker_Env.is_iface);
+                     (uu___3.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___502_3902.FStar_TypeChecker_Env.admit);
+                     (uu___3.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___502_3902.FStar_TypeChecker_Env.lax);
+                     (uu___3.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___502_3902.FStar_TypeChecker_Env.lax_universes);
+                     (uu___3.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___502_3902.FStar_TypeChecker_Env.phase1);
+                     (uu___3.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___502_3902.FStar_TypeChecker_Env.failhard);
+                     (uu___3.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___502_3902.FStar_TypeChecker_Env.nosynth);
+                     (uu___3.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___502_3902.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___502_3902.FStar_TypeChecker_Env.tc_term);
+                     (uu___3.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___502_3902.FStar_TypeChecker_Env.type_of);
+                     (uu___3.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___502_3902.FStar_TypeChecker_Env.universe_of);
+                     (uu___3.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___502_3902.FStar_TypeChecker_Env.check_type_of);
+                     (uu___3.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___502_3902.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___3.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___502_3902.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___3.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___502_3902.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___3.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___502_3902.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___3.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___502_3902.FStar_TypeChecker_Env.proof_ns);
+                     (uu___3.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___502_3902.FStar_TypeChecker_Env.synth_hook);
+                     (uu___3.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___502_3902.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___3.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___502_3902.FStar_TypeChecker_Env.splice);
+                     (uu___3.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___502_3902.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___3.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___502_3902.FStar_TypeChecker_Env.postprocess);
+                     (uu___3.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___502_3902.FStar_TypeChecker_Env.identifier_info);
+                     (uu___3.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___502_3902.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___3.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___502_3902.FStar_TypeChecker_Env.dsenv);
+                     (uu___3.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___502_3902.FStar_TypeChecker_Env.nbe);
+                     (uu___3.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___502_3902.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___3.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___502_3902.FStar_TypeChecker_Env.erasable_types_tab);
+                     (uu___3.FStar_TypeChecker_Env.erasable_types_tab);
                    FStar_TypeChecker_Env.enable_defer_to_tac =
-                     (uu___502_3902.FStar_TypeChecker_Env.enable_defer_to_tac)
+                     (uu___3.FStar_TypeChecker_Env.enable_defer_to_tac)
                  }) e) in
-       match uu____3881 with
+       match uu___1 with
        | (r, ms) ->
-           ((let uu____3924 =
+           ((let uu___3 =
                FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-             if uu____3924
+             if uu___3
              then
-               ((let uu____3926 =
-                   let uu____3927 = FStar_TypeChecker_Env.get_range env in
-                   FStar_All.pipe_left FStar_Range.string_of_range uu____3927 in
-                 let uu____3928 = FStar_Syntax_Print.term_to_string e in
-                 let uu____3929 =
-                   let uu____3930 = FStar_Syntax_Subst.compress e in
-                   FStar_Syntax_Print.tag_of_term uu____3930 in
-                 let uu____3931 = FStar_Util.string_of_int ms in
+               ((let uu___5 =
+                   let uu___6 = FStar_TypeChecker_Env.get_range env in
+                   FStar_All.pipe_left FStar_Range.string_of_range uu___6 in
+                 let uu___6 = FStar_Syntax_Print.term_to_string e in
+                 let uu___7 =
+                   let uu___8 = FStar_Syntax_Subst.compress e in
+                   FStar_Syntax_Print.tag_of_term uu___8 in
+                 let uu___8 = FStar_Util.string_of_int ms in
                  FStar_Util.print4 "(%s) } tc_term of %s (%s) took %sms\n"
-                   uu____3926 uu____3928 uu____3929 uu____3931);
-                (let uu____3932 = r in
-                 match uu____3932 with
-                 | (e1, lc, uu____3941) ->
-                     let uu____3942 =
-                       let uu____3943 = FStar_TypeChecker_Env.get_range env in
-                       FStar_All.pipe_left FStar_Range.string_of_range
-                         uu____3943 in
-                     let uu____3944 = FStar_Syntax_Print.term_to_string e1 in
-                     let uu____3945 =
-                       FStar_TypeChecker_Common.lcomp_to_string lc in
-                     let uu____3946 =
-                       let uu____3947 = FStar_Syntax_Subst.compress e1 in
-                       FStar_Syntax_Print.tag_of_term uu____3947 in
+                   uu___5 uu___6 uu___7 uu___8);
+                (let uu___5 = r in
+                 match uu___5 with
+                 | (e1, lc, uu___6) ->
+                     let uu___7 =
+                       let uu___8 = FStar_TypeChecker_Env.get_range env in
+                       FStar_All.pipe_left FStar_Range.string_of_range uu___8 in
+                     let uu___8 = FStar_Syntax_Print.term_to_string e1 in
+                     let uu___9 = FStar_TypeChecker_Common.lcomp_to_string lc in
+                     let uu___10 =
+                       let uu___11 = FStar_Syntax_Subst.compress e1 in
+                       FStar_Syntax_Print.tag_of_term uu___11 in
                      FStar_Util.print4 "(%s) Result is: (%s:%s) (%s)\n"
-                       uu____3942 uu____3944 uu____3945 uu____3946))
+                       uu___7 uu___8 uu___9 uu___10))
              else ());
             r))
 and (tc_maybe_toplevel_term :
@@ -1407,49 +1363,47 @@ and (tc_maybe_toplevel_term :
         then env
         else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
       let top = FStar_Syntax_Subst.compress e in
-      (let uu____3961 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
-       if uu____3961
+      (let uu___1 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
+       if uu___1
        then
-         let uu____3962 =
-           let uu____3963 = FStar_TypeChecker_Env.get_range env1 in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____3963 in
-         let uu____3964 = FStar_Syntax_Print.tag_of_term top in
-         let uu____3965 = FStar_Syntax_Print.term_to_string top in
-         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu____3962 uu____3964
-           uu____3965
+         let uu___2 =
+           let uu___3 = FStar_TypeChecker_Env.get_range env1 in
+           FStar_All.pipe_left FStar_Range.string_of_range uu___3 in
+         let uu___3 = FStar_Syntax_Print.tag_of_term top in
+         let uu___4 = FStar_Syntax_Print.term_to_string top in
+         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu___2 uu___3 uu___4
        else ());
       (match top.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____3973 -> failwith "Impossible"
-       | FStar_Syntax_Syntax.Tm_uinst uu____3994 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_uvar uu____4001 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_bvar uu____4014 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_name uu____4015 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_fvar uu____4016 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_constant uu____4017 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_abs uu____4018 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_arrow uu____4037 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_refine uu____4052 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_type uu____4059 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+       | FStar_Syntax_Syntax.Tm_uinst uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_uvar uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_bvar uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_name uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_fvar uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_constant uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_abs uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_arrow uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_refine uu___1 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_type uu___1 -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_unknown -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
-           let projl uu___2_4075 =
-             match uu___2_4075 with
+           let projl uu___1 =
+             match uu___1 with
              | FStar_Util.Inl x -> x
-             | FStar_Util.Inr uu____4081 -> failwith "projl fail" in
+             | FStar_Util.Inr uu___2 -> failwith "projl fail" in
            let non_trivial_antiquotes qi1 =
              let is_name t =
-               let uu____4094 =
-                 let uu____4095 = FStar_Syntax_Subst.compress t in
-                 uu____4095.FStar_Syntax_Syntax.n in
-               match uu____4094 with
-               | FStar_Syntax_Syntax.Tm_name uu____4098 -> true
-               | uu____4099 -> false in
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress t in
+                 uu___2.FStar_Syntax_Syntax.n in
+               match uu___1 with
+               | FStar_Syntax_Syntax.Tm_name uu___2 -> true
+               | uu___2 -> false in
              FStar_Util.for_some
-               (fun uu____4108 ->
-                  match uu____4108 with
-                  | (uu____4113, t) ->
-                      let uu____4115 = is_name t in
-                      Prims.op_Negation uu____4115)
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (uu___2, t) ->
+                      let uu___3 = is_name t in Prims.op_Negation uu___3)
                qi1.FStar_Syntax_Syntax.antiquotes in
            (match qi.FStar_Syntax_Syntax.qkind with
             | FStar_Syntax_Syntax.Quote_static when non_trivial_antiquotes qi
@@ -1457,7 +1411,7 @@ and (tc_maybe_toplevel_term :
                 let e0 = e in
                 let newbvs =
                   FStar_List.map
-                    (fun uu____4133 ->
+                    (fun uu___1 ->
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Syntax.t_term)
@@ -1466,8 +1420,8 @@ and (tc_maybe_toplevel_term :
                   FStar_List.zip qi.FStar_Syntax_Syntax.antiquotes newbvs in
                 let lbs =
                   FStar_List.map
-                    (fun uu____4176 ->
-                       match uu____4176 with
+                    (fun uu___1 ->
+                       match uu___1 with
                        | ((bv, t), bv') ->
                            FStar_Syntax_Util.close_univs_and_mk_letbinding
                              FStar_Pervasives_Native.None
@@ -1476,19 +1430,18 @@ and (tc_maybe_toplevel_term :
                              FStar_Parser_Const.effect_Tot_lid t []
                              t.FStar_Syntax_Syntax.pos) z in
                 let qi1 =
-                  let uu___575_4205 = qi in
-                  let uu____4206 =
+                  let uu___1 = qi in
+                  let uu___2 =
                     FStar_List.map
-                      (fun uu____4234 ->
-                         match uu____4234 with
-                         | ((bv, uu____4250), bv') ->
-                             let uu____4262 =
-                               FStar_Syntax_Syntax.bv_to_name bv' in
-                             (bv, uu____4262)) z in
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | ((bv, uu___4), bv') ->
+                             let uu___5 = FStar_Syntax_Syntax.bv_to_name bv' in
+                             (bv, uu___5)) z in
                   {
                     FStar_Syntax_Syntax.qkind =
-                      (uu___575_4205.FStar_Syntax_Syntax.qkind);
-                    FStar_Syntax_Syntax.antiquotes = uu____4206
+                      (uu___1.FStar_Syntax_Syntax.qkind);
+                    FStar_Syntax_Syntax.antiquotes = uu___2
                   } in
                 let nq =
                   FStar_Syntax_Syntax.mk
@@ -1498,19 +1451,19 @@ and (tc_maybe_toplevel_term :
                   FStar_List.fold_left
                     (fun t ->
                        fun lb ->
-                         let uu____4274 =
-                           let uu____4275 =
-                             let uu____4288 =
-                               let uu____4291 =
-                                 let uu____4292 =
-                                   let uu____4299 =
+                         let uu___1 =
+                           let uu___2 =
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 =
+                                   let uu___6 =
                                      projl lb.FStar_Syntax_Syntax.lbname in
-                                   FStar_Syntax_Syntax.mk_binder uu____4299 in
-                                 [uu____4292] in
-                               FStar_Syntax_Subst.close uu____4291 t in
-                             ((false, [lb]), uu____4288) in
-                           FStar_Syntax_Syntax.Tm_let uu____4275 in
-                         FStar_Syntax_Syntax.mk uu____4274
+                                   FStar_Syntax_Syntax.mk_binder uu___6 in
+                                 [uu___5] in
+                               FStar_Syntax_Subst.close uu___4 t in
+                             ((false, [lb]), uu___3) in
+                           FStar_Syntax_Syntax.Tm_let uu___2 in
+                         FStar_Syntax_Syntax.mk uu___1
                            top.FStar_Syntax_Syntax.pos) nq lbs in
                 tc_maybe_toplevel_term env1 e1
             | FStar_Syntax_Syntax.Quote_static ->
@@ -1518,26 +1471,26 @@ and (tc_maybe_toplevel_term :
                 let env_tm =
                   FStar_TypeChecker_Env.set_expected_typ env1
                     FStar_Syntax_Syntax.t_term in
-                let uu____4332 =
+                let uu___1 =
                   FStar_List.fold_right
-                    (fun uu____4368 ->
-                       fun uu____4369 ->
-                         match (uu____4368, uu____4369) with
+                    (fun uu___2 ->
+                       fun uu___3 ->
+                         match (uu___2, uu___3) with
                          | ((bv, tm), (aqs_rev, guard)) ->
-                             let uu____4438 = tc_term env_tm tm in
-                             (match uu____4438 with
-                              | (tm1, uu____4456, g) ->
-                                  let uu____4458 =
+                             let uu___4 = tc_term env_tm tm in
+                             (match uu___4 with
+                              | (tm1, uu___5, g) ->
+                                  let uu___6 =
                                     FStar_TypeChecker_Env.conj_guard g guard in
-                                  (((bv, tm1) :: aqs_rev), uu____4458))) aqs
+                                  (((bv, tm1) :: aqs_rev), uu___6))) aqs
                     ([], FStar_TypeChecker_Env.trivial_guard) in
-                (match uu____4332 with
+                (match uu___1 with
                  | (aqs_rev, guard) ->
                      let qi1 =
-                       let uu___603_4500 = qi in
+                       let uu___2 = qi in
                        {
                          FStar_Syntax_Syntax.qkind =
-                           (uu___603_4500.FStar_Syntax_Syntax.qkind);
+                           (uu___2.FStar_Syntax_Syntax.qkind);
                          FStar_Syntax_Syntax.antiquotes =
                            (FStar_List.rev aqs_rev)
                        } in
@@ -1549,122 +1502,121 @@ and (tc_maybe_toplevel_term :
                        (FStar_Util.Inl FStar_Syntax_Syntax.t_term) guard)
             | FStar_Syntax_Syntax.Quote_dynamic ->
                 let c = FStar_Syntax_Syntax.mk_Tac FStar_Syntax_Syntax.t_term in
-                let uu____4511 =
-                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-                (match uu____4511 with
-                 | (env', uu____4525) ->
-                     let uu____4530 =
+                let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                (match uu___1 with
+                 | (env', uu___2) ->
+                     let uu___3 =
                        tc_term
-                         (let uu___612_4539 = env' in
+                         (let uu___4 = env' in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___612_4539.FStar_TypeChecker_Env.solver);
+                              (uu___4.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___612_4539.FStar_TypeChecker_Env.range);
+                              (uu___4.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___612_4539.FStar_TypeChecker_Env.curmodule);
+                              (uu___4.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___612_4539.FStar_TypeChecker_Env.gamma);
+                              (uu___4.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___612_4539.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___4.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___612_4539.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___4.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___612_4539.FStar_TypeChecker_Env.modules);
+                              (uu___4.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___612_4539.FStar_TypeChecker_Env.expected_typ);
+                              (uu___4.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___612_4539.FStar_TypeChecker_Env.sigtab);
+                              (uu___4.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___612_4539.FStar_TypeChecker_Env.attrtab);
+                              (uu___4.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___612_4539.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___612_4539.FStar_TypeChecker_Env.effects);
+                              (uu___4.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___612_4539.FStar_TypeChecker_Env.generalize);
+                              (uu___4.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___612_4539.FStar_TypeChecker_Env.letrecs);
+                              (uu___4.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___612_4539.FStar_TypeChecker_Env.top_level);
+                              (uu___4.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___612_4539.FStar_TypeChecker_Env.check_uvars);
+                              (uu___4.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___612_4539.FStar_TypeChecker_Env.use_eq);
+                              (uu___4.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___612_4539.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___612_4539.FStar_TypeChecker_Env.is_iface);
+                              (uu___4.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___612_4539.FStar_TypeChecker_Env.admit);
+                              (uu___4.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___612_4539.FStar_TypeChecker_Env.lax_universes);
+                              (uu___4.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___612_4539.FStar_TypeChecker_Env.phase1);
+                              (uu___4.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___612_4539.FStar_TypeChecker_Env.failhard);
+                              (uu___4.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___612_4539.FStar_TypeChecker_Env.nosynth);
+                              (uu___4.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___612_4539.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___612_4539.FStar_TypeChecker_Env.tc_term);
+                              (uu___4.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___612_4539.FStar_TypeChecker_Env.type_of);
+                              (uu___4.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___612_4539.FStar_TypeChecker_Env.universe_of);
+                              (uu___4.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___612_4539.FStar_TypeChecker_Env.check_type_of);
+                              (uu___4.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___612_4539.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___612_4539.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___612_4539.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___612_4539.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___612_4539.FStar_TypeChecker_Env.proof_ns);
+                              (uu___4.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___612_4539.FStar_TypeChecker_Env.synth_hook);
+                              (uu___4.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___612_4539.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___612_4539.FStar_TypeChecker_Env.splice);
+                              (uu___4.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___612_4539.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___4.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___612_4539.FStar_TypeChecker_Env.postprocess);
+                              (uu___4.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___612_4539.FStar_TypeChecker_Env.identifier_info);
+                              (uu___4.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___612_4539.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___4.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___612_4539.FStar_TypeChecker_Env.dsenv);
+                              (uu___4.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___612_4539.FStar_TypeChecker_Env.nbe);
+                              (uu___4.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___612_4539.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___612_4539.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___612_4539.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                           }) qt in
-                     (match uu____4530 with
-                      | (qt1, uu____4547, uu____4548) ->
+                     (match uu___3 with
+                      | (qt1, uu___4, uu___5) ->
                           let t =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_quoted (qt1, qi))
                               top.FStar_Syntax_Syntax.pos in
-                          let uu____4554 =
-                            let uu____4561 =
-                              let uu____4566 =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
                                 FStar_TypeChecker_Common.lcomp_of_comp c in
-                              FStar_Util.Inr uu____4566 in
-                            value_check_expected_typ env1 top uu____4561
+                              FStar_Util.Inr uu___8 in
+                            value_check_expected_typ env1 top uu___7
                               FStar_TypeChecker_Env.trivial_guard in
-                          (match uu____4554 with
+                          (match uu___6 with
                            | (t1, lc, g) ->
                                let t2 =
                                  FStar_Syntax_Syntax.mk
@@ -1677,14 +1629,13 @@ and (tc_maybe_toplevel_term :
                                    t1.FStar_Syntax_Syntax.pos in
                                (t2, lc, g)))))
        | FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____4583;
+           { FStar_Syntax_Syntax.blob = uu___1;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____4584;
-             FStar_Syntax_Syntax.ltyp = uu____4585;
-             FStar_Syntax_Syntax.rng = uu____4586;_}
+               uu___2;
+             FStar_Syntax_Syntax.ltyp = uu___3;
+             FStar_Syntax_Syntax.rng = uu___4;_}
            ->
-           let uu____4597 = FStar_Syntax_Util.unlazy top in
-           tc_term env1 uu____4597
+           let uu___5 = FStar_Syntax_Util.unlazy top in tc_term env1 uu___5
        | FStar_Syntax_Syntax.Tm_lazy i ->
            value_check_expected_typ env1 top
              (FStar_Util.Inl (i.FStar_Syntax_Syntax.ltyp))
@@ -1693,98 +1644,97 @@ and (tc_maybe_toplevel_term :
            (e1, FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Meta_smt_pat))
            ->
-           let uu____4604 = tc_tot_or_gtot_term env1 e1 in
-           (match uu____4604 with
+           let uu___1 = tc_tot_or_gtot_term env1 e1 in
+           (match uu___1 with
             | (e2, c, g) ->
                 let g1 =
-                  let uu___642_4621 = g in
+                  let uu___2 = g in
                   {
                     FStar_TypeChecker_Common.guard_f =
                       FStar_TypeChecker_Common.Trivial;
                     FStar_TypeChecker_Common.deferred_to_tac =
-                      (uu___642_4621.FStar_TypeChecker_Common.deferred_to_tac);
+                      (uu___2.FStar_TypeChecker_Common.deferred_to_tac);
                     FStar_TypeChecker_Common.deferred =
-                      (uu___642_4621.FStar_TypeChecker_Common.deferred);
+                      (uu___2.FStar_TypeChecker_Common.deferred);
                     FStar_TypeChecker_Common.univ_ineqs =
-                      (uu___642_4621.FStar_TypeChecker_Common.univ_ineqs);
+                      (uu___2.FStar_TypeChecker_Common.univ_ineqs);
                     FStar_TypeChecker_Common.implicits =
-                      (uu___642_4621.FStar_TypeChecker_Common.implicits)
+                      (uu___2.FStar_TypeChecker_Common.implicits)
                   } in
-                let uu____4622 =
+                let uu___2 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta
                        (e2,
                          (FStar_Syntax_Syntax.Meta_desugared
                             FStar_Syntax_Syntax.Meta_smt_pat)))
                     top.FStar_Syntax_Syntax.pos in
-                (uu____4622, c, g1))
+                (uu___2, c, g1))
        | FStar_Syntax_Syntax.Tm_meta
            (e1, FStar_Syntax_Syntax.Meta_pattern (names, pats)) ->
-           let uu____4664 = FStar_Syntax_Util.type_u () in
-           (match uu____4664 with
+           let uu___1 = FStar_Syntax_Util.type_u () in
+           (match uu___1 with
             | (t, u) ->
-                let uu____4677 = tc_check_tot_or_gtot_term env1 e1 t "" in
-                (match uu____4677 with
+                let uu___2 = tc_check_tot_or_gtot_term env1 e1 t "" in
+                (match uu___2 with
                  | (e2, c, g) ->
-                     let uu____4693 =
-                       let uu____4710 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_TypeChecker_Env.clear_expected_typ env1 in
-                       match uu____4710 with
-                       | (env2, uu____4734) -> tc_smt_pats env2 pats in
-                     (match uu____4693 with
+                       match uu___4 with
+                       | (env2, uu___5) -> tc_smt_pats env2 pats in
+                     (match uu___3 with
                       | (pats1, g') ->
                           let g'1 =
-                            let uu___665_4772 = g' in
+                            let uu___4 = g' in
                             {
                               FStar_TypeChecker_Common.guard_f =
                                 FStar_TypeChecker_Common.Trivial;
                               FStar_TypeChecker_Common.deferred_to_tac =
-                                (uu___665_4772.FStar_TypeChecker_Common.deferred_to_tac);
+                                (uu___4.FStar_TypeChecker_Common.deferred_to_tac);
                               FStar_TypeChecker_Common.deferred =
-                                (uu___665_4772.FStar_TypeChecker_Common.deferred);
+                                (uu___4.FStar_TypeChecker_Common.deferred);
                               FStar_TypeChecker_Common.univ_ineqs =
-                                (uu___665_4772.FStar_TypeChecker_Common.univ_ineqs);
+                                (uu___4.FStar_TypeChecker_Common.univ_ineqs);
                               FStar_TypeChecker_Common.implicits =
-                                (uu___665_4772.FStar_TypeChecker_Common.implicits)
+                                (uu___4.FStar_TypeChecker_Common.implicits)
                             } in
-                          let uu____4773 =
+                          let uu___4 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_meta
                                  (e2,
                                    (FStar_Syntax_Syntax.Meta_pattern
                                       (names, pats1))))
                               top.FStar_Syntax_Syntax.pos in
-                          let uu____4792 =
-                            FStar_TypeChecker_Env.conj_guard g g'1 in
-                          (uu____4773, c, uu____4792))))
+                          let uu___5 = FStar_TypeChecker_Env.conj_guard g g'1 in
+                          (uu___4, c, uu___5))))
        | FStar_Syntax_Syntax.Tm_meta
            (e1, FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Sequence))
            ->
-           let uu____4798 =
-             let uu____4799 = FStar_Syntax_Subst.compress e1 in
-             uu____4799.FStar_Syntax_Syntax.n in
-           (match uu____4798 with
+           let uu___1 =
+             let uu___2 = FStar_Syntax_Subst.compress e1 in
+             uu___2.FStar_Syntax_Syntax.n in
+           (match uu___1 with
             | FStar_Syntax_Syntax.Tm_let
-                ((uu____4808,
+                ((uu___2,
                   { FStar_Syntax_Syntax.lbname = x;
-                    FStar_Syntax_Syntax.lbunivs = uu____4810;
-                    FStar_Syntax_Syntax.lbtyp = uu____4811;
-                    FStar_Syntax_Syntax.lbeff = uu____4812;
+                    FStar_Syntax_Syntax.lbunivs = uu___3;
+                    FStar_Syntax_Syntax.lbtyp = uu___4;
+                    FStar_Syntax_Syntax.lbeff = uu___5;
                     FStar_Syntax_Syntax.lbdef = e11;
-                    FStar_Syntax_Syntax.lbattrs = uu____4814;
-                    FStar_Syntax_Syntax.lbpos = uu____4815;_}::[]),
+                    FStar_Syntax_Syntax.lbattrs = uu___6;
+                    FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
                  e2)
                 ->
-                let uu____4843 =
-                  let uu____4850 =
+                let uu___8 =
+                  let uu___9 =
                     FStar_TypeChecker_Env.set_expected_typ env1
                       FStar_Syntax_Syntax.t_unit in
-                  tc_term uu____4850 e11 in
-                (match uu____4843 with
+                  tc_term uu___9 e11 in
+                (match uu___8 with
                  | (e12, c1, g1) ->
-                     let uu____4860 = tc_term env1 e2 in
-                     (match uu____4860 with
+                     let uu___9 = tc_term env1 e2 in
+                     (match uu___9 with
                       | (e21, c2, g2) ->
                           let c =
                             FStar_TypeChecker_Util.maybe_return_e2_and_bind
@@ -1802,29 +1752,29 @@ and (tc_maybe_toplevel_term :
                               c.FStar_TypeChecker_Common.eff_name
                               c2.FStar_TypeChecker_Common.res_typ in
                           let attrs =
-                            let uu____4884 =
+                            let uu___10 =
                               FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                 env1 c1.FStar_TypeChecker_Common.eff_name in
-                            if uu____4884
+                            if uu___10
                             then [FStar_Syntax_Util.inline_let_attr]
                             else [] in
                           let e3 =
-                            let uu____4891 =
-                              let uu____4892 =
-                                let uu____4905 =
-                                  let uu____4912 =
-                                    let uu____4915 =
+                            let uu___10 =
+                              let uu___11 =
+                                let uu___12 =
+                                  let uu___13 =
+                                    let uu___14 =
                                       FStar_Syntax_Syntax.mk_lb
                                         (x, [],
                                           (c.FStar_TypeChecker_Common.eff_name),
                                           FStar_Syntax_Syntax.t_unit, e13,
                                           attrs,
                                           (e13.FStar_Syntax_Syntax.pos)) in
-                                    [uu____4915] in
-                                  (false, uu____4912) in
-                                (uu____4905, e22) in
-                              FStar_Syntax_Syntax.Tm_let uu____4892 in
-                            FStar_Syntax_Syntax.mk uu____4891
+                                    [uu___14] in
+                                  (false, uu___13) in
+                                (uu___12, e22) in
+                              FStar_Syntax_Syntax.Tm_let uu___11 in
+                            FStar_Syntax_Syntax.mk uu___10
                               e1.FStar_Syntax_Syntax.pos in
                           let e4 =
                             FStar_TypeChecker_Util.maybe_monadic env1 e3
@@ -1837,12 +1787,12 @@ and (tc_maybe_toplevel_term :
                                    (FStar_Syntax_Syntax.Meta_desugared
                                       FStar_Syntax_Syntax.Sequence)))
                               top.FStar_Syntax_Syntax.pos in
-                          let uu____4936 =
+                          let uu___10 =
                             FStar_TypeChecker_Env.conj_guard g1 g2 in
-                          (e5, c, uu____4936)))
-            | uu____4937 ->
-                let uu____4938 = tc_term env1 e1 in
-                (match uu____4938 with
+                          (e5, c, uu___10)))
+            | uu___2 ->
+                let uu___3 = tc_term env1 e1 in
+                (match uu___3 with
                  | (e2, c, g) ->
                      let e3 =
                        FStar_Syntax_Syntax.mk
@@ -1853,14 +1803,13 @@ and (tc_maybe_toplevel_term :
                          top.FStar_Syntax_Syntax.pos in
                      (e3, c, g)))
        | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_monadic uu____4960) ->
-           tc_term env1 e1
+           (e1, FStar_Syntax_Syntax.Meta_monadic uu___1) -> tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_monadic_lift uu____4972) ->
+           (e1, FStar_Syntax_Syntax.Meta_monadic_lift uu___1) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta (e1, m) ->
-           let uu____4991 = tc_term env1 e1 in
-           (match uu____4991 with
+           let uu___1 = tc_term env1 e1 in
+           (match uu___1 with
             | (e2, c, g) ->
                 let e3 =
                   FStar_Syntax_Syntax.mk
@@ -1869,24 +1818,24 @@ and (tc_maybe_toplevel_term :
                 (e3, c, g))
        | FStar_Syntax_Syntax.Tm_ascribed
            (e1, (asc, FStar_Pervasives_Native.Some tac), labopt) ->
-           let uu____5064 =
+           let uu___1 =
              tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
                env1 tac in
-           (match uu____5064 with
-            | (tac1, uu____5078, g_tac) ->
+           (match uu___1 with
+            | (tac1, uu___2, g_tac) ->
                 let t' =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_ascribed
                        (e1, (asc, FStar_Pervasives_Native.None), labopt))
                     top.FStar_Syntax_Syntax.pos in
-                let uu____5117 = tc_term env1 t' in
-                (match uu____5117 with
+                let uu___3 = tc_term env1 t' in
+                (match uu___3 with
                  | (t'1, c, g) ->
                      let t'2 =
-                       let uu____5134 =
-                         let uu____5135 = FStar_Syntax_Subst.compress t'1 in
-                         uu____5135.FStar_Syntax_Syntax.n in
-                       match uu____5134 with
+                       let uu___4 =
+                         let uu___5 = FStar_Syntax_Subst.compress t'1 in
+                         uu___5.FStar_Syntax_Syntax.n in
+                       match uu___4 with
                        | FStar_Syntax_Syntax.Tm_ascribed
                            (e2, (asc1, FStar_Pervasives_Native.None),
                             labopt1)
@@ -1896,75 +1845,71 @@ and (tc_maybe_toplevel_term :
                                 (e2,
                                   (asc1, (FStar_Pervasives_Native.Some tac1)),
                                   labopt1)) t'1.FStar_Syntax_Syntax.pos
-                       | uu____5221 -> failwith "impossible" in
+                       | uu___5 -> failwith "impossible" in
                      let g1 =
                        wrap_guard_with_tactic_opt
                          (FStar_Pervasives_Native.Some tac1) g in
-                     let uu____5223 =
-                       FStar_TypeChecker_Env.conj_guard g1 g_tac in
-                     (t'2, c, uu____5223)))
+                     let uu___4 = FStar_TypeChecker_Env.conj_guard g1 g_tac in
+                     (t'2, c, uu___4)))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (uu____5224,
+           (uu___1,
             (FStar_Util.Inr expected_c, FStar_Pervasives_Native.None),
-            uu____5226)
+            uu___2)
            when
-           let uu____5271 = FStar_All.pipe_right top is_comp_ascribed_reflect in
-           FStar_All.pipe_right uu____5271 FStar_Util.is_some ->
-           let uu____5302 =
-             let uu____5313 =
-               FStar_All.pipe_right top is_comp_ascribed_reflect in
-             FStar_All.pipe_right uu____5313 FStar_Util.must in
-           (match uu____5302 with
+           let uu___3 = FStar_All.pipe_right top is_comp_ascribed_reflect in
+           FStar_All.pipe_right uu___3 FStar_Util.is_some ->
+           let uu___3 =
+             let uu___4 = FStar_All.pipe_right top is_comp_ascribed_reflect in
+             FStar_All.pipe_right uu___4 FStar_Util.must in
+           (match uu___3 with
             | (effect_lid, e1, aqual) ->
-                let uu____5371 =
-                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-                (match uu____5371 with
-                 | (env0, uu____5385) ->
-                     let uu____5390 = tc_comp env0 expected_c in
-                     (match uu____5390 with
-                      | (expected_c1, uu____5404, g_c) ->
+                let uu___4 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                (match uu___4 with
+                 | (env0, uu___5) ->
+                     let uu___6 = tc_comp env0 expected_c in
+                     (match uu___6 with
+                      | (expected_c1, uu___7, g_c) ->
                           let expected_ct =
                             FStar_TypeChecker_Env.unfold_effect_abbrev env0
                               expected_c1 in
-                          ((let uu____5408 =
-                              let uu____5409 =
+                          ((let uu___9 =
+                              let uu___10 =
                                 FStar_Ident.lid_equals effect_lid
                                   expected_ct.FStar_Syntax_Syntax.effect_name in
-                              Prims.op_Negation uu____5409 in
-                            if uu____5408
+                              Prims.op_Negation uu___10 in
+                            if uu___9
                             then
-                              let uu____5410 =
-                                let uu____5415 =
-                                  let uu____5416 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
                                     FStar_Ident.string_of_lid effect_lid in
-                                  let uu____5417 =
+                                  let uu___13 =
                                     FStar_Ident.string_of_lid
                                       expected_ct.FStar_Syntax_Syntax.effect_name in
                                   FStar_Util.format2
                                     "The effect on reflect %s does not match with the annotation %s\n"
-                                    uu____5416 uu____5417 in
+                                    uu___12 uu___13 in
                                 (FStar_Errors.Fatal_UnexpectedEffect,
-                                  uu____5415) in
-                              FStar_Errors.raise_error uu____5410
+                                  uu___11) in
+                              FStar_Errors.raise_error uu___10
                                 top.FStar_Syntax_Syntax.pos
                             else ());
-                           (let uu____5420 =
-                              let uu____5421 =
+                           (let uu___10 =
+                              let uu___11 =
                                 FStar_TypeChecker_Env.is_user_reflectable_effect
                                   env1 effect_lid in
-                              Prims.op_Negation uu____5421 in
-                            if uu____5420
+                              Prims.op_Negation uu___11 in
+                            if uu___10
                             then
-                              let uu____5422 =
-                                let uu____5427 =
-                                  let uu____5428 =
+                              let uu___11 =
+                                let uu___12 =
+                                  let uu___13 =
                                     FStar_Ident.string_of_lid effect_lid in
                                   FStar_Util.format1
-                                    "Effect %s cannot be reflected"
-                                    uu____5428 in
+                                    "Effect %s cannot be reflected" uu___13 in
                                 (FStar_Errors.Fatal_EffectCannotBeReified,
-                                  uu____5427) in
-                              FStar_Errors.raise_error uu____5422
+                                  uu___12) in
+                              FStar_Errors.raise_error uu___11
                                 top.FStar_Syntax_Syntax.pos
                             else ());
                            (let u_c =
@@ -1972,59 +1917,57 @@ and (tc_maybe_toplevel_term :
                                 expected_ct.FStar_Syntax_Syntax.comp_univs
                                 FStar_List.hd in
                             let repr =
-                              let uu____5434 =
-                                let uu____5437 =
+                              let uu___10 =
+                                let uu___11 =
                                   FStar_All.pipe_right expected_ct
                                     FStar_Syntax_Syntax.mk_Comp in
                                 FStar_TypeChecker_Env.effect_repr env0
-                                  uu____5437 u_c in
-                              FStar_All.pipe_right uu____5434 FStar_Util.must in
+                                  uu___11 u_c in
+                              FStar_All.pipe_right uu___10 FStar_Util.must in
                             let e2 =
-                              let uu____5443 =
-                                let uu____5444 =
-                                  let uu____5471 =
-                                    let uu____5488 =
-                                      let uu____5497 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
                                         FStar_Syntax_Syntax.mk_Total' repr
                                           (FStar_Pervasives_Native.Some u_c) in
-                                      FStar_Util.Inr uu____5497 in
-                                    (uu____5488,
-                                      FStar_Pervasives_Native.None) in
-                                  (e1, uu____5471,
-                                    FStar_Pervasives_Native.None) in
-                                FStar_Syntax_Syntax.Tm_ascribed uu____5444 in
-                              FStar_Syntax_Syntax.mk uu____5443
+                                      FStar_Util.Inr uu___14 in
+                                    (uu___13, FStar_Pervasives_Native.None) in
+                                  (e1, uu___12, FStar_Pervasives_Native.None) in
+                                FStar_Syntax_Syntax.Tm_ascribed uu___11 in
+                              FStar_Syntax_Syntax.mk uu___10
                                 e1.FStar_Syntax_Syntax.pos in
-                            (let uu____5539 =
+                            (let uu___11 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env0)
                                  FStar_Options.Extreme in
-                             if uu____5539
+                             if uu___11
                              then
-                               let uu____5540 =
+                               let uu___12 =
                                  FStar_Syntax_Print.term_to_string e2 in
                                FStar_Util.print1
                                  "Typechecking ascribed reflect, inner ascribed term: %s\n"
-                                 uu____5540
+                                 uu___12
                              else ());
-                            (let uu____5542 = tc_tot_or_gtot_term env0 e2 in
-                             match uu____5542 with
-                             | (e3, uu____5556, g_e) ->
+                            (let uu___11 = tc_tot_or_gtot_term env0 e2 in
+                             match uu___11 with
+                             | (e3, uu___12, g_e) ->
                                  let e4 = FStar_Syntax_Util.unascribe e3 in
-                                 ((let uu____5560 =
+                                 ((let uu___14 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env0)
                                        FStar_Options.Extreme in
-                                   if uu____5560
+                                   if uu___14
                                    then
-                                     let uu____5561 =
+                                     let uu___15 =
                                        FStar_Syntax_Print.term_to_string e4 in
-                                     let uu____5562 =
+                                     let uu___16 =
                                        FStar_TypeChecker_Rel.guard_to_string
                                          env0 g_e in
                                      FStar_Util.print2
                                        "Typechecking ascribed reflect, after typechecking inner ascribed term: %s and guard: %s\n"
-                                       uu____5561 uu____5562
+                                       uu___15 uu___16
                                    else ());
                                   (let top1 =
                                      let r = top.FStar_Syntax_Syntax.pos in
@@ -2037,69 +1980,69 @@ and (tc_maybe_toplevel_term :
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
                                             (tm, [(e4, aqual)])) r in
-                                     let uu____5606 =
-                                       let uu____5607 =
-                                         let uu____5634 =
-                                           let uu____5637 =
+                                     let uu___14 =
+                                       let uu___15 =
+                                         let uu___16 =
+                                           let uu___17 =
                                              FStar_All.pipe_right expected_c1
                                                FStar_Syntax_Util.comp_effect_name in
-                                           FStar_All.pipe_right uu____5637
-                                             (fun uu____5642 ->
+                                           FStar_All.pipe_right uu___17
+                                             (fun uu___18 ->
                                                 FStar_Pervasives_Native.Some
-                                                  uu____5642) in
+                                                  uu___18) in
                                          (tm1,
                                            ((FStar_Util.Inr expected_c1),
                                              FStar_Pervasives_Native.None),
-                                           uu____5634) in
+                                           uu___16) in
                                        FStar_Syntax_Syntax.Tm_ascribed
-                                         uu____5607 in
-                                     FStar_Syntax_Syntax.mk uu____5606 r in
-                                   let uu____5681 =
-                                     let uu____5688 =
+                                         uu___15 in
+                                     FStar_Syntax_Syntax.mk uu___14 r in
+                                   let uu___14 =
+                                     let uu___15 =
                                        FStar_All.pipe_right expected_c1
                                          FStar_TypeChecker_Common.lcomp_of_comp in
                                      comp_check_expected_typ env1 top1
-                                       uu____5688 in
-                                   match uu____5681 with
+                                       uu___15 in
+                                   match uu___14 with
                                    | (top2, c, g_env) ->
-                                       let uu____5698 =
+                                       let uu___15 =
                                          FStar_TypeChecker_Env.conj_guards
                                            [g_c; g_e; g_env] in
-                                       (top2, c, uu____5698)))))))))
+                                       (top2, c, uu___15)))))))))
        | FStar_Syntax_Syntax.Tm_ascribed
            (e1, (FStar_Util.Inr expected_c, FStar_Pervasives_Native.None),
-            uu____5701)
+            uu___1)
            ->
-           let uu____5746 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-           (match uu____5746 with
-            | (env0, uu____5760) ->
-                let uu____5765 = tc_comp env0 expected_c in
-                (match uu____5765 with
-                 | (expected_c1, uu____5779, g) ->
-                     let uu____5781 =
-                       let uu____5788 =
+           let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+           (match uu___2 with
+            | (env0, uu___3) ->
+                let uu___4 = tc_comp env0 expected_c in
+                (match uu___4 with
+                 | (expected_c1, uu___5, g) ->
+                     let uu___6 =
+                       let uu___7 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.comp_result expected_c1)
                            (FStar_TypeChecker_Env.set_expected_typ env0) in
-                       tc_term uu____5788 e1 in
-                     (match uu____5781 with
+                       tc_term uu___7 e1 in
+                     (match uu___6 with
                       | (e2, c', g') ->
-                          let uu____5798 =
-                            let uu____5809 =
+                          let uu___7 =
+                            let uu___8 =
                               FStar_TypeChecker_Common.lcomp_comp c' in
-                            match uu____5809 with
+                            match uu___8 with
                             | (c'1, g_c') ->
-                                let uu____5826 =
+                                let uu___9 =
                                   check_expected_effect env0
                                     (FStar_Pervasives_Native.Some expected_c1)
                                     (e2, c'1) in
-                                (match uu____5826 with
+                                (match uu___9 with
                                  | (e3, expected_c2, g'') ->
-                                     let uu____5846 =
+                                     let uu___10 =
                                        FStar_TypeChecker_Env.conj_guard g_c'
                                          g'' in
-                                     (e3, expected_c2, uu____5846)) in
-                          (match uu____5798 with
+                                     (e3, expected_c2, uu___10)) in
+                          (match uu___7 with
                            | (e3, expected_c2, g'') ->
                                let e4 =
                                  FStar_Syntax_Syntax.mk
@@ -2115,46 +2058,44 @@ and (tc_maybe_toplevel_term :
                                  FStar_TypeChecker_Common.lcomp_of_comp
                                    expected_c2 in
                                let f =
-                                 let uu____5911 =
+                                 let uu___8 =
                                    FStar_TypeChecker_Env.conj_guard g' g'' in
-                                 FStar_TypeChecker_Env.conj_guard g
-                                   uu____5911 in
-                               let uu____5912 =
+                                 FStar_TypeChecker_Env.conj_guard g uu___8 in
+                               let uu___8 =
                                  comp_check_expected_typ env1 e4 lc in
-                               (match uu____5912 with
+                               (match uu___8 with
                                 | (e5, c, f2) ->
-                                    let uu____5928 =
+                                    let uu___9 =
                                       FStar_TypeChecker_Env.conj_guard f f2 in
-                                    (e5, c, uu____5928))))))
+                                    (e5, c, uu___9))))))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1, (FStar_Util.Inl t, FStar_Pervasives_Native.None), uu____5931)
-           ->
-           let uu____5976 = FStar_Syntax_Util.type_u () in
-           (match uu____5976 with
+           (e1, (FStar_Util.Inl t, FStar_Pervasives_Native.None), uu___1) ->
+           let uu___2 = FStar_Syntax_Util.type_u () in
+           (match uu___2 with
             | (k, u) ->
-                let uu____5989 = tc_check_tot_or_gtot_term env1 t k "" in
-                (match uu____5989 with
-                 | (t1, uu____6003, f) ->
-                     let uu____6005 =
-                       let uu____6012 =
+                let uu___3 = tc_check_tot_or_gtot_term env1 t k "" in
+                (match uu___3 with
+                 | (t1, uu___4, f) ->
+                     let uu___5 =
+                       let uu___6 =
                          FStar_TypeChecker_Env.set_expected_typ env1 t1 in
-                       tc_term uu____6012 e1 in
-                     (match uu____6005 with
+                       tc_term uu___6 e1 in
+                     (match uu___5 with
                       | (e2, c, g) ->
-                          let uu____6022 =
-                            let uu____6027 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_TypeChecker_Env.set_range env1
                                 t1.FStar_Syntax_Syntax.pos in
                             FStar_TypeChecker_Util.strengthen_precondition
                               (FStar_Pervasives_Native.Some
-                                 (fun uu____6032 ->
+                                 (fun uu___8 ->
                                     FStar_Util.return_all
                                       FStar_TypeChecker_Err.ill_kinded_type))
-                              uu____6027 e2 c f in
-                          (match uu____6022 with
+                              uu___7 e2 c f in
+                          (match uu___6 with
                            | (c1, f1) ->
-                               let uu____6041 =
-                                 let uu____6048 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_ascribed
                                         (e2,
@@ -2163,33 +2104,33 @@ and (tc_maybe_toplevel_term :
                                           (FStar_Pervasives_Native.Some
                                              (c1.FStar_TypeChecker_Common.eff_name))))
                                      top.FStar_Syntax_Syntax.pos in
-                                 comp_check_expected_typ env1 uu____6048 c1 in
-                               (match uu____6041 with
+                                 comp_check_expected_typ env1 uu___8 c1 in
+                               (match uu___7 with
                                 | (e3, c2, f2) ->
-                                    let uu____6096 =
-                                      let uu____6097 =
+                                    let uu___8 =
+                                      let uu___9 =
                                         FStar_TypeChecker_Env.conj_guard g f2 in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____6097 in
-                                    (e3, c2, uu____6096))))))
+                                        uu___9 in
+                                    (e3, c2, uu___8))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____6098;
-              FStar_Syntax_Syntax.vars = uu____6099;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6178 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6178 with
-            | (unary_op, uu____6202) ->
+           let uu___3 = FStar_Syntax_Util.head_and_args top in
+           (match uu___3 with
+            | (unary_op, uu___4) ->
                 let head =
-                  let uu____6230 =
+                  let uu___5 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6230 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___5 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2199,20 +2140,20 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu____6278;
-              FStar_Syntax_Syntax.vars = uu____6279;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6358 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6358 with
-            | (unary_op, uu____6382) ->
+           let uu___3 = FStar_Syntax_Util.head_and_args top in
+           (match uu___3 with
+            | (unary_op, uu___4) ->
                 let head =
-                  let uu____6410 =
+                  let uu___5 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6410 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___5 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2221,21 +2162,21 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____6458);
-              FStar_Syntax_Syntax.pos = uu____6459;
-              FStar_Syntax_Syntax.vars = uu____6460;_},
+                (FStar_Const.Const_reflect uu___1);
+              FStar_Syntax_Syntax.pos = uu___2;
+              FStar_Syntax_Syntax.vars = uu___3;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6539 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6539 with
-            | (unary_op, uu____6563) ->
+           let uu___4 = FStar_Syntax_Util.head_and_args top in
+           (match uu___4 with
+            | (unary_op, uu___5) ->
                 let head =
-                  let uu____6591 =
+                  let uu___6 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6591 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___6 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2245,21 +2186,20 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____6639;
-              FStar_Syntax_Syntax.vars = uu____6640;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             a1::a2::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6736 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6736 with
-            | (unary_op, uu____6760) ->
+           let uu___3 = FStar_Syntax_Util.head_and_args top in
+           (match uu___3 with
+            | (unary_op, uu___4) ->
                 let head =
-                  let uu____6788 =
+                  let uu___5 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                    uu____6788 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___5 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2269,101 +2209,101 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____6844;
-              FStar_Syntax_Syntax.vars = uu____6845;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             (e1, FStar_Pervasives_Native.None)::[])
            ->
-           let uu____6883 =
-             let uu____6890 =
-               let uu____6891 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____6891 in
-             tc_term uu____6890 e1 in
-           (match uu____6883 with
+           let uu___3 =
+             let uu___4 =
+               let uu___5 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_left FStar_Pervasives_Native.fst uu___5 in
+             tc_term uu___4 e1 in
+           (match uu___3 with
             | (e2, c, g) ->
-                let uu____6915 = FStar_Syntax_Util.head_and_args top in
-                (match uu____6915 with
-                 | (head, uu____6939) ->
-                     let uu____6964 =
+                let uu___4 = FStar_Syntax_Util.head_and_args top in
+                (match uu___4 with
+                 | (head, uu___5) ->
+                     let uu___6 =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_app
                             (head, [(e2, FStar_Pervasives_Native.None)]))
                          top.FStar_Syntax_Syntax.pos in
-                     let uu____6997 =
-                       let uu____6998 =
-                         let uu____6999 =
+                     let uu___7 =
+                       let uu___8 =
+                         let uu___9 =
                            FStar_Syntax_Syntax.tabbrev
                              FStar_Parser_Const.range_lid in
-                         FStar_Syntax_Syntax.mk_Total uu____6999 in
+                         FStar_Syntax_Syntax.mk_Total uu___9 in
                        FStar_All.pipe_left
-                         FStar_TypeChecker_Common.lcomp_of_comp uu____6998 in
-                     (uu____6964, uu____6997, g)))
+                         FStar_TypeChecker_Common.lcomp_of_comp uu___8 in
+                     (uu___6, uu___7, g)))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____7000;
-              FStar_Syntax_Syntax.vars = uu____7001;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             (t, FStar_Pervasives_Native.None)::(r,
                                                 FStar_Pervasives_Native.None)::[])
            ->
-           let uu____7054 = FStar_Syntax_Util.head_and_args top in
-           (match uu____7054 with
-            | (head, uu____7078) ->
+           let uu___3 = FStar_Syntax_Util.head_and_args top in
+           (match uu___3 with
+            | (head, uu___4) ->
                 let env' =
-                  let uu____7104 =
+                  let uu___5 =
                     FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu____7104 in
-                let uu____7105 = tc_term env' r in
-                (match uu____7105 with
-                 | (er, uu____7119, gr) ->
-                     let uu____7121 = tc_term env1 t in
-                     (match uu____7121 with
+                  FStar_TypeChecker_Env.set_expected_typ env1 uu___5 in
+                let uu___5 = tc_term env' r in
+                (match uu___5 with
+                 | (er, uu___6, gr) ->
+                     let uu___7 = tc_term env1 t in
+                     (match uu___7 with
                       | (t1, tt, gt) ->
                           let g = FStar_TypeChecker_Env.conj_guard gr gt in
-                          let uu____7138 =
-                            let uu____7139 =
-                              let uu____7140 = FStar_Syntax_Syntax.as_arg t1 in
-                              let uu____7149 =
-                                let uu____7160 = FStar_Syntax_Syntax.as_arg r in
-                                [uu____7160] in
-                              uu____7140 :: uu____7149 in
-                            FStar_Syntax_Syntax.mk_Tm_app head uu____7139
+                          let uu___8 =
+                            let uu___9 =
+                              let uu___10 = FStar_Syntax_Syntax.as_arg t1 in
+                              let uu___11 =
+                                let uu___12 = FStar_Syntax_Syntax.as_arg r in
+                                [uu___12] in
+                              uu___10 :: uu___11 in
+                            FStar_Syntax_Syntax.mk_Tm_app head uu___9
                               top.FStar_Syntax_Syntax.pos in
-                          (uu____7138, tt, g))))
+                          (uu___8, tt, g))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____7193;
-              FStar_Syntax_Syntax.vars = uu____7194;_},
-            uu____7195)
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            uu___3)
            ->
-           let uu____7220 =
-             let uu____7225 =
-               let uu____7226 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.format1 "Ill-applied constant %s" uu____7226 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____7225) in
-           FStar_Errors.raise_error uu____7220 e.FStar_Syntax_Syntax.pos
+           let uu___4 =
+             let uu___5 =
+               let uu___6 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu___6 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu___5) in
+           FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____7233;
-              FStar_Syntax_Syntax.vars = uu____7234;_},
-            uu____7235)
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
+            uu___3)
            ->
-           let uu____7260 =
-             let uu____7265 =
-               let uu____7266 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.format1 "Ill-applied constant %s" uu____7266 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____7265) in
-           FStar_Errors.raise_error uu____7260 e.FStar_Syntax_Syntax.pos
+           let uu___4 =
+             let uu___5 =
+               let uu___6 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu___6 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu___5) in
+           FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu____7273;
-              FStar_Syntax_Syntax.vars = uu____7274;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             (e1, aqual)::[])
            ->
            (if FStar_Option.isSome aqual
@@ -2372,41 +2312,40 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
                   "Qualifier on argument to reify is irrelevant and will be ignored")
             else ();
-            (let uu____7317 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-             match uu____7317 with
-             | (env0, uu____7331) ->
-                 let uu____7336 = tc_term env0 e1 in
-                 (match uu____7336 with
+            (let uu___4 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+             match uu___4 with
+             | (env0, uu___5) ->
+                 let uu___6 = tc_term env0 e1 in
+                 (match uu___6 with
                   | (e2, c, g) ->
-                      let uu____7352 = FStar_Syntax_Util.head_and_args top in
-                      (match uu____7352 with
-                       | (reify_op, uu____7376) ->
+                      let uu___7 = FStar_Syntax_Util.head_and_args top in
+                      (match uu___7 with
+                       | (reify_op, uu___8) ->
                            let u_c =
                              env1.FStar_TypeChecker_Env.universe_of env1
                                c.FStar_TypeChecker_Common.res_typ in
-                           let uu____7402 =
-                             FStar_TypeChecker_Common.lcomp_comp c in
-                           (match uu____7402 with
+                           let uu___9 = FStar_TypeChecker_Common.lcomp_comp c in
+                           (match uu___9 with
                             | (c1, g_c) ->
                                 let ef =
                                   FStar_Syntax_Util.comp_effect_name c1 in
-                                ((let uu____7417 =
-                                    let uu____7418 =
+                                ((let uu___11 =
+                                    let uu___12 =
                                       FStar_TypeChecker_Env.is_user_reifiable_effect
                                         env1 ef in
-                                    Prims.op_Negation uu____7418 in
-                                  if uu____7417
+                                    Prims.op_Negation uu___12 in
+                                  if uu___11
                                   then
-                                    let uu____7419 =
-                                      let uu____7424 =
-                                        let uu____7425 =
+                                    let uu___12 =
+                                      let uu___13 =
+                                        let uu___14 =
                                           FStar_Ident.string_of_lid ef in
                                         FStar_Util.format1
                                           "Effect %s cannot be reified"
-                                          uu____7425 in
+                                          uu___14 in
                                       (FStar_Errors.Fatal_EffectCannotBeReified,
-                                        uu____7424) in
-                                    FStar_Errors.raise_error uu____7419
+                                        uu___13) in
+                                    FStar_Errors.raise_error uu___12
                                       e2.FStar_Syntax_Syntax.pos
                                   else ());
                                  (let repr =
@@ -2418,14 +2357,14 @@ and (tc_maybe_toplevel_term :
                                          (reify_op, [(e2, aqual)]))
                                       top.FStar_Syntax_Syntax.pos in
                                   let c2 =
-                                    let uu____7464 =
+                                    let uu___11 =
                                       FStar_TypeChecker_Env.is_total_effect
                                         env1 ef in
-                                    if uu____7464
+                                    if uu___11
                                     then
-                                      let uu____7465 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.mk_Total repr in
-                                      FStar_All.pipe_right uu____7465
+                                      FStar_All.pipe_right uu___12
                                         FStar_TypeChecker_Common.lcomp_of_comp
                                     else
                                       (let ct =
@@ -2440,27 +2379,27 @@ and (tc_maybe_toplevel_term :
                                              [];
                                            FStar_Syntax_Syntax.flags = []
                                          } in
-                                       let uu____7476 =
+                                       let uu___13 =
                                          FStar_Syntax_Syntax.mk_Comp ct in
-                                       FStar_All.pipe_right uu____7476
+                                       FStar_All.pipe_right uu___13
                                          FStar_TypeChecker_Common.lcomp_of_comp) in
-                                  let uu____7477 =
+                                  let uu___11 =
                                     comp_check_expected_typ env1 e3 c2 in
-                                  match uu____7477 with
+                                  match uu___11 with
                                   | (e4, c3, g') ->
-                                      let uu____7493 =
-                                        let uu____7494 =
+                                      let uu___12 =
+                                        let uu___13 =
                                           FStar_TypeChecker_Env.conj_guard
                                             g_c g' in
                                         FStar_TypeChecker_Env.conj_guard g
-                                          uu____7494 in
-                                      (e4, c3, uu____7493))))))))
+                                          uu___13 in
+                                      (e4, c3, uu___12))))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu____7496;
-              FStar_Syntax_Syntax.vars = uu____7497;_},
+              FStar_Syntax_Syntax.pos = uu___1;
+              FStar_Syntax_Syntax.vars = uu___2;_},
             (e1, aqual)::[])
            ->
            (if FStar_Option.isSome aqual
@@ -2469,52 +2408,49 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
                   "Qualifier on argument to reflect is irrelevant and will be ignored")
             else ();
-            (let uu____7541 =
-               let uu____7542 =
+            (let uu___5 =
+               let uu___6 =
                  FStar_TypeChecker_Env.is_user_reflectable_effect env1 l in
-               Prims.op_Negation uu____7542 in
-             if uu____7541
+               Prims.op_Negation uu___6 in
+             if uu___5
              then
-               let uu____7543 =
-                 let uu____7548 =
-                   let uu____7549 = FStar_Ident.string_of_lid l in
-                   FStar_Util.format1 "Effect %s cannot be reflected"
-                     uu____7549 in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7548) in
-               FStar_Errors.raise_error uu____7543 e1.FStar_Syntax_Syntax.pos
+               let uu___6 =
+                 let uu___7 =
+                   let uu___8 = FStar_Ident.string_of_lid l in
+                   FStar_Util.format1 "Effect %s cannot be reflected" uu___8 in
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu___7) in
+               FStar_Errors.raise_error uu___6 e1.FStar_Syntax_Syntax.pos
              else ());
-            (let uu____7551 = FStar_Syntax_Util.head_and_args top in
-             match uu____7551 with
-             | (reflect_op, uu____7575) ->
-                 let uu____7600 =
-                   FStar_TypeChecker_Env.effect_decl_opt env1 l in
-                 (match uu____7600 with
+            (let uu___5 = FStar_Syntax_Util.head_and_args top in
+             match uu___5 with
+             | (reflect_op, uu___6) ->
+                 let uu___7 = FStar_TypeChecker_Env.effect_decl_opt env1 l in
+                 (match uu___7 with
                   | FStar_Pervasives_Native.None ->
-                      let uu____7621 =
-                        let uu____7626 =
-                          let uu____7627 = FStar_Ident.string_of_lid l in
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 = FStar_Ident.string_of_lid l in
                           FStar_Util.format1
-                            "Effect %s not found (for reflect)" uu____7627 in
-                        (FStar_Errors.Fatal_EffectNotFound, uu____7626) in
-                      FStar_Errors.raise_error uu____7621
+                            "Effect %s not found (for reflect)" uu___10 in
+                        (FStar_Errors.Fatal_EffectNotFound, uu___9) in
+                      FStar_Errors.raise_error uu___8
                         e1.FStar_Syntax_Syntax.pos
                   | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                      let uu____7646 =
+                      let uu___8 =
                         FStar_TypeChecker_Env.clear_expected_typ env1 in
-                      (match uu____7646 with
-                       | (env_no_ex, uu____7660) ->
-                           let uu____7665 =
-                             let uu____7674 =
-                               tc_tot_or_gtot_term env_no_ex e1 in
-                             match uu____7674 with
+                      (match uu___8 with
+                       | (env_no_ex, uu___9) ->
+                           let uu___10 =
+                             let uu___11 = tc_tot_or_gtot_term env_no_ex e1 in
+                             match uu___11 with
                              | (e2, c, g) ->
-                                 ((let uu____7693 =
-                                     let uu____7694 =
+                                 ((let uu___13 =
+                                     let uu___14 =
                                        FStar_TypeChecker_Common.is_total_lcomp
                                          c in
                                      FStar_All.pipe_left Prims.op_Negation
-                                       uu____7694 in
-                                   if uu____7693
+                                       uu___14 in
+                                   if uu___13
                                    then
                                      FStar_TypeChecker_Err.add_errors env1
                                        [(FStar_Errors.Error_UnexpectedGTotComputation,
@@ -2522,26 +2458,25 @@ and (tc_maybe_toplevel_term :
                                           (e2.FStar_Syntax_Syntax.pos))]
                                    else ());
                                   (e2, c, g)) in
-                           (match uu____7665 with
+                           (match uu___10 with
                             | (e2, c_e, g_e) ->
-                                let uu____7723 =
-                                  let uu____7738 =
-                                    FStar_Syntax_Util.type_u () in
-                                  match uu____7738 with
+                                let uu___11 =
+                                  let uu___12 = FStar_Syntax_Util.type_u () in
+                                  match uu___12 with
                                   | (a, u_a) ->
-                                      let uu____7759 =
+                                      let uu___13 =
                                         FStar_TypeChecker_Util.new_implicit_var
                                           "" e2.FStar_Syntax_Syntax.pos
                                           env_no_ex a in
-                                      (match uu____7759 with
-                                       | (a_uvar, uu____7787, g_a) ->
-                                           let uu____7801 =
+                                      (match uu___13 with
+                                       | (a_uvar, uu___14, g_a) ->
+                                           let uu___15 =
                                              FStar_TypeChecker_Util.fresh_effect_repr_en
                                                env_no_ex
                                                e2.FStar_Syntax_Syntax.pos l
                                                u_a a_uvar in
-                                           (uu____7801, u_a, a_uvar, g_a)) in
-                                (match uu____7723 with
+                                           (uu___15, u_a, a_uvar, g_a)) in
+                                (match uu___11 with
                                  | ((expected_repr_typ, g_repr), u_a, a, g_a)
                                      ->
                                      let g_eq =
@@ -2549,37 +2484,34 @@ and (tc_maybe_toplevel_term :
                                          c_e.FStar_TypeChecker_Common.res_typ
                                          expected_repr_typ in
                                      let eff_args =
-                                       let uu____7843 =
-                                         let uu____7844 =
+                                       let uu___12 =
+                                         let uu___13 =
                                            FStar_Syntax_Subst.compress
                                              expected_repr_typ in
-                                         uu____7844.FStar_Syntax_Syntax.n in
-                                       match uu____7843 with
+                                         uu___13.FStar_Syntax_Syntax.n in
+                                       match uu___12 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____7857, uu____7858::args) ->
-                                           args
-                                       | uu____7900 ->
-                                           let uu____7901 =
-                                             let uu____7906 =
-                                               let uu____7907 =
+                                           (uu___13, uu___14::args) -> args
+                                       | uu___13 ->
+                                           let uu___14 =
+                                             let uu___15 =
+                                               let uu___16 =
                                                  FStar_Ident.string_of_lid l in
-                                               let uu____7908 =
+                                               let uu___17 =
                                                  FStar_Syntax_Print.tag_of_term
                                                    expected_repr_typ in
-                                               let uu____7909 =
+                                               let uu___18 =
                                                  FStar_Syntax_Print.term_to_string
                                                    expected_repr_typ in
                                                FStar_Util.format3
                                                  "Expected repr type for %s is not an application node (%s:%s)"
-                                                 uu____7907 uu____7908
-                                                 uu____7909 in
+                                                 uu___16 uu___17 uu___18 in
                                              (FStar_Errors.Fatal_UnexpectedEffect,
-                                               uu____7906) in
-                                           FStar_Errors.raise_error
-                                             uu____7901
+                                               uu___15) in
+                                           FStar_Errors.raise_error uu___14
                                              top.FStar_Syntax_Syntax.pos in
                                      let c =
-                                       let uu____7921 =
+                                       let uu___12 =
                                          FStar_Syntax_Syntax.mk_Comp
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
@@ -2593,16 +2525,16 @@ and (tc_maybe_toplevel_term :
                                                = eff_args;
                                              FStar_Syntax_Syntax.flags = []
                                            } in
-                                       FStar_All.pipe_right uu____7921
+                                       FStar_All.pipe_right uu___12
                                          FStar_TypeChecker_Common.lcomp_of_comp in
                                      let e3 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
                                             (reflect_op, [(e2, aqual)]))
                                          top.FStar_Syntax_Syntax.pos in
-                                     let uu____7957 =
+                                     let uu___12 =
                                        comp_check_expected_typ env1 e3 c in
-                                     (match uu____7957 with
+                                     (match uu___12 with
                                       | (e4, c1, g') ->
                                           let e5 =
                                             FStar_Syntax_Syntax.mk
@@ -2612,37 +2544,37 @@ and (tc_maybe_toplevel_term :
                                                       ((c1.FStar_TypeChecker_Common.eff_name),
                                                         (c1.FStar_TypeChecker_Common.res_typ)))))
                                               e4.FStar_Syntax_Syntax.pos in
-                                          let uu____7980 =
+                                          let uu___13 =
                                             FStar_TypeChecker_Env.conj_guards
                                               [g_e; g_repr; g_a; g_eq; g'] in
-                                          (e5, c1, uu____7980))))))))
+                                          (e5, c1, uu___13))))))))
        | FStar_Syntax_Syntax.Tm_app
            (head, (tau, FStar_Pervasives_Native.None)::[]) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8019 = FStar_Syntax_Util.head_and_args top in
-           (match uu____8019 with
+           let uu___1 = FStar_Syntax_Util.head_and_args top in
+           (match uu___1 with
             | (head1, args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app
            (head,
-            (uu____8069, FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Implicit uu____8070))::(tau,
-                                                          FStar_Pervasives_Native.None)::[])
+            (uu___1, FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Implicit uu___2))::(tau,
+                                                      FStar_Pervasives_Native.None)::[])
            when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8122 = FStar_Syntax_Util.head_and_args top in
-           (match uu____8122 with
+           let uu___3 = FStar_Syntax_Util.head_and_args top in
+           (match uu___3 with
             | (head1, args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8197 =
+           let uu___1 =
              match args with
              | (tau, FStar_Pervasives_Native.None)::rest ->
                  ([(tau, FStar_Pervasives_Native.None)], rest)
@@ -2652,160 +2584,159 @@ and (tc_maybe_toplevel_term :
                      (FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit b)));
                   (tau, FStar_Pervasives_Native.None)], rest)
-             | uu____8406 ->
+             | uu___2 ->
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_SynthByTacticError,
                      "synth_by_tactic: bad application")
                    top.FStar_Syntax_Syntax.pos in
-           (match uu____8197 with
+           (match uu___1 with
             | (args1, args2) ->
                 let t1 = FStar_Syntax_Util.mk_app head args1 in
                 let t2 = FStar_Syntax_Util.mk_app t1 args2 in tc_term env1 t2)
        | FStar_Syntax_Syntax.Tm_app (head, args) ->
            let env0 = env1 in
            let env2 =
-             let uu____8523 =
-               let uu____8524 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_All.pipe_right uu____8524 FStar_Pervasives_Native.fst in
-             FStar_All.pipe_right uu____8523 instantiate_both in
-           ((let uu____8540 =
-               FStar_TypeChecker_Env.debug env2 FStar_Options.High in
-             if uu____8540
+             let uu___1 =
+               let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_right uu___2 FStar_Pervasives_Native.fst in
+             FStar_All.pipe_right uu___1 instantiate_both in
+           ((let uu___2 = FStar_TypeChecker_Env.debug env2 FStar_Options.High in
+             if uu___2
              then
-               let uu____8541 =
+               let uu___3 =
                  FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
-               let uu____8542 = FStar_Syntax_Print.term_to_string top in
-               let uu____8543 =
-                 let uu____8544 = FStar_TypeChecker_Env.expected_typ env0 in
-                 FStar_All.pipe_right uu____8544
-                   (fun uu___3_8550 ->
-                      match uu___3_8550 with
+               let uu___4 = FStar_Syntax_Print.term_to_string top in
+               let uu___5 =
+                 let uu___6 = FStar_TypeChecker_Env.expected_typ env0 in
+                 FStar_All.pipe_right uu___6
+                   (fun uu___7 ->
+                      match uu___7 with
                       | FStar_Pervasives_Native.None -> "none"
                       | FStar_Pervasives_Native.Some t ->
                           FStar_Syntax_Print.term_to_string t) in
                FStar_Util.print3
-                 "(%s) Checking app %s, expected type is %s\n" uu____8541
-                 uu____8542 uu____8543
+                 "(%s) Checking app %s, expected type is %s\n" uu___3 uu___4
+                 uu___5
              else ());
-            (let uu____8555 = tc_term (no_inst env2) head in
-             match uu____8555 with
+            (let uu___2 = tc_term (no_inst env2) head in
+             match uu___2 with
              | (head1, chead, g_head) ->
-                 let uu____8571 =
-                   let uu____8576 = FStar_TypeChecker_Common.lcomp_comp chead in
-                   FStar_All.pipe_right uu____8576
-                     (fun uu____8593 ->
-                        match uu____8593 with
+                 let uu___3 =
+                   let uu___4 = FStar_TypeChecker_Common.lcomp_comp chead in
+                   FStar_All.pipe_right uu___4
+                     (fun uu___5 ->
+                        match uu___5 with
                         | (c, g) ->
-                            let uu____8604 =
+                            let uu___6 =
                               FStar_TypeChecker_Env.conj_guard g_head g in
-                            (c, uu____8604)) in
-                 (match uu____8571 with
+                            (c, uu___6)) in
+                 (match uu___3 with
                   | (chead1, g_head1) ->
-                      let uu____8613 =
-                        let uu____8620 =
+                      let uu___4 =
+                        let uu___5 =
                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
                              &&
-                             (let uu____8622 = FStar_Options.lax () in
-                              Prims.op_Negation uu____8622))
+                             (let uu___6 = FStar_Options.lax () in
+                              Prims.op_Negation uu___6))
                             &&
                             (FStar_TypeChecker_Util.short_circuit_head head1) in
-                        if uu____8620
+                        if uu___5
                         then
-                          let uu____8629 =
-                            let uu____8636 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_TypeChecker_Env.expected_typ env0 in
                             check_short_circuit_args env2 head1 chead1
-                              g_head1 args uu____8636 in
-                          match uu____8629 with | (e1, c, g) -> (e1, c, g)
+                              g_head1 args uu___7 in
+                          match uu___6 with | (e1, c, g) -> (e1, c, g)
                         else
-                          (let uu____8649 =
+                          (let uu___7 =
                              FStar_TypeChecker_Env.expected_typ env0 in
                            check_application_args env2 head1 chead1 g_head1
-                             args uu____8649) in
-                      (match uu____8613 with
+                             args uu___7) in
+                      (match uu___4 with
                        | (e1, c, g) ->
-                           let uu____8661 =
-                             let uu____8668 =
+                           let uu___5 =
+                             let uu___6 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  c in
-                             if uu____8668
+                             if uu___6
                              then
-                               let uu____8675 =
+                               let uu___7 =
                                  FStar_TypeChecker_Util.maybe_instantiate
                                    env0 e1 c.FStar_TypeChecker_Common.res_typ in
-                               match uu____8675 with
+                               match uu___7 with
                                | (e2, res_typ, implicits) ->
-                                   let uu____8691 =
+                                   let uu___8 =
                                      FStar_TypeChecker_Common.set_result_typ_lc
                                        c res_typ in
-                                   (e2, uu____8691, implicits)
+                                   (e2, uu___8, implicits)
                              else
                                (e1, c, FStar_TypeChecker_Env.trivial_guard) in
-                           (match uu____8661 with
+                           (match uu___5 with
                             | (e2, c1, implicits) ->
-                                ((let uu____8703 =
+                                ((let uu___7 =
                                     FStar_TypeChecker_Env.debug env2
                                       FStar_Options.Extreme in
-                                  if uu____8703
+                                  if uu___7
                                   then
-                                    let uu____8704 =
+                                    let uu___8 =
                                       FStar_TypeChecker_Rel.print_pending_implicits
                                         g in
                                     FStar_Util.print1
                                       "Introduced {%s} implicits in application\n"
-                                      uu____8704
+                                      uu___8
                                   else ());
-                                 (let uu____8706 =
+                                 (let uu___7 =
                                     comp_check_expected_typ env0 e2 c1 in
-                                  match uu____8706 with
+                                  match uu___7 with
                                   | (e3, c2, g') ->
                                       let gres =
                                         FStar_TypeChecker_Env.conj_guard g g' in
                                       let gres1 =
                                         FStar_TypeChecker_Env.conj_guard gres
                                           implicits in
-                                      ((let uu____8725 =
+                                      ((let uu___9 =
                                           FStar_TypeChecker_Env.debug env2
                                             FStar_Options.Extreme in
-                                        if uu____8725
+                                        if uu___9
                                         then
-                                          let uu____8726 =
+                                          let uu___10 =
                                             FStar_Syntax_Print.term_to_string
                                               e3 in
-                                          let uu____8727 =
+                                          let uu___11 =
                                             FStar_TypeChecker_Rel.guard_to_string
                                               env2 gres1 in
                                           FStar_Util.print2
                                             "Guard from application node %s is %s\n"
-                                            uu____8726 uu____8727
+                                            uu___10 uu___11
                                         else ());
                                        (e3, c2, gres1)))))))))
-       | FStar_Syntax_Syntax.Tm_match uu____8729 -> tc_match env1 top
+       | FStar_Syntax_Syntax.Tm_match uu___1 -> tc_match env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((false,
-             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8752;
-               FStar_Syntax_Syntax.lbunivs = uu____8753;
-               FStar_Syntax_Syntax.lbtyp = uu____8754;
-               FStar_Syntax_Syntax.lbeff = uu____8755;
-               FStar_Syntax_Syntax.lbdef = uu____8756;
-               FStar_Syntax_Syntax.lbattrs = uu____8757;
-               FStar_Syntax_Syntax.lbpos = uu____8758;_}::[]),
-            uu____8759)
+             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu___1;
+               FStar_Syntax_Syntax.lbunivs = uu___2;
+               FStar_Syntax_Syntax.lbtyp = uu___3;
+               FStar_Syntax_Syntax.lbeff = uu___4;
+               FStar_Syntax_Syntax.lbdef = uu___5;
+               FStar_Syntax_Syntax.lbattrs = uu___6;
+               FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
+            uu___8)
            -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false, uu____8782), uu____8783) ->
+       | FStar_Syntax_Syntax.Tm_let ((false, uu___1), uu___2) ->
            check_inner_let env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((true,
-             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8798;
-               FStar_Syntax_Syntax.lbunivs = uu____8799;
-               FStar_Syntax_Syntax.lbtyp = uu____8800;
-               FStar_Syntax_Syntax.lbeff = uu____8801;
-               FStar_Syntax_Syntax.lbdef = uu____8802;
-               FStar_Syntax_Syntax.lbattrs = uu____8803;
-               FStar_Syntax_Syntax.lbpos = uu____8804;_}::uu____8805),
-            uu____8806)
+             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu___1;
+               FStar_Syntax_Syntax.lbunivs = uu___2;
+               FStar_Syntax_Syntax.lbtyp = uu___3;
+               FStar_Syntax_Syntax.lbeff = uu___4;
+               FStar_Syntax_Syntax.lbdef = uu___5;
+               FStar_Syntax_Syntax.lbattrs = uu___6;
+               FStar_Syntax_Syntax.lbpos = uu___7;_}::uu___8),
+            uu___9)
            -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true, uu____8831), uu____8832) ->
+       | FStar_Syntax_Syntax.Tm_let ((true, uu___1), uu___2) ->
            check_inner_let_rec env1 top)
 and (tc_match :
   FStar_TypeChecker_Env.env ->
@@ -2815,60 +2746,60 @@ and (tc_match :
   =
   fun env ->
     fun top ->
-      let uu____8855 =
-        let uu____8856 = FStar_Syntax_Subst.compress top in
-        uu____8856.FStar_Syntax_Syntax.n in
-      match uu____8855 with
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress top in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
       | FStar_Syntax_Syntax.Tm_match (e1, eqns) ->
-          let uu____8903 = FStar_TypeChecker_Env.clear_expected_typ env in
-          (match uu____8903 with
+          let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env in
+          (match uu___1 with
            | (env1, topt) ->
                let env11 = instantiate_both env1 in
-               let uu____8923 = tc_term env11 e1 in
-               (match uu____8923 with
+               let uu___2 = tc_term env11 e1 in
+               (match uu___2 with
                 | (e11, c1, g1) ->
-                    let uu____8939 =
-                      let uu____8950 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_TypeChecker_Util.coerce_views env e11 c1 in
-                      match uu____8950 with
+                      match uu___4 with
                       | FStar_Pervasives_Native.Some (e12, c11) ->
                           (e12, c11, eqns)
                       | FStar_Pervasives_Native.None -> (e11, c1, eqns) in
-                    (match uu____8939 with
+                    (match uu___3 with
                      | (e12, c11, eqns1) ->
                          let eqns2 = eqns1 in
-                         let uu____9005 =
+                         let uu___4 =
                            match topt with
                            | FStar_Pervasives_Native.Some t -> (env, t, g1)
                            | FStar_Pervasives_Native.None ->
-                               let uu____9019 = FStar_Syntax_Util.type_u () in
-                               (match uu____9019 with
-                                | (k, uu____9031) ->
-                                    let uu____9032 =
+                               let uu___5 = FStar_Syntax_Util.type_u () in
+                               (match uu___5 with
+                                | (k, uu___6) ->
+                                    let uu___7 =
                                       FStar_TypeChecker_Util.new_implicit_var
                                         "match result"
                                         e12.FStar_Syntax_Syntax.pos env k in
-                                    (match uu____9032 with
-                                     | (res_t, uu____9052, g) ->
-                                         let uu____9066 =
+                                    (match uu___7 with
+                                     | (res_t, uu___8, g) ->
+                                         let uu___9 =
                                            FStar_TypeChecker_Env.set_expected_typ
                                              env res_t in
-                                         let uu____9067 =
+                                         let uu___10 =
                                            FStar_TypeChecker_Env.conj_guard
                                              g1 g in
-                                         (uu____9066, res_t, uu____9067))) in
-                         (match uu____9005 with
+                                         (uu___9, res_t, uu___10))) in
+                         (match uu___4 with
                           | (env_branches, res_t, g11) ->
-                              ((let uu____9078 =
+                              ((let uu___6 =
                                   FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme in
-                                if uu____9078
+                                if uu___6
                                 then
-                                  let uu____9079 =
+                                  let uu___7 =
                                     FStar_Syntax_Print.term_to_string res_t in
                                   FStar_Util.print1
                                     "Tm_match: expected type of branches is %s\n"
-                                    uu____9079
+                                    uu___7
                                 else ());
                                (let guard_x =
                                   FStar_Syntax_Syntax.new_bv
@@ -2879,33 +2810,32 @@ and (tc_match :
                                   FStar_All.pipe_right eqns2
                                     (FStar_List.map
                                        (tc_eqn guard_x env_branches)) in
-                                let uu____9178 =
-                                  let uu____9185 =
+                                let uu___6 =
+                                  let uu___7 =
                                     FStar_List.fold_right
-                                      (fun uu____9272 ->
-                                         fun uu____9273 ->
-                                           match (uu____9272, uu____9273)
-                                           with
+                                      (fun uu___8 ->
+                                         fun uu___9 ->
+                                           match (uu___8, uu___9) with
                                            | ((branch, f, eff_label, cflags,
                                                c, g, erasable_branch),
                                               (caccum, gaccum, erasable)) ->
-                                               let uu____9523 =
+                                               let uu___10 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g gaccum in
                                                (((f, eff_label, cflags, c) ::
-                                                 caccum), uu____9523,
+                                                 caccum), uu___10,
                                                  (erasable || erasable_branch)))
                                       t_eqns
                                       ([],
                                         FStar_TypeChecker_Env.trivial_guard,
                                         false) in
-                                  match uu____9185 with
+                                  match uu___7 with
                                   | (cases, g, erasable) ->
-                                      let uu____9624 =
+                                      let uu___8 =
                                         FStar_TypeChecker_Util.bind_cases env
                                           res_t cases guard_x in
-                                      (uu____9624, g, erasable) in
-                                match uu____9178 with
+                                      (uu___8, g, erasable) in
+                                match uu___6 with
                                 | (c_branches, g_branches, erasable) ->
                                     let cres =
                                       FStar_TypeChecker_Util.bind
@@ -2924,13 +2854,13 @@ and (tc_match :
                                             FStar_Syntax_Util.t_bool
                                             (FStar_Pervasives_Native.Some
                                                FStar_Syntax_Syntax.U_zero) in
-                                        let uu____9640 =
+                                        let uu___7 =
                                           FStar_TypeChecker_Common.lcomp_of_comp
                                             c in
                                         FStar_TypeChecker_Util.bind
                                           e.FStar_Syntax_Syntax.pos env
                                           (FStar_Pervasives_Native.Some e)
-                                          uu____9640
+                                          uu___7
                                           (FStar_Pervasives_Native.None,
                                             cres)
                                       else cres in
@@ -2939,104 +2869,103 @@ and (tc_match :
                                         let branches =
                                           FStar_All.pipe_right t_eqns
                                             (FStar_List.map
-                                               (fun uu____9777 ->
-                                                  match uu____9777 with
-                                                  | ((pat, wopt, br),
-                                                     uu____9823, eff_label,
-                                                     uu____9825, uu____9826,
-                                                     uu____9827, uu____9828)
-                                                      ->
-                                                      let uu____9863 =
+                                               (fun uu___7 ->
+                                                  match uu___7 with
+                                                  | ((pat, wopt, br), uu___8,
+                                                     eff_label, uu___9,
+                                                     uu___10, uu___11,
+                                                     uu___12) ->
+                                                      let uu___13 =
                                                         FStar_TypeChecker_Util.maybe_lift
                                                           env br eff_label
                                                           cres1.FStar_TypeChecker_Common.eff_name
                                                           res_t in
-                                                      (pat, wopt, uu____9863))) in
-                                        let e =
+                                                      (pat, wopt, uu___13))) in
+                                        let e2 =
                                           FStar_Syntax_Syntax.mk
                                             (FStar_Syntax_Syntax.Tm_match
                                                (scrutinee, branches))
                                             top.FStar_Syntax_Syntax.pos in
-                                        let e2 =
+                                        let e3 =
                                           FStar_TypeChecker_Util.maybe_monadic
-                                            env e
+                                            env e2
                                             cres1.FStar_TypeChecker_Common.eff_name
                                             cres1.FStar_TypeChecker_Common.res_typ in
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_ascribed
-                                             (e2,
+                                             (e3,
                                                ((FStar_Util.Inl
                                                    (cres1.FStar_TypeChecker_Common.res_typ)),
                                                  FStar_Pervasives_Native.None),
                                                (FStar_Pervasives_Native.Some
                                                   (cres1.FStar_TypeChecker_Common.eff_name))))
-                                          e2.FStar_Syntax_Syntax.pos in
-                                      let uu____9930 =
+                                          e3.FStar_Syntax_Syntax.pos in
+                                      let uu___7 =
                                         FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                           env
                                           c11.FStar_TypeChecker_Common.eff_name in
-                                      if uu____9930
+                                      if uu___7
                                       then mk_match e12
                                       else
                                         (let e_match =
-                                           let uu____9935 =
+                                           let uu___9 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                guard_x in
-                                           mk_match uu____9935 in
+                                           mk_match uu___9 in
                                          let lb =
-                                           let uu____9939 =
+                                           let uu___9 =
                                              FStar_TypeChecker_Env.norm_eff_name
                                                env
                                                c11.FStar_TypeChecker_Common.eff_name in
                                            FStar_Syntax_Util.mk_letbinding
                                              (FStar_Util.Inl guard_x) []
                                              c11.FStar_TypeChecker_Common.res_typ
-                                             uu____9939 e12 []
+                                             uu___9 e12 []
                                              e12.FStar_Syntax_Syntax.pos in
-                                         let e =
-                                           let uu____9945 =
-                                             let uu____9946 =
-                                               let uu____9959 =
-                                                 let uu____9962 =
-                                                   let uu____9963 =
+                                         let e2 =
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_Syntax_Syntax.mk_binder
                                                        guard_x in
-                                                   [uu____9963] in
+                                                   [uu___13] in
                                                  FStar_Syntax_Subst.close
-                                                   uu____9962 e_match in
-                                               ((false, [lb]), uu____9959) in
+                                                   uu___12 e_match in
+                                               ((false, [lb]), uu___11) in
                                              FStar_Syntax_Syntax.Tm_let
-                                               uu____9946 in
-                                           FStar_Syntax_Syntax.mk uu____9945
+                                               uu___10 in
+                                           FStar_Syntax_Syntax.mk uu___9
                                              top.FStar_Syntax_Syntax.pos in
                                          FStar_TypeChecker_Util.maybe_monadic
-                                           env e
+                                           env e2
                                            cres1.FStar_TypeChecker_Common.eff_name
                                            cres1.FStar_TypeChecker_Common.res_typ) in
-                                    ((let uu____9993 =
+                                    ((let uu___8 =
                                         FStar_TypeChecker_Env.debug env
                                           FStar_Options.Extreme in
-                                      if uu____9993
+                                      if uu___8
                                       then
-                                        let uu____9994 =
+                                        let uu___9 =
                                           FStar_Range.string_of_range
                                             top.FStar_Syntax_Syntax.pos in
-                                        let uu____9995 =
+                                        let uu___10 =
                                           FStar_TypeChecker_Common.lcomp_to_string
                                             cres1 in
                                         FStar_Util.print2
                                           "(%s) Typechecked Tm_match, comp type = %s\n"
-                                          uu____9994 uu____9995
+                                          uu___9 uu___10
                                       else ());
-                                     (let uu____9997 =
+                                     (let uu___8 =
                                         FStar_TypeChecker_Env.conj_guard g11
                                           g_branches in
-                                      (e, cres1, uu____9997)))))))))
-      | uu____9998 ->
-          let uu____9999 =
-            let uu____10000 = FStar_Syntax_Print.tag_of_term top in
-            FStar_Util.format1 "tc_match called on %s\n" uu____10000 in
-          failwith uu____9999
+                                      (e, cres1, uu___8)))))))))
+      | uu___1 ->
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Print.tag_of_term top in
+            FStar_Util.format1 "tc_match called on %s\n" uu___3 in
+          failwith uu___2
 and (tc_synth :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_TypeChecker_Env.env ->
@@ -3051,80 +2980,76 @@ and (tc_synth :
     fun env ->
       fun args ->
         fun rng ->
-          let uu____10023 =
+          let uu___ =
             match args with
             | (tau, FStar_Pervasives_Native.None)::[] ->
                 (tau, FStar_Pervasives_Native.None)
             | (a, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-               uu____10062))::(tau, FStar_Pervasives_Native.None)::[] ->
+               uu___1))::(tau, FStar_Pervasives_Native.None)::[] ->
                 (tau, (FStar_Pervasives_Native.Some a))
-            | uu____10102 ->
+            | uu___1 ->
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_SynthByTacticError,
                     "synth_by_tactic: bad application") rng in
-          match uu____10023 with
+          match uu___ with
           | (tau, atyp) ->
               let typ =
                 match atyp with
                 | FStar_Pervasives_Native.Some t -> t
                 | FStar_Pervasives_Native.None ->
-                    let uu____10133 = FStar_TypeChecker_Env.expected_typ env in
-                    (match uu____10133 with
+                    let uu___1 = FStar_TypeChecker_Env.expected_typ env in
+                    (match uu___1 with
                      | FStar_Pervasives_Native.Some t -> t
                      | FStar_Pervasives_Native.None ->
-                         let uu____10137 =
-                           FStar_TypeChecker_Env.get_range env in
+                         let uu___2 = FStar_TypeChecker_Env.get_range env in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_SynthByTacticError,
                              "synth_by_tactic: need a type annotation when no expected type is present")
-                           uu____10137) in
-              let uu____10138 =
-                let uu____10145 =
-                  let uu____10146 =
-                    let uu____10147 = FStar_Syntax_Util.type_u () in
-                    FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____10147 in
-                  FStar_TypeChecker_Env.set_expected_typ env uu____10146 in
-                tc_term uu____10145 typ in
-              (match uu____10138 with
-               | (typ1, uu____10163, g1) ->
+                           uu___2) in
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Syntax_Util.type_u () in
+                    FStar_All.pipe_left FStar_Pervasives_Native.fst uu___4 in
+                  FStar_TypeChecker_Env.set_expected_typ env uu___3 in
+                tc_term uu___2 typ in
+              (match uu___1 with
+               | (typ1, uu___2, g1) ->
                    (FStar_TypeChecker_Rel.force_trivial_guard env g1;
-                    (let uu____10166 =
+                    (let uu___4 =
                        tc_tactic FStar_Syntax_Syntax.t_unit
                          FStar_Syntax_Syntax.t_unit env tau in
-                     match uu____10166 with
-                     | (tau1, uu____10180, g2) ->
+                     match uu___4 with
+                     | (tau1, uu___5, g2) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env g2;
                           (let t =
                              env.FStar_TypeChecker_Env.synth_hook env typ1
-                               (let uu___1360_10185 = tau1 in
+                               (let uu___7 = tau1 in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1360_10185.FStar_Syntax_Syntax.n);
+                                    (uu___7.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos = rng;
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1360_10185.FStar_Syntax_Syntax.vars)
+                                    (uu___7.FStar_Syntax_Syntax.vars)
                                 }) in
-                           (let uu____10187 =
+                           (let uu___8 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Tac") in
-                            if uu____10187
+                            if uu___8
                             then
-                              let uu____10188 =
+                              let uu___9 =
                                 FStar_Syntax_Print.term_to_string t in
-                              FStar_Util.print1 "Got %s\n" uu____10188
+                              FStar_Util.print1 "Got %s\n" uu___9
                             else ());
                            FStar_TypeChecker_Util.check_uvars
                              tau1.FStar_Syntax_Syntax.pos t;
-                           (let uu____10191 =
-                              let uu____10192 =
-                                FStar_Syntax_Syntax.mk_Total typ1 in
+                           (let uu___9 =
+                              let uu___10 = FStar_Syntax_Syntax.mk_Total typ1 in
                               FStar_All.pipe_left
                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10192 in
-                            (t, uu____10191,
-                              FStar_TypeChecker_Env.trivial_guard)))))))
+                                uu___10 in
+                            (t, uu___9, FStar_TypeChecker_Env.trivial_guard)))))))
 and (tc_tactic :
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.typ ->
@@ -3138,104 +3063,102 @@ and (tc_tactic :
       fun env ->
         fun tau ->
           let env1 =
-            let uu___1370_10198 = env in
+            let uu___ = env in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___1370_10198.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___1370_10198.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___1370_10198.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___1370_10198.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___1370_10198.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___1370_10198.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___1370_10198.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___1370_10198.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___1370_10198.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___1370_10198.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___1370_10198.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___1370_10198.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___1370_10198.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___1370_10198.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___1370_10198.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___1370_10198.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___1370_10198.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___1370_10198.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___1370_10198.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___1370_10198.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___1370_10198.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___1370_10198.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___1370_10198.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard = true;
               FStar_TypeChecker_Env.nosynth =
-                (uu___1370_10198.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___1370_10198.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___1370_10198.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___1370_10198.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___1370_10198.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___1370_10198.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___1370_10198.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___1370_10198.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___1370_10198.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___1370_10198.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___1370_10198.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___1370_10198.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___1370_10198.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___1370_10198.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___1370_10198.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___1370_10198.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___1370_10198.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___1370_10198.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___1370_10198.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___1370_10198.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___1370_10198.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___1370_10198.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___1370_10198.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let uu____10199 = FStar_Syntax_Syntax.t_tac_of a b in
-          tc_check_tot_or_gtot_term env1 tau uu____10199 ""
+          let uu___ = FStar_Syntax_Syntax.t_tac_of a b in
+          tc_check_tot_or_gtot_term env1 tau uu___ ""
 and (tc_tactic_opt :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
@@ -3248,11 +3171,11 @@ and (tc_tactic_opt :
       | FStar_Pervasives_Native.None ->
           (FStar_Pervasives_Native.None, FStar_TypeChecker_Env.trivial_guard)
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____10213 =
+          let uu___ =
             tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
               env tactic in
-          (match uu____10213 with
-           | (tactic1, uu____10227, g) ->
+          (match uu___ with
+           | (tactic1, uu___1, g) ->
                ((FStar_Pervasives_Native.Some tactic1), g))
 and (check_instantiated_fvar :
   FStar_TypeChecker_Env.env ->
@@ -3268,46 +3191,45 @@ and (check_instantiated_fvar :
       fun q ->
         fun e ->
           fun t0 ->
-            let is_data_ctor uu___4_10251 =
-              match uu___4_10251 with
+            let is_data_ctor uu___ =
+              match uu___ with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-                  uu____10254) -> true
-              | uu____10261 -> false in
-            (let uu____10265 =
+                  uu___1) -> true
+              | uu___1 -> false in
+            (let uu___1 =
                (is_data_ctor q) &&
-                 (let uu____10267 =
+                 (let uu___2 =
                     FStar_TypeChecker_Env.is_datacon env
                       v.FStar_Syntax_Syntax.v in
-                  Prims.op_Negation uu____10267) in
-             if uu____10265
+                  Prims.op_Negation uu___2) in
+             if uu___1
              then
-               let uu____10268 =
-                 let uu____10273 =
-                   let uu____10274 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
                      FStar_Ident.string_of_lid v.FStar_Syntax_Syntax.v in
                    FStar_Util.format1 "Expected a data constructor; got %s"
-                     uu____10274 in
-                 (FStar_Errors.Fatal_MissingDataConstructor, uu____10273) in
-               let uu____10275 = FStar_TypeChecker_Env.get_range env in
-               FStar_Errors.raise_error uu____10268 uu____10275
+                     uu___4 in
+                 (FStar_Errors.Fatal_MissingDataConstructor, uu___3) in
+               let uu___3 = FStar_TypeChecker_Env.get_range env in
+               FStar_Errors.raise_error uu___2 uu___3
              else ());
             (let t = FStar_Syntax_Util.remove_inacc t0 in
-             let uu____10278 =
-               FStar_TypeChecker_Util.maybe_instantiate env e t in
-             match uu____10278 with
+             let uu___1 = FStar_TypeChecker_Util.maybe_instantiate env e t in
+             match uu___1 with
              | (e1, t1, implicits) ->
                  let tc =
-                   let uu____10299 = FStar_TypeChecker_Env.should_verify env in
-                   if uu____10299
+                   let uu___2 = FStar_TypeChecker_Env.should_verify env in
+                   if uu___2
                    then FStar_Util.Inl t1
                    else
-                     (let uu____10305 =
-                        let uu____10306 = FStar_Syntax_Syntax.mk_Total t1 in
+                     (let uu___4 =
+                        let uu___5 = FStar_Syntax_Syntax.mk_Total t1 in
                         FStar_All.pipe_left
-                          FStar_TypeChecker_Common.lcomp_of_comp uu____10306 in
-                      FStar_Util.Inr uu____10305) in
+                          FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                      FStar_Util.Inr uu___4) in
                  value_check_expected_typ env e1 tc implicits)
 and (tc_value :
   FStar_TypeChecker_Env.env ->
@@ -3322,211 +3244,205 @@ and (tc_value :
       let top = FStar_Syntax_Subst.compress e in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____10324 =
-            let uu____10329 =
-              let uu____10330 = FStar_Syntax_Print.term_to_string top in
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Print.term_to_string top in
               FStar_Util.format1
-                "Violation of locally nameless convention: %s" uu____10330 in
-            (FStar_Errors.Error_IllScopedTerm, uu____10329) in
-          FStar_Errors.raise_error uu____10324 top.FStar_Syntax_Syntax.pos
+                "Violation of locally nameless convention: %s" uu___2 in
+            (FStar_Errors.Error_IllScopedTerm, uu___1) in
+          FStar_Errors.raise_error uu___ top.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-          let uu____10355 =
-            let uu____10360 =
+          let uu___ =
+            let uu___1 =
               FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ in
-            FStar_Util.Inl uu____10360 in
-          value_check_expected_typ env1 e uu____10355
+            FStar_Util.Inl uu___1 in
+          value_check_expected_typ env1 e uu___
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_unknown ->
           let r = FStar_TypeChecker_Env.get_range env1 in
-          let uu____10362 =
-            let uu____10375 = FStar_TypeChecker_Env.expected_typ env1 in
-            match uu____10375 with
+          let uu___ =
+            let uu___1 = FStar_TypeChecker_Env.expected_typ env1 in
+            match uu___1 with
             | FStar_Pervasives_Native.None ->
-                let uu____10390 = FStar_Syntax_Util.type_u () in
-                (match uu____10390 with
+                let uu___2 = FStar_Syntax_Util.type_u () in
+                (match uu___2 with
                  | (k, u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
                 (t, [], FStar_TypeChecker_Env.trivial_guard) in
-          (match uu____10362 with
-           | (t, uu____10427, g0) ->
-               let uu____10441 =
-                 let uu____10454 =
-                   let uu____10455 = FStar_Range.string_of_range r in
-                   Prims.op_Hat "user-provided implicit term at " uu____10455 in
-                 FStar_TypeChecker_Util.new_implicit_var uu____10454 r env1 t in
-               (match uu____10441 with
-                | (e1, uu____10463, g1) ->
-                    let uu____10477 =
-                      let uu____10478 = FStar_Syntax_Syntax.mk_Total t in
-                      FStar_All.pipe_right uu____10478
+          (match uu___ with
+           | (t, uu___1, g0) ->
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Range.string_of_range r in
+                   Prims.op_Hat "user-provided implicit term at " uu___4 in
+                 FStar_TypeChecker_Util.new_implicit_var uu___3 r env1 t in
+               (match uu___2 with
+                | (e1, uu___3, g1) ->
+                    let uu___4 =
+                      let uu___5 = FStar_Syntax_Syntax.mk_Total t in
+                      FStar_All.pipe_right uu___5
                         FStar_TypeChecker_Common.lcomp_of_comp in
-                    let uu____10479 = FStar_TypeChecker_Env.conj_guard g0 g1 in
-                    (e1, uu____10477, uu____10479)))
+                    let uu___5 = FStar_TypeChecker_Env.conj_guard g0 g1 in
+                    (e1, uu___4, uu___5)))
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____10481 =
+          let uu___ =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____10490 = FStar_Syntax_Syntax.range_of_bv x in
-              ((x.FStar_Syntax_Syntax.sort), uu____10490)
+              let uu___1 = FStar_Syntax_Syntax.range_of_bv x in
+              ((x.FStar_Syntax_Syntax.sort), uu___1)
             else FStar_TypeChecker_Env.lookup_bv env1 x in
-          (match uu____10481 with
+          (match uu___ with
            | (t, rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___1436_10503 = x in
+                   (let uu___1 = x in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___1436_10503.FStar_Syntax_Syntax.ppname);
+                        (uu___1.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___1436_10503.FStar_Syntax_Syntax.index);
+                        (uu___1.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
                     }) rng in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
                 (let e1 = FStar_Syntax_Syntax.bv_to_name x1 in
-                 let uu____10506 =
+                 let uu___2 =
                    FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
-                 match uu____10506 with
+                 match uu___2 with
                  | (e2, t1, implicits) ->
                      let tc =
-                       let uu____10527 =
-                         FStar_TypeChecker_Env.should_verify env1 in
-                       if uu____10527
+                       let uu___3 = FStar_TypeChecker_Env.should_verify env1 in
+                       if uu___3
                        then FStar_Util.Inl t1
                        else
-                         (let uu____10533 =
-                            let uu____10534 = FStar_Syntax_Syntax.mk_Total t1 in
+                         (let uu___5 =
+                            let uu___6 = FStar_Syntax_Syntax.mk_Total t1 in
                             FStar_All.pipe_left
-                              FStar_TypeChecker_Common.lcomp_of_comp
-                              uu____10534 in
-                          FStar_Util.Inr uu____10533) in
+                              FStar_TypeChecker_Common.lcomp_of_comp uu___6 in
+                          FStar_Util.Inr uu___5) in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10536;
-             FStar_Syntax_Syntax.vars = uu____10537;_},
-           uu____10538)
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
+           uu___2)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10543 = FStar_TypeChecker_Env.get_range env1 in
+          let uu___3 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10543
+              "Badly instantiated synth_by_tactic") uu___3
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10551 = FStar_TypeChecker_Env.get_range env1 in
+          let uu___ = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10551
+              "Badly instantiated synth_by_tactic") uu___
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10559;
-             FStar_Syntax_Syntax.vars = uu____10560;_},
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
            us)
           ->
           let us1 = FStar_List.map (tc_universe env1) us in
-          let uu____10569 =
+          let uu___2 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10569 with
+          (match uu___2 with
            | ((us', t), range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
                 if (FStar_List.length us1) <> (FStar_List.length us')
                 then
-                  (let uu____10594 =
-                     let uu____10599 =
-                       let uu____10600 = FStar_Syntax_Print.fv_to_string fv1 in
-                       let uu____10601 =
+                  (let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Print.fv_to_string fv1 in
+                       let uu___8 =
                          FStar_Util.string_of_int (FStar_List.length us1) in
-                       let uu____10602 =
+                       let uu___9 =
                          FStar_Util.string_of_int (FStar_List.length us') in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____10600 uu____10601 uu____10602 in
-                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____10599) in
-                   let uu____10603 = FStar_TypeChecker_Env.get_range env1 in
-                   FStar_Errors.raise_error uu____10594 uu____10603)
+                         uu___7 uu___8 uu___9 in
+                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse, uu___6) in
+                   let uu___6 = FStar_TypeChecker_Env.get_range env1 in
+                   FStar_Errors.raise_error uu___5 uu___6)
                 else ();
                 FStar_List.iter2
                   (fun ul ->
                      fun ur ->
                        match (ul, ur) with
-                       | (FStar_Syntax_Syntax.U_unif u'', uu____10613) ->
+                       | (FStar_Syntax_Syntax.U_unif u'', uu___6) ->
                            FStar_Syntax_Unionfind.univ_change u'' ur
                        | (FStar_Syntax_Syntax.U_name n1,
                           FStar_Syntax_Syntax.U_name n2) when
                            FStar_Ident.ident_equals n1 n2 -> ()
-                       | uu____10626 ->
-                           let uu____10631 =
-                             let uu____10636 =
-                               let uu____10637 =
+                       | uu___6 ->
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
                                  FStar_Syntax_Print.fv_to_string fv1 in
-                               let uu____10638 =
+                               let uu___10 =
                                  FStar_Syntax_Print.univ_to_string ul in
-                               let uu____10639 =
+                               let uu___11 =
                                  FStar_Syntax_Print.univ_to_string ur in
                                FStar_Util.format3
                                  "Incompatible universe application for %s, expected %s got %s\n"
-                                 uu____10637 uu____10638 uu____10639 in
+                                 uu___9 uu___10 uu___11 in
                              (FStar_Errors.Fatal_IncompatibleUniverse,
-                               uu____10636) in
-                           let uu____10640 =
-                             FStar_TypeChecker_Env.get_range env1 in
-                           FStar_Errors.raise_error uu____10631 uu____10640)
-                  us' us1;
+                               uu___8) in
+                           let uu___8 = FStar_TypeChecker_Env.get_range env1 in
+                           FStar_Errors.raise_error uu___7 uu___8) us' us1;
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____10643 =
+                   let uu___7 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
                        e.FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10643 us1 in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu___7 us1 in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
-      | FStar_Syntax_Syntax.Tm_uinst (uu____10644, us) ->
-          let uu____10650 = FStar_TypeChecker_Env.get_range env1 in
+      | FStar_Syntax_Syntax.Tm_uinst (uu___, us) ->
+          let uu___1 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
               "Universe applications are only allowed on top-level identifiers")
-            uu____10650
+            uu___1
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____10658 =
+          let uu___ =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10658 with
+          (match uu___ with
            | ((us, t), range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
-                (let uu____10683 =
+                (let uu___3 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Range") in
-                 if uu____10683
+                 if uu___3
                  then
-                   let uu____10684 =
-                     let uu____10685 = FStar_Syntax_Syntax.lid_of_fv fv1 in
-                     FStar_Syntax_Print.lid_to_string uu____10685 in
-                   let uu____10686 =
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Syntax.lid_of_fv fv1 in
+                     FStar_Syntax_Print.lid_to_string uu___5 in
+                   let uu___5 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                   let uu____10687 = FStar_Range.string_of_range range in
-                   let uu____10688 = FStar_Range.string_of_use_range range in
-                   let uu____10689 = FStar_Syntax_Print.term_to_string t in
+                   let uu___6 = FStar_Range.string_of_range range in
+                   let uu___7 = FStar_Range.string_of_use_range range in
+                   let uu___8 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s\n"
-                     uu____10684 uu____10686 uu____10687 uu____10688
-                     uu____10689
+                     uu___4 uu___5 uu___6 uu___7 uu___8
                  else ());
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____10693 =
+                   let uu___4 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
                        e.FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10693 us in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu___4 us in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
       | FStar_Syntax_Syntax.Tm_constant c ->
@@ -3537,30 +3453,28 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____10721 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____10721 with
+          let uu___ = FStar_Syntax_Subst.open_comp bs c in
+          (match uu___ with
            | (bs1, c1) ->
                let env0 = env1 in
-               let uu____10735 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____10735 with
-                | (env2, uu____10749) ->
-                    let uu____10754 = tc_binders env2 bs1 in
-                    (match uu____10754 with
+               let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               (match uu___1 with
+                | (env2, uu___2) ->
+                    let uu___3 = tc_binders env2 bs1 in
+                    (match uu___3 with
                      | (bs2, env3, g, us) ->
-                         let uu____10773 = tc_comp env3 c1 in
-                         (match uu____10773 with
+                         let uu___4 = tc_comp env3 c1 in
+                         (match uu___4 with
                           | (c2, uc, f) ->
                               let e1 =
-                                let uu___1530_10792 =
-                                  FStar_Syntax_Util.arrow bs2 c2 in
+                                let uu___5 = FStar_Syntax_Util.arrow bs2 c2 in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1530_10792.FStar_Syntax_Syntax.n);
+                                    (uu___5.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1530_10792.FStar_Syntax_Syntax.vars)
+                                    (uu___5.FStar_Syntax_Syntax.vars)
                                 } in
                               (check_smt_pat env3 e1 bs2 c2;
                                (let u = FStar_Syntax_Syntax.U_max (uc :: us) in
@@ -3569,11 +3483,10 @@ and (tc_value :
                                     (FStar_Syntax_Syntax.Tm_type u)
                                     top.FStar_Syntax_Syntax.pos in
                                 let g1 =
-                                  let uu____10803 =
+                                  let uu___6 =
                                     FStar_TypeChecker_Env.close_guard_univs
                                       us bs2 f in
-                                  FStar_TypeChecker_Env.conj_guard g
-                                    uu____10803 in
+                                  FStar_TypeChecker_Env.conj_guard g uu___6 in
                                 let g2 =
                                   FStar_TypeChecker_Util.close_guard_implicits
                                     env3 false bs2 g1 in
@@ -3591,106 +3504,101 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x, phi) ->
-          let uu____10819 =
-            let uu____10824 =
-              let uu____10825 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____10825] in
-            FStar_Syntax_Subst.open_term uu____10824 phi in
-          (match uu____10819 with
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_Syntax_Syntax.mk_binder x in [uu___2] in
+            FStar_Syntax_Subst.open_term uu___1 phi in
+          (match uu___ with
            | (x1, phi1) ->
                let env0 = env1 in
-               let uu____10853 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____10853 with
-                | (env2, uu____10867) ->
-                    let uu____10872 =
-                      let uu____10887 = FStar_List.hd x1 in
-                      tc_binder env2 uu____10887 in
-                    (match uu____10872 with
+               let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               (match uu___1 with
+                | (env2, uu___2) ->
+                    let uu___3 =
+                      let uu___4 = FStar_List.hd x1 in tc_binder env2 uu___4 in
+                    (match uu___3 with
                      | (x2, env3, f1, u) ->
-                         ((let uu____10923 =
+                         ((let uu___5 =
                              FStar_TypeChecker_Env.debug env3
                                FStar_Options.High in
-                           if uu____10923
+                           if uu___5
                            then
-                             let uu____10924 =
+                             let uu___6 =
                                FStar_Range.string_of_range
                                  top.FStar_Syntax_Syntax.pos in
-                             let uu____10925 =
+                             let uu___7 =
                                FStar_Syntax_Print.term_to_string phi1 in
-                             let uu____10926 =
+                             let uu___8 =
                                FStar_Syntax_Print.bv_to_string
                                  (FStar_Pervasives_Native.fst x2) in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____10924 uu____10925 uu____10926
+                               uu___6 uu___7 uu___8
                            else ());
-                          (let uu____10930 = FStar_Syntax_Util.type_u () in
-                           match uu____10930 with
-                           | (t_phi, uu____10942) ->
-                               let uu____10943 =
+                          (let uu___5 = FStar_Syntax_Util.type_u () in
+                           match uu___5 with
+                           | (t_phi, uu___6) ->
+                               let uu___7 =
                                  tc_check_tot_or_gtot_term env3 phi1 t_phi
                                    "refinement formula must be pure or ghost" in
-                               (match uu____10943 with
-                                | (phi2, uu____10957, f2) ->
+                               (match uu___7 with
+                                | (phi2, uu___8, f2) ->
                                     let e1 =
-                                      let uu___1568_10962 =
+                                      let uu___9 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
                                           phi2 in
                                       {
                                         FStar_Syntax_Syntax.n =
-                                          (uu___1568_10962.FStar_Syntax_Syntax.n);
+                                          (uu___9.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
-                                          (uu___1568_10962.FStar_Syntax_Syntax.vars)
+                                          (uu___9.FStar_Syntax_Syntax.vars)
                                       } in
                                     let t =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_type u)
                                         top.FStar_Syntax_Syntax.pos in
                                     let g =
-                                      let uu____10971 =
+                                      let uu___9 =
                                         FStar_TypeChecker_Env.close_guard_univs
                                           [u] [x2] f2 in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____10971 in
+                                        uu___9 in
                                     let g1 =
                                       FStar_TypeChecker_Util.close_guard_implicits
                                         env3 false [x2] g in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____10999) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___) ->
           let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs in
-          ((let uu____11026 =
+          ((let uu___2 =
               FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
-            if uu____11026
+            if uu___2
             then
-              let uu____11027 =
+              let uu___3 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___1581_11030 = top in
+                  (let uu___4 = top in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
                           (bs1, body, FStar_Pervasives_Native.None));
                      FStar_Syntax_Syntax.pos =
-                       (uu___1581_11030.FStar_Syntax_Syntax.pos);
+                       (uu___4.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___1581_11030.FStar_Syntax_Syntax.vars)
+                       (uu___4.FStar_Syntax_Syntax.vars)
                    }) in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____11027
+              FStar_Util.print1 "Abstraction is: %s\n" uu___3
             else ());
-           (let uu____11044 = FStar_Syntax_Subst.open_term bs1 body in
-            match uu____11044 with
-            | (bs2, body1) -> tc_abs env1 top bs2 body1))
-      | uu____11057 ->
-          let uu____11058 =
-            let uu____11059 = FStar_Syntax_Print.term_to_string top in
-            let uu____11060 = FStar_Syntax_Print.tag_of_term top in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11059
-              uu____11060 in
-          failwith uu____11058
+           (let uu___2 = FStar_Syntax_Subst.open_term bs1 body in
+            match uu___2 with | (bs2, body1) -> tc_abs env1 top bs2 body1))
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.term_to_string top in
+            let uu___3 = FStar_Syntax_Print.tag_of_term top in
+            FStar_Util.format2 "Unexpected value: %s (%s)" uu___2 uu___3 in
+          failwith uu___1
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
     FStar_Range.range -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ)
@@ -3701,11 +3609,11 @@ and (tc_constant :
         let res =
           match c with
           | FStar_Const.Const_unit -> FStar_Syntax_Syntax.t_unit
-          | FStar_Const.Const_bool uu____11071 -> FStar_Syntax_Util.t_bool
-          | FStar_Const.Const_int (uu____11072, FStar_Pervasives_Native.None)
-              -> FStar_Syntax_Syntax.t_int
-          | FStar_Const.Const_int
-              (uu____11083, FStar_Pervasives_Native.Some msize) ->
+          | FStar_Const.Const_bool uu___ -> FStar_Syntax_Util.t_bool
+          | FStar_Const.Const_int (uu___, FStar_Pervasives_Native.None) ->
+              FStar_Syntax_Syntax.t_int
+          | FStar_Const.Const_int (uu___, FStar_Pervasives_Native.Some msize)
+              ->
               FStar_Syntax_Syntax.tconst
                 (match msize with
                  | (FStar_Const.Signed, FStar_Const.Int8) ->
@@ -3724,56 +3632,53 @@ and (tc_constant :
                      FStar_Parser_Const.uint32_lid
                  | (FStar_Const.Unsigned, FStar_Const.Int64) ->
                      FStar_Parser_Const.uint64_lid)
-          | FStar_Const.Const_string uu____11099 ->
-              FStar_Syntax_Syntax.t_string
-          | FStar_Const.Const_real uu____11104 -> FStar_Syntax_Syntax.t_real
-          | FStar_Const.Const_float uu____11105 ->
-              FStar_Syntax_Syntax.t_float
-          | FStar_Const.Const_char uu____11106 ->
-              let uu____11107 =
+          | FStar_Const.Const_string uu___ -> FStar_Syntax_Syntax.t_string
+          | FStar_Const.Const_real uu___ -> FStar_Syntax_Syntax.t_real
+          | FStar_Const.Const_float uu___ -> FStar_Syntax_Syntax.t_float
+          | FStar_Const.Const_char uu___ ->
+              let uu___1 =
                 FStar_Syntax_DsEnv.try_lookup_lid
                   env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid in
-              FStar_All.pipe_right uu____11107 FStar_Util.must
+              FStar_All.pipe_right uu___1 FStar_Util.must
           | FStar_Const.Const_effect -> FStar_Syntax_Util.ktype0
-          | FStar_Const.Const_range uu____11112 ->
-              FStar_Syntax_Syntax.t_range
+          | FStar_Const.Const_range uu___ -> FStar_Syntax_Syntax.t_range
           | FStar_Const.Const_range_of ->
-              let uu____11113 =
-                let uu____11118 =
-                  let uu____11119 = FStar_Parser_Const.const_to_string c in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11119 in
-                (FStar_Errors.Fatal_IllTyped, uu____11118) in
-              FStar_Errors.raise_error uu____11113 r
+                    uu___2 in
+                (FStar_Errors.Fatal_IllTyped, uu___1) in
+              FStar_Errors.raise_error uu___ r
           | FStar_Const.Const_set_range_of ->
-              let uu____11120 =
-                let uu____11125 =
-                  let uu____11126 = FStar_Parser_Const.const_to_string c in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11126 in
-                (FStar_Errors.Fatal_IllTyped, uu____11125) in
-              FStar_Errors.raise_error uu____11120 r
+                    uu___2 in
+                (FStar_Errors.Fatal_IllTyped, uu___1) in
+              FStar_Errors.raise_error uu___ r
           | FStar_Const.Const_reify ->
-              let uu____11127 =
-                let uu____11132 =
-                  let uu____11133 = FStar_Parser_Const.const_to_string c in
+              let uu___ =
+                let uu___1 =
+                  let uu___2 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11133 in
-                (FStar_Errors.Fatal_IllTyped, uu____11132) in
-              FStar_Errors.raise_error uu____11127 r
-          | FStar_Const.Const_reflect uu____11134 ->
-              let uu____11135 =
-                let uu____11140 =
-                  let uu____11141 = FStar_Parser_Const.const_to_string c in
+                    uu___2 in
+                (FStar_Errors.Fatal_IllTyped, uu___1) in
+              FStar_Errors.raise_error uu___ r
+          | FStar_Const.Const_reflect uu___ ->
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11141 in
-                (FStar_Errors.Fatal_IllTyped, uu____11140) in
-              FStar_Errors.raise_error uu____11135 r
-          | uu____11142 ->
+                    uu___3 in
+                (FStar_Errors.Fatal_IllTyped, uu___2) in
+              FStar_Errors.raise_error uu___1 r
+          | uu___ ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnsupportedConstant,
                   "Unsupported constant") r in
@@ -3788,28 +3693,28 @@ and (tc_comp :
     fun c ->
       let c0 = c in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t, uu____11159) ->
-          let uu____11168 = FStar_Syntax_Util.type_u () in
-          (match uu____11168 with
+      | FStar_Syntax_Syntax.Total (t, uu___) ->
+          let uu___1 = FStar_Syntax_Util.type_u () in
+          (match uu___1 with
            | (k, u) ->
-               let uu____11181 = tc_check_tot_or_gtot_term env t k "" in
-               (match uu____11181 with
-                | (t1, uu____11195, g) ->
-                    let uu____11197 =
+               let uu___2 = tc_check_tot_or_gtot_term env t k "" in
+               (match uu___2 with
+                | (t1, uu___3, g) ->
+                    let uu___4 =
                       FStar_Syntax_Syntax.mk_Total' t1
                         (FStar_Pervasives_Native.Some u) in
-                    (uu____11197, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t, uu____11199) ->
-          let uu____11208 = FStar_Syntax_Util.type_u () in
-          (match uu____11208 with
+                    (uu___4, u, g)))
+      | FStar_Syntax_Syntax.GTotal (t, uu___) ->
+          let uu___1 = FStar_Syntax_Util.type_u () in
+          (match uu___1 with
            | (k, u) ->
-               let uu____11221 = tc_check_tot_or_gtot_term env t k "" in
-               (match uu____11221 with
-                | (t1, uu____11235, g) ->
-                    let uu____11237 =
+               let uu___2 = tc_check_tot_or_gtot_term env t k "" in
+               (match uu___2 with
+                | (t1, uu___3, g) ->
+                    let uu___4 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
                         (FStar_Pervasives_Native.Some u) in
-                    (uu____11237, u, g)))
+                    (uu___4, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
@@ -3822,74 +3727,73 @@ and (tc_comp :
                   (FStar_Syntax_Syntax.Tm_uinst (head, us))
                   c0.FStar_Syntax_Syntax.pos in
           let tc =
-            let uu____11245 =
-              let uu____11246 =
+            let uu___ =
+              let uu___1 =
                 FStar_Syntax_Syntax.as_arg c1.FStar_Syntax_Syntax.result_typ in
-              uu____11246 :: (c1.FStar_Syntax_Syntax.effect_args) in
-            FStar_Syntax_Syntax.mk_Tm_app head1 uu____11245
+              uu___1 :: (c1.FStar_Syntax_Syntax.effect_args) in
+            FStar_Syntax_Syntax.mk_Tm_app head1 uu___
               (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-          let uu____11263 =
+          let uu___ =
             tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff "" in
-          (match uu____11263 with
-           | (tc1, uu____11277, f) ->
-               let uu____11279 = FStar_Syntax_Util.head_and_args tc1 in
-               (match uu____11279 with
+          (match uu___ with
+           | (tc1, uu___1, f) ->
+               let uu___2 = FStar_Syntax_Util.head_and_args tc1 in
+               (match uu___2 with
                 | (head2, args) ->
                     let comp_univs =
-                      let uu____11329 =
-                        let uu____11330 = FStar_Syntax_Subst.compress head2 in
-                        uu____11330.FStar_Syntax_Syntax.n in
-                      match uu____11329 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____11333, us) -> us
-                      | uu____11339 -> [] in
-                    let uu____11340 = FStar_Syntax_Util.head_and_args tc1 in
-                    (match uu____11340 with
-                     | (uu____11363, args1) ->
-                         let uu____11389 =
-                           let uu____11412 = FStar_List.hd args1 in
-                           let uu____11429 = FStar_List.tl args1 in
-                           (uu____11412, uu____11429) in
-                         (match uu____11389 with
+                      let uu___3 =
+                        let uu___4 = FStar_Syntax_Subst.compress head2 in
+                        uu___4.FStar_Syntax_Syntax.n in
+                      match uu___3 with
+                      | FStar_Syntax_Syntax.Tm_uinst (uu___4, us) -> us
+                      | uu___4 -> [] in
+                    let uu___3 = FStar_Syntax_Util.head_and_args tc1 in
+                    (match uu___3 with
+                     | (uu___4, args1) ->
+                         let uu___5 =
+                           let uu___6 = FStar_List.hd args1 in
+                           let uu___7 = FStar_List.tl args1 in
+                           (uu___6, uu___7) in
+                         (match uu___5 with
                           | (res, args2) ->
-                              let uu____11510 =
-                                let uu____11519 =
+                              let uu___6 =
+                                let uu___7 =
                                   FStar_All.pipe_right
                                     c1.FStar_Syntax_Syntax.flags
                                     (FStar_List.map
-                                       (fun uu___5_11547 ->
-                                          match uu___5_11547 with
+                                       (fun uu___8 ->
+                                          match uu___8 with
                                           | FStar_Syntax_Syntax.DECREASES e
                                               ->
-                                              let uu____11555 =
+                                              let uu___9 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
                                                   env in
-                                              (match uu____11555 with
-                                               | (env1, uu____11567) ->
-                                                   let uu____11572 =
+                                              (match uu___9 with
+                                               | (env1, uu___10) ->
+                                                   let uu___11 =
                                                      tc_tot_or_gtot_term env1
                                                        e in
-                                                   (match uu____11572 with
-                                                    | (e1, uu____11584, g) ->
+                                                   (match uu___11 with
+                                                    | (e1, uu___12, g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
                                                 FStar_TypeChecker_Env.trivial_guard))) in
-                                FStar_All.pipe_right uu____11519
-                                  FStar_List.unzip in
-                              (match uu____11510 with
+                                FStar_All.pipe_right uu___7 FStar_List.unzip in
+                              (match uu___6 with
                                | (flags, guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
                                        env (FStar_Pervasives_Native.fst res) in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___1711_11625 = c1 in
+                                       (let uu___7 = c1 in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
                                           FStar_Syntax_Syntax.effect_name =
-                                            (uu___1711_11625.FStar_Syntax_Syntax.effect_name);
+                                            (uu___7.FStar_Syntax_Syntax.effect_name);
                                           FStar_Syntax_Syntax.result_typ =
                                             (FStar_Pervasives_Native.fst res);
                                           FStar_Syntax_Syntax.effect_args =
@@ -3900,11 +3804,11 @@ and (tc_comp :
                                      FStar_All.pipe_right c2
                                        (FStar_TypeChecker_Util.universe_of_comp
                                           env u) in
-                                   let uu____11631 =
+                                   let uu___7 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
                                        guards in
-                                   (c2, u_c, uu____11631))))))
+                                   (c2, u_c, uu___7))))))
 and (tc_universe :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
@@ -3914,38 +3818,37 @@ and (tc_universe :
       let rec aux u1 =
         let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____11641 ->
+        | FStar_Syntax_Syntax.U_bvar uu___ ->
             failwith "Impossible: locally nameless"
         | FStar_Syntax_Syntax.U_unknown -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif uu____11642 -> u2
+        | FStar_Syntax_Syntax.U_unif uu___ -> u2
         | FStar_Syntax_Syntax.U_zero -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____11654 = aux u3 in
-            FStar_Syntax_Syntax.U_succ uu____11654
+            let uu___ = aux u3 in FStar_Syntax_Syntax.U_succ uu___
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____11658 = FStar_List.map aux us in
-            FStar_Syntax_Syntax.U_max uu____11658
+            let uu___ = FStar_List.map aux us in
+            FStar_Syntax_Syntax.U_max uu___
         | FStar_Syntax_Syntax.U_name x ->
-            let uu____11662 =
+            let uu___ =
               env.FStar_TypeChecker_Env.use_bv_sorts ||
                 (FStar_TypeChecker_Env.lookup_univ env x) in
-            if uu____11662
+            if uu___
             then u2
             else
-              (let uu____11664 =
-                 let uu____11665 =
-                   let uu____11666 = FStar_Syntax_Print.univ_to_string u2 in
-                   Prims.op_Hat uu____11666 " not found" in
-                 Prims.op_Hat "Universe variable " uu____11665 in
-               failwith uu____11664) in
+              (let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Print.univ_to_string u2 in
+                   Prims.op_Hat uu___4 " not found" in
+                 Prims.op_Hat "Universe variable " uu___3 in
+               failwith uu___2) in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown ->
-             let uu____11668 = FStar_Syntax_Util.type_u () in
-             FStar_All.pipe_right uu____11668 FStar_Pervasives_Native.snd
-         | uu____11677 -> aux u)
+             let uu___1 = FStar_Syntax_Util.type_u () in
+             FStar_All.pipe_right uu___1 FStar_Pervasives_Native.snd
+         | uu___1 -> aux u)
 and (tc_abs_expected_function_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -3965,103 +3868,98 @@ and (tc_abs_expected_function_typ :
           | FStar_Pervasives_Native.None ->
               ((match env.FStar_TypeChecker_Env.letrecs with
                 | [] -> ()
-                | uu____11711 ->
+                | uu___1 ->
                     failwith
                       "Impossible: Can't have a let rec annotation but no expected type");
-               (let uu____11722 = tc_binders env bs in
-                match uu____11722 with
-                | (bs1, envbody, g_env, uu____11752) ->
+               (let uu___1 = tc_binders env bs in
+                match uu___1 with
+                | (bs1, envbody, g_env, uu___2) ->
                     (FStar_Pervasives_Native.None, bs1, [],
                       FStar_Pervasives_Native.None, envbody, body, g_env)))
           | FStar_Pervasives_Native.Some t ->
               let t1 = FStar_Syntax_Subst.compress t in
               let rec as_function_typ norm1 t2 =
-                let uu____11796 =
-                  let uu____11797 = FStar_Syntax_Subst.compress t2 in
-                  uu____11797.FStar_Syntax_Syntax.n in
-                match uu____11796 with
-                | FStar_Syntax_Syntax.Tm_uvar uu____11820 ->
+                let uu___ =
+                  let uu___1 = FStar_Syntax_Subst.compress t2 in
+                  uu___1.FStar_Syntax_Syntax.n in
+                match uu___ with
+                | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____11842 -> failwith "Impossible");
-                     (let uu____11853 = tc_binders env bs in
-                      match uu____11853 with
-                      | (bs1, envbody, g_env, uu____11885) ->
-                          let uu____11886 =
+                      | uu___3 -> failwith "Impossible");
+                     (let uu___3 = tc_binders env bs in
+                      match uu___3 with
+                      | (bs1, envbody, g_env, uu___4) ->
+                          let uu___5 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody in
-                          (match uu____11886 with
-                           | (envbody1, uu____11914) ->
+                          (match uu___5 with
+                           | (envbody1, uu___6) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
                 | FStar_Syntax_Syntax.Tm_app
                     ({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                         uu____11925;
-                       FStar_Syntax_Syntax.pos = uu____11926;
-                       FStar_Syntax_Syntax.vars = uu____11927;_},
-                     uu____11928)
+                         uu___1;
+                       FStar_Syntax_Syntax.pos = uu___2;
+                       FStar_Syntax_Syntax.vars = uu___3;_},
+                     uu___4)
                     ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____11974 -> failwith "Impossible");
-                     (let uu____11985 = tc_binders env bs in
-                      match uu____11985 with
-                      | (bs1, envbody, g_env, uu____12017) ->
-                          let uu____12018 =
+                      | uu___6 -> failwith "Impossible");
+                     (let uu___6 = tc_binders env bs in
+                      match uu___6 with
+                      | (bs1, envbody, g_env, uu___7) ->
+                          let uu___8 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody in
-                          (match uu____12018 with
-                           | (envbody1, uu____12046) ->
+                          (match uu___8 with
+                           | (envbody1, uu___9) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
-                | FStar_Syntax_Syntax.Tm_refine (b, uu____12058) ->
-                    let uu____12063 =
+                | FStar_Syntax_Syntax.Tm_refine (b, uu___1) ->
+                    let uu___2 =
                       as_function_typ norm1 b.FStar_Syntax_Syntax.sort in
-                    (match uu____12063 with
-                     | (uu____12104, bs1, bs', copt, env_body, body1, g_env)
-                         ->
+                    (match uu___2 with
+                     | (uu___3, bs1, bs', copt, env_body, body1, g_env) ->
                          ((FStar_Pervasives_Native.Some t2), bs1, bs', copt,
                            env_body, body1, g_env))
                 | FStar_Syntax_Syntax.Tm_arrow (bs_expected, c_expected) ->
-                    let uu____12151 =
+                    let uu___1 =
                       FStar_Syntax_Subst.open_comp bs_expected c_expected in
-                    (match uu____12151 with
+                    (match uu___1 with
                      | (bs_expected1, c_expected1) ->
                          let check_actuals_against_formals env1 bs1
                            bs_expected2 body1 =
-                           let rec handle_more uu____12286 c_expected2 body2
-                             =
-                             match uu____12286 with
+                           let rec handle_more uu___2 c_expected2 body2 =
+                             match uu___2 with
                              | (env_bs, bs2, more, guard_env, subst) ->
                                  (match more with
                                   | FStar_Pervasives_Native.None ->
-                                      let uu____12400 =
+                                      let uu___3 =
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2 in
-                                      (env_bs, bs2, guard_env, uu____12400,
-                                        body2)
+                                      (env_bs, bs2, guard_env, uu___3, body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inr more_bs_expected) ->
                                       let c =
-                                        let uu____12417 =
+                                        let uu___3 =
                                           FStar_Syntax_Util.arrow
                                             more_bs_expected c_expected2 in
-                                        FStar_Syntax_Syntax.mk_Total
-                                          uu____12417 in
-                                      let uu____12418 =
+                                        FStar_Syntax_Syntax.mk_Total uu___3 in
+                                      let uu___3 =
                                         FStar_Syntax_Subst.subst_comp subst c in
-                                      (env_bs, bs2, guard_env, uu____12418,
-                                        body2)
+                                      (env_bs, bs2, guard_env, uu___3, body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inl more_bs) ->
                                       let c =
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2 in
-                                      let uu____12435 =
+                                      let uu___3 =
                                         (FStar_Options.ml_ish ()) ||
                                           (FStar_Syntax_Util.is_named_tot c) in
-                                      if uu____12435
+                                      if uu___3
                                       then
                                         let t3 =
                                           FStar_TypeChecker_Normalize.unfold_whnf
@@ -4070,17 +3968,17 @@ and (tc_abs_expected_function_typ :
                                         (match t3.FStar_Syntax_Syntax.n with
                                          | FStar_Syntax_Syntax.Tm_arrow
                                              (bs_expected3, c_expected3) ->
-                                             let uu____12499 =
+                                             let uu___4 =
                                                FStar_Syntax_Subst.open_comp
                                                  bs_expected3 c_expected3 in
-                                             (match uu____12499 with
+                                             (match uu___4 with
                                               | (bs_expected4, c_expected4)
                                                   ->
-                                                  let uu____12526 =
+                                                  let uu___5 =
                                                     tc_abs_check_binders
                                                       env_bs more_bs
                                                       bs_expected4 in
-                                                  (match uu____12526 with
+                                                  (match uu___5 with
                                                    | (env_bs_bs', bs', more1,
                                                       guard'_env_bs, subst1)
                                                        ->
@@ -4088,21 +3986,19 @@ and (tc_abs_expected_function_typ :
                                                          FStar_TypeChecker_Env.close_guard
                                                            env_bs bs2
                                                            guard'_env_bs in
-                                                       let uu____12581 =
-                                                         let uu____12608 =
+                                                       let uu___6 =
+                                                         let uu___7 =
                                                            FStar_TypeChecker_Env.conj_guard
                                                              guard_env
                                                              guard'_env in
                                                          (env_bs_bs',
                                                            (FStar_List.append
                                                               bs2 bs'),
-                                                           more1,
-                                                           uu____12608,
+                                                           more1, uu___7,
                                                            subst1) in
-                                                       handle_more
-                                                         uu____12581
+                                                       handle_more uu___6
                                                          c_expected4 body2))
-                                         | uu____12631 ->
+                                         | uu___4 ->
                                              let body3 =
                                                FStar_Syntax_Util.abs more_bs
                                                  body2
@@ -4115,397 +4011,394 @@ and (tc_abs_expected_function_typ :
                                              body2
                                              FStar_Pervasives_Native.None in
                                          (env_bs, bs2, guard_env, c, body3))) in
-                           let uu____12659 =
+                           let uu___2 =
                              tc_abs_check_binders env1 bs1 bs_expected2 in
-                           handle_more uu____12659 c_expected1 body1 in
+                           handle_more uu___2 c_expected1 body1 in
                          let mk_letrec_env envbody bs1 c =
                            let letrecs = guard_letrecs envbody bs1 c in
                            let envbody1 =
-                             let uu___1842_12724 = envbody in
+                             let uu___2 = envbody in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.solver);
+                                 (uu___2.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.range);
+                                 (uu___2.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.curmodule);
+                                 (uu___2.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.gamma);
+                                 (uu___2.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___2.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___2.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.modules);
+                                 (uu___2.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___2.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.sigtab);
+                                 (uu___2.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.attrtab);
+                                 (uu___2.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___2.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.effects);
+                                 (uu___2.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.generalize);
+                                 (uu___2.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs = [];
                                FStar_TypeChecker_Env.top_level =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.top_level);
+                                 (uu___2.FStar_TypeChecker_Env.top_level);
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___2.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.use_eq);
+                                 (uu___2.FStar_TypeChecker_Env.use_eq);
                                FStar_TypeChecker_Env.use_eq_strict =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.use_eq_strict);
+                                 (uu___2.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.is_iface);
+                                 (uu___2.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.admit);
+                                 (uu___2.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.lax);
+                                 (uu___2.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___2.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.phase1);
+                                 (uu___2.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.failhard);
+                                 (uu___2.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.nosynth);
+                                 (uu___2.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.tc_term);
+                                 (uu___2.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.type_of);
+                                 (uu___2.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.universe_of);
+                                 (uu___2.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___2.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___2.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___2.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                  =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.splice);
+                                 (uu___2.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.mpreprocess =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.mpreprocess);
+                                 (uu___2.FStar_TypeChecker_Env.mpreprocess);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.postprocess);
+                                 (uu___2.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___2.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___2.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.dsenv);
+                                 (uu___2.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.nbe);
+                                 (uu___2.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.strict_args_tab);
+                                 (uu___2.FStar_TypeChecker_Env.strict_args_tab);
                                FStar_TypeChecker_Env.erasable_types_tab =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.erasable_types_tab);
+                                 (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
                                FStar_TypeChecker_Env.enable_defer_to_tac =
-                                 (uu___1842_12724.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                 (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
                              } in
-                           let uu____12733 =
+                           let uu___2 =
                              FStar_All.pipe_right letrecs
                                (FStar_List.fold_left
-                                  (fun uu____12799 ->
-                                     fun uu____12800 ->
-                                       match (uu____12799, uu____12800) with
+                                  (fun uu___3 ->
+                                     fun uu___4 ->
+                                       match (uu___3, uu___4) with
                                        | ((env1, letrec_binders, g),
                                           (l, t3, u_names)) ->
-                                           let uu____12891 =
-                                             let uu____12898 =
-                                               let uu____12899 =
+                                           let uu___5 =
+                                             let uu___6 =
+                                               let uu___7 =
                                                  FStar_TypeChecker_Env.clear_expected_typ
                                                    env1 in
-                                               FStar_All.pipe_right
-                                                 uu____12899
+                                               FStar_All.pipe_right uu___7
                                                  FStar_Pervasives_Native.fst in
-                                             tc_term uu____12898 t3 in
-                                           (match uu____12891 with
-                                            | (t4, uu____12923, g') ->
+                                             tc_term uu___6 t3 in
+                                           (match uu___5 with
+                                            | (t4, uu___6, g') ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.push_let_binding
                                                     env1 l (u_names, t4) in
                                                 let lb =
                                                   match l with
                                                   | FStar_Util.Inl x ->
-                                                      let uu____12936 =
+                                                      let uu___7 =
                                                         FStar_Syntax_Syntax.mk_binder
-                                                          (let uu___1860_12939
-                                                             = x in
+                                                          (let uu___8 = x in
                                                            {
                                                              FStar_Syntax_Syntax.ppname
                                                                =
-                                                               (uu___1860_12939.FStar_Syntax_Syntax.ppname);
+                                                               (uu___8.FStar_Syntax_Syntax.ppname);
                                                              FStar_Syntax_Syntax.index
                                                                =
-                                                               (uu___1860_12939.FStar_Syntax_Syntax.index);
+                                                               (uu___8.FStar_Syntax_Syntax.index);
                                                              FStar_Syntax_Syntax.sort
                                                                = t4
                                                            }) in
-                                                      uu____12936 ::
+                                                      uu___7 ::
                                                         letrec_binders
-                                                  | uu____12940 ->
-                                                      letrec_binders in
-                                                let uu____12945 =
+                                                  | uu___7 -> letrec_binders in
+                                                let uu___7 =
                                                   FStar_TypeChecker_Env.conj_guard
                                                     g g' in
-                                                (env2, lb, uu____12945)))
+                                                (env2, lb, uu___7)))
                                   (envbody1, [],
                                     FStar_TypeChecker_Env.trivial_guard)) in
-                           match uu____12733 with
+                           match uu___2 with
                            | (envbody2, letrec_binders, g) ->
-                               let uu____12965 =
+                               let uu___3 =
                                  FStar_TypeChecker_Env.close_guard envbody2
                                    bs1 g in
-                               (envbody2, letrec_binders, uu____12965) in
+                               (envbody2, letrec_binders, uu___3) in
                          let envbody =
-                           let uu___1868_12969 = env in
+                           let uu___2 = env in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1868_12969.FStar_TypeChecker_Env.solver);
+                               (uu___2.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1868_12969.FStar_TypeChecker_Env.range);
+                               (uu___2.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1868_12969.FStar_TypeChecker_Env.curmodule);
+                               (uu___2.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1868_12969.FStar_TypeChecker_Env.gamma);
+                               (uu___2.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1868_12969.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___2.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1868_12969.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___2.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1868_12969.FStar_TypeChecker_Env.modules);
+                               (uu___2.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1868_12969.FStar_TypeChecker_Env.expected_typ);
+                               (uu___2.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1868_12969.FStar_TypeChecker_Env.sigtab);
+                               (uu___2.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1868_12969.FStar_TypeChecker_Env.attrtab);
+                               (uu___2.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1868_12969.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___2.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1868_12969.FStar_TypeChecker_Env.effects);
+                               (uu___2.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1868_12969.FStar_TypeChecker_Env.generalize);
+                               (uu___2.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs = [];
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1868_12969.FStar_TypeChecker_Env.top_level);
+                               (uu___2.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1868_12969.FStar_TypeChecker_Env.check_uvars);
+                               (uu___2.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1868_12969.FStar_TypeChecker_Env.use_eq);
+                               (uu___2.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1868_12969.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___2.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1868_12969.FStar_TypeChecker_Env.is_iface);
+                               (uu___2.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1868_12969.FStar_TypeChecker_Env.admit);
+                               (uu___2.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___1868_12969.FStar_TypeChecker_Env.lax);
+                               (uu___2.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1868_12969.FStar_TypeChecker_Env.lax_universes);
+                               (uu___2.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1868_12969.FStar_TypeChecker_Env.phase1);
+                               (uu___2.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1868_12969.FStar_TypeChecker_Env.failhard);
+                               (uu___2.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1868_12969.FStar_TypeChecker_Env.nosynth);
+                               (uu___2.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1868_12969.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___2.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1868_12969.FStar_TypeChecker_Env.tc_term);
+                               (uu___2.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1868_12969.FStar_TypeChecker_Env.type_of);
+                               (uu___2.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1868_12969.FStar_TypeChecker_Env.universe_of);
+                               (uu___2.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1868_12969.FStar_TypeChecker_Env.check_type_of);
+                               (uu___2.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1868_12969.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___2.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1868_12969.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___2.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1868_12969.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___2.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1868_12969.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___2.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1868_12969.FStar_TypeChecker_Env.proof_ns);
+                               (uu___2.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1868_12969.FStar_TypeChecker_Env.synth_hook);
+                               (uu___2.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1868_12969.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___2.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1868_12969.FStar_TypeChecker_Env.splice);
+                               (uu___2.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1868_12969.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___2.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1868_12969.FStar_TypeChecker_Env.postprocess);
+                               (uu___2.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1868_12969.FStar_TypeChecker_Env.identifier_info);
+                               (uu___2.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1868_12969.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___2.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1868_12969.FStar_TypeChecker_Env.dsenv);
+                               (uu___2.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1868_12969.FStar_TypeChecker_Env.nbe);
+                               (uu___2.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1868_12969.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___2.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1868_12969.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___2.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___1868_12969.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___2.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
-                         let uu____12978 =
+                         let uu___2 =
                            check_actuals_against_formals envbody bs
                              bs_expected1 body in
-                         (match uu____12978 with
+                         (match uu___2 with
                           | (envbody1, bs1, g_env, c, body1) ->
                               let envbody2 =
-                                let uu___1877_13015 = envbody1 in
+                                let uu___3 = envbody1 in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.solver);
+                                    (uu___3.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.range);
+                                    (uu___3.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.curmodule);
+                                    (uu___3.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.gamma);
+                                    (uu___3.FStar_TypeChecker_Env.gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___3.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.gamma_cache);
+                                    (uu___3.FStar_TypeChecker_Env.gamma_cache);
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.modules);
+                                    (uu___3.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___3.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.sigtab);
+                                    (uu___3.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.attrtab);
+                                    (uu___3.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___3.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.effects);
+                                    (uu___3.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.generalize);
+                                    (uu___3.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
                                     (env.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.top_level);
+                                    (uu___3.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___3.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.use_eq);
+                                    (uu___3.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___3.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.is_iface);
+                                    (uu___3.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.admit);
+                                    (uu___3.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.lax);
+                                    (uu___3.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___3.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.phase1);
+                                    (uu___3.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.failhard);
+                                    (uu___3.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.nosynth);
+                                    (uu___3.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.tc_term);
+                                    (uu___3.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.type_of);
+                                    (uu___3.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.universe_of);
+                                    (uu___3.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___3.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___3.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___3.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___3.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___3.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___3.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___3.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___3.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.splice);
+                                    (uu___3.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___3.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.postprocess);
+                                    (uu___3.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___3.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___3.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.dsenv);
+                                    (uu___3.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.nbe);
+                                    (uu___3.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___3.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.erasable_types_tab);
+                                    (uu___3.FStar_TypeChecker_Env.erasable_types_tab);
                                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (uu___1877_13015.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    (uu___3.FStar_TypeChecker_Env.enable_defer_to_tac)
                                 } in
-                              let uu____13016 = mk_letrec_env envbody2 bs1 c in
-                              (match uu____13016 with
+                              let uu___3 = mk_letrec_env envbody2 bs1 c in
+                              (match uu___3 with
                                | (envbody3, letrecs, g_annots) ->
                                    let envbody4 =
                                      FStar_TypeChecker_Env.set_expected_typ
                                        envbody3
                                        (FStar_Syntax_Util.comp_result c) in
-                                   let uu____13053 =
+                                   let uu___4 =
                                      FStar_TypeChecker_Env.conj_guard g_env
                                        g_annots in
                                    ((FStar_Pervasives_Native.Some t2), bs1,
                                      letrecs,
                                      (FStar_Pervasives_Native.Some c),
-                                     envbody4, body1, uu____13053))))
-                | uu____13060 ->
+                                     envbody4, body1, uu___4))))
+                | uu___1 ->
                     if Prims.op_Negation norm1
                     then
-                      let uu____13081 =
-                        let uu____13082 =
+                      let uu___2 =
+                        let uu___3 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.unfold_whnf env) in
-                        FStar_All.pipe_right uu____13082
+                        FStar_All.pipe_right uu___3
                           FStar_Syntax_Util.unascribe in
-                      as_function_typ true uu____13081
+                      as_function_typ true uu___2
                     else
-                      (let uu____13084 =
+                      (let uu___3 =
                          tc_abs_expected_function_typ env bs
                            FStar_Pervasives_Native.None body in
-                       match uu____13084 with
-                       | (uu____13123, bs1, uu____13125, c_opt, envbody,
-                          body1, g_env) ->
+                       match uu___3 with
+                       | (uu___4, bs1, uu___5, c_opt, envbody, body1, g_env)
+                           ->
                            ((FStar_Pervasives_Native.Some t2), bs1, [],
                              c_opt, envbody, body1, g_env)) in
               as_function_typ false t1
@@ -4521,152 +4414,148 @@ and (tc_abs_check_binders :
   fun env ->
     fun bs ->
       fun bs_expected ->
-        let rec aux uu____13198 bs1 bs_expected1 =
-          match uu____13198 with
+        let rec aux uu___ bs1 bs_expected1 =
+          match uu___ with
           | (env1, subst) ->
               (match (bs1, bs_expected1) with
                | ([], []) ->
                    (env1, [], FStar_Pervasives_Native.None,
                      FStar_TypeChecker_Env.trivial_guard, subst)
-               | ((uu____13305, FStar_Pervasives_Native.None)::uu____13306,
-                  (hd_e, q)::uu____13309) when
+               | ((uu___1, FStar_Pervasives_Native.None)::uu___2,
+                  (hd_e, q)::uu___3) when
                    FStar_Syntax_Syntax.is_implicit_or_meta q ->
                    let bv =
-                     let uu____13361 =
-                       let uu____13364 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.range_of_id
                            hd_e.FStar_Syntax_Syntax.ppname in
-                       FStar_Pervasives_Native.Some uu____13364 in
-                     let uu____13365 =
+                       FStar_Pervasives_Native.Some uu___5 in
+                     let uu___5 =
                        FStar_Syntax_Subst.subst subst
                          hd_e.FStar_Syntax_Syntax.sort in
-                     FStar_Syntax_Syntax.new_bv uu____13361 uu____13365 in
+                     FStar_Syntax_Syntax.new_bv uu___4 uu___5 in
                    aux (env1, subst) ((bv, q) :: bs1) bs_expected1
                | ((hd, imp)::bs2, (hd_expected, imp')::bs_expected2) ->
                    ((let special q1 q2 =
                        match (q1, q2) with
                        | (FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13458),
+                          (FStar_Syntax_Syntax.Meta uu___2),
                           FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13459)) -> true
+                          (FStar_Syntax_Syntax.Meta uu___3)) -> true
                        | (FStar_Pervasives_Native.None,
                           FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Equality)) -> true
                        | (FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____13468),
+                          (FStar_Syntax_Syntax.Implicit uu___2),
                           FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13469)) -> true
-                       | uu____13474 -> false in
-                     let uu____13483 =
+                          (FStar_Syntax_Syntax.Meta uu___3)) -> true
+                       | uu___2 -> false in
+                     let uu___2 =
                        (Prims.op_Negation (special imp imp')) &&
-                         (let uu____13485 =
-                            FStar_Syntax_Util.eq_aqual imp imp' in
-                          uu____13485 <> FStar_Syntax_Util.Equal) in
-                     if uu____13483
+                         (let uu___3 = FStar_Syntax_Util.eq_aqual imp imp' in
+                          uu___3 <> FStar_Syntax_Util.Equal) in
+                     if uu___2
                      then
-                       let uu____13486 =
-                         let uu____13491 =
-                           let uu____13492 =
-                             FStar_Syntax_Print.bv_to_string hd in
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Syntax_Print.bv_to_string hd in
                            FStar_Util.format1
                              "Inconsistent implicit argument annotation on argument %s"
-                             uu____13492 in
+                             uu___5 in
                          (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                           uu____13491) in
-                       let uu____13493 = FStar_Syntax_Syntax.range_of_bv hd in
-                       FStar_Errors.raise_error uu____13486 uu____13493
+                           uu___4) in
+                       let uu___4 = FStar_Syntax_Syntax.range_of_bv hd in
+                       FStar_Errors.raise_error uu___3 uu___4
                      else ());
                     (let expected_t =
                        FStar_Syntax_Subst.subst subst
                          hd_expected.FStar_Syntax_Syntax.sort in
-                     let uu____13496 =
-                       let uu____13503 =
-                         let uu____13504 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_Syntax_Util.unmeta
                              hd.FStar_Syntax_Syntax.sort in
-                         uu____13504.FStar_Syntax_Syntax.n in
-                       match uu____13503 with
+                         uu___4.FStar_Syntax_Syntax.n in
+                       match uu___3 with
                        | FStar_Syntax_Syntax.Tm_unknown ->
                            (expected_t, FStar_TypeChecker_Env.trivial_guard)
-                       | uu____13515 ->
-                           ((let uu____13517 =
+                       | uu___4 ->
+                           ((let uu___6 =
                                FStar_TypeChecker_Env.debug env1
                                  FStar_Options.High in
-                             if uu____13517
+                             if uu___6
                              then
-                               let uu____13518 =
+                               let uu___7 =
                                  FStar_Syntax_Print.bv_to_string hd in
                                FStar_Util.print1 "Checking binder %s\n"
-                                 uu____13518
+                                 uu___7
                              else ());
-                            (let uu____13520 =
+                            (let uu___6 =
                                tc_tot_or_gtot_term env1
                                  hd.FStar_Syntax_Syntax.sort in
-                             match uu____13520 with
-                             | (t, uu____13534, g1_env) ->
+                             match uu___6 with
+                             | (t, uu___7, g1_env) ->
                                  let g2_env =
-                                   let uu____13537 =
+                                   let uu___8 =
                                      FStar_TypeChecker_Rel.teq_nosmt env1 t
                                        expected_t in
-                                   match uu____13537 with
+                                   match uu___8 with
                                    | FStar_Pervasives_Native.Some g ->
                                        FStar_All.pipe_right g
                                          (FStar_TypeChecker_Rel.resolve_implicits
                                             env1)
                                    | FStar_Pervasives_Native.None ->
-                                       let uu____13541 =
+                                       let uu___9 =
                                          FStar_TypeChecker_Rel.get_subtyping_prop
                                            env1 expected_t t in
-                                       (match uu____13541 with
+                                       (match uu___9 with
                                         | FStar_Pervasives_Native.None ->
-                                            let uu____13544 =
+                                            let uu___10 =
                                               FStar_TypeChecker_Err.basic_type_error
                                                 env1
                                                 FStar_Pervasives_Native.None
                                                 expected_t t in
-                                            let uu____13549 =
+                                            let uu___11 =
                                               FStar_TypeChecker_Env.get_range
                                                 env1 in
-                                            FStar_Errors.raise_error
-                                              uu____13544 uu____13549
+                                            FStar_Errors.raise_error uu___10
+                                              uu___11
                                         | FStar_Pervasives_Native.Some g_env
                                             ->
                                             FStar_TypeChecker_Util.label_guard
                                               (hd.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                                               "Type annotation on parameter incompatible with the expected type"
                                               g_env) in
-                                 let uu____13551 =
+                                 let uu___8 =
                                    FStar_TypeChecker_Env.conj_guard g1_env
                                      g2_env in
-                                 (t, uu____13551))) in
-                     match uu____13496 with
+                                 (t, uu___8))) in
+                     match uu___2 with
                      | (t, g_env) ->
                          let hd1 =
-                           let uu___1973_13577 = hd in
+                           let uu___3 = hd in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___1973_13577.FStar_Syntax_Syntax.ppname);
+                               (uu___3.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___1973_13577.FStar_Syntax_Syntax.index);
+                               (uu___3.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t
                            } in
                          let b = (hd1, imp) in
                          let b_expected = (hd_expected, imp') in
                          let env_b = push_binding env1 b in
                          let subst1 =
-                           let uu____13600 =
-                             FStar_Syntax_Syntax.bv_to_name hd1 in
-                           maybe_extend_subst subst b_expected uu____13600 in
-                         let uu____13603 =
-                           aux (env_b, subst1) bs2 bs_expected2 in
-                         (match uu____13603 with
+                           let uu___3 = FStar_Syntax_Syntax.bv_to_name hd1 in
+                           maybe_extend_subst subst b_expected uu___3 in
+                         let uu___3 = aux (env_b, subst1) bs2 bs_expected2 in
+                         (match uu___3 with
                           | (env_bs, bs3, rest, g'_env_b, subst2) ->
                               let g'_env =
                                 FStar_TypeChecker_Env.close_guard env_bs 
                                   [b] g'_env_b in
-                              let uu____13668 =
+                              let uu___4 =
                                 FStar_TypeChecker_Env.conj_guard g_env g'_env in
-                              (env_bs, (b :: bs3), rest, uu____13668, subst2))))
+                              (env_bs, (b :: bs3), rest, uu___4, subst2))))
                | (rest, []) ->
                    (env1, [],
                      (FStar_Pervasives_Native.Some (FStar_Util.Inl rest)),
@@ -4689,438 +4578,435 @@ and (tc_abs :
       fun bs ->
         fun body ->
           let fail msg t =
-            let uu____13805 =
+            let uu___ =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
                 env msg t top in
-            FStar_Errors.raise_error uu____13805 top.FStar_Syntax_Syntax.pos in
+            FStar_Errors.raise_error uu___ top.FStar_Syntax_Syntax.pos in
           let use_eq = env.FStar_TypeChecker_Env.use_eq in
-          let uu____13811 = FStar_TypeChecker_Env.clear_expected_typ env in
-          match uu____13811 with
+          let uu___ = FStar_TypeChecker_Env.clear_expected_typ env in
+          match uu___ with
           | (env1, topt) ->
-              ((let uu____13831 =
+              ((let uu___2 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High in
-                if uu____13831
+                if uu___2
                 then
-                  let uu____13832 =
+                  let uu___3 =
                     match topt with
                     | FStar_Pervasives_Native.None -> "None"
                     | FStar_Pervasives_Native.Some t ->
                         FStar_Syntax_Print.term_to_string t in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____13832
+                    uu___3
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____13836 =
-                  tc_abs_expected_function_typ env1 bs topt body in
-                match uu____13836 with
+               (let uu___2 = tc_abs_expected_function_typ env1 bs topt body in
+                match uu___2 with
                 | (tfun_opt, bs1, letrec_binders, c_opt, envbody, body1,
                    g_env) ->
-                    ((let uu____13877 =
+                    ((let uu___4 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme in
-                      if uu____13877
+                      if uu___4
                       then
-                        let uu____13878 =
+                        let uu___5 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t in
-                        let uu____13880 =
+                        let uu___6 =
                           match c_opt with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t in
-                        let uu____13882 =
-                          let uu____13883 =
+                        let uu___7 =
+                          let uu___8 =
                             FStar_TypeChecker_Env.expected_typ envbody in
-                          match uu____13883 with
+                          match uu___8 with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____13878 uu____13880 uu____13882
+                          uu___5 uu___6 uu___7
                       else ());
-                     (let uu____13889 =
+                     (let uu___5 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC") in
-                      if uu____13889
+                      if uu___5
                       then
-                        let uu____13890 =
+                        let uu___6 =
                           FStar_Syntax_Print.binders_to_string ", " bs1 in
-                        let uu____13891 =
+                        let uu___7 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____13890 uu____13891
+                          uu___6 uu___7
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos in
-                      let uu____13894 =
-                        let uu____13905 =
-                          let uu____13912 =
+                      let uu___5 =
+                        let uu___6 =
+                          let uu___7 =
                             (FStar_All.pipe_right c_opt FStar_Util.is_some)
                               &&
-                              (let uu____13920 =
-                                 let uu____13921 =
+                              (let uu___8 =
+                                 let uu___9 =
                                    FStar_Syntax_Subst.compress body1 in
-                                 uu____13921.FStar_Syntax_Syntax.n in
-                               match uu____13920 with
+                                 uu___9.FStar_Syntax_Syntax.n in
+                               match uu___8 with
                                | FStar_Syntax_Syntax.Tm_app (head, args) when
                                    (FStar_List.length args) = Prims.int_one
                                    ->
-                                   let uu____13958 =
-                                     let uu____13959 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_Syntax_Subst.compress head in
-                                     uu____13959.FStar_Syntax_Syntax.n in
-                                   (match uu____13958 with
+                                     uu___10.FStar_Syntax_Syntax.n in
+                                   (match uu___9 with
                                     | FStar_Syntax_Syntax.Tm_constant
-                                        (FStar_Const.Const_reflect
-                                        uu____13962) -> true
-                                    | uu____13963 -> false)
-                               | uu____13964 -> false) in
-                          if uu____13912
+                                        (FStar_Const.Const_reflect uu___10)
+                                        -> true
+                                    | uu___10 -> false)
+                               | uu___9 -> false) in
+                          if uu___7
                           then
-                            let uu____13971 =
-                              let uu____13972 =
+                            let uu___8 =
+                              let uu___9 =
                                 FStar_TypeChecker_Env.clear_expected_typ
                                   envbody1 in
-                              FStar_All.pipe_right uu____13972
+                              FStar_All.pipe_right uu___9
                                 FStar_Pervasives_Native.fst in
-                            let uu____13987 =
-                              let uu____13988 =
-                                let uu____13989 =
-                                  let uu____14016 =
-                                    let uu____14033 =
-                                      let uu____14042 =
+                            let uu___9 =
+                              let uu___10 =
+                                let uu___11 =
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
                                         FStar_All.pipe_right c_opt
                                           FStar_Util.must in
-                                      FStar_Util.Inr uu____14042 in
-                                    (uu____14033,
-                                      FStar_Pervasives_Native.None) in
-                                  (body1, uu____14016,
+                                      FStar_Util.Inr uu___14 in
+                                    (uu___13, FStar_Pervasives_Native.None) in
+                                  (body1, uu___12,
                                     FStar_Pervasives_Native.None) in
-                                FStar_Syntax_Syntax.Tm_ascribed uu____13989 in
-                              FStar_Syntax_Syntax.mk uu____13988
+                                FStar_Syntax_Syntax.Tm_ascribed uu___11 in
+                              FStar_Syntax_Syntax.mk uu___10
                                 FStar_Range.dummyRange in
-                            (uu____13971, uu____13987, false)
+                            (uu___8, uu___9, false)
                           else
-                            (let uu____14088 =
-                               let uu____14089 =
-                                 let uu____14096 =
-                                   let uu____14097 =
+                            (let uu___9 =
+                               let uu___10 =
+                                 let uu___11 =
+                                   let uu___12 =
                                      FStar_Syntax_Subst.compress body1 in
-                                   uu____14097.FStar_Syntax_Syntax.n in
-                                 (c_opt, uu____14096) in
-                               match uu____14089 with
+                                   uu___12.FStar_Syntax_Syntax.n in
+                                 (c_opt, uu___11) in
+                               match uu___10 with
                                | (FStar_Pervasives_Native.None,
                                   FStar_Syntax_Syntax.Tm_ascribed
-                                  (uu____14102,
-                                   (FStar_Util.Inr expected_c, uu____14104),
-                                   uu____14105)) -> false
-                               | uu____14154 -> true in
-                             (envbody1, body1, uu____14088)) in
-                        match uu____13905 with
+                                  (uu___11,
+                                   (FStar_Util.Inr expected_c, uu___12),
+                                   uu___13)) -> false
+                               | uu___11 -> true in
+                             (envbody1, body1, uu___9)) in
+                        match uu___6 with
                         | (envbody2, body2, should_check_expected_effect) ->
-                            let uu____14174 =
+                            let uu___7 =
                               tc_term
-                                (let uu___2058_14183 = envbody2 in
+                                (let uu___8 = envbody2 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.solver);
+                                     (uu___8.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.range);
+                                     (uu___8.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.curmodule);
+                                     (uu___8.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.gamma);
+                                     (uu___8.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___8.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___8.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.modules);
+                                     (uu___8.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___8.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.sigtab);
+                                     (uu___8.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.attrtab);
+                                     (uu___8.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___8.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.effects);
+                                     (uu___8.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.generalize);
+                                     (uu___8.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.letrecs);
+                                     (uu___8.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level = false;
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___8.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq = use_eq;
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___8.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.is_iface);
+                                     (uu___8.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.admit);
+                                     (uu___8.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.lax);
+                                     (uu___8.FStar_TypeChecker_Env.lax);
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___8.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.phase1);
+                                     (uu___8.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.failhard);
+                                     (uu___8.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.nosynth);
+                                     (uu___8.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___8.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.tc_term);
+                                     (uu___8.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.type_of);
+                                     (uu___8.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.universe_of);
+                                     (uu___8.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___8.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___8.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___8.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___8.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___8.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___8.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___8.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.splice);
+                                     (uu___8.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___8.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.postprocess);
+                                     (uu___8.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___8.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___8.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.dsenv);
+                                     (uu___8.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.nbe);
+                                     (uu___8.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___8.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___8.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___2058_14183.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___8.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) body2 in
-                            (match uu____14174 with
+                            (match uu___7 with
                              | (body3, cbody, guard_body) ->
                                  let guard_body1 =
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
                                      envbody2 guard_body in
                                  if should_check_expected_effect
                                  then
-                                   let uu____14208 =
+                                   let uu___8 =
                                      FStar_TypeChecker_Common.lcomp_comp
                                        cbody in
-                                   (match uu____14208 with
+                                   (match uu___8 with
                                     | (cbody1, g_lc) ->
-                                        let uu____14225 =
+                                        let uu___9 =
                                           check_expected_effect
-                                            (let uu___2069_14234 = envbody2 in
+                                            (let uu___10 = envbody2 in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.solver);
+                                                 (uu___10.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.range);
+                                                 (uu___10.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___10.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.gamma);
+                                                 (uu___10.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___10.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___10.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.modules);
+                                                 (uu___10.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___10.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___10.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___10.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___10.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.effects);
+                                                 (uu___10.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.generalize);
+                                                 (uu___10.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___10.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.top_level);
+                                                 (uu___10.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___10.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
                                                  use_eq;
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___10.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___10.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.admit);
+                                                 (uu___10.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.lax);
+                                                 (uu___10.FStar_TypeChecker_Env.lax);
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___10.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.phase1);
+                                                 (uu___10.FStar_TypeChecker_Env.phase1);
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.failhard);
+                                                 (uu___10.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___10.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___10.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___10.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.type_of);
+                                                 (uu___10.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___10.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___10.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___10.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___10.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___10.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___10.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___10.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___10.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___10.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.splice);
+                                                 (uu___10.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___10.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___10.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___10.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___10.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___10.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.nbe);
+                                                 (uu___10.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___10.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.erasable_types_tab);
+                                                 (uu___10.FStar_TypeChecker_Env.erasable_types_tab);
                                                FStar_TypeChecker_Env.enable_defer_to_tac
                                                  =
-                                                 (uu___2069_14234.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                 (uu___10.FStar_TypeChecker_Env.enable_defer_to_tac)
                                              }) c_opt (body3, cbody1) in
-                                        (match uu____14225 with
+                                        (match uu___9 with
                                          | (body4, cbody2, guard) ->
-                                             let uu____14248 =
-                                               let uu____14249 =
+                                             let uu___10 =
+                                               let uu___11 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g_lc guard in
                                                FStar_TypeChecker_Env.conj_guard
-                                                 guard_body1 uu____14249 in
-                                             (body4, cbody2, uu____14248)))
+                                                 guard_body1 uu___11 in
+                                             (body4, cbody2, uu___10)))
                                  else
-                                   (let uu____14255 =
+                                   (let uu___9 =
                                       FStar_TypeChecker_Common.lcomp_comp
                                         cbody in
-                                    match uu____14255 with
+                                    match uu___9 with
                                     | (cbody1, g_lc) ->
-                                        let uu____14272 =
+                                        let uu___10 =
                                           FStar_TypeChecker_Env.conj_guard
                                             guard_body1 g_lc in
-                                        (body3, cbody1, uu____14272))) in
-                      match uu____13894 with
+                                        (body3, cbody1, uu___10))) in
+                      match uu___5 with
                       | (body2, cbody, guard_body) ->
                           let guard =
-                            let uu____14295 =
+                            let uu___6 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____14297 =
+                                (let uu___7 =
                                    FStar_TypeChecker_Env.should_verify env1 in
-                                 Prims.op_Negation uu____14297) in
-                            if uu____14295
+                                 Prims.op_Negation uu___7) in
+                            if uu___6
                             then
-                              let uu____14298 =
+                              let uu___7 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env in
-                              let uu____14299 =
+                              let uu___8 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body in
-                              FStar_TypeChecker_Env.conj_guard uu____14298
-                                uu____14299
+                              FStar_TypeChecker_Env.conj_guard uu___7 uu___8
                             else
-                              (let guard =
-                                 let uu____14302 =
+                              (let guard1 =
+                                 let uu___8 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____14302 in
-                               guard) in
+                                   uu___8 in
+                               guard1) in
                           let guard1 =
                             FStar_TypeChecker_Util.close_guard_implicits env1
                               false bs1 guard in
@@ -5131,7 +5017,7 @@ and (tc_abs :
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt))) in
-                          let uu____14316 =
+                          let uu___6 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t in
@@ -5142,37 +5028,36 @@ and (tc_abs :
                                       failwith
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some" in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____14339
-                                     -> (e, t_annot, guard1)
-                                 | uu____14354 ->
+                                 | FStar_Syntax_Syntax.Tm_arrow uu___7 ->
+                                     (e, t_annot, guard1)
+                                 | uu___7 ->
                                      let lc =
-                                       let uu____14356 =
+                                       let uu___8 =
                                          FStar_Syntax_Syntax.mk_Total
                                            tfun_computed in
-                                       FStar_All.pipe_right uu____14356
+                                       FStar_All.pipe_right uu___8
                                          FStar_TypeChecker_Common.lcomp_of_comp in
-                                     let uu____14357 =
+                                     let uu___8 =
                                        FStar_TypeChecker_Util.check_has_type
                                          env1 e lc t1 in
-                                     (match uu____14357 with
-                                      | (e1, uu____14371, guard') ->
-                                          let uu____14373 =
+                                     (match uu___8 with
+                                      | (e1, uu___9, guard') ->
+                                          let uu___10 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard' in
-                                          (e1, t_annot, uu____14373)))
+                                          (e1, t_annot, uu___10)))
                             | FStar_Pervasives_Native.None ->
                                 (e, tfun_computed, guard1) in
-                          (match uu____14316 with
+                          (match uu___6 with
                            | (e1, tfun, guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun in
-                               let uu____14384 =
-                                 let uu____14389 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____14389 guard2 in
-                               (match uu____14384 with
-                                | (c1, g) -> (e1, c1, g)))))))
+                                   uu___8 guard2 in
+                               (match uu___7 with | (c1, g) -> (e1, c1, g)))))))
 and (check_application_args :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -5194,82 +5079,79 @@ and (check_application_args :
               let n_args = FStar_List.length args in
               let r = FStar_TypeChecker_Env.get_range env in
               let thead = FStar_Syntax_Util.comp_result chead in
-              (let uu____14439 =
+              (let uu___1 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High in
-               if uu____14439
+               if uu___1
                then
-                 let uu____14440 =
+                 let uu___2 =
                    FStar_Range.string_of_range head.FStar_Syntax_Syntax.pos in
-                 let uu____14441 = FStar_Syntax_Print.term_to_string thead in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14440
-                   uu____14441
+                 let uu___3 = FStar_Syntax_Print.term_to_string thead in
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu___2 uu___3
                else ());
-              (let monadic_application uu____14520 subst arg_comps_rev
+              (let monadic_application uu___1 subst arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____14520 with
+                 match uu___1 with
                  | (head1, chead1, ghead1, cres) ->
-                     let uu____14589 =
+                     let uu___2 =
                        check_no_escape (FStar_Pervasives_Native.Some head1)
                          env fvs (FStar_Syntax_Util.comp_result cres) in
-                     (match uu____14589 with
+                     (match uu___2 with
                       | (rt, g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt in
-                          let uu____14603 =
+                          let uu___3 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____14619 =
+                                  let uu___4 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____14619 in
+                                    uu___4 in
                                 (cres1, g)
-                            | uu____14620 ->
+                            | uu___4 ->
                                 let g =
-                                  let uu____14630 =
-                                    let uu____14631 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard in
-                                    FStar_All.pipe_right uu____14631
+                                    FStar_All.pipe_right uu___6
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env) in
-                                  FStar_TypeChecker_Env.conj_guard g0
-                                    uu____14630 in
-                                let uu____14632 =
-                                  let uu____14633 =
+                                  FStar_TypeChecker_Env.conj_guard g0 uu___5 in
+                                let uu___5 =
+                                  let uu___6 =
                                     FStar_Syntax_Util.arrow bs cres1 in
-                                  FStar_Syntax_Syntax.mk_Total uu____14633 in
-                                (uu____14632, g) in
-                          (match uu____14603 with
+                                  FStar_Syntax_Syntax.mk_Total uu___6 in
+                                (uu___5, g) in
+                          (match uu___3 with
                            | (cres2, guard1) ->
-                               ((let uu____14643 =
+                               ((let uu___5 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Medium in
-                                 if uu____14643
+                                 if uu___5
                                  then
-                                   let uu____14644 =
+                                   let uu___6 =
                                      FStar_Syntax_Print.comp_to_string cres2 in
                                    FStar_Util.print1
-                                     "\t Type of result cres is %s\n"
-                                     uu____14644
+                                     "\t Type of result cres is %s\n" uu___6
                                  else ());
-                                (let uu____14646 =
-                                   let uu____14651 =
-                                     let uu____14652 =
+                                (let uu___5 =
+                                   let uu___6 =
+                                     let uu___7 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          chead1 in
-                                     FStar_All.pipe_right uu____14652
+                                     FStar_All.pipe_right uu___7
                                        FStar_TypeChecker_Common.lcomp_of_comp in
-                                   let uu____14653 =
-                                     let uu____14654 =
+                                   let uu___7 =
+                                     let uu___8 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          cres2 in
-                                     FStar_All.pipe_right uu____14654
+                                     FStar_All.pipe_right uu___8
                                        FStar_TypeChecker_Common.lcomp_of_comp in
-                                   (uu____14651, uu____14653) in
-                                 match uu____14646 with
+                                   (uu___6, uu___7) in
+                                 match uu___5 with
                                  | (chead2, cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -5278,15 +5160,14 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____14677 ->
-                                                 match uu____14677 with
-                                                 | (uu____14686, uu____14687,
-                                                    lc) ->
-                                                     (let uu____14695 =
+                                              (fun uu___6 ->
+                                                 match uu___6 with
+                                                 | (uu___7, uu___8, lc) ->
+                                                     (let uu___9 =
                                                         FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                           lc in
                                                       Prims.op_Negation
-                                                        uu____14695)
+                                                        uu___9)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev) in
@@ -5294,54 +5175,54 @@ and (check_application_args :
                                          FStar_Syntax_Syntax.mk_Tm_app head1
                                            (FStar_List.rev arg_rets_rev)
                                            head1.FStar_Syntax_Syntax.pos in
-                                       let uu____14705 =
+                                       let uu___6 =
                                          (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful in
-                                       if uu____14705
+                                       if uu___6
                                        then
-                                         ((let uu____14707 =
+                                         ((let uu___8 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme in
-                                           if uu____14707
+                                           if uu___8
                                            then
-                                             let uu____14708 =
+                                             let uu___9 =
                                                FStar_Syntax_Print.term_to_string
                                                  term in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____14708
+                                               uu___9
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____14712 =
+                                         ((let uu___9 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme in
-                                           if uu____14712
+                                           if uu___9
                                            then
-                                             let uu____14713 =
+                                             let uu___10 =
                                                FStar_Syntax_Print.term_to_string
                                                  term in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____14713
+                                               uu___10
                                            else ());
                                           cres3) in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c ->
-                                            fun uu____14741 ->
-                                              match uu____14741 with
+                                            fun uu___6 ->
+                                              match uu___6 with
                                               | ((e, q), x, c) ->
-                                                  ((let uu____14783 =
+                                                  ((let uu___8 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme in
-                                                    if uu____14783
+                                                    if uu___8
                                                     then
-                                                      let uu____14784 =
+                                                      let uu___9 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                             -> "_"
@@ -5349,22 +5230,21 @@ and (check_application_args :
                                                             x1 ->
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1 in
-                                                      let uu____14786 =
+                                                      let uu___10 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e in
-                                                      let uu____14787 =
+                                                      let uu___11 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____14784
-                                                        uu____14786
-                                                        uu____14787
+                                                        uu___9 uu___10
+                                                        uu___11
                                                     else ());
-                                                   (let uu____14789 =
+                                                   (let uu___8 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c in
-                                                    if uu____14789
+                                                    if uu___8
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5379,22 +5259,22 @@ and (check_application_args :
                                                         c (x, out_c)))) cres4
                                          arg_comps_rev in
                                      let comp1 =
-                                       (let uu____14797 =
+                                       (let uu___7 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme in
-                                        if uu____14797
+                                        if uu___7
                                         then
-                                          let uu____14798 =
+                                          let uu___8 =
                                             FStar_Syntax_Print.term_to_string
                                               head1 in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____14798
+                                            uu___8
                                         else ());
-                                       (let uu____14800 =
+                                       (let uu___7 =
                                           FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             chead2 in
-                                        if uu____14800
+                                        if uu___7
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head1.FStar_Syntax_Syntax.pos env
@@ -5410,74 +5290,73 @@ and (check_application_args :
                                             (FStar_Pervasives_Native.None,
                                               comp)) in
                                      let shortcuts_evaluation_order =
-                                       let uu____14807 =
-                                         let uu____14808 =
+                                       let uu___6 =
+                                         let uu___7 =
                                            FStar_Syntax_Subst.compress head1 in
-                                         uu____14808.FStar_Syntax_Syntax.n in
-                                       match uu____14807 with
+                                         uu___7.FStar_Syntax_Syntax.n in
+                                       match uu___6 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____14812 -> false in
+                                       | uu___7 -> false in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
-                                             (fun args1 ->
-                                                fun uu____14833 ->
-                                                  match uu____14833 with
-                                                  | (arg, uu____14847,
-                                                     uu____14848) -> arg ::
-                                                      args1) [] arg_comps_rev in
-                                         let app =
+                                             (fun args2 ->
+                                                fun uu___6 ->
+                                                  match uu___6 with
+                                                  | (arg, uu___7, uu___8) ->
+                                                      arg :: args2) []
+                                             arg_comps_rev in
+                                         let app1 =
                                            FStar_Syntax_Syntax.mk_Tm_app
                                              head1 args1 r in
-                                         let app1 =
+                                         let app2 =
                                            FStar_TypeChecker_Util.maybe_lift
-                                             env app
+                                             env app1
                                              cres4.FStar_TypeChecker_Common.eff_name
                                              comp1.FStar_TypeChecker_Common.eff_name
                                              comp1.FStar_TypeChecker_Common.res_typ in
                                          FStar_TypeChecker_Util.maybe_monadic
-                                           env app1
+                                           env app2
                                            comp1.FStar_TypeChecker_Common.eff_name
                                            comp1.FStar_TypeChecker_Common.res_typ
                                        else
-                                         (let uu____14856 =
-                                            let map_fun uu____14922 =
-                                              match uu____14922 with
-                                              | ((e, q), uu____14963, c) ->
-                                                  ((let uu____14986 =
+                                         (let uu___7 =
+                                            let map_fun uu___8 =
+                                              match uu___8 with
+                                              | ((e, q), uu___9, c) ->
+                                                  ((let uu___11 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme in
-                                                    if uu____14986
+                                                    if uu___11
                                                     then
-                                                      let uu____14987 =
+                                                      let uu___12 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e in
-                                                      let uu____14988 =
+                                                      let uu___13 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____14987
-                                                        uu____14988
+                                                        uu___12 uu___13
                                                     else ());
-                                                   (let uu____14990 =
+                                                   (let uu___11 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c in
-                                                    if uu____14990
+                                                    if uu___11
                                                     then
-                                                      ((let uu____15014 =
+                                                      ((let uu___13 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme in
-                                                        if uu____15014
+                                                        if uu___13
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5491,61 +5370,56 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_TypeChecker_Common.res_typ)
                                                            &&
-                                                           (let uu____15049 =
-                                                              let uu____15050
-                                                                =
-                                                                let uu____15051
-                                                                  =
+                                                           (let uu___13 =
+                                                              let uu___14 =
+                                                                let uu___15 =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head1 in
-                                                                uu____15051.FStar_Syntax_Syntax.n in
-                                                              match uu____15050
+                                                                uu___15.FStar_Syntax_Syntax.n in
+                                                              match uu___14
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____15055
+                                                                  let uu___15
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore" in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____15055
-                                                              | uu____15056
-                                                                  -> true in
+                                                                    uu___15
+                                                              | uu___15 ->
+                                                                  true in
                                                             Prims.op_Negation
-                                                              uu____15049) in
+                                                              uu___13) in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____15058 =
-                                                            let uu____15063 =
-                                                              let uu____15064
-                                                                =
+                                                         (let uu___14 =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e in
-                                                              let uu____15065
-                                                                =
+                                                              let uu___17 =
                                                                 FStar_Ident.string_of_lid
                                                                   c.FStar_TypeChecker_Common.eff_name in
-                                                              let uu____15066
-                                                                =
+                                                              let uu___18 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head1 in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____15064
-                                                                uu____15065
-                                                                uu____15066 in
+                                                                uu___16
+                                                                uu___17
+                                                                uu___18 in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____15063) in
+                                                              uu___15) in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____15058)
+                                                            uu___14)
                                                        else ();
-                                                       (let uu____15069 =
+                                                       (let uu___15 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme in
-                                                        if uu____15069
+                                                        if uu___15
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5560,67 +5434,64 @@ and (check_application_args :
                                                             c.FStar_TypeChecker_Common.eff_name
                                                             comp1.FStar_TypeChecker_Common.eff_name
                                                             c.FStar_TypeChecker_Common.res_typ in
-                                                        let uu____15073 =
-                                                          let uu____15082 =
+                                                        let uu___15 =
+                                                          let uu___16 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
-                                                          (uu____15082, q) in
+                                                          (uu___16, q) in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_TypeChecker_Common.eff_name),
                                                               (c.FStar_TypeChecker_Common.res_typ),
-                                                              e1)),
-                                                          uu____15073))))) in
-                                            let uu____15111 =
-                                              let uu____15142 =
-                                                let uu____15171 =
-                                                  let uu____15182 =
-                                                    let uu____15191 =
+                                                              e1)), uu___15))))) in
+                                            let uu___8 =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  let uu___11 =
+                                                    let uu___12 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head1 in
-                                                    (uu____15191,
+                                                    (uu___12,
                                                       FStar_Pervasives_Native.None,
                                                       chead2) in
-                                                  uu____15182 ::
-                                                    arg_comps_rev in
+                                                  uu___11 :: arg_comps_rev in
                                                 FStar_List.map map_fun
-                                                  uu____15171 in
+                                                  uu___10 in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____15142 in
-                                            match uu____15111 with
+                                                FStar_List.split uu___9 in
+                                            match uu___8 with
                                             | (lifted_args, reverse_args) ->
-                                                let uu____15392 =
-                                                  let uu____15393 =
+                                                let uu___9 =
+                                                  let uu___10 =
                                                     FStar_List.hd
                                                       reverse_args in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____15393 in
-                                                let uu____15414 =
-                                                  let uu____15415 =
+                                                    uu___10 in
+                                                let uu___10 =
+                                                  let uu___11 =
                                                     FStar_List.tl
                                                       reverse_args in
-                                                  FStar_List.rev uu____15415 in
-                                                (lifted_args, uu____15392,
-                                                  uu____15414) in
-                                          match uu____14856 with
+                                                  FStar_List.rev uu___11 in
+                                                (lifted_args, uu___9,
+                                                  uu___10) in
+                                          match uu___7 with
                                           | (lifted_args, head2, args1) ->
-                                              let app =
+                                              let app1 =
                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                   head2 args1 r in
-                                              let app1 =
+                                              let app2 =
                                                 FStar_TypeChecker_Util.maybe_lift
-                                                  env app
+                                                  env app1
                                                   cres4.FStar_TypeChecker_Common.eff_name
                                                   comp1.FStar_TypeChecker_Common.eff_name
                                                   comp1.FStar_TypeChecker_Common.res_typ in
-                                              let app2 =
+                                              let app3 =
                                                 FStar_TypeChecker_Util.maybe_monadic
-                                                  env app1
+                                                  env app2
                                                   comp1.FStar_TypeChecker_Common.eff_name
                                                   comp1.FStar_TypeChecker_Common.res_typ in
-                                              let bind_lifted_args e
-                                                uu___6_15524 =
-                                                match uu___6_15524 with
+                                              let bind_lifted_args e uu___8 =
+                                                match uu___8 with
                                                 | FStar_Pervasives_Native.None
                                                     -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5631,23 +5502,22 @@ and (check_application_args :
                                                         t m e1 []
                                                         e1.FStar_Syntax_Syntax.pos in
                                                     let letbinding =
-                                                      let uu____15585 =
-                                                        let uu____15586 =
-                                                          let uu____15599 =
-                                                            let uu____15602 =
-                                                              let uu____15603
-                                                                =
+                                                      let uu___9 =
+                                                        let uu___10 =
+                                                          let uu___11 =
+                                                            let uu___12 =
+                                                              let uu___13 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   x in
-                                                              [uu____15603] in
+                                                              [uu___13] in
                                                             FStar_Syntax_Subst.close
-                                                              uu____15602 e in
+                                                              uu___12 e in
                                                           ((false, [lb]),
-                                                            uu____15599) in
+                                                            uu___11) in
                                                         FStar_Syntax_Syntax.Tm_let
-                                                          uu____15586 in
+                                                          uu___10 in
                                                       FStar_Syntax_Syntax.mk
-                                                        uu____15585
+                                                        uu___9
                                                         e.FStar_Syntax_Syntax.pos in
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
@@ -5657,239 +5527,227 @@ and (check_application_args :
                                                                 (comp1.FStar_TypeChecker_Common.res_typ)))))
                                                       e.FStar_Syntax_Syntax.pos in
                                               FStar_List.fold_left
-                                                bind_lifted_args app2
+                                                bind_lifted_args app3
                                                 lifted_args) in
-                                     let uu____15652 =
+                                     let uu___6 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1 in
-                                     (match uu____15652 with
+                                     (match uu___6 with
                                       | (comp2, g) ->
-                                          ((let uu____15669 =
+                                          ((let uu___8 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme in
-                                            if uu____15669
+                                            if uu___8
                                             then
-                                              let uu____15670 =
+                                              let uu___9 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app in
-                                              let uu____15671 =
+                                              let uu___10 =
                                                 FStar_TypeChecker_Common.lcomp_to_string
                                                   comp2 in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____15670 uu____15671
+                                                uu___9 uu___10
                                             else ());
                                            (app, comp2, g))))))) in
-               let rec tc_args head_info uu____15757 bs args1 =
-                 match uu____15757 with
+               let rec tc_args head_info uu___1 bs args1 =
+                 match uu___1 with
                  | (subst, outargs, arg_rets, g, fvs) ->
                      (match (bs, args1) with
                       | ((x, FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____15920))::rest,
-                         (uu____15922, FStar_Pervasives_Native.None)::uu____15923)
-                          ->
+                          (FStar_Syntax_Syntax.Implicit uu___2))::rest,
+                         (uu___3, FStar_Pervasives_Native.None)::uu___4) ->
                           let t =
                             FStar_Syntax_Subst.subst subst
                               x.FStar_Syntax_Syntax.sort in
-                          let uu____15983 =
+                          let uu___5 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head) env fvs t in
-                          (match uu____15983 with
+                          (match uu___5 with
                            | (t1, g_ex) ->
                                let r1 =
                                  match outargs with
                                  | [] -> head.FStar_Syntax_Syntax.pos
-                                 | ((t2, uu____16014), uu____16015,
-                                    uu____16016)::uu____16017 ->
-                                     let uu____16072 =
+                                 | ((t2, uu___6), uu___7, uu___8)::uu___9 ->
+                                     let uu___10 =
                                        FStar_Range.def_range
                                          head.FStar_Syntax_Syntax.pos in
-                                     let uu____16073 =
-                                       let uu____16074 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_Range.use_range
                                            head.FStar_Syntax_Syntax.pos in
-                                       let uu____16075 =
+                                       let uu___13 =
                                          FStar_Range.use_range
                                            t2.FStar_Syntax_Syntax.pos in
-                                       FStar_Range.union_rng uu____16074
-                                         uu____16075 in
-                                     FStar_Range.range_of_rng uu____16072
-                                       uu____16073 in
-                               let uu____16076 =
+                                       FStar_Range.union_rng uu___12 uu___13 in
+                                     FStar_Range.range_of_rng uu___10 uu___11 in
+                               let uu___6 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    r1 env t1 in
-                               (match uu____16076 with
-                                | (varg, uu____16096, implicits) ->
+                               (match uu___6 with
+                                | (varg, uu___7, implicits) ->
                                     let subst1 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst in
                                     let arg =
-                                      let uu____16124 =
+                                      let uu___8 =
                                         FStar_Syntax_Syntax.as_implicit true in
-                                      (varg, uu____16124) in
+                                      (varg, uu___8) in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits in
-                                    let uu____16132 =
-                                      let uu____16175 =
-                                        let uu____16194 =
-                                          let uu____16211 =
-                                            let uu____16212 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_Syntax_Syntax.mk_Total t1 in
-                                            FStar_All.pipe_right uu____16212
+                                            FStar_All.pipe_right uu___12
                                               FStar_TypeChecker_Common.lcomp_of_comp in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____16211) in
-                                        uu____16194 :: outargs in
-                                      (subst1, uu____16175, (arg ::
-                                        arg_rets), guard, fvs) in
-                                    tc_args head_info uu____16132 rest args1))
+                                            uu___11) in
+                                        uu___10 :: outargs in
+                                      (subst1, uu___9, (arg :: arg_rets),
+                                        guard, fvs) in
+                                    tc_args head_info uu___8 rest args1))
                       | ((x, FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Meta tau_or_attr))::rest,
-                         (uu____16282, FStar_Pervasives_Native.None)::uu____16283)
-                          ->
-                          let uu____16342 =
+                         (uu___2, FStar_Pervasives_Native.None)::uu___3) ->
+                          let uu___4 =
                             match tau_or_attr with
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_tac tau
                                 ->
                                 let tau1 = FStar_Syntax_Subst.subst subst tau in
-                                let uu____16355 =
+                                let uu___5 =
                                   tc_tactic FStar_Syntax_Syntax.t_unit
                                     FStar_Syntax_Syntax.t_unit env tau1 in
-                                (match uu____16355 with
-                                 | (tau2, uu____16367, g_tau) ->
-                                     let uu____16369 =
-                                       let uu____16370 =
-                                         let uu____16377 =
-                                           FStar_Dyn.mkdyn env in
-                                         (uu____16377, tau2) in
+                                (match uu___5 with
+                                 | (tau2, uu___6, g_tau) ->
+                                     let uu___7 =
+                                       let uu___8 =
+                                         let uu___9 = FStar_Dyn.mkdyn env in
+                                         (uu___9, tau2) in
                                        FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                         uu____16370 in
-                                     (uu____16369, g_tau))
+                                         uu___8 in
+                                     (uu___7, g_tau))
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                 attr ->
                                 let attr1 =
                                   FStar_Syntax_Subst.subst subst attr in
-                                let uu____16384 =
-                                  tc_tot_or_gtot_term env attr1 in
-                                (match uu____16384 with
-                                 | (attr2, uu____16396, g_attr) ->
+                                let uu___5 = tc_tot_or_gtot_term env attr1 in
+                                (match uu___5 with
+                                 | (attr2, uu___6, g_attr) ->
                                      ((FStar_Syntax_Syntax.Ctx_uvar_meta_attr
                                          attr2), g_attr)) in
-                          (match uu____16342 with
+                          (match uu___4 with
                            | (ctx_uvar_meta, g_tau_or_attr) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst
                                    x.FStar_Syntax_Syntax.sort in
-                               let uu____16407 =
+                               let uu___5 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head) env
                                    fvs t in
-                               (match uu____16407 with
+                               (match uu___5 with
                                 | (t1, g_ex) ->
                                     let r1 =
                                       match outargs with
                                       | [] -> head.FStar_Syntax_Syntax.pos
-                                      | ((t2, uu____16438), uu____16439,
-                                         uu____16440)::uu____16441 ->
-                                          let uu____16496 =
+                                      | ((t2, uu___6), uu___7, uu___8)::uu___9
+                                          ->
+                                          let uu___10 =
                                             FStar_Range.def_range
                                               head.FStar_Syntax_Syntax.pos in
-                                          let uu____16497 =
-                                            let uu____16498 =
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_Range.use_range
                                                 head.FStar_Syntax_Syntax.pos in
-                                            let uu____16499 =
+                                            let uu___13 =
                                               FStar_Range.use_range
                                                 t2.FStar_Syntax_Syntax.pos in
-                                            FStar_Range.union_rng uu____16498
-                                              uu____16499 in
-                                          FStar_Range.range_of_rng
-                                            uu____16496 uu____16497 in
-                                    let uu____16500 =
+                                            FStar_Range.union_rng uu___12
+                                              uu___13 in
+                                          FStar_Range.range_of_rng uu___10
+                                            uu___11 in
+                                    let uu___6 =
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         r1 env t1 FStar_Syntax_Syntax.Strict
                                         (FStar_Pervasives_Native.Some
                                            ctx_uvar_meta) in
-                                    (match uu____16500 with
-                                     | (varg, uu____16520, implicits) ->
+                                    (match uu___6 with
+                                     | (varg, uu___7, implicits) ->
                                          let subst1 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst in
                                          let arg =
-                                           let uu____16548 =
+                                           let uu___8 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true in
-                                           (varg, uu____16548) in
+                                           (varg, uu___8) in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau_or_attr]
                                              implicits in
-                                         let uu____16556 =
-                                           let uu____16599 =
-                                             let uu____16618 =
-                                               let uu____16635 =
-                                                 let uu____16636 =
+                                         let uu___8 =
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 =
+                                                 let uu___12 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1 in
-                                                 FStar_All.pipe_right
-                                                   uu____16636
+                                                 FStar_All.pipe_right uu___12
                                                    FStar_TypeChecker_Common.lcomp_of_comp in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____16635) in
-                                             uu____16618 :: outargs in
-                                           (subst1, uu____16599, (arg ::
+                                                 uu___11) in
+                                             uu___10 :: outargs in
+                                           (subst1, uu___9, (arg ::
                                              arg_rets), guard, fvs) in
-                                         tc_args head_info uu____16556 rest
-                                           args1)))
+                                         tc_args head_info uu___8 rest args1)))
                       | ((x, aqual)::rest, (e, aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____16776, FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____16777)) ->
+                            | (uu___3, FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu___4)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____16784),
+                               (FStar_Syntax_Syntax.Meta uu___3),
                                FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16785)) ->
-                                ()
+                               (FStar_Syntax_Syntax.Implicit uu___4)) -> ()
                             | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16790),
+                               (FStar_Syntax_Syntax.Implicit uu___3),
                                FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16791)) ->
-                                ()
+                               (FStar_Syntax_Syntax.Implicit uu___4)) -> ()
                             | (FStar_Pervasives_Native.None,
                                FStar_Pervasives_Native.None) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality),
                                FStar_Pervasives_Native.None) -> ()
-                            | uu____16804 ->
-                                let uu____16813 =
-                                  let uu____16818 =
-                                    let uu____16819 =
+                            | uu___3 ->
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual in
-                                    let uu____16820 =
+                                    let uu___7 =
                                       FStar_Syntax_Print.aqual_to_string aq in
-                                    let uu____16821 =
+                                    let uu___8 =
                                       FStar_Syntax_Print.bv_to_string x in
-                                    let uu____16822 =
+                                    let uu___9 =
                                       FStar_Syntax_Print.term_to_string e in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; expected `%s` got `%s` for bvar %s and term %s"
-                                      uu____16819 uu____16820 uu____16821
-                                      uu____16822 in
+                                      uu___6 uu___7 uu___8 uu___9 in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____16818) in
-                                FStar_Errors.raise_error uu____16813
+                                    uu___5) in
+                                FStar_Errors.raise_error uu___4
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst
@@ -5897,202 +5755,198 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst aqual in
                             let x1 =
-                              let uu___2380_16826 = x in
+                              let uu___3 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2380_16826.FStar_Syntax_Syntax.ppname);
+                                  (uu___3.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2380_16826.FStar_Syntax_Syntax.index);
+                                  (uu___3.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               } in
-                            (let uu____16828 =
+                            (let uu___4 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme in
-                             if uu____16828
+                             if uu___4
                              then
-                               let uu____16829 =
+                               let uu___5 =
                                  FStar_Syntax_Print.bv_to_string x1 in
-                               let uu____16830 =
+                               let uu___6 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort in
-                               let uu____16831 =
+                               let uu___7 =
                                  FStar_Syntax_Print.term_to_string e in
-                               let uu____16832 =
+                               let uu___8 =
                                  FStar_Syntax_Print.subst_to_string subst in
-                               let uu____16833 =
+                               let uu___9 =
                                  FStar_Syntax_Print.term_to_string targ in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____16829 uu____16830 uu____16831
-                                 uu____16832 uu____16833
+                                 uu___5 uu___6 uu___7 uu___8 uu___9
                              else ());
-                            (let uu____16835 =
+                            (let uu___4 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head) env fvs
                                  targ in
-                             match uu____16835 with
+                             match uu___4 with
                              | (targ1, g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1 in
                                  let env2 =
-                                   let uu___2389_16850 = env1 in
+                                   let uu___5 = env1 in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.solver);
+                                       (uu___5.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.range);
+                                       (uu___5.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.curmodule);
+                                       (uu___5.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.gamma);
+                                       (uu___5.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___5.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___5.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.modules);
+                                       (uu___5.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___5.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.sigtab);
+                                       (uu___5.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.attrtab);
+                                       (uu___5.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___5.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.effects);
+                                       (uu___5.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.generalize);
+                                       (uu___5.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.letrecs);
+                                       (uu___5.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.top_level);
+                                       (uu___5.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___5.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___5.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.is_iface);
+                                       (uu___5.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.admit);
+                                       (uu___5.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.lax);
+                                       (uu___5.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___5.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.phase1);
+                                       (uu___5.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.failhard);
+                                       (uu___5.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.nosynth);
+                                       (uu___5.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___5.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.tc_term);
+                                       (uu___5.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.type_of);
+                                       (uu___5.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.universe_of);
+                                       (uu___5.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___5.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___5.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___5.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___5.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___5.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___5.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___5.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___5.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.splice);
+                                       (uu___5.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___5.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.postprocess);
+                                       (uu___5.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___5.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___5.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.dsenv);
+                                       (uu___5.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.nbe);
+                                       (uu___5.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___5.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.erasable_types_tab);
+                                       (uu___5.FStar_TypeChecker_Env.erasable_types_tab);
                                      FStar_TypeChecker_Env.enable_defer_to_tac
                                        =
-                                       (uu___2389_16850.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                       (uu___5.FStar_TypeChecker_Env.enable_defer_to_tac)
                                    } in
-                                 ((let uu____16852 =
+                                 ((let uu___6 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High in
-                                   if uu____16852
+                                   if uu___6
                                    then
-                                     let uu____16853 =
+                                     let uu___7 =
                                        FStar_Syntax_Print.tag_of_term e in
-                                     let uu____16854 =
+                                     let uu___8 =
                                        FStar_Syntax_Print.term_to_string e in
-                                     let uu____16855 =
+                                     let uu___9 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1 in
-                                     let uu____16856 =
+                                     let uu___10 =
                                        FStar_Util.string_of_bool
                                          env2.FStar_TypeChecker_Env.use_eq in
                                      FStar_Util.print4
                                        "Checking arg (%s) %s at type %s with use_eq:%s\n"
-                                       uu____16853 uu____16854 uu____16855
-                                       uu____16856
+                                       uu___7 uu___8 uu___9 uu___10
                                    else ());
-                                  (let uu____16858 = tc_term env2 e in
-                                   match uu____16858 with
+                                  (let uu___6 = tc_term env2 e in
+                                   match uu___6 with
                                    | (e1, c, g_e) ->
                                        let g1 =
-                                         let uu____16875 =
+                                         let uu___7 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____16875 in
+                                              g_ex) uu___7 in
                                        let arg = (e1, aq) in
                                        let xterm =
-                                         let uu____16898 =
-                                           let uu____16901 =
-                                             let uu____16910 =
+                                         let uu___7 =
+                                           let uu___8 =
+                                             let uu___9 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____16910 in
-                                           FStar_Pervasives_Native.fst
-                                             uu____16901 in
-                                         (uu____16898, aq) in
-                                       let uu____16919 =
+                                               uu___9 in
+                                           FStar_Pervasives_Native.fst uu___8 in
+                                         (uu___7, aq) in
+                                       let uu___7 =
                                          (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                             c)
                                            ||
                                            (FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                               env2
                                               c.FStar_TypeChecker_Common.eff_name) in
-                                       if uu____16919
+                                       if uu___7
                                        then
                                          let subst1 =
-                                           let uu____16927 = FStar_List.hd bs in
-                                           maybe_extend_subst subst
-                                             uu____16927 e1 in
+                                           let uu___8 = FStar_List.hd bs in
+                                           maybe_extend_subst subst uu___8 e1 in
                                          tc_args head_info
                                            (subst1,
                                              ((arg,
@@ -6108,49 +5962,49 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____17073, []) ->
+                      | (uu___2, []) ->
                           monadic_application head_info subst outargs
                             arg_rets g fvs bs
-                      | ([], arg::uu____17109) ->
-                          let uu____17160 =
+                      | ([], arg::uu___2) ->
+                          let uu___3 =
                             monadic_application head_info subst outargs
                               arg_rets g fvs [] in
-                          (match uu____17160 with
+                          (match uu___3 with
                            | (head1, chead1, ghead1) ->
-                               let uu____17182 =
-                                 let uu____17187 =
+                               let uu___4 =
+                                 let uu___5 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1 in
-                                 FStar_All.pipe_right uu____17187
-                                   (fun uu____17204 ->
-                                      match uu____17204 with
+                                 FStar_All.pipe_right uu___5
+                                   (fun uu___6 ->
+                                      match uu___6 with
                                       | (c, g1) ->
-                                          let uu____17215 =
+                                          let uu___7 =
                                             FStar_TypeChecker_Env.conj_guard
                                               ghead1 g1 in
-                                          (c, uu____17215)) in
-                               (match uu____17182 with
+                                          (c, uu___7)) in
+                               (match uu___4 with
                                 | (chead2, ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
                                       let tres1 =
-                                        let uu____17254 =
+                                        let uu___5 =
                                           FStar_Syntax_Subst.compress tres in
-                                        FStar_All.pipe_right uu____17254
+                                        FStar_All.pipe_right uu___5
                                           FStar_Syntax_Util.unrefine in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (bs1, cres') ->
-                                          let uu____17285 =
+                                          let uu___5 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               cres' in
-                                          (match uu____17285 with
+                                          (match uu___5 with
                                            | (bs2, cres'1) ->
                                                let head_info1 =
                                                  (head1, chead2, ghead3,
                                                    cres'1) in
-                                               ((let uu____17308 =
+                                               ((let uu___7 =
                                                    FStar_TypeChecker_Env.debug
                                                      env FStar_Options.Low in
-                                                 if uu____17308
+                                                 if uu___7
                                                  then
                                                    FStar_Errors.log_issue
                                                      tres1.FStar_Syntax_Syntax.pos
@@ -6161,280 +6015,270 @@ and (check_application_args :
                                                   ([], [], [],
                                                     FStar_TypeChecker_Env.trivial_guard,
                                                     []) bs2 args1))
-                                      | uu____17366 when
-                                          Prims.op_Negation norm1 ->
+                                      | uu___5 when Prims.op_Negation norm1
+                                          ->
                                           let rec norm_tres tres2 =
                                             let tres3 =
-                                              let uu____17374 =
+                                              let uu___6 =
                                                 FStar_All.pipe_right tres2
                                                   (FStar_TypeChecker_Normalize.unfold_whnf
                                                      env) in
-                                              FStar_All.pipe_right
-                                                uu____17374
+                                              FStar_All.pipe_right uu___6
                                                 FStar_Syntax_Util.unascribe in
-                                            let uu____17375 =
-                                              let uu____17376 =
+                                            let uu___6 =
+                                              let uu___7 =
                                                 FStar_Syntax_Subst.compress
                                                   tres3 in
-                                              uu____17376.FStar_Syntax_Syntax.n in
-                                            match uu____17375 with
+                                              uu___7.FStar_Syntax_Syntax.n in
+                                            match uu___6 with
                                             | FStar_Syntax_Syntax.Tm_refine
                                                 ({
                                                    FStar_Syntax_Syntax.ppname
-                                                     = uu____17379;
+                                                     = uu___7;
                                                    FStar_Syntax_Syntax.index
-                                                     = uu____17380;
+                                                     = uu___8;
                                                    FStar_Syntax_Syntax.sort =
                                                      tres4;_},
-                                                 uu____17382)
+                                                 uu___9)
                                                 -> norm_tres tres4
-                                            | uu____17389 -> tres3 in
-                                          let uu____17390 = norm_tres tres1 in
-                                          aux true solve ghead3 uu____17390
-                                      | uu____17391 when
-                                          Prims.op_Negation solve ->
+                                            | uu___7 -> tres3 in
+                                          let uu___6 = norm_tres tres1 in
+                                          aux true solve ghead3 uu___6
+                                      | uu___5 when Prims.op_Negation solve
+                                          ->
                                           let ghead4 =
                                             FStar_TypeChecker_Rel.solve_deferred_constraints
                                               env ghead3 in
                                           aux norm1 true ghead4 tres1
-                                      | uu____17393 ->
-                                          let uu____17394 =
-                                            let uu____17399 =
-                                              let uu____17400 =
+                                      | uu___5 ->
+                                          let uu___6 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_TypeChecker_Normalize.term_to_string
                                                   env thead in
-                                              let uu____17401 =
+                                              let uu___9 =
                                                 FStar_Util.string_of_int
                                                   n_args in
-                                              let uu____17402 =
+                                              let uu___10 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tres1 in
                                               FStar_Util.format3
                                                 "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                                uu____17400 uu____17401
-                                                uu____17402 in
+                                                uu___8 uu___9 uu___10 in
                                             (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                              uu____17399) in
-                                          let uu____17403 =
+                                              uu___7) in
+                                          let uu___7 =
                                             FStar_Syntax_Syntax.argpos arg in
-                                          FStar_Errors.raise_error
-                                            uu____17394 uu____17403 in
+                                          FStar_Errors.raise_error uu___6
+                                            uu___7 in
                                     aux false false ghead2
                                       (FStar_Syntax_Util.comp_result chead2)))) in
                let rec check_function_app tf guard =
-                 let uu____17431 =
-                   let uu____17432 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf in
-                   uu____17432.FStar_Syntax_Syntax.n in
-                 match uu____17431 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____17441 ->
-                     let uu____17454 =
+                   uu___2.FStar_Syntax_Syntax.n in
+                 match uu___1 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
+                     let uu___3 =
                        FStar_List.fold_right
-                         (fun uu____17485 ->
-                            fun uu____17486 ->
-                              match uu____17486 with
+                         (fun uu___4 ->
+                            fun uu___5 ->
+                              match uu___5 with
                               | (bs, guard1) ->
-                                  let uu____17513 =
-                                    let uu____17526 =
-                                      let uu____17527 =
+                                  let uu___6 =
+                                    let uu___7 =
+                                      let uu___8 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_All.pipe_right uu____17527
+                                      FStar_All.pipe_right uu___8
                                         FStar_Pervasives_Native.fst in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
-                                      tf.FStar_Syntax_Syntax.pos env
-                                      uu____17526 in
-                                  (match uu____17513 with
-                                   | (t, uu____17543, g) ->
-                                       let uu____17557 =
-                                         let uu____17560 =
+                                      tf.FStar_Syntax_Syntax.pos env uu___7 in
+                                  (match uu___6 with
+                                   | (t, uu___7, g) ->
+                                       let uu___8 =
+                                         let uu___9 =
                                            FStar_Syntax_Syntax.null_binder t in
-                                         uu____17560 :: bs in
-                                       let uu____17561 =
+                                         uu___9 :: bs in
+                                       let uu___9 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1 in
-                                       (uu____17557, uu____17561))) args
-                         ([], guard) in
-                     (match uu____17454 with
+                                       (uu___8, uu___9))) args ([], guard) in
+                     (match uu___3 with
                       | (bs, guard1) ->
-                          let uu____17578 =
-                            let uu____17585 =
-                              let uu____17598 =
-                                let uu____17599 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____17599
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Syntax_Util.type_u () in
+                                FStar_All.pipe_right uu___7
                                   FStar_Pervasives_Native.fst in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17598 in
-                            match uu____17585 with
-                            | (t, uu____17615, g) ->
-                                let uu____17629 = FStar_Options.ml_ish () in
-                                if uu____17629
+                                uu___6 in
+                            match uu___5 with
+                            | (t, uu___6, g) ->
+                                let uu___7 = FStar_Options.ml_ish () in
+                                if uu___7
                                 then
-                                  let uu____17636 =
-                                    FStar_Syntax_Util.ml_comp t r in
-                                  let uu____17639 =
+                                  let uu___8 = FStar_Syntax_Util.ml_comp t r in
+                                  let uu___9 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g in
-                                  (uu____17636, uu____17639)
+                                  (uu___8, uu___9)
                                 else
-                                  (let uu____17643 =
+                                  (let uu___9 =
                                      FStar_Syntax_Syntax.mk_Total t in
-                                   let uu____17646 =
+                                   let uu___10 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g in
-                                   (uu____17643, uu____17646)) in
-                          (match uu____17578 with
+                                   (uu___9, uu___10)) in
+                          (match uu___4 with
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                               ((let uu____17665 =
+                               ((let uu___6 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu____17665
+                                 if uu___6
                                  then
-                                   let uu____17666 =
+                                   let uu___7 =
                                      FStar_Syntax_Print.term_to_string head in
-                                   let uu____17667 =
+                                   let uu___8 =
                                      FStar_Syntax_Print.term_to_string tf in
-                                   let uu____17668 =
+                                   let uu___9 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17666 uu____17667 uu____17668
+                                     uu___7 uu___8 uu___9
                                  else ());
                                 (let g =
-                                   let uu____17671 =
+                                   let uu___6 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17671 in
-                                 let uu____17672 =
+                                     env uu___6 in
+                                 let uu___6 =
                                    FStar_TypeChecker_Env.conj_guard g guard2 in
-                                 check_function_app bs_cres uu____17672))))
+                                 check_function_app bs_cres uu___6))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____17673;
-                        FStar_Syntax_Syntax.pos = uu____17674;
-                        FStar_Syntax_Syntax.vars = uu____17675;_},
-                      uu____17676)
+                          uu___2;
+                        FStar_Syntax_Syntax.pos = uu___3;
+                        FStar_Syntax_Syntax.vars = uu___4;_},
+                      uu___5)
                      ->
-                     let uu____17713 =
+                     let uu___6 =
                        FStar_List.fold_right
-                         (fun uu____17744 ->
-                            fun uu____17745 ->
-                              match uu____17745 with
+                         (fun uu___7 ->
+                            fun uu___8 ->
+                              match uu___8 with
                               | (bs, guard1) ->
-                                  let uu____17772 =
-                                    let uu____17785 =
-                                      let uu____17786 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      let uu___11 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_All.pipe_right uu____17786
+                                      FStar_All.pipe_right uu___11
                                         FStar_Pervasives_Native.fst in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
-                                      tf.FStar_Syntax_Syntax.pos env
-                                      uu____17785 in
-                                  (match uu____17772 with
-                                   | (t, uu____17802, g) ->
-                                       let uu____17816 =
-                                         let uu____17819 =
+                                      tf.FStar_Syntax_Syntax.pos env uu___10 in
+                                  (match uu___9 with
+                                   | (t, uu___10, g) ->
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_Syntax_Syntax.null_binder t in
-                                         uu____17819 :: bs in
-                                       let uu____17820 =
+                                         uu___12 :: bs in
+                                       let uu___12 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1 in
-                                       (uu____17816, uu____17820))) args
-                         ([], guard) in
-                     (match uu____17713 with
+                                       (uu___11, uu___12))) args ([], guard) in
+                     (match uu___6 with
                       | (bs, guard1) ->
-                          let uu____17837 =
-                            let uu____17844 =
-                              let uu____17857 =
-                                let uu____17858 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____17858
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 = FStar_Syntax_Util.type_u () in
+                                FStar_All.pipe_right uu___10
                                   FStar_Pervasives_Native.fst in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17857 in
-                            match uu____17844 with
-                            | (t, uu____17874, g) ->
-                                let uu____17888 = FStar_Options.ml_ish () in
-                                if uu____17888
+                                uu___9 in
+                            match uu___8 with
+                            | (t, uu___9, g) ->
+                                let uu___10 = FStar_Options.ml_ish () in
+                                if uu___10
                                 then
-                                  let uu____17895 =
-                                    FStar_Syntax_Util.ml_comp t r in
-                                  let uu____17898 =
+                                  let uu___11 = FStar_Syntax_Util.ml_comp t r in
+                                  let uu___12 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g in
-                                  (uu____17895, uu____17898)
+                                  (uu___11, uu___12)
                                 else
-                                  (let uu____17902 =
+                                  (let uu___12 =
                                      FStar_Syntax_Syntax.mk_Total t in
-                                   let uu____17905 =
+                                   let uu___13 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g in
-                                   (uu____17902, uu____17905)) in
-                          (match uu____17837 with
+                                   (uu___12, uu___13)) in
+                          (match uu___7 with
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                               ((let uu____17924 =
+                               ((let uu___9 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu____17924
+                                 if uu___9
                                  then
-                                   let uu____17925 =
+                                   let uu___10 =
                                      FStar_Syntax_Print.term_to_string head in
-                                   let uu____17926 =
+                                   let uu___11 =
                                      FStar_Syntax_Print.term_to_string tf in
-                                   let uu____17927 =
+                                   let uu___12 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17925 uu____17926 uu____17927
+                                     uu___10 uu___11 uu___12
                                  else ());
                                 (let g =
-                                   let uu____17930 =
+                                   let uu___9 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17930 in
-                                 let uu____17931 =
+                                     env uu___9 in
+                                 let uu___9 =
                                    FStar_TypeChecker_Env.conj_guard g guard2 in
-                                 check_function_app bs_cres uu____17931))))
+                                 check_function_app bs_cres uu___9))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                     let uu____17954 = FStar_Syntax_Subst.open_comp bs c in
-                     (match uu____17954 with
+                     let uu___2 = FStar_Syntax_Subst.open_comp bs c in
+                     (match uu___2 with
                       | (bs1, c1) ->
                           let head_info = (head, chead, ghead, c1) in
-                          ((let uu____17977 =
+                          ((let uu___4 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme in
-                            if uu____17977
+                            if uu___4
                             then
-                              let uu____17978 =
+                              let uu___5 =
                                 FStar_Syntax_Print.term_to_string head in
-                              let uu____17979 =
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string tf in
-                              let uu____17980 =
+                              let uu___7 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1 in
-                              let uu____17981 =
+                              let uu___8 =
                                 FStar_Syntax_Print.comp_to_string c1 in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____17978 uu____17979 uu____17980
-                                uu____17981
+                                uu___5 uu___6 uu___7 uu___8
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv, uu____18040) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv, uu___2) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
-                 | FStar_Syntax_Syntax.Tm_ascribed
-                     (t, uu____18046, uu____18047) ->
+                 | FStar_Syntax_Syntax.Tm_ascribed (t, uu___2, uu___3) ->
                      check_function_app t guard
-                 | uu____18088 ->
-                     let uu____18089 =
+                 | uu___2 ->
+                     let uu___3 =
                        FStar_TypeChecker_Err.expected_function_typ env tf in
-                     FStar_Errors.raise_error uu____18089
+                     FStar_Errors.raise_error uu___3
                        head.FStar_Syntax_Syntax.pos in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
 and (check_short_circuit_args :
@@ -6465,79 +6309,76 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c in
-                  let uu____18171 =
+                  let uu___ =
                     FStar_List.fold_left2
-                      (fun uu____18238 ->
-                         fun uu____18239 ->
-                           fun uu____18240 ->
-                             match (uu____18238, uu____18239, uu____18240)
-                             with
+                      (fun uu___1 ->
+                         fun uu___2 ->
+                           fun uu___3 ->
+                             match (uu___1, uu___2, uu___3) with
                              | ((seen, guard, ghost), (e, aq), (b, aq')) ->
-                                 ((let uu____18387 =
-                                     let uu____18388 =
+                                 ((let uu___5 =
+                                     let uu___6 =
                                        FStar_Syntax_Util.eq_aqual aq aq' in
-                                     uu____18388 <> FStar_Syntax_Util.Equal in
-                                   if uu____18387
+                                     uu___6 <> FStar_Syntax_Util.Equal in
+                                   if uu___5
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____18390 =
+                                  (let uu___5 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                        "arguments to short circuiting operators must be pure or ghost" in
-                                   match uu____18390 with
+                                   match uu___5 with
                                    | (e1, c1, g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head seen in
                                        let g1 =
-                                         let uu____18418 =
+                                         let uu___6 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____18418 g in
+                                           uu___6 g in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____18422 =
+                                           ((let uu___6 =
                                                FStar_TypeChecker_Common.is_total_lcomp
                                                  c1 in
-                                             Prims.op_Negation uu____18422)
-                                              &&
-                                              (let uu____18424 =
+                                             Prims.op_Negation uu___6) &&
+                                              (let uu___6 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_TypeChecker_Common.eff_name in
-                                               Prims.op_Negation uu____18424)) in
-                                       let uu____18425 =
-                                         let uu____18436 =
-                                           let uu____18447 =
+                                               Prims.op_Negation uu___6)) in
+                                       let uu___6 =
+                                         let uu___7 =
+                                           let uu___8 =
                                              FStar_Syntax_Syntax.as_arg e1 in
-                                           [uu____18447] in
-                                         FStar_List.append seen uu____18436 in
-                                       let uu____18480 =
+                                           [uu___8] in
+                                         FStar_List.append seen uu___7 in
+                                       let uu___7 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1 in
-                                       (uu____18425, uu____18480, ghost1))))
+                                       (uu___6, uu___7, ghost1))))
                       ([], g_head, false) args bs in
-                  (match uu____18171 with
+                  (match uu___ with
                    | (args1, guard, ghost) ->
                        let e = FStar_Syntax_Syntax.mk_Tm_app head args1 r in
                        let c1 =
                          if ghost
                          then
-                           let uu____18540 =
-                             FStar_Syntax_Syntax.mk_GTotal res_t in
-                           FStar_All.pipe_right uu____18540
+                           let uu___1 = FStar_Syntax_Syntax.mk_GTotal res_t in
+                           FStar_All.pipe_right uu___1
                              FStar_TypeChecker_Common.lcomp_of_comp
                          else FStar_TypeChecker_Common.lcomp_of_comp c in
-                       let uu____18542 =
+                       let uu___1 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard in
-                       (match uu____18542 with | (c2, g) -> (e, c2, g)))
-              | uu____18558 ->
+                       (match uu___1 with | (c2, g) -> (e, c2, g)))
+              | uu___ ->
                   check_application_args env head chead g_head args
                     expected_topt
 and (tc_pat :
@@ -6559,52 +6400,52 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t in
-            let uu____18650 = FStar_Syntax_Util.head_and_args t1 in
-            match uu____18650 with
+            let uu___ = FStar_Syntax_Util.head_and_args t1 in
+            match uu___ with
             | (head, args) ->
-                let uu____18693 =
-                  let uu____18694 = FStar_Syntax_Subst.compress head in
-                  uu____18694.FStar_Syntax_Syntax.n in
-                (match uu____18693 with
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Subst.compress head in
+                  uu___2.FStar_Syntax_Syntax.n in
+                (match uu___1 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____18698;
-                        FStar_Syntax_Syntax.vars = uu____18699;_},
+                        FStar_Syntax_Syntax.pos = uu___2;
+                        FStar_Syntax_Syntax.vars = uu___3;_},
                       us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____18706 ->
+                 | uu___2 ->
                      if norm1
                      then t1
                      else
-                       (let uu____18708 =
+                       (let uu___4 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
                             FStar_TypeChecker_Env.Unascribe;
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1 in
-                        aux true uu____18708))
+                        aux true uu___4))
           and unfold_once t f us args =
-            let uu____18725 =
+            let uu___ =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            if uu____18725
+            if uu___
             then t
             else
-              (let uu____18727 =
+              (let uu___2 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-               match uu____18727 with
+               match uu___2 with
                | FStar_Pervasives_Native.None -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____18747 =
+                   let uu___3 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us in
-                   (match uu____18747 with
-                    | (uu____18752, head_def) ->
+                   (match uu___3 with
+                    | (uu___4, head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
                             t.FStar_Syntax_Syntax.pos in
@@ -6613,69 +6454,67 @@ and (tc_pat :
                             [FStar_TypeChecker_Env.Beta;
                             FStar_TypeChecker_Env.Iota] env1 t' in
                         aux false t'1)) in
-          let uu____18756 =
+          let uu___ =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t in
-          aux false uu____18756 in
+          aux false uu___ in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____18774 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns") in
-           if uu____18774
+           if uu___1
            then
-             let uu____18775 = FStar_Syntax_Print.term_to_string pat_t1 in
-             let uu____18776 = FStar_Syntax_Print.term_to_string scrutinee_t in
-             FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____18775 uu____18776
+             let uu___2 = FStar_Syntax_Print.term_to_string pat_t1 in
+             let uu___3 = FStar_Syntax_Print.term_to_string scrutinee_t in
+             FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n" uu___2
+               uu___3
            else ());
           (let fail1 msg =
              let msg1 =
-               let uu____18790 = FStar_Syntax_Print.term_to_string pat_t1 in
-               let uu____18791 =
-                 FStar_Syntax_Print.term_to_string scrutinee_t in
+               let uu___1 = FStar_Syntax_Print.term_to_string pat_t1 in
+               let uu___2 = FStar_Syntax_Print.term_to_string scrutinee_t in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____18790 uu____18791 msg in
+                 uu___1 uu___2 msg in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p in
-           let uu____18792 = FStar_Syntax_Util.head_and_args scrutinee_t in
-           match uu____18792 with
+           let uu___1 = FStar_Syntax_Util.head_and_args scrutinee_t in
+           match uu___1 with
            | (head_s, args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1 in
-               let uu____18836 = FStar_Syntax_Util.un_uinst head_s in
-               (match uu____18836 with
+               let uu___2 = FStar_Syntax_Util.un_uinst head_s in
+               (match uu___2 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____18837;
-                    FStar_Syntax_Syntax.pos = uu____18838;
-                    FStar_Syntax_Syntax.vars = uu____18839;_} ->
-                    let uu____18842 = FStar_Syntax_Util.head_and_args pat_t2 in
-                    (match uu____18842 with
+                      uu___3;
+                    FStar_Syntax_Syntax.pos = uu___4;
+                    FStar_Syntax_Syntax.vars = uu___5;_} ->
+                    let uu___6 = FStar_Syntax_Util.head_and_args pat_t2 in
+                    (match uu___6 with
                      | (head_p, args_p) ->
-                         let uu____18885 =
+                         let uu___7 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s in
-                         if uu____18885
+                         if uu___7
                          then
-                           let uu____18886 =
-                             let uu____18887 =
-                               FStar_Syntax_Util.un_uinst head_p in
-                             uu____18887.FStar_Syntax_Syntax.n in
-                           (match uu____18886 with
+                           let uu___8 =
+                             let uu___9 = FStar_Syntax_Util.un_uinst head_p in
+                             uu___9.FStar_Syntax_Syntax.n in
+                           (match uu___8 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____18892 =
-                                    let uu____18893 =
-                                      let uu____18894 =
+                                ((let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____18894 in
+                                        env1 uu___12 in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____18893 in
-                                  if uu____18892
+                                      uu___11 in
+                                  if uu___10
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -6685,54 +6524,51 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu____18914 =
-                                    let uu____18939 =
-                                      let uu____18942 =
+                                 (let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____18942 in
-                                    match uu____18939 with
+                                        env1 uu___13 in
+                                    match uu___12 with
                                     | FStar_Pervasives_Native.None ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu____18988 =
+                                        let uu___13 =
                                           FStar_Util.first_N n args_p in
-                                        (match uu____18988 with
-                                         | (params_p, uu____19046) ->
-                                             let uu____19087 =
+                                        (match uu___13 with
+                                         | (params_p, uu___14) ->
+                                             let uu___15 =
                                                FStar_Util.first_N n args_s in
-                                             (match uu____19087 with
-                                              | (params_s, uu____19145) ->
+                                             (match uu___15 with
+                                              | (params_s, uu___16) ->
                                                   (params_p, params_s))) in
-                                  match uu____18914 with
+                                  match uu___11 with
                                   | (params_p, params_s) ->
                                       FStar_List.fold_left2
                                         (fun out ->
-                                           fun uu____19274 ->
-                                             fun uu____19275 ->
-                                               match (uu____19274,
-                                                       uu____19275)
-                                               with
-                                               | ((p, uu____19309),
-                                                  (s, uu____19311)) ->
-                                                   let uu____19344 =
+                                           fun uu___12 ->
+                                             fun uu___13 ->
+                                               match (uu___12, uu___13) with
+                                               | ((p, uu___14), (s, uu___15))
+                                                   ->
+                                                   let uu___16 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s in
-                                                   (match uu____19344 with
+                                                   (match uu___16 with
                                                     | FStar_Pervasives_Native.None
                                                         ->
-                                                        let uu____19347 =
-                                                          let uu____19348 =
+                                                        let uu___17 =
+                                                          let uu___18 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p in
-                                                          let uu____19349 =
+                                                          let uu___19 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____19348
-                                                            uu____19349 in
-                                                        fail1 uu____19347
+                                                            uu___18 uu___19 in
+                                                        fail1 uu___17
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -6742,21 +6578,21 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____19352 ->
+                            | uu___9 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu____19354 =
-                              let uu____19355 =
+                           (let uu___9 =
+                              let uu___10 =
                                 FStar_Syntax_Print.term_to_string head_p in
-                              let uu____19356 =
+                              let uu___11 =
                                 FStar_Syntax_Print.term_to_string head_s in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____19355 uu____19356 in
-                            fail1 uu____19354))
-                | uu____19357 ->
-                    let uu____19358 =
+                                uu___10 uu___11 in
+                            fail1 uu___9))
+                | uu___3 ->
+                    let uu___4 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t in
-                    (match uu____19358 with
+                    (match uu___4 with
                      | FStar_Pervasives_Native.None -> fail1 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -6764,18 +6600,18 @@ and (tc_pat :
                              g in
                          g1))) in
         let type_of_simple_pat env1 e =
-          let uu____19398 = FStar_Syntax_Util.head_and_args e in
-          match uu____19398 with
+          let uu___ = FStar_Syntax_Util.head_and_args e in
+          match uu___ with
           | (head, args) ->
               (match head.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____19466 =
+                   let uu___1 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                   (match uu____19466 with
+                   (match uu___1 with
                     | (us, t_f) ->
-                        let uu____19485 = FStar_Syntax_Util.arrow_formals t_f in
-                        (match uu____19485 with
+                        let uu___2 = FStar_Syntax_Util.arrow_formals t_f in
+                        (match uu___2 with
                          | (formals, t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t in
@@ -6786,8 +6622,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____19590 formals1 args1 =
-                                 match uu____19590 with
+                              (let rec aux uu___4 formals1 args1 =
+                                 match uu___4 with
                                  | (subst, args_out, bvs, guard) ->
                                      (match (formals1, args1) with
                                       | ([], []) ->
@@ -6798,32 +6634,32 @@ and (tc_pat :
                                             FStar_Syntax_Syntax.mk_Tm_app
                                               head1 args_out
                                               e.FStar_Syntax_Syntax.pos in
-                                          let uu____19733 =
+                                          let uu___5 =
                                             FStar_Syntax_Subst.subst subst t in
-                                          (pat_e, uu____19733, bvs, guard,
+                                          (pat_e, uu___5, bvs, guard,
                                             erasable)
-                                      | ((f1, uu____19737)::formals2,
+                                      | ((f1, uu___5)::formals2,
                                          (a, imp_a)::args2) ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f1.FStar_Syntax_Syntax.sort in
-                                          let uu____19795 =
-                                            let uu____19816 =
-                                              let uu____19817 =
+                                          let uu___6 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_Syntax_Subst.compress a in
-                                              uu____19817.FStar_Syntax_Syntax.n in
-                                            match uu____19816 with
+                                              uu___8.FStar_Syntax_Syntax.n in
+                                            match uu___7 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2696_19842 = x in
+                                                  let uu___8 = x in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2696_19842.FStar_Syntax_Syntax.ppname);
+                                                      (uu___8.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2696_19842.FStar_Syntax_Syntax.index);
+                                                      (uu___8.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   } in
@@ -6838,14 +6674,14 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____19865 ->
+                                                uu___8 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1 in
-                                                let uu____19879 =
+                                                let uu___9 =
                                                   tc_tot_or_gtot_term env2 a in
-                                                (match uu____19879 with
-                                                 | (a1, uu____19907, g) ->
+                                                (match uu___9 with
+                                                 | (a1, uu___10, g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g in
@@ -6855,36 +6691,36 @@ and (tc_pat :
                                                        :: subst in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g1))
-                                            | uu____19931 ->
+                                            | uu___8 ->
                                                 fail "Not a simple pattern" in
-                                          (match uu____19795 with
+                                          (match uu___6 with
                                            | (a1, subst1, bvs1, g) ->
-                                               let uu____19992 =
-                                                 let uu____20015 =
+                                               let uu___7 =
+                                                 let uu___8 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard in
                                                  (subst1,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____20015) in
-                                               aux uu____19992 formals2 args2)
-                                      | uu____20054 ->
+                                                   uu___8) in
+                                               aux uu___7 formals2 args2)
+                                      | uu___5 ->
                                           fail "Not a fully applued pattern") in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____20109 -> fail "Not a simple pattern") in
+               | uu___1 -> fail "Not a simple pattern") in
         let rec check_nested_pattern env1 p t =
-          (let uu____20171 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns") in
-           if uu____20171
+           if uu___1
            then
-             let uu____20172 = FStar_Syntax_Print.pat_to_string p in
-             let uu____20173 = FStar_Syntax_Print.term_to_string t in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20172
-               uu____20173
+             let uu___2 = FStar_Syntax_Print.pat_to_string p in
+             let uu___3 = FStar_Syntax_Print.term_to_string t in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu___2
+               uu___3
            else ());
           (let id =
              FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
@@ -6892,120 +6728,117 @@ and (tc_pat :
                FStar_Pervasives_Native.None in
            let mk_disc_t disc inner_t =
              let x_b =
-               let uu____20194 =
+               let uu___1 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t in
-               FStar_All.pipe_right uu____20194 FStar_Syntax_Syntax.mk_binder in
+               FStar_All.pipe_right uu___1 FStar_Syntax_Syntax.mk_binder in
              let tm =
-               let uu____20202 =
-                 let uu____20203 =
-                   let uu____20212 =
-                     let uu____20213 =
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 =
                        FStar_All.pipe_right x_b FStar_Pervasives_Native.fst in
-                     FStar_All.pipe_right uu____20213
+                     FStar_All.pipe_right uu___4
                        FStar_Syntax_Syntax.bv_to_name in
-                   FStar_All.pipe_right uu____20212
-                     FStar_Syntax_Syntax.as_arg in
-                 [uu____20203] in
-               FStar_Syntax_Syntax.mk_Tm_app disc uu____20202
+                   FStar_All.pipe_right uu___3 FStar_Syntax_Syntax.as_arg in
+                 [uu___2] in
+               FStar_Syntax_Syntax.mk_Tm_app disc uu___1
                  FStar_Range.dummyRange in
              let tm1 =
-               let uu____20247 =
-                 let uu____20248 =
+               let uu___1 =
+                 let uu___2 =
                    FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg in
-                 [uu____20248] in
-               FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20247
+                 [uu___2] in
+               FStar_Syntax_Syntax.mk_Tm_app inner_t uu___1
                  FStar_Range.dummyRange in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None in
            match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____20309 ->
-               let uu____20316 =
-                 let uu____20317 = FStar_Syntax_Print.pat_to_string p in
+           | FStar_Syntax_Syntax.Pat_dot_term uu___1 ->
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Print.pat_to_string p in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____20317 in
-               failwith uu____20316
+                   uu___3 in
+               failwith uu___2
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2735_20336 = x in
+                 let uu___1 = x in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2735_20336.FStar_Syntax_Syntax.ppname);
+                     (uu___1.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2735_20336.FStar_Syntax_Syntax.index);
+                     (uu___1.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  } in
-               let uu____20337 = FStar_Syntax_Syntax.bv_to_name x1 in
-               ([x1], [id], uu____20337,
-                 (let uu___2738_20343 = p in
+               let uu___1 = FStar_Syntax_Syntax.bv_to_name x1 in
+               ([x1], [id], uu___1,
+                 (let uu___2 = p in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-                    FStar_Syntax_Syntax.p =
-                      (uu___2738_20343.FStar_Syntax_Syntax.p)
+                    FStar_Syntax_Syntax.p = (uu___2.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2742_20346 = x in
+                 let uu___1 = x in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2742_20346.FStar_Syntax_Syntax.ppname);
+                     (uu___1.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2742_20346.FStar_Syntax_Syntax.index);
+                     (uu___1.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  } in
-               let uu____20347 = FStar_Syntax_Syntax.bv_to_name x1 in
-               ([x1], [id], uu____20347,
-                 (let uu___2745_20353 = p in
+               let uu___1 = FStar_Syntax_Syntax.bv_to_name x1 in
+               ([x1], [id], uu___1,
+                 (let uu___2 = p in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-                    FStar_Syntax_Syntax.p =
-                      (uu___2745_20353.FStar_Syntax_Syntax.p)
+                    FStar_Syntax_Syntax.p = (uu___2.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_constant c ->
                ((match c with
                  | FStar_Const.Const_unit -> ()
-                 | FStar_Const.Const_bool uu____20356 -> ()
-                 | FStar_Const.Const_int uu____20357 -> ()
-                 | FStar_Const.Const_char uu____20368 -> ()
-                 | FStar_Const.Const_float uu____20369 -> ()
-                 | FStar_Const.Const_string uu____20370 -> ()
-                 | uu____20375 ->
-                     let uu____20376 =
-                       let uu____20377 = FStar_Syntax_Print.const_to_string c in
+                 | FStar_Const.Const_bool uu___2 -> ()
+                 | FStar_Const.Const_int uu___2 -> ()
+                 | FStar_Const.Const_char uu___2 -> ()
+                 | FStar_Const.Const_float uu___2 -> ()
+                 | FStar_Const.Const_string uu___2 -> ()
+                 | uu___2 ->
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Print.const_to_string c in
                        FStar_Util.format1
                          "Pattern matching a constant that does not have decidable equality: %s"
-                         uu____20377 in
-                     fail uu____20376);
-                (let uu____20378 =
+                         uu___4 in
+                     fail uu___3);
+                (let uu___2 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p in
-                 match uu____20378 with
-                 | (uu____20405, e_c, uu____20407, uu____20408) ->
-                     let uu____20413 = tc_tot_or_gtot_term env1 e_c in
-                     (match uu____20413 with
+                 match uu___2 with
+                 | (uu___3, e_c, uu___4, uu___5) ->
+                     let uu___6 = tc_tot_or_gtot_term env1 e_c in
+                     (match uu___6 with
                       | (e_c1, lc, g) ->
                           (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                            (let expected_t =
                               expected_pat_typ env1 p0.FStar_Syntax_Syntax.p
                                 t in
-                            (let uu____20442 =
-                               let uu____20443 =
+                            (let uu___9 =
+                               let uu___10 =
                                  FStar_TypeChecker_Rel.teq_nosmt_force env1
                                    lc.FStar_TypeChecker_Common.res_typ
                                    expected_t in
-                               Prims.op_Negation uu____20443 in
-                             if uu____20442
+                               Prims.op_Negation uu___10 in
+                             if uu___9
                              then
-                               let uu____20444 =
-                                 let uu____20445 =
+                               let uu___10 =
+                                 let uu___11 =
                                    FStar_Syntax_Print.term_to_string
                                      lc.FStar_TypeChecker_Common.res_typ in
-                                 let uu____20446 =
+                                 let uu___12 =
                                    FStar_Syntax_Print.term_to_string
                                      expected_t in
                                  FStar_Util.format2
                                    "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                   uu____20445 uu____20446 in
-                               fail uu____20444
+                                   uu___11 uu___12 in
+                               fail uu___10
                              else ());
                             ([], [], e_c1, p,
                               FStar_TypeChecker_Env.trivial_guard, false))))))
@@ -7013,141 +6846,138 @@ and (tc_pat :
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____20498 ->
-                        match uu____20498 with
+                     (fun uu___1 ->
+                        match uu___1 with
                         | (p1, b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____20523
-                                 -> (p1, b)
-                             | uu____20532 ->
-                                 let uu____20533 =
-                                   let uu____20536 =
-                                     let uu____20537 =
+                             | FStar_Syntax_Syntax.Pat_dot_term uu___2 ->
+                                 (p1, b)
+                             | uu___2 ->
+                                 let uu___3 =
+                                   let uu___4 =
+                                     let uu___5 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun in
-                                     FStar_Syntax_Syntax.Pat_var uu____20537 in
-                                   FStar_Syntax_Syntax.withinfo uu____20536
+                                     FStar_Syntax_Syntax.Pat_var uu___5 in
+                                   FStar_Syntax_Syntax.withinfo uu___4
                                      p1.FStar_Syntax_Syntax.p in
-                                 (uu____20533, b))) sub_pats in
-                 let uu___2786_20540 = p in
+                                 (uu___3, b))) sub_pats in
+                 let uu___1 = p in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
-                   FStar_Syntax_Syntax.p =
-                     (uu___2786_20540.FStar_Syntax_Syntax.p)
+                   FStar_Syntax_Syntax.p = (uu___1.FStar_Syntax_Syntax.p)
                  } in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____20580 ->
-                         match uu____20580 with
-                         | (x, uu____20588) ->
+                      (fun uu___1 ->
+                         match uu___1 with
+                         | (x, uu___2) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____20593
-                                  -> false
-                              | uu____20600 -> true))) in
-               let uu____20601 =
+                              | FStar_Syntax_Syntax.Pat_dot_term uu___3 ->
+                                  false
+                              | uu___3 -> true))) in
+               let uu___1 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat in
-               (match uu____20601 with
+               (match uu___1 with
                 | (simple_bvs, simple_pat_e, g0, simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____20641 =
-                          let uu____20642 =
+                       (let uu___3 =
+                          let uu___4 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p in
-                          let uu____20643 =
+                          let uu___5 =
                             FStar_Syntax_Print.pat_to_string simple_pat in
-                          let uu____20644 =
+                          let uu___6 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1) in
-                          let uu____20649 =
+                          let uu___7 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs) in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____20642 uu____20643 uu____20644 uu____20649 in
-                        failwith uu____20641)
+                            uu___4 uu___5 uu___6 uu___7 in
+                        failwith uu___3)
                      else ();
-                     (let uu____20651 =
-                        let uu____20662 =
-                          type_of_simple_pat env1 simple_pat_e in
-                        match uu____20662 with
+                     (let uu___3 =
+                        let uu___4 = type_of_simple_pat env1 simple_pat_e in
+                        match uu___4 with
                         | (simple_pat_e1, simple_pat_t, simple_bvs1, guard,
                            erasable) ->
                             let g' =
-                              let uu____20695 =
+                              let uu___5 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t in
-                              pat_typ_ok env1 simple_pat_t uu____20695 in
+                              pat_typ_ok env1 simple_pat_t uu___5 in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g' in
-                            ((let uu____20698 =
+                            ((let uu___6 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns") in
-                              if uu____20698
+                              if uu___6
                               then
-                                let uu____20699 =
+                                let uu___7 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1 in
-                                let uu____20700 =
+                                let uu___8 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t in
-                                let uu____20701 =
-                                  let uu____20702 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_List.map
                                       (fun x ->
-                                         let uu____20708 =
-                                           let uu____20709 =
+                                         let uu___11 =
+                                           let uu___12 =
                                              FStar_Syntax_Print.bv_to_string
                                                x in
-                                           let uu____20710 =
-                                             let uu____20711 =
-                                               let uu____20712 =
+                                           let uu___13 =
+                                             let uu___14 =
+                                               let uu___15 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort in
-                                               Prims.op_Hat uu____20712 ")" in
-                                             Prims.op_Hat " : " uu____20711 in
-                                           Prims.op_Hat uu____20709
-                                             uu____20710 in
-                                         Prims.op_Hat "(" uu____20708)
+                                               Prims.op_Hat uu___15 ")" in
+                                             Prims.op_Hat " : " uu___14 in
+                                           Prims.op_Hat uu___12 uu___13 in
+                                         Prims.op_Hat "(" uu___11)
                                       simple_bvs1 in
-                                  FStar_All.pipe_right uu____20702
+                                  FStar_All.pipe_right uu___10
                                     (FStar_String.concat " ") in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____20699 uu____20700 uu____20701
+                                  uu___7 uu___8 uu___9
                               else ());
                              (simple_pat_e1, simple_bvs1, guard1, erasable)) in
-                      match uu____20651 with
+                      match uu___3 with
                       | (simple_pat_e1, simple_bvs1, g1, erasable) ->
-                          let uu____20742 =
-                            let uu____20771 =
-                              let uu____20800 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1 in
-                              (env1, [], [], [], [], uu____20800, erasable,
+                              (env1, [], [], [], [], uu___6, erasable,
                                 Prims.int_zero) in
                             FStar_List.fold_left2
-                              (fun uu____20873 ->
-                                 fun uu____20874 ->
+                              (fun uu___6 ->
+                                 fun uu___7 ->
                                    fun x ->
-                                     match (uu____20873, uu____20874) with
+                                     match (uu___6, uu___7) with
                                      | ((env2, bvs, tms, pats, subst, g,
                                          erasable1, i),
                                         (p1, b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort in
-                                         let uu____21035 =
+                                         let uu___8 =
                                            check_nested_pattern env2 p1
                                              expected_t in
-                                         (match uu____21035 with
+                                         (match uu___8 with
                                           | (bvs_p, tms_p, e_p, p2, g',
                                              erasable_p) ->
                                               let env3 =
@@ -7155,24 +6985,24 @@ and (tc_pat :
                                                   env2 bvs_p in
                                               let tms_p1 =
                                                 let disc_tm =
-                                                  let uu____21099 =
+                                                  let uu___9 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu____21099 i in
-                                                let uu____21100 =
-                                                  let uu____21109 =
-                                                    let uu____21114 =
+                                                    env3 uu___9 i in
+                                                let uu___9 =
+                                                  let uu___10 =
+                                                    let uu___11 =
                                                       FStar_Syntax_Syntax.fvar
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
                                                         FStar_Pervasives_Native.None in
-                                                    mk_disc_t uu____21114 in
-                                                  FStar_List.map uu____21109 in
+                                                    mk_disc_t uu___11 in
+                                                  FStar_List.map uu___10 in
                                                 FStar_All.pipe_right tms_p
-                                                  uu____21100 in
-                                              let uu____21119 =
+                                                  uu___9 in
+                                              let uu___9 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g' in
                                               (env3,
@@ -7182,13 +7012,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst),
-                                                uu____21119,
+                                                uu___9,
                                                 (erasable1 || erasable_p),
-                                                (i + Prims.int_one))))
-                              uu____20771 sub_pats1 simple_bvs1 in
-                          (match uu____20742 with
+                                                (i + Prims.int_one)))) uu___5
+                              sub_pats1 simple_bvs1 in
+                          (match uu___4 with
                            | (_env, bvs, tms, checked_sub_pats, subst, g,
-                              erasable1, uu____21169) ->
+                              erasable1, uu___5) ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1 in
                                let reconstruct_nested_pat pat =
@@ -7203,33 +7033,33 @@ and (tc_pat :
                                               FStar_Syntax_Subst.subst subst
                                                 e in
                                             let hd1 =
-                                              let uu___2870_21326 = hd in
+                                              let uu___6 = hd in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2870_21326.FStar_Syntax_Syntax.p)
+                                                  (uu___6.FStar_Syntax_Syntax.p)
                                               } in
-                                            let uu____21331 =
+                                            let uu___6 =
                                               aux simple_pats1 bvs1 sub_pats2 in
-                                            (hd1, b) :: uu____21331
+                                            (hd1, b) :: uu___6
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
                                              | (x'::bvs2,
-                                                (hd1, uu____21370)::sub_pats3)
+                                                (hd1, uu___6)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____21402 =
+                                                 let uu___7 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3 in
-                                                 (hd1, b) :: uu____21402
-                                             | uu____21419 ->
+                                                 (hd1, b) :: uu___7
+                                             | uu___6 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____21442 ->
+                                        | uu___6 ->
                                             failwith
                                               "Impossible: expected a simple pattern") in
                                  match pat.FStar_Syntax_Syntax.v with
@@ -7238,147 +7068,144 @@ and (tc_pat :
                                      let nested_pats =
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats in
-                                     let uu___2891_21480 = pat in
+                                     let uu___6 = pat in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2891_21480.FStar_Syntax_Syntax.p)
+                                         (uu___6.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____21491 -> failwith "Impossible" in
-                               let uu____21494 =
+                                 | uu___6 -> failwith "Impossible" in
+                               let uu___6 =
                                  reconstruct_nested_pat simple_pat_elab in
-                               (bvs, tms, pat_e, uu____21494, g, erasable1)))))) in
-        (let uu____21500 =
+                               (bvs, tms, pat_e, uu___6, g, erasable1)))))) in
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns") in
-         if uu____21500
+         if uu___1
          then
-           let uu____21501 = FStar_Syntax_Print.pat_to_string p0 in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____21501
+           let uu___2 = FStar_Syntax_Print.pat_to_string p0 in
+           FStar_Util.print1 "Checking pattern: %s\n" uu___2
          else ());
-        (let uu____21503 =
-           let uu____21520 =
-             let uu___2896_21521 =
-               let uu____21522 = FStar_TypeChecker_Env.clear_expected_typ env in
-               FStar_All.pipe_right uu____21522 FStar_Pervasives_Native.fst in
+        (let uu___1 =
+           let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_TypeChecker_Env.clear_expected_typ env in
+               FStar_All.pipe_right uu___4 FStar_Pervasives_Native.fst in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2896_21521.FStar_TypeChecker_Env.solver);
+                 (uu___3.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2896_21521.FStar_TypeChecker_Env.range);
+                 (uu___3.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2896_21521.FStar_TypeChecker_Env.curmodule);
+                 (uu___3.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2896_21521.FStar_TypeChecker_Env.gamma);
+                 (uu___3.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2896_21521.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___3.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2896_21521.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___3.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2896_21521.FStar_TypeChecker_Env.modules);
+                 (uu___3.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2896_21521.FStar_TypeChecker_Env.expected_typ);
+                 (uu___3.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2896_21521.FStar_TypeChecker_Env.sigtab);
+                 (uu___3.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2896_21521.FStar_TypeChecker_Env.attrtab);
+                 (uu___3.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2896_21521.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___3.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2896_21521.FStar_TypeChecker_Env.effects);
+                 (uu___3.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2896_21521.FStar_TypeChecker_Env.generalize);
+                 (uu___3.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2896_21521.FStar_TypeChecker_Env.letrecs);
+                 (uu___3.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2896_21521.FStar_TypeChecker_Env.top_level);
+                 (uu___3.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2896_21521.FStar_TypeChecker_Env.check_uvars);
+                 (uu___3.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2896_21521.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___3.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2896_21521.FStar_TypeChecker_Env.is_iface);
+                 (uu___3.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2896_21521.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax =
-                 (uu___2896_21521.FStar_TypeChecker_Env.lax);
+                 (uu___3.FStar_TypeChecker_Env.admit);
+               FStar_TypeChecker_Env.lax = (uu___3.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2896_21521.FStar_TypeChecker_Env.lax_universes);
+                 (uu___3.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2896_21521.FStar_TypeChecker_Env.phase1);
+                 (uu___3.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2896_21521.FStar_TypeChecker_Env.failhard);
+                 (uu___3.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2896_21521.FStar_TypeChecker_Env.nosynth);
+                 (uu___3.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2896_21521.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2896_21521.FStar_TypeChecker_Env.tc_term);
+                 (uu___3.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2896_21521.FStar_TypeChecker_Env.type_of);
+                 (uu___3.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2896_21521.FStar_TypeChecker_Env.universe_of);
+                 (uu___3.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2896_21521.FStar_TypeChecker_Env.check_type_of);
+                 (uu___3.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2896_21521.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___3.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2896_21521.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___3.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2896_21521.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___3.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2896_21521.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___3.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2896_21521.FStar_TypeChecker_Env.proof_ns);
+                 (uu___3.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2896_21521.FStar_TypeChecker_Env.synth_hook);
+                 (uu___3.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2896_21521.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___3.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2896_21521.FStar_TypeChecker_Env.splice);
+                 (uu___3.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2896_21521.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___3.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2896_21521.FStar_TypeChecker_Env.postprocess);
+                 (uu___3.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2896_21521.FStar_TypeChecker_Env.identifier_info);
+                 (uu___3.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2896_21521.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___3.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2896_21521.FStar_TypeChecker_Env.dsenv);
-               FStar_TypeChecker_Env.nbe =
-                 (uu___2896_21521.FStar_TypeChecker_Env.nbe);
+                 (uu___3.FStar_TypeChecker_Env.dsenv);
+               FStar_TypeChecker_Env.nbe = (uu___3.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2896_21521.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___3.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2896_21521.FStar_TypeChecker_Env.erasable_types_tab);
+                 (uu___3.FStar_TypeChecker_Env.erasable_types_tab);
                FStar_TypeChecker_Env.enable_defer_to_tac =
-                 (uu___2896_21521.FStar_TypeChecker_Env.enable_defer_to_tac)
+                 (uu___3.FStar_TypeChecker_Env.enable_defer_to_tac)
              } in
-           let uu____21537 =
-             FStar_TypeChecker_PatternUtils.elaborate_pat env p0 in
-           check_nested_pattern uu____21520 uu____21537 pat_t in
-         match uu____21503 with
+           let uu___3 = FStar_TypeChecker_PatternUtils.elaborate_pat env p0 in
+           check_nested_pattern uu___2 uu___3 pat_t in
+         match uu___1 with
          | (bvs, tms, pat_e, pat, g, erasable) ->
-             ((let uu____21573 =
+             ((let uu___3 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns") in
-               if uu____21573
+               if uu___3
                then
-                 let uu____21574 = FStar_Syntax_Print.pat_to_string pat in
-                 let uu____21575 = FStar_Syntax_Print.term_to_string pat_e in
+                 let uu___4 = FStar_Syntax_Print.pat_to_string pat in
+                 let uu___5 = FStar_Syntax_Print.term_to_string pat_e in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____21574
-                   uu____21575
+                   "Done checking pattern %s as expression %s\n" uu___4
+                   uu___5
                else ());
-              (let uu____21577 = FStar_TypeChecker_Env.push_bvs env bvs in
-               let uu____21578 =
+              (let uu___3 = FStar_TypeChecker_Env.push_bvs env bvs in
+               let uu___4 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e in
-               (pat, bvs, tms, uu____21577, pat_e, uu____21578, g, erasable))))
+               (pat, bvs, tms, uu___3, pat_e, uu___4, g, erasable))))
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
     FStar_TypeChecker_Env.env ->
@@ -7393,78 +7220,76 @@ and (tc_eqn :
   fun scrutinee ->
     fun env ->
       fun branch ->
-        let uu____21613 = FStar_Syntax_Subst.open_branch branch in
-        match uu____21613 with
+        let uu___ = FStar_Syntax_Subst.open_branch branch in
+        match uu___ with
         | (pattern, when_clause, branch_exp) ->
-            let uu____21660 = branch in
-            (match uu____21660 with
-             | (cpat, uu____21689, cbr) ->
+            let uu___1 = branch in
+            (match uu___1 with
+             | (cpat, uu___2, cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee in
-                 let uu____21711 =
-                   let uu____21718 =
-                     FStar_TypeChecker_Env.push_bv env scrutinee in
-                   FStar_All.pipe_right uu____21718
+                 let uu___3 =
+                   let uu___4 = FStar_TypeChecker_Env.push_bv env scrutinee in
+                   FStar_All.pipe_right uu___4
                      FStar_TypeChecker_Env.clear_expected_typ in
-                 (match uu____21711 with
-                  | (scrutinee_env, uu____21753) ->
-                      let uu____21758 = tc_pat env pat_t pattern in
-                      (match uu____21758 with
+                 (match uu___3 with
+                  | (scrutinee_env, uu___4) ->
+                      let uu___5 = tc_pat env pat_t pattern in
+                      (match uu___5 with
                        | (pattern1, pat_bvs, pat_bv_tms, pat_env, pat_exp,
                           norm_pat_exp, guard_pat, erasable) ->
-                           ((let uu____21823 =
+                           ((let uu___7 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  FStar_Options.Extreme in
-                             if uu____21823
+                             if uu___7
                              then
-                               let uu____21824 =
+                               let uu___8 =
                                  FStar_Syntax_Print.pat_to_string pattern1 in
-                               let uu____21825 =
+                               let uu___9 =
                                  FStar_Syntax_Print.bvs_to_string ";" pat_bvs in
-                               let uu____21826 =
+                               let uu___10 =
                                  FStar_List.fold_left
                                    (fun s ->
                                       fun t ->
-                                        let uu____21832 =
-                                          let uu____21833 =
+                                        let uu___11 =
+                                          let uu___12 =
                                             FStar_Syntax_Print.term_to_string
                                               t in
-                                          Prims.op_Hat ";" uu____21833 in
-                                        Prims.op_Hat s uu____21832) ""
-                                   pat_bv_tms in
+                                          Prims.op_Hat ";" uu___12 in
+                                        Prims.op_Hat s uu___11) "" pat_bv_tms in
                                FStar_Util.print3
                                  "tc_eqn: typechecked pattern %s with bvs %s and pat_bv_tms %s"
-                                 uu____21824 uu____21825 uu____21826
+                                 uu___8 uu___9 uu___10
                              else ());
-                            (let uu____21835 =
+                            (let uu___7 =
                                match when_clause with
                                | FStar_Pervasives_Native.None ->
                                    (FStar_Pervasives_Native.None,
                                      FStar_TypeChecker_Env.trivial_guard)
                                | FStar_Pervasives_Native.Some e ->
-                                   let uu____21865 =
+                                   let uu___8 =
                                      FStar_TypeChecker_Env.should_verify env in
-                                   if uu____21865
+                                   if uu___8
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_WhenClauseNotSupported,
                                          "When clauses are not yet supported in --verify mode; they will be some day")
                                        e.FStar_Syntax_Syntax.pos
                                    else
-                                     (let uu____21883 =
-                                        let uu____21890 =
+                                     (let uu___10 =
+                                        let uu___11 =
                                           FStar_TypeChecker_Env.set_expected_typ
                                             pat_env FStar_Syntax_Util.t_bool in
-                                        tc_term uu____21890 e in
-                                      match uu____21883 with
+                                        tc_term uu___11 e in
+                                      match uu___10 with
                                       | (e1, c, g) ->
                                           ((FStar_Pervasives_Native.Some e1),
                                             g)) in
-                             match uu____21835 with
+                             match uu___7 with
                              | (when_clause1, g_when) ->
-                                 let uu____21945 = tc_term pat_env branch_exp in
-                                 (match uu____21945 with
+                                 let uu___8 = tc_term pat_env branch_exp in
+                                 (match uu___8 with
                                   | (branch_exp1, c, g_branch) ->
                                       (FStar_TypeChecker_Env.def_check_guard_wf
                                          cbr.FStar_Syntax_Syntax.pos
@@ -7474,22 +7299,22 @@ and (tc_eqn :
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____22001 =
+                                              let uu___10 =
                                                 FStar_Syntax_Util.mk_eq2
                                                   FStar_Syntax_Syntax.U_zero
                                                   FStar_Syntax_Util.t_bool w
                                                   FStar_Syntax_Util.exp_true_bool in
                                               FStar_All.pipe_left
-                                                (fun uu____22012 ->
+                                                (fun uu___11 ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____22012) uu____22001 in
+                                                     uu___11) uu___10 in
                                         let branch_guard =
-                                          let uu____22016 =
-                                            let uu____22017 =
+                                          let uu___10 =
+                                            let uu___11 =
                                               FStar_TypeChecker_Env.should_verify
                                                 env in
-                                            Prims.op_Negation uu____22017 in
-                                          if uu____22016
+                                            Prims.op_Negation uu___11 in
+                                          if uu___10
                                           then
                                             FStar_Syntax_Util.exp_true_bool
                                           else
@@ -7498,14 +7323,14 @@ and (tc_eqn :
                                                pat_exp1 =
                                                let discriminate scrutinee_tm2
                                                  f =
-                                                 let uu____22070 =
-                                                   let uu____22077 =
+                                                 let uu___12 =
+                                                   let uu___13 =
                                                      FStar_TypeChecker_Env.typ_of_datacon
                                                        env
                                                        f.FStar_Syntax_Syntax.v in
                                                    FStar_TypeChecker_Env.datacons_of_typ
-                                                     env uu____22077 in
-                                                 match uu____22070 with
+                                                     env uu___13 in
+                                                 match uu___12 with
                                                  | (is_induc, datacons) ->
                                                      if
                                                        (Prims.op_Negation
@@ -7518,50 +7343,45 @@ and (tc_eqn :
                                                        let discriminator =
                                                          FStar_Syntax_Util.mk_discriminator
                                                            f.FStar_Syntax_Syntax.v in
-                                                       let uu____22089 =
+                                                       let uu___13 =
                                                          FStar_TypeChecker_Env.try_lookup_lid
                                                            env discriminator in
-                                                       (match uu____22089
-                                                        with
+                                                       (match uu___13 with
                                                         | FStar_Pervasives_Native.None
                                                             -> []
-                                                        | uu____22110 ->
+                                                        | uu___14 ->
                                                             let disc =
                                                               FStar_Syntax_Syntax.fvar
                                                                 discriminator
                                                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                    Prims.int_one)
                                                                 FStar_Pervasives_Native.None in
-                                                            let uu____22122 =
-                                                              let uu____22123
-                                                                =
-                                                                let uu____22124
-                                                                  =
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                let uu___17 =
                                                                   FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2 in
-                                                                [uu____22124] in
+                                                                [uu___17] in
                                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                                disc
-                                                                uu____22123
+                                                                disc uu___16
                                                                 scrutinee_tm2.FStar_Syntax_Syntax.pos in
-                                                            [uu____22122])
+                                                            [uu___15])
                                                      else [] in
-                                               let fail uu____22155 =
-                                                 let uu____22156 =
-                                                   let uu____22157 =
+                                               let fail uu___12 =
+                                                 let uu___13 =
+                                                   let uu___14 =
                                                      FStar_Range.string_of_range
                                                        pat_exp1.FStar_Syntax_Syntax.pos in
-                                                   let uu____22158 =
+                                                   let uu___15 =
                                                      FStar_Syntax_Print.term_to_string
                                                        pat_exp1 in
-                                                   let uu____22159 =
+                                                   let uu___16 =
                                                      FStar_Syntax_Print.tag_of_term
                                                        pat_exp1 in
                                                    FStar_Util.format3
                                                      "tc_eqn: Impossible (%s) %s (%s)"
-                                                     uu____22157 uu____22158
-                                                     uu____22159 in
-                                                 failwith uu____22156 in
+                                                     uu___14 uu___15 uu___16 in
+                                                 failwith uu___13 in
                                                let rec head_constructor t =
                                                  match t.FStar_Syntax_Syntax.n
                                                  with
@@ -7569,42 +7389,39 @@ and (tc_eqn :
                                                      fv ->
                                                      fv.FStar_Syntax_Syntax.fv_name
                                                  | FStar_Syntax_Syntax.Tm_uinst
-                                                     (t1, uu____22172) ->
+                                                     (t1, uu___12) ->
                                                      head_constructor t1
-                                                 | uu____22177 -> fail () in
-                                               let force_scrutinee
-                                                 uu____22183 =
+                                                 | uu___12 -> fail () in
+                                               let force_scrutinee uu___12 =
                                                  match scrutinee_tm1 with
                                                  | FStar_Pervasives_Native.None
                                                      ->
-                                                     let uu____22184 =
-                                                       let uu____22185 =
+                                                     let uu___13 =
+                                                       let uu___14 =
                                                          FStar_Range.string_of_range
                                                            pattern2.FStar_Syntax_Syntax.p in
-                                                       let uu____22186 =
+                                                       let uu___15 =
                                                          FStar_Syntax_Print.pat_to_string
                                                            pattern2 in
                                                        FStar_Util.format2
                                                          "Impossible (%s): scrutinee of match is not defined %s"
-                                                         uu____22185
-                                                         uu____22186 in
-                                                     failwith uu____22184
+                                                         uu___14 uu___15 in
+                                                     failwith uu___13
                                                  | FStar_Pervasives_Native.Some
                                                      t -> t in
                                                let pat_exp2 =
-                                                 let uu____22191 =
+                                                 let uu___12 =
                                                    FStar_Syntax_Subst.compress
                                                      pat_exp1 in
-                                                 FStar_All.pipe_right
-                                                   uu____22191
+                                                 FStar_All.pipe_right uu___12
                                                    FStar_Syntax_Util.unmeta in
                                                match ((pattern2.FStar_Syntax_Syntax.v),
                                                        (pat_exp2.FStar_Syntax_Syntax.n))
                                                with
-                                               | (uu____22196,
+                                               | (uu___12,
                                                   FStar_Syntax_Syntax.Tm_name
-                                                  uu____22197) -> []
-                                               | (uu____22198,
+                                                  uu___13) -> []
+                                               | (uu___12,
                                                   FStar_Syntax_Syntax.Tm_constant
                                                   (FStar_Const.Const_unit))
                                                    -> []
@@ -7612,139 +7429,136 @@ and (tc_eqn :
                                                   _c,
                                                   FStar_Syntax_Syntax.Tm_constant
                                                   c1) ->
-                                                   let uu____22201 =
-                                                     let uu____22202 =
+                                                   let uu___12 =
+                                                     let uu___13 =
                                                        tc_constant env
                                                          pat_exp2.FStar_Syntax_Syntax.pos
                                                          c1 in
-                                                     let uu____22203 =
+                                                     let uu___14 =
                                                        force_scrutinee () in
                                                      FStar_Syntax_Util.mk_decidable_eq
-                                                       uu____22202
-                                                       uu____22203 pat_exp2 in
-                                                   [uu____22201]
+                                                       uu___13 uu___14
+                                                       pat_exp2 in
+                                                   [uu___12]
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   (FStar_Const.Const_int
-                                                  (uu____22206,
+                                                  (uu___12,
                                                    FStar_Pervasives_Native.Some
-                                                   uu____22207)),
-                                                  uu____22208) ->
-                                                   let uu____22223 =
-                                                     let uu____22230 =
+                                                   uu___13)),
+                                                  uu___14) ->
+                                                   let uu___15 =
+                                                     let uu___16 =
                                                        FStar_TypeChecker_Env.clear_expected_typ
                                                          env in
-                                                     match uu____22230 with
-                                                     | (env1, uu____22244) ->
+                                                     match uu___16 with
+                                                     | (env1, uu___17) ->
                                                          env1.FStar_TypeChecker_Env.type_of
                                                            env1 pat_exp2 in
-                                                   (match uu____22223 with
-                                                    | (uu____22251, t,
-                                                       uu____22253) ->
-                                                        let uu____22254 =
-                                                          let uu____22255 =
+                                                   (match uu___15 with
+                                                    | (uu___16, t, uu___17)
+                                                        ->
+                                                        let uu___18 =
+                                                          let uu___19 =
                                                             force_scrutinee
                                                               () in
                                                           FStar_Syntax_Util.mk_decidable_eq
-                                                            t uu____22255
+                                                            t uu___19
                                                             pat_exp2 in
-                                                        [uu____22254])
+                                                        [uu___18])
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22258, []),
+                                                  (uu___12, []),
                                                   FStar_Syntax_Syntax.Tm_uinst
-                                                  uu____22259) ->
+                                                  uu___13) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2 in
-                                                   let uu____22281 =
-                                                     let uu____22282 =
+                                                   let uu___14 =
+                                                     let uu___15 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v in
                                                      Prims.op_Negation
-                                                       uu____22282 in
-                                                   if uu____22281
+                                                       uu___15 in
+                                                   if uu___14
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22288 =
+                                                     (let uu___16 =
                                                         force_scrutinee () in
-                                                      let uu____22291 =
+                                                      let uu___17 =
                                                         head_constructor
                                                           pat_exp2 in
-                                                      discriminate
-                                                        uu____22288
-                                                        uu____22291)
+                                                      discriminate uu___16
+                                                        uu___17)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22294, []),
+                                                  (uu___12, []),
                                                   FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____22295) ->
+                                                  uu___13) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2 in
-                                                   let uu____22311 =
-                                                     let uu____22312 =
+                                                   let uu___14 =
+                                                     let uu___15 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v in
                                                      Prims.op_Negation
-                                                       uu____22312 in
-                                                   if uu____22311
+                                                       uu___15 in
+                                                   if uu___14
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22318 =
+                                                     (let uu___16 =
                                                         force_scrutinee () in
-                                                      let uu____22321 =
+                                                      let uu___17 =
                                                         head_constructor
                                                           pat_exp2 in
-                                                      discriminate
-                                                        uu____22318
-                                                        uu____22321)
+                                                      discriminate uu___16
+                                                        uu___17)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22324, pat_args),
+                                                  (uu___12, pat_args),
                                                   FStar_Syntax_Syntax.Tm_app
                                                   (head, args)) ->
                                                    let f =
                                                      head_constructor head in
-                                                   let uu____22369 =
-                                                     (let uu____22372 =
+                                                   let uu___13 =
+                                                     (let uu___14 =
                                                         FStar_TypeChecker_Env.is_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v in
                                                       Prims.op_Negation
-                                                        uu____22372)
+                                                        uu___14)
                                                        ||
                                                        ((FStar_List.length
                                                            pat_args)
                                                           <>
                                                           (FStar_List.length
                                                              args)) in
-                                                   if uu____22369
+                                                   if uu___13
                                                    then
                                                      failwith
                                                        "Impossible: application patterns must be fully-applied data constructors"
                                                    else
                                                      (let sub_term_guards =
-                                                        let uu____22395 =
-                                                          let uu____22400 =
+                                                        let uu___15 =
+                                                          let uu___16 =
                                                             FStar_List.zip
                                                               pat_args args in
                                                           FStar_All.pipe_right
-                                                            uu____22400
+                                                            uu___16
                                                             (FStar_List.mapi
                                                                (fun i ->
-                                                                  fun
-                                                                    uu____22482
+                                                                  fun uu___17
                                                                     ->
-                                                                    match uu____22482
+                                                                    match uu___17
                                                                     with
                                                                     | 
                                                                     ((pi,
-                                                                    uu____22502),
+                                                                    uu___18),
                                                                     (ei,
-                                                                    uu____22504))
+                                                                    uu___19))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -7754,209 +7568,204 @@ and (tc_eqn :
                                                                     i in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____22529
+                                                                    let uu___20
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector in
-                                                                    match uu____22529
+                                                                    match uu___20
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                     ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____22550
+                                                                    uu___21
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____22562
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____22562
+                                                                    uu___22
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None in
-                                                                    let uu____22563
+                                                                    let uu___22
                                                                     =
-                                                                    let uu____22564
+                                                                    let uu___23
                                                                     =
-                                                                    let uu____22565
+                                                                    let uu___24
                                                                     =
-                                                                    let uu____22574
+                                                                    let uu___25
                                                                     =
                                                                     force_scrutinee
                                                                     () in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____22574 in
-                                                                    [uu____22565] in
+                                                                    uu___25 in
+                                                                    [uu___24] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____22564
+                                                                    uu___23
                                                                     f.FStar_Syntax_Syntax.p in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____22563 in
+                                                                    uu___22 in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei)) in
                                                         FStar_All.pipe_right
-                                                          uu____22395
+                                                          uu___15
                                                           FStar_List.flatten in
-                                                      let uu____22597 =
-                                                        let uu____22600 =
+                                                      let uu___15 =
+                                                        let uu___16 =
                                                           force_scrutinee () in
-                                                        discriminate
-                                                          uu____22600 f in
+                                                        discriminate uu___16
+                                                          f in
                                                       FStar_List.append
-                                                        uu____22597
+                                                        uu___15
                                                         sub_term_guards)
                                                | (FStar_Syntax_Syntax.Pat_dot_term
-                                                  uu____22603, uu____22604)
-                                                   -> []
-                                               | uu____22611 ->
-                                                   let uu____22616 =
-                                                     let uu____22617 =
+                                                  uu___12, uu___13) -> []
+                                               | uu___12 ->
+                                                   let uu___13 =
+                                                     let uu___14 =
                                                        FStar_Syntax_Print.pat_to_string
                                                          pattern2 in
-                                                     let uu____22618 =
+                                                     let uu___15 =
                                                        FStar_Syntax_Print.term_to_string
                                                          pat_exp2 in
                                                      FStar_Util.format2
                                                        "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                       uu____22617
-                                                       uu____22618 in
-                                                   failwith uu____22616 in
+                                                       uu___14 uu___15 in
+                                                   failwith uu___13 in
                                              let build_and_check_branch_guard
                                                scrutinee_tm1 pattern2 pat =
-                                               let uu____22645 =
-                                                 let uu____22646 =
+                                               let uu___12 =
+                                                 let uu___13 =
                                                    FStar_TypeChecker_Env.should_verify
                                                      env in
-                                                 Prims.op_Negation
-                                                   uu____22646 in
-                                               if uu____22645
+                                                 Prims.op_Negation uu___13 in
+                                               if uu___12
                                                then
                                                  FStar_Syntax_Util.exp_true_bool
                                                else
                                                  (let t =
-                                                    let uu____22649 =
+                                                    let uu___14 =
                                                       build_branch_guard
                                                         scrutinee_tm1
                                                         pattern2 pat in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Util.mk_and_l
-                                                      uu____22649 in
-                                                  let uu____22658 =
+                                                      uu___14 in
+                                                  let uu___14 =
                                                     tc_check_tot_or_gtot_term
                                                       scrutinee_env t
                                                       FStar_Syntax_Util.t_bool
                                                       "" in
-                                                  match uu____22658 with
-                                                  | (t1, uu____22666,
-                                                     uu____22667) -> t1) in
-                                             let branch_guard =
+                                                  match uu___14 with
+                                                  | (t1, uu___15, uu___16) ->
+                                                      t1) in
+                                             let branch_guard1 =
                                                build_and_check_branch_guard
                                                  (FStar_Pervasives_Native.Some
                                                     scrutinee_tm) pattern1
                                                  norm_pat_exp in
-                                             let branch_guard1 =
+                                             let branch_guard2 =
                                                match when_condition with
                                                | FStar_Pervasives_Native.None
-                                                   -> branch_guard
+                                                   -> branch_guard1
                                                | FStar_Pervasives_Native.Some
                                                    w ->
                                                    FStar_Syntax_Util.mk_and
-                                                     branch_guard w in
-                                             branch_guard1) in
-                                        (let uu____22682 =
+                                                     branch_guard1 w in
+                                             branch_guard2) in
+                                        (let uu___11 =
                                            FStar_All.pipe_left
                                              (FStar_TypeChecker_Env.debug env)
                                              FStar_Options.Extreme in
-                                         if uu____22682
+                                         if uu___11
                                          then
-                                           let uu____22683 =
+                                           let uu___12 =
                                              FStar_Syntax_Print.term_to_string
                                                branch_guard in
                                            FStar_Util.print1
                                              "tc_eqn: branch guard : %s\n"
-                                             uu____22683
+                                             uu___12
                                          else ());
-                                        (let uu____22685 =
+                                        (let uu___11 =
                                            let eqs =
-                                             let uu____22704 =
-                                               let uu____22705 =
+                                             let uu___12 =
+                                               let uu___13 =
                                                  FStar_TypeChecker_Env.should_verify
                                                    env in
-                                               Prims.op_Negation uu____22705 in
-                                             if uu____22704
+                                               Prims.op_Negation uu___13 in
+                                             if uu___12
                                              then
                                                FStar_Pervasives_Native.None
                                              else
                                                (let e =
                                                   FStar_Syntax_Subst.compress
                                                     pat_exp in
-                                                let uu____22710 =
-                                                  let uu____22711 =
+                                                let uu___14 =
+                                                  let uu___15 =
                                                     env.FStar_TypeChecker_Env.universe_of
                                                       env pat_t in
                                                   FStar_Syntax_Util.mk_eq2
-                                                    uu____22711 pat_t
+                                                    uu___15 pat_t
                                                     scrutinee_tm e in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____22710) in
-                                           let uu____22712 =
+                                                  uu___14) in
+                                           let uu___12 =
                                              FStar_TypeChecker_Util.strengthen_precondition
                                                FStar_Pervasives_Native.None
                                                env branch_exp1 c g_branch in
-                                           match uu____22712 with
+                                           match uu___12 with
                                            | (c1, g_branch1) ->
                                                let branch_has_layered_effect
                                                  =
-                                                 let uu____22738 =
+                                                 let uu___13 =
                                                    FStar_All.pipe_right
                                                      c1.FStar_TypeChecker_Common.eff_name
                                                      (FStar_TypeChecker_Env.norm_eff_name
                                                         env) in
-                                                 FStar_All.pipe_right
-                                                   uu____22738
+                                                 FStar_All.pipe_right uu___13
                                                    (FStar_TypeChecker_Env.is_layered_effect
                                                       env) in
-                                               let uu____22739 =
+                                               let uu___13 =
                                                  let env1 =
-                                                   let uu____22745 =
+                                                   let uu___14 =
                                                      FStar_All.pipe_right
                                                        pat_bvs
                                                        (FStar_List.map
                                                           FStar_Syntax_Syntax.mk_binder) in
                                                    FStar_TypeChecker_Env.push_binders
-                                                     scrutinee_env
-                                                     uu____22745 in
+                                                     scrutinee_env uu___14 in
                                                  if branch_has_layered_effect
                                                  then
                                                    let c2 =
-                                                     let uu____22753 =
-                                                       let uu____22754 =
+                                                     let uu___14 =
+                                                       let uu___15 =
                                                          FStar_Syntax_Util.b2t
                                                            branch_guard in
                                                        FStar_TypeChecker_Common.NonTrivial
-                                                         uu____22754 in
+                                                         uu___15 in
                                                      FStar_TypeChecker_Util.weaken_precondition
-                                                       env1 c1 uu____22753 in
+                                                       env1 c1 uu___14 in
                                                    (c2,
                                                      FStar_TypeChecker_Env.trivial_guard)
                                                  else
                                                    (match (eqs,
                                                             when_condition)
                                                     with
-                                                    | uu____22766 when
-                                                        let uu____22777 =
+                                                    | uu___15 when
+                                                        let uu___16 =
                                                           FStar_TypeChecker_Env.should_verify
                                                             env1 in
                                                         Prims.op_Negation
-                                                          uu____22777
+                                                          uu___16
                                                         -> (c1, g_when)
                                                     | (FStar_Pervasives_Native.None,
                                                        FStar_Pervasives_Native.None)
@@ -7971,14 +7780,13 @@ and (tc_eqn :
                                                         let g =
                                                           FStar_TypeChecker_Env.guard_of_guard_formula
                                                             gf in
-                                                        let uu____22797 =
+                                                        let uu___15 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 gf in
-                                                        let uu____22798 =
+                                                        let uu___16 =
                                                           FStar_TypeChecker_Env.imp_guard
                                                             g g_when in
-                                                        (uu____22797,
-                                                          uu____22798)
+                                                        (uu___15, uu___16)
                                                     | (FStar_Pervasives_Native.Some
                                                        f,
                                                        FStar_Pervasives_Native.Some
@@ -7987,23 +7795,21 @@ and (tc_eqn :
                                                           FStar_TypeChecker_Common.NonTrivial
                                                             f in
                                                         let g_fw =
-                                                          let uu____22813 =
+                                                          let uu___15 =
                                                             FStar_Syntax_Util.mk_conj
                                                               f w in
                                                           FStar_TypeChecker_Common.NonTrivial
-                                                            uu____22813 in
-                                                        let uu____22814 =
+                                                            uu___15 in
+                                                        let uu___15 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 g_fw in
-                                                        let uu____22815 =
-                                                          let uu____22816 =
+                                                        let uu___16 =
+                                                          let uu___17 =
                                                             FStar_TypeChecker_Env.guard_of_guard_formula
                                                               g_f in
                                                           FStar_TypeChecker_Env.imp_guard
-                                                            uu____22816
-                                                            g_when in
-                                                        (uu____22814,
-                                                          uu____22815)
+                                                            uu___17 g_when in
+                                                        (uu___15, uu___16)
                                                     | (FStar_Pervasives_Native.None,
                                                        FStar_Pervasives_Native.Some
                                                        w) ->
@@ -8013,11 +7819,11 @@ and (tc_eqn :
                                                         let g =
                                                           FStar_TypeChecker_Env.guard_of_guard_formula
                                                             g_w in
-                                                        let uu____22830 =
+                                                        let uu___15 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 g_w in
-                                                        (uu____22830, g_when)) in
-                                               (match uu____22739 with
+                                                        (uu___15, g_when)) in
+                                               (match uu___13 with
                                                 | (c_weak, g_when_weak) ->
                                                     let binders =
                                                       FStar_List.map
@@ -8026,11 +7832,11 @@ and (tc_eqn :
                                                     let maybe_return_c_weak
                                                       should_return =
                                                       let c_weak1 =
-                                                        let uu____22870 =
+                                                        let uu___14 =
                                                           should_return &&
                                                             (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                                c_weak) in
-                                                        if uu____22870
+                                                        if uu___14
                                                         then
                                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                             env branch_exp1
@@ -8039,13 +7845,13 @@ and (tc_eqn :
                                                       if
                                                         branch_has_layered_effect
                                                       then
-                                                        ((let uu____22873 =
+                                                        ((let uu___15 =
                                                             FStar_All.pipe_left
                                                               (FStar_TypeChecker_Env.debug
                                                                  env)
                                                               (FStar_Options.Other
                                                                  "LayeredEffects") in
-                                                          if uu____22873
+                                                          if uu___15
                                                           then
                                                             FStar_Util.print_string
                                                               "Typechecking pat_bv_tms ...\n"
@@ -8057,179 +7863,177 @@ and (tc_eqn :
                                                                  (fun
                                                                     pat_bv_tm
                                                                     ->
-                                                                    let uu____22885
+                                                                    let uu___15
                                                                     =
-                                                                    let uu____22886
+                                                                    let uu___16
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     scrutinee_tm
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                    [uu____22886] in
+                                                                    [uu___16] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
-                                                                    uu____22885
+                                                                    uu___15
                                                                     FStar_Range.dummyRange)) in
                                                           let pat_bv_tms2 =
                                                             let env1 =
-                                                              let uu___3127_22923
-                                                                =
+                                                              let uu___15 =
                                                                 FStar_TypeChecker_Env.push_bv
                                                                   env
                                                                   scrutinee in
                                                               {
                                                                 FStar_TypeChecker_Env.solver
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.solver);
+                                                                  (uu___15.FStar_TypeChecker_Env.solver);
                                                                 FStar_TypeChecker_Env.range
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.range);
+                                                                  (uu___15.FStar_TypeChecker_Env.range);
                                                                 FStar_TypeChecker_Env.curmodule
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.curmodule);
+                                                                  (uu___15.FStar_TypeChecker_Env.curmodule);
                                                                 FStar_TypeChecker_Env.gamma
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.gamma);
+                                                                  (uu___15.FStar_TypeChecker_Env.gamma);
                                                                 FStar_TypeChecker_Env.gamma_sig
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.gamma_sig);
+                                                                  (uu___15.FStar_TypeChecker_Env.gamma_sig);
                                                                 FStar_TypeChecker_Env.gamma_cache
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.gamma_cache);
+                                                                  (uu___15.FStar_TypeChecker_Env.gamma_cache);
                                                                 FStar_TypeChecker_Env.modules
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.modules);
+                                                                  (uu___15.FStar_TypeChecker_Env.modules);
                                                                 FStar_TypeChecker_Env.expected_typ
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.expected_typ);
+                                                                  (uu___15.FStar_TypeChecker_Env.expected_typ);
                                                                 FStar_TypeChecker_Env.sigtab
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.sigtab);
+                                                                  (uu___15.FStar_TypeChecker_Env.sigtab);
                                                                 FStar_TypeChecker_Env.attrtab
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.attrtab);
+                                                                  (uu___15.FStar_TypeChecker_Env.attrtab);
                                                                 FStar_TypeChecker_Env.instantiate_imp
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.instantiate_imp);
+                                                                  (uu___15.FStar_TypeChecker_Env.instantiate_imp);
                                                                 FStar_TypeChecker_Env.effects
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.effects);
+                                                                  (uu___15.FStar_TypeChecker_Env.effects);
                                                                 FStar_TypeChecker_Env.generalize
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.generalize);
+                                                                  (uu___15.FStar_TypeChecker_Env.generalize);
                                                                 FStar_TypeChecker_Env.letrecs
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.letrecs);
+                                                                  (uu___15.FStar_TypeChecker_Env.letrecs);
                                                                 FStar_TypeChecker_Env.top_level
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.top_level);
+                                                                  (uu___15.FStar_TypeChecker_Env.top_level);
                                                                 FStar_TypeChecker_Env.check_uvars
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.check_uvars);
+                                                                  (uu___15.FStar_TypeChecker_Env.check_uvars);
                                                                 FStar_TypeChecker_Env.use_eq
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.use_eq);
+                                                                  (uu___15.FStar_TypeChecker_Env.use_eq);
                                                                 FStar_TypeChecker_Env.use_eq_strict
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.use_eq_strict);
+                                                                  (uu___15.FStar_TypeChecker_Env.use_eq_strict);
                                                                 FStar_TypeChecker_Env.is_iface
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.is_iface);
+                                                                  (uu___15.FStar_TypeChecker_Env.is_iface);
                                                                 FStar_TypeChecker_Env.admit
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.admit);
+                                                                  (uu___15.FStar_TypeChecker_Env.admit);
                                                                 FStar_TypeChecker_Env.lax
                                                                   = true;
                                                                 FStar_TypeChecker_Env.lax_universes
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.lax_universes);
+                                                                  (uu___15.FStar_TypeChecker_Env.lax_universes);
                                                                 FStar_TypeChecker_Env.phase1
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.phase1);
+                                                                  (uu___15.FStar_TypeChecker_Env.phase1);
                                                                 FStar_TypeChecker_Env.failhard
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.failhard);
+                                                                  (uu___15.FStar_TypeChecker_Env.failhard);
                                                                 FStar_TypeChecker_Env.nosynth
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.nosynth);
+                                                                  (uu___15.FStar_TypeChecker_Env.nosynth);
                                                                 FStar_TypeChecker_Env.uvar_subtyping
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                  (uu___15.FStar_TypeChecker_Env.uvar_subtyping);
                                                                 FStar_TypeChecker_Env.tc_term
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.tc_term);
+                                                                  (uu___15.FStar_TypeChecker_Env.tc_term);
                                                                 FStar_TypeChecker_Env.type_of
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.type_of);
+                                                                  (uu___15.FStar_TypeChecker_Env.type_of);
                                                                 FStar_TypeChecker_Env.universe_of
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.universe_of);
+                                                                  (uu___15.FStar_TypeChecker_Env.universe_of);
                                                                 FStar_TypeChecker_Env.check_type_of
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.check_type_of);
+                                                                  (uu___15.FStar_TypeChecker_Env.check_type_of);
                                                                 FStar_TypeChecker_Env.use_bv_sorts
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                  (uu___15.FStar_TypeChecker_Env.use_bv_sorts);
                                                                 FStar_TypeChecker_Env.qtbl_name_and_index
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                  (uu___15.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                 FStar_TypeChecker_Env.normalized_eff_names
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                  (uu___15.FStar_TypeChecker_Env.normalized_eff_names);
                                                                 FStar_TypeChecker_Env.fv_delta_depths
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                  (uu___15.FStar_TypeChecker_Env.fv_delta_depths);
                                                                 FStar_TypeChecker_Env.proof_ns
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.proof_ns);
+                                                                  (uu___15.FStar_TypeChecker_Env.proof_ns);
                                                                 FStar_TypeChecker_Env.synth_hook
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.synth_hook);
+                                                                  (uu___15.FStar_TypeChecker_Env.synth_hook);
                                                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                  (uu___15.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                 FStar_TypeChecker_Env.splice
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.splice);
+                                                                  (uu___15.FStar_TypeChecker_Env.splice);
                                                                 FStar_TypeChecker_Env.mpreprocess
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.mpreprocess);
+                                                                  (uu___15.FStar_TypeChecker_Env.mpreprocess);
                                                                 FStar_TypeChecker_Env.postprocess
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.postprocess);
+                                                                  (uu___15.FStar_TypeChecker_Env.postprocess);
                                                                 FStar_TypeChecker_Env.identifier_info
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.identifier_info);
+                                                                  (uu___15.FStar_TypeChecker_Env.identifier_info);
                                                                 FStar_TypeChecker_Env.tc_hooks
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.tc_hooks);
+                                                                  (uu___15.FStar_TypeChecker_Env.tc_hooks);
                                                                 FStar_TypeChecker_Env.dsenv
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.dsenv);
+                                                                  (uu___15.FStar_TypeChecker_Env.dsenv);
                                                                 FStar_TypeChecker_Env.nbe
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.nbe);
+                                                                  (uu___15.FStar_TypeChecker_Env.nbe);
                                                                 FStar_TypeChecker_Env.strict_args_tab
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.strict_args_tab);
+                                                                  (uu___15.FStar_TypeChecker_Env.strict_args_tab);
                                                                 FStar_TypeChecker_Env.erasable_types_tab
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                  (uu___15.FStar_TypeChecker_Env.erasable_types_tab);
                                                                 FStar_TypeChecker_Env.enable_defer_to_tac
                                                                   =
-                                                                  (uu___3127_22923.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                  (uu___15.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                               } in
-                                                            let uu____22924 =
-                                                              let uu____22927
-                                                                =
+                                                            let uu___15 =
+                                                              let uu___16 =
                                                                 FStar_List.fold_left2
                                                                   (fun
-                                                                    uu____22955
+                                                                    uu___17
                                                                     ->
                                                                     fun
                                                                     pat_bv_tm
                                                                     ->
                                                                     fun bv ->
-                                                                    match uu____22955
+                                                                    match uu___17
                                                                     with
                                                                     | 
                                                                     (substs,
@@ -8241,28 +8045,28 @@ and (tc_eqn :
                                                                     bv.FStar_Syntax_Syntax.sort in
                                                                     let pat_bv_tm1
                                                                     =
-                                                                    let uu____22996
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____23003
+                                                                    let uu___19
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pat_bv_tm
                                                                     (FStar_Syntax_Subst.subst
                                                                     substs) in
-                                                                    let uu____23004
+                                                                    let uu___20
                                                                     =
-                                                                    let uu____23015
+                                                                    let uu___21
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t in
                                                                     tc_trivial_guard
-                                                                    uu____23015 in
+                                                                    uu___21 in
                                                                     FStar_All.pipe_right
-                                                                    uu____23003
-                                                                    uu____23004 in
+                                                                    uu___19
+                                                                    uu___20 in
                                                                     FStar_All.pipe_right
-                                                                    uu____22996
+                                                                    uu___18
                                                                     FStar_Pervasives_Native.fst in
                                                                     ((FStar_List.append
                                                                     substs
@@ -8277,65 +8081,61 @@ and (tc_eqn :
                                                                   pat_bv_tms1
                                                                   pat_bvs in
                                                               FStar_All.pipe_right
-                                                                uu____22927
+                                                                uu___16
                                                                 FStar_Pervasives_Native.snd in
                                                             FStar_All.pipe_right
-                                                              uu____22924
+                                                              uu___15
                                                               (FStar_List.map
                                                                  (FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.Beta]
                                                                     env1)) in
-                                                          (let uu____23077 =
+                                                          (let uu___16 =
                                                              FStar_All.pipe_left
                                                                (FStar_TypeChecker_Env.debug
                                                                   env)
                                                                (FStar_Options.Other
                                                                   "LayeredEffects") in
-                                                           if uu____23077
+                                                           if uu___16
                                                            then
-                                                             let uu____23078
-                                                               =
+                                                             let uu___17 =
                                                                FStar_List.fold_left
                                                                  (fun s ->
                                                                     fun t ->
-                                                                    let uu____23084
+                                                                    let uu___18
                                                                     =
-                                                                    let uu____23085
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23085 in
+                                                                    uu___19 in
                                                                     Prims.op_Hat
-                                                                    s
-                                                                    uu____23084)
+                                                                    s uu___18)
                                                                  ""
                                                                  pat_bv_tms2 in
-                                                             let uu____23086
-                                                               =
+                                                             let uu___18 =
                                                                FStar_List.fold_left
                                                                  (fun s ->
                                                                     fun t ->
-                                                                    let uu____23092
+                                                                    let uu___19
                                                                     =
-                                                                    let uu____23093
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     t in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23093 in
+                                                                    uu___20 in
                                                                     Prims.op_Hat
-                                                                    s
-                                                                    uu____23092)
+                                                                    s uu___19)
                                                                  "" pat_bvs in
                                                              FStar_Util.print2
                                                                "tc_eqn: typechecked pat_bv_tms %s (pat_bvs : %s)\n"
-                                                               uu____23078
-                                                               uu____23086
+                                                               uu___17
+                                                               uu___18
                                                            else ());
-                                                          (let uu____23095 =
+                                                          (let uu___16 =
                                                              FStar_All.pipe_right
                                                                c_weak1
                                                                (FStar_TypeChecker_Common.apply_lcomp
@@ -8352,69 +8152,65 @@ and (tc_eqn :
                                                                     eqs1 ->
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g eqs1)) in
-                                                           let uu____23102 =
-                                                             let uu____23107
-                                                               =
+                                                           let uu___17 =
+                                                             let uu___18 =
                                                                FStar_TypeChecker_Env.push_bv
                                                                  env
                                                                  scrutinee in
                                                              FStar_TypeChecker_Util.close_layered_lcomp
-                                                               uu____23107
+                                                               uu___18
                                                                pat_bvs
                                                                pat_bv_tms2 in
                                                            FStar_All.pipe_right
-                                                             uu____23095
-                                                             uu____23102)))
+                                                             uu___16 uu___17)))
                                                       else
                                                         FStar_TypeChecker_Util.close_wp_lcomp
                                                           env pat_bvs c_weak1 in
-                                                    let uu____23109 =
+                                                    let uu___14 =
                                                       FStar_TypeChecker_Env.close_guard
                                                         env binders
                                                         g_when_weak in
-                                                    let uu____23110 =
+                                                    let uu___15 =
                                                       FStar_TypeChecker_Env.conj_guard
                                                         guard_pat g_branch1 in
                                                     ((c_weak.FStar_TypeChecker_Common.eff_name),
                                                       (c_weak.FStar_TypeChecker_Common.cflags),
                                                       maybe_return_c_weak,
-                                                      uu____23109,
-                                                      uu____23110)) in
-                                         match uu____22685 with
+                                                      uu___14, uu___15)) in
+                                         match uu___11 with
                                          | (effect_label, cflags,
                                             maybe_return_c, g_when1,
                                             g_branch1) ->
                                              let guard =
                                                FStar_TypeChecker_Env.conj_guard
                                                  g_when1 g_branch1 in
-                                             ((let uu____23160 =
+                                             ((let uu___13 =
                                                  FStar_TypeChecker_Env.debug
                                                    env FStar_Options.High in
-                                               if uu____23160
+                                               if uu___13
                                                then
-                                                 let uu____23161 =
+                                                 let uu___14 =
                                                    FStar_TypeChecker_Rel.guard_to_string
                                                      env guard in
                                                  FStar_All.pipe_left
                                                    (FStar_Util.print1
                                                       "Carrying guard from match: %s\n")
-                                                   uu____23161
+                                                   uu___14
                                                else ());
-                                              (let uu____23163 =
+                                              (let uu___13 =
                                                  FStar_Syntax_Subst.close_branch
                                                    (pattern1, when_clause1,
                                                      branch_exp1) in
-                                               let uu____23180 =
-                                                 let uu____23181 =
+                                               let uu___14 =
+                                                 let uu___15 =
                                                    FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder
                                                      pat_bvs in
                                                  FStar_TypeChecker_Util.close_guard_implicits
-                                                   env false uu____23181
-                                                   guard in
-                                               (uu____23163, branch_guard,
+                                                   env false uu___15 guard in
+                                               (uu___13, branch_guard,
                                                  effect_label, cflags,
-                                                 maybe_return_c, uu____23180,
+                                                 maybe_return_c, uu___14,
                                                  erasable))))))))))))
 and (check_top_level_let :
   FStar_TypeChecker_Env.env ->
@@ -8427,38 +8223,38 @@ and (check_top_level_let :
       let env1 = instantiate_both env in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), e2) ->
-          let uu____23224 = check_let_bound_def true env1 lb in
-          (match uu____23224 with
+          let uu___ = check_let_bound_def true env1 lb in
+          (match uu___ with
            | (e1, univ_vars, c1, g1, annotated) ->
-               let uu____23246 =
+               let uu___1 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____23267 =
+                   let uu___2 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1 in
-                   (g1, uu____23267, univ_vars, c1)
+                   (g1, uu___2, univ_vars, c1)
                  else
                    (let g11 =
-                      let uu____23272 =
+                      let uu___3 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1 in
-                      FStar_All.pipe_right uu____23272
+                      FStar_All.pipe_right uu___3
                         (FStar_TypeChecker_Rel.resolve_implicits env1) in
-                    let uu____23273 = FStar_TypeChecker_Common.lcomp_comp c1 in
-                    match uu____23273 with
+                    let uu___3 = FStar_TypeChecker_Common.lcomp_comp c1 in
+                    match uu___3 with
                     | (comp1, g_comp1) ->
                         let g12 =
                           FStar_TypeChecker_Env.conj_guard g11 g_comp1 in
-                        let uu____23291 =
-                          let uu____23304 =
+                        let uu___4 =
+                          let uu___5 =
                             FStar_TypeChecker_Generalize.generalize env1
                               false
                               [((lb.FStar_Syntax_Syntax.lbname), e1, comp1)] in
-                          FStar_List.hd uu____23304 in
-                        (match uu____23291 with
-                         | (uu____23353, univs, e11, c11, gvs) ->
+                          FStar_List.hd uu___5 in
+                        (match uu___4 with
+                         | (uu___5, univs, e11, c11, gvs) ->
                              let g13 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.map_guard g12)
@@ -8471,40 +8267,39 @@ and (check_top_level_let :
                                       FStar_TypeChecker_Env.Zeta] env1) in
                              let g14 =
                                FStar_TypeChecker_Env.abstract_guard_n gvs g13 in
-                             let uu____23367 =
+                             let uu___6 =
                                FStar_TypeChecker_Common.lcomp_of_comp c11 in
-                             (g14, e11, univs, uu____23367))) in
-               (match uu____23246 with
+                             (g14, e11, univs, uu___6))) in
+               (match uu___1 with
                 | (g11, e11, univ_vars1, c11) ->
-                    let uu____23384 =
-                      let uu____23393 =
-                        FStar_TypeChecker_Env.should_verify env1 in
-                      if uu____23393
+                    let uu___2 =
+                      let uu___3 = FStar_TypeChecker_Env.should_verify env1 in
+                      if uu___3
                       then
-                        let uu____23402 =
+                        let uu___4 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11 in
-                        match uu____23402 with
+                        match uu___4 with
                         | (ok, c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____23431 =
+                               ((let uu___7 =
                                    FStar_TypeChecker_Env.get_range env1 in
-                                 FStar_Errors.log_issue uu____23431
+                                 FStar_Errors.log_issue uu___7
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____23432 =
+                                (let uu___7 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
                                           (FStar_Syntax_Syntax.Meta_desugared
                                              FStar_Syntax_Syntax.Masked_effect)))
                                      e2.FStar_Syntax_Syntax.pos in
-                                 (uu____23432, c12))))
+                                 (uu___7, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let uu____23443 =
+                         (let uu___6 =
                             FStar_TypeChecker_Common.lcomp_comp c11 in
-                          match uu____23443 with
+                          match uu___6 with
                           | (comp1, g_comp1) ->
                               (FStar_TypeChecker_Rel.force_trivial_guard env1
                                  g_comp1;
@@ -8516,14 +8311,14 @@ and (check_top_level_let :
                                        FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                        env1) in
                                 let e21 =
-                                  let uu____23467 =
+                                  let uu___8 =
                                     FStar_Syntax_Util.is_pure_comp c in
-                                  if uu____23467
+                                  if uu___8
                                   then e2
                                   else
-                                    ((let uu____23472 =
+                                    ((let uu___11 =
                                         FStar_TypeChecker_Env.get_range env1 in
-                                      FStar_Errors.log_issue uu____23472
+                                      FStar_Errors.log_issue uu___11
                                         FStar_TypeChecker_Err.top_level_effect);
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_meta
@@ -8532,21 +8327,21 @@ and (check_top_level_let :
                                                FStar_Syntax_Syntax.Masked_effect)))
                                        e2.FStar_Syntax_Syntax.pos) in
                                 (e21, c))))) in
-                    (match uu____23384 with
+                    (match uu___2 with
                      | (e21, c12) ->
-                         ((let uu____23496 =
+                         ((let uu___4 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium in
-                           if uu____23496
+                           if uu___4
                            then
-                             let uu____23497 =
+                             let uu___5 =
                                FStar_Syntax_Print.term_to_string e11 in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____23497
+                               "Let binding BEFORE tcnorm: %s\n" uu___5
                            else ());
                           (let e12 =
-                             let uu____23500 = FStar_Options.tcnorm () in
-                             if uu____23500
+                             let uu___4 = FStar_Options.tcnorm () in
+                             if uu___4
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -8559,20 +8354,20 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11 in
-                           (let uu____23503 =
+                           (let uu___5 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium in
-                            if uu____23503
+                            if uu___5
                             then
-                              let uu____23504 =
+                              let uu___6 =
                                 FStar_Syntax_Print.term_to_string e12 in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____23504
+                                "Let binding AFTER tcnorm: %s\n" uu___6
                             else ());
                            (let cres =
-                              let uu____23507 =
+                              let uu___5 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12 in
-                              if uu____23507
+                              if uu___5
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -8586,8 +8381,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp, uu____23512)::[] -> wp
-                                   | uu____23537 ->
+                                   | (wp, uu___7)::[] -> wp
+                                   | uu___7 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args" in
                                  let c1_eff_decl =
@@ -8597,65 +8392,64 @@ and (check_top_level_let :
                                    let ret =
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_return_vc_combinator in
-                                   let uu____23551 =
+                                   let uu___7 =
                                      FStar_TypeChecker_Env.inst_effect_fun_with
                                        [FStar_Syntax_Syntax.U_zero] env1
                                        c1_eff_decl ret in
-                                   let uu____23552 =
-                                     let uu____23553 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Syntax_Syntax.as_arg
                                          FStar_Syntax_Syntax.t_unit in
-                                     let uu____23562 =
-                                       let uu____23573 =
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.unit_const in
-                                       [uu____23573] in
-                                     uu____23553 :: uu____23562 in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____23551
-                                     uu____23552 e21.FStar_Syntax_Syntax.pos in
+                                       [uu___11] in
+                                     uu___9 :: uu___10 in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu___7
+                                     uu___8 e21.FStar_Syntax_Syntax.pos in
                                  let wp =
                                    let bind =
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_bind_vc_combinator in
-                                   let uu____23608 =
+                                   let uu___7 =
                                      FStar_TypeChecker_Env.inst_effect_fun_with
                                        (FStar_List.append
                                           c1_comp_typ.FStar_Syntax_Syntax.comp_univs
                                           [FStar_Syntax_Syntax.U_zero]) env1
                                        c1_eff_decl bind in
-                                   let uu____23609 =
-                                     let uu____23610 =
-                                       let uu____23619 =
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 =
                                          FStar_Syntax_Syntax.mk
                                            (FStar_Syntax_Syntax.Tm_constant
                                               (FStar_Const.Const_range
                                                  (lb.FStar_Syntax_Syntax.lbpos)))
                                            lb.FStar_Syntax_Syntax.lbpos in
                                        FStar_All.pipe_left
-                                         FStar_Syntax_Syntax.as_arg
-                                         uu____23619 in
-                                     let uu____23628 =
-                                       let uu____23639 =
+                                         FStar_Syntax_Syntax.as_arg uu___10 in
+                                     let uu___10 =
+                                       let uu___11 =
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
                                            c1_comp_typ.FStar_Syntax_Syntax.result_typ in
-                                       let uu____23656 =
-                                         let uu____23667 =
+                                       let uu___12 =
+                                         let uu___13 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.t_unit in
-                                         let uu____23676 =
-                                           let uu____23687 =
+                                         let uu___14 =
+                                           let uu___15 =
                                              FStar_Syntax_Syntax.as_arg c1_wp in
-                                           let uu____23696 =
-                                             let uu____23707 =
-                                               let uu____23716 =
-                                                 let uu____23717 =
-                                                   let uu____23718 =
+                                           let uu___16 =
+                                             let uu___17 =
+                                               let uu___18 =
+                                                 let uu___19 =
+                                                   let uu___20 =
                                                      FStar_Syntax_Syntax.null_binder
                                                        c1_comp_typ.FStar_Syntax_Syntax.result_typ in
-                                                   [uu____23718] in
+                                                   [uu___20] in
                                                  FStar_Syntax_Util.abs
-                                                   uu____23717 wp2
+                                                   uu___19 wp2
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Util.mk_residual_comp
                                                          FStar_Parser_Const.effect_Tot_lid
@@ -8663,19 +8457,19 @@ and (check_top_level_let :
                                                          [FStar_Syntax_Syntax.TOTAL])) in
                                                FStar_All.pipe_left
                                                  FStar_Syntax_Syntax.as_arg
-                                                 uu____23716 in
-                                             [uu____23707] in
-                                           uu____23687 :: uu____23696 in
-                                         uu____23667 :: uu____23676 in
-                                       uu____23639 :: uu____23656 in
-                                     uu____23610 :: uu____23628 in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____23608
-                                     uu____23609 lb.FStar_Syntax_Syntax.lbpos in
-                                 let uu____23795 =
-                                   let uu____23796 =
-                                     let uu____23807 =
+                                                 uu___18 in
+                                             [uu___17] in
+                                           uu___15 :: uu___16 in
+                                         uu___13 :: uu___14 in
+                                       uu___11 :: uu___12 in
+                                     uu___9 :: uu___10 in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu___7
+                                     uu___8 lb.FStar_Syntax_Syntax.lbpos in
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Syntax_Syntax.as_arg wp in
-                                     [uu____23807] in
+                                     [uu___9] in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -8683,11 +8477,10 @@ and (check_top_level_let :
                                        (c1_comp_typ.FStar_Syntax_Syntax.effect_name);
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
-                                     FStar_Syntax_Syntax.effect_args =
-                                       uu____23796;
+                                     FStar_Syntax_Syntax.effect_args = uu___8;
                                      FStar_Syntax_Syntax.flags = []
                                    } in
-                                 FStar_Syntax_Syntax.mk_Comp uu____23795) in
+                                 FStar_Syntax_Syntax.mk_Comp uu___7) in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                 FStar_Pervasives_Native.None
@@ -8696,16 +8489,16 @@ and (check_top_level_let :
                                 (FStar_Syntax_Util.comp_effect_name c12) e12
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos in
-                            let uu____23835 =
+                            let uu___5 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
                                 e.FStar_Syntax_Syntax.pos in
-                            let uu____23846 =
+                            let uu___6 =
                               FStar_TypeChecker_Common.lcomp_of_comp cres in
-                            (uu____23835, uu____23846,
+                            (uu___5, uu___6,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____23847 -> failwith "Impossible"
+      | uu___ -> failwith "Impossible"
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -8714,15 +8507,15 @@ and (maybe_intro_smt_lemma :
   fun env ->
     fun lem_typ ->
       fun c2 ->
-        let uu____23857 = FStar_Syntax_Util.is_smt_lemma lem_typ in
-        if uu____23857
+        let uu___ = FStar_Syntax_Util.is_smt_lemma lem_typ in
+        if uu___
         then
           let universe_of_binders bs =
-            let uu____23882 =
+            let uu___1 =
               FStar_List.fold_left
-                (fun uu____23907 ->
+                (fun uu___2 ->
                    fun b ->
-                     match uu____23907 with
+                     match uu___2 with
                      | (env1, us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -8730,7 +8523,7 @@ and (maybe_intro_smt_lemma :
                          let env2 =
                            FStar_TypeChecker_Env.push_binders env1 [b] in
                          (env2, (u :: us))) (env, []) bs in
-            match uu____23882 with | (uu____23955, us) -> FStar_List.rev us in
+            match uu___1 with | (uu___2, us) -> FStar_List.rev us in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders in
           FStar_TypeChecker_Util.weaken_precondition env c2
@@ -8748,109 +8541,107 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), e2) ->
           let env2 =
-            let uu___3259_23987 = env1 in
+            let uu___ = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3259_23987.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3259_23987.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3259_23987.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3259_23987.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3259_23987.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3259_23987.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3259_23987.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3259_23987.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3259_23987.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3259_23987.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3259_23987.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3259_23987.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3259_23987.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3259_23987.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3259_23987.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3259_23987.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___3259_23987.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3259_23987.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3259_23987.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___3259_23987.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3259_23987.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3259_23987.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3259_23987.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3259_23987.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3259_23987.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3259_23987.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3259_23987.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3259_23987.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3259_23987.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___3259_23987.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3259_23987.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3259_23987.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3259_23987.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3259_23987.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3259_23987.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___3259_23987.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3259_23987.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___3259_23987.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3259_23987.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3259_23987.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3259_23987.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3259_23987.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___3259_23987.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3259_23987.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___3259_23987.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___3259_23987.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let uu____23988 =
-            let uu____23999 =
-              let uu____24000 = FStar_TypeChecker_Env.clear_expected_typ env2 in
-              FStar_All.pipe_right uu____24000 FStar_Pervasives_Native.fst in
-            check_let_bound_def false uu____23999 lb in
-          (match uu____23988 with
-           | (e1, uu____24022, c1, g1, annotated) ->
+          let uu___ =
+            let uu___1 =
+              let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env2 in
+              FStar_All.pipe_right uu___2 FStar_Pervasives_Native.fst in
+            check_let_bound_def false uu___1 lb in
+          (match uu___ with
+           | (e1, uu___1, c1, g1, annotated) ->
                let pure_or_ghost =
                  FStar_TypeChecker_Common.is_pure_or_ghost_lcomp c1 in
                let is_inline_let =
@@ -8860,68 +8651,64 @@ and (check_inner_let :
                    lb.FStar_Syntax_Syntax.lbattrs in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____24031 =
-                     let uu____24036 =
-                       let uu____24037 = FStar_Syntax_Print.term_to_string e1 in
-                       let uu____24038 =
+                  (let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Print.term_to_string e1 in
+                       let uu___6 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_TypeChecker_Common.eff_name in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____24037 uu____24038 in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24036) in
-                   FStar_Errors.raise_error uu____24031
-                     e1.FStar_Syntax_Syntax.pos)
+                         uu___5 uu___6 in
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu___4) in
+                   FStar_Errors.raise_error uu___3 e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____24045 =
+                   let uu___3 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_TypeChecker_Common.res_typ) in
-                   if uu____24045
+                   if uu___3
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs in
                  let x =
-                   let uu___3274_24054 =
-                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                   let uu___3 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___3274_24054.FStar_Syntax_Syntax.ppname);
+                       (uu___3.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___3274_24054.FStar_Syntax_Syntax.index);
+                       (uu___3.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_TypeChecker_Common.res_typ)
                    } in
-                 let uu____24055 =
-                   let uu____24060 =
-                     let uu____24061 = FStar_Syntax_Syntax.mk_binder x in
-                     [uu____24061] in
-                   FStar_Syntax_Subst.open_term uu____24060 e2 in
-                 match uu____24055 with
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Syntax_Syntax.mk_binder x in [uu___5] in
+                   FStar_Syntax_Subst.open_term uu___4 e2 in
+                 match uu___3 with
                  | (xb, e21) ->
                      let xbinder = FStar_List.hd xb in
                      let x1 = FStar_Pervasives_Native.fst xbinder in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1 in
-                     let uu____24105 =
-                       let uu____24112 = tc_term env_x e21 in
-                       FStar_All.pipe_right uu____24112
-                         (fun uu____24138 ->
-                            match uu____24138 with
+                     let uu___4 =
+                       let uu___5 = tc_term env_x e21 in
+                       FStar_All.pipe_right uu___5
+                         (fun uu___6 ->
+                            match uu___6 with
                             | (e22, c2, g2) ->
-                                let uu____24154 =
-                                  let uu____24159 =
+                                let uu___7 =
+                                  let uu___8 =
                                     FStar_All.pipe_right
-                                      (fun uu____24174 ->
+                                      (fun uu___9 ->
                                          "folding guard g2 of e2 in the lcomp")
-                                      (fun uu____24178 ->
-                                         FStar_Pervasives_Native.Some
-                                           uu____24178) in
+                                      (fun uu___9 ->
+                                         FStar_Pervasives_Native.Some uu___9) in
                                   FStar_TypeChecker_Util.strengthen_precondition
-                                    uu____24159 env_x e22 c2 g2 in
-                                (match uu____24154 with
+                                    uu___8 env_x e22 c2 g2 in
+                                (match uu___7 with
                                  | (c21, g21) -> (e22, c21, g21))) in
-                     (match uu____24105 with
+                     (match uu___4 with
                       | (e22, c2, g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -8948,94 +8735,91 @@ and (check_inner_let :
                               cres.FStar_TypeChecker_Common.eff_name e11
                               attrs lb.FStar_Syntax_Syntax.lbpos in
                           let e3 =
-                            let uu____24206 =
-                              let uu____24207 =
-                                let uu____24220 =
-                                  FStar_Syntax_Subst.close xb e23 in
-                                ((false, [lb1]), uu____24220) in
-                              FStar_Syntax_Syntax.Tm_let uu____24207 in
-                            FStar_Syntax_Syntax.mk uu____24206
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Syntax_Subst.close xb e23 in
+                                ((false, [lb1]), uu___7) in
+                              FStar_Syntax_Syntax.Tm_let uu___6 in
+                            FStar_Syntax_Syntax.mk uu___5
                               e.FStar_Syntax_Syntax.pos in
                           let e4 =
                             FStar_TypeChecker_Util.maybe_monadic env2 e3
                               cres.FStar_TypeChecker_Common.eff_name
                               cres.FStar_TypeChecker_Common.res_typ in
                           let g21 =
-                            let uu____24235 =
-                              let uu____24236 =
+                            let uu___5 =
+                              let uu___6 =
                                 FStar_All.pipe_right
                                   cres.FStar_TypeChecker_Common.eff_name
                                   (FStar_TypeChecker_Env.norm_eff_name env2) in
-                              FStar_All.pipe_right uu____24236
+                              FStar_All.pipe_right uu___6
                                 (FStar_TypeChecker_Env.is_layered_effect env2) in
                             FStar_TypeChecker_Util.close_guard_implicits env2
-                              uu____24235 xb g2 in
+                              uu___5 xb g2 in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21 in
-                          let uu____24238 =
-                            let uu____24239 =
+                          let uu___5 =
+                            let uu___6 =
                               FStar_TypeChecker_Env.expected_typ env2 in
-                            FStar_Option.isSome uu____24239 in
-                          if uu____24238
+                            FStar_Option.isSome uu___6 in
+                          if uu___5
                           then
                             let tt =
-                              let uu____24249 =
+                              let uu___6 =
                                 FStar_TypeChecker_Env.expected_typ env2 in
-                              FStar_All.pipe_right uu____24249
-                                FStar_Option.get in
-                            ((let uu____24255 =
+                              FStar_All.pipe_right uu___6 FStar_Option.get in
+                            ((let uu___7 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports") in
-                              if uu____24255
+                              if uu___7
                               then
-                                let uu____24256 =
+                                let uu___8 =
                                   FStar_Syntax_Print.term_to_string tt in
-                                let uu____24257 =
+                                let uu___9 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_TypeChecker_Common.res_typ in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____24256 uu____24257
+                                  uu___8 uu___9
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____24260 =
+                            (let uu___7 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1]
                                  cres.FStar_TypeChecker_Common.res_typ in
-                             match uu____24260 with
+                             match uu___7 with
                              | (t, g_ex) ->
-                                 ((let uu____24274 =
+                                 ((let uu___9 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports") in
-                                   if uu____24274
+                                   if uu___9
                                    then
-                                     let uu____24275 =
+                                     let uu___10 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_TypeChecker_Common.res_typ in
-                                     let uu____24276 =
+                                     let uu___11 =
                                        FStar_Syntax_Print.term_to_string t in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____24275 uu____24276
+                                       uu___10 uu___11
                                    else ());
-                                  (let uu____24278 =
+                                  (let uu___9 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard in
                                    (e4,
-                                     (let uu___3313_24280 = cres in
+                                     (let uu___10 = cres in
                                       {
                                         FStar_TypeChecker_Common.eff_name =
-                                          (uu___3313_24280.FStar_TypeChecker_Common.eff_name);
+                                          (uu___10.FStar_TypeChecker_Common.eff_name);
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          (uu___3313_24280.FStar_TypeChecker_Common.cflags);
+                                          (uu___10.FStar_TypeChecker_Common.cflags);
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          (uu___3313_24280.FStar_TypeChecker_Common.comp_thunk)
-                                      }), uu____24278))))))))
-      | uu____24281 ->
-          failwith "Impossible (inner let with more than one lb)"
+                                          (uu___10.FStar_TypeChecker_Common.comp_thunk)
+                                      }), uu___9))))))))
+      | uu___ -> failwith "Impossible (inner let with more than one lb)"
 and (check_top_level_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -9047,40 +8831,39 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) ->
-          let uu____24313 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____24313 with
+          let uu___ = FStar_Syntax_Subst.open_let_rec lbs e2 in
+          (match uu___ with
            | (lbs1, e21) ->
-               let uu____24332 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____24332 with
+               let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               (match uu___1 with
                 | (env0, topt) ->
-                    let uu____24351 = build_let_rec_env true env0 lbs1 in
-                    (match uu____24351 with
+                    let uu___2 = build_let_rec_env true env0 lbs1 in
+                    (match uu___2 with
                      | (lbs2, rec_env, g_t) ->
-                         let uu____24373 = check_let_recs rec_env lbs2 in
-                         (match uu____24373 with
+                         let uu___3 = check_let_recs rec_env lbs2 in
+                         (match uu___3 with
                           | (lbs3, g_lbs) ->
                               let g_lbs1 =
-                                let uu____24393 =
-                                  let uu____24394 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs in
-                                  FStar_All.pipe_right uu____24394
+                                  FStar_All.pipe_right uu___5
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1) in
-                                FStar_All.pipe_right uu____24393
+                                FStar_All.pipe_right uu___4
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1) in
                               let all_lb_names =
-                                let uu____24400 =
+                                let uu___4 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname)) in
-                                FStar_All.pipe_right uu____24400
-                                  (fun uu____24417 ->
-                                     FStar_Pervasives_Native.Some uu____24417) in
+                                FStar_All.pipe_right uu___4
+                                  (fun uu___5 ->
+                                     FStar_Pervasives_Native.Some uu___5) in
                               let lbs4 =
                                 if
                                   Prims.op_Negation
@@ -9109,22 +8892,22 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____24450 =
+                                     let uu___5 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb ->
-                                               let uu____24484 =
+                                               let uu___6 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____24484))) in
+                                                 uu___6))) in
                                      FStar_TypeChecker_Generalize.generalize
-                                       env1 true uu____24450 in
+                                       env1 true uu___5 in
                                    FStar_List.map2
-                                     (fun uu____24518 ->
+                                     (fun uu___5 ->
                                         fun lb ->
-                                          match uu____24518 with
+                                          match uu___5 with
                                           | (x, uvs, e, c, gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -9136,30 +8919,30 @@ and (check_top_level_let_rec :
                                                 lb.FStar_Syntax_Syntax.lbpos)
                                      ecs lbs3) in
                               let cres =
-                                let uu____24566 =
+                                let uu___4 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit in
                                 FStar_All.pipe_left
                                   FStar_TypeChecker_Common.lcomp_of_comp
-                                  uu____24566 in
-                              let uu____24567 =
+                                  uu___4 in
+                              let uu___4 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21 in
-                              (match uu____24567 with
+                              (match uu___4 with
                                | (lbs5, e22) ->
-                                   ((let uu____24587 =
+                                   ((let uu___6 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1 in
-                                     FStar_All.pipe_right uu____24587
+                                     FStar_All.pipe_right uu___6
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____24588 =
+                                    (let uu___6 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          top.FStar_Syntax_Syntax.pos in
-                                     (uu____24588, cres,
+                                     (uu___6, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____24599 -> failwith "Impossible"
+      | uu___ -> failwith "Impossible"
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -9171,61 +8954,60 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) ->
-          let uu____24631 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____24631 with
+          let uu___ = FStar_Syntax_Subst.open_let_rec lbs e2 in
+          (match uu___ with
            | (lbs1, e21) ->
-               let uu____24650 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____24650 with
+               let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               (match uu___1 with
                 | (env0, topt) ->
-                    let uu____24669 = build_let_rec_env false env0 lbs1 in
-                    (match uu____24669 with
+                    let uu___2 = build_let_rec_env false env0 lbs1 in
+                    (match uu___2 with
                      | (lbs2, rec_env, g_t) ->
-                         let uu____24691 =
-                           let uu____24698 = check_let_recs rec_env lbs2 in
-                           FStar_All.pipe_right uu____24698
-                             (fun uu____24721 ->
-                                match uu____24721 with
+                         let uu___3 =
+                           let uu___4 = check_let_recs rec_env lbs2 in
+                           FStar_All.pipe_right uu___4
+                             (fun uu___5 ->
+                                match uu___5 with
                                 | (lbs3, g) ->
-                                    let uu____24740 =
+                                    let uu___6 =
                                       FStar_TypeChecker_Env.conj_guard g_t g in
-                                    (lbs3, uu____24740)) in
-                         (match uu____24691 with
+                                    (lbs3, uu___6)) in
+                         (match uu___3 with
                           | (lbs3, g_lbs) ->
-                              let uu____24755 =
+                              let uu___4 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2 ->
                                         fun lb ->
                                           let x =
-                                            let uu___3388_24778 =
+                                            let uu___5 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3388_24778.FStar_Syntax_Syntax.ppname);
+                                                (uu___5.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3388_24778.FStar_Syntax_Syntax.index);
+                                                (uu___5.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             } in
                                           let lb1 =
-                                            let uu___3391_24780 = lb in
+                                            let uu___5 = lb in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___5.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___5.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbeff);
+                                                (uu___5.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbdef);
+                                                (uu___5.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___5.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3391_24780.FStar_Syntax_Syntax.lbpos)
+                                                (uu___5.FStar_Syntax_Syntax.lbpos)
                                             } in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -9234,7 +9016,7 @@ and (check_inner_let_rec :
                                               ([],
                                                 (lb1.FStar_Syntax_Syntax.lbtyp)) in
                                           (env3, lb1)) env1) in
-                              (match uu____24755 with
+                              (match uu___4 with
                                | (env2, lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -9242,16 +9024,16 @@ and (check_inner_let_rec :
                                           (fun lb ->
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname)) in
-                                   let uu____24807 = tc_term env2 e21 in
-                                   (match uu____24807 with
+                                   let uu___5 = tc_term env2 e21 in
+                                   (match uu___5 with
                                     | (e22, cres, g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
                                             (fun lb ->
-                                               fun cres1 ->
+                                               fun cres2 ->
                                                  maybe_intro_smt_lemma env2
                                                    lb.FStar_Syntax_Syntax.lbtyp
-                                                   cres1) lbs4 cres in
+                                                   cres2) lbs4 cres in
                                         let cres2 =
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env2 e22 cres1 in
@@ -9260,15 +9042,15 @@ and (check_inner_let_rec :
                                             cres2
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE] in
                                         let guard =
-                                          let uu____24831 =
-                                            let uu____24832 =
+                                          let uu___6 =
+                                            let uu___7 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____24832 g2 in
+                                              env2 uu___7 g2 in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____24831 in
+                                            g_lbs uu___6 in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_wp_lcomp
                                             env2 bvs cres3 in
@@ -9276,35 +9058,35 @@ and (check_inner_let_rec :
                                           norm env2
                                             cres4.FStar_TypeChecker_Common.res_typ in
                                         let cres5 =
-                                          let uu___3412_24842 = cres4 in
+                                          let uu___6 = cres4 in
                                           {
                                             FStar_TypeChecker_Common.eff_name
                                               =
-                                              (uu___3412_24842.FStar_TypeChecker_Common.eff_name);
+                                              (uu___6.FStar_TypeChecker_Common.eff_name);
                                             FStar_TypeChecker_Common.res_typ
                                               = tres;
                                             FStar_TypeChecker_Common.cflags =
-                                              (uu___3412_24842.FStar_TypeChecker_Common.cflags);
+                                              (uu___6.FStar_TypeChecker_Common.cflags);
                                             FStar_TypeChecker_Common.comp_thunk
                                               =
-                                              (uu___3412_24842.FStar_TypeChecker_Common.comp_thunk)
+                                              (uu___6.FStar_TypeChecker_Common.comp_thunk)
                                           } in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb ->
-                                                    let uu____24850 =
+                                                    let uu___6 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____24850)) in
+                                                      uu___6)) in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard in
-                                        let uu____24851 =
+                                        let uu___6 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22 in
-                                        (match uu____24851 with
+                                        (match uu___6 with
                                          | (lbs5, e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
@@ -9313,38 +9095,36 @@ and (check_inner_let_rec :
                                                  top.FStar_Syntax_Syntax.pos in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____24889 ->
+                                                  uu___7 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None
                                                   ->
-                                                  let uu____24890 =
+                                                  let uu___7 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres in
-                                                  (match uu____24890 with
+                                                  (match uu___7 with
                                                    | (tres1, g_ex) ->
                                                        let cres6 =
-                                                         let uu___3428_24904
-                                                           = cres5 in
+                                                         let uu___8 = cres5 in
                                                          {
                                                            FStar_TypeChecker_Common.eff_name
                                                              =
-                                                             (uu___3428_24904.FStar_TypeChecker_Common.eff_name);
+                                                             (uu___8.FStar_TypeChecker_Common.eff_name);
                                                            FStar_TypeChecker_Common.res_typ
                                                              = tres1;
                                                            FStar_TypeChecker_Common.cflags
                                                              =
-                                                             (uu___3428_24904.FStar_TypeChecker_Common.cflags);
+                                                             (uu___8.FStar_TypeChecker_Common.cflags);
                                                            FStar_TypeChecker_Common.comp_thunk
                                                              =
-                                                             (uu___3428_24904.FStar_TypeChecker_Common.comp_thunk)
+                                                             (uu___8.FStar_TypeChecker_Common.comp_thunk)
                                                          } in
-                                                       let uu____24905 =
+                                                       let uu___8 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1 in
-                                                       (e, cres6,
-                                                         uu____24905))))))))))
-      | uu____24906 -> failwith "Impossible"
+                                                       (e, cres6, uu___8))))))))))
+      | uu___ -> failwith "Impossible"
 and (build_let_rec_env :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -9357,70 +9137,70 @@ and (build_let_rec_env :
       fun lbs ->
         let env0 = env in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____24955 = FStar_Options.ml_ish () in
-          if uu____24955
+          let uu___ = FStar_Options.ml_ish () in
+          if uu___
           then FStar_Pervasives_Native.None
           else
             (let lbtyp0 = lbtyp in
-             let uu____24968 = FStar_Syntax_Util.abs_formals lbdef in
-             match uu____24968 with
+             let uu___2 = FStar_Syntax_Util.abs_formals lbdef in
+             match uu___2 with
              | (actuals, body, body_lc) ->
                  let actuals1 =
-                   let uu____24991 =
+                   let uu___3 =
                      FStar_TypeChecker_Env.set_expected_typ env lbtyp in
-                   FStar_TypeChecker_Util.maybe_add_implicit_binders
-                     uu____24991 actuals in
+                   FStar_TypeChecker_Util.maybe_add_implicit_binders uu___3
+                     actuals in
                  let nactuals = FStar_List.length actuals1 in
-                 let uu____24999 =
+                 let uu___3 =
                    FStar_TypeChecker_Normalize.get_n_binders env nactuals
                      lbtyp in
-                 (match uu____24999 with
+                 (match uu___3 with
                   | (formals, c) ->
                       (if
                          (FStar_List.isEmpty formals) ||
                            (FStar_List.isEmpty actuals1)
                        then
-                         (let uu____25025 =
-                            let uu____25030 =
-                              let uu____25031 =
+                         (let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
                                 FStar_Syntax_Print.term_to_string lbdef in
-                              let uu____25032 =
+                              let uu___8 =
                                 FStar_Syntax_Print.term_to_string lbtyp in
                               FStar_Util.format2
                                 "Only function literals with arrow types can be defined recursively; got %s : %s"
-                                uu____25031 uu____25032 in
+                                uu___7 uu___8 in
                             (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                              uu____25030) in
-                          FStar_Errors.raise_error uu____25025
+                              uu___6) in
+                          FStar_Errors.raise_error uu___5
                             lbtyp.FStar_Syntax_Syntax.pos)
                        else ();
                        (let nformals = FStar_List.length formals in
-                        let uu____25035 =
-                          let uu____25036 =
+                        let uu___5 =
+                          let uu___6 =
                             FStar_All.pipe_right
                               (FStar_Syntax_Util.comp_effect_name c)
                               (FStar_TypeChecker_Env.lookup_effect_quals env) in
-                          FStar_All.pipe_right uu____25036
+                          FStar_All.pipe_right uu___6
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect) in
-                        if uu____25035
+                        if uu___5
                         then
-                          let uu____25049 =
-                            let uu____25054 =
+                          let uu___6 =
+                            let uu___7 =
                               FStar_Syntax_Util.abs actuals1 body body_lc in
-                            (nformals, uu____25054) in
-                          FStar_Pervasives_Native.Some uu____25049
+                            (nformals, uu___7) in
+                          FStar_Pervasives_Native.Some uu___6
                         else FStar_Pervasives_Native.None)))) in
-        let uu____25064 =
+        let uu___ =
           FStar_List.fold_left
-            (fun uu____25098 ->
+            (fun uu___1 ->
                fun lb ->
-                 match uu____25098 with
+                 match uu___1 with
                  | (lbs1, env1, g_acc) ->
-                     let uu____25123 =
+                     let uu___2 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb in
-                     (match uu____25123 with
+                     (match uu___2 with
                       | (univ_vars, t, check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -9428,302 +9208,301 @@ and (build_let_rec_env :
                           let e =
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef in
-                          let uu____25143 =
+                          let uu___3 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
                               (let env01 =
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars in
-                               let uu____25160 =
-                                 let uu____25167 =
-                                   let uu____25168 =
-                                     FStar_Syntax_Util.type_u () in
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 = FStar_Syntax_Util.type_u () in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____25168 in
+                                     FStar_Pervasives_Native.fst uu___7 in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3468_25179 = env01 in
+                                   (let uu___7 = env01 in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.solver);
+                                        (uu___7.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.range);
+                                        (uu___7.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.curmodule);
+                                        (uu___7.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.gamma);
+                                        (uu___7.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___7.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___7.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.modules);
+                                        (uu___7.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___7.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.sigtab);
+                                        (uu___7.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.attrtab);
+                                        (uu___7.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___7.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.effects);
+                                        (uu___7.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.generalize);
+                                        (uu___7.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.letrecs);
+                                        (uu___7.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.top_level);
+                                        (uu___7.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.use_eq);
+                                        (uu___7.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___7.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.is_iface);
+                                        (uu___7.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.admit);
+                                        (uu___7.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.lax);
+                                        (uu___7.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___7.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.phase1);
+                                        (uu___7.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.failhard);
+                                        (uu___7.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.nosynth);
+                                        (uu___7.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.tc_term);
+                                        (uu___7.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.type_of);
+                                        (uu___7.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.universe_of);
+                                        (uu___7.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___7.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___7.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___7.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___7.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___7.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___7.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___7.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___7.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.splice);
+                                        (uu___7.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___7.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.postprocess);
+                                        (uu___7.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___7.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___7.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.dsenv);
+                                        (uu___7.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.nbe);
+                                        (uu___7.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___7.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.erasable_types_tab);
+                                        (uu___7.FStar_TypeChecker_Env.erasable_types_tab);
                                       FStar_TypeChecker_Env.enable_defer_to_tac
                                         =
-                                        (uu___3468_25179.FStar_TypeChecker_Env.enable_defer_to_tac)
-                                    }) t uu____25167 "" in
-                               match uu____25160 with
-                               | (t1, uu____25187, g) ->
-                                   let uu____25189 =
-                                     let uu____25190 =
-                                       let uu____25191 =
+                                        (uu___7.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    }) t uu___6 "" in
+                               match uu___5 with
+                               | (t1, uu___6, g) ->
+                                   let uu___7 =
+                                     let uu___8 =
+                                       let uu___9 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2) in
-                                       FStar_All.pipe_right uu____25191
+                                       FStar_All.pipe_right uu___9
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2) in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____25190 in
-                                   let uu____25192 = norm env01 t1 in
-                                   (uu____25189, uu____25192)) in
-                          (match uu____25143 with
+                                       uu___8 in
+                                   let uu___8 = norm env01 t1 in
+                                   (uu___7, uu___8)) in
+                          (match uu___3 with
                            | (g, t1) ->
-                               let uu____25211 =
-                                 let uu____25216 =
+                               let uu___4 =
+                                 let uu___5 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1 in
-                                 match uu____25216 with
+                                 match uu___5 with
                                  | FStar_Pervasives_Native.Some (arity, def)
                                      ->
                                      let lb1 =
-                                       let uu___3481_25234 = lb in
+                                       let uu___6 = lb in
                                        {
                                          FStar_Syntax_Syntax.lbname =
-                                           (uu___3481_25234.FStar_Syntax_Syntax.lbname);
+                                           (uu___6.FStar_Syntax_Syntax.lbname);
                                          FStar_Syntax_Syntax.lbunivs =
                                            univ_vars;
                                          FStar_Syntax_Syntax.lbtyp = t1;
                                          FStar_Syntax_Syntax.lbeff =
-                                           (uu___3481_25234.FStar_Syntax_Syntax.lbeff);
+                                           (uu___6.FStar_Syntax_Syntax.lbeff);
                                          FStar_Syntax_Syntax.lbdef = def;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           (uu___3481_25234.FStar_Syntax_Syntax.lbattrs);
+                                           (uu___6.FStar_Syntax_Syntax.lbattrs);
                                          FStar_Syntax_Syntax.lbpos =
-                                           (uu___3481_25234.FStar_Syntax_Syntax.lbpos)
+                                           (uu___6.FStar_Syntax_Syntax.lbpos)
                                        } in
                                      let env3 =
-                                       let uu___3484_25236 = env2 in
+                                       let uu___6 = env2 in
                                        {
                                          FStar_TypeChecker_Env.solver =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.solver);
+                                           (uu___6.FStar_TypeChecker_Env.solver);
                                          FStar_TypeChecker_Env.range =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.range);
+                                           (uu___6.FStar_TypeChecker_Env.range);
                                          FStar_TypeChecker_Env.curmodule =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.curmodule);
+                                           (uu___6.FStar_TypeChecker_Env.curmodule);
                                          FStar_TypeChecker_Env.gamma =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.gamma);
+                                           (uu___6.FStar_TypeChecker_Env.gamma);
                                          FStar_TypeChecker_Env.gamma_sig =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.gamma_sig);
+                                           (uu___6.FStar_TypeChecker_Env.gamma_sig);
                                          FStar_TypeChecker_Env.gamma_cache =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.gamma_cache);
+                                           (uu___6.FStar_TypeChecker_Env.gamma_cache);
                                          FStar_TypeChecker_Env.modules =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.modules);
+                                           (uu___6.FStar_TypeChecker_Env.modules);
                                          FStar_TypeChecker_Env.expected_typ =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.expected_typ);
+                                           (uu___6.FStar_TypeChecker_Env.expected_typ);
                                          FStar_TypeChecker_Env.sigtab =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.sigtab);
+                                           (uu___6.FStar_TypeChecker_Env.sigtab);
                                          FStar_TypeChecker_Env.attrtab =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.attrtab);
+                                           (uu___6.FStar_TypeChecker_Env.attrtab);
                                          FStar_TypeChecker_Env.instantiate_imp
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.instantiate_imp);
+                                           (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                                          FStar_TypeChecker_Env.effects =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.effects);
+                                           (uu___6.FStar_TypeChecker_Env.effects);
                                          FStar_TypeChecker_Env.generalize =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.generalize);
+                                           (uu___6.FStar_TypeChecker_Env.generalize);
                                          FStar_TypeChecker_Env.letrecs =
                                            (((lb1.FStar_Syntax_Syntax.lbname),
                                               arity, t1, univ_vars) ::
                                            (env2.FStar_TypeChecker_Env.letrecs));
                                          FStar_TypeChecker_Env.top_level =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.top_level);
+                                           (uu___6.FStar_TypeChecker_Env.top_level);
                                          FStar_TypeChecker_Env.check_uvars =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.check_uvars);
+                                           (uu___6.FStar_TypeChecker_Env.check_uvars);
                                          FStar_TypeChecker_Env.use_eq =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.use_eq);
+                                           (uu___6.FStar_TypeChecker_Env.use_eq);
                                          FStar_TypeChecker_Env.use_eq_strict
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.use_eq_strict);
+                                           (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                                          FStar_TypeChecker_Env.is_iface =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.is_iface);
+                                           (uu___6.FStar_TypeChecker_Env.is_iface);
                                          FStar_TypeChecker_Env.admit =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.admit);
+                                           (uu___6.FStar_TypeChecker_Env.admit);
                                          FStar_TypeChecker_Env.lax =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.lax);
+                                           (uu___6.FStar_TypeChecker_Env.lax);
                                          FStar_TypeChecker_Env.lax_universes
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.lax_universes);
+                                           (uu___6.FStar_TypeChecker_Env.lax_universes);
                                          FStar_TypeChecker_Env.phase1 =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.phase1);
+                                           (uu___6.FStar_TypeChecker_Env.phase1);
                                          FStar_TypeChecker_Env.failhard =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.failhard);
+                                           (uu___6.FStar_TypeChecker_Env.failhard);
                                          FStar_TypeChecker_Env.nosynth =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.nosynth);
+                                           (uu___6.FStar_TypeChecker_Env.nosynth);
                                          FStar_TypeChecker_Env.uvar_subtyping
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.uvar_subtyping);
+                                           (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                                          FStar_TypeChecker_Env.tc_term =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.tc_term);
+                                           (uu___6.FStar_TypeChecker_Env.tc_term);
                                          FStar_TypeChecker_Env.type_of =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.type_of);
+                                           (uu___6.FStar_TypeChecker_Env.type_of);
                                          FStar_TypeChecker_Env.universe_of =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.universe_of);
+                                           (uu___6.FStar_TypeChecker_Env.universe_of);
                                          FStar_TypeChecker_Env.check_type_of
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.check_type_of);
+                                           (uu___6.FStar_TypeChecker_Env.check_type_of);
                                          FStar_TypeChecker_Env.use_bv_sorts =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.use_bv_sorts);
+                                           (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                                          FStar_TypeChecker_Env.qtbl_name_and_index
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                           (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                                          FStar_TypeChecker_Env.normalized_eff_names
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.normalized_eff_names);
+                                           (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                                          FStar_TypeChecker_Env.fv_delta_depths
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.fv_delta_depths);
+                                           (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                                          FStar_TypeChecker_Env.proof_ns =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.proof_ns);
+                                           (uu___6.FStar_TypeChecker_Env.proof_ns);
                                          FStar_TypeChecker_Env.synth_hook =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.synth_hook);
+                                           (uu___6.FStar_TypeChecker_Env.synth_hook);
                                          FStar_TypeChecker_Env.try_solve_implicits_hook
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                           (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                          FStar_TypeChecker_Env.splice =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.splice);
+                                           (uu___6.FStar_TypeChecker_Env.splice);
                                          FStar_TypeChecker_Env.mpreprocess =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.mpreprocess);
+                                           (uu___6.FStar_TypeChecker_Env.mpreprocess);
                                          FStar_TypeChecker_Env.postprocess =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.postprocess);
+                                           (uu___6.FStar_TypeChecker_Env.postprocess);
                                          FStar_TypeChecker_Env.identifier_info
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.identifier_info);
+                                           (uu___6.FStar_TypeChecker_Env.identifier_info);
                                          FStar_TypeChecker_Env.tc_hooks =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.tc_hooks);
+                                           (uu___6.FStar_TypeChecker_Env.tc_hooks);
                                          FStar_TypeChecker_Env.dsenv =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.dsenv);
+                                           (uu___6.FStar_TypeChecker_Env.dsenv);
                                          FStar_TypeChecker_Env.nbe =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.nbe);
+                                           (uu___6.FStar_TypeChecker_Env.nbe);
                                          FStar_TypeChecker_Env.strict_args_tab
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.strict_args_tab);
+                                           (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                                          FStar_TypeChecker_Env.erasable_types_tab
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.erasable_types_tab);
+                                           (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                                          FStar_TypeChecker_Env.enable_defer_to_tac
                                            =
-                                           (uu___3484_25236.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                           (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                                        } in
                                      (lb1, env3)
                                  | FStar_Pervasives_Native.None ->
                                      let lb1 =
-                                       let uu___3488_25250 = lb in
+                                       let uu___6 = lb in
                                        {
                                          FStar_Syntax_Syntax.lbname =
-                                           (uu___3488_25250.FStar_Syntax_Syntax.lbname);
+                                           (uu___6.FStar_Syntax_Syntax.lbname);
                                          FStar_Syntax_Syntax.lbunivs =
                                            univ_vars;
                                          FStar_Syntax_Syntax.lbtyp = t1;
                                          FStar_Syntax_Syntax.lbeff =
-                                           (uu___3488_25250.FStar_Syntax_Syntax.lbeff);
+                                           (uu___6.FStar_Syntax_Syntax.lbeff);
                                          FStar_Syntax_Syntax.lbdef = e;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           (uu___3488_25250.FStar_Syntax_Syntax.lbattrs);
+                                           (uu___6.FStar_Syntax_Syntax.lbattrs);
                                          FStar_Syntax_Syntax.lbpos =
-                                           (uu___3488_25250.FStar_Syntax_Syntax.lbpos)
+                                           (uu___6.FStar_Syntax_Syntax.lbpos)
                                        } in
-                                     let uu____25251 =
+                                     let uu___6 =
                                        FStar_TypeChecker_Env.push_let_binding
                                          env2 lb1.FStar_Syntax_Syntax.lbname
                                          (univ_vars, t1) in
-                                     (lb1, uu____25251) in
-                               (match uu____25211 with
+                                     (lb1, uu___6) in
+                               (match uu___4 with
                                 | (lb1, env3) -> ((lb1 :: lbs1), env3, g)))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs in
-        match uu____25064 with
+        match uu___ with
         | (lbs1, env1, g) -> ((FStar_List.rev lbs1), env1, g)
 and (check_let_recs :
   FStar_TypeChecker_Env.env_t ->
@@ -9733,36 +9512,36 @@ and (check_let_recs :
   =
   fun env ->
     fun lbs ->
-      let uu____25291 =
-        let uu____25300 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb ->
-                  let uu____25326 =
+                  let uu___2 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef in
-                  match uu____25326 with
+                  match uu___2 with
                   | (bs, t, lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____25356 =
+                           let uu___3 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____25356
-                       | uu____25361 ->
+                             uu___3
+                       | uu___3 ->
                            let arity =
-                             let uu____25364 =
+                             let uu___5 =
                                FStar_TypeChecker_Env.get_letrec_arity env
                                  lb.FStar_Syntax_Syntax.lbname in
-                             match uu____25364 with
+                             match uu___5 with
                              | FStar_Pervasives_Native.Some n -> n
                              | FStar_Pervasives_Native.None ->
                                  FStar_List.length bs in
-                           let uu____25374 = FStar_List.splitAt arity bs in
-                           (match uu____25374 with
+                           let uu___5 = FStar_List.splitAt arity bs in
+                           (match uu___5 with
                             | (bs0, bs1) ->
                                 let def =
                                   if FStar_List.isEmpty bs1
@@ -9780,36 +9559,36 @@ and (check_let_recs :
                                             FStar_Pervasives_Native.None))
                                        inner1.FStar_Syntax_Syntax.pos) in
                                 let lb1 =
-                                  let uu___3520_25469 = lb in
+                                  let uu___6 = lb in
                                   {
                                     FStar_Syntax_Syntax.lbname =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbname);
+                                      (uu___6.FStar_Syntax_Syntax.lbname);
                                     FStar_Syntax_Syntax.lbunivs =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbunivs);
+                                      (uu___6.FStar_Syntax_Syntax.lbunivs);
                                     FStar_Syntax_Syntax.lbtyp =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbtyp);
+                                      (uu___6.FStar_Syntax_Syntax.lbtyp);
                                     FStar_Syntax_Syntax.lbeff =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbeff);
+                                      (uu___6.FStar_Syntax_Syntax.lbeff);
                                     FStar_Syntax_Syntax.lbdef = def;
                                     FStar_Syntax_Syntax.lbattrs =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbattrs);
+                                      (uu___6.FStar_Syntax_Syntax.lbattrs);
                                     FStar_Syntax_Syntax.lbpos =
-                                      (uu___3520_25469.FStar_Syntax_Syntax.lbpos)
+                                      (uu___6.FStar_Syntax_Syntax.lbpos)
                                   } in
-                                let uu____25470 =
-                                  let uu____25477 =
+                                let uu___6 =
+                                  let uu___7 =
                                     FStar_TypeChecker_Env.set_expected_typ
                                       env lb1.FStar_Syntax_Syntax.lbtyp in
-                                  tc_tot_or_gtot_term uu____25477
+                                  tc_tot_or_gtot_term uu___7
                                     lb1.FStar_Syntax_Syntax.lbdef in
-                                (match uu____25470 with
+                                (match uu___6 with
                                  | (e, c, g) ->
-                                     ((let uu____25486 =
-                                         let uu____25487 =
+                                     ((let uu___8 =
+                                         let uu___9 =
                                            FStar_TypeChecker_Common.is_total_lcomp
                                              c in
-                                         Prims.op_Negation uu____25487 in
-                                       if uu____25486
+                                         Prims.op_Negation uu___9 in
+                                       if uu___8
                                        then
                                          FStar_Errors.raise_error
                                            (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -9825,8 +9604,8 @@ and (check_let_recs :
                                            e lb1.FStar_Syntax_Syntax.lbattrs
                                            lb1.FStar_Syntax_Syntax.lbpos in
                                        (lb2, g)))))))) in
-        FStar_All.pipe_right uu____25300 FStar_List.unzip in
-      match uu____25291 with
+        FStar_All.pipe_right uu___1 FStar_List.unzip in
+      match uu___ with
       | (lbs1, gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -9843,12 +9622,12 @@ and (check_let_bound_def :
   fun top_level ->
     fun env ->
       fun lb ->
-        let uu____25536 = FStar_TypeChecker_Env.clear_expected_typ env in
-        match uu____25536 with
-        | (env1, uu____25554) ->
+        let uu___ = FStar_TypeChecker_Env.clear_expected_typ env in
+        match uu___ with
+        | (env1, uu___1) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef in
-            let uu____25562 = check_lbtyp top_level env lb in
-            (match uu____25562 with
+            let uu___2 = check_lbtyp top_level env lb in
+            (match uu___2 with
              | (topt, wf_annot, univ_vars, univ_opening, env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars <> [])
                   then
@@ -9858,137 +9637,137 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1 in
-                   let uu____25606 =
+                   let uu___5 =
                      tc_maybe_toplevel_term
-                       (let uu___3551_25615 = env11 in
+                       (let uu___6 = env11 in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3551_25615.FStar_TypeChecker_Env.solver);
+                            (uu___6.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3551_25615.FStar_TypeChecker_Env.range);
+                            (uu___6.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3551_25615.FStar_TypeChecker_Env.curmodule);
+                            (uu___6.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3551_25615.FStar_TypeChecker_Env.gamma);
+                            (uu___6.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3551_25615.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___6.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3551_25615.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___6.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3551_25615.FStar_TypeChecker_Env.modules);
+                            (uu___6.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3551_25615.FStar_TypeChecker_Env.expected_typ);
+                            (uu___6.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3551_25615.FStar_TypeChecker_Env.sigtab);
+                            (uu___6.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3551_25615.FStar_TypeChecker_Env.attrtab);
+                            (uu___6.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3551_25615.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___6.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3551_25615.FStar_TypeChecker_Env.effects);
+                            (uu___6.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3551_25615.FStar_TypeChecker_Env.generalize);
+                            (uu___6.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3551_25615.FStar_TypeChecker_Env.letrecs);
+                            (uu___6.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3551_25615.FStar_TypeChecker_Env.check_uvars);
+                            (uu___6.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3551_25615.FStar_TypeChecker_Env.use_eq);
+                            (uu___6.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___3551_25615.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3551_25615.FStar_TypeChecker_Env.is_iface);
+                            (uu___6.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3551_25615.FStar_TypeChecker_Env.admit);
+                            (uu___6.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3551_25615.FStar_TypeChecker_Env.lax);
+                            (uu___6.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3551_25615.FStar_TypeChecker_Env.lax_universes);
+                            (uu___6.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3551_25615.FStar_TypeChecker_Env.phase1);
+                            (uu___6.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3551_25615.FStar_TypeChecker_Env.failhard);
+                            (uu___6.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3551_25615.FStar_TypeChecker_Env.nosynth);
+                            (uu___6.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3551_25615.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3551_25615.FStar_TypeChecker_Env.tc_term);
+                            (uu___6.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3551_25615.FStar_TypeChecker_Env.type_of);
+                            (uu___6.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3551_25615.FStar_TypeChecker_Env.universe_of);
+                            (uu___6.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3551_25615.FStar_TypeChecker_Env.check_type_of);
+                            (uu___6.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3551_25615.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3551_25615.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___6.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3551_25615.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___6.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3551_25615.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___6.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3551_25615.FStar_TypeChecker_Env.proof_ns);
+                            (uu___6.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3551_25615.FStar_TypeChecker_Env.synth_hook);
+                            (uu___6.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___3551_25615.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___6.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3551_25615.FStar_TypeChecker_Env.splice);
+                            (uu___6.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___3551_25615.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___6.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3551_25615.FStar_TypeChecker_Env.postprocess);
+                            (uu___6.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3551_25615.FStar_TypeChecker_Env.identifier_info);
+                            (uu___6.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3551_25615.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___6.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3551_25615.FStar_TypeChecker_Env.dsenv);
+                            (uu___6.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3551_25615.FStar_TypeChecker_Env.nbe);
+                            (uu___6.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3551_25615.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___6.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___3551_25615.FStar_TypeChecker_Env.erasable_types_tab);
+                            (uu___6.FStar_TypeChecker_Env.erasable_types_tab);
                           FStar_TypeChecker_Env.enable_defer_to_tac =
-                            (uu___3551_25615.FStar_TypeChecker_Env.enable_defer_to_tac)
+                            (uu___6.FStar_TypeChecker_Env.enable_defer_to_tac)
                         }) e11 in
-                   match uu____25606 with
+                   match uu___5 with
                    | (e12, c1, g1) ->
-                       let uu____25629 =
-                         let uu____25634 =
+                       let uu___6 =
+                         let uu___7 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____25639 ->
+                              (fun uu___8 ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____25634 e12 c1 wf_annot in
-                       (match uu____25629 with
+                           uu___7 e12 c1 wf_annot in
+                       (match uu___6 with
                         | (c11, guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f in
-                            ((let uu____25654 =
+                            ((let uu___8 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme in
-                              if uu____25654
+                              if uu___8
                               then
-                                let uu____25655 =
+                                let uu___9 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname in
-                                let uu____25656 =
+                                let uu___10 =
                                   FStar_TypeChecker_Common.lcomp_to_string
                                     c11 in
-                                let uu____25657 =
+                                let uu___11 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11 in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____25655 uu____25656 uu____25657
+                                  uu___9 uu___10 uu___11
                               else ());
                              (e12, univ_vars, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -10007,21 +9786,21 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown ->
-            let uu____25691 =
+            let uu___ =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs in
-            (match uu____25691 with
+            (match uu___ with
              | (univ_opening, univ_vars) ->
-                 let uu____25724 =
+                 let uu___1 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                   univ_opening, uu____25724))
-        | uu____25729 ->
-            let uu____25730 =
+                   univ_opening, uu___1))
+        | uu___ ->
+            let uu___1 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs in
-            (match uu____25730 with
+            (match uu___1 with
              | (univ_opening, univ_vars) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t in
                  let env1 =
@@ -10030,41 +9809,40 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____25779 =
+                   let uu___2 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1 in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                     univ_opening, uu____25779)
+                     univ_opening, uu___2)
                  else
-                   (let uu____25785 = FStar_Syntax_Util.type_u () in
-                    match uu____25785 with
-                    | (k, uu____25805) ->
-                        let uu____25806 =
-                          tc_check_tot_or_gtot_term env1 t1 k "" in
-                        (match uu____25806 with
-                         | (t2, uu____25828, g) ->
-                             ((let uu____25831 =
+                   (let uu___3 = FStar_Syntax_Util.type_u () in
+                    match uu___3 with
+                    | (k, uu___4) ->
+                        let uu___5 = tc_check_tot_or_gtot_term env1 t1 k "" in
+                        (match uu___5 with
+                         | (t2, uu___6, g) ->
+                             ((let uu___8 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium in
-                               if uu____25831
+                               if uu___8
                                then
-                                 let uu____25832 =
-                                   let uu____25833 =
+                                 let uu___9 =
+                                   let uu___10 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname in
-                                   FStar_Range.string_of_range uu____25833 in
-                                 let uu____25834 =
+                                   FStar_Range.string_of_range uu___10 in
+                                 let uu___10 =
                                    FStar_Syntax_Print.term_to_string t2 in
                                  FStar_Util.print2
-                                   "(%s) Checked type annotation %s\n"
-                                   uu____25832 uu____25834
+                                   "(%s) Checked type annotation %s\n" uu___9
+                                   uu___10
                                else ());
                               (let t3 = norm env1 t2 in
-                               let uu____25837 =
+                               let uu___8 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3 in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars, univ_opening, uu____25837))))))
+                                 univ_vars, univ_opening, uu___8))))))
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -10074,86 +9852,85 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env ->
-    fun uu____25843 ->
-      match uu____25843 with
+    fun uu___ ->
+      match uu___ with
       | (x, imp) ->
-          let uu____25870 = FStar_Syntax_Util.type_u () in
-          (match uu____25870 with
+          let uu___1 = FStar_Syntax_Util.type_u () in
+          (match uu___1 with
            | (tu, u) ->
-               ((let uu____25892 =
+               ((let uu___3 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-                 if uu____25892
+                 if uu___3
                  then
-                   let uu____25893 = FStar_Syntax_Print.bv_to_string x in
-                   let uu____25894 =
+                   let uu___4 = FStar_Syntax_Print.bv_to_string x in
+                   let uu___5 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort in
-                   let uu____25895 = FStar_Syntax_Print.term_to_string tu in
+                   let uu___6 = FStar_Syntax_Print.term_to_string tu in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____25893 uu____25894 uu____25895
+                     uu___4 uu___5 uu___6
                  else ());
-                (let uu____25897 =
+                (let uu___3 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu "" in
-                 match uu____25897 with
-                 | (t, uu____25919, g) ->
-                     let uu____25921 =
+                 match uu___3 with
+                 | (t, uu___4, g) ->
+                     let uu___5 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau_or_attr) ->
                            (match tau_or_attr with
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_tac tau
                                 ->
-                                let uu____25944 =
+                                let uu___6 =
                                   tc_tactic FStar_Syntax_Syntax.t_unit
                                     FStar_Syntax_Syntax.t_unit env tau in
-                                (match uu____25944 with
-                                 | (tau1, uu____25958, g1) ->
+                                (match uu___6 with
+                                 | (tau1, uu___7, g1) ->
                                      ((FStar_Pervasives_Native.Some
                                          (FStar_Syntax_Syntax.Meta
                                             (FStar_Syntax_Syntax.Arg_qualifier_meta_tac
                                                tau1))), g1))
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                 attr ->
-                                let uu____25965 =
+                                let uu___6 =
                                   tc_check_tot_or_gtot_term env attr
                                     FStar_Syntax_Syntax.t_unit "" in
-                                (match uu____25965 with
-                                 | (attr1, uu____25979, g1) ->
+                                (match uu___6 with
+                                 | (attr1, uu___7, g1) ->
                                      ((FStar_Pervasives_Native.Some
                                          (FStar_Syntax_Syntax.Meta
                                             (FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                                attr1))),
                                        FStar_TypeChecker_Env.trivial_guard)))
-                       | uu____25983 ->
-                           (imp, FStar_TypeChecker_Env.trivial_guard) in
-                     (match uu____25921 with
+                       | uu___6 -> (imp, FStar_TypeChecker_Env.trivial_guard) in
+                     (match uu___5 with
                       | (imp1, g') ->
                           let x1 =
-                            ((let uu___3621_26018 = x in
+                            ((let uu___6 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3621_26018.FStar_Syntax_Syntax.ppname);
+                                  (uu___6.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3621_26018.FStar_Syntax_Syntax.index);
+                                  (uu___6.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1) in
-                          ((let uu____26020 =
+                          ((let uu___7 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High in
-                            if uu____26020
+                            if uu___7
                             then
-                              let uu____26021 =
+                              let uu___8 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1) in
-                              let uu____26024 =
+                              let uu___9 =
                                 FStar_Syntax_Print.term_to_string t in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____26021
-                                uu____26024
+                                "Pushing binder %s at type %s\n" uu___8
+                                uu___9
                             else ());
-                           (let uu____26026 = push_binding env x1 in
-                            (x1, uu____26026, g, u)))))))
+                           (let uu___7 = push_binding env x1 in
+                            (x1, uu___7, g, u)))))))
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -10162,29 +9939,28 @@ and (tc_binders :
   =
   fun env ->
     fun bs ->
-      (let uu____26038 =
-         FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-       if uu____26038
+      (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
+       if uu___1
        then
-         let uu____26039 = FStar_Syntax_Print.binders_to_string ", " bs in
-         FStar_Util.print1 "Checking binders %s\n" uu____26039
+         let uu___2 = FStar_Syntax_Print.binders_to_string ", " bs in
+         FStar_Util.print1 "Checking binders %s\n" uu___2
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____26148 = tc_binder env1 b in
-             (match uu____26148 with
+             let uu___1 = tc_binder env1 b in
+             (match uu___1 with
               | (b1, env', g, u) ->
-                  let uu____26197 = aux env' bs2 in
-                  (match uu____26197 with
+                  let uu___2 = aux env' bs2 in
+                  (match uu___2 with
                    | (bs3, env'1, g', us) ->
-                       let uu____26258 =
-                         let uu____26259 =
+                       let uu___3 =
+                         let uu___4 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g' in
-                         FStar_TypeChecker_Env.conj_guard g uu____26259 in
-                       ((b1 :: bs3), env'1, uu____26258, (u :: us)))) in
+                         FStar_TypeChecker_Env.conj_guard g uu___4 in
+                       ((b1 :: bs3), env'1, uu___3, (u :: us)))) in
        aux env bs)
 and (tc_smt_pats :
   FStar_TypeChecker_Env.env ->
@@ -10199,28 +9975,27 @@ and (tc_smt_pats :
     fun pats ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____26367 ->
-             fun uu____26368 ->
-               match (uu____26367, uu____26368) with
+          (fun uu___ ->
+             fun uu___1 ->
+               match (uu___, uu___1) with
                | ((t, imp), (args1, g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____26460 = tc_term en1 t in
-                     match uu____26460 with
-                     | (t1, uu____26480, g') ->
-                         let uu____26482 =
-                           FStar_TypeChecker_Env.conj_guard g g' in
-                         (((t1, imp) :: args1), uu____26482)))) args
+                    (let uu___3 = tc_term en1 t in
+                     match uu___3 with
+                     | (t1, uu___4, g') ->
+                         let uu___5 = FStar_TypeChecker_Env.conj_guard g g' in
+                         (((t1, imp) :: args1), uu___5)))) args
           ([], FStar_TypeChecker_Env.trivial_guard) in
       FStar_List.fold_right
         (fun p ->
-           fun uu____26536 ->
-             match uu____26536 with
+           fun uu___ ->
+             match uu___ with
              | (pats1, g) ->
-                 let uu____26563 = tc_args en p in
-                 (match uu____26563 with
+                 let uu___1 = tc_args en p in
+                 (match uu___1 with
                   | (args, g') ->
-                      let uu____26576 = FStar_TypeChecker_Env.conj_guard g g' in
-                      ((args :: pats1), uu____26576))) pats
+                      let uu___2 = FStar_TypeChecker_Env.conj_guard g g' in
+                      ((args :: pats1), uu___2))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 and (tc_tot_or_gtot_term' :
   FStar_TypeChecker_Env.env ->
@@ -10232,62 +10007,61 @@ and (tc_tot_or_gtot_term' :
   fun env ->
     fun e ->
       fun msg ->
-        let uu____26590 = tc_maybe_toplevel_term env e in
-        match uu____26590 with
+        let uu___ = tc_maybe_toplevel_term env e in
+        match uu___ with
         | (e1, c, g) ->
-            let uu____26606 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c in
-            if uu____26606
+            let uu___1 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c in
+            if uu___1
             then (e1, c, g)
             else
               (let g1 =
                  FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-               let uu____26615 = FStar_TypeChecker_Common.lcomp_comp c in
-               match uu____26615 with
+               let uu___3 = FStar_TypeChecker_Common.lcomp_comp c in
+               match uu___3 with
                | (c1, g_c) ->
                    let c2 = norm_c env c1 in
-                   let uu____26629 =
-                     let uu____26634 =
+                   let uu___4 =
+                     let uu___5 =
                        FStar_TypeChecker_Util.is_pure_effect env
                          (FStar_Syntax_Util.comp_effect_name c2) in
-                     if uu____26634
+                     if uu___5
                      then
-                       let uu____26639 =
+                       let uu___6 =
                          FStar_Syntax_Syntax.mk_Total
                            (FStar_Syntax_Util.comp_result c2) in
-                       (uu____26639, false)
+                       (uu___6, false)
                      else
-                       (let uu____26641 =
+                       (let uu___7 =
                           FStar_Syntax_Syntax.mk_GTotal
                             (FStar_Syntax_Util.comp_result c2) in
-                        (uu____26641, true)) in
-                   (match uu____26629 with
+                        (uu___7, true)) in
+                   (match uu___4 with
                     | (target_comp, allow_ghost) ->
-                        let uu____26650 =
+                        let uu___5 =
                           FStar_TypeChecker_Rel.sub_comp env c2 target_comp in
-                        (match uu____26650 with
+                        (match uu___5 with
                          | FStar_Pervasives_Native.Some g' ->
-                             let uu____26660 =
+                             let uu___6 =
                                FStar_TypeChecker_Common.lcomp_of_comp
                                  target_comp in
-                             let uu____26661 =
-                               let uu____26662 =
+                             let uu___7 =
+                               let uu___8 =
                                  FStar_TypeChecker_Env.conj_guard g_c g' in
-                               FStar_TypeChecker_Env.conj_guard g1
-                                 uu____26662 in
-                             (e1, uu____26660, uu____26661)
-                         | uu____26663 ->
+                               FStar_TypeChecker_Env.conj_guard g1 uu___8 in
+                             (e1, uu___6, uu___7)
+                         | uu___6 ->
                              if allow_ghost
                              then
-                               let uu____26672 =
+                               let uu___7 =
                                  FStar_TypeChecker_Err.expected_ghost_expression
                                    e1 c2 msg in
-                               FStar_Errors.raise_error uu____26672
+                               FStar_Errors.raise_error uu___7
                                  e1.FStar_Syntax_Syntax.pos
                              else
-                               (let uu____26684 =
+                               (let uu___8 =
                                   FStar_TypeChecker_Err.expected_pure_expression
                                     e1 c2 msg in
-                                FStar_Errors.raise_error uu____26684
+                                FStar_Errors.raise_error uu___8
                                   e1.FStar_Syntax_Syntax.pos))))
 and (tc_tot_or_gtot_term :
   FStar_TypeChecker_Env.env ->
@@ -10316,8 +10090,8 @@ and (tc_trivial_guard :
   =
   fun env ->
     fun t ->
-      let uu____26710 = tc_tot_or_gtot_term env t in
-      match uu____26710 with
+      let uu___ = tc_tot_or_gtot_term env t in
+      match uu___ with
       | (t1, c, g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 let (tc_check_trivial_guard :
@@ -10328,9 +10102,9 @@ let (tc_check_trivial_guard :
   fun env ->
     fun t ->
       fun k ->
-        let uu____26740 = tc_check_tot_or_gtot_term env t k "" in
-        match uu____26740 with
-        | (t1, uu____26748, g) ->
+        let uu___ = tc_check_tot_or_gtot_term env t k "" in
+        match uu___ with
+        | (t1, uu___1, g) ->
             (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
 let (type_of_tot_term :
   FStar_TypeChecker_Env.env ->
@@ -10340,150 +10114,144 @@ let (type_of_tot_term :
   =
   fun env ->
     fun e ->
-      (let uu____26768 =
+      (let uu___1 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck") in
-       if uu____26768
+       if uu___1
        then
-         let uu____26769 = FStar_Syntax_Print.term_to_string e in
-         FStar_Util.print1 "Checking term %s\n" uu____26769
+         let uu___2 = FStar_Syntax_Print.term_to_string e in
+         FStar_Util.print1 "Checking term %s\n" uu___2
        else ());
       (let env1 =
-         let uu___3717_26772 = env in
+         let uu___1 = env in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3717_26772.FStar_TypeChecker_Env.solver);
-           FStar_TypeChecker_Env.range =
-             (uu___3717_26772.FStar_TypeChecker_Env.range);
+             (uu___1.FStar_TypeChecker_Env.solver);
+           FStar_TypeChecker_Env.range = (uu___1.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3717_26772.FStar_TypeChecker_Env.curmodule);
-           FStar_TypeChecker_Env.gamma =
-             (uu___3717_26772.FStar_TypeChecker_Env.gamma);
+             (uu___1.FStar_TypeChecker_Env.curmodule);
+           FStar_TypeChecker_Env.gamma = (uu___1.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3717_26772.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3717_26772.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3717_26772.FStar_TypeChecker_Env.modules);
+             (uu___1.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3717_26772.FStar_TypeChecker_Env.expected_typ);
+             (uu___1.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3717_26772.FStar_TypeChecker_Env.sigtab);
+             (uu___1.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3717_26772.FStar_TypeChecker_Env.attrtab);
+             (uu___1.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3717_26772.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3717_26772.FStar_TypeChecker_Env.effects);
+             (uu___1.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3717_26772.FStar_TypeChecker_Env.generalize);
+             (uu___1.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3717_26772.FStar_TypeChecker_Env.check_uvars);
+             (uu___1.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3717_26772.FStar_TypeChecker_Env.use_eq);
+             (uu___1.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___3717_26772.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3717_26772.FStar_TypeChecker_Env.is_iface);
-           FStar_TypeChecker_Env.admit =
-             (uu___3717_26772.FStar_TypeChecker_Env.admit);
-           FStar_TypeChecker_Env.lax =
-             (uu___3717_26772.FStar_TypeChecker_Env.lax);
+             (uu___1.FStar_TypeChecker_Env.is_iface);
+           FStar_TypeChecker_Env.admit = (uu___1.FStar_TypeChecker_Env.admit);
+           FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3717_26772.FStar_TypeChecker_Env.lax_universes);
+             (uu___1.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3717_26772.FStar_TypeChecker_Env.phase1);
+             (uu___1.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3717_26772.FStar_TypeChecker_Env.failhard);
+             (uu___1.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3717_26772.FStar_TypeChecker_Env.nosynth);
+             (uu___1.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3717_26772.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3717_26772.FStar_TypeChecker_Env.tc_term);
+             (uu___1.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3717_26772.FStar_TypeChecker_Env.type_of);
+             (uu___1.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3717_26772.FStar_TypeChecker_Env.universe_of);
+             (uu___1.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3717_26772.FStar_TypeChecker_Env.check_type_of);
+             (uu___1.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3717_26772.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3717_26772.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3717_26772.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3717_26772.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3717_26772.FStar_TypeChecker_Env.proof_ns);
+             (uu___1.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3717_26772.FStar_TypeChecker_Env.synth_hook);
+             (uu___1.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___3717_26772.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3717_26772.FStar_TypeChecker_Env.splice);
+             (uu___1.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___3717_26772.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3717_26772.FStar_TypeChecker_Env.postprocess);
+             (uu___1.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3717_26772.FStar_TypeChecker_Env.identifier_info);
+             (uu___1.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3717_26772.FStar_TypeChecker_Env.tc_hooks);
-           FStar_TypeChecker_Env.dsenv =
-             (uu___3717_26772.FStar_TypeChecker_Env.dsenv);
-           FStar_TypeChecker_Env.nbe =
-             (uu___3717_26772.FStar_TypeChecker_Env.nbe);
+             (uu___1.FStar_TypeChecker_Env.tc_hooks);
+           FStar_TypeChecker_Env.dsenv = (uu___1.FStar_TypeChecker_Env.dsenv);
+           FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3717_26772.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___3717_26772.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___3717_26772.FStar_TypeChecker_Env.enable_defer_to_tac)
+             (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
          } in
-       let uu____26781 =
+       let uu___1 =
          try
-           (fun uu___3721_26795 ->
-              match () with | () -> tc_tot_or_gtot_term env1 e) ()
+           (fun uu___2 -> match () with | () -> tc_tot_or_gtot_term env1 e)
+             ()
          with
-         | FStar_Errors.Error (e1, msg, uu____26816) ->
-             let uu____26817 = FStar_TypeChecker_Env.get_range env1 in
-             FStar_Errors.raise_error (e1, msg) uu____26817 in
-       match uu____26781 with
+         | FStar_Errors.Error (e1, msg, uu___3) ->
+             let uu___4 = FStar_TypeChecker_Env.get_range env1 in
+             FStar_Errors.raise_error (e1, msg) uu___4 in
+       match uu___1 with
        | (t, c, g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c in
-           let uu____26834 = FStar_TypeChecker_Common.is_total_lcomp c1 in
-           if uu____26834
+           let uu___2 = FStar_TypeChecker_Common.is_total_lcomp c1 in
+           if uu___2
            then (t, (c1.FStar_TypeChecker_Common.res_typ), g)
            else
-             (let uu____26842 =
-                let uu____26847 =
-                  let uu____26848 = FStar_Syntax_Print.term_to_string e in
+             (let uu___4 =
+                let uu___5 =
+                  let uu___6 = FStar_Syntax_Print.term_to_string e in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____26848 in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____26847) in
-              let uu____26849 = FStar_TypeChecker_Env.get_range env1 in
-              FStar_Errors.raise_error uu____26842 uu____26849))
+                    uu___6 in
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu___5) in
+              let uu___5 = FStar_TypeChecker_Env.get_range env1 in
+              FStar_Errors.raise_error uu___4 uu___5))
 let level_of_type_fail :
-  'uuuuuu26864 .
+  'uuuuu .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu26864
+      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuu
   =
   fun env ->
     fun e ->
       fun t ->
-        let uu____26880 =
-          let uu____26885 =
-            let uu____26886 = FStar_Syntax_Print.term_to_string e in
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.term_to_string e in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____26886 t in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____26885) in
-        let uu____26887 = FStar_TypeChecker_Env.get_range env in
-        FStar_Errors.raise_error uu____26880 uu____26887
+              uu___2 t in
+          (FStar_Errors.Fatal_UnexpectedTermType, uu___1) in
+        let uu___1 = FStar_TypeChecker_Env.get_range env in
+        FStar_Errors.raise_error uu___ uu___1
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -10493,12 +10261,12 @@ let (level_of_type :
     fun e ->
       fun t ->
         let rec aux retry t1 =
-          let uu____26918 =
-            let uu____26919 = FStar_Syntax_Util.unrefine t1 in
-            uu____26919.FStar_Syntax_Syntax.n in
-          match uu____26918 with
+          let uu___ =
+            let uu___1 = FStar_Syntax_Util.unrefine t1 in
+            uu___1.FStar_Syntax_Syntax.n in
+          match uu___ with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____26923 ->
+          | uu___1 ->
               if retry
               then
                 let t2 =
@@ -10507,113 +10275,112 @@ let (level_of_type :
                        FStar_Syntax_Syntax.delta_constant] env t1 in
                 aux false t2
               else
-                (let uu____26926 = FStar_Syntax_Util.type_u () in
-                 match uu____26926 with
+                (let uu___3 = FStar_Syntax_Util.type_u () in
+                 match uu___3 with
                  | (t_u, u) ->
                      let env1 =
-                       let uu___3753_26934 = env in
+                       let uu___4 = env in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3753_26934.FStar_TypeChecker_Env.solver);
+                           (uu___4.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3753_26934.FStar_TypeChecker_Env.range);
+                           (uu___4.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3753_26934.FStar_TypeChecker_Env.curmodule);
+                           (uu___4.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3753_26934.FStar_TypeChecker_Env.gamma);
+                           (uu___4.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3753_26934.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___4.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3753_26934.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___4.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3753_26934.FStar_TypeChecker_Env.modules);
+                           (uu___4.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3753_26934.FStar_TypeChecker_Env.expected_typ);
+                           (uu___4.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3753_26934.FStar_TypeChecker_Env.sigtab);
+                           (uu___4.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3753_26934.FStar_TypeChecker_Env.attrtab);
+                           (uu___4.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3753_26934.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3753_26934.FStar_TypeChecker_Env.effects);
+                           (uu___4.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3753_26934.FStar_TypeChecker_Env.generalize);
+                           (uu___4.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3753_26934.FStar_TypeChecker_Env.letrecs);
+                           (uu___4.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3753_26934.FStar_TypeChecker_Env.top_level);
+                           (uu___4.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3753_26934.FStar_TypeChecker_Env.check_uvars);
+                           (uu___4.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3753_26934.FStar_TypeChecker_Env.use_eq);
+                           (uu___4.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3753_26934.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3753_26934.FStar_TypeChecker_Env.is_iface);
+                           (uu___4.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3753_26934.FStar_TypeChecker_Env.admit);
+                           (uu___4.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3753_26934.FStar_TypeChecker_Env.lax_universes);
+                           (uu___4.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3753_26934.FStar_TypeChecker_Env.phase1);
+                           (uu___4.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3753_26934.FStar_TypeChecker_Env.failhard);
+                           (uu___4.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3753_26934.FStar_TypeChecker_Env.nosynth);
+                           (uu___4.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3753_26934.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3753_26934.FStar_TypeChecker_Env.tc_term);
+                           (uu___4.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3753_26934.FStar_TypeChecker_Env.type_of);
+                           (uu___4.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3753_26934.FStar_TypeChecker_Env.universe_of);
+                           (uu___4.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3753_26934.FStar_TypeChecker_Env.check_type_of);
+                           (uu___4.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3753_26934.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3753_26934.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3753_26934.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3753_26934.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3753_26934.FStar_TypeChecker_Env.proof_ns);
+                           (uu___4.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3753_26934.FStar_TypeChecker_Env.synth_hook);
+                           (uu___4.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3753_26934.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3753_26934.FStar_TypeChecker_Env.splice);
+                           (uu___4.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3753_26934.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___4.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3753_26934.FStar_TypeChecker_Env.postprocess);
+                           (uu___4.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3753_26934.FStar_TypeChecker_Env.identifier_info);
+                           (uu___4.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3753_26934.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___4.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3753_26934.FStar_TypeChecker_Env.dsenv);
+                           (uu___4.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3753_26934.FStar_TypeChecker_Env.nbe);
+                           (uu___4.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3753_26934.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3753_26934.FStar_TypeChecker_Env.erasable_types_tab);
+                           (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                           (uu___3753_26934.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                        } in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u in
                      ((match g.FStar_TypeChecker_Common.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____26938 =
-                             FStar_Syntax_Print.term_to_string t1 in
-                           level_of_type_fail env1 e uu____26938
-                       | uu____26939 ->
+                           let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                           level_of_type_fail env1 e uu___5
+                       | uu___5 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u)) in
         aux true t
@@ -10624,110 +10391,107 @@ let rec (universe_of_aux :
   =
   fun env ->
     fun e ->
-      let uu____26954 =
-        let uu____26955 = FStar_Syntax_Subst.compress e in
-        uu____26955.FStar_Syntax_Syntax.n in
-      match uu____26954 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____26958 -> failwith "Impossible"
+      let uu___ =
+        let uu___1 = FStar_Syntax_Subst.compress e in
+        uu___1.FStar_Syntax_Syntax.n in
+      match uu___ with
+      | FStar_Syntax_Syntax.Tm_bvar uu___1 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____26959 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____26974 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu___1 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs, t, uu____26990) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs, t, uu___1) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t, uu____27034) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t, uu___1) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____27041 =
+          let uu___1 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____27041 with | ((uu____27050, t), uu____27052) -> t)
+          (match uu___1 with | ((uu___2, t), uu___3) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____27058 = FStar_Syntax_Util.unfold_lazy i in
-          universe_of_aux env uu____27058
+          let uu___1 = FStar_Syntax_Util.unfold_lazy i in
+          universe_of_aux env uu___1
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27061, (FStar_Util.Inl t, uu____27063), uu____27064) -> t
+          (uu___1, (FStar_Util.Inl t, uu___2), uu___3) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27111, (FStar_Util.Inr c, uu____27113), uu____27114) ->
+          (uu___1, (FStar_Util.Inr c, uu___2), uu___3) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
             e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____27162 -> FStar_Syntax_Util.ktype0
+      | FStar_Syntax_Syntax.Tm_quoted uu___1 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____27171;
-             FStar_Syntax_Syntax.vars = uu____27172;_},
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.vars = uu___2;_},
            us)
           ->
-          let uu____27178 =
+          let uu___3 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____27178 with
-           | ((us', t), uu____27189) ->
+          (match uu___3 with
+           | ((us', t), uu___4) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____27195 = FStar_TypeChecker_Env.get_range env in
+                  (let uu___6 = FStar_TypeChecker_Env.get_range env in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       "Unexpected number of universe instantiations")
-                     uu____27195)
+                       "Unexpected number of universe instantiations") uu___6)
                 else ();
                 FStar_List.iter2
                   (fun ul ->
                      fun ur ->
                        match (ul, ur) with
-                       | (FStar_Syntax_Syntax.U_unif u'', uu____27205) ->
+                       | (FStar_Syntax_Syntax.U_unif u'', uu___7) ->
                            FStar_Syntax_Unionfind.univ_change u'' ur
                        | (FStar_Syntax_Syntax.U_name n1,
                           FStar_Syntax_Syntax.U_name n2) when
                            FStar_Ident.ident_equals n1 n2 -> ()
-                       | uu____27218 ->
-                           let uu____27223 =
-                             let uu____27228 =
-                               let uu____27229 =
+                       | uu___7 ->
+                           let uu___8 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Print.fv_to_string fv in
-                               let uu____27230 =
+                               let uu___11 =
                                  FStar_Syntax_Print.univ_to_string ul in
-                               let uu____27231 =
+                               let uu___12 =
                                  FStar_Syntax_Print.univ_to_string ur in
                                FStar_Util.format3
                                  "Incompatible universe application for %s, expected %s got %s\n"
-                                 uu____27229 uu____27230 uu____27231 in
+                                 uu___10 uu___11 uu___12 in
                              (FStar_Errors.Fatal_IncompatibleUniverse,
-                               uu____27228) in
-                           let uu____27232 =
-                             FStar_TypeChecker_Env.get_range env in
-                           FStar_Errors.raise_error uu____27223 uu____27232)
-                  us' us;
+                               uu___9) in
+                           let uu___9 = FStar_TypeChecker_Env.get_range env in
+                           FStar_Errors.raise_error uu___8 uu___9) us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____27233 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x, uu____27241) ->
+      | FStar_Syntax_Syntax.Tm_refine (x, uu___1) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____27268 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____27268 with
+          let uu___1 = FStar_Syntax_Subst.open_comp bs c in
+          (match uu___1 with
            | (bs1, c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____27288 ->
-                      match uu____27288 with
-                      | (b, uu____27296) ->
-                          let uu____27301 =
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (b, uu___3) ->
+                          let uu___4 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort in
-                          level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____27301) bs1 in
+                          level_of_type env b.FStar_Syntax_Syntax.sort uu___4)
+                   bs1 in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1 in
-                 let uu____27306 = universe_of_aux env res in
-                 level_of_type env res uu____27306 in
+                 let uu___2 = universe_of_aux env res in
+                 level_of_type env res uu___2 in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res) in
@@ -10741,195 +10505,179 @@ let rec (universe_of_aux :
             let hd2 = FStar_Syntax_Subst.compress hd1 in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____27414 ->
-                failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____27429 ->
-                failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____27458 ->
-                let uu____27459 = universe_of_aux env hd2 in
-                (uu____27459, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____27470 ->
-                let uu____27471 = universe_of_aux env hd2 in
-                (uu____27471, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____27482 ->
-                let uu____27495 = universe_of_aux env hd2 in
-                (uu____27495, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____27506 ->
-                let uu____27513 = universe_of_aux env hd2 in
-                (uu____27513, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____27524 ->
-                let uu____27551 = universe_of_aux env hd2 in
-                (uu____27551, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____27562 ->
-                let uu____27569 = universe_of_aux env hd2 in
-                (uu____27569, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____27580 ->
-                let uu____27581 = universe_of_aux env hd2 in
-                (uu____27581, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____27592 ->
-                let uu____27607 = universe_of_aux env hd2 in
-                (uu____27607, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____27618 ->
-                let uu____27625 = universe_of_aux env hd2 in
-                (uu____27625, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____27636 ->
-                let uu____27637 = universe_of_aux env hd2 in
-                (uu____27637, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____27648, hd3::uu____27650) ->
-                let uu____27715 = FStar_Syntax_Subst.open_branch hd3 in
-                (match uu____27715 with
-                 | (uu____27730, uu____27731, hd4) ->
-                     let uu____27749 = FStar_Syntax_Util.head_and_args hd4 in
-                     (match uu____27749 with
+            | FStar_Syntax_Syntax.Tm_bvar uu___1 -> failwith "Impossible"
+            | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+            | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_name uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_type uu___1 ->
+                let uu___2 = universe_of_aux env hd2 in (uu___2, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu___1, hd3::uu___2) ->
+                let uu___3 = FStar_Syntax_Subst.open_branch hd3 in
+                (match uu___3 with
+                 | (uu___4, uu___5, hd4) ->
+                     let uu___6 = FStar_Syntax_Util.head_and_args hd4 in
+                     (match uu___6 with
                       | (hd5, args') ->
                           type_of_head retry hd5
                             (FStar_List.append args' args1)))
-            | uu____27814 when retry ->
+            | uu___1 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e in
-                let uu____27816 = FStar_Syntax_Util.head_and_args e1 in
-                (match uu____27816 with
+                let uu___2 = FStar_Syntax_Util.head_and_args e1 in
+                (match uu___2 with
                  | (hd3, args2) -> type_of_head false hd3 args2)
-            | uu____27873 ->
-                let uu____27874 =
-                  FStar_TypeChecker_Env.clear_expected_typ env in
-                (match uu____27874 with
-                 | (env1, uu____27896) ->
+            | uu___1 ->
+                let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env in
+                (match uu___2 with
+                 | (env1, uu___3) ->
                      let env2 =
-                       let uu___3922_27902 = env1 in
+                       let uu___4 = env1 in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3922_27902.FStar_TypeChecker_Env.solver);
+                           (uu___4.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3922_27902.FStar_TypeChecker_Env.range);
+                           (uu___4.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3922_27902.FStar_TypeChecker_Env.curmodule);
+                           (uu___4.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3922_27902.FStar_TypeChecker_Env.gamma);
+                           (uu___4.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3922_27902.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___4.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3922_27902.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___4.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3922_27902.FStar_TypeChecker_Env.modules);
+                           (uu___4.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3922_27902.FStar_TypeChecker_Env.expected_typ);
+                           (uu___4.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3922_27902.FStar_TypeChecker_Env.sigtab);
+                           (uu___4.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3922_27902.FStar_TypeChecker_Env.attrtab);
+                           (uu___4.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3922_27902.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___4.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3922_27902.FStar_TypeChecker_Env.effects);
+                           (uu___4.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3922_27902.FStar_TypeChecker_Env.generalize);
+                           (uu___4.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3922_27902.FStar_TypeChecker_Env.letrecs);
+                           (uu___4.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3922_27902.FStar_TypeChecker_Env.check_uvars);
+                           (uu___4.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3922_27902.FStar_TypeChecker_Env.use_eq);
+                           (uu___4.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3922_27902.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___4.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3922_27902.FStar_TypeChecker_Env.is_iface);
+                           (uu___4.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3922_27902.FStar_TypeChecker_Env.admit);
+                           (uu___4.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3922_27902.FStar_TypeChecker_Env.lax_universes);
+                           (uu___4.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3922_27902.FStar_TypeChecker_Env.phase1);
+                           (uu___4.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3922_27902.FStar_TypeChecker_Env.failhard);
+                           (uu___4.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3922_27902.FStar_TypeChecker_Env.nosynth);
+                           (uu___4.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3922_27902.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3922_27902.FStar_TypeChecker_Env.tc_term);
+                           (uu___4.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3922_27902.FStar_TypeChecker_Env.type_of);
+                           (uu___4.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3922_27902.FStar_TypeChecker_Env.universe_of);
+                           (uu___4.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3922_27902.FStar_TypeChecker_Env.check_type_of);
+                           (uu___4.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3922_27902.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3922_27902.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3922_27902.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3922_27902.FStar_TypeChecker_Env.proof_ns);
+                           (uu___4.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3922_27902.FStar_TypeChecker_Env.synth_hook);
+                           (uu___4.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3922_27902.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3922_27902.FStar_TypeChecker_Env.splice);
+                           (uu___4.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3922_27902.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___4.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3922_27902.FStar_TypeChecker_Env.postprocess);
+                           (uu___4.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3922_27902.FStar_TypeChecker_Env.identifier_info);
+                           (uu___4.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3922_27902.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___4.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3922_27902.FStar_TypeChecker_Env.dsenv);
+                           (uu___4.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3922_27902.FStar_TypeChecker_Env.nbe);
+                           (uu___4.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3922_27902.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___4.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3922_27902.FStar_TypeChecker_Env.erasable_types_tab);
+                           (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                           (uu___3922_27902.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac)
                        } in
-                     ((let uu____27904 =
+                     ((let uu___5 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf") in
-                       if uu____27904
+                       if uu___5
                        then
-                         let uu____27905 =
-                           let uu____27906 =
-                             FStar_TypeChecker_Env.get_range env2 in
-                           FStar_Range.string_of_range uu____27906 in
-                         let uu____27907 =
-                           FStar_Syntax_Print.term_to_string hd2 in
+                         let uu___6 =
+                           let uu___7 = FStar_TypeChecker_Env.get_range env2 in
+                           FStar_Range.string_of_range uu___7 in
+                         let uu___7 = FStar_Syntax_Print.term_to_string hd2 in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____27905 uu____27907
+                           uu___6 uu___7
                        else ());
-                      (let uu____27909 = tc_term env2 hd2 in
-                       match uu____27909 with
-                       | (uu____27930,
-                          { FStar_TypeChecker_Common.eff_name = uu____27931;
+                      (let uu___5 = tc_term env2 hd2 in
+                       match uu___5 with
+                       | (uu___6,
+                          { FStar_TypeChecker_Common.eff_name = uu___7;
                             FStar_TypeChecker_Common.res_typ = t;
-                            FStar_TypeChecker_Common.cflags = uu____27933;
-                            FStar_TypeChecker_Common.comp_thunk = uu____27934;_},
+                            FStar_TypeChecker_Common.cflags = uu___8;
+                            FStar_TypeChecker_Common.comp_thunk = uu___9;_},
                           g) ->
-                           ((let uu____27952 =
+                           ((let uu___11 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g in
-                             FStar_All.pipe_right uu____27952
-                               (fun uu____27953 -> ()));
+                             FStar_All.pipe_right uu___11 (fun uu___12 -> ()));
                             (t, args1))))) in
-          let uu____27964 = type_of_head true hd args in
-          (match uu____27964 with
+          let uu___1 = type_of_head true hd args in
+          (match uu___1 with
            | (t, args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t in
-               let uu____28002 = FStar_Syntax_Util.arrow_formals_comp t1 in
-               (match uu____28002 with
+               let uu___2 = FStar_Syntax_Util.arrow_formals_comp t1 in
+               (match uu___2 with
                 | (bs, res) ->
                     let res1 = FStar_Syntax_Util.comp_result res in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -10937,14 +10685,13 @@ let rec (universe_of_aux :
                       let subst = FStar_Syntax_Util.subst_of_list bs args1 in
                       FStar_Syntax_Subst.subst subst res1
                     else
-                      (let uu____28028 =
-                         FStar_Syntax_Print.term_to_string res1 in
-                       level_of_type_fail env e uu____28028)))
-      | FStar_Syntax_Syntax.Tm_match (uu____28029, hd::uu____28031) ->
-          let uu____28096 = FStar_Syntax_Subst.open_branch hd in
-          (match uu____28096 with
-           | (uu____28097, uu____28098, hd1) -> universe_of_aux env hd1)
-      | FStar_Syntax_Syntax.Tm_match (uu____28116, []) ->
+                      (let uu___4 = FStar_Syntax_Print.term_to_string res1 in
+                       level_of_type_fail env e uu___4)))
+      | FStar_Syntax_Syntax.Tm_match (uu___1, hd::uu___2) ->
+          let uu___3 = FStar_Syntax_Subst.open_branch hd in
+          (match uu___3 with
+           | (uu___4, uu___5, hd1) -> universe_of_aux env hd1)
+      | FStar_Syntax_Syntax.Tm_match (uu___1, []) ->
           level_of_type_fail env e "empty match cases"
 let (universe_of :
   FStar_TypeChecker_Env.env ->
@@ -10952,19 +10699,18 @@ let (universe_of :
   =
   fun env ->
     fun e ->
-      (let uu____28162 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-       if uu____28162
+      (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+       if uu___1
        then
-         let uu____28163 = FStar_Syntax_Print.term_to_string e in
-         FStar_Util.print1 "Calling universe_of_aux with %s\n" uu____28163
+         let uu___2 = FStar_Syntax_Print.term_to_string e in
+         FStar_Util.print1 "Calling universe_of_aux with %s\n" uu___2
        else ());
       (let r = universe_of_aux env e in
-       (let uu____28167 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-        if uu____28167
+       (let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+        if uu___2
         then
-          let uu____28168 = FStar_Syntax_Print.term_to_string r in
-          FStar_Util.print1 "Got result from universe_of_aux = %s\n"
-            uu____28168
+          let uu___3 = FStar_Syntax_Print.term_to_string r in
+          FStar_Util.print1 "Got result from universe_of_aux = %s\n" uu___3
         else ());
        level_of_type env e r)
 let (tc_tparams :
@@ -10975,8 +10721,8 @@ let (tc_tparams :
   =
   fun env0 ->
     fun tps ->
-      let uu____28192 = tc_binders env0 tps in
-      match uu____28192 with
+      let uu___ = tc_binders env0 tps in
+      match uu___ with
       | (tps1, env, g, us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
 let rec (type_of_well_typed_term :
@@ -10991,130 +10737,129 @@ let rec (type_of_well_typed_term :
           t.FStar_Syntax_Syntax.pos in
       let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____28249 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____28266 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____28271 = FStar_Syntax_Util.unfold_lazy i in
-          type_of_well_typed_term env uu____28271
+          let uu___ = FStar_Syntax_Util.unfold_lazy i in
+          type_of_well_typed_term env uu___
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____28273 =
+          let uu___ =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Util.bind_opt uu____28273
-            (fun uu____28287 ->
-               match uu____28287 with
-               | (t2, uu____28295) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu___
+            (fun uu___1 ->
+               match uu___1 with
+               | (t2, uu___2) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____28297;
-             FStar_Syntax_Syntax.vars = uu____28298;_},
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
            us)
           ->
-          let uu____28304 =
+          let uu___2 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Util.bind_opt uu____28304
-            (fun uu____28318 ->
-               match uu____28318 with
-               | (t2, uu____28326) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu___2
+            (fun uu___3 ->
+               match uu___3 with
+               | (t2, uu___4) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____28327) -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect uu___) ->
+          FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____28329 = tc_constant env t1.FStar_Syntax_Syntax.pos sc in
-          FStar_Pervasives_Native.Some uu____28329
+          let uu___ = tc_constant env t1.FStar_Syntax_Syntax.pos sc in
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____28331 = mk_tm_type (FStar_Syntax_Syntax.U_succ u) in
-          FStar_Pervasives_Native.Some uu____28331
+          let uu___ = mk_tm_type (FStar_Syntax_Syntax.U_succ u) in
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Tm_abs
           (bs, body, FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____28336;_})
+             FStar_Syntax_Syntax.residual_flags = uu___;_})
           ->
           let mk_comp =
-            let uu____28380 =
+            let uu___1 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid in
-            if uu____28380
+            if uu___1
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____28408 =
+              (let uu___3 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid in
-               if uu____28408
+               if uu___3
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None) in
           FStar_Util.bind_opt mk_comp
             (fun f ->
-               let uu____28475 = universe_of_well_typed_term env tbody in
-               FStar_Util.bind_opt uu____28475
+               let uu___1 = universe_of_well_typed_term env tbody in
+               FStar_Util.bind_opt uu___1
                  (fun u ->
-                    let uu____28483 =
-                      let uu____28486 =
-                        let uu____28487 =
-                          let uu____28502 =
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
                             f tbody (FStar_Pervasives_Native.Some u) in
-                          (bs, uu____28502) in
-                        FStar_Syntax_Syntax.Tm_arrow uu____28487 in
-                      FStar_Syntax_Syntax.mk uu____28486
+                          (bs, uu___5) in
+                        FStar_Syntax_Syntax.Tm_arrow uu___4 in
+                      FStar_Syntax_Syntax.mk uu___3
                         t1.FStar_Syntax_Syntax.pos in
-                    FStar_Pervasives_Native.Some uu____28483))
+                    FStar_Pervasives_Native.Some uu___2))
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____28539 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____28539 with
+          let uu___ = FStar_Syntax_Subst.open_comp bs c in
+          (match uu___ with
            | (bs1, c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____28598 =
+                     let uu___1 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1) in
-                     FStar_Util.bind_opt uu____28598
+                     FStar_Util.bind_opt uu___1
                        (fun uc ->
-                          let uu____28606 =
+                          let uu___2 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us)) in
-                          FStar_Pervasives_Native.Some uu____28606)
+                          FStar_Pervasives_Native.Some uu___2)
                  | (x, imp)::bs3 ->
-                     let uu____28632 =
+                     let uu___1 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort in
-                     FStar_Util.bind_opt uu____28632
+                     FStar_Util.bind_opt uu___1
                        (fun u_x ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x in
                           aux env2 (u_x :: us) bs3) in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____28641 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x, uu____28661) ->
-          let uu____28666 =
+      | FStar_Syntax_Syntax.Tm_abs uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_refine (x, uu___) ->
+          let uu___1 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort in
-          FStar_Util.bind_opt uu____28666
+          FStar_Util.bind_opt uu___1
             (fun u_x ->
-               let uu____28674 = mk_tm_type u_x in
-               FStar_Pervasives_Native.Some uu____28674)
+               let uu___2 = mk_tm_type u_x in
+               FStar_Pervasives_Native.Some uu___2)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____28679;
-             FStar_Syntax_Syntax.vars = uu____28680;_},
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
            a::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____28759 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____28759 with
-           | (unary_op, uu____28779) ->
+          let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+          (match uu___2 with
+           | (unary_op, uu___3) ->
                let head =
-                 let uu____28807 =
+                 let uu___4 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                  FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____28807 in
+                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___4 in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -11124,21 +10869,20 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____28855;
-             FStar_Syntax_Syntax.vars = uu____28856;_},
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
            a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____28952 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____28952 with
-           | (unary_op, uu____28972) ->
+          let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+          (match uu___2 with
+           | (unary_op, uu___3) ->
                let head =
-                 let uu____29000 =
+                 let uu___4 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                  FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                   uu____29000 in
+                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___4 in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -11148,63 +10892,62 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____29056;
-             FStar_Syntax_Syntax.vars = uu____29057;_},
-           uu____29058::[])
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
+           uu___2::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____29097;
-             FStar_Syntax_Syntax.vars = uu____29098;_},
-           (t2, uu____29100)::uu____29101::[])
+             FStar_Syntax_Syntax.pos = uu___;
+             FStar_Syntax_Syntax.vars = uu___1;_},
+           (t2, uu___2)::uu___3::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd, args) ->
           let t_hd = type_of_well_typed_term env hd in
           let rec aux t_hd1 =
-            let uu____29197 =
-              let uu____29198 =
-                FStar_TypeChecker_Normalize.unfold_whnf env t_hd1 in
-              uu____29198.FStar_Syntax_Syntax.n in
-            match uu____29197 with
+            let uu___ =
+              let uu___1 = FStar_TypeChecker_Normalize.unfold_whnf env t_hd1 in
+              uu___1.FStar_Syntax_Syntax.n in
+            match uu___ with
             | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                 let n_args = FStar_List.length args in
                 let n_bs = FStar_List.length bs in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____29270 = FStar_Util.first_N n_args bs in
-                    match uu____29270 with
+                    let uu___1 = FStar_Util.first_N n_args bs in
+                    match uu___1 with
                     | (bs1, rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (rest, c))
                             t_hd1.FStar_Syntax_Syntax.pos in
-                        let uu____29358 =
-                          let uu____29363 = FStar_Syntax_Syntax.mk_Total t2 in
-                          FStar_Syntax_Subst.open_comp bs1 uu____29363 in
-                        (match uu____29358 with
+                        let uu___2 =
+                          let uu___3 = FStar_Syntax_Syntax.mk_Total t2 in
+                          FStar_Syntax_Subst.open_comp bs1 uu___3 in
+                        (match uu___2 with
                          | (bs2, c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____29415 = FStar_Syntax_Subst.open_comp bs c in
-                       match uu____29415 with
+                      (let uu___2 = FStar_Syntax_Subst.open_comp bs c in
+                       match uu___2 with
                        | (bs1, c1) ->
-                           let uu____29436 =
+                           let uu___3 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1 in
-                           if uu____29436
+                           if uu___3
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
                            else FStar_Pervasives_Native.None)
                     else FStar_Pervasives_Native.None in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____29514 ->
-                     match uu____29514 with
+                  (fun uu___1 ->
+                     match uu___1 with
                      | (bs1, t2) ->
                          let subst =
                            FStar_List.map2
@@ -11214,35 +10957,31 @@ let rec (type_of_well_typed_term :
                                     ((FStar_Pervasives_Native.fst b),
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args in
-                         let uu____29590 = FStar_Syntax_Subst.subst subst t2 in
-                         FStar_Pervasives_Native.Some uu____29590)
-            | FStar_Syntax_Syntax.Tm_refine (x, uu____29592) ->
+                         let uu___2 = FStar_Syntax_Subst.subst subst t2 in
+                         FStar_Pervasives_Native.Some uu___2)
+            | FStar_Syntax_Syntax.Tm_refine (x, uu___1) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____29598, uu____29599)
-                -> aux t2
-            | uu____29640 -> FStar_Pervasives_Native.None in
+            | FStar_Syntax_Syntax.Tm_ascribed (t2, uu___1, uu___2) -> aux t2
+            | uu___1 -> FStar_Pervasives_Native.None in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____29641, (FStar_Util.Inl t2, uu____29643), uu____29644) ->
+          (uu___, (FStar_Util.Inl t2, uu___1), uu___2) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____29691, (FStar_Util.Inr c, uu____29693), uu____29694) ->
+          (uu___, (FStar_Util.Inr c, uu___1), uu___2) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-          let uu____29759 =
+          let uu___ =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ in
-          FStar_Pervasives_Native.Some uu____29759
+          FStar_Pervasives_Native.Some uu___
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2, uu____29767) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2, uu___) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____29772 ->
-          FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____29795 ->
-          FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_match uu___ -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_let uu___ -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____29808 ->
-          FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_uinst uu___ -> FStar_Pervasives_Native.None
 and (universe_of_well_typed_term :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -11250,14 +10989,14 @@ and (universe_of_well_typed_term :
   =
   fun env ->
     fun t ->
-      let uu____29819 = type_of_well_typed_term env t in
-      match uu____29819 with
+      let uu___ = type_of_well_typed_term env t in
+      match uu___ with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____29825;
-            FStar_Syntax_Syntax.vars = uu____29826;_}
+            FStar_Syntax_Syntax.pos = uu___1;
+            FStar_Syntax_Syntax.vars = uu___2;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____29829 -> FStar_Pervasives_Native.None
+      | uu___1 -> FStar_Pervasives_Native.None
 let (check_type_of_well_typed_term' :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -11270,143 +11009,141 @@ let (check_type_of_well_typed_term' :
         fun k ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k in
           let env2 =
-            let uu___4206_29854 = env1 in
+            let uu___ = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4206_29854.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4206_29854.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4206_29854.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4206_29854.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4206_29854.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4206_29854.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4206_29854.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4206_29854.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4206_29854.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4206_29854.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4206_29854.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4206_29854.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4206_29854.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4206_29854.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4206_29854.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4206_29854.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4206_29854.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4206_29854.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4206_29854.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4206_29854.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___4206_29854.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4206_29854.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4206_29854.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4206_29854.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4206_29854.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4206_29854.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4206_29854.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4206_29854.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4206_29854.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4206_29854.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4206_29854.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4206_29854.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4206_29854.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4206_29854.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4206_29854.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4206_29854.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4206_29854.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4206_29854.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4206_29854.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4206_29854.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4206_29854.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4206_29854.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___4206_29854.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4206_29854.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4206_29854.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___4206_29854.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let slow_check uu____29860 =
+          let slow_check uu___ =
             if must_total
             then
-              let uu____29861 = env2.FStar_TypeChecker_Env.type_of env2 t in
-              match uu____29861 with | (uu____29868, uu____29869, g) -> g
+              let uu___1 = env2.FStar_TypeChecker_Env.type_of env2 t in
+              match uu___1 with | (uu___2, uu___3, g) -> g
             else
-              (let uu____29872 = env2.FStar_TypeChecker_Env.tc_term env2 t in
-               match uu____29872 with | (uu____29879, uu____29880, g) -> g) in
-          let uu____29882 = type_of_well_typed_term env2 t in
-          match uu____29882 with
+              (let uu___2 = env2.FStar_TypeChecker_Env.tc_term env2 t in
+               match uu___2 with | (uu___3, uu___4, g) -> g) in
+          let uu___ = type_of_well_typed_term env2 t in
+          match uu___ with
           | FStar_Pervasives_Native.None -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____29887 =
+              ((let uu___2 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits") in
-                if uu____29887
+                if uu___2
                 then
-                  let uu____29888 =
+                  let uu___3 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
-                  let uu____29889 = FStar_Syntax_Print.term_to_string t in
-                  let uu____29890 = FStar_Syntax_Print.term_to_string k' in
-                  let uu____29891 = FStar_Syntax_Print.term_to_string k in
+                  let uu___4 = FStar_Syntax_Print.term_to_string t in
+                  let uu___5 = FStar_Syntax_Print.term_to_string k' in
+                  let uu___6 = FStar_Syntax_Print.term_to_string k in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____29888 uu____29889 uu____29890 uu____29891
+                    uu___3 uu___4 uu___5 uu___6
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k in
-                (let uu____29897 =
+                (let uu___3 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits") in
-                 if uu____29897
+                 if uu___3
                  then
-                   let uu____29898 =
+                   let uu___4 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
-                   let uu____29899 = FStar_Syntax_Print.term_to_string t in
-                   let uu____29900 = FStar_Syntax_Print.term_to_string k' in
-                   let uu____29901 = FStar_Syntax_Print.term_to_string k in
+                   let uu___5 = FStar_Syntax_Print.term_to_string t in
+                   let uu___6 = FStar_Syntax_Print.term_to_string k' in
+                   let uu___7 = FStar_Syntax_Print.term_to_string k in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____29898
+                     uu___4
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____29899 uu____29900 uu____29901
+                      else "failed") uu___5 uu___6 uu___7
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None -> slow_check ()
@@ -11423,113 +11160,111 @@ let (check_type_of_well_typed_term :
         fun k ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k in
           let env2 =
-            let uu___4237_29927 = env1 in
+            let uu___ = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4237_29927.FStar_TypeChecker_Env.solver);
+                (uu___.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4237_29927.FStar_TypeChecker_Env.range);
+                (uu___.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4237_29927.FStar_TypeChecker_Env.curmodule);
+                (uu___.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4237_29927.FStar_TypeChecker_Env.gamma);
+                (uu___.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4237_29927.FStar_TypeChecker_Env.gamma_sig);
+                (uu___.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4237_29927.FStar_TypeChecker_Env.gamma_cache);
+                (uu___.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4237_29927.FStar_TypeChecker_Env.modules);
+                (uu___.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4237_29927.FStar_TypeChecker_Env.expected_typ);
+                (uu___.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4237_29927.FStar_TypeChecker_Env.sigtab);
+                (uu___.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4237_29927.FStar_TypeChecker_Env.attrtab);
+                (uu___.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4237_29927.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4237_29927.FStar_TypeChecker_Env.effects);
+                (uu___.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4237_29927.FStar_TypeChecker_Env.generalize);
+                (uu___.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4237_29927.FStar_TypeChecker_Env.letrecs);
+                (uu___.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4237_29927.FStar_TypeChecker_Env.top_level);
+                (uu___.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4237_29927.FStar_TypeChecker_Env.check_uvars);
+                (uu___.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4237_29927.FStar_TypeChecker_Env.use_eq);
+                (uu___.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4237_29927.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4237_29927.FStar_TypeChecker_Env.is_iface);
+                (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4237_29927.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax =
-                (uu___4237_29927.FStar_TypeChecker_Env.lax);
+                (uu___.FStar_TypeChecker_Env.admit);
+              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4237_29927.FStar_TypeChecker_Env.lax_universes);
+                (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4237_29927.FStar_TypeChecker_Env.phase1);
+                (uu___.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4237_29927.FStar_TypeChecker_Env.failhard);
+                (uu___.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4237_29927.FStar_TypeChecker_Env.nosynth);
+                (uu___.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4237_29927.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4237_29927.FStar_TypeChecker_Env.tc_term);
+                (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4237_29927.FStar_TypeChecker_Env.type_of);
+                (uu___.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4237_29927.FStar_TypeChecker_Env.universe_of);
+                (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4237_29927.FStar_TypeChecker_Env.check_type_of);
+                (uu___.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4237_29927.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4237_29927.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4237_29927.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4237_29927.FStar_TypeChecker_Env.proof_ns);
+                (uu___.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4237_29927.FStar_TypeChecker_Env.synth_hook);
+                (uu___.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4237_29927.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4237_29927.FStar_TypeChecker_Env.splice);
+                (uu___.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4237_29927.FStar_TypeChecker_Env.mpreprocess);
+                (uu___.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4237_29927.FStar_TypeChecker_Env.postprocess);
+                (uu___.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4237_29927.FStar_TypeChecker_Env.identifier_info);
+                (uu___.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4237_29927.FStar_TypeChecker_Env.tc_hooks);
+                (uu___.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4237_29927.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe =
-                (uu___4237_29927.FStar_TypeChecker_Env.nbe);
+                (uu___.FStar_TypeChecker_Env.dsenv);
+              FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4237_29927.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4237_29927.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___4237_29927.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let slow_check uu____29933 =
+          let slow_check uu___ =
             if must_total
             then
-              let uu____29934 = env2.FStar_TypeChecker_Env.type_of env2 t in
-              match uu____29934 with | (uu____29941, uu____29942, g) -> g
+              let uu___1 = env2.FStar_TypeChecker_Env.type_of env2 t in
+              match uu___1 with | (uu___2, uu___3, g) -> g
             else
-              (let uu____29945 = env2.FStar_TypeChecker_Env.tc_term env2 t in
-               match uu____29945 with | (uu____29952, uu____29953, g) -> g) in
-          let uu____29955 =
-            let uu____29956 = FStar_Options.__temp_fast_implicits () in
-            FStar_All.pipe_left Prims.op_Negation uu____29956 in
-          if uu____29955
+              (let uu___2 = env2.FStar_TypeChecker_Env.tc_term env2 t in
+               match uu___2 with | (uu___3, uu___4, g) -> g) in
+          let uu___ =
+            let uu___1 = FStar_Options.__temp_fast_implicits () in
+            FStar_All.pipe_left Prims.op_Negation uu___1 in
+          if uu___
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -5,9 +5,9 @@ type lcomp_with_binder =
 let (report : FStar_TypeChecker_Env.env -> Prims.string Prims.list -> unit) =
   fun env ->
     fun errs ->
-      let uu____20 = FStar_TypeChecker_Env.get_range env in
-      let uu____21 = FStar_TypeChecker_Err.failed_to_prove_specification errs in
-      FStar_Errors.log_issue uu____20 uu____21
+      let uu___ = FStar_TypeChecker_Env.get_range env in
+      let uu___1 = FStar_TypeChecker_Err.failed_to_prove_specification errs in
+      FStar_Errors.log_issue uu___ uu___1
 let (new_implicit_var :
   Prims.string ->
     FStar_Range.range ->
@@ -32,68 +32,68 @@ let (close_guard_implicits :
     fun solve_deferred ->
       fun xs ->
         fun g ->
-          let uu____78 = (FStar_Options.eager_subtyping ()) || solve_deferred in
-          if uu____78
+          let uu___ = (FStar_Options.eager_subtyping ()) || solve_deferred in
+          if uu___
           then
-            let uu____79 =
+            let uu___1 =
               FStar_All.pipe_right g.FStar_TypeChecker_Common.deferred
                 (FStar_List.partition
-                   (fun uu____125 ->
-                      match uu____125 with
-                      | (uu____130, p) ->
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (uu___3, p) ->
                           FStar_TypeChecker_Rel.flex_prob_closing env xs p)) in
-            match uu____79 with
+            match uu___1 with
             | (solve_now, defer) ->
-                ((let uu____159 =
+                ((let uu___3 =
                     FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "Rel") in
-                  if uu____159
+                  if uu___3
                   then
                     (FStar_Util.print_string "SOLVE BEFORE CLOSING:\n";
                      FStar_List.iter
-                       (fun uu____170 ->
-                          match uu____170 with
+                       (fun uu___6 ->
+                          match uu___6 with
                           | (s, p) ->
-                              let uu____177 =
+                              let uu___7 =
                                 FStar_TypeChecker_Rel.prob_to_string env p in
-                              FStar_Util.print2 "%s: %s\n" s uu____177)
+                              FStar_Util.print2 "%s: %s\n" s uu___7)
                        solve_now;
                      FStar_Util.print_string " ...DEFERRED THE REST:\n";
                      FStar_List.iter
-                       (fun uu____188 ->
-                          match uu____188 with
+                       (fun uu___8 ->
+                          match uu___8 with
                           | (s, p) ->
-                              let uu____195 =
+                              let uu___9 =
                                 FStar_TypeChecker_Rel.prob_to_string env p in
-                              FStar_Util.print2 "%s: %s\n" s uu____195) defer;
+                              FStar_Util.print2 "%s: %s\n" s uu___9) defer;
                      FStar_Util.print_string "END\n")
                   else ());
                  (let g1 =
                     FStar_TypeChecker_Rel.solve_deferred_constraints env
-                      (let uu___49_199 = g in
+                      (let uu___3 = g in
                        {
                          FStar_TypeChecker_Common.guard_f =
-                           (uu___49_199.FStar_TypeChecker_Common.guard_f);
+                           (uu___3.FStar_TypeChecker_Common.guard_f);
                          FStar_TypeChecker_Common.deferred_to_tac =
-                           (uu___49_199.FStar_TypeChecker_Common.deferred_to_tac);
+                           (uu___3.FStar_TypeChecker_Common.deferred_to_tac);
                          FStar_TypeChecker_Common.deferred = solve_now;
                          FStar_TypeChecker_Common.univ_ineqs =
-                           (uu___49_199.FStar_TypeChecker_Common.univ_ineqs);
+                           (uu___3.FStar_TypeChecker_Common.univ_ineqs);
                          FStar_TypeChecker_Common.implicits =
-                           (uu___49_199.FStar_TypeChecker_Common.implicits)
+                           (uu___3.FStar_TypeChecker_Common.implicits)
                        }) in
                   let g2 =
-                    let uu___52_201 = g1 in
+                    let uu___3 = g1 in
                     {
                       FStar_TypeChecker_Common.guard_f =
-                        (uu___52_201.FStar_TypeChecker_Common.guard_f);
+                        (uu___3.FStar_TypeChecker_Common.guard_f);
                       FStar_TypeChecker_Common.deferred_to_tac =
-                        (uu___52_201.FStar_TypeChecker_Common.deferred_to_tac);
+                        (uu___3.FStar_TypeChecker_Common.deferred_to_tac);
                       FStar_TypeChecker_Common.deferred = defer;
                       FStar_TypeChecker_Common.univ_ineqs =
-                        (uu___52_201.FStar_TypeChecker_Common.univ_ineqs);
+                        (uu___3.FStar_TypeChecker_Common.univ_ineqs);
                       FStar_TypeChecker_Common.implicits =
-                        (uu___52_201.FStar_TypeChecker_Common.implicits)
+                        (uu___3.FStar_TypeChecker_Common.implicits)
                     } in
                   g2))
           else g
@@ -101,30 +101,29 @@ let (check_uvars : FStar_Range.range -> FStar_Syntax_Syntax.typ -> unit) =
   fun r ->
     fun t ->
       let uvs = FStar_Syntax_Free.uvars t in
-      let uu____216 =
-        let uu____217 = FStar_Util.set_is_empty uvs in
-        Prims.op_Negation uu____217 in
-      if uu____216
+      let uu___ =
+        let uu___1 = FStar_Util.set_is_empty uvs in Prims.op_Negation uu___1 in
+      if uu___
       then
         let us =
-          let uu____219 =
-            let uu____222 = FStar_Util.set_elements uvs in
+          let uu___1 =
+            let uu___2 = FStar_Util.set_elements uvs in
             FStar_List.map
               (fun u ->
                  FStar_Syntax_Print.uvar_to_string
-                   u.FStar_Syntax_Syntax.ctx_uvar_head) uu____222 in
-          FStar_All.pipe_right uu____219 (FStar_String.concat ", ") in
+                   u.FStar_Syntax_Syntax.ctx_uvar_head) uu___2 in
+          FStar_All.pipe_right uu___1 (FStar_String.concat ", ") in
         (FStar_Options.push ();
          FStar_Options.set_option "hide_uvar_nums" (FStar_Options.Bool false);
          FStar_Options.set_option "print_implicits" (FStar_Options.Bool true);
-         (let uu____233 =
-            let uu____238 =
-              let uu____239 = FStar_Syntax_Print.term_to_string t in
+         (let uu___5 =
+            let uu___6 =
+              let uu___7 = FStar_Syntax_Print.term_to_string t in
               FStar_Util.format2
                 "Unconstrained unification variables %s in type signature %s; please add an annotation"
-                us uu____239 in
-            (FStar_Errors.Error_UncontrainedUnificationVar, uu____238) in
-          FStar_Errors.log_issue r uu____233);
+                us uu___7 in
+            (FStar_Errors.Error_UncontrainedUnificationVar, uu___6) in
+          FStar_Errors.log_issue r uu___5);
          FStar_Options.pop ())
       else ()
 let (extract_let_rec_annotation :
@@ -133,21 +132,20 @@ let (extract_let_rec_annotation :
       (FStar_Syntax_Syntax.univ_names * FStar_Syntax_Syntax.typ * Prims.bool))
   =
   fun env ->
-    fun uu____256 ->
-      match uu____256 with
+    fun uu___ ->
+      match uu___ with
       | { FStar_Syntax_Syntax.lbname = lbname;
           FStar_Syntax_Syntax.lbunivs = univ_vars;
-          FStar_Syntax_Syntax.lbtyp = t;
-          FStar_Syntax_Syntax.lbeff = uu____266;
+          FStar_Syntax_Syntax.lbtyp = t; FStar_Syntax_Syntax.lbeff = uu___1;
           FStar_Syntax_Syntax.lbdef = e;
-          FStar_Syntax_Syntax.lbattrs = uu____268;
-          FStar_Syntax_Syntax.lbpos = uu____269;_} ->
+          FStar_Syntax_Syntax.lbattrs = uu___2;
+          FStar_Syntax_Syntax.lbpos = uu___3;_} ->
           let rng = FStar_Syntax_Syntax.range_of_lbname lbname in
           let t1 = FStar_Syntax_Subst.compress t in
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown ->
-               let uu____302 = FStar_Syntax_Subst.open_univ_vars univ_vars e in
-               (match uu____302 with
+               let uu___4 = FStar_Syntax_Subst.open_univ_vars univ_vars e in
+               (match uu___4 with
                 | (univ_vars1, e1) ->
                     let env1 =
                       FStar_TypeChecker_Env.push_univ_vars env univ_vars1 in
@@ -155,60 +153,60 @@ let (extract_let_rec_annotation :
                     let rec aux e2 =
                       let e3 = FStar_Syntax_Subst.compress e2 in
                       match e3.FStar_Syntax_Syntax.n with
-                      | FStar_Syntax_Syntax.Tm_meta (e4, uu____339) -> aux e4
-                      | FStar_Syntax_Syntax.Tm_ascribed (e4, t2, uu____346)
-                          -> FStar_Pervasives_Native.fst t2
-                      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____401) ->
+                      | FStar_Syntax_Syntax.Tm_meta (e4, uu___5) -> aux e4
+                      | FStar_Syntax_Syntax.Tm_ascribed (e4, t2, uu___5) ->
+                          FStar_Pervasives_Native.fst t2
+                      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___5) ->
                           let res = aux body in
                           let c =
                             match res with
                             | FStar_Util.Inl t2 ->
-                                let uu____437 = FStar_Options.ml_ish () in
-                                if uu____437
+                                let uu___6 = FStar_Options.ml_ish () in
+                                if uu___6
                                 then FStar_Syntax_Util.ml_comp t2 r
                                 else FStar_Syntax_Syntax.mk_Total t2
-                            | FStar_Util.Inr c -> c in
+                            | FStar_Util.Inr c1 -> c1 in
                           let t2 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_arrow (bs, c))
                               c.FStar_Syntax_Syntax.pos in
-                          ((let uu____456 =
+                          ((let uu___7 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.High in
-                            if uu____456
+                            if uu___7
                             then
-                              let uu____457 = FStar_Range.string_of_range r in
-                              let uu____458 =
+                              let uu___8 = FStar_Range.string_of_range r in
+                              let uu___9 =
                                 FStar_Syntax_Print.term_to_string t2 in
-                              FStar_Util.print2 "(%s) Using type %s\n"
-                                uu____457 uu____458
+                              FStar_Util.print2 "(%s) Using type %s\n" uu___8
+                                uu___9
                             else ());
                            FStar_Util.Inl t2)
-                      | uu____460 -> FStar_Util.Inl FStar_Syntax_Syntax.tun in
+                      | uu___5 -> FStar_Util.Inl FStar_Syntax_Syntax.tun in
                     let t2 =
-                      let uu____462 = aux e1 in
-                      match uu____462 with
+                      let uu___5 = aux e1 in
+                      match uu___5 with
                       | FStar_Util.Inr c ->
-                          let uu____468 =
+                          let uu___6 =
                             FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                          if uu____468
+                          if uu___6
                           then FStar_Syntax_Util.comp_result c
                           else
-                            (let uu____470 =
-                               let uu____475 =
-                                 let uu____476 =
+                            (let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
                                    FStar_Syntax_Print.comp_to_string c in
                                  FStar_Util.format1
                                    "Expected a 'let rec' to be annotated with a value type; got a computation type %s"
-                                   uu____476 in
+                                   uu___10 in
                                (FStar_Errors.Fatal_UnexpectedComputationTypeForLetRec,
-                                 uu____475) in
-                             FStar_Errors.raise_error uu____470 rng)
-                      | FStar_Util.Inl t2 -> t2 in
+                                 uu___9) in
+                             FStar_Errors.raise_error uu___8 rng)
+                      | FStar_Util.Inl t3 -> t3 in
                     (univ_vars1, t2, true))
-           | uu____480 ->
-               let uu____481 = FStar_Syntax_Subst.open_univ_vars univ_vars t1 in
-               (match uu____481 with
+           | uu___4 ->
+               let uu___5 = FStar_Syntax_Subst.open_univ_vars univ_vars t1 in
+               (match uu___5 with
                 | (univ_vars1, t2) -> (univ_vars1, t2, false)))
 let rec (decorated_pattern_as_term :
   FStar_Syntax_Syntax.pat ->
@@ -216,42 +214,38 @@ let rec (decorated_pattern_as_term :
   =
   fun pat ->
     let mk f = FStar_Syntax_Syntax.mk f pat.FStar_Syntax_Syntax.p in
-    let pat_as_arg uu____540 =
-      match uu____540 with
+    let pat_as_arg uu___ =
+      match uu___ with
       | (p, i) ->
-          let uu____557 = decorated_pattern_as_term p in
-          (match uu____557 with
+          let uu___1 = decorated_pattern_as_term p in
+          (match uu___1 with
            | (vars, te) ->
-               let uu____580 =
-                 let uu____585 = FStar_Syntax_Syntax.as_implicit i in
-                 (te, uu____585) in
-               (vars, uu____580)) in
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Syntax.as_implicit i in
+                 (te, uu___3) in
+               (vars, uu___2)) in
     match pat.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_constant c ->
-        let uu____599 = mk (FStar_Syntax_Syntax.Tm_constant c) in
-        ([], uu____599)
+        let uu___ = mk (FStar_Syntax_Syntax.Tm_constant c) in ([], uu___)
     | FStar_Syntax_Syntax.Pat_wild x ->
-        let uu____603 = mk (FStar_Syntax_Syntax.Tm_name x) in
-        ([x], uu____603)
+        let uu___ = mk (FStar_Syntax_Syntax.Tm_name x) in ([x], uu___)
     | FStar_Syntax_Syntax.Pat_var x ->
-        let uu____607 = mk (FStar_Syntax_Syntax.Tm_name x) in
-        ([x], uu____607)
+        let uu___ = mk (FStar_Syntax_Syntax.Tm_name x) in ([x], uu___)
     | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-        let uu____628 =
-          let uu____647 =
-            FStar_All.pipe_right pats (FStar_List.map pat_as_arg) in
-          FStar_All.pipe_right uu____647 FStar_List.unzip in
-        (match uu____628 with
+        let uu___ =
+          let uu___1 = FStar_All.pipe_right pats (FStar_List.map pat_as_arg) in
+          FStar_All.pipe_right uu___1 FStar_List.unzip in
+        (match uu___ with
          | (vars, args) ->
              let vars1 = FStar_List.flatten vars in
-             let uu____783 =
-               let uu____784 =
-                 let uu____785 =
-                   let uu____802 = FStar_Syntax_Syntax.fv_to_tm fv in
-                   (uu____802, args) in
-                 FStar_Syntax_Syntax.Tm_app uu____785 in
-               mk uu____784 in
-             (vars1, uu____783))
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Syntax.fv_to_tm fv in
+                   (uu___4, args) in
+                 FStar_Syntax_Syntax.Tm_app uu___3 in
+               mk uu___2 in
+             (vars1, uu___1))
     | FStar_Syntax_Syntax.Pat_dot_term (x, e) -> ([], e)
 let (comp_univ_opt :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -259,23 +253,21 @@ let (comp_univ_opt :
   =
   fun c ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (uu____840, uopt) -> uopt
-    | FStar_Syntax_Syntax.GTotal (uu____850, uopt) -> uopt
+    | FStar_Syntax_Syntax.Total (uu___, uopt) -> uopt
+    | FStar_Syntax_Syntax.GTotal (uu___, uopt) -> uopt
     | FStar_Syntax_Syntax.Comp c1 ->
         (match c1.FStar_Syntax_Syntax.comp_univs with
          | [] -> FStar_Pervasives_Native.None
-         | hd::uu____864 -> FStar_Pervasives_Native.Some hd)
+         | hd::uu___ -> FStar_Pervasives_Native.Some hd)
 let (lcomp_univ_opt :
   FStar_TypeChecker_Common.lcomp ->
     (FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option *
       FStar_TypeChecker_Common.guard_t))
   =
   fun lc ->
-    let uu____878 =
-      FStar_All.pipe_right lc FStar_TypeChecker_Common.lcomp_comp in
-    FStar_All.pipe_right uu____878
-      (fun uu____906 ->
-         match uu____906 with | (c, g) -> ((comp_univ_opt c), g))
+    let uu___ = FStar_All.pipe_right lc FStar_TypeChecker_Common.lcomp_comp in
+    FStar_All.pipe_right uu___
+      (fun uu___1 -> match uu___1 with | (c, g) -> ((comp_univ_opt c), g))
 let (destruct_wp_comp :
   FStar_Syntax_Syntax.comp_typ ->
     (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ *
@@ -293,17 +285,17 @@ let (mk_comp_l :
       fun result ->
         fun wp ->
           fun flags ->
-            let uu____977 =
-              let uu____978 =
-                let uu____989 = FStar_Syntax_Syntax.as_arg wp in [uu____989] in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Syntax.as_arg wp in [uu___2] in
               {
                 FStar_Syntax_Syntax.comp_univs = [u_result];
                 FStar_Syntax_Syntax.effect_name = mname;
                 FStar_Syntax_Syntax.result_typ = result;
-                FStar_Syntax_Syntax.effect_args = uu____978;
+                FStar_Syntax_Syntax.effect_args = uu___1;
                 FStar_Syntax_Syntax.flags = flags
               } in
-            FStar_Syntax_Syntax.mk_Comp uu____977
+            FStar_Syntax_Syntax.mk_Comp uu___
 let (mk_comp :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.universe ->
@@ -318,34 +310,34 @@ let (effect_args_from_repr :
   fun repr ->
     fun is_layered ->
       fun r ->
-        let err uu____1069 =
-          let uu____1070 =
-            let uu____1075 =
-              let uu____1076 = FStar_Syntax_Print.term_to_string repr in
-              let uu____1077 = FStar_Util.string_of_bool is_layered in
+        let err uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.term_to_string repr in
+              let uu___4 = FStar_Util.string_of_bool is_layered in
               FStar_Util.format2
                 "Could not get effect args from repr %s with is_layered %s"
-                uu____1076 uu____1077 in
-            (FStar_Errors.Fatal_UnexpectedEffect, uu____1075) in
-          FStar_Errors.raise_error uu____1070 r in
+                uu___3 uu___4 in
+            (FStar_Errors.Fatal_UnexpectedEffect, uu___2) in
+          FStar_Errors.raise_error uu___1 r in
         let repr1 = FStar_Syntax_Subst.compress repr in
         if is_layered
         then
           match repr1.FStar_Syntax_Syntax.n with
-          | FStar_Syntax_Syntax.Tm_app (uu____1085, uu____1086::is) ->
+          | FStar_Syntax_Syntax.Tm_app (uu___, uu___1::is) ->
               FStar_All.pipe_right is
                 (FStar_List.map FStar_Pervasives_Native.fst)
-          | uu____1154 -> err ()
+          | uu___ -> err ()
         else
           (match repr1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_arrow (uu____1158, c) ->
-               let uu____1180 =
+           | FStar_Syntax_Syntax.Tm_arrow (uu___1, c) ->
+               let uu___2 =
                  FStar_All.pipe_right c FStar_Syntax_Util.comp_to_comp_typ in
-               FStar_All.pipe_right uu____1180
+               FStar_All.pipe_right uu___2
                  (fun ct ->
                     FStar_All.pipe_right ct.FStar_Syntax_Syntax.effect_args
                       (FStar_List.map FStar_Pervasives_Native.fst))
-           | uu____1215 -> err ())
+           | uu___1 -> err ())
 let (mk_wp_return :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->
@@ -361,60 +353,59 @@ let (mk_wp_return :
           fun e ->
             fun r ->
               let c =
-                let uu____1247 =
-                  let uu____1248 =
+                let uu___ =
+                  let uu___1 =
                     FStar_TypeChecker_Env.lid_exists env
                       FStar_Parser_Const.effect_GTot_lid in
-                  FStar_All.pipe_left Prims.op_Negation uu____1248 in
-                if uu____1247
+                  FStar_All.pipe_left Prims.op_Negation uu___1 in
+                if uu___
                 then FStar_Syntax_Syntax.mk_Total a
                 else
-                  (let uu____1250 = FStar_Syntax_Util.is_unit a in
-                   if uu____1250
+                  (let uu___2 = FStar_Syntax_Util.is_unit a in
+                   if uu___2
                    then
                      FStar_Syntax_Syntax.mk_Total' a
                        (FStar_Pervasives_Native.Some
                           FStar_Syntax_Syntax.U_zero)
                    else
                      (let wp =
-                        let uu____1253 =
+                        let uu___4 =
                           env.FStar_TypeChecker_Env.lax &&
                             (FStar_Options.ml_ish ()) in
-                        if uu____1253
+                        if uu___4
                         then FStar_Syntax_Syntax.tun
                         else
                           (let ret_wp =
                              FStar_All.pipe_right ed
                                FStar_Syntax_Util.get_return_vc_combinator in
-                           let uu____1256 =
-                             let uu____1257 =
+                           let uu___6 =
+                             let uu___7 =
                                FStar_TypeChecker_Env.inst_effect_fun_with
                                  [u_a] env ed ret_wp in
-                             let uu____1258 =
-                               let uu____1259 = FStar_Syntax_Syntax.as_arg a in
-                               let uu____1268 =
-                                 let uu____1279 =
-                                   FStar_Syntax_Syntax.as_arg e in
-                                 [uu____1279] in
-                               uu____1259 :: uu____1268 in
-                             FStar_Syntax_Syntax.mk_Tm_app uu____1257
-                               uu____1258 e.FStar_Syntax_Syntax.pos in
+                             let uu___8 =
+                               let uu___9 = FStar_Syntax_Syntax.as_arg a in
+                               let uu___10 =
+                                 let uu___11 = FStar_Syntax_Syntax.as_arg e in
+                                 [uu___11] in
+                               uu___9 :: uu___10 in
+                             FStar_Syntax_Syntax.mk_Tm_app uu___7 uu___8
+                               e.FStar_Syntax_Syntax.pos in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.Beta;
-                             FStar_TypeChecker_Env.NoFullNorm] env uu____1256) in
+                             FStar_TypeChecker_Env.NoFullNorm] env uu___6) in
                       mk_comp ed u_a a wp [FStar_Syntax_Syntax.RETURN])) in
-              (let uu____1313 =
+              (let uu___1 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Return") in
-               if uu____1313
+               if uu___1
                then
-                 let uu____1314 =
+                 let uu___2 =
                    FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                 let uu____1315 = FStar_Syntax_Print.term_to_string e in
-                 let uu____1316 =
+                 let uu___3 = FStar_Syntax_Print.term_to_string e in
+                 let uu___4 =
                    FStar_TypeChecker_Normalize.comp_to_string env c in
                  FStar_Util.print3 "(%s) returning %s at comp type %s\n"
-                   uu____1314 uu____1315 uu____1316
+                   uu___2 uu___3 uu___4
                else ());
               c
 let (mk_indexed_return :
@@ -432,119 +423,117 @@ let (mk_indexed_return :
         fun a ->
           fun e ->
             fun r ->
-              (let uu____1357 =
+              (let uu___1 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "LayeredEffects") in
-               if uu____1357
+               if uu___1
                then
-                 let uu____1358 =
+                 let uu___2 =
                    FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-                 let uu____1359 = FStar_Syntax_Print.univ_to_string u_a in
-                 let uu____1360 = FStar_Syntax_Print.term_to_string a in
-                 let uu____1361 = FStar_Syntax_Print.term_to_string e in
+                 let uu___3 = FStar_Syntax_Print.univ_to_string u_a in
+                 let uu___4 = FStar_Syntax_Print.term_to_string a in
+                 let uu___5 = FStar_Syntax_Print.term_to_string e in
                  FStar_Util.print4
-                   "Computing %s.return for u_a:%s, a:%s, and e:%s{\n"
-                   uu____1358 uu____1359 uu____1360 uu____1361
+                   "Computing %s.return for u_a:%s, a:%s, and e:%s{\n" uu___2
+                   uu___3 uu___4 uu___5
                else ());
-              (let uu____1363 =
-                 let uu____1368 =
+              (let uu___1 =
+                 let uu___2 =
                    FStar_All.pipe_right ed
                      FStar_Syntax_Util.get_return_vc_combinator in
-                 FStar_TypeChecker_Env.inst_tscheme_with uu____1368 [u_a] in
-               match uu____1363 with
-               | (uu____1373, return_t) ->
+                 FStar_TypeChecker_Env.inst_tscheme_with uu___2 [u_a] in
+               match uu___1 with
+               | (uu___2, return_t) ->
                    let return_t_shape_error s =
-                     let uu____1385 =
-                       let uu____1386 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_Ident.string_of_lid
                            ed.FStar_Syntax_Syntax.mname in
-                       let uu____1387 =
+                       let uu___5 =
                          FStar_Syntax_Print.term_to_string return_t in
                        FStar_Util.format3
                          "%s.return %s does not have proper shape (reason:%s)"
-                         uu____1386 uu____1387 s in
-                     (FStar_Errors.Fatal_UnexpectedEffect, uu____1385) in
-                   let uu____1388 =
-                     let uu____1417 =
-                       let uu____1418 = FStar_Syntax_Subst.compress return_t in
-                       uu____1418.FStar_Syntax_Syntax.n in
-                     match uu____1417 with
+                         uu___4 uu___5 s in
+                     (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Subst.compress return_t in
+                       uu___5.FStar_Syntax_Syntax.n in
+                     match uu___4 with
                      | FStar_Syntax_Syntax.Tm_arrow (bs, c) when
                          (FStar_List.length bs) >= (Prims.of_int (2)) ->
-                         let uu____1477 = FStar_Syntax_Subst.open_comp bs c in
-                         (match uu____1477 with
+                         let uu___5 = FStar_Syntax_Subst.open_comp bs c in
+                         (match uu___5 with
                           | (a_b::x_b::bs1, c1) ->
-                              let uu____1546 =
+                              let uu___6 =
                                 FStar_Syntax_Util.comp_to_comp_typ c1 in
-                              (a_b, x_b, bs1, uu____1546))
-                     | uu____1567 ->
-                         let uu____1568 =
+                              (a_b, x_b, bs1, uu___6))
+                     | uu___5 ->
+                         let uu___6 =
                            return_t_shape_error
                              "Either not an arrow or not enough binders" in
-                         FStar_Errors.raise_error uu____1568 r in
-                   (match uu____1388 with
+                         FStar_Errors.raise_error uu___6 r in
+                   (match uu___3 with
                     | (a_b, x_b, rest_bs, return_ct) ->
-                        let uu____1649 =
-                          let uu____1656 =
-                            let uu____1657 =
-                              let uu____1658 =
-                                let uu____1665 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 =
                                   FStar_All.pipe_right a_b
                                     FStar_Pervasives_Native.fst in
-                                (uu____1665, a) in
-                              FStar_Syntax_Syntax.NT uu____1658 in
-                            let uu____1676 =
-                              let uu____1679 =
-                                let uu____1680 =
-                                  let uu____1687 =
+                                (uu___8, a) in
+                              FStar_Syntax_Syntax.NT uu___7 in
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
                                     FStar_All.pipe_right x_b
                                       FStar_Pervasives_Native.fst in
-                                  (uu____1687, e) in
-                                FStar_Syntax_Syntax.NT uu____1680 in
-                              [uu____1679] in
-                            uu____1657 :: uu____1676 in
+                                  (uu___10, e) in
+                                FStar_Syntax_Syntax.NT uu___9 in
+                              [uu___8] in
+                            uu___6 :: uu___7 in
                           FStar_TypeChecker_Env.uvars_for_binders env rest_bs
-                            uu____1656
+                            uu___5
                             (fun b ->
-                               let uu____1703 =
+                               let uu___6 =
                                  FStar_Syntax_Print.binder_to_string b in
-                               let uu____1704 =
-                                 let uu____1705 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Ident.string_of_lid
                                      ed.FStar_Syntax_Syntax.mname in
-                                 FStar_Util.format1 "%s.return" uu____1705 in
-                               let uu____1706 = FStar_Range.string_of_range r in
+                                 FStar_Util.format1 "%s.return" uu___8 in
+                               let uu___8 = FStar_Range.string_of_range r in
                                FStar_Util.format3
                                  "implicit var for binder %s of %s at %s"
-                                 uu____1703 uu____1704 uu____1706) r in
-                        (match uu____1649 with
+                                 uu___6 uu___7 uu___8) r in
+                        (match uu___4 with
                          | (rest_bs_uvars, g_uvars) ->
                              let subst =
                                FStar_List.map2
                                  (fun b ->
                                     fun t ->
-                                      let uu____1741 =
-                                        let uu____1748 =
+                                      let uu___5 =
+                                        let uu___6 =
                                           FStar_All.pipe_right b
                                             FStar_Pervasives_Native.fst in
-                                        (uu____1748, t) in
-                                      FStar_Syntax_Syntax.NT uu____1741) (a_b
-                                 :: x_b :: rest_bs) (a :: e :: rest_bs_uvars) in
+                                        (uu___6, t) in
+                                      FStar_Syntax_Syntax.NT uu___5) (a_b ::
+                                 x_b :: rest_bs) (a :: e :: rest_bs_uvars) in
                              let is =
-                               let uu____1774 =
-                                 let uu____1777 =
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_Syntax_Subst.compress
                                      return_ct.FStar_Syntax_Syntax.result_typ in
-                                 let uu____1778 =
-                                   FStar_Syntax_Util.is_layered ed in
-                                 effect_args_from_repr uu____1777 uu____1778
-                                   r in
-                               FStar_All.pipe_right uu____1774
+                                 let uu___7 = FStar_Syntax_Util.is_layered ed in
+                                 effect_args_from_repr uu___6 uu___7 r in
+                               FStar_All.pipe_right uu___5
                                  (FStar_List.map
                                     (FStar_Syntax_Subst.subst subst)) in
                              let c =
-                               let uu____1784 =
-                                 let uu____1785 =
+                               let uu___5 =
+                                 let uu___6 =
                                    FStar_All.pipe_right is
                                      (FStar_List.map
                                         FStar_Syntax_Syntax.as_arg) in
@@ -553,21 +542,20 @@ let (mk_indexed_return :
                                    FStar_Syntax_Syntax.effect_name =
                                      (ed.FStar_Syntax_Syntax.mname);
                                    FStar_Syntax_Syntax.result_typ = a;
-                                   FStar_Syntax_Syntax.effect_args =
-                                     uu____1785;
+                                   FStar_Syntax_Syntax.effect_args = uu___6;
                                    FStar_Syntax_Syntax.flags = []
                                  } in
-                               FStar_Syntax_Syntax.mk_Comp uu____1784 in
-                             ((let uu____1809 =
+                               FStar_Syntax_Syntax.mk_Comp uu___5 in
+                             ((let uu___6 =
                                  FStar_All.pipe_left
                                    (FStar_TypeChecker_Env.debug env)
                                    (FStar_Options.Other "LayeredEffects") in
-                               if uu____1809
+                               if uu___6
                                then
-                                 let uu____1810 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.comp_to_string c in
                                  FStar_Util.print1 "} c after return %s\n"
-                                   uu____1810
+                                   uu___7
                                else ());
                               (c, g_uvars)))))
 let (mk_return :
@@ -585,13 +573,13 @@ let (mk_return :
         fun a ->
           fun e ->
             fun r ->
-              let uu____1850 =
+              let uu___ =
                 FStar_All.pipe_right ed FStar_Syntax_Util.is_layered in
-              if uu____1850
+              if uu___
               then mk_indexed_return env ed u_a a e r
               else
-                (let uu____1856 = mk_wp_return env ed u_a a e r in
-                 (uu____1856, FStar_TypeChecker_Env.trivial_guard))
+                (let uu___2 = mk_wp_return env ed u_a a e r in
+                 (uu___2, FStar_TypeChecker_Env.trivial_guard))
 let (lift_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp_typ ->
@@ -601,22 +589,21 @@ let (lift_comp :
   fun env ->
     fun c ->
       fun lift ->
-        let uu____1880 =
+        let uu___ =
           FStar_All.pipe_right
-            (let uu___257_1882 = c in
+            (let uu___1 = c in
              {
                FStar_Syntax_Syntax.comp_univs =
-                 (uu___257_1882.FStar_Syntax_Syntax.comp_univs);
+                 (uu___1.FStar_Syntax_Syntax.comp_univs);
                FStar_Syntax_Syntax.effect_name =
-                 (uu___257_1882.FStar_Syntax_Syntax.effect_name);
+                 (uu___1.FStar_Syntax_Syntax.effect_name);
                FStar_Syntax_Syntax.result_typ =
-                 (uu___257_1882.FStar_Syntax_Syntax.result_typ);
+                 (uu___1.FStar_Syntax_Syntax.result_typ);
                FStar_Syntax_Syntax.effect_args =
-                 (uu___257_1882.FStar_Syntax_Syntax.effect_args);
+                 (uu___1.FStar_Syntax_Syntax.effect_args);
                FStar_Syntax_Syntax.flags = []
              }) FStar_Syntax_Syntax.mk_Comp in
-        FStar_All.pipe_right uu____1880
-          (lift.FStar_TypeChecker_Env.mlift_wp env)
+        FStar_All.pipe_right uu___ (lift.FStar_TypeChecker_Env.mlift_wp env)
 let (join_effects :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident -> FStar_Ident.lident -> FStar_Ident.lident)
@@ -624,33 +611,30 @@ let (join_effects :
   fun env ->
     fun l1_in ->
       fun l2_in ->
-        let uu____1902 =
-          let uu____1907 = FStar_TypeChecker_Env.norm_eff_name env l1_in in
-          let uu____1908 = FStar_TypeChecker_Env.norm_eff_name env l2_in in
-          (uu____1907, uu____1908) in
-        match uu____1902 with
+        let uu___ =
+          let uu___1 = FStar_TypeChecker_Env.norm_eff_name env l1_in in
+          let uu___2 = FStar_TypeChecker_Env.norm_eff_name env l2_in in
+          (uu___1, uu___2) in
+        match uu___ with
         | (l1, l2) ->
-            let uu____1911 = FStar_TypeChecker_Env.join_opt env l1 l2 in
-            (match uu____1911 with
-             | FStar_Pervasives_Native.Some (m, uu____1921, uu____1922) -> m
+            let uu___1 = FStar_TypeChecker_Env.join_opt env l1 l2 in
+            (match uu___1 with
+             | FStar_Pervasives_Native.Some (m, uu___2, uu___3) -> m
              | FStar_Pervasives_Native.None ->
-                 let uu____1935 =
+                 let uu___2 =
                    FStar_TypeChecker_Env.exists_polymonadic_bind env l1 l2 in
-                 (match uu____1935 with
-                  | FStar_Pervasives_Native.Some (m, uu____1949) -> m
+                 (match uu___2 with
+                  | FStar_Pervasives_Native.Some (m, uu___3) -> m
                   | FStar_Pervasives_Native.None ->
-                      let uu____1982 =
-                        let uu____1987 =
-                          let uu____1988 =
-                            FStar_Syntax_Print.lid_to_string l1_in in
-                          let uu____1989 =
-                            FStar_Syntax_Print.lid_to_string l2_in in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Print.lid_to_string l1_in in
+                          let uu___6 = FStar_Syntax_Print.lid_to_string l2_in in
                           FStar_Util.format2
-                            "Effects %s and %s cannot be composed" uu____1988
-                            uu____1989 in
-                        (FStar_Errors.Fatal_EffectsCannotBeComposed,
-                          uu____1987) in
-                      FStar_Errors.raise_error uu____1982
+                            "Effects %s and %s cannot be composed" uu___5
+                            uu___6 in
+                        (FStar_Errors.Fatal_EffectsCannotBeComposed, uu___4) in
+                      FStar_Errors.raise_error uu___3
                         env.FStar_TypeChecker_Env.range))
 let (join_lcomp :
   FStar_TypeChecker_Env.env ->
@@ -660,10 +644,10 @@ let (join_lcomp :
   fun env ->
     fun c1 ->
       fun c2 ->
-        let uu____2005 =
+        let uu___ =
           (FStar_TypeChecker_Common.is_total_lcomp c1) &&
             (FStar_TypeChecker_Common.is_total_lcomp c2) in
-        if uu____2005
+        if uu___
         then FStar_Parser_Const.effect_Tot_lid
         else
           join_effects env c1.FStar_TypeChecker_Common.eff_name
@@ -685,16 +669,16 @@ let (lift_comps_sep_guards :
           fun for_bind ->
             let c11 = FStar_TypeChecker_Env.unfold_effect_abbrev env c1 in
             let c21 = FStar_TypeChecker_Env.unfold_effect_abbrev env c2 in
-            let uu____2058 =
+            let uu___ =
               FStar_TypeChecker_Env.join_opt env
                 c11.FStar_Syntax_Syntax.effect_name
                 c21.FStar_Syntax_Syntax.effect_name in
-            match uu____2058 with
+            match uu___ with
             | FStar_Pervasives_Native.Some (m, lift1, lift2) ->
-                let uu____2086 = lift_comp env c11 lift1 in
-                (match uu____2086 with
+                let uu___1 = lift_comp env c11 lift1 in
+                (match uu___1 with
                  | (c12, g1) ->
-                     let uu____2103 =
+                     let uu___2 =
                        if Prims.op_Negation for_bind
                        then lift_comp env c21 lift2
                        else
@@ -707,28 +691,27 @@ let (lift_comps_sep_guards :
                                 FStar_Syntax_Syntax.mk_binder x in
                           let env_x =
                             FStar_TypeChecker_Env.push_binders env [x_a] in
-                          let uu____2140 = lift_comp env_x c21 lift2 in
-                          match uu____2140 with
+                          let uu___4 = lift_comp env_x c21 lift2 in
+                          match uu___4 with
                           | (c22, g2) ->
-                              let uu____2151 =
+                              let uu___5 =
                                 FStar_TypeChecker_Env.close_guard env 
                                   [x_a] g2 in
-                              (c22, uu____2151)) in
-                     (match uu____2103 with
-                      | (c22, g2) -> (m, c12, c22, g1, g2)))
+                              (c22, uu___5)) in
+                     (match uu___2 with | (c22, g2) -> (m, c12, c22, g1, g2)))
             | FStar_Pervasives_Native.None ->
-                let uu____2182 =
-                  let uu____2187 =
-                    let uu____2188 =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
                       FStar_Syntax_Print.lid_to_string
                         c11.FStar_Syntax_Syntax.effect_name in
-                    let uu____2189 =
+                    let uu___4 =
                       FStar_Syntax_Print.lid_to_string
                         c21.FStar_Syntax_Syntax.effect_name in
                     FStar_Util.format2 "Effects %s and %s cannot be composed"
-                      uu____2188 uu____2189 in
-                  (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____2187) in
-                FStar_Errors.raise_error uu____2182
+                      uu___3 uu___4 in
+                  (FStar_Errors.Fatal_EffectsCannotBeComposed, uu___2) in
+                FStar_Errors.raise_error uu___1
                   env.FStar_TypeChecker_Env.range
 let (lift_comps :
   FStar_TypeChecker_Env.env ->
@@ -744,11 +727,11 @@ let (lift_comps :
       fun c2 ->
         fun b ->
           fun for_bind ->
-            let uu____2245 = lift_comps_sep_guards env c1 c2 b for_bind in
-            match uu____2245 with
+            let uu___ = lift_comps_sep_guards env c1 c2 b for_bind in
+            match uu___ with
             | (l, c11, c21, g1, g2) ->
-                let uu____2269 = FStar_TypeChecker_Env.conj_guard g1 g2 in
-                (l, c11, c21, uu____2269)
+                let uu___1 = FStar_TypeChecker_Env.conj_guard g1 g2 in
+                (l, c11, c21, uu___1)
 let (is_pure_effect :
   FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
   fun env ->
@@ -778,21 +761,21 @@ let (lax_mk_tot_or_comp_l :
     fun u_result ->
       fun result ->
         fun flags ->
-          let uu____2331 =
+          let uu___ =
             FStar_Ident.lid_equals mname FStar_Parser_Const.effect_Tot_lid in
-          if uu____2331
+          if uu___
           then
             FStar_Syntax_Syntax.mk_Total' result
               (FStar_Pervasives_Native.Some u_result)
           else mk_comp_l mname u_result result FStar_Syntax_Syntax.tun flags
 let (is_function : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____2338 =
-      let uu____2339 = FStar_Syntax_Subst.compress t in
-      uu____2339.FStar_Syntax_Syntax.n in
-    match uu____2338 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____2342 -> true
-    | uu____2357 -> false
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_arrow uu___1 -> true
+    | uu___1 -> false
 let (label :
   Prims.string ->
     FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
@@ -816,12 +799,12 @@ let (label_opt :
           match reason with
           | FStar_Pervasives_Native.None -> f
           | FStar_Pervasives_Native.Some reason1 ->
-              let uu____2414 =
-                let uu____2415 = FStar_TypeChecker_Env.should_verify env in
-                FStar_All.pipe_left Prims.op_Negation uu____2415 in
-              if uu____2414
+              let uu___ =
+                let uu___1 = FStar_TypeChecker_Env.should_verify env in
+                FStar_All.pipe_left Prims.op_Negation uu___1 in
+              if uu___
               then f
-              else (let uu____2417 = reason1 () in label uu____2417 r f)
+              else (let uu___2 = reason1 () in label uu___2 r f)
 let (label_guard :
   FStar_Range.range ->
     Prims.string ->
@@ -833,20 +816,20 @@ let (label_guard :
         match g.FStar_TypeChecker_Common.guard_f with
         | FStar_TypeChecker_Common.Trivial -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___354_2434 = g in
-            let uu____2435 =
-              let uu____2436 = label reason r f in
-              FStar_TypeChecker_Common.NonTrivial uu____2436 in
+            let uu___ = g in
+            let uu___1 =
+              let uu___2 = label reason r f in
+              FStar_TypeChecker_Common.NonTrivial uu___2 in
             {
-              FStar_TypeChecker_Common.guard_f = uu____2435;
+              FStar_TypeChecker_Common.guard_f = uu___1;
               FStar_TypeChecker_Common.deferred_to_tac =
-                (uu___354_2434.FStar_TypeChecker_Common.deferred_to_tac);
+                (uu___.FStar_TypeChecker_Common.deferred_to_tac);
               FStar_TypeChecker_Common.deferred =
-                (uu___354_2434.FStar_TypeChecker_Common.deferred);
+                (uu___.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___354_2434.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___354_2434.FStar_TypeChecker_Common.implicits)
+                (uu___.FStar_TypeChecker_Common.implicits)
             }
 let (close_wp_comp :
   FStar_TypeChecker_Env.env ->
@@ -856,34 +839,34 @@ let (close_wp_comp :
   fun env ->
     fun bvs ->
       fun c ->
-        let uu____2456 = FStar_Syntax_Util.is_ml_comp c in
-        if uu____2456
+        let uu___ = FStar_Syntax_Util.is_ml_comp c in
+        if uu___
         then c
         else
-          (let uu____2458 =
+          (let uu___2 =
              env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-           if uu____2458
+           if uu___2
            then c
            else
              (let close_wp u_res md res_t bvs1 wp0 =
                 let close =
-                  let uu____2497 =
+                  let uu___4 =
                     FStar_All.pipe_right md
                       FStar_Syntax_Util.get_wp_close_combinator in
-                  FStar_All.pipe_right uu____2497 FStar_Util.must in
+                  FStar_All.pipe_right uu___4 FStar_Util.must in
                 FStar_List.fold_right
                   (fun x ->
                      fun wp ->
                        let bs =
-                         let uu____2526 = FStar_Syntax_Syntax.mk_binder x in
-                         [uu____2526] in
+                         let uu___4 = FStar_Syntax_Syntax.mk_binder x in
+                         [uu___4] in
                        let us =
-                         let uu____2548 =
-                           let uu____2551 =
+                         let uu___4 =
+                           let uu___5 =
                              env.FStar_TypeChecker_Env.universe_of env
                                x.FStar_Syntax_Syntax.sort in
-                           [uu____2551] in
-                         u_res :: uu____2548 in
+                           [uu___5] in
+                         u_res :: uu___4 in
                        let wp1 =
                          FStar_Syntax_Util.abs bs wp
                            (FStar_Pervasives_Native.Some
@@ -891,25 +874,25 @@ let (close_wp_comp :
                                  FStar_Parser_Const.effect_Tot_lid
                                  FStar_Pervasives_Native.None
                                  [FStar_Syntax_Syntax.TOTAL])) in
-                       let uu____2557 =
+                       let uu___4 =
                          FStar_TypeChecker_Env.inst_effect_fun_with us env md
                            close in
-                       let uu____2558 =
-                         let uu____2559 = FStar_Syntax_Syntax.as_arg res_t in
-                         let uu____2568 =
-                           let uu____2579 =
+                       let uu___5 =
+                         let uu___6 = FStar_Syntax_Syntax.as_arg res_t in
+                         let uu___7 =
+                           let uu___8 =
                              FStar_Syntax_Syntax.as_arg
                                x.FStar_Syntax_Syntax.sort in
-                           let uu____2588 =
-                             let uu____2599 = FStar_Syntax_Syntax.as_arg wp1 in
-                             [uu____2599] in
-                           uu____2579 :: uu____2588 in
-                         uu____2559 :: uu____2568 in
-                       FStar_Syntax_Syntax.mk_Tm_app uu____2557 uu____2558
+                           let uu___9 =
+                             let uu___10 = FStar_Syntax_Syntax.as_arg wp1 in
+                             [uu___10] in
+                           uu___8 :: uu___9 in
+                         uu___6 :: uu___7 in
+                       FStar_Syntax_Syntax.mk_Tm_app uu___4 uu___5
                          wp0.FStar_Syntax_Syntax.pos) bvs1 wp0 in
               let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-              let uu____2641 = destruct_wp_comp c1 in
-              match uu____2641 with
+              let uu___4 = destruct_wp_comp c1 in
+              match uu___4 with
               | (u_res_t, res_t, wp) ->
                   let md =
                     FStar_TypeChecker_Env.get_effect_decl env
@@ -931,10 +914,10 @@ let (close_wp_lcomp :
         FStar_All.pipe_right lc
           (FStar_TypeChecker_Common.apply_lcomp (close_wp_comp env bvs)
              (fun g ->
-                let uu____2680 =
+                let uu___ =
                   FStar_All.pipe_right g
                     (FStar_TypeChecker_Env.close_guard env bs) in
-                FStar_All.pipe_right uu____2680
+                FStar_All.pipe_right uu___
                   (close_guard_implicits env false bs)))
 let (close_layered_lcomp :
   FStar_TypeChecker_Env.env ->
@@ -956,19 +939,19 @@ let (close_layered_lcomp :
             (FStar_TypeChecker_Common.apply_lcomp
                (FStar_Syntax_Subst.subst_comp substs)
                (fun g ->
-                  let uu____2728 =
+                  let uu___ =
                     FStar_All.pipe_right g
                       (FStar_TypeChecker_Env.close_guard env bs) in
-                  FStar_All.pipe_right uu____2728
+                  FStar_All.pipe_right uu___
                     (close_guard_implicits env false bs)))
 let (should_not_inline_lc : FStar_TypeChecker_Common.lcomp -> Prims.bool) =
   fun lc ->
     FStar_All.pipe_right lc.FStar_TypeChecker_Common.cflags
       (FStar_Util.for_some
-         (fun uu___0_2737 ->
-            match uu___0_2737 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-            | uu____2738 -> false))
+            | uu___1 -> false))
 let (should_return :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
@@ -978,45 +961,41 @@ let (should_return :
     fun eopt ->
       fun lc ->
         let lc_is_unit_or_effectful =
-          let uu____2759 =
-            let uu____2762 =
+          let uu___ =
+            let uu___1 =
               FStar_All.pipe_right lc.FStar_TypeChecker_Common.res_typ
                 FStar_Syntax_Util.arrow_formals_comp in
-            FStar_All.pipe_right uu____2762 FStar_Pervasives_Native.snd in
-          FStar_All.pipe_right uu____2759
+            FStar_All.pipe_right uu___1 FStar_Pervasives_Native.snd in
+          FStar_All.pipe_right uu___
             (fun c ->
-               (let uu____2785 =
-                  FStar_TypeChecker_Env.is_reifiable_comp env c in
-                Prims.op_Negation uu____2785) &&
+               (let uu___1 = FStar_TypeChecker_Env.is_reifiable_comp env c in
+                Prims.op_Negation uu___1) &&
                  ((FStar_All.pipe_right (FStar_Syntax_Util.comp_result c)
                      FStar_Syntax_Util.is_unit)
                     ||
-                    (let uu____2787 =
-                       FStar_Syntax_Util.is_pure_or_ghost_comp c in
-                     Prims.op_Negation uu____2787))) in
+                    (let uu___1 = FStar_Syntax_Util.is_pure_or_ghost_comp c in
+                     Prims.op_Negation uu___1))) in
         match eopt with
         | FStar_Pervasives_Native.None -> false
         | FStar_Pervasives_Native.Some e ->
             (((FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lc) &&
                 (Prims.op_Negation lc_is_unit_or_effectful))
                &&
-               (let uu____2795 = FStar_Syntax_Util.head_and_args' e in
-                match uu____2795 with
-                | (head, uu____2811) ->
-                    let uu____2832 =
-                      let uu____2833 = FStar_Syntax_Util.un_uinst head in
-                      uu____2833.FStar_Syntax_Syntax.n in
-                    (match uu____2832 with
+               (let uu___ = FStar_Syntax_Util.head_and_args' e in
+                match uu___ with
+                | (head, uu___1) ->
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Util.un_uinst head in
+                      uu___3.FStar_Syntax_Syntax.n in
+                    (match uu___2 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
-                         let uu____2837 =
-                           let uu____2838 = FStar_Syntax_Syntax.lid_of_fv fv in
-                           FStar_TypeChecker_Env.is_irreducible env
-                             uu____2838 in
-                         Prims.op_Negation uu____2837
-                     | uu____2839 -> true)))
+                         let uu___3 =
+                           let uu___4 = FStar_Syntax_Syntax.lid_of_fv fv in
+                           FStar_TypeChecker_Env.is_irreducible env uu___4 in
+                         Prims.op_Negation uu___3
+                     | uu___3 -> true)))
               &&
-              (let uu____2841 = should_not_inline_lc lc in
-               Prims.op_Negation uu____2841)
+              (let uu___ = should_not_inline_lc lc in Prims.op_Negation uu___)
 let (return_value :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -1034,10 +1013,9 @@ let (return_value :
               match u_t_opt with
               | FStar_Pervasives_Native.None ->
                   env.FStar_TypeChecker_Env.universe_of env t
-              | FStar_Pervasives_Native.Some u -> u in
-            let uu____2885 =
-              FStar_TypeChecker_Env.get_effect_decl env eff_lid in
-            mk_return env uu____2885 u t v v.FStar_Syntax_Syntax.pos
+              | FStar_Pervasives_Native.Some u1 -> u1 in
+            let uu___ = FStar_TypeChecker_Env.get_effect_decl env eff_lid in
+            mk_return env uu___ u t v v.FStar_Syntax_Syntax.pos
 let (mk_indexed_bind :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -1063,123 +1041,121 @@ let (mk_indexed_bind :
                   fun flags ->
                     fun r1 ->
                       let bind_name =
-                        let uu____2953 =
-                          let uu____2954 =
+                        let uu___ =
+                          let uu___1 =
                             FStar_All.pipe_right m FStar_Ident.ident_of_lid in
-                          FStar_All.pipe_right uu____2954
+                          FStar_All.pipe_right uu___1
                             FStar_Ident.string_of_id in
-                        let uu____2955 =
-                          let uu____2956 =
+                        let uu___1 =
+                          let uu___2 =
                             FStar_All.pipe_right n FStar_Ident.ident_of_lid in
-                          FStar_All.pipe_right uu____2956
+                          FStar_All.pipe_right uu___2
                             FStar_Ident.string_of_id in
-                        let uu____2957 =
-                          let uu____2958 =
+                        let uu___2 =
+                          let uu___3 =
                             FStar_All.pipe_right p FStar_Ident.ident_of_lid in
-                          FStar_All.pipe_right uu____2958
+                          FStar_All.pipe_right uu___3
                             FStar_Ident.string_of_id in
-                        FStar_Util.format3 "(%s, %s) |> %s" uu____2953
-                          uu____2955 uu____2957 in
-                      (let uu____2960 =
+                        FStar_Util.format3 "(%s, %s) |> %s" uu___ uu___1
+                          uu___2 in
+                      (let uu___1 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env)
                            (FStar_Options.Other "LayeredEffects") in
-                       if uu____2960
+                       if uu___1
                        then
-                         let uu____2961 =
-                           let uu____2962 = FStar_Syntax_Syntax.mk_Comp ct1 in
-                           FStar_Syntax_Print.comp_to_string uu____2962 in
-                         let uu____2963 =
-                           let uu____2964 = FStar_Syntax_Syntax.mk_Comp ct2 in
-                           FStar_Syntax_Print.comp_to_string uu____2964 in
+                         let uu___2 =
+                           let uu___3 = FStar_Syntax_Syntax.mk_Comp ct1 in
+                           FStar_Syntax_Print.comp_to_string uu___3 in
+                         let uu___3 =
+                           let uu___4 = FStar_Syntax_Syntax.mk_Comp ct2 in
+                           FStar_Syntax_Print.comp_to_string uu___4 in
                          FStar_Util.print2 "Binding c1:%s and c2:%s {\n"
-                           uu____2961 uu____2963
+                           uu___2 uu___3
                        else ());
-                      (let uu____2967 =
+                      (let uu___2 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env)
                            (FStar_Options.Other "ResolveImplicitsHook") in
-                       if uu____2967
+                       if uu___2
                        then
-                         let uu____2968 =
-                           let uu____2969 =
-                             FStar_TypeChecker_Env.get_range env in
-                           FStar_Range.string_of_range uu____2969 in
-                         let uu____2970 =
+                         let uu___3 =
+                           let uu___4 = FStar_TypeChecker_Env.get_range env in
+                           FStar_Range.string_of_range uu___4 in
+                         let uu___4 =
                            FStar_Syntax_Print.tscheme_to_string bind_t in
                          FStar_Util.print2
                            "///////////////////////////////Bind at %s/////////////////////\nwith bind_t = %s\n"
-                           uu____2968 uu____2970
+                           uu___3 uu___4
                        else ());
-                      (let uu____2972 =
-                         let uu____2979 =
+                      (let uu___2 =
+                         let uu___3 =
                            FStar_TypeChecker_Env.get_effect_decl env m in
-                         let uu____2980 =
+                         let uu___4 =
                            FStar_TypeChecker_Env.get_effect_decl env n in
-                         let uu____2981 =
+                         let uu___5 =
                            FStar_TypeChecker_Env.get_effect_decl env p in
-                         (uu____2979, uu____2980, uu____2981) in
-                       match uu____2972 with
+                         (uu___3, uu___4, uu___5) in
+                       match uu___2 with
                        | (m_ed, n_ed, p_ed) ->
-                           let uu____2989 =
-                             let uu____3002 =
+                           let uu___3 =
+                             let uu___4 =
                                FStar_List.hd
                                  ct1.FStar_Syntax_Syntax.comp_univs in
-                             let uu____3003 =
+                             let uu___5 =
                                FStar_List.map FStar_Pervasives_Native.fst
                                  ct1.FStar_Syntax_Syntax.effect_args in
-                             (uu____3002,
-                               (ct1.FStar_Syntax_Syntax.result_typ),
-                               uu____3003) in
-                           (match uu____2989 with
+                             (uu___4, (ct1.FStar_Syntax_Syntax.result_typ),
+                               uu___5) in
+                           (match uu___3 with
                             | (u1, t1, is1) ->
-                                let uu____3047 =
-                                  let uu____3060 =
+                                let uu___4 =
+                                  let uu___5 =
                                     FStar_List.hd
                                       ct2.FStar_Syntax_Syntax.comp_univs in
-                                  let uu____3061 =
+                                  let uu___6 =
                                     FStar_List.map
                                       FStar_Pervasives_Native.fst
                                       ct2.FStar_Syntax_Syntax.effect_args in
-                                  (uu____3060,
+                                  (uu___5,
                                     (ct2.FStar_Syntax_Syntax.result_typ),
-                                    uu____3061) in
-                                (match uu____3047 with
+                                    uu___6) in
+                                (match uu___4 with
                                  | (u2, t2, is2) ->
-                                     let uu____3105 =
+                                     let uu___5 =
                                        FStar_TypeChecker_Env.inst_tscheme_with
                                          bind_t [u1; u2] in
-                                     (match uu____3105 with
-                                      | (uu____3114, bind_t1) ->
+                                     (match uu___5 with
+                                      | (uu___6, bind_t1) ->
                                           let bind_t_shape_error s =
-                                            let uu____3126 =
-                                              let uu____3127 =
+                                            let uu___7 =
+                                              let uu___8 =
                                                 FStar_Syntax_Print.term_to_string
                                                   bind_t1 in
                                               FStar_Util.format3
                                                 "bind %s (%s) does not have proper shape (reason:%s)"
-                                                uu____3127 bind_name s in
+                                                uu___8 bind_name s in
                                             (FStar_Errors.Fatal_UnexpectedEffect,
-                                              uu____3126) in
-                                          let uu____3128 =
-                                            let uu____3173 =
-                                              let uu____3174 =
+                                              uu___7) in
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
                                                 FStar_Syntax_Subst.compress
                                                   bind_t1 in
-                                              uu____3174.FStar_Syntax_Syntax.n in
-                                            match uu____3173 with
+                                              uu___9.FStar_Syntax_Syntax.n in
+                                            match uu___8 with
                                             | FStar_Syntax_Syntax.Tm_arrow
                                                 (bs, c) when
                                                 (FStar_List.length bs) >=
                                                   (Prims.of_int (4))
                                                 ->
-                                                let uu____3249 =
+                                                let uu___9 =
                                                   FStar_Syntax_Subst.open_comp
                                                     bs c in
-                                                (match uu____3249 with
+                                                (match uu___9 with
                                                  | (a_b::b_b::bs1, c1) ->
-                                                     let uu____3334 =
-                                                       let uu____3361 =
+                                                     let uu___10 =
+                                                       let uu___11 =
                                                          FStar_List.splitAt
                                                            ((FStar_List.length
                                                                bs1)
@@ -1187,108 +1163,104 @@ let (mk_indexed_bind :
                                                               (Prims.of_int (2)))
                                                            bs1 in
                                                        FStar_All.pipe_right
-                                                         uu____3361
-                                                         (fun uu____3445 ->
-                                                            match uu____3445
+                                                         uu___11
+                                                         (fun uu___12 ->
+                                                            match uu___12
                                                             with
                                                             | (l1, l2) ->
-                                                                let uu____3526
-                                                                  =
+                                                                let uu___13 =
                                                                   FStar_List.hd
                                                                     l2 in
-                                                                let uu____3539
-                                                                  =
-                                                                  let uu____3546
+                                                                let uu___14 =
+                                                                  let uu___15
                                                                     =
                                                                     FStar_List.tl
                                                                     l2 in
                                                                   FStar_List.hd
-                                                                    uu____3546 in
-                                                                (l1,
-                                                                  uu____3526,
-                                                                  uu____3539)) in
-                                                     (match uu____3334 with
+                                                                    uu___15 in
+                                                                (l1, uu___13,
+                                                                  uu___14)) in
+                                                     (match uu___10 with
                                                       | (rest_bs, f_b, g_b)
                                                           ->
                                                           (a_b, b_b, rest_bs,
                                                             f_b, g_b, c1)))
-                                            | uu____3706 ->
-                                                let uu____3707 =
+                                            | uu___9 ->
+                                                let uu___10 =
                                                   bind_t_shape_error
                                                     "Either not an arrow or not enough binders" in
                                                 FStar_Errors.raise_error
-                                                  uu____3707 r1 in
-                                          (match uu____3128 with
+                                                  uu___10 r1 in
+                                          (match uu___7 with
                                            | (a_b, b_b, rest_bs, f_b, g_b,
                                               bind_c) ->
-                                               let uu____3830 =
-                                                 let uu____3837 =
-                                                   let uu____3838 =
-                                                     let uu____3839 =
-                                                       let uu____3846 =
+                                               let uu___8 =
+                                                 let uu___9 =
+                                                   let uu___10 =
+                                                     let uu___11 =
+                                                       let uu___12 =
                                                          FStar_All.pipe_right
                                                            a_b
                                                            FStar_Pervasives_Native.fst in
-                                                       (uu____3846, t1) in
+                                                       (uu___12, t1) in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____3839 in
-                                                   let uu____3857 =
-                                                     let uu____3860 =
-                                                       let uu____3861 =
-                                                         let uu____3868 =
+                                                       uu___11 in
+                                                   let uu___11 =
+                                                     let uu___12 =
+                                                       let uu___13 =
+                                                         let uu___14 =
                                                            FStar_All.pipe_right
                                                              b_b
                                                              FStar_Pervasives_Native.fst in
-                                                         (uu____3868, t2) in
+                                                         (uu___14, t2) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____3861 in
-                                                     [uu____3860] in
-                                                   uu____3838 :: uu____3857 in
+                                                         uu___13 in
+                                                     [uu___12] in
+                                                   uu___10 :: uu___11 in
                                                  FStar_TypeChecker_Env.uvars_for_binders
-                                                   env rest_bs uu____3837
+                                                   env rest_bs uu___9
                                                    (fun b1 ->
-                                                      let uu____3883 =
+                                                      let uu___10 =
                                                         FStar_Syntax_Print.binder_to_string
                                                           b1 in
-                                                      let uu____3884 =
+                                                      let uu___11 =
                                                         FStar_Range.string_of_range
                                                           r1 in
                                                       FStar_Util.format3
                                                         "implicit var for binder %s of %s at %s"
-                                                        uu____3883 bind_name
-                                                        uu____3884) r1 in
-                                               (match uu____3830 with
+                                                        uu___10 bind_name
+                                                        uu___11) r1 in
+                                               (match uu___8 with
                                                 | (rest_bs_uvars, g_uvars) ->
-                                                    ((let uu____3896 =
+                                                    ((let uu___10 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "ResolveImplicitsHook") in
-                                                      if uu____3896
+                                                      if uu___10
                                                       then
                                                         FStar_All.pipe_right
                                                           rest_bs_uvars
                                                           (FStar_List.iter
                                                              (fun t ->
-                                                                let uu____3906
-                                                                  =
-                                                                  let uu____3907
+                                                                let uu___11 =
+                                                                  let uu___12
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     t in
-                                                                  uu____3907.FStar_Syntax_Syntax.n in
-                                                                match uu____3906
+                                                                  uu___12.FStar_Syntax_Syntax.n in
+                                                                match uu___11
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_uvar
                                                                     (u,
-                                                                    uu____3911)
+                                                                    uu___12)
                                                                     ->
-                                                                    let uu____3928
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t in
-                                                                    let uu____3929
+                                                                    let uu___14
                                                                     =
                                                                     match 
                                                                     u.FStar_Syntax_Syntax.ctx_uvar_meta
@@ -1300,54 +1272,50 @@ let (mk_indexed_bind :
                                                                     FStar_Syntax_Print.term_to_string
                                                                     a
                                                                     | 
-                                                                    uu____3933
+                                                                    uu___15
                                                                     ->
                                                                     "<no attr>" in
                                                                     FStar_Util.print2
                                                                     "Generated uvar %s with attribute %s\n"
-                                                                    uu____3928
-                                                                    uu____3929))
+                                                                    uu___13
+                                                                    uu___14))
                                                       else ());
                                                      (let subst =
                                                         FStar_List.map2
                                                           (fun b1 ->
                                                              fun t ->
-                                                               let uu____3961
-                                                                 =
-                                                                 let uu____3968
+                                                               let uu___10 =
+                                                                 let uu___11
                                                                    =
                                                                    FStar_All.pipe_right
                                                                     b1
                                                                     FStar_Pervasives_Native.fst in
-                                                                 (uu____3968,
-                                                                   t) in
+                                                                 (uu___11, t) in
                                                                FStar_Syntax_Syntax.NT
-                                                                 uu____3961)
+                                                                 uu___10)
                                                           (a_b :: b_b ::
                                                           rest_bs) (t1 :: t2
                                                           :: rest_bs_uvars) in
                                                       let f_guard =
                                                         let f_sort_is =
-                                                          let uu____3997 =
-                                                            let uu____4000 =
-                                                              let uu____4001
-                                                                =
-                                                                let uu____4002
-                                                                  =
+                                                          let uu___10 =
+                                                            let uu___11 =
+                                                              let uu___12 =
+                                                                let uu___13 =
                                                                   FStar_All.pipe_right
                                                                     f_b
                                                                     FStar_Pervasives_Native.fst in
-                                                                uu____4002.FStar_Syntax_Syntax.sort in
+                                                                uu___13.FStar_Syntax_Syntax.sort in
                                                               FStar_Syntax_Subst.compress
-                                                                uu____4001 in
-                                                            let uu____4011 =
+                                                                uu___12 in
+                                                            let uu___12 =
                                                               FStar_Syntax_Util.is_layered
                                                                 m_ed in
                                                             effect_args_from_repr
-                                                              uu____4000
-                                                              uu____4011 r1 in
+                                                              uu___11 uu___12
+                                                              r1 in
                                                           FStar_All.pipe_right
-                                                            uu____3997
+                                                            uu___10
                                                             (FStar_List.map
                                                                (FStar_Syntax_Subst.subst
                                                                   subst)) in
@@ -1355,30 +1323,29 @@ let (mk_indexed_bind :
                                                           (fun g ->
                                                              fun i1 ->
                                                                fun f_i1 ->
-                                                                 (let uu____4035
+                                                                 (let uu___11
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
                                                                     env)
                                                                     (FStar_Options.Other
                                                                     "ResolveImplicitsHook") in
-                                                                  if
-                                                                    uu____4035
+                                                                  if uu___11
                                                                   then
-                                                                    let uu____4036
+                                                                    let uu___12
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     i1 in
-                                                                    let uu____4037
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     f_i1 in
                                                                     FStar_Util.print2
                                                                     "Generating constraint %s = %s\n"
-                                                                    uu____4036
-                                                                    uu____4037
+                                                                    uu___12
+                                                                    uu___13
                                                                   else ());
-                                                                 (let uu____4039
+                                                                 (let uu___11
                                                                     =
                                                                     FStar_TypeChecker_Rel.layered_effect_teq
                                                                     env i1
@@ -1386,8 +1353,7 @@ let (mk_indexed_bind :
                                                                     (FStar_Pervasives_Native.Some
                                                                     bind_name) in
                                                                   FStar_TypeChecker_Env.conj_guard
-                                                                    g
-                                                                    uu____4039))
+                                                                    g uu___11))
                                                           FStar_TypeChecker_Env.trivial_guard
                                                           is1 f_sort_is in
                                                       let g_guard =
@@ -1402,93 +1368,89 @@ let (mk_indexed_bind :
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 x in
                                                         let g_sort_is =
-                                                          let uu____4058 =
-                                                            let uu____4059 =
-                                                              let uu____4062
-                                                                =
-                                                                let uu____4063
-                                                                  =
+                                                          let uu___10 =
+                                                            let uu___11 =
+                                                              let uu___12 =
+                                                                let uu___13 =
                                                                   FStar_All.pipe_right
                                                                     g_b
                                                                     FStar_Pervasives_Native.fst in
-                                                                uu____4063.FStar_Syntax_Syntax.sort in
+                                                                uu___13.FStar_Syntax_Syntax.sort in
                                                               FStar_Syntax_Subst.compress
-                                                                uu____4062 in
-                                                            uu____4059.FStar_Syntax_Syntax.n in
-                                                          match uu____4058
-                                                          with
+                                                                uu___12 in
+                                                            uu___11.FStar_Syntax_Syntax.n in
+                                                          match uu___10 with
                                                           | FStar_Syntax_Syntax.Tm_arrow
                                                               (bs, c) ->
-                                                              let uu____4096
-                                                                =
+                                                              let uu___11 =
                                                                 FStar_Syntax_Subst.open_comp
                                                                   bs c in
-                                                              (match uu____4096
+                                                              (match uu___11
                                                                with
                                                                | (bs1, c1) ->
                                                                    let bs_subst
                                                                     =
-                                                                    let uu____4106
+                                                                    let uu___12
                                                                     =
-                                                                    let uu____4113
+                                                                    let uu___13
                                                                     =
-                                                                    let uu____4114
+                                                                    let uu___14
                                                                     =
                                                                     FStar_List.hd
                                                                     bs1 in
                                                                     FStar_All.pipe_right
-                                                                    uu____4114
+                                                                    uu___14
                                                                     FStar_Pervasives_Native.fst in
-                                                                    let uu____4135
+                                                                    let uu___14
                                                                     =
-                                                                    let uu____4138
+                                                                    let uu___15
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     x_a
                                                                     FStar_Pervasives_Native.fst in
                                                                     FStar_All.pipe_right
-                                                                    uu____4138
+                                                                    uu___15
                                                                     FStar_Syntax_Syntax.bv_to_name in
-                                                                    (uu____4113,
-                                                                    uu____4135) in
+                                                                    (uu___13,
+                                                                    uu___14) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____4106 in
+                                                                    uu___12 in
                                                                    let c2 =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     [bs_subst]
                                                                     c1 in
-                                                                   let uu____4152
+                                                                   let uu___12
                                                                     =
-                                                                    let uu____4155
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c2) in
-                                                                    let uu____4156
+                                                                    let uu___14
                                                                     =
                                                                     FStar_Syntax_Util.is_layered
                                                                     n_ed in
                                                                     effect_args_from_repr
-                                                                    uu____4155
-                                                                    uu____4156
+                                                                    uu___13
+                                                                    uu___14
                                                                     r1 in
                                                                    FStar_All.pipe_right
-                                                                    uu____4152
+                                                                    uu___12
                                                                     (FStar_List.map
                                                                     (FStar_Syntax_Subst.subst
                                                                     subst)))
-                                                          | uu____4161 ->
+                                                          | uu___11 ->
                                                               failwith
                                                                 "impossible: mk_indexed_bind" in
                                                         let env_g =
                                                           FStar_TypeChecker_Env.push_binders
                                                             env [x_a] in
-                                                        let uu____4177 =
+                                                        let uu___10 =
                                                           FStar_List.fold_left2
                                                             (fun g ->
                                                                fun i1 ->
                                                                  fun g_i1 ->
-                                                                   (let uu____4195
+                                                                   (let uu___12
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -1496,22 +1458,22 @@ let (mk_indexed_bind :
                                                                     (FStar_Options.Other
                                                                     "ResolveImplicitsHook") in
                                                                     if
-                                                                    uu____4195
+                                                                    uu___12
                                                                     then
-                                                                    let uu____4196
+                                                                    let uu___13
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     i1 in
-                                                                    let uu____4197
+                                                                    let uu___14
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     g_i1 in
                                                                     FStar_Util.print2
                                                                     "Generating constraint %s = %s\n"
-                                                                    uu____4196
-                                                                    uu____4197
+                                                                    uu___13
+                                                                    uu___14
                                                                     else ());
-                                                                   (let uu____4199
+                                                                   (let uu___12
                                                                     =
                                                                     FStar_TypeChecker_Rel.layered_effect_teq
                                                                     env_g i1
@@ -1519,37 +1481,35 @@ let (mk_indexed_bind :
                                                                     (FStar_Pervasives_Native.Some
                                                                     bind_name) in
                                                                     FStar_TypeChecker_Env.conj_guard
-                                                                    g
-                                                                    uu____4199))
+                                                                    g uu___12))
                                                             FStar_TypeChecker_Env.trivial_guard
                                                             is2 g_sort_is in
                                                         FStar_All.pipe_right
-                                                          uu____4177
+                                                          uu___10
                                                           (FStar_TypeChecker_Env.close_guard
                                                              env [x_a]) in
                                                       let bind_ct =
-                                                        let uu____4213 =
+                                                        let uu___10 =
                                                           FStar_All.pipe_right
                                                             bind_c
                                                             (FStar_Syntax_Subst.subst_comp
                                                                subst) in
                                                         FStar_All.pipe_right
-                                                          uu____4213
+                                                          uu___10
                                                           FStar_Syntax_Util.comp_to_comp_typ in
                                                       let fml =
-                                                        let uu____4215 =
-                                                          let uu____4220 =
+                                                        let uu___10 =
+                                                          let uu___11 =
                                                             FStar_List.hd
                                                               bind_ct.FStar_Syntax_Syntax.comp_univs in
-                                                          let uu____4221 =
-                                                            let uu____4222 =
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               FStar_List.hd
                                                                 bind_ct.FStar_Syntax_Syntax.effect_args in
                                                             FStar_Pervasives_Native.fst
-                                                              uu____4222 in
-                                                          (uu____4220,
-                                                            uu____4221) in
-                                                        match uu____4215 with
+                                                              uu___13 in
+                                                          (uu___11, uu___12) in
+                                                        match uu___10 with
                                                         | (u, wp) ->
                                                             FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                               env u
@@ -1557,18 +1517,17 @@ let (mk_indexed_bind :
                                                               wp
                                                               FStar_Range.dummyRange in
                                                       let is =
-                                                        let uu____4248 =
+                                                        let uu___10 =
                                                           FStar_Syntax_Subst.compress
                                                             bind_ct.FStar_Syntax_Syntax.result_typ in
-                                                        let uu____4249 =
+                                                        let uu___11 =
                                                           FStar_Syntax_Util.is_layered
                                                             p_ed in
                                                         effect_args_from_repr
-                                                          uu____4248
-                                                          uu____4249 r1 in
+                                                          uu___10 uu___11 r1 in
                                                       let c =
-                                                        let uu____4251 =
-                                                          let uu____4252 =
+                                                        let uu___10 =
+                                                          let uu___11 =
                                                             FStar_List.map
                                                               FStar_Syntax_Syntax.as_arg
                                                               is in
@@ -1582,68 +1541,65 @@ let (mk_indexed_bind :
                                                             FStar_Syntax_Syntax.result_typ
                                                               = t2;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____4252;
+                                                              = uu___11;
                                                             FStar_Syntax_Syntax.flags
                                                               = flags
                                                           } in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____4251 in
-                                                      (let uu____4272 =
+                                                          uu___10 in
+                                                      (let uu___11 =
                                                          FStar_All.pipe_left
                                                            (FStar_TypeChecker_Env.debug
                                                               env)
                                                            (FStar_Options.Other
                                                               "LayeredEffects") in
-                                                       if uu____4272
+                                                       if uu___11
                                                        then
-                                                         let uu____4273 =
+                                                         let uu___12 =
                                                            FStar_Syntax_Print.comp_to_string
                                                              c in
                                                          FStar_Util.print1
                                                            "} c after bind: %s\n"
-                                                           uu____4273
+                                                           uu___12
                                                        else ());
                                                       (let guard =
-                                                         let uu____4276 =
-                                                           let uu____4279 =
-                                                             let uu____4282 =
-                                                               let uu____4285
-                                                                 =
-                                                                 let uu____4288
+                                                         let uu___11 =
+                                                           let uu___12 =
+                                                             let uu___13 =
+                                                               let uu___14 =
+                                                                 let uu___15
                                                                    =
                                                                    FStar_TypeChecker_Env.guard_of_guard_formula
                                                                     (FStar_TypeChecker_Common.NonTrivial
                                                                     fml) in
-                                                                 [uu____4288] in
+                                                                 [uu___15] in
                                                                g_guard ::
-                                                                 uu____4285 in
+                                                                 uu___14 in
                                                              f_guard ::
-                                                               uu____4282 in
-                                                           g_uvars ::
-                                                             uu____4279 in
+                                                               uu___13 in
+                                                           g_uvars :: uu___12 in
                                                          FStar_TypeChecker_Env.conj_guards
-                                                           uu____4276 in
-                                                       (let uu____4290 =
+                                                           uu___11 in
+                                                       (let uu___12 =
                                                           FStar_All.pipe_left
                                                             (FStar_TypeChecker_Env.debug
                                                                env)
                                                             (FStar_Options.Other
                                                                "ResolveImplicitsHook") in
-                                                        if uu____4290
+                                                        if uu___12
                                                         then
-                                                          let uu____4291 =
-                                                            let uu____4292 =
+                                                          let uu___13 =
+                                                            let uu___14 =
                                                               FStar_TypeChecker_Env.get_range
                                                                 env in
                                                             FStar_Range.string_of_range
-                                                              uu____4292 in
-                                                          let uu____4293 =
+                                                              uu___14 in
+                                                          let uu___14 =
                                                             FStar_TypeChecker_Rel.guard_to_string
                                                               env guard in
                                                           FStar_Util.print2
                                                             "///////////////////////////////EndBind at %s/////////////////////\nguard = %s\n"
-                                                            uu____4291
-                                                            uu____4293
+                                                            uu___13 uu___14
                                                         else ());
                                                        (c, guard))))))))))
 let (mk_wp_bind :
@@ -1662,24 +1618,24 @@ let (mk_wp_bind :
           fun ct2 ->
             fun flags ->
               fun r1 ->
-                let uu____4338 =
+                let uu___ =
                   let md = FStar_TypeChecker_Env.get_effect_decl env m in
-                  let uu____4364 = FStar_TypeChecker_Env.wp_signature env m in
-                  match uu____4364 with
+                  let uu___1 = FStar_TypeChecker_Env.wp_signature env m in
+                  match uu___1 with
                   | (a, kwp) ->
-                      let uu____4395 = destruct_wp_comp ct1 in
-                      let uu____4402 = destruct_wp_comp ct2 in
-                      ((md, a, kwp), uu____4395, uu____4402) in
-                match uu____4338 with
+                      let uu___2 = destruct_wp_comp ct1 in
+                      let uu___3 = destruct_wp_comp ct2 in
+                      ((md, a, kwp), uu___2, uu___3) in
+                match uu___ with
                 | ((md, a, kwp), (u_t1, t1, wp1), (u_t2, t2, wp2)) ->
                     let bs =
                       match b with
                       | FStar_Pervasives_Native.None ->
-                          let uu____4455 = FStar_Syntax_Syntax.null_binder t1 in
-                          [uu____4455]
+                          let uu___1 = FStar_Syntax_Syntax.null_binder t1 in
+                          [uu___1]
                       | FStar_Pervasives_Native.Some x ->
-                          let uu____4475 = FStar_Syntax_Syntax.mk_binder x in
-                          [uu____4475] in
+                          let uu___1 = FStar_Syntax_Syntax.mk_binder x in
+                          [uu___1] in
                     let mk_lam wp =
                       FStar_Syntax_Util.abs bs wp
                         (FStar_Pervasives_Native.Some
@@ -1692,30 +1648,30 @@ let (mk_wp_bind :
                         (FStar_Syntax_Syntax.Tm_constant
                            (FStar_Const.Const_range r1)) r1 in
                     let wp_args =
-                      let uu____4522 = FStar_Syntax_Syntax.as_arg r11 in
-                      let uu____4531 =
-                        let uu____4542 = FStar_Syntax_Syntax.as_arg t1 in
-                        let uu____4551 =
-                          let uu____4562 = FStar_Syntax_Syntax.as_arg t2 in
-                          let uu____4571 =
-                            let uu____4582 = FStar_Syntax_Syntax.as_arg wp1 in
-                            let uu____4591 =
-                              let uu____4602 =
-                                let uu____4611 = mk_lam wp2 in
-                                FStar_Syntax_Syntax.as_arg uu____4611 in
-                              [uu____4602] in
-                            uu____4582 :: uu____4591 in
-                          uu____4562 :: uu____4571 in
-                        uu____4542 :: uu____4551 in
-                      uu____4522 :: uu____4531 in
+                      let uu___1 = FStar_Syntax_Syntax.as_arg r11 in
+                      let uu___2 =
+                        let uu___3 = FStar_Syntax_Syntax.as_arg t1 in
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Syntax.as_arg t2 in
+                          let uu___6 =
+                            let uu___7 = FStar_Syntax_Syntax.as_arg wp1 in
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 = mk_lam wp2 in
+                                FStar_Syntax_Syntax.as_arg uu___10 in
+                              [uu___9] in
+                            uu___7 :: uu___8 in
+                          uu___5 :: uu___6 in
+                        uu___3 :: uu___4 in
+                      uu___1 :: uu___2 in
                     let bind_wp =
                       FStar_All.pipe_right md
                         FStar_Syntax_Util.get_bind_vc_combinator in
                     let wp =
-                      let uu____4662 =
+                      let uu___1 =
                         FStar_TypeChecker_Env.inst_effect_fun_with
                           [u_t1; u_t2] env md bind_wp in
-                      FStar_Syntax_Syntax.mk_Tm_app uu____4662 wp_args
+                      FStar_Syntax_Syntax.mk_Tm_app uu___1 wp_args
                         t2.FStar_Syntax_Syntax.pos in
                     mk_comp md u_t2 t2 wp flags
 let (mk_bind :
@@ -1733,59 +1689,59 @@ let (mk_bind :
         fun c2 ->
           fun flags ->
             fun r1 ->
-              let uu____4709 =
-                let uu____4714 =
+              let uu___ =
+                let uu___1 =
                   FStar_TypeChecker_Env.unfold_effect_abbrev env c1 in
-                let uu____4715 =
+                let uu___2 =
                   FStar_TypeChecker_Env.unfold_effect_abbrev env c2 in
-                (uu____4714, uu____4715) in
-              match uu____4709 with
+                (uu___1, uu___2) in
+              match uu___ with
               | (ct1, ct2) ->
-                  let uu____4722 =
+                  let uu___1 =
                     FStar_TypeChecker_Env.exists_polymonadic_bind env
                       ct1.FStar_Syntax_Syntax.effect_name
                       ct2.FStar_Syntax_Syntax.effect_name in
-                  (match uu____4722 with
+                  (match uu___1 with
                    | FStar_Pervasives_Native.Some (p, f_bind) ->
                        f_bind env ct1 b ct2 flags r1
                    | FStar_Pervasives_Native.None ->
-                       let uu____4773 = lift_comps env c1 c2 b true in
-                       (match uu____4773 with
+                       let uu___2 = lift_comps env c1 c2 b true in
+                       (match uu___2 with
                         | (m, c11, c21, g_lift) ->
-                            let uu____4790 =
-                              let uu____4795 =
+                            let uu___3 =
+                              let uu___4 =
                                 FStar_Syntax_Util.comp_to_comp_typ c11 in
-                              let uu____4796 =
+                              let uu___5 =
                                 FStar_Syntax_Util.comp_to_comp_typ c21 in
-                              (uu____4795, uu____4796) in
-                            (match uu____4790 with
+                              (uu___4, uu___5) in
+                            (match uu___3 with
                              | (ct11, ct21) ->
-                                 let uu____4803 =
-                                   let uu____4808 =
+                                 let uu___4 =
+                                   let uu___5 =
                                      FStar_TypeChecker_Env.is_layered_effect
                                        env m in
-                                   if uu____4808
+                                   if uu___5
                                    then
                                      let bind_t =
-                                       let uu____4814 =
+                                       let uu___6 =
                                          FStar_All.pipe_right m
                                            (FStar_TypeChecker_Env.get_effect_decl
                                               env) in
-                                       FStar_All.pipe_right uu____4814
+                                       FStar_All.pipe_right uu___6
                                          FStar_Syntax_Util.get_bind_vc_combinator in
                                      mk_indexed_bind env m m m bind_t ct11 b
                                        ct21 flags r1
                                    else
-                                     (let uu____4816 =
+                                     (let uu___7 =
                                         mk_wp_bind env m ct11 b ct21 flags r1 in
-                                      (uu____4816,
+                                      (uu___7,
                                         FStar_TypeChecker_Env.trivial_guard)) in
-                                 (match uu____4803 with
+                                 (match uu___4 with
                                   | (c, g_bind) ->
-                                      let uu____4823 =
+                                      let uu___5 =
                                         FStar_TypeChecker_Env.conj_guard
                                           g_lift g_bind in
-                                      (c, uu____4823)))))
+                                      (c, uu___5)))))
 let (bind_pure_wp_with :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -1799,40 +1755,40 @@ let (bind_pure_wp_with :
         fun flags ->
           let r = FStar_TypeChecker_Env.get_range env in
           let pure_c =
-            let uu____4858 =
-              let uu____4859 =
-                let uu____4870 =
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
                   FStar_All.pipe_right wp1 FStar_Syntax_Syntax.as_arg in
-                [uu____4870] in
+                [uu___2] in
               {
                 FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_zero];
                 FStar_Syntax_Syntax.effect_name =
                   FStar_Parser_Const.effect_PURE_lid;
                 FStar_Syntax_Syntax.result_typ = FStar_Syntax_Syntax.t_unit;
-                FStar_Syntax_Syntax.effect_args = uu____4859;
+                FStar_Syntax_Syntax.effect_args = uu___1;
                 FStar_Syntax_Syntax.flags = []
               } in
-            FStar_Syntax_Syntax.mk_Comp uu____4858 in
+            FStar_Syntax_Syntax.mk_Comp uu___ in
           mk_bind env pure_c FStar_Pervasives_Native.None c flags r
 let (weaken_flags :
   FStar_Syntax_Syntax.cflag Prims.list ->
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun flags ->
-    let uu____4914 =
+    let uu___ =
       FStar_All.pipe_right flags
         (FStar_Util.for_some
-           (fun uu___1_4918 ->
-              match uu___1_4918 with
+           (fun uu___1 ->
+              match uu___1 with
               | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-              | uu____4919 -> false)) in
-    if uu____4914
+              | uu___2 -> false)) in
+    if uu___
     then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
     else
       FStar_All.pipe_right flags
         (FStar_List.collect
-           (fun uu___2_4928 ->
-              match uu___2_4928 with
+           (fun uu___2 ->
+              match uu___2 with
               | FStar_Syntax_Syntax.TOTAL ->
                   [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
               | FStar_Syntax_Syntax.RETURN ->
@@ -1848,28 +1804,27 @@ let (weaken_comp :
   fun env ->
     fun c ->
       fun formula ->
-        let uu____4955 = FStar_Syntax_Util.is_ml_comp c in
-        if uu____4955
+        let uu___ = FStar_Syntax_Util.is_ml_comp c in
+        if uu___
         then (c, FStar_TypeChecker_Env.trivial_guard)
         else
           (let ct = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
            let pure_assume_wp =
-             let uu____4963 =
+             let uu___2 =
                FStar_Syntax_Syntax.lid_as_fv
                  FStar_Parser_Const.pure_assume_wp_lid
                  (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
                  FStar_Pervasives_Native.None in
-             FStar_Syntax_Syntax.fv_to_tm uu____4963 in
+             FStar_Syntax_Syntax.fv_to_tm uu___2 in
            let pure_assume_wp1 =
-             let uu____4965 =
-               let uu____4966 =
+             let uu___2 =
+               let uu___3 =
                  FStar_All.pipe_left FStar_Syntax_Syntax.as_arg formula in
-               [uu____4966] in
-             let uu____4999 = FStar_TypeChecker_Env.get_range env in
-             FStar_Syntax_Syntax.mk_Tm_app pure_assume_wp uu____4965
-               uu____4999 in
-           let uu____5000 = weaken_flags ct.FStar_Syntax_Syntax.flags in
-           bind_pure_wp_with env pure_assume_wp1 c uu____5000)
+               [uu___3] in
+             let uu___3 = FStar_TypeChecker_Env.get_range env in
+             FStar_Syntax_Syntax.mk_Tm_app pure_assume_wp uu___2 uu___3 in
+           let uu___2 = weaken_flags ct.FStar_Syntax_Syntax.flags in
+           bind_pure_wp_with env pure_assume_wp1 c uu___2)
 let (weaken_precondition :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.lcomp ->
@@ -1879,28 +1834,28 @@ let (weaken_precondition :
   fun env ->
     fun lc ->
       fun f ->
-        let weaken uu____5027 =
-          let uu____5028 = FStar_TypeChecker_Common.lcomp_comp lc in
-          match uu____5028 with
+        let weaken uu___ =
+          let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
+          match uu___1 with
           | (c, g_c) ->
-              let uu____5039 =
+              let uu___2 =
                 env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-              if uu____5039
+              if uu___2
               then (c, g_c)
               else
                 (match f with
                  | FStar_TypeChecker_Common.Trivial -> (c, g_c)
                  | FStar_TypeChecker_Common.NonTrivial f1 ->
-                     let uu____5050 = weaken_comp env c f1 in
-                     (match uu____5050 with
+                     let uu___4 = weaken_comp env c f1 in
+                     (match uu___4 with
                       | (c1, g_w) ->
-                          let uu____5061 =
+                          let uu___5 =
                             FStar_TypeChecker_Env.conj_guard g_c g_w in
-                          (c1, uu____5061))) in
-        let uu____5062 = weaken_flags lc.FStar_TypeChecker_Common.cflags in
+                          (c1, uu___5))) in
+        let uu___ = weaken_flags lc.FStar_TypeChecker_Common.cflags in
         FStar_TypeChecker_Common.mk_lcomp
           lc.FStar_TypeChecker_Common.eff_name
-          lc.FStar_TypeChecker_Common.res_typ uu____5062 weaken
+          lc.FStar_TypeChecker_Common.res_typ uu___ weaken
 let (strengthen_comp :
   FStar_TypeChecker_Env.env ->
     (unit -> Prims.string) FStar_Pervasives_Native.option ->
@@ -1919,20 +1874,19 @@ let (strengthen_comp :
             else
               (let r = FStar_TypeChecker_Env.get_range env in
                let pure_assert_wp =
-                 let uu____5114 =
+                 let uu___1 =
                    FStar_Syntax_Syntax.lid_as_fv
                      FStar_Parser_Const.pure_assert_wp_lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None in
-                 FStar_Syntax_Syntax.fv_to_tm uu____5114 in
+                 FStar_Syntax_Syntax.fv_to_tm uu___1 in
                let pure_assert_wp1 =
-                 let uu____5116 =
-                   let uu____5117 =
-                     let uu____5126 = label_opt env reason r f in
-                     FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
-                       uu____5126 in
-                   [uu____5117] in
-                 FStar_Syntax_Syntax.mk_Tm_app pure_assert_wp uu____5116 r in
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 = label_opt env reason r f in
+                     FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu___3 in
+                   [uu___2] in
+                 FStar_Syntax_Syntax.mk_Tm_app pure_assert_wp uu___1 r in
                bind_pure_wp_with env pure_assert_wp1 c flags)
 let (strengthen_precondition :
   (unit -> Prims.string) FStar_Pervasives_Native.option ->
@@ -1948,26 +1902,25 @@ let (strengthen_precondition :
       fun e_for_debugging_only ->
         fun lc ->
           fun g0 ->
-            let uu____5193 =
-              FStar_TypeChecker_Env.is_trivial_guard_formula g0 in
-            if uu____5193
+            let uu___ = FStar_TypeChecker_Env.is_trivial_guard_formula g0 in
+            if uu___
             then (lc, g0)
             else
               (let flags =
-                 let uu____5202 =
-                   let uu____5209 =
+                 let uu___2 =
+                   let uu___3 =
                      FStar_TypeChecker_Common.is_tot_or_gtot_lcomp lc in
-                   if uu____5209
+                   if uu___3
                    then (true, [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION])
                    else (false, []) in
-                 match uu____5202 with
-                 | (maybe_trivial_post, flags) ->
-                     let uu____5229 =
+                 match uu___2 with
+                 | (maybe_trivial_post, flags1) ->
+                     let uu___3 =
                        FStar_All.pipe_right
                          lc.FStar_TypeChecker_Common.cflags
                          (FStar_List.collect
-                            (fun uu___3_5237 ->
-                               match uu___3_5237 with
+                            (fun uu___4 ->
+                               match uu___4 with
                                | FStar_Syntax_Syntax.RETURN ->
                                    [FStar_Syntax_Syntax.PARTIAL_RETURN]
                                | FStar_Syntax_Syntax.PARTIAL_RETURN ->
@@ -1981,73 +1934,73 @@ let (strengthen_precondition :
                                    [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
                                | FStar_Syntax_Syntax.SHOULD_NOT_INLINE ->
                                    [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
-                               | uu____5240 -> [])) in
-                     FStar_List.append flags uu____5229 in
-               let strengthen uu____5250 =
-                 let uu____5251 = FStar_TypeChecker_Common.lcomp_comp lc in
-                 match uu____5251 with
+                               | uu___5 -> [])) in
+                     FStar_List.append flags1 uu___3 in
+               let strengthen uu___2 =
+                 let uu___3 = FStar_TypeChecker_Common.lcomp_comp lc in
+                 match uu___3 with
                  | (c, g_c) ->
                      if env.FStar_TypeChecker_Env.lax
                      then (c, g_c)
                      else
                        (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0 in
-                        let uu____5268 = FStar_TypeChecker_Env.guard_form g01 in
-                        match uu____5268 with
+                        let uu___5 = FStar_TypeChecker_Env.guard_form g01 in
+                        match uu___5 with
                         | FStar_TypeChecker_Common.Trivial -> (c, g_c)
                         | FStar_TypeChecker_Common.NonTrivial f ->
-                            ((let uu____5275 =
+                            ((let uu___7 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Extreme in
-                              if uu____5275
+                              if uu___7
                               then
-                                let uu____5276 =
+                                let uu___8 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env e_for_debugging_only in
-                                let uu____5277 =
+                                let uu___9 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env f in
                                 FStar_Util.print2
                                   "-------------Strengthening pre-condition of term %s with guard %s\n"
-                                  uu____5276 uu____5277
+                                  uu___8 uu___9
                               else ());
-                             (let uu____5279 =
+                             (let uu___7 =
                                 strengthen_comp env reason c f flags in
-                              match uu____5279 with
+                              match uu___7 with
                               | (c1, g_s) ->
-                                  let uu____5290 =
+                                  let uu___8 =
                                     FStar_TypeChecker_Env.conj_guard g_c g_s in
-                                  (c1, uu____5290)))) in
-               let uu____5291 =
-                 let uu____5292 =
+                                  (c1, uu___8)))) in
+               let uu___2 =
+                 let uu___3 =
                    FStar_TypeChecker_Env.norm_eff_name env
                      lc.FStar_TypeChecker_Common.eff_name in
-                 FStar_TypeChecker_Common.mk_lcomp uu____5292
+                 FStar_TypeChecker_Common.mk_lcomp uu___3
                    lc.FStar_TypeChecker_Common.res_typ flags strengthen in
-               (uu____5291,
-                 (let uu___678_5294 = g0 in
+               (uu___2,
+                 (let uu___3 = g0 in
                   {
                     FStar_TypeChecker_Common.guard_f =
                       FStar_TypeChecker_Common.Trivial;
                     FStar_TypeChecker_Common.deferred_to_tac =
-                      (uu___678_5294.FStar_TypeChecker_Common.deferred_to_tac);
+                      (uu___3.FStar_TypeChecker_Common.deferred_to_tac);
                     FStar_TypeChecker_Common.deferred =
-                      (uu___678_5294.FStar_TypeChecker_Common.deferred);
+                      (uu___3.FStar_TypeChecker_Common.deferred);
                     FStar_TypeChecker_Common.univ_ineqs =
-                      (uu___678_5294.FStar_TypeChecker_Common.univ_ineqs);
+                      (uu___3.FStar_TypeChecker_Common.univ_ineqs);
                     FStar_TypeChecker_Common.implicits =
-                      (uu___678_5294.FStar_TypeChecker_Common.implicits)
+                      (uu___3.FStar_TypeChecker_Common.implicits)
                   })))
 let (lcomp_has_trivial_postcondition :
   FStar_TypeChecker_Common.lcomp -> Prims.bool) =
   fun lc ->
     (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp lc) ||
       (FStar_Util.for_some
-         (fun uu___4_5301 ->
-            match uu___4_5301 with
+         (fun uu___ ->
+            match uu___ with
             | FStar_Syntax_Syntax.SOMETRIVIAL -> true
             | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION -> true
-            | uu____5302 -> false) lc.FStar_TypeChecker_Common.cflags)
+            | uu___1 -> false) lc.FStar_TypeChecker_Common.cflags)
 let (maybe_add_with_type :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option ->
@@ -2059,23 +2012,23 @@ let (maybe_add_with_type :
     fun uopt ->
       fun lc ->
         fun e ->
-          let uu____5329 =
+          let uu___ =
             (FStar_TypeChecker_Common.is_lcomp_partial_return lc) ||
               env.FStar_TypeChecker_Env.lax in
-          if uu____5329
+          if uu___
           then e
           else
-            (let uu____5333 =
+            (let uu___2 =
                (lcomp_has_trivial_postcondition lc) &&
-                 (let uu____5335 =
+                 (let uu___3 =
                     FStar_TypeChecker_Env.try_lookup_lid env
                       FStar_Parser_Const.with_type_lid in
-                  FStar_Option.isSome uu____5335) in
-             if uu____5333
+                  FStar_Option.isSome uu___3) in
+             if uu___2
              then
                let u =
                  match uopt with
-                 | FStar_Pervasives_Native.Some u -> u
+                 | FStar_Pervasives_Native.Some u1 -> u1
                  | FStar_Pervasives_Native.None ->
                      env.FStar_TypeChecker_Env.universe_of env
                        lc.FStar_TypeChecker_Common.res_typ in
@@ -2103,22 +2056,22 @@ let (maybe_capture_unit_refinement :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.unit_lid
-                | uu____5400 -> false in
+                | uu___ -> false in
               if is_unit
               then
-                let uu____5405 =
-                  let uu____5406 =
-                    let uu____5407 =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 =
                       FStar_All.pipe_right c
                         FStar_Syntax_Util.comp_effect_name in
-                    FStar_All.pipe_right uu____5407
+                    FStar_All.pipe_right uu___2
                       (FStar_TypeChecker_Env.norm_eff_name env) in
-                  FStar_All.pipe_right uu____5406
+                  FStar_All.pipe_right uu___1
                     (FStar_TypeChecker_Env.is_layered_effect env) in
-                (if uu____5405
+                (if uu___
                  then
-                   let uu____5414 = FStar_Syntax_Subst.open_term_bv b phi in
-                   match uu____5414 with
+                   let uu___1 = FStar_Syntax_Subst.open_term_bv b phi in
+                   match uu___1 with
                    | (b1, phi1) ->
                        let phi2 =
                          FStar_Syntax_Subst.subst
@@ -2126,10 +2079,10 @@ let (maybe_capture_unit_refinement :
                               (b1, FStar_Syntax_Syntax.unit_const)] phi1 in
                        weaken_comp env c phi2
                  else
-                   (let uu____5429 = close_wp_comp env [x] c in
-                    (uu____5429, FStar_TypeChecker_Env.trivial_guard)))
+                   (let uu___2 = close_wp_comp env [x] c in
+                    (uu___2, FStar_TypeChecker_Env.trivial_guard)))
               else (c, FStar_TypeChecker_Env.trivial_guard)
-          | uu____5431 -> (c, FStar_TypeChecker_Env.trivial_guard)
+          | uu___ -> (c, FStar_TypeChecker_Env.trivial_guard)
 let (bind :
   FStar_Range.range ->
     FStar_TypeChecker_Env.env ->
@@ -2141,187 +2094,184 @@ let (bind :
     fun env ->
       fun e1opt ->
         fun lc1 ->
-          fun uu____5458 ->
-            match uu____5458 with
+          fun uu___ ->
+            match uu___ with
             | (b, lc2) ->
                 let debug f =
-                  let uu____5478 =
+                  let uu___1 =
                     (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "bind")) in
-                  if uu____5478 then f () else () in
+                  if uu___1 then f () else () in
                 let lc11 =
                   FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1 in
                 let lc21 =
                   FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2 in
                 let joined_eff = join_lcomp env lc11 lc21 in
                 let bind_flags =
-                  let uu____5486 =
+                  let uu___1 =
                     (should_not_inline_lc lc11) ||
                       (should_not_inline_lc lc21) in
-                  if uu____5486
+                  if uu___1
                   then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                   else
                     (let flags =
-                       let uu____5493 =
+                       let uu___3 =
                          FStar_TypeChecker_Common.is_total_lcomp lc11 in
-                       if uu____5493
+                       if uu___3
                        then
-                         let uu____5496 =
+                         let uu___4 =
                            FStar_TypeChecker_Common.is_total_lcomp lc21 in
-                         (if uu____5496
+                         (if uu___4
                           then [FStar_Syntax_Syntax.TOTAL]
                           else
-                            (let uu____5500 =
+                            (let uu___6 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  lc21 in
-                             if uu____5500
+                             if uu___6
                              then [FStar_Syntax_Syntax.SOMETRIVIAL]
                              else []))
                        else
-                         (let uu____5505 =
+                         (let uu___5 =
                             (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                lc11)
                               &&
                               (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  lc21) in
-                          if uu____5505
+                          if uu___5
                           then [FStar_Syntax_Syntax.SOMETRIVIAL]
                           else []) in
-                     let uu____5509 = lcomp_has_trivial_postcondition lc21 in
-                     if uu____5509
+                     let uu___3 = lcomp_has_trivial_postcondition lc21 in
+                     if uu___3
                      then FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION :: flags
                      else flags) in
-                let bind_it uu____5522 =
-                  let uu____5523 =
+                let bind_it uu___1 =
+                  let uu___2 =
                     env.FStar_TypeChecker_Env.lax &&
                       (FStar_Options.ml_ish ()) in
-                  if uu____5523
+                  if uu___2
                   then
                     let u_t =
                       env.FStar_TypeChecker_Env.universe_of env
                         lc21.FStar_TypeChecker_Common.res_typ in
-                    let uu____5529 =
+                    let uu___3 =
                       lax_mk_tot_or_comp_l joined_eff u_t
                         lc21.FStar_TypeChecker_Common.res_typ [] in
-                    (uu____5529, FStar_TypeChecker_Env.trivial_guard)
+                    (uu___3, FStar_TypeChecker_Env.trivial_guard)
                   else
-                    (let uu____5531 =
-                       FStar_TypeChecker_Common.lcomp_comp lc11 in
-                     match uu____5531 with
+                    (let uu___4 = FStar_TypeChecker_Common.lcomp_comp lc11 in
+                     match uu___4 with
                      | (c1, g_c1) ->
-                         let uu____5542 =
+                         let uu___5 =
                            FStar_TypeChecker_Common.lcomp_comp lc21 in
-                         (match uu____5542 with
+                         (match uu___5 with
                           | (c2, g_c2) ->
                               let trivial_guard =
-                                let uu____5554 =
+                                let uu___6 =
                                   match b with
                                   | FStar_Pervasives_Native.Some x ->
                                       let b1 =
                                         FStar_Syntax_Syntax.mk_binder x in
-                                      let uu____5557 =
+                                      let uu___7 =
                                         FStar_Syntax_Syntax.is_null_binder b1 in
-                                      if uu____5557
+                                      if uu___7
                                       then g_c2
                                       else
                                         FStar_TypeChecker_Env.close_guard env
                                           [b1] g_c2
                                   | FStar_Pervasives_Native.None -> g_c2 in
-                                FStar_TypeChecker_Env.conj_guard g_c1
-                                  uu____5554 in
+                                FStar_TypeChecker_Env.conj_guard g_c1 uu___6 in
                               (debug
-                                 (fun uu____5580 ->
-                                    let uu____5581 =
+                                 (fun uu___7 ->
+                                    let uu___8 =
                                       FStar_Syntax_Print.comp_to_string c1 in
-                                    let uu____5582 =
+                                    let uu___9 =
                                       match b with
                                       | FStar_Pervasives_Native.None ->
                                           "none"
                                       | FStar_Pervasives_Native.Some x ->
                                           FStar_Syntax_Print.bv_to_string x in
-                                    let uu____5584 =
+                                    let uu___10 =
                                       FStar_Syntax_Print.comp_to_string c2 in
                                     FStar_Util.print3
                                       "(1) bind: \n\tc1=%s\n\tx=%s\n\tc2=%s\n(1. end bind)\n"
-                                      uu____5581 uu____5582 uu____5584);
-                               (let aux uu____5598 =
-                                  let uu____5599 =
+                                      uu___8 uu___9 uu___10);
+                               (let aux uu___7 =
+                                  let uu___8 =
                                     FStar_Syntax_Util.is_trivial_wp c1 in
-                                  if uu____5599
+                                  if uu___8
                                   then
                                     match b with
                                     | FStar_Pervasives_Native.None ->
                                         FStar_Util.Inl
                                           (c2, "trivial no binder")
-                                    | FStar_Pervasives_Native.Some uu____5620
-                                        ->
-                                        let uu____5621 =
+                                    | FStar_Pervasives_Native.Some uu___9 ->
+                                        let uu___10 =
                                           FStar_Syntax_Util.is_ml_comp c2 in
-                                        (if uu____5621
+                                        (if uu___10
                                          then
                                            FStar_Util.Inl (c2, "trivial ml")
                                          else
                                            FStar_Util.Inr
                                              "c1 trivial; but c2 is not ML")
                                   else
-                                    (let uu____5640 =
+                                    (let uu___10 =
                                        (FStar_Syntax_Util.is_ml_comp c1) &&
                                          (FStar_Syntax_Util.is_ml_comp c2) in
-                                     if uu____5640
+                                     if uu___10
                                      then FStar_Util.Inl (c2, "both ml")
                                      else
                                        FStar_Util.Inr
                                          "c1 not trivial, and both are not ML") in
-                                let try_simplify uu____5673 =
-                                  let aux_with_trivial_guard uu____5699 =
-                                    let uu____5700 = aux () in
-                                    match uu____5700 with
+                                let try_simplify uu___7 =
+                                  let aux_with_trivial_guard uu___8 =
+                                    let uu___9 = aux () in
+                                    match uu___9 with
                                     | FStar_Util.Inl (c, reason) ->
                                         FStar_Util.Inl
                                           (c, trivial_guard, reason)
                                     | FStar_Util.Inr reason ->
                                         FStar_Util.Inr reason in
-                                  let uu____5742 =
-                                    let uu____5743 =
+                                  let uu___8 =
+                                    let uu___9 =
                                       FStar_TypeChecker_Env.try_lookup_effect_lid
                                         env
                                         FStar_Parser_Const.effect_GTot_lid in
-                                    FStar_Option.isNone uu____5743 in
-                                  if uu____5742
+                                    FStar_Option.isNone uu___9 in
+                                  if uu___8
                                   then
-                                    let uu____5756 =
+                                    let uu___9 =
                                       (FStar_Syntax_Util.is_tot_or_gtot_comp
                                          c1)
                                         &&
                                         (FStar_Syntax_Util.is_tot_or_gtot_comp
                                            c2) in
-                                    (if uu____5756
+                                    (if uu___9
                                      then
                                        FStar_Util.Inl
                                          (c2, trivial_guard,
                                            "Early in prims; we don't have bind yet")
                                      else
-                                       (let uu____5774 =
+                                       (let uu___11 =
                                           FStar_TypeChecker_Env.get_range env in
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NonTrivialPreConditionInPrims,
                                             "Non-trivial pre-conditions very early in prims, even before we have defined the PURE monad")
-                                          uu____5774))
+                                          uu___11))
                                   else
-                                    (let uu____5786 =
+                                    (let uu___10 =
                                        FStar_Syntax_Util.is_total_comp c1 in
-                                     if uu____5786
+                                     if uu___10
                                      then
                                        let close_with_type_of_x x c =
                                          let x1 =
-                                           let uu___781_5813 = x in
+                                           let uu___11 = x in
                                            {
                                              FStar_Syntax_Syntax.ppname =
-                                               (uu___781_5813.FStar_Syntax_Syntax.ppname);
+                                               (uu___11.FStar_Syntax_Syntax.ppname);
                                              FStar_Syntax_Syntax.index =
-                                               (uu___781_5813.FStar_Syntax_Syntax.index);
+                                               (uu___11.FStar_Syntax_Syntax.index);
                                              FStar_Syntax_Syntax.sort =
                                                (FStar_Syntax_Util.comp_result
                                                   c1)
@@ -2331,107 +2281,106 @@ let (bind :
                                        match (e1opt, b) with
                                        | (FStar_Pervasives_Native.Some e,
                                           FStar_Pervasives_Native.Some x) ->
-                                           let uu____5842 =
-                                             let uu____5847 =
+                                           let uu___11 =
+                                             let uu___12 =
                                                FStar_All.pipe_right c2
                                                  (FStar_Syntax_Subst.subst_comp
                                                     [FStar_Syntax_Syntax.NT
                                                        (x, e)]) in
-                                             FStar_All.pipe_right uu____5847
+                                             FStar_All.pipe_right uu___12
                                                (close_with_type_of_x x) in
-                                           (match uu____5842 with
+                                           (match uu___11 with
                                             | (c21, g_close) ->
-                                                let uu____5866 =
-                                                  let uu____5873 =
-                                                    let uu____5874 =
-                                                      let uu____5877 =
-                                                        let uu____5880 =
+                                                let uu___12 =
+                                                  let uu___13 =
+                                                    let uu___14 =
+                                                      let uu___15 =
+                                                        let uu___16 =
                                                           FStar_TypeChecker_Env.map_guard
                                                             g_c2
                                                             (FStar_Syntax_Subst.subst
                                                                [FStar_Syntax_Syntax.NT
                                                                   (x, e)]) in
-                                                        [uu____5880; g_close] in
-                                                      g_c1 :: uu____5877 in
+                                                        [uu___16; g_close] in
+                                                      g_c1 :: uu___15 in
                                                     FStar_TypeChecker_Env.conj_guards
-                                                      uu____5874 in
-                                                  (c21, uu____5873, "c1 Tot") in
-                                                FStar_Util.Inl uu____5866)
-                                       | (uu____5889,
+                                                      uu___14 in
+                                                  (c21, uu___13, "c1 Tot") in
+                                                FStar_Util.Inl uu___12)
+                                       | (uu___11,
                                           FStar_Pervasives_Native.Some x) ->
-                                           let uu____5901 =
+                                           let uu___12 =
                                              FStar_All.pipe_right c2
                                                (close_with_type_of_x x) in
-                                           (match uu____5901 with
+                                           (match uu___12 with
                                             | (c21, g_close) ->
-                                                let uu____5922 =
-                                                  let uu____5929 =
-                                                    let uu____5930 =
-                                                      let uu____5933 =
-                                                        let uu____5936 =
-                                                          let uu____5937 =
-                                                            let uu____5938 =
+                                                let uu___13 =
+                                                  let uu___14 =
+                                                    let uu___15 =
+                                                      let uu___16 =
+                                                        let uu___17 =
+                                                          let uu___18 =
+                                                            let uu___19 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 x in
-                                                            [uu____5938] in
+                                                            [uu___19] in
                                                           FStar_TypeChecker_Env.close_guard
-                                                            env uu____5937
-                                                            g_c2 in
-                                                        [uu____5936; g_close] in
-                                                      g_c1 :: uu____5933 in
+                                                            env uu___18 g_c2 in
+                                                        [uu___17; g_close] in
+                                                      g_c1 :: uu___16 in
                                                     FStar_TypeChecker_Env.conj_guards
-                                                      uu____5930 in
-                                                  (c21, uu____5929,
+                                                      uu___15 in
+                                                  (c21, uu___14,
                                                     "c1 Tot only close") in
-                                                FStar_Util.Inl uu____5922)
-                                       | (uu____5963, uu____5964) ->
+                                                FStar_Util.Inl uu___13)
+                                       | (uu___11, uu___12) ->
                                            aux_with_trivial_guard ()
                                      else
-                                       (let uu____5978 =
+                                       (let uu___12 =
                                           (FStar_Syntax_Util.is_tot_or_gtot_comp
                                              c1)
                                             &&
                                             (FStar_Syntax_Util.is_tot_or_gtot_comp
                                                c2) in
-                                        if uu____5978
+                                        if uu___12
                                         then
-                                          let uu____5989 =
-                                            let uu____5996 =
+                                          let uu___13 =
+                                            let uu___14 =
                                               FStar_Syntax_Syntax.mk_GTotal
                                                 (FStar_Syntax_Util.comp_result
                                                    c2) in
-                                            (uu____5996, trivial_guard,
+                                            (uu___14, trivial_guard,
                                               "both GTot") in
-                                          FStar_Util.Inl uu____5989
+                                          FStar_Util.Inl uu___13
                                         else aux_with_trivial_guard ())) in
-                                let uu____6004 = try_simplify () in
-                                match uu____6004 with
+                                let uu___7 = try_simplify () in
+                                match uu___7 with
                                 | FStar_Util.Inl (c, g, reason) ->
                                     (debug
-                                       (fun uu____6033 ->
-                                          let uu____6034 =
+                                       (fun uu___9 ->
+                                          let uu___10 =
                                             FStar_Syntax_Print.comp_to_string
                                               c in
                                           FStar_Util.print2
                                             "(2) bind: Simplified (because %s) to\n\t%s\n"
-                                            reason uu____6034);
+                                            reason uu___10);
                                      (c, g))
                                 | FStar_Util.Inr reason ->
                                     (debug
-                                       (fun uu____6045 ->
+                                       (fun uu___9 ->
                                           FStar_Util.print1
                                             "(2) bind: Not simplified because %s\n"
                                             reason);
                                      (let mk_bind1 c11 b1 c21 g =
-                                        let uu____6075 =
+                                        let uu___9 =
                                           mk_bind env c11 b1 c21 bind_flags
                                             r1 in
-                                        match uu____6075 with
+                                        match uu___9 with
                                         | (c, g_bind) ->
-                                            let uu____6086 =
+                                            let uu___10 =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g g_bind in
-                                            (c, uu____6086) in
+                                            (c, uu___10) in
                                       let mk_seq c11 b1 c21 =
                                         let c12 =
                                           FStar_TypeChecker_Env.unfold_effect_abbrev
@@ -2439,152 +2388,149 @@ let (bind :
                                         let c22 =
                                           FStar_TypeChecker_Env.unfold_effect_abbrev
                                             env c21 in
-                                        let uu____6113 =
+                                        let uu___9 =
                                           FStar_TypeChecker_Env.join env
                                             c12.FStar_Syntax_Syntax.effect_name
                                             c22.FStar_Syntax_Syntax.effect_name in
-                                        match uu____6113 with
-                                        | (m, uu____6125, lift2) ->
-                                            let uu____6127 =
+                                        match uu___9 with
+                                        | (m, uu___10, lift2) ->
+                                            let uu___11 =
                                               lift_comp env c22 lift2 in
-                                            (match uu____6127 with
+                                            (match uu___11 with
                                              | (c23, g2) ->
-                                                 let uu____6138 =
+                                                 let uu___12 =
                                                    destruct_wp_comp c12 in
-                                                 (match uu____6138 with
+                                                 (match uu___12 with
                                                   | (u1, t1, wp1) ->
                                                       let md_pure_or_ghost =
                                                         FStar_TypeChecker_Env.get_effect_decl
                                                           env
                                                           c12.FStar_Syntax_Syntax.effect_name in
                                                       let trivial =
-                                                        let uu____6154 =
+                                                        let uu___13 =
                                                           FStar_All.pipe_right
                                                             md_pure_or_ghost
                                                             FStar_Syntax_Util.get_wp_trivial_combinator in
                                                         FStar_All.pipe_right
-                                                          uu____6154
+                                                          uu___13
                                                           FStar_Util.must in
                                                       let vc1 =
-                                                        let uu____6162 =
+                                                        let uu___13 =
                                                           FStar_TypeChecker_Env.inst_effect_fun_with
                                                             [u1] env
                                                             md_pure_or_ghost
                                                             trivial in
-                                                        let uu____6163 =
-                                                          let uu____6164 =
+                                                        let uu___14 =
+                                                          let uu___15 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               t1 in
-                                                          let uu____6173 =
-                                                            let uu____6184 =
+                                                          let uu___16 =
+                                                            let uu___17 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 wp1 in
-                                                            [uu____6184] in
-                                                          uu____6164 ::
-                                                            uu____6173 in
+                                                            [uu___17] in
+                                                          uu___15 :: uu___16 in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____6162
-                                                          uu____6163 r1 in
-                                                      let uu____6217 =
+                                                          uu___13 uu___14 r1 in
+                                                      let uu___13 =
                                                         strengthen_comp env
                                                           FStar_Pervasives_Native.None
                                                           c23 vc1 bind_flags in
-                                                      (match uu____6217 with
+                                                      (match uu___13 with
                                                        | (c, g_s) ->
-                                                           let uu____6231 =
+                                                           let uu___14 =
                                                              FStar_TypeChecker_Env.conj_guards
                                                                [g_c1;
                                                                g_c2;
                                                                g2;
                                                                g_s] in
-                                                           (c, uu____6231)))) in
-                                      let uu____6232 =
+                                                           (c, uu___14)))) in
+                                      let uu___9 =
                                         let t =
                                           FStar_Syntax_Util.comp_result c1 in
                                         match comp_univ_opt c1 with
                                         | FStar_Pervasives_Native.None ->
-                                            let uu____6248 =
+                                            let uu___10 =
                                               env.FStar_TypeChecker_Env.universe_of
                                                 env t in
-                                            (uu____6248, t)
+                                            (uu___10, t)
                                         | FStar_Pervasives_Native.Some u ->
                                             (u, t) in
-                                      match uu____6232 with
+                                      match uu___9 with
                                       | (u_res_t1, res_t1) ->
-                                          let uu____6264 =
+                                          let uu___10 =
                                             (FStar_Option.isSome b) &&
                                               (should_return env e1opt lc11) in
-                                          if uu____6264
+                                          if uu___10
                                           then
                                             let e1 = FStar_Option.get e1opt in
                                             let x = FStar_Option.get b in
-                                            let uu____6271 =
+                                            let uu___11 =
                                               FStar_Syntax_Util.is_partial_return
                                                 c1 in
-                                            (if uu____6271
+                                            (if uu___11
                                              then
                                                (debug
-                                                  (fun uu____6283 ->
-                                                     let uu____6284 =
+                                                  (fun uu___13 ->
+                                                     let uu___14 =
                                                        FStar_TypeChecker_Normalize.term_to_string
                                                          env e1 in
-                                                     let uu____6285 =
+                                                     let uu___15 =
                                                        FStar_Syntax_Print.bv_to_string
                                                          x in
                                                      FStar_Util.print2
                                                        "(3) bind (case a): Substituting %s for %s"
-                                                       uu____6284 uu____6285);
+                                                       uu___14 uu___15);
                                                 (let c21 =
                                                    FStar_Syntax_Subst.subst_comp
                                                      [FStar_Syntax_Syntax.NT
                                                         (x, e1)] c2 in
                                                  let g =
-                                                   let uu____6290 =
+                                                   let uu___13 =
                                                      FStar_TypeChecker_Env.map_guard
                                                        g_c2
                                                        (FStar_Syntax_Subst.subst
                                                           [FStar_Syntax_Syntax.NT
                                                              (x, e1)]) in
                                                    FStar_TypeChecker_Env.conj_guard
-                                                     g_c1 uu____6290 in
+                                                     g_c1 uu___13 in
                                                  mk_bind1 c1 b c21 g))
                                              else
-                                               (let uu____6294 =
+                                               (let uu___13 =
                                                   ((FStar_Options.vcgen_optimize_bind_as_seq
                                                       ())
                                                      &&
                                                      (lcomp_has_trivial_postcondition
                                                         lc11))
                                                     &&
-                                                    (let uu____6296 =
+                                                    (let uu___14 =
                                                        FStar_TypeChecker_Env.try_lookup_lid
                                                          env
                                                          FStar_Parser_Const.with_type_lid in
                                                      FStar_Option.isSome
-                                                       uu____6296) in
-                                                if uu____6294
+                                                       uu___14) in
+                                                if uu___13
                                                 then
                                                   let e1' =
-                                                    let uu____6320 =
+                                                    let uu___14 =
                                                       FStar_Options.vcgen_decorate_with_type
                                                         () in
-                                                    if uu____6320
+                                                    if uu___14
                                                     then
                                                       FStar_Syntax_Util.mk_with_type
                                                         u_res_t1 res_t1 e1
                                                     else e1 in
                                                   (debug
-                                                     (fun uu____6329 ->
-                                                        let uu____6330 =
+                                                     (fun uu___15 ->
+                                                        let uu___16 =
                                                           FStar_TypeChecker_Normalize.term_to_string
                                                             env e1' in
-                                                        let uu____6331 =
+                                                        let uu___17 =
                                                           FStar_Syntax_Print.bv_to_string
                                                             x in
                                                         FStar_Util.print2
                                                           "(3) bind (case b): Substituting %s for %s"
-                                                          uu____6330
-                                                          uu____6331);
+                                                          uu___16 uu___17);
                                                    (let c21 =
                                                       FStar_Syntax_Subst.subst_comp
                                                         [FStar_Syntax_Syntax.NT
@@ -2592,84 +2538,77 @@ let (bind :
                                                     mk_seq c1 b c21))
                                                 else
                                                   (debug
-                                                     (fun uu____6343 ->
-                                                        let uu____6344 =
+                                                     (fun uu___16 ->
+                                                        let uu___17 =
                                                           FStar_TypeChecker_Normalize.term_to_string
                                                             env e1 in
-                                                        let uu____6345 =
+                                                        let uu___18 =
                                                           FStar_Syntax_Print.bv_to_string
                                                             x in
                                                         FStar_Util.print2
                                                           "(3) bind (case c): Adding equality %s = %s"
-                                                          uu____6344
-                                                          uu____6345);
+                                                          uu___17 uu___18);
                                                    (let c21 =
                                                       FStar_Syntax_Subst.subst_comp
                                                         [FStar_Syntax_Syntax.NT
                                                            (x, e1)] c2 in
                                                     let x_eq_e =
-                                                      let uu____6350 =
+                                                      let uu___16 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           x in
                                                       FStar_Syntax_Util.mk_eq2
                                                         u_res_t1 res_t1 e1
-                                                        uu____6350 in
-                                                    let uu____6351 =
-                                                      let uu____6356 =
-                                                        let uu____6357 =
-                                                          let uu____6358 =
+                                                        uu___16 in
+                                                    let uu___16 =
+                                                      let uu___17 =
+                                                        let uu___18 =
+                                                          let uu___19 =
                                                             FStar_Syntax_Syntax.mk_binder
                                                               x in
-                                                          [uu____6358] in
+                                                          [uu___19] in
                                                         FStar_TypeChecker_Env.push_binders
-                                                          env uu____6357 in
-                                                      weaken_comp uu____6356
-                                                        c21 x_eq_e in
-                                                    match uu____6351 with
+                                                          env uu___18 in
+                                                      weaken_comp uu___17 c21
+                                                        x_eq_e in
+                                                    match uu___16 with
                                                     | (c22, g_w) ->
                                                         let g =
-                                                          let uu____6384 =
-                                                            let uu____6387 =
-                                                              let uu____6390
-                                                                =
-                                                                let uu____6391
-                                                                  =
-                                                                  let uu____6392
+                                                          let uu___17 =
+                                                            let uu___18 =
+                                                              let uu___19 =
+                                                                let uu___20 =
+                                                                  let uu___21
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x in
-                                                                  [uu____6392] in
+                                                                  [uu___21] in
                                                                 FStar_TypeChecker_Env.close_guard
-                                                                  env
-                                                                  uu____6391
+                                                                  env uu___20
                                                                   g_w in
-                                                              let uu____6411
-                                                                =
-                                                                let uu____6414
-                                                                  =
-                                                                  let uu____6415
+                                                              let uu___20 =
+                                                                let uu___21 =
+                                                                  let uu___22
                                                                     =
-                                                                    let uu____6416
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x in
-                                                                    [uu____6416] in
-                                                                  let uu____6435
+                                                                    [uu___23] in
+                                                                  let uu___23
                                                                     =
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g_c2
                                                                     x_eq_e in
                                                                   FStar_TypeChecker_Env.close_guard
                                                                     env
-                                                                    uu____6415
-                                                                    uu____6435 in
-                                                                [uu____6414] in
-                                                              uu____6390 ::
-                                                                uu____6411 in
-                                                            g_c1 ::
-                                                              uu____6387 in
+                                                                    uu___22
+                                                                    uu___23 in
+                                                                [uu___21] in
+                                                              uu___19 ::
+                                                                uu___20 in
+                                                            g_c1 :: uu___18 in
                                                           FStar_TypeChecker_Env.conj_guards
-                                                            uu____6384 in
+                                                            uu___17 in
                                                         mk_bind1 c1 b c22 g))))
                                           else mk_bind1 c1 b c2 trivial_guard)))))) in
                 FStar_TypeChecker_Common.mk_lcomp joined_eff
@@ -2686,7 +2625,7 @@ let (weaken_guard :
          FStar_TypeChecker_Common.NonTrivial f2) ->
           let g = FStar_Syntax_Util.mk_imp f1 f2 in
           FStar_TypeChecker_Common.NonTrivial g
-      | uu____6450 -> g2
+      | uu___ -> g2
 let (assume_result_eq_pure_term_in_m :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident FStar_Pervasives_Native.option ->
@@ -2698,63 +2637,63 @@ let (assume_result_eq_pure_term_in_m :
       fun e ->
         fun lc ->
           let m =
-            let uu____6480 =
+            let uu___ =
               (FStar_All.pipe_right m_opt FStar_Util.is_none) ||
                 (is_ghost_effect env lc.FStar_TypeChecker_Common.eff_name) in
-            if uu____6480
+            if uu___
             then FStar_Parser_Const.effect_PURE_lid
             else FStar_All.pipe_right m_opt FStar_Util.must in
           let flags =
-            let uu____6489 = FStar_TypeChecker_Common.is_total_lcomp lc in
-            if uu____6489
+            let uu___ = FStar_TypeChecker_Common.is_total_lcomp lc in
+            if uu___
             then FStar_Syntax_Syntax.RETURN ::
               (lc.FStar_TypeChecker_Common.cflags)
             else FStar_Syntax_Syntax.PARTIAL_RETURN ::
               (lc.FStar_TypeChecker_Common.cflags) in
-          let refine uu____6502 =
-            let uu____6507 = FStar_TypeChecker_Common.lcomp_comp lc in
-            match uu____6507 with
+          let refine uu___ =
+            let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
+            match uu___1 with
             | (c, g_c) ->
                 let u_t =
                   match comp_univ_opt c with
-                  | FStar_Pervasives_Native.Some u_t -> u_t
+                  | FStar_Pervasives_Native.Some u_t1 -> u_t1
                   | FStar_Pervasives_Native.None ->
                       env.FStar_TypeChecker_Env.universe_of env
                         (FStar_Syntax_Util.comp_result c) in
-                let uu____6520 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
-                if uu____6520
+                let uu___2 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
+                if uu___2
                 then
-                  let uu____6525 =
+                  let uu___3 =
                     return_value env m (FStar_Pervasives_Native.Some u_t)
                       (FStar_Syntax_Util.comp_result c) e in
-                  (match uu____6525 with
+                  (match uu___3 with
                    | (retc, g_retc) ->
                        let g_c1 = FStar_TypeChecker_Env.conj_guard g_c g_retc in
-                       let uu____6537 =
-                         let uu____6538 = FStar_Syntax_Util.is_pure_comp c in
-                         Prims.op_Negation uu____6538 in
-                       if uu____6537
+                       let uu___4 =
+                         let uu___5 = FStar_Syntax_Util.is_pure_comp c in
+                         Prims.op_Negation uu___5 in
+                       if uu___4
                        then
                          let retc1 = FStar_Syntax_Util.comp_to_comp_typ retc in
                          let retc2 =
-                           let uu___907_6545 = retc1 in
+                           let uu___5 = retc1 in
                            {
                              FStar_Syntax_Syntax.comp_univs =
-                               (uu___907_6545.FStar_Syntax_Syntax.comp_univs);
+                               (uu___5.FStar_Syntax_Syntax.comp_univs);
                              FStar_Syntax_Syntax.effect_name =
                                FStar_Parser_Const.effect_GHOST_lid;
                              FStar_Syntax_Syntax.result_typ =
-                               (uu___907_6545.FStar_Syntax_Syntax.result_typ);
+                               (uu___5.FStar_Syntax_Syntax.result_typ);
                              FStar_Syntax_Syntax.effect_args =
-                               (uu___907_6545.FStar_Syntax_Syntax.effect_args);
+                               (uu___5.FStar_Syntax_Syntax.effect_args);
                              FStar_Syntax_Syntax.flags = flags
                            } in
-                         let uu____6546 = FStar_Syntax_Syntax.mk_Comp retc2 in
-                         (uu____6546, g_c1)
+                         let uu___5 = FStar_Syntax_Syntax.mk_Comp retc2 in
+                         (uu___5, g_c1)
                        else
-                         (let uu____6548 =
+                         (let uu___6 =
                             FStar_Syntax_Util.comp_set_flags retc flags in
-                          (uu____6548, g_c1)))
+                          (uu___6, g_c1)))
                 else
                   (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
                    let t = c1.FStar_Syntax_Syntax.result_typ in
@@ -2765,51 +2704,51 @@ let (assume_result_eq_pure_term_in_m :
                           (t.FStar_Syntax_Syntax.pos)) t in
                    let xexp = FStar_Syntax_Syntax.bv_to_name x in
                    let env_x = FStar_TypeChecker_Env.push_bv env x in
-                   let uu____6558 =
+                   let uu___4 =
                      return_value env_x m (FStar_Pervasives_Native.Some u_t)
                        t xexp in
-                   match uu____6558 with
+                   match uu___4 with
                    | (ret, g_ret) ->
                        let ret1 =
-                         let uu____6570 =
+                         let uu___5 =
                            FStar_Syntax_Util.comp_set_flags ret
                              [FStar_Syntax_Syntax.PARTIAL_RETURN] in
                          FStar_All.pipe_left
-                           FStar_TypeChecker_Common.lcomp_of_comp uu____6570 in
+                           FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                        let eq = FStar_Syntax_Util.mk_eq2 u_t t xexp e in
                        let eq_ret =
                          weaken_precondition env_x ret1
                            (FStar_TypeChecker_Common.NonTrivial eq) in
-                       let uu____6573 =
-                         let uu____6578 =
-                           let uu____6579 =
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
                              FStar_TypeChecker_Common.lcomp_of_comp c2 in
                            bind e.FStar_Syntax_Syntax.pos env
-                             FStar_Pervasives_Native.None uu____6579
+                             FStar_Pervasives_Native.None uu___7
                              ((FStar_Pervasives_Native.Some x), eq_ret) in
-                         FStar_TypeChecker_Common.lcomp_comp uu____6578 in
-                       (match uu____6573 with
+                         FStar_TypeChecker_Common.lcomp_comp uu___6 in
+                       (match uu___5 with
                         | (bind_c, g_bind) ->
-                            let uu____6588 =
+                            let uu___6 =
                               FStar_Syntax_Util.comp_set_flags bind_c flags in
-                            let uu____6589 =
+                            let uu___7 =
                               FStar_TypeChecker_Env.conj_guards
                                 [g_c; g_ret; g_bind] in
-                            (uu____6588, uu____6589))) in
-          let uu____6590 = should_not_inline_lc lc in
-          if uu____6590
+                            (uu___6, uu___7))) in
+          let uu___ = should_not_inline_lc lc in
+          if uu___
           then
-            let uu____6591 =
-              let uu____6596 =
-                let uu____6597 = FStar_Syntax_Print.term_to_string e in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.term_to_string e in
                 FStar_Util.format1
                   "assume_result_eq_pure_term cannot inline an non-inlineable lc : %s"
-                  uu____6597 in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____6596) in
-            FStar_Errors.raise_error uu____6591 e.FStar_Syntax_Syntax.pos
+                  uu___3 in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu___2) in
+            FStar_Errors.raise_error uu___1 e.FStar_Syntax_Syntax.pos
           else
-            (let uu____6599 = refine () in
-             match uu____6599 with
+            (let uu___2 = refine () in
+             match uu___2 with
              | (c, g) -> FStar_TypeChecker_Common.lcomp_of_comp_guard c g)
 let (maybe_assume_result_eq_pure_term_in_m :
   FStar_TypeChecker_Env.env ->
@@ -2827,9 +2766,9 @@ let (maybe_assume_result_eq_pure_term_in_m :
                    FStar_Parser_Const.effect_GTot_lid))
                && (should_return env (FStar_Pervasives_Native.Some e) lc))
               &&
-              (let uu____6632 =
+              (let uu___ =
                  FStar_TypeChecker_Common.is_lcomp_partial_return lc in
-               Prims.op_Negation uu____6632) in
+               Prims.op_Negation uu___) in
           if Prims.op_Negation should_return1
           then lc
           else assume_result_eq_pure_term_in_m env m_opt e lc
@@ -2856,8 +2795,8 @@ let (maybe_return_e2_and_bind :
       fun e1opt ->
         fun lc1 ->
           fun e2 ->
-            fun uu____6680 ->
-              match uu____6680 with
+            fun uu___ ->
+              match uu___ with
               | (x, lc2) ->
                   let env_x =
                     match x with
@@ -2871,39 +2810,38 @@ let (maybe_return_e2_and_bind :
                     let eff2 =
                       FStar_TypeChecker_Env.norm_eff_name env
                         lc2.FStar_TypeChecker_Common.eff_name in
-                    let uu____6694 =
+                    let uu___1 =
                       ((FStar_Ident.lid_equals eff2
                           FStar_Parser_Const.effect_PURE_lid)
                          &&
-                         (let uu____6696 =
+                         (let uu___2 =
                             FStar_TypeChecker_Env.join_opt env eff1 eff2 in
-                          FStar_All.pipe_right uu____6696 FStar_Util.is_none))
+                          FStar_All.pipe_right uu___2 FStar_Util.is_none))
                         &&
-                        (let uu____6720 =
+                        (let uu___2 =
                            FStar_TypeChecker_Env.exists_polymonadic_bind env
                              eff1 eff2 in
-                         FStar_All.pipe_right uu____6720 FStar_Util.is_none) in
-                    if uu____6694
+                         FStar_All.pipe_right uu___2 FStar_Util.is_none) in
+                    if uu___1
                     then
-                      let uu____6755 =
+                      let uu___2 =
                         FStar_All.pipe_right eff1
-                          (fun uu____6760 ->
-                             FStar_Pervasives_Native.Some uu____6760) in
-                      assume_result_eq_pure_term_in_m env_x uu____6755 e2 lc2
+                          (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) in
+                      assume_result_eq_pure_term_in_m env_x uu___2 e2 lc2
                     else
-                      (let uu____6762 =
-                         ((let uu____6765 = is_pure_or_ghost_effect env eff1 in
-                           Prims.op_Negation uu____6765) ||
+                      (let uu___3 =
+                         ((let uu___4 = is_pure_or_ghost_effect env eff1 in
+                           Prims.op_Negation uu___4) ||
                             (should_not_inline_lc lc1))
                            && (is_pure_or_ghost_effect env eff2) in
-                       if uu____6762
+                       if uu___3
                        then
-                         let uu____6766 =
+                         let uu___4 =
                            FStar_All.pipe_right eff1
-                             (fun uu____6771 ->
-                                FStar_Pervasives_Native.Some uu____6771) in
-                         maybe_assume_result_eq_pure_term_in_m env_x
-                           uu____6766 e2 lc2
+                             (fun uu___5 ->
+                                FStar_Pervasives_Native.Some uu___5) in
+                         maybe_assume_result_eq_pure_term_in_m env_x uu___4
+                           e2 lc2
                        else lc2) in
                   bind r env e1opt lc1 (x, lc21)
 let (fvar_const :
@@ -2911,10 +2849,10 @@ let (fvar_const :
   =
   fun env ->
     fun lid ->
-      let uu____6785 =
-        let uu____6786 = FStar_TypeChecker_Env.get_range env in
-        FStar_Ident.set_lid_range lid uu____6786 in
-      FStar_Syntax_Syntax.fvar uu____6785 FStar_Syntax_Syntax.delta_constant
+      let uu___ =
+        let uu___1 = FStar_TypeChecker_Env.get_range env in
+        FStar_Ident.set_lid_range lid uu___1 in
+      FStar_Syntax_Syntax.fvar uu___ FStar_Syntax_Syntax.delta_constant
         FStar_Pervasives_Native.None
 let (mk_layered_conjunction :
   FStar_TypeChecker_Env.env ->
@@ -2937,216 +2875,214 @@ let (mk_layered_conjunction :
               fun ct2 ->
                 fun r ->
                   let conjunction_name =
-                    let uu____6836 =
+                    let uu___ =
                       FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
-                    FStar_Util.format1 "%s.conjunction" uu____6836 in
-                  let uu____6837 =
-                    let uu____6842 =
-                      let uu____6843 =
+                    FStar_Util.format1 "%s.conjunction" uu___ in
+                  let uu___ =
+                    let uu___1 =
+                      let uu___2 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                      FStar_All.pipe_right uu____6843 FStar_Util.must in
-                    FStar_TypeChecker_Env.inst_tscheme_with uu____6842 [u_a] in
-                  match uu____6837 with
-                  | (uu____6854, conjunction) ->
-                      let uu____6856 =
-                        let uu____6865 =
+                      FStar_All.pipe_right uu___2 FStar_Util.must in
+                    FStar_TypeChecker_Env.inst_tscheme_with uu___1 [u_a] in
+                  match uu___ with
+                  | (uu___1, conjunction) ->
+                      let uu___2 =
+                        let uu___3 =
                           FStar_List.map FStar_Pervasives_Native.fst
                             ct1.FStar_Syntax_Syntax.effect_args in
-                        let uu____6880 =
+                        let uu___4 =
                           FStar_List.map FStar_Pervasives_Native.fst
                             ct2.FStar_Syntax_Syntax.effect_args in
-                        (uu____6865, uu____6880) in
-                      (match uu____6856 with
+                        (uu___3, uu___4) in
+                      (match uu___2 with
                        | (is1, is2) ->
                            let conjunction_t_error s =
-                             let uu____6923 =
-                               let uu____6924 =
+                             let uu___3 =
+                               let uu___4 =
                                  FStar_Syntax_Print.term_to_string
                                    conjunction in
                                FStar_Util.format3
                                  "conjunction %s (%s) does not have proper shape (reason:%s)"
-                                 uu____6924 conjunction_name s in
-                             (FStar_Errors.Fatal_UnexpectedEffect,
-                               uu____6923) in
-                           let uu____6925 =
-                             let uu____6970 =
-                               let uu____6971 =
+                                 uu___4 conjunction_name s in
+                             (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
                                  FStar_Syntax_Subst.compress conjunction in
-                               uu____6971.FStar_Syntax_Syntax.n in
-                             match uu____6970 with
-                             | FStar_Syntax_Syntax.Tm_abs
-                                 (bs, body, uu____7020) when
+                               uu___5.FStar_Syntax_Syntax.n in
+                             match uu___4 with
+                             | FStar_Syntax_Syntax.Tm_abs (bs, body, uu___5)
+                                 when
                                  (FStar_List.length bs) >= (Prims.of_int (4))
                                  ->
-                                 let uu____7051 =
+                                 let uu___6 =
                                    FStar_Syntax_Subst.open_term bs body in
-                                 (match uu____7051 with
+                                 (match uu___6 with
                                   | (a_b::bs1, body1) ->
-                                      let uu____7123 =
+                                      let uu___7 =
                                         FStar_List.splitAt
                                           ((FStar_List.length bs1) -
                                              (Prims.of_int (3))) bs1 in
-                                      (match uu____7123 with
+                                      (match uu___7 with
                                        | (rest_bs, f_b::g_b::p_b::[]) ->
-                                           let uu____7270 =
+                                           let uu___8 =
                                              FStar_All.pipe_right body1
                                                FStar_Syntax_Util.unascribe in
                                            (a_b, rest_bs, f_b, g_b, p_b,
-                                             uu____7270)))
-                             | uu____7303 ->
-                                 let uu____7304 =
+                                             uu___8)))
+                             | uu___5 ->
+                                 let uu___6 =
                                    conjunction_t_error
                                      "Either not an abstraction or not enough binders" in
-                                 FStar_Errors.raise_error uu____7304 r in
-                           (match uu____6925 with
+                                 FStar_Errors.raise_error uu___6 r in
+                           (match uu___3 with
                             | (a_b, rest_bs, f_b, g_b, p_b, body) ->
-                                let uu____7427 =
-                                  let uu____7434 =
-                                    let uu____7435 =
-                                      let uu____7436 =
-                                        let uu____7443 =
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
+                                      let uu___7 =
+                                        let uu___8 =
                                           FStar_All.pipe_right a_b
                                             FStar_Pervasives_Native.fst in
-                                        (uu____7443, a) in
-                                      FStar_Syntax_Syntax.NT uu____7436 in
-                                    [uu____7435] in
+                                        (uu___8, a) in
+                                      FStar_Syntax_Syntax.NT uu___7 in
+                                    [uu___6] in
                                   FStar_TypeChecker_Env.uvars_for_binders env
-                                    rest_bs uu____7434
+                                    rest_bs uu___5
                                     (fun b ->
-                                       let uu____7459 =
+                                       let uu___6 =
                                          FStar_Syntax_Print.binder_to_string
                                            b in
-                                       let uu____7460 =
+                                       let uu___7 =
                                          FStar_Ident.string_of_lid
                                            ed.FStar_Syntax_Syntax.mname in
-                                       let uu____7461 =
+                                       let uu___8 =
                                          FStar_All.pipe_right r
                                            FStar_Range.string_of_range in
                                        FStar_Util.format3
                                          "implicit var for binder %s of %s:conjunction at %s"
-                                         uu____7459 uu____7460 uu____7461) r in
-                                (match uu____7427 with
+                                         uu___6 uu___7 uu___8) r in
+                                (match uu___4 with
                                  | (rest_bs_uvars, g_uvars) ->
                                      let substs =
                                        FStar_List.map2
                                          (fun b ->
                                             fun t ->
-                                              let uu____7496 =
-                                                let uu____7503 =
+                                              let uu___5 =
+                                                let uu___6 =
                                                   FStar_All.pipe_right b
                                                     FStar_Pervasives_Native.fst in
-                                                (uu____7503, t) in
-                                              FStar_Syntax_Syntax.NT
-                                                uu____7496) (a_b ::
+                                                (uu___6, t) in
+                                              FStar_Syntax_Syntax.NT uu___5)
+                                         (a_b ::
                                          (FStar_List.append rest_bs [p_b]))
                                          (a ::
                                          (FStar_List.append rest_bs_uvars [p])) in
                                      let f_guard =
                                        let f_sort_is =
-                                         let uu____7542 =
-                                           let uu____7543 =
-                                             let uu____7546 =
-                                               let uu____7547 =
+                                         let uu___5 =
+                                           let uu___6 =
+                                             let uu___7 =
+                                               let uu___8 =
                                                  FStar_All.pipe_right f_b
                                                    FStar_Pervasives_Native.fst in
-                                               uu____7547.FStar_Syntax_Syntax.sort in
+                                               uu___8.FStar_Syntax_Syntax.sort in
                                              FStar_Syntax_Subst.compress
-                                               uu____7546 in
-                                           uu____7543.FStar_Syntax_Syntax.n in
-                                         match uu____7542 with
+                                               uu___7 in
+                                           uu___6.FStar_Syntax_Syntax.n in
+                                         match uu___5 with
                                          | FStar_Syntax_Syntax.Tm_app
-                                             (uu____7558, uu____7559::is) ->
-                                             let uu____7601 =
+                                             (uu___6, uu___7::is) ->
+                                             let uu___8 =
                                                FStar_All.pipe_right is
                                                  (FStar_List.map
                                                     FStar_Pervasives_Native.fst) in
-                                             FStar_All.pipe_right uu____7601
+                                             FStar_All.pipe_right uu___8
                                                (FStar_List.map
                                                   (FStar_Syntax_Subst.subst
                                                      substs))
-                                         | uu____7634 ->
-                                             let uu____7635 =
+                                         | uu___6 ->
+                                             let uu___7 =
                                                conjunction_t_error
                                                  "f's type is not a repr type" in
-                                             FStar_Errors.raise_error
-                                               uu____7635 r in
+                                             FStar_Errors.raise_error uu___7
+                                               r in
                                        FStar_List.fold_left2
                                          (fun g ->
                                             fun i1 ->
                                               fun f_i ->
-                                                let uu____7649 =
+                                                let uu___5 =
                                                   FStar_TypeChecker_Rel.layered_effect_teq
                                                     env i1 f_i
                                                     (FStar_Pervasives_Native.Some
                                                        conjunction_name) in
                                                 FStar_TypeChecker_Env.conj_guard
-                                                  g uu____7649)
+                                                  g uu___5)
                                          FStar_TypeChecker_Env.trivial_guard
                                          is1 f_sort_is in
                                      let g_guard =
                                        let g_sort_is =
-                                         let uu____7654 =
-                                           let uu____7655 =
-                                             let uu____7658 =
-                                               let uu____7659 =
+                                         let uu___5 =
+                                           let uu___6 =
+                                             let uu___7 =
+                                               let uu___8 =
                                                  FStar_All.pipe_right g_b
                                                    FStar_Pervasives_Native.fst in
-                                               uu____7659.FStar_Syntax_Syntax.sort in
+                                               uu___8.FStar_Syntax_Syntax.sort in
                                              FStar_Syntax_Subst.compress
-                                               uu____7658 in
-                                           uu____7655.FStar_Syntax_Syntax.n in
-                                         match uu____7654 with
+                                               uu___7 in
+                                           uu___6.FStar_Syntax_Syntax.n in
+                                         match uu___5 with
                                          | FStar_Syntax_Syntax.Tm_app
-                                             (uu____7670, uu____7671::is) ->
-                                             let uu____7713 =
+                                             (uu___6, uu___7::is) ->
+                                             let uu___8 =
                                                FStar_All.pipe_right is
                                                  (FStar_List.map
                                                     FStar_Pervasives_Native.fst) in
-                                             FStar_All.pipe_right uu____7713
+                                             FStar_All.pipe_right uu___8
                                                (FStar_List.map
                                                   (FStar_Syntax_Subst.subst
                                                      substs))
-                                         | uu____7746 ->
-                                             let uu____7747 =
+                                         | uu___6 ->
+                                             let uu___7 =
                                                conjunction_t_error
                                                  "g's type is not a repr type" in
-                                             FStar_Errors.raise_error
-                                               uu____7747 r in
+                                             FStar_Errors.raise_error uu___7
+                                               r in
                                        FStar_List.fold_left2
                                          (fun g ->
                                             fun i2 ->
                                               fun g_i ->
-                                                let uu____7761 =
+                                                let uu___5 =
                                                   FStar_TypeChecker_Rel.layered_effect_teq
                                                     env i2 g_i
                                                     (FStar_Pervasives_Native.Some
                                                        conjunction_name) in
                                                 FStar_TypeChecker_Env.conj_guard
-                                                  g uu____7761)
+                                                  g uu___5)
                                          FStar_TypeChecker_Env.trivial_guard
                                          is2 g_sort_is in
                                      let body1 =
                                        FStar_Syntax_Subst.subst substs body in
                                      let is =
-                                       let uu____7766 =
-                                         let uu____7767 =
+                                       let uu___5 =
+                                         let uu___6 =
                                            FStar_Syntax_Subst.compress body1 in
-                                         uu____7767.FStar_Syntax_Syntax.n in
-                                       match uu____7766 with
+                                         uu___6.FStar_Syntax_Syntax.n in
+                                       match uu___5 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____7772, a1::args) ->
+                                           (uu___6, a1::args) ->
                                            FStar_List.map
                                              FStar_Pervasives_Native.fst args
-                                       | uu____7827 ->
-                                           let uu____7828 =
+                                       | uu___6 ->
+                                           let uu___7 =
                                              conjunction_t_error
                                                "body is not a repr type" in
-                                           FStar_Errors.raise_error
-                                             uu____7828 r in
-                                     let uu____7835 =
-                                       let uu____7836 =
-                                         let uu____7837 =
+                                           FStar_Errors.raise_error uu___7 r in
+                                     let uu___5 =
+                                       let uu___6 =
+                                         let uu___7 =
                                            FStar_All.pipe_right is
                                              (FStar_List.map
                                                 FStar_Syntax_Syntax.as_arg) in
@@ -3157,17 +3093,17 @@ let (mk_layered_conjunction :
                                              (ed.FStar_Syntax_Syntax.mname);
                                            FStar_Syntax_Syntax.result_typ = a;
                                            FStar_Syntax_Syntax.effect_args =
-                                             uu____7837;
+                                             uu___7;
                                            FStar_Syntax_Syntax.flags = []
                                          } in
-                                       FStar_Syntax_Syntax.mk_Comp uu____7836 in
-                                     let uu____7860 =
-                                       let uu____7861 =
+                                       FStar_Syntax_Syntax.mk_Comp uu___6 in
+                                     let uu___6 =
+                                       let uu___7 =
                                          FStar_TypeChecker_Env.conj_guard
                                            g_uvars f_guard in
                                        FStar_TypeChecker_Env.conj_guard
-                                         uu____7861 g_guard in
-                                     (uu____7835, uu____7860))))
+                                         uu___7 g_guard in
+                                     (uu___5, uu___6))))
 let (mk_non_layered_conjunction :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->
@@ -3187,46 +3123,45 @@ let (mk_non_layered_conjunction :
           fun p ->
             fun ct1 ->
               fun ct2 ->
-                fun uu____7905 ->
+                fun uu___ ->
                   let p1 = FStar_Syntax_Util.b2t p in
                   let if_then_else =
-                    let uu____7914 =
+                    let uu___1 =
                       FStar_All.pipe_right ed
                         FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                    FStar_All.pipe_right uu____7914 FStar_Util.must in
-                  let uu____7921 = destruct_wp_comp ct1 in
-                  match uu____7921 with
-                  | (uu____7932, uu____7933, wp_t) ->
-                      let uu____7935 = destruct_wp_comp ct2 in
-                      (match uu____7935 with
-                       | (uu____7946, uu____7947, wp_e) ->
+                    FStar_All.pipe_right uu___1 FStar_Util.must in
+                  let uu___1 = destruct_wp_comp ct1 in
+                  match uu___1 with
+                  | (uu___2, uu___3, wp_t) ->
+                      let uu___4 = destruct_wp_comp ct2 in
+                      (match uu___4 with
+                       | (uu___5, uu___6, wp_e) ->
                            let wp =
-                             let uu____7950 =
+                             let uu___7 =
                                FStar_TypeChecker_Env.inst_effect_fun_with
                                  [u_a] env ed if_then_else in
-                             let uu____7951 =
-                               let uu____7952 = FStar_Syntax_Syntax.as_arg a in
-                               let uu____7961 =
-                                 let uu____7972 =
-                                   FStar_Syntax_Syntax.as_arg p1 in
-                                 let uu____7981 =
-                                   let uu____7992 =
+                             let uu___8 =
+                               let uu___9 = FStar_Syntax_Syntax.as_arg a in
+                               let uu___10 =
+                                 let uu___11 = FStar_Syntax_Syntax.as_arg p1 in
+                                 let uu___12 =
+                                   let uu___13 =
                                      FStar_Syntax_Syntax.as_arg wp_t in
-                                   let uu____8001 =
-                                     let uu____8012 =
+                                   let uu___14 =
+                                     let uu___15 =
                                        FStar_Syntax_Syntax.as_arg wp_e in
-                                     [uu____8012] in
-                                   uu____7992 :: uu____8001 in
-                                 uu____7972 :: uu____7981 in
-                               uu____7952 :: uu____7961 in
-                             let uu____8061 =
+                                     [uu___15] in
+                                   uu___13 :: uu___14 in
+                                 uu___11 :: uu___12 in
+                               uu___9 :: uu___10 in
+                             let uu___9 =
                                FStar_Range.union_ranges
                                  wp_t.FStar_Syntax_Syntax.pos
                                  wp_e.FStar_Syntax_Syntax.pos in
-                             FStar_Syntax_Syntax.mk_Tm_app uu____7950
-                               uu____7951 uu____8061 in
-                           let uu____8062 = mk_comp ed u_a a wp [] in
-                           (uu____8062, FStar_TypeChecker_Env.trivial_guard))
+                             FStar_Syntax_Syntax.mk_Tm_app uu___7 uu___8
+                               uu___9 in
+                           let uu___7 = mk_comp ed u_a a wp [] in
+                           (uu___7, FStar_TypeChecker_Env.trivial_guard))
 let (comp_pure_wp_false :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe ->
@@ -3236,27 +3171,22 @@ let (comp_pure_wp_false :
     fun u ->
       fun t ->
         let post_k =
-          let uu____8081 =
-            let uu____8090 = FStar_Syntax_Syntax.null_binder t in
-            [uu____8090] in
-          let uu____8109 =
-            FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-          FStar_Syntax_Util.arrow uu____8081 uu____8109 in
+          let uu___ =
+            let uu___1 = FStar_Syntax_Syntax.null_binder t in [uu___1] in
+          let uu___1 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+          FStar_Syntax_Util.arrow uu___ uu___1 in
         let kwp =
-          let uu____8115 =
-            let uu____8124 = FStar_Syntax_Syntax.null_binder post_k in
-            [uu____8124] in
-          let uu____8143 =
-            FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
-          FStar_Syntax_Util.arrow uu____8115 uu____8143 in
+          let uu___ =
+            let uu___1 = FStar_Syntax_Syntax.null_binder post_k in [uu___1] in
+          let uu___1 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+          FStar_Syntax_Util.arrow uu___ uu___1 in
         let post =
           FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None post_k in
         let wp =
-          let uu____8150 =
-            let uu____8151 = FStar_Syntax_Syntax.mk_binder post in
-            [uu____8151] in
-          let uu____8170 = fvar_const env FStar_Parser_Const.false_lid in
-          FStar_Syntax_Util.abs uu____8150 uu____8170
+          let uu___ =
+            let uu___1 = FStar_Syntax_Syntax.mk_binder post in [uu___1] in
+          let uu___1 = fvar_const env FStar_Parser_Const.false_lid in
+          FStar_Syntax_Util.abs uu___ uu___1
             (FStar_Pervasives_Native.Some
                (FStar_Syntax_Util.mk_residual_comp
                   FStar_Parser_Const.effect_Tot_lid
@@ -3278,283 +3208,271 @@ let (bind_cases :
       fun lcases ->
         fun scrutinee ->
           let env =
-            let uu____8226 =
-              let uu____8227 =
+            let uu___ =
+              let uu___1 =
                 FStar_All.pipe_right scrutinee FStar_Syntax_Syntax.mk_binder in
-              [uu____8227] in
-            FStar_TypeChecker_Env.push_binders env0 uu____8226 in
+              [uu___1] in
+            FStar_TypeChecker_Env.push_binders env0 uu___ in
           let eff =
             FStar_List.fold_left
-              (fun eff ->
-                 fun uu____8273 ->
-                   match uu____8273 with
-                   | (uu____8286, eff_label, uu____8288, uu____8289) ->
-                       join_effects env eff eff_label)
+              (fun eff1 ->
+                 fun uu___ ->
+                   match uu___ with
+                   | (uu___1, eff_label, uu___2, uu___3) ->
+                       join_effects env eff1 eff_label)
               FStar_Parser_Const.effect_PURE_lid lcases in
-          let uu____8300 =
-            let uu____8307 =
+          let uu___ =
+            let uu___1 =
               FStar_All.pipe_right lcases
                 (FStar_Util.for_some
-                   (fun uu____8341 ->
-                      match uu____8341 with
-                      | (uu____8354, uu____8355, flags, uu____8357) ->
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (uu___3, uu___4, flags, uu___5) ->
                           FStar_All.pipe_right flags
                             (FStar_Util.for_some
-                               (fun uu___5_8371 ->
-                                  match uu___5_8371 with
+                               (fun uu___6 ->
+                                  match uu___6 with
                                   | FStar_Syntax_Syntax.SHOULD_NOT_INLINE ->
                                       true
-                                  | uu____8372 -> false)))) in
-            if uu____8307
+                                  | uu___7 -> false)))) in
+            if uu___1
             then (true, [FStar_Syntax_Syntax.SHOULD_NOT_INLINE])
             else (false, []) in
-          match uu____8300 with
+          match uu___ with
           | (should_not_inline_whole_match, bind_cases_flags) ->
-              let bind_cases uu____8399 =
+              let bind_cases1 uu___1 =
                 let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t in
-                let uu____8401 =
+                let uu___2 =
                   env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-                if uu____8401
+                if uu___2
                 then
-                  let uu____8406 = lax_mk_tot_or_comp_l eff u_res_t res_t [] in
-                  (uu____8406, FStar_TypeChecker_Env.trivial_guard)
+                  let uu___3 = lax_mk_tot_or_comp_l eff u_res_t res_t [] in
+                  (uu___3, FStar_TypeChecker_Env.trivial_guard)
                 else
                   (let maybe_return eff_label_then cthen =
-                     let uu____8424 =
+                     let uu___4 =
                        should_not_inline_whole_match ||
-                         (let uu____8426 = is_pure_or_ghost_effect env eff in
-                          Prims.op_Negation uu____8426) in
-                     if uu____8424 then cthen true else cthen false in
-                   let uu____8428 =
-                     let uu____8439 =
-                       let uu____8452 =
-                         let uu____8457 =
-                           let uu____8468 =
+                         (let uu___5 = is_pure_or_ghost_effect env eff in
+                          Prims.op_Negation uu___5) in
+                     if uu___4 then cthen true else cthen false in
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
+                           let uu___8 =
                              FStar_All.pipe_right lcases
                                (FStar_List.map
-                                  (fun uu____8516 ->
-                                     match uu____8516 with
-                                     | (g, uu____8534, uu____8535,
-                                        uu____8536) -> g)) in
-                           FStar_All.pipe_right uu____8468
+                                  (fun uu___9 ->
+                                     match uu___9 with
+                                     | (g, uu___10, uu___11, uu___12) -> g)) in
+                           FStar_All.pipe_right uu___8
                              (FStar_List.fold_left
-                                (fun uu____8582 ->
+                                (fun uu___9 ->
                                    fun g ->
-                                     match uu____8582 with
+                                     match uu___9 with
                                      | (conds, acc) ->
                                          let cond =
-                                           let uu____8623 =
-                                             let uu____8626 =
+                                           let uu___10 =
+                                             let uu___11 =
                                                FStar_All.pipe_right g
                                                  FStar_Syntax_Util.b2t in
-                                             FStar_All.pipe_right uu____8626
+                                             FStar_All.pipe_right uu___11
                                                FStar_Syntax_Util.mk_neg in
                                            FStar_Syntax_Util.mk_conj acc
-                                             uu____8623 in
+                                             uu___10 in
                                          ((FStar_List.append conds [cond]),
                                            cond))
                                 ([FStar_Syntax_Util.t_true],
                                   FStar_Syntax_Util.t_true)) in
-                         FStar_All.pipe_right uu____8457
+                         FStar_All.pipe_right uu___7
                            FStar_Pervasives_Native.fst in
-                       FStar_All.pipe_right uu____8452
+                       FStar_All.pipe_right uu___6
                          (fun l ->
                             FStar_List.splitAt
                               ((FStar_List.length l) - Prims.int_one) l) in
-                     FStar_All.pipe_right uu____8439
-                       (fun uu____8731 ->
-                          match uu____8731 with
+                     FStar_All.pipe_right uu___5
+                       (fun uu___6 ->
+                          match uu___6 with
                           | (l1, l2) ->
-                              let uu____8772 = FStar_List.hd l2 in
-                              (l1, uu____8772)) in
-                   match uu____8428 with
+                              let uu___7 = FStar_List.hd l2 in (l1, uu___7)) in
+                   match uu___4 with
                    | (neg_branch_conds, exhaustiveness_branch_cond) ->
-                       let uu____8801 =
+                       let uu___5 =
                          match lcases with
                          | [] ->
-                             let uu____8831 =
+                             let uu___6 =
                                comp_pure_wp_false env u_res_t res_t in
-                             (FStar_Pervasives_Native.None, uu____8831,
+                             (FStar_Pervasives_Native.None, uu___6,
                                FStar_TypeChecker_Env.trivial_guard)
-                         | uu____8834 ->
-                             let uu____8850 =
-                               let uu____8882 =
-                                 let uu____8893 =
+                         | uu___6 ->
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_All.pipe_right neg_branch_conds
                                      (FStar_List.splitAt
                                         ((FStar_List.length lcases) -
                                            Prims.int_one)) in
-                                 FStar_All.pipe_right uu____8893
-                                   (fun uu____8963 ->
-                                      match uu____8963 with
+                                 FStar_All.pipe_right uu___9
+                                   (fun uu___10 ->
+                                      match uu___10 with
                                       | (l1, l2) ->
-                                          let uu____9004 = FStar_List.hd l2 in
-                                          (l1, uu____9004)) in
-                               match uu____8882 with
+                                          let uu___11 = FStar_List.hd l2 in
+                                          (l1, uu___11)) in
+                               match uu___8 with
                                | (neg_branch_conds1, neg_last) ->
-                                   let uu____9060 =
-                                     let uu____9097 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_All.pipe_right lcases
                                          (FStar_List.splitAt
                                             ((FStar_List.length lcases) -
                                                Prims.int_one)) in
-                                     FStar_All.pipe_right uu____9097
-                                       (fun uu____9297 ->
-                                          match uu____9297 with
+                                     FStar_All.pipe_right uu___10
+                                       (fun uu___11 ->
+                                          match uu___11 with
                                           | (l1, l2) ->
-                                              let uu____9440 =
-                                                FStar_List.hd l2 in
-                                              (l1, uu____9440)) in
-                                   (match uu____9060 with
+                                              let uu___12 = FStar_List.hd l2 in
+                                              (l1, uu___12)) in
+                                   (match uu___9 with
                                     | (lcases1,
-                                       (g_last, eff_last, uu____9537, c_last))
+                                       (g_last, eff_last, uu___10, c_last))
                                         ->
-                                        let uu____9602 =
+                                        let uu___11 =
                                           let lc =
                                             maybe_return eff_last c_last in
-                                          let uu____9608 =
+                                          let uu___12 =
                                             FStar_TypeChecker_Common.lcomp_comp
                                               lc in
-                                          match uu____9608 with
+                                          match uu___12 with
                                           | (c, g) ->
-                                              let uu____9619 =
-                                                let uu____9620 =
-                                                  let uu____9621 =
+                                              let uu___13 =
+                                                let uu___14 =
+                                                  let uu___15 =
                                                     FStar_Syntax_Util.b2t
                                                       g_last in
                                                   FStar_Syntax_Util.mk_conj
-                                                    uu____9621 neg_last in
+                                                    uu___15 neg_last in
                                                 FStar_TypeChecker_Common.weaken_guard_formula
-                                                  g uu____9620 in
-                                              (c, uu____9619) in
-                                        (match uu____9602 with
+                                                  g uu___14 in
+                                              (c, uu___13) in
+                                        (match uu___11 with
                                          | (c, g) ->
-                                             let uu____9657 =
-                                               let uu____9658 =
+                                             let uu___12 =
+                                               let uu___13 =
                                                  FStar_All.pipe_right
                                                    eff_last
                                                    (FStar_TypeChecker_Env.norm_eff_name
                                                       env) in
-                                               FStar_All.pipe_right
-                                                 uu____9658
+                                               FStar_All.pipe_right uu___13
                                                  (FStar_TypeChecker_Env.get_effect_decl
                                                     env) in
                                              (lcases1, neg_branch_conds1,
-                                               uu____9657, c, g))) in
-                             (match uu____8850 with
+                                               uu___12, c, g))) in
+                             (match uu___7 with
                               | (lcases1, neg_branch_conds1, md, comp,
                                  g_comp) ->
                                   FStar_List.fold_right2
-                                    (fun uu____9787 ->
+                                    (fun uu___8 ->
                                        fun neg_cond ->
-                                         fun uu____9789 ->
-                                           match (uu____9787, uu____9789)
-                                           with
-                                           | ((g, eff_label, uu____9847,
-                                               cthen),
-                                              (uu____9849, celse, g_comp1))
-                                               ->
-                                               let uu____9893 =
-                                                 let uu____9898 =
+                                         fun uu___9 ->
+                                           match (uu___8, uu___9) with
+                                           | ((g, eff_label, uu___10, cthen),
+                                              (uu___11, celse, g_comp1)) ->
+                                               let uu___12 =
+                                                 let uu___13 =
                                                    maybe_return eff_label
                                                      cthen in
                                                  FStar_TypeChecker_Common.lcomp_comp
-                                                   uu____9898 in
-                                               (match uu____9893 with
+                                                   uu___13 in
+                                               (match uu___12 with
                                                 | (cthen1, g_then) ->
-                                                    let uu____9909 =
-                                                      let uu____9920 =
+                                                    let uu___13 =
+                                                      let uu___14 =
                                                         lift_comps_sep_guards
                                                           env cthen1 celse
                                                           FStar_Pervasives_Native.None
                                                           false in
-                                                      match uu____9920 with
+                                                      match uu___14 with
                                                       | (m, cthen2, celse1,
                                                          g_lift_then,
                                                          g_lift_else) ->
                                                           let md1 =
                                                             FStar_TypeChecker_Env.get_effect_decl
                                                               env m in
-                                                          let uu____9947 =
+                                                          let uu___15 =
                                                             FStar_All.pipe_right
                                                               cthen2
                                                               FStar_Syntax_Util.comp_to_comp_typ in
-                                                          let uu____9948 =
+                                                          let uu___16 =
                                                             FStar_All.pipe_right
                                                               celse1
                                                               FStar_Syntax_Util.comp_to_comp_typ in
-                                                          (md1, uu____9947,
-                                                            uu____9948,
+                                                          (md1, uu___15,
+                                                            uu___16,
                                                             g_lift_then,
                                                             g_lift_else) in
-                                                    (match uu____9909 with
+                                                    (match uu___13 with
                                                      | (md1, ct_then,
                                                         ct_else, g_lift_then,
                                                         g_lift_else) ->
                                                          let fn =
-                                                           let uu____9999 =
+                                                           let uu___14 =
                                                              FStar_All.pipe_right
                                                                md1
                                                                FStar_Syntax_Util.is_layered in
-                                                           if uu____9999
+                                                           if uu___14
                                                            then
                                                              mk_layered_conjunction
                                                            else
                                                              mk_non_layered_conjunction in
-                                                         let uu____10029 =
-                                                           let uu____10034 =
+                                                         let uu___14 =
+                                                           let uu___15 =
                                                              FStar_TypeChecker_Env.get_range
                                                                env in
                                                            fn env md1 u_res_t
                                                              res_t g ct_then
-                                                             ct_else
-                                                             uu____10034 in
-                                                         (match uu____10029
-                                                          with
+                                                             ct_else uu___15 in
+                                                         (match uu___14 with
                                                           | (c,
                                                              g_conjunction)
                                                               ->
-                                                              let uu____10045
-                                                                =
+                                                              let uu___15 =
                                                                 let g1 =
                                                                   FStar_Syntax_Util.b2t
                                                                     g in
-                                                                let uu____10053
-                                                                  =
-                                                                  let uu____10054
+                                                                let uu___16 =
+                                                                  let uu___17
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_then
                                                                     g_lift_then in
-                                                                  let uu____10055
+                                                                  let uu___18
                                                                     =
                                                                     FStar_Syntax_Util.mk_conj
                                                                     neg_cond
                                                                     g1 in
                                                                   FStar_TypeChecker_Common.weaken_guard_formula
-                                                                    uu____10054
-                                                                    uu____10055 in
-                                                                let uu____10056
-                                                                  =
-                                                                  let uu____10057
+                                                                    uu___17
+                                                                    uu___18 in
+                                                                let uu___17 =
+                                                                  let uu___18
                                                                     =
-                                                                    let uu____10058
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Util.mk_neg
                                                                     g1 in
                                                                     FStar_Syntax_Util.mk_conj
                                                                     neg_cond
-                                                                    uu____10058 in
+                                                                    uu___19 in
                                                                   FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g_lift_else
-                                                                    uu____10057 in
-                                                                (uu____10053,
-                                                                  uu____10056) in
-                                                              (match uu____10045
+                                                                    uu___18 in
+                                                                (uu___16,
+                                                                  uu___17) in
+                                                              (match uu___15
                                                                with
                                                                | (g_then1,
                                                                   g_else) ->
-                                                                   let uu____10071
+                                                                   let uu___16
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guards
                                                                     [g_comp1;
@@ -3563,53 +3481,53 @@ let (bind_cases :
                                                                     g_conjunction] in
                                                                    ((FStar_Pervasives_Native.Some
                                                                     md1), c,
-                                                                    uu____10071))))))
+                                                                    uu___16))))))
                                     lcases1 neg_branch_conds1
                                     ((FStar_Pervasives_Native.Some md), comp,
                                       g_comp)) in
-                       (match uu____8801 with
+                       (match uu___5 with
                         | (md, comp, g_comp) ->
-                            let uu____10087 =
-                              let uu____10092 =
+                            let uu___6 =
+                              let uu___7 =
                                 let check =
                                   FStar_Syntax_Util.mk_imp
                                     exhaustiveness_branch_cond
                                     FStar_Syntax_Util.t_false in
                                 let check1 =
-                                  let uu____10099 =
+                                  let uu___8 =
                                     FStar_TypeChecker_Env.get_range env in
                                   label
                                     FStar_TypeChecker_Err.exhaustiveness_check
-                                    uu____10099 check in
+                                    uu___8 check in
                                 strengthen_comp env
                                   FStar_Pervasives_Native.None comp check1
                                   bind_cases_flags in
-                              match uu____10092 with
+                              match uu___7 with
                               | (c, g) ->
-                                  let uu____10109 =
+                                  let uu___8 =
                                     FStar_TypeChecker_Env.conj_guard g_comp g in
-                                  (c, uu____10109) in
-                            (match uu____10087 with
+                                  (c, uu___8) in
+                            (match uu___6 with
                              | (comp1, g_comp1) ->
                                  let g_comp2 =
-                                   let uu____10117 =
-                                     let uu____10118 =
+                                   let uu___7 =
+                                     let uu___8 =
                                        FStar_All.pipe_right scrutinee
                                          FStar_Syntax_Syntax.mk_binder in
-                                     [uu____10118] in
+                                     [uu___8] in
                                    FStar_TypeChecker_Env.close_guard env0
-                                     uu____10117 g_comp1 in
+                                     uu___7 g_comp1 in
                                  (match lcases with
                                   | [] -> (comp1, g_comp2)
-                                  | uu____10160::[] -> (comp1, g_comp2)
-                                  | uu____10200 ->
-                                      let uu____10216 =
-                                        let uu____10217 =
+                                  | uu___7::[] -> (comp1, g_comp2)
+                                  | uu___7 ->
+                                      let uu___8 =
+                                        let uu___9 =
                                           FStar_All.pipe_right md
                                             FStar_Util.must in
-                                        FStar_All.pipe_right uu____10217
+                                        FStar_All.pipe_right uu___9
                                           FStar_Syntax_Util.is_layered in
-                                      if uu____10216
+                                      if uu___8
                                       then (comp1, g_comp2)
                                       else
                                         (let comp2 =
@@ -3619,39 +3537,38 @@ let (bind_cases :
                                            FStar_TypeChecker_Env.get_effect_decl
                                              env
                                              comp2.FStar_Syntax_Syntax.effect_name in
-                                         let uu____10227 =
-                                           destruct_wp_comp comp2 in
-                                         match uu____10227 with
-                                         | (uu____10238, uu____10239, wp) ->
+                                         let uu___10 = destruct_wp_comp comp2 in
+                                         match uu___10 with
+                                         | (uu___11, uu___12, wp) ->
                                              let ite_wp =
-                                               let uu____10242 =
+                                               let uu___13 =
                                                  FStar_All.pipe_right md1
                                                    FStar_Syntax_Util.get_wp_ite_combinator in
-                                               FStar_All.pipe_right
-                                                 uu____10242 FStar_Util.must in
+                                               FStar_All.pipe_right uu___13
+                                                 FStar_Util.must in
                                              let wp1 =
-                                               let uu____10250 =
+                                               let uu___13 =
                                                  FStar_TypeChecker_Env.inst_effect_fun_with
                                                    [u_res_t] env md1 ite_wp in
-                                               let uu____10251 =
-                                                 let uu____10252 =
+                                               let uu___14 =
+                                                 let uu___15 =
                                                    FStar_Syntax_Syntax.as_arg
                                                      res_t in
-                                                 let uu____10261 =
-                                                   let uu____10272 =
+                                                 let uu___16 =
+                                                   let uu___17 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        wp in
-                                                   [uu____10272] in
-                                                 uu____10252 :: uu____10261 in
+                                                   [uu___17] in
+                                                 uu___15 :: uu___16 in
                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                 uu____10250 uu____10251
+                                                 uu___13 uu___14
                                                  wp.FStar_Syntax_Syntax.pos in
-                                             let uu____10305 =
+                                             let uu___13 =
                                                mk_comp md1 u_res_t res_t wp1
                                                  bind_cases_flags in
-                                             (uu____10305, g_comp2)))))) in
+                                             (uu___13, g_comp2)))))) in
               FStar_TypeChecker_Common.mk_lcomp eff res_t bind_cases_flags
-                bind_cases
+                bind_cases1
 let (check_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -3664,22 +3581,22 @@ let (check_comp :
     fun e ->
       fun c ->
         fun c' ->
-          let uu____10339 = FStar_TypeChecker_Rel.sub_comp env c c' in
-          match uu____10339 with
+          let uu___1 = FStar_TypeChecker_Rel.sub_comp env c c' in
+          match uu___1 with
           | FStar_Pervasives_Native.None ->
               if env.FStar_TypeChecker_Env.use_eq
               then
-                let uu____10354 =
+                let uu___2 =
                   FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation_eq
                     env e c c' in
-                let uu____10359 = FStar_TypeChecker_Env.get_range env in
-                FStar_Errors.raise_error uu____10354 uu____10359
+                let uu___3 = FStar_TypeChecker_Env.get_range env in
+                FStar_Errors.raise_error uu___2 uu___3
               else
-                (let uu____10367 =
+                (let uu___3 =
                    FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation
                      env e c c' in
-                 let uu____10372 = FStar_TypeChecker_Env.get_range env in
-                 FStar_Errors.raise_error uu____10367 uu____10372)
+                 let uu___4 = FStar_TypeChecker_Env.get_range env in
+                 FStar_Errors.raise_error uu___3 uu___4)
           | FStar_Pervasives_Native.Some g -> (e, c', g)
 let (universe_of_comp :
   FStar_TypeChecker_Env.env ->
@@ -3690,36 +3607,33 @@ let (universe_of_comp :
     fun u_res ->
       fun c ->
         let c_lid =
-          let uu____10396 =
+          let uu___ =
             FStar_All.pipe_right c FStar_Syntax_Util.comp_effect_name in
-          FStar_All.pipe_right uu____10396
+          FStar_All.pipe_right uu___
             (FStar_TypeChecker_Env.norm_eff_name env) in
-        let uu____10399 = FStar_Syntax_Util.is_pure_or_ghost_effect c_lid in
-        if uu____10399
+        let uu___ = FStar_Syntax_Util.is_pure_or_ghost_effect c_lid in
+        if uu___
         then u_res
         else
           (let is_total =
-             let uu____10402 =
-               FStar_TypeChecker_Env.lookup_effect_quals env c_lid in
-             FStar_All.pipe_right uu____10402
+             let uu___2 = FStar_TypeChecker_Env.lookup_effect_quals env c_lid in
+             FStar_All.pipe_right uu___2
                (FStar_List.existsb
                   (fun q -> q = FStar_Syntax_Syntax.TotalEffect)) in
            if Prims.op_Negation is_total
            then FStar_Syntax_Syntax.U_zero
            else
-             (let uu____10410 = FStar_TypeChecker_Env.effect_repr env c u_res in
-              match uu____10410 with
+             (let uu___3 = FStar_TypeChecker_Env.effect_repr env c u_res in
+              match uu___3 with
               | FStar_Pervasives_Native.None ->
-                  let uu____10413 =
-                    let uu____10418 =
-                      let uu____10419 =
-                        FStar_Syntax_Print.lid_to_string c_lid in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Print.lid_to_string c_lid in
                       FStar_Util.format1
                         "Effect %s is marked total but does not have a repr"
-                        uu____10419 in
-                    (FStar_Errors.Fatal_EffectCannotBeReified, uu____10418) in
-                  FStar_Errors.raise_error uu____10413
-                    c.FStar_Syntax_Syntax.pos
+                        uu___6 in
+                    (FStar_Errors.Fatal_EffectCannotBeReified, uu___5) in
+                  FStar_Errors.raise_error uu___4 c.FStar_Syntax_Syntax.pos
               | FStar_Pervasives_Native.Some tm ->
                   env.FStar_TypeChecker_Env.universe_of env tm))
 let (check_trivial_precondition :
@@ -3736,30 +3650,28 @@ let (check_trivial_precondition :
       let md =
         FStar_TypeChecker_Env.get_effect_decl env
           ct.FStar_Syntax_Syntax.effect_name in
-      let uu____10439 = destruct_wp_comp ct in
-      match uu____10439 with
+      let uu___ = destruct_wp_comp ct in
+      match uu___ with
       | (u_t, t, wp) ->
           let vc =
-            let uu____10456 =
-              let uu____10457 =
-                let uu____10458 =
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
                   FStar_All.pipe_right md
                     FStar_Syntax_Util.get_wp_trivial_combinator in
-                FStar_All.pipe_right uu____10458 FStar_Util.must in
-              FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md
-                uu____10457 in
-            let uu____10465 =
-              let uu____10466 = FStar_Syntax_Syntax.as_arg t in
-              let uu____10475 =
-                let uu____10486 = FStar_Syntax_Syntax.as_arg wp in
-                [uu____10486] in
-              uu____10466 :: uu____10475 in
-            let uu____10519 = FStar_TypeChecker_Env.get_range env in
-            FStar_Syntax_Syntax.mk_Tm_app uu____10456 uu____10465 uu____10519 in
-          let uu____10520 =
+                FStar_All.pipe_right uu___3 FStar_Util.must in
+              FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md uu___2 in
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.as_arg t in
+              let uu___4 =
+                let uu___5 = FStar_Syntax_Syntax.as_arg wp in [uu___5] in
+              uu___3 :: uu___4 in
+            let uu___3 = FStar_TypeChecker_Env.get_range env in
+            FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 uu___3 in
+          let uu___1 =
             FStar_All.pipe_left FStar_TypeChecker_Env.guard_of_guard_formula
               (FStar_TypeChecker_Common.NonTrivial vc) in
-          (ct, vc, uu____10520)
+          (ct, vc, uu___1)
 let (coerce_with :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -3779,23 +3691,22 @@ let (coerce_with :
             fun us ->
               fun eargs ->
                 fun mkcomp ->
-                  let uu____10574 =
-                    FStar_TypeChecker_Env.try_lookup_lid env f in
-                  match uu____10574 with
-                  | FStar_Pervasives_Native.Some uu____10589 ->
-                      ((let uu____10607 =
+                  let uu___ = FStar_TypeChecker_Env.try_lookup_lid env f in
+                  match uu___ with
+                  | FStar_Pervasives_Native.Some uu___1 ->
+                      ((let uu___3 =
                           FStar_TypeChecker_Env.debug env
                             (FStar_Options.Other "Coercions") in
-                        if uu____10607
+                        if uu___3
                         then
-                          let uu____10608 = FStar_Ident.string_of_lid f in
-                          FStar_Util.print1 "Coercing with %s!\n" uu____10608
+                          let uu___4 = FStar_Ident.string_of_lid f in
+                          FStar_Util.print1 "Coercing with %s!\n" uu___4
                         else ());
                        (let coercion =
-                          let uu____10611 =
+                          let uu___3 =
                             FStar_Ident.set_lid_range f
                               e.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.fvar uu____10611
+                          FStar_Syntax_Syntax.fvar uu___3
                             (FStar_Syntax_Syntax.Delta_constant_at_level
                                Prims.int_one) FStar_Pervasives_Native.None in
                         let coercion1 =
@@ -3803,48 +3714,44 @@ let (coerce_with :
                         let coercion2 =
                           FStar_Syntax_Util.mk_app coercion1 eargs in
                         let lc1 =
-                          let uu____10617 =
-                            let uu____10618 =
-                              let uu____10619 = mkcomp ty in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 = mkcomp ty in
                               FStar_All.pipe_left
-                                FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10619 in
-                            (FStar_Pervasives_Native.None, uu____10618) in
+                                FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                            (FStar_Pervasives_Native.None, uu___4) in
                           bind e.FStar_Syntax_Syntax.pos env
-                            (FStar_Pervasives_Native.Some e) lc uu____10617 in
+                            (FStar_Pervasives_Native.Some e) lc uu___3 in
                         let e1 =
-                          let uu____10623 =
-                            let uu____10624 = FStar_Syntax_Syntax.as_arg e in
-                            [uu____10624] in
-                          FStar_Syntax_Syntax.mk_Tm_app coercion2 uu____10623
+                          let uu___3 =
+                            let uu___4 = FStar_Syntax_Syntax.as_arg e in
+                            [uu___4] in
+                          FStar_Syntax_Syntax.mk_Tm_app coercion2 uu___3
                             e.FStar_Syntax_Syntax.pos in
                         (e1, lc1)))
                   | FStar_Pervasives_Native.None ->
-                      ((let uu____10658 =
-                          let uu____10663 =
-                            let uu____10664 = FStar_Ident.string_of_lid f in
+                      ((let uu___2 =
+                          let uu___3 =
+                            let uu___4 = FStar_Ident.string_of_lid f in
                             FStar_Util.format1
                               "Coercion %s was not found in the environment, not coercing."
-                              uu____10664 in
-                          (FStar_Errors.Warning_CoercionNotFound,
-                            uu____10663) in
+                              uu___4 in
+                          (FStar_Errors.Warning_CoercionNotFound, uu___3) in
                         FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
-                          uu____10658);
+                          uu___2);
                        (e, lc))
 type isErased =
   | Yes of FStar_Syntax_Syntax.term 
   | Maybe 
   | No 
 let (uu___is_Yes : isErased -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Yes _0 -> true | uu____10676 -> false
+  fun projectee -> match projectee with | Yes _0 -> true | uu___ -> false
 let (__proj__Yes__item___0 : isErased -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Yes _0 -> _0
 let (uu___is_Maybe : isErased -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Maybe -> true | uu____10688 -> false
+  fun projectee -> match projectee with | Maybe -> true | uu___ -> false
 let (uu___is_No : isErased -> Prims.bool) =
-  fun projectee -> match projectee with | No -> true | uu____10694 -> false
+  fun projectee -> match projectee with | No -> true | uu___ -> false
 let rec (check_erased :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> isErased) =
   fun env ->
@@ -3862,56 +3769,54 @@ let rec (check_erased :
           FStar_TypeChecker_Env.Iota] in
       let t1 = norm' env t in
       let t2 = FStar_Syntax_Util.unrefine t1 in
-      let uu____10716 = FStar_Syntax_Util.head_and_args t2 in
-      match uu____10716 with
+      let uu___ = FStar_Syntax_Util.head_and_args t2 in
+      match uu___ with
       | (h, args) ->
           let h1 = FStar_Syntax_Util.un_uinst h in
           let r =
-            let uu____10761 =
-              let uu____10776 =
-                let uu____10777 = FStar_Syntax_Subst.compress h1 in
-                uu____10777.FStar_Syntax_Syntax.n in
-              (uu____10776, args) in
-            match uu____10761 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Subst.compress h1 in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            match uu___1 with
             | (FStar_Syntax_Syntax.Tm_fvar fv,
                (a, FStar_Pervasives_Native.None)::[]) when
                 FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.erased_lid
                 -> Yes a
-            | (FStar_Syntax_Syntax.Tm_uvar uu____10824, uu____10825) -> Maybe
-            | (FStar_Syntax_Syntax.Tm_unknown, uu____10858) -> Maybe
-            | (FStar_Syntax_Syntax.Tm_match (uu____10879, branches),
-               uu____10881) ->
+            | (FStar_Syntax_Syntax.Tm_uvar uu___2, uu___3) -> Maybe
+            | (FStar_Syntax_Syntax.Tm_unknown, uu___2) -> Maybe
+            | (FStar_Syntax_Syntax.Tm_match (uu___2, branches), uu___3) ->
                 FStar_All.pipe_right branches
                   (FStar_List.fold_left
                      (fun acc ->
                         fun br ->
                           match acc with
-                          | Yes uu____10945 -> Maybe
+                          | Yes uu___4 -> Maybe
                           | Maybe -> Maybe
                           | No ->
-                              let uu____10946 =
-                                FStar_Syntax_Subst.open_branch br in
-                              (match uu____10946 with
-                               | (uu____10947, uu____10948, br_body) ->
-                                   let uu____10966 =
-                                     let uu____10967 =
-                                       let uu____10972 =
-                                         let uu____10973 =
-                                           let uu____10976 =
+                              let uu___4 = FStar_Syntax_Subst.open_branch br in
+                              (match uu___4 with
+                               | (uu___5, uu___6, br_body) ->
+                                   let uu___7 =
+                                     let uu___8 =
+                                       let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 =
                                              FStar_All.pipe_right br_body
                                                FStar_Syntax_Free.names in
-                                           FStar_All.pipe_right uu____10976
+                                           FStar_All.pipe_right uu___11
                                              FStar_Util.set_elements in
-                                         FStar_All.pipe_right uu____10973
+                                         FStar_All.pipe_right uu___10
                                            (FStar_TypeChecker_Env.push_bvs
                                               env) in
-                                       check_erased uu____10972 in
-                                     FStar_All.pipe_right br_body uu____10967 in
-                                   (match uu____10966 with
+                                       check_erased uu___9 in
+                                     FStar_All.pipe_right br_body uu___8 in
+                                   (match uu___7 with
                                     | No -> No
-                                    | uu____10987 -> Maybe))) No)
-            | uu____10988 -> No in
+                                    | uu___8 -> Maybe))) No)
+            | uu___2 -> No in
           r
 let (maybe_coerce_lc :
   FStar_TypeChecker_Env.env ->
@@ -3926,9 +3831,8 @@ let (maybe_coerce_lc :
       fun lc ->
         fun exp_t ->
           let should_coerce =
-            (((let uu____11038 = FStar_Options.use_two_phase_tc () in
-               Prims.op_Negation uu____11038) ||
-                env.FStar_TypeChecker_Env.phase1)
+            (((let uu___ = FStar_Options.use_two_phase_tc () in
+               Prims.op_Negation uu___) || env.FStar_TypeChecker_Env.phase1)
                || env.FStar_TypeChecker_Env.lax)
               || (FStar_Options.lax ()) in
           if Prims.op_Negation should_coerce
@@ -3936,79 +3840,76 @@ let (maybe_coerce_lc :
           else
             (let is_t_term t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t in
-               let uu____11053 =
-                 let uu____11054 = FStar_Syntax_Subst.compress t1 in
-                 uu____11054.FStar_Syntax_Syntax.n in
-               match uu____11053 with
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress t1 in
+                 uu___2.FStar_Syntax_Syntax.n in
+               match uu___1 with
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.term_lid
-               | uu____11058 -> false in
+               | uu___2 -> false in
              let is_t_term_view t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t in
-               let uu____11066 =
-                 let uu____11067 = FStar_Syntax_Subst.compress t1 in
-                 uu____11067.FStar_Syntax_Syntax.n in
-               match uu____11066 with
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress t1 in
+                 uu___2.FStar_Syntax_Syntax.n in
+               match uu___1 with
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.term_view_lid
-               | uu____11071 -> false in
+               | uu___2 -> false in
              let is_type t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t in
                let t2 = FStar_Syntax_Util.unrefine t1 in
-               let uu____11080 =
-                 let uu____11081 = FStar_Syntax_Subst.compress t2 in
-                 uu____11081.FStar_Syntax_Syntax.n in
-               match uu____11080 with
-               | FStar_Syntax_Syntax.Tm_type uu____11084 -> true
-               | uu____11085 -> false in
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress t2 in
+                 uu___2.FStar_Syntax_Syntax.n in
+               match uu___1 with
+               | FStar_Syntax_Syntax.Tm_type uu___2 -> true
+               | uu___2 -> false in
              let res_typ =
                FStar_Syntax_Util.unrefine lc.FStar_TypeChecker_Common.res_typ in
-             let uu____11087 = FStar_Syntax_Util.head_and_args res_typ in
-             match uu____11087 with
+             let uu___1 = FStar_Syntax_Util.head_and_args res_typ in
+             match uu___1 with
              | (head, args) ->
-                 ((let uu____11137 =
+                 ((let uu___3 =
                      FStar_TypeChecker_Env.debug env
                        (FStar_Options.Other "Coercions") in
-                   if uu____11137
+                   if uu___3
                    then
-                     let uu____11138 =
+                     let uu___4 =
                        FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                     let uu____11139 = FStar_Syntax_Print.term_to_string e in
-                     let uu____11140 =
-                       FStar_Syntax_Print.term_to_string res_typ in
-                     let uu____11141 =
-                       FStar_Syntax_Print.term_to_string exp_t in
+                     let uu___5 = FStar_Syntax_Print.term_to_string e in
+                     let uu___6 = FStar_Syntax_Print.term_to_string res_typ in
+                     let uu___7 = FStar_Syntax_Print.term_to_string exp_t in
                      FStar_Util.print4
                        "(%s) Trying to coerce %s from type (%s) to type (%s)\n"
-                       uu____11138 uu____11139 uu____11140 uu____11141
+                       uu___4 uu___5 uu___6 uu___7
                    else ());
                   (let mk_erased u t =
-                     let uu____11156 =
-                       let uu____11159 =
+                     let uu___3 =
+                       let uu___4 =
                          fvar_const env FStar_Parser_Const.erased_lid in
-                       FStar_Syntax_Syntax.mk_Tm_uinst uu____11159 [u] in
-                     let uu____11160 =
-                       let uu____11171 = FStar_Syntax_Syntax.as_arg t in
-                       [uu____11171] in
-                     FStar_Syntax_Util.mk_app uu____11156 uu____11160 in
-                   let uu____11196 =
-                     let uu____11211 =
-                       let uu____11212 = FStar_Syntax_Util.un_uinst head in
-                       uu____11212.FStar_Syntax_Syntax.n in
-                     (uu____11211, args) in
-                   match uu____11196 with
+                       FStar_Syntax_Syntax.mk_Tm_uinst uu___4 [u] in
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Syntax.as_arg t in [uu___5] in
+                     FStar_Syntax_Util.mk_app uu___3 uu___4 in
+                   let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Syntax_Util.un_uinst head in
+                       uu___5.FStar_Syntax_Syntax.n in
+                     (uu___4, args) in
+                   match uu___3 with
                    | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                        (FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.bool_lid)
                          && (is_type exp_t)
                        ->
-                       let uu____11250 =
+                       let uu___4 =
                          coerce_with env e lc FStar_Syntax_Util.ktype0
                            FStar_Parser_Const.b2t_lid [] []
                            FStar_Syntax_Syntax.mk_Total in
-                       (match uu____11250 with
+                       (match uu___4 with
                         | (e1, lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
@@ -4016,11 +3917,11 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.term_lid)
                          && (is_t_term_view exp_t)
                        ->
-                       let uu____11290 =
+                       let uu___4 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term_view
                            FStar_Parser_Const.inspect [] []
                            FStar_Syntax_Syntax.mk_Tac in
-                       (match uu____11290 with
+                       (match uu___4 with
                         | (e1, lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
@@ -4028,11 +3929,11 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.term_view_lid)
                          && (is_t_term exp_t)
                        ->
-                       let uu____11330 =
+                       let uu___4 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term
                            FStar_Parser_Const.pack [] []
                            FStar_Syntax_Syntax.mk_Tac in
-                       (match uu____11330 with
+                       (match uu___4 with
                         | (e1, lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
@@ -4040,56 +3941,55 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.binder_lid)
                          && (is_t_term exp_t)
                        ->
-                       let uu____11370 =
+                       let uu___4 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term
                            FStar_Parser_Const.binder_to_term [] []
                            FStar_Syntax_Syntax.mk_Tac in
-                       (match uu____11370 with
+                       (match uu___4 with
                         | (e1, lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
-                   | uu____11391 ->
-                       let uu____11406 =
-                         let uu____11411 = check_erased env res_typ in
-                         let uu____11412 = check_erased env exp_t in
-                         (uu____11411, uu____11412) in
-                       (match uu____11406 with
+                   | uu___4 ->
+                       let uu___5 =
+                         let uu___6 = check_erased env res_typ in
+                         let uu___7 = check_erased env exp_t in
+                         (uu___6, uu___7) in
+                       (match uu___5 with
                         | (No, Yes ty) ->
                             let u =
                               env.FStar_TypeChecker_Env.universe_of env ty in
-                            let uu____11421 =
+                            let uu___6 =
                               FStar_TypeChecker_Rel.get_subtyping_predicate
                                 env res_typ ty in
-                            (match uu____11421 with
+                            (match uu___6 with
                              | FStar_Pervasives_Native.None ->
                                  (e, lc, FStar_TypeChecker_Env.trivial_guard)
                              | FStar_Pervasives_Native.Some g ->
                                  let g1 =
                                    FStar_TypeChecker_Env.apply_guard g e in
-                                 let uu____11432 =
-                                   let uu____11437 =
-                                     let uu____11438 =
-                                       FStar_Syntax_Syntax.iarg ty in
-                                     [uu____11438] in
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 = FStar_Syntax_Syntax.iarg ty in
+                                     [uu___9] in
                                    coerce_with env e lc exp_t
-                                     FStar_Parser_Const.hide [u] uu____11437
+                                     FStar_Parser_Const.hide [u] uu___8
                                      FStar_Syntax_Syntax.mk_Total in
-                                 (match uu____11432 with
+                                 (match uu___7 with
                                   | (e1, lc1) -> (e1, lc1, g1)))
                         | (Yes ty, No) ->
                             let u =
                               env.FStar_TypeChecker_Env.universe_of env ty in
-                            let uu____11473 =
-                              let uu____11478 =
-                                let uu____11479 = FStar_Syntax_Syntax.iarg ty in
-                                [uu____11479] in
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Syntax_Syntax.iarg ty in
+                                [uu___8] in
                               coerce_with env e lc ty
-                                FStar_Parser_Const.reveal [u] uu____11478
+                                FStar_Parser_Const.reveal [u] uu___7
                                 FStar_Syntax_Syntax.mk_GTotal in
-                            (match uu____11473 with
+                            (match uu___6 with
                              | (e1, lc1) ->
                                  (e1, lc1,
                                    FStar_TypeChecker_Env.trivial_guard))
-                        | uu____11512 ->
+                        | uu___6 ->
                             (e, lc, FStar_TypeChecker_Env.trivial_guard)))))
 let (coerce_views :
   FStar_TypeChecker_Env.env ->
@@ -4103,26 +4003,25 @@ let (coerce_views :
       fun lc ->
         let rt = lc.FStar_TypeChecker_Common.res_typ in
         let rt1 = FStar_Syntax_Util.unrefine rt in
-        let uu____11546 = FStar_Syntax_Util.head_and_args rt1 in
-        match uu____11546 with
+        let uu___ = FStar_Syntax_Util.head_and_args rt1 in
+        match uu___ with
         | (hd, args) ->
-            let uu____11595 =
-              let uu____11610 =
-                let uu____11611 = FStar_Syntax_Subst.compress hd in
-                uu____11611.FStar_Syntax_Syntax.n in
-              (uu____11610, args) in
-            (match uu____11595 with
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Subst.compress hd in
+                uu___3.FStar_Syntax_Syntax.n in
+              (uu___2, args) in
+            (match uu___1 with
              | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.term_lid
                  ->
-                 let uu____11649 =
+                 let uu___2 =
                    coerce_with env e lc FStar_Syntax_Syntax.t_term_view
                      FStar_Parser_Const.inspect [] []
                      FStar_Syntax_Syntax.mk_Tac in
                  FStar_All.pipe_left
-                   (fun uu____11676 ->
-                      FStar_Pervasives_Native.Some uu____11676) uu____11649
-             | uu____11677 -> FStar_Pervasives_Native.None)
+                   (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2
+             | uu___2 -> FStar_Pervasives_Native.None)
 let (weaken_result_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -4135,97 +4034,93 @@ let (weaken_result_typ :
     fun e ->
       fun lc ->
         fun t ->
-          (let uu____11729 =
-             FStar_TypeChecker_Env.debug env FStar_Options.High in
-           if uu____11729
+          (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+           if uu___1
            then
-             let uu____11730 = FStar_Syntax_Print.term_to_string e in
-             let uu____11731 = FStar_TypeChecker_Common.lcomp_to_string lc in
-             let uu____11732 = FStar_Syntax_Print.term_to_string t in
+             let uu___2 = FStar_Syntax_Print.term_to_string e in
+             let uu___3 = FStar_TypeChecker_Common.lcomp_to_string lc in
+             let uu___4 = FStar_Syntax_Print.term_to_string t in
              FStar_Util.print3 "weaken_result_typ e=(%s) lc=(%s) t=(%s)\n"
-               uu____11730 uu____11731 uu____11732
+               uu___2 uu___3 uu___4
            else ());
           (let use_eq =
              (env.FStar_TypeChecker_Env.use_eq_strict ||
                 env.FStar_TypeChecker_Env.use_eq)
                ||
-               (let uu____11738 =
+               (let uu___1 =
                   FStar_TypeChecker_Env.effect_decl_opt env
                     lc.FStar_TypeChecker_Common.eff_name in
-                match uu____11738 with
+                match uu___1 with
                 | FStar_Pervasives_Native.Some (ed, qualifiers) ->
                     FStar_All.pipe_right qualifiers
                       (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-                | uu____11761 -> false) in
+                | uu___2 -> false) in
            let gopt =
              if use_eq
              then
-               let uu____11783 =
+               let uu___1 =
                  FStar_TypeChecker_Rel.try_teq true env
                    lc.FStar_TypeChecker_Common.res_typ t in
-               (uu____11783, false)
+               (uu___1, false)
              else
-               (let uu____11789 =
+               (let uu___2 =
                   FStar_TypeChecker_Rel.get_subtyping_predicate env
                     lc.FStar_TypeChecker_Common.res_typ t in
-                (uu____11789, true)) in
+                (uu___2, true)) in
            match gopt with
-           | (FStar_Pervasives_Native.None, uu____11800) ->
+           | (FStar_Pervasives_Native.None, uu___1) ->
                if env.FStar_TypeChecker_Env.failhard
                then
-                 let uu____11809 =
+                 let uu___2 =
                    FStar_TypeChecker_Err.basic_type_error env
                      (FStar_Pervasives_Native.Some e) t
                      lc.FStar_TypeChecker_Common.res_typ in
-                 FStar_Errors.raise_error uu____11809
-                   e.FStar_Syntax_Syntax.pos
+                 FStar_Errors.raise_error uu___2 e.FStar_Syntax_Syntax.pos
                else
                  (FStar_TypeChecker_Rel.subtype_fail env e
                     lc.FStar_TypeChecker_Common.res_typ t;
                   (e,
-                    ((let uu___1419_11823 = lc in
+                    ((let uu___4 = lc in
                       {
                         FStar_TypeChecker_Common.eff_name =
-                          (uu___1419_11823.FStar_TypeChecker_Common.eff_name);
+                          (uu___4.FStar_TypeChecker_Common.eff_name);
                         FStar_TypeChecker_Common.res_typ = t;
                         FStar_TypeChecker_Common.cflags =
-                          (uu___1419_11823.FStar_TypeChecker_Common.cflags);
+                          (uu___4.FStar_TypeChecker_Common.cflags);
                         FStar_TypeChecker_Common.comp_thunk =
-                          (uu___1419_11823.FStar_TypeChecker_Common.comp_thunk)
+                          (uu___4.FStar_TypeChecker_Common.comp_thunk)
                       })), FStar_TypeChecker_Env.trivial_guard))
            | (FStar_Pervasives_Native.Some g, apply_guard) ->
-               let uu____11828 = FStar_TypeChecker_Env.guard_form g in
-               (match uu____11828 with
+               let uu___1 = FStar_TypeChecker_Env.guard_form g in
+               (match uu___1 with
                 | FStar_TypeChecker_Common.Trivial ->
-                    let strengthen_trivial uu____11844 =
-                      let uu____11845 =
-                        FStar_TypeChecker_Common.lcomp_comp lc in
-                      match uu____11845 with
+                    let strengthen_trivial uu___2 =
+                      let uu___3 = FStar_TypeChecker_Common.lcomp_comp lc in
+                      match uu___3 with
                       | (c, g_c) ->
                           let res_t = FStar_Syntax_Util.comp_result c in
                           let set_result_typ c1 =
                             FStar_Syntax_Util.set_result_typ c1 t in
-                          let uu____11865 =
-                            let uu____11866 = FStar_Syntax_Util.eq_tm t res_t in
-                            uu____11866 = FStar_Syntax_Util.Equal in
-                          if uu____11865
+                          let uu___4 =
+                            let uu___5 = FStar_Syntax_Util.eq_tm t res_t in
+                            uu___5 = FStar_Syntax_Util.Equal in
+                          if uu___4
                           then
-                            ((let uu____11872 =
+                            ((let uu___6 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Extreme in
-                              if uu____11872
+                              if uu___6
                               then
-                                let uu____11873 =
+                                let uu___7 =
                                   FStar_Syntax_Print.term_to_string res_t in
-                                let uu____11874 =
+                                let uu___8 =
                                   FStar_Syntax_Print.term_to_string t in
                                 FStar_Util.print2
                                   "weaken_result_type::strengthen_trivial: res_t:%s is same as t:%s\n"
-                                  uu____11873 uu____11874
+                                  uu___7 uu___8
                               else ());
-                             (let uu____11876 = set_result_typ c in
-                              (uu____11876, g_c)))
+                             (let uu___6 = set_result_typ c in (uu___6, g_c)))
                           else
                             (let is_res_t_refinement =
                                let res_t1 =
@@ -4233,88 +4128,86 @@ let (weaken_result_typ :
                                    FStar_TypeChecker_Normalize.whnf_steps env
                                    res_t in
                                match res_t1.FStar_Syntax_Syntax.n with
-                               | FStar_Syntax_Syntax.Tm_refine uu____11880 ->
-                                   true
-                               | uu____11887 -> false in
+                               | FStar_Syntax_Syntax.Tm_refine uu___6 -> true
+                               | uu___6 -> false in
                              if is_res_t_refinement
                              then
                                let x =
                                  FStar_Syntax_Syntax.new_bv
                                    (FStar_Pervasives_Native.Some
                                       (res_t.FStar_Syntax_Syntax.pos)) res_t in
-                               let uu____11893 =
-                                 let uu____11898 =
-                                   let uu____11899 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_All.pipe_right c
                                        FStar_Syntax_Util.comp_effect_name in
-                                   FStar_All.pipe_right uu____11899
+                                   FStar_All.pipe_right uu___8
                                      (FStar_TypeChecker_Env.norm_eff_name env) in
-                                 let uu____11902 =
+                                 let uu___8 =
                                    FStar_Syntax_Syntax.bv_to_name x in
-                                 return_value env uu____11898
-                                   (comp_univ_opt c) res_t uu____11902 in
-                               match uu____11893 with
+                                 return_value env uu___7 (comp_univ_opt c)
+                                   res_t uu___8 in
+                               match uu___6 with
                                | (cret, gret) ->
                                    let lc1 =
-                                     let uu____11912 =
+                                     let uu___7 =
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                          c in
-                                     let uu____11913 =
-                                       let uu____11914 =
+                                     let uu___8 =
+                                       let uu___9 =
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                            cret in
                                        ((FStar_Pervasives_Native.Some x),
-                                         uu____11914) in
+                                         uu___9) in
                                      bind e.FStar_Syntax_Syntax.pos env
                                        (FStar_Pervasives_Native.Some e)
-                                       uu____11912 uu____11913 in
-                                   ((let uu____11918 =
+                                       uu___7 uu___8 in
+                                   ((let uu___8 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env)
                                          FStar_Options.Extreme in
-                                     if uu____11918
+                                     if uu___8
                                      then
-                                       let uu____11919 =
+                                       let uu___9 =
                                          FStar_Syntax_Print.term_to_string e in
-                                       let uu____11920 =
+                                       let uu___10 =
                                          FStar_Syntax_Print.comp_to_string c in
-                                       let uu____11921 =
+                                       let uu___11 =
                                          FStar_Syntax_Print.term_to_string t in
-                                       let uu____11922 =
+                                       let uu___12 =
                                          FStar_TypeChecker_Common.lcomp_to_string
                                            lc1 in
                                        FStar_Util.print4
                                          "weaken_result_type::strengthen_trivial: inserting a return for e: %s, c: %s, t: %s, and then post return lc: %s\n"
-                                         uu____11919 uu____11920 uu____11921
-                                         uu____11922
+                                         uu___9 uu___10 uu___11 uu___12
                                      else ());
-                                    (let uu____11924 =
+                                    (let uu___8 =
                                        FStar_TypeChecker_Common.lcomp_comp
                                          lc1 in
-                                     match uu____11924 with
+                                     match uu___8 with
                                      | (c1, g_lc) ->
-                                         let uu____11935 = set_result_typ c1 in
-                                         let uu____11936 =
+                                         let uu___9 = set_result_typ c1 in
+                                         let uu___10 =
                                            FStar_TypeChecker_Env.conj_guards
                                              [g_c; gret; g_lc] in
-                                         (uu____11935, uu____11936)))
+                                         (uu___9, uu___10)))
                              else
-                               ((let uu____11939 =
+                               ((let uu___8 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu____11939
+                                 if uu___8
                                  then
-                                   let uu____11940 =
+                                   let uu___9 =
                                      FStar_Syntax_Print.term_to_string res_t in
-                                   let uu____11941 =
+                                   let uu___10 =
                                      FStar_Syntax_Print.comp_to_string c in
                                    FStar_Util.print2
                                      "weaken_result_type::strengthen_trivial: res_t:%s is not a refinement, leaving c:%s as is\n"
-                                     uu____11940 uu____11941
+                                     uu___9 uu___10
                                  else ());
-                                (let uu____11943 = set_result_typ c in
-                                 (uu____11943, g_c)))) in
+                                (let uu___8 = set_result_typ c in
+                                 (uu___8, g_c)))) in
                     let lc1 =
                       FStar_TypeChecker_Common.mk_lcomp
                         lc.FStar_TypeChecker_Common.eff_name t
@@ -4322,24 +4215,24 @@ let (weaken_result_typ :
                     (e, lc1, g)
                 | FStar_TypeChecker_Common.NonTrivial f ->
                     let g1 =
-                      let uu___1458_11947 = g in
+                      let uu___2 = g in
                       {
                         FStar_TypeChecker_Common.guard_f =
                           FStar_TypeChecker_Common.Trivial;
                         FStar_TypeChecker_Common.deferred_to_tac =
-                          (uu___1458_11947.FStar_TypeChecker_Common.deferred_to_tac);
+                          (uu___2.FStar_TypeChecker_Common.deferred_to_tac);
                         FStar_TypeChecker_Common.deferred =
-                          (uu___1458_11947.FStar_TypeChecker_Common.deferred);
+                          (uu___2.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
-                          (uu___1458_11947.FStar_TypeChecker_Common.univ_ineqs);
+                          (uu___2.FStar_TypeChecker_Common.univ_ineqs);
                         FStar_TypeChecker_Common.implicits =
-                          (uu___1458_11947.FStar_TypeChecker_Common.implicits)
+                          (uu___2.FStar_TypeChecker_Common.implicits)
                       } in
-                    let strengthen uu____11957 =
-                      let uu____11958 =
+                    let strengthen uu___2 =
+                      let uu___3 =
                         env.FStar_TypeChecker_Env.lax &&
                           (FStar_Options.ml_ish ()) in
-                      if uu____11958
+                      if uu___3
                       then FStar_TypeChecker_Common.lcomp_comp lc
                       else
                         (let f1 =
@@ -4348,62 +4241,61 @@ let (weaken_result_typ :
                              FStar_TypeChecker_Env.Eager_unfolding;
                              FStar_TypeChecker_Env.Simplify;
                              FStar_TypeChecker_Env.Primops] env f in
-                         let uu____11965 =
-                           let uu____11966 = FStar_Syntax_Subst.compress f1 in
-                           uu____11966.FStar_Syntax_Syntax.n in
-                         match uu____11965 with
+                         let uu___5 =
+                           let uu___6 = FStar_Syntax_Subst.compress f1 in
+                           uu___6.FStar_Syntax_Syntax.n in
+                         match uu___5 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (uu____11973,
+                             (uu___6,
                               {
                                 FStar_Syntax_Syntax.n =
                                   FStar_Syntax_Syntax.Tm_fvar fv;
-                                FStar_Syntax_Syntax.pos = uu____11975;
-                                FStar_Syntax_Syntax.vars = uu____11976;_},
-                              uu____11977)
+                                FStar_Syntax_Syntax.pos = uu___7;
+                                FStar_Syntax_Syntax.vars = uu___8;_},
+                              uu___9)
                              when
                              FStar_Syntax_Syntax.fv_eq_lid fv
                                FStar_Parser_Const.true_lid
                              ->
                              let lc1 =
-                               let uu___1474_12003 = lc in
+                               let uu___10 = lc in
                                {
                                  FStar_TypeChecker_Common.eff_name =
-                                   (uu___1474_12003.FStar_TypeChecker_Common.eff_name);
+                                   (uu___10.FStar_TypeChecker_Common.eff_name);
                                  FStar_TypeChecker_Common.res_typ = t;
                                  FStar_TypeChecker_Common.cflags =
-                                   (uu___1474_12003.FStar_TypeChecker_Common.cflags);
+                                   (uu___10.FStar_TypeChecker_Common.cflags);
                                  FStar_TypeChecker_Common.comp_thunk =
-                                   (uu___1474_12003.FStar_TypeChecker_Common.comp_thunk)
+                                   (uu___10.FStar_TypeChecker_Common.comp_thunk)
                                } in
                              FStar_TypeChecker_Common.lcomp_comp lc1
-                         | uu____12004 ->
-                             let uu____12005 =
+                         | uu___6 ->
+                             let uu___7 =
                                FStar_TypeChecker_Common.lcomp_comp lc in
-                             (match uu____12005 with
+                             (match uu___7 with
                               | (c, g_c) ->
-                                  ((let uu____12017 =
+                                  ((let uu___9 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
                                         FStar_Options.Extreme in
-                                    if uu____12017
+                                    if uu___9
                                     then
-                                      let uu____12018 =
+                                      let uu___10 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env
                                           lc.FStar_TypeChecker_Common.res_typ in
-                                      let uu____12019 =
+                                      let uu___11 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env t in
-                                      let uu____12020 =
+                                      let uu___12 =
                                         FStar_TypeChecker_Normalize.comp_to_string
                                           env c in
-                                      let uu____12021 =
+                                      let uu___13 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env f1 in
                                       FStar_Util.print4
                                         "Weakened from %s to %s\nStrengthening %s with guard %s\n"
-                                        uu____12018 uu____12019 uu____12020
-                                        uu____12021
+                                        uu___10 uu___11 uu___12 uu___13
                                     else ());
                                    (let u_t_opt = comp_univ_opt c in
                                     let x =
@@ -4412,135 +4304,133 @@ let (weaken_result_typ :
                                            (t.FStar_Syntax_Syntax.pos)) t in
                                     let xexp =
                                       FStar_Syntax_Syntax.bv_to_name x in
-                                    let uu____12028 =
-                                      let uu____12033 =
-                                        let uu____12034 =
+                                    let uu___9 =
+                                      let uu___10 =
+                                        let uu___11 =
                                           FStar_All.pipe_right c
                                             FStar_Syntax_Util.comp_effect_name in
-                                        FStar_All.pipe_right uu____12034
+                                        FStar_All.pipe_right uu___11
                                           (FStar_TypeChecker_Env.norm_eff_name
                                              env) in
-                                      return_value env uu____12033 u_t_opt t
-                                        xexp in
-                                    match uu____12028 with
+                                      return_value env uu___10 u_t_opt t xexp in
+                                    match uu___9 with
                                     | (cret, gret) ->
                                         let guard =
                                           if apply_guard
                                           then
-                                            let uu____12044 =
-                                              let uu____12045 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_Syntax_Syntax.as_arg
                                                   xexp in
-                                              [uu____12045] in
+                                              [uu___11] in
                                             FStar_Syntax_Syntax.mk_Tm_app f1
-                                              uu____12044
+                                              uu___10
                                               f1.FStar_Syntax_Syntax.pos
                                           else f1 in
-                                        let uu____12071 =
-                                          let uu____12076 =
+                                        let uu___10 =
+                                          let uu___11 =
                                             FStar_All.pipe_left
-                                              (fun uu____12093 ->
+                                              (fun uu___12 ->
                                                  FStar_Pervasives_Native.Some
-                                                   uu____12093)
+                                                   uu___12)
                                               (FStar_TypeChecker_Err.subtyping_failed
                                                  env
                                                  lc.FStar_TypeChecker_Common.res_typ
                                                  t) in
-                                          let uu____12094 =
-                                            let uu____12095 =
+                                          let uu___12 =
+                                            let uu___13 =
                                               FStar_TypeChecker_Env.push_bvs
                                                 env [x] in
                                             FStar_TypeChecker_Env.set_range
-                                              uu____12095
+                                              uu___13
                                               e.FStar_Syntax_Syntax.pos in
-                                          let uu____12096 =
+                                          let uu___13 =
                                             FStar_TypeChecker_Common.lcomp_of_comp
                                               cret in
-                                          let uu____12097 =
+                                          let uu___14 =
                                             FStar_All.pipe_left
                                               FStar_TypeChecker_Env.guard_of_guard_formula
                                               (FStar_TypeChecker_Common.NonTrivial
                                                  guard) in
-                                          strengthen_precondition uu____12076
-                                            uu____12094 e uu____12096
-                                            uu____12097 in
-                                        (match uu____12071 with
+                                          strengthen_precondition uu___11
+                                            uu___12 e uu___13 uu___14 in
+                                        (match uu___10 with
                                          | (eq_ret,
                                             _trivial_so_ok_to_discard) ->
                                              let x1 =
-                                               let uu___1494_12105 = x in
+                                               let uu___11 = x in
                                                {
                                                  FStar_Syntax_Syntax.ppname =
-                                                   (uu___1494_12105.FStar_Syntax_Syntax.ppname);
+                                                   (uu___11.FStar_Syntax_Syntax.ppname);
                                                  FStar_Syntax_Syntax.index =
-                                                   (uu___1494_12105.FStar_Syntax_Syntax.index);
+                                                   (uu___11.FStar_Syntax_Syntax.index);
                                                  FStar_Syntax_Syntax.sort =
                                                    (lc.FStar_TypeChecker_Common.res_typ)
                                                } in
                                              let c1 =
-                                               let uu____12107 =
+                                               let uu___11 =
                                                  FStar_TypeChecker_Common.lcomp_of_comp
                                                    c in
                                                bind e.FStar_Syntax_Syntax.pos
                                                  env
                                                  (FStar_Pervasives_Native.Some
-                                                    e) uu____12107
+                                                    e) uu___11
                                                  ((FStar_Pervasives_Native.Some
                                                      x1), eq_ret) in
-                                             let uu____12110 =
+                                             let uu___11 =
                                                FStar_TypeChecker_Common.lcomp_comp
                                                  c1 in
-                                             (match uu____12110 with
+                                             (match uu___11 with
                                               | (c2, g_lc) ->
-                                                  ((let uu____12122 =
+                                                  ((let uu___13 =
                                                       FStar_All.pipe_left
                                                         (FStar_TypeChecker_Env.debug
                                                            env)
                                                         FStar_Options.Extreme in
-                                                    if uu____12122
+                                                    if uu___13
                                                     then
-                                                      let uu____12123 =
+                                                      let uu___14 =
                                                         FStar_TypeChecker_Normalize.comp_to_string
                                                           env c2 in
                                                       FStar_Util.print1
                                                         "Strengthened to %s\n"
-                                                        uu____12123
+                                                        uu___14
                                                     else ());
-                                                   (let uu____12125 =
+                                                   (let uu___13 =
                                                       FStar_TypeChecker_Env.conj_guards
                                                         [g_c; gret; g_lc] in
-                                                    (c2, uu____12125))))))))) in
+                                                    (c2, uu___13))))))))) in
                     let flags =
                       FStar_All.pipe_right lc.FStar_TypeChecker_Common.cflags
                         (FStar_List.collect
-                           (fun uu___6_12134 ->
-                              match uu___6_12134 with
+                           (fun uu___2 ->
+                              match uu___2 with
                               | FStar_Syntax_Syntax.RETURN ->
                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
                               | FStar_Syntax_Syntax.PARTIAL_RETURN ->
                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
                               | FStar_Syntax_Syntax.CPS ->
                                   [FStar_Syntax_Syntax.CPS]
-                              | uu____12137 -> [])) in
+                              | uu___3 -> [])) in
                     let lc1 =
-                      let uu____12139 =
+                      let uu___2 =
                         FStar_TypeChecker_Env.norm_eff_name env
                           lc.FStar_TypeChecker_Common.eff_name in
-                      FStar_TypeChecker_Common.mk_lcomp uu____12139 t flags
+                      FStar_TypeChecker_Common.mk_lcomp uu___2 t flags
                         strengthen in
                     let g2 =
-                      let uu___1510_12141 = g1 in
+                      let uu___2 = g1 in
                       {
                         FStar_TypeChecker_Common.guard_f =
                           FStar_TypeChecker_Common.Trivial;
                         FStar_TypeChecker_Common.deferred_to_tac =
-                          (uu___1510_12141.FStar_TypeChecker_Common.deferred_to_tac);
+                          (uu___2.FStar_TypeChecker_Common.deferred_to_tac);
                         FStar_TypeChecker_Common.deferred =
-                          (uu___1510_12141.FStar_TypeChecker_Common.deferred);
+                          (uu___2.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
-                          (uu___1510_12141.FStar_TypeChecker_Common.univ_ineqs);
+                          (uu___2.FStar_TypeChecker_Common.univ_ineqs);
                         FStar_TypeChecker_Common.implicits =
-                          (uu___1510_12141.FStar_TypeChecker_Common.implicits)
+                          (uu___2.FStar_TypeChecker_Common.implicits)
                       } in
                     (e, lc1, g2)))
 let (pure_or_ghost_pre_and_post :
@@ -4553,137 +4443,131 @@ let (pure_or_ghost_pre_and_post :
     fun comp ->
       let mk_post_type res_t ens =
         let x = FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None res_t in
-        let uu____12176 =
-          let uu____12179 =
-            let uu____12180 =
-              let uu____12189 = FStar_Syntax_Syntax.bv_to_name x in
-              FStar_Syntax_Syntax.as_arg uu____12189 in
-            [uu____12180] in
-          FStar_Syntax_Syntax.mk_Tm_app ens uu____12179
+        let uu___ =
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Syntax.bv_to_name x in
+              FStar_Syntax_Syntax.as_arg uu___3 in
+            [uu___2] in
+          FStar_Syntax_Syntax.mk_Tm_app ens uu___1
             res_t.FStar_Syntax_Syntax.pos in
-        FStar_Syntax_Util.refine x uu____12176 in
+        FStar_Syntax_Util.refine x uu___ in
       let norm t =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Env.Beta;
           FStar_TypeChecker_Env.Eager_unfolding;
           FStar_TypeChecker_Env.EraseUniverses] env t in
-      let uu____12212 = FStar_Syntax_Util.is_tot_or_gtot_comp comp in
-      if uu____12212
+      let uu___ = FStar_Syntax_Util.is_tot_or_gtot_comp comp in
+      if uu___
       then
         (FStar_Pervasives_Native.None, (FStar_Syntax_Util.comp_result comp))
       else
         (match comp.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.GTotal uu____12228 -> failwith "Impossible"
-         | FStar_Syntax_Syntax.Total uu____12243 -> failwith "Impossible"
+         | FStar_Syntax_Syntax.GTotal uu___2 -> failwith "Impossible"
+         | FStar_Syntax_Syntax.Total uu___2 -> failwith "Impossible"
          | FStar_Syntax_Syntax.Comp ct ->
-             let uu____12259 =
+             let uu___2 =
                (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_Pure_lid)
                  ||
                  (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                     FStar_Parser_Const.effect_Ghost_lid) in
-             if uu____12259
+             if uu___2
              then
                (match ct.FStar_Syntax_Syntax.effect_args with
-                | (req, uu____12273)::(ens, uu____12275)::uu____12276 ->
-                    let uu____12319 =
-                      let uu____12322 = norm req in
-                      FStar_Pervasives_Native.Some uu____12322 in
-                    let uu____12323 =
-                      let uu____12324 =
+                | (req, uu___3)::(ens, uu___4)::uu___5 ->
+                    let uu___6 =
+                      let uu___7 = norm req in
+                      FStar_Pervasives_Native.Some uu___7 in
+                    let uu___7 =
+                      let uu___8 =
                         mk_post_type ct.FStar_Syntax_Syntax.result_typ ens in
-                      FStar_All.pipe_left norm uu____12324 in
-                    (uu____12319, uu____12323)
-                | uu____12327 ->
-                    let uu____12338 =
-                      let uu____12343 =
-                        let uu____12344 =
-                          FStar_Syntax_Print.comp_to_string comp in
+                      FStar_All.pipe_left norm uu___8 in
+                    (uu___6, uu___7)
+                | uu___3 ->
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Print.comp_to_string comp in
                         FStar_Util.format1
                           "Effect constructor is not fully applied; got %s"
-                          uu____12344 in
+                          uu___6 in
                       (FStar_Errors.Fatal_EffectConstructorNotFullyApplied,
-                        uu____12343) in
-                    FStar_Errors.raise_error uu____12338
+                        uu___5) in
+                    FStar_Errors.raise_error uu___4
                       comp.FStar_Syntax_Syntax.pos)
              else
                (let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env comp in
                 match ct1.FStar_Syntax_Syntax.effect_args with
-                | (wp, uu____12360)::uu____12361 ->
-                    let uu____12388 =
-                      let uu____12393 =
+                | (wp, uu___4)::uu___5 ->
+                    let uu___6 =
+                      let uu___7 =
                         FStar_TypeChecker_Env.lookup_lid env
                           FStar_Parser_Const.as_requires in
-                      FStar_All.pipe_left FStar_Pervasives_Native.fst
-                        uu____12393 in
-                    (match uu____12388 with
-                     | (us_r, uu____12425) ->
-                         let uu____12426 =
-                           let uu____12431 =
+                      FStar_All.pipe_left FStar_Pervasives_Native.fst uu___7 in
+                    (match uu___6 with
+                     | (us_r, uu___7) ->
+                         let uu___8 =
+                           let uu___9 =
                              FStar_TypeChecker_Env.lookup_lid env
                                FStar_Parser_Const.as_ensures in
                            FStar_All.pipe_left FStar_Pervasives_Native.fst
-                             uu____12431 in
-                         (match uu____12426 with
-                          | (us_e, uu____12463) ->
+                             uu___9 in
+                         (match uu___8 with
+                          | (us_e, uu___9) ->
                               let r =
                                 (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
                               let as_req =
-                                let uu____12466 =
-                                  let uu____12467 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_requires r in
-                                  FStar_Syntax_Syntax.fvar uu____12467
+                                  FStar_Syntax_Syntax.fvar uu___11
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12466
-                                  us_r in
+                                FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_r in
                               let as_ens =
-                                let uu____12469 =
-                                  let uu____12470 =
+                                let uu___10 =
+                                  let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_ensures r in
-                                  FStar_Syntax_Syntax.fvar uu____12470
+                                  FStar_Syntax_Syntax.fvar uu___11
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12469
-                                  us_e in
+                                FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_e in
                               let req =
-                                let uu____12472 =
-                                  let uu____12473 =
-                                    let uu____12484 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_Syntax_Syntax.as_arg wp in
-                                    [uu____12484] in
+                                    [uu___12] in
                                   ((ct1.FStar_Syntax_Syntax.result_typ),
                                     (FStar_Pervasives_Native.Some
                                        FStar_Syntax_Syntax.imp_tag))
-                                    :: uu____12473 in
-                                FStar_Syntax_Syntax.mk_Tm_app as_req
-                                  uu____12472
+                                    :: uu___11 in
+                                FStar_Syntax_Syntax.mk_Tm_app as_req uu___10
                                   (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
                               let ens =
-                                let uu____12522 =
-                                  let uu____12523 =
-                                    let uu____12534 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
                                       FStar_Syntax_Syntax.as_arg wp in
-                                    [uu____12534] in
+                                    [uu___12] in
                                   ((ct1.FStar_Syntax_Syntax.result_typ),
                                     (FStar_Pervasives_Native.Some
                                        FStar_Syntax_Syntax.imp_tag))
-                                    :: uu____12523 in
-                                FStar_Syntax_Syntax.mk_Tm_app as_ens
-                                  uu____12522
+                                    :: uu___11 in
+                                FStar_Syntax_Syntax.mk_Tm_app as_ens uu___10
                                   (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-                              let uu____12571 =
-                                let uu____12574 = norm req in
-                                FStar_Pervasives_Native.Some uu____12574 in
-                              let uu____12575 =
-                                let uu____12576 =
+                              let uu___10 =
+                                let uu___11 = norm req in
+                                FStar_Pervasives_Native.Some uu___11 in
+                              let uu___11 =
+                                let uu___12 =
                                   mk_post_type
                                     ct1.FStar_Syntax_Syntax.result_typ ens in
-                                norm uu____12576 in
-                              (uu____12571, uu____12575)))
-                | uu____12579 -> failwith "Impossible"))
+                                norm uu___12 in
+                              (uu___10, uu___11)))
+                | uu___4 -> failwith "Impossible"))
 let (reify_body :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.steps ->
@@ -4703,15 +4587,14 @@ let (reify_body :
                FStar_TypeChecker_Env.AllowUnboundUniverses;
                FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta]
                steps) env tm in
-        (let uu____12616 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "SMTEncodingReify") in
-         if uu____12616
+         if uu___1
          then
-           let uu____12617 = FStar_Syntax_Print.term_to_string tm in
-           let uu____12618 = FStar_Syntax_Print.term_to_string tm' in
-           FStar_Util.print2 "Reified body %s \nto %s\n" uu____12617
-             uu____12618
+           let uu___2 = FStar_Syntax_Print.term_to_string tm in
+           let uu___3 = FStar_Syntax_Print.term_to_string tm' in
+           FStar_Util.print2 "Reified body %s \nto %s\n" uu___2 uu___3
          else ());
         tm'
 let (reify_body_with_arg :
@@ -4737,45 +4620,44 @@ let (reify_body_with_arg :
                  FStar_TypeChecker_Env.AllowUnboundUniverses;
                  FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta]
                  steps) env tm in
-          (let uu____12673 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "SMTEncodingReify") in
-           if uu____12673
+           if uu___1
            then
-             let uu____12674 = FStar_Syntax_Print.term_to_string tm in
-             let uu____12675 = FStar_Syntax_Print.term_to_string tm' in
-             FStar_Util.print2 "Reified body %s \nto %s\n" uu____12674
-               uu____12675
+             let uu___2 = FStar_Syntax_Print.term_to_string tm in
+             let uu___3 = FStar_Syntax_Print.term_to_string tm' in
+             FStar_Util.print2 "Reified body %s \nto %s\n" uu___2 uu___3
            else ());
           tm'
 let (remove_reify : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu____12682 =
-      let uu____12683 =
-        let uu____12684 = FStar_Syntax_Subst.compress t in
-        uu____12684.FStar_Syntax_Syntax.n in
-      match uu____12683 with
-      | FStar_Syntax_Syntax.Tm_app uu____12687 -> false
-      | uu____12704 -> true in
-    if uu____12682
+    let uu___ =
+      let uu___1 =
+        let uu___2 = FStar_Syntax_Subst.compress t in
+        uu___2.FStar_Syntax_Syntax.n in
+      match uu___1 with
+      | FStar_Syntax_Syntax.Tm_app uu___2 -> false
+      | uu___2 -> true in
+    if uu___
     then t
     else
-      (let uu____12706 = FStar_Syntax_Util.head_and_args t in
-       match uu____12706 with
+      (let uu___2 = FStar_Syntax_Util.head_and_args t in
+       match uu___2 with
        | (head, args) ->
-           let uu____12749 =
-             let uu____12750 =
-               let uu____12751 = FStar_Syntax_Subst.compress head in
-               uu____12751.FStar_Syntax_Syntax.n in
-             match uu____12750 with
+           let uu___3 =
+             let uu___4 =
+               let uu___5 = FStar_Syntax_Subst.compress head in
+               uu___5.FStar_Syntax_Syntax.n in
+             match uu___4 with
              | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) ->
                  true
-             | uu____12754 -> false in
-           if uu____12749
+             | uu___5 -> false in
+           if uu___3
            then
              (match args with
               | x::[] -> FStar_Pervasives_Native.fst x
-              | uu____12784 ->
+              | uu___4 ->
                   failwith
                     "Impossible : Reify applied to multiple arguments after normalization.")
            else t)
@@ -4793,25 +4675,24 @@ let (maybe_instantiate :
         if Prims.op_Negation env.FStar_TypeChecker_Env.instantiate_imp
         then (e, torig, FStar_TypeChecker_Env.trivial_guard)
         else
-          ((let uu____12826 =
-              FStar_TypeChecker_Env.debug env FStar_Options.High in
-            if uu____12826
+          ((let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+            if uu___2
             then
-              let uu____12827 = FStar_Syntax_Print.term_to_string e in
-              let uu____12828 = FStar_Syntax_Print.term_to_string t in
-              let uu____12829 =
-                let uu____12830 = FStar_TypeChecker_Env.expected_typ env in
+              let uu___3 = FStar_Syntax_Print.term_to_string e in
+              let uu___4 = FStar_Syntax_Print.term_to_string t in
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_Env.expected_typ env in
                 FStar_Common.string_of_option
-                  FStar_Syntax_Print.term_to_string uu____12830 in
+                  FStar_Syntax_Print.term_to_string uu___6 in
               FStar_Util.print3
                 "maybe_instantiate: starting check for (%s) of type (%s), expected type is %s\n"
-                uu____12827 uu____12828 uu____12829
+                uu___3 uu___4 uu___5
             else ());
            (let unfolded_arrow_formals t1 =
               let rec aux bs t2 =
                 let t3 = FStar_TypeChecker_Normalize.unfold_whnf env t2 in
-                let uu____12864 = FStar_Syntax_Util.arrow_formals t3 in
-                match uu____12864 with
+                let uu___2 = FStar_Syntax_Util.arrow_formals t3 in
+                match uu___2 with
                 | (bs', t4) ->
                     (match bs' with
                      | [] -> bs
@@ -4820,102 +4701,99 @@ let (maybe_instantiate :
             let number_of_implicits t1 =
               let formals = unfolded_arrow_formals t1 in
               let n_implicits =
-                let uu____12898 =
+                let uu___2 =
                   FStar_All.pipe_right formals
                     (FStar_Util.prefix_until
-                       (fun uu____12976 ->
-                          match uu____12976 with
-                          | (uu____12983, imp) ->
+                       (fun uu___3 ->
+                          match uu___3 with
+                          | (uu___4, imp) ->
                               (FStar_Option.isNone imp) ||
-                                (let uu____12990 =
+                                (let uu___5 =
                                    FStar_Syntax_Util.eq_aqual imp
                                      (FStar_Pervasives_Native.Some
                                         FStar_Syntax_Syntax.Equality) in
-                                 uu____12990 = FStar_Syntax_Util.Equal))) in
-                match uu____12898 with
+                                 uu___5 = FStar_Syntax_Util.Equal))) in
+                match uu___2 with
                 | FStar_Pervasives_Native.None -> FStar_List.length formals
                 | FStar_Pervasives_Native.Some
                     (implicits, _first_explicit, _rest) ->
                     FStar_List.length implicits in
               n_implicits in
             let inst_n_binders t1 =
-              let uu____13108 = FStar_TypeChecker_Env.expected_typ env in
-              match uu____13108 with
+              let uu___2 = FStar_TypeChecker_Env.expected_typ env in
+              match uu___2 with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some expected_t ->
                   let n_expected = number_of_implicits expected_t in
                   let n_available = number_of_implicits t1 in
                   if n_available < n_expected
                   then
-                    let uu____13118 =
-                      let uu____13123 =
-                        let uu____13124 = FStar_Util.string_of_int n_expected in
-                        let uu____13125 = FStar_Syntax_Print.term_to_string e in
-                        let uu____13126 =
-                          FStar_Util.string_of_int n_available in
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 = FStar_Util.string_of_int n_expected in
+                        let uu___6 = FStar_Syntax_Print.term_to_string e in
+                        let uu___7 = FStar_Util.string_of_int n_available in
                         FStar_Util.format3
                           "Expected a term with %s implicit arguments, but %s has only %s"
-                          uu____13124 uu____13125 uu____13126 in
-                      (FStar_Errors.Fatal_MissingImplicitArguments,
-                        uu____13123) in
-                    let uu____13127 = FStar_TypeChecker_Env.get_range env in
-                    FStar_Errors.raise_error uu____13118 uu____13127
+                          uu___5 uu___6 uu___7 in
+                      (FStar_Errors.Fatal_MissingImplicitArguments, uu___4) in
+                    let uu___4 = FStar_TypeChecker_Env.get_range env in
+                    FStar_Errors.raise_error uu___3 uu___4
                   else
                     FStar_Pervasives_Native.Some (n_available - n_expected) in
-            let decr_inst uu___7_13140 =
-              match uu___7_13140 with
+            let decr_inst uu___2 =
+              match uu___2 with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some i ->
                   FStar_Pervasives_Native.Some (i - Prims.int_one) in
             let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t in
             match t1.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                let uu____13175 = FStar_Syntax_Subst.open_comp bs c in
-                (match uu____13175 with
+                let uu___2 = FStar_Syntax_Subst.open_comp bs c in
+                (match uu___2 with
                  | (bs1, c1) ->
                      let rec aux subst inst_n bs2 =
                        match (inst_n, bs2) with
-                       | (FStar_Pervasives_Native.Some uu____13301,
-                          uu____13290) when uu____13301 = Prims.int_zero ->
+                       | (FStar_Pervasives_Native.Some uu___3, uu___4) when
+                           uu___3 = Prims.int_zero ->
                            ([], bs2, subst,
                              FStar_TypeChecker_Env.trivial_guard)
-                       | (uu____13334,
+                       | (uu___3,
                           (x, FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Implicit uu____13336))::rest)
-                           ->
+                           (FStar_Syntax_Syntax.Implicit uu___4))::rest) ->
                            let t2 =
                              FStar_Syntax_Subst.subst subst
                                x.FStar_Syntax_Syntax.sort in
-                           let uu____13367 =
+                           let uu___5 =
                              new_implicit_var
                                "Instantiation of implicit argument"
                                e.FStar_Syntax_Syntax.pos env t2 in
-                           (match uu____13367 with
-                            | (v, uu____13407, g) ->
-                                ((let uu____13422 =
+                           (match uu___5 with
+                            | (v, uu___6, g) ->
+                                ((let uu___8 =
                                     FStar_TypeChecker_Env.debug env
                                       FStar_Options.High in
-                                  if uu____13422
+                                  if uu___8
                                   then
-                                    let uu____13423 =
+                                    let uu___9 =
                                       FStar_Syntax_Print.term_to_string v in
                                     FStar_Util.print1
                                       "maybe_instantiate: Instantiating implicit with %s\n"
-                                      uu____13423
+                                      uu___9
                                   else ());
                                  (let subst1 =
                                     (FStar_Syntax_Syntax.NT (x, v)) :: subst in
-                                  let uu____13430 =
+                                  let uu___8 =
                                     aux subst1 (decr_inst inst_n) rest in
-                                  match uu____13430 with
+                                  match uu___8 with
                                   | (args, bs3, subst2, g') ->
-                                      let uu____13523 =
+                                      let uu___9 =
                                         FStar_TypeChecker_Env.conj_guard g g' in
                                       (((v,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag)) ::
-                                        args), bs3, subst2, uu____13523))))
-                       | (uu____13550,
+                                        args), bs3, subst2, uu___9))))
+                       | (uu___3,
                           (x, FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tac_or_attr))::rest) ->
                            let t2 =
@@ -4925,73 +4803,70 @@ let (maybe_instantiate :
                              match tac_or_attr with
                              | FStar_Syntax_Syntax.Arg_qualifier_meta_tac tau
                                  ->
-                                 let uu____13587 =
-                                   let uu____13594 = FStar_Dyn.mkdyn env in
-                                   (uu____13594, tau) in
-                                 FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                   uu____13587
+                                 let uu___4 =
+                                   let uu___5 = FStar_Dyn.mkdyn env in
+                                   (uu___5, tau) in
+                                 FStar_Syntax_Syntax.Ctx_uvar_meta_tac uu___4
                              | FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                  attr ->
                                  FStar_Syntax_Syntax.Ctx_uvar_meta_attr attr in
-                           let uu____13600 =
+                           let uu___4 =
                              FStar_TypeChecker_Env.new_implicit_var_aux
                                "Instantiation of meta argument"
                                e.FStar_Syntax_Syntax.pos env t2
                                FStar_Syntax_Syntax.Strict
                                (FStar_Pervasives_Native.Some meta_t) in
-                           (match uu____13600 with
-                            | (v, uu____13640, g) ->
-                                ((let uu____13655 =
+                           (match uu___4 with
+                            | (v, uu___5, g) ->
+                                ((let uu___7 =
                                     FStar_TypeChecker_Env.debug env
                                       FStar_Options.High in
-                                  if uu____13655
+                                  if uu___7
                                   then
-                                    let uu____13656 =
+                                    let uu___8 =
                                       FStar_Syntax_Print.term_to_string v in
                                     FStar_Util.print1
                                       "maybe_instantiate: Instantiating meta argument with %s\n"
-                                      uu____13656
+                                      uu___8
                                   else ());
                                  (let subst1 =
                                     (FStar_Syntax_Syntax.NT (x, v)) :: subst in
-                                  let uu____13663 =
+                                  let uu___7 =
                                     aux subst1 (decr_inst inst_n) rest in
-                                  match uu____13663 with
+                                  match uu___7 with
                                   | (args, bs3, subst2, g') ->
-                                      let uu____13756 =
+                                      let uu___8 =
                                         FStar_TypeChecker_Env.conj_guard g g' in
                                       (((v,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag)) ::
-                                        args), bs3, subst2, uu____13756))))
-                       | (uu____13783, bs3) ->
+                                        args), bs3, subst2, uu___8))))
+                       | (uu___3, bs3) ->
                            ([], bs3, subst,
                              FStar_TypeChecker_Env.trivial_guard) in
-                     let uu____13829 =
-                       let uu____13856 = inst_n_binders t1 in
-                       aux [] uu____13856 bs1 in
-                     (match uu____13829 with
+                     let uu___3 =
+                       let uu___4 = inst_n_binders t1 in aux [] uu___4 bs1 in
+                     (match uu___3 with
                       | (args, bs2, subst, guard) ->
                           (match (args, bs2) with
-                           | ([], uu____13927) -> (e, torig, guard)
-                           | (uu____13958, []) when
-                               let uu____13989 =
+                           | ([], uu___4) -> (e, torig, guard)
+                           | (uu___4, []) when
+                               let uu___5 =
                                  FStar_Syntax_Util.is_total_comp c1 in
-                               Prims.op_Negation uu____13989 ->
+                               Prims.op_Negation uu___5 ->
                                (e, torig,
                                  FStar_TypeChecker_Env.trivial_guard)
-                           | uu____13990 ->
+                           | uu___4 ->
                                let t2 =
                                  match bs2 with
                                  | [] -> FStar_Syntax_Util.comp_result c1
-                                 | uu____14018 ->
-                                     FStar_Syntax_Util.arrow bs2 c1 in
+                                 | uu___5 -> FStar_Syntax_Util.arrow bs2 c1 in
                                let t3 = FStar_Syntax_Subst.subst subst t2 in
                                let e1 =
                                  FStar_Syntax_Syntax.mk_Tm_app e args
                                    e.FStar_Syntax_Syntax.pos in
                                (e1, t3, guard))))
-            | uu____14029 -> (e, torig, FStar_TypeChecker_Env.trivial_guard)))
+            | uu___2 -> (e, torig, FStar_TypeChecker_Env.trivial_guard)))
 let (check_has_type :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -5009,55 +4884,50 @@ let (check_has_type :
           let check env2 t1 t21 =
             if env2.FStar_TypeChecker_Env.use_eq_strict
             then
-              let uu____14083 =
-                FStar_TypeChecker_Rel.teq_nosmt_force env2 t1 t21 in
-              (if uu____14083
+              let uu___ = FStar_TypeChecker_Rel.teq_nosmt_force env2 t1 t21 in
+              (if uu___
                then
                  FStar_All.pipe_right FStar_TypeChecker_Env.trivial_guard
-                   (fun uu____14088 ->
-                      FStar_Pervasives_Native.Some uu____14088)
+                   (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
                else FStar_Pervasives_Native.None)
             else
               if env2.FStar_TypeChecker_Env.use_eq
               then FStar_TypeChecker_Rel.try_teq true env2 t1 t21
               else
-                (let uu____14093 =
+                (let uu___2 =
                    FStar_TypeChecker_Rel.get_subtyping_predicate env2 t1 t21 in
-                 match uu____14093 with
+                 match uu___2 with
                  | FStar_Pervasives_Native.None ->
                      FStar_Pervasives_Native.None
                  | FStar_Pervasives_Native.Some f ->
-                     let uu____14099 = FStar_TypeChecker_Env.apply_guard f e in
+                     let uu___3 = FStar_TypeChecker_Env.apply_guard f e in
                      FStar_All.pipe_left
-                       (fun uu____14102 ->
-                          FStar_Pervasives_Native.Some uu____14102)
-                       uu____14099) in
-          let uu____14103 = maybe_coerce_lc env1 e lc t2 in
-          match uu____14103 with
+                       (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       uu___3) in
+          let uu___ = maybe_coerce_lc env1 e lc t2 in
+          match uu___ with
           | (e1, lc1, g_c) ->
-              let uu____14119 =
-                check env1 lc1.FStar_TypeChecker_Common.res_typ t2 in
-              (match uu____14119 with
+              let uu___1 = check env1 lc1.FStar_TypeChecker_Common.res_typ t2 in
+              (match uu___1 with
                | FStar_Pervasives_Native.None ->
-                   let uu____14128 =
+                   let uu___2 =
                      FStar_TypeChecker_Err.expected_expression_of_type env1
                        t2 e1 lc1.FStar_TypeChecker_Common.res_typ in
-                   let uu____14133 = FStar_TypeChecker_Env.get_range env1 in
-                   FStar_Errors.raise_error uu____14128 uu____14133
+                   let uu___3 = FStar_TypeChecker_Env.get_range env1 in
+                   FStar_Errors.raise_error uu___2 uu___3
                | FStar_Pervasives_Native.Some g ->
-                   ((let uu____14142 =
+                   ((let uu___3 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "Rel") in
-                     if uu____14142
+                     if uu___3
                      then
-                       let uu____14143 =
+                       let uu___4 =
                          FStar_TypeChecker_Rel.guard_to_string env1 g in
                        FStar_All.pipe_left
-                         (FStar_Util.print1 "Applied guard is %s\n")
-                         uu____14143
+                         (FStar_Util.print1 "Applied guard is %s\n") uu___4
                      else ());
-                    (let uu____14145 = FStar_TypeChecker_Env.conj_guard g g_c in
-                     (e1, lc1, uu____14145))))
+                    (let uu___3 = FStar_TypeChecker_Env.conj_guard g g_c in
+                     (e1, lc1, uu___3))))
 let (check_top_level :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.guard_t ->
@@ -5067,152 +4937,147 @@ let (check_top_level :
   fun env ->
     fun g ->
       fun lc ->
-        (let uu____14170 =
-           FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-         if uu____14170
+        (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
+         if uu___1
          then
-           let uu____14171 = FStar_TypeChecker_Common.lcomp_to_string lc in
-           FStar_Util.print1 "check_top_level, lc = %s\n" uu____14171
+           let uu___2 = FStar_TypeChecker_Common.lcomp_to_string lc in
+           FStar_Util.print1 "check_top_level, lc = %s\n" uu___2
          else ());
         (let discharge g1 =
            FStar_TypeChecker_Rel.force_trivial_guard env g1;
            FStar_TypeChecker_Common.is_pure_lcomp lc in
          let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-         let uu____14181 = FStar_TypeChecker_Common.lcomp_comp lc in
-         match uu____14181 with
+         let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
+         match uu___1 with
          | (c, g_c) ->
-             let uu____14192 = FStar_TypeChecker_Common.is_total_lcomp lc in
-             if uu____14192
+             let uu___2 = FStar_TypeChecker_Common.is_total_lcomp lc in
+             if uu___2
              then
-               let uu____14197 =
-                 let uu____14198 = FStar_TypeChecker_Env.conj_guard g1 g_c in
-                 discharge uu____14198 in
-               (uu____14197, c)
+               let uu___3 =
+                 let uu___4 = FStar_TypeChecker_Env.conj_guard g1 g_c in
+                 discharge uu___4 in
+               (uu___3, c)
              else
                (let steps =
                   [FStar_TypeChecker_Env.Beta;
                   FStar_TypeChecker_Env.NoFullNorm;
                   FStar_TypeChecker_Env.DoNotUnfoldPureLets] in
                 let c1 =
-                  let uu____14204 =
-                    let uu____14205 =
+                  let uu___4 =
+                    let uu___5 =
                       FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                    FStar_All.pipe_right uu____14205
-                      FStar_Syntax_Syntax.mk_Comp in
-                  FStar_All.pipe_right uu____14204
+                    FStar_All.pipe_right uu___5 FStar_Syntax_Syntax.mk_Comp in
+                  FStar_All.pipe_right uu___4
                     (FStar_TypeChecker_Normalize.normalize_comp steps env) in
-                let uu____14206 = check_trivial_precondition env c1 in
-                match uu____14206 with
+                let uu___4 = check_trivial_precondition env c1 in
+                match uu___4 with
                 | (ct, vc, g_pre) ->
-                    ((let uu____14221 =
+                    ((let uu___6 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Simplification") in
-                      if uu____14221
+                      if uu___6
                       then
-                        let uu____14222 =
-                          FStar_Syntax_Print.term_to_string vc in
-                        FStar_Util.print1 "top-level VC: %s\n" uu____14222
+                        let uu___7 = FStar_Syntax_Print.term_to_string vc in
+                        FStar_Util.print1 "top-level VC: %s\n" uu___7
                       else ());
-                     (let uu____14224 =
-                        let uu____14225 =
-                          let uu____14226 =
+                     (let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
                             FStar_TypeChecker_Env.conj_guard g_c g_pre in
-                          FStar_TypeChecker_Env.conj_guard g1 uu____14226 in
-                        discharge uu____14225 in
-                      let uu____14227 =
+                          FStar_TypeChecker_Env.conj_guard g1 uu___8 in
+                        discharge uu___7 in
+                      let uu___7 =
                         FStar_All.pipe_right ct FStar_Syntax_Syntax.mk_Comp in
-                      (uu____14224, uu____14227)))))
+                      (uu___6, uu___7)))))
 let (short_circuit :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.args -> FStar_TypeChecker_Common.guard_formula)
   =
   fun head ->
     fun seen_args ->
-      let short_bin_op f uu___8_14259 =
-        match uu___8_14259 with
+      let short_bin_op f uu___ =
+        match uu___ with
         | [] -> FStar_TypeChecker_Common.Trivial
-        | (fst, uu____14269)::[] -> f fst
-        | uu____14294 -> failwith "Unexpexted args to binary operator" in
+        | (fst, uu___1)::[] -> f fst
+        | uu___1 -> failwith "Unexpexted args to binary operator" in
       let op_and_e e =
-        let uu____14305 = FStar_Syntax_Util.b2t e in
-        FStar_All.pipe_right uu____14305
-          (fun uu____14306 -> FStar_TypeChecker_Common.NonTrivial uu____14306) in
+        let uu___ = FStar_Syntax_Util.b2t e in
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
       let op_or_e e =
-        let uu____14317 =
-          let uu____14318 = FStar_Syntax_Util.b2t e in
-          FStar_Syntax_Util.mk_neg uu____14318 in
-        FStar_All.pipe_right uu____14317
-          (fun uu____14321 -> FStar_TypeChecker_Common.NonTrivial uu____14321) in
+        let uu___ =
+          let uu___1 = FStar_Syntax_Util.b2t e in
+          FStar_Syntax_Util.mk_neg uu___1 in
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
       let op_and_t t =
         FStar_All.pipe_right t
-          (fun uu____14328 -> FStar_TypeChecker_Common.NonTrivial uu____14328) in
+          (fun uu___ -> FStar_TypeChecker_Common.NonTrivial uu___) in
       let op_or_t t =
-        let uu____14339 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg in
-        FStar_All.pipe_right uu____14339
-          (fun uu____14342 -> FStar_TypeChecker_Common.NonTrivial uu____14342) in
+        let uu___ = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg in
+        FStar_All.pipe_right uu___
+          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
       let op_imp_t t =
         FStar_All.pipe_right t
-          (fun uu____14349 -> FStar_TypeChecker_Common.NonTrivial uu____14349) in
-      let short_op_ite uu___9_14355 =
-        match uu___9_14355 with
+          (fun uu___ -> FStar_TypeChecker_Common.NonTrivial uu___) in
+      let short_op_ite uu___ =
+        match uu___ with
         | [] -> FStar_TypeChecker_Common.Trivial
-        | (guard, uu____14365)::[] ->
-            FStar_TypeChecker_Common.NonTrivial guard
-        | _then::(guard, uu____14392)::[] ->
-            let uu____14433 = FStar_Syntax_Util.mk_neg guard in
-            FStar_All.pipe_right uu____14433
-              (fun uu____14434 ->
-                 FStar_TypeChecker_Common.NonTrivial uu____14434)
-        | uu____14435 -> failwith "Unexpected args to ITE" in
+        | (guard, uu___1)::[] -> FStar_TypeChecker_Common.NonTrivial guard
+        | _then::(guard, uu___1)::[] ->
+            let uu___2 = FStar_Syntax_Util.mk_neg guard in
+            FStar_All.pipe_right uu___2
+              (fun uu___3 -> FStar_TypeChecker_Common.NonTrivial uu___3)
+        | uu___1 -> failwith "Unexpected args to ITE" in
       let table =
-        let uu____14446 =
-          let uu____14454 = short_bin_op op_and_e in
-          (FStar_Parser_Const.op_And, uu____14454) in
-        let uu____14462 =
-          let uu____14472 =
-            let uu____14480 = short_bin_op op_or_e in
-            (FStar_Parser_Const.op_Or, uu____14480) in
-          let uu____14488 =
-            let uu____14498 =
-              let uu____14506 = short_bin_op op_and_t in
-              (FStar_Parser_Const.and_lid, uu____14506) in
-            let uu____14514 =
-              let uu____14524 =
-                let uu____14532 = short_bin_op op_or_t in
-                (FStar_Parser_Const.or_lid, uu____14532) in
-              let uu____14540 =
-                let uu____14550 =
-                  let uu____14558 = short_bin_op op_imp_t in
-                  (FStar_Parser_Const.imp_lid, uu____14558) in
-                [uu____14550; (FStar_Parser_Const.ite_lid, short_op_ite)] in
-              uu____14524 :: uu____14540 in
-            uu____14498 :: uu____14514 in
-          uu____14472 :: uu____14488 in
-        uu____14446 :: uu____14462 in
+        let uu___ =
+          let uu___1 = short_bin_op op_and_e in
+          (FStar_Parser_Const.op_And, uu___1) in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = short_bin_op op_or_e in
+            (FStar_Parser_Const.op_Or, uu___3) in
+          let uu___3 =
+            let uu___4 =
+              let uu___5 = short_bin_op op_and_t in
+              (FStar_Parser_Const.and_lid, uu___5) in
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = short_bin_op op_or_t in
+                (FStar_Parser_Const.or_lid, uu___7) in
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 = short_bin_op op_imp_t in
+                  (FStar_Parser_Const.imp_lid, uu___9) in
+                [uu___8; (FStar_Parser_Const.ite_lid, short_op_ite)] in
+              uu___6 :: uu___7 in
+            uu___4 :: uu___5 in
+          uu___2 :: uu___3 in
+        uu___ :: uu___1 in
       match head.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          let uu____14620 =
+          let uu___ =
             FStar_Util.find_map table
-              (fun uu____14635 ->
-                 match uu____14635 with
+              (fun uu___1 ->
+                 match uu___1 with
                  | (x, mk) ->
-                     let uu____14652 = FStar_Ident.lid_equals x lid in
-                     if uu____14652
+                     let uu___2 = FStar_Ident.lid_equals x lid in
+                     if uu___2
                      then
-                       let uu____14655 = mk seen_args in
-                       FStar_Pervasives_Native.Some uu____14655
+                       let uu___3 = mk seen_args in
+                       FStar_Pervasives_Native.Some uu___3
                      else FStar_Pervasives_Native.None) in
-          (match uu____14620 with
+          (match uu___ with
            | FStar_Pervasives_Native.None -> FStar_TypeChecker_Common.Trivial
            | FStar_Pervasives_Native.Some g -> g)
-      | uu____14658 -> FStar_TypeChecker_Common.Trivial
+      | uu___ -> FStar_TypeChecker_Common.Trivial
 let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun l ->
-    let uu____14664 =
-      let uu____14665 = FStar_Syntax_Util.un_uinst l in
-      uu____14665.FStar_Syntax_Syntax.n in
-    match uu____14664 with
+    let uu___ =
+      let uu___1 = FStar_Syntax_Util.un_uinst l in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)
           [FStar_Parser_Const.op_And;
@@ -5221,7 +5086,7 @@ let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
           FStar_Parser_Const.or_lid;
           FStar_Parser_Const.imp_lid;
           FStar_Parser_Const.ite_lid]
-    | uu____14669 -> false
+    | uu___1 -> false
 let (maybe_add_implicit_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
@@ -5230,62 +5095,59 @@ let (maybe_add_implicit_binders :
     fun bs ->
       let pos bs1 =
         match bs1 with
-        | (hd, uu____14703)::uu____14704 ->
-            FStar_Syntax_Syntax.range_of_bv hd
-        | uu____14723 -> FStar_TypeChecker_Env.get_range env in
+        | (hd, uu___)::uu___1 -> FStar_Syntax_Syntax.range_of_bv hd
+        | uu___ -> FStar_TypeChecker_Env.get_range env in
       match bs with
-      | (uu____14732, FStar_Pervasives_Native.Some
-         (FStar_Syntax_Syntax.Implicit uu____14733))::uu____14734 -> bs
-      | uu____14751 ->
-          let uu____14752 = FStar_TypeChecker_Env.expected_typ env in
-          (match uu____14752 with
+      | (uu___, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
+         uu___1))::uu___2 -> bs
+      | uu___ ->
+          let uu___1 = FStar_TypeChecker_Env.expected_typ env in
+          (match uu___1 with
            | FStar_Pervasives_Native.None -> bs
            | FStar_Pervasives_Native.Some t ->
-               let uu____14756 =
-                 let uu____14757 = FStar_Syntax_Subst.compress t in
-                 uu____14757.FStar_Syntax_Syntax.n in
-               (match uu____14756 with
-                | FStar_Syntax_Syntax.Tm_arrow (bs', uu____14761) ->
-                    let uu____14782 =
+               let uu___2 =
+                 let uu___3 = FStar_Syntax_Subst.compress t in
+                 uu___3.FStar_Syntax_Syntax.n in
+               (match uu___2 with
+                | FStar_Syntax_Syntax.Tm_arrow (bs', uu___3) ->
+                    let uu___4 =
                       FStar_Util.prefix_until
-                        (fun uu___10_14822 ->
-                           match uu___10_14822 with
-                           | (uu____14829, FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____14830)) ->
-                               false
-                           | uu____14833 -> true) bs' in
-                    (match uu____14782 with
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (uu___6, FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Implicit uu___7)) -> false
+                           | uu___6 -> true) bs' in
+                    (match uu___4 with
                      | FStar_Pervasives_Native.None -> bs
-                     | FStar_Pervasives_Native.Some
-                         ([], uu____14868, uu____14869) -> bs
-                     | FStar_Pervasives_Native.Some
-                         (imps, uu____14941, uu____14942) ->
-                         let uu____15015 =
+                     | FStar_Pervasives_Native.Some ([], uu___5, uu___6) ->
+                         bs
+                     | FStar_Pervasives_Native.Some (imps, uu___5, uu___6) ->
+                         let uu___7 =
                            FStar_All.pipe_right imps
                              (FStar_Util.for_all
-                                (fun uu____15034 ->
-                                   match uu____15034 with
-                                   | (x, uu____15042) ->
-                                       let uu____15047 =
+                                (fun uu___8 ->
+                                   match uu___8 with
+                                   | (x, uu___9) ->
+                                       let uu___10 =
                                          FStar_Ident.string_of_id
                                            x.FStar_Syntax_Syntax.ppname in
-                                       FStar_Util.starts_with uu____15047 "'")) in
-                         if uu____15015
+                                       FStar_Util.starts_with uu___10 "'")) in
+                         if uu___7
                          then
                            let r = pos bs in
                            let imps1 =
                              FStar_All.pipe_right imps
                                (FStar_List.map
-                                  (fun uu____15090 ->
-                                     match uu____15090 with
+                                  (fun uu___8 ->
+                                     match uu___8 with
                                      | (x, i) ->
-                                         let uu____15109 =
+                                         let uu___9 =
                                            FStar_Syntax_Syntax.set_range_of_bv
                                              x r in
-                                         (uu____15109, i))) in
+                                         (uu___9, i))) in
                            FStar_List.append imps1 bs
                          else bs)
-                | uu____15119 -> bs))
+                | uu___3 -> bs))
 let (maybe_lift :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -5300,14 +5162,14 @@ let (maybe_lift :
           fun t ->
             let m1 = FStar_TypeChecker_Env.norm_eff_name env c1 in
             let m2 = FStar_TypeChecker_Env.norm_eff_name env c2 in
-            let uu____15147 =
+            let uu___ =
               ((FStar_Ident.lid_equals m1 m2) ||
                  ((FStar_Syntax_Util.is_pure_effect c1) &&
                     (FStar_Syntax_Util.is_ghost_effect c2)))
                 ||
                 ((FStar_Syntax_Util.is_pure_effect c2) &&
                    (FStar_Syntax_Util.is_ghost_effect c1)) in
-            if uu____15147
+            if uu___
             then e
             else
               FStar_Syntax_Syntax.mk
@@ -5325,12 +5187,12 @@ let (maybe_monadic :
       fun c ->
         fun t ->
           let m = FStar_TypeChecker_Env.norm_eff_name env c in
-          let uu____15174 =
+          let uu___ =
             ((is_pure_or_ghost_effect env m) ||
                (FStar_Ident.lid_equals m FStar_Parser_Const.effect_Tot_lid))
               ||
               (FStar_Ident.lid_equals m FStar_Parser_Const.effect_GTot_lid) in
-          if uu____15174
+          if uu___
           then e
           else
             FStar_Syntax_Syntax.mk
@@ -5348,20 +5210,19 @@ let (mk_toplevel_definition :
   fun env ->
     fun lident ->
       fun def ->
-        (let uu____15209 =
+        (let uu___1 =
            FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-         if uu____15209
+         if uu___1
          then
-           ((let uu____15211 = FStar_Ident.string_of_lid lident in
-             d uu____15211);
-            (let uu____15212 = FStar_Ident.string_of_lid lident in
-             let uu____15213 = FStar_Syntax_Print.term_to_string def in
+           ((let uu___3 = FStar_Ident.string_of_lid lident in d uu___3);
+            (let uu___3 = FStar_Ident.string_of_lid lident in
+             let uu___4 = FStar_Syntax_Print.term_to_string def in
              FStar_Util.print2 "Registering top-level definition: %s\n%s\n"
-               uu____15212 uu____15213))
+               uu___3 uu___4))
          else ());
         (let fv =
-           let uu____15216 = FStar_Syntax_Util.incr_delta_qualifier def in
-           FStar_Syntax_Syntax.lid_as_fv lident uu____15216
+           let uu___1 = FStar_Syntax_Util.incr_delta_qualifier def in
+           FStar_Syntax_Syntax.lid_as_fv lident uu___1
              FStar_Pervasives_Native.None in
          let lbname = FStar_Util.Inr fv in
          let lb =
@@ -5372,64 +5233,62 @@ let (mk_toplevel_definition :
          let sig_ctx =
            FStar_Syntax_Syntax.mk_sigelt
              (FStar_Syntax_Syntax.Sig_let (lb, [lident])) in
-         let uu____15226 =
+         let uu___1 =
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
              FStar_Range.dummyRange in
-         ((let uu___1891_15228 = sig_ctx in
+         ((let uu___2 = sig_ctx in
            {
-             FStar_Syntax_Syntax.sigel =
-               (uu___1891_15228.FStar_Syntax_Syntax.sigel);
-             FStar_Syntax_Syntax.sigrng =
-               (uu___1891_15228.FStar_Syntax_Syntax.sigrng);
+             FStar_Syntax_Syntax.sigel = (uu___2.FStar_Syntax_Syntax.sigel);
+             FStar_Syntax_Syntax.sigrng = (uu___2.FStar_Syntax_Syntax.sigrng);
              FStar_Syntax_Syntax.sigquals =
                [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen];
              FStar_Syntax_Syntax.sigmeta =
-               (uu___1891_15228.FStar_Syntax_Syntax.sigmeta);
+               (uu___2.FStar_Syntax_Syntax.sigmeta);
              FStar_Syntax_Syntax.sigattrs =
-               (uu___1891_15228.FStar_Syntax_Syntax.sigattrs);
+               (uu___2.FStar_Syntax_Syntax.sigattrs);
              FStar_Syntax_Syntax.sigopts =
-               (uu___1891_15228.FStar_Syntax_Syntax.sigopts)
-           }), uu____15226))
+               (uu___2.FStar_Syntax_Syntax.sigopts)
+           }), uu___1))
 let (check_sigelt_quals :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env ->
     fun se ->
-      let visibility uu___11_15244 =
-        match uu___11_15244 with
+      let visibility uu___ =
+        match uu___ with
         | FStar_Syntax_Syntax.Private -> true
-        | uu____15245 -> false in
-      let reducibility uu___12_15251 =
-        match uu___12_15251 with
+        | uu___1 -> false in
+      let reducibility uu___ =
+        match uu___ with
         | FStar_Syntax_Syntax.Irreducible -> true
         | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen -> true
         | FStar_Syntax_Syntax.Visible_default -> true
         | FStar_Syntax_Syntax.Inline_for_extraction -> true
-        | uu____15252 -> false in
-      let assumption uu___13_15258 =
-        match uu___13_15258 with
+        | uu___1 -> false in
+      let assumption uu___ =
+        match uu___ with
         | FStar_Syntax_Syntax.Assumption -> true
         | FStar_Syntax_Syntax.New -> true
-        | uu____15259 -> false in
-      let reification uu___14_15265 =
-        match uu___14_15265 with
+        | uu___1 -> false in
+      let reification uu___ =
+        match uu___ with
         | FStar_Syntax_Syntax.Reifiable -> true
-        | FStar_Syntax_Syntax.Reflectable uu____15266 -> true
-        | uu____15267 -> false in
-      let inferred uu___15_15273 =
-        match uu___15_15273 with
-        | FStar_Syntax_Syntax.Discriminator uu____15274 -> true
-        | FStar_Syntax_Syntax.Projector uu____15275 -> true
-        | FStar_Syntax_Syntax.RecordType uu____15280 -> true
-        | FStar_Syntax_Syntax.RecordConstructor uu____15289 -> true
+        | FStar_Syntax_Syntax.Reflectable uu___1 -> true
+        | uu___1 -> false in
+      let inferred uu___ =
+        match uu___ with
+        | FStar_Syntax_Syntax.Discriminator uu___1 -> true
+        | FStar_Syntax_Syntax.Projector uu___1 -> true
+        | FStar_Syntax_Syntax.RecordType uu___1 -> true
+        | FStar_Syntax_Syntax.RecordConstructor uu___1 -> true
         | FStar_Syntax_Syntax.ExceptionConstructor -> true
         | FStar_Syntax_Syntax.HasMaskedEffect -> true
         | FStar_Syntax_Syntax.Effect -> true
-        | uu____15298 -> false in
-      let has_eq uu___16_15304 =
-        match uu___16_15304 with
+        | uu___1 -> false in
+      let has_eq uu___ =
+        match uu___ with
         | FStar_Syntax_Syntax.Noeq -> true
         | FStar_Syntax_Syntax.Unopteq -> true
-        | uu____15305 -> false in
+        | uu___1 -> false in
       let quals_combo_ok quals q =
         match q with
         | FStar_Syntax_Syntax.Assumption ->
@@ -5540,7 +5399,7 @@ let (check_sigelt_quals :
                     ((((reification x) || (inferred x)) || (visibility x)) ||
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
-        | FStar_Syntax_Syntax.Reflectable uu____15365 ->
+        | FStar_Syntax_Syntax.Reflectable uu___ ->
             FStar_All.pipe_right quals
               (FStar_List.for_all
                  (fun x ->
@@ -5548,16 +5407,15 @@ let (check_sigelt_quals :
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
         | FStar_Syntax_Syntax.Private -> true
-        | uu____15370 -> true in
+        | uu___ -> true in
       let check_erasable quals se1 r =
         let lids = FStar_Syntax_Util.lids_of_sigelt se1 in
         let val_exists =
           FStar_All.pipe_right lids
             (FStar_Util.for_some
                (fun l ->
-                  let uu____15400 =
-                    FStar_TypeChecker_Env.try_lookup_val_decl env l in
-                  FStar_Option.isSome uu____15400)) in
+                  let uu___ = FStar_TypeChecker_Env.try_lookup_val_decl env l in
+                  FStar_Option.isSome uu___)) in
         let val_has_erasable_attr =
           FStar_All.pipe_right lids
             (FStar_Util.for_some
@@ -5565,8 +5423,8 @@ let (check_sigelt_quals :
                   let attrs_opt =
                     FStar_TypeChecker_Env.lookup_attrs_of_lid env l in
                   (FStar_Option.isSome attrs_opt) &&
-                    (let uu____15429 = FStar_Option.get attrs_opt in
-                     FStar_Syntax_Util.has_attribute uu____15429
+                    (let uu___ = FStar_Option.get attrs_opt in
+                     FStar_Syntax_Util.has_attribute uu___
                        FStar_Parser_Const.erasable_attr))) in
         let se_has_erasable_attr =
           FStar_Syntax_Util.has_attribute se1.FStar_Syntax_Syntax.sigattrs
@@ -5592,49 +5450,47 @@ let (check_sigelt_quals :
         if se_has_erasable_attr
         then
           (match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_bundle uu____15439 ->
-               let uu____15448 =
-                 let uu____15449 =
+           | FStar_Syntax_Syntax.Sig_bundle uu___2 ->
+               let uu___3 =
+                 let uu___4 =
                    FStar_All.pipe_right quals
                      (FStar_Util.for_some
-                        (fun uu___17_15453 ->
-                           match uu___17_15453 with
+                        (fun uu___5 ->
+                           match uu___5 with
                            | FStar_Syntax_Syntax.Noeq -> true
-                           | uu____15454 -> false)) in
-                 Prims.op_Negation uu____15449 in
-               if uu____15448
+                           | uu___6 -> false)) in
+                 Prims.op_Negation uu___4 in
+               if uu___3
                then
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_QulifierListNotPermitted,
                      "Incompatible attributes and qualifiers: erasable types do not support decidable equality and must be marked `noeq`")
                    r
                else ()
-           | FStar_Syntax_Syntax.Sig_declare_typ uu____15456 -> ()
-           | FStar_Syntax_Syntax.Sig_fail uu____15463 -> ()
-           | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____15475) ->
-               let uu____15482 =
+           | FStar_Syntax_Syntax.Sig_declare_typ uu___2 -> ()
+           | FStar_Syntax_Syntax.Sig_fail uu___2 -> ()
+           | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___2) ->
+               let uu___3 =
                  FStar_Syntax_Util.abs_formals lb.FStar_Syntax_Syntax.lbdef in
-               (match uu____15482 with
-                | (uu____15491, body, uu____15493) ->
-                    let uu____15498 =
-                      let uu____15499 =
+               (match uu___3 with
+                | (uu___4, body, uu___5) ->
+                    let uu___6 =
+                      let uu___7 =
                         FStar_TypeChecker_Normalize.non_info_norm env body in
-                      Prims.op_Negation uu____15499 in
-                    if uu____15498
+                      Prims.op_Negation uu___7 in
+                    if uu___6
                     then
-                      let uu____15500 =
-                        let uu____15505 =
-                          let uu____15506 =
-                            FStar_Syntax_Print.term_to_string body in
+                      let uu___7 =
+                        let uu___8 =
+                          let uu___9 = FStar_Syntax_Print.term_to_string body in
                           FStar_Util.format1
                             "Illegal attribute: the `erasable` attribute is only permitted on inductive type definitions and abbreviations for non-informative types. %s is considered informative."
-                            uu____15506 in
-                        (FStar_Errors.Fatal_QulifierListNotPermitted,
-                          uu____15505) in
-                      FStar_Errors.raise_error uu____15500
+                            uu___9 in
+                        (FStar_Errors.Fatal_QulifierListNotPermitted, uu___8) in
+                      FStar_Errors.raise_error uu___7
                         body.FStar_Syntax_Syntax.pos
                     else ())
-           | uu____15508 ->
+           | uu___2 ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_QulifierListNotPermitted,
                    "Illegal attribute: the `erasable` attribute is only permitted on inductive type definitions and abbreviations for non-informative types")
@@ -5644,64 +5500,63 @@ let (check_sigelt_quals :
         FStar_All.pipe_right (FStar_Syntax_Util.quals_of_sigelt se)
           (FStar_List.filter
              (fun x -> Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))) in
-      let uu____15519 =
-        let uu____15520 =
+      let uu___ =
+        let uu___1 =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___18_15524 ->
-                  match uu___18_15524 with
+               (fun uu___2 ->
+                  match uu___2 with
                   | FStar_Syntax_Syntax.OnlyName -> true
-                  | uu____15525 -> false)) in
-        FStar_All.pipe_right uu____15520 Prims.op_Negation in
-      if uu____15519
+                  | uu___3 -> false)) in
+        FStar_All.pipe_right uu___1 Prims.op_Negation in
+      if uu___
       then
         let r = FStar_Syntax_Util.range_of_sigelt se in
         let no_dup_quals =
           FStar_Util.remove_dups (fun x -> fun y -> x = y) quals in
         let err' msg =
-          let uu____15540 =
-            let uu____15545 =
-              let uu____15546 = FStar_Syntax_Print.quals_to_string quals in
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Print.quals_to_string quals in
               FStar_Util.format2
                 "The qualifier list \"[%s]\" is not permissible for this element%s"
-                uu____15546 msg in
-            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____15545) in
-          FStar_Errors.raise_error uu____15540 r in
+                uu___3 msg in
+            (FStar_Errors.Fatal_QulifierListNotPermitted, uu___2) in
+          FStar_Errors.raise_error uu___1 r in
         let err msg = err' (Prims.op_Hat ": " msg) in
-        let err'1 uu____15558 = err' "" in
+        let err'1 uu___1 = err' "" in
         (if (FStar_List.length quals) <> (FStar_List.length no_dup_quals)
          then err "duplicate qualifiers"
          else ();
-         (let uu____15562 =
-            let uu____15563 =
+         (let uu___3 =
+            let uu___4 =
               FStar_All.pipe_right quals
                 (FStar_List.for_all (quals_combo_ok quals)) in
-            Prims.op_Negation uu____15563 in
-          if uu____15562 then err "ill-formed combination" else ());
+            Prims.op_Negation uu___4 in
+          if uu___3 then err "ill-formed combination" else ());
          check_erasable quals se r;
          (match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_let ((is_rec, uu____15569), uu____15570)
-              ->
-              ((let uu____15580 =
+          | FStar_Syntax_Syntax.Sig_let ((is_rec, uu___4), uu___5) ->
+              ((let uu___7 =
                   is_rec &&
                     (FStar_All.pipe_right quals
                        (FStar_List.contains
                           FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) in
-                if uu____15580
+                if uu___7
                 then err "recursive definitions cannot be marked inline"
                 else ());
-               (let uu____15584 =
+               (let uu___7 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
                        (fun x -> (assumption x) || (has_eq x))) in
-                if uu____15584
+                if uu___7
                 then
                   err
                     "definitions cannot be assumed or marked with equality qualifiers"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_bundle uu____15590 ->
-              ((let uu____15600 =
-                  let uu____15601 =
+          | FStar_Syntax_Syntax.Sig_bundle uu___4 ->
+              ((let uu___6 =
+                  let uu___7 =
                     FStar_All.pipe_right quals
                       (FStar_Util.for_all
                          (fun x ->
@@ -5710,41 +5565,41 @@ let (check_sigelt_quals :
                                 || (inferred x))
                                || (visibility x))
                               || (has_eq x))) in
-                  Prims.op_Negation uu____15601 in
-                if uu____15600 then err'1 () else ());
-               (let uu____15607 =
+                  Prims.op_Negation uu___7 in
+                if uu___6 then err'1 () else ());
+               (let uu___6 =
                   (FStar_All.pipe_right quals
                      (FStar_List.existsb
-                        (fun uu___19_15611 ->
-                           match uu___19_15611 with
+                        (fun uu___7 ->
+                           match uu___7 with
                            | FStar_Syntax_Syntax.Unopteq -> true
-                           | uu____15612 -> false)))
+                           | uu___8 -> false)))
                     &&
                     (FStar_Syntax_Util.has_attribute
                        se.FStar_Syntax_Syntax.sigattrs
                        FStar_Parser_Const.erasable_attr) in
-                if uu____15607
+                if uu___6
                 then
                   err
                     "unopteq is not allowed on an erasable inductives since they don't have decidable equality"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_declare_typ uu____15614 ->
-              let uu____15621 =
+          | FStar_Syntax_Syntax.Sig_declare_typ uu___4 ->
+              let uu___5 =
                 FStar_All.pipe_right quals (FStar_Util.for_some has_eq) in
-              if uu____15621 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_assume uu____15625 ->
-              let uu____15632 =
-                let uu____15633 =
+              if uu___5 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_assume uu___4 ->
+              let uu___5 =
+                let uu___6 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x ->
                           (visibility x) ||
                             (x = FStar_Syntax_Syntax.Assumption))) in
-                Prims.op_Negation uu____15633 in
-              if uu____15632 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____15639 ->
-              let uu____15640 =
-                let uu____15641 =
+                Prims.op_Negation uu___6 in
+              if uu___5 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu___4 ->
+              let uu___5 =
+                let uu___6 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x ->
@@ -5752,30 +5607,30 @@ let (check_sigelt_quals :
                               (inferred x))
                              || (visibility x))
                             || (reification x))) in
-                Prims.op_Negation uu____15641 in
-              if uu____15640 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____15647 ->
-              let uu____15660 =
-                let uu____15661 =
+                Prims.op_Negation uu___6 in
+              if uu___5 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_effect_abbrev uu___4 ->
+              let uu___5 =
+                let uu___6 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x -> (inferred x) || (visibility x))) in
-                Prims.op_Negation uu____15661 in
-              if uu____15660 then err'1 () else ()
-          | uu____15667 -> ()))
+                Prims.op_Negation uu___6 in
+              if uu___5 then err'1 () else ()
+          | uu___4 -> ()))
       else ()
 let (must_erase_for_extraction :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun g ->
     fun t ->
       let rec descend env t1 =
-        let uu____15701 =
-          let uu____15702 = FStar_Syntax_Subst.compress t1 in
-          uu____15702.FStar_Syntax_Syntax.n in
-        match uu____15701 with
-        | FStar_Syntax_Syntax.Tm_arrow uu____15705 ->
-            let uu____15720 = FStar_Syntax_Util.arrow_formals_comp t1 in
-            (match uu____15720 with
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress t1 in
+          uu___1.FStar_Syntax_Syntax.n in
+        match uu___ with
+        | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
+            let uu___2 = FStar_Syntax_Util.arrow_formals_comp t1 in
+            (match uu___2 with
              | (bs, c) ->
                  let env1 = FStar_TypeChecker_Env.push_binders env bs in
                  (FStar_Syntax_Util.is_ghost_effect
@@ -5784,18 +5639,17 @@ let (must_erase_for_extraction :
                    ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
                       (aux env1 (FStar_Syntax_Util.comp_result c))))
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____15728;
-               FStar_Syntax_Syntax.index = uu____15729;
+            ({ FStar_Syntax_Syntax.ppname = uu___1;
+               FStar_Syntax_Syntax.index = uu___2;
                FStar_Syntax_Syntax.sort = t2;_},
-             uu____15731)
+             uu___3)
             -> aux env t2
-        | FStar_Syntax_Syntax.Tm_app (head, uu____15739) -> descend env head
-        | FStar_Syntax_Syntax.Tm_uinst (head, uu____15765) ->
-            descend env head
+        | FStar_Syntax_Syntax.Tm_app (head, uu___1) -> descend env head
+        | FStar_Syntax_Syntax.Tm_uinst (head, uu___1) -> descend env head
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             FStar_TypeChecker_Env.fv_has_attr env fv
               FStar_Parser_Const.must_erase_for_extraction_attr
-        | uu____15771 -> false
+        | uu___1 -> false
       and aux env t1 =
         let t2 =
           FStar_TypeChecker_Normalize.normalize
@@ -5811,14 +5665,14 @@ let (must_erase_for_extraction :
             FStar_TypeChecker_Env.Unascribe] env t1 in
         let res =
           (FStar_TypeChecker_Env.non_informative env t2) || (descend env t2) in
-        (let uu____15779 =
+        (let uu___1 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Extraction") in
-         if uu____15779
+         if uu___1
          then
-           let uu____15780 = FStar_Syntax_Print.term_to_string t2 in
+           let uu___2 = FStar_Syntax_Print.term_to_string t2 in
            FStar_Util.print2 "must_erase=%s: %s\n"
-             (if res then "true" else "false") uu____15780
+             (if res then "true" else "false") uu___2
          else ());
         res in
       aux g t
@@ -5840,45 +5694,44 @@ let (fresh_effect_repr :
             fun u ->
               fun a_tm ->
                 let fail t =
-                  let uu____15836 =
+                  let uu___ =
                     FStar_TypeChecker_Err.unexpected_signature_for_monad env
                       eff_name t in
-                  FStar_Errors.raise_error uu____15836 r in
-                let uu____15845 =
-                  FStar_TypeChecker_Env.inst_tscheme signature_ts in
-                match uu____15845 with
-                | (uu____15854, signature) ->
-                    let uu____15856 =
-                      let uu____15857 = FStar_Syntax_Subst.compress signature in
-                      uu____15857.FStar_Syntax_Syntax.n in
-                    (match uu____15856 with
-                     | FStar_Syntax_Syntax.Tm_arrow (bs, uu____15865) ->
+                  FStar_Errors.raise_error uu___ r in
+                let uu___ = FStar_TypeChecker_Env.inst_tscheme signature_ts in
+                match uu___ with
+                | (uu___1, signature) ->
+                    let uu___2 =
+                      let uu___3 = FStar_Syntax_Subst.compress signature in
+                      uu___3.FStar_Syntax_Syntax.n in
+                    (match uu___2 with
+                     | FStar_Syntax_Syntax.Tm_arrow (bs, uu___3) ->
                          let bs1 = FStar_Syntax_Subst.open_binders bs in
                          (match bs1 with
                           | a::bs2 ->
-                              let uu____15913 =
+                              let uu___4 =
                                 FStar_TypeChecker_Env.uvars_for_binders env
                                   bs2
                                   [FStar_Syntax_Syntax.NT
                                      ((FStar_Pervasives_Native.fst a), a_tm)]
                                   (fun b ->
-                                     let uu____15929 =
+                                     let uu___5 =
                                        FStar_Syntax_Print.binder_to_string b in
-                                     let uu____15930 =
+                                     let uu___6 =
                                        FStar_Ident.string_of_lid eff_name in
-                                     let uu____15931 =
+                                     let uu___7 =
                                        FStar_Range.string_of_range r in
                                      FStar_Util.format3
                                        "uvar for binder %s when creating a fresh repr for %s at %s"
-                                       uu____15929 uu____15930 uu____15931) r in
-                              (match uu____15913 with
+                                       uu___5 uu___6 uu___7) r in
+                              (match uu___4 with
                                | (is, g) ->
-                                   let uu____15942 =
+                                   let uu___5 =
                                      match repr_ts_opt with
                                      | FStar_Pervasives_Native.None ->
                                          let eff_c =
-                                           let uu____15944 =
-                                             let uu____15945 =
+                                           let uu___6 =
+                                             let uu___7 =
                                                FStar_List.map
                                                  FStar_Syntax_Syntax.as_arg
                                                  is in
@@ -5890,46 +5743,45 @@ let (fresh_effect_repr :
                                                FStar_Syntax_Syntax.result_typ
                                                  = a_tm;
                                                FStar_Syntax_Syntax.effect_args
-                                                 = uu____15945;
+                                                 = uu___7;
                                                FStar_Syntax_Syntax.flags = []
                                              } in
-                                           FStar_Syntax_Syntax.mk_Comp
-                                             uu____15944 in
-                                         let uu____15964 =
-                                           let uu____15965 =
-                                             let uu____15980 =
-                                               let uu____15989 =
+                                           FStar_Syntax_Syntax.mk_Comp uu___6 in
+                                         let uu___6 =
+                                           let uu___7 =
+                                             let uu___8 =
+                                               let uu___9 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    FStar_Syntax_Syntax.t_unit in
-                                               [uu____15989] in
-                                             (uu____15980, eff_c) in
+                                               [uu___9] in
+                                             (uu___8, eff_c) in
                                            FStar_Syntax_Syntax.Tm_arrow
-                                             uu____15965 in
-                                         FStar_Syntax_Syntax.mk uu____15964 r
+                                             uu___7 in
+                                         FStar_Syntax_Syntax.mk uu___6 r
                                      | FStar_Pervasives_Native.Some repr_ts
                                          ->
                                          let repr =
-                                           let uu____16020 =
+                                           let uu___6 =
                                              FStar_TypeChecker_Env.inst_tscheme_with
                                                repr_ts [u] in
-                                           FStar_All.pipe_right uu____16020
+                                           FStar_All.pipe_right uu___6
                                              FStar_Pervasives_Native.snd in
                                          let is_args =
                                            FStar_List.map2
                                              (fun i ->
-                                                fun uu____16055 ->
-                                                  match uu____16055 with
-                                                  | (uu____16068, aqual) ->
+                                                fun uu___6 ->
+                                                  match uu___6 with
+                                                  | (uu___7, aqual) ->
                                                       (i, aqual)) is bs2 in
-                                         let uu____16076 =
-                                           let uu____16077 =
+                                         let uu___6 =
+                                           let uu___7 =
                                              FStar_Syntax_Syntax.as_arg a_tm in
-                                           uu____16077 :: is_args in
+                                           uu___7 :: is_args in
                                          FStar_Syntax_Syntax.mk_Tm_app repr
-                                           uu____16076 r in
-                                   (uu____15942, g))
-                          | uu____16090 -> fail signature)
-                     | uu____16091 -> fail signature)
+                                           uu___6 r in
+                                   (uu___5, g))
+                          | uu___4 -> fail signature)
+                     | uu___3 -> fail signature)
 let (fresh_effect_repr_en :
   FStar_TypeChecker_Env.env ->
     FStar_Range.range ->
@@ -5943,15 +5795,15 @@ let (fresh_effect_repr_en :
       fun eff_name ->
         fun u ->
           fun a_tm ->
-            let uu____16121 =
+            let uu___ =
               FStar_All.pipe_right eff_name
                 (FStar_TypeChecker_Env.get_effect_decl env) in
-            FStar_All.pipe_right uu____16121
+            FStar_All.pipe_right uu___
               (fun ed ->
-                 let uu____16129 =
+                 let uu___1 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
                  fresh_effect_repr env r eff_name
-                   ed.FStar_Syntax_Syntax.signature uu____16129 u a_tm)
+                   ed.FStar_Syntax_Syntax.signature uu___1 u a_tm)
 let (layered_effect_indices_as_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Range.range ->
@@ -5966,28 +5818,27 @@ let (layered_effect_indices_as_binders :
         fun sig_ts ->
           fun u ->
             fun a_tm ->
-              let uu____16164 =
-                FStar_TypeChecker_Env.inst_tscheme_with sig_ts [u] in
-              match uu____16164 with
-              | (uu____16169, sig_tm) ->
+              let uu___ = FStar_TypeChecker_Env.inst_tscheme_with sig_ts [u] in
+              match uu___ with
+              | (uu___1, sig_tm) ->
                   let fail t =
-                    let uu____16177 =
+                    let uu___2 =
                       FStar_TypeChecker_Err.unexpected_signature_for_monad
                         env eff_name t in
-                    FStar_Errors.raise_error uu____16177 r in
-                  let uu____16182 =
-                    let uu____16183 = FStar_Syntax_Subst.compress sig_tm in
-                    uu____16183.FStar_Syntax_Syntax.n in
-                  (match uu____16182 with
-                   | FStar_Syntax_Syntax.Tm_arrow (bs, uu____16187) ->
+                    FStar_Errors.raise_error uu___2 r in
+                  let uu___2 =
+                    let uu___3 = FStar_Syntax_Subst.compress sig_tm in
+                    uu___3.FStar_Syntax_Syntax.n in
+                  (match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_arrow (bs, uu___3) ->
                        let bs1 = FStar_Syntax_Subst.open_binders bs in
                        (match bs1 with
-                        | (a', uu____16210)::bs2 ->
+                        | (a', uu___4)::bs2 ->
                             FStar_All.pipe_right bs2
                               (FStar_Syntax_Subst.subst_binders
                                  [FStar_Syntax_Syntax.NT (a', a_tm)])
-                        | uu____16232 -> fail sig_tm)
-                   | uu____16233 -> fail sig_tm)
+                        | uu___4 -> fail sig_tm)
+                   | uu___3 -> fail sig_tm)
 let (lift_tf_layered_effect :
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.tscheme ->
@@ -5999,191 +5850,183 @@ let (lift_tf_layered_effect :
     fun lift_ts ->
       fun env ->
         fun c ->
-          (let uu____16263 =
+          (let uu___1 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffects") in
-           if uu____16263
+           if uu___1
            then
-             let uu____16264 = FStar_Syntax_Print.comp_to_string c in
-             let uu____16265 = FStar_Syntax_Print.lid_to_string tgt in
+             let uu___2 = FStar_Syntax_Print.comp_to_string c in
+             let uu___3 = FStar_Syntax_Print.lid_to_string tgt in
              FStar_Util.print2 "Lifting comp %s to layered effect %s {\n"
-               uu____16264 uu____16265
+               uu___2 uu___3
            else ());
           (let r = FStar_TypeChecker_Env.get_range env in
            let ct = FStar_Syntax_Util.comp_to_comp_typ c in
            let lift_name =
-             let uu____16270 =
+             let uu___1 =
                FStar_Ident.string_of_lid ct.FStar_Syntax_Syntax.effect_name in
-             let uu____16271 = FStar_Ident.string_of_lid tgt in
-             FStar_Util.format2 "%s ~> %s" uu____16270 uu____16271 in
-           let uu____16272 =
-             let uu____16283 =
-               FStar_List.hd ct.FStar_Syntax_Syntax.comp_univs in
-             let uu____16284 =
+             let uu___2 = FStar_Ident.string_of_lid tgt in
+             FStar_Util.format2 "%s ~> %s" uu___1 uu___2 in
+           let uu___1 =
+             let uu___2 = FStar_List.hd ct.FStar_Syntax_Syntax.comp_univs in
+             let uu___3 =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.effect_args
                  (FStar_List.map FStar_Pervasives_Native.fst) in
-             (uu____16283, (ct.FStar_Syntax_Syntax.result_typ), uu____16284) in
-           match uu____16272 with
+             (uu___2, (ct.FStar_Syntax_Syntax.result_typ), uu___3) in
+           match uu___1 with
            | (u, a, c_is) ->
-               let uu____16332 =
+               let uu___2 =
                  FStar_TypeChecker_Env.inst_tscheme_with lift_ts [u] in
-               (match uu____16332 with
-                | (uu____16341, lift_t) ->
+               (match uu___2 with
+                | (uu___3, lift_t) ->
                     let lift_t_shape_error s =
-                      let uu____16349 =
+                      let uu___4 =
                         FStar_Ident.string_of_lid
                           ct.FStar_Syntax_Syntax.effect_name in
-                      let uu____16350 = FStar_Ident.string_of_lid tgt in
-                      let uu____16351 =
-                        FStar_Syntax_Print.term_to_string lift_t in
+                      let uu___5 = FStar_Ident.string_of_lid tgt in
+                      let uu___6 = FStar_Syntax_Print.term_to_string lift_t in
                       FStar_Util.format4
                         "Lift from %s to %s has unexpected shape, reason: %s (lift:%s)"
-                        uu____16349 uu____16350 s uu____16351 in
-                    let uu____16352 =
-                      let uu____16385 =
-                        let uu____16386 = FStar_Syntax_Subst.compress lift_t in
-                        uu____16386.FStar_Syntax_Syntax.n in
-                      match uu____16385 with
+                        uu___4 uu___5 s uu___6 in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Subst.compress lift_t in
+                        uu___6.FStar_Syntax_Syntax.n in
+                      match uu___5 with
                       | FStar_Syntax_Syntax.Tm_arrow (bs, c1) when
                           (FStar_List.length bs) >= (Prims.of_int (2)) ->
-                          let uu____16449 =
-                            FStar_Syntax_Subst.open_comp bs c1 in
-                          (match uu____16449 with
+                          let uu___6 = FStar_Syntax_Subst.open_comp bs c1 in
+                          (match uu___6 with
                            | (a_b::bs1, c2) ->
-                               let uu____16509 =
+                               let uu___7 =
                                  FStar_All.pipe_right bs1
                                    (FStar_List.splitAt
                                       ((FStar_List.length bs1) -
                                          Prims.int_one)) in
-                               (a_b, uu____16509, c2))
-                      | uu____16596 ->
-                          let uu____16597 =
-                            let uu____16602 =
+                               (a_b, uu___7, c2))
+                      | uu___6 ->
+                          let uu___7 =
+                            let uu___8 =
                               lift_t_shape_error
                                 "either not an arrow or not enough binders" in
-                            (FStar_Errors.Fatal_UnexpectedEffect,
-                              uu____16602) in
-                          FStar_Errors.raise_error uu____16597 r in
-                    (match uu____16352 with
+                            (FStar_Errors.Fatal_UnexpectedEffect, uu___8) in
+                          FStar_Errors.raise_error uu___7 r in
+                    (match uu___4 with
                      | (a_b, (rest_bs, f_b::[]), lift_c) ->
-                         let uu____16717 =
-                           let uu____16724 =
-                             let uu____16725 =
-                               let uu____16726 =
-                                 let uu____16733 =
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 =
                                    FStar_All.pipe_right a_b
                                      FStar_Pervasives_Native.fst in
-                                 (uu____16733, a) in
-                               FStar_Syntax_Syntax.NT uu____16726 in
-                             [uu____16725] in
+                                 (uu___9, a) in
+                               FStar_Syntax_Syntax.NT uu___8 in
+                             [uu___7] in
                            FStar_TypeChecker_Env.uvars_for_binders env
-                             rest_bs uu____16724
+                             rest_bs uu___6
                              (fun b ->
-                                let uu____16750 =
+                                let uu___7 =
                                   FStar_Syntax_Print.binder_to_string b in
-                                let uu____16751 =
+                                let uu___8 =
                                   FStar_Ident.string_of_lid
                                     ct.FStar_Syntax_Syntax.effect_name in
-                                let uu____16752 =
-                                  FStar_Ident.string_of_lid tgt in
-                                let uu____16753 =
-                                  FStar_Range.string_of_range r in
+                                let uu___9 = FStar_Ident.string_of_lid tgt in
+                                let uu___10 = FStar_Range.string_of_range r in
                                 FStar_Util.format4
                                   "implicit var for binder %s of %s~>%s at %s"
-                                  uu____16750 uu____16751 uu____16752
-                                  uu____16753) r in
-                         (match uu____16717 with
+                                  uu___7 uu___8 uu___9 uu___10) r in
+                         (match uu___5 with
                           | (rest_bs_uvars, g) ->
-                              ((let uu____16765 =
+                              ((let uu___7 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "LayeredEffects") in
-                                if uu____16765
+                                if uu___7
                                 then
-                                  let uu____16766 =
+                                  let uu___8 =
                                     FStar_List.fold_left
                                       (fun s ->
                                          fun u1 ->
-                                           let uu____16772 =
-                                             let uu____16773 =
+                                           let uu___9 =
+                                             let uu___10 =
                                                FStar_Syntax_Print.term_to_string
                                                  u1 in
-                                             Prims.op_Hat ";;;;" uu____16773 in
-                                           Prims.op_Hat s uu____16772) ""
+                                             Prims.op_Hat ";;;;" uu___10 in
+                                           Prims.op_Hat s uu___9) ""
                                       rest_bs_uvars in
                                   FStar_Util.print1 "Introduced uvars: %s\n"
-                                    uu____16766
+                                    uu___8
                                 else ());
                                (let substs =
                                   FStar_List.map2
                                     (fun b ->
                                        fun t ->
-                                         let uu____16799 =
-                                           let uu____16806 =
+                                         let uu___7 =
+                                           let uu___8 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst in
-                                           (uu____16806, t) in
-                                         FStar_Syntax_Syntax.NT uu____16799)
-                                    (a_b :: rest_bs) (a :: rest_bs_uvars) in
+                                           (uu___8, t) in
+                                         FStar_Syntax_Syntax.NT uu___7) (a_b
+                                    :: rest_bs) (a :: rest_bs_uvars) in
                                 let guard_f =
                                   let f_sort =
-                                    let uu____16825 =
+                                    let uu___7 =
                                       FStar_All.pipe_right
                                         (FStar_Pervasives_Native.fst f_b).FStar_Syntax_Syntax.sort
                                         (FStar_Syntax_Subst.subst substs) in
-                                    FStar_All.pipe_right uu____16825
+                                    FStar_All.pipe_right uu___7
                                       FStar_Syntax_Subst.compress in
                                   let f_sort_is =
-                                    let uu____16831 =
+                                    let uu___7 =
                                       FStar_TypeChecker_Env.is_layered_effect
                                         env
                                         ct.FStar_Syntax_Syntax.effect_name in
-                                    effect_args_from_repr f_sort uu____16831
-                                      r in
+                                    effect_args_from_repr f_sort uu___7 r in
                                   FStar_List.fold_left2
                                     (fun g1 ->
                                        fun i1 ->
                                          fun i2 ->
-                                           let uu____16839 =
+                                           let uu___7 =
                                              FStar_TypeChecker_Rel.layered_effect_teq
                                                env i1 i2
                                                (FStar_Pervasives_Native.Some
                                                   lift_name) in
                                            FStar_TypeChecker_Env.conj_guard
-                                             g1 uu____16839)
+                                             g1 uu___7)
                                     FStar_TypeChecker_Env.trivial_guard c_is
                                     f_sort_is in
                                 let lift_ct =
-                                  let uu____16841 =
+                                  let uu___7 =
                                     FStar_All.pipe_right lift_c
                                       (FStar_Syntax_Subst.subst_comp substs) in
-                                  FStar_All.pipe_right uu____16841
+                                  FStar_All.pipe_right uu___7
                                     FStar_Syntax_Util.comp_to_comp_typ in
                                 let is =
-                                  let uu____16845 =
+                                  let uu___7 =
                                     FStar_TypeChecker_Env.is_layered_effect
                                       env tgt in
                                   effect_args_from_repr
                                     lift_ct.FStar_Syntax_Syntax.result_typ
-                                    uu____16845 r in
+                                    uu___7 r in
                                 let fml =
-                                  let uu____16849 =
-                                    let uu____16854 =
+                                  let uu___7 =
+                                    let uu___8 =
                                       FStar_List.hd
                                         lift_ct.FStar_Syntax_Syntax.comp_univs in
-                                    let uu____16855 =
-                                      let uu____16856 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_List.hd
                                           lift_ct.FStar_Syntax_Syntax.effect_args in
-                                      FStar_Pervasives_Native.fst uu____16856 in
-                                    (uu____16854, uu____16855) in
-                                  match uu____16849 with
+                                      FStar_Pervasives_Native.fst uu___10 in
+                                    (uu___8, uu___9) in
+                                  match uu___7 with
                                   | (u1, wp) ->
                                       FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                         env u1
                                         lift_ct.FStar_Syntax_Syntax.result_typ
                                         wp FStar_Range.dummyRange in
-                                (let uu____16882 =
+                                (let uu___8 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects"))
@@ -6191,16 +6034,16 @@ let (lift_tf_layered_effect :
                                      (FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
                                         FStar_Options.Extreme) in
-                                 if uu____16882
+                                 if uu___8
                                  then
-                                   let uu____16883 =
+                                   let uu___9 =
                                      FStar_Syntax_Print.term_to_string fml in
                                    FStar_Util.print1 "Guard for lift is: %s"
-                                     uu____16883
+                                     uu___9
                                  else ());
                                 (let c1 =
-                                   let uu____16886 =
-                                     let uu____16887 =
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_All.pipe_right is
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.as_arg) in
@@ -6210,35 +6053,35 @@ let (lift_tf_layered_effect :
                                        FStar_Syntax_Syntax.effect_name = tgt;
                                        FStar_Syntax_Syntax.result_typ = a;
                                        FStar_Syntax_Syntax.effect_args =
-                                         uu____16887;
+                                         uu___9;
                                        FStar_Syntax_Syntax.flags = []
                                      } in
-                                   FStar_Syntax_Syntax.mk_Comp uu____16886 in
-                                 (let uu____16911 =
+                                   FStar_Syntax_Syntax.mk_Comp uu___8 in
+                                 (let uu___9 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects") in
-                                  if uu____16911
+                                  if uu___9
                                   then
-                                    let uu____16912 =
+                                    let uu___10 =
                                       FStar_Syntax_Print.comp_to_string c1 in
                                     FStar_Util.print1 "} Lifted comp: %s\n"
-                                      uu____16912
+                                      uu___10
                                   else ());
-                                 (let uu____16914 =
-                                    let uu____16915 =
+                                 (let uu___9 =
+                                    let uu___10 =
                                       FStar_TypeChecker_Env.conj_guard g
                                         guard_f in
-                                    let uu____16916 =
+                                    let uu___11 =
                                       FStar_TypeChecker_Env.guard_of_guard_formula
                                         (FStar_TypeChecker_Common.NonTrivial
                                            fml) in
-                                    FStar_TypeChecker_Env.conj_guard
-                                      uu____16915 uu____16916 in
-                                  (c1, uu____16914)))))))))
+                                    FStar_TypeChecker_Env.conj_guard uu___10
+                                      uu___11 in
+                                  (c1, uu___9)))))))))
 let lift_tf_layered_effect_term :
-  'uuuuuu16929 .
-    'uuuuuu16929 ->
+  'uuuuu .
+    'uuuuu ->
       FStar_Syntax_Syntax.sub_eff ->
         FStar_Syntax_Syntax.universe ->
           FStar_Syntax_Syntax.typ ->
@@ -6250,58 +6093,55 @@ let lift_tf_layered_effect_term :
         fun a ->
           fun e ->
             let lift =
-              let uu____16958 =
-                let uu____16963 =
+              let uu___ =
+                let uu___1 =
                   FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift
                     FStar_Util.must in
-                FStar_All.pipe_right uu____16963
+                FStar_All.pipe_right uu___1
                   (fun ts -> FStar_TypeChecker_Env.inst_tscheme_with ts [u]) in
-              FStar_All.pipe_right uu____16958 FStar_Pervasives_Native.snd in
+              FStar_All.pipe_right uu___ FStar_Pervasives_Native.snd in
             let rest_bs =
               let lift_t =
                 FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                   FStar_Util.must in
-              let uu____17006 =
-                let uu____17007 =
-                  let uu____17010 =
+              let uu___ =
+                let uu___1 =
+                  let uu___2 =
                     FStar_All.pipe_right lift_t FStar_Pervasives_Native.snd in
-                  FStar_All.pipe_right uu____17010
-                    FStar_Syntax_Subst.compress in
-                uu____17007.FStar_Syntax_Syntax.n in
-              match uu____17006 with
-              | FStar_Syntax_Syntax.Tm_arrow (uu____17033::bs, uu____17035)
-                  when (FStar_List.length bs) >= Prims.int_one ->
-                  let uu____17074 =
+                  FStar_All.pipe_right uu___2 FStar_Syntax_Subst.compress in
+                uu___1.FStar_Syntax_Syntax.n in
+              match uu___ with
+              | FStar_Syntax_Syntax.Tm_arrow (uu___1::bs, uu___2) when
+                  (FStar_List.length bs) >= Prims.int_one ->
+                  let uu___3 =
                     FStar_All.pipe_right bs
                       (FStar_List.splitAt
                          ((FStar_List.length bs) - Prims.int_one)) in
-                  FStar_All.pipe_right uu____17074
-                    FStar_Pervasives_Native.fst
-              | uu____17179 ->
-                  let uu____17180 =
-                    let uu____17185 =
-                      let uu____17186 =
+                  FStar_All.pipe_right uu___3 FStar_Pervasives_Native.fst
+              | uu___1 ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Print.tscheme_to_string lift_t in
                       FStar_Util.format1
                         "lift_t tscheme %s is not an arrow with enough binders"
-                        uu____17186 in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____17185) in
-                  FStar_Errors.raise_error uu____17180
+                        uu___4 in
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                  FStar_Errors.raise_error uu___2
                     (FStar_Pervasives_Native.snd lift_t).FStar_Syntax_Syntax.pos in
             let args =
-              let uu____17210 = FStar_Syntax_Syntax.as_arg a in
-              let uu____17219 =
-                let uu____17230 =
+              let uu___ = FStar_Syntax_Syntax.as_arg a in
+              let uu___1 =
+                let uu___2 =
                   FStar_All.pipe_right rest_bs
                     (FStar_List.map
-                       (fun uu____17266 ->
+                       (fun uu___3 ->
                           FStar_Syntax_Syntax.as_arg
                             FStar_Syntax_Syntax.unit_const)) in
-                let uu____17273 =
-                  let uu____17284 = FStar_Syntax_Syntax.as_arg e in
-                  [uu____17284] in
-                FStar_List.append uu____17230 uu____17273 in
-              uu____17210 :: uu____17219 in
+                let uu___3 =
+                  let uu___4 = FStar_Syntax_Syntax.as_arg e in [uu___4] in
+                FStar_List.append uu___2 uu___3 in
+              uu___ :: uu___1 in
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (lift, args))
               e.FStar_Syntax_Syntax.pos
 let (get_field_projector_name :
@@ -6311,65 +6151,65 @@ let (get_field_projector_name :
   fun env ->
     fun datacon ->
       fun index ->
-        let uu____17352 = FStar_TypeChecker_Env.lookup_datacon env datacon in
-        match uu____17352 with
-        | (uu____17357, t) ->
+        let uu___ = FStar_TypeChecker_Env.lookup_datacon env datacon in
+        match uu___ with
+        | (uu___1, t) ->
             let err n =
-              let uu____17365 =
-                let uu____17370 =
-                  let uu____17371 = FStar_Ident.string_of_lid datacon in
-                  let uu____17372 = FStar_Util.string_of_int n in
-                  let uu____17373 = FStar_Util.string_of_int index in
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = FStar_Ident.string_of_lid datacon in
+                  let uu___5 = FStar_Util.string_of_int n in
+                  let uu___6 = FStar_Util.string_of_int index in
                   FStar_Util.format3
                     "Data constructor %s does not have enough binders (has %s, tried %s)"
-                    uu____17371 uu____17372 uu____17373 in
-                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu____17370) in
-              let uu____17374 = FStar_TypeChecker_Env.get_range env in
-              FStar_Errors.raise_error uu____17365 uu____17374 in
-            let uu____17375 =
-              let uu____17376 = FStar_Syntax_Subst.compress t in
-              uu____17376.FStar_Syntax_Syntax.n in
-            (match uu____17375 with
-             | FStar_Syntax_Syntax.Tm_arrow (bs, uu____17380) ->
+                    uu___4 uu___5 uu___6 in
+                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu___3) in
+              let uu___3 = FStar_TypeChecker_Env.get_range env in
+              FStar_Errors.raise_error uu___2 uu___3 in
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Subst.compress t in
+              uu___3.FStar_Syntax_Syntax.n in
+            (match uu___2 with
+             | FStar_Syntax_Syntax.Tm_arrow (bs, uu___3) ->
                  let bs1 =
                    FStar_All.pipe_right bs
                      (FStar_List.filter
-                        (fun uu____17435 ->
-                           match uu____17435 with
-                           | (uu____17442, q) ->
+                        (fun uu___4 ->
+                           match uu___4 with
+                           | (uu___5, q) ->
                                (match q with
                                 | FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Implicit (true)) ->
                                     false
-                                | uu____17448 -> true))) in
+                                | uu___6 -> true))) in
                  if (FStar_List.length bs1) <= index
                  then err (FStar_List.length bs1)
                  else
                    (let b = FStar_List.nth bs1 index in
                     FStar_Syntax_Util.mk_field_projector_name datacon
                       (FStar_Pervasives_Native.fst b) index)
-             | uu____17479 -> err Prims.int_zero)
+             | uu___3 -> err Prims.int_zero)
 let (get_mlift_for_subeff :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sub_eff -> FStar_TypeChecker_Env.mlift)
   =
   fun env ->
     fun sub ->
-      let uu____17490 =
+      let uu___ =
         (FStar_TypeChecker_Env.is_layered_effect env
            sub.FStar_Syntax_Syntax.source)
           ||
           (FStar_TypeChecker_Env.is_layered_effect env
              sub.FStar_Syntax_Syntax.target) in
-      if uu____17490
+      if uu___
       then
-        let uu____17491 =
-          let uu____17504 =
+        let uu___1 =
+          let uu___2 =
             FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
               FStar_Util.must in
-          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu____17504 in
+          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu___2 in
         {
-          FStar_TypeChecker_Env.mlift_wp = uu____17491;
+          FStar_TypeChecker_Env.mlift_wp = uu___1;
           FStar_TypeChecker_Env.mlift_term =
             (FStar_Pervasives_Native.Some
                (lift_tf_layered_effect_term env sub))
@@ -6377,77 +6217,76 @@ let (get_mlift_for_subeff :
       else
         (let mk_mlift_wp ts env1 c =
            let ct = FStar_Syntax_Util.comp_to_comp_typ c in
-           let uu____17538 =
+           let uu___2 =
              FStar_TypeChecker_Env.inst_tscheme_with ts
                ct.FStar_Syntax_Syntax.comp_univs in
-           match uu____17538 with
-           | (uu____17547, lift_t) ->
+           match uu___2 with
+           | (uu___3, lift_t) ->
                let wp = FStar_List.hd ct.FStar_Syntax_Syntax.effect_args in
-               let uu____17566 =
-                 let uu____17567 =
-                   let uu___2283_17568 = ct in
-                   let uu____17569 =
-                     let uu____17580 =
-                       let uu____17589 =
-                         let uu____17590 =
-                           let uu____17591 =
-                             let uu____17608 =
-                               let uu____17619 =
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 = ct in
+                   let uu___7 =
+                     let uu___8 =
+                       let uu___9 =
+                         let uu___10 =
+                           let uu___11 =
+                             let uu___12 =
+                               let uu___13 =
                                  FStar_Syntax_Syntax.as_arg
                                    ct.FStar_Syntax_Syntax.result_typ in
-                               [uu____17619; wp] in
-                             (lift_t, uu____17608) in
-                           FStar_Syntax_Syntax.Tm_app uu____17591 in
-                         FStar_Syntax_Syntax.mk uu____17590
+                               [uu___13; wp] in
+                             (lift_t, uu___12) in
+                           FStar_Syntax_Syntax.Tm_app uu___11 in
+                         FStar_Syntax_Syntax.mk uu___10
                            (FStar_Pervasives_Native.fst wp).FStar_Syntax_Syntax.pos in
-                       FStar_All.pipe_right uu____17589
-                         FStar_Syntax_Syntax.as_arg in
-                     [uu____17580] in
+                       FStar_All.pipe_right uu___9 FStar_Syntax_Syntax.as_arg in
+                     [uu___8] in
                    {
                      FStar_Syntax_Syntax.comp_univs =
-                       (uu___2283_17568.FStar_Syntax_Syntax.comp_univs);
+                       (uu___6.FStar_Syntax_Syntax.comp_univs);
                      FStar_Syntax_Syntax.effect_name =
                        (sub.FStar_Syntax_Syntax.target);
                      FStar_Syntax_Syntax.result_typ =
-                       (uu___2283_17568.FStar_Syntax_Syntax.result_typ);
-                     FStar_Syntax_Syntax.effect_args = uu____17569;
+                       (uu___6.FStar_Syntax_Syntax.result_typ);
+                     FStar_Syntax_Syntax.effect_args = uu___7;
                      FStar_Syntax_Syntax.flags =
-                       (uu___2283_17568.FStar_Syntax_Syntax.flags)
+                       (uu___6.FStar_Syntax_Syntax.flags)
                    } in
-                 FStar_Syntax_Syntax.mk_Comp uu____17567 in
-               (uu____17566, FStar_TypeChecker_Common.trivial_guard) in
+                 FStar_Syntax_Syntax.mk_Comp uu___5 in
+               (uu___4, FStar_TypeChecker_Common.trivial_guard) in
          let mk_mlift_term ts u r e =
-           let uu____17719 = FStar_TypeChecker_Env.inst_tscheme_with ts [u] in
-           match uu____17719 with
-           | (uu____17726, lift_t) ->
-               let uu____17728 =
-                 let uu____17729 =
-                   let uu____17746 =
-                     let uu____17757 = FStar_Syntax_Syntax.as_arg r in
-                     let uu____17766 =
-                       let uu____17777 =
+           let uu___2 = FStar_TypeChecker_Env.inst_tscheme_with ts [u] in
+           match uu___2 with
+           | (uu___3, lift_t) ->
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 = FStar_Syntax_Syntax.as_arg r in
+                     let uu___8 =
+                       let uu___9 =
                          FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun in
-                       let uu____17786 =
-                         let uu____17797 = FStar_Syntax_Syntax.as_arg e in
-                         [uu____17797] in
-                       uu____17777 :: uu____17786 in
-                     uu____17757 :: uu____17766 in
-                   (lift_t, uu____17746) in
-                 FStar_Syntax_Syntax.Tm_app uu____17729 in
-               FStar_Syntax_Syntax.mk uu____17728 e.FStar_Syntax_Syntax.pos in
-         let uu____17850 =
-           let uu____17863 =
+                       let uu___10 =
+                         let uu___11 = FStar_Syntax_Syntax.as_arg e in
+                         [uu___11] in
+                       uu___9 :: uu___10 in
+                     uu___7 :: uu___8 in
+                   (lift_t, uu___6) in
+                 FStar_Syntax_Syntax.Tm_app uu___5 in
+               FStar_Syntax_Syntax.mk uu___4 e.FStar_Syntax_Syntax.pos in
+         let uu___2 =
+           let uu___3 =
              FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                FStar_Util.must in
-           FStar_All.pipe_right uu____17863 mk_mlift_wp in
+           FStar_All.pipe_right uu___3 mk_mlift_wp in
          {
-           FStar_TypeChecker_Env.mlift_wp = uu____17850;
+           FStar_TypeChecker_Env.mlift_wp = uu___2;
            FStar_TypeChecker_Env.mlift_term =
              (match sub.FStar_Syntax_Syntax.lift with
               | FStar_Pervasives_Native.None ->
                   FStar_Pervasives_Native.Some
-                    ((fun uu____17899 ->
-                        fun uu____17900 -> fun e -> FStar_Util.return_all e))
+                    ((fun uu___3 ->
+                        fun uu___4 -> fun e -> FStar_Util.return_all e))
               | FStar_Pervasives_Native.Some ts ->
                   FStar_Pervasives_Native.Some (mk_mlift_term ts))
          })
@@ -6461,200 +6300,188 @@ let (update_env_sub_eff :
       fun r ->
         let r0 = env.FStar_TypeChecker_Env.range in
         let env1 =
-          let uu____17929 = get_mlift_for_subeff env sub in
+          let uu___ = get_mlift_for_subeff env sub in
           FStar_TypeChecker_Env.update_effect_lattice
-            (let uu___2303_17932 = env in
+            (let uu___1 = env in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2303_17932.FStar_TypeChecker_Env.solver);
+                 (uu___1.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range = r;
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2303_17932.FStar_TypeChecker_Env.curmodule);
+                 (uu___1.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2303_17932.FStar_TypeChecker_Env.gamma);
+                 (uu___1.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2303_17932.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___1.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2303_17932.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___1.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2303_17932.FStar_TypeChecker_Env.modules);
+                 (uu___1.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2303_17932.FStar_TypeChecker_Env.expected_typ);
+                 (uu___1.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2303_17932.FStar_TypeChecker_Env.sigtab);
+                 (uu___1.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2303_17932.FStar_TypeChecker_Env.attrtab);
+                 (uu___1.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2303_17932.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2303_17932.FStar_TypeChecker_Env.effects);
+                 (uu___1.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2303_17932.FStar_TypeChecker_Env.generalize);
+                 (uu___1.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2303_17932.FStar_TypeChecker_Env.letrecs);
+                 (uu___1.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2303_17932.FStar_TypeChecker_Env.top_level);
+                 (uu___1.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2303_17932.FStar_TypeChecker_Env.check_uvars);
+                 (uu___1.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq =
-                 (uu___2303_17932.FStar_TypeChecker_Env.use_eq);
+                 (uu___1.FStar_TypeChecker_Env.use_eq);
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2303_17932.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2303_17932.FStar_TypeChecker_Env.is_iface);
+                 (uu___1.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2303_17932.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax =
-                 (uu___2303_17932.FStar_TypeChecker_Env.lax);
+                 (uu___1.FStar_TypeChecker_Env.admit);
+               FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2303_17932.FStar_TypeChecker_Env.lax_universes);
+                 (uu___1.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2303_17932.FStar_TypeChecker_Env.phase1);
+                 (uu___1.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2303_17932.FStar_TypeChecker_Env.failhard);
+                 (uu___1.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2303_17932.FStar_TypeChecker_Env.nosynth);
+                 (uu___1.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2303_17932.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2303_17932.FStar_TypeChecker_Env.tc_term);
+                 (uu___1.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2303_17932.FStar_TypeChecker_Env.type_of);
+                 (uu___1.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2303_17932.FStar_TypeChecker_Env.universe_of);
+                 (uu___1.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2303_17932.FStar_TypeChecker_Env.check_type_of);
+                 (uu___1.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2303_17932.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2303_17932.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2303_17932.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2303_17932.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2303_17932.FStar_TypeChecker_Env.proof_ns);
+                 (uu___1.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2303_17932.FStar_TypeChecker_Env.synth_hook);
+                 (uu___1.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2303_17932.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2303_17932.FStar_TypeChecker_Env.splice);
+                 (uu___1.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2303_17932.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___1.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2303_17932.FStar_TypeChecker_Env.postprocess);
+                 (uu___1.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2303_17932.FStar_TypeChecker_Env.identifier_info);
+                 (uu___1.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2303_17932.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___1.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2303_17932.FStar_TypeChecker_Env.dsenv);
-               FStar_TypeChecker_Env.nbe =
-                 (uu___2303_17932.FStar_TypeChecker_Env.nbe);
+                 (uu___1.FStar_TypeChecker_Env.dsenv);
+               FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2303_17932.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2303_17932.FStar_TypeChecker_Env.erasable_types_tab);
+                 (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                FStar_TypeChecker_Env.enable_defer_to_tac =
-                 (uu___2303_17932.FStar_TypeChecker_Env.enable_defer_to_tac)
+                 (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
              }) sub.FStar_Syntax_Syntax.source sub.FStar_Syntax_Syntax.target
-            uu____17929 in
-        let uu___2306_17933 = env1 in
+            uu___ in
+        let uu___ = env1 in
         {
-          FStar_TypeChecker_Env.solver =
-            (uu___2306_17933.FStar_TypeChecker_Env.solver);
+          FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
           FStar_TypeChecker_Env.range = r0;
           FStar_TypeChecker_Env.curmodule =
-            (uu___2306_17933.FStar_TypeChecker_Env.curmodule);
-          FStar_TypeChecker_Env.gamma =
-            (uu___2306_17933.FStar_TypeChecker_Env.gamma);
+            (uu___.FStar_TypeChecker_Env.curmodule);
+          FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
           FStar_TypeChecker_Env.gamma_sig =
-            (uu___2306_17933.FStar_TypeChecker_Env.gamma_sig);
+            (uu___.FStar_TypeChecker_Env.gamma_sig);
           FStar_TypeChecker_Env.gamma_cache =
-            (uu___2306_17933.FStar_TypeChecker_Env.gamma_cache);
+            (uu___.FStar_TypeChecker_Env.gamma_cache);
           FStar_TypeChecker_Env.modules =
-            (uu___2306_17933.FStar_TypeChecker_Env.modules);
+            (uu___.FStar_TypeChecker_Env.modules);
           FStar_TypeChecker_Env.expected_typ =
-            (uu___2306_17933.FStar_TypeChecker_Env.expected_typ);
-          FStar_TypeChecker_Env.sigtab =
-            (uu___2306_17933.FStar_TypeChecker_Env.sigtab);
+            (uu___.FStar_TypeChecker_Env.expected_typ);
+          FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
           FStar_TypeChecker_Env.attrtab =
-            (uu___2306_17933.FStar_TypeChecker_Env.attrtab);
+            (uu___.FStar_TypeChecker_Env.attrtab);
           FStar_TypeChecker_Env.instantiate_imp =
-            (uu___2306_17933.FStar_TypeChecker_Env.instantiate_imp);
+            (uu___.FStar_TypeChecker_Env.instantiate_imp);
           FStar_TypeChecker_Env.effects =
-            (uu___2306_17933.FStar_TypeChecker_Env.effects);
+            (uu___.FStar_TypeChecker_Env.effects);
           FStar_TypeChecker_Env.generalize =
-            (uu___2306_17933.FStar_TypeChecker_Env.generalize);
+            (uu___.FStar_TypeChecker_Env.generalize);
           FStar_TypeChecker_Env.letrecs =
-            (uu___2306_17933.FStar_TypeChecker_Env.letrecs);
+            (uu___.FStar_TypeChecker_Env.letrecs);
           FStar_TypeChecker_Env.top_level =
-            (uu___2306_17933.FStar_TypeChecker_Env.top_level);
+            (uu___.FStar_TypeChecker_Env.top_level);
           FStar_TypeChecker_Env.check_uvars =
-            (uu___2306_17933.FStar_TypeChecker_Env.check_uvars);
-          FStar_TypeChecker_Env.use_eq =
-            (uu___2306_17933.FStar_TypeChecker_Env.use_eq);
+            (uu___.FStar_TypeChecker_Env.check_uvars);
+          FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
           FStar_TypeChecker_Env.use_eq_strict =
-            (uu___2306_17933.FStar_TypeChecker_Env.use_eq_strict);
+            (uu___.FStar_TypeChecker_Env.use_eq_strict);
           FStar_TypeChecker_Env.is_iface =
-            (uu___2306_17933.FStar_TypeChecker_Env.is_iface);
-          FStar_TypeChecker_Env.admit =
-            (uu___2306_17933.FStar_TypeChecker_Env.admit);
-          FStar_TypeChecker_Env.lax =
-            (uu___2306_17933.FStar_TypeChecker_Env.lax);
+            (uu___.FStar_TypeChecker_Env.is_iface);
+          FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+          FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
           FStar_TypeChecker_Env.lax_universes =
-            (uu___2306_17933.FStar_TypeChecker_Env.lax_universes);
-          FStar_TypeChecker_Env.phase1 =
-            (uu___2306_17933.FStar_TypeChecker_Env.phase1);
+            (uu___.FStar_TypeChecker_Env.lax_universes);
+          FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
           FStar_TypeChecker_Env.failhard =
-            (uu___2306_17933.FStar_TypeChecker_Env.failhard);
+            (uu___.FStar_TypeChecker_Env.failhard);
           FStar_TypeChecker_Env.nosynth =
-            (uu___2306_17933.FStar_TypeChecker_Env.nosynth);
+            (uu___.FStar_TypeChecker_Env.nosynth);
           FStar_TypeChecker_Env.uvar_subtyping =
-            (uu___2306_17933.FStar_TypeChecker_Env.uvar_subtyping);
+            (uu___.FStar_TypeChecker_Env.uvar_subtyping);
           FStar_TypeChecker_Env.tc_term =
-            (uu___2306_17933.FStar_TypeChecker_Env.tc_term);
+            (uu___.FStar_TypeChecker_Env.tc_term);
           FStar_TypeChecker_Env.type_of =
-            (uu___2306_17933.FStar_TypeChecker_Env.type_of);
+            (uu___.FStar_TypeChecker_Env.type_of);
           FStar_TypeChecker_Env.universe_of =
-            (uu___2306_17933.FStar_TypeChecker_Env.universe_of);
+            (uu___.FStar_TypeChecker_Env.universe_of);
           FStar_TypeChecker_Env.check_type_of =
-            (uu___2306_17933.FStar_TypeChecker_Env.check_type_of);
+            (uu___.FStar_TypeChecker_Env.check_type_of);
           FStar_TypeChecker_Env.use_bv_sorts =
-            (uu___2306_17933.FStar_TypeChecker_Env.use_bv_sorts);
+            (uu___.FStar_TypeChecker_Env.use_bv_sorts);
           FStar_TypeChecker_Env.qtbl_name_and_index =
-            (uu___2306_17933.FStar_TypeChecker_Env.qtbl_name_and_index);
+            (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
           FStar_TypeChecker_Env.normalized_eff_names =
-            (uu___2306_17933.FStar_TypeChecker_Env.normalized_eff_names);
+            (uu___.FStar_TypeChecker_Env.normalized_eff_names);
           FStar_TypeChecker_Env.fv_delta_depths =
-            (uu___2306_17933.FStar_TypeChecker_Env.fv_delta_depths);
+            (uu___.FStar_TypeChecker_Env.fv_delta_depths);
           FStar_TypeChecker_Env.proof_ns =
-            (uu___2306_17933.FStar_TypeChecker_Env.proof_ns);
+            (uu___.FStar_TypeChecker_Env.proof_ns);
           FStar_TypeChecker_Env.synth_hook =
-            (uu___2306_17933.FStar_TypeChecker_Env.synth_hook);
+            (uu___.FStar_TypeChecker_Env.synth_hook);
           FStar_TypeChecker_Env.try_solve_implicits_hook =
-            (uu___2306_17933.FStar_TypeChecker_Env.try_solve_implicits_hook);
-          FStar_TypeChecker_Env.splice =
-            (uu___2306_17933.FStar_TypeChecker_Env.splice);
+            (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+          FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
           FStar_TypeChecker_Env.mpreprocess =
-            (uu___2306_17933.FStar_TypeChecker_Env.mpreprocess);
+            (uu___.FStar_TypeChecker_Env.mpreprocess);
           FStar_TypeChecker_Env.postprocess =
-            (uu___2306_17933.FStar_TypeChecker_Env.postprocess);
+            (uu___.FStar_TypeChecker_Env.postprocess);
           FStar_TypeChecker_Env.identifier_info =
-            (uu___2306_17933.FStar_TypeChecker_Env.identifier_info);
+            (uu___.FStar_TypeChecker_Env.identifier_info);
           FStar_TypeChecker_Env.tc_hooks =
-            (uu___2306_17933.FStar_TypeChecker_Env.tc_hooks);
-          FStar_TypeChecker_Env.dsenv =
-            (uu___2306_17933.FStar_TypeChecker_Env.dsenv);
-          FStar_TypeChecker_Env.nbe =
-            (uu___2306_17933.FStar_TypeChecker_Env.nbe);
+            (uu___.FStar_TypeChecker_Env.tc_hooks);
+          FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+          FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
           FStar_TypeChecker_Env.strict_args_tab =
-            (uu___2306_17933.FStar_TypeChecker_Env.strict_args_tab);
+            (uu___.FStar_TypeChecker_Env.strict_args_tab);
           FStar_TypeChecker_Env.erasable_types_tab =
-            (uu___2306_17933.FStar_TypeChecker_Env.erasable_types_tab);
+            (uu___.FStar_TypeChecker_Env.erasable_types_tab);
           FStar_TypeChecker_Env.enable_defer_to_tac =
-            (uu___2306_17933.FStar_TypeChecker_Env.enable_defer_to_tac)
+            (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
         }
 let (update_env_polymonadic_bind :
   FStar_TypeChecker_Env.env ->

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -11,105 +11,103 @@ let with_dsenv_of_tcenv :
   =
   fun tcenv ->
     fun f ->
-      let uu____36 = f tcenv.FStar_TypeChecker_Env.dsenv in
-      match uu____36 with
+      let uu___ = f tcenv.FStar_TypeChecker_Env.dsenv in
+      match uu___ with
       | (a1, dsenv) ->
           (a1,
-            (let uu___9_48 = tcenv in
+            (let uu___1 = tcenv in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___9_48.FStar_TypeChecker_Env.solver);
+                 (uu___1.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___9_48.FStar_TypeChecker_Env.range);
+                 (uu___1.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___9_48.FStar_TypeChecker_Env.curmodule);
+                 (uu___1.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___9_48.FStar_TypeChecker_Env.gamma);
+                 (uu___1.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___9_48.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___1.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___9_48.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___1.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___9_48.FStar_TypeChecker_Env.modules);
+                 (uu___1.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___9_48.FStar_TypeChecker_Env.expected_typ);
+                 (uu___1.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___9_48.FStar_TypeChecker_Env.sigtab);
+                 (uu___1.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___9_48.FStar_TypeChecker_Env.attrtab);
+                 (uu___1.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___9_48.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___1.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___9_48.FStar_TypeChecker_Env.effects);
+                 (uu___1.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___9_48.FStar_TypeChecker_Env.generalize);
+                 (uu___1.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___9_48.FStar_TypeChecker_Env.letrecs);
+                 (uu___1.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___9_48.FStar_TypeChecker_Env.top_level);
+                 (uu___1.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___9_48.FStar_TypeChecker_Env.check_uvars);
+                 (uu___1.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq =
-                 (uu___9_48.FStar_TypeChecker_Env.use_eq);
+                 (uu___1.FStar_TypeChecker_Env.use_eq);
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___9_48.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___9_48.FStar_TypeChecker_Env.is_iface);
+                 (uu___1.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___9_48.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax =
-                 (uu___9_48.FStar_TypeChecker_Env.lax);
+                 (uu___1.FStar_TypeChecker_Env.admit);
+               FStar_TypeChecker_Env.lax = (uu___1.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___9_48.FStar_TypeChecker_Env.lax_universes);
+                 (uu___1.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___9_48.FStar_TypeChecker_Env.phase1);
+                 (uu___1.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___9_48.FStar_TypeChecker_Env.failhard);
+                 (uu___1.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___9_48.FStar_TypeChecker_Env.nosynth);
+                 (uu___1.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___9_48.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___9_48.FStar_TypeChecker_Env.tc_term);
+                 (uu___1.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___9_48.FStar_TypeChecker_Env.type_of);
+                 (uu___1.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___9_48.FStar_TypeChecker_Env.universe_of);
+                 (uu___1.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___9_48.FStar_TypeChecker_Env.check_type_of);
+                 (uu___1.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___9_48.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___9_48.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___9_48.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___9_48.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___9_48.FStar_TypeChecker_Env.proof_ns);
+                 (uu___1.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___9_48.FStar_TypeChecker_Env.synth_hook);
+                 (uu___1.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___9_48.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___9_48.FStar_TypeChecker_Env.splice);
+                 (uu___1.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___9_48.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___1.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___9_48.FStar_TypeChecker_Env.postprocess);
+                 (uu___1.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___9_48.FStar_TypeChecker_Env.identifier_info);
+                 (uu___1.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___9_48.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___1.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv = dsenv;
-               FStar_TypeChecker_Env.nbe =
-                 (uu___9_48.FStar_TypeChecker_Env.nbe);
+               FStar_TypeChecker_Env.nbe = (uu___1.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___9_48.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___1.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___9_48.FStar_TypeChecker_Env.erasable_types_tab);
+                 (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
                FStar_TypeChecker_Env.enable_defer_to_tac =
-                 (uu___9_48.FStar_TypeChecker_Env.enable_defer_to_tac)
+                 (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac)
              }))
 let with_tcenv_of_env :
   'a .
@@ -119,47 +117,46 @@ let with_tcenv_of_env :
   =
   fun e ->
     fun f ->
-      let uu____83 =
-        let uu____88 = FStar_Extraction_ML_UEnv.tcenv_of_uenv e in f uu____88 in
-      match uu____83 with
+      let uu___ =
+        let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv e in f uu___1 in
+      match uu___ with
       | (a1, t') ->
-          let uu____95 = FStar_Extraction_ML_UEnv.set_tcenv e t' in
-          (a1, uu____95)
+          let uu___1 = FStar_Extraction_ML_UEnv.set_tcenv e t' in
+          (a1, uu___1)
 let with_dsenv_of_env :
   'a . uenv -> 'a FStar_Syntax_DsEnv.withenv -> ('a * uenv) =
   fun e ->
     fun f ->
-      let uu____123 =
-        let uu____128 = FStar_Extraction_ML_UEnv.tcenv_of_uenv e in
-        with_dsenv_of_tcenv uu____128 f in
-      match uu____123 with
+      let uu___ =
+        let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv e in
+        with_dsenv_of_tcenv uu___1 f in
+      match uu___ with
       | (a1, tcenv) ->
-          let uu____135 = FStar_Extraction_ML_UEnv.set_tcenv e tcenv in
-          (a1, uu____135)
+          let uu___1 = FStar_Extraction_ML_UEnv.set_tcenv e tcenv in
+          (a1, uu___1)
 let (push_env : uenv -> uenv) =
   fun env ->
-    let uu____141 =
+    let uu___ =
       with_tcenv_of_env env
         (fun tcenv ->
-           let uu____149 =
-             let uu____150 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
-             FStar_TypeChecker_Env.push uu____150 "top-level: push_env" in
-           ((), uu____149)) in
-    FStar_Pervasives_Native.snd uu____141
+           let uu___1 =
+             let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
+             FStar_TypeChecker_Env.push uu___2 "top-level: push_env" in
+           ((), uu___1)) in
+    FStar_Pervasives_Native.snd uu___
 let (pop_env : uenv -> uenv) =
   fun env ->
-    let uu____156 =
+    let uu___ =
       with_tcenv_of_env env
         (fun tcenv ->
-           let uu____164 =
-             FStar_TypeChecker_Env.pop tcenv "top-level: pop_env" in
-           ((), uu____164)) in
-    FStar_Pervasives_Native.snd uu____156
+           let uu___1 = FStar_TypeChecker_Env.pop tcenv "top-level: pop_env" in
+           ((), uu___1)) in
+    FStar_Pervasives_Native.snd uu___
 let with_env : 'a . uenv -> (uenv -> 'a) -> 'a =
   fun env ->
     fun f ->
       let env1 = push_env env in
-      let res = f env1 in let uu____189 = pop_env env1 in res
+      let res = f env1 in let uu___ = pop_env env1 in res
 let (env_of_tcenv :
   FStar_TypeChecker_Env.env -> FStar_Extraction_ML_UEnv.uenv) =
   fun env -> FStar_Extraction_ML_UEnv.new_uenv env
@@ -171,554 +168,469 @@ let (parse :
   fun env ->
     fun pre_fn ->
       fun fn ->
-        let uu____222 = FStar_Parser_Driver.parse_file fn in
-        match uu____222 with
-        | (ast, uu____238) ->
-            let uu____251 =
+        let uu___ = FStar_Parser_Driver.parse_file fn in
+        match uu___ with
+        | (ast, uu___1) ->
+            let uu___2 =
               match pre_fn with
               | FStar_Pervasives_Native.None -> (ast, env)
               | FStar_Pervasives_Native.Some pre_fn1 ->
-                  let uu____261 = FStar_Parser_Driver.parse_file pre_fn1 in
-                  (match uu____261 with
-                   | (pre_ast, uu____277) ->
+                  let uu___3 = FStar_Parser_Driver.parse_file pre_fn1 in
+                  (match uu___3 with
+                   | (pre_ast, uu___4) ->
                        (match (pre_ast, ast) with
-                        | (FStar_Parser_AST.Interface
-                           (lid1, decls1, uu____296), FStar_Parser_AST.Module
-                           (lid2, decls2)) when
+                        | (FStar_Parser_AST.Interface (lid1, decls1, uu___5),
+                           FStar_Parser_AST.Module (lid2, decls2)) when
                             FStar_Ident.lid_equals lid1 lid2 ->
-                            let uu____307 =
-                              let uu____312 =
+                            let uu___6 =
+                              let uu___7 =
                                 FStar_ToSyntax_Interleave.initialize_interface
                                   lid1 decls1 in
-                              with_dsenv_of_env env uu____312 in
-                            (match uu____307 with
-                             | (uu____321, env1) ->
-                                 let uu____323 =
+                              with_dsenv_of_env env uu___7 in
+                            (match uu___6 with
+                             | (uu___7, env1) ->
+                                 let uu___8 =
                                    FStar_ToSyntax_Interleave.interleave_module
                                      ast true in
-                                 with_dsenv_of_env env1 uu____323)
-                        | uu____328 ->
+                                 with_dsenv_of_env env1 uu___8)
+                        | uu___5 ->
                             FStar_Errors.raise_err
                               (FStar_Errors.Fatal_PreModuleMismatch,
                                 "mismatch between pre-module and module\n"))) in
-            (match uu____251 with
+            (match uu___2 with
              | (ast1, env1) ->
-                 let uu____343 =
-                   FStar_ToSyntax_ToSyntax.ast_modul_to_modul ast1 in
-                 with_dsenv_of_env env1 uu____343)
+                 let uu___3 = FStar_ToSyntax_ToSyntax.ast_modul_to_modul ast1 in
+                 with_dsenv_of_env env1 uu___3)
 let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
   fun deps ->
     let solver =
-      let uu____354 = FStar_Options.lax () in
-      if uu____354
+      let uu___ = FStar_Options.lax () in
+      if uu___
       then FStar_SMTEncoding_Solver.dummy
       else
-        (let uu___65_356 = FStar_SMTEncoding_Solver.solver in
+        (let uu___2 = FStar_SMTEncoding_Solver.solver in
          {
-           FStar_TypeChecker_Env.init =
-             (uu___65_356.FStar_TypeChecker_Env.init);
-           FStar_TypeChecker_Env.push =
-             (uu___65_356.FStar_TypeChecker_Env.push);
-           FStar_TypeChecker_Env.pop =
-             (uu___65_356.FStar_TypeChecker_Env.pop);
+           FStar_TypeChecker_Env.init = (uu___2.FStar_TypeChecker_Env.init);
+           FStar_TypeChecker_Env.push = (uu___2.FStar_TypeChecker_Env.push);
+           FStar_TypeChecker_Env.pop = (uu___2.FStar_TypeChecker_Env.pop);
            FStar_TypeChecker_Env.snapshot =
-             (uu___65_356.FStar_TypeChecker_Env.snapshot);
+             (uu___2.FStar_TypeChecker_Env.snapshot);
            FStar_TypeChecker_Env.rollback =
-             (uu___65_356.FStar_TypeChecker_Env.rollback);
+             (uu___2.FStar_TypeChecker_Env.rollback);
            FStar_TypeChecker_Env.encode_sig =
-             (uu___65_356.FStar_TypeChecker_Env.encode_sig);
+             (uu___2.FStar_TypeChecker_Env.encode_sig);
            FStar_TypeChecker_Env.preprocess = FStar_Tactics_Hooks.preprocess;
-           FStar_TypeChecker_Env.solve =
-             (uu___65_356.FStar_TypeChecker_Env.solve);
+           FStar_TypeChecker_Env.solve = (uu___2.FStar_TypeChecker_Env.solve);
            FStar_TypeChecker_Env.finish =
-             (uu___65_356.FStar_TypeChecker_Env.finish);
+             (uu___2.FStar_TypeChecker_Env.finish);
            FStar_TypeChecker_Env.refresh =
-             (uu___65_356.FStar_TypeChecker_Env.refresh)
+             (uu___2.FStar_TypeChecker_Env.refresh)
          }) in
     let env =
-      let uu____358 =
-        let uu____373 = FStar_Tactics_Interpreter.primitive_steps () in
-        FStar_TypeChecker_NBE.normalize uu____373 in
+      let uu___ =
+        let uu___1 = FStar_Tactics_Interpreter.primitive_steps () in
+        FStar_TypeChecker_NBE.normalize uu___1 in
       FStar_TypeChecker_Env.initial_env deps FStar_TypeChecker_TcTerm.tc_term
         FStar_TypeChecker_TcTerm.type_of_tot_term
         FStar_TypeChecker_TcTerm.universe_of
         FStar_TypeChecker_TcTerm.check_type_of_well_typed_term solver
-        FStar_Parser_Const.prims_lid uu____358 in
+        FStar_Parser_Const.prims_lid uu___ in
     let env1 =
-      let uu___69_377 = env in
+      let uu___ = env in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___69_377.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___69_377.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___69_377.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___69_377.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___69_377.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___69_377.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___69_377.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___69_377.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___69_377.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___69_377.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___69_377.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___69_377.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___69_377.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___69_377.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___69_377.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___69_377.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___69_377.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___69_377.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___69_377.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___69_377.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___69_377.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___69_377.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___69_377.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___69_377.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___69_377.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___69_377.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___69_377.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___69_377.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___69_377.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___69_377.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___69_377.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___69_377.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___69_377.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___69_377.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___69_377.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook = FStar_Tactics_Hooks.synthesize;
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___69_377.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___69_377.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___69_377.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___69_377.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___69_377.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___69_377.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___69_377.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___69_377.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___69_377.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___69_377.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___69_377.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
     let env2 =
-      let uu___72_379 = env1 in
+      let uu___ = env1 in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___72_379.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___72_379.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___72_379.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___72_379.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___72_379.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___72_379.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___72_379.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___72_379.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___72_379.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___72_379.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___72_379.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___72_379.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___72_379.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___72_379.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___72_379.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___72_379.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___72_379.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___72_379.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___72_379.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___72_379.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___72_379.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___72_379.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___72_379.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___72_379.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___72_379.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___72_379.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___72_379.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___72_379.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___72_379.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___72_379.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___72_379.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___72_379.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___72_379.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___72_379.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___72_379.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___72_379.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
           FStar_Tactics_Hooks.solve_implicits;
-        FStar_TypeChecker_Env.splice =
-          (uu___72_379.FStar_TypeChecker_Env.splice);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___72_379.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___72_379.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___72_379.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___72_379.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___72_379.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___72_379.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___72_379.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___72_379.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___72_379.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
     let env3 =
-      let uu___75_381 = env2 in
+      let uu___ = env2 in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___75_381.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___75_381.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___75_381.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___75_381.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___75_381.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___75_381.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___75_381.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___75_381.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___75_381.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___75_381.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___75_381.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___75_381.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___75_381.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___75_381.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___75_381.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___75_381.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___75_381.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___75_381.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___75_381.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___75_381.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___75_381.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___75_381.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___75_381.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___75_381.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___75_381.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___75_381.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___75_381.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___75_381.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___75_381.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___75_381.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___75_381.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___75_381.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___75_381.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___75_381.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___75_381.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___75_381.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___75_381.FStar_TypeChecker_Env.try_solve_implicits_hook);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
         FStar_TypeChecker_Env.splice = FStar_Tactics_Hooks.splice;
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___75_381.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess =
-          (uu___75_381.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___75_381.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___75_381.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___75_381.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___75_381.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___75_381.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___75_381.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___75_381.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
     let env4 =
-      let uu___78_383 = env3 in
+      let uu___ = env3 in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___78_383.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___78_383.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___78_383.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___78_383.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___78_383.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___78_383.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___78_383.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___78_383.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___78_383.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___78_383.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___78_383.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___78_383.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___78_383.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___78_383.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___78_383.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___78_383.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___78_383.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___78_383.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___78_383.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___78_383.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___78_383.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___78_383.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___78_383.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___78_383.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___78_383.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___78_383.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___78_383.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___78_383.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___78_383.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___78_383.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___78_383.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___78_383.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___78_383.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___78_383.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___78_383.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___78_383.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___78_383.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___78_383.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess = FStar_Tactics_Hooks.mpreprocess;
         FStar_TypeChecker_Env.postprocess =
-          (uu___78_383.FStar_TypeChecker_Env.postprocess);
+          (uu___.FStar_TypeChecker_Env.postprocess);
         FStar_TypeChecker_Env.identifier_info =
-          (uu___78_383.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___78_383.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___78_383.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___78_383.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___78_383.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___78_383.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___78_383.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
     let env5 =
-      let uu___81_385 = env4 in
+      let uu___ = env4 in
       {
-        FStar_TypeChecker_Env.solver =
-          (uu___81_385.FStar_TypeChecker_Env.solver);
-        FStar_TypeChecker_Env.range =
-          (uu___81_385.FStar_TypeChecker_Env.range);
+        FStar_TypeChecker_Env.solver = (uu___.FStar_TypeChecker_Env.solver);
+        FStar_TypeChecker_Env.range = (uu___.FStar_TypeChecker_Env.range);
         FStar_TypeChecker_Env.curmodule =
-          (uu___81_385.FStar_TypeChecker_Env.curmodule);
-        FStar_TypeChecker_Env.gamma =
-          (uu___81_385.FStar_TypeChecker_Env.gamma);
+          (uu___.FStar_TypeChecker_Env.curmodule);
+        FStar_TypeChecker_Env.gamma = (uu___.FStar_TypeChecker_Env.gamma);
         FStar_TypeChecker_Env.gamma_sig =
-          (uu___81_385.FStar_TypeChecker_Env.gamma_sig);
+          (uu___.FStar_TypeChecker_Env.gamma_sig);
         FStar_TypeChecker_Env.gamma_cache =
-          (uu___81_385.FStar_TypeChecker_Env.gamma_cache);
-        FStar_TypeChecker_Env.modules =
-          (uu___81_385.FStar_TypeChecker_Env.modules);
+          (uu___.FStar_TypeChecker_Env.gamma_cache);
+        FStar_TypeChecker_Env.modules = (uu___.FStar_TypeChecker_Env.modules);
         FStar_TypeChecker_Env.expected_typ =
-          (uu___81_385.FStar_TypeChecker_Env.expected_typ);
-        FStar_TypeChecker_Env.sigtab =
-          (uu___81_385.FStar_TypeChecker_Env.sigtab);
-        FStar_TypeChecker_Env.attrtab =
-          (uu___81_385.FStar_TypeChecker_Env.attrtab);
+          (uu___.FStar_TypeChecker_Env.expected_typ);
+        FStar_TypeChecker_Env.sigtab = (uu___.FStar_TypeChecker_Env.sigtab);
+        FStar_TypeChecker_Env.attrtab = (uu___.FStar_TypeChecker_Env.attrtab);
         FStar_TypeChecker_Env.instantiate_imp =
-          (uu___81_385.FStar_TypeChecker_Env.instantiate_imp);
-        FStar_TypeChecker_Env.effects =
-          (uu___81_385.FStar_TypeChecker_Env.effects);
+          (uu___.FStar_TypeChecker_Env.instantiate_imp);
+        FStar_TypeChecker_Env.effects = (uu___.FStar_TypeChecker_Env.effects);
         FStar_TypeChecker_Env.generalize =
-          (uu___81_385.FStar_TypeChecker_Env.generalize);
-        FStar_TypeChecker_Env.letrecs =
-          (uu___81_385.FStar_TypeChecker_Env.letrecs);
+          (uu___.FStar_TypeChecker_Env.generalize);
+        FStar_TypeChecker_Env.letrecs = (uu___.FStar_TypeChecker_Env.letrecs);
         FStar_TypeChecker_Env.top_level =
-          (uu___81_385.FStar_TypeChecker_Env.top_level);
+          (uu___.FStar_TypeChecker_Env.top_level);
         FStar_TypeChecker_Env.check_uvars =
-          (uu___81_385.FStar_TypeChecker_Env.check_uvars);
-        FStar_TypeChecker_Env.use_eq =
-          (uu___81_385.FStar_TypeChecker_Env.use_eq);
+          (uu___.FStar_TypeChecker_Env.check_uvars);
+        FStar_TypeChecker_Env.use_eq = (uu___.FStar_TypeChecker_Env.use_eq);
         FStar_TypeChecker_Env.use_eq_strict =
-          (uu___81_385.FStar_TypeChecker_Env.use_eq_strict);
+          (uu___.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface =
-          (uu___81_385.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit =
-          (uu___81_385.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___81_385.FStar_TypeChecker_Env.lax);
+          (uu___.FStar_TypeChecker_Env.is_iface);
+        FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
+        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
-          (uu___81_385.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 =
-          (uu___81_385.FStar_TypeChecker_Env.phase1);
+          (uu___.FStar_TypeChecker_Env.lax_universes);
+        FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
         FStar_TypeChecker_Env.failhard =
-          (uu___81_385.FStar_TypeChecker_Env.failhard);
-        FStar_TypeChecker_Env.nosynth =
-          (uu___81_385.FStar_TypeChecker_Env.nosynth);
+          (uu___.FStar_TypeChecker_Env.failhard);
+        FStar_TypeChecker_Env.nosynth = (uu___.FStar_TypeChecker_Env.nosynth);
         FStar_TypeChecker_Env.uvar_subtyping =
-          (uu___81_385.FStar_TypeChecker_Env.uvar_subtyping);
-        FStar_TypeChecker_Env.tc_term =
-          (uu___81_385.FStar_TypeChecker_Env.tc_term);
-        FStar_TypeChecker_Env.type_of =
-          (uu___81_385.FStar_TypeChecker_Env.type_of);
+          (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+        FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
+        FStar_TypeChecker_Env.type_of = (uu___.FStar_TypeChecker_Env.type_of);
         FStar_TypeChecker_Env.universe_of =
-          (uu___81_385.FStar_TypeChecker_Env.universe_of);
+          (uu___.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.check_type_of =
-          (uu___81_385.FStar_TypeChecker_Env.check_type_of);
+          (uu___.FStar_TypeChecker_Env.check_type_of);
         FStar_TypeChecker_Env.use_bv_sorts =
-          (uu___81_385.FStar_TypeChecker_Env.use_bv_sorts);
+          (uu___.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
-          (uu___81_385.FStar_TypeChecker_Env.qtbl_name_and_index);
+          (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
         FStar_TypeChecker_Env.normalized_eff_names =
-          (uu___81_385.FStar_TypeChecker_Env.normalized_eff_names);
+          (uu___.FStar_TypeChecker_Env.normalized_eff_names);
         FStar_TypeChecker_Env.fv_delta_depths =
-          (uu___81_385.FStar_TypeChecker_Env.fv_delta_depths);
+          (uu___.FStar_TypeChecker_Env.fv_delta_depths);
         FStar_TypeChecker_Env.proof_ns =
-          (uu___81_385.FStar_TypeChecker_Env.proof_ns);
+          (uu___.FStar_TypeChecker_Env.proof_ns);
         FStar_TypeChecker_Env.synth_hook =
-          (uu___81_385.FStar_TypeChecker_Env.synth_hook);
+          (uu___.FStar_TypeChecker_Env.synth_hook);
         FStar_TypeChecker_Env.try_solve_implicits_hook =
-          (uu___81_385.FStar_TypeChecker_Env.try_solve_implicits_hook);
-        FStar_TypeChecker_Env.splice =
-          (uu___81_385.FStar_TypeChecker_Env.splice);
+          (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+        FStar_TypeChecker_Env.splice = (uu___.FStar_TypeChecker_Env.splice);
         FStar_TypeChecker_Env.mpreprocess =
-          (uu___81_385.FStar_TypeChecker_Env.mpreprocess);
+          (uu___.FStar_TypeChecker_Env.mpreprocess);
         FStar_TypeChecker_Env.postprocess = FStar_Tactics_Hooks.postprocess;
         FStar_TypeChecker_Env.identifier_info =
-          (uu___81_385.FStar_TypeChecker_Env.identifier_info);
+          (uu___.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks =
-          (uu___81_385.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv =
-          (uu___81_385.FStar_TypeChecker_Env.dsenv);
-        FStar_TypeChecker_Env.nbe = (uu___81_385.FStar_TypeChecker_Env.nbe);
+          (uu___.FStar_TypeChecker_Env.tc_hooks);
+        FStar_TypeChecker_Env.dsenv = (uu___.FStar_TypeChecker_Env.dsenv);
+        FStar_TypeChecker_Env.nbe = (uu___.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
-          (uu___81_385.FStar_TypeChecker_Env.strict_args_tab);
+          (uu___.FStar_TypeChecker_Env.strict_args_tab);
         FStar_TypeChecker_Env.erasable_types_tab =
-          (uu___81_385.FStar_TypeChecker_Env.erasable_types_tab);
+          (uu___.FStar_TypeChecker_Env.erasable_types_tab);
         FStar_TypeChecker_Env.enable_defer_to_tac =
-          (uu___81_385.FStar_TypeChecker_Env.enable_defer_to_tac)
+          (uu___.FStar_TypeChecker_Env.enable_defer_to_tac)
       } in
     (env5.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env5; env5
 let (tc_one_fragment :
@@ -732,130 +644,128 @@ let (tc_one_fragment :
     fun env ->
       fun frag ->
         let fname env1 =
-          let uu____418 = FStar_Options.lsp_server () in
-          if uu____418
+          let uu___ = FStar_Options.lsp_server () in
+          if uu___
           then
-            let uu____419 = FStar_TypeChecker_Env.get_range env1 in
-            FStar_Range.file_of_range uu____419
+            let uu___1 = FStar_TypeChecker_Env.get_range env1 in
+            FStar_Range.file_of_range uu___1
           else
-            (let uu____421 = FStar_Options.file_list () in
-             FStar_List.hd uu____421) in
+            (let uu___2 = FStar_Options.file_list () in FStar_List.hd uu___2) in
         let acceptable_mod_name modul =
-          let uu____430 =
-            let uu____431 = fname env in
-            FStar_Parser_Dep.lowercase_module_name uu____431 in
-          let uu____432 =
-            let uu____433 =
+          let uu___ =
+            let uu___1 = fname env in
+            FStar_Parser_Dep.lowercase_module_name uu___1 in
+          let uu___1 =
+            let uu___2 =
               FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-            FStar_String.lowercase uu____433 in
-          uu____430 = uu____432 in
+            FStar_String.lowercase uu___2 in
+          uu___ = uu___1 in
         let range_of_first_mod_decl modul =
           match modul with
           | FStar_Parser_AST.Module
-              (uu____440,
-               { FStar_Parser_AST.d = uu____441; FStar_Parser_AST.drange = d;
-                 FStar_Parser_AST.quals = uu____443;
-                 FStar_Parser_AST.attrs = uu____444;_}::uu____445)
+              (uu___,
+               { FStar_Parser_AST.d = uu___1; FStar_Parser_AST.drange = d;
+                 FStar_Parser_AST.quals = uu___2;
+                 FStar_Parser_AST.attrs = uu___3;_}::uu___4)
               -> d
           | FStar_Parser_AST.Interface
-              (uu____450,
-               { FStar_Parser_AST.d = uu____451; FStar_Parser_AST.drange = d;
-                 FStar_Parser_AST.quals = uu____453;
-                 FStar_Parser_AST.attrs = uu____454;_}::uu____455,
-               uu____456)
+              (uu___,
+               { FStar_Parser_AST.d = uu___1; FStar_Parser_AST.drange = d;
+                 FStar_Parser_AST.quals = uu___2;
+                 FStar_Parser_AST.attrs = uu___3;_}::uu___4,
+               uu___5)
               -> d
-          | uu____461 -> FStar_Range.dummyRange in
-        let uu____462 = FStar_Parser_Driver.parse_fragment frag in
-        match uu____462 with
+          | uu___ -> FStar_Range.dummyRange in
+        let uu___ = FStar_Parser_Driver.parse_fragment frag in
+        match uu___ with
         | FStar_Parser_Driver.Empty -> (curmod, env)
         | FStar_Parser_Driver.Decls [] -> (curmod, env)
         | FStar_Parser_Driver.Modul ast_modul ->
-            let uu____474 =
-              let uu____479 =
+            let uu___1 =
+              let uu___2 =
                 FStar_ToSyntax_Interleave.interleave_module ast_modul false in
-              FStar_All.pipe_left (with_dsenv_of_tcenv env) uu____479 in
-            (match uu____474 with
+              FStar_All.pipe_left (with_dsenv_of_tcenv env) uu___2 in
+            (match uu___1 with
              | (ast_modul1, env1) ->
-                 let uu____499 =
-                   let uu____504 =
+                 let uu___2 =
+                   let uu___3 =
                      FStar_ToSyntax_ToSyntax.partial_ast_modul_to_modul
                        curmod ast_modul1 in
-                   FStar_All.pipe_left (with_dsenv_of_tcenv env1) uu____504 in
-                 (match uu____499 with
+                   FStar_All.pipe_left (with_dsenv_of_tcenv env1) uu___3 in
+                 (match uu___2 with
                   | (modul, env2) ->
-                      ((let uu____525 =
-                          let uu____526 = acceptable_mod_name modul in
-                          Prims.op_Negation uu____526 in
-                        if uu____525
+                      ((let uu___4 =
+                          let uu___5 = acceptable_mod_name modul in
+                          Prims.op_Negation uu___5 in
+                        if uu___4
                         then
                           let msg =
-                            let uu____528 =
-                              let uu____529 = fname env2 in
-                              FStar_Parser_Dep.module_name_of_file uu____529 in
+                            let uu___5 =
+                              let uu___6 = fname env2 in
+                              FStar_Parser_Dep.module_name_of_file uu___6 in
                             FStar_Util.format1
                               "Interactive mode only supports a single module at the top-level. Expected module %s"
-                              uu____528 in
+                              uu___5 in
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_NonSingletonTopLevelModule,
                               msg) (range_of_first_mod_decl ast_modul1)
                         else ());
-                       (let uu____531 =
-                          let uu____536 =
+                       (let uu___4 =
+                          let uu___5 =
                             FStar_Syntax_DsEnv.syntax_only
                               env2.FStar_TypeChecker_Env.dsenv in
-                          if uu____536
+                          if uu___5
                           then (modul, env2)
                           else
                             FStar_TypeChecker_Tc.tc_partial_modul env2 modul in
-                        match uu____531 with
+                        match uu___4 with
                         | (modul1, env3) ->
                             ((FStar_Pervasives_Native.Some modul1), env3)))))
         | FStar_Parser_Driver.Decls ast_decls ->
             (match curmod with
              | FStar_Pervasives_Native.None ->
-                 let uu____561 = FStar_List.hd ast_decls in
-                 (match uu____561 with
-                  | { FStar_Parser_AST.d = uu____568;
+                 let uu___1 = FStar_List.hd ast_decls in
+                 (match uu___1 with
+                  | { FStar_Parser_AST.d = uu___2;
                       FStar_Parser_AST.drange = rng;
-                      FStar_Parser_AST.quals = uu____570;
-                      FStar_Parser_AST.attrs = uu____571;_} ->
+                      FStar_Parser_AST.quals = uu___3;
+                      FStar_Parser_AST.attrs = uu___4;_} ->
                       FStar_Errors.raise_error
                         (FStar_Errors.Fatal_ModuleFirstStatement,
                           "First statement must be a module declaration") rng)
              | FStar_Pervasives_Native.Some modul ->
-                 let uu____579 =
+                 let uu___1 =
                    FStar_Util.fold_map
                      (fun env1 ->
                         fun a_decl ->
-                          let uu____597 =
-                            let uu____604 =
+                          let uu___2 =
+                            let uu___3 =
                               FStar_ToSyntax_Interleave.prefix_with_interface_decls
                                 modul.FStar_Syntax_Syntax.name a_decl in
                             FStar_All.pipe_left (with_dsenv_of_tcenv env1)
-                              uu____604 in
-                          match uu____597 with
-                          | (decls, env2) -> (env2, decls)) env ast_decls in
-                 (match uu____579 with
+                              uu___3 in
+                          match uu___2 with | (decls, env2) -> (env2, decls))
+                     env ast_decls in
+                 (match uu___1 with
                   | (env1, ast_decls_l) ->
-                      let uu____654 =
-                        let uu____659 =
+                      let uu___2 =
+                        let uu___3 =
                           FStar_ToSyntax_ToSyntax.decls_to_sigelts
                             (FStar_List.flatten ast_decls_l) in
-                        FStar_All.pipe_left (with_dsenv_of_tcenv env1)
-                          uu____659 in
-                      (match uu____654 with
+                        FStar_All.pipe_left (with_dsenv_of_tcenv env1) uu___3 in
+                      (match uu___2 with
                        | (sigelts, env2) ->
-                           let uu____679 =
-                             let uu____688 =
+                           let uu___3 =
+                             let uu___4 =
                                FStar_Syntax_DsEnv.syntax_only
                                  env2.FStar_TypeChecker_Env.dsenv in
-                             if uu____688
+                             if uu___4
                              then (modul, [], env2)
                              else
                                FStar_TypeChecker_Tc.tc_more_partial_modul
                                  env2 modul sigelts in
-                           (match uu____679 with
-                            | (modul1, uu____707, env3) ->
+                           (match uu___3 with
+                            | (modul1, uu___4, env3) ->
                                 ((FStar_Pervasives_Native.Some modul1), env3)))))
 let (load_interface_decls :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env_t) =
@@ -866,25 +776,25 @@ let (load_interface_decls :
           (FStar_Parser_ParseIt.Filename interface_file_name) in
       match r with
       | FStar_Parser_ParseIt.ASTFragment
-          (FStar_Util.Inl (FStar_Parser_AST.Interface (l, decls, uu____728)),
-           uu____729)
+          (FStar_Util.Inl (FStar_Parser_AST.Interface (l, decls, uu___)),
+           uu___1)
           ->
-          let uu____748 =
-            let uu____753 =
+          let uu___2 =
+            let uu___3 =
               FStar_ToSyntax_Interleave.initialize_interface l decls in
-            FStar_All.pipe_left (with_dsenv_of_tcenv env) uu____753 in
-          FStar_Pervasives_Native.snd uu____748
-      | FStar_Parser_ParseIt.ASTFragment uu____765 ->
-          let uu____776 =
-            let uu____781 =
+            FStar_All.pipe_left (with_dsenv_of_tcenv env) uu___3 in
+          FStar_Pervasives_Native.snd uu___2
+      | FStar_Parser_ParseIt.ASTFragment uu___ ->
+          let uu___1 =
+            let uu___2 =
               FStar_Util.format1
                 "Unexpected result from parsing %s; expected a single interface"
                 interface_file_name in
-            (FStar_Errors.Fatal_ParseErrors, uu____781) in
-          FStar_Errors.raise_err uu____776
+            (FStar_Errors.Fatal_ParseErrors, uu___2) in
+          FStar_Errors.raise_err uu___1
       | FStar_Parser_ParseIt.ParseError (err, msg, rng) ->
           FStar_Exn.raise (FStar_Errors.Error (err, msg, rng))
-      | FStar_Parser_ParseIt.Term uu____785 ->
+      | FStar_Parser_ParseIt.Term uu___ ->
           failwith
             "Impossible: parsing a Toplevel always results in an ASTFragment"
 let (emit : FStar_Extraction_ML_Syntax.mllib Prims.list -> unit) =
@@ -898,7 +808,7 @@ let (emit : FStar_Extraction_ML_Syntax.mllib Prims.list -> unit) =
         | FStar_Pervasives_Native.Some (FStar_Options.OCaml) -> ".ml"
         | FStar_Pervasives_Native.Some (FStar_Options.Plugin) -> ".ml"
         | FStar_Pervasives_Native.Some (FStar_Options.Kremlin) -> ".krml"
-        | uu____801 -> failwith "Unrecognized option" in
+        | uu___ -> failwith "Unrecognized option" in
       match opt with
       | FStar_Pervasives_Native.Some (FStar_Options.FSharp) ->
           let outdir = FStar_Options.output_dir () in
@@ -917,14 +827,14 @@ let (emit : FStar_Extraction_ML_Syntax.mllib Prims.list -> unit) =
             FStar_List.collect FStar_Extraction_Kremlin.translate mllibs in
           let bin = (FStar_Extraction_Kremlin.current_version, programs) in
           (match programs with
-           | (name, uu____820)::[] ->
-               let uu____821 =
+           | (name, uu___)::[] ->
+               let uu___1 =
                  FStar_Options.prepend_output_dir (Prims.op_Hat name ext) in
-               FStar_Util.save_value_to_file uu____821 bin
-           | uu____822 ->
-               let uu____825 = FStar_Options.prepend_output_dir "out.krml" in
-               FStar_Util.save_value_to_file uu____825 bin)
-      | uu____826 -> failwith "Unrecognized option"
+               FStar_Util.save_value_to_file uu___1 bin
+           | uu___ ->
+               let uu___1 = FStar_Options.prepend_output_dir "out.krml" in
+               FStar_Util.save_value_to_file uu___1 bin)
+      | uu___ -> failwith "Unrecognized option"
     else ()
 let (tc_one_file :
   uenv ->
@@ -939,105 +849,103 @@ let (tc_one_file :
       fun fn ->
         fun parsing_data ->
           FStar_Ident.reset_gensym ();
-          (let maybe_restore_opts uu____876 =
-             let uu____877 =
-               let uu____878 = FStar_Options.interactive () in
-               Prims.op_Negation uu____878 in
-             if uu____877
+          (let maybe_restore_opts uu___1 =
+             let uu___2 =
+               let uu___3 = FStar_Options.interactive () in
+               Prims.op_Negation uu___3 in
+             if uu___2
              then
-               let uu____879 = FStar_Options.restore_cmd_line_options true in
-               FStar_All.pipe_right uu____879 (fun uu____880 -> ())
+               let uu___3 = FStar_Options.restore_cmd_line_options true in
+               FStar_All.pipe_right uu___3 (fun uu___4 -> ())
              else () in
-           let post_smt_encoding uu____887 = FStar_SMTEncoding_Z3.refresh () in
+           let post_smt_encoding uu___1 = FStar_SMTEncoding_Z3.refresh () in
            let maybe_extract_mldefs tcmod env1 =
-             let uu____905 =
-               (let uu____908 = FStar_Options.codegen () in
-                uu____908 = FStar_Pervasives_Native.None) ||
-                 (let uu____914 =
-                    let uu____915 =
+             let uu___1 =
+               (let uu___2 = FStar_Options.codegen () in
+                uu___2 = FStar_Pervasives_Native.None) ||
+                 (let uu___2 =
+                    let uu___3 =
                       FStar_Ident.string_of_lid
                         tcmod.FStar_Syntax_Syntax.name in
-                    FStar_Options.should_extract uu____915 in
-                  Prims.op_Negation uu____914) in
-             if uu____905
+                    FStar_Options.should_extract uu___3 in
+                  Prims.op_Negation uu___2) in
+             if uu___1
              then (FStar_Pervasives_Native.None, Prims.int_zero)
              else
                FStar_Util.record_time
-                 (fun uu____928 ->
+                 (fun uu___3 ->
                     with_env env1
                       (fun env2 ->
-                         let uu____936 =
+                         let uu___4 =
                            FStar_Extraction_ML_Modul.extract env2 tcmod in
-                         match uu____936 with | (uu____945, defs) -> defs)) in
+                         match uu___4 with | (uu___5, defs) -> defs)) in
            let maybe_extract_ml_iface tcmod env1 =
-             let uu____966 =
-               let uu____967 = FStar_Options.codegen () in
-               uu____967 = FStar_Pervasives_Native.None in
-             if uu____966
+             let uu___1 =
+               let uu___2 = FStar_Options.codegen () in
+               uu___2 = FStar_Pervasives_Native.None in
+             if uu___1
              then (env1, Prims.int_zero)
              else
                FStar_Util.record_time
-                 (fun uu____981 ->
-                    let uu____982 =
+                 (fun uu___3 ->
+                    let uu___4 =
                       with_env env1
                         (fun env2 ->
                            FStar_Extraction_ML_Modul.extract_iface env2 tcmod) in
-                    match uu____982 with | (env2, uu____994) -> env2) in
-           let tc_source_file uu____1008 =
-             let uu____1009 = parse env pre_fn fn in
-             match uu____1009 with
+                    match uu___4 with | (env2, uu___5) -> env2) in
+           let tc_source_file uu___1 =
+             let uu___2 = parse env pre_fn fn in
+             match uu___2 with
              | (fmod, env1) ->
                  let mii =
-                   let uu____1025 =
-                     let uu____1026 =
-                       FStar_Extraction_ML_UEnv.tcenv_of_uenv env1 in
-                     uu____1026.FStar_TypeChecker_Env.dsenv in
-                   FStar_Syntax_DsEnv.inclusion_info uu____1025
+                   let uu___3 =
+                     let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env1 in
+                     uu___4.FStar_TypeChecker_Env.dsenv in
+                   FStar_Syntax_DsEnv.inclusion_info uu___3
                      fmod.FStar_Syntax_Syntax.name in
-                 let check_mod uu____1040 =
+                 let check_mod uu___3 =
                    let check env2 =
                      with_tcenv_of_env env2
                        (fun tcenv ->
                           (match tcenv.FStar_TypeChecker_Env.gamma with
                            | [] -> ()
-                           | uu____1080 ->
+                           | uu___5 ->
                                failwith
                                  "Impossible: gamma contains leaked names");
-                          (let uu____1083 =
+                          (let uu___5 =
                              FStar_TypeChecker_Tc.check_module tcenv fmod
                                (FStar_Util.is_some pre_fn) in
-                           match uu____1083 with
+                           match uu___5 with
                            | (modul, env3) ->
                                (maybe_restore_opts ();
                                 (let smt_decls =
-                                   let uu____1112 =
-                                     let uu____1113 = FStar_Options.lax () in
-                                     Prims.op_Negation uu____1113 in
-                                   if uu____1112
+                                   let uu___7 =
+                                     let uu___8 = FStar_Options.lax () in
+                                     Prims.op_Negation uu___8 in
+                                   if uu___7
                                    then
-                                     let smt_decls =
+                                     let smt_decls1 =
                                        FStar_SMTEncoding_Encode.encode_modul
                                          env3 modul in
-                                     (post_smt_encoding (); smt_decls)
+                                     (post_smt_encoding (); smt_decls1)
                                    else ([], []) in
                                  ((modul, smt_decls), env3))))) in
-                   let uu____1147 =
-                     let uu____1162 =
-                       let uu____1165 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_Ident.string_of_lid
                            fmod.FStar_Syntax_Syntax.name in
-                       FStar_Pervasives_Native.Some uu____1165 in
-                     FStar_Profiling.profile (fun uu____1181 -> check env1)
-                       uu____1162 "FStar.Universal.tc_source_file" in
-                   match uu____1147 with
+                       FStar_Pervasives_Native.Some uu___6 in
+                     FStar_Profiling.profile (fun uu___6 -> check env1)
+                       uu___5 "FStar.Universal.tc_source_file" in
+                   match uu___4 with
                    | ((tcmod, smt_decls), env2) ->
                        let tc_time = Prims.int_zero in
-                       let uu____1216 = maybe_extract_mldefs tcmod env2 in
-                       (match uu____1216 with
+                       let uu___5 = maybe_extract_mldefs tcmod env2 in
+                       (match uu___5 with
                         | (extracted_defs, extract_time) ->
-                            let uu____1237 =
-                              maybe_extract_ml_iface tcmod env2 in
-                            (match uu____1237 with
+                            let uu___6 = maybe_extract_ml_iface tcmod env2 in
+                            (match uu___6 with
                              | (env3, iface_extraction_time) ->
                                  ({
                                     FStar_CheckedFiles.checked_module = tcmod;
@@ -1047,71 +955,69 @@ let (tc_one_file :
                                     FStar_CheckedFiles.extraction_time =
                                       (extract_time + iface_extraction_time)
                                   }, extracted_defs, env3))) in
-                 let uu____1254 =
-                   (let uu____1257 =
+                 let uu___3 =
+                   (let uu___4 =
                       FStar_Ident.string_of_lid fmod.FStar_Syntax_Syntax.name in
-                    FStar_Options.should_verify uu____1257) &&
+                    FStar_Options.should_verify uu___4) &&
                      ((FStar_Options.record_hints ()) ||
                         (FStar_Options.use_hints ())) in
-                 if uu____1254
+                 if uu___3
                  then
-                   let uu____1266 = FStar_Parser_ParseIt.find_file fn in
-                   FStar_SMTEncoding_Solver.with_hints_db uu____1266
-                     check_mod
+                   let uu___4 = FStar_Parser_ParseIt.find_file fn in
+                   FStar_SMTEncoding_Solver.with_hints_db uu___4 check_mod
                  else check_mod () in
-           let uu____1276 =
-             let uu____1277 = FStar_Options.cache_off () in
-             Prims.op_Negation uu____1277 in
-           if uu____1276
+           let uu___1 =
+             let uu___2 = FStar_Options.cache_off () in
+             Prims.op_Negation uu___2 in
+           if uu___1
            then
              let r = FStar_CheckedFiles.load_module_from_cache env fn in
              let r1 =
-               let uu____1292 =
+               let uu___2 =
                  (FStar_Options.force ()) &&
                    (FStar_Options.should_check_file fn) in
-               if uu____1292 then FStar_Pervasives_Native.None else r in
+               if uu___2 then FStar_Pervasives_Native.None else r in
              match r1 with
              | FStar_Pervasives_Native.None ->
-                 ((let uu____1305 =
-                     let uu____1306 = FStar_Parser_Dep.module_name_of_file fn in
-                     FStar_Options.should_be_already_cached uu____1306 in
-                   if uu____1305
+                 ((let uu___3 =
+                     let uu___4 = FStar_Parser_Dep.module_name_of_file fn in
+                     FStar_Options.should_be_already_cached uu___4 in
+                   if uu___3
                    then
-                     let uu____1307 =
-                       let uu____1312 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Util.format1
                            "Expected %s to already be checked" fn in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1312) in
-                     FStar_Errors.raise_err uu____1307
+                         uu___5) in
+                     FStar_Errors.raise_err uu___4
                    else ());
-                  (let uu____1315 =
-                     (let uu____1318 = FStar_Options.codegen () in
-                      FStar_Option.isSome uu____1318) &&
-                       (FStar_Options.cmi ()) in
-                   if uu____1315
+                  (let uu___4 =
+                     (let uu___5 = FStar_Options.codegen () in
+                      FStar_Option.isSome uu___5) && (FStar_Options.cmi ()) in
+                   if uu___4
                    then
-                     let uu____1321 =
-                       let uu____1326 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_Util.format1
                            "Cross-module inlining expects all modules to be checked first; %s was not checked"
                            fn in
                        (FStar_Errors.Error_AlreadyCachedAssertionFailure,
-                         uu____1326) in
-                     FStar_Errors.raise_err uu____1321
+                         uu___6) in
+                     FStar_Errors.raise_err uu___5
                    else ());
-                  (let uu____1328 = tc_source_file () in
-                   match uu____1328 with
+                  (let uu___4 = tc_source_file () in
+                   match uu___4 with
                    | (tc_result, mllib, env1) ->
-                       ((let uu____1353 =
-                           (let uu____1356 = FStar_Errors.get_err_count () in
-                            uu____1356 = Prims.int_zero) &&
+                       ((let uu___6 =
+                           (let uu___7 = FStar_Errors.get_err_count () in
+                            uu___7 = Prims.int_zero) &&
                              ((FStar_Options.lax ()) ||
-                                (let uu____1358 =
+                                (let uu___7 =
                                    FStar_Ident.string_of_lid
                                      (tc_result.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name in
-                                 FStar_Options.should_verify uu____1358)) in
-                         if uu____1353
+                                 FStar_Options.should_verify uu___7)) in
+                         if uu___6
                          then
                            FStar_CheckedFiles.store_module_to_cache env1 fn
                              parsing_data tc_result
@@ -1120,36 +1026,34 @@ let (tc_one_file :
              | FStar_Pervasives_Native.Some tc_result ->
                  let tcmod = tc_result.FStar_CheckedFiles.checked_module in
                  let smt_decls = tc_result.FStar_CheckedFiles.smt_decls in
-                 ((let uu____1372 =
-                     let uu____1373 =
+                 ((let uu___3 =
+                     let uu___4 =
                        FStar_Ident.string_of_lid
                          tcmod.FStar_Syntax_Syntax.name in
-                     FStar_Options.dump_module uu____1373 in
-                   if uu____1372
+                     FStar_Options.dump_module uu___4 in
+                   if uu___3
                    then
-                     let uu____1374 =
-                       FStar_Syntax_Print.modul_to_string tcmod in
+                     let uu___4 = FStar_Syntax_Print.modul_to_string tcmod in
                      FStar_Util.print1 "Module after type checking:\n%s\n"
-                       uu____1374
+                       uu___4
                    else ());
                   (let extend_tcenv tcmod1 tcenv =
-                     let uu____1391 =
-                       let uu____1396 =
+                     let uu___3 =
+                       let uu___4 =
                          FStar_ToSyntax_ToSyntax.add_modul_to_env tcmod1
                            tc_result.FStar_CheckedFiles.mii
                            (FStar_TypeChecker_Normalize.erase_universes tcenv) in
-                       FStar_All.pipe_left (with_dsenv_of_tcenv tcenv)
-                         uu____1396 in
-                     match uu____1391 with
-                     | (uu____1412, tcenv1) ->
+                       FStar_All.pipe_left (with_dsenv_of_tcenv tcenv) uu___4 in
+                     match uu___3 with
+                     | (uu___4, tcenv1) ->
                          let env1 =
                            FStar_TypeChecker_Tc.load_checked_module tcenv1
                              tcmod1 in
                          (maybe_restore_opts ();
-                          (let uu____1417 =
-                             let uu____1418 = FStar_Options.lax () in
-                             Prims.op_Negation uu____1418 in
-                           if uu____1417
+                          (let uu___7 =
+                             let uu___8 = FStar_Options.lax () in
+                             Prims.op_Negation uu___8 in
+                           if uu___7
                            then
                              (FStar_SMTEncoding_Encode.encode_modul_from_cache
                                 env1 tcmod1 smt_decls;
@@ -1158,41 +1062,41 @@ let (tc_one_file :
                           ((), env1)) in
                    let env1 =
                      FStar_Profiling.profile
-                       (fun uu____1424 ->
-                          let uu____1425 =
+                       (fun uu___3 ->
+                          let uu___4 =
                             with_tcenv_of_env env (extend_tcenv tcmod) in
-                          FStar_All.pipe_right uu____1425
+                          FStar_All.pipe_right uu___4
                             FStar_Pervasives_Native.snd)
                        FStar_Pervasives_Native.None
                        "FStar.Universal.extend_tcenv" in
                    let mllib =
-                     let uu____1437 =
-                       ((let uu____1440 = FStar_Options.codegen () in
-                         uu____1440 <> FStar_Pervasives_Native.None) &&
-                          (let uu____1446 =
+                     let uu___3 =
+                       ((let uu___4 = FStar_Options.codegen () in
+                         uu___4 <> FStar_Pervasives_Native.None) &&
+                          (let uu___4 =
                              FStar_Ident.string_of_lid
                                tcmod.FStar_Syntax_Syntax.name in
-                           FStar_Options.should_extract uu____1446))
+                           FStar_Options.should_extract uu___4))
                          &&
                          ((Prims.op_Negation
                              tcmod.FStar_Syntax_Syntax.is_interface)
                             ||
-                            (let uu____1448 = FStar_Options.codegen () in
-                             uu____1448 =
+                            (let uu___4 = FStar_Options.codegen () in
+                             uu___4 =
                                (FStar_Pervasives_Native.Some
                                   FStar_Options.Kremlin))) in
-                     if uu____1437
+                     if uu___3
                      then
-                       let uu____1455 = maybe_extract_mldefs tcmod env1 in
-                       match uu____1455 with
+                       let uu___4 = maybe_extract_mldefs tcmod env1 in
+                       match uu___4 with
                        | (extracted_defs, _extraction_time) -> extracted_defs
                      else FStar_Pervasives_Native.None in
-                   let uu____1471 = maybe_extract_ml_iface tcmod env1 in
-                   match uu____1471 with
+                   let uu___3 = maybe_extract_ml_iface tcmod env1 in
+                   match uu___3 with
                    | (env2, _time) -> (tc_result, mllib, env2)))
            else
-             (let uu____1489 = tc_source_file () in
-              match uu____1489 with
+             (let uu___3 = tc_source_file () in
+              match uu___3 with
               | (tc_result, mllib, env1) -> (tc_result, mllib, env1)))
 let (tc_one_file_for_ide :
   FStar_TypeChecker_Env.env_t ->
@@ -1206,22 +1110,22 @@ let (tc_one_file_for_ide :
       fun fn ->
         fun parsing_data ->
           let env1 = env_of_tcenv env in
-          let uu____1548 = tc_one_file env1 pre_fn fn parsing_data in
-          match uu____1548 with
-          | (tc_result, uu____1562, env2) ->
-              let uu____1568 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env2 in
-              (tc_result, uu____1568)
+          let uu___ = tc_one_file env1 pre_fn fn parsing_data in
+          match uu___ with
+          | (tc_result, uu___1, env2) ->
+              let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env2 in
+              (tc_result, uu___2)
 let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
   fun intf ->
     fun impl ->
       let m1 = FStar_Parser_Dep.lowercase_module_name intf in
       let m2 = FStar_Parser_Dep.lowercase_module_name impl in
       ((m1 = m2) &&
-         (let uu____1582 = FStar_Util.get_file_extension intf in
-          FStar_List.mem uu____1582 ["fsti"; "fsi"]))
+         (let uu___ = FStar_Util.get_file_extension intf in
+          FStar_List.mem uu___ ["fsti"; "fsi"]))
         &&
-        (let uu____1584 = FStar_Util.get_file_extension impl in
-         FStar_List.mem uu____1584 ["fst"; "fs"])
+        (let uu___ = FStar_Util.get_file_extension impl in
+         FStar_List.mem uu___ ["fst"; "fs"])
 let (tc_one_file_from_remaining :
   Prims.string Prims.list ->
     uenv ->
@@ -1233,28 +1137,28 @@ let (tc_one_file_from_remaining :
   fun remaining ->
     fun env ->
       fun deps ->
-        let uu____1616 =
+        let uu___ =
           match remaining with
           | intf::impl::remaining1 when needs_interleaving intf impl ->
-              let uu____1650 =
-                let uu____1659 =
+              let uu___1 =
+                let uu___2 =
                   FStar_All.pipe_right impl
                     (FStar_Parser_Dep.parsing_data_of deps) in
                 tc_one_file env (FStar_Pervasives_Native.Some intf) impl
-                  uu____1659 in
-              (match uu____1650 with
+                  uu___2 in
+              (match uu___1 with
                | (m, mllib, env1) -> (remaining1, (m, mllib, env1)))
           | intf_or_impl::remaining1 ->
-              let uu____1697 =
-                let uu____1706 =
+              let uu___1 =
+                let uu___2 =
                   FStar_All.pipe_right intf_or_impl
                     (FStar_Parser_Dep.parsing_data_of deps) in
                 tc_one_file env FStar_Pervasives_Native.None intf_or_impl
-                  uu____1706 in
-              (match uu____1697 with
+                  uu___2 in
+              (match uu___1 with
                | (m, mllib, env1) -> (remaining1, (m, mllib, env1)))
           | [] -> failwith "Impossible: Empty remaining modules" in
-        match uu____1616 with
+        match uu___ with
         | (remaining1, (nmods, mllib, env1)) ->
             (remaining1, nmods, mllib, env1)
 let rec (tc_fold_interleave :
@@ -1268,30 +1172,29 @@ let rec (tc_fold_interleave :
   fun deps ->
     fun acc ->
       fun remaining ->
-        let as_list uu___0_1848 =
-          match uu___0_1848 with
+        let as_list uu___ =
+          match uu___ with
           | FStar_Pervasives_Native.None -> []
           | FStar_Pervasives_Native.Some l -> [l] in
         match remaining with
         | [] -> acc
-        | uu____1864 ->
-            let uu____1867 = acc in
-            (match uu____1867 with
+        | uu___ ->
+            let uu___1 = acc in
+            (match uu___1 with
              | (mods, mllibs, env) ->
-                 let uu____1899 =
-                   tc_one_file_from_remaining remaining env deps in
-                 (match uu____1899 with
+                 let uu___2 = tc_one_file_from_remaining remaining env deps in
+                 (match uu___2 with
                   | (remaining1, nmod, mllib, env1) ->
-                      ((let uu____1935 =
-                          let uu____1936 =
+                      ((let uu___4 =
+                          let uu___5 =
                             FStar_Options.profile_group_by_decls () in
-                          Prims.op_Negation uu____1936 in
-                        if uu____1935
+                          Prims.op_Negation uu___5 in
+                        if uu___4
                         then
-                          let uu____1937 =
+                          let uu___5 =
                             FStar_Ident.string_of_lid
                               (nmod.FStar_CheckedFiles.checked_module).FStar_Syntax_Syntax.name in
-                          FStar_Profiling.report_and_clear uu____1937
+                          FStar_Profiling.report_and_clear uu___5
                         else ());
                        tc_fold_interleave deps
                          ((FStar_List.append mods [nmod]),
@@ -1304,38 +1207,38 @@ let (batch_mode_tc :
   =
   fun filenames ->
     fun dep_graph ->
-      (let uu____1969 =
+      (let uu___1 =
          FStar_Options.debug_at_level_no_module (FStar_Options.Other "Dep") in
-       if uu____1969
+       if uu___1
        then
          (FStar_Util.print_endline "Auto-deps kicked in; here's some info.";
           FStar_Util.print1
             "Here's the list of filenames we will process: %s\n"
             (FStar_String.concat " " filenames);
-          (let uu____1972 =
-             let uu____1973 =
+          (let uu___4 =
+             let uu___5 =
                FStar_All.pipe_right filenames
                  (FStar_List.filter FStar_Options.should_verify_file) in
-             FStar_String.concat " " uu____1973 in
+             FStar_String.concat " " uu___5 in
            FStar_Util.print1
-             "Here's the list of modules we will verify: %s\n" uu____1972))
+             "Here's the list of modules we will verify: %s\n" uu___4))
        else ());
       (let env =
-         let uu____1982 = init_env dep_graph in
-         FStar_Extraction_ML_UEnv.new_uenv uu____1982 in
-       let uu____1983 = tc_fold_interleave dep_graph ([], [], env) filenames in
-       match uu____1983 with
+         let uu___1 = init_env dep_graph in
+         FStar_Extraction_ML_UEnv.new_uenv uu___1 in
+       let uu___1 = tc_fold_interleave dep_graph ([], [], env) filenames in
+       match uu___1 with
        | (all_mods, mllibs, env1) ->
            (emit mllibs;
             (let solver_refresh env2 =
-               let uu____2027 =
+               let uu___3 =
                  with_tcenv_of_env env2
                    (fun tcenv ->
-                      (let uu____2036 =
+                      (let uu___5 =
                          (FStar_Options.interactive ()) &&
-                           (let uu____2038 = FStar_Errors.get_err_count () in
-                            uu____2038 = Prims.int_zero) in
-                       if uu____2036
+                           (let uu___6 = FStar_Errors.get_err_count () in
+                            uu___6 = Prims.int_zero) in
+                       if uu___5
                        then
                          (tcenv.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
                            ()
@@ -1343,5 +1246,5 @@ let (batch_mode_tc :
                          (tcenv.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.finish
                            ());
                       ((), tcenv)) in
-               FStar_All.pipe_left FStar_Pervasives_Native.snd uu____2027 in
+               FStar_All.pipe_left FStar_Pervasives_Native.snd uu___3 in
              (all_mods, env1, solver_refresh))))

--- a/tests/bug-reports/Bug310.ml.expected
+++ b/tests/bug-reports/Bug310.ml.expected
@@ -5,12 +5,11 @@ let (struct11 : Prims.int) = (Prims.of_int (2))
 let (test : (Prims.int * Prims.int)) =
   let x = Prims.int_zero in let x1 = (Prims.of_int (2)) in (x, x1)
 let (r : unit -> unit -> (Obj.t -> Obj.t) -> Prims.int) =
-  fun uu____986 -> fun uu____987 -> fun uu____988 -> Prims.int_zero
+  fun uu___ -> fun uu___1 -> fun uu___2 -> Prims.int_zero
 let (g : Prims.int -> Prims.int -> Prims.int) =
-  fun uu____1001 -> fun uu____1002 -> Prims.int_zero
+  fun uu___ -> fun uu___1 -> Prims.int_zero
 let (ko : Prims.int -> Prims.int) =
-  fun a ->
-    let a1 = a in r () () (fun uu____1011 -> (Obj.magic (g a1)) uu____1011)
+  fun a -> let a1 = a in r () () (fun uu___ -> (Obj.magic (g a1)) uu___)
 type record_t = {
   struct1: Prims.int ;
   constraint1: Prims.bool }


### PR DESCRIPTION
Pasting commit message below. I think this change is correct given the recent changes to name generation for extraction by Nik. Having this change means snapshot diffs will be a lot smaller and actually readable, so I'd be super happy to have this. I think it will also impact C code generation, since many internal variables end up appearing there. Having more concise names and less noise would be good IMO, but curious to hear @protz's opinion. I also don't know if Kremlin/vale have any assumption on these names.

The one downside I can think of is that, now, while reading a piece of code, one might have to mentally do name resolution in order to find the binding occurrence of a variable, but I don't think it's so bad, especially since extraction will always avoid shadowing.

----------------------


extraction: make name generation gensym independent

Do not use the .index field of BVs: this only adds noise, and a lot of
it. The extraction mechanism already takes care to avoid name clashing,
so anything we pick here will be correct. Making it independent of the
index also means we have way smaller snapshot diffs, which can then
actually be read and audited. I tested this with a small change in
FStar.Errors:

```diff
diff --git a/src/basic/FStar.Errors.fs b/src/basic/FStar.Errors.fs
index 2a685f911a..90b1a034ee 100644
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -24,6 +24,9 @@ type error_flag =
                     //          then can be silenced or escalated to errors
   | CSilent         //CSilent: never the default for any issue, but warnings can be silenced

+type something_new<'a> =
+  | MakeNew of 'a * int
+
 type raw_error =
   | Error_DependencyAnalysisFailed
   | Error_IDETooManyPops
```

And, after this patch, got this full diff:
```diff
diff --git a/src/ocaml-output/FStar_Errors.ml b/src/ocaml-output/FStar_Errors.ml
index 7d699d681d..4d7f3165ae 100644
--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -22,6 +22,12 @@ let (uu___is_CWarning : error_flag -> Prims.bool) =
   fun projectee -> match projectee with | CWarning -> true | u -> false
 let (uu___is_CSilent : error_flag -> Prims.bool) =
   fun projectee -> match projectee with | CSilent -> true | u -> false
+type 'a something_new =
+  | MakeNew of ('a * Prims.int)
+let uu___is_MakeNew : 'a . 'a something_new -> Prims.bool =
+  fun projectee -> true
+let __proj__MakeNew__item___0 : 'a . 'a something_new -> ('a * Prims.int) =
+  fun projectee -> match projectee with | MakeNew _0 -> _0
 type raw_error =
   | Error_DependencyAnalysisFailed
   | Error_IDETooManyPops
@@ -2458,7 +2464,7 @@ let (set_option_warning_callback_range :
   FStar_Range.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
     FStar_Options.set_option_warning_callback (warn_unsafe_options ropt)
-let (uu___222 :
+let (uu___228 :
   (((Prims.string -> error_setting Prims.list) -> unit) *
     (unit -> error_setting Prims.list)))
   =
@@ -2499,10 +2505,10 @@ let (uu___222 :
   (set_callbacks, get_error_flags)
 let (set_parse_warn_error :
   (Prims.string -> error_setting Prims.list) -> unit) =
-  match uu___222 with
+  match uu___228 with
   | (set_parse_warn_error, error_flags) -> set_parse_warn_error
 let (error_flags : unit -> error_setting Prims.list) =
-  match uu___222 with | (set_parse_warn_error1, error_flags) -> error_flags
+  match uu___228 with | (set_parse_warn_error1, error_flags) -> error_flags
 let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
   fun err ->
     let flags = error_flags () in
```
(The top-levels are still gensym-dependent, since we maintain their exact
names when extracting... should we also change that?).

Without this patch, the change to FStar.Errors would have resulted in a
much larger diff:
```diffstat
$ git diff --stat
 src/basic/FStar.Errors.fs        |    3 +
 src/ocaml-output/FStar_Errors.ml | 1218 +++++++++++++++++++++++++++---------------------------
 2 files changed, 616 insertions(+), 605 deletions(-)
```